### PR TITLE
[SIGNUP]: remove A/B test for alternative default logged-in landing page

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -18,7 +18,7 @@ import { ReduxWrappedLayout } from 'controller';
 import notices from 'notices';
 import { getToken } from 'lib/oauth-token';
 import emailVerification from 'components/email-verification';
-import { abtest, getSavedVariations } from 'lib/abtest'; // used by error logger
+import { getSavedVariations } from 'lib/abtest'; // used by error logger
 import accessibleFocus from 'lib/accessible-focus';
 import Logger from 'lib/catch-js-errors';
 import { bindState as bindWpLocaleState } from 'lib/wp/localization';
@@ -132,11 +132,7 @@ const loggedInMiddleware = currentUser => {
 	}
 
 	page( '/', context => {
-		const { primarySiteSlug } = currentUser.get();
-		let redirectPath =
-			primarySiteSlug && 'variant' === abtest( 'redirectToCustomerHome' )
-				? `/home/${ primarySiteSlug }`
-				: '/read';
+		let redirectPath = '/read';
 
 		if ( context.querystring ) {
 			redirectPath += `?${ context.querystring }`;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,15 +118,6 @@ export default {
 		allowExistingUsers: false,
 		localeTargets: 'any',
 	},
-	redirectToCustomerHome: {
-		datestamp: '20200117',
-		variations: {
-			variant: 10,
-			control: 90,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-	},
 	sidebarUpsellNudgeUnification: {
 		datestamp: '20200127',
 		variations: {


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR reverts #38463. Nothing else.

In p8Eqe3-Vq-p2 we concluded that we should wait until Customer Home undergoes more iterations  before testing an alternative default logged-in landing page. 

By the way, this morning I spilled coffee over my keyboard. 

I really shouldn't have placed the cup so close to my laptop, but any further than arm's length seems like a chore. 

Is there an optimal distance between cup and expensive hardware?

☕️ `+` 💻`=` 😱 

## Testing instructions

1. Spin up the branch and log in to your account. 
2. You should be taken to the Reader page.
3. Ensure that the `redirectToCustomerHome` does not appear in the A/B test list.
4. Check that your morning drink is nowhere near your keyboard. 
5. Don't use your white t-shirt to mop up the mess.

