### PR TITLE
Imports: Fix state issues

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -230,15 +230,18 @@ class SectionImport extends Component {
 				importItem.site = this.props.site;
 			}
 
+			const siteTitle = importItem.siteTitle || this.props.siteTitle;
+
 			return (
 				ImporterComponent && (
 					<ImporterComponent
 						key={ importItem.type + idx }
 						site={ importItem.site }
 						fromSite={ this.props.fromSite }
+						siteTitle={ siteTitle }
 						importerStatus={ {
 							...importItem,
-							siteTitle: importItem.siteTitle || this.props.siteTitle,
+							siteTitle: siteTitle,
 						} }
 					/>
 				)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes some state issues that were appearing in the import screen when trying to upload a file.

The importer section has a lot of expectations of how it's used and when accessing an importer directly, we don't save enough data in the state to keep for later. This makes several components down the line to fail and not being able to load the respective data they need to operate.

This PR adds a "temporary" (😊) hack to make sure we're always passing the right data down the chain of components. 

Ideally this should be fixed by reworking how the data storage works and how the import events are triggered (start, current steps, etc.)

This PR only fixes part of the bigger state issue the section has - it would just load the data initially. If you refresh the page on any of the steps that come before the actual import processing screen it will fail to `Upload succeeded` screen with no way to continue with the import.


#### Testing instructions

* Checkout branch or use Calypso.live link
* Go directly to a WordPress import by adding `/?engine=wordpress` at the end of the URL.
  * Make sure you're not navigating by clicking in the UI
* Try to upload a WXR file for import
* Make sure you're able to map the authors
* Make sure you're able to finish the import.
* Try importing a Wix/GoDaddy site both by navigating the UI and accessing the importer directly


Fixes #35815 (possibly)
