### PR TITLE
Add Jetpack Cloud Masterbar component

### DIFF
--- a/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
+++ b/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
@@ -45,6 +45,12 @@
 	--color-text-inverted-rgb: var( --studio-white-rgb );
 
 	/* Component Properties */
+	--color-masterbar-background: var( --studio-gray-80 );
+	--color-masterbar-border: var( --studio-gray-60 );
+	--color-masterbar-text: var( --studio-white );
+	--color-masterbar-item-hover-background: var( --studio-gray-60 );
+	--color-masterbar-item-active-background: var( --studio-gray-40 );
+
 	--color-sidebar-background: var( --studio-gray-0 );
 	--color-sidebar-background-rgb: var( --studio-gray-0-rgb );
 	--color-sidebar-border: var( --studio-gray-5 );

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Item from 'layout/masterbar/item';
+import JetpackLogo from 'components/jetpack-logo';
+import Masterbar from 'layout/masterbar/masterbar';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default function() {
+	return (
+		<Masterbar>
+			<Item
+				tipTarget="jetpack"
+				className="masterbar__item-home"
+				url="/"
+				tooltip="Jetpack Cloud Homepage"
+			>
+				<JetpackLogo size={ 28 } full monochrome />
+			</Item>
+		</Masterbar>
+	);
+}

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -19,10 +19,9 @@ export default function() {
 	return (
 		<Masterbar>
 			<Item
-				tipTarget="jetpack"
 				className="masterbar__item-home"
 				url="/"
-				tooltip="Jetpack Cloud Homepage"
+				tooltip="Jetpack Cloud Homepage" /* @todo: localize the string */
 			>
 				<JetpackLogo size={ 28 } full monochrome />
 			</Item>

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -1,0 +1,22 @@
+// Masterbar - home link
+.masterbar__item-home {
+	width: $sidebar-width-max;
+	padding: 0;
+	border-right: 1px solid var( --color-masterbar-border );
+
+	@include breakpoint( '<960px' ) {
+		width: $sidebar-width-min;
+	}
+
+	.masterbar__item-content {
+		display: flex;
+		justify-content: center;
+		width: 100%;
+		padding: 0 16px;
+		color: var( --color-masterbar-text );
+
+		svg {
+			fill: var( --color-masterbar-text );
+		}
+	}
+}

--- a/client/landing/jetpack-cloud/layout.js
+++ b/client/landing/jetpack-cloud/layout.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import JetpackCloudMasterbar from './masterbar';
+import JetpackCloudMasterbar from './components/masterbar';
 import EmptyContent from 'components/empty-content';
 
 class JetpackCloudLayout extends Component {

--- a/client/landing/jetpack-cloud/masterbar.jsx
+++ b/client/landing/jetpack-cloud/masterbar.jsx
@@ -1,8 +1,0 @@
-/**
- * External dependencies
- */
-import React from 'react';
-
-export default function() {
-	return <div>Jetpack</div>;
-}


### PR DESCRIPTION
This PR add a simple Masterbar foundation for Jetpack Cloud. It's based off of default Calypso Masterbar.

**Please note that the masterbar looks as expected with a monochrome Jetpack logo proposed in #39384**

<img width="1147" alt="Screenshot 2020-02-11 at 18 59 05" src="https://user-images.githubusercontent.com/478735/74264420-e9702100-4d00-11ea-9773-af2a84c88588.png">

#### Changes proposed in this Pull Request

- Create new component directory and move files there
- Use Calypso layout elements to build out a Masterbar foundation
- Add necessary styles for masterbar along with color scheme swatches

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://jetpack.cloud.localhost:3000/
* Confirm that a simple masterbar is rendered there along with the Jetpack logo (if #39384 has not been merged yet, you'll see a full-color logo; if you rebase, you should see a correct white logo)

Fixes 1156570014567299-as-1157678527369059
