### PR TITLE
Add/composite checkout complete events

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -235,7 +235,8 @@ export default function CompositeCheckout( {
 		setCart || wpcomSetCart,
 		getCart || wpcomGetCart,
 		translate,
-		showAddCouponSuccessMessage
+		showAddCouponSuccessMessage,
+		recordEvent
 	);
 
 	const { registerStore, dispatch } = registry;
@@ -593,8 +594,14 @@ function getCheckoutEventHandler( dispatch ) {
 		switch ( action.type ) {
 			case 'PAYMENT_COMPLETE':
 				return dispatch(
-					recordTracksEvent( 'calypso_checkout_payment_complete', {
+					recordTracksEvent( 'calypso_checkout_composite_payment_complete', {
 						redirect_url: action.payload.url,
+					} )
+				);
+			case 'CART_ERROR':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_cart_error', {
+						error_message: action.payload.error,
 					} )
 				);
 			case 'a8c_checkout_error':

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -359,6 +359,9 @@ export type VariantRequestStatus = 'fresh' | 'pending' | 'valid' | 'error';
  * @param showAddCouponSuccessMessage
  *     Takes a coupon code and displays a translated notice that
  *     the coupon was successfully applied.
+ * @param onEvent
+ *     Optional callback that Takes a React Standard Action object ( {
+ *     type: string, payload?: any } ) for analytics.
  * @returns ShoppingCartManager
  */
 export function useShoppingCart(
@@ -366,7 +369,8 @@ export function useShoppingCart(
 	setCart: ( string, RequestCart ) => Promise< ResponseCart >,
 	getCart: ( string ) => Promise< ResponseCart >,
 	translate: ( string ) => string,
-	showAddCouponSuccessMessage: ( string ) => void
+	showAddCouponSuccessMessage: ( string ) => void,
+	onEvent?: ( object: { type: string; payload?: any } ) => void // eslint-disable-line @typescript-eslint/no-explicit-any
 ): ShoppingCartManager {
 	cartKey = cartKey || 'no-site';
 	const setServerCart = useCallback( cartParam => setCart( cartKey, cartParam ), [
@@ -407,8 +411,9 @@ export function useShoppingCart(
 				// TODO: figure out what to do here
 				debug( 'error while initializing cart', error );
 				hookDispatch( { type: 'RAISE_ERROR', error: 'GET_SERVER_CART_ERROR' } );
+				onEvent?.( { type: 'CART_ERROR', payload: { error: 'GET_SERVER_CART_ERROR' } } );
 			} );
-	}, [ getServerCart, cacheStatus ] );
+	}, [ getServerCart, cacheStatus, onEvent ] );
 
 	// Asynchronously re-validate when the cache is dirty.
 	useEffect( () => {
@@ -433,8 +438,9 @@ export function useShoppingCart(
 				// TODO: figure out what to do here
 				debug( 'error while fetching cart', error );
 				hookDispatch( { type: 'RAISE_ERROR', error: 'SET_SERVER_CART_ERROR' } );
+				onEvent?.( { type: 'CART_ERROR', payload: { error: 'SET_SERVER_CART_ERROR' } } );
 			} );
-	}, [ setServerCart, cacheStatus, responseCart ] );
+	}, [ setServerCart, cacheStatus, responseCart, onEvent ] );
 
 	// Keep a separate cache of the displayed cart which we regenerate only when
 	// the cart has been downloaded

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -167,10 +167,10 @@ export function ApplePaySubmitButton( { disabled } ) {
 	useEffect( () => {
 		if ( transactionStatus === 'error' ) {
 			debug( 'showing error', transactionError );
-			onEvent( { type: 'APPLE_PAY_TRANSACTION_ERROR', transactionError } );
 			showErrorMessage(
 				transactionError || localize( 'An error occurred during the transaction' )
 			);
+			onEvent( { type: 'APPLE_PAY_TRANSACTION_ERROR', payload: transactionError || '' } );
 			resetTransaction();
 			setFormReady();
 		}
@@ -368,6 +368,7 @@ async function submitStripePayment( {
 		resetTransaction();
 		setFormReady();
 		debug( 'showing error for submit', error );
+		onEvent( { type: 'APPLE_PAY_TRANSACTION_ERROR', payload: error } );
 		showErrorMessage( error );
 		return;
 	}

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -230,6 +230,7 @@ function ExistingCardPayButton( { disabled, id } ) {
 			showErrorMessage(
 				transactionError || localize( 'An error occurred during the transaction' )
 			);
+			onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: transactionError || '' } );
 			setFormReady();
 		}
 		if ( transactionStatus === 'complete' ) {
@@ -242,6 +243,7 @@ function ExistingCardPayButton( { disabled, id } ) {
 			window.location = redirectUrl;
 		}
 	}, [
+		onEvent,
 		redirectUrl,
 		setFormReady,
 		setFormComplete,
@@ -271,6 +273,7 @@ function ExistingCardPayButton( { disabled, id } ) {
 					showErrorMessage(
 						localize( 'Authorization failed for that card. Please try a different payment method.' )
 					);
+					onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: error } );
 					isSubscribed && resetTransaction();
 					isSubscribed && setFormReady();
 				} );
@@ -278,6 +281,7 @@ function ExistingCardPayButton( { disabled, id } ) {
 
 		return () => ( isSubscribed = false );
 	}, [
+		onEvent,
 		resetTransaction,
 		setTransactionComplete,
 		setFormReady,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -574,6 +574,7 @@ function StripePayButton( { disabled } ) {
 					showErrorMessage(
 						localize( 'Authorization failed for that card. Please try a different payment method.' )
 					);
+					onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: error } );
 					isSubscribed && resetTransaction();
 					isSubscribed && setFormReady();
 				} );
@@ -581,6 +582,7 @@ function StripePayButton( { disabled } ) {
 
 		return () => ( isSubscribed = false );
 	}, [
+		onEvent,
 		setStripeComplete,
 		resetTransaction,
 		setFormReady,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -530,6 +530,7 @@ function StripePayButton( { disabled } ) {
 			showErrorMessage(
 				transactionError || localize( 'An error occurred during the transaction' )
 			);
+			onEvent( { type: 'STRIPE_TRANSACTION_ERROR', payload: transactionError || '' } );
 			resetTransaction();
 			setFormReady();
 		}
@@ -543,6 +544,7 @@ function StripePayButton( { disabled } ) {
 			window.location = redirectUrl;
 		}
 	}, [
+		onEvent,
 		resetTransaction,
 		setFormReady,
 		setFormComplete,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As a follow-up to #39463 this PR adds more analytics events. It adds an event for whenever a payment is complete (except for paypal, which performs its own redirect) and events for shopping cart errors.

#### Testing instructions


- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start`.
- Enable the debug logs by putting this in your JS console: `localStorage.setItem('debug', 'calypso:analytics:*')`
- Try submitting a credit card transaction and verify that the Tracks event `calypso_checkout_composite_payment_complete` was submitted by watching the debug logs.
- You can also submit a credit card transaction with the test card number `4000000000000002` (if you have the store sandboxed) which will cause a decline. You should see an event sent to Tracks with the name `calypso_checkout_composite_stripe_transaction_error`.