### PR TITLE
Domains: Use site title instead of site name for domain transfer messages

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -44,7 +44,8 @@ class TransferConfirmationDialog extends React.PureComponent {
 				isPrimary: true,
 			},
 		];
-		const targetSiteName = get( this.props.targetSite, 'name', '' );
+
+		const targetSiteTitle = get( this.props.targetSite, 'title', '' );
 
 		return (
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
@@ -52,9 +53,9 @@ class TransferConfirmationDialog extends React.PureComponent {
 				<p>
 					{ translate(
 						'Do you want to transfer {{strong}}%(domainName)s{{/strong}} ' +
-							'to site {{strong}}%(targetSiteName)s{{/strong}}?',
+							'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
 						{
-							args: { domainName, targetSiteName },
+							args: { domainName, targetSiteTitle },
 							components: { strong: <strong /> },
 						}
 					) }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/index.jsx
@@ -74,10 +74,10 @@ export class TransferToOtherSite extends React.Component {
 
 	handleConfirmTransfer = ( targetSite, closeDialog ) => {
 		const { selectedDomainName } = this.props;
-		const targetSiteName = targetSite.name;
+		const targetSiteTitle = targetSite.title;
 		const successMessage = this.props.translate(
-			'%(selectedDomainName)s has been transferred to site: %(targetSiteName)s',
-			{ args: { selectedDomainName, targetSiteName } }
+			'%(selectedDomainName)s has been transferred to site: %(targetSiteTitle)s',
+			{ args: { selectedDomainName, targetSiteTitle } }
 		);
 		const defaultErrorMessage = this.props.translate(
 			'Failed to transfer %(selectedDomainName)s, please try again or contact support.',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're using the targetSite `name` in transfer-to-other-site messages which is not working properly if your site has no Site Title set. Counterintuitively we should use the `title` attribute which actually is populated with your site address in case the Site Title is empty :)

#### Testing instructions

* Try to transfer a domain to a site that has empty Site Title - with this PR you should see the site address (without it shows buggy message)

