### PR TITLE
Customer Home: Add a welcome banner.

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -219,6 +219,7 @@ class Home extends Component {
 			siteIsUnlaunched,
 			isAtomic,
 			trackAction,
+			displayWelcomeBanner,
 		} = this.props;
 
 		// Show a thank-you message 30 mins post site creation/purchase
@@ -304,7 +305,7 @@ class Home extends Component {
 						</div>
 					</Card>
 				) }
-				<WelcomeBanner />
+				{ displayWelcomeBanner && <WelcomeBanner /> }
 			</>
 		);
 	}
@@ -646,10 +647,12 @@ const connectHome = connect(
 		const isAtomic = isAtomicSite( state, siteId );
 		const isChecklistComplete = isSiteChecklistComplete( state, siteId );
 		const createdAt = getSiteOption( state, siteId, 'created_at' );
+		const user = getCurrentUser( state );
 
 		return {
 			displayChecklist:
 				isEligibleForDotcomChecklist( state, siteId ) && hasChecklistData && ! isChecklistComplete,
+			displayWelcomeBanner: user.date ? new Date( user.date ) < new Date( '2019-08-06' ) : false,
 			site: getSelectedSite( state ),
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
@@ -669,7 +672,7 @@ const connectHome = connect(
 			staticHomePageId: getSiteFrontPage( state, siteId ),
 			showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),
 			hasCustomDomain: getGSuiteSupportedDomains( domains ).length > 0,
-			user: getCurrentUser( state ),
+			user,
 			...themeInfo,
 		};
 	},

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -304,7 +304,7 @@ class Home extends Component {
 						</div>
 					</Card>
 				) }
-				{ <WelcomeBanner /> }
+				<WelcomeBanner />
 			</>
 		);
 	}

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -319,6 +319,7 @@ class Home extends Component {
 			isChecklistComplete,
 			siteIsUnlaunched,
 			isEstablishedSite,
+			displayWelcomeBanner,
 		} = this.props;
 
 		if ( ! canUserUseCustomerHome ) {
@@ -340,7 +341,7 @@ class Home extends Component {
 				<SidebarNavigation />
 				<div className="customer-home__page-heading">{ this.renderCustomerHomeHeader() }</div>
 				{ //Only show upgrade nudges to sites > 2 days old
-				isEstablishedSite && (
+				isEstablishedSite && ! displayWelcomeBanner && (
 					<div className="customer-home__upsells">
 						<StatsBanners
 							siteId={ siteId }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -648,11 +648,14 @@ const connectHome = connect(
 		const isChecklistComplete = isSiteChecklistComplete( state, siteId );
 		const createdAt = getSiteOption( state, siteId, 'created_at' );
 		const user = getCurrentUser( state );
+		const siteIsUnlaunched = isUnlaunchedSite( state, siteId );
+		const displayWelcomeBanner =
+			siteIsUnlaunched && user.date && new Date( user.date ) < new Date( '2019-08-06' );
 
 		return {
 			displayChecklist:
 				isEligibleForDotcomChecklist( state, siteId ) && hasChecklistData && ! isChecklistComplete,
-			displayWelcomeBanner: user.date ? new Date( user.date ) < new Date( '2019-08-06' ) : false,
+			displayWelcomeBanner,
 			site: getSelectedSite( state ),
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
@@ -668,7 +671,7 @@ const connectHome = connect(
 			isNewlyCreatedSite: isNewSite( state, siteId ),
 			isEstablishedSite: moment().isAfter( moment( createdAt ).add( 2, 'days' ) ),
 			isRecentlyMigratedSite: isSiteRecentlyMigrated( state, siteId ),
-			siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
+			siteIsUnlaunched,
 			staticHomePageId: getSiteFrontPage( state, siteId ),
 			showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),
 			hasCustomDomain: getGSuiteSupportedDomains( domains ).length > 0,

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -289,7 +289,7 @@ class Home extends Component {
 						</div>
 					) }
 				</div>
-				{ ! siteIsUnlaunched && 'launched' === checklistMode && (
+				{ ! siteIsUnlaunched && 'launched' === checklistMode ? (
 					<Card className="customer-home__launch-card" highlight="info">
 						<img
 							src="/calypso/images/illustrations/fireworks.svg"
@@ -304,8 +304,9 @@ class Home extends Component {
 							</p>
 						</div>
 					</Card>
+				) : (
+					displayWelcomeBanner && <WelcomeBanner />
 				) }
-				{ displayWelcomeBanner && <WelcomeBanner /> }
 			</>
 		);
 	}
@@ -649,9 +650,7 @@ const connectHome = connect(
 		const isChecklistComplete = isSiteChecklistComplete( state, siteId );
 		const createdAt = getSiteOption( state, siteId, 'created_at' );
 		const user = getCurrentUser( state );
-		const siteIsUnlaunched = isUnlaunchedSite( state, siteId );
-		const displayWelcomeBanner =
-			siteIsUnlaunched && user.date && new Date( user.date ) < new Date( '2019-08-06' );
+		const displayWelcomeBanner = user.date && new Date( user.date ) < new Date( '2019-08-06' );
 
 		return {
 			displayChecklist:
@@ -672,7 +671,7 @@ const connectHome = connect(
 			isNewlyCreatedSite: isNewSite( state, siteId ),
 			isEstablishedSite: moment().isAfter( moment( createdAt ).add( 2, 'days' ) ),
 			isRecentlyMigratedSite: isSiteRecentlyMigrated( state, siteId ),
-			siteIsUnlaunched,
+			siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 			staticHomePageId: getSiteFrontPage( state, siteId ),
 			showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),
 			hasCustomDomain: getGSuiteSupportedDomains( domains ).length > 0,

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -57,6 +57,7 @@ import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/s
 import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
 import GoMobileCard from 'my-sites/customer-home/go-mobile-card';
+import WelcomeBanner from './welcome-banner';
 import StatsCard from './stats-card';
 import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 
@@ -303,6 +304,7 @@ class Home extends Component {
 						</div>
 					</Card>
 				) }
+				{ <WelcomeBanner /> }
 			</>
 		);
 	}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -27,36 +27,38 @@
 	}
 
 	&__welcome-banner {
-		.card {
-			@include breakpoint( '>1040px' ) {
-				@include display-grid;
-				@include grid-template-columns( 12, 24px, 1fr );
-				padding: 0;
-			}
+		@include breakpoint( '>1040px' ) {
+			@include display-grid;
+			@include grid-template-columns( 12, 24px, 1fr );
+			padding: 0;
 		}
 
-		.card img {
+		img {
 			margin: 0 33%;
 			@include breakpoint( '>1040px' ) {
 				@include grid-column( 2, 2 );
 				margin: 0;
 				padding: 24px 0;
-				position: relative;
-				top: 6px;
 			}
 
 		}
 
-		.card div {
+		div {
 			@include breakpoint( '>1040px' ) {
 				@include grid-column( 5, 8 );
 				padding: 24px 24px 24px 0;
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+
+				.card-heading {
+					margin-top: 0;
+				}
 			}
 
-			.card-heading {
-				margin-top: 0;
+			p {
+				margin-bottom: 0;
 			}
-
 		}
 	}
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -26,6 +26,38 @@
 		}
 	}
 
+	&__welcome-banner {
+		.card {
+			@include breakpoint( '>1040px' ) {
+				@include display-grid;
+				@include grid-template-columns( 12, 24px, 1fr );
+				padding: 0;
+			}
+		}
+
+		.card img {
+			margin: 0 33%;
+			@include breakpoint( '>1040px' ) {
+				@include grid-column( 2, 2 );
+				margin: 0;
+				padding: 24px 0;
+			}
+
+		}
+
+		.card div {
+			@include breakpoint( '>1040px' ) {
+				@include grid-column( 5, 8 );
+				padding: 24px 24px 24px 0;
+			}
+
+			.card-heading {
+				margin-top: 0;
+			}
+
+		}
+	}
+
 	&__upsells {
 		@include grid-column( 1, 12 );
 	}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -41,6 +41,8 @@
 				@include grid-column( 2, 2 );
 				margin: 0;
 				padding: 24px 0;
+				position: relative;
+				top: 6px;
 			}
 
 		}

--- a/client/my-sites/customer-home/welcome-banner.jsx
+++ b/client/my-sites/customer-home/welcome-banner.jsx
@@ -3,72 +3,46 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { Card, Button } from '@automattic/components';
+import DismissibleCard from 'blocks/dismissible-card';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import CardHeading from 'components/card-heading';
-import {
-	bumpStat,
-	composeAnalytics,
-	recordTracksEvent,
-	withAnalytics,
-} from 'state/analytics/actions';
-import { savePreference } from 'state/preferences/actions';
-import QueryPreferences from 'components/data/query-preferences';
-import { isFetchingPreferences, getPreference } from 'state/preferences/selectors';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
-export const WelcomeBanner = ( {
-	translate,
-	fetchingPreferences,
-	bannerDismissed,
-	dismissBanner,
-} ) => {
+export const WelcomeBanner = ( { translate, recordStats } ) => {
 	return (
-		<>
-			<QueryPreferences />
-			{ ! fetchingPreferences && ! bannerDismissed && (
-				<div className="customer-home__welcome-banner">
-					<Card>
-						<img
-							src="/calypso/images/extensions/woocommerce/woocommerce-setup.svg"
-							aria-hidden="true"
-							alt=""
-						/>
-						<div>
-							<CardHeading>{ translate( 'Learn and grow with My Home' ) }</CardHeading>
-							<p>
-								{ translate(
-									'This is your new home for quick links to common tasks, easy access to support, and guidance ' +
-										'tailored to you. We’ll keep improving what you see here to help you learn and grow with us.'
-								) }
-							</p>
-							<Button onClick={ dismissBanner }>{ translate( 'Got it!' ) }</Button>
-						</div>
-					</Card>
-				</div>
-			) }
-		</>
+		<DismissibleCard
+			className="customer-home__welcome-banner"
+			preferenceName="home-welcome-banner-dismissed"
+			onClick={ recordStats }
+		>
+			<img
+				src="/calypso/images/extensions/woocommerce/woocommerce-setup.svg"
+				aria-hidden="true"
+				alt=""
+			/>
+			<div>
+				<CardHeading>{ translate( 'Learn and grow with My Home' ) }</CardHeading>
+				<p>
+					{ translate(
+						'This is your new home for quick links to common tasks, easy access to support, and guidance ' +
+							'tailored to you. We’ll keep improving what you see here to help you learn and grow with us.'
+					) }
+				</p>
+			</div>
+		</DismissibleCard>
 	);
 };
 
-export default connect(
-	state => ( {
-		bannerDismissed: getPreference( state, 'home-welcome-banner-dismissed' ),
-		fetchingPreferences: isFetchingPreferences( state ),
-	} ),
-	dispatch => ( {
-		dismissBanner: () =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( 'calypso_home_welcome_banner_dismiss' ),
-						bumpStat( 'calypso-home-welcome-banner', 'dismiss' )
-					),
-					savePreference( 'home-welcome-banner-dismissed', true )
-				)
-			),
-	} )
-)( localize( WelcomeBanner ) );
+export default connect( null, dispatch => ( {
+	recordStats: () =>
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_home_welcome_banner_dismiss' ),
+				bumpStat( 'calypso-home-welcome-banner', 'dismiss' )
+			)
+		),
+} ) )( localize( WelcomeBanner ) );

--- a/client/my-sites/customer-home/welcome-banner.jsx
+++ b/client/my-sites/customer-home/welcome-banner.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { Card, Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 
@@ -9,29 +10,65 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import CardHeading from 'components/card-heading';
+import {
+	bumpStat,
+	composeAnalytics,
+	recordTracksEvent,
+	withAnalytics,
+} from 'state/analytics/actions';
+import { savePreference } from 'state/preferences/actions';
+import QueryPreferences from 'components/data/query-preferences';
+import { isFetchingPreferences, getPreference } from 'state/preferences/selectors';
 
-export const WelcomeBanner = ( { translate } ) => {
+export const WelcomeBanner = ( {
+	translate,
+	fetchingPreferences,
+	bannerDismissed,
+	dismissBanner,
+} ) => {
 	return (
-		<div className="customer-home__welcome-banner">
-			<Card>
-				<img
-					src="/calypso/images/extensions/woocommerce/woocommerce-setup.svg"
-					aria-hidden="true"
-					alt=""
-				/>
-				<div>
-					<CardHeading>{ translate( 'Learn and grow with My Home' ) }</CardHeading>
-					<p>
-						{ translate(
-							'This is your new home for quick links to common tasks, easy access to support, and guidance ' +
-								'tailored to you. We’ll keep improving what you see here to help you learn and grow with us.'
-						) }
-					</p>
-					<Button>{ translate( 'Got it!' ) }</Button>
+		<>
+			<QueryPreferences />
+			{ ! fetchingPreferences && ! bannerDismissed && (
+				<div className="customer-home__welcome-banner">
+					<Card>
+						<img
+							src="/calypso/images/extensions/woocommerce/woocommerce-setup.svg"
+							aria-hidden="true"
+							alt=""
+						/>
+						<div>
+							<CardHeading>{ translate( 'Learn and grow with My Home' ) }</CardHeading>
+							<p>
+								{ translate(
+									'This is your new home for quick links to common tasks, easy access to support, and guidance ' +
+										'tailored to you. We’ll keep improving what you see here to help you learn and grow with us.'
+								) }
+							</p>
+							<Button onClick={ dismissBanner }>{ translate( 'Got it!' ) }</Button>
+						</div>
+					</Card>
 				</div>
-			</Card>
-		</div>
+			) }
+		</>
 	);
 };
 
-export default localize( WelcomeBanner );
+export default connect(
+	state => ( {
+		bannerDismissed: getPreference( state, 'home-welcome-banner-dismissed' ),
+		fetchingPreferences: isFetchingPreferences( state ),
+	} ),
+	dispatch => ( {
+		dismissBanner: () =>
+			dispatch(
+				withAnalytics(
+					composeAnalytics(
+						recordTracksEvent( 'calypso_home_welcome_banner_dismiss' ),
+						bumpStat( 'calypso-home-welcome-banner', 'dismiss' )
+					),
+					savePreference( 'home-welcome-banner-dismissed', true )
+				)
+			),
+	} )
+)( localize( WelcomeBanner ) );

--- a/client/my-sites/customer-home/welcome-banner.jsx
+++ b/client/my-sites/customer-home/welcome-banner.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Card, Button } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import CardHeading from 'components/card-heading';
+
+export const WelcomeBanner = ( { translate } ) => {
+	return (
+		<div className="customer-home__welcome-banner">
+			<Card>
+				<img
+					src="/calypso/images/extensions/woocommerce/woocommerce-setup.svg"
+					aria-hidden="true"
+					alt=""
+				/>
+				<div>
+					<CardHeading>{ translate( 'Learn and grow with My Home' ) }</CardHeading>
+					<p>
+						{ translate(
+							'This is your new home for quick links to common tasks, easy access to support, and guidance ' +
+								'tailored to you. We’ll keep improving what you see here to help you learn and grow with us.'
+						) }
+					</p>
+					<Button>{ translate( 'Got it!' ) }</Button>
+				</div>
+			</Card>
+		</div>
+	);
+};
+
+export default localize( WelcomeBanner );


### PR DESCRIPTION
Add a welcoming banner to Customer Home, so that users that have never been redirected there before can understand why they're there and how the page can help them.

<img width="1032" alt="Screen Shot 2020-02-20 at 3 14 17 PM" src="https://user-images.githubusercontent.com/349751/74988938-fae9b500-53f3-11ea-957e-af8f42c947ae.png">

<img width="344" alt="Screen Shot 2020-02-20 at 3 10 10 PM" src="https://user-images.githubusercontent.com/349751/74988976-12c13900-53f4-11ea-86dd-f4798e052d37.png">

Fixes #39178 

**Testing Instructions**

* Load this branch and select a site's Customer Home ("My Home") page.
* Enable logging for Tracks in the console with `localStorage.debug = 'calypso:analytics:*'`.
* Open DevTools' Network tab.
* Click the `X` to close.
* Verify a successful POST call to `/me/preferences` was made.
* Confirm in the console that the Tracks event fired.
* To retest, use the WP.com API console to POST to `/me/preferences` with `{"dismissible-card-home-welcome-banner-dismissed":null}` in the `calypso_preferences` body.
