### PR TITLE
SPT: Make sure to get blog locale, not user locale.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -249,7 +249,9 @@ class Starter_Page_Templates {
 	 * @return string ISO 639 locale string
 	 */
 	private function get_iso_639_locale() {
-		$language = strtolower( get_locale() );
+		// Make sure to get blog locale, not user locale.
+		$language = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_locale();
+		$language = strtolower( $language );
 
 		if ( in_array( $language, [ 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ], true ) ) {
 			$language = str_replace( '_', '-', $language );


### PR DESCRIPTION
Locale works a little differently on wp.com. When we're in wp-admin the standard content local gets set to the user locale. To get the content locale, we'll have to use `get_blog_lang_code()`.

#### Changes proposed in this Pull Request

* Uses `get_blog_lang_code()` if available `get_locale()` as a fallback.

#### Testing instructions

* Manually apply this diff on dotcom and test with a sandboxed site.
* With a non-a11n account, set your site language to a non-English locale, set your account language to a _different_ non-English locale.
* Open the template selector and make sure the templates are in the content locale.

Fixes #38198
