### PR TITLE
FSE: add GitHub workflow for deploying to .org

### DIFF
--- a/.github/workflows/deploy-fse-to-org.yml
+++ b/.github/workflows/deploy-fse-to-org.yml
@@ -1,0 +1,32 @@
+name: Deploy FSE plugin to WordPress.org
+
+# Until we are ready to move to continuous deployment to Simple and Atomic sites
+# we need a manual way to trigger this workflow. One way to do it is to push a tag
+# to wp-calypso repository. Since we already have other tags for desktop releases
+# I'm prefixing this matcher with fse so it doesn't run when it's not supposed to.
+# Once we are ready to move to continuous workflow we can remove this and trigger
+# the workflow on on each merge to master that contains changes in FSE plugin folder.
+on:
+  push:
+    tags:
+    - "fse/*"
+
+jobs:
+  tag:
+    name: Deploy FSE plugin to WordPress.org
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+    - uses: actions/checkout@master
+    - name: Install dependencies
+      run: npm ci
+    - name: Build FSE
+      run: npx lerna run build --scope='@automattic/full-site-editing' --stream
+    - name: WordPress Plugin Deploy
+      uses: 10up/action-wordpress-plugin-deploy@master
+      env:
+        ASSETS_DIR: 'apps/full-site-editing/full-site-editing-plugin/'
+        SLUG: full-site-editing
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        

--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -1,3 +1,5 @@
+name: Build Full Site Editing plugin
+
 on:
   push:
     paths:
@@ -8,8 +10,6 @@ on:
     # only trigger this workflow if FSE plugin files have been modified
     paths:
     - 'apps/full-site-editing/full-site-editing-plugin/**'
-
-name: Build Full Site Editing plugin
 
 jobs:
   build:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to https://github.com/Automattic/wp-calypso/pull/39417.

Deploy latest changes in FSE master after `fse/*` tag is pushed to the wp-calypso repository.
This relies on 10up plugin deploy action documented here: https://github.com/10up/action-wordpress-plugin-deploy.

Until the whole flow is ported to use GitHub actions  we can continue using our sandbox script as an officially supported and documented way to do FSE .org releases.

#### Testing instructions

This workflow won't run on wp-calypso repo until it's merged to master. One way to test it would be to fork the repository and commit this change to your fork. After that you can push an `fse/` prefixed tag and verify that the workflow runs. The svn credentials haven't been set up yet on purpose so we don't accidentally run an actual .org deploy.
