### PR TITLE
[e2e] Update data-tip-target for Sidebar items

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -137,7 +137,7 @@ export class MySitesSidebar extends Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<SidebarItem
-				tipTarget="menus"
+				tipTarget="stats"
 				label={ translate( 'Stats' ) }
 				className="stats"
 				selected={ itemLinkMatches(
@@ -169,7 +169,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				materialIcon="home"
-				tipTarget="menus"
+				tipTarget="myhome"
 				onNavigate={ this.trackCustomerHomeClick }
 				label={ translate( 'My Home' ) }
 				selected={ itemLinkMatches( [ '/home' ], path ) }

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -60,8 +60,12 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		return await this._scrollToAndClickMenuItem( 'plan' );
 	}
 
+	async selectMyHome() {
+		return await this._scrollToAndClickMenuItem( 'myhome' );
+	}
+
 	async selectStats() {
-		return await this._scrollToAndClickMenuItem( 'menus' );
+		return await this._scrollToAndClickMenuItem( 'stats' );
 	}
 
 	async selectActivity() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update `data-tip-target` for "Stats" and "My Home" in the Sidebar. Previous value was `menus` for both, which was confusing e2e tests and eventually make them fail ([example](https://circleci.com/gh/Automattic/wp-calypso/616147)).  

#### Testing instructions

- Tests are passing in CircleCI
- Run `wp-stats-insights-spec.js` and make sure it passes

