### PR TITLE
Media: Update to use Redux instead of validation Flux store

### DIFF
--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -4,18 +4,18 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { noop } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import getMediaErrors from 'state/selectors/get-media-errors';
 import MediaDropZone from 'my-sites/media-library/drop-zone';
 import MediaActions from 'lib/media/actions';
 import { getMimePrefix } from 'lib/media/utils';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
-import MediaValidationStore from 'lib/media/validation-store';
 import markup from 'post-editor/media-modal/markup';
 import { getSelectedSite } from 'state/ui/selectors';
 import { blockSave } from 'state/ui/editor/save-blockers/actions';
@@ -90,7 +90,7 @@ class TinyMCEDropZone extends React.Component {
 	};
 
 	insertMedia = () => {
-		const { site, onInsertMedia, onRenderModal } = this.props;
+		const { site, onInsertMedia, onRenderModal, mediaValidationErrors } = this.props;
 
 		if ( ! site ) {
 			return;
@@ -102,7 +102,7 @@ class TinyMCEDropZone extends React.Component {
 		const isSingleImage =
 			1 === selectedItems.length && 'image' === getMimePrefix( selectedItems[ 0 ] );
 
-		if ( isSingleImage && ! MediaValidationStore.hasErrors( site.ID ) ) {
+		if ( isSingleImage && isEmpty( mediaValidationErrors ) ) {
 			// For single image upload, insert into post content, blocking save
 			// until the image has finished upload
 			if ( selectedItems[ 0 ].transient ) {
@@ -138,8 +138,13 @@ class TinyMCEDropZone extends React.Component {
 }
 
 export default connect(
-	state => ( {
-		site: getSelectedSite( state ),
-	} ),
+	state => {
+		const site = getSelectedSite( state );
+
+		return {
+			site,
+			mediaValidationErrors: getMediaErrors( state, site?.ID ),
+		};
+	},
 	{ blockSave }
 )( TinyMCEDropZone );

--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -61,7 +61,7 @@ class TinyMCEDropZone extends React.Component {
 		// vital properties that were part of the original event.
 		//
 		// See: https://core.trac.wordpress.org/ticket/19845#comment:36
-		window.dispatchEvent( new CustomEvent( event.type, { detail: event } ) );
+		window.dispatchEvent( new window.CustomEvent( event.type, { detail: event } ) );
 		this.setState( {
 			isDragging: true,
 		} );

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -13,9 +13,9 @@ import wpcom from 'lib/wp';
 import { reduxDispatch, reduxGetState } from 'lib/redux-bridge';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { createTransientMedia } from './utils';
+import getMediaItemErrors from 'state/selectors/get-media-item-errors';
 import MediaStore from './store';
 import MediaListStore from './list-store';
-import MediaValidationStore from './validation-store';
 import {
 	changeMediaSource,
 	clearMediaErrors,
@@ -193,7 +193,7 @@ function uploadFiles( uploader, files, site ) {
 		reduxDispatch( createMediaItem( site, transientMedia ) );
 
 		// Abort upload if file fails to pass validation.
-		if ( MediaValidationStore.getErrors( siteId, transientMedia.ID ).length ) {
+		if ( getMediaItemErrors( reduxGetState(), siteId, transientMedia.ID ).length ) {
 			return Promise.resolve();
 		}
 

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -197,6 +197,9 @@ function uploadFiles( uploader, files, site ) {
 			return Promise.resolve();
 		}
 
+		// If there are no errors, dispatch the create media item action
+		reduxDispatch( createMediaItem( site, transientMedia ) );
+
 		return lastUpload.then( () => {
 			// Achieve series upload by waiting for the previous promise to
 			// resolve before starting this item's upload

--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -190,8 +190,6 @@ function uploadFiles( uploader, files, site ) {
 			site,
 		} );
 
-		reduxDispatch( createMediaItem( site, transientMedia ) );
-
 		// Abort upload if file fails to pass validation.
 		if ( getMediaItemErrors( reduxGetState(), siteId, transientMedia.ID ).length ) {
 			return Promise.resolve();

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -9,7 +9,6 @@ import { values } from 'lodash';
 import { isItemBeingUploaded } from 'lib/media/utils';
 import Dispatcher from 'dispatcher';
 import emitter from 'lib/mixins/emitter';
-import MediaValidationStore from './validation-store';
 
 /**
  * @typedef {import('events').EventEmitter} Emitter
@@ -103,8 +102,6 @@ MediaStore.getAll = function( siteId ) {
 
 MediaStore.dispatchToken = Dispatcher.register( function( payload ) {
 	const action = payload.action;
-
-	Dispatcher.waitFor( [ MediaValidationStore.dispatchToken ] );
 
 	switch ( action.type ) {
 		case 'CHANGE_MEDIA_SOURCE':

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -12,13 +12,13 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Content from './content';
+import getMediaErrors from 'state/selectors/get-media-errors';
 import MediaActions from 'lib/media/actions';
 import MediaLibraryDropZone from './drop-zone';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import { filterItemsByMimePrefix } from 'lib/media/utils';
 import filterToMimePrefix from './filter-to-mime-prefix';
 import FilterBar from './filter-bar';
-import MediaValidationData from 'components/data/media-validation-data';
 import QueryPreferences from 'components/data/query-preferences';
 import searchUrl from 'lib/search-url';
 import {
@@ -160,37 +160,6 @@ class MediaLibrary extends Component {
 	}
 
 	render() {
-		let content;
-
-		content = (
-			<Content
-				site={ this.props.site }
-				filter={ this.props.filter }
-				filterRequiresUpgrade={ this.filterRequiresUpgrade() }
-				search={ this.props.search }
-				source={ this.props.source }
-				isConnected={ this.props.isConnected }
-				containerWidth={ this.props.containerWidth }
-				single={ this.props.single }
-				scrollable={ this.props.scrollable }
-				onAddMedia={ this.onAddMedia }
-				onAddAndEditImage={ this.props.onAddAndEditImage }
-				onMediaScaleChange={ this.props.onScaleChange }
-				onSourceChange={ this.props.onSourceChange }
-				selectedItems={ this.props.mediaLibrarySelectedItems }
-				onDeleteItem={ this.props.onDeleteItem }
-				onEditItem={ this.props.onEditItem }
-				onViewDetails={ this.props.onViewDetails }
-				postId={ this.props.postId }
-			/>
-		);
-
-		if ( this.props.site ) {
-			content = (
-				<MediaValidationData siteId={ this.props.site.ID }>{ content }</MediaValidationData>
-			);
-		}
-
 		const classes = classNames(
 			'media-library',
 			{ 'is-single': this.props.single },
@@ -216,15 +185,36 @@ class MediaLibrary extends Component {
 					disableLargeImageSources={ this.props.disableLargeImageSources }
 					disabledDataSources={ this.props.disabledDataSources }
 				/>
-				{ content }
+				<Content
+					site={ this.props.site }
+					filter={ this.props.filter }
+					filterRequiresUpgrade={ this.filterRequiresUpgrade() }
+					search={ this.props.search }
+					source={ this.props.source }
+					isConnected={ this.props.isConnected }
+					containerWidth={ this.props.containerWidth }
+					single={ this.props.single }
+					scrollable={ this.props.scrollable }
+					onAddMedia={ this.onAddMedia }
+					onAddAndEditImage={ this.props.onAddAndEditImage }
+					onMediaScaleChange={ this.props.onScaleChange }
+					onSourceChange={ this.props.onSourceChange }
+					selectedItems={ this.props.mediaLibrarySelectedItems }
+					onDeleteItem={ this.props.onDeleteItem }
+					onEditItem={ this.props.onEditItem }
+					onViewDetails={ this.props.onViewDetails }
+					postId={ this.props.postId }
+					mediaValidationErrors={ this.props.site ? this.props.mediaValidationErrors : undefined }
+				/>
 			</div>
 		);
 	}
 }
 
 export default connect(
-	( state, { source = '' } ) => ( {
+	( state, { source = '', site } ) => ( {
 		isConnected: isConnected( state, source ),
+		mediaValidationErrors: getMediaErrors( state, site?.ID ),
 		needsKeyring: needsKeyring( state, source ),
 	} ),
 	{

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -16,7 +16,6 @@ import MediaLibrary from '..';
 import { requestKeyringConnections as requestStub } from 'state/sharing/keyring/actions';
 
 jest.mock( 'components/data/query-preferences', () => require( 'components/empty-component' ) );
-jest.mock( 'components/data/media-validation-data', () => require( 'components/empty-component' ) );
 jest.mock( 'lib/media/library-selected-store', () => () => null );
 jest.mock( 'lib/media/actions', () => () => null );
 jest.mock( 'my-sites/media-library/content', () => require( 'components/empty-component' ) );

--- a/client/my-sites/media-library/test/index.jsx
+++ b/client/my-sites/media-library/test/index.jsx
@@ -31,7 +31,14 @@ jest.mock( 'state/sharing/keyring/selectors', () => ( {
 
 describe( 'MediaLibrary', () => {
 	const store = {
-		getState: () => ( {} ),
+		getState: () => ( {
+			media: {
+				errors: {},
+				queries: {},
+				queryRequests: {},
+				mediaItemRequests: {},
+			},
+		} ),
 		dispatch: () => false,
 		subscribe: () => false,
 	};

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -5,7 +5,7 @@ import { isWithinBreakpoint } from '@automattic/viewport';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { get, map, reduce, throttle } from 'lodash';
+import { get, isEmpty, map, reduce, throttle } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
@@ -19,7 +19,6 @@ import { serialize as serializeSimplePayment } from 'components/tinymce/plugins/
 import MediaActions from 'lib/media/actions';
 import MediaLibrarySelectedStore from 'lib/media/library-selected-store';
 import { getMimePrefix } from 'lib/media/utils';
-import MediaValidationStore from 'lib/media/validation-store';
 import markup from 'post-editor/media-modal/markup';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -38,6 +37,7 @@ import isDropZoneVisible from 'state/selectors/is-drop-zone-visible';
 import EditorMediaModal from 'post-editor/editor-media-modal';
 import MediaLibraryDropZone from 'my-sites/media-library/drop-zone';
 import config from 'config';
+import getMediaErrors from 'state/selectors/get-media-errors';
 import SimplePaymentsDialog from 'components/tinymce/plugins/simple-payments/dialog';
 import { withLocalizedMoment } from 'components/localized-moment';
 
@@ -480,14 +480,14 @@ export class EditorHtmlToolbar extends Component {
 	};
 
 	onFilesDrop = () => {
-		const { site } = this.props;
+		const { mediaValidationErrors, site } = this.props;
 		// Find selected images. Non-images will still be uploaded, but not
 		// inserted directly into the post contents.
 		const selectedItems = MediaLibrarySelectedStore.getAll( site.ID );
 		const isSingleImage =
 			1 === selectedItems.length && 'image' === getMimePrefix( selectedItems[ 0 ] );
 
-		if ( isSingleImage && ! MediaValidationStore.hasErrors( site.ID ) ) {
+		if ( isSingleImage && isEmpty( mediaValidationErrors ) ) {
 			// For single image upload, insert into post content, blocking save
 			// until the image has finished upload
 			if ( selectedItems[ 0 ].transient ) {
@@ -707,12 +707,17 @@ export class EditorHtmlToolbar extends Component {
 	}
 }
 
-const mapStateToProps = state => ( {
-	contactForm: get( state, 'ui.editor.contactForm', {} ),
-	isDropZoneVisible: isDropZoneVisible( state ),
-	site: getSelectedSite( state ),
-	canUserUploadFiles: canCurrentUser( state, getSelectedSiteId( state ), 'upload_files' ),
-} );
+const mapStateToProps = state => {
+	const site = getSelectedSite( state );
+
+	return {
+		contactForm: get( state, 'ui.editor.contactForm', {} ),
+		isDropZoneVisible: isDropZoneVisible( state ),
+		site,
+		canUserUploadFiles: canCurrentUser( state, getSelectedSiteId( state ), 'upload_files' ),
+		mediaValidationErrors: getMediaErrors( state, site?.ID ),
+	};
+};
 
 const mapDispatchToProps = {
 	blockSave,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update any usage of the media validation Flux store to use Redux

#### Testing instructions

* Checkout this branch.
* Verify all tests pass.
* Sandboxing API, force endpoints to fail and try the following errors:
  * Uploading a file in media library
  * Uploading a file in the post editor, view mode
  * Uploading a file in the post editor, HTML mode
  * Uploading a file in the product image uploader in the Woo extension
 * You can also try to upload a file with an unsupported extension, you should get an adequate error.
* Smoke test media library and verify it still works well.

~Note: #39374 and #39375 precede this PR and should be merged first. Feel free to review this one separately, though.~

Note: This PR is part of an iteration to remove the media validation store, see #39372 for the full effort that removes it completely. 
