### PR TITLE
Add Site Editor experiment to wp-admin

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -45,12 +45,15 @@ require_once __DIR__ . '/dotcom-fse/helpers.php';
  */
 function load_core_site_editor() {
 	$options = get_option( 'gutenberg-experiments' );
+
 	// Initialize options array if needed.
 	if ( ! $options ) {
 		$options = array();
 	}
+
 	// Check blog sticker for access to Site Editor.
 	if ( ! has_blog_sticker( 'core_site_editor_enabled' ) ) {
+
 		// Check if experiment is enabled: disable if needed.
 		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
 			$options['gutenberg-full-site-editing']      = '0';
@@ -59,6 +62,7 @@ function load_core_site_editor() {
 		}
 		return;
 	}
+	
 	// Check if experiment is disabled: enable if needed.
 	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
 		$options['gutenberg-full-site-editing']      = '1';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -44,39 +44,8 @@ require_once __DIR__ . '/dotcom-fse/helpers.php';
  * Load Core Site Editor.
  */
 function load_core_site_editor() {
-	$options = get_option( 'gutenberg-experiments' );
-
-	// Initialize options array if needed.
-	if ( ! $options ) {
-		$options = array();
-	}
-
-	// Check blog sticker for access to Site Editor.
-	if ( ! has_blog_sticker( 'core_site_editor_enabled' ) ) {
-
-		// Check if experiment is enabled: disable if needed.
-		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-			$options['gutenberg-full-site-editing']      = '0';
-			$options['gutenberg-full-site-editing-demo'] = '0';
-			update_option( 'gutenberg-experiments', $options );
-		}
-		return;
-	}
-	
-	// Check if experiment is disabled: enable if needed.
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-		$options['gutenberg-full-site-editing']      = '1';
-		$options['gutenberg-full-site-editing-demo'] = '1';
-		update_option( 'gutenberg-experiments', $options );
-	}
-	add_menu_page(
-		__( 'Site Editor (beta)', 'gutenberg' ),
-		__( 'Site Editor (beta)', 'gutenberg' ),
-		'edit_theme_options',
-		'gutenberg-edit-site',
-		'gutenberg_edit_site_page',
-		'dashicons-edit'
-	);
+	require_once __DIR__ . '/site-editor-experiment/index.php';
+	conditionally_enable_site_editor();
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_core_site_editor' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -44,30 +44,26 @@ require_once __DIR__ . '/dotcom-fse/helpers.php';
  * Load Core Site Editor.
  */
 function load_core_site_editor() {
-	// Console log current options for sanity check.
 	$options = get_option( 'gutenberg-experiments' );
-	echo '<script>' . 'console.log(' . json_encode($options, JSON_HEX_TAG) . 
-	');' . '</script>';
+	// Initialize options array if needed.
+	if ( ! $options ) {
+		$options = array();
+	}
 	// Check blog sticker for access to Site Editor.
 	if ( ! has_blog_sticker( 'core_site_editor_enabled' ) ) {
 		// Check if experiment is enabled: disable if needed.
 		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-			// @TODO: Add support for other experiments, don't override them completely. 
-			$disabled_options = array(
-				'gutenberg-full-site-editing'		=>	"0",
-				'gutenberg-full-site-editing-demo'	=> 	"0",
-			);
-			update_option( 'gutenberg-experiments', $disabled_options );
+			$options['gutenberg-full-site-editing']      = '0';
+			$options['gutenberg-full-site-editing-demo'] = '0';
+			update_option( 'gutenberg-experiments', $options );
 		}
 		return;
 	}
 	// Check if experiment is disabled: enable if needed.
 	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-		$enabled_options = array(
-			'gutenberg-full-site-editing'		=>	"1",
-			'gutenberg-full-site-editing-demo'	=> 	"1",
-		);
-		update_option( 'gutenberg-experiments', $enabled_options );
+		$options['gutenberg-full-site-editing']      = '1';
+		$options['gutenberg-full-site-editing-demo'] = '1';
+		update_option( 'gutenberg-experiments', $options );
 	}
 	add_menu_page(
 		__( 'Site Editor (beta)', 'gutenberg' ),

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -40,53 +40,43 @@ define( 'PLUGIN_VERSION', '0.19' );
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';
 
-function console_log( $output, $with_script_tags = true ) {
-	$js_code = 'console.log(' . json_encode( $output, JSON_HEX_TAG ) .
-	');';
-	if ( $with_script_tags ) {
-		$js_code = '<script>' . $js_code . '</script>';
-	}
-	echo $js_code;
-}
 /**
  * Load Core Site Editor.
  */
 function load_core_site_editor() {
+	// Console log current options for sanity check.
 	$options = get_option( 'gutenberg-experiments' );
-	console_log( $options );
-	// below is found from passing $options through console_log on core gutenberg with experiment active.
-	// {gutenberg-full-site-editing: "1", gutenberg-full-site-editing-demo: "1"}
-
+	echo '<script>' . 'console.log(' . json_encode($options, JSON_HEX_TAG) . 
+	');' . '</script>';
 	// Check blog sticker for access to Site Editor.
 	if ( ! has_blog_sticker( 'core_site_editor_enabled' ) ) {
 		// Check if experiment is enabled: disable if needed.
 		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-			// Disable ALL experiments.  (none are currently enabled on dotcom it seems?).
+			// @TODO: Add support for other experiments, don't override them completely. 
 			$disabled_options = array(
-				'gutenberg-full-site-editing'      => '0',
-				'gutenberg-full-site-editing-demo' => '0',
+				'gutenberg-full-site-editing'		=>	"0",
+				'gutenberg-full-site-editing-demo'	=> 	"0",
 			);
 			update_option( 'gutenberg-experiments', $disabled_options );
-		}
-		if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-			console_log( 'no it is not!' );
 		}
 		return;
 	}
 	// Check if experiment is disabled: enable if needed.
 	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
 		$enabled_options = array(
-			'gutenberg-full-site-editing'      => '1',
-			'gutenberg-full-site-editing-demo' => '1',
+			'gutenberg-full-site-editing'		=>	"1",
+			'gutenberg-full-site-editing-demo'	=> 	"1",
 		);
 		update_option( 'gutenberg-experiments', $enabled_options );
 	}
-	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-		console_log( 'yes it is!' );
-	}
-
-	// Load site editor.
-	// 'gutenberg_edit_site_page' - function to call site editor.
+	add_menu_page(
+		__( 'Site Editor (beta)', 'gutenberg' ),
+		__( 'Site Editor (beta)', 'gutenberg' ),
+		'edit_theme_options',
+		'gutenberg-edit-site',
+		'gutenberg_edit_site_page',
+		'dashicons-edit'
+	);
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_core_site_editor' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -40,6 +40,29 @@ define( 'PLUGIN_VERSION', '0.19' );
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';
 
+
+function load_core_site_editor() {
+	// Check blog sticker for access to Site Editor.
+	if ( ! has_blog_sticker( 'core_site_editor_enabled' ) ) {
+		// Check if experiment is enabled: disable if needed.
+		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+
+		}
+		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
+
+		}
+		return;
+	}
+	// Check if experiment is disabled: enable if needed.
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+
+	}
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
+
+	}
+	// Load site editor
+	// 'gutenberg_edit_site_page' - function to call site editor
+}
 /**
  * Load Full Site Editing.
  */
@@ -221,6 +244,6 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_blog_posts_block' );
  * Load WPCOM Block Editor NUX
  */
 // function load_wpcom_block_editor_nux() {
-// 	require_once __DIR__ . '/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php';
+// require_once __DIR__ . '/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php';
 // }
 // add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -40,29 +40,56 @@ define( 'PLUGIN_VERSION', '0.19' );
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';
 
-
+function console_log( $output, $with_script_tags = true ) {
+	$js_code = 'console.log(' . json_encode( $output, JSON_HEX_TAG ) .
+	');';
+	if ( $with_script_tags ) {
+		$js_code = '<script>' . $js_code . '</script>';
+	}
+	echo $js_code;
+}
+/**
+ * Load Core Site Editor.
+ */
 function load_core_site_editor() {
+	$options = get_option( 'gutenberg-experiments' );
+	console_log( $options );
+	// below is found from passing $options through console_log on core gutenberg with experiment active.
+	// {gutenberg-full-site-editing: "1", gutenberg-full-site-editing-demo: "1"}
+
 	// Check blog sticker for access to Site Editor.
 	if ( ! has_blog_sticker( 'core_site_editor_enabled' ) ) {
 		// Check if experiment is enabled: disable if needed.
 		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-
+			// Disable ALL experiments.  (none are currently enabled on dotcom it seems?).
+			$disabled_options = array(
+				'gutenberg-full-site-editing'      => '0',
+				'gutenberg-full-site-editing-demo' => '0',
+			);
+			update_option( 'gutenberg-experiments', $disabled_options );
 		}
-		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
-
+		if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+			console_log( 'no it is not!' );
 		}
 		return;
 	}
 	// Check if experiment is disabled: enable if needed.
 	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-
+		$enabled_options = array(
+			'gutenberg-full-site-editing'      => '1',
+			'gutenberg-full-site-editing-demo' => '1',
+		);
+		update_option( 'gutenberg-experiments', $enabled_options );
 	}
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing-demo' ) ) {
-
+	if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+		console_log( 'yes it is!' );
 	}
-	// Load site editor
-	// 'gutenberg_edit_site_page' - function to call site editor
+
+	// Load site editor.
+	// 'gutenberg_edit_site_page' - function to call site editor.
 }
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_core_site_editor' );
+
 /**
  * Load Full Site Editing.
  */

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
@@ -11,7 +11,6 @@ namespace A8C\FSE;
  * Enables/Disables site editor experiment per blog sticker.
  */
 function conditionally_enable_site_editor() {
-
 	// Check blog sticker for access to Site Editor.
 	if ( ! has_blog_sticker( 'core_site_editor_enabled' ) ) {
 
@@ -28,6 +27,7 @@ function conditionally_enable_site_editor() {
 	}
 
 	add_site_editor_plugin_page();
+	override_site_editor_init();
 }
 
 /**
@@ -51,26 +51,109 @@ function set_site_editor_experiment( $value ) {
  * Adds Site Editor page to wp-admin sidebar.
  */
 function add_site_editor_plugin_page() {
-
-	// Site Editor must be nested as a 'gutenberg' subpage to fire correct hook.
-	// May need to change core code or hack the hook somehow if we want it at top level.
+	// Without overriding init, this would need to be a submenu of gutenberg.
 	add_menu_page(
-		'Gutenberg',
-		'Gutenberg',
-		'edit_posts',
-		'gutenberg',
-		// This callback effectively loads the Gutenberg Demo from here.
-		// If empty '' on dotcom it loads the broken homepage.
-		'anything',
-		'dashicons-edit'
-	);
-
-	add_submenu_page(
-		'gutenberg',
 		__( 'Site Editor (beta)', 'gutenberg' ),
 		__( 'Site Editor (beta)', 'gutenberg' ),
 		'edit_theme_options',
 		'gutenberg-edit-site',
-		'gutenberg_edit_site_page'
+		'gutenberg_edit_site_page',
+		'dashicons-edit'
 	);
+}
+
+/**
+ * Initialize the Gutenberg Edit Site Page.
+ * Copy of core function from 7.3.0 - gutenberg_edit_site_init
+ *
+ * Currently overriding to change hook requirement to allow Site Editor at top level sidebar.
+ * And to troubleshoot the wp.editSite.initialize CORS error.
+ *
+ * Any changes will be prefixed with @DOTCOM_CUSTOMIZATION comment.
+ *
+ * @param string $hook Page.
+ */
+function fse_plugin_edit_site_init( $hook ) {
+	global $_wp_current_template_id;
+	// @DOTCOM_CUSTOMIZATION - rename hook to allow toplevel
+	if ( 'toplevel_page_gutenberg-edit-site' !== $hook ) {
+		return;
+	}
+
+	// Get editor settings.
+	$max_upload_size = wp_max_upload_size();
+	if ( ! $max_upload_size ) {
+		$max_upload_size = 0;
+	}
+
+	// This filter is documented in wp-admin/includes/media.php.
+	$image_size_names      = apply_filters(
+		'image_size_names_choose',
+		array(
+			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
+			'medium'    => __( 'Medium', 'gutenberg' ),
+			'large'     => __( 'Large', 'gutenberg' ),
+			'full'      => __( 'Full Size', 'gutenberg' ),
+		)
+	);
+	$available_image_sizes = array();
+	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
+		$available_image_sizes[] = array(
+			'slug' => $image_size_slug,
+			'name' => $image_size_name,
+		);
+	}
+
+	$settings = array(
+		'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
+		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
+		'imageSizes'             => $available_image_sizes,
+		'isRTL'                  => is_rtl(),
+		'maxUploadFileSize'      => $max_upload_size,
+	);
+
+	list( $color_palette, ) = (array) get_theme_support( 'editor-color-palette' );
+	list( $font_sizes, )    = (array) get_theme_support( 'editor-font-sizes' );
+	if ( false !== $color_palette ) {
+		$settings['colors'] = $color_palette;
+	}
+	if ( false !== $font_sizes ) {
+		$settings['fontSizes'] = $font_sizes;
+	}
+
+	// Get root template by trigerring `./template-loader.php`'s logic.
+	get_front_page_template();
+	get_index_template();
+	apply_filters( 'template_include', null );
+	$settings['templateId'] = $_wp_current_template_id;
+
+	// Initialize editor.
+	wp_add_inline_script(
+		'wp-edit-site',
+		sprintf(
+			'wp.domReady( function() {
+				wp.editSite.initialize( "edit-site-editor", %s );
+			} );',
+			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
+		)
+	);
+
+	// Preload server-registered block schemas.
+	wp_add_inline_script(
+		'wp-blocks',
+		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
+	);
+
+	wp_enqueue_script( 'wp-edit-site' );
+	wp_enqueue_script( 'wp-format-library' );
+	wp_enqueue_style( 'wp-edit-site' );
+	wp_enqueue_style( 'wp-format-library' );
+}
+
+/**
+ * Override core's site editor init function.
+ */
+function override_site_editor_init() {
+	remove_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\fse_plugin_edit_site_init' );
 }

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Site Editor experiment file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Enables/Disables site editor experiment per blog sticker.
+ */
+function conditionally_enable_site_editor() {
+
+	// Check blog sticker for access to Site Editor.
+	if ( ! has_blog_sticker( 'core_site_editor_enabled' ) ) {
+
+		// Check if experiment is enabled: disable if needed.
+		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+			set_site_editor_experiment( '0' );
+		}
+		return;
+	}
+
+	// Check if experiment is disabled: enable if needed.
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+		set_site_editor_experiment( '1' );
+	}
+
+	add_site_editor_plugin_page();
+}
+
+/**
+ * Sets the Site Editor experiment on or off.
+ *
+ * @param {string} $value - '0' for OFF, '1' for ON.
+ */
+function set_site_editor_experiment( $value ) {
+	$options = get_option( 'gutenberg-experiments' );
+
+	// Initialize options array if needed (may be set to false by default on dotcom).
+	if ( ! $options ) {
+		$options = array();
+	}
+	$options['gutenberg-full-site-editing']      = $value;
+	$options['gutenberg-full-site-editing-demo'] = $value;
+	update_option( 'gutenberg-experiments', $options );
+}
+
+/**
+ * Adds Site Editor page to wp-admin sidebar.
+ */
+function add_site_editor_plugin_page() {
+
+	// Site Editor must be nested as a 'gutenberg' subpage to fire correct hook.
+	// May need to change core code or hack the hook somehow if we want it at top level.
+	add_menu_page(
+		'Gutenberg',
+		'Gutenberg',
+		'edit_posts',
+		'gutenberg',
+		// This callback effectively loads the Gutenberg Demo from here.
+		// If empty '' on dotcom it loads the broken homepage.
+		'anything',
+		'dashicons-edit'
+	);
+
+	add_submenu_page(
+		'gutenberg',
+		__( 'Site Editor (beta)', 'gutenberg' ),
+		__( 'Site Editor (beta)', 'gutenberg' ),
+		'edit_theme_options',
+		'gutenberg-edit-site',
+		'gutenberg_edit_site_page'
+	);
+}

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
@@ -127,15 +127,6 @@ function fse_plugin_edit_site_init( $hook ) {
 	apply_filters( 'template_include', null );
 	$settings['templateId'] = $_wp_current_template_id;
 
-	// @DOTCOM_CUSTOMIZATION - set up apiFetch properly for dotcom.
-	// NOT currently calling the script we want.
-	wp_enqueue_script(
-		'gutenberg-wpcom-apifetch',
-		'/wp-content/plugins/gutenberg-wpcom/gutenberg-wpcom-apifetch.js',
-		array( 'gutenberg-wpcom-script', 'jquery.wpcom-proxy-request', 'lodash', 'wp-api-fetch', 'wp-polyfill', 'wp-url' ),
-		time()
-	);
-
 	// Initialize editor.
 	wp_add_inline_script(
 		'wp-edit-site',
@@ -153,6 +144,9 @@ function fse_plugin_edit_site_init( $hook ) {
 		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 	);
 
+	// @DOTCOM_CUSTOMIZATION - trigger enqueue_block_editor_assets to properly set apiFetch for dotcom etc.
+	do_action( 'enqueue_block_editor_assets' );
+
 	wp_enqueue_script( 'wp-edit-site' );
 	wp_enqueue_script( 'wp-format-library' );
 	wp_enqueue_style( 'wp-edit-site' );
@@ -160,7 +154,7 @@ function fse_plugin_edit_site_init( $hook ) {
 }
 
 /**
- * Override core's site editor init function.
+ * Override core's site editor init function with our own.
  */
 function override_site_editor_init() {
 	remove_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
@@ -127,6 +127,15 @@ function fse_plugin_edit_site_init( $hook ) {
 	apply_filters( 'template_include', null );
 	$settings['templateId'] = $_wp_current_template_id;
 
+	// @DOTCOM_CUSTOMIZATION - set up apiFetch properly for dotcom.
+	// NOT currently calling the script we want.
+	wp_enqueue_script(
+		'gutenberg-wpcom-apifetch',
+		'/wp-content/plugins/gutenberg-wpcom/gutenberg-wpcom-apifetch.js',
+		array( 'gutenberg-wpcom-script', 'jquery.wpcom-proxy-request', 'lodash', 'wp-api-fetch', 'wp-polyfill', 'wp-url' ),
+		time()
+	);
+
 	// Initialize editor.
 	wp_add_inline_script(
 		'wp-edit-site',

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
@@ -12,22 +12,18 @@ namespace A8C\FSE;
  */
 function conditionally_enable_site_editor() {
 	// Check blog sticker for access to Site Editor.
-	if ( ! has_blog_sticker( 'core_site_editor_enabled' ) ) {
-
-		// Check if experiment is enabled: disable if needed.
-		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-			set_site_editor_experiment( '0' );
-		}
+	if ( ! is_site_editor_active() ) {
 		return;
 	}
 
-	// Check if experiment is disabled: enable if needed.
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
-		set_site_editor_experiment( '1' );
-	}
+	add_action( 'admin_menu', 'gutenberg_menu' );
 
-	add_site_editor_plugin_page();
-	override_site_editor_init();
+	add_action(
+		'admin_enqueue_scripts',
+		function() {
+			do_action( 'enqueue_block_editor_assets' );
+		}
+	);
 }
 
 /**
@@ -48,115 +44,41 @@ function set_site_editor_experiment( $value ) {
 }
 
 /**
- * Adds Site Editor page to wp-admin sidebar.
- */
-function add_site_editor_plugin_page() {
-	// Without overriding init, this would need to be a submenu of gutenberg.
-	add_menu_page(
-		__( 'Site Editor (beta)', 'gutenberg' ),
-		__( 'Site Editor (beta)', 'gutenberg' ),
-		'edit_theme_options',
-		'gutenberg-edit-site',
-		'gutenberg_edit_site_page',
-		'dashicons-edit'
-	);
-}
-
-/**
- * Initialize the Gutenberg Edit Site Page.
- * Copy of core function from 7.3.0 - gutenberg_edit_site_init
+ * Whether or not core Site Editor is active.
  *
- * Currently overriding to change hook requirement to allow Site Editor at top level sidebar.
- * And to enqueue dotcom block editor assets before other scripts.
- *
- * Any changes will be prefixed with @DOTCOM_CUSTOMIZATION comment.
- *
- * @param string $hook Page.
+ * @returns bool True if Site Editor is active, false otherwise.
  */
-function fse_plugin_edit_site_init( $hook ) {
-	global $_wp_current_template_id;
-	// @DOTCOM_CUSTOMIZATION - rename hook to allow toplevel
-	if ( 'toplevel_page_gutenberg-edit-site' !== $hook ) {
-		return;
+function is_site_editor_active() {
+	/**
+	 * There are times when this function is called from the WordPress.com public
+	 * API context. In this case, we need to switch to the correct blog so that
+	 * the functions reference the correct blog context.
+	 */
+	$multisite_id  = apply_filters( 'a8c_fse_get_multisite_id', false );
+	$should_switch = is_multisite() && $multisite_id;
+	if ( $should_switch ) {
+		switch_to_blog( $multisite_id );
 	}
 
-	// Get editor settings.
-	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
+	// @TODO - refactor this to filter activation similar to dotcom FSE.
+	$is_active = has_blog_sticker( 'core_site_editor_enabled' );
+
+	if ( ! $is_active ) {
+		// Check if experiment is enabled: disable if needed.
+		if ( gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+			set_site_editor_experiment( '0' );
+		}
+		return $is_active;
 	}
 
-	// This filter is documented in wp-admin/includes/media.php.
-	$image_size_names      = apply_filters(
-		'image_size_names_choose',
-		array(
-			'thumbnail' => __( 'Thumbnail', 'gutenberg' ),
-			'medium'    => __( 'Medium', 'gutenberg' ),
-			'large'     => __( 'Large', 'gutenberg' ),
-			'full'      => __( 'Full Size', 'gutenberg' ),
-		)
-	);
-	$available_image_sizes = array();
-	foreach ( $image_size_names as $image_size_slug => $image_size_name ) {
-		$available_image_sizes[] = array(
-			'slug' => $image_size_slug,
-			'name' => $image_size_name,
-		);
+	// Check if experiment is disabled: enable if needed.
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-full-site-editing' ) ) {
+		set_site_editor_experiment( '1' );
 	}
 
-	$settings = array(
-		'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
-		'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
-		'imageSizes'             => $available_image_sizes,
-		'isRTL'                  => is_rtl(),
-		'maxUploadFileSize'      => $max_upload_size,
-	);
-
-	list( $color_palette, ) = (array) get_theme_support( 'editor-color-palette' );
-	list( $font_sizes, )    = (array) get_theme_support( 'editor-font-sizes' );
-	if ( false !== $color_palette ) {
-		$settings['colors'] = $color_palette;
-	}
-	if ( false !== $font_sizes ) {
-		$settings['fontSizes'] = $font_sizes;
+	if ( $should_switch ) {
+		restore_current_blog();
 	}
 
-	// Get root template by trigerring `./template-loader.php`'s logic.
-	get_front_page_template();
-	get_index_template();
-	apply_filters( 'template_include', null );
-	$settings['templateId'] = $_wp_current_template_id;
-
-	// Initialize editor.
-	wp_add_inline_script(
-		'wp-edit-site',
-		sprintf(
-			'wp.domReady( function() {
-				wp.editSite.initialize( "edit-site-editor", %s );
-			} );',
-			wp_json_encode( gutenberg_experiments_editor_settings( $settings ) )
-		)
-	);
-
-	// Preload server-registered block schemas.
-	wp_add_inline_script(
-		'wp-blocks',
-		'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
-	);
-
-	// @DOTCOM_CUSTOMIZATION - trigger enqueue_block_editor_assets to properly set apiFetch for dotcom etc.
-	do_action( 'enqueue_block_editor_assets' );
-
-	wp_enqueue_script( 'wp-edit-site' );
-	wp_enqueue_script( 'wp-format-library' );
-	wp_enqueue_style( 'wp-edit-site' );
-	wp_enqueue_style( 'wp-format-library' );
-}
-
-/**
- * Override core's site editor init function with our own.
- */
-function override_site_editor_init() {
-	remove_action( 'admin_enqueue_scripts', 'gutenberg_edit_site_init' );
-	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\fse_plugin_edit_site_init' );
+	return $is_active;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor-experiment/index.php
@@ -67,7 +67,7 @@ function add_site_editor_plugin_page() {
  * Copy of core function from 7.3.0 - gutenberg_edit_site_init
  *
  * Currently overriding to change hook requirement to allow Site Editor at top level sidebar.
- * And to troubleshoot the wp.editSite.initialize CORS error.
+ * And to enqueue dotcom block editor assets before other scripts.
  *
  * Any changes will be prefixed with @DOTCOM_CUSTOMIZATION comment.
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds the 'Site Editor' experiment as an option on wp-admin given a specific blog sticker is found.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Sync this PR to sandbox.
*  Visit wp-admin, ensure 'Site Editor' menu is NOT available.
*  Apply blog sticker `core_site_editor_enabled` OR comment out the check access conditional/return statement in the added function and re-sync.
*  Reload wp-admin, verify 'Site Editor' menu is now available.
*  Click to load the Site Editor.

Fixes #39705
