### PR TITLE
Site migration: Add a spinner in the site icon when loading a site

### DIFF
--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -13,6 +13,7 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import Badge from 'components/badge';
 import { getUrlParts } from 'lib/url';
+import Spinner from 'components/spinner';
 
 export default class SitesBlock extends Component {
 	state = {};
@@ -25,7 +26,9 @@ export default class SitesBlock extends Component {
 		return (
 			<div className="sites-block__faux-site-selector">
 				<div className="sites-block__faux-site-selector-content">
-					<div className="sites-block__faux-site-selector-icon" />
+					<div className="sites-block__faux-site-selector-icon">
+						{ this.props.loadingSourceSite && <Spinner /> }
+					</div>
 					<div className="sites-block__faux-site-selector-info">
 						<FormLabel
 							className="sites-block__faux-site-selector-label"

--- a/client/my-sites/migrate/components/sites-block/style.scss
+++ b/client/my-sites/migrate/components/sites-block/style.scss
@@ -77,6 +77,9 @@
 		align-self: flex-start;
 		margin-right: 8px;
 		flex: 0 0 auto;
+
+		display: flex;
+		justify-content: center;
 	}
 
 	.sites-block__faux-site-selector-info {

--- a/client/my-sites/migrate/components/sites-block/style.scss
+++ b/client/my-sites/migrate/components/sites-block/style.scss
@@ -77,7 +77,6 @@
 		align-self: flex-start;
 		margin-right: 8px;
 		flex: 0 0 auto;
-
 		display: flex;
 		justify-content: center;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a spinner in place of the Site Icon while the request to get information from the API is ongoing

### Screenshot

![image](https://user-images.githubusercontent.com/184938/73852701-520a5a00-4838-11ea-88c5-8f75bd4bbb3a.png)

#### Testing instructions

* Checkout branch or use Calypso.live link
* Go to migration
* Enter Site URL
* Press Continue
* You should see a spinner at the center of the dashed box.
