### PR TITLE
Migration: Don't show import type step upgrade badge when unneeded

### DIFF
--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -11,17 +11,19 @@ import { Button, CompactCard } from '@automattic/components';
  */
 import HeaderCake from 'components/header-cake';
 import CardHeading from 'components/card-heading';
-
-/**
- * Style dependencies
- */
-import './section-migrate.scss';
 import ImportTypeChoice from 'my-sites/migrate/components/import-type-choice';
 import { get } from 'lodash';
 import { redirectTo } from 'my-sites/migrate/helpers';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { connect } from 'react-redux';
+import { FEATURE_UPLOAD_THEMES_PLUGINS } from 'lib/plans/constants';
+import { planHasFeature } from 'lib/plans';
+
+/**
+ * Style dependencies
+ */
+import './section-migrate.scss';
 
 class StepImportOrMigrate extends Component {
 	static propTypes = {
@@ -64,6 +66,13 @@ class StepImportOrMigrate extends Component {
 		}
 	};
 
+	isTargetSitePlanCompatible = () => {
+		const { targetSite } = this.props;
+		const planSlug = get( targetSite, 'plan.product_slug' );
+
+		return planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS );
+	};
+
 	getJetpackOrUpgradeMessage = () => {
 		const { sourceSiteInfo, sourceHasJetpack, isTargetSiteAtomic, translate } = this.props;
 
@@ -101,6 +110,11 @@ class StepImportOrMigrate extends Component {
 		} = this.props;
 		const backHref = `/migrate/${ targetSiteSlug }`;
 
+		const everythingLabels = [];
+		if ( ! this.isTargetSitePlanCompatible() ) {
+			everythingLabels.push( translate( 'Upgrade' ) );
+		}
+
 		return (
 			<>
 				<HeaderCake backHref={ backHref }>Import from WordPress</HeaderCake>
@@ -120,7 +134,7 @@ class StepImportOrMigrate extends Component {
 						radioOptions={ {
 							everything: {
 								title: translate( 'Everything' ),
-								labels: [ translate( 'Upgrade' ) ],
+								labels: everythingLabels,
 								description: translate(
 									"All your site's content, themes, plugins, users and settings"
 								),


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* When a compatible plan already exists on the target site, remove the upgrade badge from the import or migrate step

Before:
![image](https://user-images.githubusercontent.com/363749/74752799-d98e9a80-5234-11ea-88c0-58f3ebfc9820.png)

After: 
![image](https://user-images.githubusercontent.com/363749/74752721-bf54bc80-5234-11ea-951d-713e3172f66e.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start with a simple site that has a business plan
* Visit the import section
* Select "WordPress"
* Enter the URL for a connected Jetpack site and continue
* Verify, that because you already have a business plan, the upgrade badge isn't shown
* Repeat the above for a site without a plan, and verify that the upgrade badge still appears
