### PR TITLE
Devdocs: exclude node_modules from searched docs

### DIFF
--- a/bin/generate-devdocs-search-index.js
+++ b/bin/generate-devdocs-search-index.js
@@ -27,6 +27,8 @@ function main() {
 	].map( dir => dir + '/**/*.md' );
 	// ... and the current directory
 	dirList.push( '*.md' );
+	// don't descend into node_modules
+	dirList.push( '!**/node_modules/**' );
 
 	const documents = globby
 		.sync( dirList )


### PR DESCRIPTION
Excludes `README.md` files inside `node_modules` folders from the devdocs search index.

**How to test:**
In devdocs, try to search for "redux" or "emotion". Without this patch, you'll see results from inside `node_modules` folders:

<img width="735" alt="Screenshot 2020-02-03 at 18 00 35" src="https://user-images.githubusercontent.com/664258/73695808-2b82dc80-46db-11ea-9613-30925568a7d2.png">

Verify that after this patch, these documents are gone.