### PR TITLE
composite-checkout: Hook up coupon field

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -140,8 +140,7 @@ export default function CompositeCheckout( {
 		validateDomainContactDetails || wpcomValidateDomainContactInformation
 	);
 
-	const errorMessages = useMemo( () => errors.map( error => error.message ), [ errors ] );
-	useDisplayErrors( errorMessages, showErrorMessage );
+	useDisplayErrors( errors, showErrorMessage );
 
 	useAddProductToCart( planSlug, isJetpackNotAtomic, addItem );
 
@@ -275,8 +274,20 @@ function useAddProductToCart( planSlug, isJetpackNotAtomic, addItem ) {
 }
 
 function useDisplayErrors( errors, displayError ) {
+	const couponErrorCodes = [
+		'coupon-not-found',
+		'coupon-already-used',
+		'coupon-no-longer-valid',
+		'coupon-expired',
+		'coupon-unknown-error',
+	];
+
+	const isNotCouponError = error => {
+		return ! couponErrorCodes.includes( error.code );
+	};
+
 	useEffect( () => {
-		errors.map( displayError );
+		errors.filter( isNotCouponError ).map( error => displayError( error.message ) );
 	}, [ errors, displayError ] );
 }
 

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -110,6 +110,7 @@ export default function CompositeCheckout( {
 		credits,
 		removeItem,
 		addItem,
+        submitCoupon,
 		changePlanLength,
 		errors,
 		subtotal,
@@ -215,6 +216,7 @@ export default function CompositeCheckout( {
 			>
 				<WPCheckout
 					removeItem={ removeItem }
+                    submitCoupon={ submitCoupon }
 					changePlanLength={ changePlanLength }
 					siteId={ siteId }
 					siteUrl={ siteSlug }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -101,6 +101,14 @@ export default function CompositeCheckout( {
 		notices.success( message );
 	}, [] );
 
+	const showAddCouponSuccessMessage = couponCode => {
+		showSuccessMessage(
+			translate( "The '%(couponCode)s' coupon was successfully applied to your shopping cart.", {
+				args: { couponCode },
+			} )
+		);
+	};
+
 	const countriesList = useCountryList( overrideCountryList || [] );
 
 	const {
@@ -110,13 +118,18 @@ export default function CompositeCheckout( {
 		credits,
 		removeItem,
 		addItem,
-        submitCoupon,
+		submitCoupon,
 		changePlanLength,
 		errors,
 		subtotal,
 		isLoading,
 		allowedPaymentMethods: serverAllowedPaymentMethods,
-	} = useShoppingCart( siteSlug, setCart || wpcomSetCart, getCart || wpcomGetCart );
+	} = useShoppingCart(
+		siteSlug,
+		setCart || wpcomSetCart,
+		getCart || wpcomGetCart,
+		showAddCouponSuccessMessage
+	);
 
 	const { registerStore } = registry;
 	useWpcomStore(
@@ -216,7 +229,7 @@ export default function CompositeCheckout( {
 			>
 				<WPCheckout
 					removeItem={ removeItem }
-                    submitCoupon={ submitCoupon }
+					submitCoupon={ submitCoupon }
 					changePlanLength={ changePlanLength }
 					siteId={ siteId }
 					siteUrl={ siteSlug }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -119,6 +119,7 @@ export default function CompositeCheckout( {
 		removeItem,
 		addItem,
 		submitCoupon,
+		couponStatus,
 		changePlanLength,
 		errors,
 		subtotal,
@@ -230,6 +231,7 @@ export default function CompositeCheckout( {
 				<WPCheckout
 					removeItem={ removeItem }
 					submitCoupon={ submitCoupon }
+					couponStatus={ couponStatus }
 					changePlanLength={ changePlanLength }
 					siteId={ siteId }
 					siteUrl={ siteSlug }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -114,6 +114,7 @@ export default function CompositeCheckout( {
 	const {
 		items,
 		tax,
+		couponItem,
 		total,
 		credits,
 		removeItem,
@@ -144,7 +145,7 @@ export default function CompositeCheckout( {
 
 	useAddProductToCart( planSlug, isJetpackNotAtomic, addItem );
 
-	const itemsForCheckout = items.length ? [ ...items, tax ] : [];
+	const itemsForCheckout = ( items.length ? [ ...items, tax, couponItem ] : [] ).filter( Boolean );
 	debug( 'items for checkout', itemsForCheckout );
 
 	useRedirectIfCartEmpty( items, `/plans/${ siteSlug || '' }` );

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -130,6 +130,7 @@ export default function CompositeCheckout( {
 		siteSlug,
 		setCart || wpcomSetCart,
 		getCart || wpcomGetCart,
+		translate,
 		showAddCouponSuccessMessage
 	);
 

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -76,6 +76,7 @@ describe( 'CompositeCheckout', () => {
 			total_tax_display: 'R$7',
 			total_cost_integer: 15600,
 			total_cost_display: 'R$156',
+			coupon_discounts: [],
 		};
 
 		const countryList = [

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -76,7 +76,7 @@ describe( 'CompositeCheckout', () => {
 			total_tax_display: 'R$7',
 			total_cost_integer: 15600,
 			total_cost_display: 'R$156',
-			coupon_discounts_int: [],
+			coupon_discounts_integer: [],
 		};
 
 		const countryList = [

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -76,7 +76,7 @@ describe( 'CompositeCheckout', () => {
 			total_tax_display: 'R$7',
 			total_cost_integer: 15600,
 			total_cost_display: 'R$156',
-			coupon_discounts: [],
+			coupon_discounts_int: [],
 		};
 
 		const countryList = [

--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -28,6 +28,7 @@ export default function Coupon( { id, className, disabled, submitCoupon, couponS
 	const hasCouponError = couponStatus === 'invalid' || couponStatus === 'rejected';
 	const isPending = couponStatus === 'pending';
 
+    // eslint-disable-next-line no-nested-ternary
 	const errorMessage = ( couponStatus === 'invalid')
         ? translate( "We couldn't find your coupon. Please check your code and try again." )
         : ( couponStatus === 'rejected' )

--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -15,18 +15,24 @@ import joinClasses from './join-classes';
 import Field from './field';
 import Button from './button';
 
-export default function Coupon( { id, couponAdded, className, disabled, submitCoupon } ) {
+export default function Coupon( { id, className, disabled, submitCoupon, couponStatus } ) {
 	const translate = useTranslate();
 	const onEvent = useEvents();
 	const [ isApplyButtonActive, setIsApplyButtonActive ] = useState( false );
 	const [ couponFieldValue, setCouponFieldValue ] = useState( '' );
-	const [ hasCouponError, setHasCouponError ] = useState( false );
-	const [ isCouponApplied, setIsCouponApplied ] = useState( false );
 
-	//TODO: tie the coupon field visibility based on whether there is a coupon in the cart
-	if ( isCouponApplied ) {
-		return null;
-	}
+    if ( couponStatus === 'applied' ) {
+        return null;
+    }
+
+	const hasCouponError = couponStatus === 'invalid' || couponStatus === 'rejected';
+	const isPending = couponStatus === 'pending';
+
+	const errorMessage = ( couponStatus === 'invalid')
+        ? translate( "We couldn't find your coupon. Please check your code and try again." )
+        : ( couponStatus === 'rejected' )
+            ? translate( "This coupon does not apply to any items in the cart." )
+            : null;
 
 	return (
 		<CouponWrapper
@@ -45,21 +51,24 @@ export default function Coupon( { id, couponAdded, className, disabled, submitCo
 		>
 			<Field
 				id={ id }
-				disabled={ disabled }
+				disabled={ disabled || isPending }
 				placeholder={ translate( 'Enter your coupon code' ) }
 				isError={ hasCouponError }
-				errorMessage={
-					hasCouponError
-						? translate( "We couldn't find your coupon. Please check your code and try again." )
-						: null
-				}
+				errorMessage={ errorMessage }
 				onChange={ input => {
 					handleFieldInput( input, setCouponFieldValue, setIsApplyButtonActive, setHasCouponError );
 				} }
 			/>
 
 			{ isApplyButtonActive && (
-				<ApplyButton buttonState="secondary">{ translate( 'Apply' ) }</ApplyButton>
+				<ApplyButton
+                    buttonState={ isPending ? 'disabled' : 'secondary' }
+                >
+                    { isPending
+                        ? translate( 'Processing…' )
+                        : translate( 'Apply' )
+                    }
+                </ApplyButton>
 			) }
 		</CouponWrapper>
 	);

--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -32,13 +32,7 @@ export default function Coupon( { id, className, disabled, couponStatus, couponF
 	const hasCouponError = couponStatus === 'invalid' || couponStatus === 'rejected';
 	const isPending = couponStatus === 'pending';
 
-	const errorMessage =
-		// eslint-disable-next-line no-nested-ternary
-		couponStatus === 'invalid' && ! isFreshOrEdited
-			? translate( "We couldn't find your coupon. Please check your code and try again." )
-			: couponStatus === 'rejected'
-			? translate( 'This coupon does not apply to any items in the cart.' )
-			: null;
+	const errorMessage = getCouponErrorMessageFromStatus( translate, couponStatus, isFreshOrEdited );
 
 	return (
 		<CouponWrapper
@@ -103,3 +97,13 @@ const ApplyButton = styled( Button )`
 	animation-fill-mode: backwards;
 	margin: 0;
 `;
+
+function getCouponErrorMessageFromStatus( translate, status, isFreshOrEdited ) {
+	if ( status === 'invalid' && ! isFreshOrEdited ) {
+		return translate( "We couldn't find your coupon. Please check your code and try again." );
+	}
+	if ( status === 'rejected' ) {
+		return translate( 'This coupon does not apply to any items in the cart.' );
+	}
+	return null;
+}

--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -21,6 +21,9 @@ export default function Coupon( { id, className, disabled, submitCoupon, couponS
 	const [ isApplyButtonActive, setIsApplyButtonActive ] = useState( false );
 	const [ couponFieldValue, setCouponFieldValue ] = useState( '' );
 
+	// Used to hide error messages if the user has edited the form field
+	const [ isFreshOrEdited, setIsFreshOrEdited ] = useState( true );
+
 	if ( couponStatus === 'applied' ) {
 		return null;
 	}
@@ -30,7 +33,7 @@ export default function Coupon( { id, className, disabled, submitCoupon, couponS
 
 	const errorMessage =
 		// eslint-disable-next-line no-nested-ternary
-		couponStatus === 'invalid'
+		couponStatus === 'invalid' && ! isFreshOrEdited
 			? translate( "We couldn't find your coupon. Please check your code and try again." )
 			: couponStatus === 'rejected'
 			? translate( 'This coupon does not apply to any items in the cart.' )
@@ -40,6 +43,7 @@ export default function Coupon( { id, className, disabled, submitCoupon, couponS
 		<CouponWrapper
 			className={ joinClasses( [ className, 'coupon' ] ) }
 			onSubmit={ event => {
+				setIsFreshOrEdited( false );
 				handleFormSubmit( event, couponFieldValue, onEvent, submitCoupon );
 			} }
 		>
@@ -47,9 +51,10 @@ export default function Coupon( { id, className, disabled, submitCoupon, couponS
 				id={ id }
 				disabled={ disabled || isPending }
 				placeholder={ translate( 'Enter your coupon code' ) }
-				isError={ hasCouponError }
+				isError={ hasCouponError && ! isFreshOrEdited }
 				errorMessage={ errorMessage }
 				onChange={ input => {
+					setIsFreshOrEdited( true );
 					handleFieldInput( input, setCouponFieldValue, setIsApplyButtonActive );
 				} }
 			/>

--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -15,7 +15,7 @@ import joinClasses from './join-classes';
 import Field from './field';
 import Button from './button';
 
-export default function Coupon( { id, couponAdded, className, disabled } ) {
+export default function Coupon( { id, couponAdded, className, disabled, submitCoupon } ) {
 	const translate = useTranslate();
 	const onEvent = useEvents();
 	const [ isApplyButtonActive, setIsApplyButtonActive ] = useState( false );
@@ -38,7 +38,8 @@ export default function Coupon( { id, couponAdded, className, disabled } ) {
 					setHasCouponError,
 					couponAdded,
 					setIsCouponApplied,
-					onEvent
+					onEvent,
+                    submitCoupon
 				);
 			} }
 		>
@@ -115,7 +116,8 @@ function handleFormSubmit(
 	setHasCouponError,
 	couponAdded,
 	setIsCouponApplied,
-	onEvent
+	onEvent,
+    submitCoupon
 ) {
 	event.preventDefault();
 
@@ -126,6 +128,8 @@ function handleFormSubmit(
 			type: 'a8c_checkout_add_coupon',
 			payload: { coupon: couponFieldValue },
 		} );
+
+		submitCoupon( couponFieldValue );
 
 		if ( couponAdded ) {
 			couponAdded();

--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -39,7 +39,7 @@ export default function Coupon( { id, couponAdded, className, disabled, submitCo
 					couponAdded,
 					setIsCouponApplied,
 					onEvent,
-                    submitCoupon
+					submitCoupon
 				);
 			} }
 		>
@@ -117,12 +117,12 @@ function handleFormSubmit(
 	couponAdded,
 	setIsCouponApplied,
 	onEvent,
-    submitCoupon
+	submitCoupon
 ) {
 	event.preventDefault();
 
 	//TODO: Validate coupon field and replace condition in the following if statement
-	if ( couponFieldValue === 'Add' ) {
+	if ( isCouponValid( couponFieldValue ) ) {
 		setIsCouponApplied( true );
 		onEvent( {
 			type: 'a8c_checkout_add_coupon',
@@ -143,4 +143,9 @@ function handleFormSubmit(
 		payload: { type: 'Invalid code' },
 	} );
 	setHasCouponError( true );
+}
+
+function isCouponValid( coupon ) {
+	// TODO: figure out some basic validation here
+	return coupon.match( /^[a-zA-Z0-9_-]+$/ );
 }

--- a/packages/composite-checkout-wpcom/src/components/coupon.js
+++ b/packages/composite-checkout-wpcom/src/components/coupon.js
@@ -21,33 +21,26 @@ export default function Coupon( { id, className, disabled, submitCoupon, couponS
 	const [ isApplyButtonActive, setIsApplyButtonActive ] = useState( false );
 	const [ couponFieldValue, setCouponFieldValue ] = useState( '' );
 
-    if ( couponStatus === 'applied' ) {
-        return null;
-    }
+	if ( couponStatus === 'applied' ) {
+		return null;
+	}
 
 	const hasCouponError = couponStatus === 'invalid' || couponStatus === 'rejected';
 	const isPending = couponStatus === 'pending';
 
-    // eslint-disable-next-line no-nested-ternary
-	const errorMessage = ( couponStatus === 'invalid')
-        ? translate( "We couldn't find your coupon. Please check your code and try again." )
-        : ( couponStatus === 'rejected' )
-            ? translate( "This coupon does not apply to any items in the cart." )
-            : null;
+	const errorMessage =
+		// eslint-disable-next-line no-nested-ternary
+		couponStatus === 'invalid'
+			? translate( "We couldn't find your coupon. Please check your code and try again." )
+			: couponStatus === 'rejected'
+			? translate( 'This coupon does not apply to any items in the cart.' )
+			: null;
 
 	return (
 		<CouponWrapper
 			className={ joinClasses( [ className, 'coupon' ] ) }
 			onSubmit={ event => {
-				handleFormSubmit(
-					event,
-					couponFieldValue,
-					setHasCouponError,
-					couponAdded,
-					setIsCouponApplied,
-					onEvent,
-					submitCoupon
-				);
+				handleFormSubmit( event, couponFieldValue, onEvent, submitCoupon );
 			} }
 		>
 			<Field
@@ -57,19 +50,14 @@ export default function Coupon( { id, className, disabled, submitCoupon, couponS
 				isError={ hasCouponError }
 				errorMessage={ errorMessage }
 				onChange={ input => {
-					handleFieldInput( input, setCouponFieldValue, setIsApplyButtonActive, setHasCouponError );
+					handleFieldInput( input, setCouponFieldValue, setIsApplyButtonActive );
 				} }
 			/>
 
 			{ isApplyButtonActive && (
-				<ApplyButton
-                    buttonState={ isPending ? 'disabled' : 'secondary' }
-                >
-                    { isPending
-                        ? translate( 'Processing…' )
-                        : translate( 'Apply' )
-                    }
-                </ApplyButton>
+				<ApplyButton buttonState={ isPending ? 'disabled' : 'secondary' }>
+					{ isPending ? translate( 'Processing…' ) : translate( 'Apply' ) }
+				</ApplyButton>
 			) }
 		</CouponWrapper>
 	);
@@ -109,41 +97,25 @@ const ApplyButton = styled( Button )`
 	margin: 0;
 `;
 
-function handleFieldInput( input, setCouponFieldValue, setIsApplyButtonActive, setHasCouponError ) {
+function handleFieldInput( input, setCouponFieldValue, setIsApplyButtonActive ) {
 	if ( input.length > 0 ) {
 		setCouponFieldValue( input );
 		setIsApplyButtonActive( true );
-		setHasCouponError( false );
 		return;
 	}
 
 	setIsApplyButtonActive( false );
 }
 
-function handleFormSubmit(
-	event,
-	couponFieldValue,
-	setHasCouponError,
-	couponAdded,
-	setIsCouponApplied,
-	onEvent,
-	submitCoupon
-) {
+function handleFormSubmit( event, couponFieldValue, onEvent, submitCoupon ) {
 	event.preventDefault();
-
-	//TODO: Validate coupon field and replace condition in the following if statement
 	if ( isCouponValid( couponFieldValue ) ) {
-		setIsCouponApplied( true );
 		onEvent( {
 			type: 'a8c_checkout_add_coupon',
 			payload: { coupon: couponFieldValue },
 		} );
 
 		submitCoupon( couponFieldValue );
-
-		if ( couponAdded ) {
-			couponAdded();
-		}
 
 		return;
 	}
@@ -152,7 +124,6 @@ function handleFormSubmit(
 		type: 'a8c_checkout_add_coupon_error',
 		payload: { type: 'Invalid code' },
 	} );
-	setHasCouponError( true );
 }
 
 function isCouponValid( coupon ) {

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
@@ -22,8 +22,8 @@ import {
 export default function WPCheckoutOrderReview( {
 	className,
 	removeItem,
-	submitCoupon,
 	couponStatus,
+	couponFieldStateProps,
 	siteUrl,
 } ) {
 	const [ items, total ] = useLineItems();
@@ -40,8 +40,8 @@ export default function WPCheckoutOrderReview( {
 			<CouponField
 				id="order-review-coupon"
 				disabled={ formStatus !== 'ready' }
-				submitCoupon={ submitCoupon }
 				couponStatus={ couponStatus }
+				couponFieldStateProps={ couponFieldStateProps }
 			/>
 
 			<WPOrderReviewSection>

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
@@ -19,7 +19,7 @@ import {
 	WPOrderReviewSection,
 } from './wp-order-review-line-items';
 
-export default function WPCheckoutOrderReview( { className, removeItem, siteUrl } ) {
+export default function WPCheckoutOrderReview( { className, removeItem, submitCoupon, siteUrl } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const firstDomainItem = items.find( isLineItemADomain );
@@ -31,7 +31,11 @@ export default function WPCheckoutOrderReview( { className, removeItem, siteUrl 
 				<WPOrderReviewLineItems items={ items } removeItem={ removeItem } />
 			</WPOrderReviewSection>
 
-			<CouponField id="order-review-coupon" disabled={ formStatus !== 'ready' } />
+			<CouponField
+				id="order-review-coupon"
+				disabled={ formStatus !== 'ready' }
+				submitCoupon={ submitCoupon }
+			/>
 
 			<WPOrderReviewSection>
 				<WPOrderReviewTotal total={ total } />

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
@@ -19,7 +19,13 @@ import {
 	WPOrderReviewSection,
 } from './wp-order-review-line-items';
 
-export default function WPCheckoutOrderReview( { className, removeItem, submitCoupon, siteUrl } ) {
+export default function WPCheckoutOrderReview( {
+	className,
+	removeItem,
+	submitCoupon,
+	couponStatus,
+	siteUrl,
+} ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const firstDomainItem = items.find( isLineItemADomain );
@@ -35,6 +41,7 @@ export default function WPCheckoutOrderReview( { className, removeItem, submitCo
 				id="order-review-coupon"
 				disabled={ formStatus !== 'ready' }
 				submitCoupon={ submitCoupon }
+				couponStatus={ couponStatus }
 			/>
 
 			<WPOrderReviewSection>

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -19,14 +19,14 @@ import Button from './button';
 import Coupon from './coupon';
 import { isLineItemADomain } from '../hooks/has-domains';
 
-export default function WPCheckoutOrderSummary( { siteUrl } ) {
+export default function WPCheckoutOrderSummary( { siteUrl, submitCoupon, couponStatus } ) {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
 	const [ items ] = useLineItems();
 	const onEvent = useEvents();
 	//TODO: tie the default coupon field visibility based on whether there is a coupon in the cart
 	const [ isCouponFieldVisible, setIsCouponFieldVisible ] = useState( false );
-	const [ hasCouponBeenApplied, setHasCouponBeenApplied ] = useState( false );
+	const hasCouponBeenApplied = couponStatus === 'applied';
 
 	const firstDomainItem = items.find( isLineItemADomain );
 	const domainUrl = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
@@ -58,9 +58,8 @@ export default function WPCheckoutOrderSummary( { siteUrl } ) {
 				<CouponField
 					id="order-summary-coupon"
 					disabled={ formStatus !== 'ready' }
-					couponAdded={ () => {
-						handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied );
-					} }
+					submitCoupon={ submitCoupon }
+					couponStatus={ couponStatus }
 				/>
 			) }
 		</React.Fragment>
@@ -126,11 +125,6 @@ const AddCouponButton = styled( Button )`
 		margin-top: 0;
 	}
 `;
-
-function handleCouponAdded( setIsCouponFieldVisible, setHasCouponBeenApplied ) {
-	setIsCouponFieldVisible( false );
-	setHasCouponBeenApplied( true );
-}
 
 function handleAddCouponButtonClick( setIsCouponFieldVisible, onEvent ) {
 	setIsCouponFieldVisible( true );

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -19,7 +19,7 @@ import Button from './button';
 import Coupon from './coupon';
 import { isLineItemADomain } from '../hooks/has-domains';
 
-export default function WPCheckoutOrderSummary( { siteUrl, submitCoupon, couponStatus } ) {
+export default function WPCheckoutOrderSummary( { siteUrl, couponStatus, couponFieldStateProps } ) {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
 	const [ items ] = useLineItems();
@@ -58,8 +58,8 @@ export default function WPCheckoutOrderSummary( { siteUrl, submitCoupon, couponS
 				<CouponField
 					id="order-summary-coupon"
 					disabled={ formStatus !== 'ready' }
-					submitCoupon={ submitCoupon }
 					couponStatus={ couponStatus }
+					couponFieldStateProps={ couponFieldStateProps }
 				/>
 			) }
 		</React.Fragment>

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -57,12 +57,11 @@ export default function WPCheckout( {
 	renderDomainContactFields,
 } ) {
 	const translate = useTranslate();
-	const couponFieldStateProps = useCouponFieldState();
+	const couponFieldStateProps = useCouponFieldState( submitCoupon );
 
 	const ReviewContent = () => (
 		<WPCheckoutOrderReview
 			removeItem={ removeItem }
-			submitCoupon={ submitCoupon }
 			couponStatus={ couponStatus }
 			couponFieldStateProps={ couponFieldStateProps }
 			onChangePlanLength={ changePlanLength }
@@ -87,7 +86,6 @@ export default function WPCheckout( {
 			completeStepContent: (
 				<WPCheckoutOrderSummary
 					siteUrl={ siteUrl }
-					submitCoupon={ submitCoupon }
 					couponStatus={ couponStatus }
 					couponFieldStateProps={ couponFieldStateProps }
 				/>

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -45,6 +45,7 @@ const OrderReviewTitle = () => {
 
 export default function WPCheckout( {
 	removeItem,
+	submitCoupon,
 	changePlanLength,
 	siteId,
 	siteUrl,
@@ -58,6 +59,7 @@ export default function WPCheckout( {
 	const ReviewContent = () => (
 		<WPCheckoutOrderReview
 			removeItem={ removeItem }
+			submitCoupon={ submitCoupon }
 			onChangePlanLength={ changePlanLength }
 			siteUrl={ siteUrl }
 		/>

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -46,6 +46,7 @@ const OrderReviewTitle = () => {
 export default function WPCheckout( {
 	removeItem,
 	submitCoupon,
+	couponStatus,
 	changePlanLength,
 	siteId,
 	siteUrl,
@@ -60,6 +61,7 @@ export default function WPCheckout( {
 		<WPCheckoutOrderReview
 			removeItem={ removeItem }
 			submitCoupon={ submitCoupon }
+			couponStatus={ couponStatus }
 			onChangePlanLength={ changePlanLength }
 			siteUrl={ siteUrl }
 		/>
@@ -79,7 +81,13 @@ export default function WPCheckout( {
 			className: 'checkout__order-summary-step',
 			hasStepNumber: false,
 			titleContent: <WPCheckoutOrderSummaryTitle />,
-			completeStepContent: <WPCheckoutOrderSummary siteUrl={ siteUrl } />,
+			completeStepContent: (
+				<WPCheckoutOrderSummary
+					siteUrl={ siteUrl }
+					submitCoupon={ submitCoupon }
+					couponStatus={ couponStatus }
+				/>
+			),
 			isCompleteCallback: () => true,
 		},
 		{

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -59,7 +59,7 @@ export default function WPCheckout( {
 	const translate = useTranslate();
 	const couponFieldStateProps = useCouponFieldState( submitCoupon );
 
-	const ReviewContent = () => (
+	const reviewContent = (
 		<WPCheckoutOrderReview
 			removeItem={ removeItem }
 			couponStatus={ couponStatus }
@@ -124,7 +124,7 @@ export default function WPCheckout( {
 			className: 'checkout__review-order-step',
 			hasStepNumber: true,
 			titleContent: <OrderReviewTitle />,
-			activeStepContent: <ReviewContent />,
+			activeStepContent: reviewContent,
 			isCompleteCallback: ( { activeStep } ) => {
 				const isActive = activeStep.id === 'order-review';
 				return isActive;

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -17,6 +17,7 @@ import {
  * Internal dependencies
  */
 import { areDomainsInLineItems } from '../hooks/has-domains';
+import useCouponFieldState from '../hooks/use-coupon-field-state';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
 import WPCheckoutOrderSummary, { WPCheckoutOrderSummaryTitle } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
@@ -56,12 +57,14 @@ export default function WPCheckout( {
 	renderDomainContactFields,
 } ) {
 	const translate = useTranslate();
+	const couponFieldStateProps = useCouponFieldState();
 
 	const ReviewContent = () => (
 		<WPCheckoutOrderReview
 			removeItem={ removeItem }
 			submitCoupon={ submitCoupon }
 			couponStatus={ couponStatus }
+			couponFieldStateProps={ couponFieldStateProps }
 			onChangePlanLength={ changePlanLength }
 			siteUrl={ siteUrl }
 		/>
@@ -86,6 +89,7 @@ export default function WPCheckout( {
 					siteUrl={ siteUrl }
 					submitCoupon={ submitCoupon }
 					couponStatus={ couponStatus }
+					couponFieldStateProps={ couponFieldStateProps }
 				/>
 			),
 			isCompleteCallback: () => true,

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -325,6 +325,6 @@ function returnModalCopy( product, translate, hasDomainsInCart ) {
 }
 
 function canItemBeDeleted( item ) {
-	const itemTypesThatCannotBeDeleted = [ 'tax', 'credits', 'wordpress-com-credits' ];
+	const itemTypesThatCannotBeDeleted = [ 'tax', 'coupon', 'credits', 'wordpress-com-credits' ];
 	return ! itemTypesThatCannotBeDeleted.includes( item.type );
 }

--- a/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useEvents } from '@automattic/composite-checkout';
 
 export type CouponFieldStateProps = {
@@ -31,7 +31,7 @@ export default function useCouponFieldState( submitCoupon ): CouponFieldStatePro
 		setIsApplyButtonActive( false );
 	}, [ couponFieldValue ] );
 
-	function handleCouponSubmit( event ) {
+	const handleCouponSubmit = useCallback( event => {
 		event.preventDefault();
 		if ( isCouponValid( couponFieldValue ) ) {
 			onEvent( {
@@ -48,7 +48,7 @@ export default function useCouponFieldState( submitCoupon ): CouponFieldStatePro
 			type: 'a8c_checkout_add_coupon_error',
 			payload: { type: 'Invalid code' },
 		} );
-	}
+	} );
 
 	return {
 		couponFieldValue,

--- a/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+
+export type CouponFieldStateProps = {
+	couponFieldValue: string;
+	setCouponFieldValue: ( string ) => void;
+	isApplyButtonActive: boolean;
+	setIsApplyButtonActive: ( boolean ) => void;
+	isFreshOrEdited: boolean;
+	setIsFreshOrEdited: ( boolean ) => void;
+};
+
+export default function useCouponFieldState(): CouponFieldStateProps {
+	const [ couponFieldValue, setCouponFieldValue ] = useState< string >( '' );
+
+	// Used to hide the `Apply` button
+	const [ isApplyButtonActive, setIsApplyButtonActive ] = useState< boolean >( false );
+
+	// Used to hide error messages if the user has edited the form field
+	const [ isFreshOrEdited, setIsFreshOrEdited ] = useState< boolean >( true );
+
+	return {
+		couponFieldValue,
+		setCouponFieldValue,
+		isApplyButtonActive,
+		setIsApplyButtonActive,
+		isFreshOrEdited,
+		setIsFreshOrEdited,
+	};
+}

--- a/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
@@ -1,18 +1,19 @@
 /**
  * External dependencies
  */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useEvents } from '@automattic/composite-checkout';
 
 export type CouponFieldStateProps = {
 	couponFieldValue: string;
 	setCouponFieldValue: ( string ) => void;
 	isApplyButtonActive: boolean;
-	setIsApplyButtonActive: ( boolean ) => void;
 	isFreshOrEdited: boolean;
 	setIsFreshOrEdited: ( boolean ) => void;
 };
 
-export default function useCouponFieldState(): CouponFieldStateProps {
+export default function useCouponFieldState( submitCoupon ): CouponFieldStateProps {
+	const onEvent = useEvents();
 	const [ couponFieldValue, setCouponFieldValue ] = useState< string >( '' );
 
 	// Used to hide the `Apply` button
@@ -21,12 +22,44 @@ export default function useCouponFieldState(): CouponFieldStateProps {
 	// Used to hide error messages if the user has edited the form field
 	const [ isFreshOrEdited, setIsFreshOrEdited ] = useState< boolean >( true );
 
+	useEffect( () => {
+		if ( couponFieldValue.length > 0 ) {
+			setIsApplyButtonActive( true );
+			return;
+		}
+		setIsApplyButtonActive( false );
+	}, [ couponFieldValue ] );
+
+	function handleCouponSubmit( event ) {
+		event.preventDefault();
+		if ( isCouponValid( couponFieldValue ) ) {
+			onEvent( {
+				type: 'a8c_checkout_add_coupon',
+				payload: { coupon: couponFieldValue },
+			} );
+
+			submitCoupon( couponFieldValue );
+
+			return;
+		}
+
+		onEvent( {
+			type: 'a8c_checkout_add_coupon_error',
+			payload: { type: 'Invalid code' },
+		} );
+	}
+
 	return {
 		couponFieldValue,
 		setCouponFieldValue,
 		isApplyButtonActive,
-		setIsApplyButtonActive,
 		isFreshOrEdited,
 		setIsFreshOrEdited,
+		handleCouponSubmit,
 	};
+}
+
+function isCouponValid( coupon ) {
+	// TODO: figure out some basic validation here
+	return coupon.match( /^[a-zA-Z0-9_-]+$/ );
 }

--- a/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
@@ -31,24 +31,27 @@ export default function useCouponFieldState( submitCoupon ): CouponFieldStatePro
 		setIsApplyButtonActive( false );
 	}, [ couponFieldValue ] );
 
-	const handleCouponSubmit = useCallback( event => {
-		event.preventDefault();
-		if ( isCouponValid( couponFieldValue ) ) {
+	const handleCouponSubmit = useCallback(
+		event => {
+			event.preventDefault();
+			if ( isCouponValid( couponFieldValue ) ) {
+				onEvent( {
+					type: 'a8c_checkout_add_coupon',
+					payload: { coupon: couponFieldValue },
+				} );
+
+				submitCoupon( couponFieldValue );
+
+				return;
+			}
+
 			onEvent( {
-				type: 'a8c_checkout_add_coupon',
-				payload: { coupon: couponFieldValue },
+				type: 'a8c_checkout_add_coupon_error',
+				payload: { type: 'Invalid code' },
 			} );
-
-			submitCoupon( couponFieldValue );
-
-			return;
-		}
-
-		onEvent( {
-			type: 'a8c_checkout_add_coupon_error',
-			payload: { type: 'Invalid code' },
-		} );
-	} );
+		},
+		[ couponFieldValue ]
+	);
 
 	return {
 		couponFieldValue,

--- a/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
@@ -10,6 +10,7 @@ export type CouponFieldStateProps = {
 	isApplyButtonActive: boolean;
 	isFreshOrEdited: boolean;
 	setIsFreshOrEdited: ( boolean ) => void;
+	handleCouponSubmit: ( any ) => void; // TODO: fix this type
 };
 
 export default function useCouponFieldState( submitCoupon ): CouponFieldStateProps {

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -179,11 +179,11 @@ export function useShoppingCart(
 					setCouponStatus( 'applied' );
 				}
 
-				if ( ! response.is_coupon_applied && response.coupon_discounts?.length <= 0 ) {
+				if ( ! response.is_coupon_applied && response.coupon_discounts_int?.length <= 0 ) {
 					setCouponStatus( 'invalid' );
 				}
 
-				if ( ! response.is_coupon_applied && response.coupon_discounts?.length > 0 ) {
+				if ( ! response.is_coupon_applied && response.coupon_discounts_int?.length > 0 ) {
 					setCouponStatus( 'rejected' );
 				}
 			}

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -144,6 +144,13 @@ export function useShoppingCart(
 			const response = await getServerCart();
 			debug( 'initialized cart is', response );
 			setResponseCart( response );
+
+			if ( couponStatus === 'fresh' ) {
+				if ( response.is_coupon_applied ) {
+					setCouponStatus( 'applied' );
+				}
+			}
+
 			setCacheStatus( 'valid' );
 		};
 

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -143,6 +143,10 @@ export function useShoppingCart(
 
 	// Asynchronously initialize the cart. This should happen exactly once.
 	useEffect( () => {
+		if ( cacheStatus !== 'fresh' ) {
+			return;
+		}
+
 		const initializeResponseCart = async () => {
 			const response = await getServerCart();
 			debug( 'initialized cart is', response );
@@ -157,15 +161,12 @@ export function useShoppingCart(
 			setCacheStatus( 'valid' );
 		};
 
-		debug( 'considering initializing cart to server; cacheStatus is', cacheStatus );
-		if ( cacheStatus === 'fresh' ) {
-			debug( 'initializing the cart' );
-			initializeResponseCart().catch( error => {
-				// TODO: figure out what to do here
-				setCacheStatus( 'error' );
-				debug( 'error while initializing cart', error );
-			} );
-		}
+		debug( `initializing the cart; cacheStatus is ${ cacheStatus }` );
+		initializeResponseCart().catch( error => {
+			// TODO: figure out what to do here
+			setCacheStatus( 'error' );
+			debug( 'error while initializing cart', error );
+		} );
 	}, [ getServerCart, cacheStatus ] );
 
 	// Asynchronously re-validate when the cache is dirty.

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -178,7 +178,6 @@ export function useShoppingCart(
 			setResponseCart( response );
 
 			if ( couponStatus === 'pending' ) {
-				debug( 'isSubscribed:', isSubscribed );
 				if ( response.is_coupon_applied ) {
 					showAddCouponSuccessMessage( response.coupon );
 					setCouponStatus( 'applied' );

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -42,6 +42,7 @@ export interface ShoppingCartManager {
 	tax: CheckoutCartItem;
 	total: CheckoutCartItem;
 	subtotal: CheckoutCartItem;
+	couponItem: CheckoutCartItem;
 	credits: CheckoutCartItem;
 	addItem: ( WPCOMCartItem ) => void;
 	removeItem: ( WPCOMCartItem ) => void;
@@ -260,6 +261,7 @@ export function useShoppingCart(
 		isLoading: cacheStatus === 'fresh',
 		items: cart.items,
 		tax: cart.tax,
+		couponItem: cart.coupon,
 		total: cart.total,
 		subtotal: cart.subtotal,
 		credits: cart.credits,

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -45,6 +45,7 @@ export interface ShoppingCartManager {
 	credits: CheckoutCartItem;
 	addItem: ( WPCOMCartItem ) => void;
 	removeItem: ( WPCOMCartItem ) => void;
+	submitCoupon: ( string ) => void;
 }
 
 /**
@@ -203,6 +204,16 @@ export function useShoppingCart(
 		debug( 'updating prices for address in cart', address );
 	};
 
+	const submitCoupon: ( string ) => void = useCallback( newCoupon => {
+	    debug( 'submitting coupon', newCoupon );
+	    setResponseCart( currentResponseCart => ( {
+            ...currentResponseCart,
+            coupon: newCoupon,
+            is_coupon_applied: false,
+        } ) );
+	    setCacheStatus( 'invalid' );
+    }, [] );
+
 	return {
 		isLoading: cacheStatus === 'fresh',
 		items: cart.items,
@@ -216,5 +227,6 @@ export function useShoppingCart(
 		removeItem,
 		changePlanLength,
 		updatePricesForAddress,
+        submitCoupon,
 	} as ShoppingCartManager;
 }

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -178,6 +178,7 @@ export function useShoppingCart(
 			setResponseCart( response );
 
 			if ( couponStatus === 'pending' ) {
+				debug( 'isSubscribed:', isSubscribed );
 				if ( response.is_coupon_applied ) {
 					showAddCouponSuccessMessage( response.coupon );
 					setCouponStatus( 'applied' );

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -182,11 +182,11 @@ export function useShoppingCart(
 					setCouponStatus( 'applied' );
 				}
 
-				if ( ! response.is_coupon_applied && response.coupon_discounts_int?.length <= 0 ) {
+				if ( ! response.is_coupon_applied && response.coupon_discounts_integer?.length <= 0 ) {
 					setCouponStatus( 'invalid' );
 				}
 
-				if ( ! response.is_coupon_applied && response.coupon_discounts_int?.length > 0 ) {
+				if ( ! response.is_coupon_applied && response.coupon_discounts_integer?.length > 0 ) {
 					setCouponStatus( 'rejected' );
 				}
 			}

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -204,7 +204,7 @@ export function useShoppingCart(
 				debug( 'error while fetching cart', error );
 			} );
 		}
-	}, [ setServerCart, cacheStatus, responseCart ] );
+	}, [ cacheStatus, couponStatus, responseCart, showAddCouponSuccessMessage ] );
 
 	// Keep a separate cache of the displayed cart which we regenerate only when
 	// the cart has been downloaded

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -32,7 +32,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 		sub_total_integer,
 		sub_total_display,
 		coupon,
-		coupon_discounts,
+		coupon_discounts_int,
 		is_coupon_applied,
 	} = serverCart;
 
@@ -49,11 +49,11 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 
 	// TODO: watch out for minimal currency units while localizing this
 	const couponValueRaw = products
-		.map( product => coupon_discounts[ product.product_id ] )
+		.map( product => coupon_discounts_int[ product.product_id ] )
 		.filter( Boolean )
 		.reduce( ( accum, current ) => accum + current, 0 );
-	const couponValue = Math.round( 100 * couponValueRaw );
-	const couponDisplayValue = `-$${ couponValue / 100 }`;
+	const couponValue = Math.round( couponValueRaw );
+	const couponDisplayValue = `-$${ couponValueRaw / 100 }`;
 
 	const couponLineItem: CheckoutCartItem = {
 		id: 'coupon-line-item',

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -61,7 +61,7 @@ export function translateWpcomCartToCheckoutCart(
 
 	const couponLineItem: CheckoutCartItem = {
 		id: 'coupon-line-item',
-		label: translate( 'Coupon: %s', coupon ),
+		label: translate( 'Coupon: %s', { args: coupon } ),
 		type: 'coupon',
 		amount: {
 			currency: currency,

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -46,7 +46,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 			displayValue: total_tax_display,
 		},
 	};
-    
+	
 	const couponValueRaw = products
 		.map( product => coupon_discounts[ product.product_id ] )
 		.filter( Boolean )

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -70,9 +70,9 @@ export function translateWpcomCartToCheckoutCart(
 		},
 	};
 
-    const totalItem: CheckoutCartItem = {
-        id: 'total',
-        type: 'total',
+	const totalItem: CheckoutCartItem = {
+		id: 'total',
+		type: 'total',
 		label: translate( 'Total' ),
 		amount: {
 			currency: currency,
@@ -95,13 +95,11 @@ export function translateWpcomCartToCheckoutCart(
 	// TODO: inject a real currency localization function
 	function localizeCurrency( currencyCode: string, amount: number ): string {
 		switch ( currencyCode ) {
-			case 'USD':
-				return '$' + amount / 100;
 			case 'BRL':
 				return 'R$' + amount / 100;
+			default:
+				return '$' + amount / 100;
 		}
-
-		throw new Error( 'Currency not supported: ' + currencyCode );
 	}
 
 	return {

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -31,6 +31,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 		allowed_payment_methods,
 		sub_total_integer,
 		sub_total_display,
+		coupon,
 	} = serverCart;
 
 	const taxLineItem: CheckoutCartItem = {
@@ -84,6 +85,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 			.map( readWPCOMPaymentMethodClass )
 			.map( translateWpcomPaymentMethodToCheckoutPaymentMethod )
 			.filter( Boolean ),
+		couponCode: coupon,
 	};
 }
 

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -15,10 +15,14 @@ import {
  * Translate a cart object as returned by the WPCOM cart endpoint to
  * the format required by the composite checkout component.
  *
+ * @param translate Localization function
  * @param serverCart Cart object returned by the WPCOM cart endpoint
  * @returns Cart object suitable for passing to the checkout component
  */
-export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WPCOMCart {
+export function translateWpcomCartToCheckoutCart(
+	translate: ( string, any? ) => string,
+	serverCart: ResponseCart
+): WPCOMCart {
 	const {
 		products,
 		total_tax_integer,
@@ -38,7 +42,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 
 	const taxLineItem: CheckoutCartItem = {
 		id: 'tax-line-item',
-		label: 'Tax',
+		label: translate( 'Tax' ),
 		type: 'tax', // TODO: does this need to be localized, e.g. tax-us?
 		amount: {
 			currency: currency,
@@ -57,7 +61,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 
 	const couponLineItem: CheckoutCartItem = {
 		id: 'coupon-line-item',
-		label: `Coupon: ${ coupon }`,
+		label: translate( 'Coupon: %s', coupon ),
 		type: 'coupon',
 		amount: {
 			currency: currency,
@@ -69,7 +73,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
     const totalItem: CheckoutCartItem = {
         id: 'total',
         type: 'total',
-		label: 'Total',
+		label: translate( 'Total' ),
 		amount: {
 			currency: currency,
 			value: total_cost_integer,
@@ -80,7 +84,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 	const subtotalItem: CheckoutCartItem = {
 		id: 'subtotal',
 		type: 'subtotal',
-		label: 'Subtotal',
+		label: translate( 'Subtotal' ),
 		amount: {
 			currency: currency,
 			value: sub_total_integer,
@@ -115,7 +119,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 		credits: {
 			id: 'credits',
 			type: 'credits',
-			label: 'Credits',
+			label: translate( 'Credits' ),
 			amount: { value: credits_integer, displayValue: credits_display, currency },
 		},
 		allowedPaymentMethods: allowed_payment_methods

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -36,7 +36,7 @@ export function translateWpcomCartToCheckoutCart(
 		sub_total_integer,
 		sub_total_display,
 		coupon,
-		coupon_discounts_int,
+		coupon_discounts_integer,
 		is_coupon_applied,
 	} = serverCart;
 
@@ -53,7 +53,7 @@ export function translateWpcomCartToCheckoutCart(
 
 	// TODO: watch out for minimal currency units while localizing this
 	const couponValueRaw = products
-		.map( product => coupon_discounts_int[ product.product_id ] )
+		.map( product => coupon_discounts_integer[ product.product_id ] )
 		.filter( Boolean )
 		.reduce( ( accum, current ) => accum + current, 0 );
 	const couponValue = Math.round( couponValueRaw );
@@ -108,7 +108,7 @@ export function translateWpcomCartToCheckoutCart(
 		items: products.map(
 			translateWpcomCartItemToCheckoutCartItem(
 				is_coupon_applied,
-				coupon_discounts_int,
+				coupon_discounts_integer,
 				localizeCurrency
 			)
 		),
@@ -136,7 +136,7 @@ export function translateWpcomCartToCheckoutCart(
 // Convert a backend cart item to a checkout cart item
 function translateWpcomCartItemToCheckoutCartItem(
 	is_coupon_applied: boolean,
-	coupon_discounts_int: number[],
+	coupon_discounts_integer: number[],
 	localizeCurrency: ( string, number ) => string
 ): ( ResponseCartProduct, number ) => WPCOMCartItem {
 	return ( serverCartItem: ResponseCartProduct, index: number ) => {
@@ -157,7 +157,7 @@ function translateWpcomCartItemToCheckoutCartItem(
 
 		// TODO: watch out for this when localizing
 		const value = is_coupon_applied
-			? item_subtotal_integer + ( coupon_discounts_int[ product_id ] ?? 0 )
+			? item_subtotal_integer + ( coupon_discounts_integer[ product_id ] ?? 0 )
 			: item_subtotal_integer;
 		const displayValue = localizeCurrency( currency, value );
 

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -97,7 +97,7 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 				return 'R$' + amount / 100;
 		}
 
-		throw new Error( 'Currency not supported: ' + currency );
+		throw new Error( 'Currency not supported: ' + currencyCode );
 	}
 
 	return {

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -46,13 +46,14 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 			displayValue: total_tax_display,
 		},
 	};
-	
+
+	// TODO: watch out for minimal currency units while localizing this
 	const couponValueRaw = products
 		.map( product => coupon_discounts[ product.product_id ] )
 		.filter( Boolean )
 		.reduce( ( accum, current ) => accum + current, 0 );
-	const couponValue = Math.round( 100 * couponValueRaw ) / 100;
-	const couponDisplayValue = `-$${ couponValue }`;
+	const couponValue = Math.round( 100 * couponValueRaw );
+	const couponDisplayValue = `-$${ couponValue / 100 }`;
 
 	const couponLineItem: CheckoutCartItem = {
 		id: 'coupon-line-item',

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
@@ -43,6 +43,7 @@ export async function mockSetCartEndpoint( {
 		sub_total_integer: totalInteger - taxInteger,
 		coupon: requestCoupon,
 		is_coupon_applied: true,
+		coupon_discounts: [],
 	} as ResponseCart;
 }
 

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
@@ -43,7 +43,7 @@ export async function mockSetCartEndpoint( {
 		sub_total_integer: totalInteger - taxInteger,
 		coupon: requestCoupon,
 		is_coupon_applied: true,
-		coupon_discounts: [],
+		coupon_discounts_int: [],
 	} as ResponseCart;
 }
 

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
@@ -43,7 +43,7 @@ export async function mockSetCartEndpoint( {
 		sub_total_integer: totalInteger - taxInteger,
 		coupon: requestCoupon,
 		is_coupon_applied: true,
-		coupon_discounts_int: [],
+		coupon_discounts_integer: [],
 	} as ResponseCart;
 }
 

--- a/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
@@ -55,7 +55,7 @@ export interface ResponseCart {
 	allowed_payment_methods: string[];
 	coupon: string;
 	is_coupon_applied: boolean;
-	coupon_discounts: number[];
+	coupon_discounts_int: number[];
 	locale: string;
 	messages?: { errors: ResponseCartError[] };
 }
@@ -79,7 +79,7 @@ export const emptyResponseCart = {
 	allowed_payment_methods: [],
 	coupon: '',
 	is_coupon_applied: false,
-	coupon_discounts: [],
+	coupon_discounts_int: [],
 	locale: 'en-us',
 } as ResponseCart;
 

--- a/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
@@ -114,15 +114,16 @@ export const prepareRequestCart: ( ResponseCart ) => RequestCart = ( {
 	currency,
 	locale,
 	coupon,
+	is_coupon_applied,
 }: ResponseCart ) => {
 	return {
 		products: products.map( prepareRequestCartProduct ),
 		currency,
 		locale,
 		coupon,
+		is_coupon_applied,
 		temporary: false,
 		// tax: any[]; // TODO: fix this
-		// is_coupon_applied: boolean;
 		// extra: any[]; // TODO: fix this
 	} as RequestCart;
 };

--- a/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
@@ -55,6 +55,7 @@ export interface ResponseCart {
 	allowed_payment_methods: string[];
 	coupon: string;
 	is_coupon_applied: boolean;
+	coupon_discounts: number[];
 	locale: string;
 	messages?: { errors: ResponseCartError[] };
 }
@@ -78,6 +79,7 @@ export const emptyResponseCart = {
 	allowed_payment_methods: [],
 	coupon: '',
 	is_coupon_applied: false,
+	coupon_discounts: [],
 	locale: 'en-us',
 } as ResponseCart;
 

--- a/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
@@ -55,7 +55,7 @@ export interface ResponseCart {
 	allowed_payment_methods: string[];
 	coupon: string;
 	is_coupon_applied: boolean;
-	coupon_discounts_int: number[];
+	coupon_discounts_integer: number[];
 	locale: string;
 	messages?: { errors: ResponseCartError[] };
 }
@@ -79,7 +79,7 @@ export const emptyResponseCart = {
 	allowed_payment_methods: [],
 	coupon: '',
 	is_coupon_applied: false,
-	coupon_discounts_int: [],
+	coupon_discounts_integer: [],
 	locale: 'en-us',
 } as ResponseCart;
 

--- a/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
@@ -44,6 +44,7 @@ export interface WPCOMCart {
 	tax: CheckoutCartItem;
 	total: CheckoutCartItem;
 	subtotal: CheckoutCartItem;
+	coupon: CheckoutCartItem | null;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 	credits: CheckoutCartItem;
 	couponCode: string | null;
@@ -55,6 +56,16 @@ export const emptyWPCOMCart = {
 		id: 'tax-line-item',
 		label: 'Tax',
 		type: 'tax',
+		amount: {
+			value: 0,
+			currency: '',
+			displayValue: '',
+		} as CheckoutCartItemAmount,
+	} as CheckoutCartItem,
+	coupon: {
+		id: 'coupon-line-item',
+		label: 'Coupon',
+		type: 'coupon',
 		amount: {
 			value: 0,
 			currency: '',

--- a/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
@@ -46,6 +46,7 @@ export interface WPCOMCart {
 	subtotal: CheckoutCartItem;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 	credits: CheckoutCartItem;
+	couponCode: string | null;
 }
 
 export const emptyWPCOMCart = {
@@ -83,4 +84,5 @@ export const emptyWPCOMCart = {
 		type: 'credits',
 		amount: { value: 0, currency: 'USD', displayValue: '0' },
 	},
+	couponCode: null,
 } as WPCOMCart;

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -57,7 +57,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Web_Payment',
 			],
 			coupon: 'fakecoupon',
-			coupon_discounts: [],
+			coupon_discounts_int: [],
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
@@ -226,7 +226,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Ebanx',
 				'WPCOM_Billing_Web_Payment',
 			],
-			coupon_discounts: [],
+			coupon_discounts_int: [],
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
@@ -456,7 +456,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Ebanx',
 				'WPCOM_Billing_Web_Payment',
 			],
-			coupon_discounts: [],
+			coupon_discounts_int: [],
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
@@ -610,7 +610,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Web_Payment',
 			],
 			coupon: 'fakecoupon',
-			coupon_discounts: { 1009: 17 },
+			coupon_discounts_int: { 1009: 17 },
 			is_coupon_applied: true,
 		};
 

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -56,6 +56,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Ebanx',
 				'WPCOM_Billing_Web_Payment',
 			],
+			coupon: 'fakecoupon',
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
@@ -85,6 +86,9 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			expect( clientCart.credits.amount.value ).toBe( 10000 );
 			expect( clientCart.credits.amount.currency ).toBe( 'BRL' );
 			expect( clientCart.credits.amount.displayValue ).toBe( 'R$100' );
+		} );
+		it( 'has the expected coupon', function() {
+			expect( clientCart.couponCode ).toBe( 'fakecoupon' );
 		} );
 
 		describe( 'first cart item (plan)', function() {

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -60,7 +60,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			coupon_discounts_int: [],
 		};
 
-		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
+		const clientCart = translateWpcomCartToCheckoutCart( x => x, serverResponse );
 
 		it( 'has a total property', function() {
 			expect( clientCart.total.amount ).toBeDefined();
@@ -229,7 +229,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			coupon_discounts_int: [],
 		};
 
-		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
+		const clientCart = translateWpcomCartToCheckoutCart( x => x, serverResponse );
 
 		it( 'has a total property', function() {
 			expect( clientCart.total.amount ).toBeDefined();
@@ -459,7 +459,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			coupon_discounts_int: [],
 		};
 
-		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
+		const clientCart = translateWpcomCartToCheckoutCart( x => x, serverResponse );
 
 		it( 'has a total property', function() {
 			expect( clientCart.total.amount ).toBeDefined();
@@ -614,7 +614,9 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			is_coupon_applied: true,
 		};
 
-		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
+		const clientCart = translateWpcomCartToCheckoutCart( ( string, variable ) => {
+			return string.replace( '%s', variable );
+		}, serverResponse );
 
 		it( 'has a total property', function() {
 			expect( clientCart.total.amount ).toBeDefined();

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -557,7 +557,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 		} );
 	} );
 
-	describe( 'Cart with one plan only plus a coupon (BRL)', function() {
+	describe( 'Cart with one plan only plus a coupon (USD)', function() {
 		const serverResponse = {
 			blog_id: 123,
 			products: [
@@ -566,9 +566,9 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 					product_name: 'WordPress.com Personal',
 					product_name_en: 'WordPress.com Personal',
 					product_slug: 'personal-bundle',
-					product_cost: 144,
+					product_cost: 127,
 					meta: '',
-					cost: 144,
+					cost: 127,
 					currency: 'USD',
 					volume: 1,
 					free_trial: false,
@@ -582,24 +582,24 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 					is_domain_registration: false,
 					time_added_to_cart: 1572551402,
 					is_bundled: false,
-					item_subtotal: 144,
-					item_subtotal_integer: 14400,
-					item_subtotal_display: '$144',
+					item_subtotal: 127,
+					item_subtotal_integer: 12700,
+					item_subtotal_display: '$127',
 					item_tax: 0,
-					item_total: 144,
+					item_total: 127,
 					subscription_id: 0,
 				},
 			],
 			tax: [],
-			sub_total: '144',
-			sub_total_display: '$144',
-			sub_total_integer: 14400,
+			sub_total: '127',
+			sub_total_display: '$127',
+			sub_total_integer: 12700,
 			total_tax: '5',
 			total_tax_display: '$5',
 			total_tax_integer: 500,
-			total_cost: 149,
-			total_cost_display: '$149',
-			total_cost_integer: 14900,
+			total_cost: 132,
+			total_cost_display: '$132',
+			total_cost_integer: 13200,
 			currency: 'USD',
 			credits: 100,
 			credits_integer: 10000,
@@ -610,7 +610,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Web_Payment',
 			],
 			coupon: 'fakecoupon',
-			coupon_discounts_int: { 1009: 17 },
+			coupon_discounts_int: { 1009: 1700 },
 			is_coupon_applied: true,
 		};
 
@@ -620,13 +620,13 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			expect( clientCart.total.amount ).toBeDefined();
 		} );
 		it( 'has the expected total value', function() {
-			expect( clientCart.total.amount.value ).toBe( 14900 );
+			expect( clientCart.total.amount.value ).toBe( 13200 );
 		} );
 		it( 'has the expected currency', function() {
 			expect( clientCart.total.amount.currency ).toBe( 'USD' );
 		} );
 		it( 'has the expected total display value', function() {
-			expect( clientCart.total.amount.displayValue ).toBe( '$149' );
+			expect( clientCart.total.amount.displayValue ).toBe( '$132' );
 		} );
 		it( 'has an array of items', function() {
 			expect( clientCart.items ).toBeDefined();

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -57,7 +57,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Web_Payment',
 			],
 			coupon: 'fakecoupon',
-			coupon_discounts_int: [],
+			coupon_discounts_integer: [],
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( x => x, serverResponse );
@@ -226,7 +226,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Ebanx',
 				'WPCOM_Billing_Web_Payment',
 			],
-			coupon_discounts_int: [],
+			coupon_discounts_integer: [],
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( x => x, serverResponse );
@@ -456,7 +456,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Ebanx',
 				'WPCOM_Billing_Web_Payment',
 			],
-			coupon_discounts_int: [],
+			coupon_discounts_integer: [],
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( x => x, serverResponse );
@@ -610,7 +610,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Web_Payment',
 			],
 			coupon: 'fakecoupon',
-			coupon_discounts_int: { 1009: 1700 },
+			coupon_discounts_integer: { 1009: 1700 },
 			is_coupon_applied: true,
 		};
 

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -57,6 +57,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Web_Payment',
 			],
 			coupon: 'fakecoupon',
+			coupon_discounts: [],
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
@@ -225,6 +226,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Ebanx',
 				'WPCOM_Billing_Web_Payment',
 			],
+			coupon_discounts: [],
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
@@ -454,6 +456,7 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 				'WPCOM_Billing_Ebanx',
 				'WPCOM_Billing_Web_Payment',
 			],
+			coupon_discounts: [],
 		};
 
 		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
@@ -540,6 +543,169 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			} );
 			it( 'has the expected display value', function() {
 				expect( clientCart.tax.amount.displayValue ).toBe( '$5' );
+			} );
+		} );
+
+		describe( 'allowed payment methods', function() {
+			it( 'contains the expected slugs', function() {
+				expect( clientCart.allowedPaymentMethods ).toStrictEqual( [
+					'card',
+					'ebanx',
+					'apple-pay',
+				] );
+			} );
+		} );
+	} );
+
+	describe( 'Cart with one plan only plus a coupon (BRL)', function() {
+		const serverResponse = {
+			blog_id: 123,
+			products: [
+				{
+					product_id: 1009,
+					product_name: 'WordPress.com Personal',
+					product_name_en: 'WordPress.com Personal',
+					product_slug: 'personal-bundle',
+					product_cost: 144,
+					meta: '',
+					cost: 144,
+					currency: 'USD',
+					volume: 1,
+					free_trial: false,
+					orig_cost: null,
+					cost_before_coupon: 144,
+					extra: {
+						context: 'signup',
+						domain_to_bundle: 'foo.cash',
+					},
+					bill_period: 365,
+					is_domain_registration: false,
+					time_added_to_cart: 1572551402,
+					is_bundled: false,
+					item_subtotal: 144,
+					item_subtotal_integer: 14400,
+					item_subtotal_display: '$144',
+					item_tax: 0,
+					item_total: 144,
+					subscription_id: 0,
+				},
+			],
+			tax: [],
+			sub_total: '144',
+			sub_total_display: '$144',
+			sub_total_integer: 14400,
+			total_tax: '5',
+			total_tax_display: '$5',
+			total_tax_integer: 500,
+			total_cost: 149,
+			total_cost_display: '$149',
+			total_cost_integer: 14900,
+			currency: 'USD',
+			credits: 100,
+			credits_integer: 10000,
+			credits_display: '$100',
+			allowed_payment_methods: [
+				'WPCOM_Billing_Stripe_Payment_Method',
+				'WPCOM_Billing_Ebanx',
+				'WPCOM_Billing_Web_Payment',
+			],
+			coupon: 'fakecoupon',
+			coupon_discounts: { 1009: 17 },
+			is_coupon_applied: true,
+		};
+
+		const clientCart = translateWpcomCartToCheckoutCart( serverResponse );
+
+		it( 'has a total property', function() {
+			expect( clientCart.total.amount ).toBeDefined();
+		} );
+		it( 'has the expected total value', function() {
+			expect( clientCart.total.amount.value ).toBe( 14900 );
+		} );
+		it( 'has the expected currency', function() {
+			expect( clientCart.total.amount.currency ).toBe( 'USD' );
+		} );
+		it( 'has the expected total display value', function() {
+			expect( clientCart.total.amount.displayValue ).toBe( '$149' );
+		} );
+		it( 'has an array of items', function() {
+			expect( clientCart.items ).toBeDefined();
+		} );
+		it( 'has the expected number of line items', function() {
+			expect( clientCart.items.length ).toBe( 1 );
+		} );
+		it( 'has an array of allowed payment methods', function() {
+			expect( clientCart.allowedPaymentMethods ).toBeDefined();
+		} );
+		it( 'has the expected credits', function() {
+			expect( clientCart.credits.amount.value ).toBe( 10000 );
+			expect( clientCart.credits.amount.currency ).toBe( 'USD' );
+			expect( clientCart.credits.amount.displayValue ).toBe( '$100' );
+		} );
+		it( 'has the expected coupon', function() {
+			expect( clientCart.couponCode ).toBe( 'fakecoupon' );
+		} );
+
+		describe( 'first cart item (plan)', function() {
+			it( 'has an id', function() {
+				expect( clientCart.items[ 0 ].id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.items[ 0 ].type ).toBe( 'personal-bundle' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'USD' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.items[ 0 ].amount.value ).toBe( 14400 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.items[ 0 ].amount.displayValue ).toBe( '$144' );
+			} );
+		} );
+
+		describe( 'taxes', function() {
+			it( 'has an id', function() {
+				expect( clientCart.tax.id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.tax.label ).toBe( 'Tax' );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.tax.type ).toBe( 'tax' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.tax.amount.currency ).toBe( 'USD' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.tax.amount.value ).toBe( 500 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.tax.amount.displayValue ).toBe( '$5' );
+			} );
+		} );
+
+		describe( 'coupon', function() {
+			it( 'has an id', function() {
+				expect( clientCart.coupon.id ).toBeDefined();
+			} );
+			it( 'has the expected label', function() {
+				expect( clientCart.coupon.label ).toBe( 'Coupon: fakecoupon' );
+			} );
+			it( 'has the expected type', function() {
+				expect( clientCart.coupon.type ).toBe( 'coupon' );
+			} );
+			it( 'has the expected currency', function() {
+				expect( clientCart.coupon.amount.currency ).toBe( 'USD' );
+			} );
+			it( 'has the expected value', function() {
+				expect( clientCart.coupon.amount.value ).toBe( 1700 );
+			} );
+			it( 'has the expected display value', function() {
+				expect( clientCart.coupon.amount.displayValue ).toBe( '-$17' );
 			} );
 		} );
 

--- a/packages/composite-checkout-wpcom/test/translate-cart.js
+++ b/packages/composite-checkout-wpcom/test/translate-cart.js
@@ -614,8 +614,8 @@ describe( 'translateWpcomCartToCheckoutCart', function() {
 			is_coupon_applied: true,
 		};
 
-		const clientCart = translateWpcomCartToCheckoutCart( ( string, variable ) => {
-			return string.replace( '%s', variable );
+		const clientCart = translateWpcomCartToCheckoutCart( ( string, substitution ) => {
+			return substitution ? string.replace( '%s', substitution.args ) : string;
 		}, serverResponse );
 
 		it( 'has a total property', function() {


### PR DESCRIPTION
I recommend looking at the commits in order. Depends on ~D38431~ and ~D38473~.

#### Changes proposed in this Pull Request

* This PR updates composite checkout in wpcom to pass coupons to the cart endpoint and display a notice when the coupon is added successfully.

To do:

- [x] View handling for 'pending' coupon submission (disable field and button, set button label to "Processing...")
- [x] Hide the coupon field if one has already been applied
- [x] Add a coupon line item to the order review and order summary steps
- [x] Make the coupon field in the summary active
- [x] Show an error message on the field if the coupon is invalid
- [x] Hide calypso notification on failure
- [x] Bug fix: "Processing..." button does not appear on the review coupon field if the summary field is visible
- [x] Bug fix: show original line item costs in review step
- [x] Reset field error state on input
- [x] Bug fix: Backspace twice on review order coupon field triggers step number change event
- [x] Bug fix: Typing into review order coupon field is wonky - autocomplete appears in the wrong place and textbox loses focus on each input event
- [x] Bug fix: Every input event in summary coupon field retriggers 'Apply' button animation in review order field
- [x] Update: The deployed version of D38431 uses `coupon_discounts_integer`; need to update the response cart type to reflect this.

#### Testing instructions

```
npm run test-packages composite-checkout-wpcom
```

Manual steps to test basic behavior:

1. Do _not_ sandbox the store.
2. Enter checkout with some products and proceed to the 'review order' step.
3. Try to apply an invalid coupon; that is, a string not consisting only of alphanumeric characters, '-', and '_'. Verify that the coupon field is unhappy.
4. Try to apply a valid but not active coupon such as 'blahtestcoupon'. Verify that you see a field error and that your item and total prices do not change.
5. Try to apply an active coupon. (Check with me or the field guide about how to find these.) Verify that you see a notice and that your item and total prices change appropriately, and that a 'coupon' line item appears in the cart with the correct price.
6. Enter checkout again with a fresh cart and repeat steps 3-5, this time using the "Add coupon" link in the order summary step.

Edge cases:
- Simulate entering the cart with a coupon already applied by refreshing the page after adding a coupon. Check that the coupon line item appears in the summary step, and that the "Add a coupon" button is not visible.