### PR TITLE
composite-checkout: Move stripe wrapper to host page

### DIFF
--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -265,19 +265,21 @@ function useStripeJs( stripeConfiguration ) {
  * with a value for that error.
  *
  * @param {object} requestArgs (optional) Can include `country` or `needs_intent`
+ * @param {Function} fetchStripeConfiguration (optional) If provided, will call instead of getStripeConfiguration
  * @returns {object} See above
  */
-function useStripeConfiguration( requestArgs ) {
+function useStripeConfiguration( requestArgs, fetchStripeConfiguration ) {
 	const [ stripeError, setStripeError ] = useState();
 	const [ stripeConfiguration, setStripeConfiguration ] = useState();
 	useEffect( () => {
+		const getConfig = fetchStripeConfiguration || getStripeConfiguration;
 		debug( 'loading stripe configuration' );
 		let isSubscribed = true;
-		getStripeConfiguration( requestArgs || {} ).then(
+		getConfig( requestArgs || {} ).then(
 			configuration => isSubscribed && setStripeConfiguration( configuration )
 		);
 		return () => ( isSubscribed = false );
-	}, [ requestArgs, stripeError ] );
+	}, [ requestArgs, stripeError, fetchStripeConfiguration ] );
 	return { stripeConfiguration, setStripeError };
 }
 
@@ -287,9 +289,12 @@ function StripeHookProviderInnerWrapper( { stripe, stripeData, children } ) {
 }
 const StripeInjectedWrapper = injectStripe( StripeHookProviderInnerWrapper );
 
-export function StripeHookProvider( { children, configurationArgs } ) {
+export function StripeHookProvider( { children, configurationArgs, fetchStripeConfiguration } ) {
 	debug( 'rendering StripeHookProvider' );
-	const { stripeConfiguration, setStripeError } = useStripeConfiguration( configurationArgs );
+	const { stripeConfiguration, setStripeError } = useStripeConfiguration(
+		configurationArgs,
+		fetchStripeConfiguration
+	);
 	const { stripeJs, isStripeLoading, stripeLoadingError } = useStripeJs( stripeConfiguration );
 
 	const stripeData = {

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -49,9 +49,7 @@ export default function CheckoutSystemDecider( {
 	}
 	if ( shouldShowCompositeCheckout( cart, countryCode, locale, product, isJetpack ) ) {
 		return (
-			<StripeHookProvider
-				fetchStripeConfiguration={ args => fetchStripeConfiguration( args, wpcom ) }
-			>
+			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
 				<CompositeCheckout
 					siteSlug={ selectedSite?.slug }
 					siteId={ selectedSite?.ID }
@@ -148,4 +146,8 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 	}
 	debug( 'shouldShowCompositeCheckout false because test not enabled' );
 	return false;
+}
+
+function fetchStripeConfigurationWpcom( args ) {
+	return fetchStripeConfiguration( args, wpcom );
 }

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import debugFactory from 'debug';
+import wp from 'lib/wp';
 
 /**
  * Internal Dependencies
@@ -18,6 +19,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import { abtest } from 'lib/abtest';
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
+const wpcom = wp.undocumented();
 
 // Decide if we should use CompositeCheckout or CheckoutContainer
 export default function CheckoutSystemDecider( {
@@ -47,7 +49,9 @@ export default function CheckoutSystemDecider( {
 	}
 	if ( shouldShowCompositeCheckout( cart, countryCode, locale, product, isJetpack ) ) {
 		return (
-			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+			<StripeHookProvider
+				fetchStripeConfiguration={ args => fetchStripeConfiguration( args, wpcom ) }
+			>
 				<CompositeCheckout
 					siteSlug={ selectedSite?.slug }
 					siteId={ selectedSite?.ID }

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -10,6 +10,8 @@ import debugFactory from 'debug';
  */
 import CheckoutContainer from './checkout-container';
 import CompositeCheckout from './composite-checkout';
+import { fetchStripeConfiguration } from './composite-checkout-payment-methods';
+import { StripeHookProvider } from 'lib/stripe';
 import config from 'config';
 import { getCurrentUserLocale, getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -45,16 +47,18 @@ export default function CheckoutSystemDecider( {
 	}
 	if ( shouldShowCompositeCheckout( cart, countryCode, locale, product, isJetpack ) ) {
 		return (
-			<CompositeCheckout
-				siteSlug={ selectedSite?.slug }
-				siteId={ selectedSite?.ID }
-				product={ product }
-				purchaseId={ purchaseId }
-				couponCode={ couponCode }
-				redirectTo={ redirectTo }
-				feature={ selectedFeature }
-				plan={ plan }
-			/>
+			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+				<CompositeCheckout
+					siteSlug={ selectedSite?.slug }
+					siteId={ selectedSite?.ID }
+					product={ product }
+					purchaseId={ purchaseId }
+					couponCode={ couponCode }
+					redirectTo={ redirectTo }
+					feature={ selectedFeature }
+					plan={ plan }
+				/>
+			</StripeHookProvider>
 		);
 	}
 

--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
@@ -277,7 +277,7 @@ export function useIsApplePayAvailable( stripe, stripeConfiguration, items ) {
 			isSubscribed && setCanMakePayment( !! result?.applePay );
 		} );
 
-		return ( isSubscribed = false );
+		return () => ( isSubscribed = false );
 	}, [ canMakePayment, stripe, items, stripeConfiguration ] );
 
 	return { canMakePayment: canMakePayment === true, isLoading: canMakePayment === 'loading' };

--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useReducer, useEffect } from 'react';
+import React, { useReducer, useEffect, useState } from 'react';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { prepareDomainContactDetails } from '@automattic/composite-checkout-wpcom';
@@ -99,29 +99,6 @@ export async function makePayPalExpressRequest(
 export function getDomainDetails( select ) {
 	const managedContactDetails = select( 'wpcom' )?.getContactInfo?.() ?? {};
 	return prepareDomainContactDetails( managedContactDetails );
-}
-
-export function isApplePayAvailable(): boolean {
-	// Our Apple Pay implementation uses the Payment Request API, so check that first.
-	if ( ! window.PaymentRequest ) {
-		return false;
-	}
-
-	// Check if Apple Pay is available. This can be very expensive on certain
-	// Safari versions due to a bug (https://trac.webkit.org/changeset/243447/webkit),
-	// and there is no way it can change during a page request, so cache the
-	// result.
-	if ( typeof isApplePayAvailable.canMakePayments === 'undefined' ) {
-		try {
-			isApplePayAvailable.canMakePayments = Boolean(
-				window.ApplePaySession && window.ApplePaySession.canMakePayments()
-			);
-		} catch ( error ) {
-			console.error( error ); // eslint-disable-line no-console
-			return false;
-		}
-	}
-	return isApplePayAvailable.canMakePayments;
 }
 
 export async function fetchStripeConfiguration( requestArgs, wpcom ) {
@@ -236,4 +213,72 @@ export async function wpcomPayPalExpress(
 	payload: PayPalExpressEndpointRequestPayload
 ): Promise< PayPalExpressEndpointResponse > {
 	return wp.undocumented().paypalExpressUrl( payload );
+}
+
+export function useIsApplePayAvailable( stripe, stripeConfiguration, items ) {
+	const [ canMakePayment, setCanMakePayment ] = useState( 'loading' );
+
+	useEffect( () => {
+		let isSubscribed = true;
+		// Only calculate this once
+		if ( canMakePayment !== 'loading' ) {
+			return;
+		}
+
+		// We'll need the Stripe library so wait until it is loaded
+		if ( ! stripe || ! stripeConfiguration ) {
+			return;
+		}
+
+		// Our Apple Pay implementation uses the Payment Request API, so
+		// check that first.
+		if ( ! window.PaymentRequest ) {
+			setCanMakePayment( false );
+			return;
+		}
+
+		// Ask the browser if apple pay can be used. This can be very
+		// expensive on certain Safari versions due to a bug
+		// (https://trac.webkit.org/changeset/243447/webkit)
+		try {
+			const browserResponse = !! window.ApplePaySession?.canMakePayments();
+			if ( ! browserResponse ) {
+				setCanMakePayment( false );
+				return;
+			}
+		} catch ( error ) {
+			setCanMakePayment( false );
+			return;
+		}
+
+		// Ask Stripe if apple pay can be used. This is async.
+		const countryCode =
+			stripeConfiguration && stripeConfiguration.processor_id === 'stripe_ie' ? 'IE' : 'US';
+		const currency = items.reduce(
+			( firstCurrency, item ) => firstCurrency || item.amount.currency,
+			'usd'
+		);
+		const paymentRequestOptions = {
+			requestPayerName: true,
+			requestPayerPhone: false,
+			requestPayerEmail: false,
+			requestShipping: false,
+			country: countryCode,
+			currency: currency.toLowerCase(),
+			// This is just used here to determine if apple pay is available, not for the actual payment, so we leave this blank
+			displayItems: [],
+			total: {
+				label: 'Total',
+				amount: 0,
+			},
+		};
+		const request = stripe.paymentRequest( paymentRequestOptions );
+		request.canMakePayment().then( result => {
+			isSubscribed && setCanMakePayment( !! result?.applePay );
+		} );
+
+		return ( isSubscribed = false );
+	}, [ canMakePayment, stripe, items, stripeConfiguration ] );
+
+	return { canMakePayment: canMakePayment === true, isLoading: canMakePayment === 'loading' };
 }

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -525,6 +525,7 @@ export default function CompositeCheckout( {
 				cardExpiry: storedDetails.expiry,
 				brand: storedDetails.card_type,
 				last4: storedDetails.card,
+				stripeConfiguration,
 				submitTransaction: submitData => {
 					const pending = submitExistingCardPayment(
 						{
@@ -550,7 +551,13 @@ export default function CompositeCheckout( {
 				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 			} )
 		);
-	}, [ registerStore, storedCards, dispatch, shouldLoadExistingCardsMethods ] );
+	}, [
+		registerStore,
+		stripeConfiguration,
+		storedCards,
+		dispatch,
+		shouldLoadExistingCardsMethods,
+	] );
 
 	const isPurchaseFree = ! isLoadingCart && total.amount.value === 0;
 	debug( 'is purchase free?', isPurchaseFree );

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -355,7 +355,9 @@ export default function CompositeCheckout( {
 		isStripeLoading,
 		stripeLoadingError,
 	] );
-	stripeMethod.id = 'card';
+	if ( stripeMethod ) {
+		stripeMethod.id = 'card';
+	}
 
 	const fullCreditsPaymentMethod = useMemo(
 		() =>

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -218,6 +218,13 @@ export default function CompositeCheckout( {
 		);
 	};
 
+	useEffect( () => {
+		if ( stripeLoadingError ) {
+			debug( 'showing error for loading', stripeLoadingError );
+			showErrorMessage( stripeLoadingError );
+		}
+	}, [ showErrorMessage, stripeLoadingError ] );
+
 	const countriesList = useCountryList( overrideCountryList || [] );
 
 	const { productForCart, canInitializeCart } = usePrepareProductForCart(

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -427,7 +427,7 @@ export default function CompositeCheckout( {
 	const {
 		canMakePayment: isApplePayAvailable,
 		isLoading: isApplePayLoading,
-	} = useIsApplePayAvailable( stripe, stripeConfiguration, items );
+	} = useIsApplePayAvailable( stripe, stripeConfiguration, !! stripeLoadingError, items );
 	const applePayMethod = useMemo( () => {
 		if (
 			isStripeLoading ||

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -620,7 +620,13 @@ export default function CompositeCheckout( {
 				onEvent={ recordEvent }
 				paymentMethods={ paymentMethods }
 				registry={ registry }
-				isLoading={ isLoading || isLoadingStoredCards || isApplePayLoading || items.length < 1 }
+				isLoading={
+					isLoading ||
+					isLoadingStoredCards ||
+					isApplePayLoading ||
+					paymentMethods.length < 1 ||
+					items.length < 1
+				}
 			>
 				<WPCheckout
 					removeItem={ removeItem }

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -17,6 +17,14 @@ import { render } from '@testing-library/react'; // eslint-disable-line import/n
  * Internal dependencies
  */
 import CompositeCheckout from '../composite-checkout';
+import { StripeHookProvider } from 'lib/stripe';
+
+const fetchStripeConfiguration = async () => {
+	return {
+		public_key: 'abc123',
+		js_url: 'https://js.stripe.com/v3/',
+	};
+};
 
 describe( 'CompositeCheckout', () => {
 	let container;
@@ -98,16 +106,18 @@ describe( 'CompositeCheckout', () => {
 		} );
 
 		MyCheckout = () => (
-			<ReduxProvider store={ store }>
-				<CompositeCheckout
-					siteSlug={ 'foo.com' }
-					setCart={ mockSetCartEndpoint }
-					getCart={ mockGetCartEndpointWith( initialCart ) }
-					getStoredCards={ async () => [] }
-					allowedPaymentMethods={ [ 'paypal' ] }
-					overrideCountryList={ countryList }
-				/>
-			</ReduxProvider>
+			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+				<ReduxProvider store={ store }>
+					<CompositeCheckout
+						siteSlug={ 'foo.com' }
+						setCart={ mockSetCartEndpoint }
+						getCart={ mockGetCartEndpointWith( initialCart ) }
+						getStoredCards={ async () => [] }
+						allowedPaymentMethods={ [ 'paypal' ] }
+						overrideCountryList={ countryList }
+					/>
+				</ReduxProvider>
+			</StripeHookProvider>
 		);
 	} );
 

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -114,6 +114,7 @@ describe( 'CompositeCheckout', () => {
 						getCart={ mockGetCartEndpointWith( initialCart ) }
 						getStoredCards={ async () => [] }
 						allowedPaymentMethods={ [ 'paypal' ] }
+						onlyLoadPaymentMethods={ [ 'paypal' ] }
 						overrideCountryList={ countryList }
 					/>
 				</ReduxProvider>

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -102,7 +102,6 @@ Each payment method is an object with the following properties:
 - `activeContent: React.ReactNode`. A component that displays that payment method (this can return null or something like a credit card form).
 - `submitButton: React.ReactNode`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. When disabled, it will be provided with the `disabled` prop and must disable the button.
 - `inactiveContent: React.ReactNode`. A component that renders a summary of the selected payment method when the step is inactive.
-- `checkoutWrapper?: (children: React.ReactNode) => React.ReactNode`. A [render prop](https://reactjs.org/docs/render-props.html) that returns a component to wrap the whole of the checkout form. Must render the provided `children` argument. This can be used for custom data providers (eg: `StripeProvider` to support [Stripe Elements](https://github.com/stripe/react-stripe-elements)).
 - `getAriaLabel: (localize: () => string) => string`. A function to return the name of the Payment Method. It will receive the localize function as an argument.
 - `isCompleteCallback?: ({paymentData: object, activeStep: object}) => boolean`. Used to determine if a step is complete for purposes of validation. Default is a function returning true.
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -268,7 +268,14 @@ function isContactFormComplete( { paymentData } ) {
 	return true;
 }
 
-// This is the parent component which would be included on a host page
+function HostPage() {
+	return (
+		<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+			<MyCheckout />
+		</StripeHookProvider>
+	);
+}
+
 function MyCheckout() {
 	const [ items, setItems ] = useState( initialItems );
 	useEffect( () => {
@@ -338,23 +345,21 @@ function MyCheckout() {
 	);
 
 	return (
-		<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-			<CheckoutProvider
-				locale={ 'en' }
-				items={ items }
-				total={ total }
-				onEvent={ onEvent }
-				onPaymentComplete={ onPaymentComplete }
-				showErrorMessage={ showErrorMessage }
-				showInfoMessage={ showInfoMessage }
-				showSuccessMessage={ showSuccessMessage }
-				registry={ registry }
-				isLoading={ isLoading }
-				paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
-			>
-				<Checkout steps={ steps } />
-			</CheckoutProvider>
-		</StripeHookProvider>
+		<CheckoutProvider
+			locale={ 'en' }
+			items={ items }
+			total={ total }
+			onEvent={ onEvent }
+			onPaymentComplete={ onPaymentComplete }
+			showErrorMessage={ showErrorMessage }
+			showInfoMessage={ showInfoMessage }
+			showSuccessMessage={ showSuccessMessage }
+			registry={ registry }
+			isLoading={ isLoading }
+			paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
+		>
+			<Checkout steps={ steps } />
+		</CheckoutProvider>
 	);
 }
 
@@ -371,4 +376,4 @@ async function asyncTimeout( timeout ) {
 	return new Promise( resolve => setTimeout( resolve, timeout ) );
 }
 
-ReactDOM.render( <MyCheckout />, document.getElementById( 'root' ) );
+ReactDOM.render( <HostPage />, document.getElementById( 'root' ) );

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -374,6 +374,7 @@ function MyCheckout() {
 			stripeLoadingError ||
 			! stripe ||
 			! stripeConfiguration ||
+			isApplePayLoading ||
 			! isApplePayAvailable
 		) {
 			return null;
@@ -386,7 +387,14 @@ function MyCheckout() {
 			stripe,
 			stripeConfiguration,
 		} );
-	}, [ stripe, stripeConfiguration, isStripeLoading, stripeLoadingError, isApplePayAvailable ] );
+	}, [
+		isApplePayLoading,
+		stripe,
+		stripeConfiguration,
+		isStripeLoading,
+		stripeLoadingError,
+		isApplePayAvailable,
+	] );
 
 	const paypalMethod = useMemo(
 		() =>

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -86,34 +86,6 @@ async function makePayPalExpressRequest( data ) {
 const registry = createRegistry();
 const { registerStore, select, subscribe } = registry;
 
-const stripeMethod = createStripeMethod( {
-	getCountry: () => select( 'checkout' ).getPaymentData().billing.country,
-	getPostalCode: () => 90210,
-	getPhoneNumber: () => 5555555555,
-	getSubdivisionCode: () => 'CA',
-	registerStore,
-	fetchStripeConfiguration,
-	submitTransaction: sendStripeTransaction,
-} );
-
-const applePayMethod = isApplePayAvailable()
-	? createApplePayMethod( {
-			getCountry: () => select( 'checkout' ).getPaymentData().billing.country,
-			getPostalCode: () => 90210,
-			getPhoneNumber: () => 5555555555,
-			registerStore,
-			fetchStripeConfiguration,
-			submitTransaction: sendStripeTransaction,
-	  } )
-	: null;
-
-const paypalMethod = createPayPalMethod( {
-	registerStore,
-	submitTransaction: makePayPalExpressRequest,
-	getSuccessUrl: () => '#',
-	getCancelUrl: () => '#',
-} );
-
 export function isApplePayAvailable() {
 	// Our Apple Pay implementation uses the Payment Request API, so check that first.
 	if ( ! window.PaymentRequest ) {
@@ -309,6 +281,46 @@ function MyCheckout() {
 	useEffect( () => {
 		setTimeout( () => setIsLoading( false ), 1500 );
 	}, [] );
+
+	const stripeMethod = useMemo(
+		() =>
+			createStripeMethod( {
+				getCountry: () => select( 'checkout' ).getPaymentData().billing.country,
+				getPostalCode: () => 90210,
+				getPhoneNumber: () => 5555555555,
+				getSubdivisionCode: () => 'CA',
+				registerStore,
+				fetchStripeConfiguration,
+				submitTransaction: sendStripeTransaction,
+			} ),
+		[]
+	);
+
+	const applePayMethod = useMemo(
+		() =>
+			isApplePayAvailable()
+				? createApplePayMethod( {
+						getCountry: () => select( 'checkout' ).getPaymentData().billing.country,
+						getPostalCode: () => 90210,
+						getPhoneNumber: () => 5555555555,
+						registerStore,
+						fetchStripeConfiguration,
+						submitTransaction: sendStripeTransaction,
+				  } )
+				: null,
+		[]
+	);
+
+	const paypalMethod = useMemo(
+		() =>
+			createPayPalMethod( {
+				registerStore,
+				submitTransaction: makePayPalExpressRequest,
+				getSuccessUrl: () => '#',
+				getCancelUrl: () => '#',
+			} ),
+		[]
+	);
 
 	return (
 		<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -279,7 +279,15 @@ function MyCheckout() {
 
 	const [ isLoading, setIsLoading ] = useState( true );
 	useEffect( () => {
-		if ( isStripeLoading || stripeLoadingError || ! stripe || ! stripeConfiguration ) {
+		if ( isStripeLoading ) {
+			return;
+		}
+		if ( stripeLoadingError ) {
+			setIsLoading( false );
+			showErrorMessage( stripeLoadingError );
+			return;
+		}
+		if ( ! stripe || ! stripeConfiguration ) {
 			return;
 		}
 		// This simulates an additional loading delay

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -20,6 +20,7 @@ import {
 	useIsStepActive,
 	usePaymentData,
 } from '../src/public-api';
+import { StripeHookProvider } from '../src/lib/stripe';
 
 const stripeKey = 'pk_test_zIh4nRbVgmaetTZqoG4XKxWT';
 
@@ -310,21 +311,23 @@ function MyCheckout() {
 	}, [] );
 
 	return (
-		<CheckoutProvider
-			locale={ 'en' }
-			items={ items }
-			total={ total }
-			onEvent={ onEvent }
-			onPaymentComplete={ onPaymentComplete }
-			showErrorMessage={ showErrorMessage }
-			showInfoMessage={ showInfoMessage }
-			showSuccessMessage={ showSuccessMessage }
-			registry={ registry }
-			isLoading={ isLoading }
-			paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
-		>
-			<Checkout steps={ steps } />
-		</CheckoutProvider>
+		<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
+			<CheckoutProvider
+				locale={ 'en' }
+				items={ items }
+				total={ total }
+				onEvent={ onEvent }
+				onPaymentComplete={ onPaymentComplete }
+				showErrorMessage={ showErrorMessage }
+				showInfoMessage={ showInfoMessage }
+				showSuccessMessage={ showSuccessMessage }
+				registry={ registry }
+				isLoading={ isLoading }
+				paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
+			>
+				<Checkout steps={ steps } />
+			</CheckoutProvider>
+		</StripeHookProvider>
 	);
 }
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -148,7 +148,7 @@ export function useIsApplePayAvailable( stripe, stripeConfiguration, items ) {
 			isSubscribed && setCanMakePayment( !! result?.applePay );
 		} );
 
-		return ( isSubscribed = false );
+		return () => ( isSubscribed = false );
 	}, [ canMakePayment, stripe, items, stripeConfiguration ] );
 
 	return { canMakePayment: canMakePayment === true, isLoading: canMakePayment === 'loading' };

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -301,19 +301,22 @@ function MyCheckout() {
 		} );
 	}, [ stripe, stripeConfiguration, isStripeLoading, stripeLoadingError ] );
 
-	const applePayMethod = useMemo(
-		() =>
-			isApplePayAvailable()
-				? createApplePayMethod( {
-						getCountry: () => select( 'checkout' ).getPaymentData().billing.country,
-						getPostalCode: () => 90210,
-						registerStore,
-						fetchStripeConfiguration,
-						submitTransaction: sendStripeTransaction,
-				  } )
-				: null,
-		[]
-	);
+	const applePayMethod = useMemo( () => {
+		if ( ! isApplePayAvailable() ) {
+			return null;
+		}
+		if ( isStripeLoading || stripeLoadingError || ! stripe || ! stripeConfiguration ) {
+			return null;
+		}
+		return createApplePayMethod( {
+			getCountry: () => select( 'checkout' ).getPaymentData().billing.country,
+			getPostalCode: () => 90210,
+			registerStore,
+			submitTransaction: sendStripeTransaction,
+			stripe,
+			stripeConfiguration,
+		} );
+	}, [ stripe, stripeConfiguration, isStripeLoading, stripeLoadingError ] );
 
 	const paypalMethod = useMemo(
 		() =>

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -151,7 +151,7 @@ export function useIsApplePayAvailable( stripe, stripeConfiguration, items ) {
 		return ( isSubscribed = false );
 	}, [ canMakePayment, stripe, items, stripeConfiguration ] );
 
-	return canMakePayment;
+	return { canMakePayment: canMakePayment === true, isLoading: canMakePayment === 'loading' };
 }
 
 const handleEvent = setItems => () => {
@@ -328,7 +328,10 @@ function MyCheckout() {
 	}, [] );
 	const total = useMemo( () => getTotal( items ), [ items ] );
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
-	const isApplePayAvailable = useIsApplePayAvailable( stripe, stripeConfiguration, items );
+	const {
+		canMakePayment: isApplePayAvailable,
+		isLoading: isApplePayLoading,
+	} = useIsApplePayAvailable( stripe, stripeConfiguration, items );
 
 	const [ isLoading, setIsLoading ] = useState( true );
 	useEffect( () => {
@@ -343,9 +346,12 @@ function MyCheckout() {
 		if ( ! stripe || ! stripeConfiguration ) {
 			return;
 		}
+		if ( isApplePayLoading ) {
+			return;
+		}
 		// This simulates an additional loading delay
 		setTimeout( () => setIsLoading( false ), 1500 );
-	}, [ isStripeLoading, stripeLoadingError, stripe, stripeConfiguration ] );
+	}, [ isStripeLoading, stripeLoadingError, stripe, stripeConfiguration, isApplePayLoading ] );
 
 	const stripeMethod = useMemo( () => {
 		if ( isStripeLoading || stripeLoadingError || ! stripe || ! stripeConfiguration ) {

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -63,12 +63,6 @@ export const CheckoutProvider = props => {
 		}
 	}, [ formStatus, onPaymentComplete, paymentMethodId ] );
 
-	// Remove undefined and duplicate checkoutWrapper properties
-	const wrappers = [
-		...new Set( paymentMethods.map( method => method.checkoutWrapper ).filter( Boolean ) ),
-	];
-	debug( `applying ${ wrappers.length } checkoutWrapper wrappers` );
-
 	// Create the registry automatically if it's not a prop
 	const registryRef = useRef( registry );
 	registryRef.current = registryRef.current || createRegistry();
@@ -106,11 +100,7 @@ export const CheckoutProvider = props => {
 				<RegistryProvider value={ registryRef.current }>
 					<LocalizeProvider locale={ locale }>
 						<LineItemsProvider items={ items } total={ total }>
-							<CheckoutContext.Provider value={ value }>
-								<PaymentMethodWrapperProvider wrappers={ wrappers }>
-									{ children }
-								</PaymentMethodWrapperProvider>
-							</CheckoutContext.Provider>
+							<CheckoutContext.Provider value={ value }>{ children }</CheckoutContext.Provider>
 						</LineItemsProvider>
 					</LocalizeProvider>
 				</RegistryProvider>
@@ -172,12 +162,6 @@ function CheckoutProviderPropValidator( { propsToValidate } ) {
 		total,
 	] );
 	return null;
-}
-
-function PaymentMethodWrapperProvider( { children, wrappers } ) {
-	return wrappers.reduce( ( whole, wrapper ) => {
-		return wrapper( whole );
-	}, children );
 }
 
 export function useEvents() {

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -21,7 +21,7 @@ import { sprintf, useLocalize } from '../localize';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import { useFormStatus } from '../form-status';
 import PaymentLogo from './payment-logo.js';
-import { useStripe, showStripeModalAuth } from '../stripe';
+import { showStripeModalAuth } from '../stripe';
 
 const debug = debugFactory( 'composite-checkout:existing-card-payment-method' );
 
@@ -36,6 +36,7 @@ export function createExistingCardMethod( {
 	cardExpiry,
 	brand,
 	last4,
+	stripeConfiguration,
 } ) {
 	debug( 'creating a new existing credit card payment method', {
 		id,
@@ -160,7 +161,7 @@ export function createExistingCardMethod( {
 				brand={ brand }
 			/>
 		),
-		submitButton: <ExistingCardPayButton id={ id } />,
+		submitButton: <ExistingCardPayButton id={ id } stripeConfiguration={ stripeConfiguration } />,
 		inactiveContent: (
 			<ExistingCardSummary
 				cardholderName={ cardholderName }
@@ -204,7 +205,7 @@ const CardHolderName = styled.span`
 	display: block;
 `;
 
-function ExistingCardPayButton( { disabled, id } ) {
+function ExistingCardPayButton( { disabled, id, stripeConfiguration } ) {
 	const localize = useLocalize();
 	const [ items, total ] = useLineItems();
 	const { showErrorMessage, showInfoMessage } = useMessages();
@@ -222,7 +223,6 @@ function ExistingCardPayButton( { disabled, id } ) {
 		`existing-card-${ id }`
 	);
 	const { formStatus, setFormReady, setFormComplete, setFormSubmitting } = useFormStatus();
-	const { stripeConfiguration } = useStripe();
 	const onEvent = useEvents();
 
 	useEffect( () => {

--- a/packages/composite-checkout/src/lib/stripe.js
+++ b/packages/composite-checkout/src/lib/stripe.js
@@ -197,7 +197,7 @@ function useStripeJs( stripeConfiguration ) {
 			isSubscribed && setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
 		}
 
-		debug( 'useStripeJs loading', stripeConfiguration );
+		debug( 'useStripeJs loading' );
 		if ( stripeConfiguration ) {
 			loadAndInitStripe().catch( error => {
 				debug( 'loadAndInitStripe error', error );
@@ -208,7 +208,6 @@ function useStripeJs( stripeConfiguration ) {
 		return () => ( isSubscribed = false );
 	}, [ stripeConfiguration ] );
 
-	debug( 'useStripeJs returning', isStripeLoading, stripeLoadingError );
 	return { stripeJs, isStripeLoading, stripeLoadingError };
 }
 
@@ -242,7 +241,7 @@ function useStripeConfiguration( fetchStripeConfiguration ) {
 			debug( 'loading stripe configuration' );
 			fetchStripeConfiguration()
 				.then( configuration => {
-					debug( 'stripe configuration retrieved', configuration );
+					debug( 'stripe configuration retrieved' );
 					isSubscribed && setStripeConfiguration( configuration );
 				} )
 				.catch( error => {
@@ -251,7 +250,6 @@ function useStripeConfiguration( fetchStripeConfiguration ) {
 		}
 		return () => ( isSubscribed = false );
 	}, [ stripeConfiguration, fetchStripeConfiguration ] );
-	debug( 'useStripeConfiguration returning', stripeConfiguration );
 	return stripeConfiguration;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes how payment methods load Stripe.js by forcing the host page to load it rather than handling the loading themselves. The motivation was so that we can check for Apple Pay availability before loading any payment methods, but it has the added advantage of simplifying the API of payment methods. 

Previously each payment method object could have a `checkoutWrapper` property which would be used to wrap the entirety of the checkout form. Although this could have other applications the intent was to make it possible for payment methods that required a shared stripe context to create one in state that was shared between sibling components in the form.

With this PR, we remove the concept of a `checkoutWrapper` and instead simply make it a requirement of stripe payment methods (currently credit card and apple pay) that the host page load, configure, initialize, and pass the `stripe` instance into the payment methods itself. This is actually quite a lot more flexible since the host page may want to load stripe in any number of ways and it prevents the possibility of loading stripe more than once on the same checkout.

With that done, this PR creates a hook `useIsApplePayAvailable` which it uses to determine if it should add the apple pay method.

One side effect of this change is that we no longer need to duplicate the stripe library code in the `composite-checkout` package; we can just use the version already on the host page (calypso). (The duplicate library still remains in the package but it is only used for the demo.)

#### Testing instructions

- Sandbox the store.
- First ignore apple pay and try visiting composite checkout in a non-Safari browser. Make sure that the Stripe payment method loads correctly.
- Using Mac OS Safari, visit WordPress.com and log in. This is required because once we proxy, you will not be able to log in.
- Enable Charles proxy to spoof WordPress.com. This is required because Apple Pay will only work on SSL and on a production domain. The details of how to do this are beyond the scope of this PR. Contact me if you have any issues.
- Using Mac OS Safari, reload WordPress.com and be sure you see the "dev" badge in the lower-right.
- Add a plan to your cart and visit checkout.
- Select "Apple Pay" from the available payment methods.
- Complete the form and press "Pay". You must use a real Apple Pay card. But as long as the store is sandboxed, you won't actually be charged.
- Complete the Apple Pay sheet that appears.
- Verify that the payment was successful and that the plan was added to your site.

#### Screenshots

![Screen Shot 2020-02-25 at 12 20 46 AM](https://user-images.githubusercontent.com/2036909/75217335-c152da00-5764-11ea-987e-772d4dbc7dee.png)

![Screen Shot 2020-02-25 at 12 20 55 AM](https://user-images.githubusercontent.com/2036909/75217337-c44dca80-5764-11ea-9cba-f7ec2e3c192b.png)
