### PR TITLE
Re-enable composite-checkout abtest

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -27,10 +27,10 @@ export default {
 		allowExistingUsers: true,
 	},
 	showCompositeCheckout: {
-		datestamp: '20200214',
+		datestamp: '20200218',
 		variations: {
-			composite: 0,
-			regular: 100,
+			composite: 10,
+			regular: 90,
 		},
 		defaultVariation: 'regular',
 		allowExistingUsers: true,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -27,7 +27,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	showCompositeCheckout: {
-		datestamp: '20200218',
+		datestamp: '20200219',
 		variations: {
 			composite: 10,
 			regular: 90,

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -13,6 +13,7 @@ import CompositeCheckout from './composite-checkout';
 import config from 'config';
 import { getCurrentUserLocale, getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import { abtest } from 'lib/abtest';
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
 
@@ -125,6 +126,10 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		return false;
 	}
 
+	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
+		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
+		return true;
+	}
 	debug( 'shouldShowCompositeCheckout false because test not enabled' );
 	return false;
 }


### PR DESCRIPTION
The abtest was originally added in #39419 and then was previously disabled in #39468 which this PR reverts. This also updates the datestamp.

The race condition that caused the previous test to be disabled should be taken care of by #39472

The internal launch post about this is p58i-8zB-p2

#### Testing instructions

- Start calypso _without_ the `composite-checkout-wpcom` flag.
- Use the local environment badge in the lower-right to set the `showCompositeCheckout` test to `composite` for your user.
- Visit checkout with a wpcom plan in the cart when you are in the US and have your language set to English. Verify that you see composite checkout.
- Visit checkout with a wpcom plan in the cart when you are not in the US. Verify that you see the regular checkout.
- Visit checkout with a wpcom plan in the cart when you are in the US and have your language set to something other than English. Verify that you see the regular checkout.
- Visit checkout with a domain in the cart. Verify that you see the regular checkout.
- Visit checkout with a jetpack plan in the cart. Verify that you see the regular checkout.