### PR TITLE
composite-checkout: Hide variant options for non-signups

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -53,6 +53,8 @@ function WPLineItem( {
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const modalCopy = returnModalCopy( item.type, translate, hasDomainsInCart );
 
+	const shouldShowVariantSelector = item.wpcom_meta && item.wpcom_meta.extra?.context === 'signup';
+
 	return (
 		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>
 			<ProductTitle id={ itemSpanId }>{ item.label }</ProductTitle>
@@ -84,7 +86,7 @@ function WPLineItem( {
 				</React.Fragment>
 			) }
 
-			{ item.wpcom_meta && (
+			{ shouldShowVariantSelector && (
 				<ItemVariationPicker
 					selectedItem={ item }
 					variantRequestStatus={ variantRequestStatus }

--- a/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
@@ -32,7 +32,7 @@ export interface RequestCart {
 	locale: string;
 	is_coupon_applied: boolean;
 	temporary: false;
-	extra: string; // TODO: fix this
+	extra: string;
 }
 
 /**
@@ -42,6 +42,7 @@ export interface RequestCartProduct {
 	product_slug: string;
 	product_id: number;
 	meta: string;
+	extra: object;
 }
 
 /**
@@ -119,11 +120,13 @@ export const prepareRequestCartProduct: ( ResponseCartProduct ) => RequestCartPr
 	product_slug,
 	meta,
 	product_id,
+	extra,
 }: ResponseCartProduct ) => {
 	return {
 		product_slug,
 		meta,
 		product_id,
+		extra,
 	} as RequestCartProduct;
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Only show plan length options on signup. Allowing this on renewals and upgrades is possible but requires a lot of math, which we can implement and test at a later time.

#### Testing instructions

* Enter checkout with a new plan; verify that you have the option to choose between one and two year subscriptions
* Enter checkout with a plan renewal or upgrade; verify that you don't have the option to change the term length