### PR TITLE
Domain step: Add unique key to each child in list

### DIFF
--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -139,7 +139,7 @@ export class TldFilterBar extends Component {
 		const checkboxes = this.props.availableTlds
 			.slice( 0, this.props.numberOfTldsShown )
 			.map( ( tld, index ) => (
-				<div className="search-filters__tld-checkbox">
+				<div className="search-filters__tld-checkbox" key={ tld }>
 					<FormCheckbox
 						className={ classNames( 'search-filters__tld-button', {
 							'is-active': includes( selectedTlds, tld ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a unique key so that we no longer see the following warning message in console for the domain step in signup(when in _variantDesignUpdates_ of "domainStepDesignUpdates" test).

```
backend.js:6 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `TldFilterBar`.
```

Fixes issue reported in https://github.com/Automattic/wp-calypso/pull/39346#discussion_r383823091

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through signup flow at /start. Assign yourself to _variantDesignUpdates_ of "domainStepDesignUpdates" test.
* At the domain step, verify that you no longer see the warning message in browser console. 
