### PR TITLE
Customer Home: Remove broken "email download link" button from the desktop app.

### DIFF
--- a/client/my-sites/customer-home/go-mobile-card/index.jsx
+++ b/client/my-sites/customer-home/go-mobile-card/index.jsx
@@ -33,7 +33,7 @@ export const GoMobileCard = ( { translate, email, sendMobileLoginEmail } ) => {
 	const showIosBadge = isDesktopView || isIos || ! isAndroid;
 	const showAndroidBadge = isDesktopView || isAndroid || ! isIos;
 	const showOnlyOneBadge = showIosBadge !== showAndroidBadge;
-	const isDesktopApp = [ 'desktop', 'desktop-development' ].includes( config( 'env_id' ) );
+	const isDesktopApp = config.isEnabled( 'desktop' );
 
 	const emailLogin = () => {
 		sendMobileLoginEmail( email );

--- a/client/my-sites/customer-home/go-mobile-card/index.jsx
+++ b/client/my-sites/customer-home/go-mobile-card/index.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import AppsBadge from 'blocks/get-apps/apps-badge';
 import userAgent from 'lib/user-agent';
 import CardHeading from 'components/card-heading';
@@ -32,6 +33,7 @@ export const GoMobileCard = ( { translate, email, sendMobileLoginEmail } ) => {
 	const showIosBadge = isDesktopView || isIos || ! isAndroid;
 	const showAndroidBadge = isDesktopView || isAndroid || ! isIos;
 	const showOnlyOneBadge = showIosBadge !== showAndroidBadge;
+	const isDesktopApp = [ 'desktop', 'desktop-development' ].includes( config( 'env_id' ) );
 
 	const emailLogin = () => {
 		sendMobileLoginEmail( email );
@@ -67,7 +69,7 @@ export const GoMobileCard = ( { translate, email, sendMobileLoginEmail } ) => {
 					) }
 				</div>
 			</div>
-			{ isDesktopView && (
+			{ isDesktopView && ! isDesktopApp && (
 				<Button className="go-mobile-card__email-link-button" onClick={ emailLogin }>
 					{ translate( 'Email download link' ) }
 				</Button>


### PR DESCRIPTION
[The desktop app has issues](https://github.com/Automattic/wp-desktop/issues/777#issuecomment-590390781) with the endpoints that provide the email download link, such that this button's API request will never pass authentication checks. This PR removes the button in the Go Mobile card to avoid confusion for desktop app users.

| Before | After |
| ------------- | ------------- |
|<img width="1221" alt="Screen Shot 2020-02-24 at 1 06 18 PM" src="https://user-images.githubusercontent.com/349751/75191591-7787d680-5707-11ea-8e8d-fb65284c17ed.png">|<img width="1193" alt="Screen Shot 2020-02-24 at 12 59 01 PM" src="https://user-images.githubusercontent.com/349751/75191614-81113e80-5707-11ea-98c2-6d5b544a9f68.png">| 

#### Testing instructions

* In your local desktop dev setup, change your working directory to the `/calypso` submodule.
* `git fetch origin e256398bf9cf08ed445f8882af37ba2dc0021aae`
* `git cherry-pick e256398bf9cf08ed445f8882af37ba2dc0021aae`
* Verify that on a site's Customer Home (`/home/:site`), that the Go Mobile card does not have an "Email download link" button.

Fixes https://github.com/Automattic/wp-desktop/issues/777
