### PR TITLE
Frankenflow: Hide up-selling nudge

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -73,6 +73,7 @@ class CheckoutContainer extends React.Component {
 			upgradeIntent,
 			shouldShowCart = true,
 			clearTransaction,
+			isComingFromFrankenflow,
 		} = this.props;
 
 		const TransactionData = clearTransaction ? CartData : CheckoutData;
@@ -97,6 +98,7 @@ class CheckoutContainer extends React.Component {
 							reduxStore={ reduxStore }
 							redirectTo={ redirectTo }
 							upgradeIntent={ upgradeIntent }
+							hideNudge={ isComingFromFrankenflow }
 						>
 							{ this.props.children }
 						</Checkout>

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -24,6 +24,7 @@ export default function CheckoutSystemDecider( {
 	selectedFeature,
 	couponCode,
 	isComingFromSignup,
+	isComingFromFrankenflow,
 	plan,
 	selectedSite,
 	reduxStore,
@@ -64,6 +65,7 @@ export default function CheckoutSystemDecider( {
 			selectedFeature={ selectedFeature }
 			couponCode={ couponCode }
 			isComingFromSignup={ isComingFromSignup }
+			isComingFromFrankenflow={ isComingFromFrankenflow }
 			plan={ plan }
 			selectedSite={ selectedSite }
 			reduxStore={ reduxStore }

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -474,6 +474,11 @@ export class Checkout extends React.Component {
 	}
 
 	maybeRedirectToConciergeNudge( pendingOrReceiptId ) {
+		// For testing Frankenflow we disable any redirect to Nudge
+		if ( this.props.hideNudge ) {
+			return;
+		}
+
 		const { cart, selectedSiteSlug, previousRoute } = this.props;
 
 		// For a user purchasing a qualifying plan, show either a plan upgrade upsell or concierge upsell.

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -474,7 +474,7 @@ export class Checkout extends React.Component {
 	}
 
 	maybeRedirectToConciergeNudge( pendingOrReceiptId ) {
-		// For testing Frankenflow we disable any redirect to Nudge
+		// Using hideNudge prop will disable any redirect to Nudge
 		if ( this.props.hideNudge ) {
 			return;
 		}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -62,6 +62,7 @@ export function checkout( context, next ) {
 				selectedFeature={ feature }
 				couponCode={ couponCode }
 				isComingFromSignup={ !! context.query.signup }
+				isComingFromFrankenflow={ !! context.query.preLaunch }
 				plan={ plan }
 				selectedSite={ selectedSite }
 				reduxStore={ context.store }

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -10,11 +10,18 @@ import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
 import { generateFlows } from 'signup/config/flows-pure';
+import { addQueryArgs } from 'lib/url';
 
 const user = userFactory();
 
 function getCheckoutUrl( dependencies ) {
-	return `/checkout/${ dependencies.siteSlug }?signup=1`;
+	return addQueryArgs(
+		{
+			signup: 1,
+			...( dependencies.isPreLaunch && { preLaunch: 1 } ),
+		},
+		`/checkout/${ dependencies.siteSlug }`
+	);
 }
 
 function dependenciesContainCartItem( dependencies ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -568,6 +568,7 @@ export function generateSteps( {
 			stepName: 'launch',
 			apiRequestFunction: launchSiteApi,
 			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'isPreLaunch' ],
 		},
 
 		passwordless: {

--- a/client/signup/steps/launch-site/index.jsx
+++ b/client/signup/steps/launch-site/index.jsx
@@ -12,7 +12,10 @@ import { submitSignupStep } from 'state/signup/progress/actions';
 class LaunchSiteComponent extends Component {
 	componentDidMount() {
 		const { flowName, stepName } = this.props;
-		this.props.submitSignupStep( { stepName } );
+		this.props.submitSignupStep(
+			{ stepName },
+			{ isPreLaunch: this.props.flowName === 'frankenflow' }
+		);
 		this.props.goToNextStep( flowName );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Enable checkout customisation when coming from Frankenflow by adding `preLaunch=1` as query argument to the URL.
* Don't redirect to upsell nudge when coming from Frankenflow and buying a Personal or Premium plan

#### Testing instructions
* Go to `/start/frankenflow?siteSlug=SITE_SLUG` for a non-launched site
* Choose a paid plan and on the checkout page, the URL should include `preLaunch=1`
* Purchase the _Personal_ plan and you'll be redirected directly to home (no upsell nudge)
* When launching a site using the 'Launch site' button from home, nothing should change

#### Follow up
* We can now customize checkout step https://github.com/Automattic/wp-calypso/issues/38936 - PR: https://github.com/Automattic/wp-calypso/pull/39447

Fixes #39197 
