### PR TITLE
Gutenboarding: Remove domain from flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -353,7 +353,7 @@ export function generateFlows( {
 
 	if ( isEnabled( 'gutenboarding' ) ) {
 		flows.frankenflow = {
-			steps: [ 'domains-launch', 'plans-launch', 'launch' ],
+			steps: [ 'plans-launch', 'launch' ],
 			destination: getLaunchDestination,
 			description: 'Frankenflow launch for a site created from Gutenboarding',
 			lastModified: '2020-01-22',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the domain step from frankenflow.

#### Testing instructions

* [`/gutenboarding`](https://calypso.live/gutenboarding?branch=gutenboarding/frankenflow-no-domain)
* Complete the flow.
* After creating your site, you should not be presented with a plans view before launching your site.
* You should be able to complete plan selection and arrive at your new site's home.
