### PR TITLE
Packages: Use peerDependencies for singleton modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -235,8 +235,6 @@
 				"gridicons": "^3.3.1",
 				"lodash": "^4.17.15",
 				"prop-types": "^15.7.2",
-				"react": "^16.8.3",
-				"react-dom": "^16.8.3",
 				"react-modal": "^3.8.1"
 			}
 		},
@@ -245,13 +243,11 @@
 			"requires": {
 				"@emotion/core": "10.0.22",
 				"@emotion/styled": "10.0.23",
-				"@wordpress/data": "^4.9.2",
 				"@wordpress/i18n": "3.8.0",
 				"debug": "4.1.1",
 				"emotion-theming": "10.0.19",
 				"interpolate-components": "1.1.1",
 				"prop-types": "^15.7.2",
-				"react": "^16.8.6",
 				"react-stripe-elements": "^5.1.0"
 			},
 			"dependencies": {
@@ -294,12 +290,10 @@
 				"@automattic/composite-checkout": "file:packages/composite-checkout",
 				"@emotion/core": "10.0.22",
 				"@emotion/styled": "10.0.23",
-				"@wordpress/data": "^4.9.2",
 				"debug": "4.1.1",
 				"emotion-theming": "10.0.19",
 				"i18n-calypso": "file:packages/i18n-calypso",
 				"prop-types": "^15.7.2",
-				"react": "^16.8.6",
 				"react-stripe-elements": "^5.1.0"
 			},
 			"dependencies": {
@@ -339,7 +333,6 @@
 		"@automattic/data-stores": {
 			"version": "file:packages/data-stores",
 			"requires": {
-				"@wordpress/data": "^4.10.0",
 				"@wordpress/data-controls": "^1.4.0",
 				"@wordpress/url": "^2.8.2",
 				"debug": "^4.1.1",
@@ -2079,13 +2072,6 @@
 				"@emotion/unitless": "0.7.5",
 				"@emotion/utils": "0.11.3",
 				"csstype": "^2.5.7"
-			},
-			"dependencies": {
-				"@emotion/utils": {
-					"version": "0.11.3",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-				}
 			}
 		},
 		"@emotion/sheet": {
@@ -2111,13 +2097,6 @@
 				"@emotion/is-prop-valid": "0.8.6",
 				"@emotion/serialize": "^0.11.15",
 				"@emotion/utils": "0.11.3"
-			},
-			"dependencies": {
-				"@emotion/utils": {
-					"version": "0.11.3",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-				}
 			}
 		},
 		"@emotion/stylis": {
@@ -4821,12 +4800,6 @@
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 					"dev": true
 				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"dev": true
-				},
 				"fill-range": {
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6552,261 +6525,15 @@
 			},
 			"dependencies": {
 				"@emotion/sheet": {
-					"version": "0.9.3",
-					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
+					"version": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
 					"integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
 				},
 				"@emotion/utils": {
-					"version": "0.11.2",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
+					"version": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
 					"integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA=="
 				},
-				"@wordpress/api-fetch": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.9.0.tgz",
-					"integrity": "sha512-Z9n1IZcgZPLGcxH8wtPAMEHM4bfLRumlT6GVZ/xRS69iuty+Qnc7MvqSQhKTvgMR6Mb1crzc/yQje8R1vX9EDA==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.8.0",
-						"@wordpress/url": "^2.9.0"
-					}
-				},
-				"@wordpress/block-editor": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-3.5.0.tgz",
-					"integrity": "sha512-7Yx54F/MnrYc3Ai7ERa/G+77jR3oZlgLvR+XmZbtXqL5DW0y7ldW6M5OEXAnvTlCjsvLDYeL8T2avmQa50lwoQ==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/a11y": "^2.6.0",
-						"@wordpress/blob": "^2.6.0",
-						"@wordpress/blocks": "^6.10.0",
-						"@wordpress/components": "^9.0.0",
-						"@wordpress/compose": "^3.10.0",
-						"@wordpress/data": "^4.12.0",
-						"@wordpress/deprecated": "^2.6.1",
-						"@wordpress/dom": "^2.7.0",
-						"@wordpress/element": "^2.10.0",
-						"@wordpress/hooks": "^2.6.0",
-						"@wordpress/html-entities": "^2.5.0",
-						"@wordpress/i18n": "^3.8.0",
-						"@wordpress/is-shallow-equal": "^1.7.0",
-						"@wordpress/keyboard-shortcuts": "^0.2.0",
-						"@wordpress/keycodes": "^2.8.0",
-						"@wordpress/rich-text": "^3.10.0",
-						"@wordpress/token-list": "^1.8.0",
-						"@wordpress/url": "^2.9.0",
-						"@wordpress/viewport": "^2.11.0",
-						"@wordpress/wordcount": "^2.6.2",
-						"classnames": "^2.2.5",
-						"diff": "^3.5.0",
-						"dom-scroll-into-view": "^1.2.1",
-						"inherits": "^2.0.3",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"react-autosize-textarea": "^3.0.2",
-						"react-spring": "^8.0.19",
-						"redux-multi": "^0.1.12",
-						"refx": "^3.0.0",
-						"rememo": "^3.0.0",
-						"tinycolor2": "^1.4.1",
-						"traverse": "^0.6.6"
-					}
-				},
-				"@wordpress/blocks": {
-					"version": "6.10.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.10.0.tgz",
-					"integrity": "sha512-76RX252pG2yYGBJIUnDAemUmV1NCUJgP1Nl4prRtLSceBkO4fPXODYx0j+8A14YtsrS6HJD6oOQhD97rSriehQ==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/autop": "^2.5.1",
-						"@wordpress/blob": "^2.6.0",
-						"@wordpress/block-serialization-default-parser": "^3.4.1",
-						"@wordpress/compose": "^3.10.0",
-						"@wordpress/data": "^4.12.0",
-						"@wordpress/dom": "^2.7.0",
-						"@wordpress/element": "^2.10.0",
-						"@wordpress/hooks": "^2.6.0",
-						"@wordpress/html-entities": "^2.5.0",
-						"@wordpress/i18n": "^3.8.0",
-						"@wordpress/is-shallow-equal": "^1.7.0",
-						"@wordpress/shortcode": "^2.5.0",
-						"hpq": "^1.3.0",
-						"lodash": "^4.17.15",
-						"rememo": "^3.0.0",
-						"showdown": "^1.8.6",
-						"simple-html-tokenizer": "^0.5.7",
-						"tinycolor2": "^1.4.1",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@wordpress/components": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.0.0.tgz",
-					"integrity": "sha512-Zk3pdD3pEjEwqK/qaWqre3JPaO47Fm+gXbJw0mEDtDceXvZtNp3I6j0z0x05ooxTzK9/K9iTNW/OrhOQpUa+Jw==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@emotion/core": "10.0.22",
-						"@emotion/styled": "10.0.23",
-						"@wordpress/a11y": "^2.6.0",
-						"@wordpress/compose": "^3.10.0",
-						"@wordpress/deprecated": "^2.6.1",
-						"@wordpress/dom": "^2.7.0",
-						"@wordpress/element": "^2.10.0",
-						"@wordpress/hooks": "^2.6.0",
-						"@wordpress/i18n": "^3.8.0",
-						"@wordpress/is-shallow-equal": "^1.7.0",
-						"@wordpress/keycodes": "^2.8.0",
-						"@wordpress/rich-text": "^3.10.0",
-						"classnames": "^2.2.5",
-						"clipboard": "^2.0.1",
-						"dom-scroll-into-view": "^1.2.1",
-						"downshift": "^3.3.4",
-						"gradient-parser": "^0.1.5",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"moment": "^2.22.1",
-						"re-resizable": "^6.0.0",
-						"react-dates": "^17.1.1",
-						"react-resize-aware": "^3.0.0",
-						"react-spring": "^8.0.20",
-						"reakit": "^1.0.0-beta.12",
-						"rememo": "^3.0.0",
-						"tinycolor2": "^1.4.1",
-						"uuid": "^3.3.2"
-					},
-					"dependencies": {
-						"@emotion/core": {
-							"version": "10.0.22",
-							"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.22.tgz",
-							"integrity": "sha512-7eoP6KQVUyOjAkE6y4fdlxbZRA4ILs7dqkkm6oZUJmihtHv0UBq98VgPirq9T8F9K2gKu0J/au/TpKryKMinaA==",
-							"requires": {
-								"@babel/runtime": "^7.5.5",
-								"@emotion/cache": "^10.0.17",
-								"@emotion/css": "^10.0.22",
-								"@emotion/serialize": "^0.11.12",
-								"@emotion/sheet": "0.9.3",
-								"@emotion/utils": "0.11.2"
-							}
-						}
-					}
-				},
-				"@wordpress/compose": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.10.0.tgz",
-					"integrity": "sha512-JE3QaUINiKxKAYb235s/5Q2hT8HifCvR7fdaIEHXjkMNfMVriVIgV1YE5I6l9gJXuT5adTwTSvsWhnRBYTl3Mw==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.10.0",
-						"@wordpress/is-shallow-equal": "^1.7.0",
-						"lodash": "^4.17.15",
-						"mousetrap": "^1.6.2"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.12.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.12.0.tgz",
-					"integrity": "sha512-HoHBRcY0kvVNtOdLwLzHcuGZSYnW8kq0NEyB1/2ZHdKZ8WMtvAflpz2qbKwnrPml1321hfkC9I3KFtA4Ep9lDA==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.10.0",
-						"@wordpress/deprecated": "^2.6.1",
-						"@wordpress/element": "^2.10.0",
-						"@wordpress/is-shallow-equal": "^1.7.0",
-						"@wordpress/priority-queue": "^1.4.0",
-						"@wordpress/redux-routine": "^3.6.2",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/dom": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.7.0.tgz",
-					"integrity": "sha512-KcowyDW+71AhC37xVvsVDaLlK25G6Cw8oczZHUKnqrUW9dxyLpklup6QGgYZ/pqsP0qiJWJOL6OTilysohdhrg==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"lodash": "^4.17.15"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.8.0.tgz",
-					"integrity": "sha512-SXheA3E2aA/w5/cubrIho3fCLY5Jb7zdpg7NGS3DFXYEe5VICMdmgNxeYFoeyNSw2IkNmphJhsZXzVIMf92dYQ==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.7.0.tgz",
-					"integrity": "sha512-fRHTAivQlWOQVn8wu8NHM8D5sacSvY6upJ+MgWSu1Q7pqy51zaCPE2T9lhym3GC1QzABus6VjDctR8jwfNfd/g==",
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/keycodes": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.8.0.tgz",
-					"integrity": "sha512-c1YQZbMEPplEgbXxxSDBUxG92zxwCB//SvVJw+poHBiQi+bcEuH/J/xezAXk4tfJO/gtb1r3LpFjcZqxZWc8SA==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.8.0",
-						"lodash": "^4.17.15"
-					}
-				},
-				"@wordpress/plugins": {
-					"version": "2.10.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.10.0.tgz",
-					"integrity": "sha512-Cte0YBrJzrrIjsm0s/Qf4OUelB3Hw3qP0tXKKG3x5rXf/2ty9kxFyqDo+uO3kRd8uKaCnVCLHImsD0a8yTO4Bw==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.10.0",
-						"@wordpress/element": "^2.10.0",
-						"@wordpress/hooks": "^2.6.0",
-						"lodash": "^4.17.15"
-					}
-				},
-				"@wordpress/rich-text": {
-					"version": "3.10.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.10.0.tgz",
-					"integrity": "sha512-gFzVRXDmGIolvcGRejg4LhoAQa2UALMOPnO96bl8zVNTAuk7kRYLbsxQLtcwTtDgSXTVVrIZHgQ67NwbtX3fxQ==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.10.0",
-						"@wordpress/data": "^4.12.0",
-						"@wordpress/deprecated": "^2.6.1",
-						"@wordpress/element": "^2.10.0",
-						"@wordpress/escape-html": "^1.6.0",
-						"@wordpress/is-shallow-equal": "^1.7.0",
-						"@wordpress/keycodes": "^2.8.0",
-						"classnames": "^2.2.5",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"rememo": "^3.0.0"
-					}
-				},
-				"@wordpress/viewport": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.11.0.tgz",
-					"integrity": "sha512-AfJ3rxjeM2baGq1DxwN0bHQOhuRxoR91a2ZUm9UMjfvIsbLFsgnySiAjQD1OjXucz4EHv7TbHSdbLj16dHNHtg==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.10.0",
-						"@wordpress/data": "^4.12.0",
-						"lodash": "^4.17.15"
-					}
-				},
 				"diff": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"version": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 				}
 			}
@@ -10260,25 +9987,29 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"dev": true,
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10288,13 +10019,15 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 							"dev": true,
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10304,37 +10037,43 @@
 						},
 						"chownr": {
 							"version": "1.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+							"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
 							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 							"dev": true,
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 							"dev": true,
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 							"dev": true,
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "3.2.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10343,25 +10082,29 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.7",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+							"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10370,13 +10113,15 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10392,7 +10137,8 @@
 						},
 						"glob": {
 							"version": "7.1.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+							"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10406,13 +10152,15 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10421,7 +10169,8 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+							"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10430,7 +10179,8 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10440,19 +10190,22 @@
 						},
 						"inherits": {
 							"version": "2.0.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+							"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 							"dev": true,
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10461,13 +10214,15 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10476,13 +10231,15 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 							"dev": true,
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.9.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10492,7 +10249,8 @@
 						},
 						"minizlib": {
 							"version": "1.3.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+							"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10501,7 +10259,8 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10510,13 +10269,15 @@
 						},
 						"ms": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.4.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+							"integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10527,7 +10288,8 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.14.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+							"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10545,7 +10307,8 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10555,7 +10318,8 @@
 						},
 						"npm-bundled": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+							"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10564,13 +10328,15 @@
 						},
 						"npm-normalize-package-bin": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+							"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.7",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
+							"integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10580,7 +10346,8 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10592,19 +10359,22 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 							"dev": true,
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10613,19 +10383,22 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10635,19 +10408,22 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+							"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10659,7 +10435,8 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"dev": true,
 									"optional": true
 								}
@@ -10667,7 +10444,8 @@
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10682,7 +10460,8 @@
 						},
 						"rimraf": {
 							"version": "2.7.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10691,43 +10470,50 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 							"dev": true,
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10738,7 +10524,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10747,7 +10534,8 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10756,13 +10544,15 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.13",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+							"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10777,13 +10567,15 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -10792,13 +10584,15 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"dev": true,
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 							"dev": true,
 							"optional": true
 						}
@@ -18543,7 +18337,6 @@
 				"interpolate-components": "^1.1.1",
 				"lodash": "^4.17.11",
 				"lru": "^3.1.0",
-				"react": "^16.8.3",
 				"tannin": "^1.1.1",
 				"use-subscription": "^1.2.0"
 			}
@@ -20105,25 +19898,29 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"dev": true,
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20133,13 +19930,15 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 							"dev": true,
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20149,37 +19948,43 @@
 						},
 						"chownr": {
 							"version": "1.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+							"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
 							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 							"dev": true,
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 							"dev": true,
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 							"dev": true,
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "3.2.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20188,25 +19993,29 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.7",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+							"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20215,13 +20024,15 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20237,7 +20048,8 @@
 						},
 						"glob": {
 							"version": "7.1.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+							"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20251,13 +20063,15 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20266,7 +20080,8 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+							"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20275,7 +20090,8 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20285,19 +20101,22 @@
 						},
 						"inherits": {
 							"version": "2.0.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+							"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 							"dev": true,
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20306,13 +20125,15 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20321,13 +20142,15 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 							"dev": true,
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.9.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20337,7 +20160,8 @@
 						},
 						"minizlib": {
 							"version": "1.3.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+							"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20346,7 +20170,8 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20355,13 +20180,15 @@
 						},
 						"ms": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.4.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+							"integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20372,7 +20199,8 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.14.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+							"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20390,7 +20218,8 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20400,7 +20229,8 @@
 						},
 						"npm-bundled": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+							"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20409,13 +20239,15 @@
 						},
 						"npm-normalize-package-bin": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+							"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.7",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
+							"integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20425,7 +20257,8 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20437,19 +20270,22 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 							"dev": true,
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20458,19 +20294,22 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20480,19 +20319,22 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+							"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20504,7 +20346,8 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"dev": true,
 									"optional": true
 								}
@@ -20512,7 +20355,8 @@
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20527,7 +20371,8 @@
 						},
 						"rimraf": {
 							"version": "2.7.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20536,43 +20381,50 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 							"dev": true,
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20583,7 +20435,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20592,7 +20445,8 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20601,13 +20455,15 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.13",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+							"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20622,13 +20478,15 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -20637,13 +20495,15 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"dev": true,
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 							"dev": true,
 							"optional": true
 						}
@@ -21135,12 +20995,6 @@
 				"write-file-atomic": "^2.3.0"
 			},
 			"dependencies": {
-				"ast-types": {
-					"version": "0.13.2",
-					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
-					"integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==",
-					"dev": true
-				},
 				"colors": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -23896,46 +23750,14 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"cross-spawn": {
-					"version": "5.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"decamelize": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true
-				},
-				"execa": {
-					"version": "0.7.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -23943,66 +23765,33 @@
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"get-stream": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"invert-kv": {
-					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
-				"is-stream": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"isexe": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"lcid": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"invert-kv": "^1.0.0"
-					}
-				},
 				"locate-path": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
 					}
 				},
-				"lru-cache": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
 				"mem": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
@@ -24010,38 +23799,19 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+					"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
 					"dev": true
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"npm-run-path": {
-					"version": "2.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"path-key": "^2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
@@ -24049,75 +23819,31 @@
 						"mem": "^1.1.0"
 					}
 				},
-				"p-finally": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
 				"p-limit": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+					"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
 					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
 				},
-				"path-exists": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"path-key": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"pseudomap": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"require-directory": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"shebang-command": {
-					"version": "1.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"shebang-regex": "^1.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -24127,33 +23853,17 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
-				"strip-eof": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"which": {
-					"version": "1.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
@@ -24162,17 +23872,14 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true,
-					"dev": true
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
 					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
 					"dev": true,
 					"requires": {
 						"cliui": "^3.2.0",
@@ -24191,12 +23898,14 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"cliui": {
 							"version": "3.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 							"dev": true,
 							"requires": {
 								"string-width": "^1.0.1",
@@ -24206,7 +23915,8 @@
 							"dependencies": {
 								"string-width": {
 									"version": "1.0.2",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 									"dev": true,
 									"requires": {
 										"code-point-at": "^1.0.0",
@@ -24218,7 +23928,8 @@
 						},
 						"string-width": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 							"dev": true,
 							"requires": {
 								"is-fullwidth-code-point": "^2.0.0",
@@ -24227,12 +23938,14 @@
 							"dependencies": {
 								"is-fullwidth-code-point": {
 									"version": "2.0.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+									"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 									"dev": true
 								},
 								"strip-ansi": {
 									"version": "4.0.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 									"dev": true,
 									"requires": {
 										"ansi-regex": "^3.0.0"
@@ -24244,7 +23957,8 @@
 				},
 				"yargs-parser": {
 					"version": "8.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
@@ -24252,7 +23966,8 @@
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 							"dev": true
 						}
 					}
@@ -25407,12 +25122,6 @@
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
 					}
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"dev": true
 				}
 			}
 		},

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,8 +36,8 @@
 		"react-modal": "^3.8.1"
 	},
 	"peerDependencies": {
-		"react": "^16.8.3",
-		"react-dom": "^16.8.3"
+		"react": "^16.8",
+		"react-dom": "^16.8"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,9 +33,11 @@
 		"gridicons": "^3.3.1",
 		"lodash": "^4.17.15",
 		"prop-types": "^15.7.2",
-		"react": "^16.8.3",
-		"react-dom": "^16.8.3",
 		"react-modal": "^3.8.1"
+	},
+	"peerDependencies": {
+		"react": "^16.8.3",
+		"react-dom": "^16.8.3"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -46,8 +46,8 @@
 		"react-stripe-elements": "^5.1.0"
 	},
 	"peerDependencies": {
-		"@wordpress/data": "^4.9.2",
-		"react": "^16.8.6"
+		"@wordpress/data": "^4",
+		"react": "^16.8"
 	},
 	"private": true
 }

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -39,13 +39,15 @@
 		"@automattic/composite-checkout": "file:../composite-checkout",
 		"@emotion/core": "10.0.22",
 		"@emotion/styled": "10.0.23",
-		"@wordpress/data": "^4.9.2",
 		"debug": "4.1.1",
 		"emotion-theming": "10.0.19",
 		"i18n-calypso": "file:../i18n-calypso",
 		"prop-types": "^15.7.2",
-		"react": "^16.8.6",
 		"react-stripe-elements": "^5.1.0"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^4.9.2",
+		"react": "^16.8.6"
 	},
 	"private": true
 }

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -36,14 +36,16 @@
 	"dependencies": {
 		"@emotion/core": "10.0.22",
 		"@emotion/styled": "10.0.23",
-		"@wordpress/data": "^4.9.2",
 		"@wordpress/i18n": "3.8.0",
 		"debug": "4.1.1",
 		"emotion-theming": "10.0.19",
 		"interpolate-components": "1.1.1",
 		"prop-types": "^15.7.2",
-		"react": "^16.8.6",
 		"react-stripe-elements": "^5.1.0"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^4.9.2",
+		"react": "^16.8.6"
 	},
 	"private": true
 }

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -44,8 +44,8 @@
 		"react-stripe-elements": "^5.1.0"
 	},
 	"peerDependencies": {
-		"@wordpress/data": "^4.9.2",
-		"react": "^16.8.6"
+		"@wordpress/data": "^4.6",
+		"react": "^16.8"
 	},
 	"private": true
 }

--- a/packages/data-stores/CHANGELOG.md
+++ b/packages/data-stores/CHANGELOG.md
@@ -1,3 +1,16 @@
-# 1.0.0
+# Next
 
-- Add Domain Suggestions, Verticals, and Verticals Templates stores.
+- Initial release with stores:
+  - Domain Suggestions
+  - Verticals
+  - Verticals Templates
+  - User
+  - Site
+
+# 1.0.0-alpha.1
+
+- Move `@wordpress/data` to peer dependency.
+
+# 1.0.0-alpha.0
+
+- Initial prerelease

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -32,7 +32,6 @@
 		"watch": "tsc --project ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@wordpress/data": "^4.10.0",
 		"@wordpress/data-controls": "^1.4.0",
 		"@wordpress/url": "^2.8.2",
 		"debug": "^4.1.1",
@@ -40,5 +39,8 @@
 		"redux": "^4.0.4",
 		"tslib": "^1.10.0",
 		"wpcom-proxy-request": "^5.0.2"
+	},
+	"peerDependencies": {
+		"@wordpress/data": "^4.10.0"
 	}
 }

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -41,6 +41,6 @@
 		"wpcom-proxy-request": "^5.0.2"
 	},
 	"peerDependencies": {
-		"@wordpress/data": "^4.10.0"
+		"@wordpress/data": "^4"
 	}
 }

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/data-stores",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-alpha.1",
 	"description": "Calypso Data Stores",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,6 +1,7 @@
-next
+5.0.0
 -----
 
+* Dependencies: Move `react` to `peerDependencies`. `i18n-calypso` no longer depends on `react` directly and consumers should install the dependency.
 * Breaking change: drop support for moment both in `i18n.moment` and `i18n.localize`. It's no longer desirable for moment to be a mandatory dependency of i18n-calypso.
 * Update debug to v4
 * Switch from Jed to Tannin, for smaller size as well as runtime speedups

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -26,9 +26,11 @@
 		"interpolate-components": "^1.1.1",
 		"lodash": "^4.17.11",
 		"lru": "^3.1.0",
-		"react": "^16.8.3",
 		"tannin": "^1.1.1",
 		"use-subscription": "^1.2.0"
+	},
+	"peerDependencies": {
+		"react": "^16.8.3"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "4.1.0",
+	"version": "5.0.0",
 	"description": "i18n JavaScript library on top of Tannin originally used in Calypso",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -30,7 +30,7 @@
 		"use-subscription": "^1.2.0"
 	},
 	"peerDependencies": {
-		"react": "^16.8.3"
+		"react": "^16.8"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`peerDependencies` are a good solution for packages that must use a single version of a module. Effectively, they require consumers to depend on a dependency. The result is a sort of enforced deduplication. We've had repeated issues with `@wordpress/data` when upgrading dependencies, `@wordpress/data` _will not work properly_ when multiple versions are present.

Related issue: https://github.com/WordPress/gutenberg/issues/8981

https://classic.yarnpkg.com/en/docs/dependency-types/#toc-peerdependencies

This PR moves the following package dependencies to peerDependencies:
- `@wordpress/data`
- `@wordpress/api-fetch` (no package dependency present)
- `react`
- `react-dom`

#### Questions

Should this result in a major version change for published, affected pacakges? Seems to only be `i18n-calypso`, maybe `@automattic/data-stores`.

#### Testing instructions

* e2e and smoke testing
