### PR TITLE
Plan step test: Show testimonial section only for eligible users

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -182,7 +182,7 @@ export class PlansFeaturesMain extends Component {
 					} ) }
 					siteId={ siteId }
 				/>
-				<PlanTestimonials />
+				{ isEligibleForPlanStepTest && <PlanTestimonials /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the plan step test, we show testimonials below the plan features as implemented in #39630. This section needs to be shown only to eligible users.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow while in control group of _planStepCopyUpdates_ test and verify that you are not shown the testimonial section.
* Go through the variant while in dev or wpcalypso environment and verify that you are shown the testimonial section.
