### PR TITLE
Gutenboarding: Retain language fragment across steps, drop `/about`

### DIFF
--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -7,7 +7,7 @@ import { I18nProvider } from '@automattic/react-i18n';
 import { getLanguageFile } from '../../lib/i18n-utils/switch-locale';
 import React from 'react';
 import ReactDom from 'react-dom';
-import { BrowserRouter, Route, Switch, Redirect, generatePath } from 'react-router-dom';
+import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import config from '../../config';
 import { subscribe, select } from '@wordpress/data';
 
@@ -17,7 +17,7 @@ import { subscribe, select } from '@wordpress/data';
 import { Gutenboard } from './gutenboard';
 import { setupWpDataDebug } from './devtools';
 import accessibleFocus from 'lib/accessible-focus';
-import { path, Step } from './path';
+import { path } from './path';
 import { USER_STORE } from './stores/user';
 
 /**
@@ -61,7 +61,7 @@ window.AppBoot = async () => {
 						<Gutenboard />
 					</Route>
 					<Route>
-						<Redirect to={ generatePath( path, { step: Step.IntentGathering } ) } />
+						<Redirect to="/" />
 					</Route>
 				</Switch>
 			</BrowserRouter>

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -31,7 +31,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 			<VerticalBackground />
 			{ isCreatingSite && <Redirect push to={ makePath( Step.CreateSite ) } /> }
 			<Switch>
-				<Route path={ makePath( Step.IntentGathering ) }>
+				<Route exact path={ makePath( Step.IntentGathering ) }>
 					<AcquireIntent />
 				</Route>
 

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -5,8 +5,11 @@ import { generatePath, useRouteMatch } from 'react-router-dom';
 import { getLanguageSlugs } from '../../lib/i18n-utils';
 import { ValuesType } from 'utility-types';
 
+// The first step (IntentGathering), which is found at the root route (/), is set as
+// `undefined`, as that's what matching our `path` pattern against a route with no explicit
+// step fragment will return.
 export const Step = {
-	IntentGathering: 'about',
+	IntentGathering: undefined,
 	DesignSelection: 'design',
 	PageSelection: 'pages',
 	Signup: 'signup',
@@ -14,19 +17,25 @@ export const Step = {
 } as const;
 
 export const langs: string[] = getLanguageSlugs();
-export const steps = Object.keys( Step ).map( key => Step[ key as keyof typeof Step ] );
+// We remove falsey `steps` with `.filter( Boolean )` as they'd mess up our |-separated route pattern.
+export const steps = Object.values( Step ).filter( Boolean );
 
-export const path = `/:step(${ steps.join( '|' ) })/:lang(${ langs.join( '|' ) })?`;
+// We add back the possibility of an empty step fragment through the `?` question mark at the end of that fragment.
+export const path = `/:step(${ steps.join( '|' ) })?/:lang(${ langs.join( '|' ) })?`;
 
 export type StepType = ValuesType< typeof Step >;
 
 export function usePath() {
 	const match = useRouteMatch< { lang?: string } >( path );
 
-	return ( step: StepType, lang?: string ) => {
+	return ( step?: StepType, lang?: string ) => {
 		// When lang is null, remove lang.
 		// When lang is empty or undefined, get lang from route param.
 		lang = lang === null ? '' : lang || match?.params.lang;
+
+		if ( ! step && ! lang ) {
+			return '/';
+		}
 
 		return generatePath( path, {
 			step,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Gutenboarding: Retain language fragment across steps, and drop the `/about` route (moving the initial step back to `/gutenboarding`).

This fixes an issue that @sirreal pointed out here: https://github.com/Automattic/wp-calypso/pull/39312#pullrequestreview-360945408

> When entering the flow at `/gutenboarding/es`, we're redirected to `/gutenboarding/about` and the locale is lost. Functionality that implemented this was added and removed from this PR, but I feel pretty strongly that this should work (redirect to `/gutenboarding/about/es`).

Also mentioned by @andrewserong at https://github.com/Automattic/wp-calypso/pull/39560#pullrequestreview-361665052.

To that end, I've also decided to move the initial step back to `/gutenboarding` (rather than `/about`). I think it makes conceptually sense to have the first step of the onboarding flow at the 'root route', rather than redirect from there.

This required a few changes to some of our routing utils, which I hope make sense, too :slightly_smiling_face: 

#### Testing instructions

Stolen from #39312 :grimacing: 

- `/gutenboarding` continues to work as expected for the entire flow
- `/gutenboarding/fr` keeps the lang for the entire flow
- `/gutenboarding/foobar` drops the bad language
- `/gutenboarding/design/foobar` redirects to the beginning of the flow [this has changed wrt #39312]
