### PR TITLE
Create a common function for locale route param

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -12,6 +12,7 @@ import * as controller from './controller';
 import { login } from 'lib/paths';
 import { siteSelection } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { getLanguageRouteParam } from 'lib/i18n-utils';
 
 /**
  * Style dependencies
@@ -21,6 +22,7 @@ import './style.scss';
 export default function() {
 	const user = userFactory();
 	const isLoggedOut = ! user.get();
+	const locale = getLanguageRouteParam( 'locale' );
 
 	page(
 		'/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?',
@@ -41,7 +43,7 @@ export default function() {
 		);
 	} else {
 		page(
-			'/jetpack/connect/:type(install)/:locale?',
+			`/jetpack/connect/:type(install)/${ locale }`,
 			controller.redirectWithoutLocaleIfLoggedIn,
 			controller.persistMobileAppFlow,
 			controller.setMasterbar,
@@ -62,7 +64,7 @@ export default function() {
 
 	if ( isLoggedOut ) {
 		page(
-			'/jetpack/connect/authorize/:locale?',
+			`/jetpack/connect/authorize/${ locale }`,
 			controller.setMasterbar,
 			controller.signupForm,
 			makeLayout,
@@ -70,7 +72,7 @@ export default function() {
 		);
 	} else {
 		page(
-			'/jetpack/connect/authorize/:locale?',
+			`/jetpack/connect/authorize/${ locale }`,
 			controller.redirectWithoutLocaleIfLoggedIn,
 			controller.setMasterbar,
 			controller.authorizeForm,
@@ -88,7 +90,7 @@ export default function() {
 	);
 
 	page(
-		'/jetpack/connect/store/:interval(yearly|monthly)?/:locale?',
+		`/jetpack/connect/store/:interval(yearly|monthly)?/${ locale }`,
 		controller.setLoggedOutLocale,
 		controller.plansLanding,
 		makeLayout,
@@ -140,7 +142,7 @@ export default function() {
 	);
 
 	page(
-		'/jetpack/connect/:locale?',
+		`/jetpack/connect/${ locale }`,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,

--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -6,6 +6,7 @@ import i18n from 'i18n-calypso';
 export {
 	addLocaleToPath,
 	getLanguage,
+	getLanguageRouteParam,
 	getLanguageSlugs,
 	getLocaleFromPath,
 	isDefaultLocale,

--- a/client/lib/i18n-utils/node.js
+++ b/client/lib/i18n-utils/node.js
@@ -12,6 +12,7 @@ import config from 'config';
 export {
 	addLocaleToPath,
 	getLanguage,
+	getLanguageRouteParam,
 	getLanguageSlugs,
 	getLocaleFromPath,
 	isDefaultLocale,

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -98,6 +98,17 @@ export function getLanguageSlugs() {
 }
 
 /**
+ * Return a specifier for page.js/Express route param that enumerates all supported languages.
+ *
+ * @param {string} name of the parameter. By default it's `lang`, some routes use `locale`.
+ * @param {boolean} optional whether to put the `?` character at the end, making the param optional
+ * @returns {string} Router param specifier that looks like `:lang(cs|de|fr|pl)`
+ */
+export function getLanguageRouteParam( name = 'lang', optional = true ) {
+	return `:${ name }(${ getLanguageSlugs().join( '|' ) })${ optional ? '?' : '' }`;
+}
+
+/**
  * Matches and returns language from config.languages based on the given localeSlug
  *
  * @param   {string} langSlug locale slug of the language to match

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -15,7 +15,6 @@ import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import MagicLogin from './magic-login';
 import WPLogin from './wp-login';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
-import { getLanguageSlugs } from 'lib/i18n-utils';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 
 const enhanceContextWithLogin = context => {
@@ -45,11 +44,6 @@ const enhanceContextWithLogin = context => {
 		/>
 	);
 };
-
-// Defining this here so it can be used by both ./index.node.js and ./index.web.js
-// We cannot export it from either of those (to import it from the other) because of
-// the way that `server/bundler/loader` expects only a default export and nothing else.
-export const lang = `:lang(${ getLanguageSlugs().join( '|' ) })?`;
 
 export async function login( context, next ) {
 	const {

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -3,8 +3,8 @@
  */
 import config from 'config';
 import webRouter from './index.web';
-import { lang } from './controller';
 import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
+import { getLanguageRouteParam } from 'lib/i18n-utils';
 
 /**
  * Re-exports
@@ -13,6 +13,8 @@ export { LOGIN_SECTION_DEFINITION } from './index.web';
 
 export default router => {
 	if ( config.isEnabled( 'login/magic-login' ) ) {
+		const lang = getLanguageRouteParam();
+
 		// Only do the basics for layout on the server-side
 		router( `/log-in/link/use/${ lang }`, setUpLocale, redirectLoggedIn, makeLayout );
 	}

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -9,7 +9,6 @@ import { Provider as ReduxProvider } from 'react-redux';
  */
 import config from 'config';
 import {
-	lang,
 	login,
 	magicLogin,
 	magicLoginUse,
@@ -20,6 +19,7 @@ import { setShouldServerSideRenderLogin } from './ssr';
 import { setUpLocale, setSection, makeLayoutMiddleware } from 'controller/shared';
 import { redirectLoggedIn } from 'controller/web-util';
 import LayoutLoggedOut from 'layout/logged-out';
+import { getLanguageRouteParam } from 'lib/i18n-utils';
 
 export const LOGIN_SECTION_DEFINITION = {
 	name: 'login',
@@ -41,6 +41,8 @@ const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => {
 const makeLoggedOutLayout = makeLayoutMiddleware( ReduxWrappedLayout );
 
 export default router => {
+	const lang = getLanguageRouteParam();
+
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		router(
 			`/log-in/link/use/${ lang }`,

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import store from 'store';
 import page from 'page';
-import { find, get, isEmpty, pick } from 'lodash';
+import { get } from 'lodash';
 import debugModule from 'debug';
 import i18n from 'i18n-calypso';
 
@@ -17,22 +17,13 @@ import { hideSidebar } from 'state/ui/actions';
 import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import { acceptInvite as acceptInviteAction } from 'lib/invites/actions';
 import _user from 'lib/user';
-import { getLanguage, getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
+import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
 
 /**
  * Module variables
  */
 const user = _user();
 const debug = debugModule( 'calypso:invite-accept:controller' );
-
-function getLocale( parameters ) {
-	const paths = [ 'site_id', 'invitation_key', 'activation_key', 'auth_key', 'locale' ];
-	return find( pick( parameters, paths ), isLocale );
-}
-
-function isLocale( pathFragment ) {
-	return ! isEmpty( getLanguage( pathFragment ) );
-}
 
 export function redirectWithoutLocaleifLoggedIn( context, next ) {
 	if ( user.get() && getLocaleFromPath( context.path ) ) {
@@ -79,7 +70,7 @@ export function acceptInvite( context, next ) {
 		inviteKey: context.params.invitation_key,
 		activationKey: context.params.activation_key,
 		authKey: context.params.auth_key,
-		locale: getLocale( context.params ),
+		locale: context.params.locale,
 		path: context.path,
 	} );
 	next();

--- a/client/my-sites/invites/index.js
+++ b/client/my-sites/invites/index.js
@@ -9,10 +9,17 @@ import page from 'page';
  */
 import { acceptInvite, redirectWithoutLocaleifLoggedIn } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { getLanguageRouteParam } from 'lib/i18n-utils';
 
 export default () => {
+	const locale = getLanguageRouteParam( 'locale' );
+
 	page(
-		'/accept-invite/:site_id?/:invitation_key?/:activation_key?/:auth_key?/:locale?',
+		[
+			`/accept-invite/:site_id/:invitation_key/${ locale }`,
+			`/accept-invite/:site_id/:invitation_key/:activation_key/${ locale }`,
+			`/accept-invite/:site_id/:invitation_key/:activation_key/:auth_key/${ locale }`,
+		],
 		redirectWithoutLocaleifLoggedIn,
 		acceptInvite,
 		makeLayout,

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -17,7 +17,6 @@ import {
 	getStepUrl,
 	canResumeFlow,
 	getFlowName,
-	getLocale,
 	getStepName,
 	getStepSectionName,
 	getValidPath,
@@ -45,7 +44,7 @@ let initialContext;
 export default {
 	redirectWithoutLocaleIfLoggedIn( context, next ) {
 		const userLoggedIn = isUserLoggedIn( context.store.getState() );
-		if ( userLoggedIn && getLocale( context.params ) ) {
+		if ( userLoggedIn && context.params.lang ) {
 			const flowName = getFlowName( context.params );
 			const stepName = getStepName( context.params );
 			const stepSectionName = getStepSectionName( context.params );
@@ -80,7 +79,7 @@ export default {
 
 	redirectToFlow( context, next ) {
 		const flowName = getFlowName( context.params );
-		const localeFromParams = getLocale( context.params );
+		const localeFromParams = context.params.lang;
 		const localeFromStore = store.get( 'signup-locale' );
 		const userLoggedIn = isUserLoggedIn( context.store.getState() );
 		const signupProgress = getSignupProgress( context.store.getState() );
@@ -168,7 +167,7 @@ export default {
 			store: context.store,
 			path: context.path,
 			initialContext,
-			locale: getLocale( context.params ),
+			locale: context.params.lang,
 			flowName: flowName,
 			queryObject: query,
 			refParameter: query && query.ref,

--- a/client/signup/index.node.js
+++ b/client/signup/index.node.js
@@ -1,18 +1,20 @@
 /**
  * Internal dependencies
  */
-import { getLanguage, getLanguageSlugs } from 'lib/i18n-utils';
-
-const lang = `(${ getLanguageSlugs().join( '|' ) })`;
+import { getLanguage, getLanguageRouteParam } from 'lib/i18n-utils';
 
 export default function( router ) {
-	// The idea is to look out for optional `lang` route params matching our whitelist,
-	// and fall through to the next route def (with free form `flowName`, `stepName`,
-	// and `stepSectionName` route params) if we don't match one.
-	router( `/start/:lang${ lang }?`, setUpLocale );
-	router( `/start/:flowName/:lang${ lang }?`, setUpLocale );
-	router( `/start/:flowName/:stepName/:lang${ lang }?`, setUpLocale );
-	router( `/start/:flowName/:stepName/:stepSectionName/:lang${ lang }?`, setUpLocale );
+	const lang = getLanguageRouteParam();
+
+	router(
+		[
+			`/start/${ lang }`,
+			`/start/:flowName/${ lang }`,
+			`/start/:flowName/:stepName/${ lang }`,
+			`/start/:flowName/:stepName/:stepSectionName/${ lang }`,
+		],
+		setUpLocale
+	);
 }
 
 // Set up the locale if there is one

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -8,10 +8,18 @@ import page from 'page';
  */
 import controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { getLanguageRouteParam } from 'lib/i18n-utils';
 
 export default function() {
+	const lang = getLanguageRouteParam();
+
 	page(
-		'/start/:flowName?/:stepName?/:stepSectionName?/:lang?',
+		[
+			`/start/${ lang }`,
+			`/start/:flowName/${ lang }`,
+			`/start/:flowName/:stepName/${ lang }`,
+			`/start/:flowName/:stepName/:stepSectionName/${ lang }`,
+		],
 		controller.saveInitialContext,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -14,7 +14,6 @@ import {
 	getValueFromProgressStore,
 	getValidPath,
 	getStepName,
-	getLocale,
 	getFlowName,
 	getFilteredSteps,
 } from '../utils';
@@ -33,23 +32,6 @@ jest.mock( 'signup/config/flows-pure', () => ( {
 
 describe( 'utils', () => {
 	const defaultFlowName = flows.defaultFlowName;
-
-	describe( 'getLocale', () => {
-		test( 'should find the locale anywhere in the params', () => {
-			expect( getLocale( { lang: 'fr' } ) ).toBe( 'fr' );
-			expect( getLocale( { stepName: 'fr' } ) ).toBe( 'fr' );
-			expect( getLocale( { flowName: 'fr' } ) ).toBe( 'fr' );
-		} );
-
-		test( 'should return undefined if no locale is present in the params', () => {
-			expect(
-				getLocale( {
-					stepName: 'theme-selection',
-					flowName: 'flow-one',
-				} )
-			).toBeUndefined();
-		} );
-	} );
 
 	describe( 'getStepName', () => {
 		test( 'should find the step name in either the stepName or flowName fragment', () => {
@@ -153,39 +135,29 @@ describe( 'utils', () => {
 		test( 'should redirect invalid steps to the default flow if no flow is present', () => {
 			expect(
 				getValidPath( {
-					stepName: 'fr',
-					stepSectionName: 'fr',
+					flowName: 'foo',
+					lang: 'fr',
 				} )
 			).toBe( '/start/user/fr' );
 		} );
 
-		test( 'should preserve a valid locale to the default flow if one is specified', () => {
+		test( 'should preserve a step section name and redirect to the default flow', () => {
 			expect(
 				getValidPath( {
-					stepName: 'fr',
-					stepSectionName: 'abc',
+					flowName: 'foo',
+					stepName: 'abc',
+					lang: 'fr',
 				} )
 			).toBe( '/start/user/abc/fr' );
 		} );
 
-		test( 'should redirect invalid steps to the current flow default', () => {
+		test( 'should redirect missing steps to the current flow default', () => {
 			expect(
 				getValidPath( {
 					flowName: 'account',
-					stepName: 'fr',
-					stepSectionName: 'fr',
+					lang: 'fr',
 				} )
 			).toBe( '/start/account/user/fr' );
-		} );
-
-		test( 'should preserve a valid locale if one is specified', () => {
-			expect(
-				getValidPath( {
-					flowName: 'account',
-					stepName: 'fr',
-					stepSectionName: 'abc',
-				} )
-			).toBe( '/start/account/user/abc/fr' );
 		} );
 
 		test( 'should handle arbitrary step section names', () => {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -8,7 +8,6 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { getLanguage } from 'lib/i18n-utils';
 import steps from 'signup/config/steps-pure';
 import flows from 'signup/config/flows';
 import userFactory from 'lib/user';
@@ -40,18 +39,7 @@ export function getStepSectionName( parameters ) {
 }
 
 function isStepSectionName( pathFragment ) {
-	return ! isStepName( pathFragment ) && ! isLocale( pathFragment );
-}
-
-export function getLocale( parameters ) {
-	return find(
-		pick( parameters, [ 'flowName', 'stepName', 'stepSectionName', 'lang' ] ),
-		isLocale
-	);
-}
-
-function isLocale( pathFragment ) {
-	return ! isEmpty( getLanguage( pathFragment ) );
+	return ! isStepName( pathFragment );
 }
 
 export function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
@@ -72,11 +60,11 @@ export function getStepUrl( flowName, stepName, stepSectionName, localeSlug ) {
 }
 
 export function getValidPath( parameters ) {
-	const locale = getLocale( parameters ),
-		flowName = getFlowName( parameters ),
-		currentFlowSteps = flows.getFlow( flowName ).steps,
-		stepName = getStepName( parameters ) || currentFlowSteps[ 0 ],
-		stepSectionName = getStepSectionName( parameters );
+	const locale = parameters.lang;
+	const flowName = getFlowName( parameters );
+	const currentFlowSteps = flows.getFlow( flowName ).steps;
+	const stepName = getStepName( parameters ) || currentFlowSteps[ 0 ];
+	const stepSectionName = getStepSectionName( parameters );
 
 	if ( currentFlowSteps.length === 0 ) {
 		return '/';


### PR DESCRIPTION
Routes that are entrypoints for logged out users (Login, Signup, Jetpack Connect, Accept Invite), support adding a locale slug at the end of the route, specifying a desired language:
```
/log-in/cs
```

The corresponding page.js/Express.js route definitions specify an optional route parameter, named `lang` or `locale`, and enumerate explicitly the allowed languages. Something like:
```
:lang(en|de|es|cs|pl|fr|it)?
```

This PR adds a common `getLocaleRouteParam` function to `lib/i18n-utils` that constructs this specifier and uses it consistently across all sections that need it.

**Chains of optional route params:**
In Signup and Accept Invite, we use a pattern where the route has multiple route params that are optional:
```
/start/:flow?/:step?/:lang?
```
When such a route definition is matching `/start/cs`, the locale ends up in the `flow` param, not in `lang`. The route handler then needs to search through all the params and look for something that looks like a valid locale. The set of valid locales is strictly bounded, so it's not hard to check.

In this PR, I'm changing these to:
```js
const lang = ':lang(en|de|es|cs)?';
page(
  [
    `/start/${ lang }`,
    `/start/:flow?/${ lang }`,
    `/start/:flow?/:step?/${ lang }`
  ],
  handler
)
```
With an array of routes like this, and `lang` being constrained to a fixed set of values, it's guaranteed that valid locale always ends up in `lang`.

`/start/cs` matches the first route definition, never the second one that would put `cs` into `flow` and leave `lang` empty. `/start/account` and `/start/account/cs` match the second definition, putting `account` always into `flow` and `cs` always into `lang`.

That lets us avoid code like:
```js
const localeFromParams = find( pick( context.params, [ 'flow', 'step', 'lang' ] ), isLocale );
```
and we can always write just:
```js
const localeFromParams = context.params.lang
```

It also simplifies the `getValidPath` function in `signup/utils`, because we don't need to check if `flow` and `step` parameters contain a locale: they never will, because the route matchers always put such a value into `lang`.

**Note about Accept Invite params:**
In the accept invite route definition, the `site_id` and `invitation_key` are mandatory. If they're missing, the nginx router won't even send such requests to Calypso and will handle them in wpcom. Only the `activation_key` and `auth_key` params are optional. They are needed only for logged out user to accept an invitation. For logged in users, they are not used.