### PR TITLE
Domains: Adjust SSL copy for Google domains

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -215,7 +215,7 @@ class DomainRegistrationSuggestion extends React.Component {
 						{ translate(
 							'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
 								'to host a website. When you host this domain at WordPress.com an SSL ' +
-								'certificate is included in your paid plan. {{a}}Learn more{{/a}}.',
+								'certificate is included. {{a}}Learn more{{/a}}.',
 							{
 								args: {
 									tld: '.' + getTld( domain ),

--- a/client/my-sites/checkout/checkout/domain-registration-hsts.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-hsts.jsx
@@ -59,7 +59,7 @@ class DomainRegistrationHsts extends React.PureComponent {
 					{ translate(
 						'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
 							'to host a website. When you host this domain at WordPress.com an SSL ' +
-							'certificate is included in your paid plan. {{a}}Learn more{{/a}}.',
+							'certificate is included. {{a}}Learn more{{/a}}.',
 						{
 							args: {
 								tld: tlds,


### PR DESCRIPTION
All domains ending in .dev require an SSL certificate to host a website. When you host this domain at WordPress.com an SSL certificate is included in your paid plan.
The last part does not apply to me, since I'm a non-DWPO user and does not have to have a paid plan with domain.
Suggestion: remove "in your paid plan" - then it applies to everyone.

#### Testing instructions

Go to Domains -> Add domain and search for a random `.dev` domain.
You should see the updated copy when you click on the `i` icon:

<img width="781" alt="Screenshot 2020-02-22 at 20 58 43" src="https://user-images.githubusercontent.com/3392497/75099150-451a9400-55b6-11ea-8a1a-baf81504d82e.png">

When you reach the end of checkout (just before paying), you should see the updated copy as well:
<img width="740" alt="Screenshot 2020-02-22 at 20 58 58" src="https://user-images.githubusercontent.com/3392497/75099159-55327380-55b6-11ea-9ac4-d64f1be3159c.png">
