### PR TITLE
Domain step test: Convert recommended badge to plan-pill

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -302,7 +302,7 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	renderMatchReason() {
-		if ( this.props.showTestCopy ) {
+		if ( this.props.isEligibleVariantForDomainTest ) {
 			return null;
 		}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -30,6 +30,7 @@ import { getDomainPrice, getDomainSalePrice, getTld, isHstsRequired } from 'lib/
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getProductsList } from 'state/products-list/selectors';
 import Badge from 'components/badge';
+import PlanPill from 'components/plans/plan-pill';
 import InfoPopover from 'components/info-popover';
 import { HTTPS_SSL } from 'lib/url/support';
 
@@ -242,7 +243,7 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		let title, progressBarProps;
 		if ( isRecommended ) {
-			title = this.props.showTestCopy
+			title = this.props.isEligibleVariantForDomainTest
 				? translate( 'Our Recommendation' )
 				: translate( 'Best Match' );
 			progressBarProps = {
@@ -266,9 +267,27 @@ class DomainRegistrationSuggestion extends React.Component {
 					success: isRecommended,
 					'info-blue': isBestAlternative,
 				} );
+
 				return (
 					<div className="domain-registration-suggestion__progress-bar">
 						<Badge type={ badgeClassName }>{ title }</Badge>
+					</div>
+				);
+			}
+
+			if ( this.props.showDesignUpdate ) {
+				const pillClassNames = classNames(
+					'domain-registration-suggestion__progress-bar',
+					'domain-registration-suggestion__progress-bar-design-update-test',
+					{
+						'pill-success': isRecommended,
+						'pill-primary': isBestAlternative,
+					}
+				);
+
+				return (
+					<div className={ pillClassNames }>
+						<PlanPill>{ title }</PlanPill>
 					</div>
 				);
 			}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -112,6 +112,21 @@
 			width: 25%;
 			margin-right: 1em;
 		}
+
+		&.domain-registration-suggestion__progress-bar-design-update-test {
+			order: 0;
+			margin: 5px 0;
+			
+			&.pill-success .plan-pill {
+				position: inherit;
+				background-color: var( --color-success );
+			}
+
+			&.pill-primary .plan-pill {
+				position: inherit;
+				background-color: var( --color-primary );
+			}
+		}
 	}
 
 	.domain-registration-suggestion__match-reasons {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -115,7 +115,7 @@
 
 		&.domain-registration-suggestion__progress-bar-design-update-test {
 			order: 0;
-			margin: 5px 0;
+			margin: 0.3em 0 1em;
 			
 			&.pill-success .plan-pill {
 				position: inherit;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The next domain step test is being implemented in #39276. The test is hidden behind a feature flag. We will build individual pieces of the UI in separate PRs.

This PR:
* Switches the order of the "Recommended" and "Best Alternative" tags to appear right below the domain.
* Changes the "Recommended" and "Best Alternative" tags to a "pill" UI instead of a "badge" UI.

**Web**

<img width="991" alt="Screenshot 2020-02-12 at 4 48 32 PM" src="https://user-images.githubusercontent.com/1269602/74330424-afae2180-4db7-11ea-90c3-3ff52eb4b8f6.png">

**Mobile**

![calypso localhost_3000_start_ecommerce-onboarding_domains(iPhone X) (6)](https://user-images.githubusercontent.com/1269602/74330445-bccb1080-4db7-11ea-8007-feead4e11fec.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Begin a fresh signup at /start or click "Add new site". You need to be in the _variantShowUpdates_ variant of **domainStepCopyUpdates** test and _variantDesignUpdates_ variant of **domainStepDesignUpdates**.
* At the domain step, verify the following:
    - The "Recommended" and "Best Alternative" tags UI should match the sketch shown in pbAok1-7N-p2.
    - Verify in both web and mobile.

**Verify that control group UI is unchanged**

Control of domainStepDesignUpdates test:
* Go through a fresh signup(or "Add new site") while assigned to the _variantShowUpdates_ variant of **domainStepCopyUpdates** test and _control_ of **domainStepDesignUpdates**.
* In the domain step, you should see the ["badge" version UI](https://user-images.githubusercontent.com/1269602/74306145-b91f9580-4d87-11ea-95aa-54859329bbd7.png).

Control of domainStepCopyUpdates test:
* Go through a fresh signup(or "Add new site") while assigned to the _control_ of **domainStepCopyUpdates** test.
* In the domain step, you should see the [old domain step UI](https://user-images.githubusercontent.com/1269602/74305945-339be580-4d87-11ea-9aa2-f76fc8383f12.png)(with progress bar).


