### PR TITLE
Privacy: Add a success handler to privacy policy request

### DIFF
--- a/client/blocks/privacy-policy-banner/index.jsx
+++ b/client/blocks/privacy-policy-banner/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flowRight as compose, get, identity } from 'lodash';
+import { flowRight as compose, get, identity, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -32,6 +32,7 @@ const privacyPolicyQuery = {
 				method: 'GET',
 				path: '/privacy-policy',
 				apiNamespace: 'wpcom/v2',
+				onSuccess: noop,
 			} ),
 			{
 				fromApi: () => data => [


### PR DESCRIPTION
This PR fixes a warning in the console that appears on some pages. It was being caused by a missing success handler in the privacy policy request.

![](https://cldup.com/EET0hMSNfn.png)

#### Changes proposed in this Pull Request

* Privacy: Add a success handler to privacy policy request

#### Testing instructions

* Checkout this branch and build it.
* Go to http://calypso.localhost:3000/stats/day/:site where `:site` is one of your sites.
* Verify that the warning isn't logged in the browser console.
