### PR TITLE
composite-checkout: Set generic thank-you page to be the default for getThankYouPageUrl

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/checkout/composite-checkout-thank-you.ts
@@ -202,7 +202,7 @@ function getFallbackDestination( {
 			: `/checkout/thank-you/${ siteSlug }/${ pendingOrReceiptId }`;
 	}
 
-	return '/';
+	return `/checkout/thank-you/${ siteSlug }`;
 }
 
 function getEligibleDomainFromCart( cart ) {

--- a/client/my-sites/checkout/checkout/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/checkout/composite-checkout-thank-you.ts
@@ -202,7 +202,10 @@ function getFallbackDestination( {
 			: `/checkout/thank-you/${ siteSlug }/${ pendingOrReceiptId }`;
 	}
 
-	return `/checkout/thank-you/${ siteSlug }`;
+	if ( siteSlug ) {
+		return `/checkout/thank-you/${ siteSlug }`;
+	}
+	return '/';
 }
 
 function getEligibleDomainFromCart( cart ) {

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -27,6 +27,7 @@ import {
 	createExistingCardMethod,
 } from '@automattic/composite-checkout';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { format as formatUrl, parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -283,11 +284,25 @@ export default function CompositeCheckout( {
 	paypalMethod.id = 'paypal';
 	// This is defined afterward so that getThankYouUrl can be dynamic without having to re-create payment method
 	paypalMethod.submitTransaction = () => {
+		const { protocol, hostname, port, pathname } = parseUrl( window.location.href, true );
+		const successUrl = formatUrl( {
+			protocol,
+			hostname,
+			port,
+			pathname: getThankYouUrl(),
+		} );
+		const cancelUrl = formatUrl( {
+			protocol,
+			hostname,
+			port,
+			pathname,
+		} );
+
 		return makePayPalExpressRequest(
 			{
 				items,
-				successUrl: getThankYouUrl(),
-				cancelUrl: window.location.href,
+				successUrl,
+				cancelUrl,
 				siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
 				domainDetails: getDomainDetails( select ),
 				couponId: null, // TODO: get couponId

--- a/client/my-sites/checkout/checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout-thank-you.js
@@ -23,9 +23,9 @@ const defaultArgs = {
 };
 
 describe( 'getThankYouPageUrl', () => {
-	it( 'redirects to the generic thank-you page when no site is set', () => {
+	it( 'redirects to the root page when no site is set', () => {
 		const url = getThankYouPageUrl( defaultArgs );
-		expect( url ).toBe( '/checkout/thank-you/foo.bar' );
+		expect( url ).toBe( '/' );
 	} );
 
 	it( 'redirects to the thank-you page with a purchase id when a site and purchaseId is set', () => {

--- a/client/my-sites/checkout/checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout-thank-you.js
@@ -23,9 +23,9 @@ const defaultArgs = {
 };
 
 describe( 'getThankYouPageUrl', () => {
-	it( 'redirects to the root page when no site is set', () => {
+	it( 'redirects to the generic thank-you page when no site is set', () => {
 		const url = getThankYouPageUrl( defaultArgs );
-		expect( url ).toBe( '/' );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar' );
 	} );
 
 	it( 'redirects to the thank-you page with a purchase id when a site and purchaseId is set', () => {
@@ -149,11 +149,11 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/foo/bar' );
 	} );
 
-	it( 'redirects to the root url if redirectTo does not start with admin_url for site', () => {
+	it( 'redirects to the default url if redirectTo does not start with admin_url for site', () => {
 		const adminUrl = 'https://my.site/wp-admin/';
 		const redirectTo = 'https://other.site/post.php?post=515';
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', adminUrl, redirectTo } );
-		expect( url ).toBe( '/' );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar' );
 	} );
 
 	it( 'redirects to external redirectTo url if it starts with admin_url for site', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This changes the generic thank-you page from `/` (as it is in production checkout) to `/checkout/thank-you/siteSlug`. This should make paypal redirects work.

#### Testing instructions

Try to complete a paypal purchase with composite checkout and be sure it works.