### PR TITLE
Domains: Usability fixes for the edit domain contact screens

### DIFF
--- a/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
@@ -9,9 +9,8 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { CompactCard } from '@automattic/components';
+import { Card } from '@automattic/components';
 import ContactDisplay from './contact-display';
-import SectionHeader from 'components/section-header';
 import { PUBLIC_VS_PRIVATE } from 'lib/url/support';
 import FormToggle from 'components/forms/form-toggle';
 import Gridicon from 'components/gridicon';
@@ -102,7 +101,7 @@ class ContactsPrivacyCard extends React.Component {
 		}
 
 		const contactVerificationNotice = isPendingIcannVerification ? (
-			<div class="contacts-privacy__settings warning">
+			<div className="contacts-privacy__settings warning">
 				<Gridicon icon="info-outline" size={ 18 } />
 				<p>
 					{ translate(
@@ -135,27 +134,23 @@ class ContactsPrivacyCard extends React.Component {
 
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Domain Contacts' ) } />
+				<Card className="contacts-privacy__card">
+					<p>{ translate( 'Your domain contact information' ) }</p>
 
-				<CompactCard className="contacts-privacy__card">
+					<ContactDisplay selectedDomainName={ selectedDomainName } />
+
 					{ this.getPrivacyProtection() }
 
 					{ this.getContactInfoDisclosed() }
 
-					<ContactDisplay selectedDomainName={ selectedDomainName } />
-
 					<p className="contacts-privacy__settings-explanation">
-						{ translate(
-							'Domain owners are required to provide correct contact information. ' +
-								'{{a}}Learn more{{/a}} about private registration and GDPR protection.',
-							{
-								components: {
-									a: <a href={ PUBLIC_VS_PRIVATE } target="_blank" rel="noopener noreferrer" />,
-								},
-							}
-						) }
+						{ translate( '{{a}}Learn more{{/a}} about private registration and GDPR protection.', {
+							components: {
+								a: <a href={ PUBLIC_VS_PRIVATE } target="_blank" rel="noopener noreferrer" />,
+							},
+						} ) }
 					</p>
-				</CompactCard>
+				</Card>
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
@@ -1,14 +1,16 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
-import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
 import { getWhoisData } from 'state/domains/management/selectors';
 import { requestWhois } from 'state/domains/management/actions';
-import { isEmpty } from 'lodash';
 import { findRegistrantWhois } from 'lib/domains/whois/utils';
 
 class ContactDisplay extends React.PureComponent {
@@ -23,7 +25,7 @@ class ContactDisplay extends React.PureComponent {
 	};
 
 	render() {
-		const { translate, whoisData } = this.props;
+		const { whoisData } = this.props;
 
 		const contactInformation = findRegistrantWhois( whoisData );
 
@@ -34,8 +36,6 @@ class ContactDisplay extends React.PureComponent {
 
 		return (
 			<div className="contact-display">
-				<h2>{ translate( 'Contact Information' ) }</h2>
-
 				<div className="contact-display__content">
 					<p>
 						{ contactInformation.fname } { contactInformation.lname }
@@ -67,4 +67,4 @@ export default connect(
 	{
 		requestWhois,
 	}
-)( localize( ContactDisplay ) );
+)( ContactDisplay );

--- a/client/my-sites/domains/domain-management/contacts-privacy/style.scss
+++ b/client/my-sites/domains/domain-management/contacts-privacy/style.scss
@@ -46,7 +46,7 @@
 
 	.contact-display {
 		.contact-display__content {
-			border: 1px solid var( --color-neutral-0 );
+			background-color: var( --color-neutral-0 );
 			color: var( --color-neutral );
 			font-size: 12px;
 			line-height: 140%;

--- a/client/my-sites/domains/domain-management/contacts-privacy/style.scss
+++ b/client/my-sites/domains/domain-management/contacts-privacy/style.scss
@@ -45,20 +45,6 @@
 	}
 
 	.contact-display {
-		h2 {
-			background-color: var( --color-neutral-0 );
-			border: 1px solid var( --color-neutral-0 );
-			border-bottom: 0;
-			color: var( --color-neutral-light );
-			font-size: 11px;
-			font-weight: 600;
-			line-height: 1;
-			margin: 16px 0 0;
-			padding: 8px 0;
-			text-transform: uppercase;
-			text-align: center;
-		}
-
 		.contact-display__content {
 			border: 1px solid var( --color-neutral-0 );
 			color: var( --color-neutral );
@@ -71,5 +57,6 @@
 				margin-bottom: 0;
 			}
 		}
+		margin-bottom: 1.5em;
 	}
 }

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -35,6 +35,8 @@ import { findRegistrantWhois } from 'lib/domains/whois/utils';
 
 const wpcom = wp.undocumented();
 
+import './style.scss';
+
 class EditContactInfoFormCard extends React.Component {
 	static propTypes = {
 		selectedDomain: PropTypes.object.isRequired,
@@ -45,6 +47,7 @@ class EditContactInfoFormCard extends React.Component {
 		whoisData: PropTypes.array,
 		whoisSaveError: PropTypes.object,
 		whoisSaveSuccess: PropTypes.bool,
+		showContactInfoNote: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -390,7 +393,7 @@ class EditContactInfoFormCard extends React.Component {
 	}
 
 	render() {
-		const { selectedDomain, translate } = this.props;
+		const { selectedDomain, showContactInfoNote, translate } = this.props;
 		const canUseDesignatedAgent = selectedDomain.transferLockOnWhoisUpdateOptional;
 		const whoisRegistrantData = this.getContactFormFieldValues();
 
@@ -400,6 +403,13 @@ class EditContactInfoFormCard extends React.Component {
 
 		return (
 			<Card>
+				{ showContactInfoNote && (
+					<p className="edit-contact-info__note">
+						<em>
+							{ translate( 'Domain owners are required to provide correct contact information.' ) }
+						</em>
+					</p>
+				) }
 				<form>
 					<ContactDetailsFormFields
 						eventFormName="Edit Contact Info"

--- a/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
@@ -77,6 +77,7 @@ class EditContactInfo extends React.Component {
 					domainRegistrationAgreementUrl={ domain.domainRegistrationAgreementUrl }
 					selectedDomain={ getSelectedDomain( this.props ) }
 					selectedSite={ this.props.selectedSite }
+					showContactInfoNote={ true }
 				/>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/edit-contact-info/style.scss
+++ b/client/my-sites/domains/domain-management/edit-contact-info/style.scss
@@ -1,0 +1,3 @@
+.edit-contact-info__note {
+	color: var( --color-neutral );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the "Domain Contacts" card title.
* Add a new paragraph of copy that reads "Your domain contact information"
* Remove the contact information title above the contact information. 
* Move the Privacy protection toggle under the contact information (Make sure there's some space between the two).
* Edit the help text so that it only reads "Learn more about private registration and GDPR protection."
* Add a space between the edit contact info and the card like on our other screens.
* Move the "Domain owners are required to provide correct contact information." copy to the edit contact info screen

Contacts and Privacy (before):

![Screenshot 2020-02-19 at 11 29 57](https://user-images.githubusercontent.com/1355045/74821713-b1726a80-530c-11ea-80f7-fde743a83923.png)

Contacts and Privacy (after):

![Screenshot 2020-02-19 at 11 30 02](https://user-images.githubusercontent.com/1355045/74821721-b46d5b00-530c-11ea-9d00-8ca179b68849.png)

Edit Contact Info (before):

![Screenshot 2020-02-19 at 11 30 22](https://user-images.githubusercontent.com/1355045/74821732-b7684b80-530c-11ea-9053-cc6a042cc494.png)

Edit Contact Info (after):

![Screenshot 2020-02-19 at 11 30 27](https://user-images.githubusercontent.com/1355045/74821739-ba633c00-530c-11ea-955a-f7a5f0f3a55e.png)

#### Testing instructions

* Open Contacts and Privacy and Edit Contact Info and verify that things are showing properly. Also check that everything is still working as expected - enable/disable privacy and etc.
