### PR TITLE
composite-checkout: Call analytics.recordPurchase when purchase complete

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -236,6 +236,7 @@ export default function CompositeCheckout( {
 		allowedPaymentMethods: serverAllowedPaymentMethods,
 		variantRequestStatus,
 		variantSelectOverride,
+		responseCart,
 	} = useShoppingCart(
 		siteSlug,
 		canInitializeCart,
@@ -253,11 +254,11 @@ export default function CompositeCheckout( {
 			const url = getThankYouUrl();
 			recordEvent( {
 				type: 'PAYMENT_COMPLETE',
-				payload: { url, couponItem, paymentMethodId, total },
+				payload: { url, couponItem, paymentMethodId, total, responseCart },
 			} );
 			page.redirect( url );
 		},
-		[ recordEvent, getThankYouUrl, total, couponItem ]
+		[ recordEvent, getThankYouUrl, total, couponItem, responseCart ]
 	);
 
 	const { registerStore, dispatch } = registry;
@@ -598,7 +599,7 @@ function createItemToAddToCart( { planSlug, plan, isJetpackNotAtomic } ) {
 }
 
 function getCheckoutEventHandler( dispatch ) {
-	return action => {
+	return function recordEvent( action ) {
 		debug( 'heard checkout event', action );
 		switch ( action.type ) {
 			case 'CHECKOUT_LOADED':
@@ -622,8 +623,9 @@ function getCheckoutEventHandler( dispatch ) {
 					cart: {
 						total_cost,
 						currency: action.payload.total.amount.currency,
-						is_signup,
-						products, // Needs product_slug, product_id, cost, volume, product_name, price, product_type, included_domain_purchase_amount, is_domain_registration
+						is_signup: action.payload.responseCart.is_signup,
+						// TODO: currently maybe missing (?) price, product_type, included_domain_purchase_amount
+						products: action.payload.responseCart.products,
 					},
 					orderId: transactionResult.receipt_id,
 				} );

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -624,7 +624,6 @@ function getCheckoutEventHandler( dispatch ) {
 						total_cost,
 						currency: action.payload.total.amount.currency,
 						is_signup: action.payload.responseCart.is_signup,
-						// TODO: currently maybe missing (?) price, product_type, included_domain_purchase_amount
 						products: action.payload.responseCart.products,
 					},
 					orderId: transactionResult.receipt_id,

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -287,6 +287,7 @@ export interface ShoppingCartManager {
 	updateLocation: ( CartLocation ) => void;
 	variantRequestStatus: VariantRequestStatus;
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[];
+	responseCart: ResponseCart;
 }
 
 /**
@@ -476,6 +477,7 @@ export function useShoppingCart(
 		couponCode: cart.couponCode,
 		variantRequestStatus,
 		variantSelectOverride,
+		responseCart,
 	} as ShoppingCartManager;
 }
 

--- a/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
@@ -64,6 +64,7 @@ export interface ResponseCart {
 	is_coupon_applied: boolean;
 	coupon_discounts_integer: number[];
 	locale: string;
+	is_signup: boolean;
 	messages?: { errors: ResponseCartError[] };
 	tax: {
 		location: {
@@ -97,6 +98,7 @@ export const emptyResponseCart = {
 	coupon_discounts_integer: [],
 	locale: 'en-us',
 	tax: { location: [], display_taxes: false },
+	is_signup: false,
 } as ResponseCart;
 
 /**
@@ -114,6 +116,10 @@ export interface ResponseCartProduct {
 	volume: number;
 	extra: object;
 	uuid: string;
+	cost: number;
+	price: number;
+	product_type: string;
+	included_domain_purchase_amount: number;
 }
 
 export const prepareRequestCartProduct: ( ResponseCartProduct ) => RequestCartProduct = ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a call to `analytics.recordPurchase()` to the event handler for the `PAYMENT_COMPLETE` event that gets triggered by `onPaymentComplete()`. This function is used by Marketing to track all sorts of purchase-related data.

In order to do this we need to expose the raw `ResponseCart` object stored in the shopping cart manager.

#### Testing instructions

To trigger the call, follow these steps:

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start` or by adding `?flags=composite-checkout-wpcom` to the URL when you visit the checkout page.
- Add a plan to your chart and visit checkout.
- Complete checkout and pay; you can do this with credits (although then it's possible it won't do anything because of logic in `recordPurchase`) or with a test card like `4242 4242 4242 4242` (if you've sandboxed the store).
- Make sure the correct events get triggered somehow (not sure how to do this).