### PR TITLE
CI: Disable typecheck job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,9 +689,9 @@ workflows:
       - test-server:
           requires:
             - setup
-      - typecheck:
-          requires:
-            - setup
+      # - typecheck:
+      #     requires:
+      #       - setup
       - typecheck-strict:
           requires:
             - setup


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disable the `typecheck` job on CircleCI.

The project-wide TypeScript configuration is currently broken so this job is producing no meaningful
output. Disable the job.

#### Testing instructions

- Verify that recent `typecheck` jobs are broken and do not produce relevant output.
- Verify the `typecheck` job is not run on this PR.
- Other jobs remain unaffected.
