### PR TITLE
composite-checkout: Add `calypso_checkout_payment_success` event

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -602,6 +602,14 @@ function getCheckoutEventHandler( dispatch ) {
 			case 'CHECKOUT_LOADED':
 				return dispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
 			case 'PAYMENT_COMPLETE':
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_payment_success', {
+						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
+						currency: action.payload.total.amount.currency,
+						payment_method: action.payload.paymentMethodId,
+						total_cost: action.payload.total.amount.value / 100, // TODO: This conversion only works for USD! We have to localize this or get it from the server directly (or better yet, just force people to use the integer version).
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_complete', {
 						redirect_url: action.payload.url,

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -183,13 +183,6 @@ export default function CompositeCheckout( {
 		recordEvent( { type: 'CHECKOUT_LOADED' } );
 	}, [ recordEvent ] );
 
-	const onPaymentComplete = useCallback( () => {
-		debug( 'payment completed successfully' );
-		const url = getThankYouUrl();
-		recordEvent( { type: 'PAYMENT_COMPLETE', payload: { url } } );
-		page.redirect( url );
-	}, [ recordEvent, getThankYouUrl ] );
-
 	const showErrorMessage = useCallback(
 		error => {
 			debug( 'error', error );
@@ -250,6 +243,19 @@ export default function CompositeCheckout( {
 		translate,
 		showAddCouponSuccessMessage,
 		recordEvent
+	);
+
+	const onPaymentComplete = useCallback(
+		( { paymentMethodId } ) => {
+			debug( 'payment completed successfully' );
+			const url = getThankYouUrl();
+			recordEvent( {
+				type: 'PAYMENT_COMPLETE',
+				payload: { url, couponItem, paymentMethodId, total },
+			} );
+			page.redirect( url );
+		},
+		[ recordEvent, getThankYouUrl, total, couponItem ]
 	);
 
 	const { registerStore, dispatch } = registry;
@@ -599,6 +605,10 @@ function getCheckoutEventHandler( dispatch ) {
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_complete', {
 						redirect_url: action.payload.url,
+						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
+						total: action.payload.total.amount.value,
+						currency: action.payload.total.amount.currency,
+						payment_method: action.payload.paymentMethodId,
 					} )
 				);
 			case 'CART_ERROR':

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -15,6 +15,7 @@ import {
 	useWpcomStore,
 	useShoppingCart,
 	FormFieldAnnotation,
+	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 } from '@automattic/composite-checkout-wpcom';
 import {
 	CheckoutProvider,
@@ -606,7 +607,9 @@ function getCheckoutEventHandler( dispatch ) {
 					recordTracksEvent( 'calypso_checkout_payment_success', {
 						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
 						currency: action.payload.total.amount.currency,
-						payment_method: action.payload.paymentMethodId,
+						payment_method:
+							translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
+								?.name || '',
 						total_cost: action.payload.total.amount.value / 100, // TODO: This conversion only works for USD! We have to localize this or get it from the server directly (or better yet, just force people to use the integer version).
 					} )
 				);

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -21,6 +21,7 @@ import {
 	doesCartLocationDifferFromResponseCartLocation,
 	WPCOMCart,
 	WPCOMCartItem,
+	WPCOMCartCouponItem,
 	CheckoutCartItem,
 	CartLocation,
 } from '../types';
@@ -276,7 +277,7 @@ export interface ShoppingCartManager {
 	tax: CheckoutCartItem;
 	total: CheckoutCartItem;
 	subtotal: CheckoutCartItem;
-	couponItem: CheckoutCartItem;
+	couponItem: WPCOMCartCouponItem;
 	credits: CheckoutCartItem;
 	addItem: ( ResponseCartProduct ) => void;
 	removeItem: ( string ) => void;

--- a/packages/composite-checkout-wpcom/src/index.js
+++ b/packages/composite-checkout-wpcom/src/index.js
@@ -8,7 +8,12 @@ import { useWpcomStore } from './hooks/wpcom-store';
 import { mockSetCartEndpoint, mockGetCartEndpointWith } from './mock/cart-endpoint';
 import FormFieldAnnotation from './components/form-field-annotation';
 import { getNonProductWPCOMCartItemTypes } from './lib/translate-cart';
-import { WPCOMCartItem, CheckoutCartItem, prepareDomainContactDetails } from './types';
+import {
+	WPCOMCartItem,
+	CheckoutCartItem,
+	prepareDomainContactDetails,
+	translateCheckoutPaymentMethodToWpcomPaymentMethod,
+} from './types';
 
 // Re-export the public API
 export {
@@ -23,4 +28,5 @@ export {
 	CheckoutCartItem,
 	prepareDomainContactDetails,
 	getNonProductWPCOMCartItemTypes,
+	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 };

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -6,6 +6,7 @@ import {
 	ResponseCartProduct,
 	WPCOMCart,
 	WPCOMCartItem,
+	WPCOMCartCouponItem,
 	CheckoutCartItem,
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
@@ -60,7 +61,7 @@ export function translateWpcomCartToCheckoutCart(
 	const couponValue = Math.round( couponValueRaw );
 	const couponDisplayValue = `-$${ couponValueRaw / 100 }`;
 
-	const couponLineItem: CheckoutCartItem = {
+	const couponLineItem: WPCOMCartCouponItem = {
 		id: 'coupon-line-item',
 		label: translate( 'Coupon: %s', { args: coupon } ),
 		type: 'coupon',
@@ -68,6 +69,9 @@ export function translateWpcomCartToCheckoutCart(
 			currency: currency,
 			value: couponValue,
 			displayValue: couponDisplayValue,
+		},
+		wpcom_meta: {
+			couponCode: coupon,
 		},
 	};
 

--- a/packages/composite-checkout-wpcom/src/types.ts
+++ b/packages/composite-checkout-wpcom/src/types.ts
@@ -6,6 +6,7 @@ import {
 	WPCOMPaymentMethodClass,
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
+	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 } from './types/backend/payment-method';
 import {
 	RequestCart,
@@ -49,6 +50,7 @@ export {
 	WPCOMPaymentMethodClass,
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
+	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	RequestCart,
 	RequestCartProduct,
 	ResponseCart,

--- a/packages/composite-checkout-wpcom/src/types.ts
+++ b/packages/composite-checkout-wpcom/src/types.ts
@@ -26,6 +26,7 @@ import {
 import {
 	WPCOMCart,
 	WPCOMCartItem,
+	WPCOMCartCouponItem,
 	emptyWPCOMCart,
 	CheckoutCartItem,
 	CheckoutCartItemAmount,
@@ -64,6 +65,7 @@ export {
 	processRawResponse,
 	WPCOMCart,
 	WPCOMCartItem,
+	WPCOMCartCouponItem,
 	emptyWPCOMCart,
 	CheckoutCartItem,
 	CheckoutCartItemAmount,

--- a/packages/composite-checkout-wpcom/src/types/backend/payment-method.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/payment-method.ts
@@ -164,3 +164,41 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'apple-pay';
 	}
 }
+
+export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
+	paymentMethod: CheckoutPaymentMethodSlug
+): WPCOMPaymentMethodClass | null {
+	switch ( paymentMethod ) {
+		case 'ebanx':
+			return { name: 'WPCOM_Billing_Ebanx' };
+		case 'brazil-tef':
+			return { name: 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef' };
+		case 'paypal-direct':
+			return { name: 'WPCOM_Billing_PayPal_Direct' };
+		case 'paypal':
+			return { name: 'WPCOM_Billing_PayPal_Express' };
+		case 'card':
+			return { name: 'WPCOM_Billing_Stripe_Payment_Method' };
+		case 'alipay':
+			return { name: 'WPCOM_Billing_Stripe_Source_Alipay' };
+		case 'bancontact':
+			return { name: 'WPCOM_Billing_Stripe_Source_Bancontact' };
+		case 'eps':
+			return { name: 'WPCOM_Billing_Stripe_Source_Eps' };
+		case 'giropay':
+			return { name: 'WPCOM_Billing_Stripe_Source_Giropay' };
+		case 'ideal':
+			return { name: 'WPCOM_Billing_Stripe_Source_Ideal' };
+		case 'p24':
+			return { name: 'WPCOM_Billing_Stripe_Source_P24' };
+		case 'sofort':
+			return { name: 'WPCOM_Billing_Stripe_Source_Sofort' };
+		case 'stripe-three-d-secure':
+			return { name: 'WPCOM_Billing_Stripe_Source_Three_D_Secure' };
+		case 'wechat':
+			return { name: 'WPCOM_Billing_Stripe_Source_Wechat' };
+		case 'apple-pay':
+			return { name: 'WPCOM_Billing_Web_Payment' };
+	}
+	return null;
+}

--- a/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
@@ -41,12 +41,18 @@ export type WPCOMCartItem = CheckoutCartItem & {
 	};
 };
 
+export type WPCOMCartCouponItem = CheckoutCartItem & {
+	wpcom_meta: {
+		couponCode: string;
+	};
+};
+
 export interface WPCOMCart {
 	items: WPCOMCartItem[];
 	tax: CheckoutCartItem | null;
 	total: CheckoutCartItem;
 	subtotal: CheckoutCartItem;
-	coupon: CheckoutCartItem | null;
+	coupon: WPCOMCartCouponItem | null;
 	allowedPaymentMethods: CheckoutPaymentMethodSlug[];
 	credits: CheckoutCartItem;
 	couponCode: string | null;
@@ -73,7 +79,10 @@ export const emptyWPCOMCart = {
 			currency: '',
 			displayValue: '',
 		} as CheckoutCartItemAmount,
-	} as CheckoutCartItem,
+		wpcom_meta: {
+			couponCode: '',
+		},
+	} as WPCOMCartCouponItem,
 	total: {
 		label: 'Total',
 		amount: {

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -158,7 +158,7 @@ It has the following props.
 - `items: object[]`. An array of [line item objects](#line-items) that will be displayed in the form.
 - `total: object`. A [line item object](#line-items) with the final total to be paid.
 - `theme?: object`. A [theme object](#styles-and-themes).
-- `onPaymentComplete: () => null`. A function to call for non-redirect payment methods when payment is successful.
+- `onPaymentComplete: ({paymentMethodId: string}) => null`. A function to call for non-redirect payment methods when payment is successful. Passed the current payment method id.
 - `showErrorMessage: (string) => null`. A function that will display a message with an "error" type.
 - `showInfoMessage: (string) => null`. A function that will display a message with an "info" type.
 - `showSuccessMessage: (string) => null`. A function that will display a message with a "success" type.

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -54,9 +54,11 @@ export const CheckoutProvider = props => {
 	}, [ paymentMethods, prevPaymentMethods ] );
 
 	const [ formStatus, setFormStatus ] = useFormStatusManager( isLoading );
+	const didCallOnPaymentComplete = useRef( false );
 	useEffect( () => {
-		if ( formStatus === 'complete' ) {
+		if ( formStatus === 'complete' && ! didCallOnPaymentComplete.current ) {
 			debug( "form status is complete so I'm calling onPaymentComplete" );
+			didCallOnPaymentComplete.current = true;
 			onPaymentComplete( { paymentMethodId } );
 		}
 	}, [ formStatus, onPaymentComplete, paymentMethodId ] );

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -57,9 +57,9 @@ export const CheckoutProvider = props => {
 	useEffect( () => {
 		if ( formStatus === 'complete' ) {
 			debug( "form status is complete so I'm calling onPaymentComplete" );
-			onPaymentComplete();
+			onPaymentComplete( { paymentMethodId } );
 		}
-	}, [ formStatus, onPaymentComplete ] );
+	}, [ formStatus, onPaymentComplete, paymentMethodId ] );
 
 	// Remove undefined and duplicate checkoutWrapper properties
 	const wrappers = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This records a second event, `calypso_checkout_payment_success`, which is
also used in the regular checkout, when calling `onPaymentComplete`. The existing success event, `calypso_checkout_composite_payment_complete`, will still be recorded and will be provided with some additional properties to match those recorded by the new event.

We have to do some minor refactoring to get the data that the new event needs. You should be able to read the commits one-at-a-time to see what each change means.

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start` or add `?flags=composite-checkout-wpcom` to the query string when you get to checkout.
- In the console on your local environment, enable debug logs with `localStorage.setItem('debug', 'calypso:analytics*')` and reload the page.
- Visit checkout with a plan in your cart and complete the form. You can sandbox the store and use a test Stripe card if you like (eg: `4242 4242 4242 4242`).
- Verify that you see in the debug logs, `Recording event "calypso_checkout_payment_success" with actual props`. Verify the props object looks correct.