### PR TITLE
Jetpack Cloud: Create and organize routes, sections, and root page components

### DIFF
--- a/client/landing/jetpack-cloud/controller.js
+++ b/client/landing/jetpack-cloud/controller.js
@@ -11,7 +11,6 @@ import { Provider as ReduxProvider } from 'react-redux';
 import JetpackCloudLayout from './layout';
 import JetpackCloudSidebar from './components/sidebar';
 import LogItem from './components/log-item';
-import { getCurrentUserName } from 'state/current-user/selectors';
 
 export const makeLayout = ( context, next ) => {
 	const { primary, secondary, store } = context;
@@ -31,49 +30,5 @@ export const clientRender = context => {
 
 export function setupSidebar( context, next ) {
 	context.secondary = <JetpackCloudSidebar path={ context.path } />;
-	next();
-}
-
-export function jetpackCloud( context, next ) {
-	context.primary = <div>Hi, this is the Jetpack.com Cloud!</div>;
-	next();
-}
-
-export function jetpackBackups( context, next ) {
-	context.primary = (
-		<div>
-			This is the Jetpack Backup landing page!
-			<LogItem
-				header="Unexpected core file: sx--a4bp.php"
-				subheader="Threat found on 14 September, 2019"
-			>
-				<h3>Item Header</h3>
-				<p>Foo</p>
-				<h3>Item Header 2</h3>
-				<p>Bar</p>
-			</LogItem>
-			<LogItem
-				header="Unexpected core file: sx--a4bp.php"
-				subheader="Threat found on 14 September, 2019"
-				tag="critical"
-				highlight="error"
-			>
-				Hello
-			</LogItem>
-		</div>
-	);
-	next();
-}
-
-export function jetpackScan( context, next ) {
-	const state = context.store.getState();
-	const currentUserName = getCurrentUserName( state );
-
-	context.primary = (
-		<div>
-			<p>{ currentUserName ? `Hi, ${ currentUserName }!` : 'Hi!' }</p>
-			<p>This is the Jetpack Scan landing page!</p>
-		</div>
-	);
 	next();
 }

--- a/client/landing/jetpack-cloud/controller.js
+++ b/client/landing/jetpack-cloud/controller.js
@@ -10,7 +10,6 @@ import { Provider as ReduxProvider } from 'react-redux';
  */
 import JetpackCloudLayout from './layout';
 import JetpackCloudSidebar from './components/sidebar';
-import LogItem from './components/log-item';
 
 export const makeLayout = ( context, next ) => {
 	const { primary, secondary, store } = context;

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -6,24 +6,36 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import {
-	clientRender,
-	jetpackCloud,
-	jetpackBackups,
-	jetpackScan,
-	makeLayout,
-	setupSidebar,
-} from './controller';
 import { normalize } from 'lib/route';
+import { siteSelection } from 'my-sites/controller';
+import { clientRender, makeLayout, setupSidebar } from './controller';
+import { jetpackCloudDashboard } from './sections/dashboard/controller';
+import { jetpackCloudBackups } from './sections/backups/controller';
+import { jetpackCloudBackupDetail } from './sections/backup-detail/controller';
+import { jetpackCloudBackupDownload } from './sections/backup-download/controller';
+import { jetpackCloudBackupRestore } from './sections/backup-restore/controller';
+import { jetpackCloudScan } from './sections/scan/controller';
+import { jetpackCloudScanHistory } from './sections/scan-history/controller';
+import { jetpackCloudSettings } from './sections/settings/controller';
 
 const router = () => {
 	page( '*', normalize );
 
-	page( '/', setupSidebar, jetpackCloud, makeLayout, clientRender );
+	page( '/', setupSidebar, jetpackCloudDashboard, makeLayout, clientRender );
 
-	page( '/backups', setupSidebar, jetpackBackups, makeLayout, clientRender );
+	page( '/backups', siteSelection, setupSidebar, jetpackCloudBackups, makeLayout, clientRender );
+	page( '/backups/:site', siteSelection, setupSidebar, jetpackCloudBackups, makeLayout, clientRender );
+	page( '/backups/:site/detail/:backupId', siteSelection, setupSidebar, jetpackCloudBackupDetail, makeLayout, clientRender );
+	page( '/backups/:site/download/:downloadId', siteSelection, setupSidebar, jetpackCloudBackupDownload, makeLayout, clientRender )
+	page( '/backups/:site/restore', siteSelection, setupSidebar, jetpackCloudBackupRestore, makeLayout, clientRender )
+	page( '/backups/:site/restore/:restoreId', siteSelection, setupSidebar, jetpackCloudBackupRestore, makeLayout, clientRender );
 
-	page( '/scan', setupSidebar, jetpackScan, makeLayout, clientRender );
+	page( '/scan', siteSelection, setupSidebar, jetpackCloudScan, makeLayout, clientRender );
+	page( '/scan/:site', siteSelection, setupSidebar, jetpackCloudScan, makeLayout, clientRender );
+	page( '/scan/:site/history', siteSelection, setupSidebar, jetpackCloudScanHistory, makeLayout, clientRender );
+
+	page( '/settings', siteSelection, setupSidebar, jetpackCloudSettings, makeLayout, clientRender );
+	page( '/settings/:site', siteSelection, setupSidebar, jetpackCloudSettings, makeLayout, clientRender );
 };
 
 export default router;

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -26,7 +26,7 @@ const router = () => {
 	page( '/backups', siteSelection, setupSidebar, jetpackCloudBackups, makeLayout, clientRender );
 	page( '/backups/:site', siteSelection, setupSidebar, jetpackCloudBackups, makeLayout, clientRender );
 	page( '/backups/:site/detail/:backupId', siteSelection, setupSidebar, jetpackCloudBackupDetail, makeLayout, clientRender );
-	page( '/backups/:site/download/:downloadId', siteSelection, setupSidebar, jetpackCloudBackupDownload, makeLayout, clientRender )
+	page( '/backups/:site/download/:downloadId', siteSelection, setupSidebar, jetpackCloudBackupDownload, makeLayout, clientRender );
 	page( '/backups/:site/restore', siteSelection, setupSidebar, jetpackCloudBackupRestore, makeLayout, clientRender )
 	page( '/backups/:site/restore/:restoreId', siteSelection, setupSidebar, jetpackCloudBackupRestore, makeLayout, clientRender );
 

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -27,7 +27,7 @@ const router = () => {
 	page( '/backups/:site', siteSelection, setupSidebar, jetpackCloudBackups, makeLayout, clientRender );
 	page( '/backups/:site/detail/:backupId', siteSelection, setupSidebar, jetpackCloudBackupDetail, makeLayout, clientRender );
 	page( '/backups/:site/download/:downloadId', siteSelection, setupSidebar, jetpackCloudBackupDownload, makeLayout, clientRender );
-	page( '/backups/:site/restore', siteSelection, setupSidebar, jetpackCloudBackupRestore, makeLayout, clientRender )
+	page( '/backups/:site/restore', siteSelection, setupSidebar, jetpackCloudBackupRestore, makeLayout, clientRender );
 	page( '/backups/:site/restore/:restoreId', siteSelection, setupSidebar, jetpackCloudBackupRestore, makeLayout, clientRender );
 
 	page( '/scan', siteSelection, setupSidebar, jetpackCloudScan, makeLayout, clientRender );

--- a/client/landing/jetpack-cloud/section.js
+++ b/client/landing/jetpack-cloud/section.js
@@ -1,6 +1,6 @@
 export const JETPACK_CLOUD_SECTION_DEFINITION = {
 	name: 'jetpack-cloud',
-	paths: [ '/', '/scan', '/backups' ],
+	paths: [ '/', '/scan', '/backups', '/settings' ],
 	module: 'jetpack-cloud',
 	secondary: false,
 	group: 'jetpack-cloud',

--- a/client/landing/jetpack-cloud/sections/backup-detail/controller.js
+++ b/client/landing/jetpack-cloud/sections/backup-detail/controller.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackCloudBackupDetailPage from './main';
+
+export function jetpackCloudBackupDetail( context, next ) {
+	const backupId = parseInt( context.params.backupId );
+
+	context.primary = <JetpackCloudBackupDetailPage backupId={ backupId } />
+	
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/backup-detail/controller.js
+++ b/client/landing/jetpack-cloud/sections/backup-detail/controller.js
@@ -11,7 +11,7 @@ import JetpackCloudBackupDetailPage from './main';
 export function jetpackCloudBackupDetail( context, next ) {
 	const backupId = parseInt( context.params.backupId );
 
-	context.primary = <JetpackCloudBackupDetailPage backupId={ backupId } />
+	context.primary = <JetpackCloudBackupDetailPage backupId={ backupId } />;
 	
 	next();
 }

--- a/client/landing/jetpack-cloud/sections/backup-detail/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backup-detail/main.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class JetpackCloudBackupDetailPage extends Component {
+	render() {
+		const { siteId, backupId } = this.props;
+
+		return (
+			<div>
+				<div>Welcome to the backup detail page</div>
+				<div>Site ID: { siteId }</div>
+				<div>Backup ID: { backupId }</div>
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+	};
+} )( JetpackCloudBackupDetailPage );

--- a/client/landing/jetpack-cloud/sections/backup-download/controller.js
+++ b/client/landing/jetpack-cloud/sections/backup-download/controller.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackCloudBackupDownloadPage from './main';
+
+export function jetpackCloudBackupDownload( context, next ) {
+	const downloadId = parseInt( context.params.downloadId );
+
+	context.primary = <JetpackCloudBackupDownloadPage downloadId={ downloadId } />
+	
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/backup-download/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backup-download/main.jsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class JetpackCloudBackupDownloadPage extends Component {
+	render() {
+		const { siteId, downloadId } = this.props;
+
+		return (
+			<div>
+				<div>Welcome to the download page</div>
+				<div>Site ID: { siteId }</div>
+				<div>Download ID: { downloadId }</div>
+			</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+	};
+} )( JetpackCloudBackupDownloadPage );

--- a/client/landing/jetpack-cloud/sections/backup-restore/controller.js
+++ b/client/landing/jetpack-cloud/sections/backup-restore/controller.js
@@ -15,7 +15,7 @@ export function jetpackCloudBackupRestore( context, next ) {
 		<JetpackCloudBackupRestorePage
 			restoreId={
 				context.params.restoreId
-					? parseInt( context.params.restoreId )
+					? restoreId
 					: null
 			}
 		/>

--- a/client/landing/jetpack-cloud/sections/backup-restore/controller.js
+++ b/client/landing/jetpack-cloud/sections/backup-restore/controller.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackCloudBackupRestorePage from './main';
+
+export function jetpackCloudBackupRestore( context, next ) {
+	const restoreId = parseInt( context.params.restoreId );
+
+	context.primary = (
+		<JetpackCloudBackupRestorePage
+			restoreId={
+				context.params.restoreId
+					? parseInt( context.params.restoreId )
+					: null
+			}
+		/>
+	);
+	
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/backup-restore/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backup-restore/main.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class JetpackCloudBackupRestorePage extends Component {
+	render() {
+		const { restoreId, siteId } = this.props;
+
+		return (
+			restoreId
+				? <div>Welcome to the restore page { siteId }. Restoring backup ID { restoreId }.</div>
+				: <div>Welcome to the restore page for { siteId }. You'll choose a restore point here.</div>
+		);
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+	};
+} )( JetpackCloudBackupRestorePage );

--- a/client/landing/jetpack-cloud/sections/backups/controller.js
+++ b/client/landing/jetpack-cloud/sections/backups/controller.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackCloudBackupsPage from './main';
+
+export function jetpackCloudBackups( context, next ) {
+	context.primary = <JetpackCloudBackupsPage />;
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class JetpackCloudBackupsPage extends Component {
+	render() {
+		return ( <div>Welcome to the backup detail page for site { this.props.siteId }</div> );
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+	};
+} )( JetpackCloudBackupsPage );

--- a/client/landing/jetpack-cloud/sections/dashboard/controller.js
+++ b/client/landing/jetpack-cloud/sections/dashboard/controller.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackCloudDashboardPage from './main';
+
+export function jetpackCloudDashboard( context, next ) {
+	context.primary = <JetpackCloudDashboardPage />;
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/dashboard/main.jsx
+++ b/client/landing/jetpack-cloud/sections/dashboard/main.jsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserName } from 'state/current-user/selectors';
+
+class JetpackCloudDashboardPage extends Component {
+	render() {
+		return ( <div>Welcome to the dashboard, { this.props.currentUserName }!</div> );
+	}
+}
+
+export default connect( state => {
+	return {
+		currentUserName: getCurrentUserName( state ),
+	};
+} )( JetpackCloudDashboardPage );

--- a/client/landing/jetpack-cloud/sections/scan-history/controller.js
+++ b/client/landing/jetpack-cloud/sections/scan-history/controller.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackCloudScanHistoryPage from './main';
+
+export function jetpackCloudScanHistory( context, next ) {
+	context.primary = <JetpackCloudScanHistoryPage />;
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/scan-history/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan-history/main.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class JetpackCloudScanHistoryPage extends Component {
+	render() {
+		return ( <div>Welcome to the scan history page for site { this.props.siteId }</div> );
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+	};
+} )( JetpackCloudScanHistoryPage );

--- a/client/landing/jetpack-cloud/sections/scan/controller.js
+++ b/client/landing/jetpack-cloud/sections/scan/controller.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackCloudScanPage from './main';
+
+export function jetpackCloudScan( context, next ) {
+	context.primary = <JetpackCloudScanPage />;
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class JetpackCloudScanPage extends Component {
+	render() {
+		return ( <div>Welcome to the scan page for site { this.props.siteId }</div> );
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+	};
+} )( JetpackCloudScanPage );

--- a/client/landing/jetpack-cloud/sections/settings/controller.js
+++ b/client/landing/jetpack-cloud/sections/settings/controller.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import JetpackCloudSettingsPage from './main';
+
+export function jetpackCloudSettings( context, next ) {
+	context.primary = <JetpackCloudSettingsPage />;
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class JetpackCloudSettingsPage extends Component {
+	render() {
+		return ( <div>Welcome to the settings page for { this.props.siteId }</div> );
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		siteId,
+	};
+} )( JetpackCloudSettingsPage );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Created appropriate routes for each of the pages that we'll have initially
* Reorganized page-level components into `sections` folder
* Connected page-level components to app state
* General cleanup of root controller (more to come)

#### Testing instructions

Visit the following pages, with your own jetpack test site slug substituted. Each should load its respective page with correctly resolved blog ID (and in some cases, download/backup/restore ID).

- `jetpack.cloud.localhost:3000/dashboard`
- `jetpack.cloud.localhost:3000/backups/{siteSlug}`
- `jetpack.cloud.localhost:3000/backups/{siteSlug}/details/12345678`
- `jetpack.cloud.localhost:3000/backups/{siteSlug}/download/12345678`
- `jetpack.cloud.localhost:3000/backups/{siteSlug}/restore/123455678`
- `jetpack.cloud.localhost:3000/scan/{siteSlug}`
- `jetpack.cloud.localhost:3000/scan/{siteSlug}/history`
- `jetpack.cloud.localhost:3000/settings/{siteSlug}`

Ensure there are no issues in the build, no errors in the console, and no effect when booting normal Calypso.