### PR TITLE
Add all monorepo packages as top-level deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37761,18 +37761,17 @@
 		},
 		"wpcom": {
 			"version": "file:packages/wpcom.js",
-			"integrity": "sha512-fVrJU9U979m9T0B0IEeAfpIQRM397J5NcsWLPcJov87jATubxVt6akZATczAh9rN40H1h2HCj/YtAW6L1zh8QA==",
 			"requires": {
-				"babel-runtime": "^6.9.2",
-				"debug": "^3.1.0",
+				"@babel/runtime": "^7.8.3",
+				"debug": "^4.1.1",
 				"qs": "^6.5.2",
 				"wpcom-xhr-request": "^1.1.2"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
 						"ms": "^2.1.1"
 					}

--- a/package.json
+++ b/package.json
@@ -33,9 +33,22 @@
 		]
 	},
 	"dependencies": {
+		"@automattic/calypso-polyfills": "file:packages/calypso-polyfills",
+		"@automattic/components": "file:packages/components",
+		"@automattic/composite-checkout": "file:packages/composite-checkout",
+		"@automattic/composite-checkout-wpcom": "file:packages/composite-checkout-wpcom",
+		"@automattic/data-stores": "file:packages/data-stores",
+		"@automattic/format-currency": "file:packages/format-currency",
 		"@automattic/full-site-editing": "file:apps/full-site-editing",
+		"@automattic/load-script": "file:packages/load-script",
+		"@automattic/material-design-icons": "file:packages/material-design-icons",
+		"@automattic/muriel-style": "file:packages/muriel-style",
+		"@automattic/tree-select": "file:packages/tree-select",
 		"@automattic/wpcom-block-editor": "file:apps/wpcom-block-editor",
-		"wp-calypso": "file:client"
+		"i18n-calypso": "file:packages/i18n-calypso",
+		"photon": "file:packages/photon",
+		"wp-calypso": "file:client",
+		"wpcom": "file:packages/wpcom.js"
 	},
 	"engines": {
 		"node": "^12.13.1",


### PR DESCRIPTION
Add all packages in the monorepo as dependencies of the top-level `package.json`. Some of them already are there as `devDependencies`. Here we are adding the rest.

This is a workaround for NPM bug: https://github.com/npm/cli/issues/750

**How to test:**
Do a clean (no `node_modules`) install (not `ci`) from the lockfile:
```
npm run distclean
npm install
```
Before this patch, the `npm install` failed to create symlinks to packages like `@automattic/components` and even removed the dependency from the lockfile.

After the patch, `npm install` should install everything just like `npm ci` and shouldn't change the lockfile at all.