### PR TITLE
Domain step text: Modify text for the free subdomain tooltip

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import InfoPopover from 'components/info-popover';
+import { getTld } from 'lib/domains';
 
 /**
  * Style dependencies
@@ -36,26 +37,49 @@ class DomainProductPrice extends React.Component {
 	};
 
 	getDomainPricePopoverElement() {
-		const { price, rule, isFeatured, translate } = this.props;
+		const { price, rule, isFeatured, domain, translate } = this.props;
 
 		let popoverText;
 
 		switch ( rule ) {
 			case 'FREE_DOMAIN':
-				popoverText = translate(
-					'Every WordPress.com site comes with a free address using a WordPress.com subdomain. {{a}}Learn more{{/a}}.',
-					{
-						components: {
-							a: (
-								<a
-									href="https://en.support.wordpress.com/domains/#domain-name-overview"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					}
-				);
+				if ( getTld( domain ) === 'blog' ) {
+					popoverText = translate(
+						'Every WordPress.com blog comes with a free .blog address. {{a}}Learn more{{/a}}.',
+						{
+							components: {
+								a: (
+									<a
+										href="https://en.support.wordpress.com/domains/#domain-name-overview"
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={ event => {
+											event.stopPropagation();
+										} }
+									/>
+								),
+							},
+						}
+					);
+				} else {
+					popoverText = translate(
+						'Every WordPress.com site comes with a free WordPress.com address. {{a}}Learn more{{/a}}.',
+						{
+							components: {
+								a: (
+									<a
+										href="https://en.support.wordpress.com/domains/#domain-name-overview"
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={ event => {
+											event.stopPropagation();
+										} }
+									/>
+								),
+							},
+						}
+					);
+				}
 				break;
 
 			case 'INCLUDED_IN_HIGHER_PLAN':
@@ -70,6 +94,9 @@ class DomainProductPrice extends React.Component {
 									href="https://en.support.wordpress.com/domains/domain-pricing-and-available-tlds/"
 									target="_blank"
 									rel="noopener noreferrer"
+									onClick={ event => {
+										event.stopPropagation();
+									} }
 								/>
 							),
 						},
@@ -169,6 +196,9 @@ class DomainProductPrice extends React.Component {
 								href="https://en.support.wordpress.com/domains/domain-pricing-and-available-tlds/"
 								target="_blank"
 								rel="noopener noreferrer"
+								onClick={ event => {
+									event.stopPropagation();
+								} }
 							/>
 						),
 					},

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -221,7 +221,16 @@ class DomainRegistrationSuggestion extends React.Component {
 									tld: '.' + getTld( domain ),
 								},
 								components: {
-									a: <a href={ HTTPS_SSL } target="_blank" rel="noopener noreferrer" />,
+									a: (
+										<a
+											href={ HTTPS_SSL }
+											target="_blank"
+											rel="noopener noreferrer"
+											onClick={ event => {
+												event.stopPropagation();
+											} }
+										/>
+									),
 									strong: <strong />,
 								},
 							}

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -86,6 +86,7 @@ class DomainSuggestion extends React.Component {
 							showTestCopy={ showTestCopy }
 							showDesignUpdate={ showDesignUpdate }
 							isEligibleVariantForDomainTest={ isEligibleVariantForDomainTest }
+							domain={ this.props.domain }
 						/>
 					) }
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update tooltip text for the free subdomain URL as mentioned in the comment https://github.com/Automattic/wp-calypso/issues/39393#issuecomment-586909676
* Also fixes a bug wherein clicking the "Learn More" link in the tooltip would also add the domain to cart.

<img width="1015" alt="Screenshot 2020-02-18 at 10 11 36 AM" src="https://user-images.githubusercontent.com/1269602/74705788-19f11700-523b-11ea-9281-5b18adabe0ba.png">

<img width="985" alt="Screenshot 2020-02-18 at 10 11 42 AM" src="https://user-images.githubusercontent.com/1269602/74705794-1cec0780-523b-11ea-91a0-df717fc56333.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Go through the signup flow /start - assign yourself to _variantShowUpdates_ of _domainStepCopyUpdates_ and _variantDesignUpdates_ of _domainStepDesignUpdates_.

* Verify that for the free .blog and .wordpres.com domains, the tooltip text matches the recommendations in https://github.com/Automattic/wp-calypso/issues/39393#issuecomment-586909676:
    - For .wordpress.com, we will say `Every WordPress.com site comes with a free WordPress.com address.`
    - For .blog, we will say: `Every WordPress.com blog comes with a free .blog address.`
* Verify that if you click the "Learn More" link in the domain price tooltips, the domain item does not get added to cart.

<img width="978" alt="Screenshot 2020-02-18 at 10 36 04 AM" src="https://user-images.githubusercontent.com/1269602/74705621-8881a500-523a-11ea-9a29-d4ce24abae0a.png">

* Verify that for .app domains, clicking the "Learn more" link in the tooltip does not add domain item to cart (you can use the More Extensions button to filter by .app domains if not pointed to sandbox).

<img width="962" alt="Screenshot 2020-02-18 at 10 30 34 AM" src="https://user-images.githubusercontent.com/1269602/74705698-ca125000-523a-11ea-8aa6-1f1207eb6625.png">

