### PR TITLE
Domain step test: Right align the pricing text

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -114,8 +114,8 @@ class DomainProductPrice extends React.Component {
 
 		return (
 			<div className={ className }>
-				{ popoverElement }
 				{ message }
+				{ popoverElement }
 			</div>
 		);
 	}
@@ -157,7 +157,8 @@ class DomainProductPrice extends React.Component {
 
 	renderFreeWithPlan() {
 		const className = classnames( 'domain-product-price', 'is-free-domain', {
-			'domain-product-price__domain-step-copy-updates': this.props.isEligibleVariantForDomainTest,
+			'domain-product-price__domain-step-copy-updates': this.props.showTestCopy,
+			'domain-product-price__domain-step-design-updates': this.props.showDesignUpdate,
 		} );
 
 		return (

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -172,6 +172,7 @@ class DomainProductPrice extends React.Component {
 	renderFree() {
 		const className = classnames( 'domain-product-price', {
 			'domain-product-price__domain-step-copy-updates': this.props.isEligibleVariantForDomainTest,
+			'domain-product-price__domain-step-design-updates': this.props.showDesignUpdate,
 		} );
 
 		const productPriceClassName = classnames( 'domain-product-price__price', {

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -67,7 +67,7 @@ class DomainProductPrice extends React.Component {
 	}
 
 	renderFreeWithPlanText() {
-		const { isMappingProduct, isEligibleVariantForDomainTest, translate } = this.props;
+		const { isMappingProduct, showDesignUpdate, translate } = this.props;
 
 		let message, popoverElement;
 		switch ( this.props.rule ) {
@@ -109,7 +109,7 @@ class DomainProductPrice extends React.Component {
 		}
 
 		const className = classnames( 'domain-product-price__free-text', {
-			'domain-product-price__free-text-domain-step-copy-updates': isEligibleVariantForDomainTest,
+			'domain-product-price__free-text-domain-step-design-updates': showDesignUpdate,
 		} );
 
 		return (

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -36,7 +36,51 @@ class DomainProductPrice extends React.Component {
 	};
 
 	getDomainPricePopoverElement() {
-		const { price, isFeatured, translate } = this.props;
+		const { price, rule, isFeatured, translate } = this.props;
+
+		let popoverText;
+
+		switch ( rule ) {
+			case 'FREE_DOMAIN':
+				popoverText = translate(
+					'Every WordPress.com site comes with a free address using a WordPress.com subdomain. {{a}}Learn more{{/a}}.',
+					{
+						components: {
+							a: (
+								<a
+									href="https://en.support.wordpress.com/domains/#domain-name-overview"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				);
+				break;
+
+			case 'INCLUDED_IN_HIGHER_PLAN':
+				popoverText = translate(
+					'The registration fee for this domain is free for the first year with the purchase of any paid plan. ' +
+						'It will renew for %(cost)s / year after that. {{a}}Learn more{{/a}}.',
+					{
+						args: { cost: price },
+						components: {
+							a: (
+								<a
+									href="https://en.support.wordpress.com/domains/domain-pricing-and-available-tlds/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+						},
+					}
+				);
+				break;
+		}
+
+		if ( ! popoverText ) {
+			return;
+		}
 
 		return (
 			! isFeatured && (
@@ -45,22 +89,7 @@ class DomainProductPrice extends React.Component {
 					position={ 'left' }
 					className="domain-product-price__free-text-tooltip"
 				>
-					{ translate(
-						'The registration fee for this domain is free for the first year with the purchase of any paid plan. ' +
-							'It will renew for %(cost)s / year after that. {{a}}Learn more{{/a}}.',
-						{
-							args: { cost: price },
-							components: {
-								a: (
-									<a
-										href="https://en.support.wordpress.com/domains/domain-pricing-and-available-tlds/"
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
-						}
-					) }
+					{ popoverText }
 				</InfoPopover>
 			)
 		);
@@ -170,18 +199,24 @@ class DomainProductPrice extends React.Component {
 	}
 
 	renderFree() {
+		const { isEligibleVariantForDomainTest, showDesignUpdate, translate } = this.props;
+
 		const className = classnames( 'domain-product-price', {
-			'domain-product-price__domain-step-copy-updates': this.props.isEligibleVariantForDomainTest,
-			'domain-product-price__domain-step-design-updates': this.props.showDesignUpdate,
+			'domain-product-price__domain-step-copy-updates': isEligibleVariantForDomainTest,
+			'domain-product-price__domain-step-design-updates': showDesignUpdate,
 		} );
 
 		const productPriceClassName = classnames( 'domain-product-price__price', {
-			'domain-product-price__free-price': this.props.isEligibleVariantForDomainTest,
+			'domain-product-price__free-price': isEligibleVariantForDomainTest,
+			'domain-product-price__free-price-domain-step-design-updates': showDesignUpdate,
 		} );
 
 		return (
 			<div className={ className }>
-				<div className={ productPriceClassName }>{ this.props.translate( 'Free' ) }</div>
+				<div className={ productPriceClassName }>
+					<span>{ translate( 'Free' ) }</span>
+					{ showDesignUpdate && this.getDomainPricePopoverElement() }
+				</div>
 			</div>
 		);
 	}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -89,6 +89,15 @@
 
 	.domain-product-price__free-price {
 		color: var( --color-success );
+
+		&.domain-product-price__free-price-domain-step-design-updates {
+			display: flex;
+			align-items: center;
+
+			& span {
+				margin-right: 0.3em;
+			}
+		}
 	}
 
 	.domain-product-price__price,

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -63,10 +63,11 @@
 		color: var( --color-neutral-60 );
 		display: block;
 
-		&.domain-product-price__free-text-domain-step-copy-updates {
+		&.domain-product-price__free-text-domain-step-design-updates {
 			display: flex;
 			align-items: center;
 			height: 100%;
+			color: var( --color-neutral-30 );
 
 			& del,
 			& span {
@@ -104,6 +105,10 @@
 		.domain-product-price__renewal-price {
 			font-size: 80%;
 			color: var( --color-text-subtle );
+		}
+
+		&.domain-product-price__domain-step-design-updates .domain-product-price__price {
+			color: var( --color-neutral-60 );
 		}
 
 		@include breakpoint( '>660px' ) {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -19,19 +19,18 @@
 			align-items: flex-start;
 		}
 	}
-		
 
-	.is-section-signup {
+	.is-section-signup & {
 		@include breakpoint( '>660px' ) {
 			padding-left: 1em;
 			padding-right: 2em;
 
-			.domain-product-price__domain-step-copy-updates {
+			&.domain-product-price__domain-step-copy-updates {
 				padding-left: 0;
 				padding-right: 0;
 			}
 
-			.domain-product-price__domain-step-design-updates {
+			&.domain-product-price__domain-step-design-updates {
 				padding-left: 0;
 				padding-right: 1em;
 			}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -73,6 +73,10 @@
 			& span {
 				margin-right: 0.3em;
 			}
+
+			@include breakpoint( '<480px' ) {
+				margin-top: 5px;
+			}
 		}
 	}
 
@@ -85,6 +89,10 @@
 
 	.domain-product-price__free-text-tooltip {
 		display: flex;
+
+		body.is-section-signup .layout & {
+			padding: 0;
+		}
 	}
 
 	.domain-product-price__free-price {
@@ -96,6 +104,10 @@
 
 			& span {
 				margin-right: 0.3em;
+			}
+
+			@include breakpoint( '<480px' ) {
+				margin-top: 5px;
 			}
 		}
 	}

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -17,19 +17,24 @@
 
 		&.domain-product-price__domain-step-copy-updates {
 			align-items: flex-start;
-
-			&:not( .is-free-domain ) {
-				min-width: 11%;
-				max-width: 11%;
-			}
 		}
 	}
 		
 
-	.is-section-signup &:not( .domain-product-price__domain-step-copy-updates ) {
+	.is-section-signup {
 		@include breakpoint( '>660px' ) {
 			padding-left: 1em;
 			padding-right: 2em;
+
+			.domain-product-price__domain-step-copy-updates {
+				padding-left: 0;
+				padding-right: 0;
+			}
+
+			.domain-product-price__domain-step-design-updates {
+				padding-left: 0;
+				padding-right: 1em;
+			}
 		}
 	}
 
@@ -65,8 +70,8 @@
 			height: 100%;
 
 			& del,
-			& .info-popover {
-				margin-right: 5px;
+			& span {
+				margin-right: 0.3em;
 			}
 		}
 	}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -196,7 +196,9 @@ class DomainRegistrationSuggestion extends React.Component {
 		const infoPopoverSize = isFeatured ? 22 : 18;
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain-copy-test':
-				this.props.isEligibleVariantForDomainTest && ! this.props.isFeatured,
+				this.props.showTestCopy && ! this.props.isFeatured,
+			'domain-registration-suggestion__title-domain-design-updates':
+				this.props.showDesignUpdate && ! this.props.isFeatured,
 		} );
 
 		return (

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -61,8 +61,7 @@ class DomainSuggestion extends React.Component {
 			extraClasses
 		);
 
-		const shouldApplyContentClass =
-			isEligibleVariantForDomainTest && ! isFeatured && priceRule !== 'FREE_DOMAIN';
+		const shouldApplyContentClass = showTestCopy && ! isFeatured && priceRule !== 'FREE_DOMAIN';
 
 		const contentClassName = classNames( 'domain-suggestion__content', {
 			'domain-suggestion__content-domain-copy-test': shouldApplyContentClass,

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -61,10 +61,8 @@ class DomainSuggestion extends React.Component {
 			extraClasses
 		);
 
-		const shouldApplyContentClass = showTestCopy && ! isFeatured && priceRule !== 'FREE_DOMAIN';
-
 		const contentClassName = classNames( 'domain-suggestion__content', {
-			'domain-suggestion__content-domain-copy-test': shouldApplyContentClass,
+			'domain-suggestion__content-domain-copy-test': showTestCopy && ! isFeatured,
 		} );
 
 		/* eslint-disable jsx-a11y/click-events-have-key-events */

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -135,7 +135,8 @@
 	flex-direction: row;
 	flex-wrap: wrap;
 
-	&.domain-registration-suggestion__title-domain-copy-test {
+	&.domain-registration-suggestion__title-domain-copy-test,
+	&.domain-registration-suggestion__title-domain-design-updates {
 		@include breakpoint( '>480px' ) {
 			max-width: 50%;
 			min-width: 50%;
@@ -149,10 +150,22 @@
 		}
 	}
 
+	&.domain-registration-suggestion__title-domain-design-updates {
+		font-size: 18px;
+		font-weight: 600;
+		line-height: 18px;
+	}
+
 	.domain-registration-suggestion__title {
 		width: auto;
 		max-width: 100%;
 		padding-right: 0.2em;
+	}
+
+	&.domain-registration-suggestion__title-domain-design-updates .domain-registration-suggestion__title {
+		font-size: 18px;
+		font-weight: 600;
+		line-height: 18px;
 	}
 
 	.badge {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -143,8 +143,8 @@
 		}
 
 		@include breakpoint( '>660px' ) {
-			max-width: 65%;
-			min-width: 65%;
+			max-width: 55%;
+			min-width: 55%;
 			margin-right: 1em;
 		}
 	}

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -86,6 +86,7 @@ export class FeaturedDomainSuggestions extends Component {
 		return classNames( 'featured-domain-suggestions', this.getTextSizeClass(), {
 			'featured-domain-suggestions__is-domain-management': ! this.props.isSignupStep,
 			'featured-domain-suggestions--has-match-reasons': this.hasMatchReasons(),
+			'featured-domain-suggestions__domain-step-design-updates': this.props.showDesignUpdate,
 		} );
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -121,7 +121,7 @@
 
 		&.domain-registration-suggestion__progress-bar-design-update-test {
 			order: 0;
-			margin: 0.3em 0 1em;
+			margin: 0.7em 0 1em;
 			
 			&.pill-success .plan-pill {
 				position: inherit;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -17,6 +17,12 @@
 	.is-section-signup & {
 		@include breakpoint( '>480px' ) {
 			flex-direction: row;
+
+			&.featured-domain-suggestions__domain-step-design-updates .domain-registration-suggestion__title {
+					font-size: 22px;
+					font-weight: 600;
+					line-height: 18px;
+			}
 		}
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -122,6 +122,10 @@
 		&.domain-registration-suggestion__progress-bar-design-update-test {
 			order: 0;
 			margin: 0.7em 0 1em;
+
+			@include breakpoint( '<480px' ) {
+				margin: 0 0 0.5em;
+			}
 			
 			&.pill-success .plan-pill {
 				position: inherit;

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -21,12 +22,16 @@ class FreeDomainExplainer extends React.Component {
 		this.props.onSkip( undefined, hideFreePlan );
 	};
 	render() {
-		const { translate } = this.props;
+		const { showDesignUpdate, translate } = this.props;
+
+		const titleClassnames = classNames( 'free-domain-explainer__title', {
+			'free-domain-explainer__title-domain-design-updates': showDesignUpdate,
+		} );
 
 		return (
 			<div className="free-domain-explainer card is-compact">
 				<header>
-					<h1 className="free-domain-explainer__title">
+					<h1 className={ titleClassnames }>
 						{ translate( 'Get a free one-year domain registration with any paid plan.' ) }
 					</h1>
 					<p className="free-domain-explainer__subtitle">

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -6,6 +6,12 @@
     line-height: 1.3;
     margin: 0;
     margin-bottom: 0.7em;
+
+    &.free-domain-explainer__title-domain-design-updates {
+        font-size: 18px;
+        line-height: 18px;
+        font-weight: 600;
+    }
 }
 
 .free-domain-explainer__subtitle {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -419,6 +419,7 @@ class RegisterDomainStep extends React.Component {
 
 		const searchBoxClassName = classNames( 'register-domain-step__search', {
 			'register-domain-step__search-domain-step-test': this.props.isEligibleVariantForDomainTest,
+			'register-domain-step__search-domain-step-design-updates': this.props.showDesignUpdate,
 		} );
 		return (
 			<div className="register-domain-step">
@@ -1182,7 +1183,12 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderFreeDomainExplainer() {
-		return <FreeDomainExplainer onSkip={ this.props.hideFreePlan } />;
+		return (
+			<FreeDomainExplainer
+				onSkip={ this.props.hideFreePlan }
+				showDesignUpdate={ this.props.showDesignUpdate }
+			/>
+		);
 	}
 
 	onAddDomain = suggestion => {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -30,6 +30,12 @@
 		}
 	}
 
+	&.register-domain-step__search-domain-step-design-updates .search .search__input:not( :placeholder-shown ) {
+		font-size: 16px;
+		font-weight: 600;
+		line-height: 18px;
+	}
+
 	&.disabled {
 		border-bottom: none; // so that bottom border is not there during google app dialog animation
 		opacity: 0.7;

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -129,7 +129,7 @@
 
 		legend.search-filters__filter-by {
 			font-size: 14px;
-			color: var( --color-text-subtle );
+			color: var( --color-neutral-30 );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The next domain step test is being implemented in #39276.

This PR:
* Updates the alignment of the pricing text as described in the issue https://github.com/Automattic/wp-calypso/issues/39393
* Updates the search results UI to match the screen shared in pbAok1-7N-p2.

**Desktop screen size**

<img width="1097" alt="Screenshot 2020-02-13 at 9 13 48 PM" src="https://user-images.githubusercontent.com/1269602/74451552-cfbc0e80-4ea5-11ea-9815-a31bd305c3ab.png">

**Mobile screen size**

![calypso localhost_3000_start_ecommerce-onboarding_domains(Pixel 2 XL) (1)](https://user-images.githubusercontent.com/1269602/74451593-e1051b00-4ea5-11ea-844d-8706e9e7fbef.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Begin a fresh signup at /start or click "Add new site". You need to be in the _variantShowUpdates_ variant of **domainStepCopyUpdates** test and _variantDesignUpdates_ variant of **domainStepDesignUpdates**.
* At the domain step, verify the following:
    - The pricing copy and tooltip matches the UI sketch in https://github.com/Automattic/wp-calypso/issues/39393
    -  Verify in desktop and mobile screen sizes

**Verify that control group UI is unchanged**

Scenario 1

* Go through signup flow from /start while in _variantShowUpdates_ variant of **domainStepCopyUpdates** test and _control_ of **domainStepDesignUpdates**.
* You should not be seeing the changes in this PR but instead the earlier UI version. 

Scenario 2

* Go through signup flow from /start while in control of domainStepCopyUpdates test.
* You should be seeing the old domain step UI
