### PR TITLE
FSE: add unit testing instructions to README

### DIFF
--- a/apps/full-site-editing/README.md
+++ b/apps/full-site-editing/README.md
@@ -108,7 +108,7 @@ npx lerna run test:js:watch --scope='@automattic/full-site-editing' --stream
 Occasionally you will need to update Jest Snapshots. This is so common that there's a dedicated script for this:
 
 ```shell
-npx lerna run test:js:updatesnapshots --scope='@automattic/full-site-editing' --stream
+npx lerna run test:js:update-snapshots --scope='@automattic/full-site-editing' --stream
 ```
 
 ### Writing Tests

--- a/apps/full-site-editing/README.md
+++ b/apps/full-site-editing/README.md
@@ -65,7 +65,7 @@ The output is:
 
 ### Building Individual _Plugins_
 
-You can also build one of the Plugins separately by appending the plugin slug onto the `build` portion of the command. eg: 
+You can also build one of the Plugins separately by appending the plugin slug onto the `build` portion of the command. eg:
 
 ```
 // Builds the `posts-list-block` Plugin only
@@ -85,3 +85,36 @@ ln -s ~/Dev/wp-calypso/apps/full-site-editing/full-site-editing-plugin/ ~/Dev/wo
 ```
 
 Note that if you are using Docker symlinks will not work. Instead you will need to mount the Plugin as a volume.
+
+## Testing
+
+The Plugin contains a suite of unit / integration tests powered by `@wordpress/scripts`.
+
+We use `lerna` to run the tests using the following basic command:
+
+```shell
+npx lerna run test:js --scope='@automattic/full-site-editing' --stream
+```
+
+If you wish to "watch" and run tests on file change then run:
+
+```shell
+// Note the additional `:watch` below
+npx lerna run test:js:watch --scope='@automattic/full-site-editing' --stream
+```
+
+### Updating Snapshots
+
+Occasionally you will need to update Jest Snapshots. This is so common that there's a dedicated script for this:
+
+```shell
+npx lerna run test:js:updatesnapshots --scope='@automattic/full-site-editing' --stream
+```
+
+### Writing Tests
+
+The tests make use of the 3rd party [React Testing Library](https://testing-library.com/docs/react-testing-library/). This library helps to promote healthy testing practices by encouraging testing of the component _interface_ rather than its internal APIs (ie: implementation details).
+
+When writing tests try to approach them **from the perspective of how a user would interact with your component**. Approaching tests in this fashion provides greater confidence that tests will capture true component behaviors and avoids the need for costly refactoring should the component's implementation need to change.
+
+For more on this approach please see the [excellent introduction in the React Testing Library docs](https://testing-library.com/docs/react-testing-library/intro).

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -41,7 +41,7 @@
 		"test:js": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js'",
 		"test:js:help": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --help",
 		"test:js:watch": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --watch",
-		"test:js:updatesnapshots": "npx wp-scripts test-unit-js -u --config='bin/js-unit-config.js'",
+		"test:js:update-snapshots": "npx wp-scripts test-unit-js -u --config='bin/js-unit-config.js'",
 		"clean": "npx rimraf dist full-site-editing-plugin/*/dist",
 		"prebuild": "npm run clean",
 		"predev": "npm run clean",

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -41,6 +41,7 @@
 		"test:js": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js'",
 		"test:js:help": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --help",
 		"test:js:watch": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --watch",
+		"test:js:updatesnapshots": "npx wp-scripts test-unit-js -u --config='bin/js-unit-config.js'",
 		"clean": "npx rimraf dist full-site-editing-plugin/*/dist",
 		"prebuild": "npm run clean",
 		"predev": "npm run clean",


### PR DESCRIPTION
Currently the FSE `README.md` has little or no guidance on

* Running tests
* Writing tests

This PR aims to rectify this by documenting how to run tests and also providing an insight into the recommended style of the tests.

As an additional improvement, the PR also introduces a dedicated command for updating snapshots (a common requirement that can be difficult to undertake given the additional abstraction of `lerna`).

```shell
npx lerna run test:js:update-snapshots --scope='@automattic/full-site-editing' --stream
```

#### Testing instructions

* Read the changes to the `README`.
* Check spelling and grammer.
* Check it makes sense.
* Follow the instructions running each command in turn and verifying the output is as expected based on the guidance in the README.

