### PR TITLE
Usability fixes for the site domain list and setting the primary domain

### DIFF
--- a/client/my-sites/domains/domain-management/list/item.jsx
+++ b/client/my-sites/domains/domain-management/list/item.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,19 +38,16 @@ class ListItem extends React.PureComponent {
 		} );
 
 		return (
-			<CompactCard className={ cardClass }>
+			<CompactCard className={ cardClass } onClick={ this.handleClick }>
 				{ this.selectionRadio() }
-				{ ( this.props.enableSelection && (
-					<label htmlFor={ this.getInputId() }>{ this.content() }</label>
-				) ) ||
-					this.content() }
+				{ this.content() }
 			</CompactCard>
 		);
 	}
 
 	content() {
 		return (
-			<button className="domain-management-list-item__link" onClick={ this.handleClick }>
+			<div className="domain-management-list-item__link">
 				{ this.icon() }
 				<div className="domain-management-list-item__title">{ this.props.domain.name }</div>
 				<span className="domain-management-list-item__meta">
@@ -61,7 +59,7 @@ class ListItem extends React.PureComponent {
 					<DomainTransferFlag domain={ this.props.domain } />
 				</span>
 				{ this.busyMessage() }
-			</button>
+			</div>
 		);
 	}
 
@@ -86,13 +84,10 @@ class ListItem extends React.PureComponent {
 
 	handleClick = () => {
 		if ( this.props.enableSelection ) {
-			return;
+			this.props.onSelect( this.props.selectionIndex, this.props.domain );
+		} else {
+			this.props.onClick( this.props.domain );
 		}
-		this.props.onClick( this.props.domain );
-	};
-
-	handleSelect = () => {
-		this.props.onSelect( this.props.selectionIndex, this.props.domain );
 	};
 
 	getInputId() {
@@ -110,7 +105,7 @@ class ListItem extends React.PureComponent {
 				className="domain-management-list-item__radio"
 				type="radio"
 				checked={ this.props.isSelected }
-				onChange={ this.handleSelect }
+				onChange={ noop }
 			/>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -2,6 +2,11 @@
 	margin-bottom: 0;
 }
 
+.domain-management-list__cancel-change-primary-button {
+	margin-top: 1px;
+	margin-bottom: 2px;
+}
+
 .domain-management-list-item {
 	&.busy {
 		background-color: var( --color-neutral-0 );
@@ -14,10 +19,9 @@
 }
 
 .domain-management-list-item__link {
-	cursor: pointer;
-	display: block;
 	overflow: hidden;
 	text-align: inherit;
+	line-height: normal;
 
 	.domain__primary-flag {
 		vertical-align: middle;
@@ -35,12 +39,10 @@
 	color: var( --color-neutral-70 );
 	font-size: 14px;
 	font-weight: 600;
-	text-overflow: ellipsis;
-	overflow: hidden;
 	white-space: pre;
-	max-width: 70%;
 	font-family: $serif;
 	text-align: inherit;
+	line-height: normal;
 
 	@include breakpoint( '>480px' ) {
 		font-size: 18px;
@@ -56,6 +58,7 @@
 	min-height: 20px;
 	text-overflow: ellipsis;
 	overflow: hidden;
+	line-height: normal;
 
 	@include breakpoint( '>480px' ) {
 		text-transform: uppercase;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* simplify the site domain list and use only one onClick handle on the CompactCard component so that the whole row is clickable
* remove unnecessary button and label tags
* fix up the CSS so that the item row looks good and the spinner during primary domain change looks okay

Setting primary domain before:

<img width="730" alt="Screenshot 2020-02-26 at 22 55 54" src="https://user-images.githubusercontent.com/1355045/75387267-be362600-58eb-11ea-8ada-144d8f6122f5.png">

Setting primary domain after:

<img width="1079" alt="Screenshot 2020-02-26 at 22 58 11" src="https://user-images.githubusercontent.com/1355045/75387276-c2624380-58eb-11ea-86d0-8e03964bb22c.png">


#### Testing instructions

* go in manage > domains on site with more than 1 domain and click on the `Change Primary` button
* click on any row and verify that the whole row is clickable
* verify that the spinner and the text shown during the change is not misplaced
* test the mobile version too
