### PR TITLE
[Sites]: update type interface to accept new `site_slug` property.

### DIFF
--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -7,10 +7,10 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { NewSite, NewSiteErrorResponse } from './types';
+import { NewSiteBlogDetails, NewSiteErrorResponse } from './types';
 import { Action } from './actions';
 
-const newSiteData: Reducer< NewSite | undefined, Action > = ( state, action ) => {
+const newSiteData: Reducer< NewSiteBlogDetails | undefined, Action > = ( state, action ) => {
 	if ( action.type === 'RECEIVE_NEW_SITE' ) {
 		const { response } = action;
 		return response.blog_details;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -4,16 +4,17 @@
 
 import { Action } from 'redux';
 
-export interface NewSite {
+export interface NewSiteBlogDetails {
 	url: string;
 	blogid: number;
 	blogname: string;
+	site_slug?: string;
 	xmlrpc: string;
 }
 
 export interface NewSiteSuccessResponse {
 	success: boolean;
-	blog_details: NewSite;
+	blog_details: NewSiteBlogDetails;
 	is_signup_sandbox?: boolean;
 }
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Hi, 

In Gutenboarding, we do a [bit of fiddling about](https://github.com/Automattic/wp-calypso/blob/master/client/landing/gutenboarding/utils.ts#L57) to parse a new site's url to turn it from this:

`https://aaaaa.ccc/`

to this

`aaaaa.ccc`

So in D38739-code we're adding a new property to the `blog_details` object in the success response for `sites/new`, containing this already-edited value.

The new property is called `site_slug`.

This PR prepares our types for the new property.

It also consolidates the `NewSite` and `NewSiteSuccessResponseBlogDetails` interfaces as they represent the same structure.

We hope you like it. 

## Testing instructions

Fire up the branch and create a site via Gutenboarding. (`/gutenboarding`) 

There should be no type errors.

Now apply D38739-code and create a site via Gutenboarding. 

Behold the response! 
<img width="513" alt="Screen Shot 2020-02-14 at 3 53 16 pm" src="https://user-images.githubusercontent.com/6458278/74502832-e5334600-4f42-11ea-9485-823b496d4052.png">

There should be no type errors.

