### PR TITLE
Social signup: distinguish between signup failures and user_exist failures

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -101,12 +101,16 @@ class SocialLoginForm extends Component {
 					);
 				} else if ( error.code === 'user_exists' ) {
 					this.props.createSocialUserFailed( socialInfo, error );
+					this.recordEvent( 'calypso_login_social_prompt_connect', 'google', {
+						error_code: error.code,
+						error_message: error.message,
+					} );
+				} else {
+					this.recordEvent( 'calypso_login_social_login_failure', 'google', {
+						error_code: error.code,
+						error_message: error.message,
+					} );
 				}
-
-				this.recordEvent( 'calypso_login_social_login_failure', 'google', {
-					error_code: error.code,
-					error_message: error.message,
-				} );
 			}
 		);
 	};
@@ -153,12 +157,16 @@ class SocialLoginForm extends Component {
 					);
 				} else if ( error.code === 'user_exists' ) {
 					this.props.createSocialUserFailed( socialInfo, error );
+					this.recordEvent( 'calypso_login_social_prompt_connect', 'apple', {
+						error_code: error.code,
+						error_message: error.message,
+					} );
+				} else {
+					this.recordEvent( 'calypso_login_social_login_failure', 'apple', {
+						error_code: error.code,
+						error_message: error.message,
+					} );
 				}
-
-				this.recordEvent( 'calypso_login_social_login_failure', 'apple', {
-					error_code: error.code,
-					error_message: error.message,
-				} );
 			}
 		);
 	};


### PR DESCRIPTION
## Changes proposed in this Pull Request

A significant proportion of `calypso_login_social_button_failure` errors in Tracks are for `user_exists` error codes.

When existing WordPress.com users login using social buttons for the first time we should log the `user_exist` error and subsequent prompt for connection separately from social login failures.

This PR distinguishes login failures and social connect prompts.

Props to @lsl 

## Testing instructions

1. Disconnect existing social account under https://wordpress.com/me/security/social-login
2. Logout
3. Attempt to login using a social button
4. Prompt to login using password and connect is what triggers failure event