### PR TITLE
Add webauthn support for the two step re-auth dialog

### DIFF
--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -106,6 +106,7 @@ TwoStepAuthorization.prototype.loginUserWithSecurityKey = function( args ) {
 			}
 			return postLoginRequest( 'webauthn-authentication-endpoint', {
 				client_data: JSON.stringify( assertion ),
+				create_2fa_cookies_only: 1,
 			} );
 		} )
 		.then( response => {

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -80,6 +80,9 @@ TwoStepAuthorization.prototype.loginUserWithSecurityKey = function( args ) {
 			two_step_nonce: this.getTwoStepWebauthnNonce(),
 			...data,
 		};
+		if ( ! _data.two_step_nonce ) {
+			return Promise.reject( 'Invalid nonce' );
+		}
 		for ( const key in _data ) {
 			formData.set( key, _data[ key ] );
 		}

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -4,6 +4,8 @@
 import debugFactory from 'debug';
 import { replace } from 'lodash';
 
+import { get as webauthn_auth } from '@github/webauthn-json';
+
 const debug = debugFactory( 'calypso:two-step-authorization' );
 
 /**
@@ -17,7 +19,6 @@ import { reduxDispatch } from 'lib/redux-bridge';
 import { requestConnectedApplications } from 'state/connected-applications/actions';
 import { requestUserProfileLinks } from 'state/profile-links/actions';
 import config from 'config';
-import { get as webauthn_auth } from '@github/webauthn-json';
 
 const wpcom = wp.undocumented();
 

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -104,10 +104,6 @@ TwoStepAuthorization.prototype.loginUserWithSecurityKey = function( args ) {
 			return webauthn_auth( { publicKey: parameters } );
 		} )
 		.then( assertion => {
-			const response = assertion.response;
-			if ( typeof response.userHandle !== 'undefined' && null === response.userHandle ) {
-				delete response.userHandle;
-			}
 			return postLoginRequest( 'webauthn-authentication-endpoint', {
 				client_data: JSON.stringify( assertion ),
 				create_2fa_cookies_only: 1,

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -69,21 +69,23 @@ TwoStepAuthorization.prototype.fetch = function( callback ) {
 };
 
 TwoStepAuthorization.prototype.postLoginRequest = function( endpoint, data ) {
+	if ( ! this.getTwoStepWebauthnNonce() ) {
+		return Promise.reject( 'Invalid nonce' );
+	}
+
 	const url = 'https://wordpress.com/wp-login.php?action=' + endpoint;
 	// eslint-disable-next-line no-undef
 	const formData = new FormData();
-	const _data = {
+	const requestData = {
 		client_id: config( 'wpcom_signup_id' ),
 		client_secret: config( 'wpcom_signup_key' ),
 		auth_type: 'webauthn',
 		two_step_nonce: this.getTwoStepWebauthnNonce(),
 		...data,
 	};
-	if ( ! _data.two_step_nonce ) {
-		return Promise.reject( 'Invalid nonce' );
-	}
-	for ( const key in _data ) {
-		formData.set( key, _data[ key ] );
+
+	for ( const key in requestData ) {
+		formData.set( key, requestData[ key ] );
 	}
 	// eslint-disable-next-line no-undef
 	return fetch( url, {

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -29,7 +29,7 @@ function TwoStepAuthorization() {
 		return new TwoStepAuthorization();
 	}
 
-	this.data = null;
+	this.data = {};
 	this.initialized = false;
 	this.smsResendThrottled = false;
 
@@ -73,8 +73,7 @@ TwoStepAuthorization.prototype.postLoginRequest = function( endpoint, data ) {
 	}
 
 	const url = 'https://wordpress.com/wp-login.php?action=' + endpoint;
-	// eslint-disable-next-line no-undef
-	const formData = new FormData();
+	const formData = new window.FormData();
 	const requestData = {
 		client_id: config( 'wpcom_signup_id' ),
 		client_secret: config( 'wpcom_signup_key' ),
@@ -86,12 +85,14 @@ TwoStepAuthorization.prototype.postLoginRequest = function( endpoint, data ) {
 	for ( const key in requestData ) {
 		formData.set( key, requestData[ key ] );
 	}
-	// eslint-disable-next-line no-undef
-	return fetch( url, {
-		method: 'POST',
-		body: formData,
-		credentials: 'include',
-	} ).then( response => response.json() );
+
+	return window
+		.fetch( url, {
+			method: 'POST',
+			body: formData,
+			credentials: 'include',
+		} )
+		.then( response => response.json() );
 };
 
 TwoStepAuthorization.prototype.loginUserWithSecurityKey = function( args ) {
@@ -289,27 +290,27 @@ TwoStepAuthorization.prototype.isSMSResendThrottled = function() {
 };
 
 TwoStepAuthorization.prototype.isReauthRequired = function() {
-	return this.data ? this.data.two_step_reauthorization_required : false;
+	return this.data.two_step_reauthorization_required ?? false;
 };
 
 TwoStepAuthorization.prototype.authExpiresSoon = function() {
-	return this.data ? this.data.two_step_authorization_expires_soon : false;
+	return this.data.two_step_authorization_expires_soon ?? false;
 };
 
 TwoStepAuthorization.prototype.isTwoStepSMSEnabled = function() {
-	return this.data ? this.data.two_step_sms_enabled : false;
+	return this.data.two_step_sms_enabled ?? false;
 };
 
 TwoStepAuthorization.prototype.isSecurityKeyEnabled = function() {
-	return this.data?.two_step_webauthn_enabled ?? false;
+	return this.data.two_step_webauthn_enabled ?? false;
 };
 
 TwoStepAuthorization.prototype.getTwoStepWebauthnNonce = function() {
-	return this.data?.two_step_webauthn_nonce ?? false;
+	return this.data.two_step_webauthn_nonce ?? false;
 };
 
 TwoStepAuthorization.prototype.getSMSLastFour = function() {
-	return this.data ? this.data.two_step_sms_last_four : null;
+	return this.data.two_step_sms_last_four ?? null;
 };
 
 emitter( TwoStepAuthorization.prototype );

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -75,11 +75,11 @@ TwoStepAuthorization.prototype.postLoginRequest = function( endpoint, data ) {
 	const url = 'https://wordpress.com/wp-login.php?action=' + endpoint;
 	const formData = new window.FormData();
 	const requestData = {
+		...data,
 		client_id: config( 'wpcom_signup_id' ),
 		client_secret: config( 'wpcom_signup_key' ),
 		auth_type: 'webauthn',
 		two_step_nonce: this.getTwoStepWebauthnNonce(),
-		...data,
 	};
 
 	for ( const key in requestData ) {

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { replace } from 'lodash';
-
 import { get as webauthn_auth } from '@github/webauthn-json';
+import { replace } from 'lodash';
 
 const debug = debugFactory( 'calypso:two-step-authorization' );
 
@@ -12,13 +11,13 @@ const debug = debugFactory( 'calypso:two-step-authorization' );
  * Internal Dependencies
  */
 import analytics from 'lib/analytics';
+import config from 'config';
 import emitter from 'lib/mixins/emitter';
 import userSettings from 'lib/user-settings';
-import wp from 'lib/wp';
 import { reduxDispatch } from 'lib/redux-bridge';
 import { requestConnectedApplications } from 'state/connected-applications/actions';
 import { requestUserProfileLinks } from 'state/profile-links/actions';
-import config from 'config';
+import wp from 'lib/wp';
 
 const wpcom = wp.undocumented();
 
@@ -302,7 +301,7 @@ TwoStepAuthorization.prototype.isTwoStepSMSEnabled = function() {
 };
 
 TwoStepAuthorization.prototype.isSecurityKeyEnabled = function() {
-	return this.data ? this.data.two_step_webauthn_enabled : false;
+	return this.data?.two_step_webauthn_enabled ?? false;
 };
 
 TwoStepAuthorization.prototype.getTwoStepWebauthnNonce = function() {

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -301,7 +301,7 @@ TwoStepAuthorization.prototype.isSecurityKeyEnabled = function() {
 };
 
 TwoStepAuthorization.prototype.getTwoStepWebauthnNonce = function() {
-	return this.data ? this.data.two_step_webauthn_nonce : false;
+	return this.data?.two_step_webauthn_nonce ?? false;
 };
 
 TwoStepAuthorization.prototype.getSMSLastFour = function() {

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -291,7 +291,10 @@ const ReauthRequired = createReactClass( {
 					onChange={ this.handleAuthSwitch }
 					isSmsSupported={ method === 'sms' || method === 'authenticator' }
 					isAuthenticatorSupported={ method !== 'sms' }
-					isSmsAllowed={ this.state.smsRequestsAllowed }
+					isSmsAllowed={
+						this.state.smsRequestsAllowed ||
+						( method === 'sms' && this.state.twoFactorAuthType === 'webauthn' )
+					}
 					isSecurityKeySupported={ isSecurityKeySupported }
 				/>
 			</Dialog>

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -7,6 +7,7 @@ import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { supported } from '@github/webauthn-json';
 
 const debug = debugFactory( 'calypso:me:reauth-required' );
 
@@ -28,7 +29,6 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 import userUtilities from 'lib/user/utils';
 import SecurityKeyForm from 'me/reauth-required/security-key-form';
 import { getCurrentUserId } from 'state/current-user/selectors';
-import { supported } from '@github/webauthn-json';
 
 /**
  * Style dependencies
@@ -146,25 +146,6 @@ const ReauthRequired = createReactClass( {
 		return this.state.code.length && this.state.code.length > 5;
 	},
 
-	renderSendSMSButton: function() {
-		const { smsRequestsAllowed, smsCodeSent } = this.state;
-
-		const [ clickAction, buttonLabel ] = ! smsCodeSent
-			? [ 'Send SMS Code Button on Reauth Required', this.props.translate( 'Send SMS Code' ) ]
-			: [ 'Resend SMS Code Button on Reauth Required', this.props.translate( 'Resend SMS Code' ) ];
-
-		return (
-			<FormButton
-				disabled={ ! smsRequestsAllowed }
-				isPrimary={ false }
-				onClick={ this.getClickHandler( clickAction, this.sendSMSCode ) }
-				type="button"
-			>
-				{ buttonLabel }
-			</FormButton>
-		);
-	},
-
 	renderFailedValidationMsg: function() {
 		if ( ! this.props.twoStepAuthorization.codeValidationFailed() ) {
 			return null;
@@ -249,8 +230,6 @@ const ReauthRequired = createReactClass( {
 					>
 						{ this.props.translate( 'Verify' ) }
 					</FormButton>
-
-					{ false && this.renderSendSMSButton() }
 				</form>
 			</Card>
 		);

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -279,7 +279,7 @@ const ReauthRequired = createReactClass( {
 
 	refreshNonceOnFailure( error ) {
 		const errors = [].slice.call( error?.data?.errors ?? [] );
-		if ( errors.findIndex( e => e.code === 'invalid_two_step_nonce' ) >= 0 ) {
+		if ( errors.some( e => e.code === 'invalid_two_step_nonce' ) ) {
 			this.props.twoStepAuthorization.fetch();
 		}
 	},

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -21,20 +21,20 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
 import FormVerificationCodeInput from 'components/forms/form-verification-code-input';
+import { getCurrentUserId } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 /* eslint-disable no-restricted-imports */
 import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
 import { recordGoogleEvent } from 'state/analytics/actions';
-import userUtilities from 'lib/user/utils';
 import SecurityKeyForm from 'me/reauth-required/security-key-form';
-import { getCurrentUserId } from 'state/current-user/selectors';
+import TwoFactorActions from 'me/reauth-required/two-factor-actions';
+import userUtilities from 'lib/user/utils';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import TwoFactorActions from 'me/reauth-required/two-factor-actions';
 
 // autofocus is used for tracking purposes, not an a11y issue
 /* eslint-disable jsx-a11y/no-autofocus, react/prefer-es6-class, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/anchor-is-valid */

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -258,7 +258,10 @@ const ReauthRequired = createReactClass( {
 				isVisible={ this.props.twoStepAuthorization.isReauthRequired() }
 			>
 				{ isSecurityKeySupported && twoFactorAuthType === 'webauthn' ? (
-					<SecurityKeyForm loginUserWithSecurityKey={ this.loginUserWithSecurityKey } />
+					<SecurityKeyForm
+						loginUserWithSecurityKey={ this.loginUserWithSecurityKey }
+						onComplete={ this.refreshNonceOnFailure }
+					/>
 				) : (
 					this.renderVerificationForm()
 				) }
@@ -272,6 +275,13 @@ const ReauthRequired = createReactClass( {
 				/>
 			</Dialog>
 		);
+	},
+
+	refreshNonceOnFailure( error ) {
+		const errors = [].slice.call( error?.data?.errors ?? [] );
+		if ( errors.findIndex( e => e.code === 'invalid_two_step_nonce' ) >= 0 ) {
+			this.props.twoStepAuthorization.fetch();
+		}
 	},
 
 	handleAuthSwitch( authType ) {

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -265,7 +265,7 @@ const ReauthRequired = createReactClass( {
 					? this.renderSecurityKey()
 					: this.renderVerificationForm() }
 				<TwoFactorActions
-					twoFactorAuthType={ this.state.twoFactorAuthType }
+					twoFactorAuthType={ twoFactorAuthType }
 					onChange={ this.handleAuthSwitch }
 					isSmsSupported={ method === 'sms' || method === 'authenticator' }
 					isAuthenticatorSupported={ method !== 'sms' }

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -240,10 +240,6 @@ const ReauthRequired = createReactClass( {
 		);
 	},
 
-	renderSecurityKey() {
-		return <SecurityKeyForm loginUserWithSecurityKey={ this.loginUserWithSecurityKey } />;
-	},
-
 	render: function() {
 		const method = this.props.twoStepAuthorization.isTwoStepSMSEnabled() ? 'sms' : 'authenticator';
 		const isSecurityKeySupported =
@@ -261,9 +257,11 @@ const ReauthRequired = createReactClass( {
 				isFullScreen={ false }
 				isVisible={ this.props.twoStepAuthorization.isReauthRequired() }
 			>
-				{ isSecurityKeySupported && twoFactorAuthType === 'webauthn'
-					? this.renderSecurityKey()
-					: this.renderVerificationForm() }
+				{ isSecurityKeySupported && twoFactorAuthType === 'webauthn' ? (
+					<SecurityKeyForm loginUserWithSecurityKey={ this.loginUserWithSecurityKey } />
+				) : (
+					this.renderVerificationForm()
+				) }
 				<TwoFactorActions
 					twoFactorAuthType={ twoFactorAuthType }
 					onChange={ this.handleAuthSwitch }

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -49,7 +49,6 @@ const ReauthRequired = createReactClass( {
 			smsRequestsAllowed: true, // Can the user request another SMS code?
 			smsCodeSent: false,
 			twoFactorAuthType: 'authenticator',
-			webauthnError: false,
 		};
 	},
 

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -145,6 +145,12 @@ const ReauthRequired = createReactClass( {
 		return this.state.code.length && this.state.code.length > 5;
 	},
 
+	loginUserWithSecurityKey: function() {
+		return this.props.twoStepAuthorization.loginUserWithSecurityKey( {
+			user_id: this.props.currentUserId,
+		} );
+	},
+
 	renderFailedValidationMsg: function() {
 		if ( ! this.props.twoStepAuthorization.codeValidationFailed() ) {
 			return null;
@@ -235,15 +241,7 @@ const ReauthRequired = createReactClass( {
 	},
 
 	renderSecurityKey() {
-		return (
-			<SecurityKeyForm
-				loginUserWithSecurityKey={ () => {
-					return this.props.twoStepAuthorization.loginUserWithSecurityKey( {
-						user_id: this.props.currentUserId,
-					} );
-				} }
-			/>
-		);
+		return <SecurityKeyForm loginUserWithSecurityKey={ this.loginUserWithSecurityKey } />;
 	},
 
 	render: function() {
@@ -257,8 +255,6 @@ const ReauthRequired = createReactClass( {
 				className="reauth-required__dialog"
 				isFullScreen={ false }
 				isVisible={ this.props.twoStepAuthorization.isReauthRequired() }
-				buttons={ null }
-				onClose={ null }
 			>
 				{ isSecurityKeySupported &&
 					this.state.twoFactorAuthType === 'webauthn' &&

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -248,6 +248,11 @@ const ReauthRequired = createReactClass( {
 		const method = this.props.twoStepAuthorization.isTwoStepSMSEnabled() ? 'sms' : 'authenticator';
 		const isSecurityKeySupported =
 			this.props.twoStepAuthorization.isSecurityKeyEnabled() && supported();
+		const { twoFactorAuthType } = this.state;
+		// This enables the SMS button on the security key form regardless if we can send SMS or not.
+		// Otherwise, there's no way to go back to the verification form if smsRequestsAllowed is false.
+		const shouldEnableSmsButton =
+			this.state.smsRequestsAllowed || ( method === 'sms' && twoFactorAuthType === 'webauthn' );
 
 		return (
 			<Dialog
@@ -256,19 +261,15 @@ const ReauthRequired = createReactClass( {
 				isFullScreen={ false }
 				isVisible={ this.props.twoStepAuthorization.isReauthRequired() }
 			>
-				{ isSecurityKeySupported &&
-					this.state.twoFactorAuthType === 'webauthn' &&
-					this.renderSecurityKey() }
-				{ this.state.twoFactorAuthType !== 'webauthn' && this.renderVerificationForm() }
+				{ isSecurityKeySupported && twoFactorAuthType === 'webauthn'
+					? this.renderSecurityKey()
+					: this.renderVerificationForm() }
 				<TwoFactorActions
 					twoFactorAuthType={ this.state.twoFactorAuthType }
 					onChange={ this.handleAuthSwitch }
 					isSmsSupported={ method === 'sms' || method === 'authenticator' }
 					isAuthenticatorSupported={ method !== 'sms' }
-					isSmsAllowed={
-						this.state.smsRequestsAllowed ||
-						( method === 'sms' && this.state.twoFactorAuthType === 'webauthn' )
-					}
+					isSmsAllowed={ shouldEnableSmsButton }
 					isSecurityKeySupported={ isSecurityKeySupported }
 				/>
 			</Dialog>

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import FormButton from 'components/forms/form-button';
+import { localize } from 'i18n-calypso';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
+import { formUpdate, loginUserWithSecurityKey } from 'state/login/actions';
+import TwoFactorActions from './two-factor-actions';
+import Spinner from 'components/spinner';
+
+/**
+ * Style dependencies
+ */
+import './verification-code-form.scss';
+
+class SecurityKeyForm extends Component {
+	static propTypes = {
+		formUpdate: PropTypes.func.isRequired,
+		loginUserWithSecurityKey: PropTypes.func.isRequired,
+		onSuccess: PropTypes.func.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	state = {
+		isAuthenticating: false,
+	};
+
+	initiateSecurityKeyAuthentication = event => {
+		event.preventDefault();
+
+		const { onSuccess } = this.props;
+		this.setState( { isAuthenticating: true } );
+		this.props
+			.loginUserWithSecurityKey()
+			.then( () => onSuccess() )
+			.catch( () => this.setState( { isAuthenticating: false } ) );
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<form onSubmit={ this.initiateSecurityKeyAuthentication }>
+				<Card compact className="two-factor-authentication__verification-code-form">
+					{ ! this.state.isAuthenticating && (
+						<div>
+							<p>
+								{ translate( '{{strong}}Use your security key to finish logging in.{{/strong}}', {
+									components: {
+										strong: <strong />,
+									},
+								} ) }
+							</p>
+							<p>
+								{ translate(
+									'Insert your security key into your USB port. Then tap the button or gold disc.'
+								) }
+							</p>
+						</div>
+					) }
+					{ this.state.isAuthenticating && (
+						<div className="security-key-form__add-wait-for-key">
+							<Spinner />
+							<p className="security-key-form__add-wait-for-key-heading">
+								{ translate( 'Waiting for security key' ) }
+							</p>
+							<p>{ translate( 'Connect and touch your security key to log in.' ) }</p>
+						</div>
+					) }
+					<FormButton
+						autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+						primary
+						disabled={ this.state.isAuthenticating }
+					>
+						{ translate( 'Continue with security key' ) }
+					</FormButton>
+				</Card>
+
+				<TwoFactorActions twoFactorAuthType={ 'webauthn' } />
+			</form>
+		);
+	}
+}
+
+export default connect( null, {
+	formUpdate,
+	loginUserWithSecurityKey,
+	recordTracksEvent,
+} )( localize( SecurityKeyForm ) );

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -84,14 +84,12 @@ class SecurityKeyForm extends Component {
 						</div>
 					) }
 					{ this.state.showError && (
-						<p>
-							<FormInputValidation
-								isError
-								text={ this.props.translate(
-									'An error occurred, please try again or use an alternate authentication method.'
-								) }
-							/>
-						</p>
+						<FormInputValidation
+							isError
+							text={ this.props.translate(
+								'An error occurred, please try again or use an alternate authentication method.'
+							) }
+						/>
 					) }
 					<FormButton
 						autoFocus // eslint-disable-line jsx-a11y/no-autofocus

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -8,8 +8,8 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
 import FormButton from 'components/forms/form-button';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import Spinner from 'components/spinner';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -8,23 +8,22 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import FormButton from 'components/forms/form-button';
 import { Card } from '@automattic/components';
+import FormButton from 'components/forms/form-button';
+import FormInputValidation from 'components/forms/form-input-validation';
 import { localize } from 'i18n-calypso';
 import Spinner from 'components/spinner';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
  */
 import './security-key-form.scss';
-import FormInputValidation from 'components/forms/form-input-validation';
 
 class SecurityKeyForm extends Component {
 	static propTypes = {
 		loginUserWithSecurityKey: PropTypes.func.isRequired,
 		onComplete: PropTypes.func,
-		recordTracksEvent: PropTypes.func.isRequired,
+
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -54,11 +53,12 @@ class SecurityKeyForm extends Component {
 
 	render() {
 		const { translate } = this.props;
+		const { isAuthenticating } = this.state;
 
 		return (
 			<form onSubmit={ this.initiateSecurityKeyAuthentication }>
 				<Card compact className="security-key-form__verification-code-form">
-					{ ! this.state.isAuthenticating && (
+					{ ! isAuthenticating ? (
 						<div>
 							<p>
 								{ translate( '{{strong}}Use your security key to finish logging in.{{/strong}}', {
@@ -73,8 +73,7 @@ class SecurityKeyForm extends Component {
 								) }
 							</p>
 						</div>
-					) }
-					{ this.state.isAuthenticating && (
+					) : (
 						<div className="security-key-form__add-wait-for-key">
 							<Spinner />
 							<p className="security-key-form__add-wait-for-key-heading">
@@ -94,7 +93,7 @@ class SecurityKeyForm extends Component {
 					<FormButton
 						autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 						primary
-						disabled={ this.state.isAuthenticating }
+						disabled={ isAuthenticating }
 					>
 						{ translate( 'Continue with security key' ) }
 					</FormButton>
@@ -104,6 +103,4 @@ class SecurityKeyForm extends Component {
 	}
 }
 
-export default connect( null, {
-	recordTracksEvent,
-} )( localize( SecurityKeyForm ) );
+export default connect( null, null )( localize( SecurityKeyForm ) );

--- a/client/me/reauth-required/security-key-form.scss
+++ b/client/me/reauth-required/security-key-form.scss
@@ -1,0 +1,27 @@
+.two-factor-authentication__small-print {
+	clear: both;
+	font-size: 11px;
+	padding: 1em 0;
+}
+
+.two-factor-authentication__verification-code-form .button {
+	width: 100%;
+}
+.two-factor-authentication__verification-code-form p {
+	margin-bottom: 0.5em !important;
+}
+.security-key-form__add-wait-for-key {
+	text-align: center;
+
+	.spinner {
+		margin-bottom: 1em;
+	}
+
+	p {
+		margin-bottom: 0.5em;
+	}
+}
+
+.security-key-form__add-wait-for-key-heading {
+	font-weight: bold;
+}

--- a/client/me/reauth-required/security-key-form.scss
+++ b/client/me/reauth-required/security-key-form.scss
@@ -1,13 +1,7 @@
-.two-factor-authentication__small-print {
-	clear: both;
-	font-size: 11px;
-	padding: 1em 0;
-}
-
-.two-factor-authentication__verification-code-form .button {
+.security-key-form__verification-code-form .button {
 	width: 100%;
 }
-.two-factor-authentication__verification-code-form p {
+.security-key-form__verification-code-form p {
 	margin-bottom: 0.5em !important;
 }
 .security-key-form__add-wait-for-key {

--- a/client/me/reauth-required/security-key-form.scss
+++ b/client/me/reauth-required/security-key-form.scss
@@ -1,8 +1,11 @@
-.security-key-form__verification-code-form .button {
-	width: 100%;
-}
-.security-key-form__verification-code-form p {
-	margin-bottom: 0.5em !important;
+.security-key-form__verification-code-form {
+	.button {
+		width: 100%;
+
+		&:not( :first-child ) {
+			margin-top: 20px;
+		}
+	}
 }
 .security-key-form__add-wait-for-key {
 	text-align: center;

--- a/client/me/reauth-required/style.scss
+++ b/client/me/reauth-required/style.scss
@@ -4,8 +4,12 @@
 
 .reauth-required__dialog {
 	max-width: 400px;
+	padding: 0;
 }
 
 .reauth-required__sign-out {
 	cursor: pointer;
+}
+.reauth-required__button {
+	width: 100%;
 }

--- a/client/me/reauth-required/two-factor-actions.jsx
+++ b/client/me/reauth-required/two-factor-actions.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -13,10 +12,7 @@ import page from 'page';
 
 import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { isTwoFactorAuthTypeSupported } from 'state/login/selectors';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-import { sendSmsCode } from 'state/login/actions';
-import { login } from 'lib/paths';
 
 /**
  * Style dependencies
@@ -27,40 +23,20 @@ class TwoFactorActions extends Component {
 	static propTypes = {
 		isAuthenticatorSupported: PropTypes.bool.isRequired,
 		isSecurityKeySupported: PropTypes.bool.isRequired,
-		isJetpack: PropTypes.bool,
 		isSmsSupported: PropTypes.bool.isRequired,
+		isSmsAllowed: PropTypes.bool.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
-		sendSmsCode: PropTypes.func.isRequired,
+		onChange: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string.isRequired,
 	};
 
-	sendSmsCode = event => {
+	recordButtonClicked = event => {
 		event.preventDefault();
 
 		this.props.recordTracksEvent( 'calypso_login_two_factor_switch_to_sms_link_click' );
 
-		page( login( { isNative: true, twoFactorAuthType: 'sms', isJetpack: this.props.isJetpack } ) );
-
-		this.props.sendSmsCode();
-	};
-
-	recordAuthenticatorLinkClick = event => {
-		event.preventDefault();
-
-		this.props.recordTracksEvent( 'calypso_login_two_factor_switch_to_authenticator_link_click' );
-
-		page(
-			login( {
-				isNative: true,
-				twoFactorAuthType: 'authenticator',
-				isJetpack: this.props.isJetpack,
-			} )
-		);
-	};
-	recordSecurityKey = event => {
-		event.preventDefault();
-		page( login( { isNative: true, twoFactorAuthType: 'webauthn' } ) );
+		this.props.onChange( event.target.value );
 	};
 
 	render() {
@@ -72,32 +48,45 @@ class TwoFactorActions extends Component {
 			twoFactorAuthType,
 		} = this.props;
 
-		const isSmsAvailable = isSmsSupported && twoFactorAuthType !== 'sms';
-		const isAuthenticatorAvailable =
-			isAuthenticatorSupported && twoFactorAuthType !== 'authenticator';
 		const isSecurityKeyAvailable = isSecurityKeySupported && twoFactorAuthType !== 'webauthn';
+		const isSmsAvailable = isSmsSupported;
+		const isAuthenticatorAvailable =
+			isSecurityKeySupported && isAuthenticatorSupported && twoFactorAuthType !== 'authenticator';
 
 		if ( ! isSmsAvailable && ! isAuthenticatorAvailable && ! isSecurityKeyAvailable ) {
 			return null;
 		}
 
 		return (
-			<Card className="two-factor-authentication__actions">
+			<Card className="two-factor-actions__actions">
 				{ isSecurityKeyAvailable && (
-					<Button data-e2e-link="2fa-security-key-link" onClick={ this.recordSecurityKey }>
+					<Button
+						data-e2e-link="2fa-security-key-link"
+						value="webauthn"
+						onClick={ this.recordButtonClicked }
+					>
 						{ translate( 'Continue with your security\u00A0key' ) }
 					</Button>
 				) }
 
-				{ isSmsAvailable && (
-					<Button data-e2e-link="2fa-sms-link" onClick={ this.sendSmsCode }>
-						{ translate( 'Send code via\u00A0text\u00A0message' ) }
+				{ isAuthenticatorAvailable && (
+					<Button
+						data-e2e-link="2fa-otp-link"
+						value="authenticator"
+						onClick={ this.recordButtonClicked }
+					>
+						{ translate( 'Continue with your authenticator\u00A0app' ) }
 					</Button>
 				) }
 
-				{ isAuthenticatorAvailable && (
-					<Button data-e2e-link="2fa-otp-link" onClick={ this.recordAuthenticatorLinkClick }>
-						{ translate( 'Continue with your authenticator\u00A0app' ) }
+				{ isSmsAvailable && (
+					<Button
+						data-e2e-link="2fa-sms-link"
+						value="sms"
+						disabled={ ! this.props.isSmsAllowed }
+						onClick={ this.recordButtonClicked }
+					>
+						{ translate( 'Send code via\u00A0text\u00A0message' ) }
 					</Button>
 				) }
 			</Card>
@@ -105,14 +94,6 @@ class TwoFactorActions extends Component {
 	}
 }
 
-export default connect(
-	state => ( {
-		isAuthenticatorSupported: isTwoFactorAuthTypeSupported( state, 'authenticator' ),
-		isSmsSupported: isTwoFactorAuthTypeSupported( state, 'sms' ),
-		isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'webauthn' ),
-	} ),
-	{
-		recordTracksEvent,
-		sendSmsCode,
-	}
-)( localize( TwoFactorActions ) );
+export default connect( null, {
+	recordTracksEvent,
+} )( localize( TwoFactorActions ) );

--- a/client/me/reauth-required/two-factor-actions.jsx
+++ b/client/me/reauth-required/two-factor-actions.jsx
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+
+import { Button, Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { isTwoFactorAuthTypeSupported } from 'state/login/selectors';
+import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
+import { sendSmsCode } from 'state/login/actions';
+import { login } from 'lib/paths';
+
+/**
+ * Style dependencies
+ */
+import './two-factor-actions.scss';
+
+class TwoFactorActions extends Component {
+	static propTypes = {
+		isAuthenticatorSupported: PropTypes.bool.isRequired,
+		isSecurityKeySupported: PropTypes.bool.isRequired,
+		isJetpack: PropTypes.bool,
+		isSmsSupported: PropTypes.bool.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
+		sendSmsCode: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+		twoFactorAuthType: PropTypes.string.isRequired,
+	};
+
+	sendSmsCode = event => {
+		event.preventDefault();
+
+		this.props.recordTracksEvent( 'calypso_login_two_factor_switch_to_sms_link_click' );
+
+		page( login( { isNative: true, twoFactorAuthType: 'sms', isJetpack: this.props.isJetpack } ) );
+
+		this.props.sendSmsCode();
+	};
+
+	recordAuthenticatorLinkClick = event => {
+		event.preventDefault();
+
+		this.props.recordTracksEvent( 'calypso_login_two_factor_switch_to_authenticator_link_click' );
+
+		page(
+			login( {
+				isNative: true,
+				twoFactorAuthType: 'authenticator',
+				isJetpack: this.props.isJetpack,
+			} )
+		);
+	};
+	recordSecurityKey = event => {
+		event.preventDefault();
+		page( login( { isNative: true, twoFactorAuthType: 'webauthn' } ) );
+	};
+
+	render() {
+		const {
+			isAuthenticatorSupported,
+			isSecurityKeySupported,
+			isSmsSupported,
+			translate,
+			twoFactorAuthType,
+		} = this.props;
+
+		const isSmsAvailable = isSmsSupported && twoFactorAuthType !== 'sms';
+		const isAuthenticatorAvailable =
+			isAuthenticatorSupported && twoFactorAuthType !== 'authenticator';
+		const isSecurityKeyAvailable = isSecurityKeySupported && twoFactorAuthType !== 'webauthn';
+
+		if ( ! isSmsAvailable && ! isAuthenticatorAvailable && ! isSecurityKeyAvailable ) {
+			return null;
+		}
+
+		return (
+			<Card className="two-factor-authentication__actions">
+				{ isSecurityKeyAvailable && (
+					<Button data-e2e-link="2fa-security-key-link" onClick={ this.recordSecurityKey }>
+						{ translate( 'Continue with your security\u00A0key' ) }
+					</Button>
+				) }
+
+				{ isSmsAvailable && (
+					<Button data-e2e-link="2fa-sms-link" onClick={ this.sendSmsCode }>
+						{ translate( 'Send code via\u00A0text\u00A0message' ) }
+					</Button>
+				) }
+
+				{ isAuthenticatorAvailable && (
+					<Button data-e2e-link="2fa-otp-link" onClick={ this.recordAuthenticatorLinkClick }>
+						{ translate( 'Continue with your authenticator\u00A0app' ) }
+					</Button>
+				) }
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	state => ( {
+		isAuthenticatorSupported: isTwoFactorAuthTypeSupported( state, 'authenticator' ),
+		isSmsSupported: isTwoFactorAuthTypeSupported( state, 'sms' ),
+		isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'webauthn' ),
+	} ),
+	{
+		recordTracksEvent,
+		sendSmsCode,
+	}
+)( localize( TwoFactorActions ) );

--- a/client/me/reauth-required/two-factor-actions.jsx
+++ b/client/me/reauth-required/two-factor-actions.jsx
@@ -24,10 +24,12 @@ class TwoFactorActions extends Component {
 		isSecurityKeySupported: PropTypes.bool.isRequired,
 		isSmsSupported: PropTypes.bool.isRequired,
 		isSmsAllowed: PropTypes.bool.isRequired,
-		recordTracksEventWithClientId: PropTypes.func.isRequired,
 		onChange: PropTypes.func.isRequired,
-		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string.isRequired,
+
+		recordTracksEventWithClientId: PropTypes.func.isRequired,
+
+		translate: PropTypes.func.isRequired,
 	};
 
 	recordButtonClicked = event => {

--- a/client/me/reauth-required/two-factor-actions.jsx
+++ b/client/me/reauth-required/two-factor-actions.jsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 
 import { Button, Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEventWithClientId } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -24,7 +24,7 @@ class TwoFactorActions extends Component {
 		isSecurityKeySupported: PropTypes.bool.isRequired,
 		isSmsSupported: PropTypes.bool.isRequired,
 		isSmsAllowed: PropTypes.bool.isRequired,
-		recordTracksEvent: PropTypes.func.isRequired,
+		recordTracksEventWithClientId: PropTypes.func.isRequired,
 		onChange: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string.isRequired,
@@ -32,8 +32,23 @@ class TwoFactorActions extends Component {
 
 	recordButtonClicked = event => {
 		event.preventDefault();
+		let tracksEvent;
 
-		this.props.recordTracksEvent( 'calypso_login_two_factor_switch_to_sms_link_click' );
+		switch ( event.target.value ) {
+			case 'sms':
+				tracksEvent = 'calypso_2fa_reauth_sms_clicked';
+				break;
+			case 'authenticator':
+				tracksEvent = 'calypso_2fa_reauth_authenticator_clicked';
+				break;
+			case 'webauthn':
+				tracksEvent = 'calypso_2fa_reauth_webauthn_clicked';
+				break;
+		}
+
+		if ( tracksEvent ) {
+			this.props.recordTracksEventWithClientId( tracksEvent );
+		}
 
 		this.props.onChange( event.target.value );
 	};
@@ -94,5 +109,5 @@ class TwoFactorActions extends Component {
 }
 
 export default connect( null, {
-	recordTracksEvent,
+	recordTracksEventWithClientId,
 } )( localize( TwoFactorActions ) );

--- a/client/me/reauth-required/two-factor-actions.jsx
+++ b/client/me/reauth-required/two-factor-actions.jsx
@@ -36,13 +36,13 @@ class TwoFactorActions extends Component {
 
 		switch ( event.target.value ) {
 			case 'sms':
-				tracksEvent = 'calypso_2fa_reauth_sms_clicked';
+				tracksEvent = 'calypso_twostep_reauth_sms_clicked';
 				break;
 			case 'authenticator':
-				tracksEvent = 'calypso_2fa_reauth_authenticator_clicked';
+				tracksEvent = 'calypso_twostep_reauth_authenticator_clicked';
 				break;
 			case 'webauthn':
-				tracksEvent = 'calypso_2fa_reauth_webauthn_clicked';
+				tracksEvent = 'calypso_twostep_reauth_webauthn_clicked';
 				break;
 		}
 

--- a/client/me/reauth-required/two-factor-actions.jsx
+++ b/client/me/reauth-required/two-factor-actions.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';

--- a/client/me/reauth-required/two-factor-actions.jsx
+++ b/client/me/reauth-required/two-factor-actions.jsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies

--- a/client/me/reauth-required/two-factor-actions.scss
+++ b/client/me/reauth-required/two-factor-actions.scss
@@ -1,0 +1,11 @@
+.two-factor-authentication__actions.card {
+	margin-bottom: 0;
+
+	.button {
+		width: 100%;
+
+		&:not( :first-child ) {
+			margin-top: 20px;
+		}
+	}
+}

--- a/client/me/reauth-required/two-factor-actions.scss
+++ b/client/me/reauth-required/two-factor-actions.scss
@@ -1,4 +1,4 @@
-.two-factor-authentication__actions.card {
+.two-factor-actions__actions.card {
 	margin-bottom: 0;
 
 	.button {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds support for security keys on the `2fa-reauth-dialog` block. 

### Testing instructions

* Add a security key to your WP.com account.
* Navigate to `/me` and remove the `twostep_auth` cookie from the browser console.
* Reload the page, and notice the `2fa-reauth-dialog` is shown along with a new option to authenticate using a hardware key. 

### Screenshots
#### Re-auth dialog
**Before**
<img  width="436" src="https://user-images.githubusercontent.com/1081870/74947345-b399ff00-53c8-11ea-99b7-a47073a4d6f9.png" />

**After**
<img  width="436" src="https://user-images.githubusercontent.com/1081870/74947405-cf050a00-53c8-11ea-8ed2-741c6a1cc437.png" />

when someone clicks the `Continue with security key` button

<img  width="436" src="https://user-images.githubusercontent.com/1081870/74947382-c14f8480-53c8-11ea-9e8d-a64f3df8fc84.png" />
