### PR TITLE
composite-checkout: Add "free" payment method

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
@@ -157,12 +157,42 @@ export function submitCreditsTransaction(
 	return submit( formattedTransactionData );
 }
 
+export function submitFreePurchaseTransaction(
+	transactionData,
+	submit: WPCOMTransactionEndpoint
+): Promise< WPCOMTransactionEndpointResponse > {
+	debug( 'formatting free transaction', transactionData );
+	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
+		debug,
+		...transactionData,
+		paymentMethodType: 'WPCOM_Billing_WPCOM',
+	} );
+	debug( 'submitting free transaction', formattedTransactionData );
+	return submit( formattedTransactionData );
+}
+
 export function isPaymentMethodEnabled( method: string, allowedPaymentMethods: string[] ): boolean {
 	// By default, allow all payment methods
 	if ( ! allowedPaymentMethods?.length ) {
 		return true;
 	}
 	return allowedPaymentMethods.includes( method );
+}
+
+export function WordPressFreePurchaseLabel() {
+	const translate = useTranslate();
+
+	return (
+		<React.Fragment>
+			<div>{ translate( "Woohoo! You don't owe us anything!" ) }</div>
+			<WordPressLogo />
+		</React.Fragment>
+	);
+}
+
+export function WordPressFreePurchaseSummary() {
+	const translate = useTranslate();
+	return <div>{ translate( 'Just complete checkout to add these upgrades to your site.' ) }</div>;
 }
 
 export function WordPressCreditsLabel( { credits } ) {

--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
@@ -184,7 +184,7 @@ export function WordPressFreePurchaseLabel() {
 
 	return (
 		<React.Fragment>
-			<div>{ translate( "Woohoo! You don't owe us anything!" ) }</div>
+			<div>{ translate( 'Free Purchase' ) }</div>
 			<WordPressLogo />
 		</React.Fragment>
 	);
@@ -192,7 +192,7 @@ export function WordPressFreePurchaseLabel() {
 
 export function WordPressFreePurchaseSummary() {
 	const translate = useTranslate();
-	return <div>{ translate( 'Just complete checkout to add these upgrades to your site.' ) }</div>;
+	return <div>{ translate( 'Free Purchase' ) }</div>;
 }
 
 export function WordPressCreditsLabel( { credits } ) {

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -469,7 +469,7 @@ export default function CompositeCheckout( {
 		[ registerStore, storedCards, dispatch ]
 	);
 
-	const isPurchaseFree = total.amount.value === 0;
+	const isPurchaseFree = ! isLoading && total.amount.value === 0;
 	debug( 'is purchase free?', isPurchaseFree );
 
 	const paymentMethods =

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -772,6 +772,30 @@ function getCheckoutEventHandler( dispatch ) {
 					} )
 				);
 			}
+			case 'FREE_TRANSACTION_BEGIN': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_form_submit', {
+						credits: null,
+						payment_method: 'WPCOM_Billing_WPCOM',
+					} )
+				);
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_free_purchase_submit_clicked', {} )
+				);
+			}
+			case 'FREE_PURCHASE_TRANSACTION_ERROR': {
+				dispatch(
+					recordTracksEvent( 'calypso_checkout_payment_error', {
+						error_code: null,
+						reason: String( action.payload ),
+					} )
+				);
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_free_purchase_transaction_error', {
+						error_message: String( action.payload ),
+					} )
+				);
+			}
 			case 'PAYPAL_TRANSACTION_BEGIN': {
 				dispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
 				dispatch(

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -11,6 +11,7 @@ import {
 	useSelect,
 	useLineItems,
 	useDispatch,
+	useTotal,
 } from '@automattic/composite-checkout';
 
 /**
@@ -62,6 +63,7 @@ export default function WPCheckout( {
 } ) {
 	const translate = useTranslate();
 	const couponFieldStateProps = useCouponFieldState( submitCoupon );
+	const total = useTotal();
 
 	const reviewContent = (
 		<WPCheckoutOrderReview
@@ -145,7 +147,12 @@ export default function WPCheckout( {
 				return isActive;
 			},
 		},
-	];
+	].filter( step => {
+		if ( total.amount.value === 0 && step.id === 'contact-form' ) {
+			return false;
+		}
+		return true;
+	} );
 
 	return <Checkout steps={ steps } />;
 }

--- a/packages/composite-checkout-wpcom/src/hooks/has-domains.js
+++ b/packages/composite-checkout-wpcom/src/hooks/has-domains.js
@@ -16,5 +16,5 @@ export function areDomainsInLineItems( items ) {
 }
 
 export function isLineItemADomain( item ) {
-	return item.type.includes( 'domain' );
+	return item.wpcom_meta?.is_domain_registration;
 }

--- a/packages/composite-checkout-wpcom/src/types/backend/payment-method.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/payment-method.ts
@@ -38,8 +38,16 @@ export type WPCOMPaymentMethodClass =
 	| WPCOMBillingStripeSourceSofort
 	| WPCOMBillingStripeSourceThreeDSecure
 	| WPCOMBillingStripeSourceWechat
+	| WPCOMBillingFullCredits
+	| WPCOMBillingFree
 	| WPCOMBillingWebPayment;
 
+export interface WPCOMBillingFullCredits {
+	name: 'WPCOM_Billing_WPCOM';
+}
+export interface WPCOMBillingFree {
+	name: 'WPCOM_Billing_WPCOM';
+}
 export interface WPCOMBillingEbanx {
 	name: 'WPCOM_Billing_Ebanx';
 }
@@ -101,6 +109,7 @@ export interface WPCOMBillingWebPayment {
  */
 export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethodClass {
 	switch ( slug ) {
+		case 'WPCOM_Billing_WPCOM':
 		case 'WPCOM_Billing_Ebanx':
 		case 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef':
 		case 'WPCOM_Billing_PayPal_Direct':
@@ -132,6 +141,8 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 	paymentMethod: WPCOMPaymentMethodClass
 ): CheckoutPaymentMethodSlug {
 	switch ( paymentMethod.name ) {
+		case 'WPCOM_Billing_WPCOM':
+			return 'free-purchase';
 		case 'WPCOM_Billing_Ebanx':
 			return 'ebanx';
 		case 'WPCOM_Billing_Ebanx_Redirect_Brazil_Tef':
@@ -203,6 +214,10 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 			return { name: 'WPCOM_Billing_Stripe_Source_Wechat' };
 		case 'apple-pay':
 			return { name: 'WPCOM_Billing_Web_Payment' };
+		case 'full-credits':
+			return { name: 'WPCOM_Billing_WPCOM' };
+		case 'free-purchase':
+			return { name: 'WPCOM_Billing_WPCOM' };
 	}
 	return null;
 }

--- a/packages/composite-checkout-wpcom/src/types/checkout-payment-method-slug.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-payment-method-slug.ts
@@ -17,5 +17,7 @@ export type CheckoutPaymentMethodSlug =
 	| 'paypal'
 	| 'paypal-direct'
 	| 'sofort'
+	| 'free-purchase'
+	| 'full-credits'
 	| 'stripe-three-d-secure'
 	| 'wechat';

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -1,0 +1,164 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../../components/button';
+import {
+	useSelect,
+	useDispatch,
+	useMessages,
+	useLineItems,
+	useEvents,
+	renderDisplayValueMarkdown,
+} from '../../public-api';
+import { sprintf, useLocalize } from '../localize';
+import { useFormStatus } from '../form-status';
+
+const debug = debugFactory( 'composite-checkout:free-purchase-payment-method' );
+
+export function createFreePaymentMethod( { registerStore, submitTransaction } ) {
+	const actions = {
+		*beginFreeTransaction( payload ) {
+			let response;
+			try {
+				response = yield {
+					type: 'FREE_TRANSACTION_BEGIN',
+					payload,
+				};
+				debug( 'free transaction complete', response );
+			} catch ( error ) {
+				debug( 'free transaction had an error', error );
+				return { type: 'FREE_PURCHASE_TRANSACTION_ERROR', payload: error };
+			}
+			debug( 'free transaction requires is successful' );
+			return { type: 'FREE_PURCHASE_TRANSACTION_END', payload: response };
+		},
+	};
+
+	const selectors = {
+		getTransactionError( state ) {
+			return state.transactionError;
+		},
+		getTransactionStatus( state ) {
+			return state.transactionStatus;
+		},
+	};
+
+	registerStore( 'free-purchase', {
+		reducer(
+			state = {
+				transactionStatus: null,
+				transactionError: null,
+			},
+			action
+		) {
+			switch ( action.type ) {
+				case 'FREE_PURCHASE_TRANSACTION_END':
+					return {
+						...state,
+						transactionStatus: 'complete',
+					};
+				case 'FREE_PURCHASE_TRANSACTION_ERROR':
+					return {
+						...state,
+						transactionStatus: 'error',
+						transactionError: action.payload,
+					};
+			}
+			return state;
+		},
+		actions,
+		selectors,
+		controls: {
+			FREE_TRANSACTION_BEGIN( action ) {
+				return submitTransaction( action.payload );
+			},
+		},
+	} );
+
+	return {
+		id: 'free-purchase',
+		label: <FreePurchaseLabel />,
+		submitButton: <FreePurchaseSubmitButton />,
+		inactiveContent: <FreePurchaseSummary />,
+		getAriaLabel: localize => localize( 'Free' ),
+	};
+}
+
+function FreePurchaseLabel() {
+	const localize = useLocalize();
+
+	return (
+		<React.Fragment>
+			<div>{ localize( "Woohoo! You don't owe us anything!" ) }</div>
+		</React.Fragment>
+	);
+}
+
+function FreePurchaseSubmitButton( { disabled } ) {
+	const localize = useLocalize();
+	const { beginFreeTransaction } = useDispatch( 'free-purchase' );
+	const [ items, total ] = useLineItems();
+	const transactionStatus = useSelect( select => select( 'free-purchase' ).getTransactionStatus() );
+	const transactionError = useSelect( select => select( 'free-purchase' ).getTransactionError() );
+	const { showErrorMessage } = useMessages();
+	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
+	const onEvent = useEvents();
+
+	useEffect( () => {
+		if ( transactionStatus === 'error' ) {
+			onEvent( { type: 'FREE_PURCHASE_TRANSACTION_ERROR', payload: transactionError || '' } );
+			showErrorMessage(
+				transactionError || localize( 'An error occurred during the transaction' )
+			);
+			setFormReady();
+		}
+		if ( transactionStatus === 'complete' ) {
+			debug( 'free transaction is complete' );
+			setFormComplete();
+		}
+	}, [
+		onEvent,
+		setFormReady,
+		setFormComplete,
+		showErrorMessage,
+		transactionStatus,
+		transactionError,
+		localize,
+	] );
+
+	const onClick = () => {
+		setFormSubmitting();
+		onEvent( { type: 'FREE_TRANSACTION_BEGIN' } );
+		beginFreeTransaction( {
+			items,
+		} );
+	};
+	const buttonString =
+		formStatus === 'submitting'
+			? localize( 'Processing...' )
+			: sprintf(
+					localize( 'Complete Checkout' ),
+					renderDisplayValueMarkdown( total.amount.displayValue )
+			  );
+	return (
+		<Button
+			disabled={ disabled }
+			onClick={ onClick }
+			buttonState={ disabled ? 'disabled' : 'primary' }
+			fullWidth
+		>
+			{ buttonString }
+		</Button>
+	);
+}
+
+function FreePurchaseSummary() {
+	const localize = useLocalize();
+	return <div>{ localize( 'Just complete checkout to add these upgrades to your site.' ) }</div>;
+}

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -95,7 +95,7 @@ function FreePurchaseLabel() {
 
 	return (
 		<React.Fragment>
-			<div>{ localize( "Woohoo! You don't owe us anything!" ) }</div>
+			<div>{ localize( 'Free Purchase' ) }</div>
 		</React.Fragment>
 	);
 }
@@ -160,5 +160,5 @@ function FreePurchaseSubmitButton( { disabled } ) {
 
 function FreePurchaseSummary() {
 	const localize = useLocalize();
-	return <div>{ localize( 'Just complete checkout to add these upgrades to your site.' ) }</div>;
+	return <div>{ localize( 'Free Purchase' ) }</div>;
 }

--- a/packages/composite-checkout/src/lib/payment-methods/index.js
+++ b/packages/composite-checkout/src/lib/payment-methods/index.js
@@ -2,11 +2,14 @@
  * External dependencies
  */
 import { useContext } from 'react';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import CheckoutContext from '../checkout-context';
+
+const debug = debugFactory( 'composite-checkout:payment-methods' );
 
 export function usePaymentMethodId() {
 	const { paymentMethodId, setPaymentMethodId } = useContext( CheckoutContext );
@@ -27,7 +30,8 @@ export function usePaymentMethod() {
 	}
 	const paymentMethod = allPaymentMethods.find( ( { id } ) => id === paymentMethodId );
 	if ( ! paymentMethod ) {
-		throw new Error( `No payment method found matching id '${ paymentMethodId }'` );
+		debug( `No payment method found matching id '${ paymentMethodId }' in`, allPaymentMethods );
+		return null;
 	}
 	return paymentMethod;
 }

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -23,6 +23,7 @@ import {
 	useSelect,
 } from './lib/registry';
 import { createFullCreditsMethod } from './lib/payment-methods/full-credits';
+import { createFreePaymentMethod } from './lib/payment-methods/free-purchase';
 import { createStripeMethod } from './lib/payment-methods/stripe-credit-card-fields';
 import { createApplePayMethod } from './lib/payment-methods/apple-pay';
 import { createPayPalMethod } from './lib/payment-methods/paypal';
@@ -54,6 +55,7 @@ export {
 	createApplePayMethod,
 	createCreditCardMethod,
 	createExistingCardMethod,
+	createFreePaymentMethod,
 	createFullCreditsMethod,
 	createPayPalMethod,
 	createRegistry,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a "free" payment method for when the cart total is 0.

![Screen Shot 2020-02-20 at 11 31 17 AM](https://user-images.githubusercontent.com/2036909/74956761-9b2fe180-53d4-11ea-8a8b-ff022ea12af5.png)

#### Testing instructions

- Run calypso with `ENABLE_FEATURES=composite-checkout-wpcom npm start` or use the `?flags=composite-checkout-wpcom` query string when you get to checkout.
- Purchase a plan if you don't have one already (I think this part is required?).
- Add _only_ a domain mapping product to your cart. You can do this by visiting http://calypso.localhost:3000/domains/add/mapping/your-site-here
- Visit checkout and verify that the only payment method you see is "Woohoo! You don't owe us anything!".
- Complete checkout and be sure your purchase is successful.
- Verify that the Tracks events for the purchase look correct; notably `calypso_checkout_composite_free_purchase_submit_clicked`, and the `payment_method` property of `calypso_checkout_composite_payment_complete`.