### PR TITLE
Jetpack Cloud: Remove extra entry point section handling

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -861,8 +861,6 @@ module.exports = function() {
 
 	handleSectionPath( GUTENBOARDING_SECTION_DEFINITION, '/gutenboarding', 'entry-gutenboarding' );
 
-	handleSectionPath( JETPACK_CLOUD_SECTION_DEFINITION, '/jetpack-cloud', 'entry-jetpack-cloud' );
-
 	// This is used to log to tracks Content Security Policy violation reports sent by browsers
 	app.post(
 		'/cspreport',


### PR DESCRIPTION
Back when we were starting experiments with Jetpack Cloud, we had a dedicated route for development and had everything run inside it. With Jetpack Cloud being ran in separate Calypso environments, this is no longer the case.

This means that we can remove the Jetpack Cloud section handling that we no longer use.

#### Changes proposed in this Pull Request

* Jetpack Cloud: Remove extra entry point section handling

#### Testing instructions

* Checkout this branch.
* Run `CALYPSO_ENV=jetpack-cloud-development npm start`
* Go to http://jetpack.cloud.localhost:3000
* Verify it works alright without any errors.
* Run `npm start`
* Verify Calypso still works well without any errors.