### PR TITLE
Plan step test: Update the plan features list UI and copy

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -72,8 +72,12 @@ const getPlanBloggerDetails = () => ( {
 const getPlanPersonalDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_PERSONAL,
-	getTitle: () => i18n.translate( 'Personal' ),
-	getAudience: () => i18n.translate( 'Best for personal use' ),
+	getTitle: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates ? 'Personal plan' : i18n.translate( 'Personal' ),
+	getAudience: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates
+			? 'WordPress essentials for a basic site.'
+			: i18n.translate( 'Best for personal use' ),
 	getBlogAudience: () => i18n.translate( 'Best for personal use' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for personal use' ),
 	getStoreAudience: () => i18n.translate( 'Best for personal use' ),
@@ -90,11 +94,13 @@ const getPlanPersonalDetails = () => ( {
 				},
 			}
 		),
-	getShortDescription: () =>
-		i18n.translate(
-			'Boost your website with a custom domain name, and remove all WordPress.com advertising. ' +
-				'Get access to high-quality email and live chat support.'
-		),
+	getShortDescription: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates
+			? 'Build your starter online home with basic site-editing tools, a custom domain name, and access to live chat support.'
+			: i18n.translate(
+					'Boost your website with a custom domain name, and remove all WordPress.com advertising. ' +
+						'Get access to high-quality email and live chat support.'
+			  ),
 	getPlanCompareFeatures: () => [
 		// pay attention to ordering, shared features should align on /plan page
 		constants.FEATURE_CUSTOM_DOMAIN,
@@ -128,8 +134,12 @@ const getPlanPersonalDetails = () => ( {
 const getPlanEcommerceDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_ECOMMERCE,
-	getTitle: () => i18n.translate( 'eCommerce' ),
-	getAudience: () => i18n.translate( 'Best for online stores' ),
+	getTitle: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates ? 'eCommerce plan' : i18n.translate( 'eCommerce' ),
+	getAudience: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates
+			? 'Build a professional online store.'
+			: i18n.translate( 'Best for online stores' ),
 	getBlogAudience: () => i18n.translate( 'Best for online stores' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for online stores' ),
 	getStoreAudience: () => i18n.translate( 'Best for online stores' ),
@@ -147,12 +157,14 @@ const getPlanEcommerceDetails = () => ( {
 			}
 		);
 	},
-	getShortDescription: () =>
-		i18n.translate(
-			'Sell products or services with this powerful, ' +
-				'all-in-one online store experience. This plan includes premium integrations and is extendable, ' +
-				'so it’ll grow with you as your business grows.'
-		),
+	getShortDescription: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates
+			? 'Start selling in no time, and create the best shopping, payment, and delivery experience for your customers.'
+			: i18n.translate(
+					'Sell products or services with this powerful, ' +
+						'all-in-one online store experience. This plan includes premium integrations and is extendable, ' +
+						'so it’ll grow with you as your business grows.'
+			  ),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with eCommerce and take advantage of its powerful marketplace features.'
@@ -219,8 +231,12 @@ const getPlanEcommerceDetails = () => ( {
 const getPlanPremiumDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_PREMIUM,
-	getTitle: () => i18n.translate( 'Premium' ),
-	getAudience: () => i18n.translate( 'Best for freelancers' ),
+	getTitle: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates ? 'Premium plan' : i18n.translate( 'Premium' ),
+	getAudience: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates
+			? 'Powerful tools at a great value.'
+			: i18n.translate( 'Best for freelancers' ),
 	getBlogAudience: () => i18n.translate( 'Best for freelancers' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for freelancers' ),
 	getStoreAudience: () => i18n.translate( 'Best for freelancers' ),
@@ -238,12 +254,14 @@ const getPlanPremiumDetails = () => ( {
 				},
 			}
 		),
-	getShortDescription: () =>
-		i18n.translate(
-			'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
-				' Google Analytics support,' +
-				' and the ability to monetize your site with ads.'
-		),
+	getShortDescription: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates
+			? 'Build a sleek site with beautiful themes, robust design and monetization tools, custom CSS, and Google Analytics.'
+			: i18n.translate(
+					'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
+						' Google Analytics support,' +
+						' and the ability to monetize your site with ads.'
+			  ),
 	getPlanCompareFeatures: () =>
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
@@ -290,8 +308,12 @@ const getPlanPremiumDetails = () => ( {
 const getPlanBusinessDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_BUSINESS,
-	getTitle: () => i18n.translate( 'Business' ),
-	getAudience: () => i18n.translate( 'Best for small businesses' ),
+	getTitle: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates ? 'Business plan' : i18n.translate( 'Business' ),
+	getAudience: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates
+			? 'All you need for a growing business.'
+			: i18n.translate( 'Best for small businesses' ),
 	getBlogAudience: () => i18n.translate( 'Best for small businesses' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for small businesses' ),
 	getStoreAudience: () => i18n.translate( 'The plan for small businesses' ),
@@ -308,11 +330,13 @@ const getPlanBusinessDetails = () => ( {
 				},
 			}
 		),
-	getShortDescription: () =>
-		i18n.translate(
-			'Power your business website with custom plugins and themes, unlimited premium and business theme templates,' +
-				' 200 GB storage, and the ability to remove WordPress.com branding.'
-		),
+	getShortDescription: isEligibleForPlanStepUpdates =>
+		isEligibleForPlanStepUpdates
+			? 'The full power of WordPress, unlocked: from plugins and custom themes  to SFTP and phpMyAdmin, this plan has it all.'
+			: i18n.translate(
+					'Power your business website with custom plugins and themes, unlimited premium and business theme templates,' +
+						' 200 GB storage, and the ability to remove WordPress.com branding.'
+			  ),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with Business and take advantage of its professional features.'

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -11,9 +11,9 @@ import i18n from 'i18n-calypso';
 import { isEnabled } from 'config';
 import * as constants from './constants';
 
-const WPComGetBillingTimeframe = rawPriceAnnual =>
-	rawPriceAnnual
-		? `Billed at ${ rawPriceAnnual } per year`
+const WPComGetBillingTimeframe = annualPriceText =>
+	annualPriceText
+		? `Billed at ${ annualPriceText } per year`
 		: i18n.translate( 'per month, billed annually' );
 const WPComGetBiennialBillingTimeframe = () => i18n.translate( '/month, billed every two years' );
 

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -11,7 +11,10 @@ import i18n from 'i18n-calypso';
 import { isEnabled } from 'config';
 import * as constants from './constants';
 
-const WPComGetBillingTimeframe = () => i18n.translate( 'per month, billed annually' );
+const WPComGetBillingTimeframe = rawPriceAnnual =>
+	rawPriceAnnual
+		? `Billed at ${ rawPriceAnnual } per year`
+		: i18n.translate( 'per month, billed annually' );
 const WPComGetBiennialBillingTimeframe = () => i18n.translate( '/month, billed every two years' );
 
 const getPlanBloggerDetails = () => ( {

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -87,7 +87,7 @@ const PlanFeaturesActions = ( {
 			}
 		} else if ( isInSignup ) {
 			buttonText = isEligibleForPlanStepTest
-				? 'Get Started'
+				? 'Get started'
 				: translate( 'Start with %(plan)s', {
 						args: {
 							plan: planName,

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -33,6 +33,7 @@ const PlanFeaturesActions = ( {
 	isPopular,
 	isInSignup,
 	isLaunchPage,
+	isEligibleForPlanStepTest,
 	onUpgradeClick = noop,
 	planName,
 	planType,
@@ -85,11 +86,13 @@ const PlanFeaturesActions = ( {
 				} );
 			}
 		} else if ( isInSignup ) {
-			buttonText = translate( 'Start with %(plan)s', {
-				args: {
-					plan: planName,
-				},
-			} );
+			buttonText = isEligibleForPlanStepTest
+				? 'Get Started'
+				: translate( 'Start with %(plan)s', {
+						args: {
+							plan: planName,
+						},
+				  } );
 		}
 
 		if (

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -168,6 +168,7 @@ export class PlanFeaturesHeader extends Component {
 			hideMonthly,
 			isInSignup,
 			plansWithScroll,
+			isEligibleForPlanStepTest,
 		} = this.props;
 
 		const isDiscounted = !! discountPrice;
@@ -177,8 +178,11 @@ export class PlanFeaturesHeader extends Component {
 		} );
 
 		if ( isInSignup || plansWithScroll ) {
+			const classes = classNames( 'plan-features__header-billing-info', {
+				'plan-features__header-billing-info-plan-step-test': isEligibleForPlanStepTest,
+			} );
 			return (
-				<div className={ 'plan-features__header-billing-info' }>
+				<div className={ classes }>
 					<span>{ billingTimeFrame }</span>
 				</div>
 			);
@@ -257,7 +261,7 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	renderPriceGroup( fullPrice, discountedPrice = null ) {
-		const { currencyCode, isInSignup, plansWithScroll } = this.props;
+		const { currencyCode, isInSignup, plansWithScroll, isEligibleForPlanStepTest } = this.props;
 		const displayFlatPrice = isInSignup && ! plansWithScroll;
 
 		if ( fullPrice && discountedPrice ) {
@@ -287,6 +291,7 @@ export class PlanFeaturesHeader extends Component {
 				currencyCode={ currencyCode }
 				rawPrice={ fullPrice }
 				isInSignup={ displayFlatPrice }
+				isEligibleForPlanStepTest={ isEligibleForPlanStepTest }
 			/>
 		);
 	}

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -90,6 +90,7 @@ export class PlanFeaturesHeader extends Component {
 			selectedPlan,
 			title,
 			audience,
+			isEligibleForPlanStepTest,
 			translate,
 		} = this.props;
 
@@ -103,7 +104,12 @@ export class PlanFeaturesHeader extends Component {
 					{ planLevelsMatch( selectedPlan, planType ) && (
 						<PlanPill>{ translate( 'Suggested' ) }</PlanPill>
 					) }
-					{ popular && ! selectedPlan && <PlanPill>{ translate( 'Popular' ) }</PlanPill> }
+					{ popular && ! selectedPlan && ! isEligibleForPlanStepTest && (
+						<PlanPill>{ translate( 'Popular' ) }</PlanPill>
+					) }
+					{ popular && ! selectedPlan && isEligibleForPlanStepTest && (
+						<PlanPill>{ translate( 'Most popular' ) }</PlanPill>
+					) }
 					{ newPlan && ! selectedPlan && <PlanPill>{ translate( 'New' ) }</PlanPill> }
 					{ bestValue && ! selectedPlan && <PlanPill>{ translate( 'Best Value' ) }</PlanPill> }
 				</header>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -647,6 +647,7 @@ export class PlanFeatures extends Component {
 			isInSignup,
 			isLandingPage,
 			isLaunchPage,
+			isEligibleForPlanStepTest,
 			planProperties,
 			selectedPlan,
 			selectedSiteSlug,
@@ -696,6 +697,7 @@ export class PlanFeatures extends Component {
 						isInSignup={ isInSignup }
 						isLandingPage={ isLandingPage }
 						isLaunchPage={ isLaunchPage }
+						isEligibleForPlanStepTest={ isEligibleForPlanStepTest }
 						manageHref={ `/plans/my-plan/${ selectedSiteSlug }` }
 						onUpgradeClick={ () => this.handleUpgradeClick( properties ) }
 						planName={ planConstantObj.getTitle() }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -348,7 +348,7 @@ export class PlanFeatures extends Component {
 		return ReactDOM.createPortal(
 			<Notice className="plan-features__notice" showDismiss={ false } status="is-info">
 				{ translate(
-					"This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner."
+					'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
 				) }
 			</Notice>,
 			bannerContainer
@@ -462,6 +462,7 @@ export class PlanFeatures extends Component {
 			displayJetpackPlans,
 			isInSignup,
 			isJetpack,
+			isEligibleForPlanStepTest,
 			planProperties,
 			selectedPlan,
 			siteType,
@@ -486,7 +487,7 @@ export class PlanFeatures extends Component {
 			} = properties;
 			let { discountPrice } = properties;
 			const classes = classNames( 'plan-features__table-item', 'has-border-top' );
-			let audience = planConstantObj.getAudience();
+			let audience = planConstantObj.getAudience( isEligibleForPlanStepTest );
 			let billingTimeFrame = planConstantObj.getBillingTimeFrame();
 
 			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
@@ -537,7 +538,7 @@ export class PlanFeatures extends Component {
 						relatedMonthlyPlan={ relatedMonthlyPlan }
 						selectedPlan={ selectedPlan }
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
-						title={ planConstantObj.getTitle() }
+						title={ planConstantObj.getTitle( isEligibleForPlanStepTest ) }
 						plansWithScroll={ withScroll }
 					/>
 				</th>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -570,7 +570,7 @@ export class PlanFeatures extends Component {
 	}
 
 	renderPlanDescriptions() {
-		const { planProperties, withScroll } = this.props;
+		const { planProperties, withScroll, isEligibleForPlanStepTest } = this.props;
 
 		return map( planProperties, properties => {
 			const { planName, planConstantObj, isPlaceholder } = properties;
@@ -582,7 +582,7 @@ export class PlanFeatures extends Component {
 
 			let description = null;
 			if ( withScroll ) {
-				description = planConstantObj.getShortDescription( abtest );
+				description = planConstantObj.getShortDescription( isEligibleForPlanStepTest );
 			} else {
 				description = planConstantObj.getDescription( abtest );
 			}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -9,7 +9,7 @@ import ReactDOM from 'react-dom';
 import { compact, get, findIndex, last, map, noop, reduce } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { formatCurrency, getCurrencyObject } from '@automattic/format-currency';
+import formatCurrency, { getCurrencyObject } from '@automattic/format-currency';
 
 /**
  * Internal dependencies

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -866,6 +866,10 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		color: var( --color-text-subtle );
 		align-items: center;
 		text-align: center;
+
+		&.plan-features__header-billing-info-plan-step-test {
+			font-size: 12px;
+		}
 	}
 
 	.plan-features__pricing {
@@ -883,6 +887,12 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		.plan-price__currency-symbol {
 			font-size: 50%;
 			font-weight: 400;
+		}
+
+		.plan-price__currency-symbol-plan-step-test {
+			font-size: 35%;
+			font-weight: 800;
+			vertical-align: text-top;
 		}
 
 		.plan-price__integer {

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -28,6 +28,7 @@ export class PlanPrice extends Component {
 			className,
 			isInSignup,
 			isOnSale,
+			isEligibleForPlanStepTest,
 			taxText,
 			translate,
 		} = this.props;
@@ -52,6 +53,10 @@ export class PlanPrice extends Component {
 		const classes = classNames( 'plan-price', className, {
 			'is-original': original,
 			'is-discounted': discounted,
+		} );
+
+		const currencySymbolClasses = classNames( 'plan-price__currency-symbol', {
+			'plan-price__currency-symbol-plan-step-test': isEligibleForPlanStepTest,
 		} );
 
 		const renderPrice = priceObj => {
@@ -99,7 +104,7 @@ export class PlanPrice extends Component {
 
 		return (
 			<h4 className={ classes }>
-				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
+				<sup className={ currencySymbolClasses }>{ priceRange[ 0 ].price.symbol }</sup>
 				{ ! higherPriceHtml && renderPriceHtml( priceRange[ 0 ] ) }
 				{ higherPriceHtml &&
 					translate( '{{smallerPrice/}}-{{higherPrice/}}', {
@@ -110,6 +115,9 @@ export class PlanPrice extends Component {
 					<sup className="plan-price__tax-amount">
 						{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
 					</sup>
+				) }
+				{ isEligibleForPlanStepTest && (
+					<sub className="plan-price__timeframe-month"> per month</sub>
 				) }
 				{ isOnSale && <Badge>{ saleBadgeText }</Badge> }
 			</h4>

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -75,3 +75,10 @@
 .plan-price__fraction {
 	font-weight: 500;
 }
+
+.plan-price__timeframe-month {
+	vertical-align: baseline;
+	font-size: 14px;
+	color: var( --color-text-subtle );
+	font-weight: 400;
+}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -119,6 +119,7 @@ export class PlansFeaturesMain extends Component {
 			isJetpack,
 			isLandingPage,
 			isLaunchPage,
+			isEligibleForPlanStepTest,
 			onUpgradeClick,
 			selectedFeature,
 			selectedPlan,
@@ -164,6 +165,7 @@ export class PlansFeaturesMain extends Component {
 					isInSignup={ isInSignup }
 					isLandingPage={ isLandingPage }
 					isLaunchPage={ isLaunchPage }
+					isEligibleForPlanStepTest={ isEligibleForPlanStepTest }
 					onUpgradeClick={ onUpgradeClick }
 					plans={ plans }
 					redirectTo={ redirectTo }

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -102,6 +102,7 @@ export class PlansStep extends Component {
 	isEligibleForPlanStepTest() {
 		return (
 			config.isEnabled( 'plans-step-copy-updates' ) &&
+			! this.props.isLaunchPage &&
 			'variantCopyUpdates' === abtest( 'planStepCopyUpdates' )
 		);
 	}
@@ -141,10 +142,7 @@ export class PlansStep extends Component {
 	}
 
 	getHeaderTextAB() {
-		if (
-			config.isEnabled( 'plans-step-copy-updates' ) &&
-			'variantCopyUpdates' === abtest( 'planStepCopyUpdates' )
-		) {
+		if ( this.isEligibleForPlanStepTest() ) {
 			return 'Select your WordPress.com plan';
 		}
 
@@ -152,10 +150,7 @@ export class PlansStep extends Component {
 	}
 
 	getSubHeaderTextAB() {
-		if (
-			config.isEnabled( 'plans-step-copy-updates' ) &&
-			'variantCopyUpdates' === abtest( 'planStepCopyUpdates' )
-		) {
+		if ( this.isEligibleForPlanStepTest() ) {
 			return 'All plans include blazing-fast WordPress hosting.';
 		}
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -99,6 +99,13 @@ export class PlansStep extends Component {
 		this.onSelectPlan( null ); // onUpgradeClick expects a cart item -- null means Free Plan.
 	};
 
+	isEligibleForPlanStepTest() {
+		return (
+			config.isEnabled( 'plans-step-copy-updates' ) &&
+			'variantCopyUpdates' === abtest( 'planStepCopyUpdates' )
+		);
+	}
+
 	plansFeaturesList() {
 		const {
 			disableBloggerPlanWithNonBlogDomain,
@@ -118,6 +125,7 @@ export class PlansStep extends Component {
 					hideFreePlan={ hideFreePlan }
 					isInSignup={ true }
 					isLaunchPage={ isLaunchPage }
+					isEligibleForPlanStepTest={ this.isEligibleForPlanStepTest() }
 					onUpgradeClick={ this.onSelectPlan }
 					showFAQ={ false }
 					displayJetpackPlans={ false }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The new plan step AB test is enabled in #39600. Individual pieces of the UI will be built in separate PRs and finally merged together.

* Update the plan features box with the latest UI proposed in p8Eqe3-144-p2.

**BEFORE**

<img width="1617" alt="Screenshot 2020-02-25 at 10 51 06 AM" src="https://user-images.githubusercontent.com/1269602/75217356-da877500-57bc-11ea-998a-1637f63558ec.png">

**AFTER**

<img width="1636" alt="Screenshot 2020-02-25 at 11 17 20 AM" src="https://user-images.githubusercontent.com/1269602/75218509-7797dd00-57c0-11ea-9cff-ef82f096b42d.png">

**Mobile view**

![calypso localhost_3000_start_plans(Pixel 2 XL)](https://user-images.githubusercontent.com/1269602/75220759-3276a980-57c6-11ea-81f4-a02d1646cdd4.png)

**SUMMARY OF CHANGES**

* Changed plan header from "Personal", "Business" etc. to "Personal plan", "Business plan" etc.
* Plan sub-header changed for each plan - "WordPress essentials ...", "Powerful tools at a great value", ...
* Plan price changed from $4 to $4 per month, currency symbol in the new UI is aligned to top of the price text.
* Below the plan price, showing annual price in the new UI "Billed at $96 per year."
* Update plan descriptions copy
* Updated CTA button text and placed it below the plan description.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**

* Go through the signup flow after assigning yourself to _variantShowUpdates_ of planStepCopyUpdates test.
* In the plan step, verify that the UI for the plan features box matches the UI in p8Eqe3-144-p2, and matches the summary of changes described above.
* Verify UI changes are seen both in desktop and mobile screen sizes.

**Scenario 2**

* Go through the signup flow at /start.
* Confirm that in any step before the plans step, you are not assigned to the _planStepCopyUpdates_ test.

**Scenario 3**

* Log in to a fresh unlaunched(private) wpcom site and go to the plans page at /plans. You should not be seeing the new UI.
* Now go through the launch flow. At the plans step in launch flow, you should not show the new UI.
* You should not have been assigned to the AB test since you haven't visited the plans step in signup flow context. Confirm this by typing `localstorage.ABTests;` in your browser console and verify that the _planStepCopyUpdates_ test is not in the output.

**Scenario 4**

Verify UI looks fine a few currencies:

<img width="1542" alt="Screenshot 2020-02-25 at 12 30 26 PM" src="https://user-images.githubusercontent.com/1269602/75222652-b599fe80-57ca-11ea-9674-6786c288b391.png">

<img width="1557" alt="Screenshot 2020-02-25 at 12 23 11 PM" src="https://user-images.githubusercontent.com/1269602/75222680-c21e5700-57ca-11ea-9edb-529d0f8a1f46.png">




