### PR TITLE
Fix/hardcoded string

### DIFF
--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -211,9 +211,10 @@ class AdsFormSettings extends Component {
 	}
 
 	jetpackPlacementControls() {
-		const linkHref = '/marketing/traffic/' + this.props.site.slug;
+		const { translate, site } = this.props;
+		const linkHref = '/marketing/traffic/' + site?.slug;
 
-		return <Card href={ linkHref }>Manage ad placements</Card>;
+		return <Card href={ linkHref }>{ translate( 'Manage ad placements' ) }</Card>;
 	}
 
 	showAdsToOptions() {

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -151,7 +151,7 @@ class AdsWrapper extends Component {
 						</div>
 					</div>
 					<ActionCard
-						headerText={ 'Start Earning Income from Your Site' }
+						headerText={ translate( 'Start Earning Income from Your Site' ) }
 						mainText={ translate(
 							'WordAds is the leading advertising optimization platform for WordPress sites, ' +
 								'where the internet’s top ad suppliers bid against each other to deliver their ads to your site, maximizing your revenue.' +
@@ -166,7 +166,7 @@ class AdsWrapper extends Component {
 								},
 							}
 						) }
-						buttonText={ 'Learn More on WordAds.co' }
+						buttonText={ translate( 'Learn More on WordAds.co' ) }
 						buttonIcon="external"
 						buttonPrimary={ false }
 						buttonHref="https://wordads.co"


### PR DESCRIPTION
As reported by @davipontesblog there are a few hard coded strings in the AdWords section under earn that are not wrapped by the translation function. Somehow this passed code-review. It may be worth auditing other sections as a follow up to see if there's any other easy wins. 

(Folks may mistake hardcoded strings for new strings or missing translations)

### Testing Instructions

- Verify that there are no regressions.