### PR TITLE
Move the use your domain option below Show More

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -295,6 +295,7 @@ class DomainSearchResults extends React.Component {
 					<DomainTransferSuggestion
 						onButtonClick={ this.props.onClickUseYourDomain }
 						tracksButtonClickSource="search-suggestions-bottom"
+						showDesignUpdate={ this.props.showDesignUpdate }
 					/>
 				);
 			}

--- a/client/components/domains/domain-transfer-suggestion/index.jsx
+++ b/client/components/domains/domain-transfer-suggestion/index.jsx
@@ -21,6 +21,10 @@ class DomainTransferSuggestion extends React.Component {
 	};
 
 	render() {
+		if ( this.props.showDesignUpdate ) {
+			return null;
+		}
+
 		const { translate } = this.props;
 		const buttonContent = translate( 'Use a domain I own', {
 			context: 'Domain transfer or mapping suggestion button',

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -27,6 +27,7 @@ import { v4 as uuid } from 'uuid';
 import { stringify } from 'qs';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -493,7 +494,36 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderUseYourDomain() {
-		return <div>Already own a domain? Use it as your site's address.</div>;
+		const { translate } = this.props;
+
+		if ( this.state.searchResults === null ) {
+			return null;
+		}
+
+		return (
+			<div className="register-domain-step__use-your-domain">
+				<h3>
+					{ translate( 'Already own a domain?', {
+						context: 'Upgrades: Register domain header',
+						comment: 'Asks if you already own a domain name.',
+					} ) }{ ' ' }
+					{ translate( "You can use it as your site's address.", {
+						context: 'Upgrades: Register domain description',
+						comment: 'Explains how you could use an existing domain name with your site.',
+					} ) }
+				</h3>
+				<div className="register-domain-step__use-your-domain-action">
+					<div className="register-domain-step__use-your-domain-action-text">
+						{ translate( 'Use a domain I own', {
+							context: 'Domain transfer or mapping suggestion button',
+						} ) }
+					</div>
+					<div className="register-domain-step__use-your-domain-action-chevron">
+						<Gridicon className="register-domain-step__chevron" icon="chevron-right" />
+					</div>
+				</div>
+			</div>
+		);
 	}
 
 	rejectTrademarkClaim = () => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -462,6 +462,7 @@ class RegisterDomainStep extends React.Component {
 				{ this.renderContent() }
 				{ this.renderFilterResetNotice() }
 				{ this.renderPaginationControls() }
+				{ this.props.showDesignUpdate && this.renderUseYourDomain() }
 				{ queryObject && <QueryDomainsSuggestions { ...queryObject } /> }
 				<QueryContactDetailsCache />
 			</div>
@@ -489,6 +490,10 @@ class RegisterDomainStep extends React.Component {
 				/>
 			)
 		);
+	}
+
+	renderUseYourDomain() {
+		return <div>Already own a domain? Use it as your site's address.</div>;
 	}
 
 	rejectTrademarkClaim = () => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -496,10 +496,19 @@ class RegisterDomainStep extends React.Component {
 	renderUseYourDomain() {
 		const { translate } = this.props;
 
-		if ( this.state.searchResults === null ) {
+		const { searchResults, lastDomainStatus } = this.state;
+
+		if ( searchResults === null ) {
 			return null;
 		}
 
+		const useYourDomainFunction =
+			domainAvailability.MAPPED === lastDomainStatus
+				? this.goToTransferDomainStep
+				: this.goToUseYourDomainStep;
+
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/interactive-supports-focus */
 		return (
 			<div className="register-domain-step__use-your-domain">
 				<h3>
@@ -512,7 +521,12 @@ class RegisterDomainStep extends React.Component {
 						comment: 'Explains how you could use an existing domain name with your site.',
 					} ) }
 				</h3>
-				<div className="register-domain-step__use-your-domain-action">
+				<div
+					className="register-domain-step__use-your-domain-action is-clickable"
+					onClick={ useYourDomainFunction }
+					data-tracks-button-click-source="initial-suggestions-bottom"
+					role="button"
+				>
 					<div className="register-domain-step__use-your-domain-action-text">
 						{ translate( 'Use a domain I own', {
 							context: 'Domain transfer or mapping suggestion button',
@@ -524,6 +538,8 @@ class RegisterDomainStep extends React.Component {
 				</div>
 			</div>
 		);
+		/* eslint-enable jsx-a11y/click-events-have-key-events */
+		/* eslint-enable jsx-a11y/interactive-supports-focus */
 	}
 
 	rejectTrademarkClaim = () => {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -106,6 +106,18 @@
 		display: flex;
 		justify-content: center;
 		margin: 1em 0;
+
+		&.is-clickable {
+			cursor: pointer;
+	
+			// NOTE: easeOutExpo easing function from http://easings.net/#easeOutExpo
+			transition: box-shadow 0.25s cubic-bezier( 0.19, 1, 0.22, 1 );
+	
+			&:hover {
+				font-weight: 450;
+				z-index: z-index( 'root', '.domain-suggestion.is-clickable:hover' );
+			}
+		}
 	}
 
 	.register-domain-step__chevron {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -96,3 +96,26 @@
 		background: var( --color-neutral-0 );
 	}
 }
+
+.register-domain-step__use-your-domain {
+	padding: 16px 24px;
+	text-align: center;
+	color: var( --color-text-inverted );
+
+	.register-domain-step__use-your-domain-action {
+		display: flex;
+		justify-content: center;
+		margin: 1em 0;
+	}
+
+	.register-domain-step__chevron {
+		margin-left: 10px;
+		flex: 1 0 auto;
+		color: var( --color-text-inverted );
+	
+		.is-placeholder & {
+			animation: loading-fade 1.6s ease-in-out infinite;
+			color: var( --color-neutral-0 );
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The next domain step test is being implemented in #39276. The test is hidden behind a feature flag. We will build individual pieces of the UI in separate PRs.

This PR:
* Moves "Already own a domain" out of search results list, and adds it below the search results.

**Web**

<img width="1002" alt="Screenshot 2020-02-12 at 7 09 29 PM" src="https://user-images.githubusercontent.com/1269602/74340142-67006380-4dcb-11ea-9e49-dd46223aee11.png">

**Mobile**

![calypso localhost_3000_start_ecommerce-onboarding_domains(Pixel 2 XL)](https://user-images.githubusercontent.com/1269602/74340092-5223d000-4dcb-11ea-9315-d1adbc6e774b.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Begin a fresh signup at /start or click "Add new site". You need to be in the _variantShowUpdates_ variant of **domainStepCopyUpdates** test and _variantDesignUpdates_ variant of **domainStepDesignUpdates**.
* At the domain step, verify the following:
    - The "Already own a domain" UI should match the sketch in pbAok1-7N-p2.
    - Click the link and verify that it takes you to the Transfer domain page

**Verify that control group UI is unchanged**

Scenario 1
* Go through signup flow from /start while in _variantShowUpdates_ variant of **domainStepCopyUpdates** test and _control_ of **domainStepDesignUpdates**.
* You should not be seeing the changes in this PR but instead the [earlier UI version](https://user-images.githubusercontent.com/1269602/74341118-302b4d00-4dcd-11ea-9612-2677839da28d.png).

Scenario 2
* Go through signup flow from /start while in _control_  of **domainStepCopyUpdates** test.
* You should not be seeing the changes in this PR but instead the [earlier UI version](https://user-images.githubusercontent.com/1269602/74341118-302b4d00-4dcd-11ea-9612-2677839da28d.png).

