### PR TITLE
Checkout: Add plan upsell when non primary domain is purchased

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
@@ -24,12 +24,14 @@ import { EMAIL_VALIDATION_AND_VERIFICATION, DOMAIN_WAITING } from 'lib/url/suppo
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const DomainRegistrationDetails = ( {
 	selectedSite,
 	domain,
 	purchases,
 	hasNonPrimaryDomainsFlag,
+	onPickPlanUpsellClick,
 } ) => {
 	const googleAppsWasPurchased = purchases.some( isGoogleApps ),
 		domainContactEmailVerified = purchases.some( purchase => purchase.isEmailVerified ),
@@ -120,11 +122,12 @@ const DomainRegistrationDetails = ( {
 					) }
 					buttonText={ i18n.translate( 'Pick a plan' ) }
 					href={ `/plans/${ selectedSite.slug }` }
+					onClick={ onPickPlanUpsellClick }
 				/>
 			) }
 
 			{ showPlanUpsell && (
-				<TrackComponentView eventName="calypso_non_primary_domain_thank_you_upsell_impression" />
+				<TrackComponentView eventName="calypso_non_primary_domain_thank_you_plan_upsell_impression" />
 			) }
 		</div>
 	);
@@ -145,4 +148,11 @@ const mapStateToProps = state => {
 	};
 };
 
-export default connect( mapStateToProps )( DomainRegistrationDetails );
+const mapDispatchToProps = dispatch => {
+	return {
+		onPickPlanUpsellClick: () =>
+			dispatch( recordTracksEvent( 'calypso_non_primary_domain_thank_you_plan_upsell_click', {} ) ),
+	};
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( DomainRegistrationDetails );

--- a/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
@@ -23,6 +23,7 @@ import PurchaseDetail from 'components/purchase-detail';
 import { EMAIL_VALIDATION_AND_VERIFICATION, DOMAIN_WAITING } from 'lib/url/support';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants';
+import TrackComponentView from 'lib/analytics/track-component-view';
 
 const DomainRegistrationDetails = ( {
 	selectedSite,
@@ -120,6 +121,10 @@ const DomainRegistrationDetails = ( {
 					buttonText={ i18n.translate( 'Pick a plan' ) }
 					href={ `/plans/${ selectedSite.slug }` }
 				/>
+			) }
+
+			{ showPlanUpsell && (
+				<TrackComponentView eventName="calypso_non_primary_domain_thank_you_upsell_impression" />
 			) }
 		</div>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
@@ -108,18 +108,34 @@ const DomainRegistrationDetails = ( {
 				<PurchaseDetail
 					icon={ <img alt="" src="/calypso/images/upgrades/custom-domain.svg" /> }
 					title={ i18n.translate( 'Your primary domain' ) }
-					description={ i18n.translate(
-						'Your existing domain, %(primaryDomain)s, is the primary domain visitors ' +
-							'see when they visit your site. %(purchasedDomain)s will redirect to %(primaryDomain)s. ' +
-							'Upgrade to a paid plan to make %(purchasedDomain)s the domain people see when they ' +
-							'visit your site.',
-						{
-							args: {
-								primaryDomain: selectedSite.slug,
-								purchasedDomain,
-							},
-						}
-					) }
+					description={
+						<div>
+							<p>
+								{ i18n.translate(
+									'Your existing domain, %(primaryDomain)s, is the primary domain visitors ' +
+										'see when they visit your site. %(purchasedDomain)s will redirect to %(primaryDomain)s.',
+									{
+										args: {
+											primaryDomain: selectedSite.slug,
+											purchasedDomain,
+										},
+									}
+								) }
+							</p>
+
+							<p>
+								{ i18n.translate(
+									'Upgrade to a paid plan to make %(purchasedDomain)s the domain people ' +
+										'see when they visit your site.',
+									{
+										args: {
+											purchasedDomain,
+										},
+									}
+								) }
+							</p>
+						</div>
+					}
 					buttonText={ i18n.translate( 'Pick a plan' ) }
 					href={ `/plans/${ selectedSite.slug }` }
 					onClick={ onPickPlanUpsellClick }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a plan upsell card after the purchase of a domain by free users as part of this test: p99Zz8-10j-p2

#### Testing instructions

Recommended to use Store Sandbox:

* Select a site that is on a free plan
* Purchase a domain
* Right after the purchase, in the Thank You page, you should see this card among others:

<img width="711" alt="Screenshot 2020-02-26 at 3 08 54 PM" src="https://user-images.githubusercontent.com/13062352/75352902-c621a600-58aa-11ea-8b8a-e61fdc045743.png">

Also verify that the functionality works, and that clicking the button takes you to the right page.
