### PR TITLE
Add support for i18n to Jetpack Cloud masterbar and sidebar

### DIFF
--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,12 +17,14 @@ import Masterbar from 'layout/masterbar/masterbar';
 import './style.scss';
 
 export default function() {
+	const translate = useTranslate();
+
 	return (
 		<Masterbar>
 			<Item
 				className="masterbar__item-home"
 				url="/"
-				tooltip="Jetpack Cloud Homepage" /* @todo: localize the string */
+				tooltip={ translate( 'Jetpack Cloud Homepage' ) }
 			>
 				<JetpackLogo size={ 28 } full monochrome />
 			</Item>

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -24,7 +24,7 @@ export default function() {
 			<Item
 				className="masterbar__item-home"
 				url="/"
-				tooltip={ translate( 'Jetpack Cloud Homepage', {
+				tooltip={ translate( 'Jetpack Cloud Dashboard', {
 					comment: 'Jetpack Cloud masterbar nav item',
 				} ) }
 			>

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -25,7 +25,7 @@ export default function() {
 				className="masterbar__item-home"
 				url="/"
 				tooltip={ translate( 'Jetpack Cloud Dashboard', {
-					comment: 'Jetpack Cloud masterbar nav item',
+					comment: 'Jetpack Cloud top navigation bar item',
 				} ) }
 			>
 				<JetpackLogo size={ 28 } full monochrome />

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -24,7 +24,9 @@ export default function() {
 			<Item
 				className="masterbar__item-home"
 				url="/"
-				tooltip={ translate( 'Jetpack Cloud Homepage' ) }
+				tooltip={ translate( 'Jetpack Cloud Homepage', {
+					comment: 'Jetpack Cloud masterbar nav item',
+				} ) }
 			>
 				<JetpackLogo size={ 28 } full monochrome />
 			</Item>

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -69,6 +70,8 @@ class JetpackCloudSidebar extends Component {
 	};
 
 	render() {
+		const { translate } = this.props;
+
 		return (
 			<Sidebar>
 				<SidebarRegion>
@@ -76,7 +79,7 @@ class JetpackCloudSidebar extends Component {
 					<SidebarMenu>
 						<SidebarItem
 							link="/"
-							label="Dashboard" // @todo: Localize
+							label={ translate( 'Dashboard' ) }
 							materialIcon="dashboard"
 							materialIconStyle="filled"
 							selected={ this.isSelected( '/' ) }
@@ -87,23 +90,23 @@ class JetpackCloudSidebar extends Component {
 						onClick={ this.handleExpandableMenuClick( '/backups' ) }
 						materialIcon="backup"
 						materialIconStyle="filled"
-						title="Backups" // @todo: Localize
+						title={ translate( 'Backups' ) }
 					>
 						<ul>
 							<SidebarItem
-								label="Backups" // @todo: Localize
+								label={ translate( 'Backups' ) }
 								link="/backups"
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/backups' ) }
 							/>
 							<SidebarItem
-								label="Restore site" // @todo: Localize
+								label={ translate( 'Restore site' ) }
 								link="#" // @todo: Add /backup/restore route
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/backups/restore' ) }
 							/>
 							<SidebarItem
-								label="Settings" // @todo: Localize
+								label={ translate( 'Settings' ) }
 								link="#" // @todo: Add backup/settings route
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/backups/settings' ) }
@@ -115,23 +118,23 @@ class JetpackCloudSidebar extends Component {
 						onClick={ this.handleExpandableMenuClick( '/scan' ) }
 						materialIcon="security" // @todo: The Scan logo differs from the Material Icon used here
 						materialIconStyle="filled"
-						title="Scan" // @todo: Localize
+						title={ translate( 'Scan' ) }
 					>
 						<ul>
 							<SidebarItem
-								label="Scanner" // @todo: Localize
+								label={ translate( 'Scanner' ) }
 								link="/scan"
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/scan' ) }
 							/>
 							<SidebarItem
-								label="History" // @todo: Localize
+								label={ translate( 'History' ) }
 								link="#" // @todo: Add /scan/history route
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/scan/history' ) }
 							/>
 							<SidebarItem
-								label="Settings" // @todo: Localize
+								label={ translate( 'Settings' ) }
 								link="#" // @todo: Add /scan/settings route
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/scan/settings' ) }
@@ -142,7 +145,7 @@ class JetpackCloudSidebar extends Component {
 				<SidebarFooter>
 					<SidebarMenu>
 						<SidebarItem
-							label="Support" // @todo: Localize
+							label={ translate( 'Support' ) }
 							link="#" // @todo: Add /support route or change link to other destination
 							materialIcon="help"
 							materialIconStyle="filled"
@@ -151,7 +154,7 @@ class JetpackCloudSidebar extends Component {
 						/>
 						<SidebarItem
 							forceInternalLink={ true }
-							label="Manage site" // @todo: Localize
+							label={ translate( 'Manage site' ) }
 							link="https://wordpress.com/stats" // @todo: Confirm a correct link is used here
 							materialIcon="arrow_back"
 							materialIconStyle="filled"
@@ -163,4 +166,4 @@ class JetpackCloudSidebar extends Component {
 	}
 }
 
-export default JetpackCloudSidebar;
+export default localize( JetpackCloudSidebar );

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -79,7 +79,9 @@ class JetpackCloudSidebar extends Component {
 					<SidebarMenu>
 						<SidebarItem
 							link="/"
-							label={ translate( 'Dashboard' ) }
+							label={ translate( 'Dashboard', {
+								comment: 'Jetpack Cloud sidebar navigation item',
+							} ) }
 							materialIcon="dashboard"
 							materialIconStyle="filled"
 							selected={ this.isSelected( '/' ) }
@@ -90,23 +92,29 @@ class JetpackCloudSidebar extends Component {
 						onClick={ this.handleExpandableMenuClick( '/backups' ) }
 						materialIcon="backup"
 						materialIconStyle="filled"
-						title={ translate( 'Backups' ) }
+						title={ translate( 'Backups', { comment: 'Jetpack Cloud sidebar navigation item' } ) }
 					>
 						<ul>
 							<SidebarItem
-								label={ translate( 'Backups' ) }
+								label={ translate( 'Backups', {
+									comment: 'Jetpack Cloud sidebar navigation item',
+								} ) }
 								link="/backups"
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/backups' ) }
 							/>
 							<SidebarItem
-								label={ translate( 'Restore site' ) }
+								label={ translate( 'Restore site', {
+									comment: 'Jetpack Cloud / Backups sidebar navigation item',
+								} ) }
 								link="#" // @todo: Add /backup/restore route
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/backups/restore' ) }
 							/>
 							<SidebarItem
-								label={ translate( 'Settings' ) }
+								label={ translate( 'Settings', {
+									comment: 'Jetpack Cloud / Backups sidebar navigation item',
+								} ) }
 								link="#" // @todo: Add backup/settings route
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/backups/settings' ) }
@@ -118,23 +126,29 @@ class JetpackCloudSidebar extends Component {
 						onClick={ this.handleExpandableMenuClick( '/scan' ) }
 						materialIcon="security" // @todo: The Scan logo differs from the Material Icon used here
 						materialIconStyle="filled"
-						title={ translate( 'Scan' ) }
+						title={ translate( 'Scan', { comment: 'Jetpack Cloud sidebar navigation item' } ) }
 					>
 						<ul>
 							<SidebarItem
-								label={ translate( 'Scanner' ) }
+								label={ translate( 'Scanner', {
+									comment: 'Jetpack Cloud / Scan sidebar navigation item',
+								} ) }
 								link="/scan"
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/scan' ) }
 							/>
 							<SidebarItem
-								label={ translate( 'History' ) }
+								label={ translate( 'History', {
+									comment: 'Jetpack Cloud / Scan sidebar navigation item',
+								} ) }
 								link="#" // @todo: Add /scan/history route
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/scan/history' ) }
 							/>
 							<SidebarItem
-								label={ translate( 'Settings' ) }
+								label={ translate( 'Settings', {
+									comment: 'Jetpack Cloud / Scan sidebar navigation item',
+								} ) }
 								link="#" // @todo: Add /scan/settings route
 								onNavigate={ this.onNavigate }
 								selected={ this.isSelected( '/scan/settings' ) }
@@ -145,7 +159,7 @@ class JetpackCloudSidebar extends Component {
 				<SidebarFooter>
 					<SidebarMenu>
 						<SidebarItem
-							label={ translate( 'Support' ) }
+							label={ translate( 'Support', { comment: 'Jetpack Cloud sidebar navigation item' } ) }
 							link="#" // @todo: Add /support route or change link to other destination
 							materialIcon="help"
 							materialIconStyle="filled"
@@ -154,7 +168,9 @@ class JetpackCloudSidebar extends Component {
 						/>
 						<SidebarItem
 							forceInternalLink={ true }
-							label={ translate( 'Manage site' ) }
+							label={ translate( 'Manage site', {
+								comment: 'Jetpack Cloud sidebar navigation item',
+							} ) }
 							link="https://wordpress.com/stats" // @todo: Confirm a correct link is used here
 							materialIcon="arrow_back"
 							materialIconStyle="filled"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `i18n-calypso` HoC and hook in Masterbar and Sidebar

<img width="674" alt="Screenshot 2020-02-12 at 19 01 44" src="https://user-images.githubusercontent.com/478735/74363434-d88be200-4dca-11ea-8b71-3160b4f10193.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/me/account
* Switch the language to something else than EN (e.g. DE) and save
* Go to http://jetpack.cloud.localhost:3000/
* Confirm that the menu items in the sidebar are translated

Please note that if using any other language than EN, a console error message is thrown:

<img width="689" alt="Screenshot 2020-02-12 at 19 03 50" src="https://user-images.githubusercontent.com/478735/74363518-fd805500-4dca-11ea-9226-c4cea25d882c.png">

It seems it's caused because of the fact that the `<Layout />` is not wrapped with a `<MomentProvider />`, even though we are not making any use of `moment` just yet.

I tried fixing the issue, however it seems we first need a Redux store to be added to the app since `<MomentProvider />` relies on it. Because the problem is more complex than I initially thought, it will get fixed in another PR.

Fixes 1156570014567299-as-1158979045972118
