### PR TITLE
Add publishConfig to viewport packages.

### DIFF
--- a/packages/viewport-react/package.json
+++ b/packages/viewport-react/package.json
@@ -27,5 +27,8 @@
 		"clean": "npx rimraf dist",
 		"prepublish": "npm run clean",
 		"prepare": "transpile"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -20,5 +20,8 @@
 		"clean": "npx rimraf dist",
 		"prepublish": "npm run clean",
 		"prepare": "transpile"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }


### PR DESCRIPTION
I missed this setting in the initial code; it's required for publishing the package publicly.

#### Changes proposed in this Pull Request

* Add `publishConfig` to `package.json` for `viewport` and `viewport-react`.

#### Testing instructions

Configuration-only change; no testing needed.
