### PR TITLE
Crowdsignal Signup: Bail out before using `FontFace` if it isn't supported in the browser.

### DIFF
--- a/client/layout/masterbar/crowdsignal.jsx
+++ b/client/layout/masterbar/crowdsignal.jsx
@@ -20,12 +20,19 @@ class CrowdsignalOauthMasterbar extends Component {
 		// Crowdsignal's OAuth2 pages should load and use the 'Recoleta' font to match the style of the app
 		// By loading it here we're not affecting any other pages inside Calypso that don't need the font
 
+		if ( 'undefined' === typeof FontFace ) {
+			// Probably IE or older Edge browser
+			return;
+		}
+
+		/* eslint-disable no-undef */
 		const crowdsignalFonts = [
 			new FontFace( 'Recoleta', 'url(https://s1.wp.com/i/fonts/recoleta/400.woff2)' ),
 			new FontFace( 'Recoleta', 'url(https://s1.wp.com/i/fonts/recoleta/700.woff2)', {
 				weight: 700,
 			} ),
 		];
+		/* eslint-enable no-undef */
 
 		if ( ! document.fonts.check( '12px Recoleta' ) ) {
 			map( crowdsignalFonts, font => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a failsafe for when a browser visits the Crowdsignal signup page that doesn't support `FontFace()`

#### Testing instructions

* Visit `/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D1ee70c5d3d0c36744fc60cb47734a2d881cdb57143e8d168a4bf37334e0805a1%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1` from a Chromium browser. You should see the login page!
* Now visit the same url from IE 11 or Edge (non-chromium release). You should also see the login page with no js errors! 

Edge screenshot:
<img width="923" alt="Screen Shot 2020-01-29 at 11 55 56 AM" src="https://user-images.githubusercontent.com/789137/73389080-aa69b680-4290-11ea-9e8c-72825a21f2ad.png">
