### PR TITLE
composite-checkout: Include error message in cart error

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -719,7 +719,8 @@ function getCheckoutEventHandler( dispatch ) {
 			case 'CART_ERROR':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_cart_error', {
-						error_message: action.payload.error,
+						error_type: action.payload.type,
+						error_message: String( action.payload.message ),
 					} )
 				);
 			case 'a8c_checkout_error':

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -532,7 +532,10 @@ function useInitializeCartFromServer(
 				// TODO: figure out what to do here
 				debug( 'error while initializing cart', error );
 				hookDispatch( { type: 'RAISE_ERROR', error: 'GET_SERVER_CART_ERROR' } );
-				onEvent?.( { type: 'CART_ERROR', payload: { error: 'GET_SERVER_CART_ERROR' } } );
+				onEvent?.( {
+					type: 'CART_ERROR',
+					payload: { type: 'GET_SERVER_CART_ERROR', message: error },
+				} );
 			} );
 	}, [
 		cacheStatus,
@@ -574,7 +577,10 @@ function useCartUpdateAndRevalidate(
 				// TODO: figure out what to do here
 				debug( 'error while fetching cart', error );
 				hookDispatch( { type: 'RAISE_ERROR', error: 'SET_SERVER_CART_ERROR' } );
-				onEvent?.( { type: 'CART_ERROR', payload: { error: 'SET_SERVER_CART_ERROR' } } );
+				onEvent?.( {
+					type: 'CART_ERROR',
+					payload: { type: 'SET_SERVER_CART_ERROR', message: error },
+				} );
 			} );
 	}, [ setServerCart, cacheStatus, responseCart, onEvent, hookDispatch ] );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the `calypso_checkout_composite_cart_error` analytics event to include the actual error message itself.

#### Testing instructions

Somehow you need to cause `getServerCart()` to fail. Probably the easiest thing to do is to modify `packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts` and add this change: 

```diff
--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -505,6 +505,9 @@ function useInitializeCartFromServer(
                debug( `initializing the cart; cacheStatus is ${ cacheStatus }` );

                getServerCart()
+                       .then( () => {
+                               throw new Error( 'testing error' );
+                       } )
                        .then( response => {
                                if ( productToAdd ) {
                                        debug(
```
Next enable debug by putting this in your console: `localStorage.setItem('debug', 'calypso:analytics:*')`

Then visit composite checkout in Calypso and verify that you see the event `calypso_checkout_composite_cart_error` with the `type` property set to "GET_SERVER_CART_ERROR" and the `message` property set to "testing error".