### PR TITLE
Connects to activity log and displays backup entries

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-list/docs/example.tsx
+++ b/client/landing/jetpack-cloud/components/activity-list/docs/example.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+
+import React, { PureComponent, ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import ActivityList from '../';
+import { LogData } from '../types';
+
+export default class ActivityListExample extends PureComponent {
+	static displayName = 'ActivityList';
+
+	render(): ReactNode {
+		const logs: LogData = {
+			state: 'success',
+			data: [
+				{
+					activityDate: '',
+					activityDescription: [],
+					activityId: 'test',
+					activityName: '',
+					activityStatus: 'success',
+					activityTitle: 'Backup complete',
+				},
+			],
+		};
+
+		return (
+			<div>
+				<ActivityList logs={ logs } />
+			</div>
+		);
+	}
+}

--- a/client/landing/jetpack-cloud/components/activity-list/index.tsx
+++ b/client/landing/jetpack-cloud/components/activity-list/index.tsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import React, { ReactNode } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { ActivityDescriptionPart, LogData } from './types';
+import LogItem, { Props as LogItemProps } from '../log-item';
+import FormattedBlock from 'components/notes-formatted-block';
+
+interface Props {
+	logs?: LogData;
+}
+
+class ActivityList extends React.PureComponent< Props > {
+	render() {
+		if ( ! this.props.logs ) {
+			return [];
+		}
+
+		const {
+			logs: { data: logItems, state },
+		} = this.props;
+
+		if ( 'success' !== state || ! Array.isArray( logItems ) ) {
+			return false;
+		}
+
+		if ( 0 === logItems.length ) {
+			return <p className="activity-list__no-items">No backups found.</p>;
+		}
+
+		return logItems.map(
+			( { activityId, activityTitle, activityStatus, activityDescription, activityName } ) => {
+				let highlight = 'success';
+				if ( 'success' !== activityStatus ) {
+					highlight = 'error';
+				}
+
+				const subheader = activityDescription.map( ( part: ActivityDescriptionPart, i ) => {
+					const { intent, section } = part;
+					return (
+						<FormattedBlock
+							key={ i }
+							content={ part }
+							meta={ { activity: activityName, intent, section } }
+						/>
+					);
+				} );
+
+				return (
+					<LogItem
+						key={ activityId }
+						header={ activityTitle }
+						subheader={ subheader as ReactNode }
+						highlight={ highlight as LogItemProps[ 'highlight' ] }
+					/>
+				);
+			}
+		);
+	}
+}
+
+export default ActivityList;

--- a/client/landing/jetpack-cloud/components/activity-list/types.ts
+++ b/client/landing/jetpack-cloud/components/activity-list/types.ts
@@ -1,0 +1,20 @@
+export type ActivityDescriptionPart = {
+	children: string[];
+	intent?: string;
+	section?: string;
+	type: string;
+};
+
+export type LogItemType = {
+	activityId: string;
+	activityTitle: string;
+	activityStatus: string;
+	activityDate: string;
+	activityDescription: ActivityDescriptionPart[];
+	activityName: string;
+};
+
+export type LogData = {
+	state: string;
+	data: LogItemType[];
+};

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -11,10 +11,10 @@ import FoldableCard from 'components/foldable-card';
 
 import './style.scss';
 
-interface Props {
+export interface Props {
 	children?: ReactNode;
 	header: string;
-	subheader?: string;
+	subheader?: string | ReactNode;
 	highlight?: 'info' | 'success' | 'warning' | 'error';
 	tag?: string;
 }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -8,17 +8,26 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { requestActivityLogs } from 'state/data-getters';
+import ActivityList from '../../components/activity-list';
 
 class BackupsPage extends Component {
 	render() {
-		return <div>Welcome to the backup detail page for site { this.props.siteId }</div>;
+		return (
+			<div>
+				<p>Welcome to the backup detail page for site { this.props.siteId }</p>
+				<ActivityList logs={ this.props.logs } />
+			</div>
+		);
 	}
 }
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
+	const logs = requestActivityLogs( siteId, { group: 'rewind' } );
 
 	return {
 		siteId,
+		logs,
 	};
 } )( BackupsPage );


### PR DESCRIPTION
This creates a new `<ActivityList>` component which displays Rewind entries from the activity log.

#### Changes proposed in this Pull Request

* Adds new `<ActivityList>` component.
* Wires activity log data to new component.

#### Testing instructions

1. Visit jetpack.cloud.localhost:3000/backups/[site].
2. View activity log entries.

Screenshot:
<img width="547" alt="Screen Shot 2020-02-25 at 5 22 39 PM" src="https://user-images.githubusercontent.com/1760168/75293261-d7f44200-57f3-11ea-90e9-27a74540e744.png">

Fixes 1156570014567299-as-1163126197389644.