### PR TITLE
Domain step test: Show at least one checkbox filter in mobile view

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -125,19 +125,11 @@
 		button.search-filters__popover-button-domain-step-test {
 			flex: 1 0 auto;
 			margin-left: 2em;
-
-			@include breakpoint( '<480px' ) {
-				margin-left: 0;
-			}
 		}
 
 		legend.search-filters__filter-by {
 			font-size: 14px;
 			color: var( --color-text-subtle );
-
-			@include breakpoint( '<480px' ) {
-				display: none;
-			}
 		}
 	}
 
@@ -201,7 +193,7 @@
 
 	@include breakpoint( '<480px' ) {
 		.search-filters__tld-button:nth-child( n + 2 ),
-		.search-filters__tld-checkbox:nth-child( n + 1 ) {
+		.search-filters__tld-checkbox:nth-child( n + 2 ) {
 			display: none;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The next domain step test is being implemented in #39276. The test is hidden behind a feature flag. We will build individual pieces of the UI in separate PRs.

This PR:
* Shows at least one checkbox filter(implemented in https://github.com/Automattic/wp-calypso/pull/39346) in mobile view

**Before**

![calypso localhost_3000_start_ecommerce-onboarding_domains(iPhone X) (5)](https://user-images.githubusercontent.com/1269602/74329975-d586f680-4db6-11ea-8d0b-2422403352c7.png)

**After**

![calypso localhost_3000_start_ecommerce-onboarding_domains(iPhone X) (4)](https://user-images.githubusercontent.com/1269602/74330022-ec2d4d80-4db6-11ea-9f04-4e25e50a23b7.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the UI in mobile view works as described.