### PR TITLE
Concierge banner: Fix alignment in Safari browser

### DIFF
--- a/client/me/purchases/purchases-site/style.scss
+++ b/client/me/purchases/purchases-site/style.scss
@@ -45,7 +45,7 @@
 	&.card {
 		@include breakpoint( '>480px' ) {
 			padding: 10px;
-			align-items: center;
+			align-items: flex-start;
 		}
 	}
 

--- a/client/me/purchases/purchases-site/style.scss
+++ b/client/me/purchases/purchases-site/style.scss
@@ -45,6 +45,7 @@
 	&.card {
 		@include breakpoint( '>480px' ) {
 			padding: 10px;
+			align-items: center;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The concierge banner shown in /me/purchases page has an alignment issue in Safari, though it works well in Chrome / Firefox / Edge. This PR fixes the alignment issue.
* The issue appears to be due to Safari trying to take up the entire viewport height for the image in the concierge banner in a flexbox. I explored the option of using the css property `height:intrinsic` for the image on the concierge banner, but this property is still experimental(and not supported in other browsers). So, I've instead opted to go for an alignment fix. 

In Safari:

<img width="1450" alt="Screenshot 2020-02-04 at 6 24 02 PM" src="https://user-images.githubusercontent.com/1269602/73749312-25473b80-4781-11ea-89a1-466ac44de96b.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site that has a Business plan, open /me/purchases page in Safari browser. 
* Verify that the concierge banner appears in normal size as shown in the Before/After image above.
* Verify that the banner appears in normal size in Chrome / FF / IE.

Fixes #38877. Thanks @eltongo for reporting the issue. 
