### PR TITLE
Gutenboarding - Test Dynamic Previewing all Designs

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -7,11 +7,12 @@ import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
 import { Popover, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 // Uncomment and remove the redundant sass import from `./style.css` when a release after @wordpress/components@8.5.0 is published.
 // See https://github.com/WordPress/gutenberg/pull/19535
 // import '@wordpress/components/build-style/style.css';
 import { useRouteMatch } from 'react-router-dom';
+import { registerCoreBlocks } from '@wordpress/block-library';
 
 /**
  * Internal dependencies
@@ -24,6 +25,10 @@ import './style.scss';
 registerBlockType( name, settings );
 
 export function Gutenboard() {
+	useEffect( () => {
+		registerCoreBlocks();
+	}, [] );
+
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)
 	// for the 'Back' and 'Next' buttons in the header. If we remove those (and move navigation
 	// entirely into the block), we'll be able to remove this code.

--- a/client/landing/gutenboarding/onboarding-block/design-selector/dynamic-preview.js
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/dynamic-preview.js
@@ -14,18 +14,20 @@ import { BlockPreview } from '@wordpress/block-editor';
 // import { BlockPreview } from '@wordpress/block-editor';
 /* eslint-enable import/no-extraneous-dependencies */
 
-const BlockTemplatePreview = ( { blocks = [] } ) => {
+const BlockTemplatePreview = ( { blocks = [], onClick } ) => {
 	if ( ! blocks || ! blocks.length ) {
 		return null;
 	}
 
 	return (
 		<div
+            onClick={ onClick }
 			style={ {
 				width: '300px',
 				height: '300px',
 				overflowY: 'scroll',
-				backgroundColor: 'white',
+                backgroundColor: 'white',
+                cursor: 'pointer'
 			} }
 		>
 			<BlockPreview blocks={ blocks } viewportWidth={ 1280 } />

--- a/client/landing/gutenboarding/onboarding-block/design-selector/dynamic-preview.js
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/dynamic-preview.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { BlockPreview } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
@@ -10,9 +9,10 @@ import { BlockPreview } from '@wordpress/block-editor';
 /**
  * WordPress dependencies
  */
-/* eslint-disable import/no-extraneous-dependencies */
-// import { BlockPreview } from '@wordpress/block-editor';
-/* eslint-enable import/no-extraneous-dependencies */
+import { BlockPreview } from '@wordpress/block-editor';
+import '@wordpress/block-library/build-style/style.css';
+import '@wordpress/block-library/build-style/theme.css';
+import '@wordpress/block-library/build-style/editor.css';
 
 const BlockTemplatePreview = ( { blocks = [], onClick } ) => {
 	if ( ! blocks || ! blocks.length ) {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/dynamic-preview.js
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/dynamic-preview.js
@@ -25,6 +25,7 @@ const BlockTemplatePreview = ( { blocks = [] } ) => {
 				width: '300px',
 				height: '300px',
 				overflowY: 'scroll',
+				backgroundColor: 'white',
 			} }
 		>
 			<BlockPreview blocks={ blocks } viewportWidth={ 1280 } />

--- a/client/landing/gutenboarding/onboarding-block/design-selector/dynamic-preview.js
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/dynamic-preview.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { BlockPreview } from '@wordpress/block-editor';
+/**
+ * Internal dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+/* eslint-disable import/no-extraneous-dependencies */
+// import { BlockPreview } from '@wordpress/block-editor';
+/* eslint-enable import/no-extraneous-dependencies */
+
+const BlockTemplatePreview = ( { blocks = [] } ) => {
+	if ( ! blocks || ! blocks.length ) {
+		return null;
+	}
+
+	return (
+		<div
+			style={ {
+				width: '300px',
+				height: '300px',
+				overflowY: 'scroll',
+			} }
+		>
+			<BlockPreview blocks={ blocks } viewportWidth={ 1280 } />
+		</div>
+	);
+};
+
+export default BlockTemplatePreview;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -3,7 +3,7 @@
  */
 import { __ as NO__ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
-import React, { useLayoutEffect, useRef, FunctionComponent } from 'react';
+import React, { useLayoutEffect, useRef, FunctionComponent, useState, useEffect } from 'react';
 import classnames from 'classnames';
 import PageLayoutSelector from './page-layout-selector';
 import { partition, memoize, reduce } from 'lodash';
@@ -50,18 +50,19 @@ const DesignSelector: FunctionComponent< Props > = ( { showPageSelector = false 
 			select( VERTICALS_TEMPLATES_STORE ).getTemplates( siteVertical?.id ?? 'm1' )
 		) ?? [];
 
-	// Parse templates blocks and memoize them.
-	const getBlocksByTemplateSlugs = memoize( designTemplate =>
-		reduce(
-			designTemplate,
+	// Parse blocks to state when templates updates.
+	const [ blocksByTemplateSlug, setBlocksByTemplateSlug ] = useState< object >( {} );
+	useEffect( () => {
+		const templateBlocks = reduce(
+			templates,
 			( prev, { slug, content } ) => {
 				prev[ slug ] = content ? parseBlocks( content ) : [];
 				return prev;
 			},
 			{}
-		)
-	);
-	const blocksByTemplateSlug = getBlocksByTemplateSlugs( templates );
+		);
+		setBlocksByTemplateSlug( templateBlocks );
+	}, [ templates ] );
 
 	const [ designs, otherTemplates ] = partition(
 		templates,
@@ -139,9 +140,9 @@ const DesignSelector: FunctionComponent< Props > = ( { showPageSelector = false 
 						// repeatDesigns.map( design => (
 						// otherTemplates.map( design => (
 						// repeatPages.map( design => (
-						<DynamicPreview 
-							key={ design.slug } 
-							blocks={ blocksByTemplateSlug[ design.slug ] } 
+						<DynamicPreview
+							key={ design.slug }
+							blocks={ blocksByTemplateSlug[ design.slug ] }
 							onClick={ () => {
 								window.scrollTo( 0, 0 );
 								setSelectedDesign( design );

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -51,9 +51,9 @@ const DesignSelector: FunctionComponent< Props > = ( { showPageSelector = false 
 		) ?? [];
 
 	// Parse templates blocks and memoize them.
-	const getBlocksByTemplateSlugs = memoize( templates =>
+	const getBlocksByTemplateSlugs = memoize( designTemplate =>
 		reduce(
-			templates,
+			designTemplate,
 			( prev, { slug, content } ) => {
 				prev[ slug ] = content ? parseBlocks( content ) : [];
 				return prev;
@@ -67,6 +67,13 @@ const DesignSelector: FunctionComponent< Props > = ( { showPageSelector = false 
 		templates,
 		( { category } ) => category === 'home'
 	);
+
+	// Try previewing multiple copies of the same designs
+	const repeatDesigns = [];
+	designs.forEach( ( design, index ) => repeatDesigns.push( designs[ ( index % 2 ) + 5 ] ) );
+
+	const repeatPages = [];
+	otherTemplates.forEach( ( temp, i ) => repeatPages.push( otherTemplates[ i % 2 ] ) );
 
 	const headingContainer = useRef< HTMLDivElement >( null );
 	const selectionTransitionShift = useRef< number >( 0 );
@@ -129,6 +136,10 @@ const DesignSelector: FunctionComponent< Props > = ( { showPageSelector = false 
 			>
 				<div className="design-selector__grid">
 					{ designs.map( design => (
+						// repeatDesigns.map( design => (
+						// otherTemplates.map( design => (
+						// repeatPages.map( design => (
+						<DynamicPreview key={ design.slug } blocks={ blocksByTemplateSlug[ design.slug ] } />
 						// <DesignCard
 						// 	key={ design.slug }
 						// 	dialogId={ dialogId }
@@ -149,7 +160,6 @@ const DesignSelector: FunctionComponent< Props > = ( { showPageSelector = false 
 						// 		history.push( Step.PageSelection );
 						// 	} }
 						// />
-						<DynamicPreview key={ design.slug } blocks={ blocksByTemplateSlug[ design.slug ] } />
 					) ) }
 				</div>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -139,7 +139,15 @@ const DesignSelector: FunctionComponent< Props > = ( { showPageSelector = false 
 						// repeatDesigns.map( design => (
 						// otherTemplates.map( design => (
 						// repeatPages.map( design => (
-						<DynamicPreview key={ design.slug } blocks={ blocksByTemplateSlug[ design.slug ] } />
+						<DynamicPreview 
+							key={ design.slug } 
+							blocks={ blocksByTemplateSlug[ design.slug ] } 
+							onClick={ () => {
+								window.scrollTo( 0, 0 );
+								setSelectedDesign( design );
+								history.push( Step.PageSelection );
+							} }
+						/>
 						// <DesignCard
 						// 	key={ design.slug }
 						// 	dialogId={ dialogId }


### PR DESCRIPTION
For summary of these `BlockPreview` draft experiments, please visit `pbAok1-lN-p2`.

### Changes proposed in this Pull Request

This branch tests dynamic previewing in the design step of Gutenboarding by using `BlockPreview` for all designs in the selector.  See #39471 for testing previews only has a hover/focus effect, #39496 for 3 at a time, and #39526 for testing global font settings.

**TLDR:** Having multiple block previews at the same time is not efficient and rendering all design options dynamically at the same time does not seem to be an option.  Loading single block previews on demand is a possibility but doing so independently from the editor will require us to include 3rd party block support, theme styles and settings, etc.


**More Info**
Currently the previews render broken layouts due to lack of 3rd party block support and missing theme styles and settings.  However, they are running and rendering some images so they are set up to give us a good idea about what could be possible in future iterations of Gutenboarding designs.

Some observations thus far:
1.  Running Block Preview for 18 templates at once is not performant and takes a considerable amount of time to load.
2.  Running Block Preview for 2 templates 9 times each does not seem to make a notable improvement in load times.  Thus having templates share images to match the site vertical will not make this any better.  
3.  Parsing blocks out of the content strings in all templates seems to take about 1-2 seconds on its own.  This can be seen by leaving in the parsing functions while commenting out the `DynamicPreview` component in favor of the old cards.  In gutenboarding, go 'back' to the intent page and click 'continue' again.  You should notice a delay before the design page is loaded.  (This delay can be noticed in SPTs as well by opening them through the sidebar and verifying the modal).

Im thinking we may want to limit Block Previews to one at a time ( and best case would be to load one previewer to then use for all previews as in starter page templates ).   I think having scrollable static images per vertical / design will serve us better for a step like design/page selectors.

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this Branch in Calypso.
* Go to the design page to see the 18 (kinda broken) dynamic previews.
* If desired to explore further, adjust Comments in `design-selector/index.tsx` to try rendering different groups of templates or repeat templates, as well as rendering the old Cards instead to see the impact of Parsing blocks alone.

Fixes #39248
