### PR TITLE
Home: Don't allow line breaks in the View Site button text.

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -67,6 +67,7 @@
 
 			.button {
 				text-align: center;
+				white-space: nowrap;
 			}
 		}
 	}


### PR DESCRIPTION
Buttons with line breaks in their text look disorienting, and our mobile views of Customer Home can display the View Site button in this way. This PR ensures the button text does not wrap.

**Before**
<img width="347" alt="Screen Shot 2020-02-21 at 9 52 01 AM" src="https://user-images.githubusercontent.com/349751/75058737-67b28d00-5490-11ea-9923-52f2f638dc47.png">

**After**
<img width="340" alt="Screen Shot 2020-02-21 at 9 50 25 AM" src="https://user-images.githubusercontent.com/349751/75058748-6d0fd780-5490-11ea-85ba-85b90dc32080.png">


#### Testing instructions

- Load this branch and go to a newer test site that has Customer Home.
- View http://calypso.localhost:3000/home/:site on a mobile view.
- Verify the View Site button has no line breaks.