### PR TITLE
Site migration. Redirect to homepage when migration is complete.

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -11,15 +11,22 @@ import page from 'page';
 import CustomerHome from './main';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import { canCurrentUserUseCustomerHome } from 'state/sites/selectors';
+import isRecentlyMigratedSite from 'state/selectors/is-site-recently-migrated';
 
 export default function( context, next ) {
-	const siteId = getSelectedSiteId( context.store.getState() );
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );
 	}
 
-	context.primary = <CustomerHome checklistMode={ get( context, 'query.d' ) } key={ siteId } />;
+	let checklistMode = get( context, 'query.d' );
+	if ( isRecentlyMigratedSite( state, siteId ) ) {
+		checklistMode = 'migrated';
+	}
+
+	context.primary = <CustomerHome checklistMode={ checklistMode } key={ siteId } />;
 
 	next();
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -47,6 +47,7 @@ import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actio
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import isSiteRecentlyMigrated from 'state/selectors/is-site-recently-migrated';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import StatsBanners from 'my-sites/stats/stats-banners';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
@@ -194,6 +195,9 @@ class Home extends Component {
 			case 'launched':
 				return translate( 'Make sure you share it with everyone and show it off.' );
 
+			case 'migrated':
+				return translate( 'Next, make sure everything looks the way' + ' you expected.' );
+
 			default:
 				return translate(
 					'Next, use this quick list of setup tasks to get your site ready to share.'
@@ -205,6 +209,7 @@ class Home extends Component {
 		const {
 			displayChecklist,
 			isNewlyCreatedSite,
+			isRecentlyMigratedSite,
 			translate,
 			checklistMode,
 			site,
@@ -216,7 +221,7 @@ class Home extends Component {
 		} = this.props;
 
 		// Show a thank-you message 30 mins post site creation/purchase
-		if ( isNewlyCreatedSite && displayChecklist ) {
+		if ( isNewlyCreatedSite && ! isRecentlyMigratedSite && displayChecklist ) {
 			if ( siteIsUnlaunched || isAtomic ) {
 				//Only show pre-launch, or for Atomic sites
 				return (
@@ -242,6 +247,25 @@ class Home extends Component {
 					</>
 				);
 			}
+		}
+
+		if ( isRecentlyMigratedSite ) {
+			return (
+				<Card className="customer-home__migrate-card" highlight="info">
+					<img
+						src="/calypso/images/illustrations/fireworks.svg"
+						aria-hidden="true"
+						className="customer-home__migrate-fireworks"
+						alt=""
+					/>
+					<div className="customer-home__migrate-card-text">
+						<CardHeading>{ translate( 'Your site has been imported!' ) }</CardHeading>
+						<p className="customer-home__migrate-card-subtext">
+							{ this.getChecklistSubHeaderText() }
+						</p>
+					</div>
+				</Card>
+			);
 		}
 
 		// If launched, show a congratulatory message, else show the standard heading
@@ -638,6 +662,7 @@ const connectHome = connect(
 			siteHasPaidPlan: isSiteOnPaidPlan( state, siteId ),
 			isNewlyCreatedSite: isNewSite( state, siteId ),
 			isEstablishedSite: moment().isAfter( moment( createdAt ).add( 2, 'days' ) ),
+			isRecentlyMigratedSite: isSiteRecentlyMigrated( state, siteId ),
 			siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 			staticHomePageId: getSiteFrontPage( state, siteId ),
 			showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -196,7 +196,7 @@ class Home extends Component {
 				return translate( 'Make sure you share it with everyone and show it off.' );
 
 			case 'migrated':
-				return translate( 'Next, make sure everything looks the way' + ' you expected.' );
+				return translate( 'Next, make sure everything looks the way you expected.' );
 
 			default:
 				return translate(

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -1,4 +1,3 @@
-
 @mixin display-grid {
 	display: -ms-grid;
 	display: grid;
@@ -54,7 +53,7 @@
 	&__heading {
 		display: flex;
 		@include breakpoint( '<660px' ) {
-			margin: 1.5em 16px 0 16px;
+			margin: 1.5em 16px 0;
 		}
 
 		.formatted-header {
@@ -78,11 +77,13 @@
 			height: 50px;
 		}
 	}
-	&__launch-card {
+	&__launch-card,
+	&__migrate-card {
 		display: flex;
 		padding: 12px 16px;
 
-		.customer-home__launch-fireworks {
+		.customer-home__launch-fireworks,
+		.customer-home__migrate-fireworks {
 			margin-right: 18px;
 			width: 100px;
 
@@ -91,7 +92,8 @@
 			}
 		}
 
-		.customer-home__launch-card-text {
+		.customer-home__launch-card-text,
+		.customer-home__migrate-card-text {
 			margin: auto 0;
 
 			.card-heading {
@@ -99,7 +101,8 @@
 			}
 		}
 
-		.customer-home__launch-card-subtext {
+		.customer-home__launch-card-subtext,
+		.customer-home__migrate-card-subtext {
 			margin: 0;
 			font-size: 14px;
 			font-weight: 300;

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -379,8 +379,26 @@ class SectionMigrate extends Component {
 					{ this.state.errorMessage }
 				</div>
 				<Button primary onClick={ this.resetMigration }>
-					{ translate( 'Back to your site' ) }
+					{ translate( 'Try again' ) }
 				</Button>
+				<p>
+					{ translate(
+						'Or {{supportLink}}contact us{{/supportLink}} so we can' +
+							' figure out exactly' +
+							' what needs adjusting and get your site imported.',
+						{
+							components: {
+								supportLink: (
+									<a
+										href="https://support.wordpress.com"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+					) }
+				</p>
 			</Card>
 		);
 	}

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -74,6 +74,10 @@ class SectionMigrate extends Component {
 		if ( this.props.targetSiteId !== prevProps.targetSiteId ) {
 			this.updateFromAPI();
 		}
+
+		if ( 'done' === this.state.migrationStatus ) {
+			this.finishMigration();
+		}
 	}
 
 	fetchSourceSitePluginsAndThemes = () => {
@@ -113,6 +117,17 @@ class SectionMigrate extends Component {
 		const { targetSiteId } = this.props;
 
 		return sourceSite.jetpack && sourceSite.ID !== targetSiteId;
+	};
+
+	finishMigration = () => {
+		const { targetSiteId, targetSiteSlug } = this.props;
+
+		wpcom
+			.undocumented()
+			.resetMigration( targetSiteId )
+			.finally( () => {
+				page( `/home/${ targetSiteSlug }` );
+			} );
 	};
 
 	resetMigration = () => {
@@ -574,8 +589,7 @@ class SectionMigrate extends Component {
 				break;
 
 			case 'done':
-				migrationElement = this.renderMigrationComplete();
-				break;
+				return null;
 
 			case 'error':
 				migrationElement = this.renderMigrationError();

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -81,8 +81,8 @@ class StepUpgrade extends Component {
 							<h4 className="migrate__plan-feature-header">
 								{ translate( 'Your custom themes' ) }
 							</h4>
-							{ themes.slice( 0, 2 ).map( theme => (
-								<div className="migrate__plan-upsell-item">
+							{ themes.slice( 0, 2 ).map( ( theme, index ) => (
+								<div className="migrate__plan-upsell-item" key={ index }>
 									<Gridicon size={ 18 } icon="checkmark" />
 									<div className="migrate__plan-upsell-item-label">{ theme.name }</div>
 								</div>
@@ -100,8 +100,8 @@ class StepUpgrade extends Component {
 							<h4 className="migrate__plan-feature-header">
 								{ translate( 'Your active plugins' ) }
 							</h4>
-							{ plugins.slice( 0, 2 ).map( plugin => (
-								<div className="migrate__plan-upsell-item">
+							{ plugins.slice( 0, 2 ).map( ( plugin, index ) => (
+								<div className="migrate__plan-upsell-item" key={ index }>
 									<Gridicon size={ 18 } icon="checkmark" />
 									<div className="migrate__plan-upsell-item-label">{ plugin.name }</div>
 								</div>

--- a/client/state/selectors/is-site-recently-migrated.js
+++ b/client/state/selectors/is-site-recently-migrated.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import getRawSite from 'state/selectors/get-raw-site';
+
+/**
+ * Returns true if someone has recently migrated another WordPress site
+ * into this one.
+ *
+ * @param {object} state Global state tree
+ * @param {object} siteId Site ID
+ * @returns {boolean} True if site has recently been the target of a migration
+ */
+export default function isSiteRecentlyMigrated( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	const siteMigrationMeta = get( site, 'site_migration', {} );
+	const status = get( siteMigrationMeta, 'status' );
+	const lastModified = get( siteMigrationMeta, 'last_modified' );
+
+	if ( ! status || ! lastModified ) {
+		return false;
+	}
+
+	if ( 'done' === status ) {
+		const lastModMoment = moment( lastModified );
+		if ( moment().diff( lastModMoment, 'days' ) <= 2 ) {
+			return true;
+		}
+	}
+
+	return false;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a migration is complete we reset it and redirect to the Customer Home.
* If a site has been the target of a successful migration in the last two days, we show a custom header on the Customer Home.

The design also calls for a customised checklist on the Home – we'll look at that in a separate PR.

#### Testing instructions

* Apply the PR and run Calypso locally, or use calypso.live (for the latter, add `?flags=tools/migrate` to the end of the URL to enable the feature flag).
* Do a migration: go to the import section of a Simple site, enter the URL of a Jetpack site and follow the steps you're presented with. (If you're migrating to a site you've migrated to whose `done` status hasn't been cleared yet, you may need to reset the migration first with a request to the `reset-migration` endpoint.)
* When the migration finishes you should be redirected to the My Home, unless there was an error.
* If you visit My Home for any site that has been migrated in the last two days, you should see the special header on the page telling you that your site has been migrated. For any other site, you should see the default header.

![image](https://user-images.githubusercontent.com/1647564/74931762-37a7b300-53d8-11ea-8848-659727dcc5c9.png)

