### PR TITLE
Customer Home: Add better copy for completed email and mobile app tasks

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -614,7 +614,7 @@ class WpcomChecklistComponent extends PureComponent {
 				bannerImageSrc="/calypso/images/stats/tasks/mobile-app.svg"
 				completedButtonText={ translate( 'Re-download mobile app' ) }
 				completedTitle={ translate( 'You downloaded the WordPress app' ) }
-				completedDescription={ translate( `You can re-download the app at any time.` ) }
+				completedDescription={ translate( 'You can re-download the app at any time.' ) }
 				description={ translate(
 					'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
 				) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -336,7 +336,7 @@ class WpcomChecklistComponent extends PureComponent {
 				buttonText={ this.verificationTaskButtonText() }
 				completedTitle={ translate( 'You validated your email address' ) }
 				completedDescription={ translate(
-					'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
+					'Need to change something? {{changeButton}}Update your email address here{{/changeButton}}.',
 					{
 						args: {
 							email: this.props.userEmail,

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -335,6 +335,17 @@ class WpcomChecklistComponent extends PureComponent {
 				bannerImageSrc="/calypso/images/illustrations/checkEmailsDesktop.svg"
 				buttonText={ this.verificationTaskButtonText() }
 				completedTitle={ translate( 'You validated your email address' ) }
+				completedDescription={ translate(
+					'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
+					{
+						args: {
+							email: this.props.userEmail,
+						},
+						components: {
+							changeButton: <a href="/me/account?tour=checklistUserEmail" />,
+						},
+					}
+				) }
 				description={ translate(
 					'Please click the link in the email we sent to %(email)s.{{br /}}' +
 						'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
@@ -601,8 +612,9 @@ class WpcomChecklistComponent extends PureComponent {
 			<TaskComponent
 				{ ...baseProps }
 				bannerImageSrc="/calypso/images/stats/tasks/mobile-app.svg"
-				completedButtonText={ translate( 'Download mobile app' ) }
+				completedButtonText={ translate( 'Re-download mobile app' ) }
 				completedTitle={ translate( 'You downloaded the WordPress app' ) }
+				completedDescription={ translate( `You can re-download the app at any time.` ) }
 				description={ translate(
 					'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The original mobile app and email verification completed copy was confusing, suggesting the task had not actually been completed. Let's update it to make that clearer.
* /cc @obi2020 and others for feedback/suggestions, my copy in this PR is probably not rock solid. Suggestions welcome!

**Before**

<img width="732" alt="Screen Shot 2020-02-18 at 1 25 55 PM" src="https://user-images.githubusercontent.com/2124984/74765802-35b3e780-5252-11ea-9fa5-ebff542fa2bd.png">
<img width="732" alt="Screen Shot 2020-02-18 at 1 25 48 PM" src="https://user-images.githubusercontent.com/2124984/74765806-36e51480-5252-11ea-8353-ff5106238c15.png">

**After**

<img width="729" alt="Screen Shot 2020-02-18 at 1 18 04 PM" src="https://user-images.githubusercontent.com/2124984/74765733-1cab3680-5252-11ea-9f1c-aacebc020dda.png">
<img width="722" alt="Screen Shot 2020-02-19 at 8 53 54 AM" src="https://user-images.githubusercontent.com/2124984/74843267-abbf5980-52f9-11ea-8ce6-29a08ce8036d.png">

#### Testing instructions

* Switch to this PR, create a new site, and navigate to Customer Home
* Complete email verification and downloading the mobile app
* You should see the tasks in the completed list, with updated copy

Fixes #39416
