### PR TITLE
Add expiring soon messages in the new domain status screen

### DIFF
--- a/client/lib/domains/utils/index.js
+++ b/client/lib/domains/utils/index.js
@@ -5,3 +5,4 @@ export { getDomainRegistrationAgreementUrl } from 'lib/domains/utils/get-domain-
 export { isDomainConnectAuthorizePath } from 'lib/domains/utils/is-domain-connect-authorize-path';
 export { parseDomainAgainstTldList } from 'lib/domains/utils/parse-domain-against-tld-list';
 export { isRecentlyRegistered } from 'lib/domains/utils/is-recently-registered';
+export { isExpiringSoon } from 'lib/domains/utils/is-expiring-soon';

--- a/client/lib/domains/utils/is-expiring-soon.js
+++ b/client/lib/domains/utils/is-expiring-soon.js
@@ -3,6 +3,9 @@
  */
 import moment from 'moment';
 
-export function isExpiringSoon( expiry, expiresWithinDays ) {
-	return moment.utc( expiry ).isBefore( moment.utc().add( expiresWithinDays, 'days' ) );
+export function isExpiringSoon( domain, expiresWithinDays ) {
+	return (
+		! domain.expired &&
+		moment.utc( domain.expiry ).isBefore( moment.utc().add( expiresWithinDays, 'days' ) )
+	);
 }

--- a/client/lib/domains/utils/is-expiring-soon.js
+++ b/client/lib/domains/utils/is-expiring-soon.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+export function isExpiringSoon( expiry, expiresWithinDays ) {
+	return moment.utc( expiry ).isBefore( moment.utc().add( expiresWithinDays, 'days' ) );
+}

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -87,12 +87,12 @@ class RegisteredDomainType extends React.Component {
 		const { domain, translate, moment } = this.props;
 		const { registrationDate, expiry } = domain;
 
-		if ( isExpiringSoon( expiry, 30 ) ) {
+		if ( isExpiringSoon( domain, 30 ) ) {
 			const expiresMessage = translate( 'Expires in %(days)s', {
 				args: { days: moment.utc( expiry ).fromNow( true ) },
 			} );
 
-			if ( isExpiringSoon( expiry, 5 ) ) {
+			if ( isExpiringSoon( domain, 5 ) ) {
 				return {
 					statusText: expiresMessage,
 					statusClass: 'status-error',
@@ -144,11 +144,7 @@ class RegisteredDomainType extends React.Component {
 		const { domain, translate, moment } = this.props;
 		const { expiry } = domain;
 
-		if ( domain.expired ) {
-			return null;
-		}
-
-		if ( isExpiringSoon( expiry, 30 ) ) {
+		if ( isExpiringSoon( domain, 30 ) ) {
 			return (
 				<div>
 					{ translate(

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -144,6 +144,10 @@ class RegisteredDomainType extends React.Component {
 		const { domain, translate, moment } = this.props;
 		const { expiry } = domain;
 
+		if ( domain.expired ) {
+			return null;
+		}
+
 		if ( isExpiringSoon( expiry, 30 ) ) {
 			return (
 				<div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* somehow I missed those messages. Anyway this PR introduces an expiring soon message with different styling depending on when it expires  (within 30 days or within 5 days)

if a domain is within 5 days of expiration:

<img width="738" alt="Screenshot 2020-02-24 at 14 51 03" src="https://user-images.githubusercontent.com/1355045/75154074-883f4900-5715-11ea-835b-76c6773820f6.png">

if a domain is within 30 days of expiration:

<img width="743" alt="Screenshot 2020-02-24 at 14 51 56" src="https://user-images.githubusercontent.com/1355045/75154067-85445880-5715-11ea-81e2-572c70cec5a7.png">


#### Testing instructions

* Just open the domain settings screen for domain that is within 30 or 5 days of expiration
