### PR TITLE
Remove all usages of nonEnglishDomainStepCopyUpdates

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -97,17 +97,6 @@ export default {
 		defaultVariation: 'variantShowUpdates',
 		allowExistingUsers: true,
 	},
-	nonEnglishDomainStepCopyUpdates: {
-		datestamp: '20191219',
-		variations: {
-			variantShowUpdates: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-		localeExceptions: [ 'en' ],
-	},
 	showBusinessPlanPopular: {
 		datestamp: '20200109',
 		variations: {

--- a/client/lib/plans/test/get-popular-plan-spec.js
+++ b/client/lib/plans/test/get-popular-plan-spec.js
@@ -7,8 +7,6 @@ import { GROUP_WPCOM, TYPE_BUSINESS, TYPE_PREMIUM } from '../constants';
 const abtest = test => {
 	if ( 'showBusinessPlanPopular' === test ) {
 		return 'variantShowBizPopular';
-	} else if ( 'nonEnglishDomainStepCopyUpdates' === test ) {
-		return 'control';
 	}
 	return;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The A/B test `nonEnglishDomainStepCopyUpdates` was removed in #38746 but was re-instated erroneously(due to a merge issue) in #38747. This PR removes all references to the A/B test since it's no longer running.

Fixes 188-gh-martech
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This PR should have no effect since we are only removing unused code.
* Begin signup in a non-EN locale, for example at `http://calypso.localhost:3000/start/fr` and verify that you are shown the new domain step version(as per the screenshot in #38746).
