### PR TITLE
Blog Posts Block: Disable for CLI and plugin activation

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -192,9 +192,13 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_coblocks_gallery_scr
  * Load Blog Posts block.
  */
 function load_blog_posts_block() {
+	$slug          = 'newspack-blocks/newspack-blocks.php';
 	$disable_block = (
-		in_array( 'newspack-blocks/newspack-blocks.php', (array) get_option( 'active_plugins', array() ), true ) ||
-		in_array( 'newspack-blocks/newspack-blocks.php', (array) get_site_option( 'active_sitewide_plugins', array() ), true )
+		( defined( 'WP_CLI' ) && WP_CLI ) ||
+		/* phpcs:ignore WordPress.Security.NonceVerification */
+		( isset( $_GET['action'], $_GET['plugin'] ) && 'activate' === $_GET['action'] && $slug === $_GET['plugin'] ) ||
+		in_array( $slug, (array) get_option( 'active_plugins', array() ), true ) ||
+		in_array( $slug, (array) get_site_option( 'active_sitewide_plugins', array() ), true )
 	);
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disables block when in WP CLI mode
* Disables block when request indicates the newspack-blocks plugins is being activated.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have the Full Site Editing plugin active on your test site.
* Activate Newspack Blocks plugin from plugins screen.
* Plugin should be activated and not show fatal errors from activation sandbox.
* Activate Newspack Blocks plugin from WP CLI
* Success message should be returned, no fatal errors.

Fixes https://github.com/Automattic/newspack-blocks/issues/324
