### PR TITLE
SPT: Make cover block images fill entire block in SPT preview

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -383,6 +383,9 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		.wp-block-cover {
 			padding: 0;
 		}
+		.wp-block-cover.has-parallax {
+			background-attachment: scroll;
+		}
 	}
 
 	// `core/columns`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to provide a pragmatic solution to the issue reported in https://github.com/Automattic/wp-calypso/issues/39351. With this PR in place, fixed background images on the cover block should fill the entire block in the SPT preview.

For further details please see this [in-depth comment](https://github.com/Automattic/wp-calypso/issues/39351#issuecomment-590954987).


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR locally and run `npx lerna run dev --scope='@automattic/full-site-editing' --stream` from Calypso root 
* Navigate to `Pages` > `Add New` to create a new page
* In the page template selector, scroll down to `Home Pages`
* Select the `Rockfield` page template (the one with cook's hands on it)
* Verify that the result you see matches the After state below

**Before:** 

![rockfield-before](https://user-images.githubusercontent.com/1562646/75269804-cd3cab80-57f9-11ea-9aee-3a6342336915.gif)


**After:**

![rockfield-after](https://user-images.githubusercontent.com/1562646/75269737-a9796580-57f9-11ea-8f47-9478ae0e542e.gif)


Fixes https://github.com/Automattic/wp-calypso/issues/39351
