### PR TITLE
Try: Add Jetpack Cloud login flow

### DIFF
--- a/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
+++ b/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
@@ -1,5 +1,6 @@
 // Jetpack Cloud color scheme for Calypso
-.is-group-jetpack-cloud.is-section-jetpack-cloud {
+.is-group-jetpack-cloud.is-section-jetpack-cloud,
+.layout.is-jetpack-cloud-flow {
 	/* Theme Properties */
 	--color-link: var( --studio-jetpack-green-40 );
 	--color-link-rgb: var( --studio-jetpack-green-40-rgb );

--- a/client/assets/stylesheets/jetpack-cloud.scss
+++ b/client/assets/stylesheets/jetpack-cloud.scss
@@ -6,27 +6,8 @@
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined
 @import 'shared/animation';
+@import 'shared/loading';
 
 // Global layout
 @import 'main';
 
-.is-section-jetpack-cloud {
-	.wpcom-site__loader {
-		position: fixed;
-		top: 50%;
-		left: 50%;
-		transform: translate( -50%, -50% );
-		color: var( --color-text-subtle );
-		text-align: center;
-		animation: loading-fade 1.6s ease-in-out infinite;
-	}
-
-	.wpcom-site__logo {
-		display: block;
-		margin-bottom: 10px;
-
-		path {
-			fill: var( --color-text-subtle );
-		}
-	}
-}

--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -10,3 +10,25 @@
 		height: 100px;
 	}
 }
+
+.is-section-jetpack-cloud,
+.layout.is-jetpack-cloud-flow {
+	.wpcom-site__loader {
+		position: fixed;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+		color: var( --color-text-subtle );
+		text-align: center;
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
+
+	.wpcom-site__logo {
+		display: block;
+		margin-bottom: 10px;
+
+		path {
+			fill: var( --color-text-subtle );
+		}
+	}
+}

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -3,6 +3,7 @@
 
 // Color Schemes
 @import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import './calypso-color-scheme-jetpack-cloud';
 
 // Shared
 @import 'shared/reset'; // css reset before the rest of the styles are defined

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -128,11 +128,12 @@ class Document extends React.Component {
 									[ 'is-section-' + sectionName ]: sectionName,
 									'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
 									'is-wccom-oauth-flow': isWCComConnect,
+									'is-jetpack-cloud-flow': config.isEnabled( 'jetpack-cloud' ),
 								} ) }
 							>
 								<div className="masterbar" />
 								<div className="layout__content">
-									{ 'jetpack-cloud' === sectionName ? (
+									{ config.isEnabled( 'jetpack-cloud' ) ? (
 										<div className="wpcom-site__loader">
 											<JetpackLogo size={ 72 } className="wpcom-site__logo" />
 											{ translate( 'Loading' ) }

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -19,4 +19,9 @@
 			fill: var( --color-masterbar-text );
 		}
 	}
+
+	.is-section-login.is-jetpack-cloud-flow & {
+		width: 100%;
+		border: none;
+	}
 }

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -6,7 +6,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import { normalize } from 'lib/route';
 import { siteSelection } from 'my-sites/controller';
 import { clientRender, makeLayout, setupSidebar } from './controller';
 import { jetpackCloudDashboard } from './sections/dashboard/controller';
@@ -19,23 +18,70 @@ import { jetpackCloudScanHistory } from './sections/scan-history/controller';
 import { jetpackCloudSettings } from './sections/settings/controller';
 
 const router = () => {
-	page( '*', normalize );
-
 	page( '/', setupSidebar, jetpackCloudDashboard, makeLayout, clientRender );
 
 	page( '/backups', siteSelection, setupSidebar, jetpackCloudBackups, makeLayout, clientRender );
-	page( '/backups/:site', siteSelection, setupSidebar, jetpackCloudBackups, makeLayout, clientRender );
-	page( '/backups/:site/detail/:backupId', siteSelection, setupSidebar, jetpackCloudBackupDetail, makeLayout, clientRender );
-	page( '/backups/:site/download/:downloadId', siteSelection, setupSidebar, jetpackCloudBackupDownload, makeLayout, clientRender );
-	page( '/backups/:site/restore', siteSelection, setupSidebar, jetpackCloudBackupRestore, makeLayout, clientRender );
-	page( '/backups/:site/restore/:restoreId', siteSelection, setupSidebar, jetpackCloudBackupRestore, makeLayout, clientRender );
+	page(
+		'/backups/:site',
+		siteSelection,
+		setupSidebar,
+		jetpackCloudBackups,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/backups/:site/detail/:backupId',
+		siteSelection,
+		setupSidebar,
+		jetpackCloudBackupDetail,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/backups/:site/download/:downloadId',
+		siteSelection,
+		setupSidebar,
+		jetpackCloudBackupDownload,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/backups/:site/restore',
+		siteSelection,
+		setupSidebar,
+		jetpackCloudBackupRestore,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/backups/:site/restore/:restoreId',
+		siteSelection,
+		setupSidebar,
+		jetpackCloudBackupRestore,
+		makeLayout,
+		clientRender
+	);
 
 	page( '/scan', siteSelection, setupSidebar, jetpackCloudScan, makeLayout, clientRender );
 	page( '/scan/:site', siteSelection, setupSidebar, jetpackCloudScan, makeLayout, clientRender );
-	page( '/scan/:site/history', siteSelection, setupSidebar, jetpackCloudScanHistory, makeLayout, clientRender );
+	page(
+		'/scan/:site/history',
+		siteSelection,
+		setupSidebar,
+		jetpackCloudScanHistory,
+		makeLayout,
+		clientRender
+	);
 
 	page( '/settings', siteSelection, setupSidebar, jetpackCloudSettings, makeLayout, clientRender );
-	page( '/settings/:site', siteSelection, setupSidebar, jetpackCloudSettings, makeLayout, clientRender );
+	page(
+		'/settings/:site',
+		siteSelection,
+		setupSidebar,
+		jetpackCloudSettings,
+		makeLayout,
+		clientRender
+	);
 };
 
 export default router;

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -13,6 +13,7 @@ import { includes, get, startsWith } from 'lodash';
 import config from 'config';
 import GlobalNotices from 'components/global-notices';
 import MasterbarLoggedOut from 'layout/masterbar/logged-out';
+import JetpackCloudMasterbar from 'landing/jetpack-cloud/components/masterbar';
 import notices from 'notices';
 import OauthClientMasterbar from 'layout/masterbar/oauth-client';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
@@ -70,6 +71,7 @@ const LayoutLoggedOut = ( {
 			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 			isWooOAuth2Client( oauth2Client ) &&
 			wccomFrom,
+		'is-jetpack-cloud-flow': config.isEnabled( 'jetpack-cloud' ),
 	};
 
 	let masterbar = null;
@@ -93,6 +95,8 @@ const LayoutLoggedOut = ( {
 
 			masterbar = <OauthClientMasterbar oauth2Client={ oauth2Client } />;
 		}
+	} else if ( config.isEnabled( 'jetpack-cloud' ) ) {
+		masterbar = <JetpackCloudMasterbar />;
 	} else {
 		masterbar = (
 			<MasterbarLoggedOut

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -13,6 +13,7 @@ import { startCase } from 'lodash';
  * Internal dependencies
  */
 import AutomatticLogo from 'components/automattic-logo';
+import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
 import getCurrentRoute from 'state/selectors/get-current-route';
@@ -110,7 +111,7 @@ export class Login extends React.Component {
 		const { currentRoute, translate } = this.props;
 		const isOauthLogin = !! this.props.oauth2Client;
 
-		if ( currentRoute === '/log-in/jetpack' ) {
+		if ( currentRoute === '/log-in/jetpack' || config.isEnabled( 'jetpack-cloud' ) ) {
 			return null;
 		}
 
@@ -227,6 +228,8 @@ export class Login extends React.Component {
 			twoFactorAuthType,
 		} = this.props;
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
+		const showTranslatorInvite = isLoginView && ! config.isEnabled( 'jetpack-cloud' );
+
 		return (
 			<div>
 				<Main className="wp-login__main">
@@ -248,7 +251,7 @@ export class Login extends React.Component {
 								twoFactorAuthType={ twoFactorAuthType }
 							/>
 						) }
-						{ isLoginView && <TranslatorInvite path={ path } /> }
+						{ showTranslatorInvite && <TranslatorInvite path={ path } /> }
 					</div>
 				</Main>
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -279,6 +279,10 @@ export class LoginLinks extends React.Component {
 			signupUrl = `${ signupUrl }/wpcc?${ stringify( oauth2Params ) }`;
 		}
 
+		if ( ! signupUrl ) {
+			return null;
+		}
+
 		return (
 			<a
 				href={ signupUrl }

--- a/config/development.json
+++ b/config/development.json
@@ -71,7 +71,7 @@
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,
-		"jetpack-cloud": true,
+		"jetpack-cloud": false,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -8,9 +8,12 @@
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
 	"rtl": false,
+	"wpcom_signup_id": "39911",
+	"wpcom_signup_key": "cOaYKdrkgXz8xY7aysv4fU6wL6sK5J8a6ojReEIAPwggsznj4Cb6mW0nffTxtYT8",
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"features": {
-		"jetpack-cloud": true
+		"jetpack-cloud": true,
+		"login/wp-login": true
 	}
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -9,6 +9,7 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"features": {
-		"jetpack-cloud": true
+		"jetpack-cloud": true,
+		"login/wp-login": true
 	}
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -9,6 +9,7 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"features": {
-		"jetpack-cloud": true
+		"jetpack-cloud": true,
+		"login/wp-login": true
 	}
 }


### PR DESCRIPTION
This PR is an experiment around adding a login flow to Jetpack Cloud. Since the login flow is quite convoluted and complex, you may find some things that simply make no sense... 🙂

<img width="809" alt="Screenshot 2020-02-21 at 18 12 46" src="https://user-images.githubusercontent.com/478735/75055719-d82fcd00-54d5-11ea-81ae-f4cbdd81d9b6.png">

I'm not sure if it should get merged. However, if you agree it goes in the right direction, then feel free to remove the "DO NOT MERGE" label and ship.

There are also a few TODO items that should be eventually tackled in separate PRs, like:
* I wasn't able to figure out a way to effectively redirect a logged-out user to the `/log-in` page (right now you have to access the login page manually by going to http://jetpack.cloud.localhost:3000/log-in)
* Migrate lost password recovery flow to Jetpack Cloud
* Make sure the back button under the login card doesn't mention "WordPress.com"
* Add social login (Google, Facebook)
* Update the colors of the form elements so that they match the designs
* Remove the link from the Masterbar on the login page (it's getting highlighted right now on hover)

Since the PR is not small, I'd suggest reviewing it first on a commit-by-commit basis, as listed below.

#### Changes proposed in this Pull Request

* Set config flow to enable login flow for Jetpack Cloud (f9fda2e)
* Reuse login entry point setup from Calypso in Jetpack Cloud (e17976a)
* Render Jetpack Cloud Masterbar on the login screen (9ec624e)
* Don't render sign-up link, translators invite and footer on the login screen (80fb3fe)
* Add Jetpack Cloud's look and feel for the logged-out loading screen (22585dd)
* Remove redundant normalization - it's already done in the app boot (76538d4)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start your local Jetpack Cloud environment with `npm run start-jetpack-cloud`
* Make sure you're logged out from WPCOM (or use an incognito mode)
* Go to http://jetpack.cloud.localhost:3000/log-in and confirm you're able to log in successfully

Fixes 1156570014567299-as-1162690910730752
