### PR TITLE
Sidebar: Display the WP Admin menu item for all users.

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -593,10 +593,6 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		if ( ! this.useWPAdminFlows() ) {
-			return null;
-		}
-
 		const adminUrl =
 			this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip
 				? formatUrl( {
@@ -625,31 +621,6 @@ export class MySitesSidebar extends Component {
 			</SidebarMenu>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
-	}
-
-	// Check for cases where WP Admin links should appear, where we need support for legacy reasons (VIP, older users, testing).
-	useWPAdminFlows() {
-		const { isJetpack, isVip } = this.props;
-		const currentUser = this.props.currentUser;
-		const userRegisteredDate = new Date( currentUser.date );
-		const cutOffDate = new Date( '2015-09-07' );
-
-		// VIP sites should always show a WP Admin link regardless of the current user.
-		if ( isVip ) {
-			return true;
-		}
-
-		// Jetpack (including Atomic) sites should always show a WP Admin
-		if ( isJetpack ) {
-			return true;
-		}
-
-		// User registered before the cut-off date of September 7, 2015 and we want to support them as legacy users.
-		if ( userRegisteredDate < cutOffDate ) {
-			return true;
-		}
-
-		return false;
 	}
 
 	trackWpadminClick = () => {


### PR DESCRIPTION
Back in #9764, filtering was added so that new users after September 7, 2015 would not be given a WP Admin sidebar item for their Simple sites. This PR removes this filtering, now that it is no longer considered beneficial; the link should show for all sites of any user.

<img width="661" alt="Screen Shot 2020-02-06 at 4 52 12 PM" src="https://user-images.githubusercontent.com/349751/73991484-243d1800-4901-11ea-9135-b4467331254d.png">

#### Testing instructions

- With a user created before Sept 7, 2015, ensure the WP Admin link is present with all site types (Simple, Jetpack, Atomic, VIP).
- Go through signup (https://wordpress.com/start/) in an Incognito window and create a new user and site.
- Add that user to one of each site type.
- Verify the WP Admin link is present for that user for all site types.

Fixes #36241.
