### PR TITLE
Migration: Remove from tools sidebar

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -238,25 +238,6 @@ export class MySitesSidebar extends Component {
 		this.onNavigate();
 	};
 
-	migrate() {
-		const { path, siteSuffix, translate } = this.props;
-
-		if ( ! isEnabled( 'tools/migrate' ) ) {
-			return null;
-		}
-
-		return (
-			<SidebarItem
-				label={ translate( 'Migrate' ) }
-				selected={ itemLinkMatches( '/migrate', path ) }
-				link={ `/migrate${ siteSuffix }` }
-				onNavigate={ this.trackMigrateClick }
-				tipTarget="migrate"
-				expandSection={ this.expandToolsSection }
-			/>
-		);
-	}
-
 	trackCustomizeClick = () => {
 		this.trackMenuItemClick( 'customize' );
 		this.onNavigate();
@@ -718,7 +699,6 @@ export class MySitesSidebar extends Component {
 						materialIcon="build"
 					>
 						{ this.tools() }
-						{ this.migrate() }
 						{ this.marketing() }
 						{ this.earn() }
 						{ this.activity() }

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -60,7 +60,7 @@ class ToolsMenu extends PureComponent {
 			capability: 'manage_options',
 			queryable: ! isJetpack,
 			link: '/import',
-			paths: [ '/import' ],
+			paths: [ '/import', '/migrate' ],
 			wpAdminLink: 'import.php',
 		};
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the "Migrate" menu-item from sidebar
* Highlight the "Import" item for `/migrate` paths

Before:
![image](https://user-images.githubusercontent.com/363749/74683078-6c73fa00-518d-11ea-93d7-8b1f83801647.png)

After: 
![image](https://user-images.githubusercontent.com/363749/74683043-59612a00-518d-11ea-84fa-6571fcef6ede.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that "Migrate" is missing from the sidebar.
* Make sure the `tools/migrate` feature-flag is enabled.
* Select "Import" from the sidebar on a simple-site.
* Select "WordPress". You should be taken to a `/migrate` path, but "Import" should remain selected in the sidebare.


