### PR TITLE
AT: update warnings to note site changes instead of lost functionality

### DIFF
--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -80,8 +80,8 @@ function getWarningDescription(
 	translate: LocalizeProps[ 'translate' ]
 ) {
 	const defaultCopy = translate(
-		"By proceeding you'll lose %d feature:",
-		"By proceeding you'll lose these %d features:",
+		'By proceeding the following change will be made to the site:',
+		'By proceeding the following changes will be made to the site:',
 		{
 			count: warningCount,
 			args: warningCount,
@@ -90,11 +90,11 @@ function getWarningDescription(
 	switch ( context ) {
 		case 'plugins':
 			return hasLocalizedText(
-				"This feature isn't (yet) compatible with plugin uploads and will be disabled:"
+				'By installing a plugin the following change will be made to the site:'
 			)
 				? translate(
-						"This feature isn't (yet) compatible with plugin uploads and will be disabled:",
-						"These features aren't (yet) compatible with plugin uploads and will be disabled:",
+						'By installing a plugin the following change will be made to the site:',
+						'By installing a plugin the following changes will be made to the site:',
 						{
 							count: warningCount,
 							args: warningCount,
@@ -104,11 +104,11 @@ function getWarningDescription(
 
 		case 'themes':
 			return hasLocalizedText(
-				"This feature isn't (yet) compatible with theme uploads and will be disabled:"
+				'By installing a theme the following change will be made to the site:'
 			)
 				? translate(
-						"This feature isn't (yet) compatible with theme uploads and will be disabled:",
-						"These features aren't (yet) compatible with theme uploads and will be disabled:",
+						'By installing a theme the following change will be made to the site:',
+						'By installing a theme the following changes will be made to the site:',
 						{
 							count: warningCount,
 							args: warningCount,
@@ -118,11 +118,11 @@ function getWarningDescription(
 
 		case 'hosting':
 			return hasLocalizedText(
-				"This feature isn't (yet) compatible with hosting access and will be disabled:"
+				'By activating hosting access the following change will be made to the site:'
 			)
 				? translate(
-						"This feature isn't (yet) compatible with hosting access and will be disabled:",
-						"These features aren't (yet) compatible with hosting access and will be disabled:",
+						'By activating hosting access the following change will be made to the site:',
+						'By activating hosting access the following changes will be made to the site:',
 						{
 							count: warningCount,
 							args: warningCount,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/39256 where we warn about a subdomain. This PR updates copy here to note that this is a site change rather than a loss of a feature.

Before:

<img width="778" alt="Screen Shot 2020-02-11 at 4 44 24 PM" src="https://user-images.githubusercontent.com/1270189/74292795-d6078a80-4ced-11ea-84a7-263230635093.png">


After Singular
| Themes | Plugins | Hosting |
| ------------- | ------------- |------------- |
| <img width="791" alt="Screen Shot 2020-02-11 at 4 38 34 PM" src="https://user-images.githubusercontent.com/1270189/74292967-48786a80-4cee-11ea-8384-332ffc1656dc.png"> | <img width="802" alt="Screen Shot 2020-02-11 at 4 38 24 PM" src="https://user-images.githubusercontent.com/1270189/74292950-3b5b7b80-4cee-11ea-9c5b-65e079f2433d.png"> | <img width="864" alt="Screen Shot 2020-02-11 at 4 39 14 PM" src="https://user-images.githubusercontent.com/1270189/74292986-55955980-4cee-11ea-9f40-f954094464c6.png"> |


After Plural (note that I simulated the max number of warnings that can possibly display).

| Themes | Plugins | Hosting |
| ------------- | ------------- |------------- |
| <img width="783" alt="Screen Shot 2020-02-11 at 4 39 49 PM" src="https://user-images.githubusercontent.com/1270189/74294474-d8b8ae80-4cf2-11ea-8d3e-6580ea315413.png">  |  <img width="770" alt="Screen Shot 2020-02-11 at 4 40 06 PM" src="https://user-images.githubusercontent.com/1270189/74294484-dfdfbc80-4cf2-11ea-871c-e1ffc27547ee.png">| <img width="791" alt="Screen Shot 2020-02-11 at 4 39 38 PM" src="https://user-images.githubusercontent.com/1270189/74293152-c50b4900-4cee-11ea-95b7-f96fec1b8d1e.png"> |

### Testing Instructions
- Create a new test site with a Business plan
- Launch your site in My Home
- Visit /themes and try to upload a theme, /plugins and upload a plugin, or /hosting and activate it to trigger the eligibility warnings dialog
- Verify that copy makes more sense in context