### PR TITLE
Fix theme activation homepage confusion.

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1651,14 +1651,14 @@ Undocumented.prototype.activeTheme = function ( siteId, fn ) {
 	return this.wpcom.req.get( { path: '/sites/' + siteId + '/themes/mine' }, fn );
 };
 
-Undocumented.prototype.activateTheme = function ( themeId, siteId, dontChangeShowOnFront, fn ) {
+Undocumented.prototype.activateTheme = function ( themeId, siteId, dontChangeHomepage, fn ) {
 	debug( '/sites/:site_id/themes/mine' );
 	return this.wpcom.req.post(
 		{
 			path: '/sites/' + siteId + '/themes/mine',
 			body: {
 				theme: themeId,
-				...( dontChangeShowOnFront && { dont_change_show_on_front: true } ),
+				...( dontChangeHomepage && { dont_change_homepage: true } ),
 			},
 		},
 		fn

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1651,12 +1651,15 @@ Undocumented.prototype.activeTheme = function ( siteId, fn ) {
 	return this.wpcom.req.get( { path: '/sites/' + siteId + '/themes/mine' }, fn );
 };
 
-Undocumented.prototype.activateTheme = function ( themeId, siteId, fn ) {
+Undocumented.prototype.activateTheme = function ( themeId, siteId, dontChangeShowOnFront, fn ) {
 	debug( '/sites/:site_id/themes/mine' );
 	return this.wpcom.req.post(
 		{
 			path: '/sites/' + siteId + '/themes/mine',
-			body: { theme: themeId },
+			body: {
+				theme: themeId,
+				...( dontChangeShowOnFront && { dont_change_show_on_front: true } ),
+			},
 		},
 		fn
 	);

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -11,9 +11,9 @@ import { stringify } from 'qs';
 import Site from './site';
 import Me from './me';
 import MailingList from './mailing-list';
-import config from 'config';
-import { getLanguage, getLocaleSlug } from 'lib/i18n-utils';
-import readerContentWidth from 'reader/lib/content-width';
+import config from 'calypso/config';
+import { getLanguage, getLocaleSlug } from 'calypso/lib/i18n-utils';
+import readerContentWidth from 'calypso/reader/lib/content-width';
 
 const debug = debugFactory( 'calypso:wpcom-undocumented:undocumented' );
 const { Blob } = globalThis; // The linter complains if I don't do this...?

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -77,7 +77,7 @@ class AutoLoadingHomepageModal extends Component {
 			hasAutoLoadingHomepage,
 			isCurrentTheme,
 			isVisible = false,
-			siteOptions,
+			siteOptions: { show_on_front },
 		} = this.props;
 
 		// Nothing to do when it's the current theme.
@@ -108,15 +108,19 @@ class AutoLoadingHomepageModal extends Component {
 				buttons={ [
 					{
 						action: 'keepCurrentTheme',
-						label: translate( 'No, keep my current theme' ),
+						label:
+							show_on_front === 'posts'
+								? translate( 'Keep my current theme' )
+								: translate( 'No, keep my current theme' ),
 						isPrimary: false,
 						onClick: this.closeModalHandler( false ),
 					},
 					{
 						action: 'activeTheme',
-						label: translate( 'Yes, activate %(themeName)s', {
-							args: { themeName },
-						} ),
+						label:
+							show_on_front === 'posts'
+								? translate( 'Activate %(themeName)s', { args: { themeName } } )
+								: translate( 'Yes, activate %(themeName)s', { args: { themeName } } ),
 						isPrimary: true,
 						onClick: this.closeModalHandler( true ),
 					},
@@ -124,51 +128,54 @@ class AutoLoadingHomepageModal extends Component {
 				onClose={ this.closeModalHandler( false ) }
 			>
 				<div>
-					<h1 className="themes__auto-loading-homepage-modal-title">
-						{ siteOptions.show_on_front === 'posts'
-							? translate(
-									'Your homepage currently shows the latest posts. {{strong}}%(themeName)s{{/strong}} can replace your homepage layout.',
-									{
-										args: { themeName },
-										components: { strong: <strong /> },
-									}
-							  )
+					<h1>
+						{ show_on_front === 'posts'
+							? translate( "Activating %(themeName)s can change your existing homepage's content", {
+									args: { themeName },
+							  } )
 							: translate(
-									'Your already have an existing homepage. {{strong}}%(themeName)s{{/strong}} can replace your homepage layout.',
+									"Activating %(themeName)s will change your existing homepage's content",
 									{
 										args: { themeName },
-										components: { strong: <strong /> },
 									}
 							  ) }
 					</h1>
-					<h2>{ translate( 'How would you like to continue?' ) }</h2>
-					{ siteOptions.show_on_front === 'posts' ? (
-						<FormLabel>
-							<FormRadio
-								value="keep_latest_posts"
-								checked={ 'keep_latest_posts' === this.state.homepageAction }
-								onChange={ this.handleHomepageAction }
-							/>
-							<span>With latest post</span>
-						</FormLabel>
+					{ show_on_front === 'posts' ? (
+						<>
+							<h2 className="themes__auto-loading-homepage-modal-options-heading">
+								{ translate( 'How would you like to continue?' ) }
+							</h2>
+							<FormLabel>
+								<FormRadio
+									value="keep_latest_posts"
+									checked={ 'keep_latest_posts' === this.state.homepageAction }
+									onChange={ this.handleHomepageAction }
+								/>
+								<span>{ translate( 'Keep using my latest posts' ) }</span>
+							</FormLabel>
+							<FormLabel>
+								<FormRadio
+									value="use_new_homepage"
+									checked={ 'use_new_homepage' === this.state.homepageAction }
+									onChange={ this.handleHomepageAction }
+								/>
+								<span>
+									{ translate( "Use %(themeName)s's homepage and content", {
+										args: { themeName },
+									} ) }
+								</span>
+							</FormLabel>
+						</>
 					) : (
-						<FormLabel>
-							<FormRadio
-								value="keep_existing_homepage"
-								checked={ 'keep_existing_homepage' === this.state.homepageAction }
-								onChange={ this.handleHomepageAction }
-							/>
-							<span>Keep existing homepage</span>
-						</FormLabel>
+						<p>
+							{ translate(
+								'{{strong}}Your existing homepage will be set to draft.{{/strong}} Would you like to continue?',
+								{
+									components: { strong: <strong /> },
+								}
+							) }
+						</p>
 					) }
-					<FormLabel>
-						<FormRadio
-							value="use_new_homepage"
-							checked={ 'use_new_homepage' === this.state.homepageAction }
-							onChange={ this.handleHomepageAction }
-						/>
-						<span>Use new theme homepage</span>
-					</FormLabel>
 				</div>
 			</Dialog>
 		);

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -143,37 +143,32 @@ class AutoLoadingHomepageModal extends Component {
 			>
 				<div>
 					<h1>
-						{ translate( 'Homepage Content', {
-							args: { themeName },
-						} ) }
-					</h1>
-					<h2 className="themes__auto-loading-homepage-modal-options-heading">
 						{ translate( 'How would you like to use %(themeName)s on your site?', {
 							args: { themeName },
 						} ) }
-					</h2>
+					</h1>
 					<FormLabel>
 						<FormRadio
 							value="keep_current_homepage"
 							checked={ 'keep_current_homepage' === this.state.homepageAction }
 							onChange={ this.handleHomepageAction }
+							label={ translate( 'Use %(themeName)s without changing my homepage content', {
+								args: { themeName },
+							} ) }
 						/>
-						{ translate( 'Use %(themeName)s without changing my homepage content', {
-							args: { themeName },
-						} ) }
 					</FormLabel>
 					<FormLabel>
 						<FormRadio
 							value="use_new_homepage"
 							checked={ 'use_new_homepage' === this.state.homepageAction }
 							onChange={ this.handleHomepageAction }
+							label={ translate(
+								"Use %(themeName)s's homepage content and make my existing homepage a draft",
+								{
+									args: { themeName },
+								}
+							) }
 						/>
-						{ translate(
-							"Use %(themeName)s's homepage content and make my existing homepage a draft",
-							{
-								args: { themeName },
-							}
-						) }
 					</FormLabel>
 				</div>
 			</Dialog>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -149,20 +149,25 @@ class AutoLoadingHomepageModal extends Component {
 									checked={ 'keep_latest_posts' === this.state.homepageAction }
 									onChange={ this.handleHomepageAction }
 								/>
-								<span>{ translate( 'Keep using my latest posts' ) }</span>
+								{ translate( 'Keep using my latest posts' ) }
 							</FormLabel>
 							<FormLabel>
 								<FormRadio
 									value="use_new_homepage"
 									checked={ 'use_new_homepage' === this.state.homepageAction }
 									onChange={ this.handleHomepageAction }
+									aria-describedby="themes__auto-loading-homepage-modal-homepage-hint"
 								/>
-								<span>
-									{ translate( "Use %(themeName)s's homepage and content", {
-										args: { themeName },
-									} ) }
-								</span>
+								{ translate( "Use %(themeName)s's homepage and content", {
+									args: { themeName },
+								} ) }
 							</FormLabel>
+							<div
+								className="themes__auto-loading-homepage-modal-homepage-hint"
+								id="themes__auto-loading-homepage-modal-homepage-hint"
+							>
+								{ translate( '(This will set your existing homepage to draft)' ) }
+							</div>
 						</>
 					) : (
 						<p>

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -152,7 +152,7 @@ class AutoLoadingHomepageModal extends Component {
 							value="keep_current_homepage"
 							checked={ 'keep_current_homepage' === this.state.homepageAction }
 							onChange={ this.handleHomepageAction }
-							label={ translate( 'Use %(themeName)s without changing my homepage content', {
+							label={ translate( 'Use %(themeName)s without changing my homepage content.', {
 								args: { themeName },
 							} ) }
 						/>
@@ -163,7 +163,7 @@ class AutoLoadingHomepageModal extends Component {
 							checked={ 'use_new_homepage' === this.state.homepageAction }
 							onChange={ this.handleHomepageAction }
 							label={ translate(
-								"Use %(themeName)s's homepage content and make my existing homepage a draft",
+								"Use %(themeName)s's homepage content and make my existing homepage a draft.",
 								{
 									args: { themeName },
 								}

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -56,12 +56,15 @@ class AutoLoadingHomepageModal extends Component {
 		this.state = {
 			homepageAction: 'keep_current_homepage',
 
-			// Used to reset state when dialog re-opens
+			// Used to reset state when dialog re-opens, see `getDerivedStateFromProps`
 			wasVisible: props.isVisible,
 		};
 	}
 
 	static getDerivedStateFromProps( nextProps, prevState ) {
+		// This component doesn't unmount when the dialog closes, so the state
+		// needs to be reset back to defaults each time it opens.
+		// Reseting `homepageAction` ensures the default option will be selected.
 		if ( nextProps.isVisible && ! prevState.wasVisible ) {
 			return { homepageAction: 'keep_current_homepage', wasVisible: true };
 		} else if ( ! nextProps.isVisible && prevState.wasVisible ) {

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -62,9 +62,10 @@ class AutoLoadingHomepageModal extends Component {
 
 	closeModalHandler = ( activate = false ) => () => {
 		if ( activate ) {
-			const { installingThemeId, siteId, source } = this.props;
+			const { installingThemeId, postsOnFrontPage, siteId, source } = this.props;
 			this.props.acceptAutoLoadingHomepageWarning( installingThemeId );
-			return this.props.activateTheme( installingThemeId, siteId, source );
+			const keepLatestPosts = postsOnFrontPage && this.state.homepageAction === 'keep_latest_posts';
+			return this.props.activateTheme( installingThemeId, siteId, source, false, keepLatestPosts );
 		}
 		this.props.hideAutoLoadingHomepageWarning();
 	};

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -77,7 +77,7 @@ class AutoLoadingHomepageModal extends Component {
 			hasAutoLoadingHomepage,
 			isCurrentTheme,
 			isVisible = false,
-			siteOptions: { show_on_front },
+			postsOnFrontPage,
 		} = this.props;
 
 		// Nothing to do when it's the current theme.
@@ -108,19 +108,17 @@ class AutoLoadingHomepageModal extends Component {
 				buttons={ [
 					{
 						action: 'keepCurrentTheme',
-						label:
-							show_on_front === 'posts'
-								? translate( 'Keep my current theme' )
-								: translate( 'No, keep my current theme' ),
+						label: postsOnFrontPage
+							? translate( 'Keep my current theme' )
+							: translate( 'No, keep my current theme' ),
 						isPrimary: false,
 						onClick: this.closeModalHandler( false ),
 					},
 					{
 						action: 'activeTheme',
-						label:
-							show_on_front === 'posts'
-								? translate( 'Activate %(themeName)s', { args: { themeName } } )
-								: translate( 'Yes, activate %(themeName)s', { args: { themeName } } ),
+						label: postsOnFrontPage
+							? translate( 'Activate %(themeName)s', { args: { themeName } } )
+							: translate( 'Yes, activate %(themeName)s', { args: { themeName } } ),
 						isPrimary: true,
 						onClick: this.closeModalHandler( true ),
 					},
@@ -129,7 +127,7 @@ class AutoLoadingHomepageModal extends Component {
 			>
 				<div>
 					<h1>
-						{ show_on_front === 'posts'
+						{ postsOnFrontPage
 							? translate( "Activating %(themeName)s can change your existing homepage's content", {
 									args: { themeName },
 							  } )
@@ -140,7 +138,7 @@ class AutoLoadingHomepageModal extends Component {
 									}
 							  ) }
 					</h1>
-					{ show_on_front === 'posts' ? (
+					{ postsOnFrontPage ? (
 						<>
 							<h2 className="themes__auto-loading-homepage-modal-options-heading">
 								{ translate( 'How would you like to continue?' ) }
@@ -190,7 +188,6 @@ export default connect(
 
 		return {
 			siteId,
-			siteOptions,
 			installingThemeId,
 			theme: installingThemeId && getCanonicalTheme( state, siteId, installingThemeId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
@@ -198,6 +195,7 @@ export default connect(
 			hasAutoLoadingHomepage: themeHasAutoLoadingHomepage( state, installingThemeId ),
 			isCurrentTheme: isThemeActive( state, installingThemeId, siteId ),
 			isVisible: shouldShowHomepageWarning( state, installingThemeId ),
+			postsOnFrontPage: siteOptions?.show_on_front === 'posts',
 		};
 	},
 	{

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -10,8 +10,8 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { Dialog } from '@automattic/components';
-import FormLabel from 'components/forms/form-label';
-import FormRadio from 'components/forms/form-radio';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormRadio from 'calypso/components/forms/form-radio';
 import {
 	getCanonicalTheme,
 	hasActivatedTheme,
@@ -20,13 +20,13 @@ import {
 	isThemeActive,
 	shouldShowHomepageWarning,
 	getPreActivateThemeId,
-} from 'state/themes/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
+} from 'calypso/state/themes/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
 	acceptAutoLoadingHomepageWarning,
 	hideAutoLoadingHomepageWarning,
 	activate as activateTheme,
-} from 'state/themes/actions';
+} from 'calypso/state/themes/actions';
 
 /**
  * Style dependencies

--- a/client/my-sites/themes/auto-loading-homepage-modal.jsx
+++ b/client/my-sites/themes/auto-loading-homepage-modal.jsx
@@ -51,9 +51,24 @@ class AutoLoadingHomepageModal extends Component {
 		installingThemeId: PropTypes.string,
 	};
 
-	state = {
-		homepageAction: 'keep_current_homepage',
-	};
+	constructor( props ) {
+		super( props );
+		this.state = {
+			homepageAction: 'keep_current_homepage',
+
+			// Used to reset state when dialog re-opens
+			wasVisible: props.isVisible,
+		};
+	}
+
+	static getDerivedStateFromProps( nextProps, prevState ) {
+		if ( nextProps.isVisible && ! prevState.wasVisible ) {
+			return { homepageAction: 'keep_current_homepage', wasVisible: true };
+		} else if ( ! nextProps.isVisible && prevState.wasVisible ) {
+			return { wasVisible: false };
+		}
+		return null;
+	}
 
 	handleHomepageAction = ( event ) => {
 		this.setState( { homepageAction: event.currentTarget.value } );

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -6,21 +6,11 @@
 	@include breakpoint-deprecated( '<480px' ) {
 		box-sizing: border-box;
 		max-width: 100%;
-	}
 
-	+ .dialog__action-buttons {
-		text-align: center;
-
-		.button:first-child {
-			margin-left: 0;
-		}
-
-		@include breakpoint-deprecated( '<480px' ) {
-			.button {
-				display: block;
-				margin: 0 auto 10px;
-				width: 100%;
-			}
+		+ .dialog__action-buttons .button {
+			display: block;
+			margin: 0 auto 10px;
+			width: 100%;
 		}
 	}
 

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -14,11 +14,6 @@
 		}
 	}
 
-	.themes__auto-loading-homepage-modal-options-heading {
-		font-weight: 600;
-		margin-bottom: 0.5em;
-	}
-
 	.form-label {
 		font-weight: 400;
 	}

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -24,12 +24,8 @@
 		}
 	}
 
-	.themes__auto-loading-homepage-modal-title {
-		display: block;
-		font-weight: 400;
-		line-height: 1.5em;
-		margin-bottom: 0;
-		text-align: center;
-		height: auto;
+	.themes__auto-loading-homepage-modal-options-heading {
+		font-weight: 600;
+		margin-bottom: 0.5em;
 	}
 }

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -18,4 +18,15 @@
 		font-weight: 600;
 		margin-bottom: 0.5em;
 	}
+
+	.form-label {
+		font-weight: 400;
+	}
+
+	.themes__auto-loading-homepage-modal-homepage-hint {
+		margin-left: 20px;
+		font-size: 0.875rem;
+		font-style: italic;
+		margin-top: -5px;
+	}
 }

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -10,13 +10,20 @@ import 'state/themes/init';
 /**
  * Triggers a network request to activate a specific theme on a given site.
  *
- * @param  {string}   themeId   Theme ID
- * @param  {number}   siteId    Site ID
- * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
- * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @param {string} themeId   Theme ID
+ * @param {number} siteId    Site ID
+ * @param {string} source    The source that is requesting theme activation, e.g. 'showcase'
+ * @param {boolean} purchased Whether the theme has been purchased prior to activation
+ * @param {boolean} keepLatestPosts Has user asked to keep their latest posts on front
  * @returns {Function}           Action thunk
  */
-export function activateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
+export function activateTheme(
+	themeId,
+	siteId,
+	source = 'unknown',
+	purchased = false,
+	keepLatestPosts = false
+) {
 	return ( dispatch ) => {
 		dispatch( {
 			type: THEME_ACTIVATE,
@@ -26,7 +33,7 @@ export function activateTheme( themeId, siteId, source = 'unknown', purchased = 
 
 		return wpcom
 			.undocumented()
-			.activateTheme( themeId, siteId )
+			.activateTheme( themeId, siteId, keepLatestPosts )
 			.then( ( theme ) => {
 				// Fall back to ID for Jetpack sites which don't return a stylesheet attr.
 				const themeStylesheet = theme.stylesheet || themeId;

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
-import { THEME_ACTIVATE, THEME_ACTIVATE_FAILURE } from 'state/themes/action-types';
-import { themeActivated } from 'state/themes/actions/theme-activated';
+import wpcom from 'calypso/lib/wp';
+import { THEME_ACTIVATE, THEME_ACTIVATE_FAILURE } from 'calypso/state/themes/action-types';
+import { themeActivated } from 'calypso/state/themes/actions/theme-activated';
 
-import 'state/themes/init';
+import 'calypso/state/themes/init';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -14,7 +14,7 @@ import 'state/themes/init';
  * @param {number} siteId    Site ID
  * @param {string} source    The source that is requesting theme activation, e.g. 'showcase'
  * @param {boolean} purchased Whether the theme has been purchased prior to activation
- * @param {boolean} keepLatestPosts Has user asked to keep their latest posts on front
+ * @param {boolean} keepCurrentHomepage Prevent theme from switching homepage content if this is what it'd normally do when activated
  * @returns {Function}           Action thunk
  */
 export function activateTheme(
@@ -22,7 +22,7 @@ export function activateTheme(
 	siteId,
 	source = 'unknown',
 	purchased = false,
-	keepLatestPosts = false
+	keepCurrentHomepage = false
 ) {
 	return ( dispatch ) => {
 		dispatch( {
@@ -33,7 +33,7 @@ export function activateTheme(
 
 		return wpcom
 			.undocumented()
-			.activateTheme( themeId, siteId, keepLatestPosts )
+			.activateTheme( themeId, siteId, keepCurrentHomepage )
 			.then( ( theme ) => {
 				// Fall back to ID for Jetpack sites which don't return a stylesheet attr.
 				const themeStylesheet = theme.stylesheet || themeId;

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -1,19 +1,19 @@
 /**
  * Internal dependencies
  */
-import { isJetpackSite } from 'state/sites/selectors';
-import { activateTheme } from 'state/themes/actions/activate-theme';
-import { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
-import { showAutoLoadingHomepageWarning } from 'state/themes/actions/show-auto-loading-homepage-warning';
-import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { activateTheme } from 'calypso/state/themes/actions/activate-theme';
+import { installAndActivateTheme } from 'calypso/state/themes/actions/install-and-activate-theme';
+import { showAutoLoadingHomepageWarning } from 'calypso/state/themes/actions/show-auto-loading-homepage-warning';
+import { suffixThemeIdForInstall } from 'calypso/state/themes/actions/suffix-theme-id-for-install';
 import {
 	getTheme,
 	hasAutoLoadingHomepageModalAccepted,
 	themeHasAutoLoadingHomepage,
-} from 'state/themes/selectors';
-import isSiteAtomic from 'state/selectors/is-site-wpcom-atomic';
+} from 'calypso/state/themes/selectors';
+import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 
-import 'state/themes/init';
+import 'calypso/state/themes/init';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -23,7 +23,7 @@ import 'state/themes/init';
  * @param  {number}   siteId    Site ID
  * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
  * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
- * @param  {boolean}  keepLatestPosts Has user asked to keep their latest posts on front
+ * @param  {boolean}  keepCurrentHomepage Prevent theme from switching homepage content if this is what it'd normally do when activated
  * @returns {Function}          Action thunk
  */
 export function activate(
@@ -31,7 +31,7 @@ export function activate(
 	siteId,
 	source = 'unknown',
 	purchased = false,
-	keepLatestPosts = false
+	keepCurrentHomepage = false
 ) {
 	return ( dispatch, getState ) => {
 		/**
@@ -53,10 +53,10 @@ export function activate(
 			// If theme is already installed, installation will silently fail,
 			// and it will just be activated.
 			return dispatch(
-				installAndActivateTheme( installId, siteId, source, purchased, keepLatestPosts )
+				installAndActivateTheme( installId, siteId, source, purchased, keepCurrentHomepage )
 			);
 		}
 
-		return dispatch( activateTheme( themeId, siteId, source, purchased, keepLatestPosts ) );
+		return dispatch( activateTheme( themeId, siteId, source, purchased, keepCurrentHomepage ) );
 	};
 }

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -23,9 +23,16 @@ import 'state/themes/init';
  * @param  {number}   siteId    Site ID
  * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
  * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @param  {boolean}  keepLatestPosts Has user asked to keep their latest posts on front
  * @returns {Function}          Action thunk
  */
-export function activate( themeId, siteId, source = 'unknown', purchased = false ) {
+export function activate(
+	themeId,
+	siteId,
+	source = 'unknown',
+	purchased = false,
+	keepLatestPosts = false
+) {
 	return ( dispatch, getState ) => {
 		/**
 		 * Let's check if the theme will change the homepage of the site,
@@ -45,9 +52,11 @@ export function activate( themeId, siteId, source = 'unknown', purchased = false
 			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );
 			// If theme is already installed, installation will silently fail,
 			// and it will just be activated.
-			return dispatch( installAndActivateTheme( installId, siteId, source, purchased ) );
+			return dispatch(
+				installAndActivateTheme( installId, siteId, source, purchased, keepLatestPosts )
+			);
 		}
 
-		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
+		return dispatch( activateTheme( themeId, siteId, source, purchased, keepLatestPosts ) );
 	};
 }

--- a/client/state/themes/actions/install-and-activate-theme.js
+++ b/client/state/themes/actions/install-and-activate-theme.js
@@ -11,18 +11,25 @@ import 'state/themes/init';
  * Jetpack site. If the themeId parameter is suffixed with '-wpcom', install the
  * theme from WordPress.com. Otherwise, install from WordPress.org.
  *
- * @param  {string}   themeId   Theme ID. If suffixed with '-wpcom', install theme from WordPress.com
- * @param  {number}   siteId    Site ID
- * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
- * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @param {string} themeId   Theme ID. If suffixed with '-wpcom', install theme from WordPress.com
+ * @param {number} siteId    Site ID
+ * @param {string} source    The source that is requesting theme activation, e.g. 'showcase'
+ * @param {boolean} purchased Whether the theme has been purchased prior to activation
+ * @param {boolean} keepLatestPosts Has user asked to keep their latest posts on front
  * @returns {Function}           Action thunk
  */
-export function installAndActivateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
+export function installAndActivateTheme(
+	themeId,
+	siteId,
+	source = 'unknown',
+	purchased = false,
+	keepLatestPosts = false
+) {
 	return ( dispatch ) => {
 		return dispatch( installTheme( themeId, siteId ) ).then( () => {
 			// This will be called even if `installTheme` silently fails. We rely on
 			// `activateTheme`'s own error handling here.
-			dispatch( activateTheme( themeId, siteId, source, purchased ) );
+			dispatch( activateTheme( themeId, siteId, source, purchased, keepLatestPosts ) );
 		} );
 	};
 }

--- a/client/state/themes/actions/install-and-activate-theme.js
+++ b/client/state/themes/actions/install-and-activate-theme.js
@@ -15,7 +15,7 @@ import 'state/themes/init';
  * @param {number} siteId    Site ID
  * @param {string} source    The source that is requesting theme activation, e.g. 'showcase'
  * @param {boolean} purchased Whether the theme has been purchased prior to activation
- * @param {boolean} keepLatestPosts Has user asked to keep their latest posts on front
+ * @param {boolean} keepCurrentHomepage Prevent theme from switching homepage content if this is what it'd normally do when activated
  * @returns {Function}           Action thunk
  */
 export function installAndActivateTheme(
@@ -23,13 +23,13 @@ export function installAndActivateTheme(
 	siteId,
 	source = 'unknown',
 	purchased = false,
-	keepLatestPosts = false
+	keepCurrentHomepage = false
 ) {
 	return ( dispatch ) => {
 		return dispatch( installTheme( themeId, siteId ) ).then( () => {
 			// This will be called even if `installTheme` silently fails. We rely on
 			// `activateTheme`'s own error handling here.
-			dispatch( activateTheme( themeId, siteId, source, purchased, keepLatestPosts ) );
+			dispatch( activateTheme( themeId, siteId, source, purchased, keepCurrentHomepage ) );
 		} );
 	};
 }

--- a/client/state/themes/actions/install-and-activate-theme.js
+++ b/client/state/themes/actions/install-and-activate-theme.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import { activateTheme } from 'state/themes/actions/activate-theme';
-import { installTheme } from 'state/themes/actions/install-theme';
+import { activateTheme } from 'calypso/state/themes/actions/activate-theme';
+import { installTheme } from 'calypso/state/themes/actions/install-theme';
 
-import 'state/themes/init';
+import 'calypso/state/themes/init';
 
 /**
  * Triggers a network request to install and activate a specific theme on a given


### PR DESCRIPTION
## Scenario 1: For sites showing a static page as homepage

### Current Flow

When user clicks on the **Activate Theme** button, it will:

 - Show a popup telling user _"XXX will automatically change your homepage layout. Your current homepage will become a draft. Would you like to continue?"_ <sup>[Screenshot 1]</sup>

When user continues activating the theme, the following happens behind the scenes:

  - Existing homepage is moved into **Draft**.
  - A new homepage **might** <sup>[3]</sup> be created by the theme and set to **Published**.
  - This new homepage **is set immediately** as your homepage. <sup>[2]</sup>

After the theme is activated:

  - A popup is shown with the button **"Edit Homepage"** as the next step for the user. <sup>[Screesnhot 2]</sup>
  - The homepage setting remains **"A Static Page"**. <sup>[1]</sup>

### Proposal for Scenario 1

 - No change. Keep everything the way it is.

## Scenario 2: For sites showing latest posts as homepage

### Current Flow

When user clicks on the **Activate Theme** button, it will:

 - Show a popup telling user _"XXX will automatically change your homepage layout. Your current homepage will become a draft. Would you like to continue?"_ <sup>[Screenshot 1]</sup>

When user continues activating the theme, **what happens next is not the same as what the popup message described**, the following happens behind the scenes:

 - Since there is no existing page being set as homepage <sup>[4]</sup>, unlike in scenario 1, no existing page will be moved to **Draft**.
 - A new homepage **might** <sup>[3]</sup> be created by the theme, unlike in scenario 1, the publishing status of this page is set to **Draft**.
- This new homepage post, unlike in scenario 1, **is not set immediately** as your homepage. <sup>[2]</sup>

After the theme is activated:

- The popup is shown with the button **Customize Site** as the next step for the step (unlike in scenario 1).
- The homepage setting remains **"Your Latest Posts"**. <sup>[1]</sup>

## Proposal for Scenario 2 (Option 1)

<details>
<summary>This PR implements option 3, but expand for details about option 1</summary>

- Change accuracy of popup message to describe what is actually happening behind the scenes.
- Hint the user to switch from latest posts to homepage created by theme (and also they tell them how to do so) if that is what they desire.
</details>

## Proposal for Scenario 2 (Option 2)

<details>
<summary>This PR implements option 3, but expand for details about option 2</summary>

- Use the same homepage creation flow in scenario 1.
- If user does not have a page set to show latest posts <sup>[5]</sup>:
  - Create an empty page.
  - Set this empty page as the page to show latest posts.
  - Set this page as the page to show latest posts <sup>[5]</sup> <sup>[Screenshot 4]</sup>.
</details>

## Proposal for Scenario 3 (Option 3)

- Use the same homepage creation flow in scenario 1.
- But do not modify the `show_on_front` setting so user keeps their Show Latest Posts option.

# Challenges

1. How do you determine if a theme is going to create a homepage since some themes does it, some themes don't <sup>[3]</sup>?
2. If the theme creates a homepage, how do you retrieve the id of this newly created page?
3. How do we resolve possible slug name conflict for empty page created to display latest posts? https://github.com/Automattic/wp-calypso/issues/39110#issuecomment-584896089

# Footnote

- [1] The config `show_on_front = page|posts` determines whether **A Static Page** or **Your Latest Posts** should be used as home page settings.
- [2] The config `page_on_front = pageId` determines which page should used as the homepage. 
- [3] Some themes like **Barnsbury** and **Dalston** create a homepage, some themes like **TwentyTwenty** does not create a homepage.
- [4] Even though there is no page being set as static page, the config `page_on_front` may still contain the id of the previous set page.
- [5] The config `page_for_posts = pageId` determines which empty page should be used to display list of blog posts.

# Screenshots (for reference)

Screenshot 1 - Pre-activation popup
![image](https://user-images.githubusercontent.com/1287077/76293563-42c17500-62ec-11ea-87e6-58eb66c6d689.png)

Screenshot 2 - Post-activation popup if the user sets an existing static page as homepage.
![image](https://user-images.githubusercontent.com/1287077/76293638-6389ca80-62ec-11ea-93fe-120e5ecc1b8c.png)

Screenshot 3 - Post-activation popup if the user sets to show latest post as homepage.
![image](https://user-images.githubusercontent.com/1287077/76293588-4ead3700-62ec-11ea-94bb-36002c4b659c.png)

Screenshot 4 - Where an empty post can be set to show list of posts in customizer
![image](https://user-images.githubusercontent.com/1287077/76293917-e6ab2080-62ec-11ea-9a21-4461a29013b1.png)

Fixes #39110