### PR TITLE
wpcom.js: make the webpack build output less chatty

### DIFF
--- a/packages/wpcom.js/package.json
+++ b/packages/wpcom.js/package.json
@@ -11,7 +11,7 @@
 		"prepublish": "npm run clean",
 		"prepare": "run-s build:modules build:bundle",
 		"build:modules": "transpile",
-		"build:bundle": "webpack"
+		"build:bundle": "webpack --display errors-only"
 	},
 	"keywords": [
 		"wordpress",


### PR DESCRIPTION
When we build the bundled script for the `wpcom` library, the webpack output is a bit too chatty:

<img width="622" alt="Screenshot 2020-02-04 at 00 06 45" src="https://user-images.githubusercontent.com/664258/73726037-f2745780-472e-11ea-93c4-9c5d3e3316f2.png">

By adding `--display errors-only`, I made it much shorter:

<img width="649" alt="Screenshot 2020-02-04 at 00 09 29" src="https://user-images.githubusercontent.com/664258/73726092-09b34500-472f-11ea-9079-61cab6dcd7e5.png">
