### PR TITLE
composite-checkout: Translate payment_method to backend version in complete stat

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -646,7 +646,9 @@ function getCheckoutEventHandler( dispatch ) {
 						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
 						total: action.payload.total.amount.value,
 						currency: action.payload.total.amount.currency,
-						payment_method: action.payload.paymentMethodId,
+						payment_method:
+							translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
+								?.name || '',
 					} )
 				);
 			}

--- a/packages/composite-checkout-wpcom/src/types/backend/payment-method.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/payment-method.ts
@@ -168,6 +168,10 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 	paymentMethod: CheckoutPaymentMethodSlug
 ): WPCOMPaymentMethodClass | null {
+	// existing cards have unique paymentMethodIds
+	if ( paymentMethod.startsWith( 'existingCard' ) ) {
+		paymentMethod = 'card';
+	}
 	switch ( paymentMethod ) {
 		case 'ebanx':
 			return { name: 'WPCOM_Billing_Ebanx' };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use translateCheckoutPaymentMethodToWpcomPaymentMethod for the `calypso_checkout_composite_payment_complete` Tracks event.

This will record a card as `WPCOM_Billing_Stripe_Payment_Method` instead of `card` as we do now. More importantly, this will report existing card payment methods, which have a unique ID like `exitingCard-2342434343`, as `WPCOM_Billing_Stripe_Payment_Method` instead of the unique ID itself.

#### Testing instructions

Complete a checkout using composite checkout using an existing card and verify that the event in Tracks has the `payment_method` property in the backend format.