### PR TITLE
UpsellNudge: Set forceHref to true for UpsellNudges in sidebar A/B test

### DIFF
--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -40,6 +40,7 @@ export default function SidebarBannerTemplate( {
 				callToAction={ CTA.message }
 				compact
 				event={ displayName }
+				forceHref={ true }
 				dismissPreferenceName={ dismissPreferenceName }
 				href={ CTA.link }
 				onDismissClick={ onDismissClick }

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,90 +1,97 @@
-.upsell-nudge {
-	&.banner.card {
-		border-left-color: var( --color-accent );
-		border-left-width: 6px;
-		background-color: var( --color-neutral-80 );
+.upsell-nudge.banner.card {
+	border-left-color: var( --color-accent );
+	border-left-width: 6px;
+	background-color: var( --color-neutral-80 );
+	box-shadow: none;
+	color: var( --color-text-inverted );
+	display: flex;
+	align-items: center;
+
+	a,
+	button {
+		border: none;
 		box-shadow: none;
 		color: var( --color-text-inverted );
-		display: flex;
-		align-items: center;
-
-		a {
-			border: none;
-			box-shadow: none;
-			color: var( --color-text-inverted );
-		}
-
-		&.is-compact {
-			border-left-width: 4px;
-			margin-bottom: 0;
-
-			.banner__icon-circle,
-			.banner__icon {
-				margin-top: -2px;
-				margin-right: 0.25em;
-			}
-			.dismissible-card__close-icon {
-				margin-left: 0.75em;
-			}
-			.banner__content {
-				padding: 0 0 0 8px;
-			}
-		}
-
-		&:hover {
-			box-shadow: none;
-		}
 	}
+}
 
-	&.banner.card .banner__icon-circle,
-	&.banner.card .banner__icon {
-		width: auto;
-		height: auto;
-		color: var( --color-text-inverted );
-		border-radius: 0;
-		background: none;
-		padding: 0;
+.upsell-nudge.banner.card.is-compact {
+	border-left-width: 4px;
+	margin-bottom: 0;
+
+	.banner__icon-circle,
+	.banner__icon {
+		margin-top: -2px;
+		margin-right: 0.25em;
 	}
-
-	&.banner.card .card__link-indicator {
-		fill: var( --color-text-inverted );
-	}
-
-	.banner__content {
-		margin-right: auto;
-		color: var( --color-text-inverted );
-	}
-
-	.banner__info .banner__title {
-		color: var( --color-text-inverted );
-		font-weight: normal;
-		margin-right: 8px;
-	}
-
-	.banner__description {
-		color: var( --color-neutral-5 );
-	}
-
-	.banner__action {
-		margin-top: 5px;
-		margin-left: auto;
-	}
-
 	.dismissible-card__close-icon {
-		fill: var( --color-text-inverted );
-		margin-left: 1em;
-		order: 2;
-
-		@include breakpoint( '>480px' ) {
-			margin-top: 0;
-			position: relative;
-			top: auto;
-			right: auto;
-		}
+		margin-left: 0.75em;
+	}
+	.banner__content {
+		padding: 0 0 0 8px;
 	}
 
-	&.is-dismissible .banner__action {
-		margin-top: 3px;
-		margin-right: 0;
+	&:hover {
+		box-shadow: none;
 	}
+}
+
+.upsell-nudge.banner.card.is-compact.is-card-link {
+	padding-right: 12px;
+
+	.gridicons-chevron-right.card__link-indicator {
+		display: none;
+	}
+}
+
+.upsell-nudge.banner.card .banner__icon-circle,
+.upsell-nudge.banner.card .banner__icon {
+	width: auto;
+	height: auto;
+	color: var( --color-text-inverted );
+	border-radius: 0;
+	background: none;
+	padding: 0;
+}
+
+.upsell-nudge.banner.card .card__link-indicator {
+	fill: var( --color-text-inverted );
+}
+
+.upsell-nudge .banner__content {
+	margin-right: auto;
+	color: var( --color-text-inverted );
+}
+
+.upsell-nudge .banner__info .banner__title {
+	color: var( --color-text-inverted );
+	font-weight: normal;
+	margin-right: 8px;
+}
+
+.upsell-nudge .banner__description {
+	color: var( --color-neutral-5 );
+}
+
+.upsell-nudge .banner__action {
+	margin-top: 3px;
+	margin-left: auto;
+}
+
+.upsell-nudge .dismissible-card__close-icon {
+	fill: var( --color-text-inverted );
+	margin-left: 1em;
+	order: 2;
+
+	@include breakpoint( '>480px' ) {
+		margin-top: 0;
+		position: relative;
+		top: auto;
+		right: auto;
+	}
+}
+
+.upsell-nudge .dismissible-card__close-icon.is-dismissible .banner__action {
+	margin-top: 3px;
+	margin-right: 0;
 }

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -39,7 +39,7 @@
 .upsell-nudge.banner.card.is-compact.is-card-link {
 	padding-right: 12px;
 
-	.gridicons-chevron-right.card__link-indicator {
+	.card__link-indicator {
 		display: none;
 	}
 }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -128,7 +128,7 @@ export default {
 		localeTargets: 'any',
 	},
 	sidebarUpsellNudgeUnification: {
-		datestamp: '20200127',
+		datestamp: '20200221',
 		variations: {
 			variantShowUnifiedUpsells: 50,
 			control: 50,

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -92,6 +92,7 @@ export class SiteNotice extends React.Component {
 					callToAction={ translate( 'Claim' ) }
 					compact
 					event={ eventName }
+					forceHref={ true }
 					href={ `/domains/add/${ this.props.site.slug }` }
 					title={ translate( 'Free domain available' ) }
 					tracksClickName="calypso_domain_credit_reminder_click"

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -29,6 +29,7 @@ function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) 
 		return (
 			<UpsellNudge
 				event={ 'free-to-paid-sidebar-reader' }
+				forceHref={ true }
 				callToAction={ translate( 'Upgrade' ) }
 				compact
 				href={ '/plans/' + siteSlug }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `forceHref` prop to UpsellNudges in the sidebar A/B test to make the whole banner click-able
* Hides chevron on compact UpsellNudges that are linked to conserve space
* Update test date to start on Friday (tentative)
* Also cleans up styles to avoid using `&` feature in SCSS for easier search-ability

One question: 

* Wrapping a `button` or `div` element with an anchor tag is invalid XHTML. Is this is a blocker? We're already doing this in the `Banner` component when `forceHref` is used with a call to action. I'm hesitant to refactor `Banner` to avoid stepping on existing nudges' toes.

#### Testing instructions

* Switch to this PR
* Open a free site; you should see the existing JITM in the sidebar.
* Switch to the `variantShowUnifiedUpsells` for the `sidebarUpsellNudgeUnification` test
* You should be able to click on the whole upsell, not just the button
* Tracks events should also fire correctly for both the button click or the banner click (but not be duplicated)
