### PR TITLE
Jetpack Cloud: Add loading screen logo and animation

### DIFF
--- a/client/assets/stylesheets/jetpack-cloud.scss
+++ b/client/assets/stylesheets/jetpack-cloud.scss
@@ -5,6 +5,19 @@
 
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined
+@import 'shared/animation';
 
 // Global layout
 @import 'main';
+
+.is-section-jetpack-cloud .wpcom-site__logo {
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+	animation: loading-fade 1.6s ease-in-out infinite;
+
+	path {
+		fill: var( --color-text-subtle );
+	}
+}

--- a/client/assets/stylesheets/jetpack-cloud.scss
+++ b/client/assets/stylesheets/jetpack-cloud.scss
@@ -10,14 +10,23 @@
 // Global layout
 @import 'main';
 
-.is-section-jetpack-cloud .wpcom-site__logo {
-	position: fixed;
-	top: 50%;
-	left: 50%;
-	transform: translate( -50%, -50% );
-	animation: loading-fade 1.6s ease-in-out infinite;
+.is-section-jetpack-cloud {
+	.wpcom-site__loader {
+		position: fixed;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+		color: var( --color-text-subtle );
+		text-align: center;
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
 
-	path {
-		fill: var( --color-text-subtle );
+	.wpcom-site__logo {
+		display: block;
+		margin-bottom: 10px;
+
+		path {
+			fill: var( --color-text-subtle );
+		}
 	}
 }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -5,6 +5,7 @@
 
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -59,6 +60,7 @@ class Document extends React.Component {
 			isWCComConnect,
 			addEvergreenCheck,
 			requestFrom,
+			translate,
 		} = this.props;
 
 		const inlineScript =
@@ -79,9 +81,6 @@ class Document extends React.Component {
 			config.isEnabled( 'jetpack/connect/woocommerce' ) &&
 			'jetpack-connect' === sectionName &&
 			'woocommerce-onboarding' === requestFrom;
-
-		const isJetpackCloudFlow =
-			config.isEnabled( 'jetpack-cloud' ) && 'jetpack-cloud' === sectionName;
 
 		return (
 			<html
@@ -137,8 +136,11 @@ class Document extends React.Component {
 							>
 								<div className="masterbar" />
 								<div className="layout__content">
-									{ isJetpackCloudFlow ? (
-										<JetpackLogo size={ 72 } className="wpcom-site__logo" />
+									{ 'jetpack-cloud' === sectionName ? (
+										<div className="wpcom-site__loader">
+											<JetpackLogo size={ 72 } className="wpcom-site__logo" />
+											{ translate( 'Loading' ) }
+										</div>
 									) : (
 										<WordPressLogo size={ 72 } className="wpcom-site__logo" />
 									) }
@@ -265,4 +267,4 @@ class Document extends React.Component {
 	}
 }
 
-export default Document;
+export default localize( Document );

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -18,6 +18,7 @@ import EnvironmentBadge, {
 	PreferencesHelper,
 } from 'components/environment-badge';
 import { chunkCssLinks } from './utils';
+import JetpackLogo from 'components/jetpack-logo';
 import WordPressLogo from 'components/wordpress-logo';
 import { jsonStringifyForHtml } from 'server/sanitize';
 
@@ -79,6 +80,9 @@ class Document extends React.Component {
 			'jetpack-connect' === sectionName &&
 			'woocommerce-onboarding' === requestFrom;
 
+		const isJetpackCloudFlow =
+			config.isEnabled( 'jetpack-cloud' ) && 'jetpack-cloud' === sectionName;
+
 		return (
 			<html
 				lang={ lang }
@@ -133,7 +137,11 @@ class Document extends React.Component {
 							>
 								<div className="masterbar" />
 								<div className="layout__content">
-									<WordPressLogo size={ 72 } className="wpcom-site__logo" />
+									{ isJetpackCloudFlow ? (
+										<JetpackLogo size={ 72 } className="wpcom-site__logo" />
+									) : (
+										<WordPressLogo size={ 72 } className="wpcom-site__logo" />
+									) }
 									{ hasSecondary && (
 										<Fragment>
 											<div className="layout__secondary" />


### PR DESCRIPTION
This PR adds a pulsating Jetpack logo when the Jetpack Cloud is being loaded:

![2020-01-31 12 36 56](https://user-images.githubusercontent.com/478735/73536654-aa9bba80-4426-11ea-806a-63ba4895c0a4.gif)

#### Changes proposed in this Pull Request

* Add animated Jetpack logo to the Jetpack Cloud loading screen 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start (or re-run) Calypso build process with: `CALYPSO_ENV=jetpack-cloud-development npm start`
* In devtools set network throttling to Slow 3G so that it's easier to see the loading screen
* Go to http://jetpack.cloud.localhost:3000/ and confirm that you can see a pulsating Jetpack logo while the Jetpack Cloud is being loaded

Asana card: 1156570014567299-as-1157678527369108
