### PR TITLE
composite-checkout: Add PageViewTracker

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -51,6 +51,7 @@ export default function CheckoutSystemDecider( {
 				couponCode={ couponCode }
 				redirectTo={ redirectTo }
 				feature={ selectedFeature }
+				plan={ plan }
 			/>
 		);
 	}

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -475,13 +475,13 @@ export default function CompositeCheckout( {
 		productSlug: getPlanProductSlugs( items )[ 0 ],
 	} );
 
-	const { analyticsPath, analyticsProps } = getAnalyticsPath( {
+	const { analyticsPath, analyticsProps } = getAnalyticsPath(
 		purchaseId,
 		product,
 		siteSlug,
 		feature,
-		plan,
-	} );
+		plan
+	);
 
 	return (
 		<React.Fragment>
@@ -956,7 +956,8 @@ function usePrepareProductForCart( planSlug, isJetpackNotAtomic ) {
 	return { productForCart, canInitializeCart };
 }
 
-function getAnalyticsPath( { purchaseId, product, selectedSiteSlug, selectedFeature, plan } ) {
+function getAnalyticsPath( purchaseId, product, selectedSiteSlug, selectedFeature, plan ) {
+	debug( 'getAnalyticsPath', { purchaseId, product, selectedSiteSlug, selectedFeature, plan } );
 	let analyticsPath = '';
 	let analyticsProps = {};
 	if ( purchaseId && product ) {

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -100,6 +100,7 @@ export default function CompositeCheckout( {
 	overrideCountryList,
 	redirectTo,
 	feature,
+	plan,
 	purchaseId,
 	cart,
 	// TODO: handle these also
@@ -519,6 +520,7 @@ CompositeCheckout.propTypes = {
 	allowedPaymentMethods: PropTypes.array,
 	redirectTo: PropTypes.string,
 	feature: PropTypes.string,
+	plan: PropTypes.string,
 	cart: PropTypes.object,
 	transaction: PropTypes.object,
 };

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -72,6 +72,7 @@ import { getPlan, findPlansKeys } from 'lib/plans';
 import { GROUP_WPCOM, TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
 import { computeProductsWithPrices } from 'state/products-list/selectors';
 import { requestProductsList } from 'state/products-list/actions';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const debug = debugFactory( 'calypso:composite-checkout' );
 
@@ -474,8 +475,17 @@ export default function CompositeCheckout( {
 		productSlug: getPlanProductSlugs( items )[ 0 ],
 	} );
 
+	const { analyticsPath, analyticsProps } = getAnalyticsPath( {
+		purchaseId,
+		product,
+		siteSlug,
+		feature,
+		plan,
+	} );
+
 	return (
 		<React.Fragment>
+			<PageViewTracker path={ analyticsPath } title="Checkout" properties={ analyticsProps } />
 			<CheckoutProvider
 				locale={ 'en-us' }
 				items={ itemsForCheckout }
@@ -944,4 +954,28 @@ function usePrepareProductForCart( planSlug, isJetpackNotAtomic ) {
 	}, [ reduxDispatch, planSlug, plan, plans, isJetpackNotAtomic ] );
 
 	return { productForCart, canInitializeCart };
+}
+
+function getAnalyticsPath( { purchaseId, product, selectedSiteSlug, selectedFeature, plan } ) {
+	let analyticsPath = '';
+	let analyticsProps = {};
+	if ( purchaseId && product ) {
+		analyticsPath = '/checkout/:product/renew/:purchase_id/:site';
+		analyticsProps = { product, purchase_id: purchaseId, site: selectedSiteSlug };
+	} else if ( selectedFeature && plan ) {
+		analyticsPath = '/checkout/features/:feature/:site/:plan';
+		analyticsProps = { feature: selectedFeature, plan, site: selectedSiteSlug };
+	} else if ( selectedFeature && ! plan ) {
+		analyticsPath = '/checkout/features/:feature/:site';
+		analyticsProps = { feature: selectedFeature, site: selectedSiteSlug };
+	} else if ( product && ! purchaseId ) {
+		analyticsPath = '/checkout/:site/:product';
+		analyticsProps = { product, site: selectedSiteSlug };
+	} else if ( selectedSiteSlug ) {
+		analyticsPath = '/checkout/:site';
+		analyticsProps = { site: selectedSiteSlug };
+	} else {
+		analyticsPath = '/checkout/no-site';
+	}
+	return { analyticsPath, analyticsProps };
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the `PageViewTracker` component to `CompositeCheckout` so that it records the same analytics as the `Checkout` component from the existing checkout. The code to construct the path and props is copied directly from `Checkout`.

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start` or add `?flags=composite-checkout-wpcom` to the query string when you get to checkout.
- In the console on your local environment, enable debug logs with `localStorage.setItem('debug', 'calypso:analytics*')` and reload the page.
- Visit checkout with a plan in your cart.
- Verify that you see in the debug logs, `Recording event "calypso_page_view" with actual props`. Verify the props object looks correct, particularly the `path` property.