### PR TITLE
[Coming Soon] Make new sites coming soon and hidden instead of private

### DIFF
--- a/client/state/selectors/get-new-site-privacy-settings.ts
+++ b/client/state/selectors/get-new-site-privacy-settings.ts
@@ -25,7 +25,7 @@ export default function getNewSitePrivacySettings( state: object ): PrivacySetti
 	if ( config.isEnabled( 'coming-soon' ) ) {
 		return {
 			comingSoon: 1,
-			public: -1,
+			public: 0,
 		};
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is related to Coming Soon/Private atomic sites. More context available at p58i-8xH-p2

It makes all new sites hidden+coming soon instead of private+coming soon (behind a feature flag)

#### Testing instructions

* On calypso.localhost...
* Create a new site (free, premium, business, ecommerce)
* Confirm it was created with `blog_public=0` and `wpcom_coming_soon=1` options
