### PR TITLE
Modularise themes actions

### DIFF
--- a/client/state/themes/actions/accept-auto-loading-homepage-warning.js
+++ b/client/state/themes/actions/accept-auto-loading-homepage-warning.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING } from 'state/action-types';
+
+import 'state/themes/init';
+
+export function acceptAutoLoadingHomepageWarning( themeId ) {
+	return {
+		type: THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
+		themeId,
+	};
+}

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import { THEME_ACTIVATE, THEME_ACTIVATE_FAILURE } from 'state/action-types';
+import { themeActivated } from 'state/themes/actions/theme-activated';
+
+import 'state/themes/init';
+
+/**
+ * Triggers a network request to activate a specific theme on a given site.
+ *
+ * @param  {string}   themeId   Theme ID
+ * @param  {number}   siteId    Site ID
+ * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
+ * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @returns {Function}           Action thunk
+ */
+export function activateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
+	return dispatch => {
+		dispatch( {
+			type: THEME_ACTIVATE,
+			themeId,
+			siteId,
+		} );
+
+		return wpcom
+			.undocumented()
+			.activateTheme( themeId, siteId )
+			.then( theme => {
+				// Fall back to ID for Jetpack sites which don't return a stylesheet attr.
+				const themeStylesheet = theme.stylesheet || themeId;
+				dispatch( themeActivated( themeStylesheet, siteId, source, purchased ) );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: THEME_ACTIVATE_FAILURE,
+					themeId,
+					siteId,
+					error,
+				} );
+			} );
+	};
+}

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+import { isJetpackSite } from 'state/sites/selectors';
+import { activateTheme } from 'state/themes/actions/activate-theme';
+import { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
+import { showAutoLoadingHomepageWarning } from 'state/themes/actions/show-auto-loading-homepage-warning';
+import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
+import {
+	getTheme,
+	hasAutoLoadingHomepageModalAccepted,
+	themeHasAutoLoadingHomepage,
+} from 'state/themes/selectors';
+
+import 'state/themes/init';
+
+/**
+ * Triggers a network request to activate a specific theme on a given site.
+ * If it's a Jetpack site, installs the theme prior to activation if it isn't already.
+ *
+ * @param  {string}   themeId   Theme ID
+ * @param  {number}   siteId    Site ID
+ * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
+ * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @returns {Function}          Action thunk
+ */
+export function activate( themeId, siteId, source = 'unknown', purchased = false ) {
+	return ( dispatch, getState ) => {
+		/**
+		 * Let's check if the theme will change the homepage of the site,
+		 * before to definitely start the theme-activating process,
+		 * allowing cancel it if it's desired.
+		 */
+		if (
+			themeHasAutoLoadingHomepage( getState(), themeId ) &&
+			! hasAutoLoadingHomepageModalAccepted( getState(), themeId )
+		) {
+			return dispatch( showAutoLoadingHomepageWarning( themeId ) );
+		}
+
+		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
+			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );
+			// If theme is already installed, installation will silently fail,
+			// and it will just be activated.
+			return dispatch( installAndActivateTheme( installId, siteId, source, purchased ) );
+		}
+
+		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
+	};
+}

--- a/client/state/themes/actions/clear-activated.js
+++ b/client/state/themes/actions/clear-activated.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_CLEAR_ACTIVATED } from 'state/action-types';
+
+import 'state/themes/init';
+
+/**
+ * Returns an action object to be used in signalling that theme activated status
+ * for site should be cleared
+ *
+ * @param  {number}   siteId    Site ID
+ * @returns {object}        Action object
+ */
+export function clearActivated( siteId ) {
+	return {
+		type: THEME_CLEAR_ACTIVATED,
+		siteId,
+	};
+}

--- a/client/state/themes/actions/clear-theme-upload.js
+++ b/client/state/themes/actions/clear-theme-upload.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_UPLOAD_CLEAR } from 'state/action-types';
+
+import 'state/themes/init';
+
+/**
+ * Clears any state remaining from a previous
+ * theme upload to the given site.
+ *
+ * @param {number} siteId -- site to clear state for
+ *
+ * @returns {object} the action object to dispatch
+ */
+export function clearThemeUpload( siteId ) {
+	return {
+		type: THEME_UPLOAD_CLEAR,
+		siteId,
+	};
+}

--- a/client/state/themes/actions/confirm-delete.js
+++ b/client/state/themes/actions/confirm-delete.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import accept from 'lib/accept';
+import { getSiteTitle } from 'state/sites/selectors';
+import { deleteTheme } from 'state/themes/actions/delete-theme';
+import { getTheme } from 'state/themes/selectors';
+
+import 'state/themes/init';
+
+/**
+ * Shows dialog asking user to confirm delete of theme
+ * from jetpack site. Deletes theme if user confirms.
+ *
+ * @param {string} themeId -- Theme to delete
+ * @param {number} siteId -- Site to delete theme from
+ *
+ * @returns {Function} Action thunk
+ */
+export function confirmDelete( themeId, siteId ) {
+	return ( dispatch, getState ) => {
+		const { name: themeName } = getTheme( getState(), siteId, themeId );
+		const siteTitle = getSiteTitle( getState(), siteId );
+		accept(
+			i18n.translate( 'Are you sure you want to delete %(themeName)s from %(siteTitle)s?', {
+				args: { themeName, siteTitle },
+				comment: 'Themes: theme delete confirmation dialog',
+			} ),
+			accepted => {
+				accepted && dispatch( deleteTheme( themeId, siteId ) );
+			},
+			i18n.translate( 'Delete %(themeName)s', {
+				args: { themeName },
+				comment: 'Themes: theme delete dialog confirm button',
+			} ),
+			i18n.translate( 'Back', { context: 'go back (like the back button in a browser)' } )
+		);
+	};
+}

--- a/client/state/themes/actions/delete-theme.js
+++ b/client/state/themes/actions/delete-theme.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import { THEME_DELETE_FAILURE, THEME_DELETE_SUCCESS, THEME_DELETE } from 'state/action-types';
+
+import 'state/themes/init';
+
+/**
+ * Deletes a theme from the given Jetpack site.
+ *
+ * @param {string} themeId -- Theme to delete
+ * @param {number} siteId -- Site to delete theme from
+ *
+ * @returns {Function} Action thunk
+ */
+export function deleteTheme( themeId, siteId ) {
+	return dispatch => {
+		dispatch( {
+			type: THEME_DELETE,
+			themeId,
+			siteId,
+		} );
+		return wpcom
+			.undocumented()
+			.deleteThemeFromJetpack( siteId, themeId )
+			.then( theme => {
+				dispatch( {
+					type: THEME_DELETE_SUCCESS,
+					themeId,
+					siteId,
+					themeName: theme.name,
+				} );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: THEME_DELETE_FAILURE,
+					themeId,
+					siteId,
+					error,
+				} );
+			} );
+	};
+}

--- a/client/state/themes/actions/hide-auto-loading-homepage-warning.js
+++ b/client/state/themes/actions/hide-auto-loading-homepage-warning.js
@@ -1,0 +1,12 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_HIDE_AUTO_LOADING_HOMEPAGE_WARNING } from 'state/action-types';
+
+import 'state/themes/init';
+
+export function hideAutoLoadingHomepageWarning() {
+	return {
+		type: THEME_HIDE_AUTO_LOADING_HOMEPAGE_WARNING,
+	};
+}

--- a/client/state/themes/actions/hide-theme-preview.js
+++ b/client/state/themes/actions/hide-theme-preview.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_PREVIEW_STATE } from 'state/action-types';
+
+import 'state/themes/init';
+
+export function hideThemePreview() {
+	return {
+		type: THEME_PREVIEW_STATE,
+		themeId: null,
+	};
+}

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -25,21 +25,10 @@ import {
 	THEME_PREVIEW_STATE,
 } from 'state/action-types';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
-import {
-	getTheme,
-	themeHasAutoLoadingHomepage,
-	hasAutoLoadingHomepageModalAccepted,
-} from 'state/themes/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 
 import 'state/data-layer/wpcom/theme-filters';
 
 import 'state/themes/init';
-
-import { activateTheme } from 'state/themes/actions/activate-theme';
-import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
-import { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
-import { showAutoLoadingHomepageWarning } from 'state/themes/actions/show-auto-loading-homepage-warning';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -61,41 +50,7 @@ export { clearThemeUpload } from 'state/themes/actions/clear-theme-upload';
 export { deleteTheme } from 'state/themes/actions/delete-theme';
 export { confirmDelete } from 'state/themes/actions/confirm-delete';
 export { showAutoLoadingHomepageWarning } from 'state/themes/actions/show-auto-loading-homepage-warning';
-
-/**
- * Triggers a network request to activate a specific theme on a given site.
- * If it's a Jetpack site, installs the theme prior to activation if it isn't already.
- *
- * @param  {string}   themeId   Theme ID
- * @param  {number}   siteId    Site ID
- * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
- * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
- * @returns {Function}          Action thunk
- */
-export function activate( themeId, siteId, source = 'unknown', purchased = false ) {
-	return ( dispatch, getState ) => {
-		/**
-		 * Let's check if the theme will change the homepage of the site,
-		 * before to definitely start the theme-activating process,
-		 * allowing cancel it if it's desired.
-		 */
-		if (
-			themeHasAutoLoadingHomepage( getState(), themeId ) &&
-			! hasAutoLoadingHomepageModalAccepted( getState(), themeId )
-		) {
-			return dispatch( showAutoLoadingHomepageWarning( themeId ) );
-		}
-
-		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
-			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );
-			// If theme is already installed, installation will silently fail,
-			// and it will just be activated.
-			return dispatch( installAndActivateTheme( installId, siteId, source, purchased ) );
-		}
-
-		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
-	};
-}
+export { activate } from 'state/themes/actions/activate';
 
 /**
  * Start an Automated Transfer with an uploaded theme.

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { filter, map, property, delay, endsWith } from 'lodash';
+import { map, property, delay, endsWith } from 'lodash';
 import debugFactory from 'debug';
 import page from 'page';
 
@@ -51,7 +51,6 @@ import {
 	THEME_UPLOAD_CLEAR,
 	THEME_UPLOAD_PROGRESS,
 	THEMES_REQUEST,
-	THEMES_REQUEST_SUCCESS,
 	THEMES_REQUEST_FAILURE,
 	THEME_PREVIEW_OPTIONS,
 	THEME_PREVIEW_STATE,
@@ -63,7 +62,6 @@ import {
 	getLastThemeQuery,
 	getThemeCustomizeUrl,
 	getWpcomParentThemeId,
-	shouldFilterWpcomThemes,
 	isDownloadableFromWpcom,
 	themeHasAutoLoadingHomepage,
 	hasAutoLoadingHomepageModalAccepted,
@@ -71,8 +69,6 @@ import {
 } from 'state/themes/selectors';
 import {
 	getThemeIdFromStylesheet,
-	isThemeMatchingQuery,
-	isThemeFromWpcom,
 	normalizeJetpackTheme,
 	normalizeWpcomTheme,
 	normalizeWporgTheme,
@@ -87,7 +83,10 @@ import 'state/data-layer/wpcom/theme-filters';
 
 import 'state/themes/init';
 
+import { receiveThemes } from 'state/themes/actions/receive-themes';
+
 export { setBackPath } from 'state/themes/actions/set-back-path';
+export { receiveThemes } from 'state/themes/actions/receive-themes';
 
 const debug = debugFactory( 'calypso:themes:actions' );
 
@@ -101,47 +100,6 @@ const debug = debugFactory( 'calypso:themes:actions' );
  */
 export function receiveTheme( theme, siteId ) {
 	return receiveThemes( [ theme ], siteId );
-}
-
-/**
- * Returns an action object to be used in signalling that theme objects from
- * a query have been received.
- *
- * @param {Array}  themes Themes received
- * @param {number} siteId ID of site for which themes have been received
- * @param {?object} query Theme query used in the API request
- * @param {?number} foundCount Number of themes returned by the query
- * @returns {object} Action object
- */
-export function receiveThemes( themes, siteId, query, foundCount ) {
-	return ( dispatch, getState ) => {
-		let filteredThemes = themes;
-		let found = foundCount;
-
-		if ( isJetpackSite( getState(), siteId ) ) {
-			/*
-			 * We need to do client-side filtering for Jetpack sites because:
-			 * 1) Jetpack theme API does not support search queries
-			 * 2) We need to filter out all wpcom themes to show an 'Uploaded' list
-			 */
-			const filterWpcom = shouldFilterWpcomThemes( getState(), siteId );
-			filteredThemes = filter(
-				themes,
-				theme =>
-					isThemeMatchingQuery( query, theme ) && ! ( filterWpcom && isThemeFromWpcom( theme ) )
-			);
-			// Jetpack API returns all themes in one response (no paging)
-			found = filteredThemes.length;
-		}
-
-		dispatch( {
-			type: THEMES_REQUEST_SUCCESS,
-			themes: filteredThemes,
-			siteId,
-			query,
-			found,
-		} );
-	};
 }
 
 /**

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -1,17 +1,3 @@
-/**
- * Internal dependencies
- */
-import wpcom from 'lib/wp';
-import {
-	RECOMMENDED_THEMES_FAIL,
-	RECOMMENDED_THEMES_FETCH,
-	RECOMMENDED_THEMES_SUCCESS,
-} from 'state/action-types';
-
-import 'state/data-layer/wpcom/theme-filters';
-
-import 'state/themes/init';
-
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
 export { receiveTheme } from 'state/themes/actions/receive-theme';
@@ -43,40 +29,7 @@ export { hideAutoLoadingHomepageWarning } from 'state/themes/actions/hide-auto-l
 export { acceptAutoLoadingHomepageWarning } from 'state/themes/actions/accept-auto-loading-homepage-warning';
 export { hideThemePreview } from 'state/themes/actions/hide-theme-preview';
 export { requestThemeFilters } from 'state/themes/actions/request-theme-filters';
-
-/**
- * Receives themes and dispatches them with recommended themes success signal.
- *
- * @param {Array} themes array of received theme objects
- * @returns {Function} Action thunk
- */
-export function receiveRecommendedThemes( themes ) {
-	return dispatch => {
-		dispatch( { type: RECOMMENDED_THEMES_SUCCESS, payload: themes } );
-	};
-}
-
-/**
- * Initiates network request for recommended themes.
- * Recommended themes are template first themes and are denoted by the 'auto-loading-homepage' tag.
- *
- * @returns {Function} Action thunk
- */
-export function getRecommendedThemes() {
-	return async dispatch => {
-		dispatch( { type: RECOMMENDED_THEMES_FETCH } );
-		const query = {
-			search: '',
-			number: 50,
-			tier: '',
-			filter: 'auto-loading-homepage',
-			apiVersion: '1.2',
-		};
-		try {
-			const res = await wpcom.undocumented().themes( null, query );
-			dispatch( receiveRecommendedThemes( res ) );
-		} catch ( error ) {
-			dispatch( { type: RECOMMENDED_THEMES_FAIL } );
-		}
-	};
-}
+export {
+	getRecommendedThemes,
+	receiveRecommendedThemes,
+} from 'state/themes/actions/recommended-themes';

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -9,7 +9,6 @@ import {
 	THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_FILTERS_REQUEST,
 	THEME_HIDE_AUTO_LOADING_HOMEPAGE_WARNING,
-	THEME_PREVIEW_OPTIONS,
 	THEME_PREVIEW_STATE,
 } from 'state/action-types';
 
@@ -42,14 +41,7 @@ export {
 	initiateThemeTransfer,
 	pollThemeTransferStatus,
 } from 'state/themes/actions/theme-transfer';
-
-export function setThemePreviewOptions( primary, secondary ) {
-	return {
-		type: THEME_PREVIEW_OPTIONS,
-		primary,
-		secondary,
-	};
-}
+export { setThemePreviewOptions } from 'state/themes/actions/set-theme-preview-options';
 
 export function showThemePreview( themeId ) {
 	return {

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -42,13 +42,7 @@ export {
 	pollThemeTransferStatus,
 } from 'state/themes/actions/theme-transfer';
 export { setThemePreviewOptions } from 'state/themes/actions/set-theme-preview-options';
-
-export function showThemePreview( themeId ) {
-	return {
-		type: THEME_PREVIEW_STATE,
-		themeId,
-	};
-}
+export { showThemePreview } from 'state/themes/actions/show-theme-preview';
 
 export function hideAutoLoadingHomepageWarning() {
 	return {

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -80,22 +80,15 @@ import 'state/themes/init';
 
 import { receiveThemes } from 'state/themes/actions/receive-themes';
 import { receiveTheme } from 'state/themes/actions/receive-theme';
+import { themeRequestFailure } from 'state/themes/actions/theme-request-failure';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
 export { receiveTheme } from 'state/themes/actions/receive-theme';
 export { requestThemes } from 'state/themes/actions/request-themes';
+export { themeRequestFailure } from 'state/themes/actions/theme-request-failure';
 
 const debug = debugFactory( 'calypso:themes:actions' );
-
-export function themeRequestFailure( siteId, themeId, error ) {
-	return {
-		type: THEME_REQUEST_FAILURE,
-		siteId,
-		themeId,
-		error,
-	};
-}
 
 /**
  * Triggers a network request to fetch a specific theme from a site.

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -13,9 +13,6 @@ import {
 	RECOMMENDED_THEMES_FETCH,
 	RECOMMENDED_THEMES_SUCCESS,
 	THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
-	THEME_DELETE,
-	THEME_DELETE_SUCCESS,
-	THEME_DELETE_FAILURE,
 	THEME_FILTERS_REQUEST,
 	THEME_HIDE_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_SHOW_AUTO_LOADING_HOMEPAGE_WARNING,
@@ -45,6 +42,7 @@ import 'state/themes/init';
 import { activateTheme } from 'state/themes/actions/activate-theme';
 import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
 import { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
+import { deleteTheme } from 'state/themes/actions/delete-theme';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -63,6 +61,7 @@ export { tryAndCustomize } from 'state/themes/actions/try-and-customize';
 export { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
 export { uploadTheme } from 'state/themes/actions/upload-theme';
 export { clearThemeUpload } from 'state/themes/actions/clear-theme-upload';
+export { deleteTheme } from 'state/themes/actions/delete-theme';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -254,43 +253,6 @@ export function pollThemeTransferStatus(
 				} );
 		};
 		return new Promise( pollStatus );
-	};
-}
-
-/**
- * Deletes a theme from the given Jetpack site.
- *
- * @param {string} themeId -- Theme to delete
- * @param {number} siteId -- Site to delete theme from
- *
- * @returns {Function} Action thunk
- */
-export function deleteTheme( themeId, siteId ) {
-	return dispatch => {
-		dispatch( {
-			type: THEME_DELETE,
-			themeId,
-			siteId,
-		} );
-		return wpcom
-			.undocumented()
-			.deleteThemeFromJetpack( siteId, themeId )
-			.then( theme => {
-				dispatch( {
-					type: THEME_DELETE_SUCCESS,
-					themeId,
-					siteId,
-					themeName: theme.name,
-				} );
-			} )
-			.catch( error => {
-				dispatch( {
-					type: THEME_DELETE_FAILURE,
-					themeId,
-					siteId,
-					error,
-				} );
-			} );
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { map, property, delay, endsWith } from 'lodash';
+import { map, delay, endsWith } from 'lodash';
 import debugFactory from 'debug';
 import page from 'page';
 
@@ -11,10 +11,7 @@ import page from 'page';
  */
 import { isExternal } from 'lib/url';
 import wpcom from 'lib/wp';
-import {
-	fetchThemesList as fetchWporgThemesList,
-	fetchThemeInformation as fetchWporgThemeInformation,
-} from 'lib/wporg';
+import { fetchThemeInformation as fetchWporgThemeInformation } from 'lib/wporg';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -50,8 +47,6 @@ import {
 	THEME_UPLOAD_FAILURE,
 	THEME_UPLOAD_CLEAR,
 	THEME_UPLOAD_PROGRESS,
-	THEMES_REQUEST,
-	THEMES_REQUEST_FAILURE,
 	THEME_PREVIEW_OPTIONS,
 	THEME_PREVIEW_STATE,
 } from 'state/action-types';
@@ -89,84 +84,9 @@ import { receiveTheme } from 'state/themes/actions/receive-theme';
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
 export { receiveTheme } from 'state/themes/actions/receive-theme';
+export { requestThemes } from 'state/themes/actions/request-themes';
 
 const debug = debugFactory( 'calypso:themes:actions' );
-
-/**
- * Triggers a network request to fetch themes for the specified site and query.
- *
- * @param  {number|string} siteId        Jetpack site ID or 'wpcom' for any WPCOM site
- * @param  {object}        query         Theme query
- * @param  {string}        query.search  Search string
- * @param  {string}        query.tier    Theme tier: 'free', 'premium', or '' (either)
- * @param  {string}        query.filter  Filter
- * @param  {number}        query.number  How many themes to return per page
- * @param  {number}        query.offset  At which item to start the set of returned themes
- * @param  {number}        query.page    Which page of matching themes to return
- * @returns {Function}                    Action thunk
- */
-export function requestThemes( siteId, query = {} ) {
-	return ( dispatch, getState ) => {
-		const startTime = new Date().getTime();
-
-		dispatch( {
-			type: THEMES_REQUEST,
-			siteId,
-			query,
-		} );
-
-		let request;
-
-		if ( siteId === 'wporg' ) {
-			request = () => fetchWporgThemesList( query );
-		} else if ( siteId === 'wpcom' ) {
-			request = () => wpcom.undocumented().themes( null, { ...query, apiVersion: '1.2' } );
-		} else {
-			request = () => wpcom.undocumented().themes( siteId, { ...query, apiVersion: '1' } );
-		}
-
-		// WP.com returns the number of results in a `found` attr, so we can use that right away.
-		// WP.org returns an `info` object containing a `results` number, so we destructure that
-		// and use it as default value for `found`.
-		return request()
-			.then( ( { themes: rawThemes, info: { results } = {}, found = results } ) => {
-				let themes;
-				if ( siteId === 'wporg' ) {
-					themes = map( rawThemes, normalizeWporgTheme );
-				} else if ( siteId === 'wpcom' ) {
-					themes = map( rawThemes, normalizeWpcomTheme );
-				} else {
-					// Jetpack Site
-					themes = map( rawThemes, normalizeJetpackTheme );
-				}
-
-				if ( ( query.search || query.filter ) && query.page === 1 ) {
-					const responseTime = new Date().getTime() - startTime;
-					const search_taxonomies = prependThemeFilterKeys( getState(), query.filter );
-					const search_term = search_taxonomies + ( query.search || '' );
-					const trackShowcaseSearch = recordTracksEvent( 'calypso_themeshowcase_search', {
-						search_term: search_term || null,
-						search_taxonomies,
-						tier: query.tier,
-						response_time_in_ms: responseTime,
-						result_count: found,
-						results_first_page: themes.map( property( 'id' ) ).join(),
-					} );
-					dispatch( trackShowcaseSearch );
-				}
-
-				dispatch( receiveThemes( themes, siteId, query, found ) );
-			} )
-			.catch( error => {
-				dispatch( {
-					type: THEMES_REQUEST_FAILURE,
-					siteId,
-					query,
-					error,
-				} );
-			} );
-	};
-}
 
 export function themeRequestFailure( siteId, themeId, error ) {
 	return {

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -15,7 +15,6 @@ import {
 	RECOMMENDED_THEMES_FETCH,
 	RECOMMENDED_THEMES_SUCCESS,
 	THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
-	THEME_CLEAR_ACTIVATED,
 	THEME_DELETE,
 	THEME_DELETE_SUCCESS,
 	THEME_DELETE_FAILURE,
@@ -67,6 +66,7 @@ export { requestActiveTheme } from 'state/themes/actions/request-active-theme';
 export { themeActivated } from 'state/themes/actions/theme-activated';
 export { activateTheme } from 'state/themes/actions/activate-theme';
 export { installTheme } from 'state/themes/actions/install-theme';
+export { clearActivated } from 'state/themes/actions/clear-activated';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -100,20 +100,6 @@ export function activate( themeId, siteId, source = 'unknown', purchased = false
 		}
 
 		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
-	};
-}
-
-/**
- * Returns an action object to be used in signalling that theme activated status
- * for site should be cleared
- *
- * @param  {number}   siteId    Site ID
- * @returns {object}        Action object
- */
-export function clearActivated( siteId ) {
-	return {
-		type: THEME_CLEAR_ACTIVATED,
-		siteId,
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -36,12 +36,10 @@ import {
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import {
 	getTheme,
-	isDownloadableFromWpcom,
 	themeHasAutoLoadingHomepage,
 	hasAutoLoadingHomepageModalAccepted,
 } from 'state/themes/selectors';
 import { getSiteTitle, isJetpackSite } from 'state/sites/selectors';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import i18n from 'i18n-calypso';
 import accept from 'lib/accept';
 
@@ -54,6 +52,7 @@ import { activateTheme } from 'state/themes/actions/activate-theme';
 import { installTheme } from 'state/themes/actions/install-theme';
 import { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
 import { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
+import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -479,27 +478,6 @@ export function requestThemeFilters() {
 	return {
 		type: THEME_FILTERS_REQUEST,
 	};
-}
-
-/**
- * Install of any theme hosted as a zip on wpcom must
- * be suffixed with -wpcom. Themes on AT sites are not
- * installed via downloaded zip.
- *
- * @param {object} state Global state tree
- * @param {number} siteId Site ID
- * @param {string} themeId Theme ID
- * @returns {string} the theme id to use when installing the theme
- */
-function suffixThemeIdForInstall( state, siteId, themeId ) {
-	// AT sites do not use the -wpcom suffix
-	if ( isSiteAutomatedTransfer( state, siteId ) ) {
-		return themeId;
-	}
-	if ( ! isDownloadableFromWpcom( state, themeId ) ) {
-		return themeId;
-	}
-	return themeId + '-wpcom';
 }
 
 /**

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -8,7 +8,6 @@ import {
 	RECOMMENDED_THEMES_SUCCESS,
 	THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_FILTERS_REQUEST,
-	THEME_HIDE_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_PREVIEW_STATE,
 } from 'state/action-types';
 
@@ -43,12 +42,7 @@ export {
 } from 'state/themes/actions/theme-transfer';
 export { setThemePreviewOptions } from 'state/themes/actions/set-theme-preview-options';
 export { showThemePreview } from 'state/themes/actions/show-theme-preview';
-
-export function hideAutoLoadingHomepageWarning() {
-	return {
-		type: THEME_HIDE_AUTO_LOADING_HOMEPAGE_WARNING,
-	};
-}
+export { hideAutoLoadingHomepageWarning } from 'state/themes/actions/hide-auto-loading-homepage-warning';
 
 export function acceptAutoLoadingHomepageWarning( themeId ) {
 	return {

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -1,9 +1,3 @@
-/* eslint-disable jsdoc/no-undefined-types */
-/**
- * External dependencies
- */
-import { delay } from 'lodash';
-
 /**
  * Internal dependencies
  */
@@ -15,16 +9,9 @@ import {
 	THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_FILTERS_REQUEST,
 	THEME_HIDE_AUTO_LOADING_HOMEPAGE_WARNING,
-	THEME_TRANSFER_INITIATE_FAILURE,
-	THEME_TRANSFER_INITIATE_PROGRESS,
-	THEME_TRANSFER_INITIATE_REQUEST,
-	THEME_TRANSFER_INITIATE_SUCCESS,
-	THEME_TRANSFER_STATUS_FAILURE,
-	THEME_TRANSFER_STATUS_RECEIVE,
 	THEME_PREVIEW_OPTIONS,
 	THEME_PREVIEW_STATE,
 } from 'state/action-types';
-import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
 import 'state/data-layer/wpcom/theme-filters';
 
@@ -51,164 +38,10 @@ export { deleteTheme } from 'state/themes/actions/delete-theme';
 export { confirmDelete } from 'state/themes/actions/confirm-delete';
 export { showAutoLoadingHomepageWarning } from 'state/themes/actions/show-auto-loading-homepage-warning';
 export { activate } from 'state/themes/actions/activate';
-
-/**
- * Start an Automated Transfer with an uploaded theme.
- *
- * @param {number} siteId -- the site to transfer
- * @param {File} file -- theme zip to upload
- * @param {string} plugin -- plugin slug
- *
- * @returns {Promise} for testing purposes only
- */
-export function initiateThemeTransfer( siteId, file, plugin ) {
-	let context = plugin ? 'plugins' : 'themes';
-	if ( ! plugin && ! file ) {
-		context = 'hosting';
-	}
-
-	return dispatch => {
-		const themeInitiateRequest = {
-			type: THEME_TRANSFER_INITIATE_REQUEST,
-			siteId,
-		};
-
-		dispatch(
-			withAnalytics(
-				recordTracksEvent( 'calypso_automated_transfer_initiate_transfer', { plugin, context } ),
-				themeInitiateRequest
-			)
-		);
-		return wpcom
-			.undocumented()
-			.initiateTransfer( siteId, plugin, file, event => {
-				dispatch( {
-					type: THEME_TRANSFER_INITIATE_PROGRESS,
-					siteId,
-					loaded: event.loaded,
-					total: event.total,
-				} );
-			} )
-			.then( ( { transfer_id } ) => {
-				if ( ! transfer_id ) {
-					return dispatch(
-						transferInitiateFailure( siteId, { error: 'initiate_failure' }, plugin, context )
-					);
-				}
-				const themeInitiateSuccessAction = {
-					type: THEME_TRANSFER_INITIATE_SUCCESS,
-					siteId,
-					transferId: transfer_id,
-				};
-				dispatch(
-					withAnalytics(
-						recordTracksEvent( 'calypso_automated_transfer_initiate_success', { plugin, context } ),
-						themeInitiateSuccessAction
-					)
-				);
-				dispatch( pollThemeTransferStatus( siteId, transfer_id, context ) );
-			} )
-			.catch( error => {
-				dispatch( transferInitiateFailure( siteId, error, plugin, context ) );
-			} );
-	};
-}
-
-// receive a transfer status
-function transferStatus( siteId, transferId, status, message, themeId ) {
-	return {
-		type: THEME_TRANSFER_STATUS_RECEIVE,
-		siteId,
-		transferId,
-		status,
-		message,
-		themeId,
-	};
-}
-
-// receive a transfer status error
-function transferStatusFailure( siteId, transferId, error ) {
-	return {
-		type: THEME_TRANSFER_STATUS_FAILURE,
-		siteId,
-		transferId,
-		error,
-	};
-}
-
-// receive a transfer initiation failure
-function transferInitiateFailure( siteId, error, plugin, context ) {
-	return dispatch => {
-		const themeInitiateFailureAction = {
-			type: THEME_TRANSFER_INITIATE_FAILURE,
-			siteId,
-			error,
-		};
-		dispatch(
-			withAnalytics(
-				recordTracksEvent( 'calypso_automated_transfer_initiate_failure', { plugin, context } ),
-				themeInitiateFailureAction
-			)
-		);
-	};
-}
-/**
- * Make API calls to the transfer status endpoint until a status complete is received,
- * or an error is received, or the timeout is reached.
- *
- * The returned promise is only for testing purposes, and therefore is never rejected,
- * to avoid unhandled rejections in production.
- *
- * @param {number} siteId -- the site being transferred
- * @param {number} transferId -- the specific transfer
- * @param {string} context -- from which the transfer was initiated
- * @param {number} [interval] -- time between poll attempts
- * @param {number} [timeout] -- time to wait for 'complete' status before bailing
- *
- * @returns {Promise} for testing purposes only
- */
-export function pollThemeTransferStatus(
-	siteId,
-	transferId,
-	context,
-	interval = 3000,
-	timeout = 180000
-) {
-	const endTime = Date.now() + timeout;
-	return dispatch => {
-		const pollStatus = ( resolve, reject ) => {
-			if ( Date.now() > endTime ) {
-				// timed-out, stop polling
-				dispatch( transferStatusFailure( siteId, transferId, 'client timeout' ) );
-				return resolve();
-			}
-			return wpcom
-				.undocumented()
-				.transferStatus( siteId, transferId )
-				.then( ( { status, message, uploaded_theme_slug } ) => {
-					dispatch( transferStatus( siteId, transferId, status, message, uploaded_theme_slug ) );
-					if ( status === 'complete' ) {
-						// finished, stop polling
-						dispatch(
-							recordTracksEvent( 'calypso_automated_transfer_complete', {
-								transfer_id: transferId,
-								context,
-							} )
-						);
-						return resolve();
-					}
-					// poll again
-					return delay( pollStatus, interval, resolve, reject );
-				} )
-				.catch( error => {
-					dispatch( transferStatusFailure( siteId, transferId, error ) );
-					// error, stop polling
-					return resolve();
-				} );
-		};
-		return new Promise( pollStatus );
-	};
-}
+export {
+	initiateThemeTransfer,
+	pollThemeTransferStatus,
+} from 'state/themes/actions/theme-transfer';
 
 export function setThemePreviewOptions( primary, secondary ) {
 	return {

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -84,23 +84,13 @@ import 'state/data-layer/wpcom/theme-filters';
 import 'state/themes/init';
 
 import { receiveThemes } from 'state/themes/actions/receive-themes';
+import { receiveTheme } from 'state/themes/actions/receive-theme';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
+export { receiveTheme } from 'state/themes/actions/receive-theme';
 
 const debug = debugFactory( 'calypso:themes:actions' );
-
-/**
- * Returns an action object to be used in signalling that a theme object has
- * been received.
- *
- * @param  {object} theme  Theme received
- * @param  {number} siteId ID of site for which themes have been received
- * @returns {object}        Action object
- */
-export function receiveTheme( theme, siteId ) {
-	return receiveThemes( [ theme ], siteId );
-}
 
 /**
  * Triggers a network request to fetch themes for the specified site and query.

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { delay, endsWith } from 'lodash';
-import debugFactory from 'debug';
 import page from 'page';
 
 /**
@@ -12,9 +11,6 @@ import page from 'page';
 import { isExternal } from 'lib/url';
 import wpcom from 'lib/wp';
 import {
-	ACTIVE_THEME_REQUEST,
-	ACTIVE_THEME_REQUEST_SUCCESS,
-	ACTIVE_THEME_REQUEST_FAILURE,
 	RECOMMENDED_THEMES_FAIL,
 	RECOMMENDED_THEMES_FETCH,
 	RECOMMENDED_THEMES_SUCCESS,
@@ -77,48 +73,7 @@ export { receiveTheme } from 'state/themes/actions/receive-theme';
 export { requestThemes } from 'state/themes/actions/request-themes';
 export { themeRequestFailure } from 'state/themes/actions/theme-request-failure';
 export { requestTheme } from 'state/themes/actions/request-theme';
-
-const debug = debugFactory( 'calypso:themes:actions' );
-
-/**
- * This action queries wpcom endpoint for active theme for site.
- * If request success information about active theme is stored in Redux themes subtree.
- * In case of error, error is stored in Redux themes subtree.
- *
- * @param  {number}   siteId Site for which to check active theme
- * @returns {Function}        Redux thunk with request action
- */
-export function requestActiveTheme( siteId ) {
-	return ( dispatch, getState ) => {
-		dispatch( {
-			type: ACTIVE_THEME_REQUEST,
-			siteId,
-		} );
-
-		return wpcom
-			.undocumented()
-			.activeTheme( siteId )
-			.then( theme => {
-				debug( 'Received current theme', theme );
-				// We want to store the theme object in the appropriate Redux subtree -- either 'wpcom'
-				// for WPCOM sites, or siteId for Jetpack sites.
-				const siteIdOrWpcom = isJetpackSite( getState(), siteId ) ? siteId : 'wpcom';
-				dispatch( receiveTheme( theme, siteIdOrWpcom ) );
-				dispatch( {
-					type: ACTIVE_THEME_REQUEST_SUCCESS,
-					siteId,
-					theme,
-				} );
-			} )
-			.catch( error => {
-				dispatch( {
-					type: ACTIVE_THEME_REQUEST_FAILURE,
-					siteId,
-					error,
-				} );
-			} );
-	};
-}
+export { requestActiveTheme } from 'state/themes/actions/request-active-theme';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -3,12 +3,10 @@
  * External dependencies
  */
 import { delay } from 'lodash';
-import page from 'page';
 
 /**
  * Internal dependencies
  */
-import { isExternal } from 'lib/url';
 import wpcom from 'lib/wp';
 import {
 	RECOMMENDED_THEMES_FAIL,
@@ -38,7 +36,6 @@ import {
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import {
 	getTheme,
-	getThemeCustomizeUrl,
 	isDownloadableFromWpcom,
 	themeHasAutoLoadingHomepage,
 	hasAutoLoadingHomepageModalAccepted,
@@ -55,6 +52,7 @@ import 'state/themes/init';
 import { receiveTheme } from 'state/themes/actions/receive-theme';
 import { activateTheme } from 'state/themes/actions/activate-theme';
 import { installTheme } from 'state/themes/actions/install-theme';
+import { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -67,6 +65,7 @@ export { themeActivated } from 'state/themes/actions/theme-activated';
 export { activateTheme } from 'state/themes/actions/activate-theme';
 export { installTheme } from 'state/themes/actions/install-theme';
 export { clearActivated } from 'state/themes/actions/clear-activated';
+export { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -139,26 +138,6 @@ export function installAndTryAndCustomizeTheme( themeId, siteId ) {
 		return dispatch( installTheme( themeId, siteId ) ).then( () => {
 			dispatch( tryAndCustomizeTheme( themeId, siteId ) );
 		} );
-	};
-}
-
-/**
- * Triggers a switch to the try&customize page of theme.
- * When theme is not available dispatches FAILURE action
- * that trigers displaying error notice by notices middlewaere
- *
- * @param  {string}   themeId      WP.com Theme ID
- * @param  {string}   siteId       Jetpack Site ID
- * @returns {Function}              Action thunk
- */
-export function tryAndCustomizeTheme( themeId, siteId ) {
-	return ( dispatch, getState ) => {
-		const url = getThemeCustomizeUrl( getState(), themeId, siteId );
-		if ( isExternal( url ) ) {
-			window.location.href = url;
-			return;
-		}
-		page( getThemeCustomizeUrl( getState(), themeId, siteId ) );
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -15,7 +15,6 @@ import {
 	THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_FILTERS_REQUEST,
 	THEME_HIDE_AUTO_LOADING_HOMEPAGE_WARNING,
-	THEME_SHOW_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_TRANSFER_INITIATE_FAILURE,
 	THEME_TRANSFER_INITIATE_PROGRESS,
 	THEME_TRANSFER_INITIATE_REQUEST,
@@ -40,6 +39,7 @@ import 'state/themes/init';
 import { activateTheme } from 'state/themes/actions/activate-theme';
 import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
 import { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
+import { showAutoLoadingHomepageWarning } from 'state/themes/actions/show-auto-loading-homepage-warning';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -60,6 +60,7 @@ export { uploadTheme } from 'state/themes/actions/upload-theme';
 export { clearThemeUpload } from 'state/themes/actions/clear-theme-upload';
 export { deleteTheme } from 'state/themes/actions/delete-theme';
 export { confirmDelete } from 'state/themes/actions/confirm-delete';
+export { showAutoLoadingHomepageWarning } from 'state/themes/actions/show-auto-loading-homepage-warning';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -265,13 +266,6 @@ export function setThemePreviewOptions( primary, secondary ) {
 export function showThemePreview( themeId ) {
 	return {
 		type: THEME_PREVIEW_STATE,
-		themeId,
-	};
-}
-
-export function showAutoLoadingHomepageWarning( themeId ) {
-	return {
-		type: THEME_SHOW_AUTO_LOADING_HOMEPAGE_WARNING,
 		themeId,
 	};
 }

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -15,8 +15,6 @@ import {
 	RECOMMENDED_THEMES_FETCH,
 	RECOMMENDED_THEMES_SUCCESS,
 	THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
-	THEME_ACTIVATE,
-	THEME_ACTIVATE_FAILURE,
 	THEME_CLEAR_ACTIVATED,
 	THEME_DELETE,
 	THEME_DELETE_SUCCESS,
@@ -60,7 +58,7 @@ import 'state/data-layer/wpcom/theme-filters';
 import 'state/themes/init';
 
 import { receiveTheme } from 'state/themes/actions/receive-theme';
-import { themeActivated } from 'state/themes/actions/theme-activated';
+import { activateTheme } from 'state/themes/actions/activate-theme';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -70,6 +68,7 @@ export { themeRequestFailure } from 'state/themes/actions/theme-request-failure'
 export { requestTheme } from 'state/themes/actions/request-theme';
 export { requestActiveTheme } from 'state/themes/actions/request-active-theme';
 export { themeActivated } from 'state/themes/actions/theme-activated';
+export { activateTheme } from 'state/themes/actions/activate-theme';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -103,42 +102,6 @@ export function activate( themeId, siteId, source = 'unknown', purchased = false
 		}
 
 		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
-	};
-}
-
-/**
- * Triggers a network request to activate a specific theme on a given site.
- *
- * @param  {string}   themeId   Theme ID
- * @param  {number}   siteId    Site ID
- * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
- * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
- * @returns {Function}           Action thunk
- */
-export function activateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
-	return dispatch => {
-		dispatch( {
-			type: THEME_ACTIVATE,
-			themeId,
-			siteId,
-		} );
-
-		return wpcom
-			.undocumented()
-			.activateTheme( themeId, siteId )
-			.then( theme => {
-				// Fall back to ID for Jetpack sites which don't return a stylesheet attr.
-				const themeStylesheet = theme.stylesheet || themeId;
-				dispatch( themeActivated( themeStylesheet, siteId, source, purchased ) );
-			} )
-			.catch( error => {
-				dispatch( {
-					type: THEME_ACTIVATE_FAILURE,
-					themeId,
-					siteId,
-					error,
-				} );
-			} );
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -7,7 +7,6 @@ import {
 	RECOMMENDED_THEMES_FETCH,
 	RECOMMENDED_THEMES_SUCCESS,
 	THEME_FILTERS_REQUEST,
-	THEME_PREVIEW_STATE,
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/theme-filters';
@@ -43,13 +42,7 @@ export { setThemePreviewOptions } from 'state/themes/actions/set-theme-preview-o
 export { showThemePreview } from 'state/themes/actions/show-theme-preview';
 export { hideAutoLoadingHomepageWarning } from 'state/themes/actions/hide-auto-loading-homepage-warning';
 export { acceptAutoLoadingHomepageWarning } from 'state/themes/actions/accept-auto-loading-homepage-warning';
-
-export function hideThemePreview() {
-	return {
-		type: THEME_PREVIEW_STATE,
-		themeId: null,
-	};
-}
+export { hideThemePreview } from 'state/themes/actions/hide-theme-preview';
 
 /**
  * Triggers a network request to fetch all available theme filters.

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -26,7 +26,6 @@ import {
 	THEME_ACTIVATE,
 	THEME_ACTIVATE_SUCCESS,
 	THEME_ACTIVATE_FAILURE,
-	THEME_BACK_PATH_SET,
 	THEME_CLEAR_ACTIVATED,
 	THEME_DELETE,
 	THEME_DELETE_SUCCESS,
@@ -88,15 +87,9 @@ import 'state/data-layer/wpcom/theme-filters';
 
 import 'state/themes/init';
 
-const debug = debugFactory( 'calypso:themes:actions' );
+export { setBackPath } from 'state/themes/actions/set-back-path';
 
-// Set destination for 'back' button on theme sheet
-export function setBackPath( path ) {
-	return {
-		type: THEME_BACK_PATH_SET,
-		path,
-	};
-}
+const debug = debugFactory( 'calypso:themes:actions' );
 
 /**
  * Returns an action object to be used in signalling that a theme object has

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -53,6 +53,7 @@ import { receiveTheme } from 'state/themes/actions/receive-theme';
 import { activateTheme } from 'state/themes/actions/activate-theme';
 import { installTheme } from 'state/themes/actions/install-theme';
 import { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
+import { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -66,6 +67,7 @@ export { activateTheme } from 'state/themes/actions/activate-theme';
 export { installTheme } from 'state/themes/actions/install-theme';
 export { clearActivated } from 'state/themes/actions/clear-activated';
 export { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
+export { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -120,24 +122,6 @@ export function tryAndCustomize( themeId, siteId ) {
 		}
 
 		return dispatch( tryAndCustomizeTheme( themeId, siteId ) );
-	};
-}
-
-/**
- * Triggers a network request to install theme on Jetpack site.
- * After installataion it switches page to the customizer
- * See installTheme doc for install options.
- * Requires Jetpack 4.4
- *
- * @param  {string}   themeId      WP.com Theme ID
- * @param  {string}   siteId       Jetpack Site ID
- * @returns {Function}              Action thunk
- */
-export function installAndTryAndCustomizeTheme( themeId, siteId ) {
-	return dispatch => {
-		return dispatch( installTheme( themeId, siteId ) ).then( () => {
-			dispatch( tryAndCustomizeTheme( themeId, siteId ) );
-		} );
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -49,8 +49,8 @@ import 'state/themes/init';
 
 import { receiveTheme } from 'state/themes/actions/receive-theme';
 import { activateTheme } from 'state/themes/actions/activate-theme';
-import { installTheme } from 'state/themes/actions/install-theme';
 import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
+import { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -66,6 +66,7 @@ export { clearActivated } from 'state/themes/actions/clear-activated';
 export { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
 export { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
 export { tryAndCustomize } from 'state/themes/actions/try-and-customize';
+export { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -99,27 +100,6 @@ export function activate( themeId, siteId, source = 'unknown', purchased = false
 		}
 
 		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
-	};
-}
-
-/**
- * Triggers a network request to install and activate a specific theme on a given
- * Jetpack site. If the themeId parameter is suffixed with '-wpcom', install the
- * theme from WordPress.com. Otherwise, install from WordPress.org.
- *
- * @param  {string}   themeId   Theme ID. If suffixed with '-wpcom', install theme from WordPress.com
- * @param  {number}   siteId    Site ID
- * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
- * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
- * @returns {Function}           Action thunk
- */
-export function installAndActivateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
-	return dispatch => {
-		return dispatch( installTheme( themeId, siteId ) ).then( () => {
-			// This will be called even if `installTheme` silently fails. We rely on
-			// `activateTheme`'s own error handling here.
-			dispatch( activateTheme( themeId, siteId, source, purchased ) );
-		} );
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -25,11 +25,7 @@ import {
 	THEME_TRANSFER_INITIATE_SUCCESS,
 	THEME_TRANSFER_STATUS_FAILURE,
 	THEME_TRANSFER_STATUS_RECEIVE,
-	THEME_UPLOAD_START,
-	THEME_UPLOAD_SUCCESS,
-	THEME_UPLOAD_FAILURE,
 	THEME_UPLOAD_CLEAR,
-	THEME_UPLOAD_PROGRESS,
 	THEME_PREVIEW_OPTIONS,
 	THEME_PREVIEW_STATE,
 } from 'state/action-types';
@@ -47,7 +43,6 @@ import 'state/data-layer/wpcom/theme-filters';
 
 import 'state/themes/init';
 
-import { receiveTheme } from 'state/themes/actions/receive-theme';
 import { activateTheme } from 'state/themes/actions/activate-theme';
 import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
 import { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
@@ -67,6 +62,7 @@ export { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-the
 export { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
 export { tryAndCustomize } from 'state/themes/actions/try-and-customize';
 export { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
+export { uploadTheme } from 'state/themes/actions/upload-theme';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -100,48 +96,6 @@ export function activate( themeId, siteId, source = 'unknown', purchased = false
 		}
 
 		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
-	};
-}
-
-/**
- * Triggers a theme upload to the given site.
- *
- * @param {number} siteId -- Site to upload to
- * @param {File} file -- the theme zip to upload
- *
- * @returns {Function} the action function
- */
-export function uploadTheme( siteId, file ) {
-	return dispatch => {
-		dispatch( {
-			type: THEME_UPLOAD_START,
-			siteId,
-		} );
-		return wpcom
-			.undocumented()
-			.uploadTheme( siteId, file, event => {
-				dispatch( {
-					type: THEME_UPLOAD_PROGRESS,
-					siteId,
-					loaded: event.loaded,
-					total: event.total,
-				} );
-			} )
-			.then( theme => {
-				dispatch( receiveTheme( theme, siteId ) );
-				dispatch( {
-					type: THEME_UPLOAD_SUCCESS,
-					siteId,
-					themeId: theme.id,
-				} );
-			} )
-			.catch( error => {
-				dispatch( {
-					type: THEME_UPLOAD_FAILURE,
-					siteId,
-					error,
-				} );
-			} );
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { map, delay, endsWith } from 'lodash';
+import { delay, endsWith } from 'lodash';
 import debugFactory from 'debug';
 import page from 'page';
 
@@ -11,7 +11,6 @@ import page from 'page';
  */
 import { isExternal } from 'lib/url';
 import wpcom from 'lib/wp';
-import { fetchThemeInformation as fetchWporgThemeInformation } from 'lib/wporg';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -32,9 +31,6 @@ import {
 	THEME_INSTALL,
 	THEME_INSTALL_SUCCESS,
 	THEME_INSTALL_FAILURE,
-	THEME_REQUEST,
-	THEME_REQUEST_SUCCESS,
-	THEME_REQUEST_FAILURE,
 	THEME_SHOW_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_TRANSFER_INITIATE_FAILURE,
 	THEME_TRANSFER_INITIATE_PROGRESS,
@@ -62,12 +58,7 @@ import {
 	hasAutoLoadingHomepageModalAccepted,
 	prependThemeFilterKeys,
 } from 'state/themes/selectors';
-import {
-	getThemeIdFromStylesheet,
-	normalizeJetpackTheme,
-	normalizeWpcomTheme,
-	normalizeWporgTheme,
-} from 'state/themes/utils';
+import { getThemeIdFromStylesheet } from 'state/themes/utils';
 import { getSiteTitle, isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { requestSitePosts } from 'state/posts/actions';
@@ -78,98 +69,16 @@ import 'state/data-layer/wpcom/theme-filters';
 
 import 'state/themes/init';
 
-import { receiveThemes } from 'state/themes/actions/receive-themes';
 import { receiveTheme } from 'state/themes/actions/receive-theme';
-import { themeRequestFailure } from 'state/themes/actions/theme-request-failure';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
 export { receiveTheme } from 'state/themes/actions/receive-theme';
 export { requestThemes } from 'state/themes/actions/request-themes';
 export { themeRequestFailure } from 'state/themes/actions/theme-request-failure';
+export { requestTheme } from 'state/themes/actions/request-theme';
 
 const debug = debugFactory( 'calypso:themes:actions' );
-
-/**
- * Triggers a network request to fetch a specific theme from a site.
- *
- * @param  {string}   themeId Theme ID
- * @param  {number}   siteId  Site ID
- * @returns {Function}         Action thunk
- */
-export function requestTheme( themeId, siteId ) {
-	return dispatch => {
-		dispatch( {
-			type: THEME_REQUEST,
-			siteId,
-			themeId,
-		} );
-
-		if ( siteId === 'wporg' ) {
-			return fetchWporgThemeInformation( themeId )
-				.then( theme => {
-					// Apparently, the WP.org REST API endpoint doesn't 404 but instead returns false
-					// if a theme can't be found.
-					if ( ! theme ) {
-						throw 'Theme not found'; // Will be caught by .catch() below
-					}
-					dispatch( receiveTheme( normalizeWporgTheme( theme ), siteId ) );
-					dispatch( {
-						type: THEME_REQUEST_SUCCESS,
-						siteId,
-						themeId,
-					} );
-				} )
-				.catch( error => {
-					dispatch( {
-						type: THEME_REQUEST_FAILURE,
-						siteId,
-						themeId,
-						error,
-					} );
-				} );
-		}
-
-		if ( siteId === 'wpcom' ) {
-			return wpcom
-				.undocumented()
-				.themeDetails( themeId )
-				.then( theme => {
-					dispatch( receiveTheme( normalizeWpcomTheme( theme ), siteId ) );
-					dispatch( {
-						type: THEME_REQUEST_SUCCESS,
-						siteId,
-						themeId,
-					} );
-				} )
-				.catch( error => {
-					dispatch( {
-						type: THEME_REQUEST_FAILURE,
-						siteId,
-						themeId,
-						error,
-					} );
-				} );
-		}
-
-		// See comment next to lib/wpcom-undocumented/lib/undocumented#jetpackThemeDetails() why we can't
-		// the regular themeDetails() method for Jetpack sites yet.
-		return wpcom
-			.undocumented()
-			.jetpackThemeDetails( themeId, siteId )
-			.then( ( { themes } ) => {
-				dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
-				dispatch( {
-					type: THEME_REQUEST_SUCCESS,
-					siteId,
-					themeId,
-				} );
-			} )
-			.catch( error => {
-				dispatch( themeRequestFailure( siteId, themeId, error ) );
-			} );
-	};
-}
 
 /**
  * This action queries wpcom endpoint for active theme for site.

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -25,7 +25,6 @@ import {
 	THEME_TRANSFER_INITIATE_SUCCESS,
 	THEME_TRANSFER_STATUS_FAILURE,
 	THEME_TRANSFER_STATUS_RECEIVE,
-	THEME_UPLOAD_CLEAR,
 	THEME_PREVIEW_OPTIONS,
 	THEME_PREVIEW_STATE,
 } from 'state/action-types';
@@ -63,6 +62,7 @@ export { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and
 export { tryAndCustomize } from 'state/themes/actions/try-and-customize';
 export { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
 export { uploadTheme } from 'state/themes/actions/upload-theme';
+export { clearThemeUpload } from 'state/themes/actions/clear-theme-upload';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -96,21 +96,6 @@ export function activate( themeId, siteId, source = 'unknown', purchased = false
 		}
 
 		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
-	};
-}
-
-/**
- * Clears any state remaining from a previous
- * theme upload to the given site.
- *
- * @param {number} siteId -- site to clear state for
- *
- * @returns {object} the action object to dispatch
- */
-export function clearThemeUpload( siteId ) {
-	return {
-		type: THEME_UPLOAD_CLEAR,
-		siteId,
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -16,7 +16,6 @@ import {
 	RECOMMENDED_THEMES_SUCCESS,
 	THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_ACTIVATE,
-	THEME_ACTIVATE_SUCCESS,
 	THEME_ACTIVATE_FAILURE,
 	THEME_CLEAR_ACTIVATED,
 	THEME_DELETE,
@@ -45,19 +44,14 @@ import {
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import {
 	getTheme,
-	getActiveTheme,
-	getLastThemeQuery,
 	getThemeCustomizeUrl,
 	getWpcomParentThemeId,
 	isDownloadableFromWpcom,
 	themeHasAutoLoadingHomepage,
 	hasAutoLoadingHomepageModalAccepted,
-	prependThemeFilterKeys,
 } from 'state/themes/selectors';
-import { getThemeIdFromStylesheet } from 'state/themes/utils';
 import { getSiteTitle, isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { requestSitePosts } from 'state/posts/actions';
 import i18n from 'i18n-calypso';
 import accept from 'lib/accept';
 
@@ -66,6 +60,7 @@ import 'state/data-layer/wpcom/theme-filters';
 import 'state/themes/init';
 
 import { receiveTheme } from 'state/themes/actions/receive-theme';
+import { themeActivated } from 'state/themes/actions/theme-activated';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -74,6 +69,7 @@ export { requestThemes } from 'state/themes/actions/request-themes';
 export { themeRequestFailure } from 'state/themes/actions/theme-request-failure';
 export { requestTheme } from 'state/themes/actions/request-theme';
 export { requestActiveTheme } from 'state/themes/actions/request-active-theme';
+export { themeActivated } from 'state/themes/actions/theme-activated';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -144,44 +140,6 @@ export function activateTheme( themeId, siteId, source = 'unknown', purchased = 
 				} );
 			} );
 	};
-}
-
-/**
- * Returns an action thunk to be used in signalling that a theme has been activated
- * on a given site. Careful, this action is different from most others here in that
- * expects a theme stylesheet string (not just a theme ID).
- *
- * @param  {string}   themeStylesheet Theme stylesheet string (*not* just a theme ID!)
- * @param  {number}   siteId          Site ID
- * @param  {string}   source          The source that is requesting theme activation, e.g. 'showcase'
- * @param  {boolean}  purchased       Whether the theme has been purchased prior to activation
- * @returns {Function}                 Action thunk
- */
-export function themeActivated( themeStylesheet, siteId, source = 'unknown', purchased = false ) {
-	const themeActivatedThunk = ( dispatch, getState ) => {
-		const action = {
-			type: THEME_ACTIVATE_SUCCESS,
-			themeStylesheet,
-			siteId,
-		};
-		const previousThemeId = getActiveTheme( getState(), siteId );
-		const query = getLastThemeQuery( getState(), siteId );
-		const search_taxonomies = prependThemeFilterKeys( getState(), query.filter );
-		const search_term = search_taxonomies + ( query.search || '' );
-		const trackThemeActivation = recordTracksEvent( 'calypso_themeshowcase_theme_activate', {
-			theme: getThemeIdFromStylesheet( themeStylesheet ),
-			previous_theme: previousThemeId,
-			source: source,
-			purchased: purchased,
-			search_term: search_term || null,
-			search_taxonomies,
-		} );
-		dispatch( withAnalytics( trackThemeActivation, action ) );
-
-		// Update pages in case the front page was updated on theme switch.
-		dispatch( requestSitePosts( siteId, { type: 'page' } ) );
-	};
-	return themeActivatedThunk; // it is named function just for testing purposes
 }
 
 /**

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -31,9 +31,7 @@ import {
 	themeHasAutoLoadingHomepage,
 	hasAutoLoadingHomepageModalAccepted,
 } from 'state/themes/selectors';
-import { getSiteTitle, isJetpackSite } from 'state/sites/selectors';
-import i18n from 'i18n-calypso';
-import accept from 'lib/accept';
+import { isJetpackSite } from 'state/sites/selectors';
 
 import 'state/data-layer/wpcom/theme-filters';
 
@@ -42,7 +40,6 @@ import 'state/themes/init';
 import { activateTheme } from 'state/themes/actions/activate-theme';
 import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
 import { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
-import { deleteTheme } from 'state/themes/actions/delete-theme';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
 export { receiveThemes } from 'state/themes/actions/receive-themes';
@@ -62,6 +59,7 @@ export { installAndActivateTheme } from 'state/themes/actions/install-and-activa
 export { uploadTheme } from 'state/themes/actions/upload-theme';
 export { clearThemeUpload } from 'state/themes/actions/clear-theme-upload';
 export { deleteTheme } from 'state/themes/actions/delete-theme';
+export { confirmDelete } from 'state/themes/actions/confirm-delete';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -253,36 +251,6 @@ export function pollThemeTransferStatus(
 				} );
 		};
 		return new Promise( pollStatus );
-	};
-}
-
-/**
- * Shows dialog asking user to confirm delete of theme
- * from jetpack site. Deletes theme if user confirms.
- *
- * @param {string} themeId -- Theme to delete
- * @param {number} siteId -- Site to delete theme from
- *
- * @returns {Function} Action thunk
- */
-export function confirmDelete( themeId, siteId ) {
-	return ( dispatch, getState ) => {
-		const { name: themeName } = getTheme( getState(), siteId, themeId );
-		const siteTitle = getSiteTitle( getState(), siteId );
-		accept(
-			i18n.translate( 'Are you sure you want to delete %(themeName)s from %(siteTitle)s?', {
-				args: { themeName, siteTitle },
-				comment: 'Themes: theme delete confirmation dialog',
-			} ),
-			accepted => {
-				accepted && dispatch( deleteTheme( themeId, siteId ) );
-			},
-			i18n.translate( 'Delete %(themeName)s', {
-				args: { themeName },
-				comment: 'Themes: theme delete dialog confirm button',
-			} ),
-			i18n.translate( 'Back', { context: 'go back (like the back button in a browser)' } )
-		);
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -6,7 +6,6 @@ import {
 	RECOMMENDED_THEMES_FAIL,
 	RECOMMENDED_THEMES_FETCH,
 	RECOMMENDED_THEMES_SUCCESS,
-	THEME_FILTERS_REQUEST,
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/theme-filters';
@@ -43,17 +42,7 @@ export { showThemePreview } from 'state/themes/actions/show-theme-preview';
 export { hideAutoLoadingHomepageWarning } from 'state/themes/actions/hide-auto-loading-homepage-warning';
 export { acceptAutoLoadingHomepageWarning } from 'state/themes/actions/accept-auto-loading-homepage-warning';
 export { hideThemePreview } from 'state/themes/actions/hide-theme-preview';
-
-/**
- * Triggers a network request to fetch all available theme filters.
- *
- * @returns {object} A nested list of theme filters, keyed by filter slug
- */
-export function requestThemeFilters() {
-	return {
-		type: THEME_FILTERS_REQUEST,
-	};
-}
+export { requestThemeFilters } from 'state/themes/actions/request-theme-filters';
 
 /**
  * Receives themes and dispatches them with recommended themes success signal.

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -50,8 +50,6 @@ import 'state/themes/init';
 import { receiveTheme } from 'state/themes/actions/receive-theme';
 import { activateTheme } from 'state/themes/actions/activate-theme';
 import { installTheme } from 'state/themes/actions/install-theme';
-import { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
-import { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
 import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
 
 export { setBackPath } from 'state/themes/actions/set-back-path';
@@ -67,6 +65,7 @@ export { installTheme } from 'state/themes/actions/install-theme';
 export { clearActivated } from 'state/themes/actions/clear-activated';
 export { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
 export { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
+export { tryAndCustomize } from 'state/themes/actions/try-and-customize';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -100,27 +99,6 @@ export function activate( themeId, siteId, source = 'unknown', purchased = false
 		}
 
 		return dispatch( activateTheme( themeId, siteId, source, purchased ) );
-	};
-}
-
-/**
- * Switches to the customizer to preview a given theme.
- * If it's a Jetpack site, installs the theme prior to activation if it isn't already.
- *
- * @param  {string}   themeId   Theme ID
- * @param  {number}   siteId    Site ID
- * @returns {Function}           Action thunk
- */
-export function tryAndCustomize( themeId, siteId ) {
-	return ( dispatch, getState ) => {
-		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
-			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );
-			// If theme is already installed, installation will silently fail,
-			// and we just switch to the customizer.
-			return dispatch( installAndTryAndCustomizeTheme( installId, siteId ) );
-		}
-
-		return dispatch( tryAndCustomizeTheme( themeId, siteId ) );
 	};
 }
 

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -1,35 +1,35 @@
-export { setBackPath } from 'state/themes/actions/set-back-path';
-export { receiveThemes } from 'state/themes/actions/receive-themes';
-export { receiveTheme } from 'state/themes/actions/receive-theme';
-export { requestThemes } from 'state/themes/actions/request-themes';
-export { themeRequestFailure } from 'state/themes/actions/theme-request-failure';
-export { requestTheme } from 'state/themes/actions/request-theme';
-export { requestActiveTheme } from 'state/themes/actions/request-active-theme';
-export { themeActivated } from 'state/themes/actions/theme-activated';
-export { activateTheme } from 'state/themes/actions/activate-theme';
-export { installTheme } from 'state/themes/actions/install-theme';
-export { clearActivated } from 'state/themes/actions/clear-activated';
-export { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
-export { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
-export { tryAndCustomize } from 'state/themes/actions/try-and-customize';
-export { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
-export { uploadTheme } from 'state/themes/actions/upload-theme';
-export { clearThemeUpload } from 'state/themes/actions/clear-theme-upload';
-export { deleteTheme } from 'state/themes/actions/delete-theme';
-export { confirmDelete } from 'state/themes/actions/confirm-delete';
-export { showAutoLoadingHomepageWarning } from 'state/themes/actions/show-auto-loading-homepage-warning';
-export { activate } from 'state/themes/actions/activate';
-export {
-	initiateThemeTransfer,
-	pollThemeTransferStatus,
-} from 'state/themes/actions/theme-transfer';
-export { setThemePreviewOptions } from 'state/themes/actions/set-theme-preview-options';
-export { showThemePreview } from 'state/themes/actions/show-theme-preview';
-export { hideAutoLoadingHomepageWarning } from 'state/themes/actions/hide-auto-loading-homepage-warning';
 export { acceptAutoLoadingHomepageWarning } from 'state/themes/actions/accept-auto-loading-homepage-warning';
+export { activate } from 'state/themes/actions/activate';
+export { activateTheme } from 'state/themes/actions/activate-theme';
+export { clearActivated } from 'state/themes/actions/clear-activated';
+export { clearThemeUpload } from 'state/themes/actions/clear-theme-upload';
+export { confirmDelete } from 'state/themes/actions/confirm-delete';
+export { deleteTheme } from 'state/themes/actions/delete-theme';
+export { hideAutoLoadingHomepageWarning } from 'state/themes/actions/hide-auto-loading-homepage-warning';
 export { hideThemePreview } from 'state/themes/actions/hide-theme-preview';
-export { requestThemeFilters } from 'state/themes/actions/request-theme-filters';
+export { installAndActivateTheme } from 'state/themes/actions/install-and-activate-theme';
+export { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
+export { installTheme } from 'state/themes/actions/install-theme';
+export { receiveTheme } from 'state/themes/actions/receive-theme';
+export { receiveThemes } from 'state/themes/actions/receive-themes';
 export {
 	getRecommendedThemes,
 	receiveRecommendedThemes,
 } from 'state/themes/actions/recommended-themes';
+export { requestActiveTheme } from 'state/themes/actions/request-active-theme';
+export { requestTheme } from 'state/themes/actions/request-theme';
+export { requestThemeFilters } from 'state/themes/actions/request-theme-filters';
+export { requestThemes } from 'state/themes/actions/request-themes';
+export { setBackPath } from 'state/themes/actions/set-back-path';
+export { setThemePreviewOptions } from 'state/themes/actions/set-theme-preview-options';
+export { showAutoLoadingHomepageWarning } from 'state/themes/actions/show-auto-loading-homepage-warning';
+export { showThemePreview } from 'state/themes/actions/show-theme-preview';
+export { themeActivated } from 'state/themes/actions/theme-activated';
+export { themeRequestFailure } from 'state/themes/actions/theme-request-failure';
+export {
+	initiateThemeTransfer,
+	pollThemeTransferStatus,
+} from 'state/themes/actions/theme-transfer';
+export { tryAndCustomize } from 'state/themes/actions/try-and-customize';
+export { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
+export { uploadTheme } from 'state/themes/actions/upload-theme';

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -69,7 +69,7 @@ import {
 	themeHasAutoLoadingHomepage,
 	hasAutoLoadingHomepageModalAccepted,
 	prependThemeFilterKeys,
-} from './selectors';
+} from 'state/themes/selectors';
 import {
 	getThemeIdFromStylesheet,
 	isThemeMatchingQuery,
@@ -77,7 +77,7 @@ import {
 	normalizeJetpackTheme,
 	normalizeWpcomTheme,
 	normalizeWporgTheme,
-} from './utils';
+} from 'state/themes/utils';
 import { getSiteTitle, isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { requestSitePosts } from 'state/posts/actions';

--- a/client/state/themes/actions/index.js
+++ b/client/state/themes/actions/index.js
@@ -6,7 +6,6 @@ import {
 	RECOMMENDED_THEMES_FAIL,
 	RECOMMENDED_THEMES_FETCH,
 	RECOMMENDED_THEMES_SUCCESS,
-	THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
 	THEME_FILTERS_REQUEST,
 	THEME_PREVIEW_STATE,
 } from 'state/action-types';
@@ -43,13 +42,7 @@ export {
 export { setThemePreviewOptions } from 'state/themes/actions/set-theme-preview-options';
 export { showThemePreview } from 'state/themes/actions/show-theme-preview';
 export { hideAutoLoadingHomepageWarning } from 'state/themes/actions/hide-auto-loading-homepage-warning';
-
-export function acceptAutoLoadingHomepageWarning( themeId ) {
-	return {
-		type: THEME_ACCEPT_AUTO_LOADING_HOMEPAGE_WARNING,
-		themeId,
-	};
-}
+export { acceptAutoLoadingHomepageWarning } from 'state/themes/actions/accept-auto-loading-homepage-warning';
 
 export function hideThemePreview() {
 	return {

--- a/client/state/themes/actions/install-and-activate-theme.js
+++ b/client/state/themes/actions/install-and-activate-theme.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { activateTheme } from 'state/themes/actions/activate-theme';
+import { installTheme } from 'state/themes/actions/install-theme';
+
+import 'state/themes/init';
+
+/**
+ * Triggers a network request to install and activate a specific theme on a given
+ * Jetpack site. If the themeId parameter is suffixed with '-wpcom', install the
+ * theme from WordPress.com. Otherwise, install from WordPress.org.
+ *
+ * @param  {string}   themeId   Theme ID. If suffixed with '-wpcom', install theme from WordPress.com
+ * @param  {number}   siteId    Site ID
+ * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
+ * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
+ * @returns {Function}           Action thunk
+ */
+export function installAndActivateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
+	return dispatch => {
+		return dispatch( installTheme( themeId, siteId ) ).then( () => {
+			// This will be called even if `installTheme` silently fails. We rely on
+			// `activateTheme`'s own error handling here.
+			dispatch( activateTheme( themeId, siteId, source, purchased ) );
+		} );
+	};
+}

--- a/client/state/themes/actions/install-and-try-and-customize-theme.js
+++ b/client/state/themes/actions/install-and-try-and-customize-theme.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { installTheme } from 'state/themes/actions/install-theme';
+import { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
+
+import 'state/themes/init';
+
+/**
+ * Triggers a network request to install theme on Jetpack site.
+ * After installataion it switches page to the customizer
+ * See installTheme doc for install options.
+ * Requires Jetpack 4.4
+ *
+ * @param  {string}   themeId      WP.com Theme ID
+ * @param  {string}   siteId       Jetpack Site ID
+ * @returns {Function}              Action thunk
+ */
+export function installAndTryAndCustomizeTheme( themeId, siteId ) {
+	return dispatch => {
+		return dispatch( installTheme( themeId, siteId ) ).then( () => {
+			dispatch( tryAndCustomizeTheme( themeId, siteId ) );
+		} );
+	};
+}

--- a/client/state/themes/actions/install-theme.js
+++ b/client/state/themes/actions/install-theme.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { endsWith } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import { THEME_INSTALL, THEME_INSTALL_SUCCESS, THEME_INSTALL_FAILURE } from 'state/action-types';
+import { receiveTheme } from 'state/themes/actions/receive-theme';
+import { getWpcomParentThemeId } from 'state/themes/selectors';
+
+import 'state/themes/init';
+
+/**
+ * Triggers a network request to install a WordPress.org or WordPress.com theme on a Jetpack site.
+ * To install a theme from WordPress.com, suffix the theme name with '-wpcom'. Note that this options
+ * requires Jetpack 4.4
+ *
+ * @param  {string}   themeId Theme ID. If suffixed with '-wpcom', install from WordPress.com
+ * @param  {string}   siteId  Jetpack Site ID
+ * @returns {Function}         Action thunk
+ */
+export function installTheme( themeId, siteId ) {
+	return ( dispatch, getState ) => {
+		dispatch( {
+			type: THEME_INSTALL,
+			siteId,
+			themeId,
+		} );
+
+		return wpcom
+			.undocumented()
+			.installThemeOnJetpack( siteId, themeId )
+			.then( theme => {
+				dispatch( receiveTheme( theme, siteId ) );
+				dispatch( {
+					type: THEME_INSTALL_SUCCESS,
+					siteId,
+					themeId,
+				} );
+
+				// Install parent theme if theme requires one
+				if ( endsWith( themeId, '-wpcom' ) ) {
+					const parentThemeId = getWpcomParentThemeId(
+						getState(),
+						themeId.replace( '-wpcom', '' )
+					);
+					if ( parentThemeId ) {
+						return dispatch( installTheme( parentThemeId + '-wpcom', siteId ) );
+					}
+				}
+			} )
+			.catch( error => {
+				dispatch( {
+					type: THEME_INSTALL_FAILURE,
+					siteId,
+					themeId,
+					error,
+				} );
+			} );
+	};
+}

--- a/client/state/themes/actions/receive-theme.js
+++ b/client/state/themes/actions/receive-theme.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { receiveThemes } from 'state/themes/actions/receive-themes';
+
+import 'state/themes/init';
+
+/**
+ * Returns an action object to be used in signalling that a theme object has
+ * been received.
+ *
+ * @param  {object} theme  Theme received
+ * @param  {number} siteId ID of site for which themes have been received
+ * @returns {object}        Action object
+ */
+export function receiveTheme( theme, siteId ) {
+	return receiveThemes( [ theme ], siteId );
+}

--- a/client/state/themes/actions/receive-themes.js
+++ b/client/state/themes/actions/receive-themes.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { filter } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { THEMES_REQUEST_SUCCESS } from 'state/action-types';
+import { isJetpackSite } from 'state/sites/selectors';
+import { shouldFilterWpcomThemes } from 'state/themes/selectors';
+import { isThemeFromWpcom, isThemeMatchingQuery } from 'state/themes/utils';
+
+import 'state/themes/init';
+
+/**
+ * Returns an action object to be used in signalling that theme objects from
+ * a query have been received.
+ *
+ * @param {Array}  themes Themes received
+ * @param {number} siteId ID of site for which themes have been received
+ * @param {?object} query Theme query used in the API request
+ * @param {?number} foundCount Number of themes returned by the query
+ * @returns {object} Action object
+ */
+export function receiveThemes( themes, siteId, query, foundCount ) {
+	return ( dispatch, getState ) => {
+		let filteredThemes = themes;
+		let found = foundCount;
+
+		if ( isJetpackSite( getState(), siteId ) ) {
+			/*
+			 * We need to do client-side filtering for Jetpack sites because:
+			 * 1) Jetpack theme API does not support search queries
+			 * 2) We need to filter out all wpcom themes to show an 'Uploaded' list
+			 */
+			const filterWpcom = shouldFilterWpcomThemes( getState(), siteId );
+			filteredThemes = filter(
+				themes,
+				theme =>
+					isThemeMatchingQuery( query, theme ) && ! ( filterWpcom && isThemeFromWpcom( theme ) )
+			);
+			// Jetpack API returns all themes in one response (no paging)
+			found = filteredThemes.length;
+		}
+
+		dispatch( {
+			type: THEMES_REQUEST_SUCCESS,
+			themes: filteredThemes,
+			siteId,
+			query,
+			found,
+		} );
+	};
+}

--- a/client/state/themes/actions/recommended-themes.js
+++ b/client/state/themes/actions/recommended-themes.js
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import {
+	RECOMMENDED_THEMES_FAIL,
+	RECOMMENDED_THEMES_FETCH,
+	RECOMMENDED_THEMES_SUCCESS,
+} from 'state/action-types';
+
+import 'state/themes/init';
+
+/**
+ * Receives themes and dispatches them with recommended themes success signal.
+ *
+ * @param {Array} themes array of received theme objects
+ * @returns {Function} Action thunk
+ */
+export function receiveRecommendedThemes( themes ) {
+	return dispatch => {
+		dispatch( { type: RECOMMENDED_THEMES_SUCCESS, payload: themes } );
+	};
+}
+
+/**
+ * Initiates network request for recommended themes.
+ * Recommended themes are template first themes and are denoted by the 'auto-loading-homepage' tag.
+ *
+ * @returns {Function} Action thunk
+ */
+export function getRecommendedThemes() {
+	return async dispatch => {
+		dispatch( { type: RECOMMENDED_THEMES_FETCH } );
+		const query = {
+			search: '',
+			number: 50,
+			tier: '',
+			filter: 'auto-loading-homepage',
+			apiVersion: '1.2',
+		};
+		try {
+			const res = await wpcom.undocumented().themes( null, query );
+			dispatch( receiveRecommendedThemes( res ) );
+		} catch ( error ) {
+			dispatch( { type: RECOMMENDED_THEMES_FAIL } );
+		}
+	};
+}

--- a/client/state/themes/actions/request-active-theme.js
+++ b/client/state/themes/actions/request-active-theme.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import {
+	ACTIVE_THEME_REQUEST_FAILURE,
+	ACTIVE_THEME_REQUEST_SUCCESS,
+	ACTIVE_THEME_REQUEST,
+} from 'state/action-types';
+import { isJetpackSite } from 'state/sites/selectors';
+import { receiveTheme } from 'state/themes/actions/receive-theme';
+
+import 'state/themes/init';
+
+const debug = debugFactory( 'calypso:themes:actions' );
+
+/**
+ * This action queries wpcom endpoint for active theme for site.
+ * If request success information about active theme is stored in Redux themes subtree.
+ * In case of error, error is stored in Redux themes subtree.
+ *
+ * @param  {number}   siteId Site for which to check active theme
+ * @returns {Function}        Redux thunk with request action
+ */
+export function requestActiveTheme( siteId ) {
+	return ( dispatch, getState ) => {
+		dispatch( {
+			type: ACTIVE_THEME_REQUEST,
+			siteId,
+		} );
+
+		return wpcom
+			.undocumented()
+			.activeTheme( siteId )
+			.then( theme => {
+				debug( 'Received current theme', theme );
+				// We want to store the theme object in the appropriate Redux subtree -- either 'wpcom'
+				// for WPCOM sites, or siteId for Jetpack sites.
+				const siteIdOrWpcom = isJetpackSite( getState(), siteId ) ? siteId : 'wpcom';
+				dispatch( receiveTheme( theme, siteIdOrWpcom ) );
+				dispatch( {
+					type: ACTIVE_THEME_REQUEST_SUCCESS,
+					siteId,
+					theme,
+				} );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: ACTIVE_THEME_REQUEST_FAILURE,
+					siteId,
+					error,
+				} );
+			} );
+	};
+}

--- a/client/state/themes/actions/request-theme-filters.js
+++ b/client/state/themes/actions/request-theme-filters.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_FILTERS_REQUEST } from 'state/action-types';
+
+import 'state/data-layer/wpcom/theme-filters';
+import 'state/themes/init';
+
+/**
+ * Triggers a network request to fetch all available theme filters.
+ *
+ * @returns {object} A nested list of theme filters, keyed by filter slug
+ */
+export function requestThemeFilters() {
+	return {
+		type: THEME_FILTERS_REQUEST,
+	};
+}

--- a/client/state/themes/actions/request-theme.js
+++ b/client/state/themes/actions/request-theme.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import { fetchThemeInformation as fetchWporgThemeInformation } from 'lib/wporg';
+import { THEME_REQUEST, THEME_REQUEST_SUCCESS, THEME_REQUEST_FAILURE } from 'state/action-types';
+import { receiveTheme } from 'state/themes/actions/receive-theme';
+import { receiveThemes } from 'state/themes/actions/receive-themes';
+import { themeRequestFailure } from 'state/themes/actions/theme-request-failure';
+import {
+	normalizeJetpackTheme,
+	normalizeWpcomTheme,
+	normalizeWporgTheme,
+} from 'state/themes/utils';
+
+import 'state/themes/init';
+
+/**
+ * Triggers a network request to fetch a specific theme from a site.
+ *
+ * @param  {string}   themeId Theme ID
+ * @param  {number}   siteId  Site ID
+ * @returns {Function}         Action thunk
+ */
+export function requestTheme( themeId, siteId ) {
+	return dispatch => {
+		dispatch( {
+			type: THEME_REQUEST,
+			siteId,
+			themeId,
+		} );
+
+		if ( siteId === 'wporg' ) {
+			return fetchWporgThemeInformation( themeId )
+				.then( theme => {
+					// Apparently, the WP.org REST API endpoint doesn't 404 but instead returns false
+					// if a theme can't be found.
+					if ( ! theme ) {
+						throw 'Theme not found'; // Will be caught by .catch() below
+					}
+					dispatch( receiveTheme( normalizeWporgTheme( theme ), siteId ) );
+					dispatch( {
+						type: THEME_REQUEST_SUCCESS,
+						siteId,
+						themeId,
+					} );
+				} )
+				.catch( error => {
+					dispatch( {
+						type: THEME_REQUEST_FAILURE,
+						siteId,
+						themeId,
+						error,
+					} );
+				} );
+		}
+
+		if ( siteId === 'wpcom' ) {
+			return wpcom
+				.undocumented()
+				.themeDetails( themeId )
+				.then( theme => {
+					dispatch( receiveTheme( normalizeWpcomTheme( theme ), siteId ) );
+					dispatch( {
+						type: THEME_REQUEST_SUCCESS,
+						siteId,
+						themeId,
+					} );
+				} )
+				.catch( error => {
+					dispatch( {
+						type: THEME_REQUEST_FAILURE,
+						siteId,
+						themeId,
+						error,
+					} );
+				} );
+		}
+
+		// See comment next to lib/wpcom-undocumented/lib/undocumented#jetpackThemeDetails() why we can't
+		// the regular themeDetails() method for Jetpack sites yet.
+		return wpcom
+			.undocumented()
+			.jetpackThemeDetails( themeId, siteId )
+			.then( ( { themes } ) => {
+				dispatch( receiveThemes( map( themes, normalizeJetpackTheme ), siteId ) );
+				dispatch( {
+					type: THEME_REQUEST_SUCCESS,
+					siteId,
+					themeId,
+				} );
+			} )
+			.catch( error => {
+				dispatch( themeRequestFailure( siteId, themeId, error ) );
+			} );
+	};
+}

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { map, property } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import { fetchThemesList as fetchWporgThemesList } from 'lib/wporg';
+import { THEMES_REQUEST, THEMES_REQUEST_FAILURE } from 'state/action-types';
+import { recordTracksEvent } from 'state/analytics/actions';
+import prependThemeFilterKeys from 'state/selectors/prepend-theme-filter-keys';
+import { receiveThemes } from 'state/themes/actions/receive-themes';
+import {
+	normalizeJetpackTheme,
+	normalizeWpcomTheme,
+	normalizeWporgTheme,
+} from 'state/themes/utils';
+
+import 'state/themes/init';
+
+/**
+ * Triggers a network request to fetch themes for the specified site and query.
+ *
+ * @param  {number|string} siteId        Jetpack site ID or 'wpcom' for any WPCOM site
+ * @param  {object}        query         Theme query
+ * @param  {string}        query.search  Search string
+ * @param  {string}        query.tier    Theme tier: 'free', 'premium', or '' (either)
+ * @param  {string}        query.filter  Filter
+ * @param  {number}        query.number  How many themes to return per page
+ * @param  {number}        query.offset  At which item to start the set of returned themes
+ * @param  {number}        query.page    Which page of matching themes to return
+ * @returns {Function}                    Action thunk
+ */
+export function requestThemes( siteId, query = {} ) {
+	return ( dispatch, getState ) => {
+		const startTime = new Date().getTime();
+
+		dispatch( {
+			type: THEMES_REQUEST,
+			siteId,
+			query,
+		} );
+
+		let request;
+
+		if ( siteId === 'wporg' ) {
+			request = () => fetchWporgThemesList( query );
+		} else if ( siteId === 'wpcom' ) {
+			request = () => wpcom.undocumented().themes( null, { ...query, apiVersion: '1.2' } );
+		} else {
+			request = () => wpcom.undocumented().themes( siteId, { ...query, apiVersion: '1' } );
+		}
+
+		// WP.com returns the number of results in a `found` attr, so we can use that right away.
+		// WP.org returns an `info` object containing a `results` number, so we destructure that
+		// and use it as default value for `found`.
+		return request()
+			.then( ( { themes: rawThemes, info: { results } = {}, found = results } ) => {
+				let themes;
+				if ( siteId === 'wporg' ) {
+					themes = map( rawThemes, normalizeWporgTheme );
+				} else if ( siteId === 'wpcom' ) {
+					themes = map( rawThemes, normalizeWpcomTheme );
+				} else {
+					// Jetpack Site
+					themes = map( rawThemes, normalizeJetpackTheme );
+				}
+
+				if ( ( query.search || query.filter ) && query.page === 1 ) {
+					const responseTime = new Date().getTime() - startTime;
+					const search_taxonomies = prependThemeFilterKeys( getState(), query.filter );
+					const search_term = search_taxonomies + ( query.search || '' );
+					const trackShowcaseSearch = recordTracksEvent( 'calypso_themeshowcase_search', {
+						search_term: search_term || null,
+						search_taxonomies,
+						tier: query.tier,
+						response_time_in_ms: responseTime,
+						result_count: found,
+						results_first_page: themes.map( property( 'id' ) ).join(),
+					} );
+					dispatch( trackShowcaseSearch );
+				}
+
+				dispatch( receiveThemes( themes, siteId, query, found ) );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: THEMES_REQUEST_FAILURE,
+					siteId,
+					query,
+					error,
+				} );
+			} );
+	};
+}

--- a/client/state/themes/actions/request-themes.js
+++ b/client/state/themes/actions/request-themes.js
@@ -10,8 +10,8 @@ import wpcom from 'lib/wp';
 import { fetchThemesList as fetchWporgThemesList } from 'lib/wporg';
 import { THEMES_REQUEST, THEMES_REQUEST_FAILURE } from 'state/action-types';
 import { recordTracksEvent } from 'state/analytics/actions';
-import prependThemeFilterKeys from 'state/selectors/prepend-theme-filter-keys';
 import { receiveThemes } from 'state/themes/actions/receive-themes';
+import { prependThemeFilterKeys } from 'state/themes/selectors';
 import {
 	normalizeJetpackTheme,
 	normalizeWpcomTheme,

--- a/client/state/themes/actions/set-back-path.js
+++ b/client/state/themes/actions/set-back-path.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_BACK_PATH_SET } from 'state/action-types';
+
+import 'state/themes/init';
+
+// Set destination for 'back' button on theme sheet
+export function setBackPath( path ) {
+	return {
+		type: THEME_BACK_PATH_SET,
+		path,
+	};
+}

--- a/client/state/themes/actions/set-theme-preview-options.js
+++ b/client/state/themes/actions/set-theme-preview-options.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_PREVIEW_OPTIONS } from 'state/action-types';
+
+import 'state/themes/init';
+
+export function setThemePreviewOptions( primary, secondary ) {
+	return {
+		type: THEME_PREVIEW_OPTIONS,
+		primary,
+		secondary,
+	};
+}

--- a/client/state/themes/actions/show-auto-loading-homepage-warning.js
+++ b/client/state/themes/actions/show-auto-loading-homepage-warning.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_SHOW_AUTO_LOADING_HOMEPAGE_WARNING } from 'state/action-types';
+
+import 'state/themes/init';
+
+export function showAutoLoadingHomepageWarning( themeId ) {
+	return {
+		type: THEME_SHOW_AUTO_LOADING_HOMEPAGE_WARNING,
+		themeId,
+	};
+}

--- a/client/state/themes/actions/show-theme-preview.js
+++ b/client/state/themes/actions/show-theme-preview.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_PREVIEW_STATE } from 'state/action-types';
+
+import 'state/themes/init';
+
+export function showThemePreview( themeId ) {
+	return {
+		type: THEME_PREVIEW_STATE,
+		themeId,
+	};
+}

--- a/client/state/themes/actions/suffix-theme-id-for-install.js
+++ b/client/state/themes/actions/suffix-theme-id-for-install.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { isDownloadableFromWpcom } from 'state/themes/selectors';
+
+import 'state/themes/init';
+
+/**
+ * Install of any theme hosted as a zip on wpcom must
+ * be suffixed with -wpcom. Themes on AT sites are not
+ * installed via downloaded zip.
+ *
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @param {string} themeId Theme ID
+ * @returns {string} the theme id to use when installing the theme
+ */
+export function suffixThemeIdForInstall( state, siteId, themeId ) {
+	// AT sites do not use the -wpcom suffix
+	if ( isSiteAutomatedTransfer( state, siteId ) ) {
+		return themeId;
+	}
+	if ( ! isDownloadableFromWpcom( state, themeId ) ) {
+		return themeId;
+	}
+	return themeId + '-wpcom';
+}

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -1,0 +1,48 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_ACTIVATE_SUCCESS } from 'state/action-types';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+import { requestSitePosts } from 'state/posts/actions';
+import { getActiveTheme, getLastThemeQuery, prependThemeFilterKeys } from 'state/themes/selectors';
+import { getThemeIdFromStylesheet } from 'state/themes/utils';
+
+import 'state/themes/init';
+
+/**
+ * Returns an action thunk to be used in signalling that a theme has been activated
+ * on a given site. Careful, this action is different from most others here in that
+ * expects a theme stylesheet string (not just a theme ID).
+ *
+ * @param  {string}   themeStylesheet Theme stylesheet string (*not* just a theme ID!)
+ * @param  {number}   siteId          Site ID
+ * @param  {string}   source          The source that is requesting theme activation, e.g. 'showcase'
+ * @param  {boolean}  purchased       Whether the theme has been purchased prior to activation
+ * @returns {Function}                 Action thunk
+ */
+export function themeActivated( themeStylesheet, siteId, source = 'unknown', purchased = false ) {
+	const themeActivatedThunk = ( dispatch, getState ) => {
+		const action = {
+			type: THEME_ACTIVATE_SUCCESS,
+			themeStylesheet,
+			siteId,
+		};
+		const previousThemeId = getActiveTheme( getState(), siteId );
+		const query = getLastThemeQuery( getState(), siteId );
+		const search_taxonomies = prependThemeFilterKeys( getState(), query.filter );
+		const search_term = search_taxonomies + ( query.search || '' );
+		const trackThemeActivation = recordTracksEvent( 'calypso_themeshowcase_theme_activate', {
+			theme: getThemeIdFromStylesheet( themeStylesheet ),
+			previous_theme: previousThemeId,
+			source: source,
+			purchased: purchased,
+			search_term: search_term || null,
+			search_taxonomies,
+		} );
+		dispatch( withAnalytics( trackThemeActivation, action ) );
+
+		// Update pages in case the front page was updated on theme switch.
+		dispatch( requestSitePosts( siteId, { type: 'page' } ) );
+	};
+	return themeActivatedThunk; // it is named function just for testing purposes
+}

--- a/client/state/themes/actions/theme-request-failure.js
+++ b/client/state/themes/actions/theme-request-failure.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { THEME_REQUEST_FAILURE } from 'state/action-types';
+
+import 'state/themes/init';
+
+export function themeRequestFailure( siteId, themeId, error ) {
+	return {
+		type: THEME_REQUEST_FAILURE,
+		siteId,
+		themeId,
+		error,
+	};
+}

--- a/client/state/themes/actions/theme-transfer.js
+++ b/client/state/themes/actions/theme-transfer.js
@@ -1,0 +1,178 @@
+/**
+ * External dependencies
+ */
+import { delay } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import {
+	THEME_TRANSFER_INITIATE_FAILURE,
+	THEME_TRANSFER_INITIATE_PROGRESS,
+	THEME_TRANSFER_INITIATE_REQUEST,
+	THEME_TRANSFER_INITIATE_SUCCESS,
+	THEME_TRANSFER_STATUS_FAILURE,
+	THEME_TRANSFER_STATUS_RECEIVE,
+} from 'state/action-types';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
+
+import 'state/themes/init';
+
+/**
+ * Start an Automated Transfer with an uploaded theme.
+ *
+ * @param {number} siteId -- the site to transfer
+ * @param {window.File} file -- theme zip to upload
+ * @param {string} plugin -- plugin slug
+ *
+ * @returns {Promise} for testing purposes only
+ */
+export function initiateThemeTransfer( siteId, file, plugin ) {
+	let context = plugin ? 'plugins' : 'themes';
+	if ( ! plugin && ! file ) {
+		context = 'hosting';
+	}
+
+	return dispatch => {
+		const themeInitiateRequest = {
+			type: THEME_TRANSFER_INITIATE_REQUEST,
+			siteId,
+		};
+
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_automated_transfer_initiate_transfer', { plugin, context } ),
+				themeInitiateRequest
+			)
+		);
+		return wpcom
+			.undocumented()
+			.initiateTransfer( siteId, plugin, file, event => {
+				dispatch( {
+					type: THEME_TRANSFER_INITIATE_PROGRESS,
+					siteId,
+					loaded: event.loaded,
+					total: event.total,
+				} );
+			} )
+			.then( ( { transfer_id } ) => {
+				if ( ! transfer_id ) {
+					return dispatch(
+						transferInitiateFailure( siteId, { error: 'initiate_failure' }, plugin, context )
+					);
+				}
+				const themeInitiateSuccessAction = {
+					type: THEME_TRANSFER_INITIATE_SUCCESS,
+					siteId,
+					transferId: transfer_id,
+				};
+				dispatch(
+					withAnalytics(
+						recordTracksEvent( 'calypso_automated_transfer_initiate_success', { plugin, context } ),
+						themeInitiateSuccessAction
+					)
+				);
+				dispatch( pollThemeTransferStatus( siteId, transfer_id, context ) );
+			} )
+			.catch( error => {
+				dispatch( transferInitiateFailure( siteId, error, plugin, context ) );
+			} );
+	};
+}
+
+// receive a transfer status
+function transferStatus( siteId, transferId, status, message, themeId ) {
+	return {
+		type: THEME_TRANSFER_STATUS_RECEIVE,
+		siteId,
+		transferId,
+		status,
+		message,
+		themeId,
+	};
+}
+
+// receive a transfer status error
+function transferStatusFailure( siteId, transferId, error ) {
+	return {
+		type: THEME_TRANSFER_STATUS_FAILURE,
+		siteId,
+		transferId,
+		error,
+	};
+}
+
+// receive a transfer initiation failure
+function transferInitiateFailure( siteId, error, plugin, context ) {
+	return dispatch => {
+		const themeInitiateFailureAction = {
+			type: THEME_TRANSFER_INITIATE_FAILURE,
+			siteId,
+			error,
+		};
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_automated_transfer_initiate_failure', { plugin, context } ),
+				themeInitiateFailureAction
+			)
+		);
+	};
+}
+/**
+ * Make API calls to the transfer status endpoint until a status complete is received,
+ * or an error is received, or the timeout is reached.
+ *
+ * The returned promise is only for testing purposes, and therefore is never rejected,
+ * to avoid unhandled rejections in production.
+ *
+ * @param {number} siteId -- the site being transferred
+ * @param {number} transferId -- the specific transfer
+ * @param {string} context -- from which the transfer was initiated
+ * @param {number} [interval] -- time between poll attempts
+ * @param {number} [timeout] -- time to wait for 'complete' status before bailing
+ *
+ * @returns {Promise} for testing purposes only
+ */
+export function pollThemeTransferStatus(
+	siteId,
+	transferId,
+	context,
+	interval = 3000,
+	timeout = 180000
+) {
+	const endTime = Date.now() + timeout;
+	return dispatch => {
+		const pollStatus = ( resolve, reject ) => {
+			if ( Date.now() > endTime ) {
+				// timed-out, stop polling
+				dispatch( transferStatusFailure( siteId, transferId, 'client timeout' ) );
+				return resolve();
+			}
+			return wpcom
+				.undocumented()
+				.transferStatus( siteId, transferId )
+				.then( ( { status, message, uploaded_theme_slug } ) => {
+					dispatch( transferStatus( siteId, transferId, status, message, uploaded_theme_slug ) );
+					if ( status === 'complete' ) {
+						// finished, stop polling
+						dispatch(
+							recordTracksEvent( 'calypso_automated_transfer_complete', {
+								transfer_id: transferId,
+								context,
+							} )
+						);
+						return resolve();
+					}
+					// poll again
+					return delay( pollStatus, interval, resolve, reject );
+				} )
+				.catch( error => {
+					dispatch( transferStatusFailure( siteId, transferId, error ) );
+					// error, stop polling
+					return resolve();
+				} );
+		};
+		return new Promise( pollStatus );
+	};
+}

--- a/client/state/themes/actions/try-and-customize-theme.js
+++ b/client/state/themes/actions/try-and-customize-theme.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { isExternal } from 'lib/url';
+import { getThemeCustomizeUrl } from 'state/themes/selectors';
+
+import 'state/themes/init';
+
+/**
+ * Triggers a switch to the try&customize page of theme.
+ * When theme is not available dispatches FAILURE action
+ * that trigers displaying error notice by notices middlewaere
+ *
+ * @param  {string}   themeId      WP.com Theme ID
+ * @param  {string}   siteId       Jetpack Site ID
+ * @returns {Function}              Action thunk
+ */
+export function tryAndCustomizeTheme( themeId, siteId ) {
+	return ( dispatch, getState ) => {
+		const url = getThemeCustomizeUrl( getState(), themeId, siteId );
+		if ( isExternal( url ) ) {
+			window.location.href = url;
+			return;
+		}
+		page( getThemeCustomizeUrl( getState(), themeId, siteId ) );
+	};
+}

--- a/client/state/themes/actions/try-and-customize.js
+++ b/client/state/themes/actions/try-and-customize.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+
+import { isJetpackSite } from 'state/sites/selectors';
+import { installAndTryAndCustomizeTheme } from 'state/themes/actions/install-and-try-and-customize-theme';
+import { suffixThemeIdForInstall } from 'state/themes/actions/suffix-theme-id-for-install';
+import { tryAndCustomizeTheme } from 'state/themes/actions/try-and-customize-theme';
+import { getTheme } from 'state/themes/selectors';
+
+import 'state/themes/init';
+
+/**
+ * Switches to the customizer to preview a given theme.
+ * If it's a Jetpack site, installs the theme prior to activation if it isn't already.
+ *
+ * @param  {string}   themeId   Theme ID
+ * @param  {number}   siteId    Site ID
+ * @returns {Function}           Action thunk
+ */
+export function tryAndCustomize( themeId, siteId ) {
+	return ( dispatch, getState ) => {
+		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
+			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );
+			// If theme is already installed, installation will silently fail,
+			// and we just switch to the customizer.
+			return dispatch( installAndTryAndCustomizeTheme( installId, siteId ) );
+		}
+
+		return dispatch( tryAndCustomizeTheme( themeId, siteId ) );
+	};
+}

--- a/client/state/themes/actions/upload-theme.js
+++ b/client/state/themes/actions/upload-theme.js
@@ -1,0 +1,55 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import {
+	THEME_UPLOAD_FAILURE,
+	THEME_UPLOAD_PROGRESS,
+	THEME_UPLOAD_START,
+	THEME_UPLOAD_SUCCESS,
+} from 'state/action-types';
+import { receiveTheme } from 'state/themes/actions/receive-theme';
+
+import 'state/themes/init';
+
+/**
+ * Triggers a theme upload to the given site.
+ *
+ * @param {number} siteId -- Site to upload to
+ * @param {window.File} file -- the theme zip to upload
+ *
+ * @returns {Function} the action function
+ */
+export function uploadTheme( siteId, file ) {
+	return dispatch => {
+		dispatch( {
+			type: THEME_UPLOAD_START,
+			siteId,
+		} );
+		return wpcom
+			.undocumented()
+			.uploadTheme( siteId, file, event => {
+				dispatch( {
+					type: THEME_UPLOAD_PROGRESS,
+					siteId,
+					loaded: event.loaded,
+					total: event.total,
+				} );
+			} )
+			.then( theme => {
+				dispatch( receiveTheme( theme, siteId ) );
+				dispatch( {
+					type: THEME_UPLOAD_SUCCESS,
+					siteId,
+					themeId: theme.id,
+				} );
+			} )
+			.catch( error => {
+				dispatch( {
+					type: THEME_UPLOAD_FAILURE,
+					siteId,
+					error,
+				} );
+			} );
+	};
+}


### PR DESCRIPTION
This is a reorganisation of theme action creators, which all lived inside a single `actions.js` file with over 1000 lines of code! This PR splits them into individual modules of a couple of exports at most, re-exporting them from an index file. It's a follow-up to all the previous theme modularisation work.

I split each extraction into its own commit, in case that makes things easier for reviewers.

This PR *may* help with loading performance, in case there are any seldom-used albeit heavy action creators in there, as they can now move freely to just the chunks they're needed in.

#### Changes proposed in this Pull Request

* Split `state/themes/actions.js` into individual modules

#### Testing instructions

This PR only changes where things live, with no changes to functionality. As such, it should be sufficient to ensure that the build continues to work and the existing unit tests don't fail.
