### PR TITLE
Duplicate Sites: After site creation in checkout add an extra history entry to redirect back to the site specific plans page

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -54,6 +54,14 @@ export function checkout( context, next ) {
 	// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
 	const couponCode = context.query.coupon || context.query.code || getRememberedCoupon();
 
+	const isComingFromSignup = !! context.query.signup;
+	if ( isComingFromSignup ) {
+		const currentHref = document.location.href;
+		window.history.pushState( null, null, `/plans/${ selectedSite?.slug ?? '' }` );
+		window.history.pushState( null, null, `/plans/${ selectedSite?.slug ?? '' }` );
+		window.history.replaceState( null, null, currentHref );
+	}
+
 	context.primary = (
 		<CartData>
 			<CheckoutSystemDecider


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/39424

### Context

When a customer picks a plan during site creation, we create the site _before_ we reach checkout. Since checkout doesn't have any escape hatches for a free option, folks may click the back button on the browser, taking them to the beginning of the start flow. People proceed with the flow and create a duplicate site.

Proposed changes here are a temporary bandaid to reduce the number of duplicate sites. We do this by adding another history entry so when the customer clicks on the back button we take them to the site specific plans page to let them pick something else (as this was likely their intent).

![Feb-13-2020 16-18-24](https://user-images.githubusercontent.com/1270189/74490392-4395f100-4e7d-11ea-81d6-4eb0161afc31.gif)

Clicking back multiple times, will happen to loop between plans/checkout since the condition matches (and we add more history entries). I think this is mostly harmless since after normal navigation back will work as expected.

Note that I experimented with popstate listeners, but they won't work in this case since the redirect to checkout from signup is a hard redirect (not using the history api).

WIP - since I need to test this hack against other browsers besides chrome. Folks are welcome to hop into the branch if this is of interest. cc @kwight @mmtr 

### Testing Instructions
- Checkout the branch
- Visit /start
- Follow the flow until we reach plans selection
- Pick a paid plan
- In checkout click the back button
- Verify that we're taken to the site specific plans page.