### PR TITLE
Reader: Remove unnecessary loading placeholders

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -115,7 +115,9 @@ const exported = {
 	},
 
 	sidebar( context, next ) {
-		context.secondary = <AsyncLoad require="reader/sidebar" path={ context.path } />;
+		context.secondary = (
+			<AsyncLoad require="reader/sidebar" path={ context.path } placeholder={ null } />
+		);
 
 		next();
 	},
@@ -195,6 +197,7 @@ const exported = {
 				showPrimaryFollowButtonOnCards={ false }
 				suppressSiteNameLink={ true }
 				showBack={ userHasHistory( context ) }
+				placeholder={ null }
 			/>
 		);
 		next();
@@ -229,6 +232,7 @@ const exported = {
 				showPrimaryFollowButtonOnCards={ false }
 				suppressSiteNameLink={ true }
 				showBack={ userHasHistory( context ) }
+				placeholder={ null }
 			/>
 		);
 		next();
@@ -263,6 +267,7 @@ const exported = {
 				) }
 				showPrimaryFollowButtonOnCards={ false }
 				onUpdatesShown={ trackUpdatesLoaded.bind( null, mcKey ) }
+				placeholder={ null }
 			/>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
I use the reader a lot, I admit it. And something I've noticed that looks odd, is the placeholders that appear here and there without a good reason. 

Seems like we're displaying some in the sidebar, and in the content.

Here's a rare screenshot that captures both of them in the same time:

![](https://cldup.com/HsKACzDbUd.png)

They are all coming from the fact that we're async loading those pieces. This PR removes all of these placeholders.

#### Changes proposed in this Pull Request

* Reader: Remove unnecessary loading placeholders

#### Testing instructions

* Go to http://calypso.localhost:3000/read
* Verify the sidebar no longer has a loading placeholder during its loading.
* Go to http://calypso.localhost:3000/read/feeds/66271116
* Verify there is no longer a placeholder in the content area before the content gets loaded.
* Go to http://calypso.localhost:3000/read/blogs/4
* Verify there is no longer a placeholder in the content area before the content gets loaded.
* Go to http://calypso.localhost:3000/read/a8c (this URL is for a12s only)
* Verify there is no longer a placeholder in the content area before the content gets loaded.
