### PR TITLE
Move the "Go to my site" button after the content

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -416,6 +416,8 @@ export class CheckoutThankYouHeader extends PureComponent {
 							<h2 className="checkout-thank-you__header-text">{ this.getText() }</h2>
 						) }
 
+						{ this.props.children }
+
 						{ this.getButtons() }
 					</div>
 				</div>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -592,42 +592,44 @@ export class CheckoutThankYou extends React.Component {
 
 		return (
 			<div>
-				<CheckoutThankYouHeader
-					isDataLoaded={ this.isDataLoaded() }
-					isSimplified={ isSimplified }
-					primaryPurchase={ primaryPurchase }
-					selectedSite={ selectedSite }
-					hasFailedPurchases={ hasFailedPurchases }
-					siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
-					upgradeIntent={ upgradeIntent }
-					primaryCta={ this.primaryCta }
-					displayMode={ displayMode }
-				/>
-
-				{ ! isSimplified && primaryPurchase && (
-					<CheckoutThankYouFeaturesHeader
+				{
+					<CheckoutThankYouHeader
 						isDataLoaded={ this.isDataLoaded() }
-						isGenericReceipt={ this.isGenericReceipt() }
-						purchases={ purchases }
+						isSimplified={ isSimplified }
+						primaryPurchase={ primaryPurchase }
+						selectedSite={ selectedSite }
 						hasFailedPurchases={ hasFailedPurchases }
-					/>
-				) }
+						siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
+						upgradeIntent={ upgradeIntent }
+						primaryCta={ this.primaryCta }
+						displayMode={ displayMode }
+					>
+						{ ! isSimplified && primaryPurchase && (
+							<CheckoutThankYouFeaturesHeader
+								isDataLoaded={ this.isDataLoaded() }
+								isGenericReceipt={ this.isGenericReceipt() }
+								purchases={ purchases }
+								hasFailedPurchases={ hasFailedPurchases }
+							/>
+						) }
 
-				{ ! isSimplified && ComponentClass && (
-					<div className="checkout-thank-you__purchase-details-list">
-						<ComponentClass
-							customizeUrl={ customizeUrl }
-							domain={ domain }
-							purchases={ purchases }
-							failedPurchases={ failedPurchases }
-							isRootDomainWithUs={ isRootDomainWithUs }
-							registrarSupportUrl={ registrarSupportUrl }
-							selectedSite={ selectedSite }
-							selectedFeature={ getFeatureByKey( this.props.selectedFeature ) }
-							sitePlans={ sitePlans }
-						/>
-					</div>
-				) }
+						{ ! isSimplified && ComponentClass && (
+							<div className="checkout-thank-you__purchase-details-list">
+								<ComponentClass
+									customizeUrl={ customizeUrl }
+									domain={ domain }
+									purchases={ purchases }
+									failedPurchases={ failedPurchases }
+									isRootDomainWithUs={ isRootDomainWithUs }
+									registrarSupportUrl={ registrarSupportUrl }
+									selectedSite={ selectedSite }
+									selectedFeature={ getFeatureByKey( this.props.selectedFeature ) }
+									sitePlans={ sitePlans }
+								/>
+							</div>
+						) }
+					</CheckoutThankYouHeader>
+				}
 			</div>
 		);
 	};

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -592,44 +592,42 @@ export class CheckoutThankYou extends React.Component {
 
 		return (
 			<div>
-				{
-					<CheckoutThankYouHeader
-						isDataLoaded={ this.isDataLoaded() }
-						isSimplified={ isSimplified }
-						primaryPurchase={ primaryPurchase }
-						selectedSite={ selectedSite }
-						hasFailedPurchases={ hasFailedPurchases }
-						siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
-						upgradeIntent={ upgradeIntent }
-						primaryCta={ this.primaryCta }
-						displayMode={ displayMode }
-					>
-						{ ! isSimplified && primaryPurchase && (
-							<CheckoutThankYouFeaturesHeader
-								isDataLoaded={ this.isDataLoaded() }
-								isGenericReceipt={ this.isGenericReceipt() }
-								purchases={ purchases }
-								hasFailedPurchases={ hasFailedPurchases }
-							/>
-						) }
+				<CheckoutThankYouHeader
+					isDataLoaded={ this.isDataLoaded() }
+					isSimplified={ isSimplified }
+					primaryPurchase={ primaryPurchase }
+					selectedSite={ selectedSite }
+					hasFailedPurchases={ hasFailedPurchases }
+					siteUnlaunchedBeforeUpgrade={ siteUnlaunchedBeforeUpgrade }
+					upgradeIntent={ upgradeIntent }
+					primaryCta={ this.primaryCta }
+					displayMode={ displayMode }
+				>
+					{ ! isSimplified && primaryPurchase && (
+						<CheckoutThankYouFeaturesHeader
+							isDataLoaded={ this.isDataLoaded() }
+							isGenericReceipt={ this.isGenericReceipt() }
+							purchases={ purchases }
+							hasFailedPurchases={ hasFailedPurchases }
+						/>
+					) }
 
-						{ ! isSimplified && ComponentClass && (
-							<div className="checkout-thank-you__purchase-details-list">
-								<ComponentClass
-									customizeUrl={ customizeUrl }
-									domain={ domain }
-									purchases={ purchases }
-									failedPurchases={ failedPurchases }
-									isRootDomainWithUs={ isRootDomainWithUs }
-									registrarSupportUrl={ registrarSupportUrl }
-									selectedSite={ selectedSite }
-									selectedFeature={ getFeatureByKey( this.props.selectedFeature ) }
-									sitePlans={ sitePlans }
-								/>
-							</div>
-						) }
-					</CheckoutThankYouHeader>
-				}
+					{ ! isSimplified && ComponentClass && (
+						<div className="checkout-thank-you__purchase-details-list">
+							<ComponentClass
+								customizeUrl={ customizeUrl }
+								domain={ domain }
+								purchases={ purchases }
+								failedPurchases={ failedPurchases }
+								isRootDomainWithUs={ isRootDomainWithUs }
+								registrarSupportUrl={ registrarSupportUrl }
+								selectedSite={ selectedSite }
+								selectedFeature={ getFeatureByKey( this.props.selectedFeature ) }
+								sitePlans={ sitePlans }
+							/>
+						</div>
+					) }
+				</CheckoutThankYouHeader>
 			</div>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move "Go to my site" button to the bottom in order to add some more importance to the rest of the page content. 

I used `props.children` of `CheckoutThankYouHeader`. I am not sure if this is the best approach, but it is definitely the simplest...

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Link website to your own domain


Fixes #39127


Before:
![Screenshot 2020-02-15 at 13 14 02](https://user-images.githubusercontent.com/790558/74588190-977a1480-4ffa-11ea-9df7-a2f2e1557b92.png)

After:
![Screenshot 2020-02-15 at 13 13 08](https://user-images.githubusercontent.com/790558/74588187-95b05100-4ffa-11ea-876d-cc73f2fb8b1e.png)