### PR TITLE
Domain step test: Launch the test by removing the feature flag

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -116,7 +116,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	domainStepDesignUpdates: {
-		datestamp: '20200205',
+		datestamp: '20200218',
 		variations: {
 			variantDesignUpdates: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -116,7 +116,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	domainStepDesignUpdates: {
-		datestamp: '20200218',
+		datestamp: '20200220',
 		variations: {
 			variantDesignUpdates: 50,
 			control: 50,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -50,7 +50,6 @@ import { fetchUsernameSuggestion } from 'state/signup/optional-dependencies/acti
 import { isSitePreviewVisible } from 'state/signup/preview/selectors';
 import { hideSitePreview, showSitePreview } from 'state/signup/preview/actions';
 import { abtest } from 'lib/abtest';
-import config from 'config';
 
 /**
  * Style dependencies
@@ -130,10 +129,7 @@ class DomainsStep extends React.Component {
 			! props.isPlanStepFulfilled &&
 			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
 		) {
-			if (
-				config.isEnabled( 'domain-step-design-update-v2' ) &&
-				'variantDesignUpdates' === abtest( 'domainStepDesignUpdates' )
-			) {
+			if ( 'variantDesignUpdates' === abtest( 'domainStepDesignUpdates' ) ) {
 				this.showDesignUpdate = true;
 			} else {
 				this.showTestCopy = true;

--- a/config/development.json
+++ b/config/development.json
@@ -56,7 +56,6 @@
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": false,
-		"domain-step-design-update-v2": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,7 +38,6 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"domain-step-design-update-v2": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We created a new A/B test for the domain step UI updates in https://github.com/Automattic/wp-calypso/pull/39276 and it was hidden behind a feature flag.
* All UI pieces for the new test are now complete, so we will remove the feature flag and launch to users.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow beginning at /start. - assign yourself to _variantShowUpdates_ of _domainStepCopyUpdates_ and _variantDesignUpdates_ of _domainStepDesignUpdates_.
* At the domain step, verify the UI matches the screens shared in pbAok1-7N-p2.

