### PR TITLE
Site migration: improve styling of migration error message

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -355,7 +355,7 @@ class SectionMigrate extends Component {
 		const { translate } = this.props;
 
 		return (
-			<Card className="migrate__pane">
+			<Card className="migrate__pane migrate__error">
 				<FormattedHeader
 					className="migrate__section-header"
 					headerText={ translate( 'Import failed' ) }
@@ -369,7 +369,7 @@ class SectionMigrate extends Component {
 				<Button primary onClick={ this.resetMigration }>
 					{ translate( 'Try again' ) }
 				</Button>
-				<p>
+				<p className="migrate__info">
 					{ translate(
 						'Or {{supportLink}}contact us{{/supportLink}} so we can' +
 							' figure out exactly' +

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -249,3 +249,12 @@
 .migrate__buttons-wrapper {
 	margin: 24px 0 8px;
 }
+
+.migrate__error {
+	.button {
+		margin-bottom: 16px;
+	}
+	.migrate__info {
+		width: 67%;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds some styling to the migration flow's error page. The CSS should've been included with https://github.com/Automattic/wp-calypso/pull/39564.

#### Testing instructions

* Apply the PR and run Calypso locally, or use calypso.live (for the latter, add `?flags=tools/migrate` to the end of the URL to enable the feature flag).
* Do a migration that will cause an error: go to the import section of a Simple site that is private, enter the URL of a Jetpack site and follow the steps you're presented with. 
    * Alternatively, force the error page by changing `switch ( this.state.migrationStatus ) {` on line 540 of `my-sites/migrate/section-migrate.jsx` to `switch ( 'error' ) {`.
* The error you see should be styled like this:

<img width="516" alt="image" src="https://user-images.githubusercontent.com/1647564/75028199-c3344900-5497-11ea-858d-a1d48b239700.png">
