### PR TITLE
Enable plans step AB test for test environments

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -135,3 +135,4 @@ export default {
 		localeTargets: 'any',
 	},
 };
+

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -134,5 +134,14 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	planStepCopyUpdates: {
+		datestamp: '20200221',
+		variations: {
+			variantCopyUpdates: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -144,4 +144,3 @@ export default {
 		allowExistingUsers: true,
 	},
 };
-

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -25,6 +25,8 @@ import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { abtest } from 'lib/abtest';
+import config from 'config';
 
 /**
  * Style dependencies
@@ -130,13 +132,40 @@ export class PlansStep extends Component {
 		);
 	}
 
+	getHeaderTextAB() {
+		if (
+			config.isEnabled( 'plans-step-copy-updates' ) &&
+			'variantCopyUpdates' === abtest( 'planStepCopyUpdates' )
+		) {
+			return 'Select your WordPress.com plan';
+		}
+
+		return null;
+	}
+
+	getSubHeaderTextAB() {
+		if (
+			config.isEnabled( 'plans-step-copy-updates' ) &&
+			'variantCopyUpdates' === abtest( 'planStepCopyUpdates' )
+		) {
+			return 'All plans include blazing-fast WordPress hosting.';
+		}
+
+		return null;
+	}
+
 	plansFeaturesSelection() {
 		const { flowName, stepName, positionInFlow, translate, selectedSite, siteSlug } = this.props;
 
-		const headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
+		const headerText =
+			this.getHeaderTextAB() ||
+			this.props.headerText ||
+			translate( "Pick a plan that's right for you." );
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
 		const subHeaderText =
-			this.props.subHeaderText || translate( 'Choose a plan. Upgrade as you grow.' );
+			this.getSubHeaderTextAB() ||
+			this.props.subHeaderText ||
+			translate( 'Choose a plan. Upgrade as you grow.' );
 		const fallbackSubHeaderText = this.props.fallbackSubHeaderText || subHeaderText;
 
 		let backUrl, backLabelText;

--- a/config/development.json
+++ b/config/development.json
@@ -126,6 +126,7 @@
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"plans-step-copy-updates": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -101,6 +101,7 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
+		"plans-step-copy-updates": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"post-editor/preview-scroll-to-content": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have a new AB test for updating the copy on the plans step in signup. Please read more on the testing post at p8Eqe3-144-p2.

* Enable the new plan step AB test for dev and wpcalypso environment
* Change the plans step header text for the variant, as shown in pbBQWj-T-p2#comment-36

_Note: The other UI pieces of the variant will be built in separate PRs on top of this PR._ 

**Control**

<img width="823" alt="Screenshot 2020-02-21 at 8 18 23 PM" src="https://user-images.githubusercontent.com/1269602/75044296-66f91580-54e7-11ea-9883-0cd0529fe170.png">

**Variant**


<img width="891" alt="Screenshot 2020-02-21 at 8 18 08 PM" src="https://user-images.githubusercontent.com/1269602/75046049-68780d00-54ea-11ea-8788-ec9726b9acc7.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**In dev or wpcalypso environments**

Use http://calypso.localhost:3000/ URL for **dev** environment or https://calypso.live/?branch=add/create-plan-step-abtest for **wpcalypso** environment.

* Go through the signup flow from /start.
* Verify that on any step before the plans step, you are not assigned to the new AB test. You can verify this by typing `localStorage.ABTests;` in your browser console and checking that the AB test name is not in the output.
* Verify that on the plans step, you are assigned to the new AB test.
* The plans step title should match the value shown in the screenshot above - depending on whether you are in control or variant group.
* Verify that you are able to complete signup.

**In production environment**

There should be no change in behaviour since we are hiding the new AB test behind a feature flag.
To simulate the production environment, we will turn off the `plans-step-copy-updates` feature flag in the URL.

1. Go through the signup flow by navigating to http://calypso.localhost:3000/start?flags=-plans-step-copy-updates or if using calypso.live URL, append `?flags=-plans-step-copy-updates` to the hashed calypso.live link e.g: https://hash-c569eeb3f845141441e27d8b7614b0b68780cece.calypso.live/start?flags=-plans-step-copy-updates.
2. In the plans step, you should not be assigned to the new AB test(`localStorage.ABTests;` should not output the plan ab test slug).
3. Verify you can complete signup

Fixes: 244-gh-martech