### PR TITLE
ToS: Add Tracks event for successful ToS acceptance

### DIFF
--- a/client/state/data-layer/wpcom/legal/index.js
+++ b/client/state/data-layer/wpcom/legal/index.js
@@ -6,6 +6,7 @@ import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { LEGAL_REQUEST, TOS_ACCEPT } from 'state/action-types';
 import { setLegalData } from 'state/legal/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const requestLegalData = action => {
 	return http(
@@ -18,7 +19,10 @@ const requestLegalData = action => {
 	);
 };
 
-const storeLegalData = ( action, legalData ) => setLegalData( legalData );
+const storeLegalData = ( action, legalData ) => [
+	setLegalData( legalData ),
+	recordTracksEvent( 'calypso_tos_accept' ),
+];
 
 const formatLegalData = ( { tos: { accepted, active_date, display_prompt } } ) => {
 	return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Registers a `calypso_tos_accept` track event when a user accepts the current ToS.

<img width="879" alt="Screenshot 2020-02-11 at 14 53 27" src="https://user-images.githubusercontent.com/1233880/74242952-1c092200-4cdf-11ea-9050-c9c85babc89f.png">


#### Testing instructions

* Make sure you don't have ToS marked as accepted. See D38262-code for instructions on how to reset ToS acceptance.
* Enable the analytics debug by running `localStorage.debug='calypso:analytics:*` in the browser console.
* Load any Calypso page.
* ToS update banner should appear.
* Click on Accept.
* Make sure a `calypso_tos_accept` track event is registered.
