### PR TITLE
FSE: Update styles to reference new changes in Gutenberg

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -11,6 +11,10 @@
 	padding: 0;
 }
 
+.components-popover.block-editor-block-list__block-popover .components-popover__content .block-editor-block-contextual-toolbar[data-type='a8c/template'] {
+	display: none;
+}
+
 .template__block-container {
 	&:hover {
 		cursor: pointer;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -16,6 +16,10 @@
 }
 
 .template__block-container {
+	&::before {
+		display: none;
+	}
+
 	&:hover {
 		cursor: pointer;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -66,7 +66,7 @@
 	}
 
 	// Remove the 50vh bottom padding that looks off with the FSE frame.
-	.editor-writing-flow__click-redirect {
+	.block-editor-writing-flow__click-redirect {
 		display: none;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
@@ -31,14 +31,17 @@ const EditorTemplateClasses = withSelect( select => {
 	return { templateClasses };
 } )( ( { templateClasses } ) => {
 	const blockListInception = setInterval( () => {
-		const blockList = document.querySelector( '.block-editor-writing-flow > div' );
+		const blockListParent = document.querySelector( '.block-editor__typewriter > div' );
 
-		if ( ! blockList ) {
+		if ( ! blockListParent ) {
 			return;
 		}
 		clearInterval( blockListInception );
 
-		blockList.className = classNames( 'a8c-template-editor fse-template-part', ...templateClasses );
+		blockListParent.className = classNames(
+			'a8c-template-editor fse-template-part',
+			...templateClasses
+		);
 	} );
 
 	return null;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
@@ -31,9 +31,7 @@ const EditorTemplateClasses = withSelect( select => {
 	return { templateClasses };
 } )( ( { templateClasses } ) => {
 	const blockListInception = setInterval( () => {
-		const blockList = document.querySelector(
-			'.block-editor-writing-flow.editor-writing-flow > div'
-		);
+		const blockList = document.querySelector( '.block-editor-writing-flow > div' );
 
 		if ( ! blockList ) {
 			return;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -402,13 +402,13 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	// `core/columns`
 	/* stylelint-disable selector-combinator-space-before */
 	.wp-block-columns
-		> .editor-inner-blocks
-		> .editor-block-list__layout
+		> .block-editor-inner-blocks
+		> .block-editor-block-list__layout
 		> [data-type='core/column']
-		> .editor-block-list__block-edit
+		> .block-editor-block-list__block-edit
 		> div
 		> .block-core-columns
-		> .editor-inner-blocks {
+		> .block-editor-inner-blocks {
 		/* stylelint-enable */
 		margin-top: 0;
 		margin-bottom: 0;


### PR DESCRIPTION
Continuation of https://github.com/Automattic/wp-calypso/pull/39035. (See some context there)

I also audited all uses of `.editor-` classnames and have fixed everything which has changed on the current Gutenberg master branch.

### Changes proposed in this Pull Request
* Fixes whitespace at the bottom of the page/template editor
* Fixes case where template block toolbar would display
* Fixes case where template block outline would display
* Renames all `.editor-` classnames to the `.block-editor-` equivalents.  (excluding newspack articles block)
* Fixes an issue where our template editor classNames were not applied to the correct parent div. This was causing the dotcom FSE nav block to not be targeted by the theme CSS, which looked really ugly.

### To fix:
* [ ] The "Loading Editor For: Header" text is not centered in the template part block.
 
#### Testing instructions
- Run this locally and make sure that SPT and FSE editors have correct styles, particularly around the header/footer blocks. Also check that the navigation block looks correct in the header/footer editor.