### PR TITLE
Customer Home: Update font weights to use 400 weight

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -54,7 +54,7 @@
 	&__heading {
 		display: flex;
 		@include breakpoint( '<660px' ) {
-			margin: 1.5em 16px 0 16px;
+			margin: 1.5em 16px 0;
 		}
 
 		.formatted-header {
@@ -102,7 +102,6 @@
 		.customer-home__launch-card-subtext {
 			margin: 0;
 			font-size: 14px;
-			font-weight: 300;
 		}
 	}
 
@@ -132,7 +131,6 @@
 			display: block;
 
 			@include breakpoint( '<480px' ) {
-				font-weight: 300;
 				margin: auto 14px;
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes instances of `font-weight:300` in the banner and buttons for better readability and consistency.
* This may be a very minor nitpick, but it stuck out to me as I was reviewing #39564; we don't use 300 weights very often, so it looked out of place. Other designers are welcome to overrule me on it, though. :)

**Before**
<img width="1063" alt="Screen Shot 2020-02-20 at 9 57 47 AM" src="https://user-images.githubusercontent.com/2124984/74946562-7bde8780-53c7-11ea-84d6-ab6f14f6c5b5.png">

**After**

<img width="1075" alt="Screen Shot 2020-02-20 at 9 56 57 AM" src="https://user-images.githubusercontent.com/2124984/74946473-59e50500-53c7-11ea-92a0-96143dd88010.png">

#### Testing instructions

* Switch to this PR
* Create a new site from `/start` and navigate to Customer Home at `/home`, then launch your site
* The welcome banner at the top should show the subtext in 400 weight