### PR TITLE
FSE: Improve Confirmation Modal Button Alignment

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -472,7 +472,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 .sidebar-modal-opener__warning-options {
-	display: flex;
-	justify-content: space-around;
+	float: right;
 	margin-top: 20px;
+	
+	.components-button {
+		margin-left: 12px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the confirmation button alignment to something a bit more familiar. 

#### Testing instructions

1. Select some page content
2. Open Page Layout in the sidebar, and click "Change Layout"
3. Verify that the modal's buttons now look more consistent with the style used elsewhere throughout WordPress

**Before:**

<img width="466" alt="Screenshot 2020-02-17 at 08 24 59" src="https://user-images.githubusercontent.com/43215253/74636282-98788680-515f-11ea-89ab-e45ca1533736.png">

**After:**

<img width="484" alt="Screenshot 2020-02-17 at 08 25 31" src="https://user-images.githubusercontent.com/43215253/74636291-9b737700-515f-11ea-901c-50ee1bf9f07b.png">

Fixes #38146
