### PR TITLE
Add renew button on the domain status screen

### DIFF
--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import classNames from 'classnames';
+import formatCurrency from '@automattic/format-currency';
+import { Button } from '@automattic/components';
+import { handleRenewNowClick, getRenewalPrice } from 'lib/purchases';
+import { getByPurchaseId } from 'state/purchases/selectors';
+import QuerySitePurchases from 'components/data/query-site-purchases';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class RenewButton extends React.Component {
+	static propTypes = {
+		compact: PropTypes.bool,
+		primary: PropTypes.bool,
+		selectedSite: PropTypes.object,
+		subscriptionId: PropTypes.number,
+	};
+
+	handleRenew = () => {
+		handleRenewNowClick( this.props.purchase, this.props.selectedSite.slug );
+	};
+
+	render() {
+		const { purchase, selectedSite } = this.props;
+
+		let formattedPrice = '...';
+		let loading = true;
+
+		if ( purchase && selectedSite.ID ) {
+			const renewalPrice = getRenewalPrice( purchase );
+			const currencyCode = purchase.currencyCode;
+			formattedPrice = formatCurrency( renewalPrice, currencyCode, { stripZeros: true } );
+			loading = false;
+		}
+
+		const buttonClasses = classNames( 'renew-button', { 'is-loading': loading } );
+
+		return (
+			<React.Fragment>
+				{ selectedSite.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
+
+				<Button
+					compact={ this.props.compact }
+					primary={ this.props.primary }
+					className={ buttonClasses }
+					onClick={ this.handleRenew }
+				>
+					{ this.props.translate( 'Renew for {{strong}}%(price)s{{/strong}}', {
+						components: { strong: <strong /> },
+						args: { price: formattedPrice },
+					} ) }
+				</Button>
+			</React.Fragment>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	return {
+		purchase: getByPurchaseId( state, ownProps.subscriptionId ),
+	};
+} )( localize( RenewButton ) );

--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
@@ -28,6 +28,7 @@ class RenewButton extends React.Component {
 		selectedSite: PropTypes.object,
 		subscriptionId: PropTypes.number,
 		redemptionProduct: PropTypes.object,
+		reactivate: PropTypes.bool,
 	};
 
 	handleRenew = () => {
@@ -35,7 +36,7 @@ class RenewButton extends React.Component {
 	};
 
 	render() {
-		const { purchase, selectedSite, redemptionProduct } = this.props;
+		const { purchase, selectedSite, redemptionProduct, reactivate } = this.props;
 
 		let formattedPrice = '...';
 		let loading = true;
@@ -60,10 +61,15 @@ class RenewButton extends React.Component {
 					className={ buttonClasses }
 					onClick={ this.handleRenew }
 				>
-					{ this.props.translate( 'Renew for {{strong}}%(price)s{{/strong}}', {
-						components: { strong: <strong /> },
-						args: { price: formattedPrice },
-					} ) }
+					{ reactivate
+						? this.props.translate( 'Reactivate for {{strong}}%(price)s{{/strong}}', {
+								components: { strong: <strong /> },
+								args: { price: formattedPrice },
+						  } )
+						: this.props.translate( 'Renew for {{strong}}%(price)s{{/strong}}', {
+								components: { strong: <strong /> },
+								args: { price: formattedPrice },
+						  } ) }
 				</Button>
 			</React.Fragment>
 		);

--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
@@ -27,6 +27,7 @@ class RenewButton extends React.Component {
 		primary: PropTypes.bool,
 		selectedSite: PropTypes.object,
 		subscriptionId: PropTypes.number,
+		redemptionProduct: PropTypes.object,
 	};
 
 	handleRenew = () => {
@@ -34,13 +35,14 @@ class RenewButton extends React.Component {
 	};
 
 	render() {
-		const { purchase, selectedSite } = this.props;
+		const { purchase, selectedSite, redemptionProduct } = this.props;
 
 		let formattedPrice = '...';
 		let loading = true;
 
 		if ( purchase && selectedSite.ID ) {
-			const renewalPrice = getRenewalPrice( purchase );
+			const renewalPrice =
+				getRenewalPrice( purchase ) + ( redemptionProduct ? redemptionProduct.cost : 0 );
 			const currencyCode = purchase.currencyCode;
 			formattedPrice = formatCurrency( renewalPrice, currencyCode, { stripZeros: true } );
 			loading = false;

--- a/client/my-sites/domains/domain-management/edit/card/renew-button/style.scss
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/style.scss
@@ -1,0 +1,5 @@
+.renew-button {
+	&.is-loading strong {
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}
+}

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -89,7 +89,10 @@
 	.domain-types__expiration-row {
 		display: flex;
 		align-items: center;
-		> div:first-child {
+		.renew-button {
+			margin-left: 10px;
+		}
+		> div:nth-last-child( 2 ) {
 			margin-right: auto;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a "Renew for X" button on the domain status screen

#### Depends on
D39372-code - in order to properly show WWD domains in ARGP

Active domain:
<img width="738" alt="Screenshot 2020-02-25 at 15 50 05" src="https://user-images.githubusercontent.com/1355045/75253419-2f3fe580-57e7-11ea-8c69-29ebd19d2437.png">

Expires soon:
<img width="739" alt="Screenshot 2020-02-25 at 15 48 07" src="https://user-images.githubusercontent.com/1355045/75253440-35ce5d00-57e7-11ea-91a1-bd8930161c77.png">

Expires very soon:
<img width="748" alt="Screenshot 2020-02-25 at 15 49 30" src="https://user-images.githubusercontent.com/1355045/75253454-3b2ba780-57e7-11ea-938b-92aa444c9b86.png">

Expired renewable:

<img width="738" alt="Screenshot 2020-02-25 at 22 25 28" src="https://user-images.githubusercontent.com/1355045/75284928-56fe7000-581e-11ea-9212-fa1875523f16.png">

Expired redeemable:

<img width="741" alt="Screenshot 2020-02-25 at 22 24 24" src="https://user-images.githubusercontent.com/1355045/75284942-5b2a8d80-581e-11ea-8158-cf9c2cbe8853.png">

#### Testing instructions

* best way is to check a domain in every of the possible states and verify if the "Renew for $XX" button is visible. You can use the following instructions - 24083-pb
* verify that other currencies also work properly
* verify that the reactivate button for domains in redemption is showing the correct amount