### PR TITLE
WpcomPR: Drop support for string param

### DIFF
--- a/packages/wpcom-proxy-request/Readme.md
+++ b/packages/wpcom-proxy-request/Readme.md
@@ -11,41 +11,42 @@ pointing to a special URL that proxies API requests on the host page's behalf.
 It is intended to be used in the browser (client-side) via a bundler like
 browserify or webpack.
 
-
 ### Installation
 
 Install `wpcom-proxy-request` using `npm`:
 
-``` bash
-$ npm install wpcom-proxy-request
+```sh
+npm install wpcom-proxy-request
 ```
 
 ### Example
 
-```es6
+```js
 // Import wpcom-proxy-request handler
 import proxy from 'wpcom-proxy-request';
 
-proxy( '/me', function( err, body, headers ) {
-  if (err) {
-    throw err;
-  }
+proxy( { path: '/me' }, function( err, body, headers ) {
+	if ( err ) {
+		throw err;
+	}
 
-  var div = document.createElement( 'div' );
-  div.innerHTML = 'Your WordPress.com "username" is: <b>@' + res.username + '<\/b>';
-  document.body.appendChild( div );
+	var div = document.createElement( 'div' );
+	div.innerHTML = 'Your WordPress.com "username" is: <b>@' + res.username + '</b>';
+	document.body.appendChild( div );
 } );
 ```
 
 ### Running tests
 
 Compile and `watch` client-test application
-```cli
+
+```sh
 make watch-test-app
 ```
 
 Run server
-```
+
+```sh
 make run-test-app
 ```
 
@@ -54,6 +55,5 @@ Open a tab pointing to `http://calypso.localhost:3001/`
 ### License
 
 MIT – Copyright Automattic 2014
-
 
 [wpcom.js]: https://github.com/Automattic/wpcom.js

--- a/packages/wpcom-proxy-request/index.js
+++ b/packages/wpcom-proxy-request/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -35,12 +34,17 @@ const origin = window.location.protocol + '//' + window.location.host;
 const postStrings = ( () => {
 	let r = false;
 	try {
-		window.postMessage( {
-			toString: function() {
-				r = true;
-			}
-		}, '*' );
-	} catch ( e ) { /* empty */ }
+		window.postMessage(
+			{
+				toString: function() {
+					r = true;
+				},
+			},
+			'*'
+		);
+	} catch ( e ) {
+		/* empty */
+	}
 	return r;
 } )();
 
@@ -94,7 +98,7 @@ debug( 'using "origin": %o', origin );
  * takes care of WordPress.com user authentication (via the currently
  * logged-in user's cookies).
  *
- * @param {Object|String} originalParams - request parameters
+ * @param {Object} originalParams - request parameters
  * @param {Function} [fn] - callback response
  * @return {XMLHttpRequest} XMLHttpRequest instance
  * @api public
@@ -107,10 +111,6 @@ const request = ( originalParams, fn ) => {
 	// inject the <iframe> upon the first proxied API request
 	if ( ! iframe ) {
 		install();
-	}
-
-	if ( 'string' === typeof params ) {
-		params = { path: params };
 	}
 
 	// generate a uid for this API request
@@ -357,7 +357,7 @@ function onmessage( e ) {
 	}
 
 	if ( ! data.length ) {
-		return debug( '`e.data` doesn\'t appear to be an Array, bailing...' );
+		return debug( "`e.data` doesn't appear to be an Array, bailing..." );
 	}
 
 	// first get the `xhr` instance that we're interested in


### PR DESCRIPTION
Docs and some code suggest the following should be accepted:

```js
proxy( '/me' );
```

However, a change in https://github.com/Automattic/wpcom-proxy-request/commit/80e1b9a688f286520603a327d71b6b48048c1bc0 / https://github.com/Automattic/wp-calypso/commit/2f93c18088f9f95ab6c273b1fa6096ce4bd5df3e introduced a regression where this fails and we must use the params object format:

```js
proxy( { path: '/me' } );
```

The issue can be seen here:

https://github.com/Automattic/wp-calypso/blob/37c884ae49b052070f855f99e06d7e78bea28cd9/packages/wpcom-proxy-request/index.js#L102-L114

```js
const params = Object.assign( {}, '/me' )
// { '0': '/', '1': 'm', '2': 'e' }
```

Further down, `params` will never be of type string and the `params = { path: originalParams }` is
never set.

Since this is several years old (introduced in https://github.com/Automattic/wpcom-proxy-request/commit/80e1b9a688f286520603a327d71b6b48048c1bc0 / https://github.com/Automattic/wp-calypso/commit/2f93c18088f9f95ab6c273b1fa6096ce4bd5df3e) and appears to be a broken feature in at least 1 major release,
let's remove support for the string argument.

<!--
This PR contains commits to (in order):

Add failing test
Fix the failing test
Remove the feature and the previous changes

Some tests are in a failing state initially. To see the tests, follow the instructions in the
Readme, roughly:

```sh
bash -c "make watch-test-app & make run-test-app & wait"
```

Open http://calypso.localhost:3001/ in your browser
-->

Initially opened in https://github.com/Automattic/wpcom-proxy-request/pull/40, which included a
failing test example of the string param.
