### PR TITLE
Remove yamlparser dependency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -161,7 +161,6 @@
 		"valid-url": "1.0.9",
 		"wpcom": "file:../packages/wpcom.js",
 		"wpcom-proxy-request": "5.0.2",
-		"wpcom-xhr-request": "1.1.3",
-		"yamlparser": "0.0.2"
+		"wpcom-xhr-request": "1.1.3"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37712,8 +37712,7 @@
 				"valid-url": "1.0.9",
 				"wpcom": "file:packages/wpcom.js",
 				"wpcom-proxy-request": "5.0.2",
-				"wpcom-xhr-request": "1.1.3",
-				"yamlparser": "0.0.2"
+				"wpcom-xhr-request": "1.1.3"
 			},
 			"dependencies": {
 				"@emotion/core": {
@@ -37986,11 +37985,6 @@
 			"requires": {
 				"@babel/runtime": "^7.6.3"
 			}
-		},
-		"yamlparser": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/yamlparser/-/yamlparser-0.0.2.tgz",
-			"integrity": "sha1-Mjk+avxwyMoGa2ZQrGc4tIFnjrw="
 		},
 		"yargs": {
 			"version": "13.3.0",


### PR DESCRIPTION
Seems like we introduced `yamlparser` as a dependency in #30768. It doesn't seem to be used, though - @sgomes were we planning to use it for anything? If not, it could be removed safely.

#### Changes proposed in this Pull Request

* Remove `yamlparser` dependency

#### Testing instructions

* Checkout this branch.
* Run `npm ci` and verify Calypso builds well.
