### PR TITLE
Site Importer: Simplify/unify duplicate logic in code

### DIFF
--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -19,6 +19,7 @@ import wpLib from 'lib/wp';
  */
 import './section-migrate.scss';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
+import { redirectTo } from 'my-sites/migrate/helpers';
 
 const wpcom = wpLib.undocumented();
 
@@ -52,16 +53,7 @@ class StepSourceSelect extends Component {
 								page( `/migrate/choose/${ this.props.targetSiteSlug }` );
 							} );
 						default:
-							if ( window && window.history && window.history.pushState ) {
-								/**
-								 * Because query parameters aren't processed by `page.show`, we're forced to use `page.redirect`.
-								 * Unfortunately, `page.redirect` breaks the back button behavior.
-								 * This is a Work-around to push importUrl to history to fix the back button.
-								 * See https://github.com/visionmedia/page.js#readme
-								 */
-								window.history.pushState( null, null, importUrl );
-							}
-							return page.redirect( importUrl );
+							return redirectTo( importUrl );
 					}
 				} )
 				.catch( error => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace a duplicate usage with already existing method that was created based on the code being replaced.

#### Testing instructions

* Checkout branch or use Calypso.live link
* Go to a WPCOM simple site
* Go to Migration
* Try to migrate a Blogger site
* You should land on the Blogger importer
* There should be no JS errors
