### PR TITLE
Change the way translations are used in Jetpack products

### DIFF
--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -19,7 +19,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePlanSlug } from 'state/sites/plans/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import { planHasFeature, planHasSuperiorFeature } from 'lib/plans';
-import { PRODUCT_SHORT_NAMES } from 'lib/products-values/constants';
+import { getJetpackProductsShortNames } from 'lib/products-values/constants';
 
 class ProductPlanOverlapNotices extends Component {
 	static propTypes = {
@@ -111,8 +111,9 @@ class ProductPlanOverlapNotices extends Component {
 			return null;
 		}
 
-		if ( PRODUCT_SHORT_NAMES[ currentProductSlug ] ) {
-			return PRODUCT_SHORT_NAMES[ currentProductSlug ].toLowerCase();
+		const productsShortNames = getJetpackProductsShortNames();
+		if ( productsShortNames[ currentProductSlug ] ) {
+			return productsShortNames[ currentProductSlug ].toLowerCase();
 		}
 
 		if ( availableProducts[ currentProductSlug ] ) {

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -26,81 +26,6 @@ export const JETPACK_BACKUP_PRODUCTS = [
 
 export const JETPACK_PRODUCTS_LIST = [ ...JETPACK_BACKUP_PRODUCTS ];
 
-export const JETPACK_BACKUP_PRODUCT_SHORT_NAMES = {
-	[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate( 'Daily Backups' ),
-	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate( 'Daily Backups' ),
-	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: translate( 'Real-Time Backups' ),
-	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate( 'Real-Time Backups' ),
-};
-
-export const PRODUCT_SHORT_NAMES = {
-	...JETPACK_BACKUP_PRODUCT_SHORT_NAMES,
-};
-
-export const JETPACK_BACKUP_PRODUCT_DAILY_DISPLAY_NAME = (
-	<Fragment>
-		{ translate( 'Jetpack Backup {{em}}Daily{{/em}}', {
-			components: {
-				em: <em />,
-			},
-		} ) }
-	</Fragment>
-);
-export const JETPACK_BACKUP_PRODUCT_REALTIME_DISPLAY_NAME = (
-	<Fragment>
-		{ translate( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-			components: {
-				em: <em />,
-			},
-		} ) }
-	</Fragment>
-);
-export const JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES = {
-	[ PRODUCT_JETPACK_BACKUP_DAILY ]: JETPACK_BACKUP_PRODUCT_DAILY_DISPLAY_NAME,
-	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: JETPACK_BACKUP_PRODUCT_DAILY_DISPLAY_NAME,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: JETPACK_BACKUP_PRODUCT_REALTIME_DISPLAY_NAME,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: JETPACK_BACKUP_PRODUCT_REALTIME_DISPLAY_NAME,
-};
-
-export const JETPACK_PRODUCT_DISPLAY_NAMES = {
-	...JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES,
-};
-
-export const JETPACK_BACKUP_PRODUCT_DAILY_TAGLINE = translate(
-	'Your data is being securely backed up every day with a 30-day archive.'
-);
-export const JETPACK_BACKUP_PRODUCT_REALTIME_TAGLINE = translate(
-	'Your data is being securely backed up as you edit.'
-);
-
-export const JETPACK_BACKUP_PRODUCT_TAGLINES = {
-	[ PRODUCT_JETPACK_BACKUP_DAILY ]: JETPACK_BACKUP_PRODUCT_DAILY_TAGLINE,
-	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: JETPACK_BACKUP_PRODUCT_DAILY_TAGLINE,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: JETPACK_BACKUP_PRODUCT_REALTIME_TAGLINE,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: JETPACK_BACKUP_PRODUCT_REALTIME_TAGLINE,
-};
-
-export const JETPACK_PRODUCT_TAGLINES = {
-	...JETPACK_BACKUP_PRODUCT_TAGLINES,
-};
-
-export const PRODUCT_JETPACK_BACKUP_DESCRIPTION = translate(
-	'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
-);
-export const PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION = translate(
-	'Always-on backups ensure you never lose your site. Your changes are saved every day with a 30-day archive.'
-);
-export const PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION = translate(
-	'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
-);
-
-export const JETPACK_BACKUP_PRODUCT_DESCRIPTIONS = {
-	[ PRODUCT_JETPACK_BACKUP_DAILY ]: PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION,
-	[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: PRODUCT_JETPACK_BACKUP_DAILY_DESCRIPTION,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME ]: PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION,
-	[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: PRODUCT_JETPACK_BACKUP_REALTIME_DESCRIPTION,
-};
-
 export const JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/backup/';
 
 export const JETPACK_PRODUCT_PRICE_MATRIX = {
@@ -114,24 +39,105 @@ export const JETPACK_PRODUCT_PRICE_MATRIX = {
 	},
 };
 
-export const JETPACK_PRODUCTS = [
+// Translatable strings
+export const getJetpackProductsShortNames = () => {
+	return {
+		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate( 'Daily Backups' ),
+		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate( 'Daily Backups' ),
+		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: translate( 'Real-Time Backups' ),
+		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate( 'Real-Time Backups' ),
+	};
+};
+
+export const getJetpackProductsDisplayNames = () => {
+	return {
+		[ PRODUCT_JETPACK_BACKUP_DAILY ]: (
+			<Fragment>
+				{ translate( 'Jetpack Backup {{em}}Daily{{/em}}', {
+					components: {
+						em: <em />,
+					},
+				} ) }
+			</Fragment>
+		),
+		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: (
+			<Fragment>
+				{ translate( 'Jetpack Backup {{em}}Daily{{/em}}', {
+					components: {
+						em: <em />,
+					},
+				} ) }
+			</Fragment>
+		),
+		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: (
+			<Fragment>
+				{ translate( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+					components: {
+						em: <em />,
+					},
+				} ) }
+			</Fragment>
+		),
+		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: (
+			<Fragment>
+				{ translate( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+					components: {
+						em: <em />,
+					},
+				} ) }
+			</Fragment>
+		),
+	};
+};
+
+export const getJetpackProductsTaglines = () => {
+	return {
+		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate(
+			'Your data is being securely backed up every day with a 30-day archive.'
+		),
+		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate(
+			'Your data is being securely backed up every day with a 30-day archive.'
+		),
+		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: translate(
+			'Your data is being securely backed up as you edit.'
+		),
+		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate(
+			'Your data is being securely backed up as you edit.'
+		),
+	};
+};
+
+export const getJetpackProductsDescriptions = () => {
+	return {
+		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate(
+			'Always-on backups ensure you never lose your site. Your changes are saved every day with a 30-day archive.'
+		),
+		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate(
+			'Always-on backups ensure you never lose your site. Your changes are saved every day with a 30-day archive.'
+		),
+		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: translate(
+			'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+		),
+		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate(
+			'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+		),
+	};
+};
+
+export const getJetpackProducts = () => [
 	{
 		title: translate( 'Jetpack Backup' ),
-		description: PRODUCT_JETPACK_BACKUP_DESCRIPTION,
+		description: translate(
+			'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
+		),
 		id: PRODUCT_JETPACK_BACKUP,
 		options: {
 			yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
 			monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
 		},
-		optionShortNames: {
-			...JETPACK_BACKUP_PRODUCT_SHORT_NAMES,
-		},
-		optionDisplayNames: {
-			...JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES,
-		},
-		optionDescriptions: {
-			...JETPACK_BACKUP_PRODUCT_DESCRIPTIONS,
-		},
+		optionShortNames: getJetpackProductsShortNames(),
+		optionDisplayNames: getJetpackProductsDisplayNames(),
+		optionDescriptions: getJetpackProductsDescriptions(),
 		optionsLabel: translate( 'Select a backup option:' ),
 	},
 ];

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -10,8 +10,8 @@ import { isGSuiteOrExtraLicenseProductSlug } from 'lib/gsuite';
 import {
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
-	JETPACK_PRODUCT_DISPLAY_NAMES,
-	JETPACK_PRODUCT_TAGLINES,
+	getJetpackProductsDisplayNames,
+	getJetpackProductsTaglines,
 } from './constants';
 import {
 	PLAN_BUSINESS_MONTHLY,
@@ -397,8 +397,9 @@ export function getProductClass( productSlug ) {
 export function getJetpackProductDisplayName( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
+	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames();
 
-	return JETPACK_PRODUCT_DISPLAY_NAMES?.[ product.productSlug ];
+	return jetpackProductsDisplayNames?.[ product.productSlug ];
 }
 
 /**
@@ -410,8 +411,9 @@ export function getJetpackProductDisplayName( product ) {
 export function getJetpackProductTagline( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
+	const jetpackProductsTaglines = getJetpackProductsTaglines();
 
-	return JETPACK_PRODUCT_TAGLINES?.[ product.productSlug ];
+	return jetpackProductsTaglines?.[ product.productSlug ];
 }
 
 export function isDependentProduct( product, dependentProduct, domainsWithPlansOnly ) {

--- a/client/lib/products-values/test/index.js
+++ b/client/lib/products-values/test/index.js
@@ -22,8 +22,8 @@ import {
 import {
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
-	JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES,
-	JETPACK_BACKUP_PRODUCT_TAGLINES,
+	getJetpackProductsDisplayNames,
+	getJetpackProductsTaglines,
 } from '../constants';
 import {
 	JETPACK_PLANS,
@@ -193,9 +193,10 @@ describe( 'isJetpackBackup', () => {
 
 describe( 'getJetpackProductDisplayName', () => {
 	test( 'should return Jetpack Backup product display name', () => {
+		const jetpackProductsDisplayNames = getJetpackProductsDisplayNames();
 		JETPACK_BACKUP_PRODUCTS.map( makeProductFromSlug ).forEach( product =>
 			expect( getJetpackProductDisplayName( product ) ).toBe(
-				JETPACK_BACKUP_PRODUCT_DISPLAY_NAMES[ product.productSlug ]
+				jetpackProductsDisplayNames[ product.productSlug ]
 			)
 		);
 	} );
@@ -203,9 +204,10 @@ describe( 'getJetpackProductDisplayName', () => {
 
 describe( 'getJetpackProductTagline', () => {
 	test( 'should return Jetpack Backup product tagline', () => {
+		const jetpackProductsTaglines = getJetpackProductsTaglines();
 		JETPACK_BACKUP_PRODUCTS.map( makeProductFromSlug ).forEach( product =>
 			expect( getJetpackProductTagline( product ) ).toBe(
-				JETPACK_BACKUP_PRODUCT_TAGLINES[ product.productSlug ]
+				jetpackProductsTaglines[ product.productSlug ]
 			)
 		);
 	} );

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -22,7 +22,7 @@ import {
 	isConciergeSession,
 } from 'lib/products-values';
 import { addItems } from 'lib/cart/actions';
-import { JETPACK_PRODUCT_DISPLAY_NAMES } from 'lib/products-values/constants';
+import { getJetpackProductsDisplayNames } from 'lib/products-values/constants';
 
 function getIncludedDomain( purchase ) {
 	return purchase.includedDomain;
@@ -72,8 +72,9 @@ function getName( purchase ) {
 }
 
 function getDisplayName( purchase ) {
-	if ( JETPACK_PRODUCT_DISPLAY_NAMES[ purchase.productSlug ] ) {
-		return JETPACK_PRODUCT_DISPLAY_NAMES[ purchase.productSlug ];
+	const jetpackProductsDisplayNames = getJetpackProductsDisplayNames();
+	if ( jetpackProductsDisplayNames[ purchase.productSlug ] ) {
+		return jetpackProductsDisplayNames[ purchase.productSlug ];
 	}
 	return getName( purchase );
 }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -32,7 +32,7 @@ import {
 import {
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PRODUCT_PRICE_MATRIX,
-	JETPACK_PRODUCTS,
+	getJetpackProducts,
 } from 'lib/products-values/constants';
 import { addQueryArgs } from 'lib/url';
 import JetpackFAQ from './jetpack-faq';
@@ -441,6 +441,7 @@ export class PlansFeaturesMain extends Component {
 		}
 
 		const { basePlansPath, intervalType, redirectTo } = this.props;
+		const jetpackProducts = getJetpackProducts();
 
 		return (
 			<div className="plans-features-main__group is-narrow">
@@ -452,7 +453,7 @@ export class PlansFeaturesMain extends Component {
 					products={ JETPACK_BACKUP_PRODUCTS }
 				/>
 				<ProductSelector
-					products={ JETPACK_PRODUCTS }
+					products={ jetpackProducts }
 					intervalType={ intervalType }
 					basePlansPath={ basePlansPath }
 					productPriceMatrix={ JETPACK_PRODUCT_PRICE_MATRIX }


### PR DESCRIPTION
In some cases, no translations are displayed in e.g. ProductsSelector even though the respective strings are already translated.

It turns out that the `translate` function inside the `client/lib/products-values/constants.js` file is executed *before* translations are loaded via `localize` HoC. The constants are imported directly to the file that consumes them and so the `translate` function is executed once, right after the app is booted.

To overcome this issue, the `translate` function calls are now wrapped with anonymous functions. This way the `translate` function call gets deferred. It's executed when localization is already available since consumers use `localize` HoC themselves. 

<img width="554" alt="Screenshot 2020-02-14 at 21 07 35" src="https://user-images.githubusercontent.com/478735/74563872-0bbaa680-4f6e-11ea-8b12-2e7ecf5c197a.png">

#### Changes proposed in this Pull Request

* Defer `translate` calls for Jetpack products

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/me/account and change the language to something else than EN (e.g. ES)
* Go to http://calypso.localhost:3000/plans and select a Jetpack site that has no Jetpack Backup product
* Confirm that all strings inside the Jetpack Backup product selector are translated
* Purchase one of the Jetpack Backup products and go back to http://calypso.localhost:3000/plans
* Confirm that all strings inside the Jetpack Backup product selector are translated
* Go to http://calypso.localhost:3000/plans/my-plan and confirm that all strings related to the Jetpack product are translated.
* Purchase a Jetpack plan that includes the Jetpack Backup product you already have
* Go to http://calypso.localhost:3000/plans/
* Confirm that the "overlapping plan/product" notice copy is correctly translated

Fixes 1142395350490785-as-1161887890451417