### PR TITLE
Site Migration: Update the confirmation page and move the confirmation prompt to final pre-migration step

### DIFF
--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -53,25 +53,22 @@ export default class SitesBlock extends Component {
 	}
 
 	getSourceSiteOrInput = () => {
-		const { sourceSite } = this.props;
+		const { sourceSite, sourceSiteInfo } = this.props;
 
-		if ( ! sourceSite ) {
+		if ( ! sourceSite && ! sourceSiteInfo ) {
 			return this.renderFauxSiteSelector();
 		}
 
-		return (
-			<Site
-				site={ this.convertSourceSiteObjectToSiteComponent( sourceSite ) }
-				indicator={ false }
-			/>
-		);
+		const site = sourceSite || this.convertSourceSiteInfoToSourceSite( sourceSiteInfo );
+
+		return <Site site={ site } indicator={ false } />;
 	};
 
-	convertSourceSiteObjectToSiteComponent = sourceSite => {
-		const { hostname } = getUrlParts( sourceSite.site_url );
+	convertSourceSiteInfoToSourceSite = sourceSiteInfo => {
+		const { hostname } = getUrlParts( sourceSiteInfo.site_url );
 		return {
-			icon: { img: sourceSite.site_favicon },
-			title: sourceSite.site_title,
+			icon: { img: sourceSiteInfo.site_favicon },
+			title: sourceSiteInfo.site_title,
 			domain: hostname,
 		};
 	};
@@ -96,6 +93,7 @@ export default class SitesBlock extends Component {
 }
 
 SitesBlock.propTypes = {
+	sourceSiteInfo: PropTypes.object,
 	sourceSite: PropTypes.object,
 	loadingSourceSite: PropTypes.bool,
 	targetSite: PropTypes.object.isRequired,

--- a/client/my-sites/migrate/migrate-button.jsx
+++ b/client/my-sites/migrate/migrate-button.jsx
@@ -39,7 +39,7 @@ class MigrateButton extends Component {
 	render() {
 		return (
 			<Button primary busy={ this.state.busy } onClick={ this.handleClick }>
-				Continue
+				{ this.props.children }
 			</Button>
 		);
 	}

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -479,7 +479,7 @@ class SectionMigrate extends Component {
 						migrationElement = (
 							<StepImportOrMigrate
 								onJetpackSelect={ this.handleJetpackSelect }
-								sourceSite={ this.state.siteInfo }
+								sourceSiteInfo={ this.state.siteInfo }
 								targetSite={ targetSite }
 								targetSiteSlug={ targetSiteSlug }
 								sourceHasJetpack={ this.state.isJetpackConnected }

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -488,7 +488,9 @@ class SectionMigrate extends Component {
 						);
 						break;
 					case 'upgrade':
-						migrationElement = <StepUpgrade startMigration={ this.startMigration } />;
+						migrationElement = (
+							<StepUpgrade startMigration={ this.startMigration } targetSite={ targetSite } />
+						);
 						break;
 					case 'input':
 					default:

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -41,6 +41,7 @@
 
 .migrate__card-footer-text {
 	vertical-align: middle;
+	margin-left: 8px;
 }
 
 .migrate__card-footer-gridicon {

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -39,8 +39,17 @@
 	}
 }
 
+.migrate__card-footer-text {
+	vertical-align: middle;
+}
+
+.migrate__card-footer-gridicon {
+	color: var( --color-text-subtle );
+	vertical-align: middle;
+}
+
 .migrate__list {
-	margin: 16px 0 32px;
+	margin: 16px 0;
 	li {
 		list-style-type: none;
 		line-height: 30px;

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -11,9 +11,10 @@ import { Button, CompactCard } from '@automattic/components';
 /**
  * Internal dependencies
  */
+import CardHeading from 'components/card-heading';
 import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
-import Site from 'blocks/site';
+import SitesBlock from 'my-sites/migrate/components/sites-block';
 import { FEATURE_UPLOAD_THEMES_PLUGINS } from 'lib/plans/constants';
 import { planHasFeature } from 'lib/plans';
 
@@ -31,45 +32,82 @@ class StepConfirmMigration extends Component {
 	};
 
 	handleClick = () => {
-		const { sourceSite, startMigration, targetSite, targetSiteSlug } = this.props;
+		const { sourceSite, startMigration, targetSiteSlug } = this.props;
 		const sourceSiteId = get( sourceSite, 'ID' );
 		const sourceSiteSlug = get( sourceSite, 'slug', sourceSiteId );
-		const planSlug = get( targetSite, 'plan.product_slug' );
-		if ( planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS ) ) {
+
+		if ( this.isTargetSitePlanCompatible() ) {
 			return startMigration();
 		}
 
 		page( `/migrate/upgrade/from/${ sourceSiteSlug }/to/${ targetSiteSlug }` );
 	};
 
+	isTargetSitePlanCompatible() {
+		const { targetSite } = this.props;
+		const planSlug = get( targetSite, 'plan.product_slug' );
+
+		return planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS );
+	}
+
+	renderCardBusinessFooter() {
+		// If the site is has an appropriate plan, no upgrade footer is required
+		if ( this.isTargetSitePlanCompatible() ) {
+			return null;
+		}
+
+		return (
+			<CompactCard className="migrate__card-footer">
+				<Gridicon className="migrate__card-footer-gridicon" icon="info-outline" size={ 12 } />
+				<span className="migrate__card-footer-text">
+					A Business Plan is required to import everything.
+				</span>
+			</CompactCard>
+		);
+	}
+
 	render() {
 		const { sourceSite, targetSite, targetSiteSlug } = this.props;
 
 		const sourceSiteDomain = get( sourceSite, 'domain' );
+		const targetSiteDomain = get( targetSite, 'domain' );
 		const backHref = `/migrate/${ targetSiteSlug }`;
 
 		return (
 			<>
 				<HeaderCake backHref={ backHref }>Import { sourceSiteDomain }</HeaderCake>
-				<div className="migrate__sites">
-					<div className="migrate__sites-item">
-						<Site site={ sourceSite } indicator={ false } />
-					</div>
-					<div className="migrate__sites-arrow-wrapper">
-						<Gridicon className="migrate__sites-arrow" icon="arrow-right" />
-					</div>
-					<div className="migrate__sites-item">
-						<Site site={ targetSite } indicator={ false } />
-						<div className="migrate__sites-labels-container">
-							<span className="migrate__token-label">This site</span>
+				<SitesBlock
+					sourceSite={ sourceSite }
+					loadingSourceSite={ false }
+					targetSite={ targetSite }
+				/>
+				<CompactCard>
+					<CardHeading>{ `Import everything from ${ sourceSiteDomain } and overwrite everything on ${ targetSiteDomain }?` }</CardHeading>
+					<div className="migrate__confirmation">
+						<ul className="migrate__list">
+							<li>
+								<Gridicon icon="checkmark" size="12" className="migrate__checkmark" />
+								All posts, pages, comments, and media
+							</li>
+							<li>
+								<Gridicon icon="checkmark" size="12" className="migrate__checkmark" />
+								All users and roles
+							</li>
+							<li>
+								<Gridicon icon="checkmark" size="12" className="migrate__checkmark" />
+								Theme, plugins, and settings
+							</li>
+						</ul>
+						<div>
+							Your site will keep working, but your WordPress.com dashboard will be locked during
+							importing.
 						</div>
 					</div>
-				</div>
-				<CompactCard>
 					<Button primary onClick={ this.handleClick }>
 						Import everything
 					</Button>
 				</CompactCard>
+				{ this.renderCardBusinessFooter() }
 			</>
 		);
 	}

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -14,6 +14,7 @@ import { Button, CompactCard } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
+import MigrateButton from './migrate-button.jsx';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
 import { FEATURE_UPLOAD_THEMES_PLUGINS } from 'lib/plans/constants';
 import { planHasFeature } from 'lib/plans';
@@ -66,6 +67,25 @@ class StepConfirmMigration extends Component {
 		);
 	}
 
+	renderMigrationButton() {
+		const { targetSite } = this.props;
+		const targetSiteDomain = get( targetSite, 'domain' );
+
+		if ( this.isTargetSitePlanCompatible() ) {
+			return (
+				<MigrateButton onClick={ this.handleClick } targetSiteDomain={ targetSiteDomain }>
+					Import everything
+				</MigrateButton>
+			);
+		}
+
+		return (
+			<Button primary onClick={ this.handleClick }>
+				Import everything
+			</Button>
+		);
+	}
+
 	render() {
 		const { sourceSite, targetSite, targetSiteSlug } = this.props;
 
@@ -103,9 +123,7 @@ class StepConfirmMigration extends Component {
 							importing.
 						</div>
 					</div>
-					<Button primary onClick={ this.handleClick }>
-						Import everything
-					</Button>
+					{ this.renderMigrationButton() }
 				</CompactCard>
 				{ this.renderCardBusinessFooter() }
 			</>

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -17,7 +17,6 @@ import CardHeading from 'components/card-heading';
  */
 import './section-migrate.scss';
 import ImportTypeChoice from 'my-sites/migrate/components/import-type-choice';
-import MigrateButton from 'my-sites/migrate/migrate-button';
 import { get } from 'lodash';
 import { redirectTo } from 'my-sites/migrate/helpers';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
@@ -72,8 +71,6 @@ class StepImportOrMigrate extends Component {
 		const { targetSite, targetSiteSlug, sourceHasJetpack, sourceSite, sourceSiteInfo } = this.props;
 		const backHref = `/migrate/${ targetSiteSlug }`;
 
-		const targetSiteDomain = get( targetSite, 'domain' );
-
 		return (
 			<>
 				<HeaderCake backHref={ backHref }>Import from WordPress</HeaderCake>
@@ -107,10 +104,9 @@ class StepImportOrMigrate extends Component {
 					/>
 					<div className="migrate__buttons-wrapper">
 						{ this.state.chosenImportType === 'everything' ? (
-							<MigrateButton
-								onClick={ this.props.onJetpackSelect }
-								targetSiteDomain={ targetSiteDomain }
-							/>
+							<Button primary onClick={ this.props.onJetpackSelect }>
+								Continue
+							</Button>
 						) : null }
 						{ this.state.chosenImportType === 'content-only' ? (
 							<Button primary onClick={ this.handleImportRedirect }>

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -69,7 +69,7 @@ class StepImportOrMigrate extends Component {
 	};
 
 	render() {
-		const { targetSite, targetSiteSlug, sourceHasJetpack, sourceSite } = this.props;
+		const { targetSite, targetSiteSlug, sourceHasJetpack, sourceSite, sourceSiteInfo } = this.props;
 		const backHref = `/migrate/${ targetSiteSlug }`;
 
 		const targetSiteDomain = get( targetSite, 'domain' );
@@ -78,7 +78,11 @@ class StepImportOrMigrate extends Component {
 			<>
 				<HeaderCake backHref={ backHref }>Import from WordPress</HeaderCake>
 
-				<SitesBlock sourceSite={ sourceSite } targetSite={ targetSite } />
+				<SitesBlock
+					sourceSite={ sourceSite }
+					sourceSiteInfo={ sourceSiteInfo }
+					targetSite={ targetSite }
+				/>
 
 				<CompactCard>
 					<CardHeading>What do you want to import?</CardHeading>

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -4,12 +4,14 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { Button, CompactCard } from '@automattic/components';
+import { get } from 'lodash';
+import { CompactCard } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
 import HeaderCake from 'components/header-cake';
+import MigrateButton from './migrate-button.jsx';
 
 /**
  * Style dependencies
@@ -19,17 +21,24 @@ import './section-migrate.scss';
 class StepUpgrade extends Component {
 	static propTypes = {
 		startMigration: PropTypes.func.isRequired,
+		targetSite: PropTypes.object.isRequired,
 	};
 
 	render() {
+		const { targetSite } = this.props;
+		const targetSiteDomain = get( targetSite, 'domain' );
+
 		return (
 			<>
 				<HeaderCake>Import Everything</HeaderCake>
 
 				<CompactCard>
-					<Button onClick={ this.props.startMigration } primary>
+					<MigrateButton
+						onClick={ this.props.startMigration }
+						targetSiteDomain={ targetSiteDomain }
+					>
 						Upgrade and import
-					</Button>
+					</MigrateButton>
 				</CompactCard>
 			</>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactors `MigrateButton` to use `children` instead of having a fixed label
* Removes `MigrateButton` (with `confirm` prompt) from import or migrate step and replaces it with a standard button (as the confirmation isn't needed on that step)
* Adds `MigrateButton` to upgrade step unconditionally (as the confirm will always be required on that step)
* Conditionally used `MigrateButton` on confirmation step, as the confirm dialog should only be shown on the step immediately before migration begins or the cart is navigated to.
* Refactors `SitesBlock` to accept either `sourceSiteInfo`, or `sourceSite`.
* Updates all prior uses of `sourceSite` (which was really just the info, not the site object) to `sourceSiteInfo`.
* Adds `MigrateButton` and checklist to confirmation page.
* Refactors the logic to check whether a business plan purchase is necessary and ties it into all the various display / action aspects on the confirmation page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select a site without a business plan, starting from `/migrate`.
* Enter a connected Jetpack URL and select "Continue".
* With the "Everything" radio selected, click "Continue". Note: The `accept` prompt no longer appears after continuing on this step.
* On the confirmation screen, select "Import everything". Note: that because you haven't purchased a business plan, the `accept` prompt is absent here as well
* The subsequent page isn't part of this PR, so it'll appear empty except for a button. Clicking on that button should display the `accept` prompt.
* Accepting the prompt should take you to the shopping cart with the business plan in your cart.

* Select a site with a business plan, starting from `/migrate`.
* Enter a connected Jetpack URL and select "Continue".
* With the "Everything" radio selected, click "Continue". Note: The `accept` prompt no longer appears after continuing on this step.
* On the confirmation screen, select "Import everything". Note: you should see the `accept` prompt, because this is the last step prior to migration, as you've already purchased a business plan.
* Accepting the prompt should start the migration.
