### PR TITLE
Enable Safari IDB mitigation on production

### DIFF
--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { kebabCase } from 'lodash';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -18,6 +19,8 @@ import { StoredItems } from './types';
 import { mc } from 'lib/analytics';
 import config from 'config';
 
+const debug = debugFactory( 'calypso:browser-storage' );
+
 let shouldBypass = false;
 
 const DB_NAME = 'calypso';
@@ -33,6 +36,8 @@ const isAffectedSafari =
 	!! window.IDBKeyRange?.lowerBound( 0 ).includes &&
 	!! ( window as any ).webkitAudioContext &&
 	!! window.PointerEvent;
+
+debug( 'Safari IDB mitigation active: %s', isAffectedSafari );
 
 const getDB = once( () => {
 	const request = window.indexedDB.open( DB_NAME, DB_VERSION );
@@ -190,9 +195,11 @@ async function idbSafariReset() {
 	if ( idbWriteBlock ) {
 		return idbWriteBlock;
 	}
+	debug( 'performing safari idb mitigation' );
 	idbWriteBlock = _idbSafariReset();
 	idbWriteBlock.finally( () => {
 		idbWriteBlock = null;
+		debug( 'idb mitigation complete' );
 	} );
 	return idbWriteBlock;
 }

--- a/config/production.json
+++ b/config/production.json
@@ -100,7 +100,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
-		"safari-idb-mitigation": false,
+		"safari-idb-mitigation": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables the Safari IDB mitigation in production. See https://github.com/Automattic/wp-calypso/pull/38781 for details
* Adds some debug logging for said mitigation

#### Testing instructions

_To test this feature in Safari, you must disable cross-site tracking prevention_

Step 0: Safari -> Preferences -> Privacy -> Uncheck `Website Tracking: Prevent cross site tracking` 

* Load Calypso
* Enable the new debug log with `localStorage.debug = 'calypso:browser-storage'` in the console
* Reload Calypso
* Verify that the mitigation is active in Safari 13, but not in other browsers
* Verify that the mitigation runs every now and again. It runs every 20 writes, so it'll take a few minutes of use to trigger it
* Check the Storage tab in the dev console and make sure entries appear for the calypso store in indexed db

Remember to re-enable cross-site tracking prevention when you're done!

Fixes #36858 
