### PR TITLE
Gutenboarding: Persisted data should expire and be conditional

### DIFF
--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -13,6 +13,7 @@ import config from '../../config';
 import { Gutenboard } from './gutenboard';
 import { setupWpDataDebug } from './devtools';
 import accessibleFocus from 'lib/accessible-focus';
+
 /**
  * Style dependencies
  */

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -13,7 +13,6 @@ import config from '../../config';
 import { Gutenboard } from './gutenboard';
 import { setupWpDataDebug } from './devtools';
 import accessibleFocus from 'lib/accessible-focus';
-
 /**
  * Style dependencies
  */

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { controls } from '@wordpress/data-controls';
 import { plugins, registerStore, use } from '@wordpress/data';
 import { isSupportSession } from 'lib/user/support-user-interop';
 
@@ -26,7 +27,8 @@ use( plugins.persistence, persistOptions );
 
 registerStore< State >( STORE_KEY, {
 	actions,
-	reducer,
+	controls,
+	reducer: reducer as any,
 	selectors,
 
 	// Remove the persistence plugin for certain conditions - ie, during a support session

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -19,8 +19,8 @@ export { STORE_KEY };
 
 // Define the conditions under which data should be persisted to localStorage
 export const shouldPersist = () => {
-	const hasFreshParam = window.location.search.indexOf( 'nopersist' ) !== -1;
-	return ! isSupportSession && ! hasFreshParam;
+	const hasNoPersistParam = window.location.search.indexOf( 'nopersist' ) !== -1;
+	return ! isSupportSession && ! hasNoPersistParam;
 };
 
 use( plugins.persistence, persistOptions );

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -3,7 +3,7 @@
  */
 import { controls } from '@wordpress/data-controls';
 import { plugins, registerStore, use } from '@wordpress/data';
-//import { isSupportSession } from 'lib/user/support-user-interop';
+import { isSupportSession } from 'lib/user/support-user-interop';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export { STORE_KEY };
 
 // Define the conditions under which data should be persisted to localStorage
 export const shouldPersist = () => {
-	return true; //&& ! isSupportSession
+	return ! isSupportSession;
 };
 
 use( plugins.persistence, persistOptions );

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { controls } from '@wordpress/data-controls';
 import { plugins, registerStore, use } from '@wordpress/data';
+import { isSupportSession } from 'lib/user/support-user-interop';
 
 /**
  * Internal dependencies
@@ -11,25 +11,37 @@ import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
+import persistOptions from './persist';
 import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
 
 export { STORE_KEY };
 
-use( plugins.persistence, {} );
+// Define the conditions under which data should be persisted to localStorage
+export const shouldPersist = () => {
+	const hasFreshParam = window.location.search.indexOf( 'nopersist' ) !== -1;
+	return isSupportSession && ! hasFreshParam;
+};
+
+use( plugins.persistence, persistOptions );
 
 registerStore< State >( STORE_KEY, {
 	actions,
-	controls,
-	reducer: reducer as any,
+	reducer,
 	selectors,
-	persist: [
-		'domain',
-		'siteTitle',
-		'siteVertical',
-		'pageLayouts',
-		'selectedDesign',
-		'shouldCreate',
-	],
+
+	// Remove the persistence plugin for certain conditions - ie, during a support session
+	...( shouldPersist()
+		? {
+				persist: [
+					'domain',
+					'siteTitle',
+					'siteVertical',
+					'pageLayouts',
+					'selectedDesign',
+					'shouldCreate',
+				],
+		  }
+		: {} ),
 } );
 
 declare module '@wordpress/data' {

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -3,7 +3,7 @@
  */
 import { controls } from '@wordpress/data-controls';
 import { plugins, registerStore, use } from '@wordpress/data';
-import { isSupportSession } from 'lib/user/support-user-interop';
+//import { isSupportSession } from 'lib/user/support-user-interop';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export { STORE_KEY };
 
 // Define the conditions under which data should be persisted to localStorage
 export const shouldPersist = () => {
-	return ! isSupportSession;
+	return true; //&& ! isSupportSession
 };
 
 use( plugins.persistence, persistOptions );

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -3,7 +3,6 @@
  */
 import { controls } from '@wordpress/data-controls';
 import { plugins, registerStore, use } from '@wordpress/data';
-//import { isSupportSession } from 'lib/user/support-user-interop';
 
 /**
  * Internal dependencies
@@ -17,11 +16,6 @@ import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
 
 export { STORE_KEY };
 
-// Define the conditions under which data should be persisted to localStorage
-export const shouldPersist = () => {
-	return true; //&& ! isSupportSession
-};
-
 use( plugins.persistence, persistOptions );
 
 registerStore< State >( STORE_KEY, {
@@ -29,20 +23,14 @@ registerStore< State >( STORE_KEY, {
 	controls,
 	reducer: reducer as any,
 	selectors,
-
-	// Remove the persistence plugin for certain conditions - ie, during a support session
-	...( shouldPersist()
-		? {
-				persist: [
-					'domain',
-					'siteTitle',
-					'siteVertical',
-					'pageLayouts',
-					'selectedDesign',
-					'shouldCreate',
-				],
-		  }
-		: {} ),
+	persist: [
+		'domain',
+		'siteTitle',
+		'siteVertical',
+		'pageLayouts',
+		'selectedDesign',
+		'shouldCreate',
+	],
 } );
 
 declare module '@wordpress/data' {

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -3,7 +3,7 @@
  */
 import { controls } from '@wordpress/data-controls';
 import { plugins, registerStore, use } from '@wordpress/data';
-import { isSupportSession } from 'lib/user/support-user-interop';
+//import { isSupportSession } from 'lib/user/support-user-interop';
 
 /**
  * Internal dependencies
@@ -19,8 +19,7 @@ export { STORE_KEY };
 
 // Define the conditions under which data should be persisted to localStorage
 export const shouldPersist = () => {
-	const hasNoPersistParam = window.location.search.indexOf( 'nopersist' ) !== -1;
-	return ! isSupportSession && ! hasNoPersistParam;
+	return true; //&& ! isSupportSession
 };
 
 use( plugins.persistence, persistOptions );

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -20,7 +20,7 @@ export { STORE_KEY };
 // Define the conditions under which data should be persisted to localStorage
 export const shouldPersist = () => {
 	const hasFreshParam = window.location.search.indexOf( 'nopersist' ) !== -1;
-	return isSupportSession && ! hasFreshParam;
+	return ! isSupportSession && ! hasFreshParam;
 };
 
 use( plugins.persistence, persistOptions );

--- a/client/landing/gutenboarding/stores/onboard/persist.ts
+++ b/client/landing/gutenboarding/stores/onboard/persist.ts
@@ -41,7 +41,7 @@ const localStorageSupport = (): boolean => {
 const storageHandler = localStorageSupport() ? window.localStorage : objStorage;
 
 // Persisted data expires after seven days
-const isFresh = ( timestampStr: string ): boolean => {
+const isNotExpired = ( timestampStr: string ): boolean => {
 	const timestamp = Number( timestampStr );
 	return Boolean( timestamp ) && timestamp + PERSISTENCE_INTERVAL > Date.now();
 };
@@ -56,7 +56,7 @@ const storage: Pick< Storage, 'getItem' | 'setItem' > = {
 	getItem( key ) {
 		const timestamp = storageHandler.getItem( STORAGE_TS_KEY );
 
-		if ( timestamp && isFresh( timestamp ) && ! hasFreshParam() ) {
+		if ( timestamp && isNotExpired( timestamp ) && ! hasFreshParam() ) {
 			return storageHandler.getItem( key );
 		}
 

--- a/client/landing/gutenboarding/stores/onboard/persist.ts
+++ b/client/landing/gutenboarding/stores/onboard/persist.ts
@@ -1,8 +1,9 @@
 /*
-    Defines the options used for the @wp/data persistence plugin, which include a persistent storage implementation to add data expiration handling.
+    Defines the options used for the @wp/data persistence plugin, 
+    which include a persistent storage implementation to add data expiration handling.
 */
 
-const PERSISTANCE_INTERVAL = 7 * 24 * 3600000; // days * hours in days * ms in hour
+const PERSISTENCE_INTERVAL = 7 * 24 * 3600000; // days * hours in days * ms in hour
 const STORAGE_KEY = 'WP_ONBOARD';
 const STORAGE_TS_KEY = 'WP_ONBOARD_TS';
 
@@ -42,7 +43,7 @@ const storageHandler = localStorageSupport() ? window.localStorage : objStorage;
 // Persisted data expires after seven days
 const isFresh = ( timestampStr: string ): boolean => {
 	const timestamp = Number( timestampStr );
-	return Boolean( timestamp ) && timestamp + PERSISTANCE_INTERVAL > Date.now();
+	return Boolean( timestamp ) && timestamp + PERSISTENCE_INTERVAL > Date.now();
 };
 
 // Check for "fresh" query param

--- a/client/landing/gutenboarding/stores/onboard/persist.ts
+++ b/client/landing/gutenboarding/stores/onboard/persist.ts
@@ -1,0 +1,78 @@
+/*
+    Defines the options used for the @wp/data persistence plugin, which include a persistent storage implementation to add data expiration handling.
+*/
+
+const PERSISTANCE_INTERVAL = 7 * 24 * 3600000; // days * hours in days * ms in hour
+const STORAGE_KEY = 'WP_ONBOARD';
+const STORAGE_TS_KEY = 'WP_ONBOARD_TS';
+
+// A plain object fallback if localStorage is not available
+const objStore: { [ key: string ]: string } = {};
+
+const objStorage: Pick< Storage, 'getItem' | 'setItem' | 'removeItem' > = {
+	getItem( key ) {
+		if ( objStore.hasOwnProperty( key ) ) {
+			return objStore[ key ];
+		}
+
+		return null;
+	},
+	setItem( key, value ) {
+		objStore[ key ] = String( value );
+	},
+	removeItem( key ) {
+		delete objStore[ key ];
+	},
+};
+
+// Make sure localStorage support exists
+const localStorageSupport = (): boolean => {
+	try {
+		window.localStorage.setItem( 'WP_ONBOARD_TEST', '1' );
+		window.localStorage.removeItem( 'WP_ONBOARD_TEST' );
+		return true;
+	} catch ( e ) {
+		return false;
+	}
+};
+
+// Choose the right storage implementation
+const storageHandler = localStorageSupport() ? window.localStorage : objStorage;
+
+// Persisted data expires after seven days
+const isFresh = ( timestampStr: string ): boolean => {
+	const timestamp = Number( timestampStr );
+	return Boolean( timestamp ) && timestamp + PERSISTANCE_INTERVAL > Date.now();
+};
+
+// Check for "fresh" query param
+const hasFreshParam = (): boolean => {
+	return window.location.search.indexOf( 'fresh' ) !== -1;
+};
+
+// Handle data expiration by providing a storage object override to the @wp/data persistence plugin.
+const storage: Pick< Storage, 'getItem' | 'setItem' > = {
+	getItem( key ) {
+		const timestamp = storageHandler.getItem( STORAGE_TS_KEY );
+
+		if ( timestamp && isFresh( timestamp ) && ! hasFreshParam() ) {
+			return storageHandler.getItem( key );
+		}
+
+		storageHandler.removeItem( STORAGE_KEY );
+		storageHandler.removeItem( STORAGE_TS_KEY );
+
+		return null;
+	},
+	setItem( key, value ) {
+		storageHandler.setItem( STORAGE_TS_KEY, JSON.stringify( Date.now() ) );
+		storageHandler.setItem( key, value );
+	},
+};
+
+const persistOptions = {
+	storageKey: STORAGE_KEY,
+	storage,
+};
+
+export default persistOptions;


### PR DESCRIPTION
### Summary

This PR adds smoother handling for persisted data in the `onboard` data stores. Specifically:

- [x]  Data is only persisted for 7 days.
- [ ]  Data is not persisted during a support session.
- [x]  Persisted data is cleared with a `fresh` URL param.

<hr>

### Specifics

This is fun because there's not exactly a smooth nor clear solution.

The persistence plugin alone is not quite a quick solution here. Predominately, because creating a new storage implementation involves rewriting the default storage option that already exists for `localStorage` - albeit, encapsulated and untouchable - and serializing/re-serializing data twice (this is handled at a higher layer within the plugin and not exposed, so data handling requires a second transform), to ultimately end up doing almost the same thing. Seems like the persistence plugin was more intended for different storage implementations, like `sessionStorage`, rather than overt data handling.

Ultimately, I went with using a secondary key in `localStorage` to act as the timestamp, given that two `setItem` calls are more performant than double serializing and that it's less overtly doing something twice. Still YAPSS (Yet Another Persistent Storage Solution), but it works with the least amount of smelliness.

<hr>

### Testing

* Spin this up locally and go to `/gutenboarding`.
    * Ensure that data persists normally:
        * Pick a vertical and enter a site title, then refresh the page. Ensure that the site title and vertical are still filled out correctly.
    * Test expired persisted data flow:
         * Go to `/`, the root of Calypso. (You want to leave the `/gutenboarding` page, as interacting with the page to refresh it will undo what you are about to do.)
         * Follow the instructions in the section below to edit local storage and set the `WP_ONBOARD_TS` to `0`.
         * Go back to `/gutenboarding` and ensure that the data entered from the first few steps is no longer persisted and that it displays as a blank slate.
    * Test URL params:
         * Go to `/gutenboarding` and set a site title or other data.
         * Go to `/gutenboarding?fresh` and ensure that the persisted data is not visible.

**Interacting with localStorage through DevTools:**
* Open up DevTools and go to the "Application" tab.
* In the sidebar, under "Storage > Local Storage", select the URL of the Calypso instance you're interacting with (either your local install `https://calypso.localhost...` or a different URL).
* Find the `WP_ONBOARD_TS` entry and set it to `0`.
<img width="987" alt="Screen Shot 2020-02-07 at 2 26 29 AM" src="https://user-images.githubusercontent.com/8892849/74009829-0a77f100-4952-11ea-85d3-2faba9b4ce2a.png">


<hr>

Fixes #37849 