### PR TITLE
Migration: Show plan price, themes, and plugins in the flow on upgrade step

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -489,7 +489,11 @@ class SectionMigrate extends Component {
 						break;
 					case 'upgrade':
 						migrationElement = (
-							<StepUpgrade startMigration={ this.startMigration } targetSite={ targetSite } />
+							<StepUpgrade
+								sourceSite={ sourceSite }
+								startMigration={ this.startMigration }
+								targetSite={ targetSite }
+							/>
 						);
 						break;
 					case 'input':

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -48,6 +48,8 @@ class SectionMigrate extends Component {
 		percent: 0,
 		siteInfo: null,
 		selectedSiteSlug: null,
+		sourceSitePlugins: [],
+		sourceSiteThemes: [],
 		startTime: '',
 		url: '',
 		chosenImportType: '',
@@ -60,14 +62,42 @@ class SectionMigrate extends Component {
 			this.startMigration();
 		}
 
+		this.fetchSourceSitePluginsAndThemes();
 		this.updateFromAPI();
 	}
 
 	componentDidUpdate( prevProps ) {
+		if ( this.props.sourceSiteId !== prevProps.sourceSiteId ) {
+			this.fetchSourceSitePluginsAndThemes();
+		}
+
 		if ( this.props.targetSiteId !== prevProps.targetSiteId ) {
 			this.updateFromAPI();
 		}
 	}
+
+	fetchSourceSitePluginsAndThemes = () => {
+		if ( ! this.props.sourceSite ) {
+			return;
+		}
+
+		wpcom.site( this.props.sourceSite.ID ).pluginsList( ( error, data ) => {
+			if ( data.plugins ) {
+				this.setState( { sourceSitePlugins: data.plugins } );
+			}
+		} );
+
+		wpcom.undocumented().themes( this.props.sourceSite.ID, { apiVersion: '1' }, ( err, data ) => {
+			if ( data.themes ) {
+				const sourceSiteThemes = [
+					// Put active theme first
+					...data.themes.filter( theme => theme.active ),
+					...data.themes.filter( theme => ! theme.active ),
+				];
+				this.setState( { sourceSiteThemes } );
+			}
+		} );
+	};
 
 	getImportHref = () => {
 		const { isTargetSiteJetpack, targetSiteImportAdminUrl, targetSiteSlug } = this.props;
@@ -490,9 +520,11 @@ class SectionMigrate extends Component {
 					case 'upgrade':
 						migrationElement = (
 							<StepUpgrade
+								plugins={ this.state.sourceSitePlugins }
 								sourceSite={ sourceSite }
 								startMigration={ this.startMigration }
 								targetSite={ targetSite }
+								themes={ this.state.sourceSiteThemes }
 							/>
 						);
 						break;

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -29,6 +29,65 @@
 	}
 }
 
+.migrate__plan-upsell {
+	display: flex;
+	border-top: 1px solid var( --color-neutral-10 );
+	border-bottom: 1px solid var( --color-neutral-10 );
+	margin: 16px 0;
+	padding: 16px 0;
+}
+
+.migrate__plan-upsell-icon,
+.migrate__plan-upsell-info,
+.migrate__plan-upsell-themes,
+.migrate__plan-upsell-plugins {
+	display: flex;
+	flex-wrap: wrap;
+	margin-right: 16px;
+}
+
+.migrate__plan-upsell-icon {
+	min-width: 64px;
+	min-height: 64px;
+	max-width: 64px;
+	max-height: 64px;
+}
+
+.migrate__plan-upsell-info {
+	flex-basis: 40%;
+}
+
+.migrate__plan-upsell-themes,
+.migrate__plan-upsell-plugins {
+	flex-basis: 25%;
+}
+
+.migrate__plan-name,
+.migrate__plan-price,
+.migrate__plan-billing-time-frame {
+	flex-basis: 100%;
+}
+
+.migrate__plan-name {
+	font-size: 18px;
+}
+
+.migrate__plan-price {
+	.plan-price__currency-symbol {
+		font-size: 18px;
+	}
+
+	.plan-price__integer {
+		font-size: 48px;
+		font-weight: bold;
+	}
+}
+
+.migrate__plan-feature-header {
+	font-weight: 600;
+	font-size: 14px;
+}
+
 .migrate__card-footer {
 	color: var( --color-text-subtle );
 	font-size: 13px;

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -88,6 +88,26 @@
 	font-size: 14px;
 }
 
+.migrate__plan-upsell-item {
+	flex-basis: 100%;
+	max-width: 180px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+
+	.gridicon {
+		vertical-align: middle;
+		margin-right: 8px;
+	}
+}
+
+.migrate__plan-upsell-item-label {
+	display: inline-block;
+	line-height: 18px;
+	vertical-align: middle;
+}
+
+
 .migrate__card-footer {
 	color: var( --color-text-subtle );
 	font-size: 13px;

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -66,7 +66,7 @@ class StepUpgrade extends Component {
 						<div className="migrate__plan-upsell-info">
 							<div className="migrate__plan-name">WordPress.com Business</div>
 							<div className="migrate__plan-price">
-								<PlanPrice rawPrice={ planPrice } currency={ currency } />
+								<PlanPrice rawPrice={ planPrice } currencyCode={ currency } />
 							</div>
 							<div className="migrate__plan-billing-time-frame">{ billingTimeFrame }</div>
 						</div>

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -44,6 +44,7 @@ class StepUpgrade extends Component {
 			sourceSite,
 			targetSite,
 			themes,
+			translate,
 		} = this.props;
 		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
@@ -51,27 +52,35 @@ class StepUpgrade extends Component {
 		return (
 			<>
 				<QueryPlans />
-				<HeaderCake>Import Everything</HeaderCake>
+				<HeaderCake>{ translate( 'Import Everything' ) }</HeaderCake>
 
 				<CompactCard>
-					<CardHeading>A Business Plan is required to import everything.</CardHeading>
+					<CardHeading>
+						{ translate( 'A Business Plan is required to import everything.' ) }
+					</CardHeading>
 					<div>
-						To import your themes, plugins, users, and settings from { sourceSiteDomain } we need to
-						upgrade your WordPress.com site.
+						{ translate(
+							'To import your themes, plugins, users, and settings from %(sourceSiteDomain)s we need to upgrade your WordPress.com site.',
+							{
+								args: { sourceSiteDomain },
+							}
+						) }
 					</div>
 					<div className="migrate__plan-upsell">
 						<div className="migrate__plan-upsell-icon">
 							<ProductIcon slug="business-bundle" />
 						</div>
 						<div className="migrate__plan-upsell-info">
-							<div className="migrate__plan-name">WordPress.com Business</div>
+							<div className="migrate__plan-name">{ translate( 'WordPress.com Business' ) }</div>
 							<div className="migrate__plan-price">
 								<PlanPrice rawPrice={ planPrice } currencyCode={ currency } />
 							</div>
 							<div className="migrate__plan-billing-time-frame">{ billingTimeFrame }</div>
 						</div>
 						<div className="migrate__plan-upsell-themes">
-							<h4 className="migrate__plan-feature-header">Your custom themes</h4>
+							<h4 className="migrate__plan-feature-header">
+								{ translate( 'Your custom themes' ) }
+							</h4>
 							{ themes.slice( 0, 2 ).map( theme => (
 								<div className="migrate__plan-upsell-item">
 									<Gridicon size={ 18 } icon="checkmark" />
@@ -81,12 +90,16 @@ class StepUpgrade extends Component {
 							{ themes.length > 2 && (
 								<div className="migrate__plan-upsell-item">
 									<Gridicon size={ 18 } icon="plus" />
-									<div className="migrate__plan-upsell-item-label">{ themes.length - 2 } more</div>
+									<div className="migrate__plan-upsell-item-label">
+										{ translate( '%(number)d more', { args: { number: themes.length - 2 } } ) }
+									</div>
 								</div>
 							) }
 						</div>
 						<div className="migrate__plan-upsell-plugins">
-							<h4 className="migrate__plan-feature-header">Your active plugins</h4>
+							<h4 className="migrate__plan-feature-header">
+								{ translate( 'Your active plugins' ) }
+							</h4>
 							{ plugins.slice( 0, 2 ).map( plugin => (
 								<div className="migrate__plan-upsell-item">
 									<Gridicon size={ 18 } icon="checkmark" />
@@ -96,7 +109,9 @@ class StepUpgrade extends Component {
 							{ plugins.length > 2 && (
 								<div className="migrate__plan-upsell-item">
 									<Gridicon size={ 18 } icon="plus" />
-									<div className="migrate__plan-upsell-item-label">{ plugins.length - 2 } more</div>
+									<div className="migrate__plan-upsell-item-label">
+										{ translate( '%(number)d more', { args: { number: plugins.length - 2 } } ) }
+									</div>
 								</div>
 							) }
 						</div>
@@ -105,7 +120,7 @@ class StepUpgrade extends Component {
 						onClick={ this.props.startMigration }
 						targetSiteDomain={ targetSiteDomain }
 					>
-						Upgrade and import
+						{ translate( 'Upgrade and import' ) }
 					</MigrateButton>
 				</CompactCard>
 			</>

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -12,6 +12,7 @@ import { CompactCard, ProductIcon } from '@automattic/components';
  * Internal dependencies
  */
 import CardHeading from 'components/card-heading';
+import Gridicon from 'components/gridicon';
 import HeaderCake from 'components/header-cake';
 import MigrateButton from './migrate-button.jsx';
 import PlanPrice from 'my-sites/plan-price';
@@ -72,16 +73,32 @@ class StepUpgrade extends Component {
 						<div className="migrate__plan-upsell-themes">
 							<h4 className="migrate__plan-feature-header">Your custom themes</h4>
 							{ themes.slice( 0, 2 ).map( theme => (
-								<div>{ theme.name }</div>
+								<div className="migrate__plan-upsell-item">
+									<Gridicon size={ 18 } icon="checkmark" />
+									<div className="migrate__plan-upsell-item-label">{ theme.name }</div>
+								</div>
 							) ) }
-							{ themes.length > 2 && <div>{ themes.length - 2 } more</div> }
+							{ themes.length > 2 && (
+								<div className="migrate__plan-upsell-item">
+									<Gridicon size={ 18 } icon="plus" />
+									<div className="migrate__plan-upsell-item-label">{ themes.length - 2 } more</div>
+								</div>
+							) }
 						</div>
 						<div className="migrate__plan-upsell-plugins">
 							<h4 className="migrate__plan-feature-header">Your active plugins</h4>
 							{ plugins.slice( 0, 2 ).map( plugin => (
-								<div>{ plugin.name }</div>
+								<div className="migrate__plan-upsell-item">
+									<Gridicon size={ 18 } icon="checkmark" />
+									<div className="migrate__plan-upsell-item-label">{ plugin.name }</div>
+								</div>
 							) ) }
-							{ plugins.length > 2 && <div>{ plugins.length - 2 } more</div> }
+							{ plugins.length > 2 && (
+								<div className="migrate__plan-upsell-item">
+									<Gridicon size={ 18 } icon="plus" />
+									<div className="migrate__plan-upsell-item-label">{ plugins.length - 2 } more</div>
+								</div>
+							) }
 						</div>
 					</div>
 					<MigrateButton

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -28,16 +28,25 @@ import './section-migrate.scss';
 
 class StepUpgrade extends Component {
 	static propTypes = {
+		plugins: PropTypes.array.isRequired,
 		sourceSite: PropTypes.object.isRequired,
 		startMigration: PropTypes.func.isRequired,
 		targetSite: PropTypes.object.isRequired,
 	};
 
 	render() {
-		const { billingTimeFrame, currency, planPrice, sourceSite, targetSite } = this.props;
+		const {
+			billingTimeFrame,
+			currency,
+			planPrice,
+			plugins,
+			sourceSite,
+			targetSite,
+			themes,
+		} = this.props;
 		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
-		window.sourceSite = sourceSite;
+
 		return (
 			<>
 				<QueryPlans />
@@ -62,9 +71,17 @@ class StepUpgrade extends Component {
 						</div>
 						<div className="migrate__plan-upsell-themes">
 							<h4 className="migrate__plan-feature-header">Your custom themes</h4>
+							{ themes.slice( 0, 2 ).map( theme => (
+								<div>{ theme.name }</div>
+							) ) }
+							{ themes.length > 2 && <div>{ themes.length - 2 } more</div> }
 						</div>
 						<div className="migrate__plan-upsell-plugins">
 							<h4 className="migrate__plan-feature-header">Your active plugins</h4>
+							{ plugins.slice( 0, 2 ).map( plugin => (
+								<div>{ plugin.name }</div>
+							) ) }
+							{ plugins.length > 2 && <div>{ plugins.length - 2 } more</div> }
 						</div>
 					</div>
 					<MigrateButton

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -3,15 +3,23 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
-import { CompactCard } from '@automattic/components';
+import { CompactCard, ProductIcon } from '@automattic/components';
 
 /**
  * Internal dependencies
  */
+import CardHeading from 'components/card-heading';
 import HeaderCake from 'components/header-cake';
 import MigrateButton from './migrate-button.jsx';
+import PlanPrice from 'my-sites/plan-price';
+import QueryPlans from 'components/data/query-plans';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import { getPlan } from 'lib/plans';
+import { getPlanRawPrice } from 'state/plans/selectors';
+import { PLAN_BUSINESS } from 'lib/plans/constants';
 
 /**
  * Style dependencies
@@ -20,19 +28,45 @@ import './section-migrate.scss';
 
 class StepUpgrade extends Component {
 	static propTypes = {
+		sourceSite: PropTypes.object.isRequired,
 		startMigration: PropTypes.func.isRequired,
 		targetSite: PropTypes.object.isRequired,
 	};
 
 	render() {
-		const { targetSite } = this.props;
+		const { billingTimeFrame, currency, planPrice, sourceSite, targetSite } = this.props;
+		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
-
+		window.sourceSite = sourceSite;
 		return (
 			<>
+				<QueryPlans />
 				<HeaderCake>Import Everything</HeaderCake>
 
 				<CompactCard>
+					<CardHeading>A Business Plan is required to import everything.</CardHeading>
+					<div>
+						To import your themes, plugins, users, and settings from { sourceSiteDomain } we need to
+						upgrade your WordPress.com site.
+					</div>
+					<div className="migrate__plan-upsell">
+						<div className="migrate__plan-upsell-icon">
+							<ProductIcon slug="business-bundle" />
+						</div>
+						<div className="migrate__plan-upsell-info">
+							<div className="migrate__plan-name">WordPress.com Business</div>
+							<div className="migrate__plan-price">
+								<PlanPrice rawPrice={ planPrice } currency={ currency } />
+							</div>
+							<div className="migrate__plan-billing-time-frame">{ billingTimeFrame }</div>
+						</div>
+						<div className="migrate__plan-upsell-themes">
+							<h4 className="migrate__plan-feature-header">Your custom themes</h4>
+						</div>
+						<div className="migrate__plan-upsell-plugins">
+							<h4 className="migrate__plan-feature-header">Your active plugins</h4>
+						</div>
+					</div>
 					<MigrateButton
 						onClick={ this.props.startMigration }
 						targetSiteDomain={ targetSiteDomain }
@@ -45,4 +79,13 @@ class StepUpgrade extends Component {
 	}
 }
 
-export default localize( StepUpgrade );
+export default connect( state => {
+	const plan = getPlan( PLAN_BUSINESS );
+	const planId = plan.getProductId();
+
+	return {
+		billingTimeFrame: plan.getBillingTimeFrame(),
+		currency: getCurrentUserCurrencyCode( state ),
+		planPrice: getPlanRawPrice( state, planId, true ),
+	};
+} )( localize( StepUpgrade ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the Migration confirmation step
* Adds a list of themes and plugins

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR and run Calypso locally, or use `calypso.live`.
* Do a migration into a site without a Business plan.
* After clicking "Import everything" on the confirm page, you should see the new style of upgrade step page:

![image](https://user-images.githubusercontent.com/363749/74617137-51ec4300-50f1-11ea-9806-b9df939aad93.png)

* On purchasing a plan and following the other steps the migration should complete.



