### PR TITLE
Language Picker: fix localized names of languages

### DIFF
--- a/client/components/data/query-language-names/index.jsx
+++ b/client/components/data/query-language-names/index.jsx
@@ -1,40 +1,22 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import { Component } from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import getLocalizedLanguageNames from 'state/selectors/get-localized-language-names';
 import { requestLanguageNames } from 'state/i18n/language-names/actions';
 
-class QueryLanguageNames extends Component {
-	static propTypes = {
-		languageNames: PropTypes.object,
-		requestLanguageNames: PropTypes.func,
-	};
+export default function QueryLanguageNames() {
+	const dispatch = useDispatch();
+	const { localeSlug } = useTranslate();
 
-	static defaultProps = {
-		requestLanguageNames: () => {},
-	};
+	useEffect( () => {
+		dispatch( requestLanguageNames() );
+	}, [ dispatch, localeSlug ] );
 
-	UNSAFE_componentWillMount() {
-		if ( ! this.props.languageNames ) {
-			this.props.requestLanguageNames();
-		}
-	}
-
-	render() {
-		return null;
-	}
+	return null;
 }
-
-export default connect(
-	state => ( {
-		languageNames: getLocalizedLanguageNames( state ),
-	} ),
-	{ requestLanguageNames }
-)( QueryLanguageNames );

--- a/client/components/language-picker/index.jsx
+++ b/client/components/language-picker/index.jsx
@@ -13,7 +13,6 @@ import { find, isString, noop } from 'lodash';
  * Internal dependencies
  */
 import LanguagePickerModal from './modal';
-import QueryLanguageNames from 'components/data/query-language-names';
 import { requestGeoLocation } from 'state/data-getters';
 import { getLanguageCodeLabels } from './utils';
 
@@ -147,7 +146,6 @@ export class LanguagePicker extends PureComponent {
 
 		return (
 			<Fragment>
-				<QueryLanguageNames />
 				<button
 					type="button"
 					className="language-picker"

--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -25,6 +25,7 @@ import {
  * Internal dependencies
  */
 import { Dialog } from '@automattic/components';
+import QueryLanguageNames from 'components/data/query-language-names';
 import SectionNav from 'components/section-nav';
 import SectionNavTabs from 'components/section-nav/tabs';
 import SectionNavTabItem from 'components/section-nav/item';
@@ -473,6 +474,7 @@ export class LanguagePickerModal extends PureComponent {
 				onClose={ this.handleClose }
 				additionalClassNames="language-picker__modal"
 			>
+				<QueryLanguageNames />
 				<SectionNav selectedText={ this.getFilterLabel( filter ) }>
 					<SectionNavTabs>{ this.renderTabItems() }</SectionNavTabs>
 					<Search

--- a/client/components/language-picker/test/__snapshots__/modal.js.snap
+++ b/client/components/language-picker/test/__snapshots__/modal.js.snap
@@ -26,6 +26,7 @@ exports[`LanguagePickerModal should render 1`] = `
   leaveTimeout={200}
   onClose={[Function]}
 >
+  <QueryLanguageNames />
   <SectionNav
     allowDropdown={true}
     onMobileNavPanelOpen={[Function]}


### PR DESCRIPTION
Fixes a bug when using Quick Language Switcher, where hovering over a language name in the picker modal should show a tooltip (`<div title>`) with a localized language name. Before this patch, it was showing just the slug, like `Ja` or `Cs`.

There are two commits:

**Language Picker: move QueryLanguageNames into the modal component**
Only the Modal uses the language names list, not the Button, so it's the right place to query the list from REST API.

Fixes Quick Language Switcher which only uses the Modal without the Button, so the query for language names wasn't issued at all.

**QueryLanguageNames: rewrite to hook, re-request when locale changes**
Rewrites the query component to a hook. And makes sure that the list is re-requested when the current locale changes by making `localeSlug` a dependency of the `useEffect` hook. The `_locale` parameter is added to the REST request automagically by the `lib/wp/localization` middleware.

**How to test:**
1. Open Calypso with `flags=quick-language-switcher`
2. Open the language picker modal
3. Verify that hovering over language names shows their translation to the current language
4. Verify that after switching to another language (using the switcher), the `i18n/language-names` REST request is issued again with a different `_locale` param and that the language picker UI is updated with the new translations.