### PR TITLE
Banner: Fix position of CTA when used with a dismiss icon in a compact style

### DIFF
--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -6,6 +6,7 @@
 	color: var( --color-text-inverted );
 	display: flex;
 	align-items: center;
+	margin-top: -1px;
 
 	a,
 	button {

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -6,7 +6,6 @@
 	color: var( --color-text-inverted );
 	display: flex;
 	align-items: center;
-	margin-top: -1px;
 
 	a,
 	button {
@@ -18,7 +17,8 @@
 
 .upsell-nudge.banner.card.is-compact {
 	border-left-width: 4px;
-	margin-bottom: 0;
+	margin-top: -1px;
+	margin-bottom: -1px;
 
 	.banner__icon-circle,
 	.banner__icon {

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -260,11 +260,6 @@
 			margin-right: 0;
 		}
 
-		.is-dismissible.is-compact & {
-			margin-top: 0;
-			margin-right: 32px;
-		}
-
 		.is-dismissible.is-horizontal & {
 			margin-top: 0;
 			margin-right: 40px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* @rickybanister noticed the last change to Banner/UpsellNudge messed up the alignment of the call to action on compact nudges when displayed with a dismiss icon. This PR fixes that bug.

**Before**

<img width="283" alt="Screen Shot 2020-02-24 at 12 23 15 PM" src="https://user-images.githubusercontent.com/2124984/75175534-7f904800-5700-11ea-9f5d-49cf1a37b3b6.png">


**After**

<img width="295" alt="Screen Shot 2020-02-24 at 12 16 15 PM" src="https://user-images.githubusercontent.com/2124984/75175368-32ac7180-5700-11ea-81be-02fdf9c0d732.png">


#### Testing instructions

* Switch to this PR
* Navigate to a site that has the "Add another domain" nudge, which is found on sites that already have a custom domain.
* Alternatively, you can open `/client/my-site/current-sites/notice.jsx` locally and make one of the existing `UpsellNudge`s dismissable by adding `showDismiss` and `dismissPreferenceName="testing"` props to it.
* You should see an improvement in the placement of the CTA :)