### PR TITLE
Add support for a monochrome Jetpack logo

### DIFF
--- a/client/components/jetpack-logo/README.md
+++ b/client/components/jetpack-logo/README.md
@@ -23,5 +23,5 @@ export default function JetpackLogoExample() {
 
 * `className` : (string) Custom class name to be added to the SVG element
 * `full` : (bool) Whether or not to show the Jetpack text alongside the icon
-* `monochrome` : (bool) Show monochrome and transparent logo. Default is `false`
+* `monochrome` : (bool) Show a monochrome Jetpack logo. Default is `false`
 * `size` : (number) The height of the SVG. Default is `32`

--- a/client/components/jetpack-logo/README.md
+++ b/client/components/jetpack-logo/README.md
@@ -21,7 +21,7 @@ export default function JetpackLogoExample() {
 
 #### Props
 
+* `className` : (string) Custom class name to be added to the SVG element
 * `full` : (bool) Whether or not to show the Jetpack text alongside the icon
-* `size` : (number) The height of the SVG
-
-All other props are passed to the underlying `Button`.
+* `monochrome` : (bool) Show monochrome and transparent logo. Default is `false`
+* `size` : (number) The height of the SVG. Default is `32`

--- a/client/components/jetpack-logo/docs/example.js
+++ b/client/components/jetpack-logo/docs/example.js
@@ -19,6 +19,9 @@ export default function JetpackLogoExample() {
 			<hr />
 			<pre>{ '<JetpackLogo full size={ 64 } />' }</pre>
 			<JetpackLogo full size={ 64 } />
+			<hr />
+			<pre>{ '<JetpackLogo full monochrome />' }</pre>
+			<JetpackLogo full monochrome />
 		</div>
 	);
 }

--- a/client/components/jetpack-logo/index.jsx
+++ b/client/components/jetpack-logo/index.jsx
@@ -12,34 +12,52 @@ import classNames from 'classnames';
 const COLOR_JETPACK = PALETTE[ 'Jetpack Green' ];
 const COLOR_WHITE = PALETTE[ 'White' ]; // eslint-disable-line dot-notation
 
-const logoPathSize32 = (
+const LogoPathSize32 = ( { monochrome = false } ) => {
+	const primary = monochrome ? 'white' : COLOR_JETPACK;
+	const secondary = monochrome ? 'black' : COLOR_WHITE;
+
+	return (
+		<>
+			<path
+				className="jetpack-logo__icon-circle"
+				fill={ primary }
+				d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
+			/>
+			<polygon
+				className="jetpack-logo__icon-triangle"
+				fill={ secondary }
+				points="15,19 7,19 15,3 "
+			/>
+			<polygon
+				className="jetpack-logo__icon-triangle"
+				fill={ secondary }
+				points="17,29 17,13 25,13 "
+			/>
+		</>
+	);
+};
+
+const LogoPathSize32Monochrome = () => (
 	<>
+		<mask id="jetpack-logo-mask">
+			<LogoPathSize32 monochrome />
+		</mask>
 		<path
-			className="jetpack-logo__icon-circle"
-			fill={ COLOR_JETPACK }
+			className="jetpack-logo__icon-monochrome"
 			d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
-		/>
-		<polygon
-			className="jetpack-logo__icon-triangle"
-			fill={ COLOR_WHITE }
-			points="15,19 7,19 15,3 "
-		/>
-		<polygon
-			className="jetpack-logo__icon-triangle"
-			fill={ COLOR_WHITE }
-			points="17,29 17,13 25,13 "
+			mask="url( #jetpack-logo-mask )"
 		/>
 	</>
 );
 
-const JetpackLogo = ( { full = false, size = 32, className } ) => {
+const JetpackLogo = ( { full = false, monochrome = false, size = 32, className } ) => {
 	const classes = classNames( 'jetpack-logo', className );
 
 	if ( full === true ) {
 		return (
 			<svg height={ size } className={ classes } viewBox="0 0 118 32">
 				<title>Jetpack</title>
-				{ logoPathSize32 }
+				{ monochrome ? <LogoPathSize32Monochrome /> : <LogoPathSize32 /> }
 				<path
 					className="jetpack-logo__text"
 					d="M41.3 26.6c-.5-.7-.9-1.4-1.3-2.1 2.3-1.4 3-2.5 3-4.6V8h-3V6h6v13.4C46 22.8 45 24.8 41.3 26.6zM58.5 21.3c-1.5.5-2.7.6-4.2.6-3.6 0-5.8-1.8-5.8-6 0-3.1 1.9-5.9 5.5-5.9s4.9 2.5 4.9 4.9c0 .8 0 1.5-.1 2h-7.3c.1 2.5 1.5 2.8 3.6 2.8 1.1 0 2.2-.3 3.4-.7C58.5 19 58.5 21.3 58.5 21.3zM56 15c0-1.4-.5-2.9-2-2.9-1.4 0-2.3 1.3-2.4 2.9C51.6 15 56 15 56 15zM65 18.4c0 1.1.8 1.3 1.4 1.3.5 0 2-.2 2.6-.4v2.1c-.9.3-2.5.5-3.7.5-1.5 0-3.2-.5-3.2-3.1V12H60v-2h2.1V7.1H65V10h4v2h-4V18.4zM71 10h3v1.3c1.1-.8 1.9-1.3 3.3-1.3 2.5 0 4.5 1.8 4.5 5.6s-2.2 6.3-5.8 6.3c-.9 0-1.3-.1-2-.3V28h-3V10zM76.5 12.3c-.8 0-1.6.4-2.5 1.2v5.9c.6.1.9.2 1.8.2 2 0 3.2-1.3 3.2-3.9C79 13.4 78.1 12.3 76.5 12.3zM93 22h-3v-1.5c-.9.7-1.9 1.5-3.5 1.5-1.5 0-3.1-1.1-3.1-3.2 0-2.9 2.5-3.4 4.2-3.7l2.4-.3v-.3c0-1.5-.5-2.3-2-2.3-.7 0-2.3.5-3.7 1.1L84 11c1.2-.4 3-1 4.4-1 2.7 0 4.6 1.4 4.6 4.7L93 22zM90 16.4l-2.2.4c-.7.1-1.4.5-1.4 1.6 0 .9.5 1.4 1.3 1.4s1.5-.5 2.3-1V16.4zM104.5 21.3c-1.1.4-2.2.6-3.5.6-4.2 0-5.9-2.4-5.9-5.9 0-3.7 2.3-6 6.1-6 1.4 0 2.3.2 3.2.5V13c-.8-.3-2-.6-3.2-.6-1.7 0-3.2.9-3.2 3.6 0 2.9 1.5 3.8 3.3 3.8.9 0 1.9-.2 3.2-.7V21.3zM110 15.2c.2-.3.2-.8 3.8-5.2h3.7l-4.6 5.7 5 6.3h-3.7l-4.2-5.8V22h-3V6h3V15.2z"
@@ -59,13 +77,14 @@ const JetpackLogo = ( { full = false, size = 32, className } ) => {
 
 	return (
 		<svg className={ classes } height={ size } width={ size } viewBox="0 0 32 32">
-			{ logoPathSize32 }
+			{ monochrome ? <LogoPathSize32Monochrome /> : <LogoPathSize32 /> }
 		</svg>
 	);
 };
 
 JetpackLogo.propTypes = {
 	full: PropTypes.bool,
+	monochrome: PropTypes.bool,
 	size: PropTypes.number,
 };
 


### PR DESCRIPTION
In the Jetpack Cloud `Masterbar` a monochrome Jetpack logo is needed. This PR adds a support for a monochrome logo in the `JetpackLogo` component.

<img width="397" alt="Screenshot 2020-02-11 at 18 46 09" src="https://user-images.githubusercontent.com/478735/74263284-ca708f80-4cfe-11ea-8c9d-6afd975f2b44.png">

#### Changes proposed in this Pull Request

- Add `monochrome` prop to the component
- Use existing SVG paths as a base for the SVG mask
- Update props description and default values in the readme
- Remove unrelated note about 'underlying Button' from the readme

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://hash-8e0781d268fc0ced5fd6e7feb04c3ee8fe181b1d.calypso.live/devdocs/design/jetpack-logo
* Confirm that a new `monochrome` logo example is displayed as a last item
* Confirm there are no regressions in the other logo versions compared to `wpcalypso` environment

Fixes 1156570014567299-as-1161366493888073