### PR TITLE
Jetpack Cloud: Enable debug on dev environment

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -260,7 +260,8 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 	// render to make sure that Redux state and markup are only cached for whitelisted query args.
 	const cacheKey = getNormalizedPath( request.path, request.query );
 	const geoLocation = ( request.headers[ 'x-geoip-country-code' ] || '' ).toLowerCase();
-	const isDebug = calypsoEnv === 'development' || request.query.debug !== undefined;
+	const devEnvironments = [ 'development', 'jetpack-cloud-development' ];
+	const isDebug = devEnvironments.includes( calypsoEnv ) || request.query.debug !== undefined;
 
 	if ( cacheKey ) {
 		const serializeCachedServerState = stateCache.get( cacheKey ) || {};


### PR DESCRIPTION
Enabling debug mode on development environments is essential for easy debugging. Calypso has several features that rely on that in the development environment, but they were not enabled for the Jetpack Cloud development environment. This PR enables them.

My personal favorite is the console dispatcher - being able to type `state` and get the up-to-date state tree and being able to traverse it and `dispatch()` to dispatch actions conveniently from the console.

#### Changes proposed in this Pull Request

* Jetpack Cloud: Enable debug on dev environment

#### Testing instructions

* Checkout this branch.
* Run `CALYPSO_ENV=jetpack-cloud-development npm start`
* Open http://jetpack.cloud.localhost:3000/
* Open your browser console and type `state` there.
* Verify you can see the state tree output by the console.
* Run `npm start`.
* Verify the console dispatcher also works as before for the development environment.
