### PR TITLE
Restart the showCompositeCheckout test at 50/50

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -27,10 +27,10 @@ export default {
 		allowExistingUsers: true,
 	},
 	showCompositeCheckout: {
-		datestamp: '20200219',
+		datestamp: '20200221',
 		variations: {
-			composite: 10,
-			regular: 90,
+			composite: 50,
+			regular: 50,
 		},
 		defaultVariation: 'regular',
 		allowExistingUsers: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This restarts the test of the composite checkout so that it becomes a 50/50 split instead of the 90% control, 10% test group that we had used for our initial soft launch.

#### Testing instructions

None.