### PR TITLE
Modularise comments state.

### DIFF
--- a/client/state/comments/actions.js
+++ b/client/state/comments/actions.js
@@ -29,12 +29,15 @@ import 'state/data-layer/wpcom/sites/comments-tree';
 import 'state/data-layer/wpcom/sites/comments';
 import 'state/data-layer/wpcom/sites/posts/replies';
 
+import 'state/comments/init';
+
 /**
  * Creates an action that requests a single comment for a given site.
  *
- * @param {number} siteId Site identifier
- * @param {number} commentId Comment identifier
- * @param {object} query API call parameters
+ * @param {object} options options object.
+ * @param {number} options.siteId Site identifier
+ * @param {number} options.commentId Comment identifier
+ * @param {object} options.query API call parameters
  * @returns {object} Action that requests a single comment
  */
 export const requestComment = ( { siteId, commentId, query = {} } ) => ( {
@@ -47,10 +50,11 @@ export const requestComment = ( { siteId, commentId, query = {} } ) => ( {
 /**
  * Creates an action for receiving comments for a specific post on a site.
  *
- * @param {number} siteId site identifier
- * @param {number} postId post identifier
- * @param {Array} comments the list of comments received
- * @param {boolean} commentById were the comments retrieved by ID directly?
+ * @param {object} options options object.
+ * @param {number} options.siteId site identifier
+ * @param {number} options.postId post identifier
+ * @param {Array} options.comments the list of comments received
+ * @param {boolean} options.commentById were the comments retrieved by ID directly?
  * @returns {object} Action for receiving comments
  */
 export const receiveComments = ( { siteId, postId, comments, commentById = false } ) => ( {
@@ -64,8 +68,9 @@ export const receiveComments = ( { siteId, postId, comments, commentById = false
 /**
  * Creates an action for receiving comment errors.
  *
- * @param {number} siteId site identifier
- * @param {number} commentId comment identifier
+ * @param {object} options options object.
+ * @param {number} options.siteId site identifier
+ * @param {number} options.commentId comment identifier
  * @returns {object} Action for receiving comment errors
  */
 export const receiveCommentsError = ( { siteId, commentId } ) => ( {
@@ -77,9 +82,10 @@ export const receiveCommentsError = ( { siteId, commentId } ) => ( {
 /**
  * Creates an action that requests comments for a given post
  *
- * @param {number} siteId site identifier
- * @param {number} postId post identifier
- * @param {string} status status filter. Defaults to approved posts
+ * @param {object} options options object.
+ * @param {number} options.siteId site identifier
+ * @param {number} options.postId post identifier
+ * @param {string} options.status status filter. Defaults to approved posts
  * @returns {Function} action that requests comments for a given post
  */
 export function requestPostComments( {
@@ -352,9 +358,10 @@ export const expandComments = ( { siteId, commentIds, postId, displayType } ) =>
  * Creates an action that sets the active reply for a given site ID and post ID
  * This is used on the front end to show a reply box under the specified comment.
  *
- * @param {number} siteId site identifier
- * @param {number} postId post identifier
- * @param {number} commentId comment identifier
+ * @param {object} options options object.
+ * @param {number} options.siteId site identifier
+ * @param {number} options.postId post identifier
+ * @param {number} options.commentId comment identifier
  * @returns {object} Action to set active reply
  */
 export const setActiveReply = ( { siteId, postId, commentId } ) => ( {

--- a/client/state/comments/init.js
+++ b/client/state/comments/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import commentsReducer from './reducer';
+
+registerReducer( [ 'comments' ], commentsReducer );

--- a/client/state/comments/package.json
+++ b/client/state/comments/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/comments/reducer.js
+++ b/client/state/comments/reducer.js
@@ -40,7 +40,7 @@ import {
 	READER_EXPAND_COMMENTS,
 	COMMENTS_SET_ACTIVE_REPLY,
 } from 'state/action-types';
-import { combineReducers, keyedReducer, withoutPersistence } from 'state/utils';
+import { combineReducers, keyedReducer, withoutPersistence, withStorageKey } from 'state/utils';
 import {
 	PLACEHOLDER_STATE,
 	NUMBER_OF_COMMENTS_PER_FETCH,
@@ -528,7 +528,7 @@ export const counts = withoutPersistence( ( state = {}, action ) => {
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	counts,
 	items,
 	pendingItems,
@@ -540,3 +540,5 @@ export default combineReducers( {
 	treesInitialized,
 	activeReplies,
 } );
+const commentsReducer = withStorageKey( 'comments', combinedReducer );
+export default commentsReducer;

--- a/client/state/comments/selectors.js
+++ b/client/state/comments/selectors.js
@@ -25,6 +25,8 @@ import treeSelect from '@automattic/tree-select';
 import { fetchStatusInitialState } from './reducer';
 import { getStateKey, deconstructStateKey, getErrorKey } from './utils';
 
+import 'state/comments/init';
+
 /**
  * Gets comment items for post
  *

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -24,7 +24,6 @@ import atomicHosting from './hosting/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import checklist from './checklist/reducer';
-import comments from './comments/reducer';
 import connectedApplications from './connected-applications/reducer';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
@@ -116,7 +115,6 @@ const reducers = {
 	atomicTransfer,
 	billingTransactions,
 	checklist,
-	comments,
 	connectedApplications,
 	countries,
 	countryStates,

--- a/client/state/selectors/get-active-reply-comment-id.js
+++ b/client/state/selectors/get-active-reply-comment-id.js
@@ -8,12 +8,15 @@ import { get } from 'lodash';
  */
 import { getStateKey } from 'state/comments/utils';
 
+import 'state/comments/init';
+
 /**
  * Returns the active reply comment for a given site and post.
  *
- * @param  {object}  state   Global state tree
- * @param  {number}  siteId  The ID of the site we're querying
- * @param  {number}  postId  The ID of the post we're querying
+ * @param  {object}  options options object.
+ * @param  {object}  options.state   Global state tree
+ * @param  {number}  options.siteId  The ID of the site we're querying
+ * @param  {number}  options.postId  The ID of the post we're querying
  * @returns {number|string}	commentId 	Can be a string if the comment is a placeholder
  */
 export default function getActiveReplyCommentId( { state, siteId, postId } ) {

--- a/client/state/selectors/get-site-comment-counts.js
+++ b/client/state/selectors/get-site-comment-counts.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import 'state/comments/init';
 
 /**
  * Return comment counts for the given site and post ID, if applicable.

--- a/client/state/selectors/get-site-comment-parent-depth.js
+++ b/client/state/selectors/get-site-comment-parent-depth.js
@@ -9,6 +9,8 @@ import { get } from 'lodash';
 import createSelector from 'lib/create-selector';
 import getSiteComment from 'state/selectors/get-site-comment';
 
+import 'state/comments/init';
+
 export const getSiteCommentParentDepth = createSelector(
 	( state, siteId, commentId ) => {
 		const comment = getSiteComment( state, siteId, commentId );

--- a/client/state/selectors/get-site-comment-replies-tree.js
+++ b/client/state/selectors/get-site-comment-replies-tree.js
@@ -9,6 +9,8 @@ import { filter, get } from 'lodash';
 import createSelector from 'lib/create-selector';
 import getSiteCommentsTree from 'state/selectors/get-site-comments-tree';
 
+import 'state/comments/init';
+
 export const getSiteCommentRepliesTree = createSelector(
 	( state, siteId, status, commentParentId ) =>
 		filter( getSiteCommentsTree( state, siteId, status ), { commentParentId } ),

--- a/client/state/selectors/get-site-comment.js
+++ b/client/state/selectors/get-site-comment.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { find } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getSiteComments from 'state/selectors/get-site-comments';
+
+import 'state/comments/init';
 
 /**
  * Returns a comment for the specified site and comment ID.

--- a/client/state/selectors/get-site-comments-tree.js
+++ b/client/state/selectors/get-site-comments-tree.js
@@ -8,6 +8,8 @@ import { filter, get } from 'lodash';
  */
 import createSelector from 'lib/create-selector';
 
+import 'state/comments/init';
+
 /**
  * Returns a tree of loaded comments for a given site, filtered by status
  *

--- a/client/state/selectors/get-site-comments.js
+++ b/client/state/selectors/get-site-comments.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { filter, get, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+
+import 'state/comments/init';
 
 function filterCommentsByStatus( comments, status ) {
 	return 'all' === status

--- a/client/state/selectors/is-comments-tree-initialized.js
+++ b/client/state/selectors/is-comments-tree-initialized.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/comments/init';
+
+/**
  * Returns true if a comment tree has been initialized.
  *
  * @param  {object}  state    Global state tree


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles comments.

For mode details on state modularisation, see #39261 and p4TIVU-9lM-p2.

In the interest of keeping this PR short, I will create a subsequent PR for moving comment-related selectors under `state/comments`, instead of handling those changes here too.

#### Changes proposed in this Pull Request

* Modularise comments state
* Minor lint fixes to touched files

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/home`.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `comments` key, even if you expand the list of keys. This indicates that the comments state hasn't been loaded yet.
* Click `Reader` on the masterbar.
* Verify that a `comments` key is added with the comments state. This indicates that the comments state has now been loaded.
* Verify that comments-related functionality works normally. This indicates that I didn't mess up.