### PR TITLE
Enable composite-checkout for Horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,6 +21,7 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
+		"composite-checkout-wpcom": true,
 		"devdocs": false,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This re-adds the `composite-checkout-wpcom` flag to Horizon, which was originally enabled in #38958 and then disabled in #39419.

#### Testing instructions

None.