### PR TITLE
Reader: fix margin-bottom for latex images

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -146,6 +146,10 @@
 
 .reader-full-post__story-content img {
 	margin-bottom: 12px;
+
+	&.latex {
+		margin-bottom: 0;
+	}
 }
 
 .reader-full-post__story-content figure img {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added a special SCSS case for .latex images. Images . in Reader full article have a 12px margin bottom (not really sure why). But I removed the margin for `.latex` images.

#### Testing instructions

URL is `read/blogs/171811648/posts/120`

Before:

![Screenshot 2020-02-10 at 21 28 59](https://user-images.githubusercontent.com/790558/74187243-70af8d00-4c4c-11ea-81c3-4471ea9cbd50.png)


After:


![Screenshot 2020-02-10 at 21 22 58](https://user-images.githubusercontent.com/790558/74187249-75744100-4c4c-11ea-8265-c12d1c883d3f.png)



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #39329
cc @zdenys
