### PR TITLE
Site Migration: Add more tracking events for the confirmation screen

### DIFF
--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -82,20 +82,20 @@ class StepConfirmMigration extends Component {
 	}
 
 	renderMigrationButton() {
-		const { targetSite } = this.props;
+		const { targetSite, translate } = this.props;
 		const targetSiteDomain = get( targetSite, 'domain' );
 
 		if ( this.isTargetSitePlanCompatible() ) {
 			return (
 				<MigrateButton onClick={ this.handleClick } targetSiteDomain={ targetSiteDomain }>
-					Import everything
+					{ translate( 'Import everything' ) }
 				</MigrateButton>
 			);
 		}
 
 		return (
 			<Button primary onClick={ this.handleClick }>
-				Import everything
+				{ translate( 'Import everything' ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -7,6 +7,8 @@ import page from 'page';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { Button, CompactCard } from '@automattic/components';
+import { connect } from 'react-redux';
+
 /**
  * Internal dependencies
  */
@@ -17,6 +19,8 @@ import MigrateButton from './migrate-button.jsx';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
 import { FEATURE_UPLOAD_THEMES_PLUGINS } from 'lib/plans/constants';
 import { planHasFeature } from 'lib/plans';
+import { recordTracksEvent } from 'state/analytics/actions';
+
 /**
  * Style dependencies
  */
@@ -30,12 +34,22 @@ class StepConfirmMigration extends Component {
 		targetSiteSlug: PropTypes.string.isRequired,
 	};
 
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_site_migration_confirm_viewed', {} );
+	}
+
 	handleClick = () => {
 		const { sourceSite, startMigration, targetSiteSlug } = this.props;
 		const sourceSiteId = get( sourceSite, 'ID' );
 		const sourceSiteSlug = get( sourceSite, 'slug', sourceSiteId );
 
-		if ( this.isTargetSitePlanCompatible() ) {
+		const hasCompatiblePlan = this.isTargetSitePlanCompatible();
+
+		this.props.recordTracksEvent( 'calypso_site_migration_confirm_clicked', {
+			plan_compatible: hasCompatiblePlan,
+		} );
+
+		if ( hasCompatiblePlan ) {
 			return startMigration();
 		}
 
@@ -142,4 +156,4 @@ class StepConfirmMigration extends Component {
 	}
 }
 
-export default localize( StepConfirmMigration );
+export default connect( null, { recordTracksEvent } )( localize( StepConfirmMigration ) );

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -88,14 +88,14 @@ class StepConfirmMigration extends Component {
 		if ( this.isTargetSitePlanCompatible() ) {
 			return (
 				<MigrateButton onClick={ this.handleClick } targetSiteDomain={ targetSiteDomain }>
-					{ translate( 'Import everything' ) }
+					{ translate( 'Import Everything' ) }
 				</MigrateButton>
 			);
 		}
 
 		return (
 			<Button primary onClick={ this.handleClick }>
-				{ translate( 'Import everything' ) }
+				{ translate( 'Import Everything' ) }
 			</Button>
 		);
 	}

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { Button, CompactCard } from '@automattic/components';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -16,7 +17,6 @@ import { get } from 'lodash';
 import { redirectTo } from 'my-sites/migrate/helpers';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { connect } from 'react-redux';
 import { FEATURE_UPLOAD_THEMES_PLUGINS } from 'lib/plans/constants';
 import { planHasFeature } from 'lib/plans';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds two more Tracks events for the confirmation screen

#### Testing instructions

* Apply diff or use Calypso.live link
* Star a migration on a Simple Site
* When you get to the migration confirmation screen (after you choose the everything/content only type) 
* Verify the `calypso_site_migration_confirm_viewed` event is sent
* Click `Import Everything`
* Verify the `calypso_site_migration_confirm_clicked` event was sent.
