### PR TITLE
Domains: Fix some usability issues with the custom nameservers controls

### DIFF
--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -16,8 +16,7 @@ import FormButton from 'components/forms/form-button';
 import FormFooter from 'my-sites/domains/domain-management/components/form-footer';
 import CustomNameserversRow from './custom-nameservers-row';
 import { change, remove } from 'lib/domains/nameservers';
-import Notice from 'components/notice';
-import { CHANGE_NAME_SERVERS, CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS } from 'lib/url/support';
+import { CHANGE_NAME_SERVERS_FINDING_OUT_NEW_NS } from 'lib/url/support';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 const MIN_NAMESERVER_LENGTH = 2;
@@ -30,31 +29,6 @@ class CustomNameserversForm extends React.PureComponent {
 		onSubmit: PropTypes.func.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		submitDisabled: PropTypes.bool.isRequired,
-	};
-
-	warning() {
-		const { translate } = this.props;
-
-		return (
-			<Notice status="is-warning" showDismiss={ false }>
-				{ translate(
-					'Your domain must use WordPress.com name servers for your ' +
-						'WordPress.com site to load & other features to be available.'
-				) }{ ' ' }
-				<a
-					href={ CHANGE_NAME_SERVERS }
-					target="_blank"
-					rel="noopener noreferrer"
-					onClick={ this.handleLearnMoreClick }
-				>
-					{ translate( 'Learn more.' ) }
-				</a>
-			</Notice>
-		);
-	}
-
-	handleLearnMoreClick = () => {
-		this.props.customNameServersLearnMoreClick( this.props.selectedDomainName );
 	};
 
 	popularHostsMessage() {
@@ -96,9 +70,11 @@ class CustomNameserversForm extends React.PureComponent {
 		return nameservers.map( ( nameserver, index ) => {
 			let placeholder;
 			if ( index < MIN_NAMESERVER_LENGTH ) {
-				placeholder = translate( 'Required' );
+				placeholder = translate( 'eg. ns%(index)d.example.com', { args: { index: index + 1 } } );
 			} else {
-				placeholder = translate( 'Optional' );
+				placeholder = translate( 'eg. ns%(index)d.example.com (optional)', {
+					args: { index: index + 1 },
+				} );
 			}
 
 			return (
@@ -132,9 +108,7 @@ class CustomNameserversForm extends React.PureComponent {
 
 		return (
 			<Card compact className="name-servers__custom-nameservers-form">
-				<span>{ translate( 'Use Custom Name Servers:' ) }</span>
-
-				{ this.warning() }
+				<strong>{ translate( 'Use custom name servers:' ) }</strong>
 
 				<form>
 					{ this.rows() }
@@ -174,20 +148,6 @@ class CustomNameserversForm extends React.PureComponent {
 		this.props.onReset();
 	};
 }
-
-const customNameServersLearnMoreClick = domainName =>
-	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Management',
-			'Clicked "Learn More" link in "Custom Name Servers" Form in Name Servers and DNS',
-			'Domain Name',
-			domainName
-		),
-		recordTracksEvent(
-			'calypso_domain_management_name_servers_custom_name_servers_learn_more_click',
-			{ domain_name: domainName }
-		)
-	);
 
 const customNameServersLookUpClick = domainName =>
 	composeAnalytics(
@@ -229,7 +189,6 @@ const resetToDefaultsClick = domainName =>
 	);
 
 export default connect( null, {
-	customNameServersLearnMoreClick,
 	customNameServersLookUpClick,
 	resetToDefaultsClick,
 	saveCustomNameServersClick,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the notice above and outside the card.
* Change the input placeholders to "eg: ns1.example.com" and "eg: ns2.example.com".
* Make the field label bold

Use custom nameservers (before):

![Screenshot 2020-02-19 at 14 18 10](https://user-images.githubusercontent.com/1355045/74834610-6e23f600-5324-11ea-9df4-2005162239d0.png)

Use custom nameservers (after):

![Screenshot 2020-02-19 at 14 18 15](https://user-images.githubusercontent.com/1355045/74834621-7419d700-5324-11ea-99b1-073c040c8876.png)

#### Testing instructions

* Open "Name Servers and DNS" and disable the "Use WordPress.com Name Servers" toggle
* verify that the notice is outside the card, the placeholders are updated and the label is bold
