### PR TITLE
Plan step test: Add testimonial section below plan features

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -163,18 +163,6 @@ export class PlanFeatures extends Component {
 			? plans.indexOf( selectedPlan )
 			: findIndex( planProperties, { popular: true } );
 
-		const a = { display: 'flex', 'justify-content': 'center', color: '#fff', 'font-size': '20px' };
-		const b = { display: 'flex', 'flex-direction': 'column', width: '35%' };
-		const c = { 'border-left': '1px solid #fff', 'margin-left': '20px', 'padding-left': '20px' };
-		const d = {
-			background:
-				"url('https://s1.wp.com/wp-content/themes/h4/landing/marketing/pages/_common/components/vip-pitch/media/vip-brands.png')",
-			'background-repeat': 'no-repeat',
-			'background-size': '340px',
-			height: '35px',
-			'margin-left': '40px',
-			'margin-top': '40px',
-		};
 		return (
 			<div className={ planWrapperClasses }>
 				<QueryActivePromotions />
@@ -209,19 +197,9 @@ export class PlanFeatures extends Component {
 								</tbody>
 							</table>
 						</PlanFeaturesScroller>
-
-						<div style={ a }>
-							<div>You're in good hands</div>
-							<div style={ b }>
-								<div style={ c }>
-									Did you know that WordPress powers 35% of the entire internet? WordPress.com is
-									the best WordPress solution out there, as trusted by:
-								</div>
-								<div style={ d }></div>
-							</div>
-						</div>
 					</div>
 				</div>
+				{ /* <PlanTestimonials /> */ }
 			</div>
 		);
 	}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -362,7 +362,7 @@ export class PlanFeatures extends Component {
 		return ReactDOM.createPortal(
 			<Notice className="plan-features__notice" showDismiss={ false } status="is-info">
 				{ translate(
-					'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
+					"This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner."
 				) }
 			</Notice>,
 			bannerContainer

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -199,7 +199,6 @@ export class PlanFeatures extends Component {
 						</PlanFeaturesScroller>
 					</div>
 				</div>
-				{ /* <PlanTestimonials /> */ }
 			</div>
 		);
 	}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -362,7 +362,7 @@ export class PlanFeatures extends Component {
 		return ReactDOM.createPortal(
 			<Notice className="plan-features__notice" showDismiss={ false } status="is-info">
 				{ translate(
-					"This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner."
+					'This plan was purchased by a different WordPress.com account. To manage this plan, log in to that account or contact the account owner.'
 				) }
 			</Notice>,
 			bannerContainer

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -163,6 +163,18 @@ export class PlanFeatures extends Component {
 			? plans.indexOf( selectedPlan )
 			: findIndex( planProperties, { popular: true } );
 
+		const a = { display: 'flex', 'justify-content': 'center', color: '#fff', 'font-size': '20px' };
+		const b = { display: 'flex', 'flex-direction': 'column', width: '35%' };
+		const c = { 'border-left': '1px solid #fff', 'margin-left': '20px', 'padding-left': '20px' };
+		const d = {
+			background:
+				"url('https://s1.wp.com/wp-content/themes/h4/landing/marketing/pages/_common/components/vip-pitch/media/vip-brands.png')",
+			'background-repeat': 'no-repeat',
+			'background-size': '340px',
+			height: '35px',
+			'margin-left': '40px',
+			'margin-top': '40px',
+		};
 		return (
 			<div className={ planWrapperClasses }>
 				<QueryActivePromotions />
@@ -197,6 +209,17 @@ export class PlanFeatures extends Component {
 								</tbody>
 							</table>
 						</PlanFeaturesScroller>
+
+						<div style={ a }>
+							<div>You're in good hands</div>
+							<div style={ b }>
+								<div style={ c }>
+									Did you know that WordPress powers 35% of the entire internet? WordPress.com is
+									the best WordPress solution out there, as trusted by:
+								</div>
+								<div style={ d }></div>
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/plan-testimonials/index.jsx
+++ b/client/my-sites/plan-testimonials/index.jsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export class PlanTestimonials extends Component {
+	render() {
+		return (
+			<div className="plan-testimonials__container">
+				<div className="plan-testimonials__content-left">You're in good hands</div>
+				<div className="plan-testimonials__content-right-container">
+					<div className="plan-testimonials__content-right">
+						Did you know that WordPress powers 35% of the entire internet? WordPress.com is the best
+						WordPress solution out there, as trusted by:
+					</div>
+					<div className="plan-testimonials__content-testimonial-image"></div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( PlanTestimonials );

--- a/client/my-sites/plan-testimonials/index.jsx
+++ b/client/my-sites/plan-testimonials/index.jsx
@@ -13,7 +13,9 @@ export class PlanTestimonials extends Component {
 	render() {
 		return (
 			<div className="plan-testimonials__container">
-				<div className="plan-testimonials__content-left">You're in good hands</div>
+				<div className="plan-testimonials__content-left">
+					You're in <br /> good hands
+				</div>
 				<div className="plan-testimonials__content-right-container">
 					<div className="plan-testimonials__content-right">
 						Did you know that WordPress powers 35% of the entire internet? WordPress.com is the best

--- a/client/my-sites/plan-testimonials/style.scss
+++ b/client/my-sites/plan-testimonials/style.scss
@@ -3,7 +3,7 @@
     display: flex;
     font-size: 14px;
     justify-content: center;
-	padding-bottom: 100px;
+    padding-bottom: 100px;
 
 	@include breakpoint( '<960px' ) {
 		padding-top: 30px;
@@ -11,14 +11,14 @@
 
     @include breakpoint( '<480px' ) {
         flex-direction: column;
-		padding-bottom: 50px;
+        padding-bottom: 50px;
     }
 
     .plan-testimonials__content-left {
         font-size: 24px;
-		font-family: 'Recoleta', serif;
-		line-height: 1.2em;
-		padding-top: 13px;
+        font-family: 'Recoleta', serif;
+        line-height: 1.2em;
+        padding-top: 13px;
 
         @include breakpoint( '<960px' ) {
             width: auto;
@@ -50,8 +50,8 @@
             border-left: 1px solid #ffffff8a;
             margin-left: 30px;
             padding-left: 30px;
-			padding-top: 10px;
-			padding-bottom: 10px;
+            padding-top: 10px;
+            padding-bottom: 10px;
 
             @include breakpoint( '<480px' ) {
                 padding: 20px;
@@ -62,11 +62,11 @@
         .plan-testimonials__content-testimonial-image {
             background:
 				url( 'https://s1.wp.com/wp-content/themes/h4/landing/marketing/pages/_common/components/vip-pitch/media/vip-brands.png' );
-			background-repeat: no-repeat;
-			background-size: 80%;
-			opacity: 0.7;
-			height: 35px;
-			margin-left: 60px;
+            background-repeat: no-repeat;
+            background-size: 80%;
+            opacity: 0.7;
+            height: 35px;
+            margin-left: 60px;
             margin-top: 24px;
 
             @include breakpoint( '<960px' ) {

--- a/client/my-sites/plan-testimonials/style.scss
+++ b/client/my-sites/plan-testimonials/style.scss
@@ -1,0 +1,68 @@
+.plan-testimonials__container {
+    color: var( --color-text-inverted );
+    display: flex;
+    font-size: 14px;
+    justify-content: center;
+
+    @include breakpoint( '<480px' ) {
+        flex-direction: column;
+    }
+
+    .plan-testimonials__content-left {
+        font-size: 24px;
+        width: 8%;
+
+        @include breakpoint( '<960px' ) {
+            width: 15%;
+        }
+
+        @include breakpoint( '<480px' ) {
+            width: auto;
+            text-align: center;
+        }
+    }
+
+    .plan-testimonials__content-right-container {
+        display: flex;
+        flex-direction: column;
+        width: 28%;
+
+        @include breakpoint( '<960px' ) {
+            width: 35%;
+        }
+
+        @include breakpoint( '<480px' ) {
+            width: auto;
+        }
+
+        .plan-testimonials__content-right {
+            border-left: 1px solid #fff;
+            margin-left: 20px;
+            padding-left: 20px;
+
+            @include breakpoint( '<480px' ) {
+                padding: 20px;
+                margin: 0;
+            }
+        }
+
+        .plan-testimonials__content-testimonial-image {
+            background:
+				url( 'https://s1.wp.com/wp-content/themes/h4/landing/marketing/pages/_common/components/vip-pitch/media/vip-brands.png' );
+			background-repeat: no-repeat;
+			background-size: 100%;
+			height: 35px;
+			margin-left: 40px;
+            margin-top: 40px;
+            
+            @include breakpoint( '<960px' ) {
+                margin-top: 20px;
+            }
+
+            @include breakpoint( '<480px' ) {
+                margin: 0 20px;
+            }
+        }
+    }
+}
+

--- a/client/my-sites/plan-testimonials/style.scss
+++ b/client/my-sites/plan-testimonials/style.scss
@@ -3,21 +3,28 @@
     display: flex;
     font-size: 14px;
     justify-content: center;
+	padding-bottom: 100px;
+
+	@include breakpoint( '<960px' ) {
+		padding-top: 30px;
+	}
 
     @include breakpoint( '<480px' ) {
         flex-direction: column;
+		padding-bottom: 50px;
     }
 
     .plan-testimonials__content-left {
         font-size: 24px;
-        width: 8%;
+		font-family: 'Recoleta', serif;
+		line-height: 1.2em;
+		padding-top: 13px;
 
         @include breakpoint( '<960px' ) {
-            width: 15%;
+            width: auto;
         }
 
         @include breakpoint( '<480px' ) {
-            width: auto;
             text-align: center;
         }
     }
@@ -25,10 +32,10 @@
     .plan-testimonials__content-right-container {
         display: flex;
         flex-direction: column;
-        width: 28%;
+        width: 35%;
 
         @include breakpoint( '<960px' ) {
-            width: 35%;
+            width: 50%;
         }
 
         @include breakpoint( '<480px' ) {
@@ -36,9 +43,11 @@
         }
 
         .plan-testimonials__content-right {
-            border-left: 1px solid #fff;
-            margin-left: 20px;
-            padding-left: 20px;
+            border-left: 1px solid #ffffff8a;
+            margin-left: 30px;
+            padding-left: 30px;
+			padding-top: 10px;
+			padding-bottom: 10px;
 
             @include breakpoint( '<480px' ) {
                 padding: 20px;
@@ -51,10 +60,11 @@
 				url( 'https://s1.wp.com/wp-content/themes/h4/landing/marketing/pages/_common/components/vip-pitch/media/vip-brands.png' );
 			background-repeat: no-repeat;
 			background-size: 100%;
+			opacity: 0.7;
 			height: 35px;
-			margin-left: 40px;
-            margin-top: 40px;
-            
+			margin-left: 60px;
+            margin-top: 24px;
+
             @include breakpoint( '<960px' ) {
                 margin-top: 20px;
             }

--- a/client/my-sites/plan-testimonials/style.scss
+++ b/client/my-sites/plan-testimonials/style.scss
@@ -32,7 +32,11 @@
     .plan-testimonials__content-right-container {
         display: flex;
         flex-direction: column;
-        width: 35%;
+        width: 28%;
+
+        @include breakpoint( '<1280px' ) {
+            width: 35%;
+        }
 
         @include breakpoint( '<960px' ) {
             width: 50%;
@@ -59,7 +63,7 @@
             background:
 				url( 'https://s1.wp.com/wp-content/themes/h4/landing/marketing/pages/_common/components/vip-pitch/media/vip-brands.png' );
 			background-repeat: no-repeat;
-			background-size: 100%;
+			background-size: 80%;
 			opacity: 0.7;
 			height: 35px;
 			margin-left: 60px;
@@ -69,8 +73,13 @@
                 margin-top: 20px;
             }
 
+            @include breakpoint( '<660px' ) {
+                background-size: 100%;
+            }
+
             @include breakpoint( '<480px' ) {
                 margin: 0 20px;
+                background-position: center;
             }
         }
     }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -70,6 +70,7 @@ import {
 import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
+import PlanTestimonials from '../plan-testimonials';
 
 /**
  * Style dependencies
@@ -181,6 +182,7 @@ export class PlansFeaturesMain extends Component {
 					} ) }
 					siteId={ siteId }
 				/>
+				<PlanTestimonials />
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The new plan step AB test is enabled in #39600. Individual pieces of the UI will be built in separate PRs and finally merged together.

* Adds the testimonial section to the plans page.

**Desktop**

<img width="1536" alt="Screenshot 2020-02-25 at 4 42 08 PM" src="https://user-images.githubusercontent.com/1269602/75245207-4553a300-57f3-11ea-8cbe-e25128361b48.png">


**Mobile**


![calypso localhost_3000_start_plans(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/1269602/75245253-60beae00-57f3-11ea-9347-61c27cf5f559.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow after assigning yourself to _variantShowUpdates_ of _planStepCopyUpdates_ test.
* In the Plans step, verify that the testimonial section matches the UI as per the P2 post p8Eqe3-144-p2.
* Desktop and mobile sceeen sizes should look okay
