### PR TITLE
[E2E]: update Gutenboarding onboarding block selector

### DIFF
--- a/test/e2e/lib/pages/gutenboarding-page.js
+++ b/test/e2e/lib/pages/gutenboarding-page.js
@@ -26,7 +26,7 @@ export default class GutenboardingPage extends AsyncBaseContainer {
 	async waitForBlock() {
 		return driverHelper.isEventuallyPresentAndDisplayed(
 			this.driver,
-			by.css( '.gutenboarding-block-list' )
+			by.css( '[data-type="automattic/onboarding"]' )
 		);
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

In #39336 the onboarding block was refactored, [removing the classname](https://github.com/Automattic/wp-calypso/commit/7e0f65ad3730c07c456c4974d3603b6ebc3e340b#diff-1762b786f4f0e0659667b586a2158493L35)`'.gutenboarding-block-list'`.

Consequently, the onboarding block no longer has a classname attached to the enveloping HTML element.

<img width="951" alt="Screen Shot 2020-02-27 at 12 11 26 pm" src="https://user-images.githubusercontent.com/6458278/75403660-6d124a80-595c-11ea-97c4-e844b3cacc5b.png">

😱 

This patch replaces the classname selector and looks instead for the [name with which the block type is registered](https://github.com/Automattic/wp-calypso/blob/master/client/landing/gutenboarding/gutenboard.tsx#L26), namely `"automattic/onboarding"`.

## Testing instructions

Run the E2E tests and bathe in the calming greeness.
