### PR TITLE
Wrap up the popular badge on Business plan test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,17 +106,6 @@ export default {
 		defaultVariation: 'variantShowUpdates',
 		allowExistingUsers: true,
 	},
-	showBusinessPlanPopular: {
-		datestamp: '20200109',
-		variations: {
-			variantShowBizPopular: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-		localeExceptions: [ 'en' ],
-	},
 	sidebarUpsellNudgeUnification: {
 		datestamp: '20200127',
 		variations: {

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -439,14 +439,7 @@ export function getPlanTermLabel( planName, translate ) {
 	}
 }
 
-export const getPopularPlanSpec = ( {
-	customerType,
-	isJetpack,
-	abtest,
-	isInSignup,
-	isLaunchPage,
-	countryCode,
-} ) => {
+export const getPopularPlanSpec = ( { customerType, isJetpack } ) => {
 	// Jetpack doesn't currently highlight "Popular" plans
 	if ( isJetpack ) {
 		return false;
@@ -458,17 +451,6 @@ export const getPopularPlanSpec = ( {
 	};
 
 	if ( customerType === 'personal' ) {
-		const isUserOutsideUS = countryCode && 'US' !== countryCode;
-
-		if (
-			isInSignup &&
-			! isLaunchPage &&
-			isUserOutsideUS &&
-			'variantShowBizPopular' === abtest( 'showBusinessPlanPopular' )
-		) {
-			return spec;
-		}
-
 		spec.type = TYPE_PREMIUM;
 	}
 

--- a/client/lib/plans/test/get-popular-plan-spec.js
+++ b/client/lib/plans/test/get-popular-plan-spec.js
@@ -4,13 +4,6 @@
 import { getPopularPlanSpec } from '..';
 import { GROUP_WPCOM, TYPE_BUSINESS, TYPE_PREMIUM } from '../constants';
 
-const abtest = test => {
-	if ( 'showBusinessPlanPopular' === test ) {
-		return 'variantShowBizPopular';
-	}
-	return;
-};
-
 describe( 'getPopularPlanSpec()', () => {
 	test( 'Should return biz for empty customer type', () => {
 		expect( getPopularPlanSpec( {} ) ).toEqual( {
@@ -36,80 +29,6 @@ describe( 'getPopularPlanSpec()', () => {
 				customerType: 'business',
 			} )
 		).toEqual( { type: TYPE_BUSINESS, group: GROUP_WPCOM } );
-	} );
-
-	describe( 'showBusinessPlanPopular A/B test === variantShowBizPopular', () => {
-		test( 'Should return biz for personal customer type in signup flow for user not in USA', () => {
-			expect(
-				getPopularPlanSpec( {
-					customerType: 'personal',
-					isInSignup: true,
-					isLaunchPage: false,
-					countryCode: 'DE',
-					abtest,
-				} )
-			).toEqual( { type: TYPE_BUSINESS, group: GROUP_WPCOM } );
-		} );
-
-		test( 'Should return premium for personal customer type in signup flow for user in USA', () => {
-			expect(
-				getPopularPlanSpec( {
-					customerType: 'personal',
-					isInSignup: true,
-					isLaunchPage: false,
-					countryCode: 'US',
-					abtest,
-				} )
-			).toEqual( { type: TYPE_PREMIUM, group: GROUP_WPCOM } );
-		} );
-
-		test( 'Should return premium for personal customer type in signup flow for country code null', () => {
-			expect(
-				getPopularPlanSpec( {
-					customerType: 'personal',
-					isInSignup: true,
-					isLaunchPage: false,
-					countryCode: null,
-					abtest,
-				} )
-			).toEqual( { type: TYPE_PREMIUM, group: GROUP_WPCOM } );
-		} );
-
-		test( 'Should return premium for personal customer type in launch flow', () => {
-			expect(
-				getPopularPlanSpec( {
-					customerType: 'personal',
-					isInSignup: true,
-					isLaunchPage: true,
-					countryCode: 'DE',
-					abtest,
-				} )
-			).toEqual( { type: TYPE_PREMIUM, group: GROUP_WPCOM } );
-		} );
-
-		test( 'Should return premium for personal customer type when not in signup flow', () => {
-			expect(
-				getPopularPlanSpec( {
-					customerType: 'personal',
-					isInSignup: false,
-					abtest,
-				} )
-			).toEqual( { type: TYPE_PREMIUM, group: GROUP_WPCOM } );
-		} );
-	} );
-
-	describe( 'showBusinessPlanPopular A/B test === control', () => {
-		test( 'Should return premium for personal customer type when in signup flow for user not in USA', () => {
-			expect(
-				getPopularPlanSpec( {
-					customerType: 'personal',
-					isInSignup: true,
-					isLaunchPage: false,
-					countryCode: 'DE',
-					abtest: () => 'control',
-				} )
-			).toEqual( { type: TYPE_PREMIUM, group: GROUP_WPCOM } );
-		} );
 	} );
 
 	test( 'Should return false when isJetpack is true', () => {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -7,7 +7,6 @@ import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -71,7 +70,6 @@ import {
 import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
-import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -113,7 +111,6 @@ export class PlansFeaturesMain extends Component {
 	getPlanFeatures() {
 		const {
 			basePlansPath,
-			countryCode,
 			customerType,
 			disableBloggerPlanWithNonBlogDomain,
 			displayJetpackPlans,
@@ -177,12 +174,8 @@ export class PlansFeaturesMain extends Component {
 					discountEndDate={ discountEndDate }
 					withScroll={ plansWithScroll }
 					popularPlanSpec={ getPopularPlanSpec( {
-						abtest,
 						customerType,
 						isJetpack,
-						isInSignup,
-						isLaunchPage,
-						countryCode,
 					} ) }
 					siteId={ siteId }
 				/>
@@ -542,12 +535,6 @@ export default connect(
 			currentPlan,
 		} );
 
-		const isDevelopment = 'development' === process.env.NODE_ENV;
-		const devCountryCode = isDevelopment && global.window && global.window.userCountryCode;
-		const cookies = cookie.parse( document.cookie );
-		const countryCodeFromCookie = cookies.country_code;
-		const countryCode = devCountryCode || countryCodeFromCookie;
-
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
 			// during the signup, and we're going to remove the code soon after the test. Also, since this endpoint is
@@ -563,7 +550,6 @@ export default connect(
 			siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
 			sitePlanSlug: currentPlan && currentPlan.product_slug,
-			countryCode,
 		};
 	},
 	{

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -308,10 +308,9 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		).toBe( 1 );
 	} );
 
-	test( 'Highlights TYPE_PREMIUM as popular plan for personal customer type if not in	signup flow', () => {
+	test( 'Highlights TYPE_PREMIUM as popular plan for personal customer type', () => {
 		const instance = new PlansFeaturesMain( {
 			customerType: 'personal',
-			isInSignup: false,
 		} );
 		const comp = shallow( instance.render() );
 		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
@@ -320,66 +319,13 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		} );
 	} );
 
-	test( 'Highlights TYPE_BUSINESS as popular plan for business customer type if not in signup flow', () => {
+	test( 'Highlights TYPE_BUSINESS as popular plan for business customer type', () => {
 		const instance = new PlansFeaturesMain( {
 			customerType: 'business',
-			isInSignup: false,
 		} );
 		const comp = shallow( instance.render() );
 		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
 			type: TYPE_BUSINESS,
-			group: GROUP_WPCOM,
-		} );
-	} );
-
-	test( 'Highlights TYPE_PREMIUM as popular plan for personal customer type in signup flow', () => {
-		const instance = new PlansFeaturesMain( {
-			customerType: 'personal',
-			isInSignup: true,
-			isLaunchPage: false,
-		} );
-		const comp = shallow( instance.render() );
-		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
-			type: TYPE_PREMIUM,
-			group: GROUP_WPCOM,
-		} );
-	} );
-
-	test( 'Highlights TYPE_BUSINESS as popular plan for business customer type in signup flow', () => {
-		const instance = new PlansFeaturesMain( {
-			customerType: 'business',
-			isInSignup: true,
-			isLaunchPage: false,
-		} );
-		const comp = shallow( instance.render() );
-		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
-			type: TYPE_BUSINESS,
-			group: GROUP_WPCOM,
-		} );
-	} );
-
-	test( 'Highlights TYPE_BUSINESS as popular plan for business customer type in launch flow', () => {
-		const instance = new PlansFeaturesMain( {
-			customerType: 'business',
-			isInSignup: true,
-			isLaunchPage: true,
-		} );
-		const comp = shallow( instance.render() );
-		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
-			type: TYPE_BUSINESS,
-			group: GROUP_WPCOM,
-		} );
-	} );
-
-	test( 'Highlights TYPE_PREMIUM as popular plan for personal customer type in launch flow', () => {
-		const instance = new PlansFeaturesMain( {
-			customerType: 'personal',
-			isInSignup: true,
-			isLaunchPage: true,
-		} );
-		const comp = shallow( instance.render() );
-		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
-			type: TYPE_PREMIUM,
 			group: GROUP_WPCOM,
 		} );
 	} );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -86,14 +86,9 @@ export class PlansStep extends Component {
 		}
 
 		const siteGoals = this.props.siteGoals.split( ',' );
-		let customerType =
+		const customerType =
 			getSiteTypePropertyValue( 'slug', this.props.siteType, 'customerType' ) ||
 			( intersection( siteGoals, [ 'sell', 'promote' ] ).length > 0 ? 'business' : 'personal' );
-
-		// Default to 'business' when the blogger plan is not available.
-		if ( customerType === 'personal' && this.props.disableBloggerPlanWithNonBlogDomain ) {
-			customerType = 'business';
-		}
 
 		return customerType;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap of the A/B test launched in https://github.com/Automattic/wp-calypso/pull/38334
* We will launch the control version to all users, as per p8Eqe3-Zs#comment-3116

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**
* Go through the signup flow and select either `Business` or `Online Store` as site type.
* Verify in Plans step that the Business plan is highlighted as Popular.

**Scenario 2**
* Go through the signup flow and select either `Blog` or `Professional` as site type.
* Verify in Plans step that the Premium plan is highlighted as Popular.

**Scenario 3**

* Log in to an account and check /plans page. 
* Verify that on the `Blogs and Personal sites` tab, the Premium plan is highlighted as Popular, and on the `Business sites and Online Stores` tab, the Business plan is highlighted as popular.

**Scenario 4**
* Log in to an account that has an unlaunched site on a free plan
* Go through the launch flow and verify that on the plans step, the Premium plan is highlighted as Popular.

**Scenarion 5**

* Verify that the bug described in https://github.com/Automattic/wp-calypso/issues/39476 is fixed.

Fixes 219-gh-martech
