### PR TITLE
G Suite: Enable customers with Atomic Sites to self-cancel their G Suite account

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -272,10 +272,6 @@ class RemovePurchase extends Component {
 			return this.renderPlanDialog();
 		}
 
-		if ( this.props.isAtomicSite ) {
-			return this.renderAtomicDialog( purchase );
-		}
-
 		if ( isGoogleApps( purchase ) ) {
 			return (
 				<GSuiteCancellationPurchaseDialog
@@ -285,6 +281,10 @@ class RemovePurchase extends Component {
 					site={ this.props.site }
 				/>
 			);
+		}
+
+		if ( this.props.isAtomicSite ) {
+			return this.renderAtomicDialog( purchase );
 		}
 
 		return this.renderPlanDialog();


### PR DESCRIPTION
Atomic sites were not able to cancel their G Suite accounts without reaching out to support. Attempting to do so will prompt this dialog.

![screen-shot-on-2020-01-27-at-192552](https://user-images.githubusercontent.com/277661/73817738-ff0ab580-47eb-11ea-8989-59d5bf979e02.png)

#### Fixes

The restriction is removed so that G Suite can be canceled without support or HEs.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an Atomic site (i.e. create or upgrade your WP.com account to the **Business** plan or higher ).
Ensure your site is launched/public, and that the hosting configuration is activated. 
* Create or access a  G Suite account in **Manage Purchases**
* Confirm that you are presented with the dialog when you attempt to remove the account
* Checkout this branch
* Confirm that a subsequent attempt to remove the account is successful and that the dialog is no longer presented to you.




