### PR TITLE
Billing details: do not show the add-card page if the user doesn't have any purchases

### DIFF
--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -21,12 +21,18 @@ import titles from 'me/purchases/titles';
 import { billingHistory } from 'me/purchases/paths';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { StripeHookProvider } from 'lib/stripe';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { isUserPaid } from 'state/purchases/selectors';
 
 function AddCreditCard( props ) {
 	const createAddCardToken = ( ...args ) => createCardToken( 'card_add', ...args );
 	const goToBillingHistory = () => page( billingHistory );
 	const recordFormSubmitEvent = () =>
 		analytics.tracks.recordEvent( 'calypso_add_credit_card_form_submit' );
+
+	if ( ! props.isUserPaid ) {
+		page.redirect( '/me/purchases' );
+	}
 
 	return (
 		<Main>
@@ -51,8 +57,13 @@ AddCreditCard.propTypes = {
 	addStoredCard: PropTypes.func.isRequired,
 };
 
+const mapStateToProps = state => {
+	const userId = getCurrentUserId( state );
+	return { isUserPaid: isUserPaid( state, userId ) };
+};
+
 const mapDispatchToProps = {
 	addStoredCard,
 };
 
-export default connect( null, mapDispatchToProps )( AddCreditCard );
+export default connect( mapStateToProps, mapDispatchToProps )( AddCreditCard );

--- a/client/me/purchases/credit-cards/index.jsx
+++ b/client/me/purchases/credit-cards/index.jsx
@@ -22,6 +22,8 @@ import {
 import QueryStoredCards from 'components/data/query-stored-cards';
 import { addCreditCard } from 'me/purchases/paths';
 import SectionHeader from 'components/section-header';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { isUserPaid } from 'state/purchases/selectors';
 
 /**
  * Style dependencies
@@ -60,6 +62,10 @@ class CreditCards extends Component {
 			return null;
 		}
 
+		if ( ! this.props.isUserPaid ) {
+			return null;
+		}
+
 		return (
 			<Button primary compact className="credit-cards__add" onClick={ this.goToAddCreditCard }>
 				{ this.props.translate( 'Add Credit Card' ) }
@@ -84,8 +90,12 @@ class CreditCards extends Component {
 	}
 }
 
-export default connect( state => ( {
-	cards: getStoredCards( state ),
-	hasLoadedFromServer: hasLoadedStoredCardsFromServer( state ),
-	isFetching: isFetchingStoredCards( state ),
-} ) )( localize( CreditCards ) );
+export default connect( state => {
+	const userId = getCurrentUserId( state );
+	return {
+		cards: getStoredCards( state ),
+		hasLoadedFromServer: hasLoadedStoredCardsFromServer( state ),
+		isFetching: isFetchingStoredCards( state ),
+		isUserPaid: isUserPaid( state, userId ),
+	};
+} )( localize( CreditCards ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If a user doesn't have any existing purchases, it doesn't make sense to show the "add card" screen. To add a new card, the user can go through the checkout flow.

#### Testing instructions

* In an account with purchases, make sure that the "add new card" button is visible in `/me/purchases/billing`, and that clicking on that opens up the "add new card" page
* In an account without any purchases, make sure that the "add new card" button isn't visible, and that you are redirected away if you try to visit `/me/purchases/add-credit-card`

Background: see p8hgLy-2Ec-p2