### PR TITLE
Add cylon as codeowners and fail script if curl fails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -131,6 +131,10 @@
 /apps/full-site-editing/full-site-editing-plugin/starter-page-templates @Automattic/ajax
 /apps/full-site-editing/full-site-editing-plugin/global-styles @Automattic/cylon @nosolosw
 
+# FSE Workflow Files
+/.github/workflows/full-site-editing-plugin.yml @Automattic/cylon
+/.github/workflows/send-calypso-app-build-trigger.sh @Automattic/cylon
+
 # WPcom Block Editor
 /apps/wpcom-block-editor @Automattic/cylon @Automattic/ajax
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Cylon is now codeowner of the FSE workflow files
* Fail the workflow if we receive a non-200 response from the MC API.

#### Testing instructions
* Should get comment with differential revision (✅) (i've now removed the test files that caused a revision to be created)
