### PR TITLE
composite-checkout: Add tracks event for when apple pay fails to load

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -971,6 +971,14 @@ function getCheckoutEventHandler( dispatch ) {
 				);
 			}
 
+			case 'APPLE_PAY_LOADING_ERROR':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
+						error_message: String( action.payload ),
+						is_loading_error: true,
+					} )
+				);
+
 			case 'APPLE_PAY_TRANSACTION_ERROR': {
 				dispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {

--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -190,6 +190,7 @@ export function ApplePaySubmitButton( { disabled } ) {
 	] );
 
 	if ( ! isLoading && ! canMakePayment ) {
+		onEvent( { type: 'APPLE_PAY_LOADING_ERROR', payload: 'This payment type is not supported' } );
 		return (
 			<PaymentRequestButton
 				paymentRequest={ paymentRequest }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a new tracks error when Apple Pay fails to load. The error uses the existing `calypso_checkout_composite_apple_pay_error` event but includes the `is_loading_error` property.

There are two checks for loading apple pay. The first is to see if Apple Pay is supported by the browser. This check is performed before showing the Apple Pay method at all. However, once we decide to try and display it, we actually contact Apple to make it appear. This can fail in certain circumstances, for example if the domain the button is hosted on is not correctly registered with Apple, or if the device is not a real Apple device.

This PR allows us to track how often this second case occurs in the wild (hopefully never).

#### Testing instructions

Using composite checkout in Safari, enable debug logs for Tracks by putting this in the console: `localStorage.setItem('debug', 'calypso:analytics')` and then reload the page. Try choosing the apple pay payment method. In localhost calypso, this will cause the error, and you should be able to see it in the debug logs.