### PR TITLE
composite-checkout: Prevent resetting active payment method when PM list is the same

### DIFF
--- a/packages/composite-checkout/src/components/checkout-payment-methods.js
+++ b/packages/composite-checkout/src/components/checkout-payment-methods.js
@@ -35,6 +35,7 @@ export default function CheckoutPaymentMethods( { summary, isComplete, className
 	const paymentMethods = useAllPaymentMethods();
 
 	if ( summary && isComplete && paymentMethod ) {
+		debug( 'rendering selected paymentMethod', paymentMethod );
 		return (
 			<div className={ joinClasses( [ className, 'checkout-payment-methods' ] ) }>
 				<CheckoutErrorBoundary
@@ -52,6 +53,12 @@ export default function CheckoutPaymentMethods( { summary, isComplete, className
 	}
 
 	if ( summary ) {
+		debug(
+			'summary requested, but no complete paymentMethod is selected; isComplete:',
+			isComplete,
+			'paymentMethod:',
+			paymentMethod
+		);
 		return null;
 	}
 	debug( 'rendering paymentMethods', paymentMethods );

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -44,10 +44,14 @@ export const CheckoutProvider = props => {
 	const [ paymentMethodId, setPaymentMethodId ] = useState(
 		paymentMethods?.length ? paymentMethods[ 0 ].id : null
 	);
+	const [ prevPaymentMethods, setPrevPaymentMethods ] = useState( [] );
 	useEffect( () => {
-		debug( 'paymentMethods changed; setting payment method to first of', paymentMethods );
-		setPaymentMethodId( paymentMethods?.length ? paymentMethods[ 0 ].id : null );
-	}, [ paymentMethods ] );
+		if ( paymentMethods.length !== prevPaymentMethods.length ) {
+			debug( 'paymentMethods changed; setting payment method to first of', paymentMethods );
+			setPaymentMethodId( paymentMethods?.length ? paymentMethods[ 0 ].id : null );
+			setPrevPaymentMethods( paymentMethods );
+		}
+	}, [ paymentMethods, prevPaymentMethods ] );
 
 	const [ formStatus, setFormStatus ] = useFormStatusManager( isLoading );
 	useEffect( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When I refactored payment method creation in the thank-you PR, I caused the payment methods array to be re-created on every render. This means that the useEffect in the provider which sets the active payment method to the first one when the payment methods change gets called on every render.

This PR only resets the active method if the length of the payment methods array changes. It's not perfect - there are cases where that would have a false positive - but it's much better.

#### Testing instructions

Choose PayPal as a payment method and make sure it "sticks" through the whole checkout process.