### PR TITLE
FSE: modify button links in SPT template selection

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -71,6 +71,19 @@ class PageTemplateModal extends Component {
 		} );
 	} );
 
+	getBlocksForSelection = selectedTemplate => {
+		const blocks = this.getBlocksByTemplateSlug( selectedTemplate );
+		// Modify the existing blocks returning new block object references.
+		return mapBlocksRecursively( blocks, function modifyBlocksForSelection( block ) {
+			// Ensure that core/button doesn't link to external template site
+			if ( 'core/button' === block.name && undefined !== block.attributes.url ) {
+				block.attributes.url = '#';
+			}
+
+			return block;
+		} );
+	};
+
 	static getDerivedStateFromProps( props, state ) {
 		// The only time `state.previewedTemplate` isn't set is before `templates`
 		// are loaded. As soon as we have our `templates`, we set it using
@@ -148,7 +161,7 @@ class PageTemplateModal extends Component {
 		const isHomepageTemplate = find( this.props.templates, { slug, category: 'home' } );
 
 		// Load content.
-		const blocks = this.getBlocksByTemplateSlug( slug );
+		const blocks = this.getBlocksForSelection( slug );
 		// Only overwrite the page title if the template is not one of the Homepage Layouts
 		const title = isHomepageTemplate ? null : this.getTitleByTemplateSlug( slug );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to fix the issue reported in https://github.com/Automattic/wp-calypso/issues/39315. Currently the buttons in the Home Page Templates link to the external template sites. To prevent this, this PR modifies the url attribute for all button links on template selection.

Fixes https://github.com/Automattic/wp-calypso/issues/39315

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
The key thing to check is:

* When selecting a Home Page template (e.g. Balasana) and adding it to the editor, the buttons should not link to external sites but instead have the link value '#'.

This requires the FSE Plugin to be active on your WP install. You can find guidance for this at `PaYJgx-sW-p2`. You can test on local WP instance or WPCom (assuming you have sandbox syncing setup).

### Before

* Activate FSE Plugin.
* Create new Page.
* See SPT selector.
* Click "Balasana" template to show the preview
* Click "Use Balasana template" to load it in the Editor
* Check the Button links, they should show an external URL e.g. 
"balasanademo.wordpress.com/classes/"

<img width="472" alt="Screenshot 2020-02-26 at 16 22 52" src="https://user-images.githubusercontent.com/1562646/75359201-59aba480-58b4-11ea-92f9-96a9752d3fe8.png">


### After

* Check out this PR branch.
* Build FSE and sync to your WP install.
* Ensure FSE Plugin is active.
* Create new Page.
* See SPT selector.
* Click "Balasana" template to show the preview
* Click "Use Balasana template" to load it in the Editor
* Check the Button links, they should not show an external URL but have the link value '#' instead.

<img width="450" alt="Screenshot 2020-02-26 at 16 23 17" src="https://user-images.githubusercontent.com/1562646/75359216-60d2b280-58b4-11ea-83af-e0c47af8a2dd.png">
