### PR TITLE
composite-checkout: Don't change the step if it is unchanged

### DIFF
--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -43,6 +43,10 @@ function useRegisterCheckoutStore() {
 		reducer( state = { stepNumber: 1, paymentData: {} }, action ) {
 			switch ( action.type ) {
 				case 'STEP_NUMBER_SET':
+					if ( state.stepNumber === action.payload ) {
+						return state;
+					}
+					onEvent( { type: 'STEP_NUMBER_CHANGE_EVENT', payload: action.payload } );
 					return { ...state, stepNumber: action.payload };
 				case 'PAYMENT_DATA_UPDATE':
 					return {
@@ -63,7 +67,6 @@ function useRegisterCheckoutStore() {
 		},
 		controls: {
 			STEP_NUMBER_CHANGE_EVENT( action ) {
-				onEvent( action );
 				saveStepNumberToUrl( action.payload );
 			},
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a small change that prevents trying to change the current checkout step if the step number has not changed. The practical benefit of this is mainly fewer Tracks stats for `calypso_checkout_composite_step_changed` when the step hasn't actually changed (eg: when first loading the form).

#### Testing instructions

- Visit checkout with just a plan in your cart and be sure you are in the abtest group by running this in your console: `localStorage.ABTests = '{"showCompositeCheckout_20200219":"composite"}'`
- Verify that changing steps works correctly.