### PR TITLE
Layout: Add bottom padding to main content area to avoid inline help covering content

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -82,6 +82,16 @@
 	}
 }
 
+// Add extra bottom padding for smaller screens to prevent
+// floating inline help from overlapping content.
+.layout__primary .main {
+	padding-bottom: 60px;
+
+	@include breakpoint( '>1400px' ) {
+		padding-bottom: 0;
+	}
+}
+
 // Setup the secondary element, which contains the sidebar and
 // the site-selector elements.
 .layout__secondary {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -85,7 +85,7 @@
 // Add extra bottom padding for smaller screens to prevent
 // floating inline help from overlapping content.
 .layout__primary .main {
-	padding-bottom: 60px;
+	padding-bottom: 88px;
 
 	@include breakpoint( '>1400px' ) {
 		padding-bottom: 0;


### PR DESCRIPTION
## Changes proposed in this Pull Request

* At small to medium screen widths, the inline help button might cover important content (often calls to action) on the right-hand side of the screen (left-hand for RTL). This will be especially noticeable if we standardize moving calls to action to the right side of the screen across Calypso.
* Adding a bit of padding to the bottom of the main content area for all but the largest breakpoint size is a quick-and-easy fix, allowing folks to scroll down so inline help doesn't cover the content.

**Before**

<img width="771" alt="Screen Shot 2020-01-31 at 10 04 23 AM" src="https://user-images.githubusercontent.com/2124984/73550157-10ca1280-4412-11ea-9c82-fdf65129c87c.png">

**After**

<img width="770" alt="Screen Shot 2020-01-31 at 10 05 10 AM" src="https://user-images.githubusercontent.com/2124984/73550177-17588a00-4412-11ea-8ec1-7b386b76d3ce.png">

#### Testing instructions

* Switch to this PR
* Browse Calypso on a mobile-sized screen. Don't forget to test signup, checkout, `/me`, etc. Look for visual breakage.
* Browse Calypso on a tablet-sized screen and repeat.

Fixes #39181