### PR TITLE
Show signup errors to user in Gutenboarding

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -2,10 +2,11 @@
  * External dependencies
  */
 import React, { useState } from 'react';
-import { Button, ExternalLink, TextControl, Modal } from '@wordpress/components';
+import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { __ as NO__, _x as NO_x } from '@wordpress/i18n';
+import { User as UserTypes } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -66,7 +67,13 @@ const SignupForm = () => {
 						'E.g., yourname@email.com',
 						"An example of a person's email, use something appropriate for the locale"
 					) }
+					required
 				/>
+				{ newUserError && (
+					<Notice className="signup-form__error-notice" status="error" isDismissible={ false }>
+						{ getErrorMessage( newUserError ) }
+					</Notice>
+				) }
 				<div className="signup-form__footer">
 					<p className="signup-form__terms-of-service-link">{ renderTos() }</p>
 
@@ -81,7 +88,6 @@ const SignupForm = () => {
 					</Button>
 				</div>
 			</form>
-			{ newUserError && <pre>Error: { JSON.stringify( newUserError, null, 2 ) }</pre> }
 			{ newUser && <pre>New user: { JSON.stringify( newUser, null, 2 ) }</pre> }
 		</Modal>
 	);
@@ -94,6 +100,20 @@ function renderTos() {
 			link_to_tos: <ExternalLink href="https://wordpress.com/tos/" />,
 		}
 	);
+}
+
+function getErrorMessage( errorObj: UserTypes.NewUserErrorResponse ): string {
+	switch ( errorObj.error ) {
+		case 'already_taken':
+		case 'already_active':
+		case 'email_exists':
+			return NO__( 'An account with this email address already exists.' );
+
+		default:
+			return NO__(
+				'Sorry, something went wrong when trying to create your account. Please try again.'
+			);
+	}
 }
 
 export default SignupForm;

--- a/client/landing/gutenboarding/onboarding-block/signup-form/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/style.scss
@@ -29,4 +29,8 @@
 		font-size: 16px;
 		height: 40px;
 	}
+
+	.signup-form__error-notice {
+		margin: 0;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds the most basic client-side validation to the email address and displays errors from server in a `<Notice>`

I couldn't find any prior art for how to show that a text input is invalid in Gutenberg. I was sort of hoping `<TextControl>` would have an `error` prop or something.

I copied the error message copy from the existing passwordless signup control in calypso.

* Add `required` attribute to email input
* Remove JSON dump of error response from the modal (the JSON dump of the success object is being removed in #39360)
* Show error messages from server in red `<Notice>`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the signup modal in gutenboarding
* Should get an error when submitting an empty field
* Should get an error when submitting an invalid email
* Should get an error (in a red notice) when submitting an existing email
* Should still be able to signup with a new email address

Fixes #39397 