### PR TITLE
Remove unnecessary whitespaces from translations

### DIFF
--- a/client/my-sites/guided-transfer/issues-notices.jsx
+++ b/client/my-sites/guided-transfer/issues-notices.jsx
@@ -26,10 +26,7 @@ class IssuesNotices extends Component {
 				{ premiumThemeIssue && ! premiumThemeIssue.prevents_transfer && (
 					<Notice status="is-warning" showDismiss={ false }>
 						{ translate(
-							`Your site uses a Premium Theme that can't be
-						transferred. Continuing will automatically activate the
-						default theme, or you can
-						{{a}}choose a free theme{{/a}}.`,
+							"Your site uses a Premium Theme that can't be transferred. Continuing will automatically activate the default theme, or you can {{a}}choose a free theme{{/a}}.",
 							{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
 						) }
 					</Notice>
@@ -38,10 +35,7 @@ class IssuesNotices extends Component {
 				{ customFontIssue && ! customFontIssue.prevents_transfer && (
 					<Notice status="is-warning" showDismiss={ false }>
 						{ translate(
-							`Your site uses a custom font that can't be
-						transferred. Continuing will automatically activate the
-						default font, or you can
-						{{a}}choose a free theme{{/a}}.`,
+							"Your site uses a custom font that can't be transferred. Continuing will automatically activate the default font, or you can {{a}}choose a free theme{{/a}}.",
 							{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
 						) }
 					</Notice>

--- a/client/my-sites/guided-transfer/transfer-unavailable-card.jsx
+++ b/client/my-sites/guided-transfer/transfer-unavailable-card.jsx
@@ -33,16 +33,15 @@ class TransferUnavailableCard extends Component {
 			return (
 				<div>
 					<Notice status="is-warning" showDismiss={ false }>
-						{ translate( `It looks like there are some customizations to your site
-						that can't be transferred.` ) }
+						{ translate(
+							"It looks like there are some customizations to your site that can't be transferred."
+						) }
 					</Notice>
 					<ul>
 						{ premiumThemeIssue && (
 							<Issue title={ translate( 'Your site uses a Premium Theme' ) }>
 								{ translate(
-									`Premium Themes can't be
-								transferred to an external site. Please {{a}}choose a free theme{{/a}}
-								to continue.`,
+									"Premium Themes can't be transferred to an external site. Please {{a}}choose a free theme{{/a}} to continue.",
 									{ components: { a: <a href={ `/themes/free/${ siteSlug }` } /> } }
 								) }
 							</Issue>
@@ -50,9 +49,7 @@ class TransferUnavailableCard extends Component {
 						{ customFontIssue && (
 							<Issue title={ translate( 'Your site uses a custom font' ) }>
 								{ translate(
-									`Custom fonts can't be
-								transferred to an external site. Please {{a}}switch back to your theme's
-								default fonts{{/a}} if you would like to proceed.`,
+									"Custom fonts can't be transferred to an external site. Please {{a}}switch back to your theme's default fonts{{/a}} if you would like to proceed.",
 									{ components: { a: <a href={ `/customize/fonts/${ siteSlug }` } /> } }
 								) }
 							</Issue>
@@ -67,8 +64,7 @@ class TransferUnavailableCard extends Component {
 			<div>
 				<p>
 					{ translate(
-						`Howdy! It looks like there's something stopping us from being able
-				to transfer your site. Please {{a}}contact support{{/a}} and we'll sort it out!`,
+						"Howdy! It looks like there's something stopping us from being able to transfer your site. Please {{a}}contact support{{/a}} and we'll sort it out!",
 						{ components: { a: <a href={ CALYPSO_CONTACT } /> } }
 					) }
 				</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes unnecessary whitespace from translations and replaces template literals since they are no longer needed.

#### Testing instructions

- Check if tests pass
- Open http://calypso.localhost:3000/export/guided/{site}
- Check if text renders as expected
