### PR TITLE
Checkout: refactor `getCheckoutCompleteRedirectPath` to clarify usage and add tests

### DIFF
--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import formatCurrency from '@automattic/format-currency';
-import { endsWith, get, includes, isNumber, isString, some, sortBy } from 'lodash';
+import { get, isNumber, isString, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -36,14 +36,16 @@ function applyPrecision( cost, precision ) {
 function canDomainAddGSuite( domainName ) {
 	const GOOGLE_APPS_INVALID_SUFFIXES = [ '.in', '.wpcomstaging.com' ];
 	const GOOGLE_APPS_BANNED_PHRASES = [ 'google' ];
-	const includesBannedPhrase = some( GOOGLE_APPS_BANNED_PHRASES, bannedPhrase =>
-		includes( domainName, bannedPhrase )
+	const includesBannedPhrase = GOOGLE_APPS_BANNED_PHRASES.some( bannedPhrase =>
+		domainName.includes( bannedPhrase )
 	);
-	const hasInvalidSuffix = some( GOOGLE_APPS_INVALID_SUFFIXES, invalidSuffix =>
-		endsWith( domainName, invalidSuffix )
+	const hasInvalidSuffix = GOOGLE_APPS_INVALID_SUFFIXES.some( invalidSuffix =>
+		domainName.endsWith( invalidSuffix )
 	);
-
-	return ! ( hasInvalidSuffix || includesBannedPhrase || isGSuiteRestricted() );
+	if ( includesBannedPhrase || hasInvalidSuffix || isGSuiteRestricted() ) {
+		return false;
+	}
+	return true;
 }
 
 /**

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -244,8 +244,11 @@ function isGSuiteOrExtraLicenseProductSlug( productSlug ) {
  */
 function isGSuiteRestricted() {
 	const user = userFactory();
-
-	return ! get( user.get(), 'is_valid_google_apps_country', false );
+	const userData = user.get();
+	if ( userData?.is_valid_google_apps_country ) {
+		return false; // not restricted
+	}
+	return true;
 }
 
 export {

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -136,13 +136,14 @@ function getGSuiteSupportedDomains( domains ) {
  * @returns {string} - ToS url redirect
  */
 function getLoginUrlWithTOSRedirect( email, domain ) {
+	const continueUrl = encodeURIComponent(
+		`https://admin.google.com/${ domain }/AcceptTermsOfService?continue=https://mail.google.com/mail/u/${ email }`
+	);
 	return (
 		'https://accounts.google.com/AccountChooser?' +
 		`Email=${ encodeURIComponent( email ) }` +
 		`&service=CPanel` +
-		`&continue=${ encodeURIComponent(
-			`https://admin.google.com/${ domain }/AcceptTermsOfService?continue=https://mail.google.com/mail/u/${ email }`
-		) }`
+		`&continue=${ continueUrl }`
 	);
 }
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -115,11 +115,13 @@ export class Checkout extends React.Component {
 		previousRoute: PropTypes.string.isRequired,
 		performRedirectTo: PropTypes.func,
 		performRedirectAndReplaceUrlTo: PropTypes.func,
+		getUrlFromCookie: PropTypes.func,
 	};
 
 	static defaultProps = {
 		performRedirectTo: url => page( url ),
 		performRedirectAndReplaceUrlTo: url => page.redirect( url ),
+		getUrlFromCookie: () => retrieveSignupDestination(),
 	};
 
 	state = {
@@ -445,7 +447,7 @@ export class Checkout extends React.Component {
 		if ( hasEcommercePlan( cart ) ) {
 			persistSignupDestination( this.getFallbackDestination( pendingOrReceiptId ) );
 		} else {
-			const signupDestination = retrieveSignupDestination();
+			const signupDestination = this.props.getUrlFromCookie();
 
 			if ( ! signupDestination ) {
 				return;
@@ -576,7 +578,7 @@ export class Checkout extends React.Component {
 		this.setDestinationIfEcommPlan( pendingOrReceiptId );
 
 		const signupDestination =
-			retrieveSignupDestination() || this.getFallbackDestination( pendingOrReceiptId );
+			this.props.getUrlFromCookie() || this.getFallbackDestination( pendingOrReceiptId );
 
 		if ( hasRenewalItem( cart ) ) {
 			renewalItem = getRenewalItems( cart )[ 0 ];
@@ -652,7 +654,7 @@ export class Checkout extends React.Component {
 		} = this.props;
 
 		const redirectPath = this.getCheckoutCompleteRedirectPath();
-		const destinationFromCookie = retrieveSignupDestination();
+		const destinationFromCookie = this.props.getUrlFromCookie();
 
 		this.props.clearPurchases();
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -1003,10 +1003,9 @@ function getCheckoutCompleteRedirectPath( {
 	// Display mode is used to show purchase specific messaging, for e.g. the Schedule Session button
 	// when purchasing a concierge session.
 	const displayModeParam = getDisplayModeParamFromCart( cart );
-	if ( isEligibleForSignupDestinationRedirect ) {
-		return getUrlWithQueryParam( signupDestination || fallbackUrl, displayModeParam );
+	if ( isEligibleForSignupDestinationRedirect && signupDestination ) {
+		return getUrlWithQueryParam( signupDestination, displayModeParam );
 	}
-
 	return getUrlWithQueryParam( fallbackUrl, displayModeParam );
 }
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -415,11 +415,11 @@ export class Checkout extends React.Component {
 			const isJetpackProduct = product && includes( JETPACK_BACKUP_PRODUCTS, product );
 			// If we just purchased a Jetpack product, redirect to the my plans page.
 			if ( isJetpackNotAtomic && isJetpackProduct ) {
-				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&product=${ product }`;
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you=true&product=${ product }`;
 			}
 			// If we just purchased a Jetpack plan (not a Jetpack product), redirect to the Jetpack onboarding plugin install flow.
 			if ( isJetpackNotAtomic ) {
-				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you=true&install=all`;
 			}
 
 			return selectedFeature && isValidFeatureKey( selectedFeature )

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -113,6 +113,13 @@ export class Checkout extends React.Component {
 		clearPurchases: PropTypes.func.isRequired,
 		fetchReceiptCompleted: PropTypes.func.isRequired,
 		previousRoute: PropTypes.string.isRequired,
+		performRedirectTo: PropTypes.func,
+		performRedirectAndReplaceUrlTo: PropTypes.func,
+	};
+
+	static defaultProps = {
+		performRedirectTo: url => page( url ),
+		performRedirectAndReplaceUrlTo: url => page.redirect( url ),
 	};
 
 	state = {
@@ -354,7 +361,7 @@ export class Checkout extends React.Component {
 			);
 		}
 
-		page.redirect( redirectTo );
+		this.props.performRedirectAndReplaceUrlTo( redirectTo );
 
 		return true;
 	}
@@ -739,7 +746,7 @@ export class Checkout extends React.Component {
 				fetchSitesAndUser(
 					domainName,
 					() => {
-						page( redirectPath );
+						this.props.performRedirectTo( redirectPath );
 					},
 					reduxStore
 				);
@@ -748,7 +755,7 @@ export class Checkout extends React.Component {
 			}
 		}
 
-		page( redirectPath );
+		this.props.performRedirectTo( redirectPath );
 	};
 
 	content() {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -109,6 +109,10 @@ export class Checkout extends React.Component {
 		isJetpackNotAtomic: PropTypes.bool,
 		selectedFeature: PropTypes.string,
 		loadTrackingTool: PropTypes.func.isRequired,
+		setHeaderText: PropTypes.func.isRequired,
+		clearPurchases: PropTypes.func.isRequired,
+		fetchReceiptCompleted: PropTypes.func.isRequired,
+		previousRoute: PropTypes.string.isRequired,
 	};
 
 	state = {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flatten, filter, find, get, includes, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import { flatten, find, get, includes, isEmpty, isEqual, reduce, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -761,23 +761,23 @@ export default connect(
 
 function getEligibleDomainFromCart( cart ) {
 	const domainRegistrations = getDomainRegistrations( cart );
-	const domainsInSignupContext = filter( domainRegistrations, { extra: { context: 'signup' } } );
-	const domainsForGSuite = filter( domainsInSignupContext, ( { meta } ) =>
-		canDomainAddGSuite( meta )
+	const domainsInSignupContext = domainRegistrations.filter(
+		domain => domain.extra?.context === 'signup'
 	);
-	return domainsForGSuite;
+	const domainsForGSuite = domainsInSignupContext.filter( domain =>
+		canDomainAddGSuite( domain.meta )
+	);
+	return domainsForGSuite.length > 0 ? domainsForGSuite[ 0 ] : null;
 }
 
 function shouldRedirectToGSuiteNudge( { stepResult, isNewlyCreatedSite, cart } ) {
 	if ( isNewlyCreatedSite && stepResult && isEmpty( stepResult.failed_purchases ) ) {
-		const hasGoogleAppsInCart = hasGoogleApps( cart );
-
-		// Maybe show either the G Suite or plan upgrade upsell pages
-		if ( ! hasGoogleAppsInCart && ! hasConciergeSession( cart ) && hasDomainRegistration( cart ) ) {
-			const domainsForGSuite = getEligibleDomainFromCart( cart );
-			if ( domainsForGSuite.length ) {
-				return true;
-			}
+		if (
+			! hasGoogleApps( cart ) &&
+			! hasConciergeSession( cart ) &&
+			hasDomainRegistration( cart )
+		) {
+			return true;
 		}
 	}
 	return false;
@@ -799,9 +799,9 @@ function getRedirectUrlForGSuiteNudge( {
 	) {
 		return null;
 	}
-	const domainsForGSuite = getEligibleDomainFromCart( cart );
-	if ( domainsForGSuite.length ) {
-		return `/checkout/${ selectedSiteSlug }/with-gsuite/${ domainsForGSuite[ 0 ].meta }/${ pendingOrReceiptId }`;
+	const domainForGSuite = getEligibleDomainFromCart( cart );
+	if ( domainForGSuite ) {
+		return `/checkout/${ selectedSiteSlug }/with-gsuite/${ domainForGSuite.meta }/${ pendingOrReceiptId }`;
 	}
 }
 

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -15,7 +15,15 @@ import { identity } from 'lodash';
 import { Checkout } from '../';
 import { hasPendingPayment } from 'lib/cart-values';
 import { isEnabled } from 'config';
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
 
+let mockGSuiteCountryIsValid = true;
+jest.mock( 'lib/user', () =>
+	jest.fn( () => ( {
+		get: () => ( { is_valid_google_apps_country: mockGSuiteCountryIsValid } ),
+	} ) )
+);
 jest.mock( 'lib/transaction/actions', () => ( {
 	resetTransaction: jest.fn(),
 } ) );
@@ -72,6 +80,10 @@ describe( 'Checkout', () => {
 		transaction: {
 			step: {},
 		},
+		setHeaderText: identity,
+		clearPurchases: identity,
+		fetchReceiptCompleted: identity,
+		previousRoute: '',
 	};
 
 	beforeAll( () => {
@@ -139,5 +151,932 @@ describe( 'Checkout', () => {
 		} );
 
 		expect( wrapper.find( 'Localized(PendingPaymentBlocker)' ) ).toHaveLength( 1 );
+	} );
+
+	describe( 'provides a handleCheckoutCompleteRedirect function to its children that', () => {
+		let container;
+		const Redirector = ( { handleCheckoutCompleteRedirect } ) => {
+			handleCheckoutCompleteRedirect();
+			return null;
+		};
+
+		beforeEach( () => {
+			mockGSuiteCountryIsValid = true;
+			container = document.createElement( 'div' );
+			document.body.appendChild( container );
+		} );
+
+		afterEach( () => {
+			document.body.removeChild( container );
+		} );
+
+		it( 'redirects to the root page when no site is set', () => {
+			const performRedirectTo = jest.fn();
+			render(
+				<Checkout { ...defaultProps } performRedirectTo={ performRedirectTo }>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/' );
+		} );
+
+		it( 'redirects to the thank-you page with a purchase id when a site and purchaseId is set', () => {
+			const performRedirectTo = jest.fn();
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					purchaseId={ '1234abcd' }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/1234abcd' );
+		} );
+
+		it( 'redirects to the thank-you page with a receipt id when a site and transaction receipt_id is set', () => {
+			const performRedirectTo = jest.fn();
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/1234abcd' );
+		} );
+
+		it( 'redirects to the thank-you page with a order id when a site and transaction orderId is set', () => {
+			const performRedirectTo = jest.fn();
+			const transaction = {
+				step: { data: { orderId: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/foo.bar/pending/1234abcd'
+			);
+		} );
+
+		it( 'redirects to the thank-you page with a placeholder receiptId with a site when the cart is not empty but there is no receipt id', () => {
+			const performRedirectTo = jest.fn();
+			const cart = { products: [ { id: 'something' } ] };
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/:receiptId' );
+		} );
+
+		it( 'redirects to the thank-you page with a feature when a site, a purchase id, and a valid feature is set', () => {
+			const performRedirectTo = jest.fn();
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					selectedFeature="all-free-features"
+					purchaseId={ '1234abcd' }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/features/all-free-features/foo.bar/1234abcd'
+			);
+		} );
+
+		it( 'redirects to the thank-you page with a feature when a site, a receipt id, and a valid feature is set', () => {
+			const performRedirectTo = jest.fn();
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					selectedFeature="all-free-features"
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/features/all-free-features/foo.bar/1234abcd'
+			);
+		} );
+
+		it( 'redirects to the thank-you page with a feature when a site, an order id, and a valid feature is set', () => {
+			const performRedirectTo = jest.fn();
+			const transaction = {
+				step: { data: { orderId: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					selectedFeature="all-free-features"
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/features/all-free-features/foo.bar/pending/1234abcd'
+			);
+		} );
+
+		it( 'redirects to the thank-you page with a feature when a site and a valid feature is set with no receipt but the cart is not empty', () => {
+			const performRedirectTo = jest.fn();
+			const cart = { products: [ { id: 'something' } ] };
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					selectedFeature="all-free-features"
+					cart={ cart }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/features/all-free-features/foo.bar/:receiptId'
+			);
+		} );
+
+		it( 'redirects to the thank-you page without a feature when a site, a purchase id, and an invalid feature is set', () => {
+			const performRedirectTo = jest.fn();
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					selectedFeature="fake-key"
+					purchaseId={ '1234abcd' }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/1234abcd' );
+		} );
+
+		it( 'redirects to the plans page with thank-you query string if there is a non-atomic jetpack product', () => {
+			const performRedirectTo = jest.fn();
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					purchaseId={ '1234abcd' }
+					isJetpackNotAtomic={ true }
+					product="jetpack_backup_daily"
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/plans/my-plan/foo.bar?thank-you=true&product=jetpack_backup_daily'
+			);
+		} );
+
+		it( 'redirects to the plans page with thank-you query string and jetpack onboarding if there is a non-atomic jetpack plan', () => {
+			const performRedirectTo = jest.fn();
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					purchaseId={ '1234abcd' }
+					isJetpackNotAtomic={ true }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/plans/my-plan/foo.bar?thank-you=true&install=all'
+			);
+		} );
+
+		it( 'redirects to the plans page with thank-you query string and jetpack onboarding if there is a non-atomic jetpack plan even if there is a feature', () => {
+			const performRedirectTo = jest.fn();
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					purchaseId={ '1234abcd' }
+					selectedFeature="all-free-features"
+					isJetpackNotAtomic={ true }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/plans/my-plan/foo.bar?thank-you=true&install=all'
+			);
+		} );
+
+		it( 'redirects to internal redirectTo url if set', () => {
+			const performRedirectTo = jest.fn();
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					redirectTo={ '/foo/bar' }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/foo/bar' );
+		} );
+
+		it( 'redirects to the root url if redirectTo does not start with admin_url for site', () => {
+			const performRedirectTo = jest.fn();
+			const adminUrl = 'https://my.site/wp-admin/';
+			const redirectTo = 'https://other.site/post.php?post=515';
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					selectedSite={ { options: { admin_url: adminUrl } } }
+					redirectTo={ redirectTo }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/' );
+		} );
+
+		it( 'redirects to external redirectTo url if it starts with admin_url for site', () => {
+			const performRedirectTo = jest.fn();
+			const adminUrl = 'https://my.site/wp-admin/';
+			const redirectTo = adminUrl + 'post.php?post=515';
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					selectedSite={ { options: { admin_url: adminUrl } } }
+					redirectTo={ redirectTo }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				redirectTo + '&action=edit&plan_upgraded=1'
+			);
+		} );
+
+		it( 'redirects to manage purchase page if there is a renewal', () => {
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{ extra: { purchaseType: 'renewal', purchaseDomain: 'foo.bar', purchaseId: '123abc' } },
+				],
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/me/purchases/foo.bar/123abc' );
+		} );
+
+		it( 'does not redirect to url from cookie if isEligibleForSignupDestination is false', () => {
+			const performRedirectTo = jest.fn();
+			const getUrlFromCookie = jest.fn( () => '/cookie' );
+			const cart = {
+				products: [ { product_slug: 'foo' } ],
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					performRedirectTo={ performRedirectTo }
+					getUrlFromCookie={ getUrlFromCookie }
+					isEligibleForSignupDestination={ false }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/:receiptId' );
+		} );
+
+		it( 'redirects to url from cookie if isEligibleForSignupDestination is set', () => {
+			const performRedirectTo = jest.fn();
+			const getUrlFromCookie = jest.fn( () => '/cookie' );
+			const cart = {
+				products: [ { product_slug: 'foo' } ],
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					performRedirectTo={ performRedirectTo }
+					getUrlFromCookie={ getUrlFromCookie }
+					isEligibleForSignupDestination={ true }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/cookie' );
+		} );
+
+		it( 'redirects to url from cookie if cart is empty and no receipt is set', () => {
+			const performRedirectTo = jest.fn();
+			const getUrlFromCookie = jest.fn( () => '/cookie' );
+			const cart = {
+				products: [],
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					performRedirectTo={ performRedirectTo }
+					getUrlFromCookie={ getUrlFromCookie }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/cookie' );
+		} );
+
+		it( 'redirects to url from cookie followed by purchase id if create_new_blog is set', () => {
+			const performRedirectTo = jest.fn();
+			const getUrlFromCookie = jest.fn( () => '/cookie' );
+			const cart = {
+				create_new_blog: true,
+				products: [ { id: '123' } ],
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					purchaseId={ '1234abcd' }
+					performRedirectTo={ performRedirectTo }
+					getUrlFromCookie={ getUrlFromCookie }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/cookie/1234abcd' );
+		} );
+
+		it( 'redirects to url from cookie followed by receipt id if create_new_blog is set', () => {
+			const performRedirectTo = jest.fn();
+			const getUrlFromCookie = jest.fn( () => '/cookie' );
+			const cart = {
+				create_new_blog: true,
+				products: [ { id: '123' } ],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+					getUrlFromCookie={ getUrlFromCookie }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/cookie/1234abcd' );
+		} );
+
+		it( 'redirects to url from cookie followed by order id if create_new_blog is set', () => {
+			const performRedirectTo = jest.fn();
+			const getUrlFromCookie = jest.fn( () => '/cookie' );
+			const cart = {
+				create_new_blog: true,
+				products: [ { id: '123' } ],
+			};
+			const transaction = {
+				step: { data: { orderId: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+					getUrlFromCookie={ getUrlFromCookie }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/cookie/pending/1234abcd' );
+		} );
+
+		it( 'redirects to url from cookie followed by placeholder receiptId if create_new_blog is set and there is no receipt', () => {
+			const performRedirectTo = jest.fn();
+			const getUrlFromCookie = jest.fn( () => '/cookie' );
+			const cart = {
+				create_new_blog: true,
+				products: [ { id: '123' } ],
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					performRedirectTo={ performRedirectTo }
+					getUrlFromCookie={ getUrlFromCookie }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/cookie/:receiptId' );
+		} );
+
+		// Note: This just verifies the existing behavior; I suspect this is a bug
+		it( 'redirects to thank-you page followed by placeholder receiptId twice if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
+			const performRedirectTo = jest.fn();
+			const cart = {
+				create_new_blog: true,
+				products: [ { id: '123' } ],
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/foo.bar/:receiptId/:receiptId'
+			);
+		} );
+
+		// Note: This just verifies the existing behavior; I suspect this is a bug
+		it( 'redirects to thank-you page followed by purchase id twice if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
+			const performRedirectTo = jest.fn();
+			const cart = {
+				create_new_blog: true,
+				products: [ { id: '123' } ],
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					purchaseId={ '1234abcd' }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/foo.bar/1234abcd/1234abcd'
+			);
+		} );
+
+		it( 'redirects to thank-you page for a new site with a domain and some failed purchases', () => {
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'some_domain',
+						is_domain_registration: true,
+						extra: { context: 'signup' },
+						meta: 'my.site',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: { foo: 'bar' } } },
+			};
+			mockGSuiteCountryIsValid = true;
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					isNewlyCreatedSite={ true }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/1234abcd' );
+		} );
+
+		it( 'redirects to thank-you page (with display mode) for a new site with a domain and no failed purchases but GSuite is in the cart', () => {
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'gapps',
+						meta: 'my.site',
+					},
+					{
+						product_slug: 'some_domain',
+						is_domain_registration: true,
+						extra: { context: 'signup' },
+						meta: 'my.site',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			mockGSuiteCountryIsValid = true;
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					isNewlyCreatedSite={ true }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/foo.bar/1234abcd?d=gsuite'
+			);
+		} );
+
+		it( 'redirects to thank-you page for a new site (via isNewlyCreatedSite) without a domain', () => {
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'some_domain',
+						is_domain_registration: false,
+						extra: { context: 'signup' },
+						meta: 'my.site',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			mockGSuiteCountryIsValid = false;
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					isNewlyCreatedSite={ true }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/1234abcd' );
+		} );
+
+		it( 'redirects to thank-you page (with concierge display mode) for a new site with a domain and no failed purchases but concierge is in the cart', () => {
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{ product_slug: 'concierge-session' },
+					{
+						product_slug: 'some_domain',
+						is_domain_registration: true,
+						extra: { context: 'signup' },
+						meta: 'my.site',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			mockGSuiteCountryIsValid = false;
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					isNewlyCreatedSite={ true }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/foo.bar/1234abcd?d=concierge'
+			);
+		} );
+
+		it( 'redirects to thank-you page for a new site with a domain and no failed purchases but neither GSuite nor concierge are in the cart if user is in invalid country', () => {
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'some_domain',
+						is_domain_registration: true,
+						extra: { context: 'signup' },
+						meta: 'my.site',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			mockGSuiteCountryIsValid = false;
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					isNewlyCreatedSite={ true }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/1234abcd' );
+		} );
+
+		it( 'redirects to gsuite nudge for a new site with a domain and no failed purchases but neither GSuite nor concierge are in the cart', () => {
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'some_domain',
+						is_domain_registration: true,
+						extra: { context: 'signup' },
+						meta: 'my.site',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			mockGSuiteCountryIsValid = true;
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					isNewlyCreatedSite={ true }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/foo.bar/with-gsuite/my.site/1234abcd'
+			);
+		} );
+
+		it( 'redirects to premium upgrade nudge if concierge and jetpack are not in the cart, personal is in the cart, and the previous route is not the nudge', () => {
+			isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'personal-bundle',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/foo.bar/offer-plan-upgrade/premium/1234abcd'
+			);
+		} );
+
+		it( 'redirects to concierge nudge if concierge and jetpack are not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {
+			isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'blogger-bundle',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/offer-quickstart-session/1234abcd/foo.bar'
+			);
+		} );
+
+		it( 'redirects to concierge nudge if concierge and jetpack are not in the cart, premium is in the cart, and the previous route is not the nudge', () => {
+			isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'value_bundle',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/offer-quickstart-session/1234abcd/foo.bar'
+			);
+		} );
+
+		it( 'redirects to thank-you page (with concierge display mode) if concierge is in the cart', () => {
+			isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'concierge-session',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith(
+				'/checkout/thank-you/foo.bar/1234abcd?d=concierge'
+			);
+		} );
+
+		it( 'redirects to thank-you page if jetpack is in the cart', () => {
+			isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'jetpack_premium',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/1234abcd' );
+		} );
+
+		it( 'redirects to thank you page if concierge and jetpack are not in the cart, personal is in the cart, but the previous route is the nudge', () => {
+			isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
+			const performRedirectTo = jest.fn();
+			const cart = {
+				products: [
+					{
+						product_slug: 'personal-bundle',
+					},
+				],
+			};
+			const transaction = {
+				step: { data: { receipt_id: '1234abcd', purchases: {}, failed_purchases: {} } },
+			};
+			render(
+				<Checkout
+					{ ...defaultProps }
+					selectedSiteSlug={ 'foo.bar' }
+					cart={ cart }
+					transaction={ transaction }
+					performRedirectTo={ performRedirectTo }
+					previousRoute="/checkout/foo.bar/offer-plan-upgrade/premium/1234abcd"
+				>
+					<Redirector />
+				</Checkout>,
+				container
+			);
+			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/1234abcd' );
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -216,7 +216,7 @@ describe( 'Checkout', () => {
 			expect( performRedirectTo ).toHaveBeenCalledWith( '/checkout/thank-you/foo.bar/1234abcd' );
 		} );
 
-		it( 'redirects to the thank-you page with a order id when a site and transaction orderId is set', () => {
+		it( 'redirects to the thank-you pending page with a order id when a site and transaction orderId is set', () => {
 			const performRedirectTo = jest.fn();
 			const transaction = {
 				step: { data: { orderId: '1234abcd', purchases: {}, failed_purchases: {} } },
@@ -295,7 +295,7 @@ describe( 'Checkout', () => {
 			);
 		} );
 
-		it( 'redirects to the thank-you page with a feature when a site, an order id, and a valid feature is set', () => {
+		it( 'redirects to the thank-you pending page with a feature when a site, an order id, and a valid feature is set', () => {
 			const performRedirectTo = jest.fn();
 			const transaction = {
 				step: { data: { orderId: '1234abcd', purchases: {}, failed_purchases: {} } },
@@ -604,7 +604,7 @@ describe( 'Checkout', () => {
 			expect( performRedirectTo ).toHaveBeenCalledWith( '/cookie/1234abcd' );
 		} );
 
-		it( 'redirects to url from cookie followed by order id if create_new_blog is set', () => {
+		it( 'redirects to url from cookie followed by the pending order id if create_new_blog is set', () => {
 			const performRedirectTo = jest.fn();
 			const getUrlFromCookie = jest.fn( () => '/cookie' );
 			const cart = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `getCheckoutCompleteRedirectPath` method of the `Checkout` component. It had some complex logic which was hard to reason about; this refactor should not change any behavior but hopefully makes it easier to read and understand.

A large part of this diff is moving methods from inside the component to pure functions outside. This should help make argument dependencies more clear and also makes the functions more easily testable.

This was a needed refactor anyway, but its main purpose is to clarify the url-choosing behavior so we can replicate it in #38725. 

**NOTE: Because of the size of this diff, which is mostly adding tests, it may be easiest to review the commits one-at-a-time. I've made an effort to keep each commit as small as possible.**

#### Testing instructions

This is difficult to test because of all the different possible conditions involved and because of how much work it takes to test each one. Therefore it may be necessary to rely on the automated tests to verify the behavior, but it's worth trying at least one purchase flow to be sure that it works. To do this, first test on master (or production) and then test on this branch: add an item to your cart, complete the purchase (you can sandbox the store to make this a test purchase), and be sure that you end up at the same thank-you page either way.

This PR adds 37 unit tests which cover all the code paths of the function. You can verify this by doing the following:

- Check out the commit after the tests are added but before the refactor: `git checkout c263979c6f`
- Run the tests: `npx jest --verbose -c test/client/jest.config.js client/my-sites/checkout/checkout/test/checkout.js`