### PR TITLE
composite-checkout: Remove form submit tracks event for domain contact validation

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -804,12 +804,8 @@ function getCheckoutEventHandler( dispatch ) {
 				);
 			}
 			case 'VALIDATE_DOMAIN_CONTACT_INFO': {
-				return dispatch(
-					recordTracksEvent( 'calypso_checkout_form_submit', {
-						credits: action.payload.credits,
-						payment_method: action.payload.payment_method,
-					} )
-				);
+				// TODO: Decide what to do here
+				return;
 			}
 			case 'SHOW_MODAL_AUTHORIZATION': {
 				return dispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is not really a "form submit" event, and doesn't happen in production yet anyway. Removing this for now.

#### Testing instructions

Attempt to complete a purchase in composite checkout.