### PR TITLE
Importing: Enable WordPress importing for WordPress.com Business sites.

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -149,7 +149,20 @@ class SectionImport extends Component {
 	 * @returns {Array} A list of react elements for each enabled importer
 	 */
 	renderIdleImporters( site, siteTitle, state ) {
-		const importerElements = getImporters().map( importer => {
+		const {
+			options: { is_wpcom_atomic: isAtomic },
+		} = site;
+
+		const importerElementsAll = getImporters();
+
+		/**
+		 * Filter out all importers except the WordPress ones for Atomic sites.
+		 */
+		const importerElementsFiltered = isAtomic
+			? importerElementsAll.filter( importer => importer.engine === 'wordpress' )
+			: importerElementsAll;
+
+		const importerElements = importerElementsFiltered.map( importer => {
 			const { engine } = importer;
 			const ImporterComponent = importerComponents[ engine ];
 
@@ -296,7 +309,10 @@ class SectionImport extends Component {
 			);
 		}
 
-		const { jetpack: isJetpack } = site;
+		const {
+			jetpack: isJetpack,
+			options: { is_wpcom_atomic: isAtomic },
+		} = site;
 
 		return (
 			<Main>
@@ -308,7 +324,7 @@ class SectionImport extends Component {
 					align="left"
 				/>
 				<EmailVerificationGate allowUnlaunched>
-					{ isJetpack ? <JetpackImporter /> : this.renderImportersList() }
+					{ isJetpack && ! isAtomic ? <JetpackImporter /> : this.renderImportersList() }
 				</EmailVerificationGate>
 			</Main>
 		);

--- a/client/my-sites/migrate/helpers/index.js
+++ b/client/my-sites/migrate/helpers/index.js
@@ -23,3 +23,16 @@ export function redirectTo( url ) {
 
 	return page.redirect( url );
 }
+
+/**
+ * Get the Import Section URL depending on if the site is Jetpack or WordPress.com Simple site.
+ *
+ * @param siteSlug The Site Slug
+ * @param isJetpack If the site is a Jetpack site
+ * @returns {string} The URL that points to the import section
+ */
+export function getImportSectionLocation( siteSlug, isJetpack = false ) {
+	return isJetpack
+		? `https://${ siteSlug }/wp-admin/import.php`
+		: `/import/${ siteSlug }/?engine=wordpress`;
+}

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -103,20 +103,8 @@ class SectionMigrate extends Component {
 		} );
 	};
 
-	getImportHref = () => {
-		const { isTargetSiteJetpack, targetSiteImportAdminUrl, targetSiteSlug } = this.props;
-
-		return isTargetSiteJetpack ? targetSiteImportAdminUrl : `/import/${ targetSiteSlug }`;
-	};
-
 	handleJetpackSelect = () => {
 		this.props.navigateToSelectedSourceSite( this.state.selectedSiteSlug );
-	};
-
-	jetpackSiteFilter = sourceSite => {
-		const { targetSiteId } = this.props;
-
-		return sourceSite.jetpack && sourceSite.ID !== targetSiteId;
 	};
 
 	finishMigration = () => {

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -14,7 +14,7 @@ import HeaderCake from 'components/header-cake';
 import CardHeading from 'components/card-heading';
 import ImportTypeChoice from 'my-sites/migrate/components/import-type-choice';
 import { get } from 'lodash';
-import { redirectTo } from 'my-sites/migrate/helpers';
+import { getImportSectionLocation, redirectTo } from 'my-sites/migrate/helpers';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { FEATURE_UPLOAD_THEMES_PLUGINS } from 'lib/plans/constants';
@@ -59,10 +59,12 @@ class StepImportOrMigrate extends Component {
 			migration_type: 'content',
 		} );
 
+		const destinationURL = getImportSectionLocation( targetSiteSlug, isTargetSiteAtomic );
+
 		if ( isTargetSiteAtomic ) {
-			window.location.href = `https://${ targetSiteSlug }/wp-admin/import.php`;
+			window.location.href = destinationURL;
 		} else {
-			redirectTo( `/import/${ targetSiteSlug }/?engine=wordpress` );
+			redirectTo( destinationURL );
 		}
 	};
 

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -23,7 +23,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
  */
 import './section-migrate.scss';
 import SitesBlock from 'my-sites/migrate/components/sites-block';
-import { redirectTo } from 'my-sites/migrate/helpers';
+import { getImportSectionLocation, redirectTo } from 'my-sites/migrate/helpers';
 
 const wpcom = wpLib.undocumented();
 
@@ -113,7 +113,7 @@ class StepSourceSelect extends Component {
 	render() {
 		const { targetSite, targetSiteSlug, translate } = this.props;
 		const backHref = `/import/${ targetSiteSlug }`;
-		const uploadFileLink = `/import/${ targetSiteSlug }?engine=wordpress`;
+		const uploadFileLink = getImportSectionLocation( targetSiteSlug, targetSite.jetpack );
 
 		return (
 			<>

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -46,7 +46,10 @@ class StepSourceSelect extends Component {
 	};
 
 	handleContinue = () => {
-		const { translate } = this.props;
+		const {
+			translate,
+			targetSite: { jetpack: isJetpackSite },
+		} = this.props;
 
 		if ( this.state.isLoading ) {
 			return;
@@ -81,7 +84,7 @@ class StepSourceSelect extends Component {
 								page( `/migrate/choose/${ this.props.targetSiteSlug }` );
 							} );
 						default:
-							if ( validEngines.indexOf( result.site_engine ) === -1 ) {
+							if ( validEngines.indexOf( result.site_engine ) === -1 || isJetpackSite ) {
 								return this.setState( {
 									error: translate( 'This is not a WordPress site' ),
 									isLoading: false,

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -54,11 +54,13 @@ class ToolsMenu extends PureComponent {
 	getImportItem() {
 		const { isJetpack, isAtomicSite, translate } = this.props;
 
+		const migrateEnabled = config.isEnabled( 'tools/migrate' );
+
 		return {
 			name: 'import',
 			label: translate( 'Import' ),
 			capability: 'manage_options',
-			queryable: ! isJetpack || isAtomicSite,
+			queryable: ! isJetpack || ( isAtomicSite && migrateEnabled ),
 			link: '/import',
 			paths: [ '/import', '/migrate' ],
 			wpAdminLink: 'import.php',

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -52,13 +52,13 @@ class ToolsMenu extends PureComponent {
 	}
 
 	getImportItem() {
-		const { isJetpack, translate } = this.props;
+		const { isJetpack, isAtomicSite, translate } = this.props;
 
 		return {
 			name: 'import',
 			label: translate( 'Import' ),
 			capability: 'manage_options',
-			queryable: ! isJetpack,
+			queryable: ! isJetpack || isAtomicSite,
 			link: '/import',
 			paths: [ '/import', '/migrate' ],
 			wpAdminLink: 'import.php',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables the import section for WordPress.com Business sites. Now we're just linking to the Import section in WP-Admin. With the updated Site Migration work we're doing, it makes sense to integrate this for WordPress.com Business sites as the functionality works well for them too.

#### Testing instructions

* Non-WordPress.com Business sites should have their import experience working correctly for WordPress imports. 
* WordPress.com Business sites should have only the WordPress importer enabled.
* Content Only imports should link to WP-Admin version for WordPress.com Business sites.
* Test with and without `tools/migrate` flag enabled, to make sure the sidebar link is working appropriately. If the `tools/migrate` flag is not enabled, the link should point to WP-Admin. If it's enabled, it should open the import selection UI. 
* Migrations should work well with both WordPress.com Business sites and non-Business sites.