### PR TITLE
Domains: Fix some small styling issues with the new domain management screens

### DIFF
--- a/client/my-sites/domains/domain-management/components/icann-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/index.jsx
@@ -72,7 +72,19 @@ class IcannVerificationCard extends React.Component {
 		const changeEmailHref = domainManagementEditContactInfo( selectedSiteSlug, selectedDomainName );
 
 		if ( ! contactDetails ) {
-			return <QueryWhois domain={ selectedDomainName } />;
+			const placeHolder = compact ? (
+				<div className="icann-verification__placeholder">
+					<p />
+					<p />
+					<p />
+				</div>
+			) : null;
+			return (
+				<React.Fragment>
+					{ placeHolder }
+					<QueryWhois domain={ selectedDomainName } />
+				</React.Fragment>
+			);
 		}
 		const verificationExplanation = this.getExplanation();
 

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -51,16 +51,16 @@
 
 .domain-types__container {
 	.status-success {
-		@include domain_status_color( #008a20 );
+		@include domain_status_color( var( --color-success ) );
 	}
 	.status-pending {
-		@include domain_status_color( #3582C4 );
+		@include domain_status_color( var( --color-primary-40 ) );
 	}
 	.status-warning {
-		@include domain_status_color( #B69000 );
+		@include domain_status_color( var( --color-warning ) );
 	}
 	.status-error {
-		@include domain_status_color( #C9356E );
+		@include domain_status_color( var( --color-accent ) );
 	}
 
 	.domain-status__card {
@@ -69,7 +69,6 @@
 		}
 
 		> .domain-status__icon {
-			font-size: 16px;
 			display: flex;
 			align-items: center;
 			> svg {

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -89,3 +89,14 @@
 		margin-top: 0;
 	}
 }
+
+.icann-verification__placeholder {
+	p {
+		@include placeholder( --color-neutral-10 );
+		margin-bottom: 0.5em;
+
+		&:last-child {
+			width: 35%;
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* fix the domain status text size
* use the proper colour variables for status colors
* show a placeholder while loading the email verification notice

#### Testing instructions

* check that the domain status colours are working
* check the status text size - should be the default one
* check how the email verification notice looks like while it loads the contact verification status
