### PR TITLE
Plan step test: Launch the test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -116,7 +116,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	planStepCopyUpdates: {
-		datestamp: '20200227',
+		datestamp: '20200312',
 		variations: {
 			variantCopyUpdates: 50,
 			control: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -116,7 +116,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	planStepCopyUpdates: {
-		datestamp: '20200221',
+		datestamp: '20200227',
 		variations: {
 			variantCopyUpdates: 50,
 			control: 50,

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -26,7 +26,6 @@ import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { abtest } from 'lib/abtest';
-import config from 'config';
 
 /**
  * Style dependencies
@@ -100,11 +99,7 @@ export class PlansStep extends Component {
 	};
 
 	isEligibleForPlanStepTest() {
-		return (
-			config.isEnabled( 'plans-step-copy-updates' ) &&
-			! this.props.isLaunchPage &&
-			'variantCopyUpdates' === abtest( 'planStepCopyUpdates' )
-		);
+		return ! this.props.isLaunchPage && 'variantCopyUpdates' === abtest( 'planStepCopyUpdates' );
 	}
 
 	plansFeaturesList() {

--- a/config/development.json
+++ b/config/development.json
@@ -124,7 +124,6 @@
 		"oauth": false,
 		"perfmon": false,
 		"persist-redux": true,
-		"plans/personal-plan": true,
 		"plans-step-copy-updates": true,
 		"post-editor-github-link": false,
 		"post-editor/html-toolbar": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -101,7 +101,6 @@
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,
-		"plans-step-copy-updates": true,
 		"post-editor/html-toolbar": true,
 		"post-editor/image-editor": true,
 		"post-editor/preview-scroll-to-content": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The new plan step AB test was enabled in #39600 with a feature flag restriction. Individual pieces of the UI were built in separate PRs https://github.com/Automattic/wp-calypso/pull/39630 and https://github.com/Automattic/wp-calypso/pull/39621.

* This PR removes the feature flag restriction and launches the PR with a 50/50 allocation.

**Desktop**

<img width="1635" alt="Screenshot 2020-02-27 at 5 10 06 PM" src="https://user-images.githubusercontent.com/1269602/75441763-3fd99280-5984-11ea-8f0c-d7517aeb99ff.png">

**Mobile screen size**

![calypso localhost_3000_start_plans(Pixel 2)](https://user-images.githubusercontent.com/1269602/75441817-4f58db80-5984-11ea-9b34-40d80321e916.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow at /start.
* When in the control group of the `planStepCopyUpdates` test, verify that you see the unchanged plan step UI version
* When in the variant group, verify that you see the updated UI that matches with p8Eqe3-144-p2.
* Verify that the plans page in Calypso /plans, and the plans step shown in launch flow of private sites both do not show the new UI.