### PR TITLE
G Suite: Change the G Suite Settings link title to Email Settings and the link URL to the corresponding page

### DIFF
--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -11,7 +11,6 @@ import {
 	GSUITE_BASIC_SLUG,
 	GSUITE_BUSINESS_SLUG,
 	GSUITE_EXTRA_LICENSE_SLUG,
-	GSUITE_LINK_PREFIX
 } from 'lib/gsuite/constants';
 import { isMappedDomainWithWpcomNameservers, isRegisteredDomain } from 'lib/domains';
 import userFactory from 'lib/user';
@@ -162,16 +161,6 @@ function getMonthlyPrice( cost, currencyCode, defaultValue = '-' ) {
 }
 
 /**
- * Returns G Suite management url
- *
- * @param {string} domainName - domain name
- * @returns {string} - Returns G Suite settings url
- */
-function getGSuiteSettingsUrl( domainName ) {
-	return GSUITE_LINK_PREFIX + domainName;
-}
-
-/**
  * Given a domain object, does that domain have G Suite with us.
  *
  * @param {object} domain - domain object
@@ -260,7 +249,6 @@ export {
 	canDomainAddGSuite,
 	getAnnualPrice,
 	getEligibleGSuiteDomain,
-	getGSuiteSettingsUrl,
 	getGSuiteSupportedDomains,
 	getLoginUrlWithTOSRedirect,
 	getMonthlyPrice,

--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -12,8 +12,8 @@ import i18n from 'i18n-calypso';
  */
 import config from 'config';
 import { domainManagementEdit } from 'my-sites/domains/paths';
+import { emailManagement } from 'my-sites/email/paths';
 import { getThemeDetailsUrl } from 'state/themes/selectors';
-import { getGSuiteSettingsUrl } from 'lib/gsuite';
 import {
 	isDomainProduct,
 	isGoogleApps,
@@ -42,8 +42,8 @@ const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
 	}
 
 	if ( isGoogleApps( purchase ) ) {
-		url = getGSuiteSettingsUrl( purchase.meta );
-		text = i18n.translate( 'G Suite Settings' );
+		url = emailManagement( selectedSite.slug, purchase.meta );
+		text = i18n.translate( 'Email Settings' );
 	}
 
 	if ( isTheme( purchase ) ) {


### PR DESCRIPTION
The `G Suite Settings` link situated in the `Manage Purchases` section points to the external G Suite management URL. To create a better experience and provide consistency, the settings link is renamed to `Email Settings` and points to the corresponding `Email` page similar to the situation for domains.

Before | After
---|---
<img alt="Before" src="https://user-images.githubusercontent.com/277661/73814375-26a95000-47e3-11ea-9bbf-9fc036f574e7.png">|<img alt="After" src="https://user-images.githubusercontent.com/277661/73814390-332da880-47e3-11ea-9bb0-11da67325a68.png">




#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch in a development server
* Visit the [manage purchases](http://calypso.localhost:3000/me/purchases) page
* Click on a G Suite subscription 
* Confirm that the `G Suite Settings` title now reads `Email Settings`
* Confirm that the link takes you to the corresponding `Email` page for the site/domain

