### PR TITLE
Domain step: Show 'More Extensions' in a pressed state only if tld is not in filter bar

### DIFF
--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -125,6 +125,12 @@
 		button.search-filters__popover-button-domain-step-test {
 			flex: 1 0 auto;
 			margin-left: 2em;
+			
+			&.is-active {
+				color: var( --color-accent );
+				background-color: unset;
+				border-width: 1px 1px 2px;
+			}
 		}
 
 		legend.search-filters__filter-by {

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -180,20 +180,27 @@ export class TldFilterBar extends Component {
 
 	renderPopoverButton() {
 		const {
+			filters: { tlds = [] } = {},
 			lastFilters: { tlds: lastFilterTlds = [] } = {},
 			availableTlds,
 			numberOfTldsShown,
 			translate,
 		} = this.props;
 
-		const visibleTldsInFilterBar = availableTlds.slice( 0, numberOfTldsShown );
-		const isSelectedFiltersNotInFilterBar =
-			difference( lastFilterTlds, visibleTldsInFilterBar ).length > 0;
+		let isActive;
+		if ( this.props.showDesignUpdate ) {
+			const visibleTldsInFilterBar = availableTlds.slice( 0, numberOfTldsShown );
+			const isSelectedFiltersNotInFilterBar =
+				difference( lastFilterTlds, visibleTldsInFilterBar ).length > 0;
+			isActive = isSelectedFiltersNotInFilterBar;
+		} else {
+			isActive = tlds.length > 0;
+		}
 
 		return (
 			<Button
 				className={ classNames( 'search-filters__popover-button', {
-					'is-active': isSelectedFiltersNotInFilterBar,
+					'is-active': isActive,
 					'search-filters__popover-button-domain-step-test': this.props.showDesignUpdate,
 				} ) }
 				onClick={ this.togglePopover }

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Gridicon from 'components/gridicon';
 import React, { Component } from 'react';
-import { includes, isEqual, pick } from 'lodash';
+import { difference, includes, isEqual, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -179,11 +179,21 @@ export class TldFilterBar extends Component {
 	}
 
 	renderPopoverButton() {
-		const { filters: { tlds = [] } = {}, translate } = this.props;
+		const {
+			lastFilters: { tlds: lastFilterTlds = [] } = {},
+			availableTlds,
+			numberOfTldsShown,
+			translate,
+		} = this.props;
+
+		const visibleTldsInFilterBar = availableTlds.slice( 0, numberOfTldsShown );
+		const isSelectedFiltersNotInFilterBar =
+			difference( lastFilterTlds, visibleTldsInFilterBar ).length > 0;
+
 		return (
 			<Button
 				className={ classNames( 'search-filters__popover-button', {
-					'is-active': tlds.length > 0,
+					'is-active': isSelectedFiltersNotInFilterBar,
 					'search-filters__popover-button-domain-step-test': this.props.showDesignUpdate,
 				} ) }
 				onClick={ this.togglePopover }

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import { difference, includes, isEqual, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { isWithinBreakpoint } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -178,18 +179,39 @@ export class TldFilterBar extends Component {
 			) );
 	}
 
+	getNumberOfTldsShownInViewport() {
+		// The number of TLDs shown for each breakpoint should match the CSS rule.
+		// e.g. .search-filters__tld-checkbox:nth-child( n + 5 ) is defined as display: none for screen size <800px,
+		// so we return 4 for isWithinBreakpoint( '<800px' ).
+		if ( isWithinBreakpoint( '<480px' ) ) {
+			return 1;
+		}
+
+		if ( isWithinBreakpoint( '<660px' ) ) {
+			return 2;
+		}
+
+		if ( isWithinBreakpoint( '<800px' ) ) {
+			return 4;
+		}
+
+		if ( isWithinBreakpoint( '>800px' ) ) {
+			return this.props.numberOfTldsShown;
+		}
+	}
+
 	renderPopoverButton() {
 		const {
 			filters: { tlds = [] } = {},
 			lastFilters: { tlds: lastFilterTlds = [] } = {},
 			availableTlds,
-			numberOfTldsShown,
 			translate,
 		} = this.props;
 
 		let isActive;
 		if ( this.props.showDesignUpdate ) {
-			const visibleTldsInFilterBar = availableTlds.slice( 0, numberOfTldsShown );
+			const numberOfTldsShownInViewport = this.getNumberOfTldsShownInViewport();
+			const visibleTldsInFilterBar = availableTlds.slice( 0, numberOfTldsShownInViewport );
 			const isSelectedFiltersNotInFilterBar =
 				difference( lastFilterTlds, visibleTldsInFilterBar ).length > 0;
 			isActive = isSelectedFiltersNotInFilterBar;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The next domain step test is being implemented in #39276. The test is hidden behind a feature flag. We will build individual pieces of the UI in separate PRs.

* This PR fixes the issue described in https://github.com/Automattic/wp-calypso/issues/39414
* ~The "More Extensions" button will be showed in a pressed state only if the selected TLD filter is NOT visible in the filter bar. If you select a TLD checkbox or button from the visible filter area, then the button will not show in a pressed state.~ Per https://github.com/Automattic/wp-calypso/issues/39414#issuecomment-587923987, the "More Extensions" button will show in a magenta text colour if the selected TLD is NOT visible in the filter bar. If you select a TLD checkbox or button from the visible filter area,  then the More Extensions button will not change.

**TLD filter selected from visible area("More extensions" button should not be in pressed state)**:

_variantShowUpdates_ of domainStepCopyUpdates and _variantDesignUpdates_ of domainStepDesignUpdates

<img width="963" alt="Screenshot 2020-02-14 at 2 05 43 PM" src="https://user-images.githubusercontent.com/1269602/74514866-74d0f880-4f33-11ea-8ff6-bc96c67d6c17.png">


The control group versions will retain their behaviour of showing the button in a pressed state:

_variantShowUpdates_ of domainStepCopyUpdates and _control_ of domainStepDesignUpdates

<img width="940" alt="Screenshot 2020-02-19 at 2 08 23 PM" src="https://user-images.githubusercontent.com/1269602/74816536-5e56e280-5321-11ea-9375-b3ac333f5b05.png">


 _control_ of domainStepCopyUpdates

<img width="965" alt="Screenshot 2020-02-19 at 2 08 37 PM" src="https://user-images.githubusercontent.com/1269602/74816551-63b42d00-5321-11ea-8410-01cd421701c7.png">


**TLD filter selected is NOT from visible area("More extensions" button text will change to magenta color)**:

_variantShowUpdates_ of domainStepCopyUpdates and _variantDesignUpdates_ of domainStepDesignUpdates


<img width="957" alt="Screenshot 2020-02-19 at 2 39 52 PM" src="https://user-images.githubusercontent.com/1269602/74819023-b5f74d00-5325-11ea-8b87-1176369eb952.png">


The control group versions will retain their behaviour of showing the button in a pressed state:

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow /start - assign yourself to _variantShowUpdates_ of _domainStepCopyUpdates_ and _variantDesignUpdates_ of _domainStepDesignUpdates_.
* Verify that if any one of the selected TLD filters is not in visible area, then button is in pressed state; if all the selected TLD filters are in visible area, then button is not in pressed state.
* Verify the same behaviour for the other variations of the domain step A/B tests - (i) _variantShowUpdates_ of _domainStepCopyUpdates_ and _control_ of _domainStepDesignUpdates_ (ii) _control_ of _domainStepCopyUpdates_.

Fixes https://github.com/Automattic/wp-calypso/issues/39414
