### PR TITLE
State: Create media validation reducer and selectors

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -68,11 +68,9 @@ describe( 'MediaUtils', () => {
 		} );
 
 		test( 'should simply return the URL if media is transient', () => {
-			let url;
-
 			media.transient = true;
 
-			url = MediaUtils.url( media, {
+			const url = MediaUtils.url( media, {
 				maxWidth: 450,
 			} );
 
@@ -355,8 +353,8 @@ describe( 'MediaUtils', () => {
 		} );
 
 		test( "should return false if the site doesn't support the item's extension", () => {
-			let item = { extension: 'avi' },
-				isSupported = MediaUtils.isSupportedFileTypeForSite( item, site );
+			const item = { extension: 'avi' };
+			const isSupported = MediaUtils.isSupportedFileTypeForSite( item, site );
 
 			expect( isSupported ).to.be.false;
 		} );
@@ -376,15 +374,15 @@ describe( 'MediaUtils', () => {
 		} );
 
 		test( "should return true if the site supports the item's extension", () => {
-			let item = { extension: 'pdf' },
-				isSupported = MediaUtils.isSupportedFileTypeForSite( item, site );
+			const item = { extension: 'pdf' };
+			const isSupported = MediaUtils.isSupportedFileTypeForSite( item, site );
 
 			expect( isSupported ).to.be.true;
 		} );
 
 		test( 'should return true despite even if different case', () => {
-			let item = { extension: 'PdF' },
-				isSupported = MediaUtils.isSupportedFileTypeForSite( item, site );
+			const item = { extension: 'PdF' };
+			const isSupported = MediaUtils.isSupportedFileTypeForSite( item, site );
 
 			expect( isSupported ).to.be.true;
 		} );

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -17,6 +17,7 @@ import {
 	GalleryColumnedTypes,
 	GallerySizeableTypes,
 	GalleryDefaultAttrs,
+	ValidationErrors as MediaValidationErrors,
 } from './constants';
 import { stringify } from 'lib/shortcode';
 import impureLodash from 'lib/impure-lodash';
@@ -587,4 +588,33 @@ export function createTransientMedia( file ) {
 	}
 
 	return transientMedia;
+}
+
+/**
+ * Validates a media item for a site, and returns validation errors (if any).
+ *
+ * @param  {object}      site Site object
+ * @param  {object}      item Media item
+ * @returns {Array|null}      Validation errors, or null if no site.
+ */
+export function validateMediaItem( site, item ) {
+	const itemErrors = [];
+
+	if ( ! site ) {
+		return;
+	}
+
+	if ( ! isSupportedFileTypeForSite( item, site ) ) {
+		if ( isSupportedFileTypeInPremium( item, site ) ) {
+			itemErrors.push( MediaValidationErrors.FILE_TYPE_NOT_IN_PLAN );
+		} else {
+			itemErrors.push( MediaValidationErrors.FILE_TYPE_UNSUPPORTED );
+		}
+	}
+
+	if ( true === isExceedingSiteMaxUploadSize( item, site ) ) {
+		itemErrors.push( MediaValidationErrors.EXCEEDS_MAX_UPLOAD_SIZE );
+	}
+
+	return itemErrors;
 }

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -2,12 +2,15 @@
  * External dependencies
  */
 
-import { omit } from 'lodash';
+import { isEmpty, mapValues, omit, pickBy, without } from 'lodash';
 /**
  * Internal dependencies
  */
 import {
 	MEDIA_DELETE,
+	MEDIA_ERRORS_CLEAR,
+	MEDIA_ITEM_ERRORS_CLEAR,
+	MEDIA_ITEM_CREATE,
 	MEDIA_ITEM_REQUEST_FAILURE,
 	MEDIA_ITEM_REQUEST_SUCCESS,
 	MEDIA_ITEM_REQUESTING,
@@ -15,9 +18,140 @@ import {
 	MEDIA_REQUEST_FAILURE,
 	MEDIA_REQUEST_SUCCESS,
 	MEDIA_REQUESTING,
+	MEDIA_SOURCE_CHANGE,
 } from 'state/action-types';
 import { combineReducers, withoutPersistence } from 'state/utils';
 import MediaQueryManager from 'lib/query-manager/media';
+import { validateMediaItem } from 'lib/media/utils';
+import { ValidationErrors as MediaValidationErrors } from 'lib/media/constants';
+
+const isExternalMediaError = message =>
+	message.error && ( message.error === 'servicefail' || message.error === 'keyring_token_error' );
+
+const isMediaError = action =>
+	action.error && ( action.siteId || isExternalMediaError( action.error ) );
+
+/**
+ * Returns the updated media errors state after an action has been
+ * dispatched. The state reflects a mapping of site ID, media ID pairing to
+ * an array of errors that occurred for that corresponding media item.
+ *
+ * @param  {object} state  Current state
+ * @param  {object} action Action payload
+ * @returns {object}        Updated state
+ */
+export const errors = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case MEDIA_ITEM_CREATE: {
+			if ( ! action.site || ! action.transientMedia ) {
+				return state;
+			}
+
+			const items = Array.isArray( action.transientMedia )
+				? action.transientMedia
+				: [ action.transientMedia ];
+			const mediaErrors = items.reduce( function( memo, item ) {
+				const itemErrors = validateMediaItem( action.site, item );
+				if ( itemErrors.length ) {
+					memo[ item.ID ] = itemErrors;
+				}
+
+				return memo;
+			}, {} );
+
+			return {
+				...state,
+				[ action.site.ID ]: {
+					...state[ action.site.ID ],
+					...mediaErrors,
+				},
+			};
+		}
+
+		case MEDIA_ITEM_REQUEST_FAILURE:
+		case MEDIA_REQUEST_FAILURE: {
+			// Track any errors which occurred during upload or getting external media
+			if ( ! isMediaError( action ) ) {
+				return state;
+			}
+
+			let mediaErrors;
+
+			if ( Array.isArray( action.error.errors ) ) {
+				mediaErrors = action.error.errors;
+			} else {
+				mediaErrors = [ action.error ];
+			}
+
+			const sanitizedErrors = mediaErrors.map( error => {
+				switch ( error.error ) {
+					case 'http_404':
+						return MediaValidationErrors.UPLOAD_VIA_URL_404;
+					case 'upload_error':
+						if ( error.message.indexOf( 'Not enough space to upload' ) === 0 ) {
+							return MediaValidationErrors.NOT_ENOUGH_SPACE;
+						}
+						if ( error.message.indexOf( 'You have used your space quota' ) === 0 ) {
+							return MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT;
+						}
+						return MediaValidationErrors.SERVER_ERROR;
+					case 'keyring_token_error':
+						return MediaValidationErrors.SERVICE_AUTH_FAILED;
+					case 'servicefail':
+						return MediaValidationErrors.SERVICE_FAILED;
+					default:
+						return MediaValidationErrors.SERVER_ERROR;
+				}
+			} );
+
+			return {
+				...state,
+				[ action.siteId ]: {
+					...state[ action.siteId ],
+					[ action?.mediaId ?? 0 ]: sanitizedErrors,
+				},
+			};
+		}
+
+		case MEDIA_ERRORS_CLEAR:
+			if ( ! action.siteId ) {
+				return state;
+			}
+
+			return {
+				...omit( state, action.siteId ),
+				[ action.siteId ]: pickBy(
+					mapValues( state[ action.siteId ], mediaErrors =>
+						without( mediaErrors, action.errorType )
+					),
+					mediaErrors => ! isEmpty( mediaErrors )
+				),
+			};
+
+		case MEDIA_ITEM_ERRORS_CLEAR: {
+			if ( ! action.siteId || ! action.mediaId ) {
+				return state;
+			}
+
+			return {
+				...omit( state, action.siteId ),
+				[ action.siteId ]: {
+					...omit( state[ action.siteId ], [ [ action.siteId ], [ action.mediaId ] ] ),
+				},
+			};
+		}
+
+		case MEDIA_SOURCE_CHANGE: {
+			if ( ! action.siteId ) {
+				return state;
+			}
+
+			return omit( state, action.siteId );
+		}
+	}
+
+	return state;
+};
 
 export const queries = ( () => {
 	function applyToManager( state, siteId, method, createDefault, ...args ) {
@@ -132,6 +266,7 @@ export const mediaItemRequests = withoutPersistence( ( state = {}, action ) => {
 } );
 
 export default combineReducers( {
+	errors,
 	queries,
 	queryRequests,
 	mediaItemRequests,

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -75,13 +75,9 @@ export const errors = ( state = {}, action ) => {
 				return state;
 			}
 
-			let mediaErrors;
-
-			if ( Array.isArray( action.error.errors ) ) {
-				mediaErrors = action.error.errors;
-			} else {
-				mediaErrors = [ action.error ];
-			}
+			const mediaErrors = Array.isArray( action.error.errors )
+				? action.error.errors
+				: [ action.error ];
 
 			const sanitizedErrors = mediaErrors.map( error => {
 				switch ( error.error ) {

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -115,7 +115,7 @@ export const errors = ( state = {}, action ) => {
 			}
 
 			return {
-				...omit( state, action.siteId ),
+				...state,
 				[ action.siteId ]: pickBy(
 					mapValues( state[ action.siteId ], mediaErrors =>
 						without( mediaErrors, action.errorType )
@@ -130,7 +130,7 @@ export const errors = ( state = {}, action ) => {
 			}
 
 			return {
-				...omit( state, action.siteId ),
+				...state,
 				[ action.siteId ]: {
 					...omit( state[ action.siteId ], [ [ action.siteId ], [ action.mediaId ] ] ),
 				},

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -84,10 +84,10 @@ export const errors = ( state = {}, action ) => {
 					case 'http_404':
 						return MediaValidationErrors.UPLOAD_VIA_URL_404;
 					case 'upload_error':
-						if ( error.message.indexOf( 'Not enough space to upload' ) === 0 ) {
+						if ( error.message.startsWith( 'Not enough space to upload' ) ) {
 							return MediaValidationErrors.NOT_ENOUGH_SPACE;
 						}
-						if ( error.message.indexOf( 'You have used your space quota' ) === 0 ) {
+						if ( error.message.startsWith( 'You have used your space quota' ) ) {
 							return MediaValidationErrors.EXCEEDS_PLAN_STORAGE_LIMIT;
 						}
 						return MediaValidationErrors.SERVER_ERROR;

--- a/client/state/media/test/reducer.js
+++ b/client/state/media/test/reducer.js
@@ -25,6 +25,7 @@ import {
 describe( 'reducer', () => {
 	test( 'should include expected keys in return value', () => {
 		expect( reducer( undefined, {} ) ).to.have.keys( [
+			'errors',
 			'queries',
 			'queryRequests',
 			'mediaItemRequests',

--- a/client/state/selectors/get-media-errors.js
+++ b/client/state/selectors/get-media-errors.js
@@ -1,0 +1,8 @@
+/**
+ * Retrieves all media validation errors for a specified site.
+ *
+ * @param {object}   state  global state tree
+ * @param {number}   siteId ID of the site
+ * @returns {object}        Media validation errors for that site.
+ */
+export default ( state, siteId ) => state.media.errors?.[ siteId ] ?? {};

--- a/client/state/selectors/get-media-item-errors.js
+++ b/client/state/selectors/get-media-item-errors.js
@@ -1,0 +1,9 @@
+/**
+ * Retrieves all media validation errors for a certain media item of a specified site.
+ *
+ * @param {object}   state   global state tree
+ * @param {number}   siteId  ID of the site
+ * @param {number}   mediaId ID of the media item
+ * @returns {Array}          Media validation errors for that media item of that site.
+ */
+export default ( state, siteId, mediaId ) => state.media.errors?.[ siteId ]?.[ mediaId ] ?? [];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Media: Move `validateMediaItem` from the store to media util.
* State: Create media validation reducer
* State: Create simple media validation selectors

#### Testing instructions

* Checkout this branch.
* Verify all tests pass.
* Try smoke testing media library and verify it still works well.

~Note: #39374 precedes this PR and should be merged first. Feel free to review this one separately, though.~

Note: This PR is part of an iteration to remove the media validation store, see #39372 for the full effort that removes it completely. 
