### PR TITLE
Mobile Theme: do not display settings in newer versions of Jetpack

### DIFF
--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -20,7 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
+import { getCustomizerUrl, isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import Notice from 'components/notice';
@@ -281,10 +281,7 @@ class ThemeEnhancements extends Component {
 	}
 
 	render() {
-		const { site, siteIsJetpack, translate } = this.props;
-
-		const jetpackVersion = get( site, 'options.jetpack_version', 0 );
-		const siteHasMinileven = jetpackVersion && versionCompare( jetpackVersion, '8.3-alpha', '<' );
+		const { siteIsJetpack, siteHasMinileven, translate } = this.props;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -329,5 +326,6 @@ export default connect( state => {
 		),
 		minilevenModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'minileven' ),
 		site,
+		siteHasMinileven: false === isJetpackMinimumVersion( state, selectedSiteId, '8.3-alpha' ),
 	};
 } )( localize( ThemeEnhancements ) );

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -277,7 +277,10 @@ class ThemeEnhancements extends Component {
 	}
 
 	render() {
-		const { siteIsJetpack, translate } = this.props;
+		const { site, siteIsJetpack, translate } = this.props;
+
+		const jetpackVersion = get( site, 'options.jetpack_version', 0 );
+		const siteHasMinileven = jetpackVersion && versionCompare( jetpackVersion, '8.3-alpha', '<' );
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
@@ -289,8 +292,12 @@ class ThemeEnhancements extends Component {
 						<Fragment>
 							{ this.renderJetpackInfiniteScrollSettings() }
 							<hr />
-							{ this.renderMinilevenSettings() }
-							<hr />
+							{ siteHasMinileven && (
+								<Fragment>
+									{ this.renderMinilevenSettings() }
+									<hr />
+								</Fragment>
+							) }
 							{ this.renderCustomCSSSettings() }
 						</Fragment>
 					) : (

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -198,10 +198,11 @@ class ThemeEnhancements extends Component {
 						jetpackVersion &&
 						versionCompare( jetpackVersion, '8.1-alpha', '>=' )
 							? translate(
-									'{{b}}Action needed:{{/b}} The Jetpack mobile theme will be retired ' +
-										'and removed from Jetpack in March. Please ensure your current theme ' +
+									'{{b}}Action needed:{{/b}} The Jetpack mobile theme is not supported ' +
+										'anymore. It will be removed when you update to the most recent ' +
+										'version of the plugin. Please ensure your current theme ' +
 										'is mobile-ready {{link}}using this tool{{/link}}. ' +
-										'If it is not, consider replacing it before March.',
+										'If it is not, consider replacing it.',
 									{
 										components: {
 											b: <strong />,
@@ -216,8 +217,9 @@ class ThemeEnhancements extends Component {
 									}
 							  )
 							: translate(
-									'{{b}}Note:{{/b}} The Jetpack mobile theme is being retired ' +
-										'and will be removed from Jetpack in March.',
+									'{{b}}Note:{{/b}} The Jetpack mobile theme is not supported ' +
+										'anymore. It will be removed when you update ' +
+										'to the most recent version of the plugin.',
 									{
 										components: {
 											b: <strong />,

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -228,7 +228,9 @@ class ThemeEnhancements extends Component {
 							  )
 					}
 				>
-					<NoticeAction href={ minilevenSupportUrl }>{ translate( 'Learn more' ) }</NoticeAction>
+					<NoticeAction href={ minilevenSupportUrl } external>
+						{ translate( 'Learn more' ) }
+					</NoticeAction>
 				</Notice>
 				<SupportInfo
 					text={ translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Jetpack Mobile Theme will be completely removed from the upcoming version of Jetpack, 8.3. (https://github.com/Automattic/jetpack/pull/14714)

This PR aims to remove the Mobile Theme section for all Jetpack sites that run a version of Jetpack that does not include the mobile theme anymore.

Internal reference: p1HpG7-85q-p2

#### Testing instructions

* Start with 2 Jetpack sites, one running the latest stable (8.2.1), and one running bleeding edge (8.3-alpha).
* Go to Settings > Writing for both sites.
    * When on latest stable, you should see the following message and greyed out Mobile Theme settings:
	> Note: The Jetpack mobile theme is not supported anymore. It will be removed when you update to the most recent version of the plugin.
	* When on bleeding edge, the whole section should be gone.

<img width="797" alt="screenshot 2020-02-18 at 17 32 17" src="https://user-images.githubusercontent.com/426388/74756567-0a8ebf80-5275-11ea-9854-e5819a1c5b38.png">
<img width="784" alt="screenshot 2020-02-18 at 17 31 54" src="https://user-images.githubusercontent.com/426388/74756573-0bbfec80-5275-11ea-93b5-656888c70329.png">

