### PR TITLE
composite-checkout: redirect if not loading and cart is empty

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -833,12 +833,12 @@ function useRedirectIfCartEmpty( items, redirectUrl, isLoading ) {
 	useEffect( () => {
 		if ( prevItemsLength > 0 && items.length === 0 ) {
 			debug( 'cart has become empty; redirecting...' );
-			window.location = redirectUrl;
+			page.redirect( redirectUrl );
 			return;
 		}
 		if ( ! isLoading && items.length === 0 ) {
 			debug( 'cart is empty and not still loading; redirecting...' );
-			window.location = redirectUrl;
+			page.redirect( redirectUrl );
 			return;
 		}
 	}, [ redirectUrl, items, prevItemsLength, isLoading ] );

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -273,7 +273,7 @@ export default function CompositeCheckout( {
 	const itemsForCheckout = ( items.length ? [ ...items, tax, couponItem ] : [] ).filter( Boolean );
 	debug( 'items for checkout', itemsForCheckout );
 
-	useRedirectIfCartEmpty( items, `/plans/${ siteSlug || '' }` );
+	useRedirectIfCartEmpty( items, `/plans/${ siteSlug || '' }`, isLoading );
 
 	const { storedCards, isLoading: isLoadingStoredCards } = useStoredCards(
 		getStoredCards || wpcomGetStoredCards
@@ -823,7 +823,7 @@ function getCheckoutEventHandler( dispatch ) {
 	};
 }
 
-function useRedirectIfCartEmpty( items, redirectUrl ) {
+function useRedirectIfCartEmpty( items, redirectUrl, isLoading ) {
 	const [ prevItemsLength, setPrevItemsLength ] = useState( 0 );
 
 	useEffect( () => {
@@ -834,8 +834,14 @@ function useRedirectIfCartEmpty( items, redirectUrl ) {
 		if ( prevItemsLength > 0 && items.length === 0 ) {
 			debug( 'cart has become empty; redirecting...' );
 			window.location = redirectUrl;
+			return;
 		}
-	}, [ redirectUrl, items, prevItemsLength ] );
+		if ( ! isLoading && items.length === 0 ) {
+			debug( 'cart is empty and not still loading; redirecting...' );
+			window.location = redirectUrl;
+			return;
+		}
+	}, [ redirectUrl, items, prevItemsLength, isLoading ] );
 }
 
 function useCountryList( overrideCountryList ) {

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -422,7 +422,7 @@ export default function CompositeCheckout( {
 	);
 
 	const paymentMethods =
-		isLoading || isLoadingStoredCards
+		isLoading || isLoadingStoredCards || items.length < 1
 			? []
 			: [
 					fullCreditsPaymentMethod,
@@ -517,7 +517,7 @@ export default function CompositeCheckout( {
 				onEvent={ recordEvent }
 				paymentMethods={ paymentMethods }
 				registry={ registry }
-				isLoading={ isLoading || isLoadingStoredCards }
+				isLoading={ isLoading || isLoadingStoredCards || items.length < 1 }
 			>
 				<WPCheckout
 					removeItem={ removeItem }

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState, useEffect, useMemo, useCallback, useRef, useReducer } from 'react';
+import { useEffect, useMemo, useCallback, useRef, useReducer } from 'react';
 import debugFactory from 'debug';
 
 /**
@@ -417,14 +417,10 @@ export function useShoppingCart(
 	// Asynchronously re-validate when the cache is dirty.
 	useCartUpdateAndRevalidate( cacheStatus, responseCart, setServerCart, hookDispatch, onEvent );
 
-	// Keep a separate cache of the displayed cart which we regenerate only when
-	// the cart has been downloaded
-	const responseCartToDisplay = useCachedValidCart( cacheStatus, responseCart );
-
 	// Translate the responseCart into the format needed in checkout.
 	const cart: WPCOMCart = useMemo(
-		() => translateWpcomCartToCheckoutCart( translate, responseCartToDisplay ),
-		[ translate, responseCartToDisplay ]
+		() => translateWpcomCartToCheckoutCart( translate, responseCart ),
+		[ translate, responseCart ]
 	);
 
 	useShowAddCouponSuccessMessage(
@@ -581,17 +577,6 @@ function useCartUpdateAndRevalidate(
 				onEvent?.( { type: 'CART_ERROR', payload: { error: 'SET_SERVER_CART_ERROR' } } );
 			} );
 	}, [ setServerCart, cacheStatus, responseCart, onEvent, hookDispatch ] );
-}
-
-function useCachedValidCart( cacheStatus: CacheStatus, responseCart: ResponseCart ): ResponseCart {
-	const [ responseCartToDisplay, setResponseCartToDisplay ] = useState( responseCart );
-	useEffect( () => {
-		if ( cacheStatus === 'valid' ) {
-			debug( 'updating the displayed cart to match the server cart' );
-			setResponseCartToDisplay( responseCart );
-		}
-	}, [ responseCart, cacheStatus ] );
-	return responseCartToDisplay;
 }
 
 function useShowAddCouponSuccessMessage(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a redirect (currently to the plans page) if checkout has loaded and the cart is empty.

Previously we added a redirect in #38841 which would trigger if the cart contained at least one product and then became empty. However, there are many situations that doesn't cover; the largest is if you manually (or via the back button) visit checkout with an empty cart and the URL does not contain an item to add.

This PR adds an additional redirect that will trigger if the cart is empty at all, except while the initial cart is loading (which includes adding initial items).

It also disables the form (keeps it in the "loading" state) if the cart is empty so you won't see a flash of the enabled form before the redirect happens.

#### Testing instructions

Make sure your cart is empty (visit checkout and remove any items in the cart if you need to). Also make sure your user is in the composite checkout abtest. 

Then visit checkout via the URL https://calypso.localhost:3000/checkout/your-site-here and make sure you are redirected to the /plans page. 

Next click a button to add a plan to your cart and make sure you are _not_ redirected away from checkout. 

Finally, complete a full purchase and make sure that you are never redirected to the plans page.