### PR TITLE
e2e- Use JS clicks to fix instagram issues

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -20,7 +20,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		this.editorType = editorType;
 
 		this.publishSelector = By.css(
-			'.editor-post-publish-panel__header-publish-button button[aria-disabled=false]'
+			'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button'
 		);
 		this.publishingSpinnerSelector = By.css(
 			'.editor-post-publish-panel__content .components-spinner'
@@ -63,14 +63,16 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishHeaderSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, this.publishSelector );
 		await this.driver.sleep( 1000 );
-		await driverHelper.clickWhenClickable( this.driver, this.publishSelector );
+		const button = await this.driver.findElement( this.publishSelector );
+		await this.driver.executeScript( 'arguments[0].click();', button );
 		await driverHelper.waitTillNotPresent( this.driver, this.publishingSpinnerSelector );
 		await this.closePublishedPanel();
 		await this.waitForSuccessViewPostNotice();
 		const url = await this.driver.findElement( snackBarNoticeLinkSelector ).getAttribute( 'href' );
 
 		if ( visit ) {
-			await driverHelper.clickWhenClickable( this.driver, snackBarNoticeLinkSelector );
+			const snackbar = await this.driver.findElement( snackBarNoticeLinkSelector );
+			await this.driver.executeScript( 'arguments[0].click();', snackbar );
 		}
 
 		await driverHelper.acceptAlertIfPresent( this.driver );
@@ -310,10 +312,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async closePublishedPanel() {
-		return await driverHelper.clickWhenClickable(
-			this.driver,
+		const closeButton = await this.driver.findElement(
 			By.css( '.editor-post-publish-panel__header button[aria-label="Close panel"]' )
 		);
+		return await this.driver.executeScript( 'arguments[0].click();', closeButton );
 	}
 
 	async ensureSaved() {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1155,14 +1155,14 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 			await gEditorComponent.enterTitle( 'Embeds: ' + blogPostTitle );
 
-			// this.instagramEditorSelector = '.wp-block-embed-instagram';
-			// const blockIdInstagram = await gEditorComponent.addBlock( 'Instagram' );
-			// const gEmbedsComponentInstagram = await EmbedsBlockComponent.Expect(
-			// 	driver,
-			// 	blockIdInstagram
-			// );
-			// await gEmbedsComponentInstagram.embedUrl( 'https://www.instagram.com/p/BlDOZMil933/' );
-			// await gEmbedsComponentInstagram.isEmbeddedInEditor( this.instagramEditorSelector );
+			this.instagramEditorSelector = '.wp-block-embed-instagram';
+			const blockIdInstagram = await gEditorComponent.addBlock( 'Instagram' );
+			const gEmbedsComponentInstagram = await EmbedsBlockComponent.Expect(
+				driver,
+				blockIdInstagram
+			);
+			await gEmbedsComponentInstagram.embedUrl( 'https://www.instagram.com/p/BlDOZMil933/' );
+			await gEmbedsComponentInstagram.isEmbeddedInEditor( this.instagramEditorSelector );
 
 			this.twitterEditorSelector = '.wp-block-embed-twitter';
 			const blockIdTwitter = await gEditorComponent.addBlock( 'Twitter' );
@@ -1191,8 +1191,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			this.youtubePostSelector = '.youtube-player';
 			await viewPostPage.embedContentDisplayed( this.youtubePostSelector ); // check YouTube content
-			// this.instagramPostSelector = '.instagram-media-rendered';
-			// await viewPostPage.embedContentDisplayed( this.instagramPostSelector ); // check Instagram content
+			this.instagramPostSelector = '.instagram-media-rendered';
+			await viewPostPage.embedContentDisplayed( this.instagramPostSelector ); // check Instagram content
 			this.instagramPostSelector = '.twitter-tweet-rendered';
 			return await viewPostPage.embedContentDisplayed( this.instagramPostSelector ); // check Twitter content
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For some reason, when the instagram block is used, it causes webdriver clicks to not work. I changed out some of the clicks with JS clicks and the tests will pass

#### Testing instructions

* Ensure that the Gutenberg Insert embeds test works in CI for mobile and desktop view.