### PR TITLE
Upgrade terser-webpack-plugin to 2.3.5

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -129,7 +129,8 @@ const webpackConfig = {
 			cache: process.env.CIRCLECI
 				? `${ process.env.HOME }/terser-cache/${ extraPath }`
 				: 'docker' !== process.env.CONTAINER,
-			parallel: workerCount,
+			// disable parallel mode when computing stats in Circle CI, hopefully to save memory
+			parallel: shouldEmitStats && process.env.CIRCLECI ? false : workerCount,
 			sourceMap: Boolean( process.env.SOURCEMAP ),
 			terserOptions: {
 				mangle: ! isDesktop,

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,7 +198,7 @@
 				"postcss-loader": "3.0.0",
 				"recursive-copy": "2.0.10",
 				"sass-loader": "8.0.0",
-				"terser-webpack-plugin": "2.3.1",
+				"terser-webpack-plugin": "2.3.5",
 				"thread-loader": "2.1.3",
 				"typescript": "3.7.5",
 				"webpack": "4.41.5",
@@ -34589,15 +34589,16 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.1.tgz",
-			"integrity": "sha512-dNxivOXmDgZqrGxOttBH6B4xaxT4zNC+Xd+2K8jwGDMK5q2CZI+KZMA1AAnSRT+BTRvuzKsDx+fpxzPAmAMVcA==",
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.5.tgz",
+			"integrity": "sha512-WlWksUoq+E4+JlJ+h+U+QUzXpcsMSSNXkDy9lBVkSqDn1w23Gg29L/ary9GeJVYCGiNJJX7LnVc4bwL1N3/g1w==",
 			"dev": true,
 			"requires": {
 				"cacache": "^13.0.1",
 				"find-cache-dir": "^3.2.0",
-				"jest-worker": "^24.9.0",
-				"schema-utils": "^2.6.1",
+				"jest-worker": "^25.1.0",
+				"p-limit": "^2.2.2",
+				"schema-utils": "^2.6.4",
 				"serialize-javascript": "^2.1.2",
 				"source-map": "^0.6.1",
 				"terser": "^4.4.3",
@@ -34649,6 +34650,22 @@
 					"requires": {
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"jest-worker": {
+					"version": "25.1.0",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.1.0.tgz",
+					"integrity": "sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==",
+					"dev": true,
+					"requires": {
+						"merge-stream": "^2.0.0",
+						"supports-color": "^7.0.0"
 					}
 				},
 				"locate-path": {
@@ -34735,6 +34752,15 @@
 					"requires": {
 						"figgy-pudding": "^3.5.1",
 						"minipass": "^3.1.1"
+					}
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
 					}
 				},
 				"yallist": {

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -65,7 +65,7 @@
 		"postcss-loader": "3.0.0",
 		"recursive-copy": "2.0.10",
 		"sass-loader": "8.0.0",
-		"terser-webpack-plugin": "2.3.1",
+		"terser-webpack-plugin": "2.3.5",
 		"thread-loader": "2.1.3",
 		"typescript": "3.7.5",
 		"webpack": "4.41.5",


### PR DESCRIPTION
Upgrades `terser-webpack-plugin` to the latest version. I was careful to ensure that the lockfile diff indeed updates only this package and its dependencies, and doesn't include unrelated updates to packages like `babel-*`.

The new `terser-webpack-plugin` version has better error reporting. Our `icfy-stats` job in CircleCI often fails with errors from webpack like this one:
```
ERROR in entry-gutenboarding.046ef0dc4f72b77893c6.min.js from Terser
Error: Call retries were exceeded
    at ChildProcessWorker.initialize (/home/circleci/wp-calypso/node_modules/jest-worker/build/workers/ChildProcessWorker.js:193:21)
    at ChildProcessWorker.onExit (/home/circleci/wp-calypso/node_modules/jest-worker/build/workers/ChildProcessWorker.js:263:12)
    at ChildProcess.emit (events.js:223:5)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:272:12)
```

The "Call retries were exceeded" error comes from `jest-worker`, which runs a pool of parallel child processes with `terser` that consume a queue of files to minify. If the child process exits with non-zero exit code, `jest-worker` tries to run it again one or more times.

But in the error message above, we don't see why `terser` failed at all! That's what the new `terser-webpack-plugin` attempts to fix, looking at the worker process stdout and stderr and reporting it.

Previous attempt at the upgrade had to be reverted by @blowery in #39400. Because there were errors on Edge, due to incorrect transpilation of object spread syntax? I believe this is not related to `terser-webpack-plugin` at all. The unwanted lockfile updates of `babel-*` package likely caused that.

See also: #39502 where the `icfy-stats` was made to fail when errors like this happen.