### PR TITLE
Encourage renewing when close to renewal

### DIFF
--- a/client/blocks/credit-card-form/helpers.js
+++ b/client/blocks/credit-card-form/helpers.js
@@ -104,11 +104,7 @@ async function updateCreditCard( {
 	if ( purchase && siteSlug && isRenewable( purchase ) ) {
 		let noticeMessage = '';
 		let noticeOptions = {};
-<<<<<<< HEAD
 		if ( shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) {
-=======
-		if ( daysAwayFromRenewal > 90 ) {
->>>>>>> Bump this to 90 days, to match the first notification that goes out for wpcom renewals
 			noticeMessage = translate( 'Your credit card details were successfully updated.' );
 			noticeOptions = {
 				persistent: true,

--- a/client/blocks/credit-card-form/helpers.js
+++ b/client/blocks/credit-card-form/helpers.js
@@ -104,7 +104,11 @@ async function updateCreditCard( {
 	if ( purchase && siteSlug && isRenewable( purchase ) ) {
 		let noticeMessage = '';
 		let noticeOptions = {};
+<<<<<<< HEAD
 		if ( shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) {
+=======
+		if ( daysAwayFromRenewal > 90 ) {
+>>>>>>> Bump this to 90 days, to match the first notification that goes out for wpcom renewals
 			noticeMessage = translate( 'Your credit card details were successfully updated.' );
 			noticeOptions = {
 				persistent: true,

--- a/client/blocks/credit-card-form/helpers.js
+++ b/client/blocks/credit-card-form/helpers.js
@@ -3,6 +3,7 @@
  */
 import { useState, useEffect, useRef } from 'react';
 import { camelCase, kebabCase, debounce } from 'lodash';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -98,17 +99,27 @@ async function updateCreditCard( {
 	}
 
 	if ( purchase && siteSlug && isRenewable( purchase ) ) {
-		const noticeMessage = translate(
-			'Your credit card details were successfully updated, but your subscription has not been renewed yet.'
-		);
-		const noticeOptions = {
-			button: translate( 'Renew Now' ),
-			onClick: function( event, closeFunction ) {
-				handleRenewNowClick( purchase, siteSlug );
-				closeFunction();
-			},
-			persistent: true,
-		};
+		const daysAwayFromRenewal = moment( purchase.renewDate ).diff( moment(), 'days' );
+		let noticeMessage = '';
+		let noticeOptions = {};
+		if ( daysAwayFromRenewal > 30 ) {
+			noticeMessage = translate( 'Your credit card details were successfully updated.' );
+			noticeOptions = {
+				persistent: true,
+			};
+		} else {
+			noticeMessage = translate(
+				'Your credit card details were successfully updated, but your subscription has not been renewed yet.'
+			);
+			noticeOptions = {
+				button: translate( 'Renew Now' ),
+				onClick: function( event, closeFunction ) {
+					handleRenewNowClick( purchase, siteSlug );
+					closeFunction();
+				},
+				persistent: true,
+			};
+		}
 		notices.info( noticeMessage, noticeOptions );
 		return;
 	}

--- a/client/blocks/credit-card-form/helpers.js
+++ b/client/blocks/credit-card-form/helpers.js
@@ -3,13 +3,16 @@
  */
 import { useState, useEffect, useRef } from 'react';
 import { camelCase, kebabCase, debounce } from 'lodash';
-import moment from 'moment';
 
 /**
  * Internal dependencies
  */
 import notices from 'notices';
-import { handleRenewNowClick, isRenewable } from 'lib/purchases';
+import {
+	handleRenewNowClick,
+	isRenewable,
+	shouldAddPaymentSourceInsteadOfRenewingNow,
+} from 'lib/purchases';
 import wpcomFactory from 'lib/wp';
 
 const wpcom = wpcomFactory.undocumented();
@@ -99,10 +102,9 @@ async function updateCreditCard( {
 	}
 
 	if ( purchase && siteSlug && isRenewable( purchase ) ) {
-		const daysAwayFromRenewal = moment( purchase.renewDate ).diff( moment(), 'days' );
 		let noticeMessage = '';
 		let noticeOptions = {};
-		if ( daysAwayFromRenewal > 30 ) {
+		if ( shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) ) {
 			noticeMessage = translate( 'Your credit card details were successfully updated.' );
 			noticeOptions = {
 				persistent: true,


### PR DESCRIPTION
In c/zUTr0lu1-tr it became apparent that messaging which encourages renewal ("your subscription hasn't renewed yet" + "Renew Now") was originally intended to show only when the customer was actually close to renewal. There have been cases of confusion due in part to this message showing up early.

#### Changes proposed in this Pull Request

* Only show this message when the 90 days away from renewal.

#### Testing instructions

* Update the payment method on a product that will be renewing more than 90 days from now. You should see a message that simply says your credit card details were updated.
![](https://d.pr/i/mciN6m.png)

* Update the payment method on a product that will be renewing less than 90 days from now. You should see a message encouraging you to renew with a "Renew Now" button.
![](https://d.pr/i/FQmAK9.png)
* When clicking the "Renew Now" button, ensure it renews as expected.

