### PR TITLE
Don't concatenate modules on `whybundled`

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -49,6 +49,7 @@ const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'fa
 const shouldShowProgress = process.env.PROGRESS && process.env.PROGRESS !== 'false';
 const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
+const shouldConcatenateModules = process.env.CONCATENATE_MODULES !== 'false';
 const isCalypsoClient = process.env.BROWSERSLIST_ENV !== 'server';
 const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
 
@@ -115,6 +116,7 @@ const webpackConfig = {
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 	},
 	optimization: {
+		concatenateModules: shouldConcatenateModules,
 		splitChunks: {
 			chunks: 'all',
 			name: !! ( isDevelopment || shouldEmitStats ),

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -116,7 +116,7 @@ const webpackConfig = {
 		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
 	},
 	optimization: {
-		concatenateModules: shouldConcatenateModules,
+		concatenateModules: ! isDevelopment && shouldConcatenateModules,
 		splitChunks: {
 			chunks: 'all',
 			name: !! ( isDevelopment || shouldEmitStats ),

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
 		"typecheck": "tsc --noEmit",
 		"update-deps": "npx rimraf package-lock.json && npm run distclean && PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i && replace --silent 'http://' 'https://' . --recursive --include='package-lock.json' && touch -m node_modules",
 		"validate-fallback-es5": "npx eslint --parser-options=ecmaVersion:5 --no-eslintrc --no-ignore ./public/fallback/*.js",
-		"prewhybundled": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons npm run -s build-client-evergreen",
+		"prewhybundled": "NODE_ENV=production CALYPSO_ENV=production EMIT_STATS=withreasons CONCATENATE_MODULES=false npm run -s build-client-evergreen",
 		"whybundled": "whybundled client/stats.json",
 		"composite-checkout-demo": "webpack-dev-server --config ./packages/composite-checkout/webpack.config.demo.js --mode development",
 		"components:storybook:start": "start-storybook -c packages/components/.storybook",


### PR DESCRIPTION
The `whybundled` task is used in determining why a package or module is being included in the build, which is useful in e.g. tracking down remaining usage of legacy libraries. However, by default, builds are done with module concatenation enabled, which sometimes makes it hard for `whybundled` to do its job as there is no longer a 1:1 mapping between input and output modules.

This PR adds a new environment variable to enable/disable module concatenation (enabled by default), and disables it for the `whybundled` task (or, more accurately, the `prewhybundled` task that runs before it).

#### Changes proposed in this Pull Request

* Add `CONCATENATE_MODULES` environment variable
* Set it to `false` in `prewhybundled` task

#### Testing instructions

This is a build-only change that shouldn't affect real builds in any way. Please ensure that there are no changes to the bundles as a result of this PR.
