### PR TITLE
[Coming soon] Consider coming soon pages as hidden instead of private

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -377,10 +377,10 @@ export class SiteSettingsFormGeneral extends Component {
 							<FormRadio
 								name="blog_public"
 								value="-1"
-								checked={ -1 === blogPublic && 1 === wpcomComingSoon }
+								checked={ 0 === blogPublic && 1 === wpcomComingSoon }
 								onChange={ () =>
 									this.handleVisibilityOptionChange( {
-										blog_public: -1,
+										blog_public: 0,
 										wpcom_coming_soon: 1,
 									} )
 								}
@@ -399,7 +399,7 @@ export class SiteSettingsFormGeneral extends Component {
 						<FormRadio
 							name="blog_public"
 							value="1"
-							checked={ blogPublic === 0 || blogPublic === 1 }
+							checked={ ( blogPublic === 0 && ! wpcomComingSoon ) || blogPublic === 1 }
 							onChange={ () =>
 								this.handleVisibilityOptionChange( {
 									blog_public: 1,
@@ -419,7 +419,7 @@ export class SiteSettingsFormGeneral extends Component {
 					<FormInputCheckbox
 						name="blog_public"
 						value="0"
-						checked={ 0 === blogPublic }
+						checked={ 0 === blogPublic && ! wpcomComingSoon }
 						onChange={ () =>
 							this.handleVisibilityOptionChange( {
 								blog_public: blogPublic === 0 ? 1 : 0,
@@ -437,7 +437,7 @@ export class SiteSettingsFormGeneral extends Component {
 							<FormRadio
 								name="blog_public"
 								value="-1"
-								checked={ -1 === blogPublic && ! wpcomComingSoon }
+								checked={ -1 === blogPublic }
 								onChange={ () =>
 									this.handleVisibilityOptionChange( {
 										blog_public: -1,

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -146,7 +146,7 @@ describe( 'SiteSettingsFormGeneral ', () => {
 		} );
 
 		[
-			[ 'Coming soon', 'Coming Soon', 1, { blog_public: -1, wpcom_coming_soon: 1 } ],
+			[ 'Coming soon', 'Coming Soon', 1, { blog_public: 0, wpcom_coming_soon: 1 } ],
 			[ 'Public', 'Public', -1, { blog_public: 1, wpcom_coming_soon: 0 } ],
 			[
 				'Hidden',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is related to Coming Soon/Private atomic sites. More context available at p58i-8xH-p2

This diff updates privacy picker to treat coming soon sites as hidden, not private. This will make it possible to launch Coming Soon mode before privacy is fully rolled out.

#### Testing instructions

* Test locally, this won't work on calypso.live
* Create a new site
* Go to settings/general
* Switch it to Public
* Confirm `blog_public` option is set to `1` and `wpcom_coming_soon` option is set to `0`
* Switch it to Coming Soon, confirm the changes got saved
* Confirm `blog_public` option is set to `0` and `wpcom_coming_soon` option is set to `1`

Fixes #
