### PR TITLE
composite-checkout: Improve step change analytics events

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -751,7 +751,16 @@ function getCheckoutEventHandler( dispatch ) {
 			case 'a8c_checkout_add_coupon_button_clicked':
 				return dispatch( recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} ) );
 
-			case 'STEP_NUMBER_CHANGE_EVENT':
+			case 'STEP_NUMBER_CHANGED':
+				if ( action.payload.stepNumber === 2 && action.payload.previousStepNumber === 1 ) {
+					dispatch(
+						recordTracksEvent( 'calypso_checkout_composite_first_step_complete', {
+							payment_method:
+								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
+									?.name || '',
+						} )
+					);
+				}
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_step_changed', { step: action.payload } )
 				);

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -762,7 +762,10 @@ function getCheckoutEventHandler( dispatch ) {
 					);
 				}
 				return dispatch(
-					recordTracksEvent( 'calypso_checkout_composite_step_changed', { step: action.payload } )
+					recordTracksEvent( 'calypso_checkout_composite_step_changed', {
+						step: action.payload.stepNumber,
+						stepId: action.payload.stepId,
+					} )
 				);
 
 			case 'STRIPE_TRANSACTION_BEGIN': {

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -764,7 +764,7 @@ function getCheckoutEventHandler( dispatch ) {
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_step_changed', {
 						step: action.payload.stepNumber,
-						stepId: action.payload.stepId,
+						step_id: action.payload.stepId,
 					} )
 				);
 

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -37,7 +37,7 @@ import useConstructor from '../lib/use-constructor';
 
 const debug = debugFactory( 'composite-checkout:checkout' );
 
-function useRegisterCheckoutStore() {
+function useRegisterCheckoutStore( steps, activePaymentMethod ) {
 	const onEvent = useEvents();
 	useRegisterPrimaryStore( {
 		reducer( state = { stepNumber: 1, paymentData: {} }, action ) {
@@ -46,7 +46,15 @@ function useRegisterCheckoutStore() {
 					if ( state.stepNumber === action.payload ) {
 						return state;
 					}
-					onEvent( { type: 'STEP_NUMBER_CHANGE_EVENT', payload: action.payload } );
+					onEvent( {
+						type: 'STEP_NUMBER_CHANGED',
+						payload: {
+							stepNumber: action.payload,
+							previousStepNumber: state.stepNumber,
+							stepId: steps[ action.payload ].id,
+							paymentMethodId: activePaymentMethod?.id,
+						},
+					} );
 					return { ...state, stepNumber: action.payload };
 				case 'PAYMENT_DATA_UPDATE':
 					return {
@@ -82,10 +90,10 @@ function useRegisterCheckoutStore() {
 }
 
 export default function Checkout( { steps, className } ) {
-	useRegisterCheckoutStore();
 	const localize = useLocalize();
 	const [ paymentData ] = usePaymentData();
 	const activePaymentMethod = usePaymentMethod();
+	useRegisterCheckoutStore( steps, activePaymentMethod );
 	const { formStatus } = useFormStatus();
 
 	// Re-render if any store changes; that way isComplete can rely on any data

--- a/packages/composite-checkout/src/components/checkout.js
+++ b/packages/composite-checkout/src/components/checkout.js
@@ -152,7 +152,7 @@ export default function Checkout( { steps, className } ) {
 										stepNumber: nextStep.stepNumber,
 										previousStepNumber: activeStep.stepNumber,
 										stepId: nextStep.id,
-										paymentMethodId: activePaymentMethod?.id,
+										paymentMethodId: activePaymentMethod?.id ?? '',
 									},
 								} );
 								changeStep( nextStep.stepNumber );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In addition to the current step number recorded by the Tracks event `calypso_checkout_composite_step_changed`, this also records the current step object's id.

It also adds a new event, `calypso_checkout_composite_first_step_complete`, which is called after
the first (payment method) step is completed. The event records the currently active payment method.

#### Testing instructions

- Enable debug by putting this in your console: `localStorage.setItem('debug', 'calypso:analytics')`
- Submit a transaction through composite checkout and be sure that the new events and event properties appear in the debug logs.