### PR TITLE
composite-checkout: Prevent race condition when adding product to cart

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -30,7 +30,9 @@ export default function CheckoutSystemDecider( {
 	const countryCode = useSelector( state => getCurrentUserCountryCode( state ) );
 	const locale = useSelector( state => getCurrentUserLocale( state ) );
 
-	if ( shouldShowCompositeCheckout( cart, countryCode, locale ) ) {
+	// TODO: fetch the current cart, ideally without using CartData, and use that to pass to shouldShowCompositeCheckout
+
+	if ( shouldShowCompositeCheckout( cart, countryCode, locale, product ) ) {
 		return (
 			<CompositeCheckout
 				siteSlug={ selectedSite?.slug }
@@ -61,9 +63,24 @@ export default function CheckoutSystemDecider( {
 	);
 }
 
-function shouldShowCompositeCheckout( cart, countryCode, locale ) {
+function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug ) {
 	if ( config.isEnabled( 'composite-checkout-wpcom' ) ) {
 		return true;
+	}
+	// If the URL is adding a product, only allow wpcom plans
+	const slugFragmentsToAllow = [
+		'personal-bundle',
+		'value_bundle',
+		'value-bundle',
+		'blogger',
+		'ecommerce',
+		'business',
+	];
+	if (
+		productSlug &&
+		! slugFragmentsToAllow.find( fragment => productSlug.includes( fragment ) )
+	) {
+		return false;
 	}
 	// Disable for non-USD
 	if ( cart?.currency !== 'USD' ) {

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -37,6 +37,10 @@ export default function CheckoutSystemDecider( {
 
 	// TODO: fetch the current cart, ideally without using CartData, and use that to pass to shouldShowCompositeCheckout
 
+	if ( ! cart || ! cart.currency ) {
+		debug( 'not deciding yet; cart has not loaded' );
+		return null; // TODO: replace with loading page
+	}
 	if ( shouldShowCompositeCheckout( cart, countryCode, locale, product, isJetpack ) ) {
 		return (
 			<CompositeCheckout
@@ -91,22 +95,22 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		return false;
 	}
 	// Disable for non-USD
-	if ( cart?.currency !== 'USD' ) {
+	if ( cart.currency !== 'USD' ) {
 		debug( 'shouldShowCompositeCheckout false because currency is not USD' );
 		return false;
 	}
 	// Disable for domains in the cart
-	if ( cart?.products?.find( product => product.is_domain_registration ) ) {
+	if ( cart.products?.find( product => product.is_domain_registration ) ) {
 		debug( 'shouldShowCompositeCheckout false because cart contains domain' );
 		return false;
 	}
 	// Disable for GSuite plans
-	if ( cart?.products?.find( product => product.product_slug.includes( 'gapps' ) ) ) {
+	if ( cart.products?.find( product => product.product_slug.includes( 'gapps' ) ) ) {
 		debug( 'shouldShowCompositeCheckout false because cart contains GSuite' );
 		return false;
 	}
 	// Disable for jetpack plans
-	if ( cart?.products?.find( product => product.product_slug.includes( 'jetpack' ) ) ) {
+	if ( cart.products?.find( product => product.product_slug.includes( 'jetpack' ) ) ) {
 		debug( 'shouldShowCompositeCheckout false because cart contains jetpack' );
 		return false;
 	}

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -232,6 +232,7 @@ export default function CompositeCheckout( {
 	const productForCart = planSlug
 		? createItemToAddToCart( { planSlug, plan, isJetpackNotAtomic } )
 		: null;
+	const canInitializeCart = ! planSlug || ( planSlug && productForCart );
 
 	const {
 		items,
@@ -252,6 +253,7 @@ export default function CompositeCheckout( {
 		variantSelectOverride,
 	} = useShoppingCart(
 		siteSlug,
+		canInitializeCart,
 		productForCart,
 		setCart || wpcomSetCart,
 		getCart || wpcomGetCart,

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -216,22 +216,7 @@ export default function CompositeCheckout( {
 
 	const countriesList = useCountryList( overrideCountryList || [] );
 
-	const plan = useSelector( state => getPlanBySlug( state, planSlug ) );
-	useEffect( () => {
-		if ( ! planSlug ) {
-			return;
-		}
-		// TODO: what if the plans did load but there is no matching plan? check for plans loaded instead
-		if ( ! plan ) {
-			debug( 'there is a request to add a plan but no plan was found', planSlug );
-			reduxDispatch( requestPlans() );
-			return;
-		}
-	}, [ reduxDispatch, planSlug, plan ] );
-	planSlug && debug( 'adding item as requested in url', { planSlug, plan, isJetpackNotAtomic } );
-	const productForCart = planSlug
-		? createItemToAddToCart( { planSlug, plan, isJetpackNotAtomic } )
-		: null;
+	const productForCart = usePrepareProductForCart( planSlug, isJetpackNotAtomic );
 	const canInitializeCart = ! planSlug || ( planSlug && productForCart );
 
 	const {
@@ -925,3 +910,29 @@ const DoNotPayThis = styled.span`
 	text-decoration: line-through;
 	margin-right: 8px;
 `;
+
+function usePrepareProductForCart( planSlug, isJetpackNotAtomic ) {
+	const plan = useSelector( state => getPlanBySlug( state, planSlug ) );
+	const reduxDispatch = useDispatch();
+
+	// Fetch plans if they are not loaded
+	useEffect( () => {
+		if ( ! planSlug ) {
+			return;
+		}
+		// TODO: what if the plans did load but there is no matching plan? check for plans loaded instead
+		if ( ! plan ) {
+			debug( 'there is a request to add a plan but no plan was found', planSlug );
+			reduxDispatch( requestPlans() );
+			return;
+		}
+	}, [ reduxDispatch, planSlug, plan ] );
+
+	const productForCart = planSlug
+		? createItemToAddToCart( { planSlug, plan, isJetpackNotAtomic } )
+		: null;
+	if ( productForCart ) {
+		debug( 'item was requested in url', { planSlug, plan, isJetpackNotAtomic }, productForCart );
+	}
+	return productForCart;
+}

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -176,6 +176,10 @@ export default function CompositeCheckout( {
 	const reduxDispatch = useDispatch();
 	const recordEvent = useCallback( getCheckoutEventHandler( reduxDispatch ), [] );
 
+	useEffect( () => {
+		recordEvent( { type: 'CHECKOUT_LOADED' } );
+	}, [ recordEvent ] );
+
 	const onPaymentComplete = useCallback( () => {
 		debug( 'payment completed successfully' );
 		const url = getThankYouUrl();
@@ -592,6 +596,8 @@ function getCheckoutEventHandler( dispatch ) {
 	return action => {
 		debug( 'heard checkout event', action );
 		switch ( action.type ) {
+			case 'CHECKOUT_LOADED':
+				return dispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
 			case 'PAYMENT_COMPLETE':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_complete', {

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -448,7 +448,6 @@ export function useShoppingCart(
 	}, [] );
 
 	const updateLocation: ( CartLocation ) => void = useCallback( location => {
-		debug( 'updating location for cart to', location );
 		hookDispatch( { type: 'SET_LOCATION', location } );
 	}, [] );
 
@@ -489,12 +488,17 @@ function useInitializeCartFromServer(
 ): void {
 	const isInitialized = useRef( false );
 	useEffect( () => {
-		if ( cacheStatus !== 'fresh' || canInitializeCart !== true ) {
+		if ( cacheStatus !== 'fresh' ) {
+			debug( 'not initializing cart; cacheStatus is not fresh' );
+			return;
+		}
+		if ( canInitializeCart !== true ) {
+			debug( 'not initializing cart; canInitializeCart is not true' );
 			return;
 		}
 
 		if ( isInitialized.current ) {
-			debug( 'not initializing cart again' );
+			debug( 'not initializing cart; already initialized' );
 			return;
 		}
 		isInitialized.current = true;

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -407,12 +407,12 @@ export function useShoppingCart(
 		[ translate, responseCartToDisplay ]
 	);
 
-	useEffect( () => {
-		if ( shouldShowNotification.didAddCoupon ) {
-			showAddCouponSuccessMessage( responseCart.coupon );
-			hookDispatch( { type: 'DID_SHOW_ADD_COUPON_SUCCESS_MESSAGE' } );
-		}
-	}, [ shouldShowNotification.didAddCoupon, responseCart.coupon, showAddCouponSuccessMessage ] );
+	useShowAddCouponSuccessMessage(
+		shouldShowNotification.didAddCoupon,
+		responseCart,
+		showAddCouponSuccessMessage,
+		hookDispatch
+	);
 
 	const addItem: ( ResponseCartProduct ) => void = useCallback( responseCartProductToAdd => {
 		hookDispatch( { type: 'ADD_CART_ITEM', responseCartProductToAdd } );
@@ -529,4 +529,18 @@ function useCachedValidCart( cacheStatus, responseCart ) {
 		}
 	}, [ responseCart, cacheStatus ] );
 	return responseCartToDisplay;
+}
+
+function useShowAddCouponSuccessMessage(
+	didAddCoupon,
+	responseCart,
+	showAddCouponSuccessMessage,
+	hookDispatch
+) {
+	useEffect( () => {
+		if ( didAddCoupon ) {
+			showAddCouponSuccessMessage( responseCart.coupon );
+			hookDispatch( { type: 'DID_SHOW_ADD_COUPON_SUCCESS_MESSAGE' } );
+		}
+	}, [ didAddCoupon, responseCart.coupon, showAddCouponSuccessMessage, hookDispatch ] );
 }

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -399,13 +399,7 @@ export function useShoppingCart(
 
 	// Keep a separate cache of the displayed cart which we regenerate only when
 	// the cart has been downloaded
-	const [ responseCartToDisplay, setResponseCartToDisplay ] = useState( responseCart );
-	useEffect( () => {
-		if ( cacheStatus === 'valid' ) {
-			debug( 'updating the displayed cart to match the server cart' );
-			setResponseCartToDisplay( responseCart );
-		}
-	}, [ responseCart, cacheStatus ] );
+	const responseCartToDisplay = useCachedValidCart( cacheStatus, responseCart );
 
 	// Translate the responseCart into the format needed in checkout.
 	const cart: WPCOMCart = useMemo(
@@ -524,4 +518,15 @@ function useCartUpdateAndRevalidate(
 				onEvent?.( { type: 'CART_ERROR', payload: { error: 'SET_SERVER_CART_ERROR' } } );
 			} );
 	}, [ setServerCart, cacheStatus, responseCart, onEvent, hookDispatch ] );
+}
+
+function useCachedValidCart( cacheStatus, responseCart ) {
+	const [ responseCartToDisplay, setResponseCartToDisplay ] = useState( responseCart );
+	useEffect( () => {
+		if ( cacheStatus === 'valid' ) {
+			debug( 'updating the displayed cart to match the server cart' );
+			setResponseCartToDisplay( responseCart );
+		}
+	}, [ responseCart, cacheStatus ] );
+	return responseCartToDisplay;
 }

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -392,28 +392,7 @@ export function useShoppingCart(
 	const shouldShowNotification = hookState.shouldShowNotification;
 
 	// Asynchronously initialize the cart. This should happen exactly once.
-	useEffect( () => {
-		if ( cacheStatus !== 'fresh' ) {
-			return;
-		}
-
-		debug( `initializing the cart; cacheStatus is ${ cacheStatus }` );
-
-		getServerCart()
-			.then( response => {
-				debug( 'initialized cart is', response );
-				hookDispatch( {
-					type: 'RECEIVE_INITIAL_RESPONSE_CART',
-					initialResponseCart: processRawResponse( response ),
-				} );
-			} )
-			.catch( error => {
-				// TODO: figure out what to do here
-				debug( 'error while initializing cart', error );
-				hookDispatch( { type: 'RAISE_ERROR', error: 'GET_SERVER_CART_ERROR' } );
-				onEvent?.( { type: 'CART_ERROR', payload: { error: 'GET_SERVER_CART_ERROR' } } );
-			} );
-	}, [ getServerCart, cacheStatus, onEvent ] );
+	useInitializeCartFromServer( cacheStatus, getServerCart, hookDispatch, onEvent );
 
 	// Asynchronously re-validate when the cache is dirty.
 	useEffect( () => {
@@ -510,4 +489,29 @@ export function useShoppingCart(
 		variantRequestStatus,
 		variantSelectOverride,
 	} as ShoppingCartManager;
+}
+
+function useInitializeCartFromServer( cacheStatus, getServerCart, hookDispatch, onEvent ) {
+	useEffect( () => {
+		if ( cacheStatus !== 'fresh' ) {
+			return;
+		}
+
+		debug( `initializing the cart; cacheStatus is ${ cacheStatus }` );
+
+		getServerCart()
+			.then( response => {
+				debug( 'initialized cart is', response );
+				hookDispatch( {
+					type: 'RECEIVE_INITIAL_RESPONSE_CART',
+					initialResponseCart: processRawResponse( response ),
+				} );
+			} )
+			.catch( error => {
+				// TODO: figure out what to do here
+				debug( 'error while initializing cart', error );
+				hookDispatch( { type: 'RAISE_ERROR', error: 'GET_SERVER_CART_ERROR' } );
+				onEvent?.( { type: 'CART_ERROR', payload: { error: 'GET_SERVER_CART_ERROR' } } );
+			} );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -395,31 +395,7 @@ export function useShoppingCart(
 	useInitializeCartFromServer( cacheStatus, getServerCart, hookDispatch, onEvent );
 
 	// Asynchronously re-validate when the cache is dirty.
-	useEffect( () => {
-		if ( cacheStatus !== 'invalid' ) {
-			return;
-		}
-
-		debug( 'sending edited cart to server', responseCart );
-
-		hookDispatch( { type: 'REQUEST_UPDATED_RESPONSE_CART' } );
-
-		setServerCart( prepareRequestCart( responseCart ) )
-			.then( response => {
-				debug( 'updated cart is', response );
-				hookDispatch( {
-					type: 'RECEIVE_UPDATED_RESPONSE_CART',
-					updatedResponseCart: processRawResponse( response ),
-				} );
-				hookDispatch( { type: 'CLEAR_VARIANT_SELECT_OVERRIDE' } );
-			} )
-			.catch( error => {
-				// TODO: figure out what to do here
-				debug( 'error while fetching cart', error );
-				hookDispatch( { type: 'RAISE_ERROR', error: 'SET_SERVER_CART_ERROR' } );
-				onEvent?.( { type: 'CART_ERROR', payload: { error: 'SET_SERVER_CART_ERROR' } } );
-			} );
-	}, [ setServerCart, cacheStatus, responseCart, onEvent ] );
+	useCartUpdateAndRevalidate( cacheStatus, responseCart, setServerCart, hookDispatch, onEvent );
 
 	// Keep a separate cache of the displayed cart which we regenerate only when
 	// the cart has been downloaded
@@ -514,4 +490,38 @@ function useInitializeCartFromServer( cacheStatus, getServerCart, hookDispatch, 
 				onEvent?.( { type: 'CART_ERROR', payload: { error: 'GET_SERVER_CART_ERROR' } } );
 			} );
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+}
+
+function useCartUpdateAndRevalidate(
+	cacheStatus,
+	responseCart,
+	setServerCart,
+	hookDispatch,
+	onEvent
+) {
+	useEffect( () => {
+		if ( cacheStatus !== 'invalid' ) {
+			return;
+		}
+
+		debug( 'sending edited cart to server', responseCart );
+
+		hookDispatch( { type: 'REQUEST_UPDATED_RESPONSE_CART' } );
+
+		setServerCart( prepareRequestCart( responseCart ) )
+			.then( response => {
+				debug( 'updated cart is', response );
+				hookDispatch( {
+					type: 'RECEIVE_UPDATED_RESPONSE_CART',
+					updatedResponseCart: processRawResponse( response ),
+				} );
+				hookDispatch( { type: 'CLEAR_VARIANT_SELECT_OVERRIDE' } );
+			} )
+			.catch( error => {
+				// TODO: figure out what to do here
+				debug( 'error while fetching cart', error );
+				hookDispatch( { type: 'RAISE_ERROR', error: 'SET_SERVER_CART_ERROR' } );
+				onEvent?.( { type: 'CART_ERROR', payload: { error: 'SET_SERVER_CART_ERROR' } } );
+			} );
+	}, [ setServerCart, cacheStatus, responseCart, onEvent, hookDispatch ] );
 }

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -323,6 +323,8 @@ export type CouponStatus = 'fresh' | 'pending' | 'applied' | 'invalid' | 'reject
  */
 export type VariantRequestStatus = 'fresh' | 'pending' | 'valid' | 'error';
 
+type ReactStandardAction = { type: string; payload?: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
+
 /**
  * Custom hook for managing state in the WPCOM checkout component.
  *
@@ -367,8 +369,7 @@ export type VariantRequestStatus = 'fresh' | 'pending' | 'valid' | 'error';
  *     Takes a coupon code and displays a translated notice that
  *     the coupon was successfully applied.
  * @param onEvent
- *     Optional callback that Takes a React Standard Action object ( {
- *     type: string, payload?: any } ) for analytics.
+ *     Optional callback that takes a ReactStandardAction object for analytics.
  * @returns ShoppingCartManager
  */
 export function useShoppingCart(
@@ -379,7 +380,7 @@ export function useShoppingCart(
 	getCart: ( string ) => Promise< ResponseCart >,
 	translate: ( string ) => string,
 	showAddCouponSuccessMessage: ( string ) => void,
-	onEvent?: ( object: { type: string; payload?: any } ) => void // eslint-disable-line @typescript-eslint/no-explicit-any
+	onEvent?: ( ReactStandardAction ) => void
 ): ShoppingCartManager {
 	cartKey = cartKey || 'no-site';
 	const setServerCart = useCallback( cartParam => setCart( cartKey, cartParam ), [
@@ -481,9 +482,9 @@ function useInitializeCartFromServer(
 	cacheStatus: CacheStatus,
 	canInitializeCart: boolean,
 	productToAdd: ResponseCartProduct | null,
-	getServerCart: Function,
-	setServerCart: Function,
-	hookDispatch: Function,
+	getServerCart: () => Promise< ResponseCart >,
+	setServerCart: ( RequestCart ) => Promise< ResponseCart >,
+	hookDispatch: ( ShoppingCartHookAction ) => void,
 	onEvent?: Function
 ): void {
 	const isInitialized = useRef( false );

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -485,7 +485,7 @@ function useInitializeCartFromServer(
 	getServerCart: () => Promise< ResponseCart >,
 	setServerCart: ( RequestCart ) => Promise< ResponseCart >,
 	hookDispatch: ( ShoppingCartHookAction ) => void,
-	onEvent?: Function
+	onEvent?: ( ReactStandardAction ) => void
 ): void {
 	const isInitialized = useRef( false );
 	useEffect( () => {
@@ -549,9 +549,9 @@ function useInitializeCartFromServer(
 function useCartUpdateAndRevalidate(
 	cacheStatus: CacheStatus,
 	responseCart: ResponseCart,
-	setServerCart: Function,
-	hookDispatch: Function,
-	onEvent?: Function
+	setServerCart: ( RequestCart ) => Promise< ResponseCart >,
+	hookDispatch: ( ShoppingCartHookAction ) => void,
+	onEvent?: ( ReactStandardAction ) => void
 ): void {
 	useEffect( () => {
 		if ( cacheStatus !== 'invalid' ) {
@@ -594,8 +594,8 @@ function useCachedValidCart( cacheStatus: CacheStatus, responseCart: ResponseCar
 function useShowAddCouponSuccessMessage(
 	didAddCoupon: boolean,
 	responseCart: ResponseCart,
-	showAddCouponSuccessMessage: Function,
-	hookDispatch: Function
+	showAddCouponSuccessMessage: ( string ) => void,
+	hookDispatch: ( ShoppingCartHookAction ) => void
 ): void {
 	useEffect( () => {
 		if ( didAddCoupon ) {

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -461,7 +461,12 @@ export function useShoppingCart(
 	} as ShoppingCartManager;
 }
 
-function useInitializeCartFromServer( cacheStatus, getServerCart, hookDispatch, onEvent ) {
+function useInitializeCartFromServer(
+	cacheStatus: CacheStatus,
+	getServerCart: Function,
+	hookDispatch: Function,
+	onEvent?: Function
+): void {
 	useEffect( () => {
 		if ( cacheStatus !== 'fresh' ) {
 			return;
@@ -487,12 +492,12 @@ function useInitializeCartFromServer( cacheStatus, getServerCart, hookDispatch, 
 }
 
 function useCartUpdateAndRevalidate(
-	cacheStatus,
-	responseCart,
-	setServerCart,
-	hookDispatch,
-	onEvent
-) {
+	cacheStatus: CacheStatus,
+	responseCart: ResponseCart,
+	setServerCart: Function,
+	hookDispatch: Function,
+	onEvent?: Function
+): void {
 	useEffect( () => {
 		if ( cacheStatus !== 'invalid' ) {
 			return;
@@ -520,7 +525,7 @@ function useCartUpdateAndRevalidate(
 	}, [ setServerCart, cacheStatus, responseCart, onEvent, hookDispatch ] );
 }
 
-function useCachedValidCart( cacheStatus, responseCart ) {
+function useCachedValidCart( cacheStatus: CacheStatus, responseCart: ResponseCart ): ResponseCart {
 	const [ responseCartToDisplay, setResponseCartToDisplay ] = useState( responseCart );
 	useEffect( () => {
 		if ( cacheStatus === 'valid' ) {
@@ -532,11 +537,11 @@ function useCachedValidCart( cacheStatus, responseCart ) {
 }
 
 function useShowAddCouponSuccessMessage(
-	didAddCoupon,
-	responseCart,
-	showAddCouponSuccessMessage,
-	hookDispatch
-) {
+	didAddCoupon: boolean,
+	responseCart: ResponseCart,
+	showAddCouponSuccessMessage: Function,
+	hookDispatch: Function
+): void {
 	useEffect( () => {
 		if ( didAddCoupon ) {
 			showAddCouponSuccessMessage( responseCart.coupon );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR does several things. Firstly, if the URL contains a product slug to add to the cart, we add it automatically when first initializing the cart to prevent a possible race condition.

Secondly, this adds additional guards to `CheckoutSystemDecider` to prevent jetpack plans and other non-wpcom-plan products from causing Composite Checkout to be displayed, even if those products are just slugs in the URL waiting to be added.

#### Testing instructions

First, click the buttons to add various Jetpack products to the cart (plans, especially "premium" which has the same URL slug as wpcom's plan, and backup products); then verify that you always see the old checkout.

Second, do the same thing for WordPress.com plans; verify that you always see the new checkout, _and_ that the plan you added has successfully been added to the cart.

Finally do the same thing for a WordPress.com plan, but use the raw URL without having first initialized Calypso's state.