### PR TITLE
Remove get with templates from woocommerce state.

### DIFF
--- a/client/extensions/woocommerce/state/sites/customers/selectors.js
+++ b/client/extensions/woocommerce/state/sites/customers/selectors.js
@@ -4,7 +4,7 @@
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 function inFlight( state, siteId, searchTerm ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers?.isSearching?.[ searchTerm ];
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers.isSearching[ searchTerm ];
 }
 
 /**
@@ -40,9 +40,9 @@ export function getCustomerSearchResults( state, searchTerm, siteId = getSelecte
 		return [];
 	}
 
-	const customers = state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers?.items ?? {};
+	const customers = state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers.items ?? {};
 	const customerIdsForTerm =
-		state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers?.queries?.[ searchTerm ] ?? [];
+		state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers.queries[ searchTerm ] ?? [];
 	return customerIdsForTerm
 		.map( ( id ) => customers[ id ] || false )
 		.filter( ( customer ) => !! customer );
@@ -55,7 +55,6 @@ export function getCustomerSearchResults( state, searchTerm, siteId = getSelecte
  * @returns {object|boolean} a customer object as stored in the API, false if not found
  */
 export function getCustomer( state, customerId, siteId = getSelectedSiteId( state ) ) {
-	const customer =
-		state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers?.items?.[ customerId ];
+	const customer = state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers.items[ customerId ];
 	return customer !== undefined ? customer : false;
 }

--- a/client/extensions/woocommerce/state/sites/customers/selectors.js
+++ b/client/extensions/woocommerce/state/sites/customers/selectors.js
@@ -3,8 +3,8 @@
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-function inFlight( state, siteId, searchTerm ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers.isSearching[ searchTerm ];
+function getCustomerSearchStatus( state, siteId, searchTerm ) {
+	return state?.extensions?.woocommerce?.sites[ siteId ]?.customers.isSearching[ searchTerm ];
 }
 
 /**
@@ -15,7 +15,7 @@ function inFlight( state, siteId, searchTerm ) {
  */
 export function isCustomerSearchLoaded( state, searchTerm, siteId = getSelectedSiteId( state ) ) {
 	// Strict check because it could also be undefined.
-	return inFlight( state, siteId, searchTerm ) === false;
+	return getCustomerSearchStatus( state, siteId, searchTerm ) === false;
 }
 
 /**
@@ -26,7 +26,7 @@ export function isCustomerSearchLoaded( state, searchTerm, siteId = getSelectedS
  */
 export function isCustomerSearchLoading( state, searchTerm, siteId = getSelectedSiteId( state ) ) {
 	// Strict check because it could also be undefined.
-	return inFlight( state, siteId, searchTerm ) === true;
+	return getCustomerSearchStatus( state, siteId, searchTerm ) === true;
 }
 
 /**
@@ -42,7 +42,7 @@ export function getCustomerSearchResults( state, searchTerm, siteId = getSelecte
 
 	const customers = state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers.items ?? {};
 	const customerIdsForTerm =
-		state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers.queries[ searchTerm ] ?? [];
+		state?.extensions?.woocommerce?.sites[ siteId ]?.customers.queries[ searchTerm ] ?? [];
 	return customerIdsForTerm
 		.map( ( id ) => customers[ id ] || false )
 		.filter( ( customer ) => !! customer );
@@ -55,6 +55,5 @@ export function getCustomerSearchResults( state, searchTerm, siteId = getSelecte
  * @returns {object|boolean} a customer object as stored in the API, false if not found
  */
 export function getCustomer( state, customerId, siteId = getSelectedSiteId( state ) ) {
-	const customer = state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers.items[ customerId ];
-	return customer !== undefined ? customer : false;
+	return state?.extensions?.woocommerce?.sites[ siteId ]?.customers.items[ customerId ] ?? false;
 }

--- a/client/extensions/woocommerce/state/sites/customers/selectors.js
+++ b/client/extensions/woocommerce/state/sites/customers/selectors.js
@@ -1,13 +1,11 @@
 /**
- * External dependencies
- */
-
-import { filter, get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
+
+function inFlight( state, siteId, searchTerm ) {
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers?.isSearching?.[ searchTerm ];
+}
 
 /**
  * @param {object} state Whole Redux state tree
@@ -15,18 +13,10 @@ import { getSelectedSiteId } from 'state/ui/selectors';
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {boolean} Whether the search results for a given term have been successfully loaded from the server.
  */
-export const isCustomerSearchLoaded = (
-	state,
-	searchTerm,
-	siteId = getSelectedSiteId( state )
-) => {
-	const inFlight = get(
-		state,
-		`extensions.woocommerce.sites[${ siteId }].customers.isSearching[${ searchTerm }]`
-	);
+export function isCustomerSearchLoaded( state, searchTerm, siteId = getSelectedSiteId( state ) ) {
 	// Strict check because it could also be undefined.
-	return false === inFlight;
-};
+	return inFlight( state, siteId, searchTerm ) === false;
+}
 
 /**
  * @param {object} state Whole Redux state tree
@@ -34,18 +24,10 @@ export const isCustomerSearchLoaded = (
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {boolean} Whether the search results for a given term are currently being retrieved from the server.
  */
-export const isCustomerSearchLoading = (
-	state,
-	searchTerm,
-	siteId = getSelectedSiteId( state )
-) => {
-	const inFlight = get(
-		state,
-		`extensions.woocommerce.sites[${ siteId }].customers.isSearching[${ searchTerm }]`
-	);
+export function isCustomerSearchLoading( state, searchTerm, siteId = getSelectedSiteId( state ) ) {
 	// Strict check because it could also be undefined.
-	return true === inFlight;
-};
+	return inFlight( state, siteId, searchTerm ) === true;
+}
 
 /**
  * @param {object} state Whole Redux state tree
@@ -53,34 +35,27 @@ export const isCustomerSearchLoading = (
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {Array} List of customer results matching term
  */
-export const getCustomerSearchResults = (
-	state,
-	searchTerm,
-	siteId = getSelectedSiteId( state )
-) => {
+export function getCustomerSearchResults( state, searchTerm, siteId = getSelectedSiteId( state ) ) {
 	if ( ! isCustomerSearchLoaded( state, searchTerm, siteId ) ) {
 		return [];
 	}
 
-	const customers = get( state, `extensions.woocommerce.sites[${ siteId }].customers.items`, {} );
-	const customerIdsForTerm = get(
-		state,
-		`extensions.woocommerce.sites[${ siteId }].customers.queries[${ searchTerm }]`,
-		[]
-	);
-	return filter( customerIdsForTerm.map( ( id ) => customers[ id ] || false ) );
-};
+	const customers = state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers?.items ?? {};
+	const customerIdsForTerm =
+		state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers?.queries?.[ searchTerm ] ?? [];
+	return customerIdsForTerm
+		.map( ( id ) => customers[ id ] || false )
+		.filter( ( customer ) => !! customer );
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} customerId Customer ID to get
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
- * @returns {object|False} a customer object as stored in the API, false if not found
+ * @returns {object|boolean} a customer object as stored in the API, false if not found
  */
-export const getCustomer = ( state, customerId, siteId = getSelectedSiteId( state ) ) => {
-	return get(
-		state,
-		`extensions.woocommerce.sites[${ siteId }].customers.items[${ customerId }]`,
-		false
-	);
-};
+export function getCustomer( state, customerId, siteId = getSelectedSiteId( state ) ) {
+	const customer =
+		state?.extensions?.woocommerce?.sites?.[ siteId ]?.customers?.items?.[ customerId ];
+	return customer !== undefined ? customer : false;
+}

--- a/client/extensions/woocommerce/state/sites/data/counts/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/counts/selectors.js
@@ -51,7 +51,7 @@ export function getCountNewOrders( state, siteId = getSelectedSiteId( state ) ) 
 	const statuses = [ ...statusWaitingPayment, ...statusWaitingFulfillment ].map(
 		( s ) => `wc-${ s }`
 	);
-	return statuses.reduce( ( total, s ) => total + items?.orders?.[ s ] ?? 0, 0 );
+	return statuses.reduce( ( total, s ) => total + ( items?.orders?.[ s ] ?? 0 ), 0 );
 }
 
 /**

--- a/client/extensions/woocommerce/state/sites/data/counts/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/counts/selectors.js
@@ -1,63 +1,66 @@
 /**
- * External dependencies
- */
-import { get, reduce } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { statusWaitingPayment, statusWaitingFulfillment } from 'woocommerce/lib/order-status';
+
+function getItems( state, siteId ) {
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.data?.counts?.items ?? {};
+}
+
+function isLoading( state, siteId ) {
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.data?.counts?.isLoading;
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {boolean} Whether the count data is already loaded for this site
  */
-export const areCountsLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const isLoading = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.isLoading` );
-	return false === isLoading;
-};
+export function areCountsLoaded( state, siteId = getSelectedSiteId( state ) ) {
+	return isLoading( state, siteId ) === false;
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {boolean} Whether the count data is currently being retrieved from the server
  */
-export const areCountsLoading = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const isLoading = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.isLoading` );
-	return true === isLoading;
-};
+export function areCountsLoading( state, siteId = getSelectedSiteId( state ) ) {
+	return isLoading( state, siteId ) === true;
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {number} The total number of products on this site
  */
-export const getCountProducts = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const items = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.items`, {} );
-	return get( items, 'products.all', 0 );
-};
+export function getCountProducts( state, siteId = getSelectedSiteId( state ) ) {
+	const items = getItems( state, siteId );
+	const allProducts = items?.products?.all;
+	return allProducts !== undefined ? allProducts : 0;
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {number} The total number of not-finished orders (awaiting payment & fulfullment) on this site
  */
-export const getCountNewOrders = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const items = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.items`, {} );
+export function getCountNewOrders( state, siteId = getSelectedSiteId( state ) ) {
+	const items = getItems( state, siteId );
 	const statuses = [ ...statusWaitingPayment, ...statusWaitingFulfillment ].map(
 		( s ) => `wc-${ s }`
 	);
-	return reduce( statuses, ( total, s ) => total + get( items, `orders.${ s }`, 0 ), 0 );
-};
+	return statuses.reduce( ( total, s ) => total + items?.orders?.[ s ] ?? 0, 0 );
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {number} The number of pending reviews on this site
  */
-export const getCountPendingReviews = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const items = get( state, `extensions.woocommerce.sites[${ siteId }].data.counts.items`, {} );
-	return get( items, 'reviews.awaiting_moderation', 0 );
-};
+export function getCountPendingReviews( state, siteId = getSelectedSiteId( state ) ) {
+	const items = getItems( state, siteId );
+	const awaitingModeration = items?.reviews?.awaiting_moderation;
+	return awaitingModeration !== undefined ? awaitingModeration : 0;
+}

--- a/client/extensions/woocommerce/state/sites/data/counts/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/counts/selectors.js
@@ -5,11 +5,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { statusWaitingPayment, statusWaitingFulfillment } from 'woocommerce/lib/order-status';
 
 function getItems( state, siteId ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.data?.counts?.items ?? {};
+	return state?.extensions?.woocommerce?.sites[ siteId ]?.data.counts.items ?? {};
 }
 
 function isLoading( state, siteId ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.data?.counts?.isLoading;
+	return state?.extensions?.woocommerce?.sites[ siteId ]?.data.counts.isLoading;
 }
 
 /**
@@ -37,8 +37,7 @@ export function areCountsLoading( state, siteId = getSelectedSiteId( state ) ) {
  */
 export function getCountProducts( state, siteId = getSelectedSiteId( state ) ) {
 	const items = getItems( state, siteId );
-	const allProducts = items?.products?.all;
-	return allProducts !== undefined ? allProducts : 0;
+	return items?.products?.all ?? 0;
 }
 
 /**
@@ -61,6 +60,5 @@ export function getCountNewOrders( state, siteId = getSelectedSiteId( state ) ) 
  */
 export function getCountPendingReviews( state, siteId = getSelectedSiteId( state ) ) {
 	const items = getItems( state, siteId );
-	const awaitingModeration = items?.reviews?.awaiting_moderation;
-	return awaitingModeration !== undefined ? awaitingModeration : 0;
+	return items?.reviews?.awaiting_moderation ?? 0;
 }

--- a/client/extensions/woocommerce/state/sites/data/currencies/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/currencies/selectors.js
@@ -11,7 +11,7 @@ import { LOADING } from 'woocommerce/state/constants';
  * if the currencies are currently being fetched, or a "falsy" value if that haven't been fetched at all.
  */
 function getRawCurrencies( state, siteId = getSelectedSiteId( state ) ) {
-	return state?.extensions?.woocommerce?.sites[ siteId ]?.data?.currencies;
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.data?.currencies;
 }
 
 /**

--- a/client/extensions/woocommerce/state/sites/data/currencies/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/currencies/selectors.js
@@ -11,7 +11,7 @@ import { LOADING } from 'woocommerce/state/constants';
  * if the currencies are currently being fetched, or a "falsy" value if that haven't been fetched at all.
  */
 function getRawCurrencies( state, siteId = getSelectedSiteId( state ) ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.data.currencies;
+	return state?.extensions?.woocommerce?.sites[ siteId ]?.data.currencies;
 }
 
 /**

--- a/client/extensions/woocommerce/state/sites/data/currencies/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/currencies/selectors.js
@@ -11,7 +11,7 @@ import { LOADING } from 'woocommerce/state/constants';
  * if the currencies are currently being fetched, or a "falsy" value if that haven't been fetched at all.
  */
 function getRawCurrencies( state, siteId = getSelectedSiteId( state ) ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.data?.currencies;
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.data.currencies;
 }
 
 /**

--- a/client/extensions/woocommerce/state/sites/data/currencies/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/currencies/selectors.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { get, isArray } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -16,36 +10,36 @@ import { LOADING } from 'woocommerce/state/constants';
  * @returns {Array} The currencies data, as retrieved from the server. It can also be the string "LOADING"
  * if the currencies are currently being fetched, or a "falsy" value if that haven't been fetched at all.
  */
-const getRawCurrencies = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return get( state, `extensions.woocommerce.sites[${ siteId }].data.currencies` );
-};
+function getRawCurrencies( state, siteId = getSelectedSiteId( state ) ) {
+	return state?.extensions?.woocommerce?.sites[ siteId ]?.data?.currencies;
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {boolean} Whether the currencies data has been successfully loaded from the server
  */
-export const areCurrenciesLoaded = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return isArray( getRawCurrencies( state, siteId ) );
-};
+export function areCurrenciesLoaded( state, siteId = getSelectedSiteId( state ) ) {
+	return Array.isArray( getRawCurrencies( state, siteId ) );
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {boolean} Whether the currencies data is currently being retrieved from the server
  */
-export const areCurrenciesLoading = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return LOADING === getRawCurrencies( state, siteId );
-};
+export function areCurrenciesLoading( state, siteId = getSelectedSiteId( state ) ) {
+	return getRawCurrencies( state, siteId ) === LOADING;
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {Array} A list of currencies, represented by { code, name, symbol }.
  */
-export const getCurrencies = ( state, siteId = getSelectedSiteId( state ) ) => {
+export function getCurrencies( state, siteId = getSelectedSiteId( state ) ) {
 	if ( ! areCurrenciesLoaded( state, siteId ) ) {
 		return [];
 	}
 	return getRawCurrencies( state, siteId );
-};
+}

--- a/client/extensions/woocommerce/state/sites/data/currencies/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/data/currencies/test/selectors.js
@@ -46,7 +46,9 @@ const loadingState = {
 
 const emptyState = {
 	extensions: {
-		woocommerce: {},
+		woocommerce: {
+			sites: {},
+		},
 	},
 	ui: {
 		selectedSiteId: 123,

--- a/client/extensions/woocommerce/state/sites/products/selectors.js
+++ b/client/extensions/woocommerce/state/sites/products/selectors.js
@@ -10,11 +10,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSerializedProductsQuery } from './utils';
 
 function getRawProducts( state, siteId ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.products.products;
+	return state?.extensions?.woocommerce?.sites[ siteId ]?.products.products;
 }
 
 function getQuery( state, siteId, key ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.products.queries?.[ key ];
+	return state?.extensions?.woocommerce?.sites[ siteId ]?.products.queries?.[ key ];
 }
 
 export function getProduct( state, productId, siteId = getSelectedSiteId( state ) ) {
@@ -39,7 +39,7 @@ export function getAllProducts( state, siteId = getSelectedSiteId( state ) ) {
  */
 export function getAllProductsWithVariations( state, siteId = getSelectedSiteId( state ) ) {
 	const products = getRawProducts( state, siteId ) ?? [];
-	const variations = state?.extensions?.woocommerce?.sites?.[ siteId ]?.productVariations ?? {};
+	const variations = state?.extensions?.woocommerce?.sites[ siteId ]?.productVariations ?? {};
 	// Flatten variations from their productId mapping down into a single array
 	const variationsList = flatten(
 		map( variations, ( items, productId ) => {

--- a/client/extensions/woocommerce/state/sites/products/selectors.js
+++ b/client/extensions/woocommerce/state/sites/products/selectors.js
@@ -10,11 +10,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSerializedProductsQuery } from './utils';
 
 function getRawProducts( state, siteId ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.products?.products;
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.products.products;
 }
 
 function getQuery( state, siteId, key ) {
-	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.products?.queries?.[ key ];
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.products.queries?.[ key ];
 }
 
 export function getProduct( state, productId, siteId = getSelectedSiteId( state ) ) {

--- a/client/extensions/woocommerce/state/sites/products/selectors.js
+++ b/client/extensions/woocommerce/state/sites/products/selectors.js
@@ -103,8 +103,7 @@ export function getProducts( state, params = {}, siteId = getSelectedSiteId( sta
  */
 export function getTotalProductsPages( state, params = {}, siteId = getSelectedSiteId( state ) ) {
 	const key = getSerializedProductsQuery( params );
-	const totalPages = getQuery( state, siteId, key )?.totalPages;
-	return totalPages !== undefined ? totalPages : 0;
+	return getQuery( state, siteId, key )?.totalPages ?? 0;
 }
 
 /**
@@ -115,6 +114,5 @@ export function getTotalProductsPages( state, params = {}, siteId = getSelectedS
  */
 export function getTotalProducts( state, params = {}, siteId = getSelectedSiteId( state ) ) {
 	const key = getSerializedProductsQuery( params );
-	const totalProducts = getQuery( state, siteId, key )?.totalProducts;
-	return totalProducts !== undefined ? totalProducts : 0;
+	return getQuery( state, siteId, key )?.totalProducts ?? 0;
 }

--- a/client/extensions/woocommerce/state/sites/products/selectors.js
+++ b/client/extensions/woocommerce/state/sites/products/selectors.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { get, find, flatten, map } from 'lodash';
+import { find, flatten, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,39 +9,37 @@ import { get, find, flatten, map } from 'lodash';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSerializedProductsQuery } from './utils';
 
-export const getProduct = ( state, productId, siteId = getSelectedSiteId( state ) ) => {
-	const allProducts = get( state, [
-		'extensions',
-		'woocommerce',
-		'sites',
-		siteId,
-		'products',
-		'products',
-	] );
+function getRawProducts( state, siteId ) {
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.products?.products;
+}
+
+function getQuery( state, siteId, key ) {
+	return state?.extensions?.woocommerce?.sites?.[ siteId ]?.products?.queries?.[ key ];
+}
+
+export function getProduct( state, productId, siteId = getSelectedSiteId( state ) ) {
+	const allProducts = getRawProducts( state, siteId );
 	return find( allProducts, { id: productId } );
-};
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {Array}  The entire list of products for this site
  */
-export const getAllProducts = ( state, siteId = getSelectedSiteId( state ) ) => {
-	return get( state, [ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'products' ], [] );
-};
+export function getAllProducts( state, siteId = getSelectedSiteId( state ) ) {
+	const allProducts = getRawProducts( state, siteId );
+	return allProducts !== undefined ? allProducts : [];
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {Array}  The entire list of products for this site with variations inline as "products"
  */
-export const getAllProductsWithVariations = ( state, siteId = getSelectedSiteId( state ) ) => {
-	const products = get( state, `extensions.woocommerce.sites[${ siteId }].products.products`, [] );
-	const variations = get(
-		state,
-		`extensions.woocommerce.sites[${ siteId }].productVariations`,
-		{}
-	);
+export function getAllProductsWithVariations( state, siteId = getSelectedSiteId( state ) ) {
+	const products = getRawProducts( state, siteId ) ?? [];
+	const variations = state?.extensions?.woocommerce?.sites?.[ siteId ]?.productVariations ?? {};
 	// Flatten variations from their productId mapping down into a single array
 	const variationsList = flatten(
 		map( variations, ( items, productId ) => {
@@ -51,7 +48,7 @@ export const getAllProductsWithVariations = ( state, siteId = getSelectedSiteId(
 	);
 
 	return [ ...products, ...variationsList ];
-};
+}
 
 /**
  * @param {object} state Whole Redux state tree
@@ -59,16 +56,11 @@ export const getAllProductsWithVariations = ( state, siteId = getSelectedSiteId(
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {boolean} Whether the products list for a requested page has been successfully loaded from the server
  */
-export const areProductsLoaded = ( state, params = {}, siteId = getSelectedSiteId( state ) ) => {
+export function areProductsLoaded( state, params = {}, siteId = getSelectedSiteId( state ) ) {
 	const key = getSerializedProductsQuery( params );
-	const isLoading = get(
-		state,
-		[ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'queries', key, 'isLoading' ],
-		null
-	);
 	// Strict check because it could also be undefined.
-	return false === isLoading;
-};
+	return getQuery( state, siteId, key )?.isLoading === false;
+}
 
 /**
  * @param {object} state Whole Redux state tree
@@ -76,41 +68,32 @@ export const areProductsLoaded = ( state, params = {}, siteId = getSelectedSiteI
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {boolean} Whether the products list for a request page is currently being retrieved from the server
  */
-export const areProductsLoading = ( state, params = {}, siteId = getSelectedSiteId( state ) ) => {
+export function areProductsLoading( state, params = {}, siteId = getSelectedSiteId( state ) ) {
 	const key = getSerializedProductsQuery( params );
-	const isLoading = get(
-		state,
-		[ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'queries', key, 'isLoading' ],
-		null
-	);
 	// Strict check because it could also be undefined.
-	return true === isLoading;
-};
+	return getQuery( state, siteId, key )?.isLoading === true;
+}
 
 /**
  * @param {object} state Whole Redux state tree
  * @param {object} [params] Query used to fetch products. Can contain page, search, etc. If not provided,
  *                          defaults to first page, all products
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
- * @returns {Array|false} List of products, or false if there was an error
+ * @returns {Array|boolean} List of products, or false if there was an error
  */
-export const getProducts = ( state, params = {}, siteId = getSelectedSiteId( state ) ) => {
+export function getProducts( state, params = {}, siteId = getSelectedSiteId( state ) ) {
 	if ( ! areProductsLoaded( state, params, siteId ) ) {
 		return [];
 	}
 	const key = getSerializedProductsQuery( params );
-	const products = get( state, `extensions.woocommerce.sites[${ siteId }].products.products`, [] );
-	const productIdsOnPage = get(
-		state,
-		`extensions.woocommerce.sites[${ siteId }].products.queries[${ key }].ids`,
-		[]
-	);
+	const products = getRawProducts( state, siteId ) ?? [];
+	const productIdsOnPage = getQuery( state, siteId, key )?.ids ?? [];
 
 	if ( productIdsOnPage.length ) {
 		return productIdsOnPage.map( ( id ) => find( products, { id } ) );
 	}
 	return false;
-};
+}
 
 /**
  * @param {object} state Whole Redux state tree
@@ -118,18 +101,11 @@ export const getProducts = ( state, params = {}, siteId = getSelectedSiteId( sta
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {number} Total number of pages of products available on a site, or 0 if not loaded yet.
  */
-export const getTotalProductsPages = (
-	state,
-	params = {},
-	siteId = getSelectedSiteId( state )
-) => {
+export function getTotalProductsPages( state, params = {}, siteId = getSelectedSiteId( state ) ) {
 	const key = getSerializedProductsQuery( params );
-	return get(
-		state,
-		[ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'queries', key, 'totalPages' ],
-		0
-	);
-};
+	const totalPages = getQuery( state, siteId, key )?.totalPages;
+	return totalPages !== undefined ? totalPages : 0;
+}
 
 /**
  * @param {object} state Whole Redux state tree
@@ -137,11 +113,8 @@ export const getTotalProductsPages = (
  * @param {number} [siteId] Site ID to check. If not provided, the Site ID selected in the UI will be used
  * @returns {number} Total number of products available on a site, or 0 if not loaded yet.
  */
-export const getTotalProducts = ( state, params = {}, siteId = getSelectedSiteId( state ) ) => {
+export function getTotalProducts( state, params = {}, siteId = getSelectedSiteId( state ) ) {
 	const key = getSerializedProductsQuery( params );
-	return get(
-		state,
-		[ 'extensions', 'woocommerce', 'sites', siteId, 'products', 'queries', key, 'totalProducts' ],
-		0
-	);
-};
+	const totalProducts = getQuery( state, siteId, key )?.totalProducts;
+	return totalProducts !== undefined ? totalProducts : 0;
+}

--- a/client/extensions/woocommerce/state/sites/products/test/selectors.js
+++ b/client/extensions/woocommerce/state/sites/products/test/selectors.js
@@ -21,7 +21,9 @@ import productVariations from '../../product-variations/test/fixtures/variations
 
 const preInitializedState = {
 	extensions: {
-		woocommerce: {},
+		woocommerce: {
+			sites: {},
+		},
 	},
 };
 const loadingState = {


### PR DESCRIPTION
Using template strings with `_.get` is unsafe, since the values being interpolated could include characters that end up changing the path structure, such as `.` or `[]`.

This PR also cleans up and DRYs these files a fair bit.

#### Changes proposed in this Pull Request

* Remove `_.get` with string templates from woocommerce state, and improve code.

#### Testing instructions

I don't have any specific testing instructions, other than ensuring that woocommerce functionality continues to work correctly.
