### PR TITLE
React i18n: Default locale 'en' and improve prop name

### DIFF
--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -9,10 +9,10 @@ export interface I18nProps {
 	_n: typeof _n;
 	_nx: typeof _nx;
 	_x: typeof _x;
-	i18nLocale?: string;
+	i18nLocale: string;
 }
 
-const I18nContext = React.createContext< I18nProps >( { __, _n, _nx, _x } );
+const I18nContext = React.createContext< I18nProps >( makeI18n( 'en' ) );
 
 interface Props {
 	/**
@@ -23,7 +23,7 @@ interface Props {
 	/**
 	 * A callback that resolves with the translations data
 	 */
-	onLocaleChange?( newLocale: string | undefined ): Promise< object >;
+	loadLocaleData?( newLocale: string ): Promise< object >;
 }
 export const I18nProvider: React.FunctionComponent< Props > = ( {
 	children,
@@ -49,7 +49,7 @@ export const I18nProvider: React.FunctionComponent< Props > = ( {
 };
 
 function makeI18n( i18nLocale: string ) {
-	return { ...( i18nLocale && { i18nLocale } ), __, _n, _nx, _x };
+	return { __, _n, _nx, _x, i18nLocale };
 }
 
 /**

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -28,7 +28,7 @@ interface Props {
 export const I18nProvider: React.FunctionComponent< Props > = ( {
 	children,
 	locale,
-	onLocaleChange = () => Promise.resolve( {} ),
+	loadLocaleData = () => Promise.resolve( {} ),
 } ) => {
 	const [ contextValue, setContextValue ] = React.useState< I18nProps >( makeI18n( locale ) );
 	React.useEffect( () => {
@@ -36,7 +36,7 @@ export const I18nProvider: React.FunctionComponent< Props > = ( {
 		const cancel = () => {
 			cancelled = true;
 		};
-		onLocaleChange( locale ).then( nextLocaleData => {
+		loadLocaleData( locale ).then( nextLocaleData => {
 			if ( cancelled ) {
 				return;
 			}
@@ -44,7 +44,7 @@ export const I18nProvider: React.FunctionComponent< Props > = ( {
 			setContextValue( makeI18n( locale ) );
 		} );
 		return cancel;
-	}, [ locale, onLocaleChange ] );
+	}, [ locale, loadLocaleData ] );
 	return <I18nContext.Provider value={ contextValue }>{ children }</I18nContext.Provider>;
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Applies suggestions from code review of #39388

* use default `en` locale
* `loadLocaleData` used for prop name for locale callback

#### Testing instructions

Demo in #39410