### PR TITLE
Adds MomentProvider component to Cloud

### DIFF
--- a/client/landing/jetpack-cloud/controller.js
+++ b/client/landing/jetpack-cloud/controller.js
@@ -18,13 +18,16 @@ import hasLoadedSites from 'state/selectors/has-loaded-sites';
 import JetpackCloudLayout from './layout';
 import JetpackCloudSidebar from './components/sidebar';
 import JetpackCloudSitePicker from './components/site-picker';
+import { MomentProvider } from 'components/localized-moment/context';
 
 export const makeLayout = ( context, next ) => {
 	const { primary, secondary, store } = context;
 
 	context.layout = (
 		<ReduxProvider store={ store }>
-			<JetpackCloudLayout primary={ primary } secondary={ secondary } />
+			<MomentProvider>
+				<JetpackCloudLayout primary={ primary } secondary={ secondary } />
+			</MomentProvider>
 		</ReduxProvider>
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Loads in `<MomentProvider />` to Cloud layouts.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add component wrapped with `withLocalizedMoment` HOC.
* Examine props of component.
