### PR TITLE
composite-checkout: Add abtest for phase 1 launch

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -26,6 +26,15 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
+	showCompositeCheckout: {
+		datestamp: '20200214',
+		variations: {
+			composite: 10,
+			regular: 90,
+		},
+		defaultVariation: 'regular',
+		allowExistingUsers: true,
+	},
 	skipThemesSelectionModal: {
 		datestamp: '20170904',
 		variations: {

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -9,7 +9,6 @@ import React from 'react';
 import CheckoutContainer from './checkout-container';
 import CompositeCheckout from './composite-checkout';
 import config from 'config';
-import CartData from 'components/data/cart';
 import { abtest } from 'lib/abtest';
 
 // Decide if we should use CompositeCheckout or CheckoutContainer
@@ -25,20 +24,19 @@ export default function CheckoutSystemDecider( {
 	redirectTo,
 	upgradeIntent,
 	clearTransaction,
+	cart,
 } ) {
-	if ( shouldShowCompositeCheckout() ) {
+	if ( shouldShowCompositeCheckout( cart ) ) {
 		return (
-			<CartData>
-				<CompositeCheckout
-					siteSlug={ selectedSite?.slug }
-					siteId={ selectedSite?.ID }
-					product={ product }
-					purchaseId={ purchaseId }
-					couponCode={ couponCode }
-					redirectTo={ redirectTo }
-					feature={ selectedFeature }
-				/>
-			</CartData>
+			<CompositeCheckout
+				siteSlug={ selectedSite?.slug }
+				siteId={ selectedSite?.ID }
+				product={ product }
+				purchaseId={ purchaseId }
+				couponCode={ couponCode }
+				redirectTo={ redirectTo }
+				feature={ selectedFeature }
+			/>
 		);
 	}
 
@@ -59,15 +57,18 @@ export default function CheckoutSystemDecider( {
 	);
 }
 
-function shouldShowCompositeCheckout() {
+function shouldShowCompositeCheckout( cart ) {
 	if ( ! config.isEnabled( 'composite-checkout-wpcom' ) ) {
 		return false;
 	}
-	// TODO: if a domain product is in the cart, return false
+	if ( cart?.products?.find( product => product.is_domain_registration ) ) {
+		return false;
+	}
 	// TODO: if a non-wpcom product is in the cart, return false
 	// TODO: if the language is not en-us, return false
 	// TODO: if the geolocation is not in the US, return false
 	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
 		return true;
 	}
+	return false;
 }

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -67,16 +67,23 @@ function shouldShowCompositeCheckout( cart, countryCode, locale ) {
 	if ( config.isEnabled( 'composite-checkout-wpcom' ) ) {
 		return true;
 	}
+	// Disable for domains in the cart
 	if ( cart?.products?.find( product => product.is_domain_registration ) ) {
 		return false;
 	}
-	// TODO: if a non-wpcom product is in the cart, return false
+	// Disable for jetpack plans
+	if ( cart?.products?.find( product => product.product_slug.includes( 'jetpack' ) ) ) {
+		return false;
+	}
+	// Disable for non-EN
 	if ( ! locale?.toLowerCase().startsWith( 'en' ) ) {
 		return false;
 	}
+	// Disable for non-US
 	if ( countryCode?.toLowerCase() !== 'us' ) {
 		return false;
 	}
+
 	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
 		return true;
 	}

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -11,8 +11,7 @@ import CheckoutContainer from './checkout-container';
 import CompositeCheckout from './composite-checkout';
 import config from 'config';
 import { abtest } from 'lib/abtest';
-import { getCurrentUserLocale } from 'state/current-user/selectors';
-import { getGeoCountryShort } from 'state/geo/selectors';
+import { getCurrentUserLocale, getCurrentUserCountryCode } from 'state/current-user/selectors';
 
 // Decide if we should use CompositeCheckout or CheckoutContainer
 export default function CheckoutSystemDecider( {
@@ -29,7 +28,7 @@ export default function CheckoutSystemDecider( {
 	clearTransaction,
 	cart,
 } ) {
-	const countryCode = useSelector( state => getGeoCountryShort( state ) );
+	const countryCode = useSelector( state => getCurrentUserCountryCode( state ) );
 	const locale = useSelector( state => getCurrentUserLocale( state ) );
 
 	if ( shouldShowCompositeCheckout( cart, countryCode, locale ) ) {

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal Dependencies
+ */
+import CheckoutContainer from './checkout-container';
+import CompositeCheckout from './composite-checkout';
+import config from 'config';
+import CartData from 'components/data/cart';
+import { abtest } from 'lib/abtest';
+
+// Decide if we should use CompositeCheckout or CheckoutContainer
+export default function CheckoutSystemDecider( {
+	product,
+	purchaseId,
+	selectedFeature,
+	couponCode,
+	isComingFromSignup,
+	plan,
+	selectedSite,
+	reduxStore,
+	redirectTo,
+	upgradeIntent,
+	clearTransaction,
+} ) {
+	if ( shouldShowCompositeCheckout() ) {
+		return (
+			<CartData>
+				<CompositeCheckout
+					siteSlug={ selectedSite?.slug }
+					siteId={ selectedSite?.ID }
+					product={ product }
+					purchaseId={ purchaseId }
+					couponCode={ couponCode }
+					redirectTo={ redirectTo }
+					feature={ selectedFeature }
+				/>
+			</CartData>
+		);
+	}
+
+	return (
+		<CheckoutContainer
+			product={ product }
+			purchaseId={ purchaseId }
+			selectedFeature={ selectedFeature }
+			couponCode={ couponCode }
+			isComingFromSignup={ isComingFromSignup }
+			plan={ plan }
+			selectedSite={ selectedSite }
+			reduxStore={ reduxStore }
+			redirectTo={ redirectTo }
+			upgradeIntent={ upgradeIntent }
+			clearTransaction={ clearTransaction }
+		/>
+	);
+}
+
+function shouldShowCompositeCheckout() {
+	if ( ! config.isEnabled( 'composite-checkout-wpcom' ) ) {
+		return false;
+	}
+	// TODO: if a domain product is in the cart, return false
+	// TODO: if a non-wpcom product is in the cart, return false
+	// TODO: if the language is not en-us, return false
+	// TODO: if the geolocation is not in the US, return false
+	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
+		return true;
+	}
+}

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -66,8 +66,16 @@ function shouldShowCompositeCheckout( cart, countryCode, locale ) {
 	if ( config.isEnabled( 'composite-checkout-wpcom' ) ) {
 		return true;
 	}
+	// Disable for non-USD
+	if ( cart?.currency !== 'USD' ) {
+		return false;
+	}
 	// Disable for domains in the cart
 	if ( cart?.products?.find( product => product.is_domain_registration ) ) {
+		return false;
+	}
+	// Disable for GSuite plans
+	if ( cart?.products?.find( product => product.product_slug.includes( 'gapps' ) ) ) {
 		return false;
 	}
 	// Disable for jetpack plans

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -64,8 +64,8 @@ export default function CheckoutSystemDecider( {
 }
 
 function shouldShowCompositeCheckout( cart, countryCode, locale ) {
-	if ( ! config.isEnabled( 'composite-checkout-wpcom' ) ) {
-		return false;
+	if ( config.isEnabled( 'composite-checkout-wpcom' ) ) {
+		return true;
 	}
 	if ( cart?.products?.find( product => product.is_domain_registration ) ) {
 		return false;

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -25,7 +25,6 @@ import {
 	createApplePayMethod,
 	createExistingCardMethod,
 } from '@automattic/composite-checkout';
-import { Card } from '@automattic/components';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -464,7 +463,6 @@ export default function CompositeCheckout( {
 
 	return (
 		<React.Fragment>
-			<TestingBanner />
 			<CheckoutProvider
 				locale={ 'en-us' }
 				items={ itemsForCheckout }
@@ -703,19 +701,6 @@ function CountrySelectMenu( {
 				aria-describedby={ countrySelectorDescriptionId }
 			/>
 		</FormFieldAnnotation>
-	);
-}
-
-function TestingBanner() {
-	return (
-		<Card
-			className="composite-checkout__testing-banner"
-			highlight="warning"
-			href="https://github.com/Automattic/wp-calypso/issues/new?title=New%20checkout&body=%3C!--%20Thanks%20for%20filling%20your%20bug%20report%20for%20our%20New%20checkout!%20Pick%20a%20clear%20title%20(%22New%20checkout%3A%20Continue%20button%20not%20working%22)%20and%20proceed.%20--%3E%0A%0A%23%23%23%23%20Steps%20to%20reproduce%0A1.%20Starting%20at%20URL%3A%0A2.%0A3.%0A4.%0A%0A%23%23%23%23%20What%20I%20expected%0A%0A%0A%23%23%23%23%20What%20happened%20instead%0A%0A%0A%23%23%23%23%20Browser%20%2F%20OS%20version%0A%0A%0A%23%23%23%23%20Screenshot%20%2F%20Video%20(Optional)%0A%0A%40sirbrillig%2C%20%40nbloomf%2C%20%40fditrapani%20%0A"
-		>
-			Warning! This checkout is a new feature still in testing. If you encounter issues, please
-			click here to report them.
-		</Card>
 	);
 }
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -22,6 +22,7 @@ import UpsellNudge from './upsell-nudge';
 import { isGSuiteRestricted } from 'lib/gsuite';
 import { getRememberedCoupon } from 'lib/cart/actions';
 import { sites } from 'my-sites/controller';
+import CartData from 'components/data/cart';
 
 export function checkout( context, next ) {
 	const { feature, plan, domainOrProduct, purchaseId } = context.params;
@@ -54,19 +55,21 @@ export function checkout( context, next ) {
 	const couponCode = context.query.coupon || context.query.code || getRememberedCoupon();
 
 	context.primary = (
-		<CheckoutSystemDecider
-			product={ product }
-			purchaseId={ purchaseId }
-			selectedFeature={ feature }
-			couponCode={ couponCode }
-			isComingFromSignup={ !! context.query.signup }
-			plan={ plan }
-			selectedSite={ selectedSite }
-			reduxStore={ context.store }
-			redirectTo={ context.query.redirect_to }
-			upgradeIntent={ context.query.intent }
-			clearTransaction={ false }
-		/>
+		<CartData>
+			<CheckoutSystemDecider
+				product={ product }
+				purchaseId={ purchaseId }
+				selectedFeature={ feature }
+				couponCode={ couponCode }
+				isComingFromSignup={ !! context.query.signup }
+				plan={ plan }
+				selectedSite={ selectedSite }
+				reduxStore={ context.store }
+				redirectTo={ context.query.redirect_to }
+				upgradeIntent={ context.query.intent }
+				clearTransaction={ false }
+			/>
+		</CartData>
 	);
 
 	next();

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -24,6 +24,7 @@ import { sites } from 'my-sites/controller';
 import config from 'config';
 import CompositeCheckout from './checkout/composite-checkout';
 import CartData from 'components/data/cart';
+import { abtest } from 'lib/abtest';
 
 export function checkout( context, next ) {
 	const { feature, plan, domainOrProduct, purchaseId } = context.params;
@@ -54,7 +55,7 @@ export function checkout( context, next ) {
 
 	const couponCode = context.query.coupon || context.query.code || getRememberedCoupon();
 
-	if ( config.isEnabled( 'composite-checkout-wpcom' ) ) {
+	if ( shouldShowCompositeCheckout() ) {
 		context.primary = (
 			<CartData>
 				<CompositeCheckout
@@ -217,4 +218,17 @@ export function redirectToSupportSession( context ) {
 		page.redirect( `/checkout/offer-support-session/${ receiptId }/${ site }` );
 	}
 	page.redirect( `/checkout/offer-support-session/${ site }` );
+}
+
+function shouldShowCompositeCheckout() {
+	if ( ! config.isEnabled( 'composite-checkout-wpcom' ) ) {
+		return false;
+	}
+	// TODO: if a domain product is in the cart, return false
+	// TODO: if a non-wpcom product is in the cart, return false
+	// TODO: if the language is not en-us, return false
+	// TODO: if the geolocation is not in the US, return false
+	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
+		return true;
+	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,7 +21,6 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
-		"composite-checkout-wpcom": true,
 		"devdocs": false,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR modifies the checkout route so that Composite Checkout is loaded for everyone if all of the following are true, or the `composite-checkout-wpcom` config flag is enabled:

- Cart contains no domain registrations
- Cart contains no Jetpack products
- User has EN language
- User has US geolocation
- User is placed in `showCompositeCheckout` abtest (10%).

This PR also removes the "testing" banner from Composite Checkout and removes the `composite-checkout-wpcom` config flag from the horizon environment (so that environment will behave as all the others).

#### Testing instructions

- Start calypso _without_ the `composite-checkout-wpcom` flag.
- Use the local environment badge in the lower-right to enable the `showCompositeCheckout` test.
- Visit checkout with a wpcom plan in the cart when you are in the US and have your language set to English. Verify that you see composite checkout.
- Visit checkout with a wpcom plan in the cart when you are not in the US. Verify that you see the regular checkout.
- Visit checkout with a wpcom plan in the cart when you are in the US and have your language set to something other than English. Verify that you see the regular checkout.
- Visit checkout with a domain in the cart. Verify that you see the regular checkout.
- Visit checkout with a jetpack plan in the cart. Verify that you see the regular checkout.