### PR TITLE
Add cancel subscription option to subscriber actions menu

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -242,6 +242,37 @@ class MembershipsSection extends Component {
 								}
 							/>
 						</div>
+						<Dialog
+							isVisible={ !! this.state.cancelledSubscriber }
+							buttons={ [
+								{
+									label: this.props.translate( 'Back' ),
+									action: 'back',
+								},
+								{
+									label: this.props.translate( 'Cancel Subscription' ),
+									isPrimary: true,
+									action: 'cancel',
+								},
+							] }
+							onClose={ this.onCloseCancelSubscription }
+						>
+							<h1>{ this.props.translate( 'Confirmation' ) }</h1>
+							<p>{ this.props.translate( 'Do you want to cancel this subscription?' ) }</p>
+							<Notice
+								text={ this.props.translate(
+									'Canceling the subscription will mean the subscriber %(email)s will no longer be charged.',
+									{
+										args: {
+											email: this.state.cancelledSubscriber
+												? this.state.cancelledSubscriber.user.user_email
+												: '',
+										},
+									}
+								) }
+								showDismiss={ false }
+							/>
+						</Dialog>
 						<div className="memberships__module-footer">
 							<Button onClick={ this.downloadSubscriberList }>
 								{ this.props.translate( 'Download list as CSV' ) }
@@ -390,35 +421,6 @@ class MembershipsSection extends Component {
 						{ this.renderSubscriberSubscriptionSummary( subscriber ) }
 					</div>
 				</div>
-				<Dialog
-					isVisible={ !! this.state.cancelledSubscriber }
-					buttons={ [
-						{
-							label: this.props.translate( 'Back' ),
-							action: 'back',
-						},
-						{
-							label: this.props.translate( 'Cancel Subscription' ),
-							isPrimary: true,
-							action: 'cancel',
-						},
-					] }
-					onClose={ this.onCloseCancelSubscription }
-				>
-					<h1>{ this.props.translate( 'Confirmation' ) }</h1>
-					<p>{ this.props.translate( 'Do you want to cancel this subscription?' ) }</p>
-					<Notice
-						text={ this.props.translate(
-							'Canceling the subscription will mean the subscriber %(email)s will no longer be charged.',
-							{
-								args: {
-									email: subscriber.user.user_email,
-								},
-							}
-						) }
-						showDismiss={ false }
-					/>
-				</Dialog>
 			</Card>
 		);
 	}

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -145,7 +145,11 @@ class MembershipsSection extends Component {
 			this.props.requestSubscriptionStop(
 				this.props.siteId,
 				this.state.cancelledSubscriber,
-				this.props.translate( 'Subscription cancelled' )
+				this.props.translate( 'Subscription cancelled for %(email)s', {
+					args: {
+						email: this.state.cancelledSubscriber.user.user_email,
+					},
+				} )
 			);
 		}
 		this.setState( { cancelledSubscriber: null } );
@@ -405,7 +409,12 @@ class MembershipsSection extends Component {
 					<p>{ this.props.translate( 'Do you want to cancel this subscription?' ) }</p>
 					<Notice
 						text={ this.props.translate(
-							'Canceling the subscription will mean the subscriber will no longer be charged.'
+							'Canceling the subscription will mean the subscriber %(email)s will no longer be charged.',
+							{
+								args: {
+									email: subscriber.user.user_email,
+								},
+							}
 						) }
 						showDismiss={ false }
 					/>

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -18,7 +18,7 @@ import InfiniteScroll from 'components/infinite-scroll';
 import QueryMembershipsEarnings from 'components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'components/data/query-memberships-settings';
 import { requestDisconnectStripeAccount } from 'state/memberships/settings/actions';
-import { requestSubscribers } from 'state/memberships/subscribers/actions';
+import { requestSubscribers, requestSubscriptionStop } from 'state/memberships/subscribers/actions';
 import { decodeEntities } from 'lib/formatting';
 import Gravatar from 'components/gravatar';
 import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
@@ -46,6 +46,7 @@ class MembershipsSection extends Component {
 		this.downloadSubscriberList = this.downloadSubscriberList.bind( this );
 	}
 	state = {
+		cancelledSubscriber: null,
 		disconnectedConnectedAccountId: null,
 	};
 	componentDidMount() {
@@ -137,6 +138,17 @@ class MembershipsSection extends Component {
 			);
 		}
 		this.setState( { disconnectedConnectedAccountId: null } );
+	};
+
+	onCloseCancelSubscription = reason => {
+		if ( reason === 'cancel' ) {
+			this.props.requestSubscriptionStop(
+				this.props.siteId,
+				this.state.cancelledSubscriber,
+				this.props.translate( 'Subscription cancelled' )
+			);
+		}
+		this.setState( { cancelledSubscriber: null } );
 	};
 
 	downloadSubscriberList( event ) {
@@ -349,6 +361,10 @@ class MembershipsSection extends Component {
 					<Gridicon size={ 18 } icon={ 'external' } />
 					{ this.props.translate( 'See transactions in Stripe Dashboard' ) }
 				</PopoverMenuItem>
+				<PopoverMenuItem onClick={ () => this.setState( { cancelledSubscriber: subscriber } ) }>
+					<Gridicon size={ 18 } icon={ 'cross' } />
+					{ this.props.translate( 'Cancel Subscription' ) }
+				</PopoverMenuItem>
 			</EllipsisMenu>
 		);
 	}
@@ -370,6 +386,30 @@ class MembershipsSection extends Component {
 						{ this.renderSubscriberSubscriptionSummary( subscriber ) }
 					</div>
 				</div>
+				<Dialog
+					isVisible={ !! this.state.cancelledSubscriber }
+					buttons={ [
+						{
+							label: this.props.translate( 'Back' ),
+							action: 'back',
+						},
+						{
+							label: this.props.translate( 'Cancel Subscription' ),
+							isPrimary: true,
+							action: 'cancel',
+						},
+					] }
+					onClose={ this.onCloseCancelSubscription }
+				>
+					<h1>{ this.props.translate( 'Confirmation' ) }</h1>
+					<p>{ this.props.translate( 'Do you want to cancel this subscription?' ) }</p>
+					<Notice
+						text={ this.props.translate(
+							'Canceling the subscription will mean the subscriber will no longer be charged.'
+						) }
+						showDismiss={ false }
+					/>
+				</Dialog>
 			</Card>
 		);
 	}
@@ -541,6 +581,8 @@ const mapStateToProps = state => {
 	};
 };
 
-export default connect( mapStateToProps, { requestSubscribers, requestDisconnectStripeAccount } )(
-	localize( withLocalizedMoment( MembershipsSection ) )
-);
+export default connect( mapStateToProps, {
+	requestSubscribers,
+	requestDisconnectStripeAccount,
+	requestSubscriptionStop,
+} )( localize( withLocalizedMoment( MembershipsSection ) ) );

--- a/client/state/memberships/subscribers/actions.js
+++ b/client/state/memberships/subscribers/actions.js
@@ -2,12 +2,76 @@
  * Internal dependencies
  */
 
-import { MEMBERSHIPS_SUBSCRIBERS_LIST } from 'state/action-types';
+import {
+	MEMBERSHIPS_SUBSCRIBERS_LIST,
+	MEMBERSHIPS_SUBSCRIPTION_STOP,
+	MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS,
+	MEMBERSHIPS_SUBSCRIPTION_STOP_FAILURE,
+	NOTICE_CREATE,
+} from 'state/action-types';
 
 import 'state/data-layer/wpcom/sites/memberships';
+import wpcom from 'lib/wp';
 
 export const requestSubscribers = ( siteId, offset ) => ( {
 	siteId,
 	type: MEMBERSHIPS_SUBSCRIBERS_LIST,
 	offset,
 } );
+
+export const requestSubscriptionStop = ( siteId, subscription, noticeText ) => {
+	return dispatch => {
+		dispatch( {
+			siteId,
+			type: MEMBERSHIPS_SUBSCRIPTION_STOP,
+			subscriptionId: subscription.id,
+		} );
+
+		return wpcom.req
+			.post( `/sites/${ siteId }/memberships/subscriptions/${ subscription.id }/cancel`, {
+				user_id: subscription.user.ID,
+			} )
+			.then( result => {
+				const errorMsg = result.error || '';
+
+				if ( errorMsg.length > 0 ) {
+					dispatch( {
+						type: MEMBERSHIPS_SUBSCRIPTION_STOP_FAILURE,
+						subscriptionId: subscription.id,
+						errorMsg,
+					} );
+
+					dispatch( {
+						type: NOTICE_CREATE,
+						notice: {
+							duration: 5000,
+							text: errorMsg,
+							status: 'is-error',
+						},
+					} );
+				}
+
+				dispatch( {
+					siteId,
+					type: MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS,
+					subscriptionId: subscription.id,
+				} );
+
+				dispatch( {
+					type: NOTICE_CREATE,
+					notice: {
+						duration: 5000,
+						text: noticeText,
+						status: 'is-success',
+					},
+				} );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: MEMBERSHIPS_SUBSCRIPTION_STOP_FAILURE,
+					subscriptionId: subscription.id,
+					error,
+				} );
+			} );
+	};
+};

--- a/client/state/memberships/subscribers/actions.js
+++ b/client/state/memberships/subscribers/actions.js
@@ -19,17 +19,17 @@ export const requestSubscribers = ( siteId, offset ) => ( {
 	offset,
 } );
 
-export const requestSubscriptionStop = ( siteId, subscription, noticeText ) => {
+export const requestSubscriptionStop = ( siteId, subscriber, noticeText ) => {
 	return dispatch => {
 		dispatch( {
 			siteId,
 			type: MEMBERSHIPS_SUBSCRIPTION_STOP,
-			subscriptionId: subscription.id,
+			subscriptionId: subscriber.id,
 		} );
 
 		return wpcom.req
-			.post( `/sites/${ siteId }/memberships/subscriptions/${ subscription.id }/cancel`, {
-				user_id: subscription.user.ID,
+			.post( `/sites/${ siteId }/memberships/subscriptions/${ subscriber.id }/cancel`, {
+				user_id: subscriber.user.ID,
 			} )
 			.then( result => {
 				const errorMsg = result.error || '';
@@ -37,7 +37,7 @@ export const requestSubscriptionStop = ( siteId, subscription, noticeText ) => {
 				if ( errorMsg.length > 0 ) {
 					dispatch( {
 						type: MEMBERSHIPS_SUBSCRIPTION_STOP_FAILURE,
-						subscriptionId: subscription.id,
+						subscriptionId: subscriber.id,
 						errorMsg,
 					} );
 
@@ -54,13 +54,12 @@ export const requestSubscriptionStop = ( siteId, subscription, noticeText ) => {
 				dispatch( {
 					siteId,
 					type: MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS,
-					subscriptionId: subscription.id,
+					subscriptionId: subscriber.id,
 				} );
 
 				dispatch( {
 					type: NOTICE_CREATE,
 					notice: {
-						duration: 5000,
 						text: noticeText,
 						status: 'is-success',
 					},
@@ -69,7 +68,7 @@ export const requestSubscriptionStop = ( siteId, subscription, noticeText ) => {
 			.catch( error => {
 				dispatch( {
 					type: MEMBERSHIPS_SUBSCRIPTION_STOP_FAILURE,
-					subscriptionId: subscription.id,
+					subscriptionId: subscriber.id,
 					error,
 				} );
 			} );

--- a/client/state/memberships/subscribers/reducer.js
+++ b/client/state/memberships/subscribers/reducer.js
@@ -1,18 +1,21 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, filter } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { combineReducers, withoutPersistence } from 'state/utils';
-import { MEMBERSHIPS_SUBSCRIBERS_RECEIVE } from '../../action-types';
+import {
+	MEMBERSHIPS_SUBSCRIBERS_RECEIVE,
+	MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS,
+} from '../../action-types';
 
 const list = withoutPersistence( ( state = {}, action ) => {
 	switch ( action.type ) {
 		case MEMBERSHIPS_SUBSCRIBERS_RECEIVE:
-			return {
+			state = {
 				...state,
 
 				[ action.siteId ]: {
@@ -26,6 +29,21 @@ const list = withoutPersistence( ( state = {}, action ) => {
 					),
 				},
 			};
+			break;
+		case MEMBERSHIPS_SUBSCRIPTION_STOP_SUCCESS: {
+			const ownerships = filter(
+				get( state, [ action.siteId, 'ownerships' ], {} ),
+				( { id } ) => id !== action.subscriptionId
+			);
+			state = {
+				...state,
+
+				[ action.siteId ]: {
+					total: ownerships.length,
+					ownerships: { ...ownerships },
+				},
+			};
+		}
 	}
 
 	return state;

--- a/client/state/memberships/subscriptions/actions.js
+++ b/client/state/memberships/subscriptions/actions.js
@@ -22,7 +22,6 @@ export const requestSubscriptionStop = subscriptionId => {
 			type: MEMBERSHIPS_SUBSCRIPTION_STOP,
 			subscriptionId,
 		} );
-
 		return wpcom.req
 			.post( `/me/memberships/subscriptions/${ subscriptionId }/cancel` )
 			.then( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is going to add a `Cancel Subscription` option to the Subscriber actions menu.
* This will allow a client to cancel their subscribers subscriptions from Calypso, rather than having to do it from the Stripe dashboard

#### Testing instructions

* Apply the [patch](https://code.a8c.com/D39519) to add the cancel subscription endpoint
* Sandbox the store on a test site
* Upgrade your test account to a Personal (if not already)
* Create a post with a recurring payment block
* Test the recurring payment block with test card details by purchasing a subscription
* Go to http://calypso.localhost:3000/earn/payments/{site}
* Click on the `...` menu next to the subscription (listed under Subscribers)
* Click on the `Cancel Subscription` option
* Confirm that the subscription has been cancelled and behaviour is as expected


