### PR TITLE
e2e: Fix broken tests due to Customer Home AB test rollout.

### DIFF
--- a/test/e2e/lib/components/nav-bar-component.js
+++ b/test/e2e/lib/components/nav-bar-component.js
@@ -41,9 +41,13 @@ export default class NavBarComponent extends AsyncBaseContainer {
 	async clickMySites() {
 		const mySitesSelector = by.css( 'header.masterbar a.masterbar__item' );
 		await driverHelper.clickWhenClickable( this.driver, mySitesSelector );
-		return await driverHelper.isEventuallyPresentAndDisplayed(
+		await driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
 			by.css( '.sidebar__menu-wrapper' )
+		);
+		return await driverHelper.isEventuallyPresentAndDisplayed(
+			this.driver,
+			by.css( '.is-group-sites' )
 		);
 	}
 	hasUnreadNotifications() {

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -10,11 +10,9 @@ import LoginPage from '../pages/login-page.js';
 import EditorPage from '../pages/editor-page';
 import WPAdminLoginPage from '../pages/wp-admin/wp-admin-logon-page';
 import ReaderPage from '../pages/reader-page.js';
-import StatsPage from '../pages/stats-page.js';
 import StoreDashboardPage from '../pages/woocommerce/store-dashboard-page';
 import PluginsBrowserPage from '../pages/plugins-browser-page';
 import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
-import CustomerHomePage from '../pages/customer-home-page';
 
 import SidebarComponent from '../components/sidebar-component.js';
 import NavBarComponent from '../components/nav-bar-component.js';
@@ -202,13 +200,6 @@ export default class LoginFlow {
 			const sideBarComponent = await SidebarComponent.Expect( this.driver );
 			await sideBarComponent.selectSiteSwitcher();
 			await sideBarComponent.searchForSite( siteURL );
-		}
-
-		if ( this.account.username !== 'e2eflowtestinggutenbergsimpleedge' ) {
-			await StatsPage.overrideABTestInLocalStorage( 'customerHomeAll', 'control' );
-			await StatsPage.Expect( this.driver );
-		} else {
-			await CustomerHomePage.Expect( this.driver );
 		}
 	}
 

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -10,6 +10,7 @@ import LoginPage from '../pages/login-page.js';
 import EditorPage from '../pages/editor-page';
 import WPAdminLoginPage from '../pages/wp-admin/wp-admin-logon-page';
 import ReaderPage from '../pages/reader-page.js';
+import StatsPage from '../pages/stats-page.js';
 import StoreDashboardPage from '../pages/woocommerce/store-dashboard-page';
 import PluginsBrowserPage from '../pages/plugins-browser-page';
 import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
@@ -203,7 +204,12 @@ export default class LoginFlow {
 			await sideBarComponent.searchForSite( siteURL );
 		}
 
-		await CustomerHomePage.Expect( this.driver );
+		if ( this.account.username !== 'e2eflowtestinggutenbergsimpleedge' ) {
+			await StatsPage.overrideABTestInLocalStorage( 'customerHomeAll', 'control' );
+			await StatsPage.Expect( this.driver );
+		} else {
+			await CustomerHomePage.Expect( this.driver );
+		}
 	}
 
 	async loginAndSelectAllSites() {

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -10,7 +10,6 @@ import LoginPage from '../pages/login-page.js';
 import EditorPage from '../pages/editor-page';
 import WPAdminLoginPage from '../pages/wp-admin/wp-admin-logon-page';
 import ReaderPage from '../pages/reader-page.js';
-import StatsPage from '../pages/stats-page.js';
 import StoreDashboardPage from '../pages/woocommerce/store-dashboard-page';
 import PluginsBrowserPage from '../pages/plugins-browser-page';
 import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
@@ -204,11 +203,7 @@ export default class LoginFlow {
 			await sideBarComponent.searchForSite( siteURL );
 		}
 
-		if ( this.account.username !== 'e2eflowtestinggutenbergsimpleedge' ) {
-			await StatsPage.Expect( this.driver );
-		} else {
-			await CustomerHomePage.Expect( this.driver );
-		}
+		await CustomerHomePage.Expect( this.driver );
 	}
 
 	async loginAndSelectAllSites() {

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-plans-spec.js
@@ -13,7 +13,6 @@ import * as dataHelper from '../lib/data-helper';
 import LoginFlow from '../lib/flows/login-flow';
 
 import PlansPage from '../lib/pages/plans-page';
-import StatsPage from '../lib/pages/stats-page';
 import WPAdminJetpackPage from '../lib/pages/wp-admin/wp-admin-jetpack-page';
 
 import ReaderPage from '../lib/pages/reader-page.js';
@@ -87,8 +86,6 @@ describe( `[${ host }] Jetpack Plans: (${ screenSize }) @jetpack`, function() {
 
 			const navbarComponent = await NavBarComponent.Expect( driver );
 			await navbarComponent.clickMySites();
-
-			await StatsPage.Expect( driver );
 
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 			await sidebarComponent.selectPlan();

--- a/test/e2e/specs/wp-manage-domains-spec.js
+++ b/test/e2e/specs/wp-manage-domains-spec.js
@@ -12,7 +12,6 @@ import * as dataHelper from '../lib/data-helper.js';
 import DomainsPage from '../lib/pages/domains-page.js';
 import CheckOutPage from '../lib/pages/signup/checkout-page.js';
 import ReaderPage from '../lib/pages/reader-page.js';
-import StatsPage from '../lib/pages/stats-page.js';
 
 import FindADomainComponent from '../lib/components/find-a-domain-component.js';
 import RegistrationUnavailableComponent from '../lib/components/domain-registration-unavailable-component';
@@ -113,7 +112,6 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function() {
 			await ReaderPage.Visit( driver );
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
-			await StatsPage.Expect( driver );
 			const sidebarComponent = await SidebarComponent.Expect( driver );
 			await sidebarComponent.selectDomains();
 			await DomainsPage.Expect( driver );
@@ -196,7 +194,6 @@ describe( `[${ host }] Managing Domains: (${ screenSize })`, function() {
 			await ReaderPage.Visit( driver );
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
-			await StatsPage.Expect( driver );
 			const sideBarComponent = await SidebarComponent.Expect( driver );
 			await sideBarComponent.selectDomains();
 			await DomainsPage.Expect( driver );

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -12,7 +12,6 @@ import * as dataHelper from '../lib/data-helper';
 
 import LoginFlow from '../lib/flows/login-flow.js';
 import PlansPage from '../lib/pages/plans-page.js';
-import StatsPage from '../lib/pages/stats-page.js';
 import SidebarComponent from '../lib/components/sidebar-component.js';
 import SecurePaymentComponent from '../lib/components/secure-payment-component';
 import NavBarComponent from '../lib/components/nav-bar-component';
@@ -42,8 +41,6 @@ describe( `[${ host }] Plans: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can Select Plans', async function() {
-			const statsPage = await StatsPage.Expect( driver );
-			await statsPage.waitForPage();
 			const sideBarComponent = await SidebarComponent.Expect( driver );
 			return await sideBarComponent.selectPlan();
 		} );
@@ -92,8 +89,6 @@ describe( `[${ host }] Plans: (${ screenSize })`, function() {
 		} );
 
 		step( 'Can Select Plans', async function() {
-			const statsPage = await StatsPage.Expect( driver );
-			await statsPage.waitForPage();
 			const sideBarComponent = await SidebarComponent.Expect( driver );
 			return await sideBarComponent.selectPlan();
 		} );


### PR DESCRIPTION
End-to-end tests that rely on landing on stats page are breaking, due to a rollout by AB test of the new Customer Home for all users. Instead of older users landing on stats, they are now sent to Customer Home like newer users, breaking all e2e sequences checking for a stats page before continuing.

This PR removes the assertion that checks that a user lands in either Stats or Customer Home after clicking on My Sites with a more generic check that verifies that the My Sites layout is loaded.