### PR TITLE
Frankenflow: Customize checkout step

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -127,7 +127,7 @@ class Layout extends Component {
 		const optionalBodyProps = () => {
 			const optionalProps = {};
 
-			if ( this.props.isFrankenflow ) {
+			if ( this.props.isFrankenflow || this.props.isCheckoutFromGutenboarding ) {
 				optionalProps.bodyClass = 'is-frankenflow';
 			}
 
@@ -255,5 +255,6 @@ export default connect( state => {
 		See https://github.com/Automattic/wp-calypso/pull/31277 for more details. */
 		shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 		isFrankenflow,
+		isCheckoutFromGutenboarding,
 	};
 } )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -214,7 +214,7 @@ export default connect( state => {
 	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
 	const isJetpack = isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
 	const isCheckoutFromGutenboarding =
-		'checkout' === sectionName && '1' === get( getCurrentQueryArguments( state ), 'preLaunch' );
+		'checkout' === sectionName && '1' === getCurrentQueryArguments( state )?.preLaunch;
 	const noMasterbarForRoute =
 		isJetpackLogin || isCheckoutFromGutenboarding || currentRoute === '/me/account/closed';
 	const noMasterbarForSection = 'signup' === sectionName || 'jetpack-connect' === sectionName;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -213,7 +213,10 @@ export default connect( state => {
 	const sectionJitmPath = getMessagePathForJITM( currentRoute );
 	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
 	const isJetpack = isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
-	const noMasterbarForRoute = isJetpackLogin || currentRoute === '/me/account/closed';
+	const isCheckoutFromGutenboarding =
+		'checkout' === sectionName && '1' === get( getCurrentQueryArguments( state ), 'preLaunch' );
+	const noMasterbarForRoute =
+		isJetpackLogin || isCheckoutFromGutenboarding || currentRoute === '/me/account/closed';
 	const noMasterbarForSection = 'signup' === sectionName || 'jetpack-connect' === sectionName;
 	const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 	const isJetpackWooCommerceFlow =

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -51,6 +51,40 @@ class CheckoutContainer extends React.Component {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	renderCheckoutHeader() {
+		if ( this.props.isComingFromGutenboarding ) {
+			return (
+				<>
+					<Button
+						borderless
+						className="navigation-link back"
+						onClick={ () => window.history.go( -2 ) } // going back to signup flow and skipping '/launch' step
+					>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ this.props.translate( 'Back' ) }
+					</Button>
+					<div className="checkout__site-created--gutenboarding">
+						<img
+							src="/calypso/images/signup/confetti.svg"
+							aria-hidden="true"
+							className="checkout__site-created-image"
+							alt=""
+						/>
+						<FormattedHeader
+							headerText={ this.props.translate(
+								'Your WordPress.com site is ready! Finish your purchase to get the most out of it.'
+							) }
+						/>
+						<div>
+							{ this.props.translate( '{{em}}%(siteSlug)s{{/em}} is up and running!', {
+								components: { em: <em /> },
+								args: { siteSlug: this.props.selectedSite.slug },
+								comment: '`siteSlug` is the WordPress.com site, e.g., testsite.wordpress.com',
+							} ) }
+						</div>
+					</div>
+				</>
+			);
+		}
 		return this.state.headerText && <FormattedHeader headerText={ this.state.headerText } />;
 	}
 
@@ -59,6 +93,7 @@ class CheckoutContainer extends React.Component {
 	shouldDisplaySiteCreatedNotice() {
 		return (
 			this.props.isComingFromSignup &&
+			! this.props.isComingFromGutenboarding &&
 			isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) )
 		);
 	}
@@ -83,40 +118,8 @@ class CheckoutContainer extends React.Component {
 
 		return (
 			<>
-				{ this.props.isComingFromGutenboarding && (
-					<>
-						<Button
-							borderless
-							className="navigation-link back"
-							onClick={ () => window.history.go( -2 ) } // going back to signup flow and skipping '/launch' step
-						>
-							<Gridicon icon="arrow-left" size={ 18 } />
-							{ this.props.translate( 'Back' ) }
-						</Button>
-						<div className="checkout__site-created--gutenboarding">
-							<img
-								src="/calypso/images/signup/confetti.svg"
-								aria-hidden="true"
-								className="checkout__site-created-image"
-								alt=""
-							/>
-							<FormattedHeader
-								headerText={ this.props.translate(
-									'Your WordPress.com site is ready! Finish your purchase to get the most out of it.'
-								) }
-							/>
-							<div>
-								{ this.props.translate( '{{em}}%(siteSlug)s{{/em}} is up and running!', {
-									components: { em: <em /> },
-									args: { siteSlug: this.props.selectedSite.slug },
-									comment: '`siteSlug` is the WordPress.com site, e.g., testsite.wordpress.com',
-								} ) }
-							</div>
-						</div>
-					</>
-				) }
-				{ ! this.props.isComingFromGutenboarding && this.renderCheckoutHeader() }
-				{ ! this.props.isComingFromGutenboarding && this.shouldDisplaySiteCreatedNotice() && (
+				{ this.renderCheckoutHeader() }
+				{ this.shouldDisplaySiteCreatedNotice() && (
 					<TransactionData>
 						<SignupSiteCreatedNotice selectedSite={ this.props.selectedSite } />
 					</TransactionData>

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -51,19 +51,6 @@ class CheckoutContainer extends React.Component {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	renderCheckoutHeader() {
-		if ( this.props.isComingFromFrankenflow ) {
-			return (
-				<Button
-					borderless
-					className="navigation-link back"
-					// href={ window.history.back() }
-					onClick={ () => window.history.go( -2 ) }
-				>
-					<Gridicon icon="arrow-left" size={ 18 } />
-					{ this.props.translate( 'Back' ) }
-				</Button>
-			);
-		}
 		return this.state.headerText && <FormattedHeader headerText={ this.state.headerText } />;
 	}
 
@@ -71,8 +58,9 @@ class CheckoutContainer extends React.Component {
 
 	shouldDisplaySiteCreatedNotice() {
 		return (
-			this.props.isComingFromSignup &&
-			isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) )
+			( this.props.isComingFromSignup &&
+				isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) ) ) ||
+			this.props.isComingFromFrankenflow
 		);
 	}
 
@@ -96,6 +84,16 @@ class CheckoutContainer extends React.Component {
 
 		return (
 			<>
+				{ this.props.isComingFromFrankenflow && (
+					<Button
+						borderless
+						className="navigation-link back"
+						onClick={ () => window.history.go( -2 ) } // going back to signup flow and skipping '/launch' step
+					>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ this.props.translate( 'Back' ) }
+					</Button>
+				) }
 				{ this.renderCheckoutHeader() }
 				{ this.shouldDisplaySiteCreatedNotice() && (
 					<TransactionData>

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -15,6 +15,8 @@ import CartData from 'components/data/cart';
 import CheckoutData from 'components/data/checkout';
 import SecondaryCart from '../cart/secondary-cart';
 import SignupSiteCreatedNotice from 'my-sites/checkout/checkout/signup-site-created-notice';
+import Gridicon from 'components/gridicon';
+import { Button } from '@automattic/components';
 
 /**
  * Style dependencies
@@ -47,7 +49,21 @@ class CheckoutContainer extends React.Component {
 		}
 	}
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	renderCheckoutHeader() {
+		if ( this.props.isComingFromFrankenflow ) {
+			return (
+				<Button
+					borderless
+					className="navigation-link back"
+					// href={ window.history.back() }
+					onClick={ () => window.history.go( -2 ) }
+				>
+					<Gridicon icon="arrow-left" size={ 18 } />
+					{ this.props.translate( 'Back' ) }
+				</Button>
+			);
+		}
 		return this.state.headerText && <FormattedHeader headerText={ this.state.headerText } />;
 	}
 

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -60,7 +60,7 @@ class CheckoutContainer extends React.Component {
 		return (
 			( this.props.isComingFromSignup &&
 				isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) ) ) ||
-			this.props.isComingFromFrankenflow
+			this.props.isComingFromGutenboarding
 		);
 	}
 
@@ -77,14 +77,14 @@ class CheckoutContainer extends React.Component {
 			upgradeIntent,
 			shouldShowCart = true,
 			clearTransaction,
-			isComingFromFrankenflow,
+			isComingFromGutenboarding,
 		} = this.props;
 
 		const TransactionData = clearTransaction ? CartData : CheckoutData;
 
 		return (
 			<>
-				{ this.props.isComingFromFrankenflow && (
+				{ this.props.isComingFromGutenboarding && (
 					<Button
 						borderless
 						className="navigation-link back"
@@ -112,7 +112,7 @@ class CheckoutContainer extends React.Component {
 							reduxStore={ reduxStore }
 							redirectTo={ redirectTo }
 							upgradeIntent={ upgradeIntent }
-							hideNudge={ isComingFromFrankenflow }
+							hideNudge={ isComingFromGutenboarding }
 						>
 							{ this.props.children }
 						</Checkout>

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -58,9 +58,8 @@ class CheckoutContainer extends React.Component {
 
 	shouldDisplaySiteCreatedNotice() {
 		return (
-			( this.props.isComingFromSignup &&
-				isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) ) ) ||
-			this.props.isComingFromGutenboarding
+			this.props.isComingFromSignup &&
+			isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) )
 		);
 	}
 
@@ -85,17 +84,39 @@ class CheckoutContainer extends React.Component {
 		return (
 			<>
 				{ this.props.isComingFromGutenboarding && (
-					<Button
-						borderless
-						className="navigation-link back"
-						onClick={ () => window.history.go( -2 ) } // going back to signup flow and skipping '/launch' step
-					>
-						<Gridicon icon="arrow-left" size={ 18 } />
-						{ this.props.translate( 'Back' ) }
-					</Button>
+					<>
+						<Button
+							borderless
+							className="navigation-link back"
+							onClick={ () => window.history.go( -2 ) } // going back to signup flow and skipping '/launch' step
+						>
+							<Gridicon icon="arrow-left" size={ 18 } />
+							{ this.props.translate( 'Back' ) }
+						</Button>
+						<div className="checkout__site-created--gutenboarding">
+							<img
+								src="/calypso/images/signup/confetti.svg"
+								aria-hidden="true"
+								className="checkout__site-created-image"
+								alt=""
+							/>
+							<FormattedHeader
+								headerText={ this.props.translate(
+									'Your WordPress.com site is ready! Finish your purchase to get the most out of it.'
+								) }
+							/>
+							<div>
+								{ this.props.translate( '{{em}}%(siteSlug)s{{/em}} is up and running!', {
+									components: { em: <em /> },
+									args: { siteSlug: this.props.selectedSite.slug },
+									comment: '`siteSlug` is the WordPress.com site, e.g., testsite.wordpress.com',
+								} ) }
+							</div>
+						</div>
+					</>
 				) }
-				{ this.renderCheckoutHeader() }
-				{ this.shouldDisplaySiteCreatedNotice() && (
+				{ ! this.props.isComingFromGutenboarding && this.renderCheckoutHeader() }
+				{ ! this.props.isComingFromGutenboarding && this.shouldDisplaySiteCreatedNotice() && (
 					<TransactionData>
 						<SignupSiteCreatedNotice selectedSite={ this.props.selectedSite } />
 					</TransactionData>

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -24,7 +24,7 @@ export default function CheckoutSystemDecider( {
 	selectedFeature,
 	couponCode,
 	isComingFromSignup,
-	isComingFromFrankenflow,
+	isComingFromGutenboarding,
 	plan,
 	selectedSite,
 	reduxStore,
@@ -65,7 +65,7 @@ export default function CheckoutSystemDecider( {
 			selectedFeature={ selectedFeature }
 			couponCode={ couponCode }
 			isComingFromSignup={ isComingFromSignup }
-			isComingFromFrankenflow={ isComingFromFrankenflow }
+			isComingFromGutenboarding={ isComingFromGutenboarding }
 			plan={ plan }
 			selectedSite={ selectedSite }
 			reduxStore={ reduxStore }

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1195,9 +1195,25 @@
   }
 }
 
-body.is-section-checkout .navigation-link.button.back {
-	position: absolute;
-	top: 6px;
-	left: 11px;
-	padding: 0;
+.is-section-checkout.is-frankenflow {
+	.layout__content {
+		padding-top: 48px;
+	}
+	.navigation-link.button.back {
+		position: absolute;
+		top: 6px;
+		left: 11px;
+		padding: 0;
+	}
+	.checkout__site-created--gutenboarding {
+		display: flex;
+		flex-direction: column;
+		text-align: center;
+		margin-bottom: 60px;
+
+		.checkout__site-created-image {
+			height: 50px;
+			margin-bottom: 16px;
+		}
+	}
 }

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -11,7 +11,7 @@
   	height: 1px;
   	box-sizing: border-box;
   	background: var( --color-border-subtle );
-  	
+
   	@include breakpoint( '>660px' ) {
   		width: calc( 100% + 60px );
   		left: -30px;
@@ -1193,4 +1193,11 @@
     margin: auto;
     max-width: 556px;
   }
+}
+
+body.is-section-checkout .navigation-link.button.back {
+	position: absolute;
+	top: 6px;
+	left: 11px;
+	padding: 0;
 }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -10,7 +10,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { setSection } from 'state/ui/actions';
+import { setSection, hideMasterbar, showMasterbar } from 'state/ui/actions';
 import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import GSuiteNudge from './gsuite-nudge';
@@ -48,6 +48,9 @@ export function checkout( context, next ) {
 
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
+
+	const masterbarToggle = context.query.preLaunch ? hideMasterbar() : showMasterbar();
+	context.store.dispatch( masterbarToggle );
 
 	context.store.dispatch( setSection( { name: 'checkout' }, { hasSidebar: false } ) );
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -10,7 +10,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
-import { setSection, hideMasterbar, showMasterbar } from 'state/ui/actions';
+import { setSection } from 'state/ui/actions';
 import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import GSuiteNudge from './gsuite-nudge';
@@ -48,9 +48,6 @@ export function checkout( context, next ) {
 
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
-
-	const masterbarToggle = context.query.preLaunch ? hideMasterbar() : showMasterbar();
-	context.store.dispatch( masterbarToggle );
 
 	context.store.dispatch( setSection( { name: 'checkout' }, { hasSidebar: false } ) );
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -65,7 +65,7 @@ export function checkout( context, next ) {
 				selectedFeature={ feature }
 				couponCode={ couponCode }
 				isComingFromSignup={ !! context.query.signup }
-				isComingFromFrankenflow={ !! context.query.preLaunch }
+				isComingFromGutenboarding={ !! context.query.preLaunch }
 				plan={ plan }
 				selectedSite={ selectedSite }
 				reduxStore={ context.store }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* hide Masterbar (blue top bar) from checkout page when `preLaunch` query param exists
* show Back button which redirects to plans step
* show custom header content

<img width="1260" alt="Screenshot 2020-03-02 at 18 19 48" src="https://user-images.githubusercontent.com/14192054/75700591-9d3a5000-5cb2-11ea-98a2-01ba453ad21a.png">

#### Testing instructions
* Go to `/start/frankenflow?siteSlug=SITE_SLUG` for a non-launched site and pick a plan
* On checkout page you should see a _Back_ button instead of the blue header and a header message saying your site is up and running and you should complete your plan purchase to upgrade.
* Pressing the _Back_ button should redirect to _Plans_ step

Fixes #38936 
