### PR TITLE
Hot fix for a bug affecting domain-only site checkout

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -145,6 +145,7 @@ class CartFreeUserPlanUpsell extends React.Component {
 
 const mapStateToProps = ( state, { cart } ) => {
 	const selectedSite = getSelectedSite( state );
+	const selectedSiteId = selectedSite ? selectedSite.ID : null;
 	const isPlansListFetching = isRequestingPlans( state );
 	const personalPlan = getPlan( PLAN_PERSONAL );
 
@@ -155,10 +156,13 @@ const mapStateToProps = ( state, { cart } ) => {
 		isRegisteringDomain: hasDomainRegistration( cart ),
 		isSitePlansListFetching: isRequestingSitePlans( state ),
 		personalPlan: personalPlan,
-		planPrice: ! isPlansListFetching && getPlanPrice( state, selectedSite.ID, personalPlan, false ),
+		planPrice:
+			! isPlansListFetching &&
+			selectedSiteId &&
+			getPlanPrice( state, selectedSiteId, personalPlan, false ),
 		selectedSite: selectedSite,
 		showPlanUpsell: getCurrentUser( state )
-			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+			? selectedSiteId && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 			: false,
 	};
 };


### PR DESCRIPTION
In domain-only checkout, no site is selected, so the existing logic didn't work. I've disabled the upsell for this case in the short term. It shouldn't be live for users yet anyway.

#### Changes proposed in this Pull Request

* Fix the logic so that we handle a null `selectedSite` - the underlying bug was introduced in #39610.

#### Testing instructions

1. Go to `/domains/` and search for a domain.
2. Select a domain and move forward with the flow.
3. When you're presented with the options for how to use your domain, click on "Just buy a domain".
4. You should be redirected to the domain registrant workflow in checkout and should not see a plan upsell. (Before this change, you'd only see a blank screen.)
