### PR TITLE
Update babel-plugin-i18n-calypso to support string extraction from @wordpress/i18n calls

### DIFF
--- a/packages/babel-plugin-i18n-calypso/README.md
+++ b/packages/babel-plugin-i18n-calypso/README.md
@@ -1,3 +1,20 @@
 # Babel plugin i18n Calypso
 
-A Babel plugin to generate a POT file for translate calls.
+A Babel plugin to generate a POT file for translate calls. Works with [i18n-calypso](https://www.npmjs.com/package/i18n-calypso) `translate` and [@wordpress/i18n](https://www.npmjs.com/package/@wordpress/i18n) `__`, `_n`, `_x`, `_nx` calls.
+
+## Usage
+
+Include in your Babel configuration as a plugin.
+
+Example Babel config file:
+
+```json
+{
+	"plugins": [ "@automattic/babel-plugin-i18n-calypso" ]
+}
+```
+
+## Options
+
+- `dir` - Set the output directory for the POT files.
+- `base` - Set a base path that will be used as a base for the relative path to the source file in the reference comment.

--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-i18n-calypso",
-	"version": "1.0.3",
+	"version": "1.1.0",
 	"description": "A Babel plugin to generate a POT file for translate calls",
 	"main": "src/index.js",
 	"dependencies": {

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -1,5 +1,6 @@
 /**
- * Extract i18n-calypso `translate` calls into a POT file.
+ * Extract i18n-calypso `translate` and @wordpress/i18n `__`, `_n`, `_x`, `_nx`
+ * calls into a POT file.
  *
  * Credits:
  *
@@ -119,9 +120,7 @@ function isValidFunctionName( name ) {
  * @returns {boolean} Whether key is valid for assignment.
  */
 function isValidTranslationKey( key ) {
-	return Object.values( DEFAULT_FUNCTIONS_ARGUMENTS_ORDER ).some(
-		args => args.includes( key )
-	);
+	return Object.values( DEFAULT_FUNCTIONS_ARGUMENTS_ORDER ).some( args => args.includes( key ) );
 }
 
 module.exports = function() {

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -212,9 +212,9 @@ module.exports = function() {
 					path.node.arguments.slice( i ).forEach( ( arg, index ) => {
 						const key = functionKeys[ index ];
 
-						if ( 'options_object' === key && arg.properties ) {
+						if ( 'ObjectExpression' === arg.type ) {
 							arg.properties.forEach( property => {
-								if ( ! 'ObjectProperty' !== property.type ) {
+								if ( 'ObjectProperty' !== property.type ) {
 									return;
 								}
 

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -128,20 +128,17 @@ module.exports = function() {
 	return {
 		visitor: {
 			ImportDeclaration( path ) {
-				// Set functions.__ as reference to functions.translate if
-				// `translate` from  `i18n-calypso`` is aliased as `__`.
-				if (
-					'i18n-calypso' === path.node.source.value &&
-					path.node.specifiers.some(
-						specifier =>
-							specifier.imported &&
-							specifier.local &&
-							'translate' === specifier.imported.name &&
-							'__' === specifier.local.name
-					)
-				) {
-					functions.__ = functions.translate;
+				// If `translate` from  `i18n-calypso`` is imported with an
+				// alias, set the specified alias as a reference to translate.
+				if ( 'i18n-calypso' !== path.node.source.value ) {
+					return;
 				}
+
+				path.node.specifiers.forEach( specifier => {
+					if ( specifier.imported && 'translate' === specifier.imported.name && specifier.local ) {
+						functions[ specifier.local.name ] = functions.translate;
+					}
+				} );
 			},
 
 			CallExpression( path, state ) {

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -57,20 +57,6 @@ const DEFAULT_HEADERS = {
 const DEFAULT_DIR = 'build/';
 
 /**
- * List of translate function to be handled for string extraction.
- *
- * @type {string[]}
- */
-const TRANSLATE_FUNCTION_NAMES = [ '__', '_n', '_nx', '_x', 'translate' ];
-
-/**
- * Set of keys which are valid to be assigned into a translation object.
- *
- * @type {string[]}
- */
-const VALID_TRANSLATION_KEYS = [ 'msgid_plural', 'msgctxt' ];
-
-/**
  * The order of arguments in translate functions.
  *
  * @type {object}
@@ -109,6 +95,17 @@ function getNodeAsString( node ) {
 }
 
 /**
+ * Returns true if the specified funciton name is valid translate function name
+ *
+ * @param {string} name Function name to test.
+ *
+ * @returns {boolean} Whether function name is valid translate function name.
+ */
+function isValidFunctionName( name ) {
+	return -1 !== Object.keys( DEFAULT_FUNCTIONS_ARGUMENTS_ORDER ).indexOf( name );
+}
+
+/**
  * Returns true if the specified key of a function is valid for assignment in
  * the translation object.
  *
@@ -117,7 +114,9 @@ function getNodeAsString( node ) {
  * @returns {boolean} Whether key is valid for assignment.
  */
 function isValidTranslationKey( key ) {
-	return -1 !== VALID_TRANSLATION_KEYS.indexOf( key );
+	return Object.values( DEFAULT_FUNCTIONS_ARGUMENTS_ORDER ).some(
+		args => -1 !== args.indexOf( key )
+	);
 }
 
 module.exports = function() {
@@ -155,7 +154,7 @@ module.exports = function() {
 				} else {
 					name = callee.name;
 				}
-				if ( ! TRANSLATE_FUNCTION_NAMES.includes( name ) ) {
+				if ( ! isValidFunctionName( name ) ) {
 					return;
 				}
 				let i = 0;
@@ -213,7 +212,7 @@ module.exports = function() {
 					path.node.arguments.slice( i ).forEach( ( arg, index ) => {
 						const key = functionKeys[ index ];
 
-						if ( 'options_object' === key ) {
+						if ( 'options_object' === key && arg.properties ) {
 							arg.properties.forEach( property => {
 								if ( ! 'ObjectProperty' !== property.type ) {
 									return;

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -257,7 +257,11 @@ module.exports = function() {
 
 				if ( ! strings[ msgctxt ].hasOwnProperty( msgid ) ) {
 					strings[ msgctxt ][ msgid ] = translation;
-				} else {
+				} else if (
+					! strings[ msgctxt ][ msgid ].comments.reference.includes(
+						translation.comments.reference
+					)
+				) {
 					strings[ msgctxt ][ msgid ].comments.reference += '\n' + translation.comments.reference;
 				}
 			},

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -147,9 +147,9 @@ module.exports = function() {
 				// Determine function name by direct invocation or property name
 				let name;
 				if ( 'MemberExpression' === callee.type ) {
-					name = callee.property.name;
+					name = callee.property.loc ? callee.property.loc.identifierName : callee.property.name;
 				} else {
-					name = callee.name;
+					name = callee.loc ? callee.loc.identifierName : callee.name;
 				}
 				if ( ! isValidFunctionName( name ) ) {
 					return;

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -107,7 +107,7 @@ function getNodeAsString( node ) {
  * @returns {boolean} Whether function name is valid translate function name.
  */
 function isValidFunctionName( name ) {
-	return -1 !== Object.keys( DEFAULT_FUNCTIONS_ARGUMENTS_ORDER ).indexOf( name );
+	return Object.keys( DEFAULT_FUNCTIONS_ARGUMENTS_ORDER ).includes( name );
 }
 
 /**
@@ -120,7 +120,7 @@ function isValidFunctionName( name ) {
  */
 function isValidTranslationKey( key ) {
 	return Object.values( DEFAULT_FUNCTIONS_ARGUMENTS_ORDER ).some(
-		args => -1 !== args.indexOf( key )
+		args => args.includes( key )
 	);
 }
 

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -203,7 +203,8 @@ module.exports = function() {
 				}
 
 				const { filename } = this.file.opts;
-				const pathname = relative( '.', filename )
+				const base = state.opts.base || '.';
+				const pathname = relative( base, filename )
 					.split( sep )
 					.join( '/' );
 				translation.comments.reference = pathname + ':' + path.node.loc.start.line;
@@ -273,7 +274,8 @@ module.exports = function() {
 					! existsSync( dir ) && mkdirSync( dir, { recursive: true } );
 
 					const { filename } = this.file.opts;
-					const pathname = relative( '.', filename )
+					const base = state.opts.base || '.';
+					const pathname = relative( base, filename )
 						.split( sep )
 						.join( '-' );
 					writeFileSync( dir + pathname + '.pot', compiled );

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -133,7 +133,7 @@ module.exports = function() {
 	return {
 		visitor: {
 			ImportDeclaration( path ) {
-				// If `translate` from  `i18n-calypso`` is imported with an
+				// If `translate` from  `i18n-calypso` is imported with an
 				// alias, set the specified alias as a reference to translate.
 				if ( 'i18n-calypso' !== path.node.source.value ) {
 					return;

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -89,6 +89,11 @@ function getNodeAsString( node ) {
 		case 'StringLiteral':
 			return node.value;
 
+		case 'TemplateLiteral':
+			return ( node.quasis || [] ).reduce( ( string, element ) => {
+				return ( string += element.value.cooked );
+			}, '' );
+
 		default:
 			return '';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds support in `babel-plugin-i18n-calypso` for string extraction from `@wordpress/i18n` calls.

#### Testing instructions

- Add the plugin to an existing babel config - ```
"plugins": [
	...,
	"@automattic/babel-plugin-i18n-calypso" 
]```
- Run the transpile process
- A POT file will be created in `build/` for each transpiled file that contains translation strings