### PR TITLE
Build: Pin terser@4.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34779,9 +34779,9 @@
 			}
 		},
 		"terser": {
-			"version": "4.6.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
-			"integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
+			"integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
 		"stylelint": "9.10.1",
 		"supertest": "4.0.2",
 		"svgstore-cli": "1.3.1",
+		"terser": "4.4.3",
 		"ts-loader": "6.2.1",
 		"typescript": "3.7.5",
 		"webpack": "4.41.5",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Builds have started to produce a broken application whenever package-lock is touched. We're not sure _exactly_ what happens, but when `terser` is on 4.4.3 the issue does not appear. `terser@>4.4` appears to have the issue.

Pin `terser@4.4.3` as a root dependency.

It's unclear exactly what the issue is, but it's worth looking at the https://github.com/terser/terser/compare/v4.4.3...v4.5.0 terser diff.

The failures look like `Uncaught TypeError: n is not a function
    at Object../boot/common.js`.

Props to @blowery for tracking the issue this far.

#### Testing instructions

* Test the build on calypso.live. Does it boot and run?