### PR TITLE
[E2E Mobile]: update blank template selector

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -417,10 +417,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async dismissPageTemplateSelector() {
 		if ( await driverHelper.isElementPresent( this.driver, By.css( '.page-template-modal' ) ) ) {
 			if ( driverManager.currentScreenSize() === 'mobile' ) {
-				await driverHelper.selectElementByText(
+				await driverHelper.clickWhenClickable(
 					this.driver,
-					By.css( '.template-selector-item__template-title' ),
-					'Blank'
+					By.css( 'button.template-selector-item__label[value="blank"]' )
 				);
 			} else {
 				await driverHelper.clickWhenClickable(


### PR DESCRIPTION
## Changes proposed in this Pull Request

The selector `.template-selector-item__template-title` was [removed](https://github.com/Automattic/wp-calypso/pull/39120/files#diff-d1ee4358c970e6821aaf0cf61ab22fb8L68) in #39120, triggering cataclysmic consequences that threaten to annihilate the good humour and sanity of hundreds of developers, with flow-on effects to spouses, domestic pets and nearby small appliances.

<img width="1101" alt="Screen Shot 2020-02-06 at 1 59 55 pm" src="https://user-images.githubusercontent.com/6458278/73902176-02d03200-48e9-11ea-8ea3-880e5e5c47b5.png">

The [failing step](https://github.com/Automattic/wp-calypso/blob/master/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js#L56) (**Calypso Gutenberg Editor: Mobile**).


This PR looks to the wrapping button and value attribute for salvation. 

`button.template-selector-item__label[value="blank"]`

This finds the blank template and clicks on the dangy thing.

#### Testing instructions

N/A

