### PR TITLE
Gutenboarding: create account using hints from the title and vertical (if available)

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -35,7 +35,9 @@ const SignupForm = () => {
 	const isFetchingNewUser = useSelect( select => select( USER_STORE ).isFetchingNewUser() );
 	const newUser = useSelect( select => select( USER_STORE ).getNewUser() );
 	const newUserError = useSelect( select => select( USER_STORE ).getNewUserError() );
-	const { shouldCreate } = useSelect( select => select( ONBOARD_STORE ) ).getState();
+	const { shouldCreate, siteTitle, siteVertical } = useSelect( select =>
+		select( ONBOARD_STORE )
+	).getState();
 	const langParam = useLangRouteParam();
 
 	const history = useHistory();
@@ -43,11 +45,16 @@ const SignupForm = () => {
 	const handleSignUp = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 
+		const username_hint = siteTitle || siteVertical?.label;
+
 		createAccount( {
 			email: emailVal,
 			is_passwordless: true,
 			signup_flow_name: 'gutenboarding',
 			locale: langParam,
+			...( username_hint && {
+				extra: { username_hint },
+			} ),
 		} );
 	};
 

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -55,6 +55,7 @@ export interface CreateAccountParams {
 	extra?: {
 		first_name?: string;
 		last_name?: string;
+		username_hint?: string;
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the user has entered a site title or vertical in the intent gathering phase, then it will be used as a suggestion to the backend code that generates the username.

e.g. If site vertical is "Fashion Designer" then the username might be "fashiondesigner48238"

It prioritises the site title first and falls back to the vertical.

Originally requested by @johnHackworth and wraps up work that started in D37924-code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create new accounts using `/gutenboarding`:
  * Pick a vertical from the list and don't enter a site title
  * Type a custom vertical and don't enter a site title
  * Enter anything in the vertical field and enter a site title
* Check the generated username is what you expect.