### PR TITLE
Sign up: Add redirect to plans before checkout to avoid duplicate sites

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -24,7 +24,7 @@ export function plans( context, next ) {
 			context.pathname,
 			{
 				...context.state,
-				query: omit( context.state.query, 'signup' ),
+				query: omit( context.query, 'signup' ),
 			},
 			false,
 			false

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -17,9 +17,6 @@ export function plans( context, next ) {
 	// assuming it will end up redirecting to the checkout page. This is a way of reducing the number of duplicate
 	// sites when users go back in the browser trying to change a plan during checkout.
 	// See https://github.com/Automattic/wp-calypso/issues/39424
-	const state = context.store.getState();
-	const selectedSite = getSelectedSite( state );
-	const checkoutUrl = `/checkout/${ selectedSite.slug }?signup=1`;
 	const isComingFromSignUp = !! context.query.signup;
 	if ( isComingFromSignUp ) {
 		// Removes the signup query param so users going back to plans are not redirected to checkout again.
@@ -33,7 +30,8 @@ export function plans( context, next ) {
 			false
 		);
 
-		return page.show( checkoutUrl, context.state );
+		const selectedSite = getSelectedSite( context.store.getState() );
+		return page.show( `/checkout/${ selectedSite.slug }?signup=1`, context.state );
 	}
 
 	context.primary = (

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -339,7 +339,7 @@ class Signup extends React.Component {
 			// deferred in case the user is logged in and the redirect triggers a dispatch
 			defer( () => {
 				debug( `Redirecting you to "${ destination }"` );
-				window.location.href = destination;
+				page.redirect( destination );
 			} );
 		}
 


### PR DESCRIPTION
Fixes #39424
Alternate to #39449

#### Changes proposed in this Pull Request

Redirects users who completed the signup flow and selected a paid plan to the plans page and then to the checkout page. This extra and invisible redirect in the middle to the plans page is a way of trying to reduce the number of duplicate sites when users go back in the browser, since their intent is likely to change the plan. Props to @millerf for the idea.

This required to replace the hard redirect after signing up with a `page.redirect`.

![Feb-17-2020 17-19-26](https://user-images.githubusercontent.com/1233880/74670587-c4b8f500-51a9-11ea-9cc7-efc98d60581c.gif)

#### Testing instructions

Test with a variety of browsers (Chrome, Firefox, IE, Edge, Safari) and make sure you get the same behavior in all of them.

* Checkout the branch.
* Visit `/start`.
* Follow the flow until we reach plans selection.
* Pick a paid plan.
* In checkout click the back button of the browser.
* Verify that we're taken to the site specific plans page.
* Repeat steps with other signup flows without selecting a paid plan. i.e selecting the free plan or purchasing a domain only (`/start/domain/domain-only` and pick “Just buy a domain”).
* Verify that clicking back in the checkout page starts again the signup flow and does not redirect to the plans page.