### PR TITLE
Adds Jetpack Cloud environment badges

### DIFF
--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -73,6 +73,10 @@
 		&.is-feedback {
 			@include env-bug-style( 'blue' );
 		}
+		&.is-jetpack-cloud-dev,
+		&.is-jetpack-cloud-stage {
+			@include env-bug-style( 'jetpack-green' );
+		}
 
 		&.branch-name {
 			text-transform: inherit;

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -74,7 +74,7 @@
 			@include env-bug-style( 'blue' );
 		}
 		&.is-jetpack-cloud-dev,
-		&.is-jetpack-cloud-stage {
+		&.is-jetpack-cloud-staging {
 			@include env-bug-style( 'jetpack-green' );
 		}
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -352,6 +352,16 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 		context.commitChecksum = getCurrentCommitShortChecksum();
 	}
 
+	if ( calypsoEnv === 'jetpack-cloud-stage' ) {
+		context.badge = 'jetpack-cloud-staging';
+		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
+	} else if ( calypsoEnv === 'jetpack-cloud-development' ) {
+		context.badge = 'jetpack-cloud-dev';
+		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
+		context.branchName = getCurrentBranchName();
+		context.commitChecksum = getCurrentCommitShortChecksum();
+	}
+
 	return context;
 }
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -355,7 +355,9 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 	if ( calypsoEnv === 'jetpack-cloud-stage' ) {
 		context.badge = 'jetpack-cloud-staging';
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
-	} else if ( calypsoEnv === 'jetpack-cloud-development' ) {
+	}
+
+	if ( calypsoEnv === 'jetpack-cloud-development' ) {
 		context.badge = 'jetpack-cloud-dev';
 		context.feedbackURL = 'https://github.com/Automattic/wp-calypso/issues/';
 		context.branchName = getCurrentBranchName();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds an environment badge for Jetpack environments.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build Jetpack Cloud via `CALYPSO_ENV=jetpack-cloud-development npm start`.
* Let it build, then visit the dashboard page. See environment badge!
* Build Jetpack Cloud staging.
* Start it and visit the dashboard page. See the environment badge.

Screenshots:
<img width="183" alt="Screen Shot 2020-01-30 at 4 48 40 PM" src="https://user-images.githubusercontent.com/1760168/73493360-9ac99b00-4380-11ea-81f0-ff20916f620f.png">

<img width="197" alt="Screen Shot 2020-01-30 at 5 37 27 PM" src="https://user-images.githubusercontent.com/1760168/73496722-38c06400-4387-11ea-849a-1fc9657d7b73.png">

Fixes 1156570014567299-as-1159371543675235.
