### PR TITLE
Renovate: Try @ in team reviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
 			"extends": "monorepo:wordpress",
 			"separateMajorMinor": false,
 			"prPriority": 2,
-			"reviewers": [ "team:Automattic/cylon", "team:Automattic/ganon", "team:Automattic/luna" ]
+			"reviewers": [ "team:@Automattic/cylon", "team:@Automattic/ganon", "team:@Automattic/luna" ]
 		},
 		{
 			"extends": "monorepo:babel",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/39383 didn't assign reviewer teams as expected. Try with a leading `@`.