### PR TITLE
UpsellNudge: Style tweaks for non-compact nudges

### DIFF
--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,7 +1,9 @@
 .upsell-nudge {
 	&.banner.card {
 		border-left-color: var( --color-accent );
+		border-left-width: 6px;
 		background-color: var( --color-neutral-80 );
+		box-shadow: none;
 		color: var( --color-text-inverted );
 		display: flex;
 		align-items: center;
@@ -13,6 +15,7 @@
 		}
 
 		&.is-compact {
+			border-left-width: 4px;
 			margin-bottom: 0;
 
 			.banner__icon-circle,
@@ -26,6 +29,10 @@
 			.banner__content {
 				padding: 0 0 0 8px;
 			}
+		}
+
+		&:hover {
+			box-shadow: none;
 		}
 	}
 
@@ -55,7 +62,7 @@
 	}
 
 	.banner__description {
-		color: var( --color-text-inverted );
+		color: var( --color-neutral-5 );
 	}
 
 	.banner__action {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm in the process of applying `UpsellNudge` to different use cases to see how well it fits. Some CSS changes may be necessary to "tailor" it to our existing nudges if this is design we choose.

* Adjust border width on larger size nudges from 3px to 8px;
* Make nudge description slightly darker to stand out from the title.

The result should look something like this:

<img width="769" alt="Screen Shot 2020-01-29 at 12 51 59 PM" src="https://user-images.githubusercontent.com/2124984/73382780-29152280-4296-11ea-80d2-b651a9a4ddfe.png">

But the sidebar nudges should not be affected, since they're compact:

<img width="285" alt="Screen Shot 2020-01-29 at 12 52 31 PM" src="https://user-images.githubusercontent.com/2124984/73382818-3b8f5c00-4296-11ea-85d0-2c024adc9af8.png">

#### Testing instructions

* Switch to this PR
* Make sure you're using the `variantShowUnifiedUpsells` variation of the `sidebarUpsellNudgeUnification` A/B test
* Make sure the sidebar nudge design is visually unaffected
* For bonus points, implement an UpsellNudge (not the compact version) and check its visual styling.
