### PR TITLE
composite-checkout: Add analytics events for all payment methods

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -625,6 +625,16 @@ function getCheckoutEventHandler( dispatch ) {
 						error_message: action.payload,
 					} )
 				);
+			case 'PAYPAL_TRANSACTION_BEGIN':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_paypal_button_clicked', {} )
+				);
+			case 'PAYPAL_TRANSACTION_ERROR':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_paypal_transaction_error', {
+						error_message: action.payload,
+					} )
+				);
 			default:
 				debug( 'unknown checkout event: not recording', action );
 				return;

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -617,7 +617,7 @@ function getCheckoutEventHandler( dispatch ) {
 				);
 			case 'STRIPE_TRANSACTION_BEGIN':
 				return dispatch(
-					recordTracksEvent( 'calypso_checkout_composite_stripe_button_clicked', {} )
+					recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
 				);
 			case 'STRIPE_TRANSACTION_ERROR':
 				return dispatch(
@@ -627,7 +627,7 @@ function getCheckoutEventHandler( dispatch ) {
 				);
 			case 'PAYPAL_TRANSACTION_BEGIN':
 				return dispatch(
-					recordTracksEvent( 'calypso_checkout_composite_paypal_button_clicked', {} )
+					recordTracksEvent( 'calypso_checkout_composite_paypal_submit_clicked', {} )
 				);
 			case 'PAYPAL_TRANSACTION_ERROR':
 				return dispatch(
@@ -637,11 +637,21 @@ function getCheckoutEventHandler( dispatch ) {
 				);
 			case 'FULL_CREDITS_TRANSACTION_BEGIN':
 				return dispatch(
-					recordTracksEvent( 'calypso_checkout_composite_full_credits_button_clicked', {} )
+					recordTracksEvent( 'calypso_checkout_composite_full_credits_submit_clicked', {} )
 				);
 			case 'FULL_CREDITS_TRANSACTION_ERROR':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_full_credits_error', {
+						error_message: action.payload,
+					} )
+				);
+			case 'EXISTING_CARD_TRANSACTION_BEGIN':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
+				);
+			case 'EXISTING_CARD_TRANSACTION_ERROR':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_existing_card_error', {
 						error_message: action.payload,
 					} )
 				);

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -615,6 +615,16 @@ function getCheckoutEventHandler( dispatch ) {
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_step_changed', { step: action.payload } )
 				);
+			case 'STRIPE_TRANSACTION_BEGIN':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_stripe_button_clicked', {} )
+				);
+			case 'STRIPE_TRANSACTION_ERROR':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
+						error_message: action.payload,
+					} )
+				);
 			default:
 				debug( 'unknown checkout event: not recording', action );
 				return;

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -622,7 +622,7 @@ function getCheckoutEventHandler( dispatch ) {
 			case 'STRIPE_TRANSACTION_ERROR':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
-						error_message: action.payload,
+						error_message: String( action.payload ),
 					} )
 				);
 			case 'PAYPAL_TRANSACTION_BEGIN':
@@ -632,7 +632,7 @@ function getCheckoutEventHandler( dispatch ) {
 			case 'PAYPAL_TRANSACTION_ERROR':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_paypal_transaction_error', {
-						error_message: action.payload,
+						error_message: String( action.payload ),
 					} )
 				);
 			case 'FULL_CREDITS_TRANSACTION_BEGIN':
@@ -642,7 +642,7 @@ function getCheckoutEventHandler( dispatch ) {
 			case 'FULL_CREDITS_TRANSACTION_ERROR':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_full_credits_error', {
-						error_message: action.payload,
+						error_message: String( action.payload ),
 					} )
 				);
 			case 'EXISTING_CARD_TRANSACTION_BEGIN':
@@ -652,7 +652,17 @@ function getCheckoutEventHandler( dispatch ) {
 			case 'EXISTING_CARD_TRANSACTION_ERROR':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_existing_card_error', {
-						error_message: action.payload,
+						error_message: String( action.payload ),
+					} )
+				);
+			case 'APPLE_PAY_TRANSACTION_BEGIN':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
+				);
+			case 'APPLE_PAY_TRANSACTION_ERROR':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
+						error_message: String( action.payload ),
 					} )
 				);
 			default:

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -635,6 +635,16 @@ function getCheckoutEventHandler( dispatch ) {
 						error_message: action.payload,
 					} )
 				);
+			case 'FULL_CREDITS_TRANSACTION_BEGIN':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_full_credits_button_clicked', {} )
+				);
+			case 'FULL_CREDITS_TRANSACTION_ERROR':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_full_credits_error', {
+						error_message: action.payload,
+					} )
+				);
 			default:
 				debug( 'unknown checkout event: not recording', action );
 				return;

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -14,6 +14,7 @@ import {
 	useDispatch,
 	useMessages,
 	useLineItems,
+	useEvents,
 	renderDisplayValueMarkdown,
 } from '../../public-api';
 import { sprintf, useLocalize } from '../localize';
@@ -222,6 +223,7 @@ function ExistingCardPayButton( { disabled, id } ) {
 	);
 	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
 	const { stripeConfiguration } = useStripe();
+	const onEvent = useEvents();
 
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
@@ -303,6 +305,7 @@ function ExistingCardPayButton( { disabled, id } ) {
 					beginCardTransaction,
 					setFormSubmitting,
 					resetTransaction,
+					onEvent,
 				} )
 			}
 			buttonState={ disabled ? 'disabled' : 'primary' }
@@ -341,9 +344,11 @@ async function submitExistingCardPayment( {
 	setFormSubmitting,
 	setFormReady,
 	resetTransaction,
+	onEvent,
 } ) {
 	debug( 'submitting existing card payment with the id', id );
 	try {
+		onEvent( { type: 'EXISTING_CARD_TRANSACTION_BEGIN' } );
 		setFormSubmitting();
 		beginCardTransaction( {
 			items,
@@ -352,6 +357,7 @@ async function submitExistingCardPayment( {
 	} catch ( error ) {
 		resetTransaction();
 		setFormReady();
+		onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: String( error ) } );
 		showErrorMessage( error );
 		return;
 	}

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -33,7 +33,7 @@ export function createFullCreditsMethod( { registerStore, submitTransaction } ) 
 				debug( 'full credits transaction complete', response );
 			} catch ( error ) {
 				debug( 'full credits transaction had an error', error );
-				return { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: String( error ) };
+				return { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: error };
 			}
 			debug( 'full credits transaction requires is successful' );
 			return { type: 'FULL_CREDITS_TRANSACTION_END', payload: response };

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -13,6 +13,7 @@ import {
 	useDispatch,
 	useMessages,
 	useLineItems,
+	useEvents,
 	renderDisplayValueMarkdown,
 } from '../../public-api';
 import { sprintf, useLocalize } from '../localize';
@@ -108,9 +109,11 @@ function FullCreditsSubmitButton( { disabled } ) {
 	const transactionError = useSelect( select => select( 'full-credits' ).getTransactionError() );
 	const { showErrorMessage } = useMessages();
 	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
+	const onEvent = useEvents();
 
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
+			onEvent( { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: transactionError || '' } );
 			showErrorMessage(
 				transactionError || localize( 'An error occurred during the transaction' )
 			);
@@ -121,6 +124,7 @@ function FullCreditsSubmitButton( { disabled } ) {
 			setFormComplete();
 		}
 	}, [
+		onEvent,
 		setFormReady,
 		setFormComplete,
 		showErrorMessage,
@@ -131,6 +135,7 @@ function FullCreditsSubmitButton( { disabled } ) {
 
 	const onClick = () => {
 		setFormSubmitting();
+		onEvent( { type: 'FULL_CREDITS_TRANSACTION_BEGIN' } );
 		beginCreditsTransaction( {
 			items,
 		} );

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -33,7 +33,7 @@ export function createFullCreditsMethod( { registerStore, submitTransaction } ) 
 				debug( 'full credits transaction complete', response );
 			} catch ( error ) {
 				debug( 'full credits transaction had an error', error );
-				return { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: error };
+				return { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: String( error ) };
 			}
 			debug( 'full credits transaction requires is successful' );
 			return { type: 'FULL_CREDITS_TRANSACTION_END', payload: response };

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -45,7 +45,7 @@ export function createPayPalMethod( { registerStore } ) {
 					debug( 'received successful paypal endpoint response', paypalResponse );
 					return { type: 'PAYPAL_TRANSACTION_END', payload: paypalResponse };
 				} catch ( error ) {
-					return { type: 'PAYPAL_TRANSACTION_ERROR', payload: String( error ) };
+					return { type: 'PAYPAL_TRANSACTION_ERROR', payload: error };
 				}
 			},
 		},

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -45,7 +45,7 @@ export function createPayPalMethod( { registerStore } ) {
 					debug( 'received successful paypal endpoint response', paypalResponse );
 					return { type: 'PAYPAL_TRANSACTION_END', payload: paypalResponse };
 				} catch ( error ) {
-					return { type: 'PAYPAL_TRANSACTION_ERROR', payload: error };
+					return { type: 'PAYPAL_TRANSACTION_ERROR', payload: String( error ) };
 				}
 			},
 		},

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -94,7 +94,7 @@ export function createStripeMethod( {
 				debug( 'stripe transaction complete', stripeResponse );
 			} catch ( error ) {
 				debug( 'stripe transaction had an error', error );
-				return { type: 'STRIPE_TRANSACTION_ERROR', payload: String( error ) };
+				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
 			}
 			if ( stripeResponse?.message?.payment_intent_client_secret ) {
 				debug( 'stripe transaction requires auth' );

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -522,6 +522,7 @@ function StripePayButton( { disabled } ) {
 	const name = useSelect( select => select( 'stripe' ).getCardholderName() );
 	const redirectUrl = useSelect( select => select( 'stripe' ).getRedirectUrl() );
 	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
+	const onEvent = useEvents();
 
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
@@ -607,6 +608,7 @@ function StripePayButton( { disabled } ) {
 					beginStripeTransaction,
 					setFormSubmitting,
 					resetTransaction,
+					onEvent,
 				} )
 			}
 			buttonState={ disabled ? 'disabled' : 'primary' }
@@ -642,10 +644,12 @@ async function submitStripePayment( {
 	setFormSubmitting,
 	setFormReady,
 	resetTransaction,
+	onEvent,
 } ) {
 	debug( 'submitting stripe payment' );
 	try {
 		setFormSubmitting();
+		onEvent( { type: 'STRIPE_TRANSACTION_BEGIN' } );
 		beginStripeTransaction( {
 			stripe,
 			name,
@@ -656,6 +660,7 @@ async function submitStripePayment( {
 	} catch ( error ) {
 		resetTransaction();
 		setFormReady();
+		onEvent( { type: 'STRIPE_TRANSACTION_ERROR', payload: error } );
 		debug( 'showing error for submit', error );
 		showErrorMessage( error );
 		return;

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -94,7 +94,7 @@ export function createStripeMethod( {
 				debug( 'stripe transaction complete', stripeResponse );
 			} catch ( error ) {
 				debug( 'stripe transaction had an error', error );
-				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
+				return { type: 'STRIPE_TRANSACTION_ERROR', payload: String( error ) };
 			}
 			if ( stripeResponse?.message?.payment_intent_client_secret ) {
 				debug( 'stripe transaction requires auth' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds analytics for all the payment methods when the method begins submission and when there is an error.

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Enable the debug logs by putting this in your JS console: `localStorage.setItem('debug', 'calypso:*')`
- Try submitting a credit card transaction and verify that the Tracks event was submitted by watching the debug logs.
- Repeat the above step with paypal, existing cards, full credits, and apple pay.