### PR TITLE
icfy-analyze: remove code that analyzes global CSS stylesheet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,7 +465,7 @@ jobs:
             npm run build-css                                      \
               && npm run preanalyze-bundles                        \
               && node bin/icfy-analyze.js                          \
-              && mv client/stats.json client/chart.json client/style.json "$CIRCLE_ARTIFACTS/icfy" \
+              && mv client/stats.json client/chart.json "$CIRCLE_ARTIFACTS/icfy" \
               || rm -fr build/.babel-client-cache # In case of failure do not save a potentially bad cache
             exit 0
       - save_cache: *save-terser-cache

--- a/bin/icfy-analyze.js
+++ b/bin/icfy-analyze.js
@@ -1,7 +1,5 @@
 const { getViewerData, readStatsFromFile } = require( 'webpack-bundle-analyzer/lib/analyzer' );
-const { existsSync, statSync, readFileSync, writeFileSync } = require( 'fs' );
-const { createHash } = require( 'crypto' );
-const gzip = require( 'gzip-size' );
+const { writeFileSync } = require( 'fs' );
 
 analyzeBundle();
 
@@ -12,25 +10,5 @@ function analyzeBundle() {
 	const chart = getViewerData( stats, './public/evergreen' );
 	console.log( 'Analyze: writing chart.json file' );
 	writeFileSync( 'client/chart.json', JSON.stringify( chart, null, 2 ) );
-	console.log( 'Analyze: analyzing the style.css file' );
-	analyzeStylesheet( './public/style.css', 'client/style.json' );
 	console.log( 'Analyze: finished' );
-}
-
-function hashFile( inputFile ) {
-	const sha = createHash( 'sha1' );
-	const data = readFileSync( inputFile );
-	sha.update( data );
-	return sha.digest( 'hex' ).slice( 0, 20 );
-}
-
-function analyzeStylesheet( inputCSSFile, outputJSONFile ) {
-	if ( ! existsSync( inputCSSFile ) ) {
-		return;
-	}
-	const parsedSize = statSync( inputCSSFile ).size;
-	const gzipSize = gzip.fileSync( inputCSSFile );
-	const hash = hashFile( inputCSSFile );
-	const styleStats = { statSize: parsedSize, parsedSize, gzipSize, hash };
-	writeFileSync( outputJSONFile, JSON.stringify( styleStats, null, 2 ) );
 }


### PR DESCRIPTION
We haven't been producing the `public/style.css` for many months, since the CSS migration to webpack was finished. Remove the code that analyzes its size and produces a `style.json` stats file.

See also: https://github.com/Automattic/wp-calypso/pull/39405#issuecomment-585157023