### PR TITLE
Gutenboarding - pressing 'Enter' on site-title to advance flow.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/site-title.tsx
@@ -3,14 +3,15 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import React, { createRef, FunctionComponent, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import { __ as NO__ } from '@wordpress/i18n';
-
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../stores/onboard';
 import { StepProps } from './stepper-wizard';
 import Question from './question';
+import { Step } from '../steps';
 
 const SiteTitle: FunctionComponent< StepProps > = ( {
 	onSelect,
@@ -20,6 +21,7 @@ const SiteTitle: FunctionComponent< StepProps > = ( {
 } ) => {
 	const { siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
+	const history = useHistory();
 
 	const handleChange = ( e: React.ChangeEvent< HTMLInputElement > ) =>
 		setSiteTitle( e.target.value.trim().length ? e.target.value : '' );
@@ -35,8 +37,14 @@ const SiteTitle: FunctionComponent< StepProps > = ( {
 		}
 	}, [ isActive, inputRef ] );
 
+	// As last input on first step, hitting 'Enter' should direct to next step.
+	const handleSubmit = ( e: React.FormEvent< HTMLFormElement > ) => {
+		e.preventDefault();
+		history.push( Step.DesignSelection );
+	};
+
 	return (
-		<>
+		<form onSubmit={ handleSubmit }>
 			<Question label={ label } displayValue={ value } isActive={ isActive } onExpand={ onExpand }>
 				<input
 					ref={ inputRef }
@@ -47,7 +55,7 @@ const SiteTitle: FunctionComponent< StepProps > = ( {
 					value={ siteTitle }
 				/>
 			</Question>
-		</>
+		</form>
 	);
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Pressing 'Enter' / 'Return' on site-title will now advance the flow to the next step.

This was achieved by:
*  Wrapping the site-title in a <form> tag instead of empty fragment.
*  Set the form's `onSubmit` function to push history to the next step in the Gutenboarding flow (design selection).

Alternatively, we could have negated adding the <form> tag by applying a function to `onKeyDown` of the input element to listen for the 'enter' keyCode.  I figured form submit may allow for more robust usage across browsers and custom accessibility settings, but if there are other downsides to this that I did not think of we can look into the other approach.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR, start Gutenboarding.
* Verify pressing 'Enter' on the site-title input advances to the next step of Gutenboarding.

Fixes #39245
