### PR TITLE
Modularise themes state.

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -15,6 +14,7 @@ import Theme from 'components/theme';
 import EmptyContent from 'components/empty-content';
 import InfiniteScroll from 'components/infinite-scroll';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
+import { getThemesBookmark } from 'state/themes/themes-ui/selectors';
 
 /**
  * Style dependencies
@@ -149,7 +149,7 @@ export class ThemesList extends React.Component {
 }
 
 const mapStateToProps = state => ( {
-	themesBookmark: state.themes.themesUI.themesBookmark,
+	themesBookmark: getThemesBookmark( state ),
 } );
 
 export default connect( mapStateToProps )( localize( ThemesList ) );

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -11,6 +10,7 @@ import { Provider as ReduxProvider } from 'react-redux';
  */
 import ThemeSheetComponent from '../main';
 import { createReduxStore } from 'state';
+import { setStore } from 'state/redux-store';
 import { receiveTheme, themeRequestFailure } from 'state/themes/actions';
 
 jest.mock( 'lib/analytics', () => ( {} ) );
@@ -39,22 +39,34 @@ describe( 'main', () => {
 			demo_uri: 'https://twentysixteendemo.wordpress.com/',
 		};
 
+		let store, initialState;
+
+		beforeAll( () => {
+			store = createReduxStore();
+			setStore( store );
+			// Preserve initial theme state by deep cloning it.
+			initialState = JSON.parse( JSON.stringify( store.getState().themes ) );
+		} );
+
+		beforeEach( () => {
+			// Ensure initial theme state at the beginning of every test.
+			store.getState().themes = initialState;
+		} );
+
 		test( "doesn't throw an exception without theme data", () => {
-			const store = createReduxStore();
 			const layout = (
 				<ReduxProvider store={ store }>
 					<ThemeSheetComponent id={ 'twentysixteen' } />
 				</ReduxProvider>
 			);
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
-			assert.isTrue( markup.includes( 'theme__sheet' ) );
+			} ).not.toThrow();
+			expect( markup.includes( 'theme__sheet' ) ).toBeTruthy();
 		} );
 
 		test( "doesn't throw an exception with theme data", () => {
-			const store = createReduxStore();
 			store.dispatch( receiveTheme( themeData ) );
 			const layout = (
 				<ReduxProvider store={ store }>
@@ -62,14 +74,13 @@ describe( 'main', () => {
 				</ReduxProvider>
 			);
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
-			assert.isTrue( markup.includes( 'theme__sheet' ) );
+			} ).not.toThrow();
+			expect( markup.includes( 'theme__sheet' ) ).toBeTruthy();
 		} );
 
 		test( "doesn't throw an exception with invalid theme data", () => {
-			const store = createReduxStore();
 			store.dispatch( themeRequestFailure( 'wpcom', 'invalidthemeid', 'not found' ) );
 			const layout = (
 				<ReduxProvider store={ store }>
@@ -77,10 +88,10 @@ describe( 'main', () => {
 				</ReduxProvider>
 			);
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
-			assert.isTrue( markup.includes( 'empty-content' ) );
+			} ).not.toThrow();
+			expect( markup.includes( 'empty-content' ) ).toBeTruthy();
 		} );
 	} );
 } );

--- a/client/my-sites/themes/recommended-themes.jsx
+++ b/client/my-sites/themes/recommended-themes.jsx
@@ -10,6 +10,10 @@ import { connect } from 'react-redux';
 import { ConnectedThemesSelection } from './themes-selection';
 import Spinner from 'components/spinner';
 import { getRecommendedThemes } from 'state/themes/actions';
+import {
+	getRecommendedThemes as getRecommendedThemesSelector,
+	areRecommendedThemesLoading,
+} from 'state/themes/selectors';
 
 class RecommendedThemes extends React.Component {
 	componentDidMount() {
@@ -45,8 +49,8 @@ class RecommendedThemes extends React.Component {
 const ConnectedRecommendedThemes = connect(
 	state => {
 		return {
-			recommendedThemes: state.themes.recommendedThemes.themes || [],
-			isLoading: state.themes.recommendedThemes.isLoading,
+			recommendedThemes: getRecommendedThemesSelector( state ),
+			isLoading: areRecommendedThemesLoading( state ),
 		};
 	},
 	{ getRecommendedThemes }

--- a/client/my-sites/themes/test/logged-out.jsx
+++ b/client/my-sites/themes/test/logged-out.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { assert } from 'chai';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { Provider as ReduxProvider } from 'react-redux';
@@ -11,6 +10,7 @@ import { Provider as ReduxProvider } from 'react-redux';
  */
 import LoggedOutShowcase from '../logged-out';
 import { createReduxStore } from 'state';
+import { setStore } from 'state/redux-store';
 import { THEMES_REQUEST_FAILURE } from 'state/action-types';
 import { receiveThemes } from 'state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
@@ -78,11 +78,18 @@ describe( 'logged-out', () => {
 					'https://i1.wp.com/theme.wordpress.com/wp-content/themes/pub/karuna/screenshot.png',
 			},
 		];
-		let layout, store;
+		let layout, store, initialState;
+
+		beforeAll( () => {
+			store = createReduxStore();
+			setStore( store );
+			// Preserve initial theme state by deep cloning it.
+			initialState = JSON.parse( JSON.stringify( store.getState().themes ) );
+		} );
 
 		beforeEach( () => {
-			store = createReduxStore();
-
+			// Ensure initial theme state at the beginning of every test.
+			store.getState().themes = initialState;
 			layout = (
 				<ReduxProvider store={ store }>
 					<LoggedOutShowcase />
@@ -92,24 +99,24 @@ describe( 'logged-out', () => {
 
 		test( 'renders without error when no themes are present', () => {
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
+			} ).not.toThrow();
 			// Should show a "No themes found" message
-			assert.isTrue( markup.includes( 'empty-content' ) );
+			expect( markup.includes( 'empty-content' ) ).toBeTruthy();
 		} );
 
 		test( 'renders without error when themes are present', () => {
 			store.dispatch( receiveThemes( themes, 'wpcom', DEFAULT_THEME_QUERY, themes.length ) );
 
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
+			} ).not.toThrow();
 			// All 5 themes should appear...
-			assert.equal( 5, markup.match( /theme__content/g ).length );
+			expect( markup.match( /theme__content/g ).length ).toBe( 5 );
 			// .. and no empty content placeholders should appear
-			assert.isFalse( markup.includes( 'empty-content' ) );
+			expect( markup.includes( 'empty-content' ) ).toBeFalsy();
 		} );
 
 		test( 'renders without error when theme fetch fails', () => {
@@ -121,11 +128,11 @@ describe( 'logged-out', () => {
 			} );
 
 			let markup;
-			assert.doesNotThrow( () => {
+			expect( () => {
 				markup = renderToString( layout );
-			} );
+			} ).not.toThrow();
 			// Should show a "No themes found" message
-			assert.isTrue( markup.includes( 'empty-content' ) );
+			expect( markup.includes( 'empty-content' ) ).toBeTruthy();
 		} );
 	} );
 } );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -31,6 +31,10 @@ import getThemeShowcaseTitle from 'state/selectors/get-theme-showcase-title';
 import prependThemeFilterKeys from 'state/selectors/prepend-theme-filter-keys';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { openThemesShowcase } from 'state/themes/themes-ui/actions';
+import {
+	getThemesBookmark,
+	hasShowcaseOpened as hasShowcaseOpenedSelector,
+} from 'state/themes/themes-ui/selectors';
 import ThemesSearchCard from './themes-magic-search-card';
 import QueryThemeFilters from 'components/data/query-theme-filters';
 import { getActiveTheme } from 'state/themes/selectors';
@@ -441,8 +445,8 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	subjects: getThemeFilterTerms( state, 'subject' ) || {},
 	filterString: prependThemeFilterKeys( state, filter ),
 	filterToTermTable: getThemeFilterToTermTable( state ),
-	hasShowcaseOpened: state.themes.themesUI.themesShowcaseOpen,
-	themesBookmark: state.themes.themesUI.themesBookmark,
+	hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
+	themesBookmark: getThemesBookmark( state ),
 } );
 
 const mapDispatchToProps = {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -45,6 +45,7 @@ import {
 } from 'server/render';
 import stateCache from 'server/state-cache';
 import { createReduxStore } from 'state';
+import { setStore } from 'state/redux-store';
 import initialReducer from 'state/reducer';
 import { DESERIALIZE, LOCALE_SET } from 'state/action-types';
 import { setCurrentUser } from 'state/current-user/actions';
@@ -293,6 +294,9 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 		request.query[ 'wccom-from' ] &&
 		isWooOAuth2Client( { id: parseInt( oauthClientId ) } );
 
+	const reduxStore = createReduxStore( initialServerState );
+	setStore( reduxStore );
+
 	const context = Object.assign( {}, request.context, {
 		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
 		compileDebug: process.env.NODE_ENV === 'development',
@@ -311,7 +315,7 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 		abTestHelper: !! config.isEnabled( 'dev/test-helper' ),
 		preferencesHelper: !! config.isEnabled( 'dev/preferences-helper' ),
 		devDocsURL: '/devdocs',
-		store: createReduxStore( initialServerState ),
+		store: reduxStore,
 		bodyClasses,
 		addEvergreenCheck: target === 'evergreen' && calypsoEnv !== 'development',
 		target: target || 'fallback',

--- a/client/state/add-reducer.ts
+++ b/client/state/add-reducer.ts
@@ -24,6 +24,11 @@ export interface WithAddReducer {
 	addReducer: ( keys: string[], subReducer: Reducer & OptionalStorageKey ) => void;
 }
 
+export function clear() {
+	initializations.clear();
+	reducers.clear();
+}
+
 function initializeState(
 	store: Store & WithAddReducer,
 	storageKey: string,

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -95,7 +95,7 @@ function shouldAddSympathy() {
 // scenario where state data may have been stored without this
 // check being performed.
 function verifyStoredRootState( state ) {
-	const currentUserId = user.get()?.ID ?? null;
+	const currentUserId = user?.get()?.ID ?? null;
 	const storedUserId = state?.currentUser?.id ?? null;
 
 	if ( currentUserId !== storedUserId ) {
@@ -160,7 +160,7 @@ export function getStateFromCache( reducer, subkey, forceLoggedOutUser = false )
 }
 
 function getReduxStateKey( forceLoggedOutUser = false ) {
-	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user.get()?.ID ?? null );
+	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : user?.get()?.ID ?? null );
 }
 
 function getReduxStateKeyForUserId( userId ) {

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -93,7 +93,6 @@ import stats from './stats/reducer';
 import storedCards from './stored-cards/reducer';
 import support from './support/reducer';
 import terms from './terms/reducer';
-import themes from './themes/reducer';
 import timezones from './timezones/reducer';
 import ui from './ui/reducer';
 import userDevices from './user-devices/reducer';
@@ -186,7 +185,6 @@ const reducers = {
 	storedCards,
 	support,
 	terms,
-	themes,
 	timezones,
 	ui,
 	userDevices,

--- a/client/state/redux-store.ts
+++ b/client/state/redux-store.ts
@@ -6,34 +6,35 @@ import { Reducer, Store } from 'redux';
 /**
  * Internal dependencies
  */
-import { addReducerToStore, WithAddReducer } from './add-reducer';
+import { addReducerToStore, clear as clearReducers, WithAddReducer } from './add-reducer';
 
 type QueueEntry = [ string[], Reducer ];
 
 let applicationStore: ( Store & WithAddReducer ) | undefined;
-let reducerRegistrationQueue: QueueEntry[] = [];
+const reducerRegistrationQueue: QueueEntry[] = [];
 
 export function setStore( store: Store & WithAddReducer ) {
-	// Only set store once.
+	// Clear any previously added reducers when replacing an existing store.
 	if ( applicationStore ) {
-		return;
+		clearReducers();
 	}
 
 	applicationStore = store;
+
 	// Synchronously add all pending reducers.
+	// These include reducers registered to previous stores, since their code has
+	// already been loaded.
 	for ( const [ key, reducer ] of reducerRegistrationQueue ) {
 		addReducerToStore( applicationStore )( key, reducer );
 	}
-	// Clear registration queue to avoid dangling references.
-	reducerRegistrationQueue = [];
 }
 
 export function registerReducer( key: string[], reducer: Reducer ) {
 	if ( applicationStore ) {
 		// Register immediately.
 		addReducerToStore( applicationStore )( key, reducer );
-		return;
 	}
 
+	// Add to queue, for future stores.
 	reducerRegistrationQueue.push( [ key, reducer ] );
 }

--- a/client/state/selectors/find-theme-filter-term.js
+++ b/client/state/selectors/find-theme-filter-term.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { filter, get } from 'lodash';
 
 /**
@@ -10,6 +9,8 @@ import { filter, get } from 'lodash';
 import createSelector from 'lib/create-selector';
 import getThemeFilters from 'state/selectors/get-theme-filters';
 import getThemeFilterTerm from 'state/selectors/get-theme-filter-term';
+
+import 'state/themes/init';
 
 /**
  * Returns a theme filter term object that corresponds to a given filter term slug

--- a/client/state/selectors/get-theme-filter-string-from-term.js
+++ b/client/state/selectors/get-theme-filter-string-from-term.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getThemeFilterTermsTable from 'state/selectors/get-theme-filter-terms-table';
+
+import 'state/themes/init';
 
 /**
  * Given the 'term' part, returns a complete filter

--- a/client/state/selectors/get-theme-filter-term-from-string.js
+++ b/client/state/selectors/get-theme-filter-term-from-string.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import isAmbiguousThemeFilterTerm from 'state/selectors/is-ambiguous-theme-filter-term';
+
+import 'state/themes/init';
 
 /**
  * return term from a taxonomy:term string

--- a/client/state/selectors/get-theme-filter-term.js
+++ b/client/state/selectors/get-theme-filter-term.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getThemeFilterTerms from 'state/selectors/get-theme-filter-terms';
+
+import 'state/themes/init';
 
 /**
  * Returns theme filter term object.

--- a/client/state/selectors/get-theme-filter-terms-table.js
+++ b/client/state/selectors/get-theme-filter-terms-table.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { forIn, keys, mapValues } from 'lodash';
 
 /**
@@ -10,6 +9,8 @@ import { forIn, keys, mapValues } from 'lodash';
 import createSelector from 'lib/create-selector';
 import getThemeFilters from 'state/selectors/get-theme-filters';
 import isAmbiguousThemeFilterTerm from 'state/selectors/is-ambiguous-theme-filter-term';
+
+import 'state/themes/init';
 
 /**
  * Return a table of theme filter terms to taxonomies, with

--- a/client/state/selectors/get-theme-filter-terms.js
+++ b/client/state/selectors/get-theme-filter-terms.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getThemeFilters from 'state/selectors/get-theme-filters';
+
+import 'state/themes/init';
 
 /**
  * Returns the list of available terms for a given theme filter.

--- a/client/state/selectors/get-theme-filter-to-term-table.js
+++ b/client/state/selectors/get-theme-filter-to-term-table.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { forIn, keys, mapValues } from 'lodash';
 
 /**
@@ -10,6 +9,8 @@ import { forIn, keys, mapValues } from 'lodash';
 import createSelector from 'lib/create-selector';
 import getThemeFilters from 'state/selectors/get-theme-filters';
 import getThemeFilterTermFromString from 'state/selectors/get-theme-filter-term-from-string';
+
+import 'state/themes/init';
 
 /**
  * Return a table of all theme filter terms indexed by

--- a/client/state/selectors/get-theme-filters.js
+++ b/client/state/selectors/get-theme-filters.js
@@ -1,11 +1,15 @@
 /**
+ * Internal dependencies
+ */
+import 'state/themes/init';
+
+/**
  * Returns the list of available theme filters
  *
  *
  * @param {object}  state Global state tree
  * @returns {object}        A nested list of theme filters, keyed by filter slug
  */
-
 export default function getThemeFilters( state ) {
 	return state.themes.themeFilters;
 }

--- a/client/state/selectors/get-theme-showcase-description.js
+++ b/client/state/selectors/get-theme-showcase-description.js
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-
 import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import findThemeFilterTerm from 'state/selectors/find-theme-filter-term';
-
 import getThemeFilterTerm from 'state/selectors/get-theme-filter-term';
+
+import 'state/themes/init';
 
 export default function getThemeShowcaseDescription( state, { filter, tier, vertical } = {} ) {
 	if ( vertical ) {

--- a/client/state/selectors/get-theme-showcase-title.js
+++ b/client/state/selectors/get-theme-showcase-title.js
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-
 import { get, includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import findThemeFilterTerm from 'state/selectors/find-theme-filter-term';
-
 import getThemeFilterTerm from 'state/selectors/get-theme-filter-term';
+
+import 'state/themes/init';
 
 export default function getThemeShowcaseTitle( state, { filter, tier, vertical } = {} ) {
 	if ( vertical ) {

--- a/client/state/selectors/is-ambiguous-theme-filter-term.js
+++ b/client/state/selectors/is-ambiguous-theme-filter-term.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { filter, get } from 'lodash';
 
 /**
@@ -10,13 +9,15 @@ import { filter, get } from 'lodash';
 import createSelector from 'lib/create-selector';
 import getThemeFilters from 'state/selectors/get-theme-filters';
 
+import 'state/themes/init';
+
 /**
  * Returns true if a theme filter term belongs to more
  * than one taxonomy.
  *
  * @param  {object}  state  Global state tree
  * @param  {string}  term   The term to check for ambiguity
- * @returns {Bool}           True if term is ambiguous
+ * @returns {boolean}           True if term is ambiguous
  */
 export default createSelector(
 	( state, term ) => {

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -80,6 +80,8 @@ import accept from 'lib/accept';
 
 import 'state/data-layer/wpcom/theme-filters';
 
+import 'state/themes/init';
+
 const debug = debugFactory( 'calypso:themes:actions' );
 
 // Set destination for 'back' button on theme sheet
@@ -594,7 +596,7 @@ export function installAndActivateTheme( themeId, siteId, source = 'unknown', pu
  * Triggers a theme upload to the given site.
  *
  * @param {number} siteId -- Site to upload to
- * @param {File} file -- the theme zip to upload
+ * @param {window.File} file -- the theme zip to upload
  *
  * @returns {Function} the action function
  */
@@ -651,7 +653,7 @@ export function clearThemeUpload( siteId ) {
  * Start an Automated Transfer with an uploaded theme.
  *
  * @param {number} siteId -- the site to transfer
- * @param {File} file -- theme zip to upload
+ * @param {window.File} file -- theme zip to upload
  * @param {string} plugin -- plugin slug
  *
  * @returns {Promise} for testing purposes only

--- a/client/state/themes/init.js
+++ b/client/state/themes/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import themesReducer from './reducer';
+
+registerReducer( [ 'themes' ], themesReducer );

--- a/client/state/themes/package.json
+++ b/client/state/themes/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -7,7 +7,12 @@ import { mapValues, omit, map } from 'lodash';
  * Internal dependencies
  */
 import ThemeQueryManager from 'lib/query-manager/theme';
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
+import {
+	combineReducers,
+	withSchemaValidation,
+	withStorageKey,
+	withoutPersistence,
+} from 'state/utils';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -436,9 +441,9 @@ export const themePreviewOptions = withoutPersistence( ( state = {}, action ) =>
  * Returns the updated previewing theme state
  * The state reflects if Theme Preview component should be visible or not.
  *
- * @param  {Bool}   state  Current state
+ * @param  {boolean}   state  Current state
  * @param  {object} action Action payload
- * @returns {Bool}          Updated state
+ * @returns {boolean}          Updated state
  */
 export const themePreviewVisibility = withoutPersistence( ( state = null, action ) => {
 	switch ( action.type ) {
@@ -483,7 +488,7 @@ export function recommendedThemes( state = { isLoading: true, themes: [] }, acti
 	return state;
 }
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	queries,
 	queryRequests,
 	queryRequestErrors,
@@ -502,3 +507,6 @@ export default combineReducers( {
 	themeFilters,
 	recommendedThemes,
 } );
+const themesReducer = withStorageKey( 'themes', combinedReducer );
+
+export default themesReducer;

--- a/client/state/themes/selectors.js
+++ b/client/state/themes/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { find, includes, intersection, isEqual, omit, some, get, uniq, flatMap } from 'lodash';
 import i18n from 'i18n-calypso';
 import createSelector from 'lib/create-selector';
@@ -32,6 +31,8 @@ import {
 } from './utils';
 import { DEFAULT_THEME_QUERY } from './constants';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
+
+import 'state/themes/init';
 
 /**
  * Returns a theme object by site ID, theme ID pair.
@@ -507,7 +508,6 @@ export function getThemeDemoUrl( state, themeId, siteId ) {
  *
  * @param  {object}  state   Global state tree
  * @param  {string}  themeId Theme ID
- * @param  {string}  siteId  Site ID
  * @returns {?string}         Theme forum URL
  */
 export function getThemeForumUrl( state, themeId ) {
@@ -730,7 +730,7 @@ export function getJetpackUpgradeUrlIfPremiumTheme( state, themeId, siteId ) {
 /**
  * Returns the price string to display for a given theme on a given site:
  *
- * @TODO Add tests!
+ * TODO: Add tests!
  *
  * @param  {object}  state   Global state tree
  * @param  {string}  themeId Theme ID
@@ -770,4 +770,28 @@ export function isThemeGutenbergFirst( state, themeId ) {
 	const neededFeatures = [ 'global-styles', 'auto-loading-homepage' ];
 	// The theme should have a positive number of matching features to qualify.
 	return !! intersection( themeFeatures, neededFeatures ).length;
+}
+
+const emptyList = [];
+
+/**
+ * Gets the list of recommended themes.
+ *
+ * @param {object} state Global state tree
+ *
+ * @returns {Array} the list of recommended themes
+ */
+export function getRecommendedThemes( state ) {
+	return state.themes.recommendedThemes.themes || emptyList;
+}
+
+/**
+ * Returns whether the recommended themes list is loading.
+ *
+ * @param {object} state Global state tree
+ *
+ * @returns {boolean} whether the recommended themes list is loading
+ */
+export function areRecommendedThemesLoading( state ) {
+	return state.themes.recommendedThemes.isLoading;
 }

--- a/client/state/themes/themes-ui/actions.js
+++ b/client/state/themes/themes-ui/actions.js
@@ -3,6 +3,8 @@
  */
 import { THEMES_BANNER_HIDE, THEMES_SHOWCASE_OPEN, THEMES_BOOKMARK_SET } from 'state/action-types';
 
+import 'state/themes/init';
+
 // Hides the theme showcase banner.
 export function hideThemesBanner() {
 	return {

--- a/client/state/themes/themes-ui/selectors.js
+++ b/client/state/themes/themes-ui/selectors.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+import 'state/themes/init';
 
 // Returns destination for theme sheet 'back' button
 export function getBackPath( state ) {
@@ -23,4 +24,14 @@ export function getBackPath( state ) {
 //  Returns true if the theme showcase banner is currently visible
 export function isThemesBannerVisible( state ) {
 	return state.themes.themesUI.themesBannerVisible;
+}
+
+// Returns the theme bookmark.
+export function getThemesBookmark( state ) {
+	return state.themes.themesUI.themesBookmark;
+}
+
+// Returns whether the showcase has opened.
+export function hasShowcaseOpened( state ) {
+	return state.themes.themesUI.themesShowcaseOpen;
 }

--- a/client/state/themes/upload-theme/selectors.js
+++ b/client/state/themes/upload-theme/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/themes/init';
 
 /**
  * Returns true if a theme upload is in progress.


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles themes.

For mode details on state modularisation, see #39261 and p4TIVU-9lM-p2.

In the interest of keeping this PR short, I will create a subsequent PR for moving theme-related selectors under `state/themes`, instead of handling those changes here too.

#### Changes proposed in this Pull Request

* Modularise themes state
* Create a few selectors to replace direct state access
* Minor lint fixes to touched files

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read`.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `themes` key, even if you expand the list of keys. This indicates that the themes state hasn't been loaded yet.
* Click `My Sites` on the masterbar.
* Verify that a `themes` key is added with the themes state. This indicates that the themes state has now been loaded.
* Verify that theme-related functionality works normally. This indicates that I didn't mess up.