### PR TITLE
Speed up bundle analysis.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"npm": "^6.12.1"
 	},
 	"scripts": {
-		"preanalyze-bundles": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=true PROGRESS=true npm run -s build-client-evergreen",
+		"preanalyze-bundles": "cross-env-shell NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=true PROGRESS=true npm run -s build-client-evergreen",
 		"analyze-bundles": "webpack-bundle-analyzer client/stats.json public/evergreen -h 127.0.0.1 -p 9898 -s gzip",
 		"autoprefixer": "postcss -u autoprefixer -r --no-map --config packages/calypso-build/postcss.config.js",
 		"postcss": "postcss -r --config packages/calypso-build/postcss.config.js",
@@ -126,7 +126,7 @@
 		"typecheck": "tsc --noEmit",
 		"update-deps": "npx rimraf package-lock.json && npm run distclean && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i && replace --silent 'http://' 'https://' . --recursive --include='package-lock.json' && touch -m node_modules",
 		"validate-fallback-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./public/fallback/*.js",
-		"prewhybundled": "cross-env-shell CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client-evergreen",
+		"prewhybundled": "cross-env-shell NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client-evergreen",
 		"whybundled": "whybundled client/stats.json",
 		"composite-checkout-demo": "webpack-dev-server --config ./packages/composite-checkout/webpack.config.demo.js --mode development",
 		"components:storybook:start": "start-storybook -c packages/components/.storybook",


### PR DESCRIPTION
`npm run analyze-bundles` and `npm run whybundled` are incredibly slow at the moment, taking upwards of an hour in my machine.

Through a fun profiling session, I found out that `BundleAnalyzerPlugin` transitively makes use of `bluebird` promises, instead of native promises. `bluebird` has an option to generate better stack traces, at the cost of runtime performance. A lot of runtime performance. From their site:

> Long stack traces imply a substantial performance penalty, around 4-5x for throughput and 0.5x for latency.

I suspect our use case results in an even worse slowdown.

We don't need any stack traces at all, let alone longer ones, as we won't be debugging `BundleAnalyzerPlugin` if it breaks, so we can safely disable this feature and use the fast path instead. Thankfully, that's as easy as setting `NODE_ENV` to `production`.

#### Changes proposed in this Pull Request

* Run bundle analysis with `NODE_ENV` set to `production`

#### Testing instructions

* Use the master branch.
* Run `time npm run preanalyze-bundles`.
* Wait approximately until the heat death of the universe.
* Observe results.

* Use this branch.
* Run `time npm run preanalyze-bundles`.
* Make yourself $HOT_BEVERAGE.
* Observe results. Should be much faster than the above; ~3min41s in my machine.