### PR TITLE
Remove i18n code from SSR-only pages

### DIFF
--- a/client/document/404.jsx
+++ b/client/document/404.jsx
@@ -12,11 +12,11 @@ import Head from 'components/head';
 import EmptyContent from 'components/empty-content';
 import { chunkCssLinks } from './utils';
 
-function NotFound( { faviconURL, entrypoint, isRTL } ) {
+function NotFound( { faviconURL, entrypoint } ) {
 	return (
 		<html lang="en">
 			<Head faviconURL={ faviconURL } cdn={ '//s1.wp.com' }>
-				{ chunkCssLinks( entrypoint, isRTL ) }
+				{ chunkCssLinks( entrypoint ) }
 			</Head>
 			<body>
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace*/ }

--- a/client/document/500.jsx
+++ b/client/document/500.jsx
@@ -12,11 +12,11 @@ import Head from 'components/head';
 import EmptyContent from 'components/empty-content';
 import { chunkCssLinks } from './utils';
 
-function ServerError( { faviconURL, entrypoint, isRTL } ) {
+function ServerError( { faviconURL, entrypoint } ) {
 	return (
 		<html lang="en">
 			<Head faviconURL={ faviconURL } cdn={ '//s1.wp.com' }>
-				{ chunkCssLinks( entrypoint, isRTL ) }
+				{ chunkCssLinks( entrypoint ) }
 			</Head>
 			<body>
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace*/ }

--- a/client/document/browsehappy.jsx
+++ b/client/document/browsehappy.jsx
@@ -1,29 +1,26 @@
 /**
  * External dependencies
- *
  */
-
 import React from 'react';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import Head from '../components/head';
+import Head from 'components/head';
 import EmptyContent from 'components/empty-content';
 import { chunkCssLinks } from './utils';
 
-function Browsehappy( { faviconURL, entrypoint, isRTL, lang, dashboardUrl } ) {
+function Browsehappy( { faviconURL, entrypoint, dashboardUrl } ) {
 	return (
-		<html lang={ lang } dir={ isRTL ? 'rtl' : 'ltr' }>
+		<html lang="en">
 			<Head
 				title="Unsupported Browser — WordPress.com"
 				faviconURL={ faviconURL }
 				cdn={ '//s1.wp.com' }
 			>
-				{ chunkCssLinks( entrypoint, isRTL ) }
+				{ chunkCssLinks( entrypoint ) }
 			</Head>
-			<body className={ classNames( { rtl: isRTL } ) }>
+			<body>
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace*/ }
 				<div id="wpcom" className="wpcom-site">
 					<div className="layout has-no-sidebar">

--- a/client/document/utils/index.jsx
+++ b/client/document/utils/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 
-export function chunkCssLinks( chunkAssets, isRTL ) {
+export function chunkCssLinks( chunkAssets, isRTL = false ) {
 	const styleAssets = chunkAssets[ isRTL ? 'css.rtl' : 'css.ltr' ];
 	return styleAssets.map( asset => (
 		<link key={ asset } rel="stylesheet" type="text/css" href={ asset } data-webpack />

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -586,7 +586,6 @@ function setUpRoute( req, res, next ) {
 const render404 = ( entrypoint = 'entry-main' ) => ( req, res ) => {
 	const ctx = {
 		faviconURL: config( 'favicon_url' ),
-		isRTL: config( 'rtl' ),
 		entrypoint: getFilesForEntrypoint( getBuildTargetFromRequest( req ), entrypoint ),
 	};
 
@@ -604,7 +603,6 @@ const renderServerError = ( entrypoint = 'entry-main' ) => ( err, req, res, next
 
 	const ctx = {
 		faviconURL: config( 'favicon_url' ),
-		isRTL: config( 'rtl' ),
 		entrypoint: getFilesForEntrypoint( getBuildTargetFromRequest( req ), entrypoint ),
 	};
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -366,6 +366,11 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 	return context;
 }
 
+const setupDefaultContext = entrypoint => ( req, res, next ) => {
+	req.context = getDefaultContext( req, entrypoint );
+	next();
+};
+
 function setUpLoggedOutRoute( req, res, next ) {
 	res.set( {
 		'X-Frame-Options': 'SAMEORIGIN',
@@ -783,30 +788,31 @@ module.exports = function() {
 	} );
 
 	// Landing pages for domains-related emails
-	app.get( '/domain-services/:action', function( req, res ) {
-		const ctx = getDefaultContext( req, 'entry-domains-landing' );
-		attachBuildTimestamp( ctx );
-		attachHead( ctx );
-		attachI18n( ctx );
+	app.get(
+		'/domain-services/:action',
+		setupDefaultContext( 'entry-domains-landing' ),
+		( req, res ) => {
+			const ctx = req.context;
+			attachBuildTimestamp( ctx );
+			attachHead( ctx );
+			attachI18n( ctx );
 
-		ctx.clientData = config.clientData;
-		ctx.domainsLandingData = {
-			action: get( req, [ 'params', 'action' ], 'unknown-action' ),
-			query: get( req, 'query', {} ),
-		};
+			ctx.clientData = config.clientData;
+			ctx.domainsLandingData = {
+				action: get( req, [ 'params', 'action' ], 'unknown-action' ),
+				query: get( req, 'query', {} ),
+			};
 
-		const pageHtml = renderJsx( 'domains-landing', ctx );
-		res.send( pageHtml );
-	} );
+			const pageHtml = renderJsx( 'domains-landing', ctx );
+			res.send( pageHtml );
+		}
+	);
 
 	function handleSectionPath( section, sectionPath, entrypoint ) {
 		const pathRegex = pathToRegExp( sectionPath );
 
-		app.get( pathRegex, function( req, res, next ) {
-			req.context = {
-				...getDefaultContext( req, entrypoint ),
-				sectionName: section.name,
-			};
+		app.get( pathRegex, setupDefaultContext( entrypoint ), function( req, res, next ) {
+			req.context.sectionName = section.name;
 
 			if ( ! entrypoint && config.isEnabled( 'code-splitting' ) ) {
 				req.context.chunkFiles = getFilesForChunk( section.name, req );
@@ -876,19 +882,16 @@ module.exports = function() {
 		}
 	);
 
-	app.get( '/browsehappy', setUpRoute, function( req, res ) {
+	app.get( '/browsehappy', setupDefaultContext(), setUpRoute, function( req, res ) {
 		const wpcomRe = /^https?:\/\/[A-z0-9_-]+\.wordpress\.com$/;
 		const primaryBlogUrl = get( req, 'context.user.primary_blog_url', '' );
 		const isWpcom = wpcomRe.test( primaryBlogUrl );
-		const dashboardUrl = isWpcom
+
+		req.context.dashboardUrl = isWpcom
 			? primaryBlogUrl + '/wp-admin'
 			: 'https://dashboard.wordpress.com/wp-admin/';
-		const ctx = {
-			...req.context,
-			dashboardUrl,
-		};
 
-		res.send( renderJsx( 'browsehappy', ctx ) );
+		res.send( renderJsx( 'browsehappy', req.context ) );
 	} );
 
 	app.get( '/support-user', function( req, res ) {


### PR DESCRIPTION
The 404, 500 and BrowseHappy pages are SSR-only, with no client-side JS and React scripting, and are not localized. Remove i18n code (i.e., the `lang` and `isRTL` props) from them that doesn't do anything useful. The rendered markup is always in the `en` language and `ltr` direction.
