### PR TITLE
Pass orderId to DCM u8 parameter

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -42,14 +42,14 @@ const isWpcomGoogleAdsGtagEnabled = true;
 const isQuantcastEnabled = true;
 const isExperianEnabled = true;
 const isOutbrainEnabled = true;
-const isIconMediaEnabled = false;
+const isIconMediaEnabled = true;
 const isPinterestEnabled = true;
 const isTwitterEnabled = false;
 const isLinkedinEnabled = false;
 const isCriteoEnabled = false;
 const isPandoraEnabled = false;
 const isQuoraEnabled = false;
-const isAdRollEnabled = false;
+const isAdRollEnabled = true;
 
 // Retargeting events are fired once every `retargetingPeriod` seconds.
 const retargetingPeriod = 60 * 60 * 24;

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -42,14 +42,14 @@ const isWpcomGoogleAdsGtagEnabled = true;
 const isQuantcastEnabled = true;
 const isExperianEnabled = true;
 const isOutbrainEnabled = true;
-const isIconMediaEnabled = true;
+const isIconMediaEnabled = false;
 const isPinterestEnabled = true;
 const isTwitterEnabled = false;
 const isLinkedinEnabled = false;
 const isCriteoEnabled = false;
 const isPandoraEnabled = false;
 const isQuoraEnabled = false;
-const isAdRollEnabled = true;
+const isAdRollEnabled = false;
 
 // Retargeting events are fired once every `retargetingPeriod` seconds.
 const retargetingPeriod = 60 * 60 * 24;
@@ -587,13 +587,9 @@ export function trackCustomAdWordsRemarketingEvent( properties ) {
 }
 
 function splitWpcomJetpackCartInfo( cart ) {
-	// Note: reduce() requires a non 0-length array.
-	const jetpackCost =
-		0 === cart.products.length
-			? 0
-			: cart.products
-					.map( product => ( productsValues.isJetpackPlan( product ) ? product.cost : 0 ) )
-					.reduce( ( accumulator, cost ) => accumulator + cost );
+	const jetpackCost = cart.products
+		.map( product => ( productsValues.isJetpackPlan( product ) ? product.cost : 0 ) )
+		.reduce( ( accumulator, cost ) => accumulator + cost, 0 );
 	const wpcomCost = cart.total_cost - jetpackCost;
 	const wpcomProducts = cart.products.filter(
 		product => ! productsValues.isJetpackPlan( product )
@@ -1231,6 +1227,7 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 		u1: wpcomJetpackCartInfo.totalCostUSD,
 		u2: cart.products.map( product => product.product_name ).join( ', ' ),
 		u3: 'USD',
+		u8: orderId,
 		send_to: 'DC-6355556/wpsal0/wpsale+transactions',
 	} );
 
@@ -1243,6 +1240,7 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 			u1: wpcomJetpackCartInfo.wpcomCostUSD,
 			u2: wpcomJetpackCartInfo.wpcomProducts.map( product => product.product_name ).join( ', ' ),
 			u3: 'USD',
+			u8: orderId,
 			send_to: 'DC-6355556/wpsal0/purch0+transactions',
 		} );
 	}
@@ -1256,6 +1254,7 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 			u1: wpcomJetpackCartInfo.jetpackCostUSD,
 			u2: wpcomJetpackCartInfo.jetpackProducts.map( product => product.product_name ).join( ', ' ),
 			u3: 'USD',
+			u8: orderId,
 			send_to: 'DC-6355556/wpsal0/purch00+transactions',
 		} );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Upon purchase we now pass the transaction id to Floodlight via the `u8` param.

Note:` u6` and `u7` prarams after further inspection did not need any fixing.

#### Testing instructions

Visit: https://calypso.live/?branch=fix/pass_transaction_id_to_floodlight_u8

Enable tracking and logging via JS console:
```
document.cookie = 'flags=gdpr-banner,google-analytics,ad-tracking; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
localStorage.setItem( 'debug', 'calypso:analytics:*' );
```

Reload browser ♻️ 

The JS console should now show various lines with: (filter by `isAdTrackingAllowed`)

```
calypso:analytics:utils isAdTrackingAllowed: true
```

Purchase a plan for a test website using free credits.

In your JS log you should see the `u8` parameter being passed in the dataLayer:

![image](https://user-images.githubusercontent.com/10284338/75168594-723a8400-5727-11ea-99ab-da54d0fc89f2.png)

and reflected in the Network activity:

![image](https://user-images.githubusercontent.com/10284338/75168626-7ff00980-5727-11ea-8ed7-224a626075c7.png)
