### PR TITLE
FSE: adds GitHub workflow to build the plugin

### DIFF
--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -1,7 +1,12 @@
 on:
   push:
     paths:
+    - 'apps/full-site-editing/full-site-editing-plugin/**'
+    branches:
+    - master
+  pull_request:
     # only trigger this workflow if FSE plugin files have been modified
+    paths:
     - 'apps/full-site-editing/full-site-editing-plugin/**'
 
 name: Build Full Site Editing plugin

--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    paths:
+    # only trigger this workflow if FSE plugin files have been modified
+    - 'apps/full-site-editing/full-site-editing-plugin/**'
+
+name: Build Full Site Editing plugin
+
+jobs:
+  build:
+    name: Build FSE plugin
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@master
+    - name: Install dependencies
+      run: npm ci
+    - name: Build FSE
+      run: npx lerna run build --scope='@automattic/full-site-editing' --stream
+    - name: Create FSE plugin archive
+      run: tar -czvf fse-build-archive.tar.gz -C apps/full-site-editing/full-site-editing-plugin .
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: fse-build-archive.tar.gz
+        path: ./fse-build-archive.tar.gz


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This will build the plugin files and create an appropriate archive artifact that will be uploaded to GitHub workflow results.

The results of the run should look like the following in the GitHub actions tab of the repo.

<img width="1680" alt="Screenshot 2020-02-12 at 19 06 02" src="https://user-images.githubusercontent.com/1182160/74363384-c27e2180-4dca-11ea-9430-c3af77a7f4a8.png">

<img width="1680" alt="Screenshot 2020-02-12 at 19 05 39" src="https://user-images.githubusercontent.com/1182160/74363377-bf833100-4dca-11ea-9e9b-61498b1cdec3.png">

Even with just this I think it's better than CircleCI job because it completes a lot faster and it's easier to find the archive here. In addition to that the workflow will only be triggered when there are actual changes that affect FSE, and not for every Calypso PR.

#### Testing instructions

This workflow won't run on `wp-calypso` repo until it's merged to master. One way to test it would be to fork the repository and commit this change to your fork. After that you can push a random change to the FSE plugin that will trigger the workflow. Keep in mind that it will ignore the changes that are not part of the `'apps/full-site-editing/full-site-editing-plugin/**'` tree.