### PR TITLE
FSE: Add externalized dependencies

### DIFF
--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -45,6 +45,24 @@
 		"wpcom-sync": "./bin/wpcom-watch-and-sync.sh"
 	},
 	"dependencies": {
-		"classnames": "2.2.6"
+		"@wordpress/api-fetch": "*",
+		"@wordpress/block-editor": "*",
+		"@wordpress/blocks": "*",
+		"@wordpress/components": "*",
+		"@wordpress/compose": "*",
+		"@wordpress/data": "*",
+		"@wordpress/dom-ready": "*",
+		"@wordpress/edit-post": "*",
+		"@wordpress/editor": "*",
+		"@wordpress/element": "*",
+		"@wordpress/hooks": "*",
+		"@wordpress/html-entities": "*",
+		"@wordpress/i18n": "*",
+		"@wordpress/keycodes": "*",
+		"@wordpress/plugins": "*",
+		"@wordpress/url": "*",
+		"classnames": "2.2.6",
+		"lodash": "*",
+		"moment": "*"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -576,7 +576,25 @@
 		"@automattic/full-site-editing": {
 			"version": "file:apps/full-site-editing",
 			"requires": {
-				"classnames": "2.2.6"
+				"@wordpress/api-fetch": "*",
+				"@wordpress/block-editor": "*",
+				"@wordpress/blocks": "*",
+				"@wordpress/components": "*",
+				"@wordpress/compose": "*",
+				"@wordpress/data": "*",
+				"@wordpress/dom-ready": "*",
+				"@wordpress/edit-post": "*",
+				"@wordpress/editor": "*",
+				"@wordpress/element": "*",
+				"@wordpress/hooks": "*",
+				"@wordpress/html-entities": "*",
+				"@wordpress/i18n": "*",
+				"@wordpress/keycodes": "*",
+				"@wordpress/plugins": "*",
+				"@wordpress/url": "*",
+				"classnames": "2.2.6",
+				"lodash": "*",
+				"moment": "*"
 			}
 		},
 		"@automattic/load-script": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

FSE didn't declaring dependencies that are externalized by webpack. However, these dependencies may still be required, in particular for testing during development.

This came to light recently with a @wordpress/* package upgrade: https://github.com/Automattic/wp-calypso/pull/39383#pullrequestreview-359283526

I propose we declare these as dependencies to ensure they're installed. 

#### Testing instructions

No extraneous imports lint issues in fse:

```
npx eslint --ignore-path=.eslintignore --ext .js --ext .jsx --ext .ts --ext .tsx apps/full-site-editing
### Pipe to grep to filter for extraneous imports:
# npx eslint --ignore-path=.eslintignore --ext .js --ext .jsx --ext .ts --ext .tsx apps/full-site-editing | grep extraneous
```

This should fix issues in https://github.com/Automattic/wp-calypso/pull/39383 when merged there.

Fixes #
