### PR TITLE
Split out a few things in lib/signup/step-actions

### DIFF
--- a/client/lib/signup/step-actions/fetch-sites-and-user.js
+++ b/client/lib/signup/step-actions/fetch-sites-and-user.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import userFactory from 'lib/user';
+
+// State actions and selectors
+import getSiteId from 'state/selectors/get-site-id';
+import { requestSites } from 'state/sites/actions';
+import { promisify } from 'utils';
+
+/**
+ * Constants
+ */
+const user = userFactory();
+const debug = debugFactory( 'calypso:signup:step-actions:fetch-sites-and-user' );
+
+function fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ) {
+	if ( getSiteId( reduxStore.getState(), siteSlug ) ) {
+		debug( 'fetchReduxSite: found new site' );
+		callback();
+		return;
+	}
+
+	// Have to manually call the thunk in order to access the promise on which
+	// to call `then`.
+	debug( 'fetchReduxSite: requesting all sites', siteSlug );
+	reduxStore
+		.dispatch( requestSites() )
+		.then( () => fetchSitesUntilSiteAppears( siteSlug, reduxStore, callback ) );
+}
+
+export function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
+	Promise.all( [
+		promisify( fetchSitesUntilSiteAppears )( siteSlug, reduxStore ),
+		new Promise( resolve => {
+			user.once( 'change', resolve );
+			user.fetch();
+		} ),
+	] ).then( onComplete );
+}

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -41,11 +41,11 @@ import getNewSitePublicSetting from 'state/selectors/get-new-site-public-setting
 import getNewSiteComingSoonSetting from 'state/selectors/get-new-site-coming-soon-setting';
 
 // Current directory dependencies
-import { isValidLandingPageVertical } from './verticals';
-import { getSiteTypePropertyValue } from './site-type';
+import { isValidLandingPageVertical } from 'lib/signup/verticals';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
-import SignupCart from './cart';
-import { promisify } from '../../utils';
+import SignupCart from 'lib/signup/cart';
+import { promisify } from 'utils';
 
 // Others
 import flows from 'signup/config/flows';

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -674,34 +674,3 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 		flows.excludeStep( stepName );
 	}
 }
-
-/**
- * Creates a user account and sends the user a verification code via email to confirm the account.
- * Returns the dependencies for the step.
- *
- * @param {Function} callback Callback function
- * @param {object}   data     POST data object
- */
-export function createPasswordlessUser( callback, { email } ) {
-	wpcom
-		.undocumented()
-		.usersEmailNew( { email }, null )
-		.then( response => callback( null, response ) )
-		.catch( err => callback( err ) );
-}
-
-/**
- * Verifies a passwordless user code.
- *
- * @param {Function} callback Callback function
- * @param {object}   data     POST data object
- */
-export function verifyPasswordlessUser( callback, { email, code } ) {
-	wpcom
-		.undocumented()
-		.usersEmailVerification( { email, code }, null )
-		.then( response =>
-			callback( null, { email, username: email, bearer_token: response.token.access_token } )
-		)
-		.catch( err => callback( err ) );
-}

--- a/client/lib/signup/step-actions/passwordless.js
+++ b/client/lib/signup/step-actions/passwordless.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+
+/**
+ * Creates a user account and sends the user a verification code via email to confirm the account.
+ * Returns the dependencies for the step.
+ *
+ * @param {Function} callback Callback function
+ * @param {object}   data     POST data object
+ */
+export function createPasswordlessUser( callback, { email } ) {
+	wpcom
+		.undocumented()
+		.usersEmailNew( { email }, null )
+		.then( response => callback( null, response ) )
+		.catch( err => callback( err ) );
+}
+
+/**
+ * Verifies a passwordless user code.
+ *
+ * @param {Function} callback Callback function
+ * @param {object}   data     POST data object
+ */
+export function verifyPasswordlessUser( callback, { email, code } ) {
+	wpcom
+		.undocumented()
+		.usersEmailVerification( { email, code }, null )
+		.then( response =>
+			callback( null, { email, username: email, bearer_token: response.token.access_token } )
+		)
+		.catch( err => callback( err ) );
+}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -76,7 +76,7 @@ import { isJetpackSite, isNewSite } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { getDomainNameFromReceiptOrCart } from 'lib/domains/cart-utils';
-import { fetchSitesAndUser } from 'lib/signup/step-actions';
+import { fetchSitesAndUser } from 'lib/signup/step-actions/fetch-sites-and-user';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -19,7 +19,7 @@ import { isEnabled } from 'config';
 jest.mock( 'lib/transaction/actions', () => ( {
 	resetTransaction: jest.fn(),
 } ) );
-jest.mock( 'lib/signup/step-actions', () => ( {} ) );
+jest.mock( 'lib/signup/step-actions/fetch-sites-and-user', () => ( {} ) );
 jest.mock( 'lib/analytics', () => ( {
 	tracks: {
 		recordEvent: jest.fn(),

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -10,10 +10,6 @@ import { identity } from 'lodash';
 /**
  * Internal dependencies
  */
-
-/**
- * Internal dependencies
- */
 import StepWrapper from 'signup/step-wrapper';
 import ValidationFieldset from 'signup/validation-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -21,7 +17,10 @@ import FormTextInput from 'components/forms/form-text-input';
 import LoggedOutForm from 'components/logged-out-form';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
 import { Button } from '@automattic/components';
-import { createPasswordlessUser, verifyPasswordlessUser } from 'lib/signup/step-actions';
+import {
+	createPasswordlessUser,
+	verifyPasswordlessUser,
+} from 'lib/signup/step-actions/passwordless';
 import Notice from 'components/notice';
 import FormStateStore from 'lib/form-state';
 import createFormStore from 'lib/form-state/store';


### PR DESCRIPTION
`lib/signup/step-actions` is currently a large file containing many loosely-related functions. Some parts of Calypso make use of many of these, but other parts make use of just one or two functions. One example of this is checkout, which only needs `fetchSitesAndUser` but ends up depending on the whole thing due to webpack being unable to tree-shake this monolithic module.

This PR splits a few things out into their own modules, to break down the monolith a little. Breaking it entirely and cleanly would require dropping the current usage of side-effects, making this a stateless library.

This PR should make checkout a little smaller, while preparing the way for potential improvements in signup as well.

#### Changes proposed in this Pull Request

* Split out `fetchSitesAndUser` from `lib/signup/step-actions`
* Split out passwordless-related functions from `lib/signup/step-actions`
* Update imports accordingly across Calypso

#### Testing instructions

There are no code changes, only things moving around, so it should be sufficient to ensure that there are no build or unit test errors.
