### PR TITLE
FSE: remove plugin archive creation step

### DIFF
--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -25,5 +25,5 @@ jobs:
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:
-        name: fse-build-archive.tar.gz
-        path: ./fse-build-archive.tar.gz
+        name: fse-build-archive
+        path: apps/full-site-editing/full-site-editing-plugin

--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -22,8 +22,6 @@ jobs:
       run: npm ci
     - name: Build FSE
       run: npx lerna run build --scope='@automattic/full-site-editing' --stream
-    - name: Create FSE plugin archive
-      run: tar -czvf fse-build-archive.tar.gz -C apps/full-site-editing/full-site-editing-plugin .
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is not needed since the existing uploader action already
creates a .zip archive for the artifact by default.

#### Testing instructions

Same as before, this can be tested on you wp-calypso repository fork. You can also check the results of the [test run in my fork](https://github.com/vindl/wp-calypso/actions/runs/39346788).