### PR TITLE
i18n: Add CircleCI extraction job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
       - run:
           working_directory: wp-babel-makepot
           command: npm run sanitize-pot
-      - run: mv ~/wp-calypso/wp-babel-makepot/build "$CIRCLE_ARTIFACTS/translate"
+      - run: mv ~/wp-calypso/wp-babel-makepot/build/bundle-strings.pot "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
       - store-artifacts-and-test-results
 
   typecheck-strict:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,6 +296,7 @@ jobs:
       - run:
           working_directory: wp-babel-makepot
           command: npm run concat
+      - run: ls -lR wp-babel-makepot
       - run:
           working_directory: wp-babel-makepot
           command: npm run sanitize-pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,14 @@ jobs:
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot
-          command: ./node_modules/.bin/babel ~/wp-calypso --out-dir "$CIRCLE_ARTIFACTS/translate""
+          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,,**/test/**"
+      - run:
+          working_directory: wp-babel-makepot
+          command: npm run concat
+      - run:
+          working_directory: wp-babel-makepot
+          command: npm run sanitize-pot
+      - run: mv ~/wp-babel-makepot/build "$CIRCLE_ARTIFACTS/translate"
       - store-artifacts-and-test-results
 
   typecheck-strict:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,8 +290,7 @@ jobs:
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot
-          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "$HOME/wp-calypso"
-      - run: mv ~/wp-calypso/wp-babel-makepot/build/bundle-strings.pot "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
+          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "$HOME/wp-calypso" --output "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
       - run:
           name: Build New Strings .pot
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,9 +278,7 @@ jobs:
     docker:
       - image: circleci/node:lts
     steps:
-      - run:
-          name: Checkout wp-calypso
-          command: git clone --depth 1 --branch "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL"
+      - checkout
       - run:
           name: Checkout wp-babel-makepot
           command: git clone --depth 1 https://github.com/Automattic/wp-babel-makepot.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
           paths:
             - wp-calypso
 
-  EXPERIMENTAL-translate:
+  translate:
     <<: *defaults
     steps:
       - checkout
@@ -291,14 +291,37 @@ jobs:
           name: Extract strings
           working_directory: wp-babel-makepot
           command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts"
-      - run:
-          working_directory: wp-babel-makepot
-          command: npm run concat
-      - run:
-          working_directory: wp-babel-makepot
-          command: npm run sanitize-pot
       - run: mv ~/wp-calypso/wp-babel-makepot/build/bundle-strings.pot "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
+      - run:
+          name: Build New Strings .pot
+          when: always
+          command: |
+            git clone --single-branch --depth=1 https://github.com/Automattic/gp-localci-client.git
+            bash gp-localci-client/generate-new-strings-pot.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1" "$CIRCLE_ARTIFACTS/translate"
+            rm -rf gp-localci-client
       - store-artifacts-and-test-results
+      - run:
+          name: Notify GlotPress translations are ready
+          when: always
+          command: |
+            curl -X POST https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh \
+              -H 'Cache-Control: no-cache' \
+              -H 'Content-Type: application/json' \
+              -d '{
+                    "payload": {
+                      "branch": "'"$CIRCLE_BRANCH"'",
+                      "build_num": '"$CIRCLE_BUILD_NUM"',
+                      "pull_requests": [
+                        {
+                          "url": "'"$CIRCLE_PULL_REQUEST"'"
+                        }
+                      ],
+                      "reponame": "'"$CIRCLE_PROJECT_REPONAME"'",
+                      "username": "'"$CIRCLE_PROJECT_USERNAME"'",
+                      "vcs_revision": "'"$CIRCLE_SHA1"'",
+                      "vcs_type": "github"
+                    }
+                  }'
 
   typecheck-strict:
     <<: *defaults
@@ -309,7 +332,7 @@ jobs:
           name: TypeScript strict typecheck of individual subprojects
           command: yarn run tsc --project client/landing/gutenboarding
 
-  lint-and-translate:
+  lint:
     <<: *defaults
     parallelism: 1
     steps:
@@ -348,42 +371,6 @@ jobs:
                 --output-file "$CIRCLE_TEST_REPORTS/eslint/results.xml" \
                 $FILES_TO_LINT
             fi
-      - run:
-          name: Build calypso-strings.pot
-          when: always
-          command: |
-            yarn run translate
-            mv calypso-strings.pot "$CIRCLE_ARTIFACTS/translate"
-      - run:
-          name: Build New Strings .pot
-          when: always
-          command: |
-            git clone --single-branch --depth=1 https://github.com/Automattic/gp-localci-client.git
-            bash gp-localci-client/generate-new-strings-pot.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1" "$CIRCLE_ARTIFACTS/translate"
-            rm -rf gp-localci-client
-      - store-artifacts-and-test-results
-      - run:
-          name: Notify GlotPress translations are ready
-          when: always
-          command: |
-            curl -X POST https://translate.wordpress.com/api/localci/-relay-new-strings-to-gh \
-              -H 'Cache-Control: no-cache' \
-              -H 'Content-Type: application/json' \
-              -d '{
-                    "payload": {
-                      "branch": "'"$CIRCLE_BRANCH"'",
-                      "build_num": '"$CIRCLE_BUILD_NUM"',
-                      "pull_requests": [
-                        {
-                          "url": "'"$CIRCLE_PULL_REQUEST"'"
-                        }
-                      ],
-                      "reponame": "'"$CIRCLE_PROJECT_REPONAME"'",
-                      "username": "'"$CIRCLE_PROJECT_USERNAME"'",
-                      "vcs_revision": "'"$CIRCLE_SHA1"'",
-                      "vcs_type": "github"
-                    }
-                  }'
 
   build-notifications:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,19 +278,11 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: sudo apt-get install gettext
-      - run:
-          name: Checkout wp-babel-makepot
-          command: git clone --depth 1 https://github.com/Automattic/wp-babel-makepot.git
-      - run:
-          name: Build wp-babel-makepot
-          working_directory: wp-babel-makepot
-          command: npm ci
       - run: *setup-results-and-artifacts
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot
-          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "$HOME/wp-calypso" --output "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
+          command: npx https://github.com/Automattic/wp-babel-makepot "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "$HOME/wp-calypso" --output "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
       - run:
           name: Build New Strings .pot
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,7 @@ jobs:
   EXPERIMENTAL-translate:
     docker:
       - image: circleci/node:lts
+    working_directory: ~/wp-calypso
     environment: *shared-environment
     steps:
       - checkout
@@ -296,7 +297,6 @@ jobs:
       - run:
           working_directory: wp-babel-makepot
           command: npm run concat
-      - run: ls -lR wp-babel-makepot
       - run:
           working_directory: wp-babel-makepot
           command: npm run sanitize-pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot
-          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**"
+          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts"
       - run:
           working_directory: wp-babel-makepot
           command: npm run concat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ jobs:
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot
-          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,,**/test/**"
+          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**"
       - run:
           working_directory: wp-babel-makepot
           command: npm run concat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ jobs:
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot
-          command: npx https://github.com/Automattic/wp-babel-makepot "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "$HOME/wp-calypso" --output "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
+          command: npx https://github.com/Automattic/wp-babel-makepot "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "$HOME/wp-calypso" --output "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
       - run:
           name: Build New Strings .pot
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
       - run:
           working_directory: wp-babel-makepot
           command: npm run sanitize-pot
-      - run: mv ~/wp-babel-makepot/build "$CIRCLE_ARTIFACTS/translate"
+      - run: mv ~/wp-calypso/wp-babel-makepot/build "$CIRCLE_ARTIFACTS/translate"
       - store-artifacts-and-test-results
 
   typecheck-strict:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,6 @@ jobs:
           working_directory: wp-babel-makepot
           command: npm ci
       - run: *setup-results-and-artifacts
-          working_directory: ~/wp-calypso
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot
-          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts"
+          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "~/wp-calypso"
       - run: mv ~/wp-calypso/wp-babel-makepot/build/bundle-strings.pot "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
       - run:
           name: Build New Strings .pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,7 @@ jobs:
   EXPERIMENTAL-translate:
     docker:
       - image: circleci/node:lts
+    environment: *shared-environment
     steps:
       - checkout
       - run:
@@ -287,6 +288,7 @@ jobs:
           working_directory: wp-babel-makepot
           command: npm ci
       - run: *setup-results-and-artifacts
+          working_directory: ~/wp-calypso
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,6 @@ references:
       - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-yarn-modules-{{ checksum ".nvmrc" }}
 
   yarn-install: &yarn-install
-    environment:
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
     name: Install dependencies
     command: |
       source "$HOME/.nvm/nvm.sh"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,7 @@ jobs:
     environment: *shared-environment
     steps:
       - checkout
+      - run: sudo apt-get install gettext
       - run:
           name: Checkout wp-babel-makepot
           command: git clone --depth 1 https://github.com/Automattic/wp-babel-makepot.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot
-          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "~/wp-calypso"
+          command: npm start "~/wp-calypso/{client,packages,apps}/**/*.{js,jsx,ts,tsx}" -- --ignore "**/node_modules/**,**/test/**,**/*.d.ts" --base "$HOME/wp-calypso"
       - run: mv ~/wp-calypso/wp-babel-makepot/build/bundle-strings.pot "$CIRCLE_ARTIFACTS/translate/calypso-strings.pot"
       - run:
           name: Build New Strings .pot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -883,9 +883,6 @@ workflows:
       - build-wpcom-block-editor:
           requires:
             - setup
-      - icfy-stats:
-          requires:
-            - setup
       - translate
       - lint:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,8 @@ references:
       - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-yarn-modules-{{ checksum ".nvmrc" }}
 
   yarn-install: &yarn-install
+    environment:
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
     name: Install dependencies
     command: |
       source "$HOME/.nvm/nvm.sh"
@@ -193,12 +195,12 @@ references:
       cp -r ./screenshots $CIRCLE_ARTIFACTS/screenshots
 
   desktop-install-app-deps: &desktop-install-app-deps
-      name: Install Desktop Dependencies
-      command: |
-        source "$HOME/.nvm/nvm.sh"
-        nvm use
-        npm install -g yarn
-        yarn run build-desktop:install-app-deps
+    name: Install Desktop Dependencies
+    command: |
+      source "$HOME/.nvm/nvm.sh"
+      nvm use
+      npm install -g yarn
+      yarn run build-desktop:install-app-deps
   desktop-cache-paths: &desktop-cache-paths
     - desktop/build
     - desktop/client
@@ -213,26 +215,26 @@ references:
       openssl aes-256-cbc -md md5 -d -in desktop/resource/certificates/mac.p12.enc -out desktop/resource/certificates/mac.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
       openssl aes-256-cbc -md md5 -d -in desktop/resource/certificates/win.p12.enc -out desktop/resource/certificates/win.p12 -k "${CALYPSO_SECRETS_ENCRYPTION_KEY}"
   desktop-restore-source-cache: &desktop-restore-source-cache
-      name: Restore desktop cache
-      keys:
-        - v6-desktop-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
+    name: Restore desktop cache
+    keys:
+      - v6-desktop-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
   desktop-save-source-cache: &desktop-save-source-cache
-      name: Save desktop cache
-      key: v6-desktop-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
-      paths: *desktop-cache-paths
+    name: Save desktop cache
+    key: v6-desktop-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_SHA1 }}
+    paths: *desktop-cache-paths
   desktop-notify-github-success: &desktop-notify-github-success
-      name: Notify Github Success
-      when: on_success
-      command: cd desktop && yarn ci:github:dismiss-review
+    name: Notify Github Success
+    when: on_success
+    command: cd desktop && yarn ci:github:dismiss-review
   desktop-notify-github-failure: &desktop-notify-github-failure
-      name: Notify Github Failure
-      when: on_fail
-      command: cd desktop && yarn ci:github:add-review
+    name: Notify Github Failure
+    when: on_fail
+    command: cd desktop && yarn ci:github:add-review
   desktop-notify-slack-failure: &desktop-notify-slack-failure
-      webhook: '$SLACK_WP_DESKTOP_E2E'
-      fail_only: true
-      mentions: '$CIRCLE_USERNAME'
-      failure_message: ':red_circle: wp-desktop tests for $CIRCLE_BRANCH have failed.\n\nCalypso PR: $CIRCLE_PULL_REQUEST'
+    webhook: '$SLACK_WP_DESKTOP_E2E'
+    fail_only: true
+    mentions: '$CIRCLE_USERNAME'
+    failure_message: ':red_circle: wp-desktop tests for $CIRCLE_BRANCH have failed.\n\nCalypso PR: $CIRCLE_PULL_REQUEST'
 
 commands:
   prepare:
@@ -271,6 +273,27 @@ jobs:
           root: '~'
           paths:
             - wp-calypso
+
+  EXPERIMENTAL-translate:
+    docker:
+      - image: circleci/node:lts
+    steps:
+      - run:
+          name: Checkout wp-calypso
+          command: git clone --depth 1 --branch "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL"
+      - run:
+          name: Checkout wp-babel-makepot
+          command: git clone --depth 1 https://github.com/Automattic/wp-babel-makepot.git
+      - run:
+          name: Build wp-babel-makepot
+          working_directory: wp-babel-makepot
+          command: npm ci
+      - run: *setup-results-and-artifacts
+      - run:
+          name: Extract strings
+          working_directory: wp-babel-makepot
+          command: ./node_modules/.bin/babel ~/wp-calypso --out-dir "$CIRCLE_ARTIFACTS/translate""
+      - store-artifacts-and-test-results
 
   typecheck-strict:
     <<: *defaults
@@ -651,7 +674,7 @@ jobs:
 
   wp-desktop-mac:
     macos:
-      xcode: "10.1.0"
+      xcode: '10.1.0'
     shell: /bin/bash --login
     working_directory: /Users/distiller/wp-calypso
     steps:
@@ -667,11 +690,11 @@ jobs:
             CSC_LINK: resource/certificates/mac.p12
             CSC_FOR_PULL_REQUEST: true
           command: |
-                  set +e
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
+            set +e
+            source $HOME/.nvm/nvm.sh
+            nvm use
 
-                  yarn run build-desktop:app
+            yarn run build-desktop:app
       - run:
           name: e2e Tests
           command: |
@@ -868,6 +891,10 @@ workflows:
       - build-wpcom-block-editor:
           requires:
             - setup
+      - icfy-stats:
+          requires:
+            - setup
+      - EXPERIMENTAL-translate
       - lint-and-translate:
           requires:
             - setup
@@ -894,10 +921,10 @@ workflows:
                 - master
                 # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
                 - /pull\/[0-9]+/
-#      - test-e2e-canary:
-#          requires:
-#            - wait-calypso-live
-#          test-flags: '-C -S $CIRCLE_SHA1'
+      #      - test-e2e-canary:
+      #          requires:
+      #            - wait-calypso-live
+      #          test-flags: '-C -S $CIRCLE_SHA1'
       - test-e2e-canary:
           name: test-e2e-canary-ie
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,10 +275,7 @@ jobs:
             - wp-calypso
 
   EXPERIMENTAL-translate:
-    docker:
-      - image: circleci/node:lts
-    working_directory: ~/wp-calypso
-    environment: *shared-environment
+    <<: *defaults
     steps:
       - checkout
       - run: sudo apt-get install gettext
@@ -882,76 +879,76 @@ workflows:
   version: 2
   calypso:
     jobs:
-      # - setup
-      # - prime-calypso-live:
-      #     filters:
-      #       branches:
-      #         ignore: master
-      # - test-full-site-editing:
-      #     requires:
-      #       - setup
-      # - build-notifications:
-      #     requires:
-      #       - setup
-      # - build-o2-blocks:
-      #     requires:
-      #       - setup
-      # - build-wpcom-block-editor:
-      #     requires:
-      #       - setup
-      # - icfy-stats:
-      #     requires:
-      #       - setup
+      - setup
+      - prime-calypso-live:
+          filters:
+            branches:
+              ignore: master
+      - test-full-site-editing:
+          requires:
+            - setup
+      - build-notifications:
+          requires:
+            - setup
+      - build-o2-blocks:
+          requires:
+            - setup
+      - build-wpcom-block-editor:
+          requires:
+            - setup
+      - icfy-stats:
+          requires:
+            - setup
       - EXPERIMENTAL-translate
-      # - lint-and-translate:
-      #     requires:
-      #       - setup
-      # - test-client:
-      #     requires:
-      #       - setup
-      # - test-packages:
-      #     requires:
-      #       - setup
-      # - test-server:
-      #     requires:
-      #       - setup
-      # - typecheck-strict:
-      #     requires:
-      #       - setup
-      # - wait-calypso-live:
-      #     requires:
-      #       - test-client
-      #       - test-server
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           # Do not spin up calypso.live for `master`
-      #           - master
-      #           # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
-      #           - /pull\/[0-9]+/
-      # #      - test-e2e-canary:
-      # #          requires:
-      # #            - wait-calypso-live
-      # #          test-flags: '-C -S $CIRCLE_SHA1'
-      # - test-e2e-canary:
-      #     name: test-e2e-canary-ie
-      #     requires:
-      #       - wait-calypso-live
-      #     test-flags: '-z -S $CIRCLE_SHA1'
-      #     test-target: 'IE11'
-      #     slack-webhook: '$SLACK_IE'
-      # - test-e2e-canary:
-      #     name: test-e2e-canary-safari
-      #     requires:
-      #       - wait-calypso-live
-      #     test-flags: '-y -S $CIRCLE_SHA1'
-      # - test-e2e-canary:
-      #     name: test-e2e-canary-woo
-      #     requires:
-      #       - wait-calypso-live
-      #     test-flags: '-W -S $CIRCLE_SHA1'
-      #     test-target: 'WOO'
-      #     slack-webhook: '$SLACK_WOO'
+      - lint-and-translate:
+          requires:
+            - setup
+      - test-client:
+          requires:
+            - setup
+      - test-packages:
+          requires:
+            - setup
+      - test-server:
+          requires:
+            - setup
+      - typecheck-strict:
+          requires:
+            - setup
+      - wait-calypso-live:
+          requires:
+            - test-client
+            - test-server
+          filters:
+            branches:
+              ignore:
+                # Do not spin up calypso.live for `master`
+                - master
+                # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
+                - /pull\/[0-9]+/
+      #      - test-e2e-canary:
+      #          requires:
+      #            - wait-calypso-live
+      #          test-flags: '-C -S $CIRCLE_SHA1'
+      - test-e2e-canary:
+          name: test-e2e-canary-ie
+          requires:
+            - wait-calypso-live
+          test-flags: '-z -S $CIRCLE_SHA1'
+          test-target: 'IE11'
+          slack-webhook: '$SLACK_IE'
+      - test-e2e-canary:
+          name: test-e2e-canary-safari
+          requires:
+            - wait-calypso-live
+          test-flags: '-y -S $CIRCLE_SHA1'
+      - test-e2e-canary:
+          name: test-e2e-canary-woo
+          requires:
+            - wait-calypso-live
+          test-flags: '-W -S $CIRCLE_SHA1'
+          test-target: 'WOO'
+          slack-webhook: '$SLACK_WOO'
   wp-desktop:
     jobs:
       - wp-desktop-source

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,8 +275,7 @@ jobs:
   translate:
     <<: *defaults
     steps:
-      - checkout
-      - run: *setup-results-and-artifacts
+      - prepare
       - run:
           name: Extract strings
           working_directory: wp-babel-makepot
@@ -872,7 +871,9 @@ workflows:
       - build-wpcom-block-editor:
           requires:
             - setup
-      - translate
+      - translate:
+          requires:
+            - setup
       - lint:
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,11 +739,11 @@ jobs:
           environment:
             CSC_LINK: resource/certificates/win.p12
           command: |
-                  set +e
-                  source $HOME/.nvm/nvm.sh
-                  nvm use
+            set +e
+            source $HOME/.nvm/nvm.sh
+            nvm use
 
-                  yarn run build-desktop:app
+            yarn run build-desktop:app
       - run:
           name: e2e Tests
           command: |
@@ -786,9 +786,9 @@ jobs:
       - run:
           name: Install Node Version
           command: |
-                  $NODE_VERSION = Get-Content .nvmrc
-                  nvm install $NODE_VERSION
-                  nvm use $NODE_VERSION
+            $NODE_VERSION = Get-Content .nvmrc
+            nvm install $NODE_VERSION
+            nvm use $NODE_VERSION
       - run:
           name: Install Yarn
           command: npm install -g yarn
@@ -804,20 +804,20 @@ jobs:
             - run:
                 name: Import Codesigning Certificate
                 command: |
-                        # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
-                        # Ref: https://travis-ci.community/t/codesigning-on-windows/
-                        #
-                        # Fix: Import .p12 into the local certificate store. Sign Tool will use
-                        # package.json's `certificateSubjectName` to find the imported cert.
-                        $env:CSC_LINK='C:\Users\circleci\wp-calypso\desktop\resource\certificates\win.p12'
-                        Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
+                  # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
+                  # Ref: https://travis-ci.community/t/codesigning-on-windows/
+                  #
+                  # Fix: Import .p12 into the local certificate store. Sign Tool will use
+                  # package.json's `certificateSubjectName` to find the imported cert.
+                  $env:CSC_LINK='C:\Users\circleci\wp-calypso\desktop\resource\certificates\win.p12'
+                  Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
       - run:
           name: Build Desktop Windows
           command: |
-                  # Use make for bash-like environment variable substitution
+            # Use make for bash-like environment variable substitution
 
-                  If ( $env:CIRCLE_TAG ) { $env:ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName=""Automattic, Inc.""' }
-                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS=$env:ELECTRON_BUILDER_ARGS
+            If ( $env:CIRCLE_TAG ) { $env:ELECTRON_BUILDER_ARGS='-c.win.certificateSubjectName=""Automattic, Inc.""' }
+            make -f desktop/Makefile package ELECTRON_BUILDER_ARGS=$env:ELECTRON_BUILDER_ARGS
       - run:
           name: Archive Unpacked Directories
           command: |
@@ -874,76 +874,76 @@ workflows:
   version: 2
   calypso:
     jobs:
-      - setup
-      - prime-calypso-live:
-          filters:
-            branches:
-              ignore: master
-      - test-full-site-editing:
-          requires:
-            - setup
-      - build-notifications:
-          requires:
-            - setup
-      - build-o2-blocks:
-          requires:
-            - setup
-      - build-wpcom-block-editor:
-          requires:
-            - setup
-      - icfy-stats:
-          requires:
-            - setup
+      # - setup
+      # - prime-calypso-live:
+      #     filters:
+      #       branches:
+      #         ignore: master
+      # - test-full-site-editing:
+      #     requires:
+      #       - setup
+      # - build-notifications:
+      #     requires:
+      #       - setup
+      # - build-o2-blocks:
+      #     requires:
+      #       - setup
+      # - build-wpcom-block-editor:
+      #     requires:
+      #       - setup
+      # - icfy-stats:
+      #     requires:
+      #       - setup
       - EXPERIMENTAL-translate
-      - lint-and-translate:
-          requires:
-            - setup
-      - test-client:
-          requires:
-            - setup
-      - test-packages:
-          requires:
-            - setup
-      - test-server:
-          requires:
-            - setup
-      - typecheck-strict:
-          requires:
-            - setup
-      - wait-calypso-live:
-          requires:
-            - test-client
-            - test-server
-          filters:
-            branches:
-              ignore:
-                # Do not spin up calypso.live for `master`
-                - master
-                # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
-                - /pull\/[0-9]+/
-      #      - test-e2e-canary:
-      #          requires:
-      #            - wait-calypso-live
-      #          test-flags: '-C -S $CIRCLE_SHA1'
-      - test-e2e-canary:
-          name: test-e2e-canary-ie
-          requires:
-            - wait-calypso-live
-          test-flags: '-z -S $CIRCLE_SHA1'
-          test-target: 'IE11'
-          slack-webhook: '$SLACK_IE'
-      - test-e2e-canary:
-          name: test-e2e-canary-safari
-          requires:
-            - wait-calypso-live
-          test-flags: '-y -S $CIRCLE_SHA1'
-      - test-e2e-canary:
-          name: test-e2e-canary-woo
-          requires:
-            - wait-calypso-live
-          test-flags: '-W -S $CIRCLE_SHA1'
-          test-target: 'WOO'
-          slack-webhook: '$SLACK_WOO'
+      # - lint-and-translate:
+      #     requires:
+      #       - setup
+      # - test-client:
+      #     requires:
+      #       - setup
+      # - test-packages:
+      #     requires:
+      #       - setup
+      # - test-server:
+      #     requires:
+      #       - setup
+      # - typecheck-strict:
+      #     requires:
+      #       - setup
+      # - wait-calypso-live:
+      #     requires:
+      #       - test-client
+      #       - test-server
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           # Do not spin up calypso.live for `master`
+      #           - master
+      #           # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
+      #           - /pull\/[0-9]+/
+      # #      - test-e2e-canary:
+      # #          requires:
+      # #            - wait-calypso-live
+      # #          test-flags: '-C -S $CIRCLE_SHA1'
+      # - test-e2e-canary:
+      #     name: test-e2e-canary-ie
+      #     requires:
+      #       - wait-calypso-live
+      #     test-flags: '-z -S $CIRCLE_SHA1'
+      #     test-target: 'IE11'
+      #     slack-webhook: '$SLACK_IE'
+      # - test-e2e-canary:
+      #     name: test-e2e-canary-safari
+      #     requires:
+      #       - wait-calypso-live
+      #     test-flags: '-y -S $CIRCLE_SHA1'
+      # - test-e2e-canary:
+      #     name: test-e2e-canary-woo
+      #     requires:
+      #       - wait-calypso-live
+      #     test-flags: '-W -S $CIRCLE_SHA1'
+      #     test-target: 'WOO'
+      #     slack-webhook: '$SLACK_WOO'
   wp-desktop:
     jobs:
       - wp-desktop-source
@@ -989,7 +989,6 @@ workflows:
           filters:
             tags:
               only: /v.*/
-
   calypso-nightly:
     jobs:
       - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -886,8 +886,8 @@ workflows:
       - icfy-stats:
           requires:
             - setup
-      - EXPERIMENTAL-translate
-      - lint-and-translate:
+      - translate
+      - lint:
           requires:
             - setup
       - test-client:

--- a/client/components/activity-card/action-bar.tsx
+++ b/client/components/activity-card/action-bar.tsx
@@ -40,6 +40,7 @@ const ActivityCardActionBar: FunctionComponent< Props > = ( {
 				onClick={ toggleMenu }
 				ref={ actionMenuRef }
 			>
+				{ translate( '@todo: remove after testing' ) }
 				<span>{ translate( 'Actions' ) }</span>
 				<Gridicon icon="add" className="activity-card__actions-icon" />
 			</Button>

--- a/client/components/activity-card/action-bar.tsx
+++ b/client/components/activity-card/action-bar.tsx
@@ -40,7 +40,6 @@ const ActivityCardActionBar: FunctionComponent< Props > = ( {
 				onClick={ toggleMenu }
 				ref={ actionMenuRef }
 			>
-				{ translate( '@todo: remove after testing' ) }
 				<span>{ translate( 'Actions' ) }</span>
 				<Gridicon icon="add" className="activity-card__actions-icon" />
 			</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR replaces old `npm run translate` based on __i18n-calypso__ CircleCI job with new one that uses [wp-babel-makepot](https://github.com/Automattic/wp-babel-makepot) for extracting translation strings.

#### Testing instructions

1. Check if translate job has completed successfully.
2. Inspect `calypso-strings.pot` artifact and confirm that it contains all translation strings as before.