### PR TITLE
[Coming soon] Privacy picker fix

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -429,7 +429,7 @@ export class SiteSettingsFormGeneral extends Component {
 							<FormRadio
 								name="blog_public"
 								value="-1"
-								checked={ -1 === blogPublic && 0 === wpcomComingSoon }
+								checked={ -1 === blogPublic && ! wpcomComingSoon }
 								onChange={ () =>
 									this.handleVisibilityOptionChange( {
 										blog_public: -1,

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -132,7 +132,7 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 			let nextSite = site;
 
 			return reduce(
-				[ 'blog_public', 'site_icon' ],
+				[ 'blog_public', 'wpcom_coming_soon', 'site_icon' ],
 				( memo, key ) => {
 					// A site settings update may or may not include the icon or blog_public property.
 					// If not, we should simply return state unchanged.
@@ -151,6 +151,19 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 							nextSite = {
 								...nextSite,
 								is_private: isPrivate,
+							};
+							break;
+						}
+						case 'wpcom_coming_soon': {
+							const isComingSoon = parseInt( settings.wpcom_coming_soon, 10 ) === 1;
+
+							if ( site.is_coming_soon === isComingSoon ) {
+								return memo;
+							}
+
+							nextSite = {
+								...nextSite,
+								is_coming_soon: isComingSoon,
 							};
 							break;
 						}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes sure that:

* A correct privacy setting is preselected in privacy picker when it's first opened
* Saving privacy settings would update the sidebar badge

#### Testing instructions

* On wpcalypso.wordpress.com, create a new site, go atomic, launch your site.
* Go to site settings, choose Private and save settings. Without navigating away, choose coming soon, and confirm the sidebar badge was updated from Private to Coming soon.
* Try saving different privacy options, confirm the badge is updated right when you save the form.
* Confirm that your choice remains selected after refreshing the page - especially private and coming soon