### PR TITLE
Replace transient Zi usage w/ getAuthResponse

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -54,7 +54,13 @@ class SocialLoginForm extends Component {
 		const { onSuccess, socialService } = this.props;
 		let redirectTo = this.props.redirectTo;
 
-		if ( ! response.Zi || ! response.Zi.access_token || ! response.Zi.id_token ) {
+		if ( ! response.getAuthResponse ) {
+			return;
+		}
+
+		const tokens = response.getAuthResponse();
+
+		if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
 			return;
 		}
 
@@ -73,8 +79,8 @@ class SocialLoginForm extends Component {
 
 		const socialInfo = {
 			service: 'google',
-			access_token: response.Zi.access_token,
-			id_token: response.Zi.id_token,
+			access_token: tokens.access_token,
+			id_token: tokens.id_token,
 		};
 
 		this.props.loginSocialUser( socialInfo, redirectTo ).then(

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -44,7 +44,13 @@ class SocialSignupForm extends Component {
 	};
 
 	handleGoogleResponse = ( response, triggeredByUser = true ) => {
-		if ( ! response.Zi || ! response.Zi.access_token || ! response.Zi.id_token ) {
+		if ( ! response.getAuthResponse ) {
+			return;
+		}
+
+		const tokens = response.getAuthResponse();
+
+		if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
 			return;
 		}
 
@@ -52,7 +58,7 @@ class SocialSignupForm extends Component {
 			return;
 		}
 
-		this.props.handleResponse( 'google', response.Zi.access_token, response.Zi.id_token );
+		this.props.handleResponse( 'google', tokens.access_token, tokens.id_token );
 	};
 
 	trackSocialLogin = service => {


### PR DESCRIPTION
https://developers.google.com/identity/sign-in/web/reference#googleusergetauthresponseincludeauthorizationdata

props @ramonjd for noticing Zi != uc

#### Changes proposed in this Pull Request

* Replace transient `response.Zi` usage w/ `response.getAuthResponse()`

Context: pbAok1-gf-p2

#### Testing instructions

* Sign in with Google
* Create an account with Google signon

