### PR TITLE
Customer Home: Show All 90/10 A/B Test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,4 +124,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	customerHomeAll: {
+		datestamp: '20200204',
+		variations: {
+			showCustomerHome: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -125,12 +125,13 @@ export default {
 		allowExistingUsers: true,
 	},
 	customerHomeAll: {
-		datestamp: '20200204',
+		datestamp: '20200224',
 		variations: {
 			showCustomerHome: 50,
 			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -127,8 +127,8 @@ export default {
 	customerHomeAll: {
 		datestamp: '20200224',
 		variations: {
-			showCustomerHome: 50,
-			control: 50,
+			showCustomerHome: 10,
+			control: 90,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -30,7 +30,10 @@ import {
 } from 'lib/plans/constants';
 
 jest.mock( 'lib/analytics', () => ( {} ) );
-jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'lib/abtest', () => ( {
+	abtest: () => {},
+} ) );
 jest.mock( 'components/main', () => 'Main' );
 jest.mock( 'components/section-header', () => 'SectionHeader' );
 jest.mock( 'me/sidebar-navigation', () => 'MeSidebarNavigation' );

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -30,7 +30,7 @@ import {
 } from 'lib/plans/constants';
 
 jest.mock( 'lib/analytics', () => ( {} ) );
-jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => {},
 } ) );

--- a/client/state/sites/selectors/can-current-user-use-customer-home.js
+++ b/client/state/sites/selectors/can-current-user-use-customer-home.js
@@ -13,7 +13,7 @@ import isVipSite from 'state/selectors/is-vip-site';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getSite from './get-site';
-import config from 'config';
+import { abtest } from 'lib/abtest';
 
 /**
  * Returns true if the current user should be able to use the customer home screen
@@ -35,7 +35,7 @@ export default function canCurrentUserUseCustomerHome( state, siteId = null ) {
 		return false;
 	}
 
-	if ( ! config.isEnabled( 'home/all' ) ) {
+	if ( abtest( 'customerHomeAll' ) === 'control' ) {
 		const siteOptions = getSiteOptions( state, siteId );
 		const createdAt = get( siteOptions, 'created_at', '' );
 

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -34,7 +34,6 @@
 		"google-my-business": false,
 		"help": true,
 		"help/courses": true,
-		"home/all": false,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/development.json
+++ b/config/development.json
@@ -65,7 +65,6 @@
 		"gutenboarding": true,
 		"help": true,
 		"help/courses": true,
-		"home/all": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,
 		"ive/me": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -38,7 +38,6 @@
 		"happychat": false,
 		"help": true,
 		"help/courses": true,
-		"home/all": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -37,7 +37,6 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"home/all": false,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,7 +38,6 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"home/all": false,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/test.json
+++ b/config/test.json
@@ -37,7 +37,6 @@
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"help": true,
-		"home/all": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -47,7 +47,6 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"home/all": false,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,


### PR DESCRIPTION
This PR removes the 'home/all' feature flag, and adds a 'customerHomeAll' A/B test set to 90% control, 10% active test. If a user rolls the `control` variant, display of Customer Home in the sidebar for a Simple or Atomic site is determined by if the site was created after Aug 2019.

| Control  | showCustomerHome |
| ------------- | ------------- |
| <img width="1235" alt="Screen Shot 2020-02-04 at 1 32 21 PM" src="https://user-images.githubusercontent.com/1270189/73789392-8e17bf00-4753-11ea-955a-58df9f8e44a2.png"> | <img width="1238" alt="Screen Shot 2020-02-04 at 1 32 52 PM" src="https://user-images.githubusercontent.com/1270189/73789416-966ffa00-4753-11ea-9dea-2728b6d3efab.png"> |

Do Not Merge Until
- [x] We confirm that `redirectToCustomerHome` test is no longer running.
- [x] We prep server patches to match masterbar sidebar a/b test
- [x] We update the A/B test start date
  
#### Testing instructions
- On a Simple Site created before Aug 2019, verify that Customer Home appears with `showCustomerHome` selected
- On a Simple Site created before Aug 2019, verify that Customer Home does not appear with `control` selected
- On an Atomic Site created before Aug 2019, verify that Customer Home appears with `showCustomerHome` selected
- On an Atomic Site created before Aug 2019, verify that Customer Home does not appear with `control` selected
- This section never displays for VIP or Standalone Jetpack

Fixes #39184

p58i-8wf-p2
p8Eqe3-15Y-p2