### PR TITLE
Build: Improve no chromium setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,6 @@ references:
       - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}
 
   npm-install: &npm-install
-    environment:
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
     name: Install npm dependencies
     command: npm ci
 

--- a/bin/install-if-deps-outdated.js
+++ b/bin/install-if-deps-outdated.js
@@ -55,7 +55,6 @@ function install() {
 	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
 		stdio: 'inherit',
-		env: { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true', ...process.env },
 	} );
 	if ( installResult.status ) {
 		console.error( 'failed to install: exited with code %d', installResult.status );

--- a/bin/install-if-no-packages.js
+++ b/bin/install-if-no-packages.js
@@ -6,7 +6,6 @@ if ( ! fs.existsSync( 'node_modules' ) ) {
 	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
 		stdio: 'inherit',
-		env: { PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true', ...process.env },
 	} );
 	if ( installResult.status ) {
 		console.error( 'failed to install: exited with code %d', installResult.status );

--- a/package.json
+++ b/package.json
@@ -282,5 +282,8 @@
 			"pre-commit": "npm run -s install-if-no-packages && node bin/pre-commit-hook.js",
 			"pre-push": "npm run -s install-if-no-packages && node bin/pre-push-hook.js"
 		}
+	},
+	"config": {
+		"puppeteer_skip_chromium_download": "true"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
 		"test-server:watch": "npm run -s test-server -- --watch",
 		"translate": "i18n-calypso --format pot --output-file ./calypso-strings.pot -k translate,__,_x,_n,_nx -e date '**/*.js' '**/*.jsx' '**/*.ts' '**/*.tsx' '!build/**' '!packages/**/dist/**' '!public/**' '!**/test/**' '!node_modules/**' '!apps/full-site-editing/**' '!**/node_modules/**'",
 		"typecheck": "tsc --noEmit",
-		"update-deps": "npx rimraf package-lock.json && npm run distclean && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i && replace --silent 'http://' 'https://' . --recursive --include='package-lock.json' && touch -m node_modules",
+		"update-deps": "npx rimraf package-lock.json && npm run distclean && npm i && replace --silent 'http://' 'https://' . --recursive --include='package-lock.json' && touch -m node_modules",
 		"validate-fallback-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./public/fallback/*.js",
 		"prewhybundled": "cross-env-shell NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client-evergreen",
 		"whybundled": "whybundled client/stats.json",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Skip chromium install via package config. This ensures it won't happen across the project, including when `npm ci` or `npm i` is run from the command line.

See puppeteer/puppeteer#3449
See https://docs.npmjs.com/files/package.json#config

#### Testing instructions

`npm ci` on master installs chromium
`npm ci` on this branch does not 🎉 
