### PR TITLE
Gutenboarding: Tighten 'fresh' URL param for data persistence

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/persist.ts
+++ b/client/landing/gutenboarding/stores/onboard/persist.ts
@@ -48,7 +48,7 @@ const isNotExpired = ( timestampStr: string ): boolean => {
 
 // Check for "fresh" query param
 const hasFreshParam = (): boolean => {
-	return window.location.search.indexOf( 'fresh' ) !== -1;
+	return new URLSearchParams( window.location.search ).has( 'fresh' );
 };
 
 // Handle data expiration by providing a storage object override to the @wp/data persistence plugin.


### PR DESCRIPTION
### Summary

This PR no longer just searches for a substring in the URL and instead looks for the "fresh" query parameter as a whole. The 'fresh' parameter is used to control data persistence for the Gutenboarding flow. [Prior PR introducing variable persistence data handling.](#39310)

<hr>

### Testing

* Spin this up locally and go to `/gutenboarding`.
* Pick a vertical and enter a site title, then refresh the page. Ensure that the site title and vertical are still filled out correctly.
* Add the `?fresh` param to the URL.
* Load the page and ensure that no data is persisted.
* Enter more data in the site title. Add a `?fresh-test` URL param.
* Ensure that the data is persisted.

<hr>

Fixes #39370
