### PR TITLE
Blog Posts Block: Add missing QueryStore registration

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
@@ -11,6 +11,7 @@ import { addFilter } from '@wordpress/hooks';
  * NHA dependencies
  */
 import { settings } from './newspack-homepage-articles/blocks/homepage-articles/index';
+import { registerQueryStore } from './newspack-homepage-articles/blocks/homepage-articles/store';
 
 /**
  * Block name in the A8C\FSE context.
@@ -36,3 +37,5 @@ registerBlockType( blockName, {
 		multiple: false,
 	},
 } );
+
+registerQueryStore();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The [recently synced version of Newspack Articles block](https://github.com/Automattic/wp-calypso/pull/39270) introduced the QueryStore in the editor. We're defining our own `editor.js` here, so apart from syncing the code, we also need to register our own QueryStore (originally added in https://github.com/Automattic/wp-calypso/pull/39509). Without it, the block doesn't work and shows the following errors:

<img width="689" alt="Screenshot 2020-02-25 17 26 47" src="https://user-images.githubusercontent.com/1451471/75267663-d2e4c200-57f6-11ea-8aea-88a26d845e7d.png">

<img width="660" alt="Screenshot 2020-02-25 17 27 04" src="https://user-images.githubusercontent.com/1451471/75267668-d4ae8580-57f6-11ea-8799-2d8093194721.png">


#### Testing instructions

Adding Blog Posts block should now not throw any errors and render the block correctly. Compare with `master` to see the errors. 