### PR TITLE
Remove `url` and `qs` from calypso-analytics.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,8 +160,7 @@
 				"@automattic/load-script": "file:packages/load-script",
 				"debug": "^4.1.1",
 				"hash.js": "^1.1.7",
-				"lodash": "^4.17.15",
-				"qs": "^6.9.1"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@automattic/calypso-build": {

--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-analytics",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-alpha.1",
 	"description": "Automattic Analytics",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -33,7 +33,6 @@
 		"@automattic/load-script": "file:../load-script",
 		"debug": "^4.1.1",
 		"hash.js": "^1.1.7",
-		"lodash": "^4.17.15",
-		"qs": "^6.9.1"
+		"lodash": "^4.17.15"
 	}
 }

--- a/packages/calypso-analytics/src/tracks.js
+++ b/packages/calypso-analytics/src/tracks.js
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import { assign, includes, isObjectLike, isUndefined, omit, pickBy, times } from 'lodash';
-import { parse } from 'qs';
+import { assign, includes, isObjectLike, isUndefined, omit, times } from 'lodash';
 import cookie from 'cookie';
-import url from 'url';
 import { EventEmitter } from 'events';
 import { loadScript } from '@automattic/load-script';
 
@@ -230,9 +228,11 @@ export function recordTracksPageView( urlPath, params ) {
 	// Record all `utm` marketing parameters as event properties on the page view event
 	// so we can analyze their performance with our analytics tools
 	if ( window.location ) {
-		const parsedUrl = url.parse( window.location.href );
-		const urlParams = parse( parsedUrl.query );
-		const utmParams = pickBy( urlParams, ( value, key ) => key.startsWith( 'utm_' ) );
+		const urlParams = new URL( window.location.href ).searchParams;
+		const utmParamEntries =
+			urlParams &&
+			Array.from( urlParams.entries() ).filter( ( [ key ] ) => key.startsWith( 'utm_' ) );
+		const utmParams = utmParamEntries ? Object.fromEntries( utmParamEntries ) : {};
 
 		eventProperties = assign( eventProperties, utmParams );
 	}


### PR DESCRIPTION
Node's `url` is deprecated, and `qs` is a largeish 3rd party library that is exceedingly complex for the simple usage needed here.

There was previous work on removing them from lib/analytics in #38750, but it didn't make it in before the new package was created.

This PR reinstates that work, replacing all usage of `url` and `qs` with standard `URL` and `URLSearchParams` APIs.

Note that the package is currently incorrectly making use of `url` without listing it as a dependency. This PR removes the need for it, and also removes `qs` as a dependency.

#### Changes proposed in this Pull Request

* Replace `url` and `qs` usage with standard `URL` and `URLSearchParams` APIs.
* Remove dependency on `qs` from package.
* Increment version number.

#### Testing instructions

Ensure that `recordTracksPageView` continues to work correctly.
