### PR TITLE
Site Migration: Add option to submit the URL input with Enter key

### DIFF
--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -18,6 +18,14 @@ import Spinner from 'components/spinner';
 export default class SitesBlock extends Component {
 	state = {};
 
+	onSubmit = event => {
+		event.preventDefault();
+
+		this.props.onSubmit( event );
+
+		return false;
+	};
+
 	renderFauxSiteSelector() {
 		const { onUrlChange, url } = this.props;
 		const { error } = this.state;
@@ -30,7 +38,7 @@ export default class SitesBlock extends Component {
 						{ this.props.loadingSourceSite && <Spinner /> }
 					</div>
 					<div className="sites-block__faux-site-selector-info">
-						<form onSubmit={ this.props.onSubmit }>
+						<form onSubmit={ this.onSubmit }>
 							<FormLabel
 								className="sites-block__faux-site-selector-label"
 								htmlFor="sites-block__faux-site-selector-url-input"

--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -30,22 +30,24 @@ export default class SitesBlock extends Component {
 						{ this.props.loadingSourceSite && <Spinner /> }
 					</div>
 					<div className="sites-block__faux-site-selector-info">
-						<FormLabel
-							className="sites-block__faux-site-selector-label"
-							htmlFor="sites-block__faux-site-selector-url-input"
-						>
-							Import from...
-						</FormLabel>
-						<div className="sites-block__faux-site-selector-url">
-							<FormTextInput
-								isError={ isError }
-								onChange={ onUrlChange }
-								value={ url }
-								placeholder="example.com"
-								id="sites-block__faux-site-selector-url-input"
-								name="sites-block__faux-site-selector-url-input"
-							/>
-						</div>
+						<form onSubmit={ this.props.onSubmit }>
+							<FormLabel
+								className="sites-block__faux-site-selector-label"
+								htmlFor="sites-block__faux-site-selector-url-input"
+							>
+								Import from...
+							</FormLabel>
+							<div className="sites-block__faux-site-selector-url">
+								<FormTextInput
+									isError={ isError }
+									onChange={ onUrlChange }
+									value={ url }
+									placeholder="example.com"
+									id="sites-block__faux-site-selector-url-input"
+									name="sites-block__faux-site-selector-url-input"
+								/>
+							</div>
+						</form>
 					</div>
 				</div>
 			</div>
@@ -99,4 +101,6 @@ SitesBlock.propTypes = {
 	sourceSite: PropTypes.object,
 	loadingSourceSite: PropTypes.bool,
 	targetSite: PropTypes.object.isRequired,
+	onUrlChange: PropTypes.func,
+	onSubmit: PropTypes.func,
 };

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -93,6 +93,7 @@ class StepSourceSelect extends Component {
 					loadingSourceSite={ this.state.isLoading }
 					targetSite={ targetSite }
 					onUrlChange={ this.props.onUrlChange }
+					onSubmit={ this.handleContinue }
 				/>
 				<Card>
 					<Button busy={ this.state.isLoading } onClick={ this.handleContinue } primary={ true }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds the option to submit the URL input field with the Enter key. Previously we were only able to do that with the Continue button

#### Testing instructions

* Checkout branch or use Calypso.live link
* Go to Migration
* Enter URL
* Press enter
* The form should procceed
