### PR TITLE
Concierge banner: Fix prop warning shown in console

### DIFF
--- a/client/me/purchases/concierge-banner/index.jsx
+++ b/client/me/purchases/concierge-banner/index.jsx
@@ -119,9 +119,9 @@ class ConciergeBanner extends Component {
 	}
 
 	render() {
-		const { bannerType } = this.props;
+		const { bannerType, showPlaceholder } = this.props;
 
-		if ( 'placeholder' === bannerType ) {
+		if ( showPlaceholder ) {
 			return this.placeholder();
 		}
 

--- a/client/me/purchases/purchases-list/index.jsx
+++ b/client/me/purchases/purchases-list/index.jsx
@@ -55,7 +55,9 @@ class PurchasesList extends Component {
 		const { nextAppointment, scheduleId, hasAvailableConciergeSessions } = this.props;
 
 		if ( null === hasAvailableConciergeSessions ) {
-			return <ConciergeBanner bannerType="placeholder" />;
+			return (
+				<ConciergeBanner bannerType={ CONCIERGE_HAS_AVAILABLE_PURCHASED_SESSION } showPlaceholder />
+			);
 		}
 
 		let bannerType;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the following warning message shown in browser console on the /me/purchases page in Calypso:

```
Failed prop type: Invalid prop `bannerType` of value `placeholder` supplied to `ConciergeBanner`, expected one of ["has-upcoming-appointment","has-available-included-session","has-available-purchased-session","suggest-purchase-concierge"].
```

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Login to an account and open /me/purchases page.
* Check in your browser console that you don't see any Warning messages.
