### PR TITLE
Site Migration: Persist the Site URL when going back to the URL input screen

### DIFF
--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -108,6 +108,7 @@ class StepSourceSelect extends Component {
 					targetSite={ targetSite }
 					onUrlChange={ this.props.onUrlChange }
 					onSubmit={ this.handleContinue }
+					url={ this.props.url }
 				/>
 				<p>{ this.state.error }</p>
 				<Card>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fix a bug where the Site URL input would be unpopulated when returning to the input stage.

#### Testing instructions

* Checkout branch or use Calypso.live link
* Go to Site Migration
* Enter a valid URL for migration. The importer should take you to the screen offering you a choice between "Everything" or "Content Only".
* Press back or Cancel
* Make sure the URL you entered is persisted on the input screen