### PR TITLE
Packages: Add react-i18n

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
 		"@automattic/format-currency": "file:../packages/format-currency",
 		"@automattic/load-script": "file:../packages/load-script",
 		"@automattic/material-design-icons": "file:../packages/material-design-icons",
+		"@automattic/react-i18n": "file:../packages/react-i18n",
 		"@automattic/react-virtualized": "9.21.2",
 		"@automattic/tree-select": "file:../packages/tree-select",
 		"@babel/runtime": "7.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,6 +410,12 @@
 				}
 			}
 		},
+		"@automattic/react-i18n": {
+			"version": "file:packages/react-i18n",
+			"requires": {
+				"tslib": "^1.10.0"
+			}
+		},
 		"@automattic/react-virtualized": {
 			"version": "9.21.2",
 			"resolved": "https://registry.npmjs.org/@automattic/react-virtualized/-/react-virtualized-9.21.2.tgz",
@@ -37662,6 +37668,7 @@
 				"@automattic/format-currency": "file:packages/format-currency",
 				"@automattic/load-script": "file:packages/load-script",
 				"@automattic/material-design-icons": "file:packages/material-design-icons",
+				"@automattic/react-i18n": "file:packages/react-i18n",
 				"@automattic/react-virtualized": "9.21.2",
 				"@automattic/tree-select": "file:packages/tree-select",
 				"@babel/runtime": "7.8.4",
@@ -37845,8 +37852,7 @@
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"debug": "^4.1.1",
-				"qs": "^6.5.2",
-				"wpcom-xhr-request": "^1.1.2"
+				"qs": "^6.5.2"
 			}
 		},
 		"wpcom-proxy-request": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"@automattic/full-site-editing": "file:apps/full-site-editing",
 		"@automattic/load-script": "file:packages/load-script",
 		"@automattic/material-design-icons": "file:packages/material-design-icons",
+		"@automattic/react-i18n": "file:packages/react-i18n",
 		"@automattic/tree-select": "file:packages/tree-select",
 		"@automattic/wpcom-block-editor": "file:apps/wpcom-block-editor",
 		"i18n-calypso": "file:packages/i18n-calypso",

--- a/packages/react-i18n/.eslintrc.js
+++ b/packages/react-i18n/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+	rules: {
+		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
+	},
+};

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -34,8 +34,8 @@
 		"tslib": "^1.10.0"
 	},
 	"peerDependencies": {
-		"@wordpress/i18n": "*",
-		"react": ">=16.8"
+		"@wordpress/i18n": "<=3",
+		"react": "^16.8"
 	},
 	"private": true
 }

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -34,7 +34,7 @@
 		"tslib": "^1.10.0"
 	},
 	"peerDependencies": {
-		"@wordpress/i18n": "<=3",
+		"@wordpress/i18n": "*",
 		"react": ">=16.8"
 	},
 	"private": true

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -1,0 +1,41 @@
+{
+	"name": "@automattic/react-i18n",
+	"version": "1.0.0-alpha.0",
+	"description": "React bindings for @wordpress/i18n",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/react-i18n"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"files": [
+		"dist",
+		"src"
+	],
+	"types": "dist/types",
+	"scripts": {
+		"clean": "npx rimraf dist",
+		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
+		"prepublish": "npm run clean",
+		"watch": "tsc --project ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"tslib": "^1.10.0"
+	},
+	"peerDependencies": {
+		"@wordpress/i18n": "<=3",
+		"react": ">=16.8"
+	},
+	"private": true
+}

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -44,14 +44,9 @@ export const useI18n = (): I18nTranslationFunctions => {
  * }
  * export default withI18n( MyComponent );
  */
-export const withI18n = ( WrappedComponent: React.ComponentType ): React.ComponentType => {
-	return class extends React.Component {
-		render() {
-			const i18n = useI18n();
-			return <WrappedComponent { ...i18n } { ...this.props } />;
-		}
-	};
-};
+export const withI18n = ( WrappedComponent: React.ComponentType ): React.ComponentType => props => (
+	<WrappedComponent { ...useI18n() } { ...props } />
+);
 
 function makeI18n(): I18nTranslationFunctions {
 	return { __, _n, _nx, _x };

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -21,7 +21,7 @@ interface I18nTranslationFunctions {
  * import { useI18n } from '@automattic/react-i18n';
  * function MyComponent() {
  *   const { __ } = useI18n();
- *   return <div>{ __( 'Translate me.' ) }</div>;
+ *   return <div>{ __( 'Translate me.', 'text-domain' ) }</div>;
  * }
  */
 export const useI18n = (): I18nTranslationFunctions => {
@@ -40,7 +40,7 @@ export const useI18n = (): I18nTranslationFunctions => {
  *
  * import { withI18n } from '@automattic/react-i18n';
  * function MyComponent( { __ } ) {
- *   return <div>{ __( 'Translate me.' ) }</div>;
+ *   return <div>{ __( 'Translate me.', 'text-domain' ) }</div>;
  * }
  * export default withI18n( MyComponent );
  */

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -6,7 +6,7 @@ import { __, _n, _nx, _x } from '@wordpress/i18n';
 
 export const I18nContext = React.createContext< undefined | string >( undefined );
 
-interface I18nTranslationFunctions {
+export interface I18nProps {
 	__: typeof __;
 	_n: typeof _n;
 	_nx: typeof _nx;
@@ -24,12 +24,17 @@ interface I18nTranslationFunctions {
  *   return <div>{ __( 'Translate me.', 'text-domain' ) }</div>;
  * }
  */
-export const useI18n = (): I18nTranslationFunctions => {
+export const useI18n = (): I18nProps => {
 	const lang = React.useContext( I18nContext );
-	const [ i18n, setI18n ] = React.useState< I18nTranslationFunctions >( makeI18n );
+	const [ i18n, setI18n ] = React.useState< I18nProps >( makeI18n );
 	React.useEffect( () => setI18n( makeI18n ), [ lang ] );
 	return i18n;
 };
+
+/**
+ * Remove from T the keys that are in common with K
+ */
+type Optionalize< T extends K, K > = Omit< T, keyof K >;
 
 /**
  * React hook providing i18n translate functions
@@ -44,10 +49,14 @@ export const useI18n = (): I18nTranslationFunctions => {
  * }
  * export default withI18n( MyComponent );
  */
-export const withI18n = ( WrappedComponent: React.ComponentType ): React.ComponentType => props => (
-	<WrappedComponent { ...useI18n() } { ...props } />
+export const withI18n = < T extends I18nProps = I18nProps >(
+	WrappedComponent: React.ComponentType< T >
+): React.FunctionComponent< Optionalize< T, I18nProps > > => props => (
+	// Required cast `props as T`
+	// See https://github.com/Microsoft/TypeScript/issues/28938
+	<WrappedComponent { ...useI18n() } { ...( props as T ) } />
 );
 
-function makeI18n(): I18nTranslationFunctions {
+function makeI18n(): I18nProps {
 	return { __, _n, _nx, _x };
 }

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -90,9 +90,10 @@ type Optionalize< T extends K, K > = Omit< T, keyof K >;
 export const withI18n = < T extends I18nProps = I18nProps >(
 	WrappedComponent: React.ComponentType< T >
 ): React.FunctionComponent< Optionalize< T, I18nProps > > => props => {
+	const i18n = useI18n();
 	return (
 		<WrappedComponent
-			{ ...useI18n() }
+			{ ...i18n }
 			// Required cast `props as T`
 			// See https://github.com/Microsoft/TypeScript/issues/28938
 			{ ...( props as T ) }

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -2,17 +2,31 @@
  * External dependencies
  */
 import * as React from 'react';
-import { __, _n, _nx, _x, setLocaleData } from '@wordpress/i18n';
 
-export interface I18nProps {
-	__: typeof __;
-	_n: typeof _n;
-	_nx: typeof _nx;
-	_x: typeof _x;
-	i18nLocale?: string;
+function makeI18n( i18nLocale: string | undefined, localeData?: object ): I18nProps {
+	delete require.cache[ require.resolve( '@wordpress/i18n' ) ];
+	const { setLocaleData, __, _n, _nx, _x } = require( '@wordpress/i18n' );
+	if ( localeData ) {
+		setLocaleData( localeData );
+	}
+	return {
+		__,
+		_n,
+		_nx,
+		_x,
+		i18nLocale,
+	};
 }
 
-const I18nContext = React.createContext< I18nProps >( { __, _n, _nx, _x } );
+export interface I18nProps {
+	__: typeof import('@wordpress/i18n').__;
+	_n: typeof import('@wordpress/i18n')._n;
+	_nx: typeof import('@wordpress/i18n')._nx;
+	_x: typeof import('@wordpress/i18n')._x;
+	i18nLocale: string | undefined;
+}
+
+const I18nContext = React.createContext< I18nProps >( makeI18n( undefined ) );
 
 interface Props {
 	/**
@@ -40,17 +54,13 @@ export const I18nProvider: React.FunctionComponent< Props > = ( {
 			if ( cancelled ) {
 				return;
 			}
-			setLocaleData( nextLocaleData );
-			setContextValue( makeI18n( locale ) );
+
+			setContextValue( makeI18n( locale, nextLocaleData ) );
 		} );
 		return cancel;
 	}, [ locale, onLocaleChange ] );
 	return <I18nContext.Provider value={ contextValue }>{ children }</I18nContext.Provider>;
 };
-
-function makeI18n( i18nLocale: string ) {
-	return { ...( i18nLocale && { i18nLocale } ), __, _n, _nx, _x };
-}
 
 /**
  * React hook providing i18n translate functions

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { __, _n, _nx, _x } from '@wordpress/i18n';
+
+export const I18nContext = React.createContext< undefined | string >( undefined );
+
+interface I18nTranslationFunctions {
+	__: typeof __;
+	_n: typeof _n;
+	_nx: typeof _nx;
+	_x: typeof _x;
+}
+
+/**
+ * React hook providing i18n translate functions
+ *
+ * @example
+ *
+ * import { useI18n } from '@automattic/react-i18n';
+ * function MyComponent() {
+ *   const { __ } = useI18n();
+ *   return <div>{ __( 'Translate me.' ) }</div>;
+ * }
+ */
+export const useI18n = (): I18nTranslationFunctions => {
+	const lang = React.useContext( I18nContext );
+	const [ i18n, setI18n ] = React.useState< I18nTranslationFunctions >( makeI18n );
+	React.useEffect( () => setI18n( makeI18n ), [ lang ] );
+	return i18n;
+};
+
+/**
+ * React hook providing i18n translate functions
+ *
+ * @param WrappedComponent Component that will receive translate functions as props
+ *
+ * @example
+ *
+ * import { withI18n } from '@automattic/react-i18n';
+ * function MyComponent( { __ } ) {
+ *   return <div>{ __( 'Translate me.' ) }</div>;
+ * }
+ * export default withI18n( MyComponent );
+ */
+export const withI18n = ( WrappedComponent: React.ComponentType ): React.ComponentType => {
+	return class extends React.Component {
+		render() {
+			const i18n = useI18n();
+			return <WrappedComponent { ...i18n } { ...this.props } />;
+		}
+	};
+};
+
+function makeI18n(): I18nTranslationFunctions {
+	return { __, _n, _nx, _x };
+}

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -11,6 +11,7 @@ export interface I18nProps {
 	_n: typeof _n;
 	_nx: typeof _nx;
 	_x: typeof _x;
+	i18nLocale?: string;
 }
 
 /**
@@ -25,9 +26,9 @@ export interface I18nProps {
  * }
  */
 export const useI18n = (): I18nProps => {
-	const lang = React.useContext( I18nContext );
-	const [ i18n, setI18n ] = React.useState< I18nProps >( makeI18n );
-	React.useEffect( () => setI18n( makeI18n ), [ lang ] );
+	const locale = React.useContext( I18nContext );
+	const [ i18n, setI18n ] = React.useState< I18nProps >( makeI18n( locale ) );
+	React.useEffect( () => setI18n( makeI18n( locale ) ), [ locale ] );
 	return i18n;
 };
 
@@ -51,12 +52,17 @@ type Optionalize< T extends K, K > = Omit< T, keyof K >;
  */
 export const withI18n = < T extends I18nProps = I18nProps >(
 	WrappedComponent: React.ComponentType< T >
-): React.FunctionComponent< Optionalize< T, I18nProps > > => props => (
-	// Required cast `props as T`
-	// See https://github.com/Microsoft/TypeScript/issues/28938
-	<WrappedComponent { ...useI18n() } { ...( props as T ) } />
-);
+): React.FunctionComponent< Optionalize< T, I18nProps > > => props => {
+	return (
+		<WrappedComponent
+			{ ...useI18n() }
+			// Required cast `props as T`
+			// See https://github.com/Microsoft/TypeScript/issues/28938
+			{ ...( props as T ) }
+		/>
+	);
+};
 
-function makeI18n(): I18nProps {
-	return { __, _n, _nx, _x };
+function makeI18n( locale: string | undefined ): I18nProps {
+	return { __, _n, _nx, _x, ...( locale && { i18nLocale: locale } ) };
 }

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -2,31 +2,17 @@
  * External dependencies
  */
 import * as React from 'react';
-
-function makeI18n( i18nLocale: string | undefined, localeData?: object ): I18nProps {
-	delete require.cache[ require.resolve( '@wordpress/i18n' ) ];
-	const { setLocaleData, __, _n, _nx, _x } = require( '@wordpress/i18n' );
-	if ( localeData ) {
-		setLocaleData( localeData );
-	}
-	return {
-		__,
-		_n,
-		_nx,
-		_x,
-		i18nLocale,
-	};
-}
+import { __, _n, _nx, _x, setLocaleData } from '@wordpress/i18n';
 
 export interface I18nProps {
-	__: typeof import('@wordpress/i18n').__;
-	_n: typeof import('@wordpress/i18n')._n;
-	_nx: typeof import('@wordpress/i18n')._nx;
-	_x: typeof import('@wordpress/i18n')._x;
-	i18nLocale: string | undefined;
+	__: typeof __;
+	_n: typeof _n;
+	_nx: typeof _nx;
+	_x: typeof _x;
+	i18nLocale?: string;
 }
 
-const I18nContext = React.createContext< I18nProps >( makeI18n( undefined ) );
+const I18nContext = React.createContext< I18nProps >( { __, _n, _nx, _x } );
 
 interface Props {
 	/**
@@ -54,13 +40,17 @@ export const I18nProvider: React.FunctionComponent< Props > = ( {
 			if ( cancelled ) {
 				return;
 			}
-
-			setContextValue( makeI18n( locale, nextLocaleData ) );
+			setLocaleData( nextLocaleData );
+			setContextValue( makeI18n( locale ) );
 		} );
 		return cancel;
 	}, [ locale, onLocaleChange ] );
 	return <I18nContext.Provider value={ contextValue }>{ children }</I18nContext.Provider>;
 };
+
+function makeI18n( i18nLocale: string ) {
+	return { ...( i18nLocale && { i18nLocale } ), __, _n, _nx, _x };
+}
 
 /**
  * React hook providing i18n translate functions

--- a/packages/react-i18n/tsconfig-cjs.json
+++ b/packages/react-i18n/tsconfig-cjs.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"declaration": false,
+		"declarationDir": null,
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -23,7 +23,7 @@
 		"forceConsistentCasingInFileNames": true,
 
 		"typeRoots": [ "../../node_modules/@types" ],
-		"types": [],
+		"types": [ "webpack-env" ],
 
 		"importHelpers": true
 	},

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -23,7 +23,7 @@
 		"forceConsistentCasingInFileNames": true,
 
 		"typeRoots": [ "../../node_modules/@types" ],
-		"types": [ "webpack-env" ],
+		"types": [],
 
 		"importHelpers": true
 	},

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "ES5",
+		"lib": [ "ES2015" ],
 
 		"baseUrl": ".",
 		"module": "esnext",

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -1,0 +1,31 @@
+{
+	"compilerOptions": {
+		"target": "ES5",
+
+		"baseUrl": ".",
+		"module": "esnext",
+		"allowJs": false,
+		"jsx": "react",
+		"declaration": true,
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+
+		"moduleResolution": "node",
+		"esModuleInterop": true,
+
+		"forceConsistentCasingInFileNames": true,
+
+		"typeRoots": [ "../../node_modules/@types" ],
+		"types": [],
+
+		"importHelpers": true
+	},
+	"files": [ "./src/index.tsx" ],
+	"exclude": [ "**/docs/*", "**/test/*" ]
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add react functionality for `@wordpress/i18n`:
- `I18nContext` - localized content should be wrapped in `<I18nContext.Provider locale={ 'en' } onLocalChange={ getNextLocalData } />`.
- `useI18n` - provides translation functions `__`, `_n`, `_nx`, and `_x` which update when the context changes.
- `withI18n` HOC providing the same translation functions

Currently provides no functionality for updating the translations in `@wordpress/i18n` via `setLocaleData`.

`@wordpress/i18n` translation functions do not consider React. A reliable way to make sure translations are rerendered when locale changes is necessary. Largely outlined by https://github.com/WordPress/gutenberg/issues/19210 

https://github.com/Automattic/wp-calypso/pull/39410 provides a handy way to demo the functionality in Gutenboarding.

#### Testing instructions

Demo in #39410
