### PR TITLE
Hide mobile app banner if ToS update banner is shown

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -73,7 +73,7 @@ export class AppBanner extends Component {
 		saveDismissTime: noop,
 		translate: identity,
 		recordAppBannerOpen: noop,
-		userAgent: globalThis?.navigator?.userAgent ?? '',
+		userAgent: typeof window !== 'undefined' ? window.navigator.userAgent : '',
 	};
 
 	stopBubblingEvents = event => {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -73,7 +73,7 @@ export class AppBanner extends Component {
 		saveDismissTime: noop,
 		translate: identity,
 		recordAppBannerOpen: noop,
-		userAgent: typeof window !== 'undefined' ? window.navigator.userAgent : '',
+		userAgent: globalThis?.navigator?.userAgent ?? '',
 	};
 
 	stopBubblingEvents = event => {

--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -39,6 +39,7 @@ import {
 } from './utils';
 import versionCompare from 'lib/version-compare';
 import { isWpMobileApp } from 'lib/mobile-app';
+import { shouldDisplayTosUpdateBanner } from 'state/selectors/should-display-tos-update-banner';
 
 /**
  * Style dependencies
@@ -72,7 +73,7 @@ export class AppBanner extends Component {
 		saveDismissTime: noop,
 		translate: identity,
 		recordAppBannerOpen: noop,
-		userAgent: typeof window !== 'undefined' ? navigator.userAgent : '',
+		userAgent: typeof window !== 'undefined' ? window.navigator.userAgent : '',
 	};
 
 	stopBubblingEvents = event => {
@@ -93,7 +94,14 @@ export class AppBanner extends Component {
 	};
 
 	isVisible() {
-		const { dismissedUntil, currentSection } = this.props;
+		const { dismissedUntil, currentSection, isTosBannerVisible } = this.props;
+
+		// The ToS update banner is displayed in the same position as the mobile app banner. Since the ToS update
+		// has higher priority, we repress all other non-essential sticky banners if the ToS update banner needs to
+		// be displayed.
+		if ( isTosBannerVisible ) {
+			return false;
+		}
 
 		return this.isMobile() && ! isWpMobileApp() && ! isDismissed( dismissedUntil, currentSection );
 	}
@@ -260,6 +268,7 @@ const mapStateToProps = state => {
 		currentRoute,
 		fetchingPreferences: isFetchingPreferences( state ),
 		siteId: getSelectedSiteId( state ),
+		isTosBannerVisible: shouldDisplayTosUpdateBanner( state ),
 	};
 };
 

--- a/client/state/selectors/should-display-tos-update-banner.js
+++ b/client/state/selectors/should-display-tos-update-banner.js
@@ -4,6 +4,6 @@
  * @param state {object}
  * @returns {boolean} Whether the ToS update banner should be displayed.
  */
-export const shouldDisplayTosUpdateBanner = state => state?.legal?.tos?.displayPrompt;
+export const shouldDisplayTosUpdateBanner = state => state?.legal?.tos?.displayPrompt === true;
 
 export default shouldDisplayTosUpdateBanner;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follows up #39297 

The ToS update banner is displayed in the same position as the mobile app banner. Since the ToS update has higher priority, we repress all other non-essential sticky banners like the "open in app" one if the ToS update banner needs to be displayed.

Before | After
--- | ---
<img width="550" alt="Screenshot 2020-02-07 at 12 07 18" src="https://user-images.githubusercontent.com/1233880/74025404-2dcb8c00-49a4-11ea-88f3-0356d3c89b75.png"> | <img width="515" alt="Screenshot 2020-02-07 at 12 15 54" src="https://user-images.githubusercontent.com/1233880/74025430-34f29a00-49a4-11ea-9d74-87550a59dea4.png">


#### Testing instructions

* Make sure you don't have ToS marked as accepted. See D38262-code for instructions on how to reset ToS acceptance.
* If you've dismissed the mobile app banner in the past, bring it back by running the following line in your browser console:
```js
dispatch( { type: 'PREFERENCES_SET', key: 'appBannerDismissTimes', value: null } );
````

* Toggle the device toolbar in your browser devtools and select "Responsive". Adjust the width to less than 300px.
<img width="240" alt="Screenshot 2020-02-07 at 12 24 12" src="https://user-images.githubusercontent.com/1233880/74025712-d8dc4580-49a4-11ea-9fbc-5e89dbc2ae1c.png">
<img width="370" alt="Screenshot 2020-02-07 at 12 24 30" src="https://user-images.githubusercontent.com/1233880/74025714-dbd73600-49a4-11ea-9c88-1aad8548c2cd.png">

* Open the network conditions tab (it is under the "more tools" option) and select an iOS or Android user agent.
<img width="950" alt="Screenshot 2020-02-07 at 12 26 46" src="https://user-images.githubusercontent.com/1233880/74025847-26f14900-49a5-11ea-86f1-35f1658a028f.png">

* Load the reader in Calypso and note how the mobile app banner is behind the ToS update banner and slightly visible on the top.
* Switch to this branch and reload the reader.
* Make sure the mobile app banner is not displayed.
* Accept the ToS.
* Make sure the mobile app banner is displayed now.

