### PR TITLE
Layout Selector: Fix blank layout selection on existing page

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -129,13 +129,6 @@ class PageTemplateModal extends Component {
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 		this.props.saveTemplateChoice( slug );
 
-		const isHomepageTemplate = find( this.props.templates, { slug, category: 'home' } );
-
-		// Load content.
-		const blocks = this.getBlocksByTemplateSlug( slug );
-		// Only overwrite the page title if the template is not one of the Homepage Layouts
-		const title = isHomepageTemplate ? null : this.getTitleByTemplateSlug( slug );
-
 		// Check to see if this is a blank template selection
 		// and reset the template if so.
 		if ( 'blank' === slug ) {
@@ -143,6 +136,13 @@ class PageTemplateModal extends Component {
 			this.setState( { isOpen: false } );
 			return;
 		}
+
+		const isHomepageTemplate = find( this.props.templates, { slug, category: 'home' } );
+
+		// Load content.
+		const blocks = this.getBlocksByTemplateSlug( slug );
+		// Only overwrite the page title if the template is not one of the Homepage Layouts
+		const title = isHomepageTemplate ? null : this.getTitleByTemplateSlug( slug );
 
 		// Skip inserting if this is not a blank template
 		// and there's nothing to insert.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -136,7 +136,16 @@ class PageTemplateModal extends Component {
 		// Only overwrite the page title if the template is not one of the Homepage Layouts
 		const title = isHomepageTemplate ? null : this.getTitleByTemplateSlug( slug );
 
-		// Skip inserting if there's nothing to insert.
+		// Check to see if this is a blank template selection
+		// and reset the template if so.
+		if ( 'blank' === slug ) {
+			this.props.insertTemplate( '', [] );
+			this.setState( { isOpen: false } );
+			return;
+		}
+
+		// Skip inserting if this is not a blank template
+		// and there's nothing to insert.
 		if ( ! blocks || ! blocks.length ) {
 			this.setState( { isOpen: false } );
 			return;


### PR DESCRIPTION
Fixes #39174

#### Changes proposed in this Pull Request

* On an existing page with a layout already selected, using the sidebar to change the selected layout to "Blank" will empty out the editor. Previously when selecting blank and returning to the editor the blocks from the existing layout remained.

#### Testing instructions

* Create a new page and select a layout other than blank.
* Using the document sidebar in Gutenberg, select the "Change Layout" button.
* Select the "Blank" layout in the selector, and insert it.
* Confirm that all blocks from the previous template have been removed in the editor.
