### PR TITLE
Fix nav bar for posts/ on small device, before the mobile breakpoint

### DIFF
--- a/client/my-sites/post-type-filter/style.scss
+++ b/client/my-sites/post-type-filter/style.scss
@@ -17,3 +17,21 @@
 		}
 	}
 }
+
+@include breakpoint( '660px-800px' ) {
+	$width-search: 40px;
+	$space-between-nav-and-search: 5px;
+
+	.section-nav.has-pinned-items {
+		padding-right: $space-between-nav-and-search + $width-search;
+	}
+	.section-nav__segmented .segmented-control {
+		margin: 0;
+	}
+	.search.is-expanded-to-container {
+		width: $width-search;
+		svg {
+			width:$width-search;
+		}
+	}
+}


### PR DESCRIPTION
Before:

![Screenshot 2020-02-09 at 21 51 02](https://user-images.githubusercontent.com/790558/74110440-f66c0380-4b8c-11ea-957c-4b49c8cf2d7c.png)

After:
![Screenshot 2020-02-09 at 22 37 16](https://user-images.githubusercontent.com/790558/74110443-fa982100-4b8c-11ea-98e2-92b829dc7391.png)

By simply playing with the margins for the 660px-800px breakpoint.

cc @mattsherman 