### PR TITLE
Enable domain step design update test for test environments

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -156,4 +156,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	domainStepDesignUpdates: {
+		datestamp: '20200205',
+		variations: {
+			variantDesignUpdates: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -50,6 +50,7 @@ import { fetchUsernameSuggestion } from 'state/signup/optional-dependencies/acti
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
 import { hideSitePreview, showSitePreview } from 'state/signup/preview/actions';
 import { abtest } from 'lib/abtest';
+import config from 'config';
 
 /**
  * Style dependencies
@@ -121,6 +122,7 @@ class DomainsStep extends React.Component {
 		}
 
 		this.showTestCopy = false;
+		this.showDesignUpdate = false;
 
 		// Do not assign user to the test if either in the launch flow or in /start/{PLAN_SLUG} flow
 		if (
@@ -128,7 +130,14 @@ class DomainsStep extends React.Component {
 			! props.isPlanStepFulfilled &&
 			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
 		) {
-			this.showTestCopy = true;
+			if (
+				config.isEnabled( 'domain-step-design-update-v2' ) &&
+				'variantDesignUpdates' === abtest( 'domainStepDesignUpdates' )
+			) {
+				this.showDesignUpdate = true;
+			} else {
+				this.showTestCopy = true;
+			}
 		}
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -53,6 +53,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"domain-step-design-update-v2": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,6 +38,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"domain-step-design-update-v2": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR creates a new A/B test for the domain copy updates changes as described in pbAok1-7N-p2.
* There's nothing more happening here other than enabling the config flag and the A/B test. 

**What next**

Subsequent UI updates will be built on top of this. Check back later to see the referenced PRs below(scroll right down to the bottom) to see all the smaller tasks that build each piece of the UI update. When all the smaller pieces are finished, then a new PR that removes the feature flag will be deployed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR introduces no UI changes, so everything should work just as before. Only change is that in `dev` and `wpcalypso` environments, user will get assigned to a new AB test when they reach the domain step in signup flow. 

**In dev or wpcalypso environments**

Use http://calypso.localhost:3000/ URL for **dev** environment or https://calypso.live/?branch=add/domain-step-signup-v2-abtest for **wpcalypso** environment.

1. Go through the signup flow by navigating to http://calypso.localhost:3000/start or https://calypso.live/start?branch=add/domain-step-signup-v2-abtest. Once you reach the domain step, verify that you get assigned to two tests - `domainStepCopyUpdates` and `domainStepDesignUpdates`. You can verify this by typing `localStorage.ABTests;` in your browser console. 
2. Verify the following:
    - If in the `control` group of `domainStepCopyUpdates`, no change in behaviour i.e you will see the [original domain step UI](https://user-images.githubusercontent.com/1269602/73847042-84718280-484b-11ea-9fe1-1ca43fafb47a.png). 
    - If in the variant of `domainStepCopyUpdates`, the domain step UI will depend on the other test:
        - If in `control` group of `domainStepDesignUpdates`, then you will see the new domain step UI introduced in #37661(check screenshots in that PR)
        - If in the variant of `domainStepDesignUpdates`, then you will see the [original domain step UI](https://user-images.githubusercontent.com/1269602/73847042-84718280-484b-11ea-9fe1-1ca43fafb47a.png).
3. Verify that you are able to complete signup. 

**In production environment**

There should be no change in behaviour since we are hiding the new AB test behind a feature flag.
To simulate the production environment, we will turn off the `domain-step-design-update-v2` feature flag in the URL.

1. Go through the signup flow by navigating to http://calypso.localhost:3000/start?flags=-domain-step-design-update-v2 or if using calypso.live URL, append `?flags=-domain-step-design-update-v2` to the hashed calypso.live link e.g: https://hash-ed3926da93141d2ed4ab69328cdf577f828561d8.calypso.live/start?flags=-domain-step-design-update-v2
2. In the domain step, you should be assigned to only `domainStepCopyUpdates` test and should not be assigned to `domainStepDesignUpdates`. 
3. Verify that you can complete signup.

Fixes 192-gh-martech