### PR TITLE
Created a client for the wpcom media api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2418,6 +2418,12 @@
 				"@hapi/hoek": "^8.3.0"
 			}
 		},
+		"@jameslnewell/react-promise": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@jameslnewell/react-promise/-/react-promise-3.3.0.tgz",
+			"integrity": "sha512-qxov9i5DT9FufOuzPNtQVq8HwEGFKFR2jYt3k8dqRc5X+f3ZJ1K9NPXxrxxVqn77m0W5tDMsYHJeR6Ct7aQuGA==",
+			"dev": true
+		},
 		"@jest/console": {
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
 		"@automattic/webpack-inline-constant-exports-plugin": "file:./packages/webpack-inline-constant-exports-plugin",
 		"@babel/cli": "7.8.4",
 		"@babel/core": "7.8.4",
+		"@jameslnewell/react-promise": "^3.3.0",
 		"@storybook/addon-actions": "5.3.8",
 		"@storybook/preset-scss": "1.0.2",
 		"@storybook/preset-typescript": "1.2.0",

--- a/packages/media-library/.eslintrc.js
+++ b/packages/media-library/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '*.stories.jsx' ],
+			files: [ '*.stories.jsx', '*.stories.tsx' ],
 			rules: {
 				'import/no-extraneous-dependencies': 'off',
 			},

--- a/packages/media-library/package.json
+++ b/packages/media-library/package.json
@@ -24,7 +24,9 @@
 		"src"
 	],
 	"types": "types",
-	"dependencies": {},
+	"dependencies": {
+		"wpcom-proxy-request": "^5.0.2"
+	},
 	"scripts": {
 		"clean": "npx rimraf dist types",
 		"prepublish": "npm run clean",

--- a/packages/media-library/src/api/Client.stories.tsx
+++ b/packages/media-library/src/api/Client.stories.tsx
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import React, { useRef } from 'react';
+import { usePromise, useInvokablePromise } from '@jameslnewell/react-promise';
+
+/**
+ * Internal dependencies
+ */
+import { Client } from './Client';
+
+const client = new Client();
+const siteId = '160146488';
+
+export default {
+	title: 'API/Client',
+};
+
+interface MediaItemProps {
+	id: string;
+	link: string;
+	title: string;
+}
+
+const MediaItem: React.FC< MediaItemProps > = ( { id, link, title } ) => {
+	return (
+		<span>
+			#{ id } - { title }
+			<br />
+			<img src={ link } alt="" />
+		</span>
+	);
+};
+
+interface MediaItemListProps {
+	items: MediaItemProps[];
+}
+
+const MediaItemList: React.FC< MediaItemListProps > = ( { items } ) => {
+	return (
+		<div>
+			{ items.map( item => (
+				<MediaItem key={ item.id } { ...item } />
+			) ) }
+		</div>
+	);
+};
+
+export const List = () => {
+	const [ result ] = usePromise( () => client.list( siteId ), [ client, siteId ] );
+	return <div>{ result && result.media && <MediaItemList items={ result.media } /> }</div>;
+};
+
+export const CreateFromFile = () => {
+	const input = useRef< HTMLInputElement >( null );
+	const [ create, result, { isPending, error } ] = useInvokablePromise(
+		( file: File ) => client.createFromFile( siteId, file ),
+		[ client, siteId ]
+	);
+
+	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		const file = input?.current?.files?.[ 0 ];
+		if ( file ) {
+			create( file );
+		}
+	};
+
+	return (
+		<div>
+			<form onSubmit={ handleSubmit }>
+				<input type="file" ref={ input } />
+				<button disabled={ isPending }>Create from File</button>
+			</form>
+			{ error && <span>{ ( error && error.message ) || error }</span> }
+			{ result && result.media && <MediaItemList items={ result.media } /> }
+		</div>
+	);
+};
+
+export const CreateFromURL = () => {
+	const input = useRef< HTMLInputElement >( null );
+	const [ create, result, { isPending, error } ] = useInvokablePromise(
+		( url: string ) => client.createFromURL( siteId, url ),
+		[ client, siteId ]
+	);
+
+	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		const url = input?.current?.value;
+		if ( url ) {
+			create( url );
+		}
+	};
+
+	return (
+		<div>
+			<form onSubmit={ handleSubmit }>
+				<input type="text" ref={ input } placeholder="URL" />
+				<button disabled={ isPending }>Create from URL</button>
+			</form>
+			{ error && <span>{ ( error && error.message ) || error }</span> }
+			{ result && result.media && <MediaItemList items={ result.media } /> }
+		</div>
+	);
+};
+
+export const Get = () => {
+	const input = useRef< HTMLInputElement >( null );
+	const [ get, result, { isPending, error } ] = useInvokablePromise(
+		( id: string ) => client.get( siteId, id ),
+		[ client, siteId ]
+	);
+
+	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		const id = input?.current?.value;
+		if ( id ) {
+			get( id );
+		}
+	};
+
+	return (
+		<div>
+			<form onSubmit={ handleSubmit }>
+				<input type="text" ref={ input } placeholder="ID" />
+				<button disabled={ isPending }>Get</button>
+			</form>
+			{ error && <span>{ ( error && error.message ) || error }</span> }
+			{ result && <MediaItem { ...result } /> }
+		</div>
+	);
+};
+
+export const Update = () => {
+	const idInput = useRef< HTMLInputElement >( null );
+	const titleInput = useRef< HTMLInputElement >( null );
+	const [ update, result, { isPending, error } ] = useInvokablePromise(
+		( id: string, title: string ) => client.update( siteId, id, { title } ),
+		[ client, siteId ]
+	);
+
+	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		const id = idInput?.current?.value;
+		const title = titleInput?.current?.value;
+		if ( id && title ) {
+			update( id, title );
+		}
+	};
+
+	return (
+		<div>
+			<form onSubmit={ handleSubmit }>
+				<input type="text" ref={ idInput } placeholder="ID" />
+				<input type="text" ref={ titleInput } placeholder="Title" />
+				<button disabled={ isPending }>Update</button>
+			</form>
+			{ error && <span>{ ( error && error.message ) || error }</span> }
+			{ result && <MediaItem { ...result } /> }
+		</div>
+	);
+};
+
+export const Delete = () => {
+	const input = useRef< HTMLInputElement >( null );
+	const [ del, , { isPending, error } ] = useInvokablePromise(
+		( id: string ) => client.delete( siteId, id ),
+		[ client, siteId ]
+	);
+
+	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		const id = input?.current?.value;
+		if ( id ) {
+			del( id );
+		}
+	};
+
+	return (
+		<div>
+			<form onSubmit={ handleSubmit }>
+				<input type="text" ref={ input } placeholder="ID" />
+				<button disabled={ isPending }>Delete</button>
+			</form>
+			{ error && <span>{ ( error && error.message ) || error }</span> }
+		</div>
+	);
+};

--- a/packages/media-library/src/api/Client.ts
+++ b/packages/media-library/src/api/Client.ts
@@ -1,0 +1,58 @@
+/**
+ * Internal dependencies
+ */
+import { fetch } from './fetch';
+
+interface MediaItem {
+	id: string;
+	link: string;
+	title: string;
+}
+
+interface ItemsResponse {
+	media: MediaItem[];
+	errors: string[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ItemResponse extends MediaItem {}
+
+export class Client {
+	public async list( siteId: string ): Promise< ItemsResponse > {
+		// TODO: support criteria e.g. mime_type
+		const res = await fetch( 'GET', `/sites/${ siteId }/media` );
+		return res;
+	}
+
+	public async createFromFile( siteId: string, file: File ): Promise< ItemsResponse > {
+		return await fetch( 'POST', `/sites/${ siteId }/media/new`, [ [ 'media[]', file ] ] );
+	}
+
+	public async createFromURL( siteId: string, url: string ): Promise< ItemsResponse > {
+		return await fetch( 'POST', `/sites/${ siteId }/media/new`, [ [ 'media_urls[]', url ] ] );
+	}
+
+	public async get( siteId: string, mediaId: string ): Promise< ItemResponse > {
+		const res = await fetch( 'GET', `/sites/${ siteId }/media/${ mediaId }` );
+		return res;
+	}
+
+	public async update(
+		siteId: string,
+		mediaId: string,
+		data: Partial< MediaItem >
+	): Promise< ItemResponse > {
+		const keys: Array< keyof MediaItem > = Object.keys( data ) as any;
+		const res = await fetch( 'POST', `/sites/${ siteId }/media/${ mediaId }`, [
+			[ 'ID', mediaId ],
+			...keys.map( key => [ key, data[ key ] ] ),
+		] );
+		return res;
+	}
+
+	public async delete( siteId: string, mediaId: string ): Promise< ItemResponse > {
+		const res = await fetch( 'POST', `/sites/${ siteId }/media/${ mediaId }/delete` );
+		res.status === 'deleted';
+		return res;
+	}
+}

--- a/packages/media-library/src/api/fetch.ts
+++ b/packages/media-library/src/api/fetch.ts
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import proxy from 'wpcom-proxy-request';
+
+let isAuthorised = false;
+
+const authorise = () => {
+	return new Promise( ( resolve, reject ) => {
+		// TODO: if there is an in-progress authorisation, don't try and authorise, instead wait untill it is resolved
+		if ( isAuthorised ) {
+			resolve();
+			return;
+		}
+		proxy( { metaAPI: { accessAllUsersBlogs: true } }, ( error: Error ) => {
+			if ( error ) {
+				reject( error );
+			} else {
+				isAuthorised = true;
+				resolve();
+			}
+		} );
+	} );
+};
+
+const request = ( method: string, path: string, data?: any ): Promise< any > => {
+	return new Promise( ( resolve, reject ) => {
+		proxy(
+			{
+				method,
+				path,
+				formData: data,
+			},
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			( error: any, body: any ) => {
+				if ( error ) {
+					reject( error );
+					return;
+				}
+				resolve( body );
+			}
+		);
+	} );
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const fetch = async ( method: string, path: string, data?: any ): Promise< any > => {
+	await authorise();
+	return await request( method, path, data );
+};

--- a/packages/media-library/src/api/fetch.ts
+++ b/packages/media-library/src/api/fetch.ts
@@ -3,12 +3,12 @@
  */
 import proxy from 'wpcom-proxy-request';
 
-let isAuthorised = false;
+let isAuthorized = false;
 
-const authorise = () => {
+const authorize = () => {
 	return new Promise( ( resolve, reject ) => {
-		// TODO: if there is an in-progress authorisation, don't try and authorise, instead wait untill it is resolved
-		if ( isAuthorised ) {
+		// TODO: if there is an in-progress authorisation, don't try and authorise, instead wait until it is resolved
+		if ( isAuthorized ) {
 			resolve();
 			return;
 		}
@@ -16,7 +16,7 @@ const authorise = () => {
 			if ( error ) {
 				reject( error );
 			} else {
-				isAuthorised = true;
+				isAuthorized = true;
 				resolve();
 			}
 		} );
@@ -45,6 +45,6 @@ const request = ( method: string, path: string, data?: any ): Promise< any > => 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fetch = async ( method: string, path: string, data?: any ): Promise< any > => {
-	await authorise();
+	await authorize();
 	return await request( method, path, data );
 };

--- a/packages/media-library/src/api/index.ts
+++ b/packages/media-library/src/api/index.ts
@@ -1,0 +1,1 @@
+export * from './Client';

--- a/packages/media-library/src/index.ts
+++ b/packages/media-library/src/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line no-console
-export default () => console.log( 'This package will expose the Media Library component! 🖼🎥🎶' );
+export * from './api';

--- a/packages/media-library/tsconfig.json
+++ b/packages/media-library/tsconfig.json
@@ -25,6 +25,6 @@
 		// "types": [],
 		"lib": [ "ESNext", "DOM" ]
 	},
-	"include": [ "src" ],
+	"include": [ "src", "typings/**/*.d.ts" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]
 }

--- a/packages/media-library/typings/wpcom-proxy-request.d.ts
+++ b/packages/media-library/typings/wpcom-proxy-request.d.ts
@@ -1,0 +1,1 @@
+declare module 'wpcom-proxy-request';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since `wpcom` is deprecated and to avoid adding large dependencies I created a new client for the `wpcom` media api using `wpcom-request-proxy.

The client will continue to be expanded and refined as part of the `media-library` work e.g. querying, improved error handling etc.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since the client is a very thin abstraction on top of the HTTP requests I didn't see much value in attempting to write unit tests with the API mocked. Instead I wrote a bunch of stories showing the API in use.

Run `npm run media-library:storybook:start` and play with the stories to see the API working.

Fixes #
