### PR TITLE
Added `@babel/runtime` as a dependency of `@automattic/components`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 1.0.0-alpha.2
+
+- Added missing dependency on `@babel/runtime`
+
 ## 1.0.0-alpha.1
 
 - Add ProductIcon

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,6 +29,7 @@
 	],
 	"types": "types",
 	"dependencies": {
+		"@babel/runtime": "^7.8.4",
 		"classnames": "^2.2.6",
 		"gridicons": "^3.3.1",
 		"lodash": "^4.17.15",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I've added `@babel/runtime` as a dependency of `@automattic/components` because after installing `@automattic/components` in a new CRA app it complains that it is missing - it is required by files in `dist/<cjs|esm>/*`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* 

Fixes #
