### PR TITLE
Remove get with templates from state / components.

### DIFF
--- a/client/components/language-picker/modal.jsx
+++ b/client/components/language-picker/modal.jsx
@@ -11,7 +11,6 @@ import {
 	capitalize,
 	deburr,
 	find,
-	get,
 	includes,
 	isEmpty,
 	map,
@@ -106,12 +105,12 @@ export class LanguagePickerModal extends PureComponent {
 
 	getLocalizedLanguageTitle( languageSlug ) {
 		const { localizedLanguageNames } = this.props;
-		return get( localizedLanguageNames, `${ languageSlug }.localized`, languageSlug );
+		return localizedLanguageNames?.[ languageSlug ]?.localized ?? languageSlug;
 	}
 
 	getEnglishLanguageTitle( languageSlug ) {
 		const { localizedLanguageNames } = this.props;
-		return get( localizedLanguageNames, `${ languageSlug }.en`, languageSlug );
+		return localizedLanguageNames?.[ languageSlug ]?.en ?? languageSlug;
 	}
 
 	getFilterLabel( filter ) {

--- a/client/my-sites/google-my-business/stats/chart.js
+++ b/client/my-sites/google-my-business/stats/chart.js
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { flatten, get, partialRight, sumBy } from 'lodash';
+import { flatten, partialRight, sumBy } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -57,8 +57,8 @@ function transformData( props ) {
 	if ( aggregation === 'total' ) {
 		return data.metricValues.map( metric => ( {
 			value: metric.totalValue.value,
-			description: get( props.dataSeriesInfo, `${ metric.metric }.description`, '' ),
-			name: get( props.dataSeriesInfo, `${ metric.metric }.name`, metric.metric ),
+			description: props.dataSeriesInfo?.[ metric.metric ]?.description ?? '',
+			name: props.dataSeriesInfo?.[ metric.metric ]?.name ?? metric.metric,
 		} ) );
 	}
 
@@ -86,8 +86,8 @@ function createLegendInfo( props ) {
 	}
 
 	return data.metricValues.map( metric => ( {
-		description: get( props.dataSeriesInfo, `${ metric.metric }.description`, '' ),
-		name: get( props.dataSeriesInfo, `${ metric.metric }.name`, metric.metric ),
+		description: props.dataSeriesInfo?.[ metric.metric ]?.description ?? '',
+		name: props.dataSeriesInfo?.[ metric.metric ]?.name ?? metric.metric,
 	} ) );
 }
 

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -36,7 +36,7 @@ import 'state/comments/init';
  * @returns {Array} comment items
  */
 export const getPostCommentItems = ( state, siteId, postId ) =>
-	get( state.comments.items, `${ siteId }-${ postId }` );
+	state.comments.items?.[ `${ siteId }-${ postId }` ];
 
 export const getDateSortedPostComments = treeSelect(
 	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
@@ -72,7 +72,7 @@ export const getCommentErrors = state => {
  * @returns {number} total comments count on the server. if not found, assume infinity
  */
 export const getPostTotalCommentsCount = ( state, siteId, postId ) =>
-	get( state.comments.totalCommentsCount, `${ siteId }-${ postId }` );
+	state.comments.totalCommentsCount?.[ `${ siteId }-${ postId }` ];
 
 /**
  * Get total number of comments in state at a given date and time

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -36,7 +36,7 @@ import 'state/comments/init';
  * @returns {Array} comment items
  */
 export const getPostCommentItems = ( state, siteId, postId ) =>
-	state.comments.items?.[ `${ siteId }-${ postId }` ];
+	state.comments.items[ `${ siteId }-${ postId }` ];
 
 export const getDateSortedPostComments = treeSelect(
 	( state, siteId, postId ) => [ getPostCommentItems( state, siteId, postId ) ],
@@ -72,7 +72,7 @@ export const getCommentErrors = state => {
  * @returns {number} total comments count on the server. if not found, assume infinity
  */
 export const getPostTotalCommentsCount = ( state, siteId, postId ) =>
-	state.comments.totalCommentsCount?.[ `${ siteId }-${ postId }` ];
+	state.comments.totalCommentsCount[ `${ siteId }-${ postId }` ];
 
 /**
  * Get total number of comments in state at a given date and time

--- a/client/state/domains/management/reducer.js
+++ b/client/state/domains/management/reducer.js
@@ -158,9 +158,12 @@ export const items = withSchemaValidation( domainWhoisSchema, ( state = {}, acti
 		}
 		case DOMAIN_MANAGEMENT_WHOIS_UPDATE: {
 			const { domain, whoisData } = action;
-			const domainState = get( state, [ `${ domain }` ], {} );
+			const domainState = state?.[ domain ];
 			return merge( {}, state, {
-				[ domain ]: mergeDomainRegistrantContactDetails( domainState, whoisData ),
+				[ domain ]: mergeDomainRegistrantContactDetails(
+					domainState !== undefined ? domainState : {},
+					whoisData
+				),
 			} );
 		}
 	}

--- a/client/state/domains/management/reducer.js
+++ b/client/state/domains/management/reducer.js
@@ -158,7 +158,7 @@ export const items = withSchemaValidation( domainWhoisSchema, ( state = {}, acti
 		}
 		case DOMAIN_MANAGEMENT_WHOIS_UPDATE: {
 			const { domain, whoisData } = action;
-			const domainState = state?.[ domain ];
+			const domainState = state[ domain ];
 			return merge( {}, state, {
 				[ domain ]: mergeDomainRegistrantContactDetails(
 					domainState !== undefined ? domainState : {},

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -23,7 +23,7 @@ export const getTwoFactorUserId = state => {
  * @returns {?string}         The nonce.
  */
 export const getTwoFactorAuthNonce = ( state, nonceType ) => {
-	return state?.login?.twoFactorAuth?.[ `two_step_nonce_${ nonceType }` ] ?? null;
+	return state.login.twoFactorAuth[ `two_step_nonce_${ nonceType }` ] ?? null;
 };
 
 /**

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -23,7 +23,7 @@ export const getTwoFactorUserId = state => {
  * @returns {?string}         The nonce.
  */
 export const getTwoFactorAuthNonce = ( state, nonceType ) => {
-	return get( state, `login.twoFactorAuth.two_step_nonce_${ nonceType }`, null );
+	return state?.login?.twoFactorAuth?.[ `two_step_nonce_${ nonceType }` ] ?? null;
 };
 
 /**

--- a/client/state/my-sites/sidebar/selectors.js
+++ b/client/state/my-sites/sidebar/selectors.js
@@ -1,8 +1,2 @@
-/**
- * External dependencies
- */
-
-import { get } from 'lodash';
-
 export const isSidebarSectionOpen = ( state, section ) =>
-	get( state, `mySites.sidebarSections.${ section }.isOpen` );
+	state?.mySites?.sidebarSections?.[ section ]?.isOpen;

--- a/client/state/my-sites/sidebar/selectors.js
+++ b/client/state/my-sites/sidebar/selectors.js
@@ -1,2 +1,2 @@
 export const isSidebarSectionOpen = ( state, section ) =>
-	state?.mySites?.sidebarSections?.[ section ]?.isOpen;
+	state.mySites.sidebarSections[ section ]?.isOpen;

--- a/client/state/oauth2-clients/selectors.js
+++ b/client/state/oauth2-clients/selectors.js
@@ -6,5 +6,5 @@
  * @returns {object}          OAuth2 client data
  */
 export const getOAuth2Client = ( state, clientId ) => {
-	return state?.oauth2Clients?.[ clientId ] ?? null;
+	return state.oauth2Clients[ clientId ] ?? null;
 };

--- a/client/state/oauth2-clients/selectors.js
+++ b/client/state/oauth2-clients/selectors.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-
-import { get } from 'lodash';
-
-/**
  * Gets the OAuth2 client data.
  *
  * @param  {object}   state  Global state tree
@@ -12,5 +6,5 @@ import { get } from 'lodash';
  * @returns {object}          OAuth2 client data
  */
 export const getOAuth2Client = ( state, clientId ) => {
-	return get( state, `oauth2Clients[${ clientId }]`, null );
+	return state?.oauth2Clients?.[ clientId ] ?? null;
 };

--- a/client/state/oauth2-clients/test/selectors.js
+++ b/client/state/oauth2-clients/test/selectors.js
@@ -10,8 +10,8 @@ import { getOAuth2Client } from '../selectors';
 
 describe( 'selectors', () => {
 	describe( 'getOAuth2Client()', () => {
-		test( 'should return null if no state provided', () => {
-			const client = getOAuth2Client();
+		test( 'should return null if empty state provided', () => {
+			const client = getOAuth2Client( { oauth2Clients: {} } );
 
 			expect( client ).to.be.null;
 		} );

--- a/client/state/selectors/get-memberships.js
+++ b/client/state/selectors/get-memberships.js
@@ -23,7 +23,7 @@ export default createSelector(
 			return null;
 		}
 
-		const membershipsProducts = state.memberships.productList.items?.[ siteId ] ?? null;
+		const membershipsProducts = state.memberships.productList.items[ siteId ] ?? null;
 
 		if ( ! membershipsProducts ) {
 			return null;

--- a/client/state/selectors/get-memberships.js
+++ b/client/state/selectors/get-memberships.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-
-import { get, find, orderBy } from 'lodash';
+import { find, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,8 +13,8 @@ import createSelector from 'lib/create-selector';
  * ID from the largest to the lowest number (the same as ordering by creation date DESC).
  *
  * @param {object} state           Global state tree
- * @param {int}    siteId          Site which the Simple Payment belongs to.
- * @param {int}    simplePaymentId The ID of the Simple Payment to get. Optional.
+ * @param {number}    siteId          Site which the Simple Payment belongs to.
+ * @param {number}    simplePaymentId The ID of the Simple Payment to get. Optional.
  * @returns {Array|object|null}     Array of Simple Payment objects or an object if `simplePaymentId` specified.
  */
 export default createSelector(
@@ -24,7 +23,7 @@ export default createSelector(
 			return null;
 		}
 
-		const membershipsProducts = get( state, `memberships.productList.items.${ siteId }`, null );
+		const membershipsProducts = state.memberships.productList.items?.[ siteId ] ?? null;
 
 		if ( ! membershipsProducts ) {
 			return null;

--- a/client/state/selectors/is-google-my-business-location-connected.js
+++ b/client/state/selectors/is-google-my-business-location-connected.js
@@ -1,14 +1,11 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { get, find } from 'lodash';
-
 import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
 
 export default function isGoogleMyBusinessLocationConnected( state, siteId ) {
-	const siteKeyrings = get( state, `siteKeyrings.items.${ siteId }`, [] );
-	const googleMyBusinessSiteKeyring = find(
-		siteKeyrings,
+	const siteKeyrings = state?.siteKeyrings?.items?.[ siteId ] ?? [];
+	const googleMyBusinessSiteKeyring = siteKeyrings.find(
 		keyring => keyring.service === 'google_my_business'
 	);
 

--- a/client/state/selectors/is-google-my-business-location-connected.js
+++ b/client/state/selectors/is-google-my-business-location-connected.js
@@ -4,7 +4,7 @@
 import { getKeyringConnectionsByName } from 'state/sharing/keyring/selectors';
 
 export default function isGoogleMyBusinessLocationConnected( state, siteId ) {
-	const siteKeyrings = state?.siteKeyrings?.items?.[ siteId ] ?? [];
+	const siteKeyrings = state.siteKeyrings.items[ siteId ] ?? [];
 	const googleMyBusinessSiteKeyring = siteKeyrings.find(
 		keyring => keyring.service === 'google_my_business'
 	);

--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -24,7 +24,7 @@ export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
 	}
 
 	// Don't show the nudge if the site is already connected (can be from another admin)
-	const siteKeyrings = state?.siteKeyrings?.items?.[ siteId ] ?? [];
+	const siteKeyrings = state.siteKeyrings.items[ siteId ] ?? [];
 	const googleMyBusinessSiteKeyring = siteKeyrings.find(
 		keyring => keyring.service === 'google_my_business' && !! keyring.external_user_id
 	);

--- a/client/state/selectors/is-google-my-business-stats-nudge-visible.js
+++ b/client/state/selectors/is-google-my-business-stats-nudge-visible.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { find, get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import isSiteGoogleMyBusinessEligible from 'state/selectors/is-site-google-my-business-eligible';
@@ -29,9 +24,8 @@ export default function isGoogleMyBusinessStatsNudgeVisible( state, siteId ) {
 	}
 
 	// Don't show the nudge if the site is already connected (can be from another admin)
-	const siteKeyrings = get( state, `siteKeyrings.items.${ siteId }`, [] );
-	const googleMyBusinessSiteKeyring = find(
-		siteKeyrings,
+	const siteKeyrings = state?.siteKeyrings?.items?.[ siteId ] ?? [];
+	const googleMyBusinessSiteKeyring = siteKeyrings.find(
 		keyring => keyring.service === 'google_my_business' && !! keyring.external_user_id
 	);
 


### PR DESCRIPTION
Using template strings with `_.get` is unsafe, since the values being interpolated could include characters that end up changing the path structure, such as `.` or `[]`.

#### Changes proposed in this Pull Request

* Remove _.get with string templates from components and state.

#### Testing instructions

No specific testing instructions, as this covers a wide range of functionality.