### PR TITLE
[Customer Home]: Make Customer Home the default landing page for logged-in users

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -49,7 +49,6 @@ import detectHistoryNavigation from 'lib/detect-history-navigation';
 import userFactory from 'lib/user';
 import { getUrlParts } from 'lib/url/url-parts';
 import { setStore } from 'state/redux-store';
-import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 
 const debug = debugFactory( 'calypso' );
 
@@ -106,37 +105,6 @@ const setupContextMiddleware = reduxStore => {
 
 // We need to require sections to load React with i18n mixin
 const loadSectionsMiddleware = () => setupRoutes();
-
-const loggedInMiddleware = ( currentUser, reduxStore ) => {
-	const jetpackCloudEnvs = [
-		'jetpack-cloud-development',
-		'jetpack-cloud-stage',
-		'jetpack-cloud-production',
-	];
-	const calypsoEnv = config( 'env_id' );
-	const currentUserData = currentUser.get();
-
-	// TODO: Remove Jetpack Cloud specific logic when root route is no longer handled by the reader section
-	if ( ! currentUserData || jetpackCloudEnvs.includes( calypsoEnv ) ) {
-		return;
-	}
-
-	page( '/', context => {
-		const { primarySiteSlug, primary_blog } = currentUserData;
-		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome(
-			reduxStore.getState(),
-			primary_blog
-		);
-		let redirectPath =
-			primarySiteSlug && isCustomerHomeEnabled ? `/home/${ primarySiteSlug }` : '/read';
-
-		if ( context.querystring ) {
-			redirectPath += `?${ context.querystring }`;
-		}
-
-		page.redirect( redirectPath );
-	} );
-};
 
 const oauthTokenMiddleware = () => {
 	if ( config.isEnabled( 'oauth' ) ) {
@@ -237,7 +205,6 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 	installPerfmonPageHandlers();
 	setupContextMiddleware( reduxStore );
 	oauthTokenMiddleware();
-	loggedInMiddleware( currentUser, reduxStore );
 	loadSectionsMiddleware();
 	setRouteMiddleware();
 	clearNoticesMiddleware();

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -49,6 +49,7 @@ import detectHistoryNavigation from 'lib/detect-history-navigation';
 import userFactory from 'lib/user';
 import { getUrlParts } from 'lib/url/url-parts';
 import { setStore } from 'state/redux-store';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 
 const debug = debugFactory( 'calypso' );
 
@@ -105,6 +106,37 @@ const setupContextMiddleware = reduxStore => {
 
 // We need to require sections to load React with i18n mixin
 const loadSectionsMiddleware = () => setupRoutes();
+
+const loggedInMiddleware = ( currentUser, reduxStore ) => {
+	const jetpackCloudEnvs = [
+		'jetpack-cloud-development',
+		'jetpack-cloud-stage',
+		'jetpack-cloud-production',
+	];
+	const calypsoEnv = config( 'env_id' );
+	const currentUserData = currentUser.get();
+
+	// TODO: Remove Jetpack Cloud specific logic when root route is no longer handled by the reader section
+	if ( ! currentUserData || jetpackCloudEnvs.includes( calypsoEnv ) ) {
+		return;
+	}
+
+	page( '/', context => {
+		const { primarySiteSlug, primary_blog } = currentUserData;
+		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome(
+			reduxStore.getState(),
+			primary_blog
+		);
+		let redirectPath =
+			primarySiteSlug && isCustomerHomeEnabled ? `/home/${ primarySiteSlug }` : '/read';
+
+		if ( context.querystring ) {
+			redirectPath += `?${ context.querystring }`;
+		}
+
+		page.redirect( redirectPath );
+	} );
+};
 
 const oauthTokenMiddleware = () => {
 	if ( config.isEnabled( 'oauth' ) ) {
@@ -205,6 +237,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 	installPerfmonPageHandlers();
 	setupContextMiddleware( reduxStore );
 	oauthTokenMiddleware();
+	loggedInMiddleware( currentUser, reduxStore );
 	loadSectionsMiddleware();
 	setRouteMiddleware();
 	clearNoticesMiddleware();

--- a/client/root.js
+++ b/client/root.js
@@ -8,6 +8,9 @@ import page from 'page';
  */
 import config from 'config';
 import userFactory from 'lib/user';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
+import { getCurrentUser } from 'state/current-user/selectors';
+import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 
 export default function() {
 	const user = userFactory();
@@ -37,7 +40,11 @@ function setupLoggedOut() {
 
 function setupLoggedIn() {
 	page( '/', context => {
-		let redirectPath = '/read';
+		const state = context.store.getState();
+		const { primarySiteSlug } = getCurrentUser( state );
+		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, getPrimarySiteId( state ) );
+		let redirectPath =
+			primarySiteSlug && isCustomerHomeEnabled ? `/home/${ primarySiteSlug }` : '/read';
 
 		if ( context.querystring ) {
 			redirectPath += `?${ context.querystring }`;

--- a/client/root.js
+++ b/client/root.js
@@ -9,8 +9,8 @@ import page from 'page';
 import config from 'config';
 import userFactory from 'lib/user';
 import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
-import { getCurrentUser } from 'state/current-user/selectors';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import { getSiteSlug } from 'state/sites/selectors';
 
 export default function() {
 	const user = userFactory();
@@ -41,10 +41,10 @@ function setupLoggedOut() {
 function setupLoggedIn() {
 	page( '/', context => {
 		const state = context.store.getState();
-		const { primarySiteSlug } = getCurrentUser( state );
-		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, getPrimarySiteId( state ) );
-		let redirectPath =
-			primarySiteSlug && isCustomerHomeEnabled ? `/home/${ primarySiteSlug }` : '/read';
+		const primarySiteId = getPrimarySiteId( state );
+		const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( state, primarySiteId );
+		const siteSlug = getSiteSlug( state, primarySiteId );
+		let redirectPath = siteSlug && isCustomerHomeEnabled ? `/home/${ siteSlug }` : '/read';
 
 		if ( context.querystring ) {
 			redirectPath += `?${ context.querystring }`;


### PR DESCRIPTION
## Changes proposed in this Pull Request

We removed the '_alternative default logged-in landing **p**age_' A/B test in #39475. 

#39475 tested redirecting logged-in users to the Customer Home rath**e**r than the Reader when l**a**nding on `/`.

This PR re-enables the default redire**c**t to Customer Home. 

There is no A/B t**e**st.

We're als**o** [checking if the **u**ser can use Customer Home](https://github.com/Automattic/wp-calypso/blob/master/client/state/sites/selectors/can-current-user-use-customer-home.js#L25) for the given primary blog ID.

The fallback redirec**t** remains `/read`.

## Testing instructions

For best results, queue up some [soothing testing music.](https://www.youtube.com/watch?v=su0mR4_z2so)

### Test the redirect

- Create a new site
- Make it your primary site over at `/me/account`
- Refresh the page at `/`
- You should land on Customer Home for your primary site
- Reflect on the good things, even the ephemeral

### Test the fallback

- Create an account, but not a site at `/start`
- Refresh the page at `/`
- You should land on the Reader
- Find new virtues in difficult exercises

The `canCurrentUserUseCustomerHome` selector returns `false` for [VIP sites, Jetpack sites and sites in the control group for the `customerHomeAll` A/B test](https://github.com/Automattic/wp-calypso/blob/master/client/state/sites/selectors/can-current-user-use-customer-home.js#L25).

You can either edit this selector to return `false`, or:

- Make a site created before `2019-08-06` your primary site
- Make sure the `customerHomeAll` A/B test is set to `control`
- You should land on the Reader
- Note that, though we are small, we can make big changes.

## Related reading
p8Eqe3-Vq-p2#comment-3232
