### PR TITLE
Use a different user for domain tests to prevent conflicts

### DIFF
--- a/test/e2e/specs/wp-manage-domains-spec.js
+++ b/test/e2e/specs/wp-manage-domains-spec.js
@@ -64,7 +64,7 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function() {
 		} );
 
 		step( 'Log In and Select Domains', async function() {
-			return await new LoginFlow( driver ).loginAndSelectDomains();
+			return await new LoginFlow( driver, 'gutenbergSimpleSiteUser' ).loginAndSelectDomains();
 		} );
 
 		step( 'Can see the Domains page and choose add a domain', async function() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We were seeing issues with the plan purchase specs seeing incorrect pages because they were conflicting with the domains tests. This PR changes the user on the domains test to remove the conflict

#### Testing instructions
* Ensure all tests pass in CI
