### PR TITLE
composite-checkout: Record unknown error types to Tracks also

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -681,8 +681,12 @@ function getCheckoutEventHandler( dispatch ) {
 					} )
 				);
 			default:
-				debug( 'unknown checkout event: not recording', action );
-				return;
+				debug( 'unknown checkout event', action );
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_unknown_error', {
+						error_type: String( action.type ),
+					} )
+				);
 		}
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This just adds a special error message to Tracks if we try to record an action we don't recognize.

Fixes #39469

#### Testing instructions

None. 