### PR TITLE
Plans: Fix button text alignment on small screens

### DIFF
--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -71,6 +71,7 @@
 .purchase-detail__button {
 	@include breakpoint( '<480px' ) {
 		display: block;
+		text-align: center;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Noticed this while I was testing another PR; on the Plans page cards, the button text on mobile devices is left aligned, which is unexpected for a full-width button. This PR centers the button text for small screens.

**Before**

<img width="379" alt="Screen Shot 2020-01-31 at 1 42 32 PM" src="https://user-images.githubusercontent.com/2124984/73565947-a83e5e00-4430-11ea-804f-e1a2fcf75805.png">

**After**

<img width="324" alt="Screen Shot 2020-01-31 at 1 48 26 PM" src="https://user-images.githubusercontent.com/2124984/73565966-ad9ba880-4430-11ea-9ea1-7765fab0dcfe.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/plans/my-plan/` on a small screen or mobile device < 480px wide.
* Scroll to view the cards; the button for each should have centered text.
