### PR TITLE
Enable ES2017 syntax support in Terser output.

### DIFF
--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -22,8 +22,14 @@ function chooseTerserEcmaVersion( browsers ) {
 	if ( ! caniuse.isSupported( 'es6-class', browsers ) ) {
 		return 5;
 	}
+	if ( ! caniuse.isSupported( 'array-includes', browsers ) ) {
+		return 2015;
+	}
+	if ( ! caniuse.isSupported( 'object-entries', browsers ) ) {
+		return 2016;
+	}
 
-	return 6;
+	return 2017;
 }
 
 /**


### PR DESCRIPTION
Terser now differentiates between ES2015, ES2016, and ES2017, at least in theory, potentially leading to smaller output for the newer syntaxes.
This PR adds some further checks when choosing the ECMA version.

#### Changes proposed in this Pull Request

* Add more checks to `chooseTerserEcmaVersion`

#### Testing instructions

Ensure that Calypso still builds and runs normally, particularly the `evergreen` build.
