### PR TITLE
composite-checkout: Fix PayPal redirect

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -281,7 +281,7 @@ export default function CompositeCheckout( {
 	paypalMethod.id = 'paypal';
 	// This is defined afterward so that getThankYouUrl can be dynamic without having to re-create payment method
 	paypalMethod.submitTransaction = () => {
-		makePayPalExpressRequest(
+		return makePayPalExpressRequest(
 			{
 				items,
 				successUrl: getThankYouUrl(),

--- a/client/my-sites/checkout/checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/checkout/types/paypal-express.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { WPCOMCartItem } from '@automattic/composite-checkout-wpcom';
+import {
+	WPCOMCartItem,
+	getNonProductWPCOMCartItemTypes,
+} from '@automattic/composite-checkout-wpcom';
 
 /**
  * Internal dependencies
@@ -58,7 +61,7 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 			country,
 			postalCode,
 			subdivisionCode,
-			items: items.filter( item => item.type !== 'tax' ),
+			items: items.filter( item => ! getNonProductWPCOMCartItemTypes().includes( item.type ) ),
 		} ),
 		country,
 		postalCode,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Return the PayPal redirect promise from `submitTransaction`

#### Testing instructions

Run calypso with composite checkout enabled using
```
ENABLE_FEATURES=composite-checkout-wpcom npm start
```
and attempt to make a purchase using PayPal. Without this PR applied, instead of redirecting to complete the payment, calypso reloads to `/checkout/undefined` because the redirect URL never arrives.