### PR TITLE
composite-checkout: Add transaction analytics

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -665,10 +665,17 @@ function getCheckoutEventHandler( dispatch ) {
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_step_changed', { step: action.payload } )
 				);
-			case 'STRIPE_TRANSACTION_BEGIN':
+			case 'STRIPE_TRANSACTION_BEGIN': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_form_submit', {
+						credits: null,
+						payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
 				);
+			}
 			case 'STRIPE_TRANSACTION_ERROR': {
 				dispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
@@ -682,11 +689,18 @@ function getCheckoutEventHandler( dispatch ) {
 					} )
 				);
 			}
-			case 'PAYPAL_TRANSACTION_BEGIN':
+			case 'PAYPAL_TRANSACTION_BEGIN': {
 				dispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_form_submit', {
+						credits: null,
+						payment_method: 'WPCOM_Billing_PayPal_Express',
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_paypal_submit_clicked', {} )
 				);
+			}
 			case 'PAYPAL_TRANSACTION_ERROR': {
 				dispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
@@ -700,10 +714,17 @@ function getCheckoutEventHandler( dispatch ) {
 					} )
 				);
 			}
-			case 'FULL_CREDITS_TRANSACTION_BEGIN':
+			case 'FULL_CREDITS_TRANSACTION_BEGIN': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_form_submit', {
+						credits: null,
+						payment_method: 'WPCOM_Billing_WPCOM',
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_full_credits_submit_clicked', {} )
 				);
+			}
 			case 'FULL_CREDITS_TRANSACTION_ERROR': {
 				dispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
@@ -717,10 +738,17 @@ function getCheckoutEventHandler( dispatch ) {
 					} )
 				);
 			}
-			case 'EXISTING_CARD_TRANSACTION_BEGIN':
+			case 'EXISTING_CARD_TRANSACTION_BEGIN': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_form_submit', {
+						credits: null,
+						payment_method: 'WPCOM_Billing_MoneyPress_Stored',
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
 				);
+			}
 			case 'EXISTING_CARD_TRANSACTION_ERROR': {
 				dispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
@@ -734,10 +762,17 @@ function getCheckoutEventHandler( dispatch ) {
 					} )
 				);
 			}
-			case 'APPLE_PAY_TRANSACTION_BEGIN':
+			case 'APPLE_PAY_TRANSACTION_BEGIN': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_form_submit', {
+						credits: null,
+						payment_method: 'WPCOM_Billing_Web_Payment',
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
 				);
+			}
 			case 'APPLE_PAY_TRANSACTION_ERROR': {
 				dispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -794,6 +794,9 @@ function getCheckoutEventHandler( dispatch ) {
 					} )
 				);
 			}
+			case 'SHOW_MODAL_AUTHORIZATION': {
+				return dispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
+			}
 			default:
 				debug( 'unknown checkout event', action );
 				return dispatch(

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -280,7 +280,8 @@ export default function CompositeCheckout( {
 	const paypalMethod = useMemo( () => createPayPalMethod( { registerStore } ), [ registerStore ] );
 	paypalMethod.id = 'paypal';
 	// This is defined afterward so that getThankYouUrl can be dynamic without having to re-create payment method
-	paypalMethod.submitTransaction = () =>
+	paypalMethod.submitTransaction = () => {
+		recordEvent( { type: 'REDIRECT_FOR_PAYMENT_AUTHORIZATION' } );
 		makePayPalExpressRequest(
 			{
 				items,
@@ -295,6 +296,7 @@ export default function CompositeCheckout( {
 			},
 			wpcomPayPalExpress
 		);
+	};
 
 	const stripeMethod = useMemo(
 		() =>
@@ -665,6 +667,7 @@ function getCheckoutEventHandler( dispatch ) {
 					} )
 				);
 			case 'PAYPAL_TRANSACTION_BEGIN':
+				dispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_paypal_submit_clicked', {} )
 				);

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -670,53 +670,88 @@ function getCheckoutEventHandler( dispatch ) {
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
 				);
-			case 'STRIPE_TRANSACTION_ERROR':
+			case 'STRIPE_TRANSACTION_ERROR': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_payment_error', {
+						error_code: null,
+						reason: String( action.payload ),
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
 						error_message: String( action.payload ),
 					} )
 				);
+			}
 			case 'PAYPAL_TRANSACTION_BEGIN':
 				dispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_paypal_submit_clicked', {} )
 				);
-			case 'PAYPAL_TRANSACTION_ERROR':
+			case 'PAYPAL_TRANSACTION_ERROR': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_payment_error', {
+						error_code: null,
+						reason: String( action.payload ),
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_paypal_transaction_error', {
 						error_message: String( action.payload ),
 					} )
 				);
+			}
 			case 'FULL_CREDITS_TRANSACTION_BEGIN':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_full_credits_submit_clicked', {} )
 				);
-			case 'FULL_CREDITS_TRANSACTION_ERROR':
+			case 'FULL_CREDITS_TRANSACTION_ERROR': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_payment_error', {
+						error_code: null,
+						reason: String( action.payload ),
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_full_credits_error', {
 						error_message: String( action.payload ),
 					} )
 				);
+			}
 			case 'EXISTING_CARD_TRANSACTION_BEGIN':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
 				);
-			case 'EXISTING_CARD_TRANSACTION_ERROR':
+			case 'EXISTING_CARD_TRANSACTION_ERROR': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_payment_error', {
+						error_code: null,
+						reason: String( action.payload ),
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_existing_card_error', {
 						error_message: String( action.payload ),
 					} )
 				);
+			}
 			case 'APPLE_PAY_TRANSACTION_BEGIN':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
 				);
-			case 'APPLE_PAY_TRANSACTION_ERROR':
+			case 'APPLE_PAY_TRANSACTION_ERROR': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_payment_error', {
+						error_code: null,
+						reason: String( action.payload ),
+					} )
+				);
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
 						error_message: String( action.payload ),
 					} )
 				);
+			}
 			case 'VALIDATE_DOMAIN_CONTACT_INFO': {
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_form_submit', {

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -281,7 +281,6 @@ export default function CompositeCheckout( {
 	paypalMethod.id = 'paypal';
 	// This is defined afterward so that getThankYouUrl can be dynamic without having to re-create payment method
 	paypalMethod.submitTransaction = () => {
-		recordEvent( { type: 'REDIRECT_FOR_PAYMENT_AUTHORIZATION' } );
 		makePayPalExpressRequest(
 			{
 				items,

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -455,7 +455,8 @@ export default function CompositeCheckout( {
 		domainNames,
 		contactDetails,
 		updateContactDetails,
-		applyDomainContactValidationResults
+		applyDomainContactValidationResults,
+		paymentMethodId
 	) => {
 		return (
 			<WPCheckoutErrorBoundary>
@@ -466,6 +467,15 @@ export default function CompositeCheckout( {
 					onValidate={ ( values, onComplete ) => {
 						// TODO: Should probably handle HTTP errors here
 						validateDomainContact( values, domainNames, ( httpErrors, data ) => {
+							recordEvent( {
+								type: 'VALIDATE_DOMAIN_CONTACT_INFO',
+								payload: {
+									credits: null,
+									payment_method: translateCheckoutPaymentMethodToWpcomPaymentMethod(
+										paymentMethodId
+									),
+								},
+							} );
 							debug(
 								'Domain contact info validation ' + ( data.messages ? 'errors:' : 'successful' ),
 								data.messages
@@ -707,6 +717,14 @@ function getCheckoutEventHandler( dispatch ) {
 						error_message: String( action.payload ),
 					} )
 				);
+			case 'VALIDATE_DOMAIN_CONTACT_INFO': {
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_form_submit', {
+						credits: action.payload.credits,
+						payment_method: action.payload.payment_method,
+					} )
+				);
+			}
 			default:
 				debug( 'unknown checkout event', action );
 				return dispatch(

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -4,7 +4,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch, useLineItems } from '@automattic/composite-checkout';
+import {
+	useSelect,
+	useDispatch,
+	useLineItems,
+	usePaymentMethodId,
+} from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -30,6 +35,7 @@ export default function WPContactForm( {
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
 	const setters = useDispatch( 'wpcom' );
 
+	const [ paymentMethodId ] = usePaymentMethodId();
 	const [ items ] = useLineItems();
 	const firstDomainItem = items.find( isLineItemADomain );
 	const domainName = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
@@ -52,6 +58,7 @@ export default function WPContactForm( {
 				setters,
 				CountrySelectMenu,
 				countriesList,
+				paymentMethodId,
 			} ) }
 		</BillingFormFields>
 	);
@@ -249,6 +256,7 @@ function renderContactDetails( {
 	setters,
 	CountrySelectMenu,
 	countriesList,
+	paymentMethodId,
 } ) {
 	const format = getContactDetailsFormat( isDomainFieldsVisible );
 	const requiresVatId = isEligibleForVat( contactInfo.countryCode.value );
@@ -265,7 +273,8 @@ function renderContactDetails( {
 						[ domainName ],
 						prepareDomainContactDetails( contactInfo ),
 						setters.updateContactDetails,
-						setters.applyDomainContactValidationResults
+						setters.applyDomainContactValidationResults,
+						paymentMethodId
 					) }
 					{ requiresVatId && <VatIdField /> }
 				</React.Fragment>

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -561,6 +561,7 @@ function StripePayButton( { disabled } ) {
 
 		if ( transactionStatus === 'auth' ) {
 			debug( 'showing auth' );
+			onEvent( { type: 'SHOW_MODAL_AUTHORIZATION' } );
 			showStripeModalAuth( {
 				stripeConfiguration,
 				response: transactionAuthData,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For continuity of data, includes the existing transaction analytics events in composite checkout.

#### Testing instructions

- Attempt a PayPal purchase and verify that a `calypso_checkout_form_redirect` tracks event is fired.
- Attempt a purchase with any payment method and verify that a `calypso_checkout_form_submit` event is fired.
- Enter checkout with a domain, complete the contact details form, and proceed to the review step. Verify that a `calypso_checkout_form_submit` tracks event is fired.
- Attempt to complete checkout with a failing payment method (e.g. card number `4000000000000002`) and verify that a `calypso_checkout_payment_error` tracks event is fired.