### PR TITLE
Site Migration: Hide default side badges from the custom Site Block component

### DIFF
--- a/client/my-sites/migrate/components/sites-block/style.scss
+++ b/client/my-sites/migrate/components/sites-block/style.scss
@@ -43,6 +43,10 @@
 	.sites-block__sites-item {
 		padding: 25px;
 		width: 50%;
+
+		.site__badge {
+			display: none;
+		}
 	}
 
 	.site__content {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR hides the default site badges, like `Private` or `Coming Soon` from the custom site block we use in the migration steps. This is done to reduce possible confusion for customers who go through the flow.

#### Testing instructions

* Create a new site and make it either Private or Coming soon
* Check without this PR, you should see both Private/Coming Soon and the `This Site` badge
* Now check on the Calypso.live link or checkout the PR locally
* The Private/Coming Soon badge should be hidden. 
