### PR TITLE
Gutenboarding - add accessible focus

### DIFF
--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -25,6 +25,7 @@ window.AppBoot = () => {
 	} else {
 		setupWpDataDebug();
 
+		// Add accessible-focus listener.
 		accessibleFocus();
 
 		ReactDom.render(

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -12,7 +12,7 @@ import config from '../../config';
  */
 import { Gutenboard } from './gutenboard';
 import { setupWpDataDebug } from './devtools';
-
+import accessibleFocus from 'lib/accessible-focus';
 /**
  * Style dependencies
  */
@@ -24,6 +24,8 @@ window.AppBoot = () => {
 		window.location.href = '/';
 	} else {
 		setupWpDataDebug();
+
+		accessibleFocus();
 
 		ReactDom.render(
 			<BrowserRouter basename="gutenboarding">

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -100,6 +100,14 @@ $design-selector-selection-space: 285px;
 			right: -2px;
 			transform: translate3d( 0, 0, 0 );
 		}
+
+		// Offset for the 2px of added border when hovered.
+		&:hover {
+			.page-layout-selector__selected-indicator {
+				top: -4px;
+				right: -4px;
+			}
+		}
 	}
 
 	&:hover {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -257,8 +257,10 @@ $design-selector-selection-space: 285px;
 	}
 
 	.design-selector__design-option {
-		.design-selector__option-overlay {
-			opacity: 1;
+		&:focus {
+			.design-selector__option-overlay {
+				opacity: 1;
+			}
 		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -102,12 +102,6 @@ $design-selector-selection-space: 285px;
 		}
 	}
 
-	&:focus {
-		box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 2px solid transparent;
-	}
-
 	&:hover {
 		border: 3px solid var( --color-neutral-dark );
 		padding: 0;
@@ -229,30 +223,9 @@ $design-selector-selection-space: 285px;
 .accessible-focus {
 	.page-layout-selector__item {
 		&:focus {
-			padding: 0;
-			border: 3px solid $blue-medium-focus;
-	
-			// Offset absolute-positioned card content when border state occurs
-			.page-layout-selector__card-media {
-				width: calc( 100% + 4px ); /* This number is the border width * 2, minus the width of the thin static state border */
-				top: -2px; /* This is half of the above number. */
-			}
-	
-			.page-layout-selector__card-footer {
-				bottom: -2px;
-				width: calc( 100% + 4px );
-			}
-
-			border-color: var( --color-neutral-dark );
-
-			.page-layout-selector__selected-indicator {
-				background: linear-gradient(
-					to bottom left,
-					var( --color-neutral-dark ),
-					var( --color-neutral-dark ) 50%,
-					transparent 51% /* 1% difference helps prevent a rough edge */
-				);
-			}
+			box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-medium-500;
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
 		}
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -170,8 +170,7 @@ $design-selector-selection-space: 285px;
 		}
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		.design-selector__option-overlay {
 			opacity: 1;
 		}
@@ -225,4 +224,41 @@ $design-selector-selection-space: 285px;
 	color: $dark-gray-800;
 	font-size: 1.3em;
 	line-height: 1.3;
+}
+
+.accessible-focus {
+	.page-layout-selector__item {
+		&:focus {
+			padding: 0;
+			border: 3px solid $blue-medium-focus;
+	
+			// Offset absolute-positioned card content when border state occurs
+			.page-layout-selector__card-media {
+				width: calc( 100% + 4px ); /* This number is the border width * 2, minus the width of the thin static state border */
+				top: -2px; /* This is half of the above number. */
+			}
+	
+			.page-layout-selector__card-footer {
+				bottom: -2px;
+				width: calc( 100% + 4px );
+			}
+
+			border-color: var( --color-neutral-dark );
+
+			.page-layout-selector__selected-indicator {
+				background: linear-gradient(
+					to bottom left,
+					var( --color-neutral-dark ),
+					var( --color-neutral-dark ) 50%,
+					transparent 51% /* 1% difference helps prevent a rough edge */
+				);
+			}
+		}
+	}
+
+	.design-selector__design-option {
+		.design-selector__option-overlay {
+			opacity: 1;
+		}
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `accessible-focus` to gutenboarding.
* Refactors design selector CSS to nest focus styles inside the `.accessible-focus` class.

![accessible-focus](https://user-images.githubusercontent.com/28742426/73399675-abf9a580-42b5-11ea-8c70-9f0dccdef62c.gif)

**Notes** . `accessible-focus` adds the `.accessible-focus` class to the html element on the document when keyboard commands are used, and removes this when mouse clicks are detected.  Focus effects that we do not want present in a non-accessibility use setting can now be nested under the `.accessible-focus` class to prevent them from appearing in standard use.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR in Calypso.
* Navigate to the Gutenboarding page selectors.
* Verify focus styles do not show up until keyboard triggers (tab) are used.
* Verify clicking selections does not leave focus styles once un-hovered.

Fixes #39138
