### PR TITLE
Customer Home: Replace My Site Card

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -11,6 +11,7 @@ import moment from 'moment';
 
 /**
  * Internal dependencies
+ * boop starting commit beep boop
  */
 import Banner from 'components/banner';
 import { Button, Card } from '@automattic/components';

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -11,7 +11,6 @@ import moment from 'moment';
 
 /**
  * Internal dependencies
- * boop starting commit beep boop
  */
 import Banner from 'components/banner';
 import { Button, Card } from '@automattic/components';
@@ -208,6 +207,7 @@ class Home extends Component {
 			isNewlyCreatedSite,
 			translate,
 			checklistMode,
+			site,
 			siteId,
 			currentThemeId,
 			siteIsUnlaunched,
@@ -243,33 +243,43 @@ class Home extends Component {
 			}
 		}
 
-		// Show a congratulatory message post-launch
-		if ( ! siteIsUnlaunched && 'launched' === checklistMode ) {
-			return (
-				<>
-					<img
-						src="/calypso/images/signup/confetti.svg"
-						aria-hidden="true"
-						className="customer-home__confetti"
-						alt=""
-					/>
-					<FormattedHeader
-						headerText={ translate( 'You launched your site!' ) }
-						subHeaderText={ this.getChecklistSubHeaderText() }
-					/>
-				</>
-			);
-		}
-
-		// Show the standard heading otherwise
+		// If launched, show a congratulatory message, else show the standard heading
 		return (
-			<FormattedHeader
-				headerText={ translate( 'My Home' ) }
-				subHeaderText={ translate(
-					'Your home base for all the posting, editing, and growing of your site'
+			<>
+				<div className="customer-home__heading">
+					<FormattedHeader
+						headerText={ translate( 'My Home' ) }
+						subHeaderText={ translate(
+							'Your home base for all the posting, editing, and growing of your site'
+						) }
+						align="left"
+					/>
+					{ ! siteIsUnlaunched && (
+						<div className="customer-home__view-site-button">
+							<Button href={ site.URL } onClick={ () => trackAction( 'my_site', 'view_site' ) }>
+								{ translate( 'View Site' ) }
+							</Button>
+						</div>
+					) }
+				</div>
+				{ ! siteIsUnlaunched && 'launched' === checklistMode && (
+					<Card className="customer-home__launch-card" highlight="info">
+						<img
+							src="/calypso/images/illustrations/fireworks.svg"
+							aria-hidden="true"
+							className="customer-home__launch-fireworks"
+							alt=""
+						/>
+						<div className="customer-home__launch-card-text">
+							<CardHeading>{ translate( 'You launched your site!' ) }</CardHeading>
+							<p className="customer-home__launch-card-subtext">
+								{ ' ' }
+								{ this.getChecklistSubHeaderText() }
+							</p>
+						</div>
+					</Card>
 				) }
-				align="left"
-			/>
+			</>
 		);
 	}
 
@@ -327,7 +337,7 @@ class Home extends Component {
 		);
 	}
 
-	renderSiteTools() {
+	renderQuickLinks() {
 		const {
 			displayChecklist,
 			translate,
@@ -336,20 +346,54 @@ class Home extends Component {
 			siteSlug,
 			trackAction,
 			isStaticHomePage,
+			staticHomePageId,
 			showCustomizer,
 			hasCustomDomain,
 		} = this.props;
 
-		const siteTools = (
+		const editHomePageUrl =
+			isStaticHomePage && `/block-editor/page/${ siteSlug }/${ staticHomePageId }`;
+
+		const quickLinks = (
 			<div className="customer-home__boxes">
-				<ActionBox
-					onClick={ () => {
-						trackAction( 'my_site', 'add_page' );
-						page( `/page/${ siteSlug }` );
-					} }
-					label={ translate( 'Add a page' ) }
-					iconSrc={ pageIcon }
-				/>
+				{ isStaticHomePage ? (
+					<ActionBox
+						onClick={ () => {
+							trackAction( 'my_site', 'edit_homepage' );
+							page( editHomePageUrl );
+						} }
+						label={ translate( 'Edit homepage' ) }
+						iconSrc={ imagesIcon }
+					/>
+				) : (
+					<ActionBox
+						onClick={ () => {
+							trackAction( 'my_site', 'write_post' );
+							page( `/post/${ siteSlug }` );
+						} }
+						label={ translate( 'Write blog post' ) }
+						iconSrc={ postIcon }
+					/>
+				) }
+				{ isStaticHomePage ? (
+					<ActionBox
+						onClick={ () => {
+							trackAction( 'my_site', 'add_page' );
+							page( `/page/${ siteSlug }` );
+						} }
+						label={ translate( 'Add a page' ) }
+						iconSrc={ pageIcon }
+					/>
+				) : (
+					<ActionBox
+						onClick={ () => {
+							trackAction( 'my_site', 'manage_comments' );
+							page( `/comments/${ siteSlug }` );
+						} }
+						label={ translate( 'Manage comments' ) }
+						iconSrc={ commentIcon }
+					/>
+				) }
 				{ isStaticHomePage ? (
 					<ActionBox
 						onClick={ () => {
@@ -362,11 +406,19 @@ class Home extends Component {
 				) : (
 					<ActionBox
 						onClick={ () => {
-							trackAction( 'my_site', 'manage_comments' );
-							page( `/comments/${ siteSlug }` );
+							trackAction( 'my_site', 'add_page' );
+							page( `/page/${ siteSlug }` );
 						} }
-						label={ translate( 'Manage comments' ) }
-						iconSrc={ commentIcon }
+						label={ translate( 'Add a page' ) }
+						iconSrc={ pageIcon }
+					/>
+				) }
+				{ showCustomizer && (
+					<ActionBox
+						href={ menusUrl }
+						onClick={ () => trackAction( 'my_site', 'edit_menus' ) }
+						label={ translate( 'Edit menus' ) }
+						iconSrc={ menuIcon }
 					/>
 				) }
 				{ showCustomizer && (
@@ -384,20 +436,6 @@ class Home extends Component {
 					} }
 					label={ translate( 'Change theme' ) }
 					iconSrc={ themeIcon }
-				/>
-				{ showCustomizer && (
-					<ActionBox
-						href={ menusUrl }
-						onClick={ () => trackAction( 'my_site', 'edit_menus' ) }
-						label={ translate( 'Edit menus' ) }
-						iconSrc={ menuIcon }
-					/>
-				) }
-				<ActionBox
-					href={ `/media/${ siteSlug }` }
-					onClick={ () => trackAction( 'my_site', 'change_images' ) }
-					label={ translate( 'Change images' ) }
-					iconSrc={ imagesIcon }
 				/>
 				<ActionBox
 					href="https://wp.me/logo-maker"
@@ -434,16 +472,16 @@ class Home extends Component {
 			<>
 				{ ! isMobile() ? (
 					<Card className="customer-home__card-boxes">
-						<CardHeading>{ translate( 'Site Tools' ) }</CardHeading>
-						{ siteTools }
+						<CardHeading>{ translate( 'Quick Links' ) }</CardHeading>
+						{ quickLinks }
 					</Card>
 				) : (
 					<FoldableCard
 						className="customer-home__card-boxes card-heading-21"
-						header={ translate( 'Site Tools' ) }
+						header={ translate( 'Quick Links' ) }
 						expanded
 					>
-						{ siteTools }
+						{ quickLinks }
 					</FoldableCard>
 				) }
 			</>
@@ -490,7 +528,7 @@ class Home extends Component {
 							<WpcomChecklist displayMode={ checklistMode } />
 						</>
 					) }
-					{ this.renderSiteTools() }
+					{ this.renderQuickLinks() }
 				</div>
 				<div className="customer-home__layout-col customer-home__layout-col-right">
 					{ siteIsUnlaunched && ! needsEmailVerification && (
@@ -510,42 +548,6 @@ class Home extends Component {
 						</Card>
 					) }
 					{ ! siteIsUnlaunched && <StatsCard /> }
-					{ ! siteIsUnlaunched && isChecklistComplete && (
-						<Card>
-							<CardHeading>{ translate( 'My Site' ) }</CardHeading>
-							<h6 className="customer-home__card-subheader">
-								{ translate( 'Make changes to your site or view its current state' ) }
-							</h6>
-							<div className="customer-home__card-col">
-								<div className="customer-home__card-col-left">
-									{ isStaticHomePage ? (
-										<Button
-											href={ editHomePageUrl }
-											primary={ isPrimary }
-											onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
-										>
-											{ translate( 'Edit Homepage' ) }
-										</Button>
-									) : (
-										<Button
-											href={ `/post/${ siteSlug }` }
-											primary={ isPrimary }
-											onClick={ () => {
-												trackAction( 'my_site', 'write_post' );
-											} }
-										>
-											{ translate( 'Write Blog Post' ) }
-										</Button>
-									) }
-								</div>
-								<div className="customer-home__card-col-right">
-									<Button href={ site.URL } onClick={ () => trackAction( 'my_site', 'view_site' ) }>
-										{ translate( 'View Site' ) }
-									</Button>
-								</div>
-							</div>
-						</Card>
-					) }
 					{ ! siteIsUnlaunched && isChecklistComplete && (
 						<Card className="customer-home__grow-earn">
 							<CardHeading>{ translate( 'Grow & Earn' ) }</CardHeading>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -212,6 +212,7 @@ class Home extends Component {
 			currentThemeId,
 			siteIsUnlaunched,
 			isAtomic,
+			trackAction,
 		} = this.props;
 
 		// Show a thank-you message 30 mins post site creation/purchase
@@ -495,7 +496,6 @@ class Home extends Component {
 			needsEmailVerification,
 			translate,
 			checklistMode,
-			site,
 			siteSlug,
 			trackAction,
 			expandToolsAndTrack,
@@ -504,8 +504,6 @@ class Home extends Component {
 			hasChecklistData,
 			siteIsUnlaunched,
 		} = this.props;
-		const editHomePageUrl =
-			isStaticHomePage && `/block-editor/page/${ siteSlug }/${ staticHomePageId }`;
 
 		if ( ! hasChecklistData ) {
 			return <div className="customer-home__loading-placeholder"></div>;

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -273,7 +273,6 @@ class Home extends Component {
 						<div className="customer-home__launch-card-text">
 							<CardHeading>{ translate( 'You launched your site!' ) }</CardHeading>
 							<p className="customer-home__launch-card-subtext">
-								{ ' ' }
 								{ this.getChecklistSubHeaderText() }
 							</p>
 						</div>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -499,8 +499,6 @@ class Home extends Component {
 			siteSlug,
 			trackAction,
 			expandToolsAndTrack,
-			isStaticHomePage,
-			staticHomePageId,
 			hasChecklistData,
 			siteIsUnlaunched,
 		} = this.props;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -45,28 +45,27 @@
 			margin: 0;
 		}
 	}
-	
 	&__confetti {
 		display: block;
 		width: 320px;
 		margin: 0 auto;
 	}
-	
+
 	&__heading {
 		display: flex;
 		@include breakpoint( '<660px' ) {
-			margin: 1.5em 16px 0 16px
+			margin: 1.5em 16px 0 16px;
 		}
-		
+
 		.formatted-header {
 			margin: 0;
 			margin-right: 12px;
 		}
-		
+
 		.customer-home__view-site-button {
 			margin: auto;
 			margin-right: 0;
-			
+
 			.button {
 				text-align: center;
 			}
@@ -82,30 +81,30 @@
 	&__launch-card {
 		display: flex;
 		padding: 12px 16px;
-		
+
 		.customer-home__launch-fireworks {
 			margin-right: 18px;
 			width: 145px;
-			
+
 			@include breakpoint( '<480px' ) {
 				display: none;
 			}
 		}
-		
+
 		.customer-home__launch-card-text {
 			margin: auto 0;
-			
+
 			.card-heading {
 				margin: 0;
 			}
 		}
-		
+
 		.customer-home__launch-card-subtext {
 			margin: 0;
 			font-weight: 300;
 		}
 	}
-			
+
 	&__box-action {
 		margin-bottom: 16px;
 		width: 100%;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -84,7 +84,7 @@
 
 		.customer-home__launch-fireworks {
 			margin-right: 18px;
-			width: 145px;
+			width: 100px;
 
 			@include breakpoint( '<480px' ) {
 				display: none;
@@ -101,6 +101,7 @@
 
 		.customer-home__launch-card-subtext {
 			margin: 0;
+			font-size: 14px;
 			font-weight: 300;
 		}
 	}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -45,10 +45,32 @@
 			margin: 0;
 		}
 	}
+	
 	&__confetti {
 		display: block;
 		width: 320px;
 		margin: 0 auto;
+	}
+	
+	&__heading {
+		display: flex;
+		@include breakpoint( '<660px' ) {
+			margin: 1.5em 16px 0 16px
+		}
+		
+		.formatted-header {
+			margin: 0;
+			margin-right: 12px;
+		}
+		
+		.customer-home__view-site-button {
+			margin: auto;
+			margin-right: 0;
+			
+			.button {
+				text-align: center;
+			}
+		}
 	}
 	&__launch-button {
 		& .button {
@@ -57,6 +79,33 @@
 			height: 50px;
 		}
 	}
+	&__launch-card {
+		display: flex;
+		padding: 12px 16px;
+		
+		.customer-home__launch-fireworks {
+			margin-right: 18px;
+			width: 145px;
+			
+			@include breakpoint( '<480px' ) {
+				display: none;
+			}
+		}
+		
+		.customer-home__launch-card-text {
+			margin: auto 0;
+			
+			.card-heading {
+				margin: 0;
+			}
+		}
+		
+		.customer-home__launch-card-subtext {
+			margin: 0;
+			font-weight: 300;
+		}
+	}
+			
 	&__box-action {
 		margin-bottom: 16px;
 		width: 100%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes a variety of changes, all of which are the ones mentioned in #39182.

### When site is launched
Note the addition of the banner instead of the confetti illustration
<img width="1282" alt="Screenshot 2020-02-08 at 12 57 53" src="https://user-images.githubusercontent.com/43215253/74086026-ea8e1d80-4a76-11ea-9cb2-841a4f291344.png">

### Site with a Static Home Page
Note the change of boxes
<img width="1277" alt="Screenshot 2020-02-08 at 13 04 32" src="https://user-images.githubusercontent.com/43215253/74086064-32ad4000-4a77-11ea-9a5f-be971ff71d38.png">

### Site without a Static Home Page
Note the change of boxes
<img width="1309" alt="Screenshot 2020-02-08 at 12 58 08" src="https://user-images.githubusercontent.com/43215253/74086076-40fb5c00-4a77-11ea-8ebc-149385845d17.png">

Other changes made, as mentioned in the initial issue:

- Site Tools replaced with Quick Links
- "View Site" button at the top right of the screen
- Formatted header at the top now always appears

As a result of this, the My Site card has now been removed. It was never being displayed before the site was launched, and the initial issue states that the things above are what is needed to remove it post-launch. Here was the logic for that, by the way.

https://github.com/Automattic/wp-calypso/blob/25d2ca0bf9148864d430e99304688a6019439b99/client/my-sites/customer-home/main.jsx#L512-L515

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify that the above all works, and that there's no issues caused by this PR. It may also be worth checking the responsive design, which should be adequate (the fireworks illustration should disappear).

Fixes #39182
