### PR TITLE
FSE: Refactor SPT template block parsing to hide Jetpack Contact Form block "placeholder"

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -26,12 +26,15 @@ import ensureAssets from './utils/ensure-assets';
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
 
 function modifyParsedBlocks( blocks ) {
-	function handleBlock( block ) {
+	function modifyBlock( block ) {
 		const attrsToMerge = {};
 
 		// `jetpack/contact-form` has a placeholder to configure form settings
 		// we need to disable this to show the full form in the preview
-		if ( block.attributes.hasFormSettingsSet !== undefined ) {
+		if (
+			'jetpack/contact-form' === block.name &&
+			undefined !== block.attributes.hasFormSettingsSet
+		) {
 			attrsToMerge.hasFormSettingsSet = true;
 		}
 
@@ -42,11 +45,11 @@ function modifyParsedBlocks( blocks ) {
 		// particular contexts. For example we may wish to show blocks
 		// differently in the preview than we do when they are inserted into the
 		// editor itself.
-		return attrsToMerge.length ? cloneBlock( block, attrsToMerge ) : block;
+		return cloneBlock( block, attrsToMerge );
 	}
 
 	return blocks.map( block => {
-		block = handleBlock( block );
+		block = modifyBlock( block );
 
 		// Recurse into nested Blocks
 		if ( block.innerBlocks && block.innerBlocks.length ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -21,7 +21,7 @@ import TemplateSelectorPreview from './components/template-selector-preview';
 import { trackDismiss, trackSelection, trackView } from './utils/tracking';
 import replacePlaceholders from './utils/replace-placeholders';
 import ensureAssets from './utils/ensure-assets';
-import modifyBlocks from './utils/modify-blocks';
+import mapBlocksRecursively from './utils/map-blocks-recursively';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
@@ -57,7 +57,7 @@ class PageTemplateModal extends Component {
 		const blocks = this.getBlocksByTemplateSlug( previewedTemplate );
 
 		// Modify the existing blocks returning new block object references.
-		return modifyBlocks( blocks, function modifyBlocksForPreview( block ) {
+		return mapBlocksRecursively( blocks, function modifyBlocksForPreview( block ) {
 			// `jetpack/contact-form` has a placeholder to configure form settings
 			// we need to disable this to show the full form in the preview
 			if (

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -74,33 +74,18 @@ class PageTemplateModal extends Component {
 	);
 
 	// Parse templates blocks and memoize them.
-	getBlocksByTemplateSlugs = memoize( templates => {
-		return reduce(
+	getBlocksByTemplateSlugs = memoize( templates =>
+		reduce(
 			templates,
 			( prev, { slug, content } ) => {
-				if ( ! content ) {
-					prev[ slug ] = [];
-					return prev;
-				}
-
-				let blocks;
-
-				// Replacements on raw Block Grammar
-				blocks = replacePlaceholders( content, this.props.siteInformation );
-
-				// Parse the Blocks
-				blocks = parseBlocks( blocks );
-
-				// Replacements on Parsed Blocks
-				// blocks = modifyParsedBlocks( blocks );
-
-				prev[ slug ] = blocks;
-
+				prev[ slug ] = content
+					? parseBlocks( replacePlaceholders( content, this.props.siteInformation ) )
+					: [];
 				return prev;
 			},
 			{}
-		);
-	} );
+		)
+	);
 
 	static getDerivedStateFromProps( props, state ) {
 		// The only time `state.previewedTemplate` isn't set is before `templates`

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -25,7 +25,7 @@ import ensureAssets from './utils/ensure-assets';
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
 
-function modifyParsedBlocks( blocks ) {
+function modifyBlocksForPreview( blocks ) {
 	function modifyBlock( block ) {
 		const attrsToMerge = {};
 
@@ -53,7 +53,7 @@ function modifyParsedBlocks( blocks ) {
 
 		// Recurse into nested Blocks
 		if ( block.innerBlocks && block.innerBlocks.length ) {
-			block.innerBlocks = modifyParsedBlocks( block.innerBlocks );
+			block.innerBlocks = modifyBlocksForPreview( block.innerBlocks );
 		}
 
 		return block;
@@ -86,6 +86,11 @@ class PageTemplateModal extends Component {
 			{}
 		)
 	);
+
+	getBlocksForPreview = memoize( previewedTemplate => {
+		const blocks = this.getBlocksByTemplateSlug( previewedTemplate );
+		return modifyBlocksForPreview( blocks );
+	} );
 
 	static getDerivedStateFromProps( props, state ) {
 		// The only time `state.previewedTemplate` isn't set is before `templates`
@@ -409,7 +414,7 @@ class PageTemplateModal extends Component {
 									) }
 							</form>
 							<TemplateSelectorPreview
-								blocks={ modifyParsedBlocks( this.getBlocksByTemplateSlug( previewedTemplate ) ) }
+								blocks={ this.getBlocksForPreview( previewedTemplate ) }
 								viewportWidth={ 960 }
 								title={ this.getTitleByTemplateSlug( previewedTemplate ) }
 							/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/map-blocks-recursively.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/map-blocks-recursively.js
@@ -1,9 +1,17 @@
 /**
  * External dependencies
  */
+import { identity } from 'lodash';
 import { cloneBlock } from '@wordpress/blocks';
 
-function modifyBlocks( blocks, cb ) {
+/**
+ * Recursively maps over a collection of blocks calling the modifier function on
+ * each to modify it and returning a collection of new block references.
+ *
+ * @param {Array} blocks an array of block objects
+ * @param {Function} modifier a callback function used to modify the blocks
+ */
+function mapBlocksRecursively( blocks, modifier = identity ) {
 	return blocks.map( block => {
 		// `blocks` is an object. Therefore any changes made here will
 		// be reflected across all references to the blocks object. To ensure we
@@ -12,15 +20,15 @@ function modifyBlocks( blocks, cb ) {
 		// particular contexts. For example we may wish to show blocks
 		// differently in the preview than we do when they are inserted into the
 		// editor itself.
-		block = cb( cloneBlock( block ) );
+		block = modifier( cloneBlock( block ) );
 
 		// Recurse into nested Blocks
 		if ( block.innerBlocks && block.innerBlocks.length ) {
-			block.innerBlocks = modifyBlocks( block.innerBlocks, cb );
+			block.innerBlocks = mapBlocksRecursively( block.innerBlocks, modifier );
 		}
 
 		return block;
 	} );
 }
 
-export default modifyBlocks;
+export default mapBlocksRecursively;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/modify-blocks.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/modify-blocks.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { cloneBlock } from '@wordpress/blocks';
+
+function modifyBlocks( blocks, cb ) {
+	return blocks.map( block => {
+		// `blocks` is an object. Therefore any changes made here will
+		// be reflected across all references to the blocks object. To ensure we
+		// only modify the blocks when needed, we return a new object reference
+		// for any blocks we modify. This allows us to modify blocks for
+		// particular contexts. For example we may wish to show blocks
+		// differently in the preview than we do when they are inserted into the
+		// editor itself.
+		block = cb( cloneBlock( block ) );
+
+		// Recurse into nested Blocks
+		if ( block.innerBlocks && block.innerBlocks.length ) {
+			block.innerBlocks = modifyBlocks( block.innerBlocks, cb );
+		}
+
+		return block;
+	} );
+}
+
+export default modifyBlocks;


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/39663

The JP contact form Block has a "placeholder" settings view which is shown to guide the user toward filling in the necessaey fields. However, this doesn't look good in the SPT template preview window.

![image](https://user-images.githubusercontent.com/545779/74182510-d2e69e80-4c08-11ea-8e45-d11197cad3ec.png)

## Todo

This PR will:

- [x] Add the ability to modify the parsed Blocks before they are shown in the template preview.
- [x] Ensure the blocks that are inserted into the Page are not modified. **_Only_** blocks in the preview should be modified. 
- [x] Modify the `jetpack/contact-form`s `hasFormSettingsSet` block attribute to `true` - this will hide the "settings" placeholder
- [ ] ~Add filters for pre/post Block parsing stages and refactor out to allow for other Block "quirks" that may need to be added in future (this may be in a followup PR).~


## Screenshots

![Screen Capture on 2020-02-26 at 11-38-22](https://user-images.githubusercontent.com/444434/75341608-b8f5be80-588c-11ea-9e3b-788aa68fa943.gif)


## Testing instructions

The key things to check are:

* The Contact form block doesn't show the settings placeholder **in the preview**.
* The form block _does_ show the settings placeholder once the template has been inserted into the Editor.

This requires the FSE Plugin to be active on your WP install. You can find guidance for this at `PaYJgx-sW-p2`. You can test on local WP instance or WPCom (assuming you have sandbox syncing setup).

### Before

* Activate FSE Plugin.
* Create new Page.
* See SPT selector.
* Click "Contact" template to show the preview - notice the "settings" placeholder is shown on the `jetpack/contact-form` Block.
* Insert the Template - notice the settings placeholder is shown (this is correct at point of insertion).

### After

* Check out this PR branch.
* Build FSE and sync to your WP install.
* Ensure FSE Plugin is active.
* Create new Page.
* See SPT selector.
* Click "Contact" template to show the preview - notice the "settings" placeholder is no longer shown on the `jetpack/contact-form` Block. Instead you should see the blank form.
* Insert the Template - verify the settings placeholder is still shown (this is correct at point of insertion).
