### PR TITLE
Add support for features flags in Jetpack Cloud

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import CurrentSite from '../current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import Sidebar from 'layout/sidebar';
@@ -89,74 +90,86 @@ class JetpackCloudSidebar extends Component {
 							selected={ this.isSelected( '/' ) }
 						/>
 					</SidebarMenu>
-					<ExpandableSidebarMenu
-						expanded={ this.isExpanded( '/backups' ) }
-						onClick={ this.handleExpandableMenuClick( '/backups' ) }
-						materialIcon="backup"
-						materialIconStyle="filled"
-						title={ translate( 'Backups', { comment: 'Jetpack Cloud sidebar navigation item' } ) }
-					>
-						<ul>
-							<SidebarItem
-								label={ translate( 'Backups', {
-									comment: 'Jetpack Cloud sidebar navigation item',
-								} ) }
-								link="/backups"
-								onNavigate={ this.onNavigate }
-								selected={ this.isSelected( '/backups' ) }
-							/>
-							<SidebarItem
-								label={ translate( 'Restore site', {
-									comment: 'Jetpack Cloud / Backups sidebar navigation item',
-								} ) }
-								link="#" // @todo: Add /backup/restore route
-								onNavigate={ this.onNavigate }
-								selected={ this.isSelected( '/backups/restore' ) }
-							/>
-							<SidebarItem
-								label={ translate( 'Settings', {
-									comment: 'Jetpack Cloud / Backups sidebar navigation item',
-								} ) }
-								link="#" // @todo: Add backup/settings route
-								onNavigate={ this.onNavigate }
-								selected={ this.isSelected( '/backups/settings' ) }
-							/>
-						</ul>
-					</ExpandableSidebarMenu>
-					<ExpandableSidebarMenu
-						expanded={ this.isExpanded( '/scan' ) }
-						onClick={ this.handleExpandableMenuClick( '/scan' ) }
-						materialIcon="security" // @todo: The Scan logo differs from the Material Icon used here
-						materialIconStyle="filled"
-						title={ translate( 'Scan', { comment: 'Jetpack Cloud sidebar navigation item' } ) }
-					>
-						<ul>
-							<SidebarItem
-								label={ translate( 'Scanner', {
-									comment: 'Jetpack Cloud / Scan sidebar navigation item',
-								} ) }
-								link="/scan"
-								onNavigate={ this.onNavigate }
-								selected={ this.isSelected( '/scan' ) }
-							/>
-							<SidebarItem
-								label={ translate( 'History', {
-									comment: 'Jetpack Cloud / Scan sidebar navigation item',
-								} ) }
-								link="#" // @todo: Add /scan/history route
-								onNavigate={ this.onNavigate }
-								selected={ this.isSelected( '/scan/history' ) }
-							/>
-							<SidebarItem
-								label={ translate( 'Settings', {
-									comment: 'Jetpack Cloud / Scan sidebar navigation item',
-								} ) }
-								link="#" // @todo: Add /scan/settings route
-								onNavigate={ this.onNavigate }
-								selected={ this.isSelected( '/scan/settings' ) }
-							/>
-						</ul>
-					</ExpandableSidebarMenu>
+					{ config.isEnabled( 'jetpack-cloud/backups' ) && (
+						<ExpandableSidebarMenu
+							expanded={ this.isExpanded( '/backups' ) }
+							onClick={ this.handleExpandableMenuClick( '/backups' ) }
+							materialIcon="backup"
+							materialIconStyle="filled"
+							title={ translate( 'Backups', { comment: 'Jetpack Cloud sidebar navigation item' } ) }
+						>
+							<ul>
+								<SidebarItem
+									label={ translate( 'Backups', {
+										comment: 'Jetpack Cloud sidebar navigation item',
+									} ) }
+									link="/backups"
+									onNavigate={ this.onNavigate }
+									selected={ this.isSelected( '/backups' ) }
+								/>
+								{ config.isEnabled( 'jetpack-cloud/backups-restore' ) && (
+									<SidebarItem
+										label={ translate( 'Restore site', {
+											comment: 'Jetpack Cloud / Backups sidebar navigation item',
+										} ) }
+										link="#" // @todo: Add /backup/restore route
+										onNavigate={ this.onNavigate }
+										selected={ this.isSelected( '/backups/restore' ) }
+									/>
+								) }
+								{ config.isEnabled( 'jetpack-cloud/settings' ) && (
+									<SidebarItem
+										label={ translate( 'Settings', {
+											comment: 'Jetpack Cloud / Backups sidebar navigation item',
+										} ) }
+										link="#" // @todo: Add backup/settings route
+										onNavigate={ this.onNavigate }
+										selected={ this.isSelected( '/backups/settings' ) }
+									/>
+								) }
+							</ul>
+						</ExpandableSidebarMenu>
+					) }
+					{ config.isEnabled( 'jetpack-cloud/scan' ) && (
+						<ExpandableSidebarMenu
+							expanded={ this.isExpanded( '/scan' ) }
+							onClick={ this.handleExpandableMenuClick( '/scan' ) }
+							materialIcon="security" // @todo: The Scan logo differs from the Material Icon used here
+							materialIconStyle="filled"
+							title={ translate( 'Scan', { comment: 'Jetpack Cloud sidebar navigation item' } ) }
+						>
+							<ul>
+								<SidebarItem
+									label={ translate( 'Scanner', {
+										comment: 'Jetpack Cloud / Scan sidebar navigation item',
+									} ) }
+									link="/scan"
+									onNavigate={ this.onNavigate }
+									selected={ this.isSelected( '/scan' ) }
+								/>
+								{ config.isEnabled( 'jetpack-cloud/scan-history' ) && (
+									<SidebarItem
+										label={ translate( 'History', {
+											comment: 'Jetpack Cloud / Scan sidebar navigation item',
+										} ) }
+										link="#" // @todo: Add /scan/history route
+										onNavigate={ this.onNavigate }
+										selected={ this.isSelected( '/scan/history' ) }
+									/>
+								) }
+								{ config.isEnabled( 'jetpack-cloud/settings' ) && (
+									<SidebarItem
+										label={ translate( 'Settings', {
+											comment: 'Jetpack Cloud / Scan sidebar navigation item',
+										} ) }
+										link="#" // @todo: Add /scan/settings route
+										onNavigate={ this.onNavigate }
+										selected={ this.isSelected( '/scan/settings' ) }
+									/>
+								) }
+							</ul>
+						</ExpandableSidebarMenu>
+					) }
 				</SidebarRegion>
 				<SidebarFooter>
 					<SidebarMenu>

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -6,6 +6,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { normalize } from 'lib/route';
 import { clientRender, makeLayout, setupSidebar, sites, siteSelection } from './controller';
 import { dashboard } from './sections/dashboard/controller';
@@ -23,64 +24,75 @@ const router = () => {
 
 	page( '/', siteSelection, setupSidebar, dashboard, makeLayout, clientRender );
 
-	page( '/backups', siteSelection, sites, setupSidebar, makeLayout, clientRender );
-	page( '/backups/:site', siteSelection, setupSidebar, backups, makeLayout, clientRender );
-	page(
-		'/backups/:site/detail',
-		siteSelection,
-		setupSidebar,
-		backupDetail,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/backups/:site/detail/:backupId',
-		siteSelection,
-		setupSidebar,
-		backupDetail,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/backups/:site/download',
-		siteSelection,
-		setupSidebar,
-		backupDownload,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/site/:site/backups/backups/download/:downloadId',
-		setupSidebar,
-		backupDownload,
-		makeLayout,
-		clientRender
-	);
+	if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
+		page( '/backups', siteSelection, sites, setupSidebar, makeLayout, clientRender );
+		page( '/backups/:site', siteSelection, setupSidebar, backups, makeLayout, clientRender );
+		page(
+			'/backups/:site/detail',
+			siteSelection,
+			setupSidebar,
+			backupDetail,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/backups/:site/detail/:backupId',
+			siteSelection,
+			setupSidebar,
+			backupDetail,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/backups/:site/download',
+			siteSelection,
+			setupSidebar,
+			backupDownload,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/site/:site/backups/backups/download/:downloadId',
+			setupSidebar,
+			backupDownload,
+			makeLayout,
+			clientRender
+		);
 
-	page( '/backups/restore', siteSelection, sites, setupSidebar, makeLayout, clientRender );
-	page(
-		'/backups/:site/restore',
-		siteSelection,
-		setupSidebar,
-		backupRestore,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/backups/:site/restore/:restoreId',
-		siteSelection,
-		setupSidebar,
-		backupRestore,
-		makeLayout,
-		clientRender
-	);
+		if ( config.isEnabled( 'jetpack-cloud/backups-restore' ) ) {
+			page( '/backups/restore', siteSelection, sites, setupSidebar, makeLayout, clientRender );
+			page(
+				'/backups/:site/restore',
+				siteSelection,
+				setupSidebar,
+				backupRestore,
+				makeLayout,
+				clientRender
+			);
+			page(
+				'/backups/:site/restore/:restoreId',
+				siteSelection,
+				setupSidebar,
+				backupRestore,
+				makeLayout,
+				clientRender
+			);
+		}
+	}
 
-	page( '/scan', siteSelection, sites, setupSidebar, makeLayout, clientRender );
-	page( '/scan/:site', siteSelection, setupSidebar, scan, makeLayout, clientRender );
-	page( '/scan/:site/history', siteSelection, setupSidebar, scanHistory, makeLayout, clientRender );
+	if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
+		page( '/scan', siteSelection, sites, setupSidebar, makeLayout, clientRender );
+		page( '/scan/:site', siteSelection, setupSidebar, scan, makeLayout, clientRender );
 
-	page( '/settings', siteSelection, sites, setupSidebar, makeLayout, clientRender );
-	page( '/settings/:site', siteSelection, setupSidebar, settings, makeLayout, clientRender );
+		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
+			page( '/scan/:site/history', siteSelection, setupSidebar, scanHistory, makeLayout, clientRender );
+		}
+	}
+
+	if ( config.isEnabled( 'jetpack-cloud/settings' ) ) {
+		page( '/settings', siteSelection, sites, setupSidebar, makeLayout, clientRender );
+		page( '/settings/:site', siteSelection, setupSidebar, settings, makeLayout, clientRender );
+	}
 };
 
 export default router;

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -11,6 +11,11 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"features": {
-		"jetpack-cloud": true
+		"jetpack-cloud": true,
+		"jetpack-cloud/backups": true,
+		"jetpack-cloud/backups-restore": true,
+		"jetpack-cloud/settings": true,
+		"jetpack-cloud/scan": true,
+		"jetpack-cloud/scan-history": true
 	}
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -9,6 +9,11 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"features": {
-		"jetpack-cloud": true
+		"jetpack-cloud": true,
+		"jetpack-cloud/backups": true,
+		"jetpack-cloud/backups-restore": true,
+		"jetpack-cloud/settings": true,
+		"jetpack-cloud/scan": true,
+		"jetpack-cloud/scan-history": true
 	}
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -9,6 +9,11 @@
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"features": {
-		"jetpack-cloud": true
+		"jetpack-cloud": true,
+		"jetpack-cloud/backups": true,
+		"jetpack-cloud/backups-restore": true,
+		"jetpack-cloud/settings": true,
+		"jetpack-cloud/scan": true,
+		"jetpack-cloud/scan-history": true
 	}
 }


### PR DESCRIPTION
This PR adds support for feature flags to Jetpack Cloud. 

#### Changes proposed in this Pull Request

* Add Jetpack Cloud feature flags in config
* Set up routes and render sidebar menu items based on feature flags

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try disabling some of the Jetpack Cloud sections in `config/jetpack-cloud-development.json`
* Restart your local environment with `npm run start-jetpack-cloud`
* Go to http://jetpack.cloud.localhost:3000/ and confirm the disabled section is no longer listed in the sidebar

Fixes 1156570014567299-as-1157678527369092
