### PR TITLE
Site Migration: Fix longer theme/plugin names not being visible on the upgrade plan confirmation screen

### DIFF
--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -92,20 +92,24 @@
 	flex-basis: 100%;
 	max-width: 180px;
 	white-space: nowrap;
+	display: flex;
+	flex-direction: row;
 
 	.gridicon {
-		vertical-align: middle;
 		margin-right: 8px;
+		flex-grow: 0;
+		flex-shrink: 0;
 	}
 }
 
 .migrate__plan-upsell-item-label {
 	display: inline-block;
-	max-width:85%;
 	line-height: 18px;
-	vertical-align: middle;
 	overflow: hidden;
 	text-overflow: ellipsis;
+
+	flex-grow: 1;
+	flex-shrink: 1;
 }
 
 .migrate__import-link {

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -89,11 +89,10 @@
 }
 
 .migrate__plan-upsell-item {
+	display: flex;
 	flex-basis: 100%;
 	max-width: 180px;
 	white-space: nowrap;
-	display: flex;
-	flex-direction: row;
 
 	.gridicon {
 		margin-right: 8px;
@@ -107,9 +106,7 @@
 	line-height: 18px;
 	overflow: hidden;
 	text-overflow: ellipsis;
-
 	flex-grow: 1;
-	flex-shrink: 1;
 }
 
 .migrate__import-link {

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -92,8 +92,6 @@
 	flex-basis: 100%;
 	max-width: 180px;
 	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
 
 	.gridicon {
 		vertical-align: middle;
@@ -103,8 +101,11 @@
 
 .migrate__plan-upsell-item-label {
 	display: inline-block;
+	max-width:85%;
 	line-height: 18px;
 	vertical-align: middle;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .migrate__import-link {

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -84,9 +84,7 @@ class StepUpgrade extends Component {
 							{ themes.slice( 0, 2 ).map( theme => (
 								<div className="migrate__plan-upsell-item">
 									<Gridicon size={ 18 } icon="checkmark" />
-									<div className="migrate__plan-upsell-item-label">
-										{ theme.name } fsaasf saf asf asf asfasf
-									</div>
+									<div className="migrate__plan-upsell-item-label">{ theme.name }</div>
 								</div>
 							) ) }
 							{ themes.length > 2 && (
@@ -105,9 +103,7 @@ class StepUpgrade extends Component {
 							{ plugins.slice( 0, 2 ).map( plugin => (
 								<div className="migrate__plan-upsell-item">
 									<Gridicon size={ 18 } icon="checkmark" />
-									<div className="migrate__plan-upsell-item-label">
-										{ plugin.name } fiuewhif wehf ehiufw huifew hf
-									</div>
+									<div className="migrate__plan-upsell-item-label">{ plugin.name }</div>
 								</div>
 							) ) }
 							{ plugins.length > 2 && (

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -84,7 +84,9 @@ class StepUpgrade extends Component {
 							{ themes.slice( 0, 2 ).map( theme => (
 								<div className="migrate__plan-upsell-item">
 									<Gridicon size={ 18 } icon="checkmark" />
-									<div className="migrate__plan-upsell-item-label">{ theme.name }</div>
+									<div className="migrate__plan-upsell-item-label">
+										{ theme.name } fsaasf saf asf asf asfasf
+									</div>
 								</div>
 							) ) }
 							{ themes.length > 2 && (
@@ -103,7 +105,9 @@ class StepUpgrade extends Component {
 							{ plugins.slice( 0, 2 ).map( plugin => (
 								<div className="migrate__plan-upsell-item">
 									<Gridicon size={ 18 } icon="checkmark" />
-									<div className="migrate__plan-upsell-item-label">{ plugin.name }</div>
+									<div className="migrate__plan-upsell-item-label">
+										{ plugin.name } fiuewhif wehf ehiufw huifew hf
+									</div>
 								</div>
 							) ) }
 							{ plugins.length > 2 && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes an issue in the Site Migration upgrade screen where all text was replaced with ellipsis for longer items.

#### Testing instructions

* Run a site migration for a site that has a longer plugin name.
* Make sure on the confirmation screen the plugin name is visible and it's cut with an ellipsis
* Make sure the UI is not broken in other ways. 
