### PR TITLE
Remove the is-fluid-width CSS class from the top HTML element

### DIFF
--- a/client/document/browsehappy.jsx
+++ b/client/document/browsehappy.jsx
@@ -13,13 +13,9 @@ import Head from '../components/head';
 import EmptyContent from 'components/empty-content';
 import { chunkCssLinks } from './utils';
 
-function Browsehappy( { faviconURL, entrypoint, isRTL, lang, isFluidWidth, dashboardUrl } ) {
+function Browsehappy( { faviconURL, entrypoint, isRTL, lang, dashboardUrl } ) {
 	return (
-		<html
-			lang={ lang }
-			dir={ isRTL ? 'rtl' : 'ltr' }
-			className={ classNames( { 'is-fluid-width': isFluidWidth } ) }
-		>
+		<html lang={ lang } dir={ isRTL ? 'rtl' : 'ltr' }>
 			<Head
 				title="Unsupported Browser — WordPress.com"
 				faviconURL={ faviconURL }

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -26,7 +26,6 @@ class Desktop extends React.Component {
 			lang,
 			hasSecondary,
 			clientData,
-			isFluidWidth,
 			badge,
 			abTestHelper,
 			branchName,
@@ -37,11 +36,7 @@ class Desktop extends React.Component {
 		} = this.props;
 
 		return (
-			<html
-				lang={ lang }
-				dir={ isRTL ? 'rtl' : 'ltr' }
-				className={ classNames( 'is-desktop', { 'is-fluid-width': isFluidWidth } ) }
-			>
+			<html lang={ lang } dir={ isRTL ? 'rtl' : 'ltr' } className={ classNames( 'is-desktop' ) }>
 				<Head title="WordPress.com" faviconURL={ faviconURL } cdn={ '//s1.wp.com' }>
 					{ chunkCssLinks( entrypoint, isRTL ) }
 					<link rel="stylesheet" id="desktop-css" href="/desktop/wordpress-desktop.css" />

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -45,7 +45,6 @@ class Document extends React.Component {
 			sectionGroup,
 			sectionName,
 			clientData,
-			isFluidWidth,
 			env,
 			badge,
 			abTestHelper,
@@ -86,10 +85,7 @@ class Document extends React.Component {
 			<html
 				lang={ lang }
 				dir={ isRTL ? 'rtl' : 'ltr' }
-				className={ classNames( {
-					'is-fluid-width': isFluidWidth,
-					'is-iframe': sectionName === 'gutenberg-editor',
-				} ) }
+				className={ classNames( { 'is-iframe': sectionName === 'gutenberg-editor' } ) }
 			>
 				<Head
 					title={ head.title }

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -307,7 +307,6 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 		entrypoint: getFilesForEntrypoint( target, entrypoint ),
 		manifest: getAssets( target ).manifests.manifest,
 		faviconURL: config( 'favicon_url' ),
-		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		preferencesHelper: !! config.isEnabled( 'dev/preferences-helper' ),
 		devDocsURL: '/devdocs',

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -30,7 +30,6 @@
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,
-		"fluid-width": true,
 		"gdpr-banner": true,
 		"google-my-business": false,
 		"help": true,

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -15,7 +15,7 @@ This document aims to provide a list of things to check and test whenever you ar
 
 It's also important to keep the general WP.com commit checklist at hand (modified for Calypso):
 
-1. It must be responsive on phone, tablet, and desktop; interactions must be fluid on a touch device. Responsive goes both ways, be sure to test with the `is-fluid-width` feature flag enabled. An easy way to do that is to add `is-fluid-width` as a CSS class to the `html` tag using the web-inspector.
+1. It must be responsive on phone, tablet, and desktop; interactions must be fluid on a touch device.
 2. Test in IE11+, Chrome, Firefox, Mac/Win on the desktop.
 3. Collect relevant and useful stats/events. What questions do they answer? How do you expect them to change over time?
 4. All strings must be fully translatable (without concatenation, handling plurals), and you should be aware of how long strings affect layout.


### PR DESCRIPTION
The class was added 5 years ago in 8904-gh-calypso-pre-oss as an experiment for desktop app, but never really used.

Removing as part of my i18n cleanups of the Calypso boot code.

**How to test:**
Verify that there is indeed no CSS rule defined for the `is-fluid-width` class. Not even in the `wp-desktop` repo.