### PR TITLE
Typography: Remove font-weight: 300

### DIFF
--- a/client/assets/stylesheets/shared/mixins/_heading.scss
+++ b/client/assets/stylesheets/shared/mixins/_heading.scss
@@ -5,6 +5,5 @@
 @mixin heading {
 	color: var( --color-neutral-50 );
 	font-size: rem( 20px );
-	font-weight: 300;
 	margin: 1em 0;
 }

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -9,7 +9,6 @@
 .action-panel__title {
 	margin-bottom: 16px;
 	font-size: 21px;
-	font-weight: 300;
 	line-height: 24px;
 	color: var( --color-neutral-70 );
 	clear: none;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -125,7 +125,6 @@ $date-picker_nav_button_size: 20px;
 	height: $date-picker_caption_height;
 	line-height: $date-picker_caption_height;
 	font-size: 18px;
-	font-weight: 300;
 	margin: 0 $date-picker_nav_button_size * 1.5;
 	position: relative;
 	cursor: pointer;

--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -21,7 +21,6 @@
 .empty-content__title {
 	color: var( --color-neutral-70 );
 	font-size: 34px;
-	font-weight: 300;
 
 	@include breakpoint( '<660px' ) {
 		font-size: 24px;
@@ -31,7 +30,6 @@
 .empty-content__line {
 	color: var( --color-neutral-50 );
 	font-size: 22px;
-	font-weight: 300;
 	margin-bottom: 40px;
 
 	@include breakpoint( '<660px' ) {

--- a/client/components/faq/style.scss
+++ b/client/components/faq/style.scss
@@ -15,7 +15,6 @@ $faq-gutter-width: 24px;
 .faq__heading {
 	margin-bottom: 32px;
 	font-size: 24px;
-	font-weight: 300;
 	color: var( --color-neutral-40 );
 }
 

--- a/client/components/forms/form-section-heading/style.scss
+++ b/client/components/forms/form-section-heading/style.scss
@@ -1,6 +1,5 @@
 .form-section-heading {
 	font-size: 24px;
-	font-weight: 300;
 	margin: 30px 0 20px;
 }
 

--- a/client/components/gsuite/gsuite-price/style.scss
+++ b/client/components/gsuite/gsuite-price/style.scss
@@ -22,7 +22,6 @@
 	strong {
 		color: var( --color-text );
 		font-size: 24px;
-		font-weight: 300;
 	}
 
 	span {

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -56,7 +56,6 @@
 	display: inline-block;
 	position: relative;
 	text-align: center;
-	font-weight: 300;
 	height: 20px;
 	line-height: 20px;
 	padding: 0 5px;

--- a/client/components/sidebar-navigation/style.scss
+++ b/client/components/sidebar-navigation/style.scss
@@ -32,7 +32,6 @@
 
 .layout__page-title {
 	font-size: 24px;
-	font-weight: 300;
 	margin: 16px;
 
 	@include breakpoint( '>660px' ) {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -275,7 +275,6 @@ a.web-preview__external.button {
 
 .web-preview__loading-message {
 	color: var( --color-text-subtle );
-	font-weight: 300;
 	font-size: 16px;
 }
 

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -3,7 +3,6 @@ $devdocs-max-width: 720px;
 // Sidebar Title
 .devdocs__title {
 	color: var( --color-sidebar-text-alternative );
-	font-weight: 300;
 	font-size: 24px;
 	padding: 24px;
 }
@@ -106,7 +105,6 @@ $devdocs-max-width: 720px;
 	.docs-example__wrapper-header-title {
 		font-family: $code;
 		font-size: 18px;
-		font-weight: 300;
 		letter-spacing: 1px;
 		border-bottom: 1px solid rgba( var( --color-neutral-10-rgb ), 0.65 );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes instances of `font-weight: 300` across SCSS typography mixin and components. 

- [x] client/assets/stylesheets/shared/mixins/_heading.scss (Also affects the following sections using the mixin:)
- [x] client/my-sites/domains/domain-search/style.scss *
- [x] client/my-sites/plugins/jetpack-plugins-setup/style.scss
- [x] client/my-sites/media-library/style.scss *
- [x] client/my-sites/stats/stats-module/style.scss
- [x] client/components/action-panel/style.scss
- [x] client/components/date-picker/style.scss
- [x] client/components/empty-content/style.scss
- [x] client/components/faq/style.scss
- [x] client/components/forms/form-section-heading/style.scss
- [x] client/components/gsuite/gsuite-price/style.scss *
- [x] client/components/post-schedule/style.scss
- [x] client/components/sidebar-navigation/style.scss *
- [x] client/components/web-preview/style.scss
- [x] client/devdocs/style.scss

`*` = I wasn't able to find the associated style with a corresponding class name in the markup, which may mean these selectors can be removed entirely.

Examples (there are many areas to check, so I won't add all the screenshots here, although I do have a library full of 'em if it would be helpful):

**Before**

<img width="398" alt="Screen Shot 2020-02-21 at 11 30 59 AM" src="https://user-images.githubusercontent.com/2124984/75061066-f255b500-54ad-11ea-828c-794a48bb24a7.png">
<img width="774" alt="Screen Shot 2020-02-21 at 11 24 31 AM" src="https://user-images.githubusercontent.com/2124984/75060986-cd614200-54ad-11ea-9ef0-3c883409923c.png">

**After**

<img width="376" alt="Screen Shot 2020-02-21 at 11 29 57 AM" src="https://user-images.githubusercontent.com/2124984/75061067-f386e200-54ad-11ea-9e84-2e648e30b0f2.png">
<img width="762" alt="Screen Shot 2020-02-21 at 11 24 47 AM" src="https://user-images.githubusercontent.com/2124984/75060984-ccc8ab80-54ad-11ea-8db9-5b6ee1b9dd69.png">

#### Testing instructions

* Switch to this PR

Visually test the following areas and component instances:

* /devdocs sidebar title
* Stats heading, throughout stats, but most noticeably on the front page with the "Stats for [date]" heading
* ActionPanel component, heading
* DatePicker component, table caption with month and year
* EmptyContent component, heading and text
* FAQ component, heading
* FormSectionHeading component
* PostSchedule component
* Web Preview component, loader heading text

See #39596 