### PR TITLE
DEMO: Use wp-i18n instances

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { sprintf } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
-import { useI18n } from '@automattic/react-i18n';
+import { useI18n, withI18n, I18nReact } from '@automattic/react-i18n';
 import { Icon, wordpress } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useHistory } from 'react-router-dom';
@@ -172,7 +172,7 @@ const Header: React.FunctionComponent = () => {
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-site-title-section">
 					<div className="gutenboarding__header-site-title">
-						{ siteTitle ? siteTitle : __( 'Start your website' ) }
+						{ siteTitle ? siteTitle : <StartYourWebsite /> }
 					</div>
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-domain-section">
@@ -207,5 +207,13 @@ const Header: React.FunctionComponent = () => {
 		</div>
 	);
 };
+
+const StartYourWebsite = withI18n(
+	class extends React.PureComponent< I18nReact > {
+		render() {
+			return this.props.__( 'Start your website' );
+		}
+	}
+);
 
 export default Header;

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -211,6 +211,9 @@ const Header: React.FunctionComponent = () => {
 const StartYourWebsite = withI18n(
 	class extends React.PureComponent< I18nReact > {
 		render() {
+			// Demonstrate a stable provider. This should update iff the locale is changed.
+			// eslint-disable-next-line no-console
+			console.log( 'Rendered <StartYourWebsite /> PureComponent!' );
 			return this.props.__( 'Start your website' );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use proposed `react-i18n` with instances from #39624 

#### Testing instructions

* [`/new`](https://calypso.live/new?branch=gutenboarding/react-i18n-instances) - renders users language
* [`/new/es`](https://calypso.live/new/es?branch=gutenboarding/react-i18n-instances) - renders Spanish
* [`/new/ar`](https://calypso.live/new/ar?branch=gutenboarding/react-i18n-instances) - renders Arabic
* Testing like below updates the langue as expected:

```js
updateLocale( 'de' );
updateLocale( 'fr' );
updateLocale( 'es' );
updateLocale( 'ar' );
```