### PR TITLE
Resolves duplicate highlight for Activity threat alerts

### DIFF
--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -332,7 +332,6 @@ export class ThreatAlert extends Component {
 			<Fragment>
 				<FoldableCard
 					className={ className }
-					highlight="error"
 					compact
 					clickableHeader={ true }
 					actionButton={ <span /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes prop to ensure activity log threat alerts aren't visually broken.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a security issue (see Pa0RFL-m9-p2 for instructions).
* Check Activity Log for visual glitch.
