### PR TITLE
Domain step test: Pricing copy update

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -42,27 +42,33 @@ class DomainProductPrice extends React.Component {
 	}
 
 	getDomainPricePopoverElement() {
-		const { price, translate } = this.props;
+		const { price, isFeatured, translate } = this.props;
 
 		return (
-			<InfoPopover iconSize={ 22 } position={ 'left' }>
-				{ translate(
-					'The registration fee for this domain is free for the first year with the purchase of any paid plan. ' +
-						'It will renew for %(cost)s / year after that. {{a}}Learn more{{/a}}.',
-					{
-						args: { cost: price },
-						components: {
-							a: (
-								<a
-									href="https://en.support.wordpress.com/domains/domain-pricing-and-available-tlds/"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					}
-				) }
-			</InfoPopover>
+			! isFeatured && (
+				<InfoPopover
+					iconSize={ 22 }
+					position={ 'left' }
+					className="domain-product-price__free-text-tooltip"
+				>
+					{ translate(
+						'The registration fee for this domain is free for the first year with the purchase of any paid plan. ' +
+							'It will renew for %(cost)s / year after that. {{a}}Learn more{{/a}}.',
+						{
+							args: { cost: price },
+							components: {
+								a: (
+									<a
+										href="https://en.support.wordpress.com/domains/domain-pricing-and-available-tlds/"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+					) }
+				</InfoPopover>
+			)
 		);
 	}
 

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -35,12 +35,6 @@ class DomainProductPrice extends React.Component {
 		isMappingProduct: false,
 	};
 
-	isEligibleVariantForDomainTest() {
-		const { showTestCopy, showDesignUpdate } = this.props;
-
-		return showTestCopy || showDesignUpdate;
-	}
-
 	getDomainPricePopoverElement() {
 		const { price, isFeatured, translate } = this.props;
 
@@ -73,7 +67,7 @@ class DomainProductPrice extends React.Component {
 	}
 
 	renderFreeWithPlanText() {
-		const { isMappingProduct, translate } = this.props;
+		const { isMappingProduct, isEligibleVariantForDomainTest, translate } = this.props;
 
 		let message, popoverElement;
 		switch ( this.props.rule ) {
@@ -115,7 +109,7 @@ class DomainProductPrice extends React.Component {
 		}
 
 		const className = classnames( 'domain-product-price__free-text', {
-			'domain-product-price__free-text-domain-step-copy-updates': this.isEligibleVariantForDomainTest(),
+			'domain-product-price__free-text-domain-step-copy-updates': isEligibleVariantForDomainTest,
 		} );
 
 		return (
@@ -163,7 +157,7 @@ class DomainProductPrice extends React.Component {
 
 	renderFreeWithPlan() {
 		const className = classnames( 'domain-product-price', 'is-free-domain', {
-			'domain-product-price__domain-step-copy-updates': this.isEligibleVariantForDomainTest(),
+			'domain-product-price__domain-step-copy-updates': this.props.isEligibleVariantForDomainTest,
 		} );
 
 		return (
@@ -176,11 +170,11 @@ class DomainProductPrice extends React.Component {
 
 	renderFree() {
 		const className = classnames( 'domain-product-price', {
-			'domain-product-price__domain-step-copy-updates': this.isEligibleVariantForDomainTest(),
+			'domain-product-price__domain-step-copy-updates': this.props.isEligibleVariantForDomainTest,
 		} );
 
 		const productPriceClassName = classnames( 'domain-product-price__price', {
-			'domain-product-price__free-price': this.isEligibleVariantForDomainTest(),
+			'domain-product-price__free-price': this.props.isEligibleVariantForDomainTest,
 		} );
 
 		return (

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -62,6 +62,7 @@
 		&.domain-product-price__free-text-domain-step-copy-updates {
 			display: flex;
 			align-items: center;
+			height: 100%;
 
 			& del,
 			& .info-popover {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -56,13 +56,12 @@
 
 		&.domain-product-price__free-text-domain-step-copy-updates {
 			display: flex;
+			align-items: center;
 
 			& del,
 			& .info-popover {
 				margin-right: 5px;
 			}
-
-			 
 		}
 	}
 
@@ -71,6 +70,10 @@
 		@include breakpoint( '>660px' ) {
 			margin-left: 0;
 		}
+	}
+
+	.domain-product-price__free-text-tooltip {
+		display: flex;
 	}
 
 	.domain-product-price__free-price {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -53,6 +53,17 @@
 	.domain-product-price__sale-price {
 		color: var( --color-neutral-60 );
 		display: block;
+
+		&.domain-product-price__free-text-domain-step-copy-updates {
+			display: flex;
+
+			& del,
+			& .info-popover {
+				margin-right: 5px;
+			}
+
+			 
+		}
 	}
 
 	&.no-price .domain-product-price__free-text,

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -17,6 +17,11 @@
 
 		&.domain-product-price__domain-step-copy-updates {
 			align-items: flex-start;
+
+			&:not( .is-free-domain ) {
+				min-width: 7%;
+				max-width: 7%;
+			}
 		}
 	}
 		

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -19,8 +19,8 @@
 			align-items: flex-start;
 
 			&:not( .is-free-domain ) {
-				min-width: 7%;
-				max-width: 7%;
+				min-width: 11%;
+				max-width: 11%;
 			}
 		}
 	}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -115,12 +115,6 @@ class DomainRegistrationSuggestion extends React.Component {
 		return includes( this.props.unavailableDomains, domain );
 	};
 
-	isEligibleVariantForDomainTest() {
-		const { showTestCopy, showDesignUpdate } = this.props;
-
-		return showTestCopy || showDesignUpdate;
-	}
-
 	getButtonProps() {
 		const {
 			cart,
@@ -201,7 +195,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		const infoPopoverSize = isFeatured ? 22 : 18;
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain-copy-test':
-				this.isEligibleVariantForDomainTest() && ! this.props.isFeatured,
+				this.props.isEligibleVariantForDomainTest && ! this.props.isFeatured,
 		} );
 
 		return (
@@ -343,6 +337,7 @@ class DomainRegistrationSuggestion extends React.Component {
 				{ ...this.getButtonProps() }
 				showTestCopy={ this.props.showTestCopy }
 				showDesignUpdate={ this.props.showDesignUpdate }
+				isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 				isFeatured={ isFeatured }
 			>
 				{ this.renderDomain() }
@@ -357,9 +352,7 @@ const mapStateToProps = ( state, props ) => {
 	const productSlug = get( props, 'suggestion.product_slug' );
 	const productsList = getProductsList( state );
 	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
-	const showTestCopy = get( props, 'showTestCopy', false );
-	const showDesignUpdate = get( props, 'showDesignUpdate', false );
-	const stripZeros = showTestCopy || showDesignUpdate ? true : false;
+	const stripZeros = props.isEligibleVariantForDomainTest ? true : false;
 
 	return {
 		showHstsNotice: isHstsRequired( productSlug, productsList ),

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -115,6 +115,12 @@ class DomainRegistrationSuggestion extends React.Component {
 		return includes( this.props.unavailableDomains, domain );
 	};
 
+	isEligibleVariantForDomainTest() {
+		const { showTestCopy, showDesignUpdate } = this.props;
+
+		return showTestCopy || showDesignUpdate;
+	}
+
 	getButtonProps() {
 		const {
 			cart,
@@ -195,7 +201,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		const infoPopoverSize = isFeatured ? 22 : 18;
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain-copy-test':
-				this.props.showTestCopy && ! this.props.isFeatured,
+				this.isEligibleVariantForDomainTest() && ! this.props.isFeatured,
 		} );
 
 		return (
@@ -336,6 +342,7 @@ class DomainRegistrationSuggestion extends React.Component {
 				onButtonClick={ this.onButtonClick }
 				{ ...this.getButtonProps() }
 				showTestCopy={ this.props.showTestCopy }
+				showDesignUpdate={ this.props.showDesignUpdate }
 				isFeatured={ isFeatured }
 			>
 				{ this.renderDomain() }
@@ -351,7 +358,8 @@ const mapStateToProps = ( state, props ) => {
 	const productsList = getProductsList( state );
 	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
 	const showTestCopy = get( props, 'showTestCopy', false );
-	const stripZeros = showTestCopy ? true : false;
+	const showDesignUpdate = get( props, 'showDesignUpdate', false );
+	const stripZeros = showTestCopy || showDesignUpdate ? true : false;
 
 	return {
 		showHstsNotice: isHstsRequired( productSlug, productsList ),

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -207,6 +207,7 @@ class DomainRegistrationSuggestion extends React.Component {
 						className="domain-registration-suggestion__hsts-tooltip"
 						iconSize={ infoPopoverSize }
 						position={ 'right' }
+						icon={ this.props.showDesignUpdate && 'help-outline' }
 					>
 						{ translate(
 							'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -207,7 +207,7 @@ class DomainRegistrationSuggestion extends React.Component {
 						className="domain-registration-suggestion__hsts-tooltip"
 						iconSize={ infoPopoverSize }
 						position={ 'right' }
-						icon={ this.props.showDesignUpdate && 'help-outline' }
+						{ ...( this.props.showDesignUpdate ? { icon: 'help-outline' } : {} ) }
 					>
 						{ translate(
 							'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -257,6 +257,7 @@ class DomainSearchResults extends React.Component {
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }
 					showTestCopy={ this.props.showTestCopy }
+					showDesignUpdate={ this.props.showDesignUpdate }
 				/>
 			);
 
@@ -282,6 +283,7 @@ class DomainSearchResults extends React.Component {
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }
 						showTestCopy={ this.props.showTestCopy }
+						showDesignUpdate={ this.props.showDesignUpdate }
 					/>
 				);
 			} );

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -258,6 +258,7 @@ class DomainSearchResults extends React.Component {
 					unavailableDomains={ this.props.unavailableDomains }
 					showTestCopy={ this.props.showTestCopy }
 					showDesignUpdate={ this.props.showDesignUpdate }
+					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 				/>
 			);
 
@@ -284,6 +285,7 @@ class DomainSearchResults extends React.Component {
 						unavailableDomains={ this.props.unavailableDomains }
 						showTestCopy={ this.props.showTestCopy }
 						showDesignUpdate={ this.props.showDesignUpdate }
+						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				);
 			} );

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -36,6 +36,12 @@ class DomainSuggestion extends React.Component {
 		showChevron: false,
 	};
 
+	isEligibleVariantForDomainTest() {
+		const { showTestCopy, showDesignUpdate } = this.props;
+
+		return showTestCopy || showDesignUpdate;
+	}
+
 	render() {
 		const {
 			children,
@@ -60,8 +66,11 @@ class DomainSuggestion extends React.Component {
 			extraClasses
 		);
 
+		const shouldApplyContentClass =
+			this.isEligibleVariantForDomainTest() && ! isFeatured && priceRule !== 'FREE_DOMAIN';
+
 		const contentClassName = classNames( 'domain-suggestion__content', {
-			'domain-suggestion__content-domain-copy-test': showTestCopy && ! isFeatured,
+			'domain-suggestion__content-domain-copy-test': shouldApplyContentClass,
 		} );
 
 		/* eslint-disable jsx-a11y/click-events-have-key-events */

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -36,12 +36,6 @@ class DomainSuggestion extends React.Component {
 		showChevron: false,
 	};
 
-	isEligibleVariantForDomainTest() {
-		const { showTestCopy, showDesignUpdate } = this.props;
-
-		return showTestCopy || showDesignUpdate;
-	}
-
 	render() {
 		const {
 			children,
@@ -53,6 +47,7 @@ class DomainSuggestion extends React.Component {
 			salePrice,
 			showTestCopy,
 			showDesignUpdate,
+			isEligibleVariantForDomainTest,
 			isFeatured,
 		} = this.props;
 		const classes = classNames(
@@ -67,7 +62,7 @@ class DomainSuggestion extends React.Component {
 		);
 
 		const shouldApplyContentClass =
-			this.isEligibleVariantForDomainTest() && ! isFeatured && priceRule !== 'FREE_DOMAIN';
+			isEligibleVariantForDomainTest && ! isFeatured && priceRule !== 'FREE_DOMAIN';
 
 		const contentClassName = classNames( 'domain-suggestion__content', {
 			'domain-suggestion__content-domain-copy-test': shouldApplyContentClass,
@@ -93,6 +88,7 @@ class DomainSuggestion extends React.Component {
 							isFeatured={ isFeatured }
 							showTestCopy={ showTestCopy }
 							showDesignUpdate={ showDesignUpdate }
+							isEligibleVariantForDomainTest={ isEligibleVariantForDomainTest }
 						/>
 					) }
 				</div>

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -46,6 +46,7 @@ class DomainSuggestion extends React.Component {
 			priceRule,
 			salePrice,
 			showTestCopy,
+			showDesignUpdate,
 			isFeatured,
 		} = this.props;
 		const classes = classNames(
@@ -80,7 +81,9 @@ class DomainSuggestion extends React.Component {
 							price={ price }
 							salePrice={ salePrice }
 							rule={ priceRule }
+							isFeatured={ isFeatured }
 							showTestCopy={ showTestCopy }
+							showDesignUpdate={ showDesignUpdate }
 						/>
 					) }
 				</div>

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -141,6 +141,12 @@
 			min-width: 50%;
 			margin-right: 1em;
 		}
+
+		@include breakpoint( '>660px' ) {
+			max-width: 68%;
+			min-width: 68%;
+			margin-right: 1em;
+		}
 	}
 
 	.domain-registration-suggestion__title {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -143,8 +143,8 @@
 		}
 
 		@include breakpoint( '>660px' ) {
-			max-width: 68%;
-			min-width: 68%;
+			max-width: 65%;
+			min-width: 65%;
 			margin-right: 1em;
 		}
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -164,6 +164,12 @@
 		align-items: center;
 		justify-content: center;
 	}
+
+	body.is-section-signup .layout:not( .dops ) & {
+		.domain-registration-suggestion__hsts-tooltip {
+			padding: 0;
+		}
+	}
 }
 
 .domain-registration-suggestion__title {

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -122,6 +122,7 @@ export class FeaturedDomainSuggestions extends Component {
 						buttonStyles={ { primary: true } }
 						{ ...childProps }
 						showTestCopy={ this.props.showTestCopy }
+						showDesignUpdate={ this.props.showDesignUpdate }
 					/>
 				) }
 				{ secondarySuggestion && (
@@ -134,6 +135,7 @@ export class FeaturedDomainSuggestions extends Component {
 						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }
 						{ ...childProps }
 						showTestCopy={ this.props.showTestCopy }
+						showDesignUpdate={ this.props.showDesignUpdate }
 					/>
 				) }
 			</div>

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -123,6 +123,7 @@ export class FeaturedDomainSuggestions extends Component {
 						{ ...childProps }
 						showTestCopy={ this.props.showTestCopy }
 						showDesignUpdate={ this.props.showDesignUpdate }
+						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				) }
 				{ secondarySuggestion && (
@@ -136,6 +137,7 @@ export class FeaturedDomainSuggestions extends Component {
 						{ ...childProps }
 						showTestCopy={ this.props.showTestCopy }
 						showDesignUpdate={ this.props.showDesignUpdate }
+						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				) }
 			</div>

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -384,16 +384,10 @@ class RegisterDomainStep extends React.Component {
 		return suggestions;
 	}
 
-	isEligibleVariantForDomainTest() {
-		const { showTestCopy, showDesignUpdate } = this.props;
-
-		return showTestCopy || showDesignUpdate;
-	}
-
 	getPlaceholderText() {
-		const { translate } = this.props;
+		const { isEligibleVariantForDomainTest, translate } = this.props;
 
-		return this.isEligibleVariantForDomainTest()
+		return isEligibleVariantForDomainTest
 			? translate( 'Type the domain you want here' )
 			: translate( 'Enter a name or keyword' );
 	}
@@ -423,7 +417,7 @@ class RegisterDomainStep extends React.Component {
 			: {};
 
 		const searchBoxClassName = classNames( 'register-domain-step__search', {
-			'register-domain-step__search-domain-step-test': this.isEligibleVariantForDomainTest(),
+			'register-domain-step__search-domain-step-test': this.props.isEligibleVariantForDomainTest,
 		} );
 		return (
 			<div className="register-domain-step">
@@ -1091,6 +1085,7 @@ class RegisterDomainStep extends React.Component {
 						unavailableDomains={ this.state.unavailableDomains }
 						showTestCopy={ this.props.showTestCopy }
 						showDesignUpdate={ this.props.showDesignUpdate }
+						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				);
 			}, this );
@@ -1246,8 +1241,11 @@ class RegisterDomainStep extends React.Component {
 				unavailableDomains={ this.state.unavailableDomains }
 				showTestCopy={ this.props.showTestCopy }
 				showDesignUpdate={ this.props.showDesignUpdate }
+				isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 			>
-				{ this.isEligibleVariantForDomainTest() && hasResults && this.renderFreeDomainExplainer() }
+				{ this.props.isEligibleVariantForDomainTest &&
+					hasResults &&
+					this.renderFreeDomainExplainer() }
 
 				{ showTldFilterBar && (
 					<TldFilterBar

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -142,6 +142,7 @@ class RegisterDomainStep extends React.Component {
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
 		showTestCopy: PropTypes.bool,
+		showDesignUpdate: PropTypes.bool,
 		onSave: PropTypes.func,
 		onAddMapping: PropTypes.func,
 		onAddDomain: PropTypes.func,
@@ -383,10 +384,16 @@ class RegisterDomainStep extends React.Component {
 		return suggestions;
 	}
 
-	getPlaceholderText() {
-		const { showTestCopy, translate } = this.props;
+	isEligibleVariantForDomainTest() {
+		const { showTestCopy, showDesignUpdate } = this.props;
 
-		return showTestCopy
+		return showTestCopy || showDesignUpdate;
+	}
+
+	getPlaceholderText() {
+		const { translate } = this.props;
+
+		return this.isEligibleVariantForDomainTest()
 			? translate( 'Type the domain you want here' )
 			: translate( 'Enter a name or keyword' );
 	}
@@ -416,7 +423,7 @@ class RegisterDomainStep extends React.Component {
 			: {};
 
 		const searchBoxClassName = classNames( 'register-domain-step__search', {
-			'register-domain-step__search-domain-step-test': this.props.showTestCopy,
+			'register-domain-step__search-domain-step-test': this.isEligibleVariantForDomainTest(),
 		} );
 		return (
 			<div className="register-domain-step">
@@ -1083,6 +1090,7 @@ class RegisterDomainStep extends React.Component {
 						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 						unavailableDomains={ this.state.unavailableDomains }
 						showTestCopy={ this.props.showTestCopy }
+						showDesignUpdate={ this.props.showDesignUpdate }
 					/>
 				);
 			}, this );
@@ -1237,8 +1245,9 @@ class RegisterDomainStep extends React.Component {
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 				unavailableDomains={ this.state.unavailableDomains }
 				showTestCopy={ this.props.showTestCopy }
+				showDesignUpdate={ this.props.showDesignUpdate }
 			>
-				{ this.props.showTestCopy && hasResults && this.renderFreeDomainExplainer() }
+				{ this.isEligibleVariantForDomainTest() && hasResults && this.renderFreeDomainExplainer() }
 
 				{ showTldFilterBar && (
 					<TldFilterBar

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -481,6 +481,7 @@ class DomainsStep extends React.Component {
 				showExampleSuggestions={ showExampleSuggestions }
 				showTestCopy={ this.showTestCopy }
 				showDesignUpdate={ this.showDesignUpdate }
+				isEligibleVariantForDomainTest={ this.isEligibleVariantForDomainTest() }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor( true ) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -160,6 +160,10 @@ class DomainsStep extends React.Component {
 		}
 	}
 
+	isEligibleVariantForDomainTest() {
+		return this.showTestCopy || this.showDesignUpdate;
+	}
+
 	getMapDomainUrl = () => {
 		return getStepUrl( this.props.flowName, this.props.stepName, 'mapping', this.props.locale );
 	};
@@ -216,7 +220,7 @@ class DomainsStep extends React.Component {
 	};
 
 	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const hideFreePlanTracksProp = this.showTestCopy
+		const hideFreePlanTracksProp = this.isEligibleVariantForDomainTest()
 			? { should_hide_free_plan: shouldHideFreePlan }
 			: {};
 
@@ -235,7 +239,9 @@ class DomainsStep extends React.Component {
 	};
 
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const shouldHideFreePlanItem = this.showTestCopy ? { shouldHideFreePlan } : {};
+		const shouldHideFreePlanItem = this.isEligibleVariantForDomainTest()
+			? { shouldHideFreePlan }
+			: {};
 
 		if ( shouldHideFreePlan ) {
 			let domainItem, isPurchasingItem, siteUrl;
@@ -474,6 +480,7 @@ class DomainsStep extends React.Component {
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
 				showTestCopy={ this.showTestCopy }
+				showDesignUpdate={ this.showDesignUpdate }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor( true ) }
@@ -555,7 +562,7 @@ class DomainsStep extends React.Component {
 
 	getSubHeaderText() {
 		const { flowName, siteType, translate } = this.props;
-		const subHeaderPropertyName = this.showTestCopy
+		const subHeaderPropertyName = this.isEligibleVariantForDomainTest()
 			? 'domainsStepSubheaderTestCopy'
 			: 'domainsStepSubheader';
 		const onboardingSubHeaderCopy =
@@ -574,7 +581,7 @@ class DomainsStep extends React.Component {
 
 	getHeaderText() {
 		const { headerText, siteType } = this.props;
-		const headerPropertyName = this.showTestCopy
+		const headerPropertyName = this.isEligibleVariantForDomainTest()
 			? 'domainsStepHeaderTestCopy'
 			: 'domainsStepHeader';
 
@@ -616,7 +623,7 @@ class DomainsStep extends React.Component {
 		}
 
 		const stepContentClassName = classNames( 'domains__step-content', {
-			'domains__step-content-domain-step-test': this.showTestCopy,
+			'domains__step-content-domain-step-test': this.isEligibleVariantForDomainTest(),
 		} );
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The next domain step test is being implemented in https://github.com/Automattic/wp-calypso/pull/39276. This PR depends on https://github.com/Automattic/wp-calypso/pull/39276 to be first merged.

* Updates copy for the domain price in the search results. 
* The price is shown crossed out and next to it the copy says "Free with a paid plan"
* Adds a tooltip next to the crossed out price that shows more information on the pricing.

A summary of UI changes:
1. Striked out domain price. Text next to it says "Free with a paid plan"
2. In the featured domains boxes (Best match & Best alternative), show renewal price - "Renews at $x / year. Learn more". Learn more links to support doc. No tooltip is shown here.
3. In each row of the search results, show a tooltip just before the striked out price(except the Free *.wordpress.com domain). 


**Web**

<img width="965" alt="Screenshot 2020-02-07 at 11 37 17 AM" src="https://user-images.githubusercontent.com/1269602/74005228-3751f580-499e-11ea-8ed0-e49ee2720761.png">

**Mobile**

![calypso localhost_3000_start_ecommerce-onboarding_domains(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/1269602/74004502-ee00a680-499b-11ea-9c8e-6ba633184a50.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go through the signup flow at http://calypso.localhost:3000/start or using the calypso.live link. You need to be in the _variantShowUpdates_ variant of _domainStepCopyUpdates_ test.
2. In the domain step, search for a domain name and verify that the domain product price matches the UI in pbAok1-7N-p2. Verify for both search results and featured domains.
3. Verify that the tooltip works.
3. Verify both in web and mobile screen sizes.

**Long domain names**

1. Type a long domain name and verify that the UI looks okay(there is a max 60 character limit for domain names). Example below:

<img width="958" alt="Screenshot 2020-02-07 at 11 04 28 AM" src="https://user-images.githubusercontent.com/1269602/74006369-7c2b5b80-49a1-11ea-89d5-3947fbf9403b.png">

**Responsive**

1. Resize browser window and verify that the UI looks okay as you resize.

**Currencies**

1. While keeping browser language to english, proxy through different countries(I used Tunnelbear) so that the currency changes. Verify that alignment is okay. [This collection of screenshots](https://d.pr/boards/5e3d559aa47e0f0019bcd667) is for the currencies GBP, JPY, SEK, INR, USD, BRL, EUR and CHF.


Fixes 197-gh-martech
