### PR TITLE
Plans: Defer page view until we get the purchase object

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -82,8 +82,14 @@ class Plans extends React.Component {
 
 		const partnerName = getPartnerName( purchase );
 
+		const eventProps = {
+			partner_managed: true,
+			partner_slug: purchase.partnerSlug ?? '',
+		};
+
 		return (
 			<div>
+				<TrackComponentView eventName="calypso_plans_view" eventProperties={ eventProps } />
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<Main wideLayout={ true }>
 					<SidebarNavigation />
@@ -134,7 +140,8 @@ class Plans extends React.Component {
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<PageViewTracker path="/plans/:site" title="Plans" />
 				<QueryContactDetailsCache />
-				<TrackComponentView eventName="calypso_plans_view" />
+				{ /* We intentionally delay the track event below so that we know whether this is a partner purchase. */ }
+				{ purchase && <TrackComponentView eventName="calypso_plans_view" /> }
 				<Main wideLayout={ true }>
 					<SidebarNavigation />
 					{ ! canAccessPlans && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add props to the `calypso_plans_view` when we display the "Your plan is managed by $x" message.
* To support ^, defer the `calypso_plans_view` event that occurs in the render method until we have the `purchase` object and are able to decide whether the purchase is managed by a hosting partner.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/plans/$site where $site is a domain that does not have a partner plan
* In the console, run`localStorage.setItem( 'debug', 'calypso:analytics:TrackComponentView' );`
* Refresh the page
* Ensure that the `calypso_plans_view` tracks event fires
* Switch to a site that has a partner managed plan and ensure that the `calypso_plans_view` tracks event fires
* Wait for the tracks events to come through and ensure that the second view had `partner_managed` and `partner_slug` props attached.
