### PR TITLE
Gutenboarding - (NOT) Enable FSE site creation

### DIFF
--- a/client/landing/gutenboarding/utils.ts
+++ b/client/landing/gutenboarding/utils.ts
@@ -35,6 +35,8 @@ export function createSite( { siteTitle, siteUrl, theme, siteVertical }: CreateS
 			site_information: {
 				title: siteTitle,
 			},
+			// TODO - Remove DOTCOM FSE creation before Gutenboarding is public facing.
+			site_creation_flow: 'test-fse',
 		},
 		public: -1,
 		validate: false,


### PR DESCRIPTION
**NOTE** - We have decided not to use dotcom FSE in Gutenboarding due to design limitations due to the small amount of FSE compatible Themes.

### Changes proposed in this Pull Request

* Enable FSE site creation for Gutenboarding as per #39168

**Important Note:**  While this enables FSE site creation, only FSE enabled themes will result in an FSE site.  Currently these themes are Maywood, Morden, Shawburn, Stow, Alves, Hever, and Exford.  Any other themes selected from the design picker will still result in a non-FSE site.  The process for converting Themes to dotcom FSE compatibility is outlined on `paYE8P-dy-P2`.  It has been noted as a time consuming process and has not been continued as a result of the dotcom FSE being phased-out.

This gives us 3 options:
1.  Enable FSE creation - but only specific Themes from the design picker will result in an FSE site.
2.  Enable FSE creation - and temporarily remove non-FSE supported themes from the design picker.
3.  Don't enable FSE site creation - Continue to use the standard wpcom block editor until another option is available.

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR and go through the Gutenboarding flow.
* At the design selection step, choose an FSE enabled theme (such as Maywood).
* Create your site, verify that you are landed into the dotcom FSE editor.  (Quick give-aways of being in the FSE editor include the header template part at the top of the site's page and the labeled back button in the top left.)

Fixes #39168
