### PR TITLE
Gutenboarding: Create account using the correct locale

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -6,14 +6,15 @@ import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/com
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
+import { useHistory } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import { USER_STORE } from '../../stores/user';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { useLangRouteParam } from '../../path';
 import './style.scss';
-import { useHistory } from 'react-router-dom';
 
 type NewUserErrorResponse = import('@automattic/data-stores').User.NewUserErrorResponse;
 
@@ -35,13 +36,19 @@ const SignupForm = () => {
 	const newUser = useSelect( select => select( USER_STORE ).getNewUser() );
 	const newUserError = useSelect( select => select( USER_STORE ).getNewUserError() );
 	const { shouldCreate } = useSelect( select => select( ONBOARD_STORE ) ).getState();
+	const langParam = useLangRouteParam();
 
 	const history = useHistory();
 
 	const handleSignUp = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 
-		createAccount( { email: emailVal, is_passwordless: true, signup_flow_name: 'gutenboarding' } );
+		createAccount( {
+			email: emailVal,
+			is_passwordless: true,
+			signup_flow_name: 'gutenboarding',
+			locale: langParam,
+		} );
 	};
 
 	const handleClose = () => {

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -21,16 +21,21 @@ export const path = `/:step(${ steps.join( '|' ) })/:lang(${ langs.join( '|' ) }
 export type StepType = ValuesType< typeof Step >;
 
 export function usePath() {
-	const match = useRouteMatch< { lang?: string } >( path );
+	const langParam = useLangRouteParam();
 
 	return ( step: StepType, lang?: string ) => {
 		// When lang is null, remove lang.
 		// When lang is empty or undefined, get lang from route param.
-		lang = lang === null ? '' : lang || match?.params.lang;
+		lang = lang === null ? '' : lang || langParam;
 
 		return generatePath( path, {
 			step,
 			...( lang && langs.includes( lang ) && { lang } ),
 		} );
 	};
+}
+
+export function useLangRouteParam() {
+	const match = useRouteMatch< { lang?: string } >( path );
+	return match?.params.lang;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The current signup framework sets the language of new accounts using the language of the signup page. Seems like good behaviour to copy to me.

* Created a new `useLangRouteParam` hook by refactoring the necessary pieces out of `usePath`
* Adds the `locale` param to the `/users/new` endpoint request

![Feb-20-2020 18-23-19](https://user-images.githubusercontent.com/1500769/74903713-a99aef00-540e-11ea-823b-fb96499a3566.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/gutenboarding/about/es` in an incognito window (UI is still in English)
* Complete signup flow
* Check network tab and see that request to `/users/new` includes the `locale=es` param
* After landing in the editor the UI should be Spanish
* Check that navigating to `/gutenboarding/about/xyz` doesn't send a bogus `xyz` locale to the new user endpoint
* Check that no `locale` param is sent if no language is specified in the url

