### PR TITLE
Change google drive service name to match changes on server

### DIFF
--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -118,7 +118,7 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 		}
 
 		if (
-			'google_drive' === service.ID &&
+			'google-drive' === service.ID &&
 			( ! config.isEnabled( 'google-drive' ) ||
 				! canCurrentUser( state, siteId, 'manage_options' ) )
 		) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the google drive service name to match a recent change to this on the server end.

#### Testing instructions

* Apply this patch on your local calypso install and also set google-drive to false in config/development.json
* Go to /marketing/connections/{site-name} and make sure Googe Drive does not appear as one of the connection options


