### PR TITLE
Data layer: Set auth token for oAuth apps

### DIFF
--- a/client/state/data-layer/wpcom-http/index.js
+++ b/client/state/data-layer/wpcom-http/index.js
@@ -56,7 +56,7 @@ export const queueRequest = ( processOutbound, processInbound ) => ( { dispatch 
 
 	const request = fetcherMap( method )(
 		...compact( [
-			{ path, formData, authToken },
+			{ path, formData, ...( authToken && { authToken, token: authToken } ) },
 			{ ...query }, // wpcom mutates the query so hand it a copy
 			method === 'POST' && body,
 			( error, data, headers ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sets the authentication token for data-layer requests originated on oAuth apps as done on the _undocumented_ wpcom.js:

https://github.com/Automattic/wp-calypso/blob/6a593a0d88df8d7622d82f31ce3503d3264f087c/client/lib/wpcom-undocumented/index.js#L38-L42

https://github.com/Automattic/wp-calypso/blob/6a593a0d88df8d7622d82f31ce3503d3264f087c/client/lib/wp/browser.js#L22-L23

#### Testing instructions

This needs to be tested on the desktop app, so make sure you have the dev environment [installed and running](https://github.com/Automattic/wp-desktop/blob/develop/docs/install.md).

- In the desktop repo, point the calypso submodule to this branch: `cd calypso && git fetch && git checkout update/data-layer-auth-token && cd ..`.
- Generate a new build: `make build`.
- Open the built app in the `release/<YOUR_OS>` folder (i.e. `release/mac/WordPress.com.app`).
- Switch to a site with Customer Home enabled and go to My Home.
- Select "Email download link" on the "Go Mobile" card.
- Make sure you get an email with a link to download the app.

Fixes https://github.com/Automattic/wp-desktop/issues/777