### PR TITLE
Site Migration: Move the error notice above the content card

### DIFF
--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -115,7 +115,7 @@
 
 .migrate__error {
 	&.notice {
-		margin-bottom: 0;
+		margin-bottom: 16px;
 	}
 }
 

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -121,6 +121,13 @@ class StepSourceSelect extends Component {
 		return (
 			<>
 				<HeaderCake backHref={ backHref }>{ translate( 'Import from WordPress' ) }</HeaderCake>
+
+				{ this.state.error && (
+					<Notice className="migrate__error" showDismiss={ false } status="is-error">
+						{ this.state.error }
+					</Notice>
+				) }
+
 				<CompactCard>
 					<CardHeading>{ translate( 'What WordPress site do you want to import?' ) }</CardHeading>
 					<div className="migrate__explain">
@@ -143,11 +150,7 @@ class StepSourceSelect extends Component {
 					onSubmit={ this.handleContinue }
 					url={ this.props.url }
 				/>
-				{ this.state.error && (
-					<Notice className="migrate__error" showDismiss={ false } status="is-error">
-						{ this.state.error }
-					</Notice>
-				) }
+
 				<Card>
 					<Button busy={ this.state.isLoading } onClick={ this.handleContinue } primary={ true }>
 						{ translate( 'Continue' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the error notice in the Site Migration screen above the content card.

#### Testing instructions

* Apply diff or use Calypso.live link
* Go to Import -> WordPress
* Type an invalid URL or a WordPress.com site address
* Check where and how the error appears

Fixes #39579
