### PR TITLE
composite-checkout: Disable CompositeCheckout in CheckoutSystemDecider for mapping

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -103,7 +103,12 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 	}
 	// Disable for domains in the cart
 	if ( cart.products?.find( product => product.is_domain_registration ) ) {
-		debug( 'shouldShowCompositeCheckout false because cart contains domain' );
+		debug( 'shouldShowCompositeCheckout false because cart contains domain registration' );
+		return false;
+	}
+	// Disable for domain mapping
+	if ( cart.products?.find( product => product.product_slug.includes( 'domain' ) ) ) {
+		debug( 'shouldShowCompositeCheckout false because cart contains domain item' );
 		return false;
 	}
 	// Disable for GSuite plans


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Domain mapping products sometimes have a 0 cost. Composite Checkout was not designed to handle that situation; you cannot submit a purchase with 0 cost.

To give us time to solve this issue, this PR disables CompositeCheckout if the cart contains a product with the word `domain` in the slug, which should cover domain mapping (slug: `domain_map`).

#### Testing instructions

Make sure you are in the composite checkout test and then visit the URL https://wordpress.com/domains/add/mapping/your-site-here

Search for a domain and click "Add".

Verify that you do not end up in Composite Checkout.