### PR TITLE
ESLint: Cleanup obsolete server dir from .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,6 @@
 /public/
 node_modules/
 !.eslintrc.js
-/server/devdocs/search-index.js
 /client/server/devdocs/search-index.js
 /packages/calypso-codemods/tests
 
@@ -19,9 +18,6 @@ node_modules/
 /stats.json
 /chart.json
 /style.json
-/server/devdocs/components-usage-stats.json
-/server/devdocs/proptypes-index.json
-/server/bundler/assets.json
 /client/stats.json
 /client/chart.json
 /client/style.json


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* ESLint: Cleanup .eslintignore from obsolete server dirs

#### Testing instructions

* Shouldn't be necessary, as this removes no longer existing entries from the .eslintignore file.