### PR TITLE
Sidebar Notices: preventWidows on upsell nudges in the sidebar

### DIFF
--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -9,6 +9,7 @@ import Gridicon from 'components/gridicon';
  */
 import UpsellNudge from 'blocks/upsell-nudge';
 import { abtest } from 'lib/abtest';
+import { preventWidows } from 'lib/formatting';
 
 /**
  * Style dependencies
@@ -44,7 +45,7 @@ export default function SidebarBannerTemplate( {
 				dismissPreferenceName={ dismissPreferenceName }
 				href={ CTA.link }
 				onDismissClick={ onDismissClick }
-				title={ message }
+				title={ preventWidows( message ) }
 				tracksClickName={ clickName }
 				tracksClickProperties={ { ...jitmProps, ...clickProps } }
 				tracksImpressionName={ displayName }
@@ -63,7 +64,7 @@ export default function SidebarBannerTemplate( {
 					<Gridicon className="sidebar-banner__icon" icon={ icon || 'info-outline' } size={ 18 } />
 				</span>
 				<span className="sidebar-banner__content">
-					<span className="sidebar-banner__text">{ message }</span>
+					<span className="sidebar-banner__text">{ preventWidows( message ) }</span>
 				</span>
 				<span className="sidebar-banner__cta">{ CTA.message }</span>
 			</a>

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -40,6 +40,7 @@ import { getTopJITM } from 'state/jitm/selectors';
 import AsyncLoad from 'components/async-load';
 import UpsellNudge from 'blocks/upsell-nudge';
 import { abtest } from 'lib/abtest';
+import { preventWidows } from 'lib/formatting';
 
 const DOMAIN_UPSELL_NUDGE_DISMISS_KEY = 'domain_upsell_nudge_dismiss';
 
@@ -85,16 +86,18 @@ export class SiteNotice extends React.Component {
 		const eventName = 'calypso_domain_credit_reminder_impression';
 		const eventProperties = { cta_name: 'current_site_domain_notice' };
 		const { translate } = this.props;
+		const noticeText = preventWidows( translate( 'Free domain available' ) );
+		const ctaText = translate( 'Claim' );
 
 		if ( abtest( 'sidebarUpsellNudgeUnification' ) === 'variantShowUnifiedUpsells' ) {
 			return (
 				<UpsellNudge
-					callToAction={ translate( 'Claim' ) }
+					callToAction={ ctaText }
 					compact
 					event={ eventName }
 					forceHref={ true }
 					href={ `/domains/add/${ this.props.site.slug }` }
-					title={ translate( 'Free domain available' ) }
+					title={ noticeText }
 					tracksClickName="calypso_domain_credit_reminder_click"
 					tracksClickProperties={ eventProperties }
 					tracksImpressionName={ eventName }
@@ -104,17 +107,12 @@ export class SiteNotice extends React.Component {
 		}
 
 		return (
-			<Notice
-				isCompact
-				status="is-success"
-				icon="info-outline"
-				text={ translate( 'Free domain available' ) }
-			>
+			<Notice isCompact status="is-success" icon="info-outline" text={ noticeText }>
 				<NoticeAction
 					onClick={ this.props.clickClaimDomainNotice }
 					href={ `/domains/add/${ this.props.site.slug }` }
 				>
-					{ translate( 'Claim' ) }
+					{ ctaText }
 					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
 				</NoticeAction>
 			</Notice>
@@ -200,7 +198,7 @@ export class SiteNotice extends React.Component {
 					onDismissClick={ this.props.clickDomainUpsellDismiss }
 					dismissPreferenceName="calypso_upgrade_nudge_cta_click"
 					event="calypso_upgrade_nudge_impression"
-					title={ noticeText }
+					title={ preventWidows( noticeText ) }
 					tracksClickName="calypso_upgrade_nudge_cta_click"
 					tracksClickProperties={ { cta_name: 'domain-upsell-nudge' } }
 					tracksImpressionName="calypso_upgrade_nudge_impression"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wraps longer strings in `preventWidows` to prevent ugly line breakage.
* Consolidates a couple duplicated string instances into constants to be reused for UpsellNudge A/B test instances.

Question for devs: Is there any concern with applying `preventWidows` to the sidebar-banner JITM template when we don't know for sure what type of input we'll get from `message`? Wondering if it would be smarter to apply `widont` on the server side...

**Before**

<img width="592" alt="Screen Shot 2020-02-24 at 1 03 31 PM" src="https://user-images.githubusercontent.com/2124984/75178528-41962280-5706-11ea-8f5c-c442768a40b1.png">

**After**

<img width="671" alt="Screen Shot 2020-02-24 at 12 40 11 PM" src="https://user-images.githubusercontent.com/2124984/75177908-0fd08c00-5705-11ea-9bd5-18fb9f5d6ddd.png">
<img width="697" alt="Screen Shot 2020-02-24 at 12 38 00 PM" src="https://user-images.githubusercontent.com/2124984/75177913-1101b900-5705-11ea-90ff-25415a25ac4e.png">


#### Testing instructions

* Switch to this PR
* Check out the following UpsellNudge instances and check the inspector for the `&nbsp;` between the last two words of the message string to ensure `preventWidows` is working as intended:

- [ ] Free Domain Credit Reminder
- [ ] Domain w/ Plan Upgrade Nudge
- [ ] Active Discount Upgrade Nudge
- [ ] Free to Paid Sidebar / Reader
- [ ] Free to Paid Plan JITM
- [ ] Domain-Only Upgrade JITM
- [ ] Blogger to Personal Plan JITM
