### PR TITLE
Move the Payment Settings button to the expiry row

### DIFF
--- a/client/my-sites/domains/domain-management/edit/card/subscription-settings/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/subscription-settings/index.jsx
@@ -20,6 +20,7 @@ import './style.scss';
 class SubscriptionSettings extends React.Component {
 	static propTypes = {
 		type: PropTypes.string.isRequired,
+		compact: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		subscriptionId: PropTypes.string,
 		onClick: PropTypes.func.isRequired,
@@ -41,6 +42,7 @@ class SubscriptionSettings extends React.Component {
 	render() {
 		return (
 			<Button
+				compact={ this.props.compact }
 				className="subscription-settings"
 				href={ this.getLink() }
 				onClick={ this.props.onClick }

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -209,29 +209,32 @@ class RegisteredDomainType extends React.Component {
 					) }
 					{ this.renderExpired() }
 					{ this.renderRecentlyRegistered() }
+				</DomainStatus>
+				<Card compact={ true } className="domain-types__expiration-row">
+					<div>
+						{ domain.expired
+							? this.props.translate( 'Expired: %(expiry_date)s', {
+									args: {
+										expiry_date: moment( domain.expiry ).format( 'LL' ),
+									},
+							  } )
+							: this.props.translate( 'Expires: %(expiry_date)s', {
+									args: {
+										expiry_date: moment( domain.expiry ).format( 'LL' ),
+									},
+							  } ) }
+					</div>
 					{ ! newStatusDesignAutoRenew && (
 						<div>
 							<SubscriptionSettings
 								type={ domain.type }
+								compact={ true }
 								subscriptionId={ domain.subscriptionId }
 								siteSlug={ this.props.selectedSite.slug }
 								onClick={ this.handlePaymentSettingsClick }
 							/>
 						</div>
 					) }
-				</DomainStatus>
-				<Card compact={ true }>
-					{ domain.expired
-						? this.props.translate( 'Expired: %(expiry_date)s', {
-								args: {
-									expiry_date: moment( domain.expiry ).format( 'LL' ),
-								},
-						  } )
-						: this.props.translate( 'Expires: %(expiry_date)s', {
-								args: {
-									expiry_date: moment( domain.expiry ).format( 'LL' ),
-								},
-						  } ) }
 				</Card>
 				{ newStatusDesignAutoRenew && this.renderAutoRenew() }
 				{ this.getVerticalNavigation() }

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -86,6 +86,14 @@
 		}
 	}
 
+	.domain-types__expiration_row {
+		display: flex;
+		align-items: center;
+		> div:first-child {
+			margin-right: auto;
+		}
+	}
+
 	.subscription-settings {
 		margin-top: 0;
 	}

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -86,7 +86,7 @@
 		}
 	}
 
-	.domain-types__expiration_row {
+	.domain-types__expiration-row {
 		display: flex;
 		align-items: center;
 		> div:first-child {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the Payment Settings button to the expiry row - it'll take a lot less space.

Before:
<img width="741" alt="Screenshot 2020-02-18 at 15 42 18" src="https://user-images.githubusercontent.com/1355045/74741352-4cb00500-5265-11ea-9843-168e61cc8b18.png">

After:
<img width="735" alt="Screenshot 2020-02-18 at 15 33 13" src="https://user-images.githubusercontent.com/1355045/74741362-50dc2280-5265-11ea-9416-8f150d5fc11a.png">

#### Testing instructions

* open the new domain status page and verify that the "Payment Settings" button is on the right side of the domain expiration date
