### PR TITLE
Domains: Improve default search experience at /domains/add

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -165,6 +165,7 @@ class RegisterDomainStep extends React.Component {
 		onDomainsAvailabilityChange: noop,
 		onSave: noop,
 		vendor: getSuggestionsVendor(),
+		showExampleSuggestions: false,
 	};
 
 	constructor( props ) {
@@ -744,6 +745,10 @@ class RegisterDomainStep extends React.Component {
 		const cleanedQuery = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
 		const loadingResults = Boolean( cleanedQuery );
 		const isInitialQueryActive = searchQuery === this.props.suggestion;
+
+		if ( isEmpty( cleanedQuery ) && ! this.props.isSignupStep ) {
+			return;
+		}
 
 		this.setState(
 			{

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -58,6 +58,7 @@ import {
 	TldFilterBar,
 } from 'components/domains/search-filters';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
 import { hasDomainInCart } from 'lib/cart-values/cart-items';
@@ -174,7 +175,7 @@ class RegisterDomainStep extends React.Component {
 		resetSearchCount();
 
 		this._isMounted = false;
-		this.state = this.getState();
+		this.state = this.getState( props );
 		this.state.filters = this.getInitialFiltersState();
 		this.state.lastFilters = this.getInitialFiltersState();
 
@@ -217,8 +218,8 @@ class RegisterDomainStep extends React.Component {
 		}
 	}
 
-	getState() {
-		const suggestion = this.props.suggestion ? getFixedDomainSearch( this.props.suggestion ) : '';
+	getState( props ) {
+		const suggestion = props.suggestion ? getFixedDomainSearch( props.suggestion ) : '';
 		const loadingResults = Boolean( suggestion );
 
 		return {
@@ -235,8 +236,7 @@ class RegisterDomainStep extends React.Component {
 			lastQuery: suggestion,
 			loadingResults,
 			loadingSubdomainResults:
-				( this.props.includeWordPressDotCom || this.props.includeDotBlogSubdomain ) &&
-				loadingResults,
+				( props.includeWordPressDotCom || props.includeDotBlogSubdomain ) && loadingResults,
 			pageNumber: 1,
 			searchResults: null,
 			showAvailabilityNotice: false,
@@ -248,7 +248,7 @@ class RegisterDomainStep extends React.Component {
 			unavailableDomains: [],
 			trademarkClaimsNoticeInfo: null,
 			selectedSuggestion: null,
-			isInitialQueryActive: !! this.props.suggestion,
+			isInitialQueryActive: !! props.suggestion,
 		};
 	}
 
@@ -267,7 +267,8 @@ class RegisterDomainStep extends React.Component {
 			nextProps.selectedSite &&
 			nextProps.selectedSite.slug !== ( this.props.selectedSite || {} ).slug
 		) {
-			this.setState( this.getState() );
+			this.setState( this.getState( nextProps ) );
+			this.onSearch( nextProps.suggestion );
 		}
 
 		if (
@@ -442,6 +443,7 @@ class RegisterDomainStep extends React.Component {
 							describedBy={ 'step-header' }
 							dir="ltr"
 							initialValue={ this.state.lastQuery }
+							value={ this.state.lastQuery }
 							inputLabel={ this.props.translate( 'What would you like your domain name to be?' ) }
 							minLength={ MIN_QUERY_LENGTH }
 							maxLength={ 60 }
@@ -1439,6 +1441,7 @@ export default connect(
 		return {
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			currentUser: getCurrentUser( state ),
+			selectedSite: getSelectedSite( state ),
 			defaultSuggestions: getDomainsSuggestions( state, queryObject ),
 			defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
 		};

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -170,6 +170,8 @@ class DomainSearch extends Component {
 				/>
 			);
 		} else {
+			const suggestion =
+				this.props.context.query.suggestion ?? selectedSite.domain.split( '.' )[ 0 ];
 			content = (
 				<span>
 					<div className="domain-search__content">
@@ -180,8 +182,7 @@ class DomainSearch extends Component {
 							noticeStatus="is-info"
 						>
 							<RegisterDomainStep
-								path={ this.props.context.path }
-								suggestion={ this.props.context.query.suggestion }
+								suggestion={ suggestion }
 								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
 								onDomainsAvailabilityChange={ this.handleDomainsAvailabilityChange }
 								onAddDomain={ this.handleAddRemoveDomain }

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -189,7 +189,6 @@ class DomainSearch extends Component {
 								onAddMapping={ this.handleAddMapping }
 								onAddTransfer={ this.handleAddTransfer }
 								cart={ this.props.cart }
-								selectedSite={ selectedSite }
 								offerUnavailableOption
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -244,7 +244,8 @@ export function waitForFieldClearable( driver, selector ) {
 		function() {
 			return driver.findElement( selector ).then(
 				element => {
-					return element.sendKeys( Key.chord( Key.CONTROL, 'a' ), Key.BACK_SPACE ).then(
+					element.sendKeys( Key.chord( Key.CONTROL, 'a' ), Key.BACK_SPACE );
+					return element.clear().then(
 						function() {
 							return element.getAttribute( 'value' ).then( value => {
 								return value === '';

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import webdriver, { until, Key } from 'selenium-webdriver';
+import webdriver, { until } from 'selenium-webdriver';
 import config from 'config';
 import { forEach } from 'lodash';
 
@@ -243,8 +243,8 @@ export function waitForFieldClearable( driver, selector ) {
 	return driver.wait(
 		function() {
 			return driver.findElement( selector ).then(
-				element => {
-					element.sendKeys( Key.chord( Key.CONTROL, 'a' ), Key.BACK_SPACE );
+				async element => {
+					await driver.executeScript( "arguments[0].value = '';", element );
 					return element.clear().then(
 						function() {
 							return element.getAttribute( 'value' ).then( value => {

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import webdriver, { until } from 'selenium-webdriver';
+import webdriver, { until, Key } from 'selenium-webdriver';
 import config from 'config';
 import { forEach } from 'lodash';
 
@@ -244,7 +244,7 @@ export function waitForFieldClearable( driver, selector ) {
 		function() {
 			return driver.findElement( selector ).then(
 				element => {
-					return element.clear().then(
+					return element.sendKeys( Key.chord( Key.CONTROL, 'a' ), Key.BACK_SPACE ).then(
 						function() {
 							return element.getAttribute( 'value' ).then( value => {
 								return value === '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The default search experience at `/domains/add` is a bit bleak - it just shows two search results, not sure where they came from (behind the scenes they are fetched based on the site slug) and we're not tracking them.

Let's improve that by making the whole search explicit and work just like any other search. Additionally, let's not go back to the "default" suggestions on clearing the search. That does not make sense, IMHO. Let's just preserve the current state of the search and let the user make another search in peace.

Before:
<img width="1074" alt="Screenshot 2020-02-25 at 11 36 24" src="https://user-images.githubusercontent.com/3392497/75244111-158ca700-57c3-11ea-96e3-379a68e0781f.png">

After:
<img width="1067" alt="Screenshot 2020-02-25 at 11 36 15" src="https://user-images.githubusercontent.com/3392497/75244121-1a515b00-57c3-11ea-9e17-bee0a4e73a69.png">

There's probably a bit of code we could clean up once this lands, but I'll leave that for a follow-up PR, to keep this one simple. The logic in this file is convoluted and I want to avoid making too many changes at once.

#### Testing instructions
Go to Domains -> Add Domain. Verify that this immediately triggers a search based on the first part of your primary domain (example.com -> example).
Verify that if you empty the search (either by removing the text or clicking the X icon), the state of the component is preserved.

Go to signup and verify that the search works there as previously.