### PR TITLE
Fixes the issue of missing "Continue with your free site" option in site launch flow

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -236,7 +236,16 @@ class DomainsStep extends React.Component {
 
 		this.props.recordTracksEvent( 'calypso_signup_skip_step', tracksProperties );
 
-		this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );
+		const stepData = {
+			stepName: this.props.stepName,
+			suggestion: undefined,
+		};
+
+		this.props.saveSignupStep( stepData );
+
+		defer( () => {
+			this.submitWithDomain( googleAppsCartItem, shouldHideFreePlan );
+		} );
 	};
 
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -249,36 +249,13 @@ class DomainsStep extends React.Component {
 	};
 
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const shouldHideFreePlanItem = this.isEligibleVariantForDomainTest()
+		const shouldHideFreePlanItem = this.isEligibleVariantForDomainTest() && shouldHideFreePlan
 			? { shouldHideFreePlan }
 			: {};
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
 		const useThemeHeadstartItem = shouldUseThemeAnnotation
 			? { useThemeHeadstart: shouldUseThemeAnnotation }
 			: {};
-
-		if ( shouldHideFreePlan ) {
-			let domainItem, isPurchasingItem, siteUrl;
-
-			this.props.submitSignupStep(
-				Object.assign(
-					{
-						stepName: this.props.stepName,
-						domainItem,
-						googleAppsCartItem,
-						isPurchasingItem,
-						siteUrl,
-						stepSectionName: this.props.stepSectionName,
-					},
-					this.getThemeArgs()
-				),
-				Object.assign( { domainItem }, shouldHideFreePlanItem, useThemeHeadstartItem )
-			);
-
-			this.props.goToNextStep();
-
-			return;
-		}
 
 		const suggestion = this.props.step.suggestion;
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -249,7 +249,7 @@ class DomainsStep extends React.Component {
 	};
 
 	submitWithDomain = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
-		const shouldHideFreePlanItem = this.isEligibleVariantForDomainTest() && shouldHideFreePlan
+		const shouldHideFreePlanItem = this.isEligibleVariantForDomainTest()
 			? { shouldHideFreePlan }
 			: {};
 		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();

--- a/config/development.json
+++ b/config/development.json
@@ -123,7 +123,7 @@
 		"oauth": false,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans-step-copy-updates": true,
+		"plans/personal-plan": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When the domain step in signup is skipped, the `suggestion` prop value is set to `undefined` so that it overwrites any earlier values assigned to the prop. This will ensure that we do not get a false positive since the suggestion prop value is used to determine if we should show the "Start with free" option in the plans step(we do not show this option if a custom domain has been chosen).
* This issue was originally reported in the slack conversation p1581446007071000-slack-onboarding-exp.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**

1. Begin at /start and go through the signup flow. 
2. At the domain step, try the following scenarios:
    - Select a custom domain -> you should not see the "Start with free" in plans step -> select a plan and verify that the selected domain and plan were added to cart
    - Select a free *.wordpress.com  -> you should see the "Start with free" in plans step -> complete signup should work
    - Select a custom domain and go to plans step -> now hit the Back button in the plans step to go back to domains step -> select a free *.wordpress.com domain -> the plans step should show "Start with free"

**Scenario 2**

1. Assign yourself to _variantShowUpdates_ of **domainStepCopyUpddates** test and begin a fresh signup at /start
2. At the domain step, try the following steps:
    - step a) Select a custom domain -> go to plans step -> verify that the `suggestion` prop in progress store has your selected domain(you can check this by typing `getState().signup.progress` in browser console). Also verify that `domainItem` prop has your selected domain
    - step b) Now hit Back button in the plans step and go back to domain step -> click the `Review our plans to get started »` link -> in the Plans step, verify that the `suggestion` prop and `domainItem` prop are empty(in the Master branch these props would still have the earlier selected domain value)
 
**Scenario 3**

1. Assign yourself to _skippable_ of **skippableDomainStep** test and begin a fresh signup at /start/
2. At the domain step, try the following steps:
    - step a) Select a custom domain -> go to plans step -> verify that the `suggestion` prop in progress store has your selected domain(you can check this by typing `getState().signup.progress` in browser console). Also verify that `domainItem` prop has your selected domain
    - step b) Now hit Back button in the plans step and go back to domain step -> click the `Choose a domain later` link -> in the Plans step, verify that the `suggestion` prop and `domainItem` prop are empty(in the Master branch these props would still have the earlier selected domain value)

**Scenario 4**

1. Login to any wpcom account that has an unlaunched site
2. Begin the site launch flow by clicking "Launch Site". Replace the launch flow URL's `wordpress.com/` with your hash URL and reload the page. At the domain step of the launch flow, try the following steps:
    - Select a custom domain -> go to plans step -> you _should not_ see the "Continue with your free" link
    - hit "Back" to the domain step -> select the "Skip purchase" button -> you _should_ see see the "Continue with your free site" link.