### PR TITLE
composite-checkout: Fix full credits calculation

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
@@ -11,7 +11,10 @@ import {
 	createExistingCardMethod,
 	createFullCreditsMethod,
 } from '@automattic/composite-checkout';
-import { prepareDomainContactDetails } from '@automattic/composite-checkout-wpcom';
+import {
+	prepareDomainContactDetails,
+	CheckoutCartItem,
+} from '@automattic/composite-checkout-wpcom';
 import wp from 'lib/wp';
 
 /**
@@ -48,9 +51,9 @@ export function createPaymentMethods( {
 	select: Function;
 	registerStore: Function;
 	wpcom: object;
-	credits: LineItem;
-	total: LineItem;
-	subtotal: LineItem;
+	credits: CheckoutCartItem;
+	total: CheckoutCartItem;
+	subtotal: CheckoutCartItem;
 	translate: Function;
 } ): Array< object > {
 	if ( isLoading ) {
@@ -363,12 +366,4 @@ async function wpcomPayPalExpress(
 	payload: PayPalExpressEndpointRequestPayload
 ): Promise< PayPalExpressEndpointResponse > {
 	return wp.undocumented().paypalExpressUrl( payload );
-}
-
-// TODO: we can probably import this from somewhere else
-interface LineItem {
-	amount: {
-		value: number;
-		displayValue: string;
-	};
 }

--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
@@ -39,23 +39,28 @@ export function createPaymentMethods( {
 	wpcom,
 	credits,
 	total,
+	subtotal,
 	translate,
-} ) {
+}: {
+	isLoading: boolean;
+	allowedPaymentMethods: Array< string >;
+	storedCards: Array< object >;
+	select: Function;
+	registerStore: Function;
+	wpcom: object;
+	credits: LineItem;
+	total: LineItem;
+	subtotal: LineItem;
+	translate: Function;
+} ): Array< object > {
 	if ( isLoading ) {
 		return [];
 	}
 
-	debug(
-		'creating payment methods; allowedPaymentMethods is',
-		allowedPaymentMethods,
-		'credits is',
-		credits.amount.value,
-		'and total is',
-		total.amount.value
-	);
+	debug( 'creating payment methods; allowedPaymentMethods is', allowedPaymentMethods );
 
 	const fullCreditsPaymentMethod =
-		credits.amount.value > 0 && credits.amount.value >= total.amount.value
+		credits.amount.value > 0 && credits.amount.value >= subtotal.amount.value
 			? createFullCreditsMethod( {
 					registerStore,
 					submitTransaction: submitData =>
@@ -358,4 +363,12 @@ async function wpcomPayPalExpress(
 	payload: PayPalExpressEndpointRequestPayload
 ): Promise< PayPalExpressEndpointResponse > {
 	return wp.undocumented().paypalExpressUrl( payload );
+}
+
+// TODO: we can probably import this from somewhere else
+interface LineItem {
+	amount: {
+		value: number;
+		displayValue: string;
+	};
 }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -112,6 +112,7 @@ export default function CompositeCheckout( {
 		addItem,
 		changePlanLength,
 		errors,
+		subtotal,
 		isLoading,
 		allowedPaymentMethods: serverAllowedPaymentMethods,
 	} = useShoppingCart( siteSlug, setCart || wpcomSetCart, getCart || wpcomGetCart );
@@ -148,6 +149,7 @@ export default function CompositeCheckout( {
 				wpcom,
 				credits,
 				total,
+				subtotal,
 				translate,
 			} ),
 		[
@@ -159,6 +161,7 @@ export default function CompositeCheckout( {
 			credits,
 			registerStore,
 			total,
+			subtotal,
 			translate,
 		]
 	);

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -41,6 +41,7 @@ export interface ShoppingCartManager {
 	items: WPCOMCartItem[];
 	tax: CheckoutCartItem;
 	total: CheckoutCartItem;
+	subtotal: CheckoutCartItem;
 	credits: CheckoutCartItem;
 	addItem: ( WPCOMCartItem ) => void;
 	removeItem: ( WPCOMCartItem ) => void;
@@ -207,6 +208,7 @@ export function useShoppingCart(
 		items: cart.items,
 		tax: cart.tax,
 		total: cart.total,
+		subtotal: cart.subtotal,
 		credits: cart.credits,
 		errors: responseCart.messages?.errors ?? [],
 		allowedPaymentMethods: cart.allowedPaymentMethods,

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -14,7 +14,6 @@ import {
 	WPCOMCart,
 	WPCOMCartItem,
 	CheckoutCartItem,
-	CheckoutCartTotal,
 } from '../types';
 import { translateWpcomCartToCheckoutCart } from '../lib/translate-cart';
 
@@ -41,7 +40,7 @@ export interface ShoppingCartManager {
 	allowedPaymentMethods: string[];
 	items: WPCOMCartItem[];
 	tax: CheckoutCartItem;
-	total: CheckoutCartTotal;
+	total: CheckoutCartItem;
 	credits: CheckoutCartItem;
 	addItem: ( WPCOMCartItem ) => void;
 	removeItem: ( WPCOMCartItem ) => void;

--- a/packages/composite-checkout-wpcom/src/index.js
+++ b/packages/composite-checkout-wpcom/src/index.js
@@ -7,7 +7,7 @@ import { useShoppingCart } from './hooks/use-shopping-cart';
 import { useWpcomStore } from './hooks/wpcom-store';
 import { mockSetCartEndpoint, mockGetCartEndpointWith } from './mock/cart-endpoint';
 import FormFieldAnnotation from './components/form-field-annotation';
-import { WPCOMCartItem, prepareDomainContactDetails } from './types';
+import { WPCOMCartItem, CheckoutCartItem, prepareDomainContactDetails } from './types';
 
 // Re-export the public API
 export {
@@ -19,5 +19,6 @@ export {
 	mockGetCartEndpointWith,
 	FormFieldAnnotation,
 	WPCOMCartItem,
+	CheckoutCartItem,
 	prepareDomainContactDetails,
 };

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -29,6 +29,8 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 		credits_integer,
 		credits_display,
 		allowed_payment_methods,
+		sub_total_integer,
+		sub_total_display,
 	} = serverCart;
 
 	const taxLineItem: CheckoutCartItem = {
@@ -53,10 +55,22 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 		},
 	};
 
+	const subtotalItem: CheckoutCartItem = {
+		id: 'total',
+		type: 'total',
+		label: 'Total',
+		amount: {
+			currency: currency,
+			value: sub_total_integer,
+			displayValue: sub_total_display,
+		},
+	};
+
 	return {
 		items: products.map( translateWpcomCartItemToCheckoutCartItem ),
 		tax: taxLineItem,
 		total: totalItem,
+		subtotal: subtotalItem,
 		credits: {
 			id: 'credits',
 			type: 'credits',

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -7,7 +7,6 @@ import {
 	WPCOMCart,
 	WPCOMCartItem,
 	CheckoutCartItem,
-	CheckoutCartTotal,
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
 } from '../types';
@@ -43,7 +42,9 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 		},
 	};
 
-	const totalItem: CheckoutCartTotal = {
+	const totalItem: CheckoutCartItem = {
+		id: 'total',
+		type: 'total',
 		label: 'Total',
 		amount: {
 			currency: currency,

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -56,9 +56,9 @@ export function translateWpcomCartToCheckoutCart( serverCart: ResponseCart ): WP
 	};
 
 	const subtotalItem: CheckoutCartItem = {
-		id: 'total',
-		type: 'total',
-		label: 'Total',
+		id: 'subtotal',
+		type: 'subtotal',
+		label: 'Subtotal',
 		amount: {
 			currency: currency,
 			value: sub_total_integer,

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
@@ -39,6 +39,8 @@ export async function mockSetCartEndpoint( {
 		total_tax_integer: taxInteger,
 		total_cost_display: 'R$156',
 		total_cost_integer: totalInteger,
+		sub_total_display: 'R$149',
+		sub_total_integer: totalInteger - taxInteger,
 		coupon: requestCoupon,
 		is_coupon_applied: true,
 	} as ResponseCart;

--- a/packages/composite-checkout-wpcom/src/types.ts
+++ b/packages/composite-checkout-wpcom/src/types.ts
@@ -21,7 +21,6 @@ import {
 	emptyWPCOMCart,
 	CheckoutCartItem,
 	CheckoutCartItemAmount,
-	CheckoutCartTotal,
 } from './types/checkout-cart';
 import {
 	WpcomStoreState,
@@ -52,7 +51,6 @@ export {
 	emptyWPCOMCart,
 	CheckoutCartItem,
 	CheckoutCartItemAmount,
-	CheckoutCartTotal,
 	WpcomStoreState,
 	initialWpcomStoreState,
 	ManagedContactDetails,

--- a/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
@@ -47,6 +47,8 @@ export interface ResponseCart {
 	total_tax_display: string;
 	total_cost_integer: number;
 	total_cost_display: string;
+	sub_total_integer: number;
+	sub_total_display: string;
 	currency: string;
 	credits_integer: number;
 	credits_display: string;
@@ -68,6 +70,8 @@ export const emptyResponseCart = {
 	total_tax_display: '0',
 	total_cost_integer: 0,
 	total_cost_display: '0',
+	sub_total_integer: 0,
+	sub_total_display: '0',
 	currency: 'USD',
 	credits_integer: 0,
 	credits_display: '0',

--- a/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
@@ -25,11 +25,6 @@ export interface CheckoutCartItem {
 	amount: CheckoutCartItemAmount;
 }
 
-export interface CheckoutCartTotal {
-	label: string;
-	amount: CheckoutCartItemAmount;
-}
-
 /**
  * Cart item with WPCOM specific info added.
  */
@@ -47,7 +42,7 @@ export type WPCOMCartItem = CheckoutCartItem & {
 export interface WPCOMCart {
 	items: WPCOMCartItem[];
 	tax: CheckoutCartItem;
-	total: CheckoutCartTotal;
+	total: CheckoutCartItem;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 	credits: CheckoutCartItem;
 }
@@ -71,7 +66,7 @@ export const emptyWPCOMCart = {
 			currency: '',
 			displayValue: '',
 		} as CheckoutCartItemAmount,
-	} as CheckoutCartTotal,
+	} as CheckoutCartItem,
 	allowedPaymentMethods: [],
 	credits: {
 		id: 'Credits',

--- a/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
@@ -43,6 +43,7 @@ export interface WPCOMCart {
 	items: WPCOMCartItem[];
 	tax: CheckoutCartItem;
 	total: CheckoutCartItem;
+	subtotal: CheckoutCartItem;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 	credits: CheckoutCartItem;
 }
@@ -61,6 +62,14 @@ export const emptyWPCOMCart = {
 	} as CheckoutCartItem,
 	total: {
 		label: 'Total',
+		amount: {
+			value: 0,
+			currency: '',
+			displayValue: '',
+		} as CheckoutCartItemAmount,
+	} as CheckoutCartItem,
+	subtotal: {
+		label: 'Subtotal',
 		amount: {
 			value: 0,
 			currency: '',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, the shopping cart response includes `total_cost` which represents the total amount that the customer must pay after taxes, coupons, discounts, etc. 

The decision to display the full credits payment method is currently based on comparing the amount of credits to the total. This works in a full credits situation because of an inconsistent behavior of the endpoint documented more fully in D38606-code.

It is sometimes incorrect for partial credits, though; for example, if the user has $50 in credits and the cost of a plan is $70, the `total_cost` is $20, and since 50 > 20 we display the full credits method. It would be correct if the user only had $5 in credits, since 5 < 65.

This PR adds the `sub_total` property returned by the shopping card endpoint to the data returned by `useShoppingCart` and then uses that value to compare against the credit amount when deciding if we should display the full credits method.

Fixes #39322

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Sandbox the store.
- Make sure your test account has no credits.
- Add a plan to your cart.
- Visit checkout and verify that the "Credits" method does not appear in the first step.
- Add enough credits to your test account to cover 50% of the plan cost.
- Visit checkout again and verify that the "Credits" method still does not appear in the first step.
- Add enough credits to your test account to cover 100% of the plan cost.
- Visit checkout again and verify that the "Credits" method appears, is the first payment method, and that it is selected by default.
- Complete checkout with the "Credits" payment method and verify that the payment is successful. 
