### PR TITLE
[reCaptcha v3]: recaptcha in signup

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -96,6 +96,7 @@ class SignupForm extends Component {
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
 		positionInFlow: PropTypes.number,
+		recaptchaClientId: PropTypes.number,
 		save: PropTypes.func,
 		signupDependencies: PropTypes.object,
 		step: PropTypes.object,
@@ -103,6 +104,7 @@ class SignupForm extends Component {
 		submitting: PropTypes.bool,
 		suggestedUsername: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+		showRecaptchaToS: PropTypes.bool,
 
 		// Connected props
 		oauth2Client: PropTypes.object,
@@ -114,6 +116,7 @@ class SignupForm extends Component {
 		displayUsernameInput: true,
 		flowName: '',
 		isSocialSignupEnabled: false,
+		showRecaptchaToS: false,
 	};
 
 	state = {
@@ -830,7 +833,7 @@ class SignupForm extends Component {
 	}
 
 	footerLink() {
-		const { flowName, translate } = this.props;
+		const { flowName, showRecaptchaToS, translate } = this.props;
 
 		const logInUrl = config.isEnabled( 'login/native-login-links' )
 			? this.getLoginLink()
@@ -851,6 +854,25 @@ class SignupForm extends Component {
 						/>
 					) }
 				</LoggedOutFormLinks>
+				{ showRecaptchaToS && (
+					<div className="signup-form__recaptcha-tos">
+						<LoggedOutFormLinks>
+							<p>
+								{ translate(
+									'This site is protected by reCAPTCHA and the Google {{a1}}Privacy Policy{{/a1}} and {{a2}}Terms of Service{{/a2}} apply.',
+									{
+										components: {
+											a1: <a href="https://policies.google.com/privacy" />,
+											a2: <a href="https://policies.google.com/terms" />,
+										},
+										comment:
+											'English wording comes from Google: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed',
+									}
+								) }
+							</p>
+						</LoggedOutFormLinks>
+					</div>
+				) }
 			</>
 		);
 	}
@@ -943,7 +965,11 @@ class SignupForm extends Component {
 				: localizeUrl( config( 'login_url' ), this.props.locale );
 
 			return (
-				<div className={ classNames( 'signup-form', this.props.className ) }>
+				<div
+					className={ classNames( 'signup-form', this.props.className, {
+						'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
+					} ) }
+				>
 					{ this.getNotice() }
 					<PasswordlessSignupForm
 						step={ this.props.step }
@@ -954,6 +980,7 @@ class SignupForm extends Component {
 						logInUrl={ logInUrl }
 						disabled={ this.props.disabled }
 						disableSubmitButton={ this.props.disableSubmitButton }
+						recaptchaClientId={ this.props.recaptchaClientId }
 					/>
 					{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
 						<SocialSignupForm
@@ -969,7 +996,11 @@ class SignupForm extends Component {
 		}
 
 		return (
-			<div className={ classNames( 'signup-form', this.props.className ) }>
+			<div
+				className={ classNames( 'signup-form', this.props.className, {
+					'is-showing-recaptcha-tos': this.props.showRecaptchaToS,
+				} ) }
+			>
 				{ this.getNotice() }
 
 				<LoggedOutForm onSubmit={ this.handleSubmit } noValidate={ true }>

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -10,10 +10,11 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getSavedVariations } from 'lib/abtest';
+import { abtest, getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
 import { recordPasswordlessRegistration } from 'lib/analytics/signup';
+import { recordGoogleRecaptchaAction } from 'lib/analytics/recaptcha';
 import { Button } from '@automattic/components';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
@@ -78,10 +79,34 @@ class PasswordlessSignupForm extends Component {
 			form,
 		} );
 
+		const isRecaptchaLoaded = typeof this.props.recaptchaClientId === 'number';
+		const isRecaptchaABTest =
+			'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' );
+
+		let recaptchaToken = undefined;
+		let recaptchaError = undefined;
+
+		if ( isRecaptchaABTest ) {
+			if ( isRecaptchaLoaded ) {
+				recaptchaToken = await recordGoogleRecaptchaAction(
+					this.props.recaptchaClientId,
+					'calypso/signup/formSubmit'
+				);
+
+				if ( ! recaptchaToken ) {
+					recaptchaError = 'recaptcha_failed';
+				}
+			} else {
+				recaptchaError = 'recaptcha_didnt_load';
+			}
+		}
+
 		try {
 			const response = await wpcom.undocumented().usersNew(
 				{
 					email: typeof this.state.email === 'string' ? this.state.email.trim() : '',
+					'g-recaptcha-error': recaptchaError,
+					'g-recaptcha-response': recaptchaToken || undefined,
 					is_passwordless: true,
 					signup_flow_name: this.props.flowName,
 					validate: false,

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { abtest, getSavedVariations } from 'lib/abtest';
+import { getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
 import { recordPasswordlessRegistration } from 'lib/analytics/signup';
@@ -80,13 +80,11 @@ class PasswordlessSignupForm extends Component {
 		} );
 
 		const isRecaptchaLoaded = typeof this.props.recaptchaClientId === 'number';
-		const isRecaptchaABTest =
-			'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' );
 
 		let recaptchaToken = undefined;
 		let recaptchaError = undefined;
 
-		if ( isRecaptchaABTest ) {
+		if ( 'onboarding' === this.props.flowName ) {
 			if ( isRecaptchaLoaded ) {
 				recaptchaToken = await recordGoogleRecaptchaAction(
 					this.props.recaptchaClientId,

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -24,6 +24,7 @@ import ValidationFieldset from 'signup/validation-fieldset';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Notice from 'components/notice';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
+import flows from 'signup/config/flows';
 
 class PasswordlessSignupForm extends Component {
 	static propTypes = {
@@ -84,7 +85,7 @@ class PasswordlessSignupForm extends Component {
 		let recaptchaToken = undefined;
 		let recaptchaError = undefined;
 
-		if ( 'onboarding' === this.props.flowName ) {
+		if ( flows.getFlow( this.props.flowName )?.showRecaptcha ) {
 			if ( isRecaptchaLoaded ) {
 				recaptchaToken = await recordGoogleRecaptchaAction(
 					this.props.recaptchaClientId,

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -72,3 +72,43 @@
 		min-height: auto;
 	}
 }
+
+.signup-form__recaptcha-tos {
+	display: none;
+	padding: 20px 10px 10px;
+	font-size: 13px;
+	color: var( --studio-blue-5 );
+	text-align: center;
+
+	p {
+		margin: 0;
+		padding-top: 9px;
+	}
+
+	a {
+		color: var( --studio-blue-5 );
+		text-decoration: underline;
+	}
+}
+
+// Replace recaptcha badge with ToS text and space
+// everything out a little more.
+@media ( max-width: 660px ) {
+	.signup-form__recaptcha-tos {
+		display: block;
+	}
+
+	.grecaptcha-badge {
+		visibility: hidden;
+	}
+
+	.signup-form.is-showing-recaptcha-tos {
+		.signup-form__social {
+			padding-bottom: 28px;
+		}
+
+		.logged-out-form__links::before {
+			margin-bottom: 16px;
+		}
+	}
+}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -156,13 +156,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	userStepRecaptcha: {
-		datestamp: '20191111',
-		variations: {
-			show: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -156,4 +156,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	userStepRecaptcha: {
+		datestamp: '20191111',
+		variations: {
+			show: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/analytics/recaptcha.js
+++ b/client/lib/analytics/recaptcha.js
@@ -1,0 +1,127 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { loadScript } from '@automattic/load-script';
+
+const debug = debugFactory( 'calypso:analytics:recaptcha' );
+
+const GOOGLE_RECAPTCHA_SCRIPT_URL = 'https://www.google.com/recaptcha/api.js?render=explicit';
+
+/**
+ * Loads Google reCAPTCHA
+ *
+ * @returns {boolean} false if the script failed to load
+ */
+async function loadGoogleRecaptchaScript() {
+	if ( window.grecaptcha ) {
+		// reCAPTCHA already loaded
+		return true;
+	}
+
+	try {
+		const src = GOOGLE_RECAPTCHA_SCRIPT_URL;
+		await loadScript( src );
+		debug( 'loadGoogleRecaptchaScript: [Loaded]', src );
+		return true;
+	} catch ( error ) {
+		debug( 'loadGoogleRecaptchaScript: [Load Error] the script failed to load: ', error );
+		return false;
+	}
+}
+
+/**
+ * Renders reCAPTCHA badge to an explicit DOM id that should already be on the page
+ *
+ * @param {string} elementId - render client to this existing DOM node
+ * @param {string} siteKey - reCAPTCHA site key
+ * @returns {number} reCAPTCHA clientId
+ */
+async function renderRecaptchaClient( elementId, siteKey ) {
+	try {
+		const clientId = await window.grecaptcha.render( elementId, {
+			sitekey: siteKey,
+			size: 'invisible',
+		} );
+		debug( 'renderRecaptchaClient: [Success]', elementId );
+		return clientId;
+	} catch ( error ) {
+		debug( 'renderRecaptchaClient: [Error]', error );
+		return null;
+	}
+}
+
+/**
+ * Records an arbitrary action to Google reCAPTCHA
+ *
+ * @param {number} clientId - a clientId of the reCAPTCHA instance
+ * @param {string} action  - name of action to record in reCAPTCHA
+ */
+export async function recordGoogleRecaptchaAction( clientId, action ) {
+	if ( ! window.grecaptcha ) {
+		debug(
+			'recordGoogleRecaptchaAction: [Error] window.grecaptcha not defined. Did you forget to init?'
+		);
+		return null;
+	}
+
+	try {
+		const token = await window.grecaptcha.execute( clientId, { action } );
+		debug( 'recordGoogleRecaptchaAction: [Success]', action, token, clientId );
+		return token;
+	} catch ( error ) {
+		debug( 'recordGoogleRecaptchaAction: [Error]', action, error );
+		return null;
+	}
+}
+
+/**
+ * @typedef RecaptchaActionResult
+ * @property {string} token
+ * @property {number} clientId
+ */
+
+/**
+ * Records reCAPTCHA action, loading Google script if necessary.
+ *
+ * @param {string} elementId - a DOM id in which to render the reCAPTCHA client
+ * @param {string} action - name of action to record in reCAPTCHA
+ * @param {string} siteKey - reCAPTCHA site key
+ *
+ * @returns {RecaptchaActionResult|null} either the reCAPTCHA token and clientId, or null if the function fails
+ */
+export async function initGoogleRecaptcha( elementId, action, siteKey ) {
+	if ( ! siteKey ) {
+		return null;
+	}
+
+	if ( ! ( await loadGoogleRecaptchaScript() ) ) {
+		return null;
+	}
+
+	await new Promise( resolve => window.grecaptcha.ready( resolve ) );
+
+	try {
+		const clientId = await renderRecaptchaClient( elementId, siteKey );
+		if ( clientId == null ) {
+			return null;
+		}
+
+		const token = await recordGoogleRecaptchaAction( clientId, action );
+		if ( token == null ) {
+			return null;
+		}
+
+		debug( 'initGoogleRecaptcha: [Success]', action, token, clientId );
+		return { token, clientId };
+	} catch ( error ) {
+		// We don't want errors interrupting our flow, so convert any exceptions
+		// into return values.
+		debug( 'initGoogleRecaptcha: [Error]', action, error );
+		return null;
+	}
+}

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -382,7 +382,18 @@ export function launchSiteApi( callback, dependencies ) {
 export function createAccount(
 	callback,
 	dependencies,
-	{ userData, flowName, queryArgs, service, access_token, id_token, oauth2Signup },
+	{
+		userData,
+		flowName,
+		queryArgs,
+		service,
+		access_token,
+		id_token,
+		oauth2Signup,
+		recaptchaDidntLoad,
+		recaptchaFailed,
+		recaptchaToken,
+	},
 	reduxStore
 ) {
 	const state = reduxStore.getState();
@@ -449,7 +460,10 @@ export function createAccount(
 							// convert to legacy oauth2_redirect format: %s@https://public-api.wordpress.com/oauth2/authorize/...
 							oauth2_redirect: queryArgs.oauth2_redirect && '0@' + queryArgs.oauth2_redirect,
 					  }
-					: null
+					: null,
+				recaptchaDidntLoad ? { 'g-recaptcha-error': 'recaptcha_didnt_load' } : null,
+				recaptchaFailed ? { 'g-recaptcha-error': 'recaptcha_failed' } : null,
+				recaptchaToken ? { 'g-recaptcha-response': recaptchaToken } : null
 			),
 			( error, response ) => {
 				const errors =

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -131,7 +131,8 @@ export function generateFlows( {
 			],
 			destination: getSignupDestination,
 			description: 'The improved onboarding flow.',
-			lastModified: '2019-06-20',
+			lastModified: '2020-02-05',
+			showRecaptcha: true,
 		},
 
 		desktop: {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -11,7 +11,6 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import StepWrapper from 'signup/step-wrapper';
 import SignupForm from 'blocks/signup-form';
@@ -76,7 +75,7 @@ export class UserStep extends Component {
 	}
 
 	componentDidMount() {
-		if ( 'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' ) ) {
+		if ( 'onboarding' === this.props.flowName ) {
 			this.initGoogleRecaptcha();
 		}
 
@@ -209,14 +208,12 @@ export class UserStep extends Component {
 		this.props.recordTracksEvent( 'calypso_signup_user_step_submit', analyticsData );
 
 		const isRecaptchaLoaded = typeof this.state.recaptchaClientId === 'number';
-		const isRecaptchaABTest =
-			'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' );
 
 		let recaptchaToken = undefined;
 		let recaptchaDidntLoad = false;
 		let recaptchaFailed = false;
 
-		if ( isRecaptchaABTest ) {
+		if ( 'onboarding' === this.props.flowName ) {
 			if ( isRecaptchaLoaded ) {
 				recaptchaToken = await recordGoogleRecaptchaAction(
 					this.state.recaptchaClientId,
@@ -391,9 +388,7 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
-					showRecaptchaToS={
-						'onboarding' === this.props.flowName && 'show' === abtest( 'userStepRecaptcha' )
-					}
+					showRecaptchaToS={ 'onboarding' === this.props.flowName }
 				/>
 				<div id="g-recaptcha"></div>
 			</>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
  */
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import StepWrapper from 'signup/step-wrapper';
+import flows from 'signup/config/flows';
 import SignupForm from 'blocks/signup-form';
 import { getFlowSteps, getNextStepName, getPreviousStepName, getStepUrl } from 'signup/utils';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
@@ -75,7 +76,7 @@ export class UserStep extends Component {
 	}
 
 	componentDidMount() {
-		if ( 'onboarding' === this.props.flowName ) {
+		if ( flows.getFlow( this.props.flowName )?.showRecaptcha ) {
 			this.initGoogleRecaptcha();
 		}
 
@@ -213,7 +214,7 @@ export class UserStep extends Component {
 		let recaptchaDidntLoad = false;
 		let recaptchaFailed = false;
 
-		if ( 'onboarding' === this.props.flowName ) {
+		if ( flows.getFlow( this.props.flowName )?.showRecaptcha ) {
 			if ( isRecaptchaLoaded ) {
 				recaptchaToken = await recordGoogleRecaptchaAction(
 					this.state.recaptchaClientId,
@@ -388,7 +389,7 @@ export class UserStep extends Component {
 					socialService={ socialService }
 					socialServiceResponse={ socialServiceResponse }
 					recaptchaClientId={ this.state.recaptchaClientId }
-					showRecaptchaToS={ 'onboarding' === this.props.flowName }
+					showRecaptchaToS={ flows.getFlow( this.props.flowName )?.showRecaptcha }
 				/>
 				<div id="g-recaptcha"></div>
 			</>

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -18,6 +18,7 @@
 	"facebook_api_key": false,
 	"features": {},
 	"google_analytics_key": false,
+	"google_recaptcha_site_key": false,
 	"hotjar_enabled": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -130,5 +130,6 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "desktop",
 	"google_analytics_key": "UA-10673494-10",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/config/development.json
+++ b/config/development.json
@@ -17,6 +17,7 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_key": "UA-10673494-15",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -125,5 +125,6 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "horizon",
 	"google_analytics_key": "UA-10673494-20",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/config/production.json
+++ b/config/production.json
@@ -159,5 +159,6 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "production",
 	"google_analytics_key": "UA-10673494-10",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }

--- a/config/stage.json
+++ b/config/stage.json
@@ -157,6 +157,7 @@
 	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"mc_analytics_enabled": false,
 	"google_analytics_key": "UA-10673494-15",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"boom_analytics_enabled": true,
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "stage",

--- a/config/test.json
+++ b/config/test.json
@@ -15,6 +15,7 @@
 	"server_side_boom_analytics_enabled": false,
 	"boom_analytics_key": "development",
 	"google_analytics_key": "UA-10673494-15",
+	"google_recaptcha_site_key": "",
 	"hotjar_enabled": true,
 	"signup_url": "/start",
 	"login_url": "https://wordpress.com/wp-login.php",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -177,5 +177,6 @@
 	"server_side_boom_analytics_enabled": true,
 	"boom_analytics_key": "wpcalypso",
 	"google_analytics_key": "UA-10673494-15",
+	"google_recaptcha_site_key": "6LdoXcAUAAAAAM61KvdgP8xwnC19YuzAiOWn5Wtn",
 	"hotjar_enabled": true
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reverts 77318c9b32568459aeb80639f8e01a137b3a5ee1 (thus re-adding recaptcha code)
* Remove the `userStepRecaptcha` AB test (which was part of the code we just reverted) and show all users the `show` variation
* Add a new `showRecaptcha` flow config to `flows-pure.js` so it's easier to enable/disable for other flows.

Fixes #39267 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Need to test that the correct recaptcha properties appear in tracks events for the onboarding flow i.e. signup will record a `wpcom_recaptcha_response_verified` event with `recaptcha_likely_good` and `recaptcha_score` properties.

Also need to test the case where users have blocked the Google script.

To test blocking the Google script I used a the ScriptBlock extension. After navigating to `/start/user` for the first time you need to click the extension's icon in the top-right to allow `calypso.localhost` and `wordpress.com` scripts before the page will load correctly.
https://chrome.google.com/webstore/detail/scriptblock/hcdjknjpbnhdoabbngpmfekaecnpajba?hl=en

When testing filter the network tab by `users/new` and check the `g-recaptcha-response` param is sent when it's supposed to be.

Cases to test:
1. **Passwordless** signup with **onboarding** flow and 3rd party script **allowed**
2. **Passwordful** signup with **onboarding** flow and 3rd party script **allowed**
3. **Passwordful** signup with a **different flow** and 3rd party script **allowed**
4. **Passwordless** signup with **onboarding** flow and 3rd party script **blocked**
5. **Passwordful** signup with **onboarding** flow and 3rd party script **blocked**
6. **Passwordful** signup with a **different flow** and 3rd party script **blocked**
