### PR TITLE
Site migration: use `site_migration` data instead of `migration_status` value

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -27,7 +27,7 @@ import StepUpgrade from './step-upgrade';
 import { Interval, EVERY_TEN_SECONDS } from 'lib/interval';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import { getSite, getSiteAdminUrl, isJetpackSite } from 'state/sites/selectors';
-import { receiveSite, updateSiteMigrationStatus } from 'state/sites/actions';
+import { receiveSite, updateSiteMigrationMeta } from 'state/sites/actions';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { urlToSlug } from 'lib/url';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
@@ -158,7 +158,11 @@ class SectionMigrate extends Component {
 		}
 
 		if ( state.migrationStatus ) {
-			this.props.updateSiteMigrationStatus( this.props.targetSiteId, state.migrationStatus );
+			this.props.updateSiteMigrationMeta(
+				this.props.targetSiteId,
+				state.migrationStatus,
+				state.lastModified
+			);
 		}
 		this.setState( state );
 	};
@@ -254,6 +258,7 @@ class SectionMigrate extends Component {
 					percent,
 					source_blog_id: sourceSiteId,
 					created: startTime,
+					last_modified: lastModified,
 				} = response;
 
 				if ( sourceSiteId && sourceSiteId !== this.props.sourceSiteId ) {
@@ -268,6 +273,7 @@ class SectionMigrate extends Component {
 							this.setMigrationState( {
 								migrationStatus,
 								percent,
+								lastModified,
 							} );
 							return;
 						}
@@ -281,6 +287,7 @@ class SectionMigrate extends Component {
 							migrationStatus,
 							percent,
 							startTime: localizedStartTime,
+							lastModified,
 						} );
 						return;
 					}
@@ -288,6 +295,7 @@ class SectionMigrate extends Component {
 					this.setMigrationState( {
 						migrationStatus,
 						percent,
+						lastModified,
 					} );
 				}
 			} )
@@ -612,5 +620,5 @@ export default connect(
 			targetSiteSlug: getSelectedSiteSlug( state ),
 		};
 	},
-	{ navigateToSelectedSourceSite, receiveSite, updateSiteMigrationStatus }
+	{ navigateToSelectedSourceSite, receiveSite, updateSiteMigrationMeta }
 )( localize( SectionMigrate ) );

--- a/client/state/selectors/get-site-migration-status.js
+++ b/client/state/selectors/get-site-migration-status.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 
@@ -13,6 +18,11 @@ import getRawSite from 'state/selectors/get-raw-site';
  */
 export default function getSiteMigrationStatus( state, siteId ) {
 	const site = getRawSite( state, siteId );
+	let status = 'inactive';
 
-	return ( site && site.migration_status ) || 'inactive';
+	if ( site ) {
+		status = get( site, 'site_migration.status', 'inactive' );
+	}
+
+	return status;
 }

--- a/client/state/selectors/get-site-migration-status.js
+++ b/client/state/selectors/get-site-migration-status.js
@@ -18,11 +18,6 @@ import getRawSite from 'state/selectors/get-raw-site';
  */
 export default function getSiteMigrationStatus( state, siteId ) {
 	const site = getRawSite( state, siteId );
-	let status = 'inactive';
 
-	if ( site ) {
-		status = get( site, 'site_migration.status', 'inactive' );
-	}
-
-	return status;
+	return get( site, 'site_migration.status', 'inactive' );
 }

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -211,10 +211,12 @@ export const updateSiteFrontPage = ( siteId, frontPageOptions ) => ( {
  *
  * @param  {number} siteId Site ID
  * @param  {string} migrationStatus The status of the migration.
+ * @param {string} lastModified Optional timestamp from the migration DB record
  * @returns {object} Action object
  */
-export const updateSiteMigrationStatus = ( siteId, migrationStatus ) => ( {
+export const updateSiteMigrationMeta = ( siteId, migrationStatus, lastModified = null ) => ( {
 	siteId,
 	type: SITE_MIGRATION_STATUS_UPDATE,
 	migrationStatus,
+	lastModified,
 } );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -16,7 +16,7 @@ export const SITE_REQUEST_FIELDS = [
 	'visible',
 	'lang',
 	'launch_status',
-	'migration_status',
+	'site_migration',
 	'is_fse_active',
 	'is_fse_eligible',
 ].join();

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -258,19 +258,23 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 		}
 
 		case SITE_MIGRATION_STATUS_UPDATE: {
-			const { siteId, migrationStatus } = action;
+			const { siteId, migrationStatus, lastModified } = action;
 			const site = state[ siteId ];
 			if ( ! site ) {
 				return state;
 			}
 
 			const siteMigrationMeta = state[ siteId ].site_migration || {};
+			const newMeta = { status: migrationStatus };
+			if ( lastModified ) {
+				newMeta.last_modified = lastModified;
+			}
 
 			return {
 				...state,
 				[ siteId ]: {
 					...state[ siteId ],
-					site_migration: merge( {}, siteMigrationMeta, { status: migrationStatus } ),
+					site_migration: merge( {}, siteMigrationMeta, newMeta ),
 				},
 			};
 		}

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -264,11 +264,13 @@ export const items = withSchemaValidation( sitesSchema, ( state = null, action )
 				return state;
 			}
 
+			const siteMigrationMeta = state[ siteId ].site_migration || {};
+
 			return {
 				...state,
 				[ siteId ]: {
 					...state[ siteId ],
-					migration_status: migrationStatus,
+					site_migration: merge( {}, siteMigrationMeta, { status: migrationStatus } ),
 				},
 			};
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR helps prepare Calypso to show the Home screen for sites which have recently been migrated into.
* In D38929-code, we are saving basic metadata about the latest site migration in a `site_migration_meta` option and returning this data from the `/me/sites` endpoint.
* This PR adapts the site migration logic to use the new `site_migration` object instead of the previous `migration_status` string.

#### Testing instructions

* Test this in conjunction with D38929-code - follow the test instructions there to enable the new object.
* Check out this PR and run Calypso locally, or use calypso.live.
* Go to `http://calypso.localhost:3000/migrate/[ TARGET SITE DOMAIN ]`.
* Check the state for the selected site. It should contain a `site_migration` object with the values returned from the `/me/sites` endpoint.
* Start a migration.
* The migration should start and complete as normal. During the migration, check the `site_migration` state again. It should update to show the different statuses of the migration.
* On selecting a different site in Calypso during the migration, the view should change to show you the "What WordPress site do you want to import?" screen. On switching back, you should see the migration progress screen. (There may be a slight delay before the UI changes.)