### PR TITLE
calypso-build: add missing changelog entry and publish 6.1.0

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,6 +1,7 @@
-# next
+# 6.1.0
 
 - Upgrade [mini-css-extract-plugin-with-rtl](https://github.com/Automattic/mini-css-extract-plugin-with-rtl) to 0.8.0, use an npm-published version instead of GitHub branch reference
+- Disable Terser's `extractComments` option to prevent Calypso build from adding LICENSE files into the minified output
 
 # 6.0.0
 

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",


### PR DESCRIPTION
Bump package version and publish 6.1.0.