### PR TITLE
e2e: Update user-agent to more recent version

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -9,6 +9,7 @@ import config from 'config';
 import proxy from 'selenium-webdriver/proxy';
 import SauceLabs from 'saucelabs';
 import { times } from 'lodash';
+import fs from 'fs';
 
 import * as remote from 'selenium-webdriver/remote';
 
@@ -133,6 +134,8 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 	} else {
 		switch ( browser.toLowerCase() ) {
 			case 'chrome':
+				const chromeVersion = await fs.readFileSync( './.chromedriver_version', 'utf8' ).trim();
+				const userAgent = `user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${ chromeVersion } Safari/537.36`;
 				options = new chrome.Options();
 				options.setUserPreferences( {
 					enable_do_not_track: true,
@@ -143,9 +146,7 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 				options.addArguments( '--no-first-run' );
 
 				if ( useCustomUA ) {
-					options.addArguments(
-						'user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
-					);
+					options.addArguments( userAgent );
 				}
 				if (
 					process.env.HEADLESS ||

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -144,7 +144,7 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 
 				if ( useCustomUA ) {
 					options.addArguments(
-						'user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36'
+						'user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
 					);
 				}
 				if (

--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -9,7 +9,7 @@ import config from 'config';
 import proxy from 'selenium-webdriver/proxy';
 import SauceLabs from 'saucelabs';
 import { times } from 'lodash';
-import fs from 'fs';
+import { readFileSync } from 'fs';
 
 import * as remote from 'selenium-webdriver/remote';
 
@@ -134,8 +134,6 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 	} else {
 		switch ( browser.toLowerCase() ) {
 			case 'chrome':
-				const chromeVersion = await fs.readFileSync( './.chromedriver_version', 'utf8' ).trim();
-				const userAgent = `user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${ chromeVersion } Safari/537.36`;
 				options = new chrome.Options();
 				options.setUserPreferences( {
 					enable_do_not_track: true,
@@ -146,6 +144,8 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 				options.addArguments( '--no-first-run' );
 
 				if ( useCustomUA ) {
+					const chromeVersion = await readFileSync( './.chromedriver_version', 'utf8' ).trim();
+					const userAgent = `user-agent=Mozilla/5.0 (wp-e2e-tests) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${ chromeVersion } Safari/537.36`;
 					options.addArguments( userAgent );
 				}
 				if (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Recently a PR (#39001) was merged that caused issues. The issues should have been caught by the e2e tests but they weren't because of the old user agent that that the tests were using. This PR uses the chromedriver version as the Chrome version. They won't always match perfectly, but the major version will.

#### Testing instructions
* Ensure tests pass in CI.
* Run test `Basic Public Post @parallel @jetpack @canary` locally against https://hash-2e3c19ab3711ef1d64fef7b632a66e3af34d4bb7.calypso.live and ensure it fails.
* Change the major version in in  `.chomedriver_version` to something prior to 78, like 51 which we were on before. Make sure the test, `Basic Public Post @parallel @jetpack @canary`, running against https://hash-2e3c19ab3711ef1d64fef7b632a66e3af34d4bb7.calypso.live passes