### PR TITLE
Adds `block-editor` class to cascade to ensure Core classes are applied

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -115,9 +115,14 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 		);
 	}
 
+	const blockEditorRequiredClasses = classnames(
+		'template-selector-preview', // SPT specific styles
+		'block-editor' // needed to enable Core classes that rely on this being in the cascade
+	);
+
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		<div className="template-selector-preview">
+		<div className={ blockEditorRequiredClasses }>
 			<Disabled>
 				<div ref={ ref } className="edit-post-visual-editor">
 					<div className="editor-styles-wrapper">

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-preview.test.js.snap
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/test/__snapshots__/template-selector-preview.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TemplateSelectorPreview Basic rendering renders the preview when blocks are provided 1`] = `
 <div>
   <div
-    class="template-selector-preview"
+    class="template-selector-preview block-editor"
   >
     <div
       class="components-disabled"


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/39343

## Changes proposed in this Pull Request

As [identified in the Issue](https://github.com/Automattic/wp-calypso/issues/39343#issuecomment-590837057) the **block preview** component was missing a class within it's cascade that Core Blocks relied upon in order to apply particular styles. This issue was not in evidence within the Post Editor - only in the Block Previews.

![image](https://user-images.githubusercontent.com/545779/74170636-d707c180-4bf2-11ea-8e66-06ae33c5021a.png)

The missing class is `.block-editor`. This is probably used by a number of Core Blocks to apply styles. 

This PR introduces this class on the **top level of the Block Preview component**. This ensures selectors that rely on this class name are applied.

In our specific case we are addressing the Issue where borders are shown on Contact Page Template's form input fields due to the [missing Core styles](https://github.com/WordPress/gutenberg/blob/ef73ed07bd59bdcbbe77cc1c537299d8e39167b1/packages/block-editor/src/components/plain-text/style.scss#L7) not being applied to "Plain text" elements such as `textarea`s (see above screenshot)

Note the `.block-editor` prefix to this selector. Prior to this PR this selector was not applied as the class `block-editor` was not in place. This resulted in the `border:none` rule not being applied.

```scss
.block-editor .block-editor-plain-text {
	box-shadow: none;
	font-family: inherit;
	font-size: inherit;
	color: inherit;
	line-height: inherit;
	border: none; 
	padding: 0;
	margin: 0;
	width: 100%;
}
```
This PR introduces the class which causes the above selector from Core to be applied thereby removing the border.

Please [see original Issue for more detail](https://github.com/Automattic/wp-calypso/issues/39343#issuecomment-590827899).


## Testing instructions

### Env Setup
To test you need to build and run the FSE Plugin and have that sync to a WP environment. I used WPCom via my sandbox.

Full instructions can be seen at `PaYJgx-sW-p2`.

### Test Steps

Verify the border issue noted in [the Issue](https://github.com/Automattic/wp-calypso/issues/39343) is resolved. 

##### Before

On `master`:
* Build the FSE Plugin and ensure it's sync to your WP env.
* Activate the FSE Plugin.
* In WP Admin go to Pages
* Create a new Page
* See the Page Template selector
* Click on the Contact page thumbnails to load into the main preview window.
* See white borders around the label elements in the preview.
* Click `Use Template` to use the template.
* See there are no white borders within the Post Editor.

##### After 

* Checkout this PR's branch.
* Build the FSE Plugin and ensure it's sync to your WP env.
* Activate the FSE Plugin.
* In WP Admin go to Pages
* Create a new Page
* See the Page Template selector
* Click on the Contact page thumbnails to load into the main preview window.
* See that there are no borders around the label elements in the preview.
* Click `Use Template` to use the template.
* See there are no white borders within the Post Editor.

