### PR TITLE
Update/domain management transfer other user usability fixes

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -26,6 +26,7 @@ import DomainMainPlaceholder from 'my-sites/domains/domain-management/components
 import { successNotice, errorNotice } from 'state/notices/actions';
 import DesignatedAgentNotice from 'my-sites/domains/domain-management/components/designated-agent-notice';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { hasLoadedSiteDomains } from 'state/sites/domains/selectors';
 
 /**
  * Style dependencies
@@ -283,7 +284,11 @@ class TransferOtherUser extends React.Component {
 	}
 
 	isDataReady() {
-		return this.props.wapiDomainInfo.hasLoadedFromServer && ! this.props.isRequestingSiteDomains;
+		return (
+			this.props.hasSiteDomainsLoaded &&
+			this.props.wapiDomainInfo.hasLoadedFromServer &&
+			! this.props.isRequestingSiteDomains
+		);
 	}
 }
 
@@ -291,6 +296,7 @@ export default connect(
 	( state, ownProps ) => ( {
 		currentUser: getCurrentUser( state ),
 		isAtomic: isSiteAutomatedTransfer( state, ownProps.selectedSite.ID ),
+		hasSiteDomainsLoaded: hasLoadedSiteDomains( state, ownProps.selectedSite.ID ),
 	} ),
 	{
 		successNotice,

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -191,6 +191,7 @@ class TransferOtherUser extends React.Component {
 			selectedUserDisplay = this.getSelectedUserDisplayName();
 		return (
 			<Dialog
+				className="transfer-to-other-user__confirmation-dialog"
 				isVisible={ this.state.showConfirmationDialog }
 				buttons={ buttons }
 				onClose={ this.handleDialogClose }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
@@ -6,3 +6,10 @@
 	}
 
 }
+.transfer-to-other-user__confirmation-dialog {
+	width: 90%;
+
+	@include breakpoint('>480px') {
+		max-width: 500px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* fixed the dialog box width
* fixed a bug when loading the state data - otherwise the page crashes if you reload it

#### Testing instructions

* try to transfer a domain to another user - check that the dialog is 500px wide at most (or 90% on mobile)
* reload the transfer to another user screen and verify it's working (without this PR I get a white screen and error in the console)
