### PR TITLE
Jetpack Cloud: Add Current Site Indicator

### DIFF
--- a/client/landing/jetpack-cloud/components/current-site/index.tsx
+++ b/client/landing/jetpack-cloud/components/current-site/index.tsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { useSelector } from 'react-redux';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import { getSelectedSite } from 'state/ui/selectors';
+import Site from 'blocks/site';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const CurrentSite = () => {
+	const selectedSite = useSelector( state => getSelectedSite( state ) );
+
+	return selectedSite ? (
+		<Card className="current-site">
+			<Site showHomeIcon={ false } site={ selectedSite } />
+		</Card>
+	) : null;
+};
+
+export default CurrentSite;

--- a/client/landing/jetpack-cloud/components/current-site/style.scss
+++ b/client/landing/jetpack-cloud/components/current-site/style.scss
@@ -10,7 +10,7 @@
 		}
 
 		.site__title {
-			color: var( --color-neutral-50 );
+			color: var( --color-sidebar-text );
 			line-height: 35px;
 		}
 

--- a/client/landing/jetpack-cloud/components/current-site/style.scss
+++ b/client/landing/jetpack-cloud/components/current-site/style.scss
@@ -1,0 +1,46 @@
+.current-site.card {
+	margin: 0;
+	padding: 0;
+	box-shadow: none;
+	background: transparent;
+
+	&.is-loading {
+		.site-icon {
+			animation: pulse-light 0.8s ease-in-out infinite;
+		}
+
+		.site__title {
+			color: var( --color-neutral-50 );
+			line-height: 35px;
+		}
+
+		.current-site__switch-sites {
+			cursor: default;
+
+			&::before {
+				visibility: hidden;
+			}
+		}
+	}
+}
+
+.current-site .site {
+	transition: opacity 0.15s ease-in-out;
+
+	.site__info {
+		animation: appear 0.3s ease-in-out;
+	}
+
+	.focus-sites & {
+		opacity: 0.2;
+		pointer-events: none;
+	}
+}
+
+.current-site {
+	.site,
+	.all-sites {
+		background: var( --color-sidebar-background );
+		border-bottom: 1px solid var( --color-sidebar-border );
+	}
+}

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import CurrentSite from '../current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
@@ -74,6 +75,7 @@ class JetpackCloudSidebar extends Component {
 
 		return (
 			<Sidebar>
+				<CurrentSite />
 				<SidebarRegion>
 					{ /* @todo: A profile info box needs to be created and added here; similar to <ProfileGravatar /> in client/me/sidebar/index.jsx */ }
 					<SidebarMenu>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Current Site Indicator if a site is selected

<img width="850" alt="Screen Shot 2020-02-24 at 3 36 40 PM" src="https://user-images.githubusercontent.com/2810519/75201016-30581080-571c-11ea-9657-0fe67f37c492.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/backups` and verify that there is no current site indicator
2. Navigate to `/backups/:siteSlug` for a valid `siteSlug` and confirm that the page matches the screenshot above

