### PR TITLE
Migration: cleanup for the source selection page

### DIFF
--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -247,8 +247,3 @@
 .migrate__buttons-wrapper {
 	margin: 24px 0 8px;
 }
-
-.migrate__site-error {
-	color: var( --color-error );
-	margin-bottom: 1rem;
-}

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -107,6 +107,10 @@
 	vertical-align: middle;
 }
 
+.migrate__import-link {
+	text-decoration: underline;
+}
+
 
 .migrate__card-footer {
 	color: var( --color-text-subtle );

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -111,6 +111,11 @@
 	text-decoration: underline;
 }
 
+.migrate__error {
+	&.notice {
+		margin-bottom: 0;
+	}
+}
 
 .migrate__card-footer {
 	color: var( --color-text-subtle );

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -121,11 +121,11 @@ class StepSourceSelect extends Component {
 					<CardHeading>{ translate( 'What WordPress site do you want to import?' ) }</CardHeading>
 					<div className="migrate__explain">
 						{ translate(
-							"Enter a URL and we'll help you move your site to WordPress.com. If you already have a" +
+							"Enter a URL and we'll help you move your site to WordPress.com. If you already have a " +
 								'backup file, you can {{uploadFileLink}}upload it to import content{{/uploadFileLink}}.',
 							{
 								components: {
-									uploadFileLink: <a href={ uploadFileLink } />,
+									uploadFileLink: <a className="migrate__import-link" href={ uploadFileLink } />,
 								},
 							}
 						) }

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -141,7 +141,7 @@ class StepSourceSelect extends Component {
 					url={ this.props.url }
 				/>
 				{ this.state.error && (
-					<Notice className="migrate__error" status="is-error">
+					<Notice className="migrate__error" showDismiss={ false } status="is-error">
 						{ this.state.error }
 					</Notice>
 				) }

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -14,6 +14,7 @@ import { get } from 'lodash';
  */
 import CardHeading from 'components/card-heading';
 import HeaderCake from 'components/header-cake';
+import Notice from 'components/notice';
 import wpLib from 'lib/wp';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -139,9 +140,12 @@ class StepSourceSelect extends Component {
 					onSubmit={ this.handleContinue }
 					url={ this.props.url }
 				/>
+				{ this.state.error && (
+					<Notice className="migrate__error" status="is-error">
+						{ this.state.error }
+					</Notice>
+				) }
 				<Card>
-					{ this.state.error && <div className="migrate__site-error">{ this.state.error }</div> }
-
 					<Button busy={ this.state.isLoading } onClick={ this.handleContinue } primary={ true }>
 						{ translate( 'Continue' ) }
 					</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds underline to the link for uploading a file.
* Corrects an issue with a missing space in the wrapped string text.
* Replaces the `<p>` tag that was used for error with a `<Notice>`.
* Conditionally shows the notice (previously, the `<p>` was always shown, and looked awkward).

Before:
![image](https://user-images.githubusercontent.com/363749/74881135-679c7b00-5332-11ea-9988-c4b602b4d2a4.png)

After:
![image](https://user-images.githubusercontent.com/363749/74881028-2ad08400-5332-11ea-82d0-41c103915619.png)


Before error:
![image](https://user-images.githubusercontent.com/363749/74881164-76832d80-5332-11ea-9b48-2838bf3d2050.png)

After error:
![image](https://user-images.githubusercontent.com/363749/74881071-42a80800-5332-11ea-90d5-2d5b353a1935.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that `tools/migrate` feature flag is enabled.
* Visit Import for your site.
* Select "WordPress".
* Verify that the upload link is now underlined.
* Verify that the spacing of the text is now correct.
* Verify that there is no blank space where an error would be displayed.
* Attempt to continue to the next step without entering a URL. Verify that the error message is displayed as a notice.

Fixes #
