### PR TITLE
[Coming Soon] Bypass proxying media thumbnail urls through photon for private atomic sites

### DIFF
--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -37,7 +37,7 @@ const REGEXP_VIDEOPRESS_GUID = /^[a-z\d]+$/i;
  * @param  {object} media   Media object
  * @param  {object} options Optional options, accepting a `photon` boolean,
  *                          `maxWidth` pixel value, `resize` string, `size`,
- *                          or `whitelistedDomains` string[].
+ *                          or `safeDomains` string[].
  * @returns {string}         URL to the media
  */
 export function url( media, options ) {

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -36,7 +36,8 @@ const REGEXP_VIDEOPRESS_GUID = /^[a-z\d]+$/i;
  *
  * @param  {object} media   Media object
  * @param  {object} options Optional options, accepting a `photon` boolean,
- *                          `maxWidth` pixel value, `resize` string, or `size`.
+ *                          `maxWidth` pixel value, `resize` string, `size`,
+ *                          or `whitelistedDomains` string[].
  * @returns {string}         URL to the media
  */
 export function url( media, options ) {
@@ -72,15 +73,27 @@ export function url( media, options ) {
 	}
 
 	if ( options.maxWidth ) {
-		return resize( media.URL, {
-			w: options.maxWidth,
-		} );
+		return resize(
+			media.URL,
+			{
+				w: options.maxWidth,
+			},
+			null,
+			true,
+			options.safeDomains
+		);
 	}
 
 	if ( options.resize ) {
-		return resize( media.URL, {
-			resize: options.resize,
-		} );
+		return resize(
+			media.URL,
+			{
+				resize: options.resize,
+			},
+			null,
+			true,
+			options.safeDomains
+		);
 	}
 
 	return media.URL;

--- a/client/lib/resize-image-url/index.js
+++ b/client/lib/resize-image-url/index.js
@@ -65,9 +65,16 @@ const scaleByFactor = value => value * IMAGE_SCALE_FACTOR;
  *                                     arguments (assuming Photon or Gravatar)
  * @param   {?number}         height   Pixel height if specifying resize width
  * @param   {?boolean}        makeSafe Should we make sure this is on a safe host?
+ * @param   {?string[]}       safeDomains List of hosts deemed safe in addition to a8c urls
  * @returns {?string}                  Resized image URL, or `null` if unable to resize
  */
-export default function resizeImageUrl( imageUrl, resize, height, makeSafe = true ) {
+export default function resizeImageUrl(
+	imageUrl,
+	resize,
+	height,
+	makeSafe = true,
+	safeDomains = []
+) {
 	if ( 'string' !== typeof imageUrl ) {
 		return imageUrl;
 	}
@@ -99,7 +106,7 @@ export default function resizeImageUrl( imageUrl, resize, height, makeSafe = tru
 	// External URLs are made "safe" (i.e. passed through Photon), so
 	// recurse with an assumed set of query arguments for Photon
 	if ( ! service && makeSafe ) {
-		return resizeImageUrl( safeImageUrl( imageUrl ), resize, null, false );
+		return resizeImageUrl( safeImageUrl( imageUrl, safeDomains ), resize, null, false );
 	}
 
 	// Map sizing parameters, multiplying their values by the scale factor

--- a/client/lib/safe-image-url/index.ts
+++ b/client/lib/safe-image-url/index.ts
@@ -13,7 +13,7 @@ import { getUrlParts } from 'lib/url/url-parts';
  *
  * @type {RegExp}
  */
-let REGEX_EXEMPT_URL : RegExp;
+let REGEX_EXEMPT_URL: RegExp;
 if ( typeof globalThis.location === 'object' ) {
 	REGEX_EXEMPT_URL = new RegExp(
 		`^(/(?!/)|data:image/[^;]+;|blob:${ globalThis.location.origin }/)`
@@ -39,10 +39,11 @@ const REGEXP_A8C_HOST = /^([-a-zA-Z0-9_]+\.)*(gravatar\.com|wordpress\.com|wp\.c
  * NOTE: This function will return `null` for external URLs with query strings,
  * because Photon itself does not support this!
  *
- * @param  {string} url The URL to secure
+ * @param  {string}      url The URL to secure
+ * @param  {?string[]}   safeDomains List of hosts deemed safe in addition to a8c urls
  * @returns {?string}    The secured URL, or `null` if we couldn't make it safe
  */
-export default function safeImageUrl( url : string, safeDomains? : string[] ) : string | null {
+export default function safeImageUrl( url: string, safeDomains?: string[] ): string | null {
 	if ( typeof url !== 'string' ) {
 		return null;
 	}

--- a/client/lib/safe-image-url/index.ts
+++ b/client/lib/safe-image-url/index.ts
@@ -13,7 +13,7 @@ import { getUrlParts } from 'lib/url/url-parts';
  *
  * @type {RegExp}
  */
-let REGEX_EXEMPT_URL;
+let REGEX_EXEMPT_URL : RegExp;
 if ( typeof globalThis.location === 'object' ) {
 	REGEX_EXEMPT_URL = new RegExp(
 		`^(/(?!/)|data:image/[^;]+;|blob:${ globalThis.location.origin }/)`
@@ -42,7 +42,7 @@ const REGEXP_A8C_HOST = /^([-a-zA-Z0-9_]+\.)*(gravatar\.com|wordpress\.com|wp\.c
  * @param  {string} url The URL to secure
  * @returns {?string}    The secured URL, or `null` if we couldn't make it safe
  */
-export default function safeImageUrl( url ) {
+export default function safeImageUrl( url : string, safeDomains? : string[] ) : string | null {
 	if ( typeof url !== 'string' ) {
 		return null;
 	}
@@ -53,8 +53,8 @@ export default function safeImageUrl( url ) {
 
 	const { hostname, pathname, search } = getUrlParts( url );
 
-	if ( REGEXP_A8C_HOST.test( hostname ) ) {
-		// Safely promote Automattic domains to HTTPS
+	if ( REGEXP_A8C_HOST.test( hostname ) || safeDomains?.indexOf( hostname ) !== -1 ) {
+		// Safely promote Automattic and whitelisted domains to HTTPS
 		return url.replace( /^http:/, 'https:' );
 	}
 

--- a/client/lib/safe-image-url/index.ts
+++ b/client/lib/safe-image-url/index.ts
@@ -54,7 +54,10 @@ export default function safeImageUrl( url: string, safeDomains?: string[] ): str
 
 	const { hostname, pathname, search } = getUrlParts( url );
 
-	if ( REGEXP_A8C_HOST.test( hostname ) || safeDomains?.indexOf( hostname ) !== -1 ) {
+	const isDomainSafe =
+		REGEXP_A8C_HOST.test( hostname ) ||
+		( Array.isArray( safeDomains ) && safeDomains.indexOf( hostname ) !== -1 );
+	if ( isDomainSafe ) {
 		// Safely promote Automattic and whitelisted domains to HTTPS
 		return url.replace( /^http:/, 'https:' );
 	}

--- a/client/lib/safe-image-url/test/index.js
+++ b/client/lib/safe-image-url/test/index.js
@@ -52,6 +52,15 @@ describe( 'safeImageUrl()', () => {
 			] );
 		} );
 
+		test( 'should not make safe variations of urls with safe domains', () => {
+			expect(
+				safeImageUrl( 'https://examplewordpress.com/foo', [ 'examplewordpress.com' ] )
+			).toEqual( 'https://examplewordpress.com/foo' );
+			expect(
+				safeImageUrl( 'http://examplewordpress.com/foo', [ 'examplewordpress.com' ] )
+			).toEqual( 'https://examplewordpress.com/foo' );
+		} );
+
 		test( 'should make a non-wpcom protocol relative url safe', () => {
 			expect( safeImageUrl( '//example.com/foo' ) ).toEqual( 'https://i1.wp.com/example.com/foo' );
 		} );

--- a/client/my-sites/media-library/list-item-image.jsx
+++ b/client/my-sites/media-library/list-item-image.jsx
@@ -4,16 +4,18 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import getSafeMediaDomains from 'state/media/selectors/get-safe-media-domains';
 import { url as mediaUrl } from 'lib/media/utils';
 import MediaLibraryListItemFileDetails from './list-item-file-details';
 
 import { MEDIA_IMAGE_THUMBNAIL, SCALE_CHOICES } from 'lib/media/constants';
 
-export default class MediaLibraryListItemImage extends React.Component {
+export class MediaLibraryListItemImage extends React.Component {
 	static propTypes = {
 		media: PropTypes.object,
 		scale: PropTypes.number,
@@ -77,6 +79,7 @@ export default class MediaLibraryListItemImage extends React.Component {
 		const url = mediaUrl( this.props.media, {
 			resize: `${ width },${ width }`,
 			size: this.props.thumbnailType === MEDIA_IMAGE_THUMBNAIL ? 'medium' : false,
+			safeDomains: this.props.safeMediaDomains,
 		} );
 
 		if ( ! url ) {
@@ -101,3 +104,7 @@ export default class MediaLibraryListItemImage extends React.Component {
 		);
 	}
 }
+
+export default connect( state => ( {
+	safeMediaDomains: getSafeMediaDomains( state ),
+} ) )( MediaLibraryListItemImage );

--- a/client/my-sites/media-library/list-item-image.jsx
+++ b/client/my-sites/media-library/list-item-image.jsx
@@ -15,7 +15,7 @@ import MediaLibraryListItemFileDetails from './list-item-file-details';
 
 import { MEDIA_IMAGE_THUMBNAIL, SCALE_CHOICES } from 'lib/media/constants';
 
-export class MediaLibraryListItemImage extends React.Component {
+export class ListItemImage extends React.Component {
 	static propTypes = {
 		media: PropTypes.object,
 		scale: PropTypes.number,
@@ -107,4 +107,4 @@ export class MediaLibraryListItemImage extends React.Component {
 
 export default connect( state => ( {
 	safeMediaDomains: getSafeMediaDomains( state ),
-} ) )( MediaLibraryListItemImage );
+} ) )( ListItemImage );

--- a/client/my-sites/media-library/test/list-item-image.jsx
+++ b/client/my-sites/media-library/test/list-item-image.jsx
@@ -14,7 +14,7 @@ import React from 'react';
  */
 import fixtures from './fixtures';
 import resize from 'lib/resize-image-url';
-import ListItemImage from 'my-sites/media-library/list-item-image';
+import { ListItemImage } from 'my-sites/media-library/list-item-image';
 
 const WIDTH = 450;
 

--- a/client/state/media/selectors/get-safe-media-domains.ts
+++ b/client/state/media/selectors/get-safe-media-domains.ts
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+import getSite from 'state/sites/selectors/get-site';
+import isPrivateSite from 'state/selectors/is-private-site';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+
+/**
+ * Returns a list of domains that we consider safe for the purposes of loading media. Non-a8c URLs
+ * refering to domains not returned by this selector are going to be wrapped in photon.
+ *
+ * @param  {object}  state  Global state tree
+ * @param  {number}  siteId Site id
+ * @returns {string[]}      Safe domains
+ */
+export default function getSafeMediaDomains( state: any, siteId: number | null ) {
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
+	if ( ! siteId ) {
+		return [];
+	}
+	const site = getSite( state, siteId );
+	if ( isSiteAutomatedTransfer( state, siteId ) && isPrivateSite( state, siteId ) ) {
+		// We need to bypass photon and go straight to site domain for private atomic sites - let's whitelist primary domain
+		return [ site.domain ];
+	}
+	return [];
+}

--- a/client/state/media/selectors/get-safe-media-domains.ts
+++ b/client/state/media/selectors/get-safe-media-domains.ts
@@ -19,7 +19,7 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
  * @param  {number}  siteId Site id
  * @returns {string[]}      Safe domains
  */
-export default function getSafeMediaDomains( state: any, siteId: number | null ) {
+export default function getSafeMediaDomains( state: object, siteId: number | null ) {
 	if ( ! config.isEnabled( 'coming-soon' ) ) {
 		return [];
 	}

--- a/client/state/media/selectors/get-safe-media-domains.ts
+++ b/client/state/media/selectors/get-safe-media-domains.ts
@@ -5,6 +5,7 @@
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getSite from 'state/sites/selectors/get-site';
 import isPrivateSite from 'state/selectors/is-private-site';
@@ -19,6 +20,10 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
  * @returns {string[]}      Safe domains
  */
 export default function getSafeMediaDomains( state: any, siteId: number | null ) {
+	if ( ! config.isEnabled( 'coming-soon' ) ) {
+		return [];
+	}
+
 	if ( ! siteId ) {
 		siteId = getSelectedSiteId( state );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is related to Coming Soon/Private atomic sites. More context available at p58i-8xH-p2

At the moment, all thumbnails in media library are loaded via photon. This is not going to work when the site is atomic and private as no authentication token of any kind is passed to the site.

This diff attempts to solve this problem by downloading full-sized images directly from the site without going through photon. It's less than perfect as it increases the loading time of thumbs in media library. A great follow-up to this PR would be exploring returning actual thumbnails in response to these direct requests.

The change should only take effect for private atomic sites when the `coming-soon` feature flag is enabled.

**Before:**
<img width="880" alt="Zrzut ekranu 2020-02-11 o 09 19 38" src="https://user-images.githubusercontent.com/205419/74220408-d1bc7c80-4caf-11ea-9475-0526bc30b7b8.png">

**After:**
<img width="841" alt="Zrzut ekranu 2020-02-11 o 09 19 46" src="https://user-images.githubusercontent.com/205419/74220409-d2eda980-4caf-11ea-9a6d-127ebd00c840.png">

#### Testing instructions

1. Create a private atomic site using a11n account via wpcalypso.wordpress.com - more details available at p58i-8xH-p2
1. Go to media library on wpcalypso.wordpress.com and confirm thumbnails aren't getting loaded
1. Go to media library on calypso.localhost:3000 and confirm thumbnails are loaded correctly
