### PR TITLE
Domains: Fix contact edit screen usability

### DIFF
--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -1,8 +1,12 @@
-fieldset.contact-details-form-fields {
+.form-fieldset.contact-details-form-fields {
 	margin-bottom: 0;
 	display: flex;
 	flex-direction: column;
 	width: 100%;
+
+	.contact-details-form-fields__field.first-name {
+		margin-top: 0;
+	}
 
 	.contact-details-form-fields__row,
 	.custom-form-fieldsets__address-fields {
@@ -96,7 +100,6 @@ fieldset.contact-details-form-fields {
 	margin-top: 15px;
 }
 
-.contact-details-form-fields__field.first-name,
 .form__hidden-input .form__hidden-input {
 	margin-top: 0;
 }

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -72,6 +72,7 @@
 
 	.domain-management-form-footer {
 		justify-content: flex-end;
+		padding-bottom: 0;
 	}
 
 	.form__hidden-input a {

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -1,4 +1,4 @@
-.contact-details-form-fields {
+fieldset.contact-details-form-fields {
 	margin-bottom: 0;
 	display: flex;
 	flex-direction: column;
@@ -72,7 +72,6 @@
 
 	.domain-management-form-footer {
 		justify-content: flex-end;
-		padding-bottom: 0;
 	}
 
 	.form__hidden-input a {

--- a/client/my-sites/domains/domain-management/components/designated-agent-notice/style.scss
+++ b/client/my-sites/domains/domain-management/components/designated-agent-notice/style.scss
@@ -10,7 +10,7 @@
 }
 
 .designated-agent-notice__copy {
-	font-size: 12px;
-	font-weight: 100;
+	font-size: 13px;
+	font-weight: 400;
 	margin-left: 24px;
 }

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -249,14 +249,6 @@ class EditContactInfoFormCard extends React.Component {
 
 	onTransferLockOptOutChange = event => this.setState( { transferLock: ! event.target.checked } );
 
-	goToContactsPrivacy = () =>
-		page(
-			domainManagementContactsPrivacy(
-				this.props.selectedSite.slug,
-				this.props.selectedDomain.name
-			)
-		);
-
 	showNonDaConfirmationDialog = () => this.setState( { showNonDaConfirmationDialog: true } );
 
 	handleContactDetailsChange = newContactDetails => {
@@ -303,7 +295,7 @@ class EditContactInfoFormCard extends React.Component {
 		} );
 
 		if ( ! this.state.requiresConfirmation ) {
-			this.props.successNotice(
+			this.showNoticeAndGoBack(
 				this.props.translate(
 					'The contact info has been updated. ' +
 						'There may be a short delay before the changes show up in the public records.'
@@ -337,7 +329,17 @@ class EditContactInfoFormCard extends React.Component {
 			);
 		}
 
+		this.showNoticeAndGoBack( message );
+	};
+
+	showNoticeAndGoBack = message => {
 		this.props.successNotice( message );
+		page(
+			domainManagementContactsPrivacy(
+				this.props.selectedSite.slug,
+				this.props.selectedDomain.name
+			)
+		);
 	};
 
 	onWhoisUpdateError = () => {
@@ -404,7 +406,6 @@ class EditContactInfoFormCard extends React.Component {
 						onSubmit={ this.handleSubmitButtonClick }
 						onValidate={ this.validate }
 						labelTexts={ { submitButton: translate( 'Save Contact Info' ) } }
-						onCancel={ this.goToContactsPrivacy }
 						disableSubmitButton={ this.shouldDisableSubmitButton() }
 						isSubmitting={ this.state.formSubmitting }
 					>

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -333,7 +333,11 @@ class EditContactInfoFormCard extends React.Component {
 	};
 
 	showNoticeAndGoBack = message => {
-		this.props.successNotice( message );
+		this.props.successNotice( message, {
+			showDismiss: true,
+			isPersistent: true,
+			duration: 5000,
+		} );
 		page(
 			domainManagementContactsPrivacy(
 				this.props.selectedSite.slug,


### PR DESCRIPTION
We fixed some small issues with the domain contact screen usability.

#### Changes proposed in this Pull Request

* don't show the cancel button
* return to previous page on successful update
* remove unnecessary padding at the bottom

#### Testing instructions

* Open "Contacts and Privacy" and click on "Edit Contact Info"
* Verify that the "60 days transfer lock text" is readable
* Verify that there is no extra padding below the form button
* Verify that there is no Cancel button
* Verify that when contacts are successfully updated you're redirected back to the "Contacts and Privacy" screen

