### PR TITLE
Page Templates: Track template insertion/removal caused by the template selector

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -472,6 +472,7 @@ export const PageTemplatesPlugin = compose(
 				} );
 			},
 			insertTemplate: ( title, blocks ) => {
+				window._isCurrentlyinsertingStarterPageTemplate = true;
 				// Set post title.
 				if ( title ) {
 					editorDispatcher.editPost( { title } );
@@ -484,6 +485,7 @@ export const PageTemplatesPlugin = compose(
 					blocks,
 					false
 				);
+				window._isCurrentlyinsertingStarterPageTemplate = false;
 			},
 			hideWelcomeGuide: () => {
 				if ( ownProps.isWelcomeGuideActive ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -2,7 +2,18 @@
 /**
  * External dependencies
  */
-import { find, isEmpty, reduce, get, keyBy, mapValues, memoize, filter, sortBy } from 'lodash';
+import {
+	find,
+	isEmpty,
+	reduce,
+	get,
+	keyBy,
+	mapValues,
+	memoize,
+	filter,
+	sortBy,
+	stubTrue,
+} from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
@@ -11,6 +22,7 @@ import { Button, Modal, Spinner, IconButton } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
 import { parse as parseBlocks } from '@wordpress/blocks';
+import { addFilter, removeFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -25,6 +37,8 @@ import mapBlocksRecursively from './utils/map-blocks-recursively';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
+const INSERTING_HOOK_NAME = 'isInsertingPageTemplate';
+const INSERTING_HOOK_NAMESPACE = 'automattic/full-site-editing/inserting-template';
 
 class PageTemplateModal extends Component {
 	state = {
@@ -472,7 +486,9 @@ export const PageTemplatesPlugin = compose(
 				} );
 			},
 			insertTemplate: ( title, blocks ) => {
-				window._isCurrentlyinsertingStarterPageTemplate = true;
+				// Add filter to let the tracking library know we are inserting a template.
+				addFilter( INSERTING_HOOK_NAME, INSERTING_HOOK_NAMESPACE, stubTrue );
+
 				// Set post title.
 				if ( title ) {
 					editorDispatcher.editPost( { title } );
@@ -485,7 +501,9 @@ export const PageTemplatesPlugin = compose(
 					blocks,
 					false
 				);
-				window._isCurrentlyinsertingStarterPageTemplate = false;
+
+				// Remove filter.
+				removeFilter( INSERTING_HOOK_NAME, INSERTING_HOOK_NAMESPACE );
 			},
 			hideWelcomeGuide: () => {
 				if ( ownProps.isWelcomeGuideActive ) {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -11,6 +12,7 @@ import debugFactory from 'debug';
  */
 import tracksRecordEvent from './tracking/track-record-event';
 import delegateEventTracking from './tracking/delegate-event-tracking';
+/* eslint-enable import/no-extraneous-dependencies */
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
@@ -74,10 +76,28 @@ const trackBlockReplacement = ( originalBlockIds, blocks ) => {
 };
 
 /**
+ * Track inner blocks replacement.
+ * This is how Page Templates insert their content into page, by replacing everything that was already there.
+ *
+ * @param {Array} rootClientId id of parent block
+ * @param {object|Array} blocks block instance object or an array of such objects
+ * @returns {void}
+ */
+const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
+	castArray( blocks ).forEach( block => {
+		tracksRecordEvent( 'wpcom_block_inserted', {
+			block_name: block.name,
+			blocks_replaced: false,
+			from_template_selector: !! window._isCurrentlyinsertingStarterPageTemplate,
+		} );
+	} );
+};
+
+/**
  * Track update and publish action for Global Styles plugin.
  *
  * @param {string} eventName Name of the track event.
- * @returns {Function}
+ * @returns {Function} tracker
  */
 const trackGlobalStyles = eventName => options => {
 	tracksRecordEvent( eventName, {
@@ -113,6 +133,7 @@ const REDUX_TRACKING = {
 		insertBlocks: trackBlockInsertion,
 		replaceBlock: trackBlockReplacement,
 		replaceBlocks: trackBlockReplacement,
+		replaceInnerBlocks: trackInnerBlocksReplacement,
 	},
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -89,6 +89,7 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 		tracksRecordEvent( 'wpcom_block_inserted', {
 			block_name: block.name,
 			blocks_replaced: false,
+			// isInsertingPageTemplate filter is set by Starter Page Templates
 			from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
 		} );
 	} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -4,6 +4,7 @@
  */
 import { use, select } from '@wordpress/data';
 import { registerPlugin } from '@wordpress/plugins';
+import { applyFilters } from '@wordpress/hooks';
 import { castArray } from 'lodash';
 import debugFactory from 'debug';
 
@@ -88,7 +89,7 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 		tracksRecordEvent( 'wpcom_block_inserted', {
 			block_name: block.name,
 			blocks_replaced: false,
-			from_template_selector: !! window._isCurrentlyinsertingStarterPageTemplate,
+			from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
 		} );
 	} );
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -124,9 +124,9 @@ const trackBlockReplacement = ( originalBlockIds, blocks ) => {
  * @returns {void}
  */
 const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
-	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( block, parent ) => ( {
-		block_name: block.name,
-		blocks_replaced: ! parent,
+	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( { name } ) => ( {
+		block_name: name,
+		blocks_replaced: true,
 		// isInsertingPageTemplate filter is set by Starter Page Templates
 		from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
 	} ) );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -30,14 +30,17 @@ const getTypeForBlockId = blockId => {
 };
 
 /**
- * This helper function trackers the given blocks recursively
- * in order to be able to track also the inner ones.
- * The event properties will be populated (optional) propertiesHandler function.
- * It acts as a callback passing two current block and the parent block (if exists).
- * Take this as an advantage to add other custom properties to the event.
+ * This helper function tracks the given blocks recursively
+ * in order to be able to do it also for its inner ones.
+ *
+ * The event properties will be populated (optional)
+ * propertiesHandler function. It acts as a callback
+ * passing two arguments: the current block and
+ * the parent block (if exists). Take this as
+ * an advantage to add other custom properties to the event.
+ *
  * Also, it adds as default `inner_block`,
- * and `parent_block_client_id` and `parent_block_name` properties
- * if the block has a parent block.
+ * and `parent_block_client_id` (if parent exists) properties.
  *
  * @param {Array}    blocks            Block instances object or an array of such objects
  * @param {string}   eventName         Event name used to track.

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -31,7 +31,7 @@ const getTypeForBlockId = blockId => {
 
 /**
  * This helper function tracks the given blocks recursively
- * in order to be able to do it also for its inner ones.
+ * in order to track inner blocks.
  *
  * The event properties will be populated (optional)
  * propertiesHandler function. It acts as a callback

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -95,12 +95,10 @@ const getBlocksTracker = eventName => blockIds => {
  * @returns {void}
  */
 const trackBlockInsertion = blocks => {
-	castArray( blocks ).forEach( block => {
-		tracksRecordEvent( 'wpcom_block_inserted', {
-			block_name: block.name,
-			blocks_replaced: false,
-		} );
-	} );
+	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( { name } ) => ( {
+		block_name: name,
+		blocks_replaced: false,
+	} ) );
 };
 
 /**
@@ -111,12 +109,10 @@ const trackBlockInsertion = blocks => {
  * @returns {void}
  */
 const trackBlockReplacement = ( originalBlockIds, blocks ) => {
-	castArray( blocks ).forEach( block => {
-		tracksRecordEvent( 'wpcom_block_picker_block_inserted', {
-			block_name: block.name,
-			blocks_replaced: true,
-		} );
-	} );
+	trackBlocksHandler( blocks, 'wpcom_block_picker_block_inserted', ( { name } ) => ( {
+		block_name: name,
+		blocks_replaced: true,
+	} ) );
 };
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -39,7 +39,7 @@ const getTypeForBlockId = blockId => {
  * the parent block (if exists). Take this as
  * an advantage to add other custom properties to the event.
  *
- * Also, it adds as default `inner_block`,
+ * Also, it adds default `inner_block`,
  * and `parent_block_client_id` (if parent exists) properties.
  *
  * @param {Array}    blocks            Block instances object or an array of such objects

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -84,14 +84,34 @@ const trackBlockReplacement = ( originalBlockIds, blocks ) => {
  * @param {object|Array} blocks block instance object or an array of such objects
  * @returns {void}
  */
-const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
-	castArray( blocks ).forEach( block => {
-		tracksRecordEvent( 'wpcom_block_inserted', {
-			block_name: block.name,
-			blocks_replaced: false,
-			// isInsertingPageTemplate filter is set by Starter Page Templates
-			from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
-		} );
+let blockCounter = 0;
+const trackInnerBlocksReplacement = ( rootClientId = '', blocks ) => {
+	const castBlocks = castArray( blocks );
+	if ( ! castBlocks || ! castBlocks.length ) {
+		return;
+	}
+
+	castBlocks.forEach( block => {
+		setTimeout(
+			( _rootId, _block ) => {
+				tracksRecordEvent( 'wpcom_block_inserted', {
+					block_name: _block.name,
+					rootClientId: _rootId,
+					blocks_replaced: false,
+					// isInsertingPageTemplate filter is set by Starter Page Templates
+					from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
+				} );
+			},
+			blockCounter * 50,
+			rootClientId,
+			block
+		);
+
+		blockCounter++;
+
+		if ( block.innerBlocks && block.innerBlocks.length ) {
+			trackInnerBlocksReplacement( block.clientId, block.innerBlocks );
+		}
 	} );
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -73,49 +73,6 @@ function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parent
 }
 
 /**
- * This helper function tracks the given blocks recursively
- * in order to be able to do it also for its inner ones.
- *
- * The event properties will be populated (optional)
- * propertiesHandler function. It acts as a callback
- * passing two arguments: the current block and
- * the parent block (if exists). Take this as
- * an advantage to add other custom properties to the event.
- *
- * Also, it adds as default `inner_block`,
- * and `parent_block_client_id` (if parent exists) properties.
- *
- * @param {Array}    blocks            Block instances object or an array of such objects
- * @param {string}   eventName         Event name used to track.
- * @param {Function} propertiesHandler Callback function to populate event properties
- * @param {object}   parentBlock       parent block. optional.
- * @returns {void}
- */
-function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parentBlock ) {
-	const castBlocks = castArray( blocks );
-	if ( ! castBlocks || ! castBlocks.length ) {
-		return;
-	}
-
-	castBlocks.forEach( block => {
-		const eventProperties = {
-			...propertiesHandler( block, parentBlock ),
-			inner_block: !! parentBlock,
-		};
-
-		if ( parentBlock ) {
-			eventProperties.parent_block_name = parentBlock.name;
-		}
-
-		tracksRecordEvent( eventName, eventProperties );
-
-		if ( block.innerBlocks && block.innerBlocks.length ) {
-			trackBlocksHandler( block.innerBlocks, eventName, propertiesHandler, block );
-		}
-	} );
-}
-
-/**
  * A lot of actions accept either string (block id)
  * or an array of multiple string when operating with multiple blocks selected.
  * This is a convenience method that processes the first argument of the action (blocks)
@@ -161,23 +118,6 @@ const trackBlockReplacement = ( originalBlockIds, blocks ) => {
 /**
  * Track inner blocks replacement.
  * Page Templates insert their content into the page replacing everything that was already there.
- *
- * @param {Array} rootClientId id of parent block
- * @param {object|Array} blocks block instance object or an array of such objects
- * @returns {void}
- */
-const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
-	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( { name } ) => ( {
-		block_name: name,
-		blocks_replaced: true,
-		// isInsertingPageTemplate filter is set by Starter Page Templates
-		from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
-	} ) );
-};
-
-/**
- * Track inner blocks replacement.
- * This is how Page Templates insert their content into page, by replacing everything that was already there.
  *
  * @param {Array} rootClientId id of parent block
  * @param {object|Array} blocks block instance object or an array of such objects

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -140,14 +140,34 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
  * @param {object|Array} blocks block instance object or an array of such objects
  * @returns {void}
  */
-const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
-	castArray( blocks ).forEach( block => {
-		tracksRecordEvent( 'wpcom_block_inserted', {
-			block_name: block.name,
-			blocks_replaced: false,
-			// isInsertingPageTemplate filter is set by Starter Page Templates
-			from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
-		} );
+let blockCounter = 0;
+const trackInnerBlocksReplacement = ( rootClientId = '', blocks ) => {
+	const castBlocks = castArray( blocks );
+	if ( ! castBlocks || ! castBlocks.length ) {
+		return;
+	}
+
+	castBlocks.forEach( block => {
+		setTimeout(
+			( _rootId, _block ) => {
+				tracksRecordEvent( 'wpcom_block_inserted', {
+					block_name: _block.name,
+					rootClientId: _rootId,
+					blocks_replaced: false,
+					// isInsertingPageTemplate filter is set by Starter Page Templates
+					from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
+				} );
+			},
+			blockCounter * 50,
+			rootClientId,
+			block
+		);
+
+		blockCounter++;
+
+		if ( block.innerBlocks && block.innerBlocks.length ) {
+			trackInnerBlocksReplacement( block.clientId, block.innerBlocks );
+		}
 	} );
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -145,6 +145,7 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 		tracksRecordEvent( 'wpcom_block_inserted', {
 			block_name: block.name,
 			blocks_replaced: false,
+			// isInsertingPageTemplate filter is set by Starter Page Templates
 			from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
 		} );
 	} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -133,6 +133,24 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 };
 
 /**
+ * Track inner blocks replacement.
+ * This is how Page Templates insert their content into page, by replacing everything that was already there.
+ *
+ * @param {Array} rootClientId id of parent block
+ * @param {object|Array} blocks block instance object or an array of such objects
+ * @returns {void}
+ */
+const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
+	castArray( blocks ).forEach( block => {
+		tracksRecordEvent( 'wpcom_block_inserted', {
+			block_name: block.name,
+			blocks_replaced: false,
+			from_template_selector: !! window._isCurrentlyinsertingStarterPageTemplate,
+		} );
+	} );
+};
+
+/**
  * Track update and publish action for Global Styles plugin.
  *
  * @param {string} eventName Name of the track event.

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -160,7 +160,7 @@ const trackBlockReplacement = ( originalBlockIds, blocks ) => {
 
 /**
  * Track inner blocks replacement.
- * This is how Page Templates insert their content into page, by replacing everything that was already there.
+ * Page Templates insert their content into the page replacing everything that was already there.
  *
  * @param {Array} rootClientId id of parent block
  * @param {object|Array} blocks block instance object or an array of such objects

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -29,6 +29,57 @@ const getTypeForBlockId = blockId => {
 	return block ? block.name : null;
 };
 
+let trackerBlocksCounter = 0;
+
+/**
+ * This helper function trackers the given blocks recursively
+ * in order to be able to track also the inner ones.
+ * The event properties will be populated (optional) propertiesHandler function.
+ * It acts as a callback passing two current block and the parent block (if exists).
+ * Take this as an advantage to add other custom properties to the event.
+ * Also, it adds as default `inner_block`,
+ * and `parent_block_client_id` and `parent_block_name` properties
+ * if the block has a parent block.
+ *
+ * @param {Array}    blocks            Block instances object or an array of such objects
+ * @param {string}   eventName         Event name used to track.
+ * @param {Function} propertiesHandler Callback function to populate event properties
+ * @param {object}   parentBlock       parent block. optional.
+ * @returns {void}
+ */
+function trackBlocks( blocks, eventName, propertiesHandler = noop, parentBlock ) {
+	const castBlocks = castArray( blocks );
+	if ( ! castBlocks || ! castBlocks.length ) {
+		return;
+	}
+
+	castBlocks.forEach( block => {
+		setTimeout(
+			( _block, _parent ) => {
+				const eventProperties = {
+					...propertiesHandler( _block, _parent ),
+					inner_block: !! _parent,
+				};
+
+				if ( _parent ) {
+					eventProperties.parent_block_client_id = _parent.clientId;
+					eventProperties.parent_block_name = _parent.name;
+				}
+				tracksRecordEvent( eventName, eventProperties );
+			},
+			trackerBlocksCounter * 50,
+			block,
+			parentBlock
+		);
+
+		trackerBlocksCounter++;
+
+		if ( block.innerBlocks && block.innerBlocks.length ) {
+			trackBlocks( block.innerBlocks, eventName, propertiesHandler, block );
+		}
+	} );
+}
+
 /**
  * This helper function tracks the given blocks recursively
  * in order to be able to do it also for its inner ones.
@@ -140,35 +191,13 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
  * @param {object|Array} blocks block instance object or an array of such objects
  * @returns {void}
  */
-let blockCounter = 0;
-const trackInnerBlocksReplacement = ( rootClientId = '', blocks ) => {
-	const castBlocks = castArray( blocks );
-	if ( ! castBlocks || ! castBlocks.length ) {
-		return;
-	}
-
-	castBlocks.forEach( block => {
-		setTimeout(
-			( _rootId, _block ) => {
-				tracksRecordEvent( 'wpcom_block_inserted', {
-					block_name: _block.name,
-					rootClientId: _rootId,
-					blocks_replaced: false,
-					// isInsertingPageTemplate filter is set by Starter Page Templates
-					from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
-				} );
-			},
-			blockCounter * 50,
-			rootClientId,
-			block
-		);
-
-		blockCounter++;
-
-		if ( block.innerBlocks && block.innerBlocks.length ) {
-			trackInnerBlocksReplacement( block.clientId, block.innerBlocks );
-		}
-	} );
+const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
+	trackBlocks( blocks, 'wpcom_block_inserted', block => ( {
+		block_name: block.name,
+		blocks_replaced: false,
+		// isInsertingPageTemplate filter is set by Starter Page Templates
+		from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
+	} ) );
 };
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -145,7 +145,7 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
 		tracksRecordEvent( 'wpcom_block_inserted', {
 			block_name: block.name,
 			blocks_replaced: false,
-			from_template_selector: !! window._isCurrentlyinsertingStarterPageTemplate,
+			from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
 		} );
 	} );
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -184,9 +184,9 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
  * @returns {void}
  */
 const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
-	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( block, parent ) => ( {
-		block_name: block.name,
-		blocks_replaced: ! parent,
+	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( { name } ) => ( {
+		block_name: name,
+		blocks_replaced: true,
 		// isInsertingPageTemplate filter is set by Starter Page Templates
 		from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
 	} ) );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -29,8 +29,6 @@ const getTypeForBlockId = blockId => {
 	return block ? block.name : null;
 };
 
-let trackerBlocksCounter = 0;
-
 /**
  * This helper function trackers the given blocks recursively
  * in order to be able to track also the inner ones.
@@ -47,35 +45,26 @@ let trackerBlocksCounter = 0;
  * @param {object}   parentBlock       parent block. optional.
  * @returns {void}
  */
-function trackBlocks( blocks, eventName, propertiesHandler = noop, parentBlock ) {
+function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parentBlock ) {
 	const castBlocks = castArray( blocks );
 	if ( ! castBlocks || ! castBlocks.length ) {
 		return;
 	}
 
 	castBlocks.forEach( block => {
-		setTimeout(
-			( _block, _parent ) => {
-				const eventProperties = {
-					...propertiesHandler( _block, _parent ),
-					inner_block: !! _parent,
-				};
+		const eventProperties = {
+			...propertiesHandler( block, parentBlock ),
+			inner_block: !! parentBlock,
+		};
 
-				if ( _parent ) {
-					eventProperties.parent_block_client_id = _parent.clientId;
-					eventProperties.parent_block_name = _parent.name;
-				}
-				tracksRecordEvent( eventName, eventProperties );
-			},
-			trackerBlocksCounter * 50,
-			block,
-			parentBlock
-		);
+		if ( parentBlock ) {
+			eventProperties.parent_block_name = parentBlock.name;
+		}
 
-		trackerBlocksCounter++;
+		tracksRecordEvent( eventName, eventProperties );
 
 		if ( block.innerBlocks && block.innerBlocks.length ) {
-			trackBlocks( block.innerBlocks, eventName, propertiesHandler, block );
+			trackBlocksHandler( block.innerBlocks, eventName, propertiesHandler, block );
 		}
 	} );
 }
@@ -192,9 +181,9 @@ const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
  * @returns {void}
  */
 const trackInnerBlocksReplacement = ( rootClientId, blocks ) => {
-	trackBlocks( blocks, 'wpcom_block_inserted', block => ( {
+	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( block, parent ) => ( {
 		block_name: block.name,
-		blocks_replaced: false,
+		blocks_replaced: ! parent,
 		// isInsertingPageTemplate filter is set by Starter Page Templates
 		from_template_selector: applyFilters( 'isInsertingPageTemplate', false ),
 	} ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds a filter in SPT so the tracking library can detect events being triggered during template insertion

#### Testing instructions

No need to checkout this PR. Just apply the diff below. 

* apply D38786-code to your sandbox (diff just for testing purposes, real deployment would be handled separately after merging this PR)
* pick a wpcom simple site with SPT active for testing
* sandbox that site.wordpress.com and widgets.wp.com
* on your (sandboxed) site, go to the editor and run `localStorage.debug = '*'` (it's easier to go through wp-admin for testing than calypso)
* refresh the page
* start a new page, you should see the layout selector and `wpcom-block-editor:tracking registering tracking handlers` message in console (you may need to use devtools' `filter` feature to filter your console logs by the term `track`)
* pick a layout
* watch dev console for messages, one of them should be `wpcom-block-editor:analytics:tracks Recording event "wpcom_block_inserted"` and in its props, you should see `from_template_selector: true`
* insert any other block manually to the page and there should be one more tracking message but *without* `from_template_selector`

Fixes #39357 