### PR TITLE
Migration: Auto focus URL input in migration flow

### DIFF
--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -49,6 +49,7 @@ class SitesBlock extends Component {
 							</FormLabel>
 							<div className="sites-block__faux-site-selector-url">
 								<FormTextInput
+									autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 									isError={ isError }
 									onChange={ onUrlChange }
 									value={ url }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Auto-focus the URL input in the migration flow

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the `tools/migrate` feature-flag is enabled.
* Select "Import" for a simple site from the sidebar.
* Select "WordPress".
* Verify that the URL input field is focused when it loads into view.

