### PR TITLE
Components: Don't update placeholder dimensions if no placeholders

### DIFF
--- a/client/components/infinite-list/scroll-helper.js
+++ b/client/components/infinite-list/scroll-helper.js
@@ -130,6 +130,10 @@ class ScrollHelper {
 		const topPlaceholderRect = this.getTopPlaceholderBounds();
 		const bottomPlaceholderRect = this.getBottomPlaceholderBounds();
 
+		if ( ! topPlaceholderRect || ! bottomPlaceholderRect ) {
+			return;
+		}
+
 		this.topPlaceholderHeight = topPlaceholderRect.height;
 		this.containerTop = topPlaceholderRect.top;
 


### PR DESCRIPTION
This PR makes the ScrollHelper a bit safer than it was before - before attempting to update the placeholder dimensions, it will verify that the corresponding placeholder element and its `getBoundingClientRect` actually exist before attempting to update the dimensions. 

Fixing this should prevent from getting the "Cannot read property 'height' of null" error that often:

![](https://cldup.com/RWQUfX0Gmq.png)

#### Changes proposed in this Pull Request

* Components: Don't update placeholder dimensions if no placeholders

#### Testing instructions

* Log in as a new fresh user, and unsubscribe from any blogs you're following.
* Go to http://calypso.localhost:3000/read
* Verify you no longer get the error from above.
