### PR TITLE
Gutenboarding: Use locale path for i18n

### DIFF
--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -85,9 +85,8 @@ window.AppBoot = async () => {
  */
 async function getLocale(): Promise< [ string, object ] > {
 	// Explicit locale slug.
-	const lastPathSegment = window.location.href.substr(
-		window.location.href.lastIndexOf( '/' ) + 1
-	);
+	const pathname = new URL( window.location.href ).pathname;
+	const lastPathSegment = pathname.substr( pathname.lastIndexOf( '/' ) + 1 );
 	if ( getLanguageSlugs().includes( lastPathSegment ) ) {
 		const data = await getLocaleData( lastPathSegment );
 		return [ lastPathSegment, data ];

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -5,7 +5,7 @@ import '@automattic/calypso-polyfills';
 import { setLocaleData } from '@wordpress/i18n';
 import { I18nProvider } from '@automattic/react-i18n';
 import { getLanguageSlugs } from '../../lib/i18n-utils';
-import { getLanguageFile } from '../../lib/i18n-utils/switch-locale';
+import { getLanguageFile, switchWebpackCSS } from '../../lib/i18n-utils/switch-locale';
 import React from 'react';
 import ReactDom from 'react-dom';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
@@ -52,6 +52,11 @@ window.AppBoot = async () => {
 		const [ userLocale, localeData ] = await getLocale();
 		setLocaleData( localeData );
 		locale = userLocale;
+
+		// FIXME: Use rtl detection tooling
+		if ( ( localeData as any )[ 'text direction\u0004ltr' ]?.[ 0 ] === 'rtl' ) {
+			switchWebpackCSS( true );
+		}
 	} catch {}
 
 	ReactDom.render(

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { generatePath, useRouteMatch } from 'react-router-dom';
-import { getLanguageSlugs } from '../../lib/i18n-utils';
+import { getLanguageRouteParam } from '../../lib/i18n-utils';
 import { ValuesType } from 'utility-types';
 
 // The first step (IntentGathering), which is found at the root route (/), is set as
@@ -16,12 +16,11 @@ export const Step = {
 	CreateSite: 'create-site',
 } as const;
 
-export const langs: string[] = getLanguageSlugs();
 // We remove falsey `steps` with `.filter( Boolean )` as they'd mess up our |-separated route pattern.
 export const steps = Object.values( Step ).filter( Boolean );
 
 // We add back the possibility of an empty step fragment through the `?` question mark at the end of that fragment.
-export const path = `/:step(${ steps.join( '|' ) })?/:lang(${ langs.join( '|' ) })?`;
+export const path = `/:step(${ steps.join( '|' ) })?/${ getLanguageRouteParam() }`;
 
 export type StepType = ValuesType< typeof Step >;
 
@@ -37,10 +36,15 @@ export function usePath() {
 			return '/';
 		}
 
-		return generatePath( path, {
-			step,
-			...( lang && langs.includes( lang ) && { lang } ),
-		} );
+		try {
+			return generatePath( path, {
+				step,
+				lang,
+			} );
+		} catch {
+			// If we get an invalid lang, `generatePath` throws a TypeError.
+			return generatePath( path, { step } );
+		}
 	};
 }
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -3,7 +3,7 @@
  */
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
-import { map, includes } from 'lodash';
+import { forEach, includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -226,10 +226,15 @@ function setRTLFlagOnCSSLink( url, isRTL ) {
 	return ! url.endsWith( '.rtl.css' ) ? url : url.replace( /\.rtl.css$/, '.css' );
 }
 
-function switchWebpackCSS( isRTL ) {
+/**
+ * Switch the Calypso CSS between RTL and LTR versions.
+ *
+ * @param {boolean} isRTL True to use RTL css.
+ */
+export function switchWebpackCSS( isRTL ) {
 	const currentLinks = document.querySelectorAll( 'link[rel="stylesheet"][data-webpack]' );
 
-	return map( currentLinks, async currentLink => {
+	forEach( currentLinks, async currentLink => {
 		const currentHref = currentLink.getAttribute( 'href' );
 		const newHref = setRTLFlagOnCSSLink( currentHref, isRTL );
 		if ( currentHref === newHref ) {


### PR DESCRIPTION
- Use the locale from the path to determine the locale.
- Switch stylesheets if RTL locale is detected.

Closes #39505 

### Testing
1. Your user language (if logged in) or English https://calypso.live/gutenboarding/about?branch=gutenboarding/locale-from-path
1. Spanish https://calypso.live/gutenboarding/about/es?branch=gutenboarding/locale-from-path
1. Arabic https://calypso.live/gutenboarding/about/ar?branch=gutenboarding/locale-from-path ~(needs RTL work)~
   Look at `document.styleSheets` for `.rtl` versions of the stylesheets to verify RTL stylesheets are loaded.

