### PR TITLE
Docker: Remove NODE_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR    /calypso
 
 
 ENV        CONTAINER 'docker'
-ENV        NODE_PATH=/calypso/server:/calypso/client
 ENV        PROGRESS=true
 
 # Build a "base" layer


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow up to https://github.com/Automattic/wp-calypso/pull/38190 and #38931 to remove the remaining NODE_PATH from Dockerfile.

#### Testing instructions

* The Docker build should work without error. Verify [devdocs on calypso.live](https://calypso.live/devdocs?branch=remove/docker-node-path).