### PR TITLE
composite-checkout: Filter non-product cart items before making transaction request

### DIFF
--- a/client/my-sites/checkout/checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/checkout/types/transaction-endpoint.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { WPCOMCartItem } from '@automattic/composite-checkout-wpcom';
+import {
+	WPCOMCartItem,
+	getNonProductWPCOMCartItemTypes,
+} from '@automattic/composite-checkout-wpcom';
 
 export type WPCOMTransactionEndpoint = (
 	_: WPCOMTransactionEndpointRequestPayload
@@ -106,7 +109,9 @@ export function createTransactionEndpointCartFromLineItems( {
 		currency: currency || '',
 		temporary: false,
 		extra: [],
-		products: items.map( convertItem ),
+		products: items
+			.filter( product => ! getNonProductWPCOMCartItemTypes().includes( product.type ) )
+			.map( convertItem ),
 		tax: {
 			location: {
 				country_code: country,

--- a/packages/composite-checkout-wpcom/src/index.js
+++ b/packages/composite-checkout-wpcom/src/index.js
@@ -7,6 +7,7 @@ import { useShoppingCart } from './hooks/use-shopping-cart';
 import { useWpcomStore } from './hooks/wpcom-store';
 import { mockSetCartEndpoint, mockGetCartEndpointWith } from './mock/cart-endpoint';
 import FormFieldAnnotation from './components/form-field-annotation';
+import { getNonProductWPCOMCartItemTypes } from './lib/translate-cart';
 import { WPCOMCartItem, CheckoutCartItem, prepareDomainContactDetails } from './types';
 
 // Re-export the public API
@@ -21,4 +22,5 @@ export {
 	WPCOMCartItem,
 	CheckoutCartItem,
 	prepareDomainContactDetails,
+	getNonProductWPCOMCartItemTypes,
 };

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -179,3 +179,7 @@ function translateWpcomCartItemToCheckoutCartItem(
 		};
 	};
 }
+
+export function getNonProductWPCOMCartItemTypes(): string[] {
+	return [ 'tax', 'coupon', 'total', 'subtotal', 'credits' ];
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Activating coupons exposed a bug in how we prepare data for the transaction endpoint. This PR ensures that the non-product items (taxes, coupons, etc.) are filtered out.

#### Testing instructions

Attempt to complete a purchase with a coupon in your cart; without this patch it should fail with a notification.
