### PR TITLE
Remove @babel/runtime duplicates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1886,18 +1886,17 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-			"integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+			"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.3.tgz",
-			"integrity": "sha512-lrIU4aVbmlM/wQPzhEvzvNJskKyYptuXb0fGC0lTQTupTOYtR2Vqbu6/jf8vTr4M8Wt1nIzxVrSvPI5qESa/xA==",
-			"dev": true,
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz",
+			"integrity": "sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==",
 			"requires": {
 				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.2"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		]
 	},
 	"dependencies": {
+		"@automattic/calypso-analytics": "file:packages/calypso-analytics",
 		"@automattic/calypso-polyfills": "file:packages/calypso-polyfills",
 		"@automattic/components": "file:packages/components",
 		"@automattic/composite-checkout": "file:packages/composite-checkout",
@@ -48,7 +49,6 @@
 		"@automattic/viewport-react": "file:packages/viewport-react",
 		"@automattic/wpcom-block-editor": "file:apps/wpcom-block-editor",
 		"browserslist": "4.8.6",
-		"@automattic/calypso-analytics": "file:packages/calypso-analytics",
 		"i18n-calypso": "file:packages/i18n-calypso",
 		"photon": "file:packages/photon",
 		"wp-calypso": "file:client",


### PR DESCRIPTION
We're currently loading multiple versions of `@babel/runtime`, due to some `package-lock.json` madness. This update should fix it.

#### Changes proposed in this Pull Request

* Update `@babel/runtime` to match versions across `package-lock.json`

#### Testing instructions

Ensure that the build continues to work. Ideally, also ensure that there are no warnings being emitted about multiple versions of `@babel/runtime` being in use.
