### PR TITLE
Jetpack Cloud: Provide Redux store

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -127,7 +127,15 @@ const loggedOutMiddleware = currentUser => {
 };
 
 const loggedInMiddleware = currentUser => {
-	if ( ! currentUser.get() ) {
+	const jetpackCloudEnvs = [
+		'jetpack-cloud-development',
+		'jetpack-cloud-stage',
+		'jetpack-cloud-production',
+	];
+	const calypsoEnv = config( 'env_id' );
+
+	// TODO: Remove Jetpack Cloud specific logic when root route is no longer handled by the reader section
+	if ( ! currentUser.get() || jetpackCloudEnvs.includes( calypsoEnv ) ) {
 		return;
 	}
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -412,7 +412,7 @@ function renderLayout( reduxStore ) {
 	debug( 'Main layout rendered.' );
 }
 
-const boot = currentUser => {
+const boot = ( currentUser, router ) => {
 	utils();
 	loadAllState().then( () => {
 		const initialState = getInitialState( initialReducer );
@@ -423,14 +423,17 @@ const boot = currentUser => {
 		configureReduxStore( currentUser, reduxStore );
 		setupMiddlewares( currentUser, reduxStore );
 		detectHistoryNavigation.start();
+		if ( router ) {
+			router();
+		}
 		page.start( { decodeURLComponents: false } );
 	} );
 };
 
-export const bootApp = appName => {
+export const bootApp = ( appName, router ) => {
 	const user = userFactory();
 	user.initialize().then( () => {
 		debug( `Starting ${ appName }. Let's do this.` );
-		boot( user );
+		boot( user, router );
 	} );
 };

--- a/client/landing/jetpack-cloud/controller.js
+++ b/client/landing/jetpack-cloud/controller.js
@@ -11,6 +11,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import JetpackCloudLayout from './layout';
 import JetpackCloudSidebar from './components/sidebar';
 import LogItem from './components/log-item';
+import { getCurrentUserName } from 'state/current-user/selectors';
 
 export const makeLayout = ( context, next ) => {
 	const { primary, secondary, store } = context;
@@ -65,6 +66,14 @@ export function jetpackBackups( context, next ) {
 }
 
 export function jetpackScan( context, next ) {
-	context.primary = <div>This is the Jetpack Scan landing page!</div>;
+	const state = context.store.getState();
+	const currentUserName = getCurrentUserName( state );
+
+	context.primary = (
+		<div>
+			<p>{ currentUserName ? `Hi, ${ currentUserName }!` : 'Hi!' }</p>
+			<p>This is the Jetpack Scan landing page!</p>
+		</div>
+	);
 	next();
 }

--- a/client/landing/jetpack-cloud/controller.js
+++ b/client/landing/jetpack-cloud/controller.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import ReactDom from 'react-dom';
+import { Provider as ReduxProvider } from 'react-redux';
 
 /**
  * Internal Dependencies
@@ -12,9 +13,13 @@ import JetpackCloudSidebar from './components/sidebar';
 import LogItem from './components/log-item';
 
 export const makeLayout = ( context, next ) => {
-	const { primary, secondary } = context;
+	const { primary, secondary, store } = context;
 
-	context.layout = <JetpackCloudLayout primary={ primary } secondary={ secondary } />;
+	context.layout = (
+		<ReduxProvider store={ store }>
+			<JetpackCloudLayout primary={ primary } secondary={ secondary } />
+		</ReduxProvider>
+	);
 
 	next();
 };

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -20,7 +20,6 @@ window.AppBoot = () => {
 	if ( ! config.isEnabled( 'jetpack-cloud' ) ) {
 		window.location.href = '/';
 	} else {
-		initJetpackCloudRoutes();
-		bootApp( 'Jetpack Cloud' );
+		bootApp( 'Jetpack Cloud', initJetpackCloudRoutes );
 	}
 };


### PR DESCRIPTION
It was brought up by both @enejb and @rcoll that the Jetpack Cloud lacks access to the Redux store. AFAIU, the Redux store is of paramount importance to continue building the Jetpack Cloud, so I drafted this PR to address that.

#### Changes proposed in this Pull Request

* Add support to common boot for registering router after boot has setup all middleware
* Move Jetpack Cloud route registration later, so context middleware can be setup before that
* Wrap the Jetpack Cloud main layout in a `Provider` to pass store down and allow for `connect()` calls in subcomponents
* Display the current user's username as a demonstration of the Redux store.

A positive side effect here is that all the middleware is not only called now, but is also setup before the routes, so in Jetpack Cloud you now have access to the current user, locale, and (almost) everything you have in Calypso by default. Some of it may make sense to be disabled in future PRs, of course.

#### Testing instructions

* Checkout this branch.
* Run `CALYPSO_ENV=jetpack-cloud-development npm start`
* Go to http://jetpack.cloud.localhost:3000/scan
* Verify you can see your username in the content of the Scan page:

![](https://cldup.com/_X9DGKUdO4.png)

* Run `npm start`
* Verify Calypso still works well without any errors.