### PR TITLE
Components: Use Element.getBoundingClientRect instead of a separate package

### DIFF
--- a/client/components/popover/util.js
+++ b/client/components/popover/util.js
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-
-import getBoundingClientRect from 'bounding-client-rect';
 import debugFactory from 'debug';
 
 /**
@@ -77,7 +75,7 @@ export function unbindWindowListeners() {
 
 export function suggested( pos, el, target ) {
 	const viewport = getViewport();
-	const targetPosition = getBoundingClientRect( target );
+	const targetPosition = target.getBoundingClientRect();
 	const h = el.clientHeight;
 	const w = el.clientWidth;
 
@@ -191,7 +189,7 @@ function chooseSecondary( primary, prefered, el, target, w, h ) {
 
 export function offset( pos, el, target, relativePosition ) {
 	const pad = 15;
-	const tipRect = getBoundingClientRect( el );
+	const tipRect = el.getBoundingClientRect();
 
 	if ( ! tipRect ) {
 		throw new Error( 'could not get bounding client rect of Tip element' );
@@ -199,7 +197,7 @@ export function offset( pos, el, target, relativePosition ) {
 
 	const ew = tipRect.width;
 	const eh = tipRect.height;
-	const targetRect = getBoundingClientRect( target );
+	const targetRect = target.getBoundingClientRect();
 
 	if ( ! targetRect ) {
 		throw new Error( 'could not get bounding client rect of `target`' );
@@ -345,7 +343,7 @@ function _offset( box, doc ) {
  */
 export function constrainLeft( off, el ) {
 	const viewport = getViewport();
-	const ew = getBoundingClientRect( el ).width;
+	const ew = el.getBoundingClientRect().width;
 	off.left = Math.max( 0, Math.min( off.left, viewport.width - ew ) );
 
 	return off;

--- a/client/package.json
+++ b/client/package.json
@@ -60,7 +60,6 @@
 		"@wordpress/viewport": "2.13.0",
 		"autosize": "4.0.2",
 		"body-parser": "1.19.0",
-		"bounding-client-rect": "1.0.5",
 		"browser-filesaver": "1.1.1",
 		"browserslist-useragent": "3.0.2",
 		"chalk": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11102,14 +11102,6 @@
 			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
 			"dev": true
 		},
-		"bounding-client-rect": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/bounding-client-rect/-/bounding-client-rect-1.0.5.tgz",
-			"integrity": "sha1-meLNJgLQfyLqO+7kIFNFBP1EJM8=",
-			"requires": {
-				"get-document": "1"
-			}
-		},
 		"boxen": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
@@ -18091,11 +18083,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-		},
-		"get-document": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz",
-			"integrity": "sha1-SCG85m8cJMsDMWAr5strEsTwHEs="
 		},
 		"get-func-name": {
 			"version": "2.0.0",
@@ -38423,7 +38410,6 @@
 				"@wordpress/viewport": "2.13.0",
 				"autosize": "4.0.2",
 				"body-parser": "1.19.0",
-				"bounding-client-rect": "1.0.5",
 				"browser-filesaver": "1.1.1",
 				"browserslist-useragent": "3.0.2",
 				"chalk": "3.0.0",


### PR DESCRIPTION
It seems like we're using the `bounding-client-rect` package at a single remaining location, while in all the other places we're using `Element.getBoundingClientRect`. This PR updates this last usage and removes the unnecessary package.

#### Changes proposed in this Pull Request

* Components: Use Element.getBoundingClientRect instead of a separate package

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/devdocs/design/popover
* Verify popover works the same as before.
* Try some popovers in Calypso and verify they work the same way as before.
