### PR TITLE
Update/safari idb mitigation

### DIFF
--- a/client/lib/memoize-last/index.ts
+++ b/client/lib/memoize-last/index.ts
@@ -2,7 +2,6 @@ interface Clearable {
 	clear(): void;
 }
 
-const UNSET_SYMBOL = Symbol();
 /**
  * Wraps a function in a utility method that remembers the last invocation's
  * arguments and results, and returns the latter if the former match.
@@ -12,18 +11,13 @@ const UNSET_SYMBOL = Symbol();
  * @returns The wrapped function.
  */
 export default function memoizeLast< T extends ( ...args: any[] ) => any >( fn: T ): T & Clearable {
-	let lastArgs: Parameters< T > | symbol = UNSET_SYMBOL;
-	let lastResult: ReturnType< T > | symbol = UNSET_SYMBOL;
+	let lastArgs: Parameters< T > | undefined;
+	let lastResult: ReturnType< T > | undefined;
 
 	const func = ( ( ...args: Parameters< T > ) => {
-		if ( lastArgs === UNSET_SYMBOL ) {
-			lastArgs = args;
-			lastResult = fn( ...args );
-			return lastResult;
-		}
-
 		const isSame =
-			args.length === ( lastArgs as Parameters< T > ).length &&
+			lastArgs &&
+			args.length === lastArgs.length &&
 			args.every( ( arg, index ) => arg === ( lastArgs as Parameters< T > )[ index ] );
 
 		if ( ! isSame ) {
@@ -35,8 +29,8 @@ export default function memoizeLast< T extends ( ...args: any[] ) => any >( fn: 
 	} ) as T & Clearable;
 
 	func.clear = () => {
-		lastArgs = UNSET_SYMBOL;
-		lastResult = UNSET_SYMBOL;
+		lastArgs = undefined;
+		lastResult = undefined;
 	};
 
 	return func;

--- a/client/lib/memoize-last/test/index.js
+++ b/client/lib/memoize-last/test/index.js
@@ -33,6 +33,15 @@ describe( 'memoizeLast', () => {
 		expect( result2 ).toBe( result1 );
 	} );
 
+	test( 'it should call the function again if it was cleared and then called with the same args', () => {
+		const result1 = memoizedFunction( 1, 2, 3 );
+		memoizedFunction.clear();
+		const result2 = memoizedFunction( 1, 2, 3 );
+		expect( mockFunction ).toHaveBeenCalledTimes( 2 );
+		expect( mockFunction ).toHaveBeenCalledWith( 1, 2, 3 );
+		expect( result2 ).not.toBe( result1 );
+	} );
+
 	test( 'it should call the function if it is called with different args', () => {
 		const result1 = memoizedFunction( 1, 2, 3 );
 		const result2 = memoizedFunction( 3, 2, 1 );
@@ -67,11 +76,20 @@ describe( 'once', () => {
 		expect( result ).toEqual( { foo: 'bar' } );
 	} );
 
-	test( 'it should not call the function if it was already called ', () => {
+	test( 'it should not call the function if it was already called', () => {
 		const result1 = memoizedFunction();
 		const result2 = memoizedFunction();
 		expect( mockFunction ).toHaveBeenCalledTimes( 1 );
 		expect( mockFunction ).toHaveBeenCalledWith();
 		expect( result2 ).toBe( result1 );
+	} );
+
+	test( 'it should call the function if it was cleared between calls', () => {
+		const result1 = memoizedFunction();
+		memoizedFunction.clear();
+		const result2 = memoizedFunction();
+		expect( mockFunction ).toHaveBeenCalledTimes( 2 );
+		expect( mockFunction ).toHaveBeenCalledWith();
+		expect( result2 ).not.toBe( result1 );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the safari mitigation to remove the entire database instead of just clearing the objectStore
* Add a `clear` method to the memoize-last module, to allow the caller to clear out the last remembered value

#### Testing instructions

Testing instructions are more complicated this time around since we missed the still expanding WAL in the last attempt.

_To test this feature in Safari, you must disable cross-site tracking prevention_

Step 0: Safari -> Preferences -> Privacy -> Uncheck `Website Tracking: Prevent cross site tracking` 

* Load Calypso
* Open a Terminal window and find the place on disk where IndexedDB is stored. It's likely something like `~/Library/Safari/Databases/___IndexedDB/v1/http_calypso.localhost_3000/(hash)`
* Run an `ls -lh` and notice the various file sizes, especially the `IndexedDB.sqlite3-wal`
* Enable the new debug log with `localStorage.debug = 'calypso:browser-storage'` in the console
* Reload Calypso
* Verify that the mitigation is active in Safari 13, but not in other browsers
* Verify that the mitigation runs every now and again. It runs every 20 writes, so it'll take a few minutes of use to trigger it
* Recheck the `IndexedDB.sqlite3-wal` after a mitigation run. It should never be larger than ~10M. _You may need to leave and re-enter the folder under `v1` as Safari completely recreates the folder heirarchy_
* Check the Storage tab in the dev console and make sure entries appear for the calypso store in indexed db


Remember to re-enable cross-site tracking prevention when you're done!

Fixes #36858
