### PR TITLE
Modularize posts state

### DIFF
--- a/client/state/posts/actions.js
+++ b/client/state/posts/actions.js
@@ -72,6 +72,8 @@ import {
 import { setEditorLastDraft, resetEditorLastDraft } from 'state/ui/editor/last-draft/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
+import 'state/posts/init';
+
 /**
  * Returns an action object to be used in signalling that a post object has
  * been received.

--- a/client/state/posts/counts/actions.js
+++ b/client/state/posts/counts/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	POST_COUNTS_RECEIVE,
@@ -9,6 +8,8 @@ import {
 	POST_COUNTS_REQUEST_SUCCESS,
 	POST_COUNTS_REQUEST_FAILURE,
 } from 'state/action-types';
+
+import 'state/posts/init';
 
 /**
  * Returns an action object signalling that post counts have been received for

--- a/client/state/posts/counts/selectors.js
+++ b/client/state/posts/counts/selectors.js
@@ -10,6 +10,8 @@ import { get } from 'lodash';
 
 import { POST_STATUSES } from '../constants';
 
+import 'state/posts/init';
+
 /**
  * Returns true if post counts request is in progress, or false otherwise.
  *

--- a/client/state/posts/init.js
+++ b/client/state/posts/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import postsReducer from './reducer';
+
+registerReducer( [ 'posts' ], postsReducer );

--- a/client/state/posts/likes/actions.js
+++ b/client/state/posts/likes/actions.js
@@ -12,6 +12,8 @@ import {
 
 import 'state/data-layer/wpcom/sites/posts/likes';
 
+import 'state/posts/init';
+
 /**
  * Returns an action thunk which, when invoked, triggers a network request to
  * retrieve post likes for a post.

--- a/client/state/posts/package.json
+++ b/client/state/posts/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/posts/revisions/actions.js
+++ b/client/state/posts/revisions/actions.js
@@ -13,6 +13,8 @@ import {
 
 import 'state/data-layer/wpcom/posts/revisions';
 
+import 'state/posts/init';
+
 /**
  * Action creator function: POST_REVISIONS_REQUEST
  *

--- a/client/state/posts/revisions/authors/actions.js
+++ b/client/state/posts/revisions/authors/actions.js
@@ -6,6 +6,8 @@ import { POST_REVISION_AUTHORS_RECEIVE, POST_REVISIONS_AUTHORS_REQUEST } from 's
 
 import 'state/data-layer/wpcom/sites/users';
 
+import 'state/posts/init';
+
 /**
  * Action creator for receiving an array of users from REST response
  *

--- a/client/state/posts/revisions/authors/selectors.js
+++ b/client/state/posts/revisions/authors/selectors.js
@@ -1,11 +1,15 @@
 /**
+ * Internal dependencies
+ */
+import 'state/posts/init';
+
+/**
  * Returns an author (user) object by ID.
  *
- *
+ * @param {any} state Redux state
  * @param {number} userId User ID
  * @returns {object}        User object
  */
-
 export function getPostRevisionAuthor( state, userId ) {
 	return state.posts.revisions.authors.items[ userId ];
 }

--- a/client/state/posts/selectors.js
+++ b/client/state/posts/selectors.js
@@ -27,6 +27,8 @@ import { DEFAULT_POST_QUERY, DEFAULT_NEW_POST_VALUES } from './constants';
 import { addQueryArgs } from 'lib/route';
 import { getFeaturedImageId } from 'state/posts/utils';
 
+import 'state/posts/init';
+
 /**
  * Returns the PostsQueryManager from the state tree for a given site ID (or
  * for queries related to all sites at once).

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -70,7 +70,6 @@ import plans from './plans/reducer';
 import plugins from './plugins/reducer';
 import postFormats from './post-formats/reducer';
 import postTypes from './post-types/reducer';
-import posts from './posts/reducer';
 import preferences from './preferences/reducer';
 import productsList from './products-list/reducer';
 import purchases from './purchases/reducer';
@@ -159,7 +158,6 @@ const reducers = {
 	plugins,
 	postFormats,
 	postTypes,
-	posts,
 	preferences,
 	productsList,
 	purchases,

--- a/client/state/selectors/can-current-user-edit-post.js
+++ b/client/state/selectors/can-current-user-edit-post.js
@@ -8,6 +8,8 @@ import { get } from 'lodash';
  */
 import { getPost } from 'state/posts/selectors';
 
+import 'state/posts/init';
+
 /**
  * Returns whether the current user can edit the post with the given global ID.
  *

--- a/client/state/selectors/count-post-likes.js
+++ b/client/state/selectors/count-post-likes.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/posts/init';
 
 /**
  * Returns the total of post likes for a given site ID, post ID.

--- a/client/state/selectors/edited-post-has-content.js
+++ b/client/state/selectors/edited-post-has-content.js
@@ -10,6 +10,8 @@ import { some, trim } from 'lodash';
 import { getEditedPost } from 'state/posts/selectors';
 import { getEditorRawContent } from 'state/ui/editor/selectors';
 
+import 'state/posts/init';
+
 const REGEXP_EMPTY_CONTENT = /^<p>(<br[^>]*>|&nbsp;|\s)*<\/p>$/;
 const CONTENT_LENGTH_ASSUME_SET = 50;
 

--- a/client/state/selectors/get-post-like-count.js
+++ b/client/state/selectors/get-post-like-count.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/posts/init';
+
+/**
  * Returns the count of post likes for a given site ID, post ID.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/selectors/get-post-like-last-updated.js
+++ b/client/state/selectors/get-post-like-last-updated.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/posts/init';
+
 export default function getPostLikeLastUpdated( state, siteId, postId ) {
 	return get( state.posts.likes.items, [ siteId, postId, 'lastUpdated' ] );
 }

--- a/client/state/selectors/get-post-likes.js
+++ b/client/state/selectors/get-post-likes.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/posts/init';
+
+/**
  * Returns the post likes for a given site ID, post ID.
  *
  * @param  {object}  state  Global state tree

--- a/client/state/selectors/get-post-revision.js
+++ b/client/state/selectors/get-post-revision.js
@@ -8,6 +8,8 @@ import { get } from 'lodash';
  */
 import createSelector from 'lib/create-selector';
 
+import 'state/posts/init';
+
 const getPostRevision = createSelector(
 	( state, siteId, postId, revisionId ) =>
 		get( state.posts.revisions.diffs, [ siteId, postId, 'revisions', revisionId ], null ),

--- a/client/state/selectors/get-post-revisions-authors-id.js
+++ b/client/state/selectors/get-post-revisions-authors-id.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { get, map, uniq } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import createSelector from 'lib/create-selector';
+
+import 'state/posts/init';
 
 const getPostRevisionsAuthorsId = createSelector(
 	( state, siteId, postId ) =>

--- a/client/state/selectors/get-post-revisions-comparisons.js
+++ b/client/state/selectors/get-post-revisions-comparisons.js
@@ -10,6 +10,8 @@ import createSelector from 'lib/create-selector';
 import getPostRevisions from 'state/selectors/get-post-revisions';
 import getPostRevisionsDiff from 'state/selectors/get-post-revisions-diff';
 
+import 'state/posts/init';
+
 const getPostRevisionsComparisons = createSelector(
 	( state, siteId, postId ) => {
 		const revisions = getPostRevisions( state, siteId, postId );

--- a/client/state/selectors/get-post-revisions-diff-view.js
+++ b/client/state/selectors/get-post-revisions-diff-view.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/posts/init';
+
 const getPostRevisionsDiffView = state => {
 	return get( state, 'posts.revisions.ui.diffView', 'unified' );
 };

--- a/client/state/selectors/get-post-revisions-diff.js
+++ b/client/state/selectors/get-post-revisions-diff.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/posts/init';
+
 export default function getPostRevisionsDiff(
 	state,
 	siteId,

--- a/client/state/selectors/get-post-revisions-selected-revision-id.js
+++ b/client/state/selectors/get-post-revisions-selected-revision-id.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/posts/init';
+
 const getPostRevisionsSelectedRevisionId = state => {
 	return get( state, 'posts.revisions.selection.revisionId' );
 };

--- a/client/state/selectors/get-post-revisions.js
+++ b/client/state/selectors/get-post-revisions.js
@@ -9,6 +9,8 @@ import { get, orderBy } from 'lodash';
  */
 import createSelector from 'lib/create-selector';
 
+import 'state/posts/init';
+
 const getPostRevisions = createSelector(
 	( state, siteId, postId ) => {
 		const revisions = get( state.posts.revisions.diffs, [ siteId, postId, 'revisions' ] );

--- a/client/state/selectors/is-liked-post.js
+++ b/client/state/selectors/is-liked-post.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/posts/init';
+
+/**
  * Whether or not the current user likes this post
  *
  * @param  {object}  state  Global state tree

--- a/client/state/selectors/is-post-revisions-dialog-visible.js
+++ b/client/state/selectors/is-post-revisions-dialog-visible.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/posts/init';
+
 export default function isPostRevisionsDialogVisible( state ) {
 	return get( state, 'posts.revisions.ui.isDialogVisible', false );
 }


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles posts.

For mode details on state modularization, see #39261 and p4TIVU-9lM-p2.

In the interest of keeping this PR short, I will create subsequent PRs for moving posts-related selectors under `state/posts`, as well as for splitting up the existing monolithic selectors and utils files, instead of handling those changes here too.

Unfortunately, posts state seems to be loaded by most routes, so there won't be any meaningful size savings, at least from modularising alone. The subsequent PRs may introduce some improvements when combined with this PR, however.

#### Changes proposed in this Pull Request

* Modularise posts state
* Minor lint fixes to touched files

#### Testing instructions

Since posts state seems to be loaded by most routes, there's no easy way to check that modularization is working. To ensure correctness, try to use posts functionality as much as possible and see if anything breaks. The unit tests and E2E tests should add a good measure of confidence.