### PR TITLE
Domains: Allow cancellation of domain transfer ins on Atomic sites

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -22,6 +22,7 @@ import { isDataLoading } from '../utils';
 import {
 	isDomainMapping,
 	isDomainRegistration,
+	isDomainTransfer,
 	isGoogleApps,
 	isJetpackPlan,
 	isPlan,
@@ -267,7 +268,7 @@ class RemovePurchase extends Component {
 			return this.renderDomainDialog();
 		}
 
-		if ( isDomainMapping( purchase ) ) {
+		if ( isDomainMapping( purchase ) || isDomainTransfer( purchase ) ) {
 			return this.renderPlanDialog();
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Related to https://github.com/Automattic/wp-calypso/pull/39084

As reported on p2MSmN-7Hr-p2, looks like we missed the domain transfer-in case. So let's lift the restriction on that too.

#### Testing instructions
After the patch, canceling a Domain Transfer should be possible from `/me/purchases`:

<img width="539" alt="Screenshot 2020-01-30 at 12 53 31" src="https://user-images.githubusercontent.com/3392497/73451588-d9029280-435f-11ea-978d-90b0116bb2d1.png">
