### PR TITLE
Build: Disable Terser's extractComments

### DIFF
--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -96,6 +96,7 @@ function getWebpackConfig(
 					: 'docker' !== process.env.CONTAINER,
 				parallel: workerCount,
 				sourceMap: Boolean( process.env.SOURCEMAP ),
+				extractComments: false,
 				terserOptions: {
 					ecma: 5,
 					safari10: true,


### PR DESCRIPTION
This PR disables `extractComments` as since updating to the latest Terser plugin calypso build generates additional unnecessary LICENSE files. Came up in p1582131921461500-slack-team-calypso and reported originally by @jeherve 

Related: https://github.com/Automattic/jetpack/issues/14731

#### Changes proposed in this Pull Request

* Disable `extractComments` to avoid generating unnecessary LICENSE files by default.

#### Testing instructions

* Verify that Calypso still builds and runs normally, particularly the evergreen build.

