### PR TITLE
Lock down terser version in calypso-build rather than calypso

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,7 @@
 				"postcss-loader": "3.0.0",
 				"recursive-copy": "2.0.10",
 				"sass-loader": "8.0.0",
+				"terser": "4.4.3",
 				"terser-webpack-plugin": "2.3.1",
 				"thread-loader": "2.1.3",
 				"typescript": "3.7.5",
@@ -197,6 +198,199 @@
 				"webpack-rtl-plugin": "2.0.0"
 			},
 			"dependencies": {
+				"@babel/compat-data": {
+					"version": "7.8.5",
+					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.5.tgz",
+					"integrity": "sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==",
+					"dev": true,
+					"requires": {
+						"browserslist": "^4.8.5",
+						"invariant": "^2.2.4",
+						"semver": "^5.5.0"
+					},
+					"dependencies": {
+						"browserslist": {
+							"version": "4.8.6",
+							"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+							"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
+							"dev": true,
+							"requires": {
+								"caniuse-lite": "^1.0.30001023",
+								"electron-to-chromium": "^1.3.341",
+								"node-releases": "^1.1.47"
+							}
+						},
+						"caniuse-lite": {
+							"version": "1.0.30001027",
+							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+							"integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
+							"dev": true
+						},
+						"electron-to-chromium": {
+							"version": "1.3.349",
+							"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.349.tgz",
+							"integrity": "sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q==",
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-compilation-targets": {
+					"version": "7.8.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz",
+					"integrity": "sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==",
+					"dev": true,
+					"requires": {
+						"@babel/compat-data": "^7.8.4",
+						"browserslist": "^4.8.5",
+						"invariant": "^2.2.4",
+						"levenary": "^1.1.1",
+						"semver": "^5.5.0"
+					},
+					"dependencies": {
+						"browserslist": {
+							"version": "4.8.6",
+							"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+							"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
+							"dev": true,
+							"requires": {
+								"caniuse-lite": "^1.0.30001023",
+								"electron-to-chromium": "^1.3.341",
+								"node-releases": "^1.1.47"
+							}
+						},
+						"caniuse-lite": {
+							"version": "1.0.30001027",
+							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+							"integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
+							"dev": true
+						},
+						"electron-to-chromium": {
+							"version": "1.3.349",
+							"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.349.tgz",
+							"integrity": "sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q==",
+							"dev": true
+						}
+					}
+				},
+				"@babel/plugin-transform-for-of": {
+					"version": "7.8.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
+					"integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.8.3"
+					}
+				},
+				"@babel/plugin-transform-parameters": {
+					"version": "7.8.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz",
+					"integrity": "sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-call-delegate": "^7.8.3",
+						"@babel/helper-get-function-arity": "^7.8.3",
+						"@babel/helper-plugin-utils": "^7.8.3"
+					}
+				},
+				"@babel/plugin-transform-typeof-symbol": {
+					"version": "7.8.4",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+					"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.8.3"
+					}
+				},
+				"@babel/preset-env": {
+					"version": "7.8.4",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
+					"integrity": "sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==",
+					"dev": true,
+					"requires": {
+						"@babel/compat-data": "^7.8.4",
+						"@babel/helper-compilation-targets": "^7.8.4",
+						"@babel/helper-module-imports": "^7.8.3",
+						"@babel/helper-plugin-utils": "^7.8.3",
+						"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+						"@babel/plugin-proposal-dynamic-import": "^7.8.3",
+						"@babel/plugin-proposal-json-strings": "^7.8.3",
+						"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+						"@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+						"@babel/plugin-proposal-optional-chaining": "^7.8.3",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+						"@babel/plugin-syntax-async-generators": "^7.8.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+						"@babel/plugin-syntax-json-strings": "^7.8.0",
+						"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+						"@babel/plugin-syntax-optional-chaining": "^7.8.0",
+						"@babel/plugin-syntax-top-level-await": "^7.8.3",
+						"@babel/plugin-transform-arrow-functions": "^7.8.3",
+						"@babel/plugin-transform-async-to-generator": "^7.8.3",
+						"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+						"@babel/plugin-transform-block-scoping": "^7.8.3",
+						"@babel/plugin-transform-classes": "^7.8.3",
+						"@babel/plugin-transform-computed-properties": "^7.8.3",
+						"@babel/plugin-transform-destructuring": "^7.8.3",
+						"@babel/plugin-transform-dotall-regex": "^7.8.3",
+						"@babel/plugin-transform-duplicate-keys": "^7.8.3",
+						"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+						"@babel/plugin-transform-for-of": "^7.8.4",
+						"@babel/plugin-transform-function-name": "^7.8.3",
+						"@babel/plugin-transform-literals": "^7.8.3",
+						"@babel/plugin-transform-member-expression-literals": "^7.8.3",
+						"@babel/plugin-transform-modules-amd": "^7.8.3",
+						"@babel/plugin-transform-modules-commonjs": "^7.8.3",
+						"@babel/plugin-transform-modules-systemjs": "^7.8.3",
+						"@babel/plugin-transform-modules-umd": "^7.8.3",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+						"@babel/plugin-transform-new-target": "^7.8.3",
+						"@babel/plugin-transform-object-super": "^7.8.3",
+						"@babel/plugin-transform-parameters": "^7.8.4",
+						"@babel/plugin-transform-property-literals": "^7.8.3",
+						"@babel/plugin-transform-regenerator": "^7.8.3",
+						"@babel/plugin-transform-reserved-words": "^7.8.3",
+						"@babel/plugin-transform-shorthand-properties": "^7.8.3",
+						"@babel/plugin-transform-spread": "^7.8.3",
+						"@babel/plugin-transform-sticky-regex": "^7.8.3",
+						"@babel/plugin-transform-template-literals": "^7.8.3",
+						"@babel/plugin-transform-typeof-symbol": "^7.8.4",
+						"@babel/plugin-transform-unicode-regex": "^7.8.3",
+						"@babel/types": "^7.8.3",
+						"browserslist": "^4.8.5",
+						"core-js-compat": "^3.6.2",
+						"invariant": "^2.2.2",
+						"levenary": "^1.1.1",
+						"semver": "^5.5.0"
+					},
+					"dependencies": {
+						"browserslist": {
+							"version": "4.8.6",
+							"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+							"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
+							"dev": true,
+							"requires": {
+								"caniuse-lite": "^1.0.30001023",
+								"electron-to-chromium": "^1.3.341",
+								"node-releases": "^1.1.47"
+							}
+						},
+						"caniuse-lite": {
+							"version": "1.0.30001027",
+							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+							"integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
+							"dev": true
+						},
+						"electron-to-chromium": {
+							"version": "1.3.349",
+							"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.349.tgz",
+							"integrity": "sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q==",
+							"dev": true
+						}
+					}
+				},
 				"browserslist": {
 					"version": "4.8.2",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
@@ -207,6 +401,21 @@
 						"electron-to-chromium": "^1.3.322",
 						"node-releases": "^1.1.42"
 					}
+				},
+				"levenary": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+					"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
+					"dev": true,
+					"requires": {
+						"leven": "^3.1.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
 				}
 			}
 		},
@@ -231,6 +440,7 @@
 		"@automattic/components": {
 			"version": "file:packages/components",
 			"requires": {
+				"@babel/runtime": "^7.8.4",
 				"classnames": "^2.2.6",
 				"gridicons": "^3.3.1",
 				"lodash": "^4.17.15",
@@ -238,6 +448,16 @@
 				"react": "^16.8.3",
 				"react-dom": "^16.8.3",
 				"react-modal": "^3.8.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.8.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+					"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				}
 			}
 		},
 		"@automattic/composite-checkout": {
@@ -37825,6 +38045,14 @@
 				"yamlparser": "0.0.2"
 			},
 			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.8.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+					"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
 				"@emotion/core": {
 					"version": "10.0.22",
 					"resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.22.tgz",

--- a/package.json
+++ b/package.json
@@ -264,7 +264,6 @@
 		"stylelint": "9.10.1",
 		"supertest": "4.0.2",
 		"svgstore-cli": "1.3.1",
-		"terser": "4.4.3",
 		"ts-loader": "6.2.1",
 		"typescript": "3.7.5",
 		"webpack": "4.41.5",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -66,6 +66,7 @@
 		"recursive-copy": "2.0.10",
 		"sass-loader": "8.0.0",
 		"terser-webpack-plugin": "2.3.1",
+		"terser": "4.4.3",
 		"thread-loader": "2.1.3",
 		"typescript": "3.7.5",
 		"webpack": "4.41.5",


### PR DESCRIPTION
#### Changes proposed in this Pull Request
We just had to pin down the `terser` version to prevent the `n is not a function` module loading error in production code. https://github.com/Automattic/wp-calypso/pull/39367

@jsnajdr raised the point that pinning the version in `wp-calypso/package.json` means that the `calypso-build` library cannot be safely used by e.g. jetpack without jetpack also needing to pin the calypso version. https://github.com/Automattic/wp-calypso/pull/39368#issuecomment-585601732

#### Testing instructions

* Test that the production build does not suffer from the `n is not a function` bug that broke staging the other week.
* Possibly test jetpack builds with this module?