### PR TITLE
Site Migration: Add event tracking to some UI actions

### DIFF
--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { includes } from 'lodash';
 import { connect } from 'react-redux';
-
 /**
  * Internal dependencies
  */
@@ -20,7 +19,6 @@ import ImportingPane from './importing-pane';
 import UploadingPane from './uploading-pane';
 import { startImport } from 'lib/importer/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
-
 /**
  * Style dependencies
  */
@@ -111,6 +109,13 @@ class FileImporter extends React.PureComponent {
 			 */
 			cardProps.href = overrideDestination.replace( '%SITE_SLUG%', site.slug );
 			cardProps.onClick = null;
+
+			if ( this.props.importerStatus.type === 'wordpress' ) {
+				this.props.recordTracksEvent( 'calypso_importer_wordpress_select', {
+					blog_id: site.ID,
+					importer_id: importerStatus.type,
+				} );
+			}
 		}
 
 		return (

--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { includes } from 'lodash';
 import { connect } from 'react-redux';
+
 /**
  * Internal dependencies
  */
@@ -19,6 +20,7 @@ import ImportingPane from './importing-pane';
 import UploadingPane from './uploading-pane';
 import { startImport } from 'lib/importer/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+
 /**
  * Style dependencies
  */
@@ -109,13 +111,6 @@ class FileImporter extends React.PureComponent {
 			 */
 			cardProps.href = overrideDestination.replace( '%SITE_SLUG%', site.slug );
 			cardProps.onClick = null;
-
-			if ( this.props.importerStatus.type === 'wordpress' ) {
-				this.props.recordTracksEvent( 'calypso_importer_wordpress_select', {
-					blog_id: site.ID,
-					importer_id: importerStatus.type,
-				} );
-			}
 		}
 
 		return (

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -5,11 +5,13 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { Button, CompactCard } from '@automattic/components';
+
 /**
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
 import CardHeading from 'components/card-heading';
+
 /**
  * Style dependencies
  */
@@ -134,7 +136,7 @@ class StepImportOrMigrate extends Component {
 					/>
 					<div className="migrate__buttons-wrapper">
 						{ this.state.chosenImportType === 'everything' ? (
-							<Button primary onClick={ this.props.onJetpackSelect }>
+							<Button primary onClick={ this.onJetpackSelect }>
 								{ translate( 'Continue' ) }
 							</Button>
 						) : null }

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -34,8 +34,24 @@ class StepImportOrMigrate extends Component {
 		this.setState( { chosenImportType: type } );
 	};
 
+	onJetpackSelect = event => {
+		const { isTargetSiteAtomic } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_importer_wordpress_select', {
+			is_atomic: isTargetSiteAtomic,
+			migration_type: 'migration',
+		} );
+
+		this.props.onJetpackSelect( event );
+	};
+
 	handleImportRedirect = () => {
 		const { isTargetSiteAtomic, targetSiteSlug } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_importer_wordpress_select', {
+			is_atomic: isTargetSiteAtomic,
+			migration_type: 'content',
+		} );
 
 		if ( isTargetSiteAtomic ) {
 			window.location.href = `https://${ targetSiteSlug }/wp-admin/import.php`;

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -18,6 +18,8 @@ import ImportTypeChoice from 'my-sites/migrate/components/import-type-choice';
 import { get } from 'lodash';
 import { redirectTo } from 'my-sites/migrate/helpers';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { connect } from 'react-redux';
 
 class StepImportOrMigrate extends Component {
 	static propTypes = {
@@ -152,4 +154,4 @@ class StepImportOrMigrate extends Component {
 	}
 }
 
-export default localize( StepImportOrMigrate );
+export default connect( null, { recordTracksEvent } )( localize( StepImportOrMigrate ) );

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -3,10 +3,12 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { Button, Card, CompactCard } from '@automattic/components';
 import page from 'page';
 import { get } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -14,13 +16,13 @@ import CardHeading from 'components/card-heading';
 import HeaderCake from 'components/header-cake';
 import wpLib from 'lib/wp';
 import { recordTracksEvent } from 'state/analytics/actions';
+
 /**
  * Style dependencies
  */
 import './section-migrate.scss';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
 import { redirectTo } from 'my-sites/migrate/helpers';
-import { connect } from 'react-redux';
 
 const wpcom = wpLib.undocumented();
 

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -12,12 +12,15 @@ import page from 'page';
 import CardHeading from 'components/card-heading';
 import HeaderCake from 'components/header-cake';
 import wpLib from 'lib/wp';
+import { recordTracksEvent } from 'state/analytics/actions';
+
 /**
  * Style dependencies
  */
 import './section-migrate.scss';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
 import { redirectTo } from 'my-sites/migrate/helpers';
+import { connect } from 'react-redux';
 
 const wpcom = wpLib.undocumented();
 
@@ -131,5 +134,4 @@ class StepSourceSelect extends Component {
 		);
 	}
 }
-
-export default localize( StepSourceSelect );
+export default connect( null, { recordTracksEvent } )( localize( StepSourceSelect ) );

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { Button, Card, CompactCard } from '@automattic/components';
 import page from 'page';
+import { get } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -13,7 +14,6 @@ import CardHeading from 'components/card-heading';
 import HeaderCake from 'components/header-cake';
 import wpLib from 'lib/wp';
 import { recordTracksEvent } from 'state/analytics/actions';
-
 /**
  * Style dependencies
  */
@@ -51,6 +51,14 @@ class StepSourceSelect extends Component {
 				.isSiteImportable( this.props.url )
 				.then( result => {
 					const importUrl = `/import/${ this.props.targetSiteSlug }?not-wp=1&engine=${ result.site_engine }&from-site=${ result.site_url }`;
+
+					this.props.recordTracksEvent( 'calypso_importer_wordpress_enter_url', {
+						url: result.site_url,
+						engine: result.site_engine,
+						has_jetpack: !! get( result, 'site_meta.jetpack_version', false ),
+						jetpack_version: get( result, 'site_meta.jetpack_version', 'no jetpack' ),
+						is_wpcom: get( result, 'site_meta.wpcom_site', false ),
+					} );
 
 					switch ( result.site_engine ) {
 						case 'wordpress':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds event tracking for some of the UI actions in Site Migration
* Included are two events:
 * `calypso_importer_wordpress_select` - when a user clicks the continue button on the Import type screen (Content only or Everything)
 * `calypso_importer_wordpress_enter_url` - when a site URL is submitted

#### Testing instructions

* Checkout branch or use Calypso.live link
* Go to Migration
* Try a WPCOM site
* Try a Jetpack connected site
* Try a random site (non-wp)
* Make sure the events are being sent with correct data 
* Continue to next step with a valid WP site
* Choose Content Only
* Choose Everything
* Make sure events are being sent with correct data
