### PR TITLE
Fixes typo with Jetpack connect landing page

### DIFF
--- a/client/my-sites/plans-features-main/products-header.jsx
+++ b/client/my-sites/plans-features-main/products-header.jsx
@@ -45,7 +45,7 @@ class PlansFeaturesMainProductsHeader extends Component {
 
 	getSubHeader() {
 		const { isFetching, siteSlug, translate } = this.props;
-		const baseCopy = translate( "Just looking for a backups? We've got you covered." );
+		const baseCopy = translate( "Just looking for backups? We've got you covered." );
 
 		// Don't render a link if a user already has a Jetpack Backup product or a plan with a backup feature.
 		if ( isFetching || this.siteHasJetpackBackup() ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Resolves typo with Jetpack Connect landing page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try to connect site to Jetpack.
* Scroll down to backup product promo area.
* Examine header.

Screenshot:
<img width="347" alt="Screen Shot 2020-02-25 at 5 59 13 PM" src="https://user-images.githubusercontent.com/1760168/75295598-07597d80-57f9-11ea-8e28-9e3e8a6fdb04.png">

Fixes 1142395350490785-as-1157925867453225.
