### PR TITLE
Gutenboarding - update design picker focus hover

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -102,29 +102,6 @@ $design-selector-selection-space: 285px;
 		}
 	}
 
-	&.is-selected,
-	&:hover,
-	&:focus {
-		// padding: 0;
-		// box-sizing: border-box;
-		// border: 3px solid $blue-medium-focus;
-
-		// Offset absolute-positioned card content when border state occurs
-		// .page-layout-selector__card-media {
-		// 	width: calc( 100% + 2px ); /* This number is the border width * 2, minus the width of the thin static state border */
-		// 	top: -1px; /* This is half of the above number. */
-		// }
-
-		// .page-layout-selector__card-footer {
-		// 	bottom: -1px;
-		// 	width: calc( 100% + 2px );
-		// }
-
-		// box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		// outline: 2px solid transparent;
-	}
-
 	&:focus {
 		box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
@@ -136,7 +113,7 @@ $design-selector-selection-space: 285px;
 		padding: 0;
 		// Offset absolute-positioned card content when border state occurs
 		.page-layout-selector__card-media {
-			width: calc( 100% + 4px ); /* This number is the border width * 2, minus the width of the thin static state border */
+			width: calc( 100% + 4px ); /* This number is the change in border width when hovered * 2 */
 			top: -2px; /* This is half of the above number. */
 		}
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -105,9 +105,35 @@ $design-selector-selection-space: 285px;
 	&.is-selected,
 	&:hover,
 	&:focus {
-		padding: 0;
-		border: 3px solid $blue-medium-focus;
+		// padding: 0;
+		// box-sizing: border-box;
+		// border: 3px solid $blue-medium-focus;
 
+		// Offset absolute-positioned card content when border state occurs
+		// .page-layout-selector__card-media {
+		// 	width: calc( 100% + 2px ); /* This number is the border width * 2, minus the width of the thin static state border */
+		// 	top: -1px; /* This is half of the above number. */
+		// }
+
+		// .page-layout-selector__card-footer {
+		// 	bottom: -1px;
+		// 	width: calc( 100% + 2px );
+		// }
+
+		// box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		// outline: 2px solid transparent;
+	}
+
+	&:focus {
+		box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
+		// Windows High Contrast mode will show this outline, but not the box-shadow.
+		outline: 2px solid transparent;
+	}
+
+	&:hover {
+		border: 3px solid var( --color-neutral-dark );
+		padding: 0;
 		// Offset absolute-positioned card content when border state occurs
 		.page-layout-selector__card-media {
 			width: calc( 100% + 4px ); /* This number is the border width * 2, minus the width of the thin static state border */
@@ -117,19 +143,6 @@ $design-selector-selection-space: 285px;
 		.page-layout-selector__card-footer {
 			bottom: -2px;
 			width: calc( 100% + 4px );
-		}
-	}
-
-	&:hover,
-	&:focus {
-		border-color: var( --color-neutral-dark );
-		.page-layout-selector__selected-indicator {
-			background: linear-gradient(
-				to bottom left,
-				var( --color-neutral-dark ),
-				var( --color-neutral-dark ) 50%,
-				transparent 51% /* 1% difference helps prevent a rough edge */
-			);
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After taking a look at Issue #38665 created by @razvanpapadopol, I thought I would spin up a quick branch with the style rules for hover / focus that were being recommended.  

I don't think these are necessarily better than what is currently in place, but figured I could open up a PR to share.

If we were to keep going down this route, I would think we should:
1 - get rid of the 1px of white border interior to the blue border on the focus style.
2 - ~set focus for items on hover, so the focus outline doesn't seem so odd by staying on the last selected card while hovering others.~   This can be handled with `lib/accessible-focus` as seen on #39156

![design-hover-focus](https://user-images.githubusercontent.com/28742426/73395447-8a94bb80-42ad-11ea-9884-725fcc9658a5.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR on Calypso and nitpick at the hover/focus styles in gutenboarding page selection.

Fixes #38665 ? 
