### PR TITLE
Renovate: Fix team reviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
 			"extends": "monorepo:wordpress",
 			"separateMajorMinor": false,
 			"prPriority": 2,
-			"reviewers": [ "team:@Automattic/cylon", "team:@Automattic/ganon", "team:@Automattic/luna" ]
+			"reviewers": [ "team:Automattic/cylon", "team:Automattic/ganon", "team:Automattic/luna" ]
 		},
 		{
 			"extends": "monorepo:babel",

--- a/renovate.json
+++ b/renovate.json
@@ -10,11 +10,7 @@
 			"extends": "monorepo:wordpress",
 			"separateMajorMinor": false,
 			"prPriority": 2,
-			"reviewers": [
-				"@Automattic/cylon",
-				"@Automattic/ganon",
-				"@Automattic/luna"
-			]
+			"reviewers": [ "team:@Automattic/cylon", "team:@Automattic/ganon", "team:@Automattic/luna" ]
 		},
 		{
 			"extends": "monorepo:babel",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add required `team:` prefix to reviewers.

https://docs.renovatebot.com/configuration-options/#reviewers