### PR TITLE
[Coming soon] Add support for ecommerce plan

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -348,7 +348,7 @@ export class PlanFeatures extends Component {
 		return ReactDOM.createPortal(
 			<Notice className="plan-features__notice" showDismiss={ false } status="is-info">
 				{ translate(
-					'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
+					"This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner."
 				) }
 			</Notice>,
 			bannerContainer

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -14,6 +14,7 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import FoldableCard from 'components/foldable-card';
 import InlineSupportLink from 'components/inline-support-link';
 import Notice from 'components/notice';
@@ -347,7 +348,7 @@ export class PlanFeatures extends Component {
 		return ReactDOM.createPortal(
 			<Notice className="plan-features__notice" showDismiss={ false } status="is-info">
 				{ translate(
-					"This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner."
+					'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
 				) }
 			</Notice>,
 			bannerContainer
@@ -597,6 +598,11 @@ export class PlanFeatures extends Component {
 		if ( siteIsPrivateAndGoingAtomic ) {
 			if ( isInSignup ) {
 				// Let signup do its thing
+				return;
+			}
+			if ( config.isEnabled( 'coming-soon' ) ) {
+				// When coming soon feature is enabled, we don't want to show any warnings
+				page( checkoutUrlWithArgs );
 				return;
 			}
 			this.setState( {

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -17,8 +17,8 @@ import { isEcommercePlan } from 'lib/plans';
  * @returns `true` for private by default & `false` for not
  */
 export default function shouldNewSiteBePrivateByDefault( state: object ): boolean {
-	// If coming-soon feature flag is enabled, we want all new sites to be private
 	if ( config.isEnabled( 'coming-soon' ) ) {
+		// When coming-soon feature flag is enabled, we want all new sites to be private
 		return true;
 	}
 

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -6,6 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { isEcommercePlan } from 'lib/plans';
 
@@ -16,6 +17,11 @@ import { isEcommercePlan } from 'lib/plans';
  * @returns `true` for private by default & `false` for not
  */
 export default function shouldNewSiteBePrivateByDefault( state: object ): boolean {
+	// If coming-soon feature flag is enabled, we want all new sites to be private
+	if ( config.isEnabled( 'coming-soon' ) ) {
+		return true;
+	}
+
 	/**
 	 * eCommerce sites are created public since they go Atomic at purchase.
 	 * p1578348423018900-slack-CCS1W9QVA


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to Coming Soon mode. More context available here: paObgF-MY-p2

At the moment, we strip privacy of all sites on upgrade to e-commerce plan. This PR removes this restriction so that every site going e-commerce remains private/coming soon.

Specifically, this PR makes sure all new e-commerce sites are marked as private+coming soon and also that the following warning is no longer displayed:

<img width="445" alt="Zrzut ekranu 2020-02-10 o 10 09 36" src="https://user-images.githubusercontent.com/205419/74135914-7629ba80-4bed-11ea-9ab0-23686aeedce0.png">

All of the above is added behind a feature flag and shouldn't affect any existing users.

#### Testing instructions

1. Open calypso in local dev environment to ensure appropriate feature flag is enabled
1. Create a new e-commerce site, confirm it's "Coming Soon"
1. Create a new free site
1. Upgrade to e-commerce plan
1. Confirm privacy warning was not displayed
1. Confirm the site is still "Coming Soon"
1. Disable `coming-soon` feature flag and confirm that the warning is still in place. Also, new e-commerce sites should be public.