### PR TITLE
Marketing: Remove `readerFreeToPaidPlanNudge` a/b test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -117,16 +117,6 @@ export default {
 		localeTargets: 'any',
 		localeExceptions: [ 'en' ],
 	},
-	readerFreeToPaidPlanNudge: {
-		datestamp: '20200102',
-		variations: {
-			display: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-		localeTargets: 'any',
-	},
 	sidebarUpsellNudgeUnification: {
 		datestamp: '20200127',
 		variations: {

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -71,6 +71,7 @@ function mapStateToProps( state ) {
 	const devCountryCode = isDevelopment && global.window && global.window.userCountryCode;
 	const countryCode = devCountryCode || getCurrentUserCountryCode( state );
 	const userLocale = getLocaleSlug( state );
+	const isEnglish = [ 'en', 'en-gb' ].indexOf( userLocale ) !== -1;
 
 	isDevelopment &&
 		debug(
@@ -89,9 +90,9 @@ function mapStateToProps( state ) {
 			! isJetpackSite( state, siteId ) && // not for Jetpack sites
 			! isDomainOnlySite( state, siteId ) && // not for domain only sites
 			isEligibleForFreeToPaidUpsell( state, siteId ) &&
-			// This test is not for English speaking US residents.
-			( ( 'en' === userLocale && 'US' === countryCode ) ||
-				'display' === abtest( 'readerFreeToPaidPlanNudge' ) ),
+			// This nudge only shows up to US EN users.
+			isEnglish &&
+			'US' === countryCode,
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `readerFreeToPaidPlanNudge` a/b test which is implemented with #38619.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You should be a user who has only one free plan dotcom site.
* Go to the Reader page.
  * If you are an English US user, you should be able to see the nudge in the sidebar.
  * If you are neither an EN user nor an US user, the nudge shouldn't display for you.

_Note: In dev env, you can change your country as follows._

```
// in browser console
window.userCountryCode = 'US';
```