### PR TITLE
[Gutenboarding]: add autofocus to account creation email input field

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/signup-form/index.tsx
@@ -81,6 +81,7 @@ const SignupForm = () => {
 			isDismissible={ false }
 			title={ NO__( 'Sign up to save your changes' ) }
 			onRequestClose={ handleClose }
+			focusOnMount={ false }
 		>
 			<form onSubmit={ handleSignUp }>
 				<TextControl
@@ -94,6 +95,7 @@ const SignupForm = () => {
 						"An example of a person's email, use something appropriate for the locale"
 					) }
 					required
+					autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 				/>
 				{ errorMessage && (
 					<Notice className="signup-form__error-notice" status="error" isDismissible={ false }>


### PR DESCRIPTION
## Changes proposed in this Pull Request

This patch prevents the `<Modal />` from focussing on itself, and instead forces focus on the email input field.

![Feb-21-2020 13-16-25](https://user-images.githubusercontent.com/6458278/74998280-74dd7500-54ac-11ea-99bc-39411326a602.gif)

❓What do folks think about the trade off in relation to accessibility? Would a better description in the label mitigate this?

## Testing instructions

Trigger the signup modal in Gutenboarding.

Stare at the cursor as it blinks at you incessantly from within the email input field. Subtly mocking you. Daring you to blur it into oblivion.

