### PR TITLE
wpcom.js: revert change that clones the query argument before modifying it

### DIFF
--- a/packages/wpcom.js/src/lib/util/send-request.js
+++ b/packages/wpcom.js/src/lib/util/send-request.js
@@ -37,9 +37,8 @@ export default function sendRequest( params, query, body, fn ) {
 		body = null;
 	}
 
-	// query could be `null`. the object is copied so we are not mutating
-	// original arguments in code below
-	query = query ? { ...query } : {};
+	// query could be `null`
+	query = query || {};
 
 	// Handle special query parameters
 	// - `apiVersion`
@@ -92,4 +91,4 @@ export default function sendRequest( params, query, body, fn ) {
 			err ? reject( err ) : resolve( res );
 		} );
 	} );
-};
+}


### PR DESCRIPTION
Reverts https://github.com/Automattic/wpcom.js/pull/211 that cloned the `query` argument before calling `delete query.apiVersion` on it.

But that broke the following pattern:
```js
let query = { a: 1, b: 2 };
query.apiVersion = '1.1';
await wpcom.req.get( path, query );
expect( 'apiVersion' in query ).toBe( false );
```
I.e., many places in Calypso add a `query.apiVersion` field and expect that after the request is finished, the field is deleted again.

One such place are WordAds stats (found by @phpmypython). The request function [adds ](https://github.com/Automattic/wp-calypso/blob/d065697e0994a8adff04bfa93098f0927e8733a8/client/lib/wpcom-undocumented/lib/site.js#L42) the `query.apiVersion` argument. And the reducer that receives the response [uses the `query` argument](https://github.com/Automattic/wp-calypso/blob/d065697e0994a8adff04bfa93098f0927e8733a8/client/state/stats/lists/reducer.js#L42) to construct a state key. But the key that the reducer uses to store the result is now different from the key that the React UI component uses to select the state -- there's an extra `apiVersion` field.

Not mutating the `query` argument is a good idea and we should try to land it again, but it will require preparation and more testing.

**How to test:**
Verify that Ads stats chart loads in Calypso. Before this patch, it's been showing a spinner forever.
