### PR TITLE
Fix the Jetpack "Clone" site tool

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -199,23 +199,21 @@ export function generateFlows( {
 		},
 	};
 
-	if ( isEnabled( 'rewind/clone-site' ) ) {
-		flows[ 'clone-site' ] = {
-			steps: [
-				'clone-start',
-				'clone-destination',
-				'clone-credentials',
-				'clone-point',
-				'clone-ready',
-				'clone-cloning',
-			],
-			destination: '/activity-log',
-			description: 'Allow Jetpack users to clone a site via Rewind (alternate restore)',
-			lastModified: '2018-05-28',
-			disallowResume: true,
-			allowContinue: false,
-		};
-	}
+	flows[ 'clone-site' ] = {
+		steps: [
+			'clone-start',
+			'clone-destination',
+			'clone-credentials',
+			'clone-point',
+			'clone-ready',
+			'clone-cloning',
+		],
+		destination: '/activity-log',
+		description: 'Allow Jetpack users to clone a site via Rewind (alternate restore)',
+		lastModified: '2018-05-28',
+		disallowResume: true,
+		allowContinue: false,
+	};
 
 	if ( isEnabled( 'signup/atomic-store-flow' ) ) {
 		// Important: For any changes done to the ecommerce flow,


### PR DESCRIPTION
#39145 removed the `rewind/site-cloning` to fully enable the feature, but there is a place left that still checks for the flag. Remove that flag check to fix the flow.


#### Testing instructions

For a dotorg site that has Jetpack Backup enabled and valid site server credentials, go to Settings->general. Clicking on "Clone" should lead to the clone flow, not `https://wordpress.com/start/site-type`

