### PR TITLE
composite-checkout: Record events to Tracks

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -592,16 +592,34 @@ function getCheckoutEventHandler( dispatch ) {
 		debug( 'heard checkout event', action );
 		switch ( action.type ) {
 			case 'a8c_checkout_error':
-				return dispatch( recordTracksEvent( action.type, action.payload ) );
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_error', {
+						error_type: action.payload.type,
+						error_field: action.payload.field,
+						error_message: action.payload.message,
+					} )
+				);
 			case 'a8c_checkout_add_coupon':
-				return dispatch( recordTracksEvent( action.type, action.payload ) );
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {
+						coupon: action.payload.coupon,
+					} )
+				);
 			case 'a8c_checkout_add_coupon_error':
-				return dispatch( recordTracksEvent( action.type, action.payload ) );
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_coupon_add_error', {
+						error_type: action.payload.type,
+					} )
+				);
 			case 'a8c_checkout_add_coupon_button_clicked':
-				return dispatch( recordTracksEvent( action.type, action.payload ) );
+				return dispatch( recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} ) );
+			case 'STEP_NUMBER_CHANGE_EVENT':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_step_changed', { step: action.payload } )
+				);
 			default:
-				debug( 'unknown checkout event being recorded', action );
-				return dispatch( recordTracksEvent( action.type, {} ) );
+				debug( 'unknown checkout event: not recording', action );
+				return;
 		}
 	};
 }

--- a/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
@@ -50,7 +50,7 @@ export default function useCouponFieldState( submitCoupon ): CouponFieldStatePro
 				payload: { type: 'Invalid code' },
 			} );
 		},
-		[ couponFieldValue ]
+		[ couponFieldValue, onEvent, submitCoupon ]
 	);
 
 	return {

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -313,9 +313,13 @@ function StripeCreditCardFields() {
 		},
 	};
 
-	if ( stripeLoadingError ) {
-		onEvent( { type: 'a8c_checkout_error', payload: { type: 'Stripe loading error' } } );
+	useEffect( () => {
+		if ( stripeLoadingError ) {
+			onEvent( { type: 'a8c_checkout_error', payload: { type: 'Stripe loading error' } } );
+		}
+	}, [ stripeLoadingError, onEvent ] );
 
+	if ( stripeLoadingError ) {
 		return (
 			<CreditCardFieldsWrapper isLoaded={ true }>
 				<ErrorMessage>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `composite-checkout` package supports a custom hook called `useEvents` that returns a function for recording analytics. This PR hooks up the Calypso implementation of the package to send those analytics to Tracks.

#### Testing instructions

- Visit checkout with the `composite-checkout-wpcom` flag enabled.
- Click continue on the first step.
- Search in Tracks for the event `calypso_checkout_composite_step_changed` and be sure it was recorded correctly with the property `step` and the step number `2`.