### PR TITLE
Gutenboarding: Route for page selection.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -10,6 +10,8 @@ import { partition } from 'lodash';
 import { Portal } from 'reakit/Portal';
 import { useDialogState, Dialog, DialogBackdrop } from 'reakit/Dialog';
 import { useSpring, animated } from 'react-spring';
+import { useHistory } from 'react-router-dom';
+import { Step } from '../../steps';
 
 /**
  * Internal dependencies
@@ -24,13 +26,14 @@ type Template = VerticalsTemplates.Template;
 
 const VERTICALS_TEMPLATES_STORE = VerticalsTemplates.register();
 
-const DesignSelector: FunctionComponent = () => {
+const DesignSelector: FunctionComponent = ( { showPageSelector } ) => {
 	const { selectedDesign, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
 
-	const [ isPageSelectorOpen, setIsPageSelectorOpen ] = useState( false );
+	// TODO: It was suggested to move this to a prop? or a
+	const [ isPageSelectorOpen, setIsPageSelectorOpen ] = useState( showPageSelector );
 
 	// @FIXME: If we don't have an ID (because we're dealing with a user-supplied vertical that
 	// WordPress.com doesn't know about), fall back to the 'm1' (Business) vertical. This is the
@@ -87,6 +90,8 @@ const DesignSelector: FunctionComponent = () => {
 		},
 	} );
 
+	const history = useHistory();
+
 	return (
 		<animated.div style={ designSelectorSpring }>
 			<div
@@ -126,6 +131,7 @@ const DesignSelector: FunctionComponent = () => {
 								window.scrollTo( 0, 0 );
 								setSelectedDesign( design );
 								setIsPageSelectorOpen( true );
+								history.push( Step.PageSelection );
 							} }
 						/>
 					) ) }
@@ -156,7 +162,10 @@ const DesignSelector: FunctionComponent = () => {
 
 			<Dialog
 				{ ...dialog }
-				hide={ () => setIsPageSelectorOpen( false ) }
+				hide={ () => {
+					setIsPageSelectorOpen( false );
+					history.push( Step.DesignSelection );
+				} }
 				aria-labelledby="page-layout-selector__title"
 				hideOnClickOutside
 				hideOnEsc

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -3,7 +3,7 @@
  */
 import { __ as NO__ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import React, { useState, useLayoutEffect, useRef, FunctionComponent } from 'react';
+import React, { useLayoutEffect, useRef, FunctionComponent } from 'react';
 import classnames from 'classnames';
 import PageLayoutSelector from './page-layout-selector';
 import { partition } from 'lodash';
@@ -26,14 +26,15 @@ type Template = VerticalsTemplates.Template;
 
 const VERTICALS_TEMPLATES_STORE = VerticalsTemplates.register();
 
-const DesignSelector: FunctionComponent = ( { showPageSelector } ) => {
+interface Props {
+	showPageSelector?: boolean;
+}
+
+const DesignSelector: FunctionComponent< Props > = ( { showPageSelector = false } ) => {
 	const { selectedDesign, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
 	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
-
-	// TODO: It was suggested to move this to a prop? or a
-	const [ isPageSelectorOpen, setIsPageSelectorOpen ] = useState( showPageSelector );
 
 	// @FIXME: If we don't have an ID (because we're dealing with a user-supplied vertical that
 	// WordPress.com doesn't know about), fall back to the 'm1' (Business) vertical. This is the
@@ -71,22 +72,22 @@ const DesignSelector: FunctionComponent = ( { showPageSelector } ) => {
 
 	const designSelectorSpring = useSpring( {
 		transform: `translate3d( 0, ${
-			isPageSelectorOpen ? -selectionTransitionShift.current : 0
+			showPageSelector ? -selectionTransitionShift.current : 0
 		}px, 0 )`,
 	} );
 
 	const descriptionContainerSpring = useSpring( {
-		transform: `translate3d( 0, ${ isPageSelectorOpen ? '0' : '100vh' }, 0 )`,
-		visibility: isPageSelectorOpen ? 'visible' : 'hidden',
+		transform: `translate3d( 0, ${ showPageSelector ? '0' : '100vh' }, 0 )`,
+		visibility: showPageSelector ? 'visible' : 'hidden',
 	} );
 
 	const pageSelectorSpring = useSpring( {
-		transform: `translate3d( 0, ${ isPageSelectorOpen ? '0' : '100vh' }, 0 )`,
+		transform: `translate3d( 0, ${ showPageSelector ? '0' : '100vh' }, 0 )`,
 		onStart: () => {
-			isPageSelectorOpen && dialog.show();
+			showPageSelector && dialog.show();
 		},
 		onRest: () => {
-			! isPageSelectorOpen && dialog.hide();
+			! showPageSelector && dialog.hide();
 		},
 	} );
 
@@ -96,7 +97,7 @@ const DesignSelector: FunctionComponent = ( { showPageSelector } ) => {
 		<animated.div style={ designSelectorSpring }>
 			<div
 				className="design-selector__header-container"
-				aria-hidden={ isPageSelectorOpen ? 'true' : undefined }
+				aria-hidden={ showPageSelector ? 'true' : undefined }
 				ref={ headingContainer }
 			>
 				<h1 className="design-selector__title">
@@ -108,7 +109,7 @@ const DesignSelector: FunctionComponent = ( { showPageSelector } ) => {
 			</div>
 			<div
 				className={ classnames( 'design-selector__grid-container', {
-					'is-page-selector-open': isPageSelectorOpen,
+					'is-page-selector-open': showPageSelector,
 				} ) }
 			>
 				<div className="design-selector__grid">
@@ -124,13 +125,12 @@ const DesignSelector: FunctionComponent = ( { showPageSelector } ) => {
 											gridColumn: descriptionOnRight ? 1 : 2,
 									  }
 									: {
-											visibility: isPageSelectorOpen ? 'hidden' : undefined,
+											visibility: showPageSelector ? 'hidden' : undefined,
 									  }
 							}
 							onClick={ () => {
 								window.scrollTo( 0, 0 );
 								setSelectedDesign( design );
-								setIsPageSelectorOpen( true );
 								history.push( Step.PageSelection );
 							} }
 						/>
@@ -155,7 +155,7 @@ const DesignSelector: FunctionComponent = ( { showPageSelector } ) => {
 
 			<Portal>
 				<DialogBackdrop
-					visible={ isPageSelectorOpen }
+					visible={ showPageSelector }
 					className="design-selector__page-layout-backdrop"
 				/>
 			</Portal>
@@ -163,7 +163,6 @@ const DesignSelector: FunctionComponent = ( { showPageSelector } ) => {
 			<Dialog
 				{ ...dialog }
 				hide={ () => {
-					setIsPageSelectorOpen( false );
 					history.push( Step.DesignSelection );
 				} }
 				aria-labelledby="page-layout-selector__title"

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -23,7 +23,9 @@ import VerticalBackground from './vertical-background';
 import Link from '../components/link';
 
 const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => {
-	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
+	const { siteVertical, siteTitle, selectedDesign } = useSelect( select =>
+		select( STORE_KEY ).getState()
+	);
 
 	return (
 		<>
@@ -57,6 +59,13 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 				</Route>
 				<Route exact path={ Step.DesignSelection }>
 					{ ! siteVertical ? <Redirect to={ Step.IntentGathering } /> : <DesignSelector /> }
+				</Route>
+				<Route exact path={ Step.PageSelection }>
+					{ ! selectedDesign ? (
+						<Redirect to={ Step.DesignSelection } />
+					) : (
+						<DesignSelector showPageSelector={ true } />
+					) }
 				</Route>
 				<Route exact path={ Step.Signup }>
 					<SignupForm />

--- a/client/landing/gutenboarding/steps.ts
+++ b/client/landing/gutenboarding/steps.ts
@@ -6,6 +6,7 @@ import { map } from 'lodash';
 export enum Step {
 	IntentGathering = '/',
 	DesignSelection = '/design',
+	PageSelection = '/pages',
 	Signup = '/signup',
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- When user enters page selection, the url should be `/gutenboarding/pages`.
- `isPageSelectorOpen` state should be replaced with `showPageSelection` prop to be able to control this routing behaviour.

#### Testing instructions

**Test Case 1: Ensure that the `/gutenboarding/pages` route is pushed:**

1. Go to gutenboarding page `/gutenboarding`.
2. Pick a site name & pick a design.
3. Now you're in page selector page, the url on the address bar should be `/gutenboarding/pages`.

**Test Case 2: Ensure that route is changed when exiting page selection:**.

1. When in page selection mode, try the following to exit page selection: 
   - Press <kbd>ESC</kbd>.
   - Click outside of the page selection modal.
   - Click the browser's Back button.
2. The url on the address bar should be `/gutenboarding/design`.
 
**Test Case 3: Ensure that pasting the `/gutenboarding/pages` url redirects back to `/gutenboarding/design` or `/gutenboarding`.**

1. Copy the `/gutenboarding/pages` url from the address bar to open it again in another browser tab.
2. It should redirect to `/gutenboarding/design` (if a site name was remembered by the browser) or `/gutenboarding` (if a site name was not given - fresh paste for users who's never used the gutenboarding page).