### PR TITLE
SPT: Add Brazilian Portuguese to the list of sub locales

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -251,7 +251,7 @@ class Starter_Page_Templates {
 	private function get_iso_639_locale() {
 		$language = strtolower( get_locale() );
 
-		if ( in_array( $language, [ 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ], true ) ) {
+		if ( in_array( $language, [ 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ], true ) ) {
 			$language = str_replace( '_', '-', $language );
 		} else {
 			$language = preg_replace( '/([-_].*)$/i', '', $language );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `pt-br` to the list of valid sub-locales for wp.com

#### Testing instructions

* On your local test site, have the FSE plugin enabled.
* Set the content locale to Brazilian Portuguese.
* Create a new page and check if the templates are in Portuguese.