### PR TITLE
Improve error UI on the site input screen

### DIFF
--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -241,5 +241,5 @@
 
 .migrate__site-error {
 	color: var( --color-error );
-	margin-bottom: 10px;
+	margin-bottom: 1rem;
 }

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -238,3 +238,8 @@
 .migrate__buttons-wrapper {
 	margin: 24px 0 8px;
 }
+
+.migrate__site-error {
+	color: var( --color-error );
+	margin-bottom: 10px;
+}

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -39,6 +39,11 @@ class StepSourceSelect extends Component {
 		isLoading: false,
 	};
 
+	onUrlChange = args => {
+		this.setState( { error: null } );
+		this.props.onUrlChange( args );
+	};
+
 	handleContinue = () => {
 		const { translate } = this.props;
 
@@ -130,12 +135,13 @@ class StepSourceSelect extends Component {
 					sourceSite={ null }
 					loadingSourceSite={ this.state.isLoading }
 					targetSite={ targetSite }
-					onUrlChange={ this.props.onUrlChange }
+					onUrlChange={ this.onUrlChange }
 					onSubmit={ this.handleContinue }
 					url={ this.props.url }
 				/>
-				<p>{ this.state.error }</p>
 				<Card>
+					{ this.state.error && <div className="migrate__site-error">{ this.state.error }</div> }
+
 					<Button busy={ this.state.isLoading } onClick={ this.handleContinue } primary={ true }>
 						{ translate( 'Continue' ) }
 					</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the UI on the Site Migration URL input screen. 
* It's still not very optimal and design-reviewed, but it's better than what we had previously.
* Also clears out the error when the URL value is changed

#### Testing instructions

* Checkout branch or use Calypso.live link
* Go to Site Migration
* Ensure there's no empty space between the site input section and the continue button
* Enter a WordPress.com site to trigger an error
* Make sure the error message shows in red color
* Change the URL (start typing in the box) - the error should disappear.
