### PR TITLE
Make sure new DWPO users will see "included in paid plans" copy in regard to domain mapping step

### DIFF
--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -18,6 +18,7 @@ import { getProductsList } from 'state/products-list/selectors';
 import {
 	currentUserHasFlag,
 	getCurrentUser,
+	isUserLoggedIn,
 	getCurrentUserCurrencyCode,
 } from 'state/current-user/selectors';
 import { Card, Button } from '@automattic/components';
@@ -439,7 +440,8 @@ export default connect(
 	state => ( {
 		currentUser: getCurrentUser( state ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
-		domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
+		domainsWithPlansOnly:
+			currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ) || ! isUserLoggedIn( state ),
 		selectedSite: getSelectedSite( state ),
 		productsList: getProductsList( state ),
 	} ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to p2MSmN-7CE-p2

At the moment, new users going through https://wordpress.com/start are erroneously seeing the following copy:

![G4IzWtGKcE-2000x2000](https://user-images.githubusercontent.com/205419/74127628-6c975700-4bdb-11ea-905d-4457f3a25ed6.png)

It says that domain mapping is paid. In reality, it's included in paid plans so they should be seeing the following copy instead:

<img width="762" alt="Zrzut ekranu 2020-02-10 o 07 53 29" src="https://user-images.githubusercontent.com/205419/74127649-78831900-4bdb-11ea-8958-049a1255fc80.png">

The problem is caused by the followind:

* Domains step users `currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )` to determine whether or not user is DWPO and <a href="https://github.com/Automattic/wp-calypso/blob/f2c9d99b07e14ea938829e9b2e5b31b6fb388a90/client/components/domains/use-your-domain-step/index.jsx#L264">which copy should be displayed</a>.
* <a href="https://github.com/Automattic/wp-calypso/blob/67c3e665fde69e406a4f96a6fb45055a2638c601/client/state/current-user/selectors.js#L164">currentUserHasFlag selector</a> checks for `state.currentUser.flags`.
* `state.currentUser` is set in <a href="https://github.com/Automattic/wp-calypso/blob/67c3e665fde69e406a4f96a6fb45055a2638c601/client/boot/app.js#L22">app.js#boot</a> so it's not populated with data for accounts created after the boot on `/start/user`.
* A proper fix would involve either need a full page reload, or some rather large architectural changes to make sure user data are populated after signing up.
* This PR is a second-best fix. Since all new users are DWPO, it enables the proper copy whenever a user doesn't seem to be logged in. Since this is only possible during signup, it should suffice.

#### Testing instructions

Only non-DWPO users should see "$13/year" message - confirm this is true by logging in as one, creating new site, going to domains step, choosing "I already have a domain".

All other users, including existing and new users, should see the same copy as on the second screenshot above. To test that, try:

* Creating new user in incognito mode, on /start, going to domains step, choosing "I already have a domain"
* Creating a new site as an existing DWPO user, again going to domains step, choosing "I already have a domain"
