### PR TITLE
Customer Home: Atomic Sites are not eligible for checklist until full support is added

### DIFF
--- a/client/state/selectors/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/is-eligible-for-dotcom-checklist.js
@@ -20,6 +20,11 @@ export default function isEligibleForDotcomChecklist( state, siteId ) {
 		return false;
 	}
 
+	//TODO: we should add checklist support for Atomic
+	if ( isAtomicSite( state, siteId ) ) {
+		return false;
+	}
+
 	const siteOptions = getSiteOptions( state, siteId );
 
 	// Checklist should not show up if the site is created before the feature was launched.

--- a/client/state/selectors/test/is-eligible-for-dotcom-checklist.js
+++ b/client/state/selectors/test/is-eligible-for-dotcom-checklist.js
@@ -46,7 +46,7 @@ describe( 'isEligibleForDotcomChecklist()', () => {
 		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( true );
 	} );
 
-	test( 'should return true for recent AT sites', () => {
+	test( 'should return false for recent AT sites, because the checklist is not fully supported', () => {
 		const state = {
 			sites: {
 				items: {
@@ -60,7 +60,7 @@ describe( 'isEligibleForDotcomChecklist()', () => {
 			},
 		};
 
-		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( true );
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( false );
 	} );
 
 	test( 'should return false for AT sites without a created_at option', () => {
@@ -96,7 +96,7 @@ describe( 'isEligibleForDotcomChecklist()', () => {
 		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( false );
 	} );
 
-	test( 'should return true for recent AT non-store sites', () => {
+	test( 'should return false for recent AT non-store sites', () => {
 		const state = {
 			sites: {
 				items: {
@@ -111,10 +111,10 @@ describe( 'isEligibleForDotcomChecklist()', () => {
 			},
 		};
 
-		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( true );
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( false );
 	} );
 
-	test( 'should return true for recent AT store sites', () => {
+	test( 'should return false for recent AT store sites', () => {
 		const state = {
 			sites: {
 				items: {
@@ -130,6 +130,6 @@ describe( 'isEligibleForDotcomChecklist()', () => {
 			},
 		};
 
-		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( true );
+		expect( isEligibleForDotcomChecklist( state, 99 ) ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/39191

Until we add full Atomic support this hides the display of the site setup checklist until we add Atomic support.

<img width="749" alt="Screen Shot 2020-02-04 at 11 28 36 AM" src="https://user-images.githubusercontent.com/1270189/73779372-80f1d480-4741-11ea-8de0-5e844f350ad5.png">
