### PR TITLE
Build: Output types to dist/types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,6 @@ cached-requests.json
 /apps/*/dist/
 /apps/*/types/
 /packages/*/dist/
+# Redundant after https://github.com/Automattic/wp-calypso/pull/39173
+# Safe to remove after some time has passed
 /packages/*/types/

--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -9,7 +9,6 @@
  * Internal dependencies
  */
 import { SiteVertical } from './stores/onboard/types';
-import { DomainName } from '@automattic/data-stores/types/domain-suggestions';
 
 /**
  * ⚠️😱 Calypso dependencies 😱⚠️
@@ -20,7 +19,7 @@ import { urlToSlug } from '../../lib/url';
 
 interface CreateSite {
 	siteTitle?: string;
-	siteUrl?: DomainName;
+	siteUrl?: string;
 	theme?: string;
 	siteVertical: SiteVertical | undefined;
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,10 +24,9 @@
 	},
 	"files": [
 		"dist",
-		"types",
 		"src"
 	],
-	"types": "types",
+	"types": "dist/types",
 	"dependencies": {
 		"classnames": "^2.2.6",
 		"gridicons": "^3.3.1",
@@ -38,7 +37,7 @@
 		"react-modal": "^3.8.1"
 	},
 	"scripts": {
-		"clean": "npx rimraf dist types",
+		"clean": "npx rimraf dist",
 		"prepublish": "npm run clean",
 		"prepare": "transpile && tsc && copy-assets"
 	}

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -6,7 +6,7 @@
 		"checkJs": false,
 		"jsx": "react",
 		"declaration": true,
-		"declarationDir": "./types",
+		"declarationDir": "dist/types",
 		"emitDeclarationOnly": true,
 		"isolatedModules": true,
 

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -4,18 +4,17 @@
 	"description": "A checkout component for WordPress.com",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
-	"types": "types/types.d.ts",
+	"types": "dist/types",
 	"sideEffects": false,
 	"scripts": {
-		"clean": "npx rimraf dist types",
+		"clean": "npx rimraf dist",
 		"prepublish": "npm run clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"typecheck": "tsc --project ./tsconfig.json --noEmit"
 	},
 	"files": [
 		"dist",
-		"src",
-		"types"
+		"src"
 	],
 	"keywords": [
 		"checkout",

--- a/packages/composite-checkout-wpcom/tsconfig.json
+++ b/packages/composite-checkout-wpcom/tsconfig.json
@@ -6,7 +6,7 @@
 		"lib": [ "DOM", "ES2015", "ES2017", "ScriptHost" ],
 		"module": "esnext",
 		"declaration": true,
-		"declarationDir": "types",
+		"declarationDir": "dist/types",
 		"outDir": "./dist/esm",
 
 		"strict": true,

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -22,12 +22,11 @@
 	"files": [
 		"autocomplete.gif",
 		"dist",
-		"types",
 		"src"
 	],
-	"types": "types",
+	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist types",
+		"clean": "npx rimraf dist",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"prepublish": "npm run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/data-stores/tsconfig-cjs.json
+++ b/packages/data-stores/tsconfig-cjs.json
@@ -4,6 +4,6 @@
 		"module": "commonjs",
 		"declaration": false,
 		"declarationDir": null,
-		"outDir": "./dist/cjs"
+		"outDir": "dist/cjs"
 	}
 }

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -12,8 +12,8 @@
 		"allowJs": false,
 		"jsx": "react",
 		"declaration": true,
-		"declarationDir": "./types",
-		"outDir": "./dist/esm",
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
 
 		"strict": true,
 		"noUnusedLocals": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Move generated types to `dist` folder. This aligns with other compilation results.

Closes #39091 (alternative)

#### Testing instructions
* `npm run build-packages`
* `rm -fr packages/{wpcom,data}*/types` (clean existing types)
* `npx eslint --ext .js --ext .jsx --ext .ts --ext .tsx packages/data-stores` should not include errors from built type files. It does on master

