### PR TITLE
Domain step test: Add checkboxes for the tld filter bar

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -172,6 +172,9 @@ class RegisterDomainStep extends React.Component {
 
 		this._isMounted = false;
 		this.state = this.getState();
+		this.state.filters = this.getInitialFiltersState();
+		this.state.lastFilters = this.getInitialFiltersState();
+
 		if ( props.initialState ) {
 			this.state = { ...this.state, ...props.initialState };
 
@@ -209,9 +212,6 @@ class RegisterDomainStep extends React.Component {
 				this.state.railcarId = this.getNewRailcarId();
 			}
 		}
-
-		this.state.filters = this.getInitialFiltersState();
-		this.state.lastFilters = this.getInitialFiltersState();
 	}
 
 	getState() {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1257,6 +1257,7 @@ class RegisterDomainStep extends React.Component {
 						onReset={ this.onFiltersReset }
 						onSubmit={ this.onFiltersSubmit }
 						showPlaceholder={ this.state.loadingResults || ! this.getSuggestionsFromProps() }
+						showDesignUpdate={ this.props.showDesignUpdate }
 					/>
 				) }
 			</DomainSearchResults>

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -89,7 +89,10 @@
 	}
 }
 
-.search-filters__buttons {
+
+
+.search-filters__buttons,
+.search-filters__checkboxes {
 	display: flex;
 	flex-flow: row;
 	justify-content: space-between;
@@ -113,11 +116,33 @@
 	// Increase specificity to override button styles in signup
 	body.is-section-signup .layout & {
 		button.search-filters__tld-button,
+		input.search-filters__tld-checkbox,
 		button.search-filters__popover-button {
 			font-size: 14px;
 			padding-top: 0.5em;
 			padding-bottom: 0.5em;
 		}
+
+		button.search-filters__popover-button-domain-step-test {
+			flex: 1 0 0;
+		}
+
+		.search-filters__filter-by {
+			margin-right: 2em;
+		}
+
+		.search-filters__tld-checkbox-wrapper {
+			display: flex;
+			flex: 1 0 auto;
+			justify-content: space-between;
+			margin-right: 1em;
+
+			& .search-filters__tld-checkbox-label span {
+				margin-left: 2em;
+			}
+		}
+
+		
 	}
 
 	@include breakpoint( '<960px' ) {
@@ -151,6 +176,10 @@
 			display: none;
 		}
 	}
+}
+
+.search-filters__checkboxes {
+	align-items: center;
 }
 
 .search-filters__popover-button .gridicon {

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -151,7 +151,7 @@
 			flex-grow: 0;
 		}
 
-		& .search-filters__tld-checkbox {
+		.search-filters__tld-checkbox {
 			display: flex;
 			align-items: center;
 			margin-left: 2em;

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -116,11 +116,14 @@
 	// Increase specificity to override button styles in signup
 	body.is-section-signup .layout & {
 		button.search-filters__tld-button,
-		input.search-filters__tld-checkbox,
 		button.search-filters__popover-button {
 			font-size: 14px;
 			padding-top: 0.5em;
 			padding-bottom: 0.5em;
+		}
+
+		input.search-filters__tld-checkbox {
+			font-size: 14px;
 		}
 
 		button.search-filters__popover-button-domain-step-test {
@@ -131,18 +134,16 @@
 			margin-right: 2em;
 		}
 
-		.search-filters__tld-checkbox-wrapper {
+		.search-filters__tld-checkbox-filter-bar {
 			display: flex;
 			flex: 1 0 auto;
 			justify-content: space-between;
 			margin-right: 1em;
 
-			& .search-filters__tld-checkbox-label span {
+			& .search-filters__tld-checkbox span {
 				margin-left: 2em;
 			}
 		}
-
-		
 	}
 
 	@include breakpoint( '<960px' ) {
@@ -154,25 +155,29 @@
 			margin-bottom: 0.5em;
 		}
 
-		.search-filters__tld-button:nth-child( n + 7 ) {
+		.search-filters__tld-button:nth-child( n + 7 ),
+		.search-filters__tld-checkbox:nth-child( n + 7 ) {
 			display: none;
 		}
 	}
 
 	@include breakpoint( '<800px' ) {
-		.search-filters__tld-button:nth-child( n + 5 ) {
+		.search-filters__tld-button:nth-child( n + 5 ),
+		.search-filters__tld-checkbox:nth-child( n + 5 ) {
 			display: none;
 		}
 	}
 
 	@include breakpoint( '<660px' ) {
-		.search-filters__tld-button:nth-child( n + 4 ) {
+		.search-filters__tld-button:nth-child( n + 4 ),
+		.search-filters__tld-checkbox:nth-child( n + 4 ) {
 			display: none;
 		}
 	}
 
 	@include breakpoint( '<480px' ) {
-		.search-filters__tld-button:nth-child( n + 2 ) {
+		.search-filters__tld-button:nth-child( n + 2 ),
+		.search-filters__tld-checkbox:nth-child( n + 2 ) {
 			display: none;
 		}
 	}

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -95,8 +95,8 @@
 .search-filters__checkboxes {
 	display: flex;
 	flex-flow: row;
-	justify-content: space-between;
 	overflow: hidden;
+	align-items: center;
 
 	.button {
 		flex: 1 0 auto;
@@ -122,26 +122,50 @@
 			padding-bottom: 0.5em;
 		}
 
-		input.search-filters__tld-checkbox {
-			font-size: 14px;
-		}
-
 		button.search-filters__popover-button-domain-step-test {
-			flex: 1 0 0;
-		}
-
-		.search-filters__filter-by {
-			margin-right: 2em;
-		}
-
-		.search-filters__tld-checkbox-filter-bar {
-			display: flex;
 			flex: 1 0 auto;
-			justify-content: space-between;
-			margin-right: 1em;
+			margin-left: 2em;
 
-			& .search-filters__tld-checkbox span {
-				margin-left: 2em;
+			@include breakpoint( '<480px' ) {
+				margin-left: 0;
+			}
+		}
+
+		legend.search-filters__filter-by {
+			font-size: 14px;
+			color: var( --color-text-subtle );
+
+			@include breakpoint( '<480px' ) {
+				display: none;
+			}
+		}
+	}
+
+	.search-filters__tld-checkbox-filter-bar {
+		display: flex;
+		flex: 1 0 auto;
+		justify-content: space-around;
+		font-size: 14px;
+
+		@include breakpoint( '<480px' ) {
+			flex-grow: 0;
+		}
+
+		& .search-filters__tld-checkbox {
+			display: flex;
+			align-items: center;
+			margin-left: 2em;
+
+			&:last-child {
+				margin-right: 0;
+			}
+
+			& .form-checkbox {
+				font-size: 14px;
+			}
+
+			& span {
+				margin-left: 1em;
 			}
 		}
 	}
@@ -170,21 +194,17 @@
 
 	@include breakpoint( '<660px' ) {
 		.search-filters__tld-button:nth-child( n + 4 ),
-		.search-filters__tld-checkbox:nth-child( n + 4 ) {
+		.search-filters__tld-checkbox:nth-child( n + 3 ) {
 			display: none;
 		}
 	}
 
 	@include breakpoint( '<480px' ) {
 		.search-filters__tld-button:nth-child( n + 2 ),
-		.search-filters__tld-checkbox:nth-child( n + 2 ) {
+		.search-filters__tld-checkbox:nth-child( n + 1 ) {
 			display: none;
 		}
 	}
-}
-
-.search-filters__checkboxes {
-	align-items: center;
 }
 
 .search-filters__popover-button .gridicon {
@@ -252,4 +272,3 @@
 		}
 	}
 }
-

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -136,7 +136,7 @@ export class TldFilterBar extends Component {
 			.map( ( tld, index ) => (
 				<div className="search-filters__tld-checkbox">
 					<FormCheckbox
-						className={ classNames( 'search-filters__tld-button', 'search-filters__tld-checkbox', {
+						className={ classNames( 'search-filters__tld-button', {
 							'is-active': includes( selectedTlds, tld ),
 						} ) }
 						checked={ includes( selectedTlds, tld ) }

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -97,20 +97,24 @@ export class TldFilterBar extends Component {
 	}
 
 	render() {
-		if ( this.props.showPlaceholder ) {
+		const { showDesignUpdate, isSignupStep, showPlaceholder, translate } = this.props;
+
+		if ( showPlaceholder ) {
 			return this.renderPlaceholder();
 		}
 
-		const className = classNames( '', {
-			'search-filters__buttons': ! this.props.showDesignUpdate,
-			'search-filters__checkboxes': this.props.showDesignUpdate,
-			'search-filters__tld-filter-bar--is-domain-management': ! this.props.isSignupStep,
+		const className = classNames( {
+			'search-filters__buttons': ! showDesignUpdate,
+			'search-filters__checkboxes': showDesignUpdate,
+			'search-filters__tld-filter-bar--is-domain-management': ! isSignupStep,
 		} );
 
-		if ( this.props.showDesignUpdate ) {
+		if ( showDesignUpdate ) {
 			return (
 				<CompactCard className={ className }>
-					<FormLegend className="search-filters__filter-by">Filter by: </FormLegend>
+					<FormLegend className="search-filters__filter-by">
+						{ translate( 'Filter by:' ) }
+					</FormLegend>
 					{ this.renderSuggestedCheckboxes() }
 					{ this.renderPopoverButton() }
 					{ this.state.showPopover && this.renderPopover() }

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -14,9 +14,11 @@ import { connect } from 'react-redux';
  */
 import { Button, CompactCard } from '@automattic/components';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormCheckbox from 'components/forms/form-checkbox';
 import Popover from 'components/popover';
 import TokenField from 'components/token-field';
 import { recordTldFilterSelected } from './analytics';
+import FormLegend from 'components/forms/form-legend';
 
 const HANDLED_FILTER_KEYS = [ 'tlds' ];
 
@@ -99,9 +101,22 @@ export class TldFilterBar extends Component {
 			return this.renderPlaceholder();
 		}
 
-		const className = classNames( 'search-filters__buttons', {
+		const className = classNames( '', {
+			'search-filters__buttons': ! this.props.showDesignUpdate,
+			'search-filters__checkboxes': this.props.showDesignUpdate,
 			'search-filters__tld-filter-bar--is-domain-management': ! this.props.isSignupStep,
 		} );
+
+		if ( this.props.showDesignUpdate ) {
+			return (
+				<CompactCard className={ className }>
+					<FormLegend className="search-filters__filter-by">Filter by: </FormLegend>
+					{ this.renderSuggestedCheckboxes() }
+					{ this.renderPopoverButton() }
+					{ this.state.showPopover && this.renderPopover() }
+				</CompactCard>
+			);
+		}
 
 		return (
 			<CompactCard className={ className }>
@@ -110,6 +125,28 @@ export class TldFilterBar extends Component {
 				{ this.state.showPopover && this.renderPopover() }
 			</CompactCard>
 		);
+	}
+
+	renderSuggestedCheckboxes() {
+		const {
+			lastFilters: { tlds: selectedTlds },
+		} = this.props;
+		const checkboxes = this.props.availableTlds
+			.slice( 0, this.props.numberOfTldsShown )
+			.map( tld => (
+				<div className="search-filters__tld-checkbox-label">
+					<FormCheckbox
+						className={ classNames( 'search-filters__tld-button', 'search-filters__tld-checkbox', {
+							'is-active': includes( selectedTlds, tld ),
+						} ) }
+						checked={ includes( selectedTlds, tld ) }
+						onChange={ this.handleButtonClick }
+					/>
+					<span>.{ tld }</span>
+				</div>
+			) );
+
+		return <div className="search-filters__tld-checkbox-wrapper">{ checkboxes }</div>;
 	}
 
 	renderSuggestedButtons() {
@@ -140,6 +177,7 @@ export class TldFilterBar extends Component {
 			<Button
 				className={ classNames( 'search-filters__popover-button', {
 					'is-active': tlds.length > 0,
+					'search-filters__popover-button-domain-step-test': this.props.showDesignUpdate,
 				} ) }
 				onClick={ this.togglePopover }
 				ref={ this.bindButton }

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -133,20 +133,23 @@ export class TldFilterBar extends Component {
 		} = this.props;
 		const checkboxes = this.props.availableTlds
 			.slice( 0, this.props.numberOfTldsShown )
-			.map( tld => (
-				<div className="search-filters__tld-checkbox-label">
+			.map( ( tld, index ) => (
+				<div className="search-filters__tld-checkbox">
 					<FormCheckbox
 						className={ classNames( 'search-filters__tld-button', 'search-filters__tld-checkbox', {
 							'is-active': includes( selectedTlds, tld ),
 						} ) }
 						checked={ includes( selectedTlds, tld ) }
+						data-selected={ includes( selectedTlds, tld ) }
+						data-index={ index }
 						onChange={ this.handleButtonClick }
+						value={ tld }
 					/>
 					<span>.{ tld }</span>
 				</div>
 			) );
 
-		return <div className="search-filters__tld-checkbox-wrapper">{ checkboxes }</div>;
+		return <div className="search-filters__tld-checkbox-filter-bar">{ checkboxes }</div>;
 	}
 
 	renderSuggestedButtons() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The next domain step test is being implemented in #39276. The test is hidden behind a feature flag. We will build individual pieces of the UI in separate PRs.

This PR:
* Replaces the buttons in the TLD filter bar with checkboxes.

<img width="983" alt="Screenshot 2020-02-11 at 6 14 33 PM" src="https://user-images.githubusercontent.com/1269602/74238414-c2632080-4cfb-11ea-8a98-9cbfd1d41772.png">

**With items checked**

<img width="1013" alt="Screenshot 2020-02-11 at 6 14 48 PM" src="https://user-images.githubusercontent.com/1269602/74238457-d27b0000-4cfb-11ea-9008-093e1c62876c.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Begin a fresh signup at /start or click "Add new site". You need to be in the _variantShowUpdates_ variant of **domainStepCopyUpdates** test and _variantDesignUpdates_ variant of **domainStepDesignUpdates**.
* At the domain step, verify the following:
    - After typing a search query, the checkbox filters should show up and the UI should match the sketch shown in pbAok1-7N-p2.
    - Selecting any of the TLD checkboxes should reload the results and show the filtered results. For example, checking .com and and .net should only show results having these TLDs.
    - Clicking the "More Extensions" button should show a popover with the checked TLDs populated:
<img width="966" alt="Screenshot 2020-02-11 at 7 10 34 PM" src="https://user-images.githubusercontent.com/1269602/74241540-40c2c100-4d02-11ea-975f-aaf57eab7aa0.png">
    
- Verify that the buttons in the popover "Apply" and "Reset" work well
- Selecting any TLD from the popover should reload the search. If that TLD appears in the filter bar, then it should appear checked. If it is not in the filter bar, then it won't appear in the filter bar. 
- Select any of the checkboxes and proceed to the plan step by selecting a domain. Then hit Back to the domain step - the checked TLDs should be remembered. 

**Responsive**

1. Resize browser window and verify that the UI looks okay as you resize.