### PR TITLE
Gutenboarding: Use useI18n

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -10,10 +10,10 @@ import {
 	PanelRow,
 	TextControl,
 } from '@wordpress/components';
-import { __ as NO__ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useDebounce } from 'use-debounce';
 import { times } from 'lodash';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -52,6 +52,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	onDomainSelect,
 	queryParameters,
 } ) => {
+	const { __: NO__ } = useI18n();
 	const label = NO__( 'Search for a domain' );
 
 	const [ domainSearch, setDomainSearch ] = useState( '' );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ as NO__ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import { Button, Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import React, { FunctionComponent, useEffect, useCallback } from 'react';
@@ -29,6 +29,8 @@ interface Props {
 }
 
 const Header: FunctionComponent< Props > = ( { prev } ) => {
+	const { __: NO__ } = useI18n();
+
 	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
 	const newUser = useSelect( select => select( USER_STORE ).getNewUser() );
 

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -68,6 +68,8 @@ export function Gutenboard() {
 							</div>
 						</div>
 					</BlockEditorProvider>
+					<div>Your locale: { useI18n().i18nLocale }</div>
+					<div>__( 'Next' ): { useI18n().__( 'Next' ) }</div>
 				</div>
 			</DropZoneProvider>
 			<Popover.Slot />

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -68,8 +68,6 @@ export function Gutenboard() {
 							</div>
 						</div>
 					</BlockEditorProvider>
-					<div>Your locale: { useI18n().i18nLocale }</div>
-					<div>__( 'Next' ): { useI18n().__( 'Next' ) }</div>
 				</div>
 			</DropZoneProvider>
 			<Popover.Slot />

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import '@wordpress/editor'; // This shouldn't be necessary
-import { __ as NO__ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
 import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
 import { Popover, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
@@ -25,6 +25,8 @@ import './style.scss';
 registerBlockType( name, settings );
 
 export function Gutenboard() {
+	const { __: NO__ } = useI18n();
+
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)
 	// for the 'Back' and 'Next' buttons in the header. If we remove those (and move navigation
 	// entirely into the block), we'll be able to remove this code.

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import '@automattic/calypso-polyfills';
+import { setLocaleData } from '@wordpress/i18n';
 import { I18nProvider } from '@automattic/react-i18n';
 import { getLanguageFile } from '../../lib/i18n-utils/switch-locale';
 import React from 'react';
@@ -46,13 +47,14 @@ window.AppBoot = async () => {
 	accessibleFocus();
 
 	let locale = DEFAULT_LOCALE_SLUG;
-	let localeData;
 	try {
-		[ locale, localeData ] = await getLocale();
+		const [ userLocale, localeData ] = await getLocale();
+		setLocaleData( localeData );
+		locale = userLocale;
 	} catch {}
 
 	ReactDom.render(
-		<I18nProvider locale={ locale } localeData={ localeData }>
+		<I18nProvider locale={ locale }>
 			<BrowserRouter basename="gutenboarding">
 				<Switch>
 					<Route exact path={ path }>

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -49,9 +49,7 @@ window.AppBoot = async () => {
 	let locale = DEFAULT_LOCALE_SLUG;
 	try {
 		const [ userLocale, localeData ] = await getLocale();
-		console.log( 'Setting locale data: %o', localeData );
 		setLocaleData( localeData );
-		console.log( 'Just invoked setLocaleData with : %o', localeData );
 		locale = userLocale;
 	} catch {}
 

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -2,10 +2,13 @@
  * External dependencies
  */
 import '@automattic/calypso-polyfills';
+import { I18nProvider } from '@automattic/react-i18n';
+import { getLanguageFile } from '../../lib/i18n-utils/switch-locale';
 import React from 'react';
 import ReactDom from 'react-dom';
 import { BrowserRouter, Route, Switch, Redirect, generatePath } from 'react-router-dom';
 import config from '../../config';
+import { subscribe, select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,6 +17,7 @@ import { Gutenboard } from './gutenboard';
 import { setupWpDataDebug } from './devtools';
 import accessibleFocus from 'lib/accessible-focus';
 import { path, Step } from './path';
+import { USER_STORE } from './stores/user';
 
 /**
  * Style dependencies
@@ -21,16 +25,34 @@ import { path, Step } from './path';
 import 'assets/stylesheets/gutenboarding.scss';
 import 'components/environment-badge/style.scss';
 
-window.AppBoot = () => {
+const DEFAULT_LOCALE_SLUG: string = config( 'i18n_default_locale_slug' );
+
+type User = import('@automattic/data-stores').User.CurrentUser;
+
+interface AppWindow extends Window {
+	currentUser?: User;
+	i18nLocaleStrings?: string;
+}
+declare const window: AppWindow;
+
+window.AppBoot = async () => {
 	if ( ! config.isEnabled( 'gutenboarding' ) ) {
 		window.location.href = '/';
-	} else {
-		setupWpDataDebug();
+		return;
+	}
+	setupWpDataDebug();
 
-		// Add accessible-focus listener.
-		accessibleFocus();
+	// Add accessible-focus listener.
+	accessibleFocus();
 
-		ReactDom.render(
+	let locale = DEFAULT_LOCALE_SLUG;
+	let localeData;
+	try {
+		[ locale, localeData ] = await getLocale();
+	} catch {}
+
+	ReactDom.render(
+		<I18nProvider locale={ locale } localeData={ localeData }>
 			<BrowserRouter basename="gutenboarding">
 				<Switch>
 					<Route exact path={ path }>
@@ -40,8 +62,61 @@ window.AppBoot = () => {
 						<Redirect to={ generatePath( path, { step: Step.IntentGathering } ) } />
 					</Route>
 				</Switch>
-			</BrowserRouter>,
-			document.getElementById( 'wpcom' )
-		);
-	}
+			</BrowserRouter>
+		</I18nProvider>,
+		document.getElementById( 'wpcom' )
+	);
 };
+
+/**
+ * Load the user's locale
+ *
+ * 1. If i18nLocalStrings is present use those strings and data.
+ * 2. If we have a currentUser object, use that locale to fetch data.
+ * 3. Fetch the current user and use language to fetch data.
+ * 4. TODO (#39312): If we have a URL locale slug, fetch and use data.
+ * 5. Fallback to "en" locale without data.
+ *
+ * @returns Tuple of locale slug and locale data
+ */
+async function getLocale(): Promise< [ string, object ] > {
+	if ( window.i18nLocaleStrings ) {
+		const bootstrappedLocaleData = JSON.parse( window.i18nLocaleStrings );
+		return [ bootstrappedLocaleData[ '' ].localeSlug, bootstrappedLocaleData ];
+	}
+	const user = window.currentUser || ( await waitForCurrentUser() );
+	if ( ! user ) {
+		return [ DEFAULT_LOCALE_SLUG, {} ];
+	}
+	const localeSlug: string = getLocaleFromUser( user );
+
+	const data = await getLocaleData( localeSlug );
+	return [ localeSlug, data ];
+}
+
+async function getLocaleData( locale: string ) {
+	if ( locale === DEFAULT_LOCALE_SLUG ) {
+		return {};
+	}
+	return getLanguageFile( locale );
+}
+
+function waitForCurrentUser(): Promise< User | undefined > {
+	let unsubscribe: () => void = () => undefined;
+	return new Promise< User | undefined >( resolve => {
+		unsubscribe = subscribe( () => {
+			const currentUser = select( USER_STORE ).getCurrentUser();
+			if ( currentUser ) {
+				resolve( currentUser );
+			}
+			if ( ! select( 'core/data' ).isResolving( USER_STORE, 'getCurrentUser' ) ) {
+				resolve( undefined );
+			}
+		} );
+		select( USER_STORE ).getCurrentUser();
+	} ).finally( unsubscribe );
+}
+
+function getLocaleFromUser( user: User ): string {
+	return user.locale_variant || user.language;
+}

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -49,7 +49,9 @@ window.AppBoot = async () => {
 	let locale = DEFAULT_LOCALE_SLUG;
 	try {
 		const [ userLocale, localeData ] = await getLocale();
+		console.log( 'Setting locale data: %o', localeData );
 		setLocaleData( localeData );
+		console.log( 'Just invoked setLocaleData with : %o', localeData );
 		locale = userLocale;
 	} catch {}
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { __ as NO__ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -17,6 +17,7 @@ import './style.scss';
 import Link from '../components/link';
 
 const AcquireIntent: FunctionComponent = () => {
+	const { __: NO__ } = useI18n();
 	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 	const makePath = usePath();
 	return (

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { __ as NO__ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+
 /**
  * Internal dependencies
  */
@@ -10,6 +11,7 @@ import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const CreateSite: FunctionComponent< {} > = () => {
+	const { __: NO__ } = useI18n();
 	return (
 		<div className="create-site__background">
 			<div className="create-site__layout">

--- a/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/design-card.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { __ as NO__ } from '@wordpress/i18n';
 import React, { FunctionComponent, MouseEventHandler, CSSProperties } from 'react';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -20,31 +20,34 @@ interface Props {
 	style?: CSSProperties;
 	dialogId: string;
 }
-const DesignCard: FunctionComponent< Props > = ( { design, dialogId, onClick, style } ) => (
-	<Card
-		as="button"
-		className="design-selector__design-option"
-		isElevated
-		onClick={ onClick }
-		style={ style }
-		aria-haspopup="dialog"
-		aria-controls={ dialogId }
-	>
-		<CardMedia as="span">
-			<img
-				width={ 480 }
-				height={ 360 }
-				alt={ design.title }
-				src={ removeQueryArgs( design.preview, 'w' ) }
-				srcSet={ srcSet( design.preview, [ gridWidth / 2, gridWidth / 4 ] ) }
-			/>
-			<span className="design-selector__option-overlay">
-				<span className="design-selector__option-overlay-text">
-					{ NO__( 'Select this design' ) }
+const DesignCard: FunctionComponent< Props > = ( { design, dialogId, onClick, style } ) => {
+	const { __: NO__ } = useI18n();
+	return (
+		<Card
+			as="button"
+			className="design-selector__design-option"
+			isElevated
+			onClick={ onClick }
+			style={ style }
+			aria-haspopup="dialog"
+			aria-controls={ dialogId }
+		>
+			<CardMedia as="span">
+				<img
+					width={ 480 }
+					height={ 360 }
+					alt={ design.title }
+					src={ removeQueryArgs( design.preview, 'w' ) }
+					srcSet={ srcSet( design.preview, [ gridWidth / 2, gridWidth / 4 ] ) }
+				/>
+				<span className="design-selector__option-overlay">
+					<span className="design-selector__option-overlay-text">
+						{ NO__( 'Select this design' ) }
+					</span>
 				</span>
-			</span>
-		</CardMedia>
-	</Card>
-);
+			</CardMedia>
+		</Card>
+	);
+};
 
 export default DesignCard;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ as NO__ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import React, { useLayoutEffect, useRef, FunctionComponent } from 'react';
 import classnames from 'classnames';
@@ -12,6 +11,7 @@ import { useDialogState, Dialog, DialogBackdrop } from 'reakit/Dialog';
 import { useSpring, animated } from 'react-spring';
 import { useHistory } from 'react-router-dom';
 import { Step, usePath } from '../../path';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -31,6 +31,7 @@ interface Props {
 }
 
 const DesignSelector: FunctionComponent< Props > = ( { showPageSelector = false } ) => {
+	const { __: NO__ } = useI18n();
 	const { selectedDesign, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);

--- a/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/page-layout-selector.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { __ as NO__ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -20,6 +20,7 @@ interface Props {
 }
 
 const PageLayoutSelector: FunctionComponent< Props > = ( { templates } ) => {
+	const { __: NO__ } = useI18n();
 	const { pageLayouts } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { togglePageLayout } = useDispatch( ONBOARD_STORE );
 

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -5,6 +5,7 @@ import { BlockEditProps } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
 import { Redirect, Switch, Route } from 'react-router-dom';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import VerticalBackground from './vertical-background';
 import AcquireIntent from './acquire-intent';
 
 const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => {
+	const { __: NO__ } = useI18n();
 	const { siteVertical, selectedDesign } = useSelect( select => select( STORE_KEY ).getState() );
 	const isCreatingSite = useSelect( select => select( SITE_STORE ).isFetchingSite() );
 

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -5,7 +5,6 @@ import { BlockEditProps } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
 import { Redirect, Switch, Route } from 'react-router-dom';
-import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -22,7 +21,6 @@ import VerticalBackground from './vertical-background';
 import AcquireIntent from './acquire-intent';
 
 const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => {
-	const { __: NO__ } = useI18n();
 	const { siteVertical, selectedDesign } = useSelect( select => select( STORE_KEY ).getState() );
 	const isCreatingSite = useSelect( select => select( SITE_STORE ).isFetchingSite() );
 

--- a/client/landing/gutenboarding/onboarding-block/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/site-title.tsx
@@ -4,7 +4,8 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import React, { createRef, FunctionComponent, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { __ as NO__ } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+
 /**
  * Internal dependencies
  */
@@ -19,6 +20,7 @@ const SiteTitle: FunctionComponent< StepProps > = ( {
 	isActive,
 	onExpand,
 } ) => {
+	const { __: NO__ } = useI18n();
 	const { siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
 	const history = useHistory();

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import React, { createRef, useState, FunctionComponent, useEffect } from 'react';
-import { __ as NO__ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Suggestions } from '@automattic/components';
 import { ENTER } from '@wordpress/keycodes';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -32,6 +32,7 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 	isActive,
 	onExpand,
 } ) => {
+	const { __: NO__ } = useI18n();
 	const popular = [
 		NO__( 'Travel Agency' ),
 		NO__( 'Digital Marketing' ),

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -89,7 +89,7 @@ function setLocaleInDOM() {
 	switchWebpackCSS( isRTL );
 }
 
-async function getLanguageFile( targetLocaleSlug ) {
+export async function getLanguageFile( targetLocaleSlug ) {
 	const url = getLanguageFileUrl( targetLocaleSlug, 'json', window.languageRevisions || {} );
 
 	const response = await dedupedGet( url );

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -188,6 +188,7 @@ const webpackConfig = {
 				store: 'store/dist/store.modern',
 				gridicons$: path.resolve( __dirname, 'components/gridicon' ),
 				'@wordpress/data': require.resolve( '@wordpress/data' ),
+				'@wordpress/i18n': require.resolve( '@wordpress/i18n' ),
 			},
 			getAliasesForExtensions( {
 				extensionsDirectory: path.resolve( __dirname, 'extensions' ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -204,141 +204,6 @@
 				"webpack": "4.41.5",
 				"webpack-cli": "3.3.10",
 				"webpack-rtl-plugin": "2.0.0"
-			},
-			"dependencies": {
-				"@babel/compat-data": {
-					"version": "7.8.5",
-					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.5.tgz",
-					"integrity": "sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==",
-					"dev": true,
-					"requires": {
-						"browserslist": "^4.8.5",
-						"invariant": "^2.2.4",
-						"semver": "^5.5.0"
-					}
-				},
-				"@babel/helper-compilation-targets": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz",
-					"integrity": "sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==",
-					"dev": true,
-					"requires": {
-						"@babel/compat-data": "^7.8.4",
-						"browserslist": "^4.8.5",
-						"invariant": "^2.2.4",
-						"levenary": "^1.1.1",
-						"semver": "^5.5.0"
-					}
-				},
-				"@babel/plugin-transform-for-of": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
-					"integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.8.3"
-					}
-				},
-				"@babel/plugin-transform-parameters": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz",
-					"integrity": "sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-call-delegate": "^7.8.3",
-						"@babel/helper-get-function-arity": "^7.8.3",
-						"@babel/helper-plugin-utils": "^7.8.3"
-					}
-				},
-				"@babel/plugin-transform-typeof-symbol": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
-					"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.8.3"
-					}
-				},
-				"@babel/preset-env": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
-					"integrity": "sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==",
-					"dev": true,
-					"requires": {
-						"@babel/compat-data": "^7.8.4",
-						"@babel/helper-compilation-targets": "^7.8.4",
-						"@babel/helper-module-imports": "^7.8.3",
-						"@babel/helper-plugin-utils": "^7.8.3",
-						"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
-						"@babel/plugin-proposal-dynamic-import": "^7.8.3",
-						"@babel/plugin-proposal-json-strings": "^7.8.3",
-						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-						"@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-						"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-						"@babel/plugin-proposal-optional-chaining": "^7.8.3",
-						"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
-						"@babel/plugin-syntax-async-generators": "^7.8.0",
-						"@babel/plugin-syntax-dynamic-import": "^7.8.0",
-						"@babel/plugin-syntax-json-strings": "^7.8.0",
-						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-						"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-						"@babel/plugin-syntax-optional-chaining": "^7.8.0",
-						"@babel/plugin-syntax-top-level-await": "^7.8.3",
-						"@babel/plugin-transform-arrow-functions": "^7.8.3",
-						"@babel/plugin-transform-async-to-generator": "^7.8.3",
-						"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
-						"@babel/plugin-transform-block-scoping": "^7.8.3",
-						"@babel/plugin-transform-classes": "^7.8.3",
-						"@babel/plugin-transform-computed-properties": "^7.8.3",
-						"@babel/plugin-transform-destructuring": "^7.8.3",
-						"@babel/plugin-transform-dotall-regex": "^7.8.3",
-						"@babel/plugin-transform-duplicate-keys": "^7.8.3",
-						"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-						"@babel/plugin-transform-for-of": "^7.8.4",
-						"@babel/plugin-transform-function-name": "^7.8.3",
-						"@babel/plugin-transform-literals": "^7.8.3",
-						"@babel/plugin-transform-member-expression-literals": "^7.8.3",
-						"@babel/plugin-transform-modules-amd": "^7.8.3",
-						"@babel/plugin-transform-modules-commonjs": "^7.8.3",
-						"@babel/plugin-transform-modules-systemjs": "^7.8.3",
-						"@babel/plugin-transform-modules-umd": "^7.8.3",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
-						"@babel/plugin-transform-new-target": "^7.8.3",
-						"@babel/plugin-transform-object-super": "^7.8.3",
-						"@babel/plugin-transform-parameters": "^7.8.4",
-						"@babel/plugin-transform-property-literals": "^7.8.3",
-						"@babel/plugin-transform-regenerator": "^7.8.3",
-						"@babel/plugin-transform-reserved-words": "^7.8.3",
-						"@babel/plugin-transform-shorthand-properties": "^7.8.3",
-						"@babel/plugin-transform-spread": "^7.8.3",
-						"@babel/plugin-transform-sticky-regex": "^7.8.3",
-						"@babel/plugin-transform-template-literals": "^7.8.3",
-						"@babel/plugin-transform-typeof-symbol": "^7.8.4",
-						"@babel/plugin-transform-unicode-regex": "^7.8.3",
-						"@babel/types": "^7.8.3",
-						"browserslist": "^4.8.5",
-						"core-js-compat": "^3.6.2",
-						"invariant": "^2.2.2",
-						"levenary": "^1.1.1",
-						"semver": "^5.5.0"
-					}
-				},
-				"levenary": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
-					"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
-					"dev": true,
-					"requires": {
-						"leven": "^3.1.0"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@automattic/calypso-color-schemes": {
@@ -368,16 +233,6 @@
 				"lodash": "^4.17.15",
 				"prop-types": "^15.7.2",
 				"react-modal": "^3.8.1"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-					"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
-					"requires": {
-						"regenerator-runtime": "^0.13.2"
-					}
-				}
 			}
 		},
 		"@automattic/composite-checkout": {
@@ -391,52 +246,6 @@
 				"interpolate-components": "1.1.1",
 				"prop-types": "^15.7.2",
 				"react-stripe-elements": "^5.1.0"
-			},
-			"dependencies": {
-				"@emotion/core": {
-					"version": "10.0.22",
-					"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.22.tgz",
-					"integrity": "sha512-7eoP6KQVUyOjAkE6y4fdlxbZRA4ILs7dqkkm6oZUJmihtHv0UBq98VgPirq9T8F9K2gKu0J/au/TpKryKMinaA==",
-					"requires": {
-						"@babel/runtime": "^7.5.5",
-						"@emotion/cache": "^10.0.17",
-						"@emotion/css": "^10.0.22",
-						"@emotion/serialize": "^0.11.12",
-						"@emotion/sheet": "0.9.3",
-						"@emotion/utils": "0.11.2"
-					}
-				},
-				"@emotion/sheet": {
-					"version": "0.9.3",
-					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
-					"integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
-				},
-				"@emotion/utils": {
-					"version": "0.11.2",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
-					"integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA=="
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"react-stripe-elements": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-5.1.0.tgz",
-					"integrity": "sha512-4UlzOLNdbJsZr4JwbTdJjxhedAfalDDtfEYLHEBo0MKG0KgSLRAeIJup0/6NSpKtBLK4ieOMAwvyln9ICOSilQ==",
-					"requires": {
-						"prop-types": "15.7.2"
-					}
-				}
 			}
 		},
 		"@automattic/composite-checkout-wpcom": {
@@ -450,39 +259,6 @@
 				"i18n-calypso": "file:packages/i18n-calypso",
 				"prop-types": "^15.7.2",
 				"react-stripe-elements": "^5.1.0"
-			},
-			"dependencies": {
-				"@emotion/core": {
-					"version": "10.0.22",
-					"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.22.tgz",
-					"integrity": "sha512-7eoP6KQVUyOjAkE6y4fdlxbZRA4ILs7dqkkm6oZUJmihtHv0UBq98VgPirq9T8F9K2gKu0J/au/TpKryKMinaA==",
-					"requires": {
-						"@babel/runtime": "^7.5.5",
-						"@emotion/cache": "^10.0.17",
-						"@emotion/css": "^10.0.22",
-						"@emotion/serialize": "^0.11.12",
-						"@emotion/sheet": "0.9.3",
-						"@emotion/utils": "0.11.2"
-					}
-				},
-				"@emotion/sheet": {
-					"version": "0.9.3",
-					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
-					"integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
-				},
-				"@emotion/utils": {
-					"version": "0.11.2",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
-					"integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA=="
-				},
-				"react-stripe-elements": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-5.1.0.tgz",
-					"integrity": "sha512-4UlzOLNdbJsZr4JwbTdJjxhedAfalDDtfEYLHEBo0MKG0KgSLRAeIJup0/6NSpKtBLK4ieOMAwvyln9ICOSilQ==",
-					"requires": {
-						"prop-types": "15.7.2"
-					}
-				}
 			}
 		},
 		"@automattic/data-stores": {
@@ -495,13 +271,6 @@
 				"redux": "^4.0.4",
 				"tslib": "^1.10.0",
 				"wpcom-proxy-request": "^5.0.2"
-			},
-			"dependencies": {
-				"fast-json-stable-stringify": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-					"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
-				}
 			}
 		},
 		"@automattic/format-currency": {
@@ -689,12 +458,12 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.1.tgz",
-			"integrity": "sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.5.tgz",
+			"integrity": "sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.8.2",
+				"browserslist": "^4.8.5",
 				"invariant": "^2.2.4",
 				"semver": "^5.5.0"
 			},
@@ -730,47 +499,6 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"@babel/generator": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-					"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.8.3",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-					"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-					"dev": true
-				},
-				"@babel/traverse": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-					"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.8.4",
-						"@babel/helper-function-name": "^7.8.3",
-						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.8.4",
-						"@babel/types": "^7.8.3",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					}
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
 				"json5": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
@@ -795,9 +523,9 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
-			"integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+			"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3",
@@ -861,15 +589,15 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.3.tgz",
-			"integrity": "sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz",
+			"integrity": "sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.8.1",
-				"browserslist": "^4.8.2",
+				"@babel/compat-data": "^7.8.4",
+				"browserslist": "^4.8.5",
 				"invariant": "^2.2.4",
-				"levenary": "^1.1.0",
+				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -1075,55 +803,6 @@
 				"@babel/template": "^7.8.3",
 				"@babel/traverse": "^7.8.4",
 				"@babel/types": "^7.8.3"
-			},
-			"dependencies": {
-				"@babel/generator": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-					"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.8.3",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-					"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-					"dev": true
-				},
-				"@babel/traverse": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-					"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.8.4",
-						"@babel/helper-function-name": "^7.8.3",
-						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.8.4",
-						"@babel/types": "^7.8.3",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					}
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
-				}
 			}
 		},
 		"@babel/highlight": {
@@ -1149,9 +828,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-			"integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+			"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -1457,9 +1136,9 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.3.tgz",
-			"integrity": "sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
+			"integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -1567,9 +1246,9 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.3.tgz",
-			"integrity": "sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz",
+			"integrity": "sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-call-delegate": "^7.8.3",
@@ -1713,9 +1392,9 @@
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.3.tgz",
-			"integrity": "sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+			"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -1743,13 +1422,13 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.3.tgz",
-			"integrity": "sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
+			"integrity": "sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.8.0",
-				"@babel/helper-compilation-targets": "^7.8.3",
+				"@babel/compat-data": "^7.8.4",
+				"@babel/helper-compilation-targets": "^7.8.4",
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
@@ -1778,7 +1457,7 @@
 				"@babel/plugin-transform-dotall-regex": "^7.8.3",
 				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
 				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-				"@babel/plugin-transform-for-of": "^7.8.3",
+				"@babel/plugin-transform-for-of": "^7.8.4",
 				"@babel/plugin-transform-function-name": "^7.8.3",
 				"@babel/plugin-transform-literals": "^7.8.3",
 				"@babel/plugin-transform-member-expression-literals": "^7.8.3",
@@ -1789,7 +1468,7 @@
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
 				"@babel/plugin-transform-new-target": "^7.8.3",
 				"@babel/plugin-transform-object-super": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.8.4",
 				"@babel/plugin-transform-property-literals": "^7.8.3",
 				"@babel/plugin-transform-regenerator": "^7.8.3",
 				"@babel/plugin-transform-reserved-words": "^7.8.3",
@@ -1797,13 +1476,13 @@
 				"@babel/plugin-transform-spread": "^7.8.3",
 				"@babel/plugin-transform-sticky-regex": "^7.8.3",
 				"@babel/plugin-transform-template-literals": "^7.8.3",
-				"@babel/plugin-transform-typeof-symbol": "^7.8.3",
+				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
 				"@babel/plugin-transform-unicode-regex": "^7.8.3",
 				"@babel/types": "^7.8.3",
-				"browserslist": "^4.8.2",
+				"browserslist": "^4.8.5",
 				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
-				"levenary": "^1.1.0",
+				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -1886,20 +1565,10 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-			"integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+			"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
 			"requires": {
-				"regenerator-runtime": "^0.13.2"
-			}
-		},
-		"@babel/runtime-corejs3": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.3.tgz",
-			"integrity": "sha512-lrIU4aVbmlM/wQPzhEvzvNJskKyYptuXb0fGC0lTQTupTOYtR2Vqbu6/jf8vTr4M8Wt1nIzxVrSvPI5qESa/xA==",
-			"dev": true,
-			"requires": {
-				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
@@ -1915,16 +1584,16 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
-			"integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+			"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.8.3",
+				"@babel/generator": "^7.8.4",
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.8.3",
+				"@babel/parser": "^7.8.4",
 				"@babel/types": "^7.8.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
@@ -2174,9 +1843,9 @@
 			}
 		},
 		"@cnakazawa/watch": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
-			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+			"integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
 			"dev": true,
 			"requires": {
 				"exec-sh": "^0.3.2",
@@ -2192,19 +1861,31 @@
 				"@emotion/stylis": "0.8.5",
 				"@emotion/utils": "0.11.3",
 				"@emotion/weak-memoize": "0.2.5"
+			},
+			"dependencies": {
+				"@emotion/sheet": {
+					"version": "0.9.4",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+					"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+				},
+				"@emotion/utils": {
+					"version": "0.11.3",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+				}
 			}
 		},
 		"@emotion/core": {
-			"version": "10.0.27",
-			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.27.tgz",
-			"integrity": "sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==",
+			"version": "10.0.22",
+			"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.22.tgz",
+			"integrity": "sha512-7eoP6KQVUyOjAkE6y4fdlxbZRA4ILs7dqkkm6oZUJmihtHv0UBq98VgPirq9T8F9K2gKu0J/au/TpKryKMinaA==",
 			"requires": {
 				"@babel/runtime": "^7.5.5",
-				"@emotion/cache": "^10.0.27",
-				"@emotion/css": "^10.0.27",
-				"@emotion/serialize": "^0.11.15",
-				"@emotion/sheet": "0.9.4",
-				"@emotion/utils": "0.11.3"
+				"@emotion/cache": "^10.0.17",
+				"@emotion/css": "^10.0.22",
+				"@emotion/serialize": "^0.11.12",
+				"@emotion/sheet": "0.9.3",
+				"@emotion/utils": "0.11.2"
 			}
 		},
 		"@emotion/css": {
@@ -2215,6 +1896,13 @@
 				"@emotion/serialize": "^0.11.15",
 				"@emotion/utils": "0.11.3",
 				"babel-plugin-emotion": "^10.0.27"
+			},
+			"dependencies": {
+				"@emotion/utils": {
+					"version": "0.11.3",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+				}
 			}
 		},
 		"@emotion/hash": {
@@ -2261,12 +1949,19 @@
 				"@emotion/unitless": "0.7.5",
 				"@emotion/utils": "0.11.3",
 				"csstype": "^2.5.7"
+			},
+			"dependencies": {
+				"@emotion/utils": {
+					"version": "0.11.3",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+				}
 			}
 		},
 		"@emotion/sheet": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
+			"integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
 		},
 		"@emotion/styled": {
 			"version": "10.0.23",
@@ -2286,6 +1981,13 @@
 				"@emotion/is-prop-valid": "0.8.6",
 				"@emotion/serialize": "^0.11.15",
 				"@emotion/utils": "0.11.3"
+			},
+			"dependencies": {
+				"@emotion/utils": {
+					"version": "0.11.3",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+				}
 			}
 		},
 		"@emotion/stylis": {
@@ -2299,9 +2001,9 @@
 			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
 		},
 		"@emotion/utils": {
-			"version": "0.11.3",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
+			"integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA=="
 		},
 		"@emotion/weak-memoize": {
 			"version": "0.2.5",
@@ -2662,6 +2364,12 @@
 				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -4083,6 +3791,122 @@
 			"requires": {
 				"inquirer": "^6.2.0",
 				"npmlog": "^4.1.2"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"cli-cursor": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^2.0.0"
+					}
+				},
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
+					}
+				},
+				"inquirer": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+					"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+					"dev": true,
+					"requires": {
+						"ansi-escapes": "^3.2.0",
+						"chalk": "^2.4.2",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.3",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.12",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^6.4.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^5.1.0",
+						"through": "^2.3.6"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+					"dev": true
+				},
+				"mute-stream": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+					"dev": true
+				},
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"restore-cursor": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"dev": true,
+					"requires": {
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				}
 			}
 		},
 		"@lerna/publish": {
@@ -4436,9 +4260,9 @@
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
-			"integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.2.tgz",
+			"integrity": "sha512-ICDcRA0C2vtTZZGud1nXRrBLXZqFayodXAKZfo3dkdcLNqcHsgaz3YSTupbURusYeucSVRjjG+RTcQhx6HPPcg==",
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^2.0.0",
@@ -4451,6 +4275,31 @@
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-3.6.2.tgz",
 			"integrity": "sha512-3wF5eueS5OHQYuAEudkpN+xVeUsg8vYEMMenEzLphUZ7PRZ8OJtDcsreL3ad9zxXmBbaFWzLmFcdob5CLyZftA==",
 			"dev": true
+		},
+		"@octokit/plugin-paginate-rest": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+			"integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^2.0.1"
+			}
+		},
+		"@octokit/plugin-request-log": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+			"integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==",
+			"dev": true
+		},
+		"@octokit/plugin-rest-endpoint-methods": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+			"integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+			"dev": true,
+			"requires": {
+				"@octokit/types": "^2.0.1",
+				"deprecation": "^2.3.1"
+			}
 		},
 		"@octokit/request": {
 			"version": "5.3.1",
@@ -4477,9 +4326,9 @@
 			}
 		},
 		"@octokit/request-error": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz",
-			"integrity": "sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+			"integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^2.0.0",
@@ -4488,12 +4337,15 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.38.1",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.38.1.tgz",
-			"integrity": "sha512-zyNFx+/Bd1EXt7LQjfrc6H4wryBQ/oDuZeZhGMBSFr1eMPFDmpEweFQR3R25zjKwBQpDY7L5GQO6A3XSaOfV1w==",
+			"version": "16.43.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
+			"integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
 			"dev": true,
 			"requires": {
 				"@octokit/auth-token": "^2.4.0",
+				"@octokit/plugin-paginate-rest": "^1.1.1",
+				"@octokit/plugin-request-log": "^1.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "2.4.0",
 				"@octokit/request": "^5.2.0",
 				"@octokit/request-error": "^1.0.2",
 				"atob-lite": "^2.0.0",
@@ -4517,26 +4369,31 @@
 				"@types/node": ">= 8"
 			}
 		},
+		"@popperjs/core": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.0.6.tgz",
+			"integrity": "sha512-zj7Gw8QC4jmR92eKUvtrZUEpl2ypRbq+qlE4pwf9n2hnUO9BOAcWUs4/Ht+gNIbFt98xtqhLvccdCfD469MzpQ=="
+		},
 		"@reach/router": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@reach/router/-/router-1.2.1.tgz",
-			"integrity": "sha512-kTaX08X4g27tzIFQGRukaHmNbtMYDS3LEWIS8+l6OayGIw6Oyo1HIF/JzeuR2FoF9z6oV+x/wJSVSq4v8tcUGQ==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.1.tgz",
+			"integrity": "sha512-Ov1j1J+pSgXliJHFL7XWhjyREwc6GxeWfgBTa5MMH5eRmYtHbPhaovba4xKo7aTVCg8fxkt2yDMNSpvwfUP+pA==",
 			"dev": true,
 			"requires": {
-				"create-react-context": "^0.2.1",
+				"create-react-context": "0.3.0",
 				"invariant": "^2.2.3",
 				"prop-types": "^15.6.1",
-				"react-lifecycles-compat": "^3.0.4",
-				"warning": "^3.0.0"
+				"react-lifecycles-compat": "^3.0.4"
 			},
 			"dependencies": {
-				"warning": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-					"integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+				"create-react-context": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+					"integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
 					"dev": true,
 					"requires": {
-						"loose-envify": "^1.0.0"
+						"gud": "^1.0.0",
+						"warning": "^4.0.3"
 					}
 				}
 			}
@@ -4640,9 +4497,9 @@
 			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
 		},
 		"@sinonjs/commons": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
-			"integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+			"integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
@@ -4922,15 +4779,6 @@
 				"webpack-virtual-modules": "^0.2.0"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-					"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -4968,19 +4816,10 @@
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
-				"cli-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^3.1.0"
-					}
-				},
 				"commander": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-					"integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+					"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
 					"dev": true
 				},
 				"emoji-regex": {
@@ -5033,55 +4872,6 @@
 						"util.promisify": "1.0.0"
 					}
 				},
-				"inquirer": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
-					"integrity": "sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^2.4.2",
-						"cli-cursor": "^3.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^3.0.0",
-						"lodash": "^4.17.15",
-						"mute-stream": "0.0.8",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.5.3",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^5.1.0",
-						"through": "^2.3.6"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-							"dev": true
-						},
-						"chalk": {
-							"version": "2.4.2",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
 				"interpret": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.0.0.tgz",
@@ -5119,9 +4909,9 @@
 					}
 				},
 				"make-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-					"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
 					"dev": true,
 					"requires": {
 						"semver": "^6.0.0"
@@ -5137,26 +4927,11 @@
 						"picomatch": "^2.0.5"
 					}
 				},
-				"mute-stream": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-					"dev": true
-				},
 				"node-fetch": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
 					"dev": true
-				},
-				"onetime": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
 				},
 				"p-locate": {
 					"version": "4.1.0",
@@ -5188,16 +4963,6 @@
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
 				},
-				"restore-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-					"dev": true,
-					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
 				"string-width": {
 					"version": "4.2.0",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -5219,9 +4984,9 @@
 					}
 				},
 				"term-size": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.1.1.tgz",
-					"integrity": "sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
+					"integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
 					"dev": true
 				},
 				"to-regex-range": {
@@ -5684,9 +5449,9 @@
 			"integrity": "sha512-ZDNn9GHcrvdhQJMSl7fyo2MUZTZrXG7IgNf1g8wRNWP3J48OAl1ZlSC7Tx81fJQHnblm3UIFVZO9XvNV94FW+g=="
 		},
 		"@testing-library/dom": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.11.0.tgz",
-			"integrity": "sha512-Pkx9LMIGshyNbfmecjt18rrAp/ayMqGH674jYER0SXj0iG9xZc+zWRjk2Pg9JgPBDvwI//xGrI/oOQkAi4YEew==",
+			"version": "6.12.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.12.2.tgz",
+			"integrity": "sha512-KCnvHra5fV+wDxg3wJObGvZFxq7v1DJt829GNFLuRDjKxVNc/B5AdsylNF5PMHFbWMXDsHwM26d2NZcZO9KjbQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.2",
@@ -5764,9 +5529,9 @@
 			}
 		},
 		"@types/babel__core": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
-			"integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.4.tgz",
+			"integrity": "sha512-c/5MuRz5HM4aizqL5ViYfW4iEnmfPcfbH4Xa6GgLT21dMc1NGeNnuS6egHheOmP+kCJ9CAzC4pv4SDCWTnRkbg==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -5851,9 +5616,9 @@
 			}
 		},
 		"@types/history": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.4.tgz",
-			"integrity": "sha512-+o2igcuZA3xtOoFH56s+MCZVidwlJNcJID57DSCyawS2i910yG9vkwehCjJNZ6ImhCR5S9DbvIJKyYHcMyOfMw==",
+			"version": "4.7.5",
+			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
+			"integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==",
 			"dev": true
 		},
 		"@types/hoist-non-react-statics": {
@@ -5931,9 +5696,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-			"integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==",
+			"version": "13.7.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
+			"integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -5972,9 +5737,9 @@
 			"dev": true
 		},
 		"@types/reach__router": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.2.6.tgz",
-			"integrity": "sha512-Oh5DAVr/L2svBvubw6QEFpXGu295Y406BPs4i9t1n2pp7M+q3pmCmhzb9oZV5wncR41KCD3NHl1Yhi7uKnTPsA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.0.tgz",
+			"integrity": "sha512-0aL79bFPJzJOJOOMZm2301ErQVaveBdpW88uuavXymUlcYIAOCmI1ujJ2XLH6Mzn76O94eQCHIl1FDzNNKJCYA==",
 			"dev": true,
 			"requires": {
 				"@types/history": "*",
@@ -6067,9 +5832,9 @@
 			"dev": true
 		},
 		"@types/testing-library__dom": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.11.1.tgz",
-			"integrity": "sha512-ImChHtQqmjwraRLqBC2sgSQFtczeFvBmBcfhTYZn/3KwXbyD07LQykEQ0xJo7QHc1GbVvf7pRyGaIe6PkCdxEw==",
+			"version": "6.12.1",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.12.1.tgz",
+			"integrity": "sha512-cgqnEjxKk31tQt29j4baSWaZPNjQf3bHalj2gcHQTpW5SuHRal76gOpF0vypeEo6o+sS5inOvvNdzLY0B3FB2A==",
 			"dev": true,
 			"requires": {
 				"pretty-format": "^24.3.0"
@@ -6310,9 +6075,9 @@
 			"dev": true
 		},
 		"@types/yargs": {
-			"version": "13.0.6",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.6.tgz",
-			"integrity": "sha512-IkltIncDQWv6fcAvnHtJ6KtkmY/vtR3bViOaCzpj/A3yNhlfZAgxNe6AEQD1cQrkYD+YsKVo08DSxvNKEsD7BA==",
+			"version": "13.0.8",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+			"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
@@ -6636,13 +6401,13 @@
 			}
 		},
 		"@wordpress/api-fetch": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.9.0.tgz",
-			"integrity": "sha512-Z9n1IZcgZPLGcxH8wtPAMEHM4bfLRumlT6GVZ/xRS69iuty+Qnc7MvqSQhKTvgMR6Mb1crzc/yQje8R1vX9EDA==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
+			"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
 			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@wordpress/i18n": "^3.8.0",
-				"@wordpress/url": "^2.9.0"
+				"@babel/runtime": "^7.8.3",
+				"@wordpress/i18n": "^3.9.0",
+				"@wordpress/url": "^2.11.0"
 			}
 		},
 		"@wordpress/autop": {
@@ -6688,30 +6453,6 @@
 				"@wordpress/element": "^2.11.0",
 				"@wordpress/warning": "^1.0.0",
 				"core-js": "^3.1.4"
-			},
-			"dependencies": {
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				}
 			}
 		},
 		"@wordpress/base-styles": {
@@ -6743,116 +6484,6 @@
 				"@wordpress/icons": "^1.1.0",
 				"@wordpress/plugins": "^2.12.0",
 				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
-					"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/block-editor": {
@@ -6895,111 +6526,6 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"traverse": "^0.6.6"
-			},
-			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				},
-				"diff": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-				}
 			}
 		},
 		"@wordpress/block-library": {
@@ -7040,116 +6566,6 @@
 				"moment": "^2.22.1",
 				"tinycolor2": "^1.4.1",
 				"url": "^0.11.0"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
-					"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/block-serialization-default-parser": {
@@ -7185,106 +6601,6 @@
 				"simple-html-tokenizer": "^0.5.7",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -7332,66 +6648,6 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				}
 			}
 		},
 		"@wordpress/compose": {
@@ -7404,36 +6660,6 @@
 				"@wordpress/is-shallow-equal": "^1.8.0",
 				"lodash": "^4.17.15",
 				"mousetrap": "^1.6.2"
-			},
-			"dependencies": {
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				}
 			}
 		},
 		"@wordpress/core-data": {
@@ -7452,136 +6678,27 @@
 				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.15",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
-					"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/data": {
-			"version": "4.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.12.0.tgz",
-			"integrity": "sha512-HoHBRcY0kvVNtOdLwLzHcuGZSYnW8kq0NEyB1/2ZHdKZ8WMtvAflpz2qbKwnrPml1321hfkC9I3KFtA4Ep9lDA==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
+			"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
 			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.10.0",
-				"@wordpress/deprecated": "^2.6.1",
-				"@wordpress/element": "^2.10.0",
-				"@wordpress/is-shallow-equal": "^1.7.0",
-				"@wordpress/priority-queue": "^1.4.0",
-				"@wordpress/redux-routine": "^3.6.2",
+				"@babel/runtime": "^7.8.3",
+				"@wordpress/compose": "^3.11.0",
+				"@wordpress/deprecated": "^2.7.0",
+				"@wordpress/element": "^2.11.0",
+				"@wordpress/is-shallow-equal": "^1.8.0",
+				"@wordpress/priority-queue": "^1.5.0",
+				"@wordpress/redux-routine": "^3.7.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^2.1.0",
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"redux": "^4.0.0",
-				"turbo-combine-reducers": "^1.0.2"
+				"turbo-combine-reducers": "^1.0.2",
+				"use-memo-one": "^1.1.1"
 			}
 		},
 		"@wordpress/data-controls": {
@@ -7591,116 +6708,6 @@
 			"requires": {
 				"@wordpress/api-fetch": "^3.11.0",
 				"@wordpress/data": "^4.14.0"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
-					"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/date": {
@@ -7725,12 +6732,12 @@
 			}
 		},
 		"@wordpress/deprecated": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.1.tgz",
-			"integrity": "sha512-nwCZ5pfFCZRwpEOMOVJcPZ6dmcaUfINehfZwPZA/6wK6Ol5sfc5MP22zmz30LFGsP4yqfgSugYDLA2LLAnuWqg==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
+			"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
 			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@wordpress/hooks": "^2.6.0"
+				"@babel/runtime": "^7.8.3",
+				"@wordpress/hooks": "^2.7.0"
 			}
 		},
 		"@wordpress/dom": {
@@ -7782,116 +6789,6 @@
 				"memize": "^1.0.5",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
-					"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/editor": {
@@ -7936,136 +6833,26 @@
 				"redux-optimist": "^1.0.0",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
-					"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/element": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.10.0.tgz",
-			"integrity": "sha512-CedhhFfcubM/lsluY7JPC49VG0/Ee0chOBJ1vyDEvIJmQk0bM3sLfgt5qVK773yivVOqD9blQMO+JihnaMXF8w==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
+			"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
 			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@wordpress/escape-html": "^1.6.0",
+				"@babel/runtime": "^7.8.3",
+				"@wordpress/escape-html": "^1.7.0",
 				"lodash": "^4.17.15",
 				"react": "^16.9.0",
 				"react-dom": "^16.9.0"
 			}
 		},
 		"@wordpress/escape-html": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.6.0.tgz",
-			"integrity": "sha512-PD4fEg7qIB2l8+buuRmYJ5edQhvUzydu6XoCigV2G4rju3BI+MO57BcEZf1LSPfbrYqTJCca3ElNW9nNbSQthQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
+			"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
 			"requires": {
-				"@babel/runtime": "^7.4.4"
+				"@babel/runtime": "^7.8.3"
 			}
 		},
 		"@wordpress/eslint-plugin": {
@@ -8187,114 +6974,14 @@
 				"@wordpress/rich-text": "^3.12.0",
 				"@wordpress/url": "^2.11.0",
 				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-			"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
+			"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
 			"requires": {
-				"@babel/runtime": "^7.4.4"
+				"@babel/runtime": "^7.8.3"
 			}
 		},
 		"@wordpress/html-entities": {
@@ -8306,11 +6993,11 @@
 			}
 		},
 		"@wordpress/i18n": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.8.0.tgz",
-			"integrity": "sha512-SXheA3E2aA/w5/cubrIho3fCLY5Jb7zdpg7NGS3DFXYEe5VICMdmgNxeYFoeyNSw2IkNmphJhsZXzVIMf92dYQ==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
+			"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
 			"requires": {
-				"@babel/runtime": "^7.4.4",
+				"@babel/runtime": "^7.8.3",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
@@ -8326,36 +7013,14 @@
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/element": "^2.11.0",
 				"@wordpress/primitives": "^1.1.0"
-			},
-			"dependencies": {
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				}
 			}
 		},
 		"@wordpress/is-shallow-equal": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.7.0.tgz",
-			"integrity": "sha512-fRHTAivQlWOQVn8wu8NHM8D5sacSvY6upJ+MgWSu1Q7pqy51zaCPE2T9lhym3GC1QzABus6VjDctR8jwfNfd/g==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
+			"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
 			"requires": {
-				"@babel/runtime": "^7.4.4"
+				"@babel/runtime": "^7.8.3"
 			}
 		},
 		"@wordpress/jest-console": {
@@ -8395,93 +7060,6 @@
 				"@wordpress/keycodes": "^2.9.0",
 				"lodash": "^4.17.15",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/keycodes": {
@@ -8492,21 +7070,6 @@
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/i18n": "^3.9.0",
 				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				}
 			}
 		},
 		"@wordpress/media-utils": {
@@ -8520,51 +7083,6 @@
 				"@wordpress/element": "^2.11.0",
 				"@wordpress/i18n": "^3.9.0",
 				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
-					"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				}
 			}
 		},
 		"@wordpress/notices": {
@@ -8576,93 +7094,6 @@
 				"@wordpress/a11y": "^2.7.0",
 				"@wordpress/data": "^4.14.0",
 				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
@@ -8686,106 +7117,6 @@
 				"@wordpress/icons": "^1.1.0",
 				"lodash": "^4.17.15",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/plugins": {
@@ -8798,43 +7129,6 @@
 				"@wordpress/element": "^2.11.0",
 				"@wordpress/hooks": "^2.7.0",
 				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				}
 			}
 		},
 		"@wordpress/primitives": {
@@ -8845,44 +7139,22 @@
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/element": "^2.11.0",
 				"classnames": "^2.2.5"
-			},
-			"dependencies": {
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				}
 			}
 		},
 		"@wordpress/priority-queue": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.4.0.tgz",
-			"integrity": "sha512-7yrAGkSdtU09CzDiuu7fCjVg5tQTYsYAQv2Ril9uGb4GzQpzfupaJq9wV8SXF4vW56dMYoeHtifa+yY49IGQNw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
+			"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
 			"requires": {
-				"@babel/runtime": "^7.4.4"
+				"@babel/runtime": "^7.8.3"
 			}
 		},
 		"@wordpress/redux-routine": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.2.tgz",
-			"integrity": "sha512-+WxQzKzaFKLfioFxIyT8J4NqOfra4DvFK1jdAqmhLdqfdY9wuSFsJHlbt5hF5fVx32n7lidx/mGkP1ysmigkqA==",
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
+			"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
 			"requires": {
-				"@babel/runtime": "^7.4.4",
+				"@babel/runtime": "^7.8.3",
 				"is-promise": "^2.1.0",
 				"lodash": "^4.17.15",
 				"rungen": "^0.3.2"
@@ -8905,93 +7177,6 @@
 				"lodash": "^4.17.15",
 				"memize": "^1.0.5",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/scripts": {
@@ -9215,116 +7400,6 @@
 				"@wordpress/i18n": "^3.9.0",
 				"@wordpress/url": "^2.11.0",
 				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
-					"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/shortcode": {
@@ -9365,93 +7440,6 @@
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/data": "^4.14.0",
 				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
-				}
 			}
 		},
 		"@wordpress/warning": {
@@ -9565,13 +7553,10 @@
 			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
 		},
 		"agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-			"dev": true,
-			"requires": {
-				"es6-promisify": "^5.0.0"
-			}
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+			"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+			"dev": true
 		},
 		"agentkeepalive": {
 			"version": "3.5.2",
@@ -9717,10 +7702,21 @@
 			"dev": true
 		},
 		"ansi-escapes": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-			"dev": true
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+			"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+			"dev": true,
+			"requires": {
+				"type-fest": "^0.8.1"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"dev": true
+				}
+			}
 		},
 		"ansi-html": {
 			"version": "0.0.7",
@@ -9742,9 +7738,9 @@
 			}
 		},
 		"ansi-to-html": {
-			"version": "0.6.13",
-			"resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.13.tgz",
-			"integrity": "sha512-Ys2/umuaTlQvP9DLkaa7UzRKF2FLrfod/hNHXS9QhXCrw7seObG6ksOGmNz3UoK+adwM8L9vQfG7mvaxfJ3Jvw==",
+			"version": "0.6.14",
+			"resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.14.tgz",
+			"integrity": "sha512-7ZslfB1+EnFSDO5Ju+ue5Y6It19DRnZXWv8jrGHgIlPna5Mh4jz7BV5jCbQneXNFurQcKoolaaAjHtgSBfOIuA==",
 			"dev": true,
 			"requires": {
 				"entities": "^1.1.2"
@@ -9953,9 +7949,9 @@
 			}
 		},
 		"array-iterate": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.3.tgz",
-			"integrity": "sha512-7MIv7HE9MuzfK6B2UnWv07oSHBLOaY1UUXAxZ07bIeRM+4IkPTlveMDs9MY//qvxPZPSvCn2XV4bmtQgSkVodg=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.4.tgz",
+			"integrity": "sha512-sNRaPGh9nnmdC8Zf+pT3UqP8rnWj5Hf9wiFGsX3wUQ2yVSIhO2ShFwCoceIPpB41QF6i2OEmrHmCo36xronCVA=="
 		},
 		"array-union": {
 			"version": "1.0.2",
@@ -10150,14 +8146,6 @@
 			"dev": true,
 			"requires": {
 				"retry": "0.12.0"
-			},
-			"dependencies": {
-				"retry": {
-					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-					"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-					"dev": true
-				}
 			}
 		},
 		"asynckit": {
@@ -10204,9 +8192,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -10224,6 +8212,12 @@
 							}
 						}
 					}
+				},
+				"postcss-value-parser": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+					"integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -10258,43 +8252,13 @@
 			"requires": {
 				"follow-redirects": "1.5.10",
 				"is-buffer": "^2.0.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"follow-redirects": {
-					"version": "1.5.10",
-					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-					"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-					"dev": true,
-					"requires": {
-						"debug": "=3.1.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
 			}
 		},
 		"axobject-query": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.1.tgz",
-			"integrity": "sha512-lF98xa/yvy6j3fBHAgQXIYl+J4eZadOSqsPojemUqClzNbBV38wWGpUbQbVEyf4eUF5yF7eHmGgGA2JiHyjeqw==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.7.4",
-				"@babel/runtime-corejs3": "^7.7.4"
-			}
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
+			"integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==",
+			"dev": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -10639,9 +8603,9 @@
 			}
 		},
 		"babel-plugin-named-asset-import": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.5.tgz",
-			"integrity": "sha512-sGhfINU+AuMw9oFAdIn/nD5sem3pn/WgxAfDZ//Q3CnF+5uaho7C7shh2rKLk6sKE/XkfmyibghocwKdVjLIKg==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz",
+			"integrity": "sha512-1aGDUfL1qOOIoqk9QKGIo2lANk+C7ko/fqH0uIyC71x3PEGz0uVP8ISgfEsFuG+FKmjHTvFK/nNM8dowpmUxLA==",
 			"dev": true
 		},
 		"babel-plugin-react-docgen": {
@@ -10806,9 +8770,9 @@
 			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
 		},
 		"bail": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
-			"integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -11306,10 +9270,10 @@
 				"node-releases": "^1.1.47"
 			},
 			"dependencies": {
-				"electron-to-chromium": {
-					"version": "1.3.349",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.349.tgz",
-					"integrity": "sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q=="
+				"caniuse-lite": {
+					"version": "1.0.30001028",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001028.tgz",
+					"integrity": "sha512-Vnrq+XMSHpT7E+LWoIYhs3Sne8h9lx9YJV3acH3THNCwU/9zV93/ta4xVfzTtnqd3rvnuVpVjE3DFqf56tr3aQ=="
 				}
 			}
 		},
@@ -11614,13 +9578,13 @@
 			}
 		},
 		"camel-case": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
+			"integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
 			"dev": true,
 			"requires": {
-				"no-case": "^2.2.0",
-				"upper-case": "^1.1.1"
+				"pascal-case": "^3.1.1",
+				"tslib": "^1.10.0"
 			}
 		},
 		"camelcase": {
@@ -11671,7 +9635,8 @@
 		"caniuse-lite": {
 			"version": "1.0.30001027",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
-			"integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg=="
+			"integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
+			"dev": true
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -11695,9 +9660,9 @@
 			"dev": true
 		},
 		"ccount": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
-			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+			"integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
 		},
 		"chai": {
 			"version": "4.2.0",
@@ -11809,6 +9774,37 @@
 				"title-case": "^2.1.0",
 				"upper-case": "^1.1.1",
 				"upper-case-first": "^1.1.0"
+			},
+			"dependencies": {
+				"camel-case": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+					"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+					"dev": true,
+					"requires": {
+						"no-case": "^2.2.0",
+						"upper-case": "^1.1.1"
+					}
+				},
+				"dot-case": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+					"integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+					"dev": true,
+					"requires": {
+						"no-case": "^2.2.0"
+					}
+				},
+				"pascal-case": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+					"integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+					"dev": true,
+					"requires": {
+						"camel-case": "^3.0.0",
+						"upper-case-first": "^1.1.0"
+					}
+				}
 			}
 		},
 		"character-entities": {
@@ -11961,9 +9957,9 @@
 					}
 				},
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -11997,6 +9993,7 @@
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
 				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
 				"glob-parent": "^3.1.0",
 				"inherits": "^2.0.3",
 				"is-binary-path": "^1.0.0",
@@ -12005,6 +10002,565 @@
 				"path-is-absolute": "^1.0.0",
 				"readdirp": "^2.2.1",
 				"upath": "^1.1.1"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "1.2.11",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+					"integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1",
+						"node-pre-gyp": "*"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "3.2.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.7",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.6.0"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.3.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.9.0"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.4.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"debug": "^3.2.6",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.14.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4.4.2"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"npm-normalize-package-bin": "^1.0.1"
+							}
+						},
+						"npm-normalize-package-bin": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.7",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.7.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.13",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.8.6",
+								"minizlib": "^1.2.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.3"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				}
 			}
 		},
 		"chokidar-cli": {
@@ -12114,9 +10670,9 @@
 			}
 		},
 		"chownr": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"dev": true
 		},
 		"chrome-trace-event": {
@@ -12198,9 +10754,9 @@
 			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"clean-css": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+			"integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
 			"dev": true,
 			"requires": {
 				"source-map": "~0.6.0"
@@ -12226,12 +10782,12 @@
 			"integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
 		},
 		"cli-cursor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^2.0.0"
+				"restore-cursor": "^3.1.0"
 			}
 		},
 		"cli-table3": {
@@ -12358,9 +10914,9 @@
 			}
 		},
 		"clsx": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
-			"integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.0.tgz",
+			"integrity": "sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA=="
 		},
 		"co": {
 			"version": "4.6.0",
@@ -12669,9 +11225,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -12883,9 +11439,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -12944,9 +11500,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -13015,9 +11571,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -13157,9 +11713,9 @@
 			"dev": true
 		},
 		"copy-to-clipboard": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz",
-			"integrity": "sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.1.tgz",
+			"integrity": "sha512-btru1Q6RD9wbonIvEU5EfnhIRGHLo//BGXQ1hNAD2avIs/nBZlpbOeKtv3mhoUByN4DB9Cb6/vXBymj1S43KmA==",
 			"dev": true,
 			"requires": {
 				"toggle-selection": "^1.0.6"
@@ -13500,9 +12056,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -13576,15 +12132,21 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
+				},
+				"postcss-value-parser": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+					"integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+					"dev": true
 				},
 				"schema-utils": {
 					"version": "2.6.4",
@@ -13676,13 +12238,6 @@
 				"camelize": "^1.0.0",
 				"css-color-keywords": "^1.0.0",
 				"postcss-value-parser": "^3.3.0"
-			},
-			"dependencies": {
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
-				}
 			}
 		},
 		"css-tree": {
@@ -13702,12 +12257,6 @@
 					"dev": true
 				}
 			}
-		},
-		"css-unit-converter": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
-			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
-			"dev": true
 		},
 		"css-what": {
 			"version": "3.2.1",
@@ -13794,9 +12343,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -13888,9 +12437,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -13959,9 +12508,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -14017,9 +12566,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.8",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.8.tgz",
-			"integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
+			"integrity": "sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -14030,9 +12579,9 @@
 			}
 		},
 		"cuss": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/cuss/-/cuss-1.17.0.tgz",
-			"integrity": "sha512-3ZCx/QsMbJczIwh7A0mFzg4fmugBVf+LS3G310RD5fX6Td2imd9WV+zO1shsN9OkMOjeS3Mk5V28mUrsR6Y6Qg=="
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/cuss/-/cuss-1.18.0.tgz",
+			"integrity": "sha512-H/DfMnWcJSY3EBkiKJQJidM6kR3WmvC1JqEUcis+CmjPo4DqLC7nhirSA+GWpyAXr/OkKN4n+I2Vh0e9ZLBUnQ=="
 		},
 		"cwd": {
 			"version": "0.10.0",
@@ -14132,9 +12681,9 @@
 			}
 		},
 		"damerau-levenshtein": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
-			"integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
+			"integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
 			"dev": true
 		},
 		"dargs": {
@@ -14415,9 +12964,9 @@
 			}
 		},
 		"defer-to-connect": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
-			"integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -14636,9 +13185,9 @@
 			}
 		},
 		"diff": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diff-sequences": {
 			"version": "24.9.0",
@@ -14679,9 +13228,9 @@
 			}
 		},
 		"direction": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.3.tgz",
-			"integrity": "sha512-8bHRqMt4w/kND19KBksE4NOJo+gIOPuiZfxQvbd6xikfKbuNBYBdLIw0hA/4lWzBaDpwpW+Olmg1BjD9+0LU2w=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="
 		},
 		"discontinuous-range": {
 			"version": "1.0.0",
@@ -14821,12 +13370,34 @@
 			}
 		},
 		"dot-case": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
-			"integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+			"integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
 			"dev": true,
 			"requires": {
-				"no-case": "^2.2.0"
+				"no-case": "^3.0.3",
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"lower-case": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+					"integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.10.0"
+					}
+				},
+				"no-case": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+					"integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+					"dev": true,
+					"requires": {
+						"lower-case": "^2.0.1",
+						"tslib": "^1.10.0"
+					}
+				}
 			}
 		},
 		"dot-prop": {
@@ -14844,9 +13415,9 @@
 			"dev": true
 		},
 		"dotenv-defaults": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.1.0.tgz",
-			"integrity": "sha512-MoWCnFZ1G6ZLww0TFmXx+CFs2X3ZFhIN5AptQBNPOmrHnvqjlzZPsiAbbISDEk4RUKCVgPF8HmvixuxnaVuNZQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.1.1.tgz",
+			"integrity": "sha512-6fPRo9o/3MxKvmRZBD3oNFdxODdhJtIy1zcJeUSCs6HCy4tarUpd+G67UTU9tF6OWXeSPqsm4fPAB+2eY9Rt9Q==",
 			"dev": true,
 			"requires": {
 				"dotenv": "^6.2.0"
@@ -15029,10 +13600,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.340",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.340.tgz",
-			"integrity": "sha512-hRFBAglhcj5iVYH+o8QU0+XId1WGoc0VGowJB1cuJAt3exHGrivZvWeAO5BRgBZqwZtwxjm8a5MQeGoT/Su3ww==",
-			"dev": true
+			"version": "1.3.355",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.355.tgz",
+			"integrity": "sha512-zKO/wS+2ChI/jz9WAo647xSW8t2RmgRLFdbUb/77cORkUTargO+SCj4ctTHjBn2VeNFrsLgDT7IuDVrd3F8mLQ=="
 		},
 		"element-resize-detector": {
 			"version": "1.2.1",
@@ -15501,17 +14071,17 @@
 			"dev": true
 		},
 		"es-get-iterator": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.0.2.tgz",
-			"integrity": "sha512-ZHb4fuNK3HKHEOvDGyHPKf5cSWh/OvAMskeM/+21NMnTuvqFvz8uHatolu+7Kf6b6oK9C+3Uo1T37pSGPWv0MA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+			"integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
 			"dev": true,
 			"requires": {
-				"es-abstract": "^1.17.0-next.1",
+				"es-abstract": "^1.17.4",
 				"has-symbols": "^1.0.1",
 				"is-arguments": "^1.0.4",
-				"is-map": "^2.0.0",
-				"is-set": "^2.0.0",
-				"is-string": "^1.0.4",
+				"is-map": "^2.0.1",
+				"is-set": "^2.0.1",
+				"is-string": "^1.0.5",
 				"isarray": "^2.0.5"
 			},
 			"dependencies": {
@@ -15655,9 +14225,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.13.0.tgz",
-			"integrity": "sha512-eYk2dCkxR07DsHA/X2hRBj0CFAZeri/LyDMc0C8JT1Hqi6JnVpMhJ7XFITbb0+yZS3lVkaPL2oCkZ3AVmeVbMw==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+			"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
 			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
@@ -15721,21 +14291,6 @@
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-					"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -15745,15 +14300,6 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
-					}
-				},
-				"cli-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^3.1.0"
 					}
 				},
 				"cross-spawn": {
@@ -15776,12 +14322,6 @@
 							"dev": true
 						}
 					}
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
 				},
 				"eslint-scope": {
 					"version": "5.0.0",
@@ -15817,85 +14357,11 @@
 					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 					"dev": true
 				},
-				"inquirer": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
-					"integrity": "sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^2.4.2",
-						"cli-cursor": "^3.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^3.0.0",
-						"lodash": "^4.17.15",
-						"mute-stream": "0.0.8",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.5.3",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^5.1.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"mute-stream": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-					"dev": true
-				},
-				"onetime": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
-					}
-				},
 				"regexpp": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
 					"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
 					"dev": true
-				},
-				"restore-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-					"dev": true,
-					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
-					}
 				},
 				"strip-json-comments": {
 					"version": "3.0.1",
@@ -16491,9 +14957,9 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^4.0.0"
@@ -16551,9 +15017,9 @@
 			"dev": true
 		},
 		"events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+			"integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
 		},
 		"eventsource": {
 			"version": "1.0.7",
@@ -17053,9 +15519,9 @@
 			"dev": true
 		},
 		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -17170,9 +15636,9 @@
 			"dev": true
 		},
 		"figures": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-			"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			}
@@ -17546,9 +16012,9 @@
 			"dev": true
 		},
 		"flow-parser": {
-			"version": "0.116.1",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.116.1.tgz",
-			"integrity": "sha512-uMbaTjiMhBKa/il1esHyWyVVWfrWdG/eLmG62MQulZ59Yghpa30H1tmukFZLptsBafZ8ddiPyf7I+SiA+euZ6A==",
+			"version": "0.118.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.118.0.tgz",
+			"integrity": "sha512-PM3aKA5K3e5kK2hJPsSVdQD4/SVZUQni9qfB0+JHBCjqoAS5mSe3SlhLR9TlH3WDQccL0H2b6zpP8LjOzx9Wtg==",
 			"dev": true
 		},
 		"flush-write-stream": {
@@ -17620,22 +16086,28 @@
 			"dev": true
 		},
 		"follow-redirects": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.10.0.tgz",
-			"integrity": "sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==",
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.0.0"
+				"debug": "=3.1.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.0.0"
 					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -18736,13 +17208,13 @@
 			"dev": true
 		},
 		"globule": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
-			"integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+			"integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
 			"dev": true,
 			"requires": {
 				"glob": "~7.1.1",
-				"lodash": "~4.17.10",
+				"lodash": "~4.17.12",
 				"minimatch": "~3.0.2"
 			}
 		},
@@ -18868,9 +17340,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
-			"integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+			"integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -19394,6 +17866,16 @@
 				"uglify-js": "3.4.x"
 			},
 			"dependencies": {
+				"camel-case": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+					"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+					"dev": true,
+					"requires": {
+						"no-case": "^2.2.0",
+						"upper-case": "^1.1.1"
+					}
+				},
 				"commander": {
 					"version": "2.17.1",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
@@ -19403,25 +17885,60 @@
 			}
 		},
 		"html-minifier-terser": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.0.2.tgz",
-			"integrity": "sha512-VAaitmbBuHaPKv9bj47XKypRhgDxT/cDLvsPiiF7w+omrN3K0eQhpigV9Z1ilrmHa9e0rOYcD6R/+LCDADGcnQ==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.0.4.tgz",
+			"integrity": "sha512-fHwmKQ+GzhlqdxEtwrqLT7MSuheiA+rif5/dZgbz3GjoMXJzcRzy1L9NXoiiyxrnap+q5guSiv8Tz5lrh9g42g==",
 			"dev": true,
 			"requires": {
-				"camel-case": "^3.0.0",
-				"clean-css": "^4.2.1",
-				"commander": "^4.0.0",
+				"camel-case": "^4.1.1",
+				"clean-css": "^4.2.3",
+				"commander": "^4.1.1",
 				"he": "^1.2.0",
-				"param-case": "^2.1.1",
+				"param-case": "^3.0.3",
 				"relateurl": "^0.2.7",
-				"terser": "^4.3.9"
+				"terser": "^4.6.3"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-					"integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+					"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
 					"dev": true
+				},
+				"param-case": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
+					"integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
+					"dev": true,
+					"requires": {
+						"dot-case": "^3.0.3",
+						"tslib": "^1.10.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"terser": {
+					"version": "4.6.3",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+					"integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.20.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.12"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.20.3",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+							"dev": true
+						}
+					}
 				}
 			}
 		},
@@ -19505,9 +18022,9 @@
 			}
 		},
 		"http-cache-semantics": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+			"integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA=="
 		},
 		"http-deceiver": {
 			"version": "1.2.7",
@@ -19561,6 +18078,15 @@
 				"debug": "3.1.0"
 			},
 			"dependencies": {
+				"agent-base": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+					"dev": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -19615,14 +18141,6 @@
 			"requires": {
 				"agent-base": "5",
 				"debug": "4"
-			},
-			"dependencies": {
-				"agent-base": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-					"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-					"dev": true
-				}
 			}
 		},
 		"human-signals": {
@@ -19923,9 +18441,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -20146,30 +18664,30 @@
 			}
 		},
 		"inquirer": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
+			"integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.2.0",
+				"ansi-escapes": "^4.2.1",
 				"chalk": "^2.4.2",
-				"cli-cursor": "^2.1.0",
+				"cli-cursor": "^3.1.0",
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
-				"figures": "^2.0.0",
-				"lodash": "^4.17.12",
-				"mute-stream": "0.0.7",
+				"figures": "^3.0.0",
+				"lodash": "^4.17.15",
+				"mute-stream": "0.0.8",
 				"run-async": "^2.2.0",
-				"rxjs": "^6.4.0",
-				"string-width": "^2.1.0",
+				"rxjs": "^6.5.3",
+				"string-width": "^4.1.0",
 				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
 				"chalk": {
@@ -20183,32 +18701,36 @@
 						"supports-color": "^5.3.0"
 					}
 				},
-				"figures": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-					"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-					"dev": true,
-					"requires": {
-						"escape-string-regexp": "^1.0.5"
-					}
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
 				},
 				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
 					},
 					"dependencies": {
 						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "^5.0.0"
 							}
 						}
 					}
@@ -20322,9 +18844,9 @@
 			}
 		},
 		"is-alphabetical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
 		},
 		"is-alphanumeric": {
 			"version": "1.0.0",
@@ -20333,9 +18855,9 @@
 			"dev": true
 		},
 		"is-alphanumerical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
 			"requires": {
 				"is-alphabetical": "^1.0.0",
 				"is-decimal": "^1.0.0"
@@ -20431,9 +18953,9 @@
 			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 		},
 		"is-decimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-			"integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -20458,6 +18980,12 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
 			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+			"dev": true
+		},
+		"is-docker": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+			"integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
 			"dev": true
 		},
 		"is-dom": {
@@ -20488,12 +19016,9 @@
 			"dev": true
 		},
 		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
@@ -20564,14 +19089,14 @@
 			}
 		},
 		"is-hexadecimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
 		},
 		"is-hidden": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/is-hidden/-/is-hidden-1.1.2.tgz",
-			"integrity": "sha512-kytBeNVW2QTIqZdJBDKIjP+EkUTzDT07rsc111w/gxqR6wK3ODkOswcpxgED6HU6t7fEhOxqojVZ2a2kU9rj+A=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-hidden/-/is-hidden-1.1.3.tgz",
+			"integrity": "sha512-FFzhGKA9h59OFxeaJl0W5ILTYetI8WsdqdofKr69uLKZdV6hbDKxj8vkpG3L9uS/6Q/XYh1tkXm6xwRGFweETA=="
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
@@ -20849,9 +19374,9 @@
 			}
 		},
 		"is-whitespace-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-			"integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
 		},
 		"is-window": {
 			"version": "1.0.2",
@@ -20866,9 +19391,9 @@
 			"dev": true
 		},
 		"is-word-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
-			"integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
@@ -21397,6 +19922,7 @@
 				"@jest/types": "^24.9.0",
 				"anymatch": "^2.0.0",
 				"fb-watchman": "^2.0.0",
+				"fsevents": "^1.2.7",
 				"graceful-fs": "^4.1.15",
 				"invariant": "^2.2.4",
 				"jest-serializer": "^24.9.0",
@@ -21405,6 +19931,565 @@
 				"micromatch": "^3.1.10",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "1.2.11",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+					"integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"nan": "^2.12.1",
+						"node-pre-gyp": "*"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "3.2.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.7",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.6.0"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "0.0.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.3.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.9.0"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"minimist": "0.0.8"
+							}
+						},
+						"ms": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.4.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"debug": "^3.2.6",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.14.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4.4.2"
+							}
+						},
+						"nopt": {
+							"version": "4.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"npm-normalize-package-bin": "^1.0.1"
+							}
+						},
+						"npm-normalize-package-bin": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.7",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							},
+							"dependencies": {
+								"minimist": {
+									"version": "1.2.0",
+									"bundled": true,
+									"dev": true,
+									"optional": true
+								}
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.7.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.13",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.8.6",
+								"minizlib": "^1.2.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.3"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"dev": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.1.1",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				}
 			}
 		},
 		"jest-jasmine2": {
@@ -21800,6 +20885,12 @@
 				"string-length": "^2.0.0"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
 				"chalk": {
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -21840,9 +20931,9 @@
 			"integrity": "sha1-Epi4i5COfH91AeuMGmHxrIM3tTE="
 		},
 		"js-base64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+			"integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
 			"dev": true
 		},
 		"js-tokens": {
@@ -22229,9 +21320,9 @@
 			"dev": true
 		},
 		"levenary": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.0.tgz",
-			"integrity": "sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+			"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
 			"dev": true,
 			"requires": {
 				"leven": "^3.1.0"
@@ -22629,9 +21720,9 @@
 			}
 		},
 		"loglevel": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
-			"integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+			"integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
 			"dev": true
 		},
 		"loglevelnext": {
@@ -22651,9 +21742,9 @@
 			"dev": true
 		},
 		"longest-streak": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
-			"integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+			"integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -22766,6 +21857,15 @@
 				"ssri": "^6.0.0"
 			},
 			"dependencies": {
+				"agent-base": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+					"dev": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
 				"debug": {
 					"version": "3.2.6",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -22894,9 +21994,9 @@
 			"dev": true
 		},
 		"markdown-to-jsx": {
-			"version": "6.10.3",
-			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.10.3.tgz",
-			"integrity": "sha512-PSoUyLnW/xoW6RsxZrquSSz5eGEOTwa15H5eqp3enmrp8esmgDJmhzd6zmQ9tgAA9TxJzx1Hmf3incYU/IamoQ==",
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.0.tgz",
+			"integrity": "sha512-RH7LCJQ4RFmPqVeZEesKaO1biRzB/k4utoofmTCp3Eiw6D7qfvK8fzZq/2bjEJAtVkfPrM5SMt5APGf2rnaKMg==",
 			"dev": true,
 			"requires": {
 				"prop-types": "^15.6.2",
@@ -23747,9 +22847,9 @@
 					}
 				},
 				"make-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-					"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
 					"dev": true,
 					"requires": {
 						"semver": "^6.0.0"
@@ -23878,9 +22978,9 @@
 			}
 		},
 		"mute-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
 		},
 		"mz": {
@@ -24015,17 +23115,17 @@
 			}
 		},
 		"nlcst-is-literal": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/nlcst-is-literal/-/nlcst-is-literal-1.2.0.tgz",
-			"integrity": "sha512-0f7SKVXHdQvXvibPzLL90Lp8KXbhO0ktZGvythpwyoc7mmXKGe2VtDjnPRailPWBO8TgzHRzvQzkPIz81PSyBA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/nlcst-is-literal/-/nlcst-is-literal-1.2.1.tgz",
+			"integrity": "sha512-abNv1XY7TUoyLn5kSSorMIYHfRvVfXbgftNFNvEMiQQkyKteLdjrGuDqEMMyK70sMbn7uPA6oUbRvykM6pg+pg==",
 			"requires": {
 				"nlcst-to-string": "^2.0.0"
 			}
 		},
 		"nlcst-normalize": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/nlcst-normalize/-/nlcst-normalize-2.1.3.tgz",
-			"integrity": "sha512-TtAmaUsjZPU6zH+yksmLwTezMti5Db8R+kdViCmWv44pWGxNr4C90p7X33YbiULxDfA7i7J7gUutDX4fT9pn7g==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/nlcst-normalize/-/nlcst-normalize-2.1.4.tgz",
+			"integrity": "sha512-dWJ3XUoAoWoau24xOM59Y1FPozv7DyYWy+rdUaXj9Ow0hBCVuwqDQbXzTF7H+HskyTVpTkRPXYPu4YsMEScmRw==",
 			"requires": {
 				"nlcst-to-string": "^2.0.0"
 			}
@@ -24041,9 +23141,9 @@
 			}
 		},
 		"nlcst-to-string": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-2.0.3.tgz",
-			"integrity": "sha512-OY2QhGdf6jpYfHqS4vJwqF7aIBZkaMjMUkcHcskMPitvXLuYNGdQvgVWI/5yKwkmIdmhft3ounSJv+Re2yydng=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-2.0.4.tgz",
+			"integrity": "sha512-3x3jwTd6UPG7vi5k4GEzvxJ5rDA7hVUIRNHPblKuMVP9Z3xmlsd9cgLcpAMkc5uPOBna82EeshROFhsPkbnTZg=="
 		},
 		"no-case": {
 			"version": "2.3.2",
@@ -24284,9 +23384,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.47",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
-			"integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
+			"version": "1.1.49",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
+			"integrity": "sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==",
 			"requires": {
 				"semver": "^6.3.0"
 			}
@@ -24649,9 +23749,9 @@
 					}
 				},
 				"node-gyp": {
-					"version": "5.0.7",
-					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.7.tgz",
-					"integrity": "sha512-K8aByl8OJD51V0VbUURTKsmdswkQQusIvlvmTyhHlIT1hBvaSxzdxpSle857XuXa7uc02UEZx9OR5aDxSWS5Qw==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
+					"integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
 					"dev": true,
 					"requires": {
 						"env-paths": "^2.2.0",
@@ -24727,14 +23827,46 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"bundled": true,
 					"dev": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "5.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -24742,33 +23874,66 @@
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+					"bundled": true,
+					"dev": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"invert-kv": {
+					"version": "1.0.0",
+					"bundled": true,
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"lcid": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"invert-kv": "^1.0.0"
+					}
+				},
 				"locate-path": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
 						"path-exists": "^3.0.0"
 					}
 				},
+				"lru-cache": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"pseudomap": "^1.0.2",
+						"yallist": "^2.1.2"
+					}
+				},
 				"mem": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
@@ -24776,19 +23941,38 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-					"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+					"bundled": true,
 					"dev": true
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+					"bundled": true,
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
@@ -24796,31 +23980,75 @@
 						"mem": "^1.1.0"
 					}
 				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
 				"p-limit": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-					"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+					"bundled": true,
 					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
 					}
 				},
+				"path-exists": {
+					"version": "3.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+					"bundled": true,
+					"dev": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
 					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -24830,17 +24058,33 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"which": {
+					"version": "1.3.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true
+				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
@@ -24849,14 +24093,17 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "2.1.2",
+					"bundled": true,
 					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cliui": "^3.2.0",
@@ -24875,14 +24122,12 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+							"bundled": true,
 							"dev": true
 						},
 						"cliui": {
 							"version": "3.2.0",
-							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"string-width": "^1.0.1",
@@ -24892,8 +24137,7 @@
 							"dependencies": {
 								"string-width": {
 									"version": "1.0.2",
-									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+									"bundled": true,
 									"dev": true,
 									"requires": {
 										"code-point-at": "^1.0.0",
@@ -24905,8 +24149,7 @@
 						},
 						"string-width": {
 							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+							"bundled": true,
 							"dev": true,
 							"requires": {
 								"is-fullwidth-code-point": "^2.0.0",
@@ -24915,14 +24158,12 @@
 							"dependencies": {
 								"is-fullwidth-code-point": {
 									"version": "2.0.0",
-									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-									"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+									"bundled": true,
 									"dev": true
 								},
 								"strip-ansi": {
 									"version": "4.0.0",
-									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+									"bundled": true,
 									"dev": true,
 									"requires": {
 										"ansi-regex": "^3.0.0"
@@ -24934,8 +24175,7 @@
 				},
 				"yargs-parser": {
 					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
@@ -24943,8 +24183,7 @@
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+							"bundled": true,
 							"dev": true
 						}
 					}
@@ -25177,7 +24416,8 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -25399,29 +24639,22 @@
 			}
 		},
 		"onetime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
-			},
-			"dependencies": {
-				"mimic-fn": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-					"dev": true
-				}
+				"mimic-fn": "^2.1.0"
 			}
 		},
 		"open": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/open/-/open-7.0.0.tgz",
-			"integrity": "sha512-K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.0.2.tgz",
+			"integrity": "sha512-70E/pFTPr7nZ9nLDPNTcj3IVqnNvKuP4VsBmoKV9YGTnChe0mlS3C4qM7qKarhZ8rGaHKLfo+vBTHXDp6ZSyLQ==",
 			"dev": true,
 			"requires": {
-				"is-wsl": "^2.1.0"
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
 			},
 			"dependencies": {
 				"is-wsl": {
@@ -25645,14 +24878,6 @@
 			"dev": true,
 			"requires": {
 				"retry": "^0.12.0"
-			},
-			"dependencies": {
-				"retry": {
-					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-					"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-					"dev": true
-				}
 			}
 		},
 		"p-try": {
@@ -25699,9 +24924,9 @@
 			}
 		},
 		"pako": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
 			"dev": true
 		},
 		"parallel-transform": {
@@ -25915,13 +25140,34 @@
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
 		},
 		"pascal-case": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
-			"integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
+			"integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
 			"dev": true,
 			"requires": {
-				"camel-case": "^3.0.0",
-				"upper-case-first": "^1.1.0"
+				"no-case": "^3.0.3",
+				"tslib": "^1.10.0"
+			},
+			"dependencies": {
+				"lower-case": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
+					"integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
+					"dev": true,
+					"requires": {
+						"tslib": "^1.10.0"
+					}
+				},
+				"no-case": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+					"integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
+					"dev": true,
+					"requires": {
+						"lower-case": "^2.0.1",
+						"tslib": "^1.10.0"
+					}
+				}
 			}
 		},
 		"pascalcase": {
@@ -26213,9 +25459,9 @@
 			}
 		},
 		"polished": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/polished/-/polished-3.4.2.tgz",
-			"integrity": "sha512-9Rch6iMZckABr6EFCLPZsxodeBpXMo9H4fRlfR/9VjMEyy5xpo1/WgXlJGgSjPyVhEZNycbW7UmYMNyWS5MI0g==",
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/polished/-/polished-3.4.4.tgz",
+			"integrity": "sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.3"
@@ -26282,15 +25528,14 @@
 			}
 		},
 		"postcss-calc": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
-			"integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.2.tgz",
+			"integrity": "sha512-rofZFHUg6ZIrvRwPeFktv06GdbDYLcGqh9EwiMutZg+a0oePCCw1zHOEiji6LCpyRcjTREtPASuUqeAvYlEVvQ==",
 			"dev": true,
 			"requires": {
-				"css-unit-converter": "^1.1.1",
-				"postcss": "^7.0.5",
-				"postcss-selector-parser": "^5.0.0-rc.4",
-				"postcss-value-parser": "^3.3.1"
+				"postcss": "^7.0.27",
+				"postcss-selector-parser": "^6.0.2",
+				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
 				"chalk": {
@@ -26315,16 +25560,10 @@
 						}
 					}
 				},
-				"cssesc": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
-					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
-					"dev": true
-				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -26332,21 +25571,10 @@
 						"supports-color": "^6.1.0"
 					}
 				},
-				"postcss-selector-parser": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
-					"dev": true,
-					"requires": {
-						"cssesc": "^2.0.0",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				},
 				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+					"integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
 					"dev": true
 				},
 				"source-map": {
@@ -26570,9 +25798,9 @@
 					"dev": true
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -26753,21 +25981,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -26819,21 +26041,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -26885,9 +26101,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -26944,9 +26160,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27003,9 +26219,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27062,9 +26278,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27121,9 +26337,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27149,12 +26365,12 @@
 			}
 		},
 		"postcss-flexbugs-fixes": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.1.0.tgz",
-			"integrity": "sha512-jr1LHxQvStNNAHlgco6PzY308zvLklh7SJVYuWUwyUQncofaAlD2l+P/gxKHOdqWKe7xJSkVLFF/2Tp+JqMSZA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.0.tgz",
+			"integrity": "sha512-QRE0n3hpkxxS/OGvzOa+PDuy4mh/Jg4o9ui22/ko5iGYOG3M5dfJabjnAZjTdh2G9F85c7Hv8hWcEDEKW/xceQ==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.0"
+				"postcss": "^7.0.26"
 			},
 			"dependencies": {
 				"chalk": {
@@ -27180,9 +26396,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27262,9 +26478,9 @@
 					}
 				},
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -27330,9 +26546,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27442,9 +26658,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27520,21 +26736,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -27589,10 +26799,25 @@
 						}
 					}
 				},
+				"dot-prop": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+					"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+					"dev": true,
+					"requires": {
+						"is-obj": "^2.0.0"
+					}
+				},
+				"is-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+					"dev": true
+				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27601,12 +26826,12 @@
 					}
 				},
 				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+					"integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.1",
+						"dot-prop": "^5.2.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
@@ -27661,21 +26886,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -27729,21 +26948,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -27799,21 +27012,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -27866,10 +27073,25 @@
 						}
 					}
 				},
+				"dot-prop": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+					"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+					"dev": true,
+					"requires": {
+						"is-obj": "^2.0.0"
+					}
+				},
+				"is-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+					"dev": true
+				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27878,12 +27100,12 @@
 					}
 				},
 				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+					"integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.1",
+						"dot-prop": "^5.2.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
@@ -27937,9 +27159,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -27999,15 +27221,21 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
+				},
+				"postcss-value-parser": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+					"integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28059,9 +27287,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -28119,9 +27347,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -28178,9 +27406,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -28239,21 +27467,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28307,21 +27529,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28375,21 +27591,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28442,21 +27652,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28509,21 +27713,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28576,21 +27774,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28650,21 +27842,15 @@
 					"dev": true
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28716,21 +27902,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28783,21 +27963,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28851,9 +28025,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -28913,21 +28087,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -28979,9 +28147,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -29015,12 +28183,12 @@
 			"dev": true
 		},
 		"postcss-safe-parser": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
-			"integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
+			"integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
 			"dev": true,
 			"requires": {
-				"postcss": "^7.0.0"
+				"postcss": "^7.0.26"
 			},
 			"dependencies": {
 				"chalk": {
@@ -29046,9 +28214,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -29106,9 +28274,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -29165,9 +28333,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -29238,21 +28406,15 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -29311,9 +28473,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -29339,15 +28501,14 @@
 			}
 		},
 		"postcss-value-parser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
-			"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
-			"dev": true
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
 		},
 		"postcss-values-parser": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-3.0.5.tgz",
-			"integrity": "sha512-0N6EUBx2Vzl0c9LQipuus90EkVh7saBQFRhgAYpHHcDCIvxRt+K/q0zwcIYtDQVNs5Y9NGqei4AuCEvAOsePfQ==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-3.1.1.tgz",
+			"integrity": "sha512-p56/Cu9wb8+lck/iOTeuFeSHKEUH1bbWQ03T6N3jDkw+15pV65rMY5pK+OWhVpRn5TIrByS6UVpO3mSqvlhZYA==",
 			"dev": true,
 			"requires": {
 				"color-name": "^1.1.4",
@@ -29392,9 +28553,9 @@
 					"dev": true
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -29595,6 +28756,14 @@
 			"requires": {
 				"err-code": "^1.0.0",
 				"retry": "^0.10.0"
+			},
+			"dependencies": {
+				"retry": {
+					"version": "0.10.1",
+					"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+					"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+					"dev": true
+				}
 			}
 		},
 		"promise.allsettled": {
@@ -29622,13 +28791,13 @@
 			}
 		},
 		"prompts": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.0.tgz",
-			"integrity": "sha512-NfbbPPg/74fT7wk2XYQ7hAIp9zJyZp5Fu19iRbORqqy1BhtrkZ0fPafBU+7bmn8ie69DpT0R6QpJIN2oisYjJg==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.1.tgz",
+			"integrity": "sha512-qIP2lQyCwYbdzcqHIUi2HAxiWixhoM9OdLCWf8txXsapC/X9YdsCoeyRIXE/GP+Q0J37Q7+XN/MFqbUa7IzXNA==",
 			"dev": true,
 			"requires": {
 				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.3"
+				"sisteransi": "^1.0.4"
 			}
 		},
 		"promzard": {
@@ -29891,9 +29060,9 @@
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		},
 		"quotation": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/quotation/-/quotation-1.1.2.tgz",
-			"integrity": "sha512-96iP6AudZyiOQWEY8hOUjliGaRMNj4yiC22vCSSFMNDdvpp/5/MyfsHSwFcFswWjDVxdBdzQS7MqA3rYglizOQ=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/quotation/-/quotation-1.1.3.tgz",
+			"integrity": "sha512-45gUgmX/RtQOQV1kwM06boP49OYXcKCPrYwdmAvs5YqkpiobhNKKwo524JM6Ma0ko3oN9tXNcWs9+ABq3Ry7YA=="
 		},
 		"raf": {
 			"version": "3.4.1",
@@ -29994,9 +29163,9 @@
 			}
 		},
 		"re-resizable": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.1.1.tgz",
-			"integrity": "sha512-ngzX5xbXi9LlIghJUYZaBDkJUIMLYqO3tQ2cJZoNprCRGhfHnbyufKm51MZRIOBlLigLzPPFKBxQE8ZLezKGfA==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.2.0.tgz",
+			"integrity": "sha512-3bi0yTzub/obnqoTPs9C8A1ecrgt5OSWlKdHDJ6gBPiEiEIG5LO0PqbwWTpABfzAzdE4kldOG2MQDQEaJJNYkQ==",
 			"requires": {
 				"fast-memoize": "^2.5.1"
 			}
@@ -30079,21 +29248,6 @@
 				"meow": "^5.0.0"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-					"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
-					"dev": true,
-					"requires": {
-						"type-fest": "^0.8.1"
-					}
-				},
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
 				"ast-types": {
 					"version": "0.11.7",
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.7.tgz",
@@ -30109,15 +29263,6 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
-					}
-				},
-				"cli-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-					"dev": true,
-					"requires": {
-						"restore-cursor": "^3.1.0"
 					}
 				},
 				"colors": {
@@ -30136,12 +29281,6 @@
 						"shebang-command": "^2.0.0",
 						"which": "^2.0.1"
 					}
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
 				},
 				"execa": {
 					"version": "3.4.0",
@@ -30169,33 +29308,6 @@
 					"requires": {
 						"pump": "^3.0.0"
 					}
-				},
-				"inquirer": {
-					"version": "7.0.3",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
-					"integrity": "sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==",
-					"dev": true,
-					"requires": {
-						"ansi-escapes": "^4.2.1",
-						"chalk": "^2.4.2",
-						"cli-cursor": "^3.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.3",
-						"figures": "^3.0.0",
-						"lodash": "^4.17.15",
-						"mute-stream": "0.0.8",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.5.3",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^5.1.0",
-						"through": "^2.3.6"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
 				},
 				"is-stream": {
 					"version": "2.0.0",
@@ -30229,12 +29341,6 @@
 						"write-file-atomic": "^2.3.0"
 					}
 				},
-				"mute-stream": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-					"dev": true
-				},
 				"npm-run-path": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -30242,15 +29348,6 @@
 					"dev": true,
 					"requires": {
 						"path-key": "^3.0.0"
-					}
-				},
-				"onetime": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^2.1.0"
 					}
 				},
 				"p-finally": {
@@ -30287,16 +29384,6 @@
 						"source-map": "~0.6.1"
 					}
 				},
-				"restore-cursor": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-					"dev": true,
-					"requires": {
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2"
-					}
-				},
 				"shebang-command": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -30316,34 +29403,6 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "6.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^5.0.0"
-							}
-						}
-					}
-				},
-				"type-fest": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 					"dev": true
 				},
 				"which": {
@@ -30427,6 +29486,12 @@
 						"@babel/highlight": "^7.0.0"
 					}
 				},
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -30453,6 +29518,15 @@
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
 						"supports-color": "^5.3.0"
+					}
+				},
+				"cli-cursor": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^2.0.0"
 					}
 				},
 				"cross-spawn": {
@@ -30560,11 +29634,32 @@
 						"through": "^2.3.6"
 					}
 				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+					"dev": true
+				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
+				},
+				"mute-stream": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+					"dev": true
+				},
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
 				},
 				"open": {
 					"version": "6.4.0",
@@ -30573,6 +29668,16 @@
 					"dev": true,
 					"requires": {
 						"is-wsl": "^1.1.0"
+					}
+				},
+				"restore-cursor": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"dev": true,
+					"requires": {
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"semver": {
@@ -30611,17 +29716,17 @@
 			}
 		},
 		"react-docgen": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.1.0.tgz",
-			"integrity": "sha512-buAVMVqDEtvC7+VRDRlA9udS9cO9jFfb7yxRvKNYR9MXS0MJwaIe7OjSEydNzH9oH7LND3whDE+koFDUBtF3zA==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.2.1.tgz",
+			"integrity": "sha512-3nvsiDKN/KIlgRyHCdkLrm8ajjSMZ4NIHuwYTAdBvQF3O7A2tmCBB3gwTjJ4zXH8aUpIjFwlVIjffzkJHIZ5/Q==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.7.5",
 				"@babel/runtime": "^7.7.6",
 				"ast-types": "^0.13.2",
-				"async": "^2.1.4",
 				"commander": "^2.19.0",
 				"doctrine": "^3.0.0",
+				"neo-async": "^2.6.1",
 				"node-dir": "^0.1.10",
 				"strip-indent": "^3.0.0"
 			},
@@ -30691,9 +29796,9 @@
 			}
 		},
 		"react-error-overlay": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.4.tgz",
-			"integrity": "sha512-ueZzLmHltszTshDMwyfELDq8zOA803wQ1ZuzCccXa1m57k1PxSHfflPD5W9YIiTXLs0JTLzoj6o1LuM5N6zzNA==",
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.6.tgz",
+			"integrity": "sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw==",
 			"dev": true
 		},
 		"react-fast-compare": {
@@ -30877,9 +29982,9 @@
 			}
 		},
 		"react-portal": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.0.tgz",
-			"integrity": "sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
+			"integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
 			"requires": {
 				"prop-types": "^15.5.8"
 			}
@@ -30965,11 +30070,11 @@
 			}
 		},
 		"react-stripe-elements": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-4.0.2.tgz",
-			"integrity": "sha512-I6JcXMyPNVoYGug7NOQsW3hmtG8+qisvIbQoJmvTyUnD3Nx60rSv3HXiwagt3Q59f/XxwAZiqbIR9ZDYv7fRCQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-5.1.0.tgz",
+			"integrity": "sha512-4UlzOLNdbJsZr4JwbTdJjxhedAfalDDtfEYLHEBo0MKG0KgSLRAeIJup0/6NSpKtBLK4ieOMAwvyln9ICOSilQ==",
 			"requires": {
-				"prop-types": "^15.5.10"
+				"prop-types": "15.7.2"
 			}
 		},
 		"react-syntax-highlighter": {
@@ -31260,25 +30365,25 @@
 			"dev": true
 		},
 		"reakit": {
-			"version": "1.0.0-beta.14",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.0-beta.14.tgz",
-			"integrity": "sha512-/KRlHT7tACx3PVvnX1DOuJxlWnfdfbdoEOJKdVPR8X4a9hkLPOZnLRaCNWKwHTVR7tAuVxo0K+ySsMuxWiGGYw==",
+			"version": "1.0.0-beta.16",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.0-beta.16.tgz",
+			"integrity": "sha512-zytLIb7Ai2b6Yi0/C8lSPSvl/9HI7M8ntO1ty7aoJ9XCKxhFi4Oq1rwF6ja/242cBH7uqspRfhagBhgJniOr8A==",
 			"requires": {
+				"@popperjs/core": "^2.0.5",
 				"body-scroll-lock": "^2.6.4",
-				"popper.js": "^1.16.0",
-				"reakit-system": "^0.7.2",
-				"reakit-utils": "^0.7.3"
+				"reakit-system": "^0.9.0",
+				"reakit-utils": "^0.9.0"
 			}
 		},
 		"reakit-system": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.7.2.tgz",
-			"integrity": "sha512-IY0NwVguy2Awp0DFRzsCBtSnn5gpHtfM3pvfi6Qcwv7Wkms6ZUWxsqFpwNJTMBfXqEBo9dDuIkpCBZivtezYzA=="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.9.0.tgz",
+			"integrity": "sha512-uxhjpxpI3XHAj3OhkDeyyulG3hNgEJ6KtEZbwRXiCv9DOKIe0zwN8qTAXRIKXtP4pu5PyETBh3XEZoxiv4FAww=="
 		},
 		"reakit-utils": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.7.3.tgz",
-			"integrity": "sha512-sQsgKYcn+OthBkvKz+TeHlYZq2SF5ZP9RutHg7O67GI+sdYqf0BVy6VeTe28TG4Vui6hoMheiMnZqhidOtN7EA=="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.9.0.tgz",
+			"integrity": "sha512-qVsGLmsFZv1+A5B/k1xEhFYD8U9fkl8ssvE3D5zIM33V0oIFvVClDTm8Iv96dpB1cod1kolLDKva6FkNxXP+bw=="
 		},
 		"realistic-structured-clone": {
 			"version": "2.0.2",
@@ -31551,9 +30656,9 @@
 			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
 		},
 		"regjsparser": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
-			"integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.3.tgz",
+			"integrity": "sha512-8uZvYbnfAtEm9Ab8NTb3hdLwL4g/LQzEYP7Xs27T96abJCCE2d6r3cPZPQEsLKy0vRSGVNG+/zVGtLr86HQduA==",
 			"requires": {
 				"jsesc": "~0.5.0"
 			}
@@ -31826,9 +30931,9 @@
 					}
 				},
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -32122,9 +31227,9 @@
 			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -32134,7 +31239,7 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
+				"har-validator": "~5.1.3",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
@@ -32144,7 +31249,7 @@
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
+				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
 			},
@@ -32160,27 +31265,11 @@
 						"mime-types": "^2.1.12"
 					}
 				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				},
 				"qs": {
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 					"dev": true
-				},
-				"tough-cookie": {
-					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-					"dev": true,
-					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
-					}
 				}
 			}
 		},
@@ -32232,9 +31321,9 @@
 			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
 		},
 		"resolve": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
-			"integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -32313,12 +31402,12 @@
 			}
 		},
 		"restore-cursor": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
+				"onetime": "^5.1.0",
 				"signal-exit": "^3.0.2"
 			}
 		},
@@ -32354,14 +31443,14 @@
 			},
 			"dependencies": {
 				"unist-util-is": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.1.tgz",
-					"integrity": "sha512-7NYjErP4LJtkEptPR22wO5RsCPnHZZrop7t2SoQzjvpFedCFer4WW8ujj9GI5DkUX7yVcffXLjoURf6h2QUv6Q=="
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
+					"integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ=="
 				},
 				"unist-util-visit": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.1.tgz",
-					"integrity": "sha512-bEDa5S/O8WRDeI1mLaMoKuFFi89AjF+UAoMNxO+bbVdo06q+53Vhq4iiv1PenL6Rx1ZxIpXIzqZoc5HD2I1oMA==",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
+					"integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
 					"requires": {
 						"@types/unist": "^2.0.0",
 						"unist-util-is": "^4.0.0",
@@ -32369,9 +31458,9 @@
 					}
 				},
 				"unist-util-visit-parents": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.1.tgz",
-					"integrity": "sha512-umEOTkm6/y1gIqPrqet55mYqlvGXCia/v1FSc5AveLAI7jFmOAIbqiwcHcviLcusAkEQt1bq2hixCKO9ltMb2Q==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
+					"integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
 					"requires": {
 						"@types/unist": "^2.0.0",
 						"unist-util-is": "^4.0.0"
@@ -32395,9 +31484,9 @@
 			}
 		},
 		"retry": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-			"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 			"dev": true
 		},
 		"reusify": {
@@ -33291,9 +32380,9 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"simple-html-tokenizer": {
-			"version": "0.5.8",
-			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.8.tgz",
-			"integrity": "sha512-0Sq4FvLlQEQODVA6PH2MIrc7tzYO0KT2HzzwvaVLYClWgIsuvaNUOrhrAvTi1pZHrcq7GDB4WiI3ukjqBMxcGQ=="
+			"version": "0.5.9",
+			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.9.tgz",
+			"integrity": "sha512-w/3FEDN94r4JQ9WoYrIr8RqDIPZdyNkdpbK9glFady1CAEyD97XWCv8HFetQO21w81e7h7Nh59iYTyG1mUJftg=="
 		},
 		"simple-swizzle": {
 			"version": "0.2.2",
@@ -33349,14 +32438,6 @@
 				"lolex": "^4.2.0",
 				"nise": "^1.5.2",
 				"supports-color": "^5.5.0"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-					"dev": true
-				}
 			}
 		},
 		"sinon-chai": {
@@ -33914,9 +32995,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -34134,9 +33215,9 @@
 			}
 		},
 		"state-toggle": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
-			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -34684,10 +33765,25 @@
 						}
 					}
 				},
+				"dot-prop": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+					"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+					"dev": true,
+					"requires": {
+						"is-obj": "^2.0.0"
+					}
+				},
+				"is-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+					"dev": true
+				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -34696,12 +33792,12 @@
 					}
 				},
 				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+					"integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.1",
+						"dot-prop": "^5.2.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
@@ -34810,6 +33906,15 @@
 						"path-type": "^3.0.0"
 					}
 				},
+				"dot-prop": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+					"integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+					"dev": true,
+					"requires": {
+						"is-obj": "^2.0.0"
+					}
+				},
 				"file-entry-cache": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-4.0.0.tgz",
@@ -34873,6 +33978,12 @@
 					"integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
 					"dev": true
 				},
+				"is-obj": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+					"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+					"dev": true
+				},
 				"leven": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -34922,9 +34033,9 @@
 					"dev": true
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -34944,21 +34055,15 @@
 					}
 				},
 				"postcss-selector-parser": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+					"integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
 					"dev": true,
 					"requires": {
-						"dot-prop": "^4.1.1",
+						"dot-prop": "^5.2.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
-				},
-				"postcss-value-parser": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -35005,6 +34110,14 @@
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-selector-parser": "^6.0.2",
 				"postcss-value-parser": "^4.0.2"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
+					"integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+					"dev": true
+				}
 			}
 		},
 		"sugarss": {
@@ -35039,9 +34152,9 @@
 					}
 				},
 				"postcss": {
-					"version": "7.0.26",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
-					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2",
@@ -35302,9 +34415,9 @@
 					}
 				},
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -35596,9 +34709,9 @@
 					}
 				},
 				"make-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-					"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
 					"dev": true,
 					"requires": {
 						"semver": "^6.0.0"
@@ -35814,9 +34927,9 @@
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
 		},
 		"tiny-invariant": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-			"integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+			"integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
 		},
 		"tiny-lr": {
 			"version": "1.1.1",
@@ -36131,14 +35244,14 @@
 			"dev": true
 		},
 		"trim-trailing-lines": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-			"integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+			"integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
 		},
 		"trough": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
-			"integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
 		},
 		"true-case-path": {
 			"version": "1.0.3",
@@ -36156,9 +35269,9 @@
 			"dev": true
 		},
 		"ts-dedent": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.0.tgz",
-			"integrity": "sha512-CVCvDwMBWZKjDxpN3mU/Dx1v3k+sJgE8nrhXcC9vRopRfoa7vVzilNvHEAUi5jQnmFHpnxDx5jZdI1TpG8ny2g==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.1.1.tgz",
+			"integrity": "sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==",
 			"dev": true
 		},
 		"ts-loader": {
@@ -36231,9 +35344,9 @@
 			}
 		},
 		"ts-pnp": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.5.tgz",
-			"integrity": "sha512-ti7OGMOUOzo66wLF3liskw6YQIaSsBgc4GOAlWRnIEj8htCxJUxskanMUoJOD6MDCRAXo36goXJZch+nOS0VMA==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
+			"integrity": "sha512-CrG5GqAAzMT7144Cl+UIFP7mz/iIhiy+xQ6GGcnjTezhALT02uPMRw7tgDSESgB5MsfKt55+GPWw4ir1kVtMIQ==",
 			"dev": true
 		},
 		"tslib": {
@@ -36351,9 +35464,9 @@
 			"dev": true
 		},
 		"typeson-registry": {
-			"version": "1.0.0-alpha.34",
-			"resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.34.tgz",
-			"integrity": "sha512-2U0R5eFGJPaqha8HBAICJv6rW2x/cAVHizURHbcAo61Mpd47s+MDn67Ktxoyl9jWgsqCAibZsrldG8v/2ZuCaw==",
+			"version": "1.0.0-alpha.35",
+			"resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.35.tgz",
+			"integrity": "sha512-a/NffrpFswBTyU6w2d6vjk62K1TZ45H64af9AfRbn7LXqNEfL+h+gw3OV2IaG+enfwqgLB5WmbkrNBaQuc/97A==",
 			"dev": true,
 			"requires": {
 				"base64-arraybuffer-es6": "0.5.0",
@@ -36438,12 +35551,12 @@
 			"dev": true
 		},
 		"unherit": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
-			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+			"integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
 			"requires": {
-				"inherits": "^2.0.1",
-				"xtend": "^4.0.1"
+				"inherits": "^2.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
@@ -36618,17 +35731,17 @@
 			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
 		},
 		"unist-util-modify-children": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.5.tgz",
-			"integrity": "sha512-XeL5qqyoS3TEueCKEzHusWXE9JBDJPE4rl6LmcLOwlzv0RIZrcMNqKx02GSK3Ms4v45ldu+ltPxG42FBMVdPZw==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.6.tgz",
+			"integrity": "sha512-TOA6W9QLil+BrHqIZNR4o6IA5QwGOveMbnQxnWYq+7EFORx9vz/CHrtzF36zWrW61E2UKw7sM1KPtIgeceVwXw==",
 			"requires": {
 				"array-iterate": "^1.0.0"
 			}
 		},
 		"unist-util-position": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.4.tgz",
-			"integrity": "sha512-tWvIbV8goayTjobxDIr4zVTyG+Q7ragMSMeKC3xnPl9xzIc0+she8mxXLM3JVNDDsfARPbCd3XdzkyLdo7fF3g=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
+			"integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
 		},
 		"unist-util-remove-position": {
 			"version": "1.1.4",
@@ -36655,9 +35768,9 @@
 			}
 		},
 		"unist-util-visit-children": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-1.1.3.tgz",
-			"integrity": "sha512-/GQ8KNRrG+qD30H76FZNc6Ok+8XTu8lxJByN5LnQ4eQfqxda2gP0CPsCX63BRB26ZRMNf6i1c+jlvNlqysEoFg=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-1.1.4.tgz",
+			"integrity": "sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ=="
 		},
 		"unist-util-visit-parents": {
 			"version": "2.1.2",
@@ -37010,9 +36123,9 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
@@ -37186,9 +36299,9 @@
 			}
 		},
 		"wait-for-expect": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.1.tgz",
-			"integrity": "sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+			"integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
 			"dev": true
 		},
 		"wait-on": {
@@ -38008,13 +37121,26 @@
 			}
 		},
 		"webpack-livereload-plugin": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-2.2.0.tgz",
-			"integrity": "sha512-sx9xA5mHoNOUgLQI0PmXT3KV9ecsVmUaTgr+fsoL69qAOHw/7VzkL1+ZMDQ8n0dPbWounswK6cBRSgMod7Nhgg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-2.3.0.tgz",
+			"integrity": "sha512-vVBLQLlNpElt2sfsBG+XLDeVbQFS4RrniVU8Hi1/hX5ycSfx6mtW8MEEITr2g0Cvo36kuPWShFFDuy+DS7KFMA==",
 			"dev": true,
 			"requires": {
+				"anymatch": "^3.1.1",
 				"portfinder": "^1.0.17",
 				"tiny-lr": "^1.1.1"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				}
 			}
 		},
 		"webpack-log": {
@@ -38532,144 +37658,54 @@
 				"yamlparser": "0.0.2"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.8.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-					"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+				"diff": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+					"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+				},
+				"events": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+					"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+				},
+				"fast-json-stable-stringify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+				},
+				"react-stripe-elements": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-4.0.2.tgz",
+					"integrity": "sha512-I6JcXMyPNVoYGug7NOQsW3hmtG8+qisvIbQoJmvTyUnD3Nx60rSv3HXiwagt3Q59f/XxwAZiqbIR9ZDYv7fRCQ==",
 					"requires": {
-						"regenerator-runtime": "^0.13.2"
+						"prop-types": "^15.5.10"
 					}
 				},
-				"@emotion/core": {
-					"version": "10.0.22",
-					"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.22.tgz",
-					"integrity": "sha512-7eoP6KQVUyOjAkE6y4fdlxbZRA4ILs7dqkkm6oZUJmihtHv0UBq98VgPirq9T8F9K2gKu0J/au/TpKryKMinaA==",
+				"reakit": {
+					"version": "1.0.0-beta.14",
+					"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.0-beta.14.tgz",
+					"integrity": "sha512-/KRlHT7tACx3PVvnX1DOuJxlWnfdfbdoEOJKdVPR8X4a9hkLPOZnLRaCNWKwHTVR7tAuVxo0K+ySsMuxWiGGYw==",
 					"requires": {
-						"@babel/runtime": "^7.5.5",
-						"@emotion/cache": "^10.0.17",
-						"@emotion/css": "^10.0.22",
-						"@emotion/serialize": "^0.11.12",
-						"@emotion/sheet": "0.9.3",
-						"@emotion/utils": "0.11.2"
+						"body-scroll-lock": "^2.6.4",
+						"popper.js": "^1.16.0",
+						"reakit-system": "^0.7.2",
+						"reakit-utils": "^0.7.3"
 					}
 				},
-				"@emotion/sheet": {
-					"version": "0.9.3",
-					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
-					"integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
+				"reakit-system": {
+					"version": "0.7.2",
+					"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.7.2.tgz",
+					"integrity": "sha512-IY0NwVguy2Awp0DFRzsCBtSnn5gpHtfM3pvfi6Qcwv7Wkms6ZUWxsqFpwNJTMBfXqEBo9dDuIkpCBZivtezYzA=="
 				},
-				"@emotion/utils": {
-					"version": "0.11.2",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
-					"integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA=="
+				"reakit-utils": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.7.3.tgz",
+					"integrity": "sha512-sQsgKYcn+OthBkvKz+TeHlYZq2SF5ZP9RutHg7O67GI+sdYqf0BVy6VeTe28TG4Vui6hoMheiMnZqhidOtN7EA=="
 				},
-				"@wordpress/api-fetch": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.11.0.tgz",
-					"integrity": "sha512-RfhGR0tI+g/b89qZmptsu5F5JfH2W0+koGfKzz4d07El5NqETX6SRocENCZd26b1CSRg7sSfMODLRt0bykO9yw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.14.0.tgz",
-					"integrity": "sha512-Q4N3DnIgzmYh2xTgBY8e6Mwu6Y8UeBSX686u3Ypu9GjgSj/XJnLD741+eowVGxbZCEA8NnqBL+R40zgoT75YmA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/priority-queue": "^1.5.0",
-						"@wordpress/redux-routine": "^3.7.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2",
-						"use-memo-one": "^1.1.1"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.7.0.tgz",
-					"integrity": "sha512-Pq5r2/p0+3BgwkinSRMTky+iNerm34qPQeil0UCtFxNP5usJaK2ZI0W/pv6DokomOtxTNZyv2lMRlUoXmglDuQ==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/hooks": "^2.7.0"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-					"integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/escape-html": "^1.7.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
-					"integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.7.0.tgz",
-					"integrity": "sha512-Cr8uGEVxuGLkMq9UsbfAQqSTFVGBDhP8PagyIYJRUX6OkLiUF72OyT3xox7aM+ZlSr3INle2mEO+ZLPw0ieIPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-					"integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/priority-queue": {
-					"version": "1.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.5.0.tgz",
-					"integrity": "sha512-r5Pqv2TXNP7yqDiBhsD/cemnoC/mpnUhOZC1HlJ1mdRSvfIkCk4TDONIAae/MexItVZzxLXdtepIa4FIar1r+w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.7.0.tgz",
-					"integrity": "sha512-dnt/NA4bgXDdkoTlmZrb5QFSgYoVH/lHrJEpy32KyIkxgF8SCvu8aU5lz08hQaV2MQ3OCJA8WtLIAMw0nCidPg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.15",
-						"rungen": "^0.3.2"
-					}
+				"uuid": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+					"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
 				}
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -6208,9 +6208,9 @@
 			}
 		},
 		"@types/wordpress__data": {
-			"version": "4.6.5",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__data/-/wordpress__data-4.6.5.tgz",
-			"integrity": "sha512-mPWutAO05xsMZlgrBefoqza9nbBFU2Zy1e+x4n3uM/+SX257GXSDXhhAYNt2I7kI1c4DB5Q0WxyBc5QtkMheEQ==",
+			"version": "4.6.6",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__data/-/wordpress__data-4.6.6.tgz",
+			"integrity": "sha512-5qqW6kUISwzEyiCN3k8lxtY52wEhxCsrY6U2Af8H0JoICFTz8xv8vV63I1aLCi3K2aKgymeBqx+uzFgt0VL3QA==",
 			"dev": true,
 			"requires": {
 				"@types/wordpress__element": "*",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
 		"@types/wordpress__block-library": "2.6.0",
 		"@types/wordpress__components": "8.5.2",
 		"@types/wordpress__compose": "3.4.0",
-		"@types/wordpress__data": "4.6.5",
+		"@types/wordpress__data": "4.6.6",
 		"@types/wordpress__data-controls": "1.0.1",
 		"@types/wordpress__editor": "9.4.1",
 		"@types/wordpress__element": "2.4.0",

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -7,6 +7,17 @@ export interface CurrentUser {
 	ID: number;
 	display_name: string;
 	username: string;
+
+	/**
+	 * The user's locale slug, e.g. `es`.
+	 */
+	language: string;
+
+	/**
+	 * The user's locale variant, e.g. `es-mx`.
+	 * If there is no variant, `""` empty string is returned.
+	 */
+	locale_variant: string;
 }
 
 export interface NewUser {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add i18n functionality (via `@automattic/react-i18n`) to Gutenboarding.
- Get user locale and locale data before mounting app:
  - Via window globals
  - Via current logged in user locale and fetched locale data


TODO (for consideration): 
- `lang`/`dir` are not set in the DOM.
     https://github.com/Automattic/wp-calypso/blob/f1e7964dc8fb5ee5a7866c61ccee1f6a5ed7b9be/client/lib/i18n-utils/switch-locale.js#L82 (#39491)
- CSS rtl is not switched
     https://github.com/Automattic/wp-calypso/blob/f1e7964dc8fb5ee5a7866c61ccee1f6a5ed7b9be/client/lib/i18n-utils/switch-locale.js#L229 (#39492)
- No user suggested translations are loaded
     https://github.com/Automattic/wp-calypso/blob/f1e7964dc8fb5ee5a7866c61ccee1f6a5ed7b9be/client/lib/i18n-utils/switch-locale.js#L156 (#39493)

#### Testing instructions

[`/gutenboarding`](https://calypso.live/gutenboarding?branch=gutenboarding/i18n-with-hooks)

There are strings in the header that should be localized on boot for logged in users with a non-English language.

- The locale should be loaded on boot with no flash of English.
- The above should be true in development (no server side user bootstrapping) and in production-like environments (with server side user bootstrapping). If `currentUser` or `i18nLocaleStrings` are available on the `window` object, the user was bootstrapped.

##### `es`
![Screen Shot 2020-02-17 at 12 06 55](https://user-images.githubusercontent.com/841763/74648565-3b3ffd80-517e-11ea-859a-3b790ad5772e.png)

##### `de`
![Screen Shot 2020-02-17 at 12 07 46](https://user-images.githubusercontent.com/841763/74648561-39763a00-517e-11ea-9c12-537b100d2a74.png)
