### PR TITLE
Site Migration: Don't persist start time of previous migration

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -217,7 +217,7 @@ class SectionMigrate extends Component {
 			return;
 		}
 
-		this.setMigrationState( { migrationStatus: 'backing-up' } );
+		this.setMigrationState( { migrationStatus: 'backing-up', startTime: null } );
 
 		wpcom
 			.undocumented()


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes a bug that persisted the old start time of the previous migration when starting a new migration. Now the start time is reset when the migration starts, so there's no old data to show to the customer. 

#### Testing instructions

* Checkout branch or use Calypso.live link
* Complete a migration (note the start time)
* At the end of the migration (without refreshing the page) press Start Over
* Start the new migration
* Make sure the Import started time is correct for the current migration
