### PR TITLE
Domain step test: Change "use your domain" to a link

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -143,7 +143,7 @@
 			margin-right: 1em;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint( '>800px' ) {
 			max-width: 55%;
 			min-width: 55%;
 			margin-right: 1em;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -27,7 +27,6 @@ import { v4 as uuid } from 'uuid';
 import { stringify } from 'qs';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -532,21 +531,16 @@ class RegisterDomainStep extends React.Component {
 						comment: 'Explains how you could use an existing domain name with your site.',
 					} ) }
 				</h3>
-				<div
+				<Button
+					borderless
 					className="register-domain-step__use-your-domain-action is-clickable"
 					onClick={ useYourDomainFunction }
 					data-tracks-button-click-source="initial-suggestions-bottom"
-					role="button"
 				>
-					<div className="register-domain-step__use-your-domain-action-text">
-						{ translate( 'Use a domain I own', {
-							context: 'Domain transfer or mapping suggestion button',
-						} ) }
-					</div>
-					<div className="register-domain-step__use-your-domain-action-chevron">
-						<Gridicon className="register-domain-step__chevron" icon="chevron-right" />
-					</div>
-				</div>
+					{ translate( 'Use a domain I own', {
+						context: 'Domain transfer or mapping suggestion button',
+					} ) }
+				</Button>
 			</div>
 		);
 		/* eslint-enable jsx-a11y/click-events-have-key-events */

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -109,31 +109,19 @@
 	color: var( --color-text-inverted );
 
 	.register-domain-step__use-your-domain-action {
-		display: flex;
-		justify-content: center;
 		margin: 1em 0;
+		color: var( --color-text-inverted );
 
 		&.is-clickable {
 			cursor: pointer;
+			text-decoration: underline;
 	
 			// NOTE: easeOutExpo easing function from http://easings.net/#easeOutExpo
 			transition: box-shadow 0.25s cubic-bezier( 0.19, 1, 0.22, 1 );
 	
 			&:hover {
-				font-weight: 450;
-				z-index: z-index( 'root', '.domain-suggestion.is-clickable:hover' );
+				color: var( --color-text-inverted );
 			}
-		}
-	}
-
-	.register-domain-step__chevron {
-		margin-left: 10px;
-		flex: 1 0 auto;
-		color: var( --color-text-inverted );
-	
-		.is-placeholder & {
-			animation: loading-fade 1.6s ease-in-out infinite;
-			color: var( --color-neutral-0 );
 		}
 	}
 }

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -109,7 +109,6 @@
 	color: var( --color-text-inverted );
 
 	.register-domain-step__use-your-domain-action {
-		margin: 1em 0;
 		color: var( --color-text-inverted );
 
 		&.is-clickable {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The next domain step test is being implemented in #39276. The test is hidden behind a feature flag. We will build individual pieces of the UI in separate PRs.

* Change the "Use your domain" button to a link(first implemented in https://github.com/Automattic/wp-calypso/pull/39366), to match it with existing UI patterns in the signup 
flow
* Fixes https://github.com/Automattic/wp-calypso/issues/39525

**BEFORE**

<img width="988" alt="Screenshot 2020-02-19 at 4 19 47 PM" src="https://user-images.githubusercontent.com/1269602/74827617-b7c80d00-5333-11ea-889d-ef5fe4a646f3.png">


**AFTER**

<img width="969" alt="Screenshot 2020-02-19 at 12 58 47 PM" src="https://user-images.githubusercontent.com/1269602/74811503-96f1be80-5317-11ea-8bb2-a4d9d77c3420.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow /start - assign yourself to _variantShowUpdates_ of **domainStepCopyUpdates** and _variantDesignUpdates_ of **domainStepDesignUpdates**.
* Verify that "use your domain" shows as a link
* Verify that clicking the link fires the Tracks event `calypso_domain_search_results_use_my_domain_button_click` (type `localStorage.setItem( 'debug', 'calypso:analytics*' );` and reload page to see tracks events)
* Clicking the link should open the domain transfers page


