### PR TITLE
Docker: Cleanup .dockerignore from obsolete server dirs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,10 +9,6 @@ Dockerfile
 /cached-requests.json
 **/node_modules
 /public
-/server/bundler/*.json
-/server/devdocs/components-usage-stats.json
-/server/devdocs/proptypes-index.json
-/server/devdocs/search-index.js
 /client/server/bundler/*.json
 /client/server/devdocs/components-usage-stats.json
 /client/server/devdocs/proptypes-index.json


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Docker: Cleanup .dockerconfig from obsolete server dirs

#### Testing instructions

* Shouldn't be necessary, as this removes no longer needed entries from the .dockerignore file