### PR TITLE
Layout: AsyncLoad MasterbarItemNew

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -12,7 +12,6 @@ import React from 'react';
 import { recordTracksEvent } from 'state/analytics/actions';
 import Masterbar from './masterbar';
 import Item from './item';
-import Publish from './publish';
 import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
 import config from 'config';
@@ -149,13 +148,15 @@ class MasterbarLoggedIn extends React.Component {
 				) }
 				{ config.isEnabled( 'resume-editing' ) && <ResumeEditing /> }
 				{ ! domainOnlySite && ! isMigrationInProgress && (
-					<Publish
+					<AsyncLoad
+						require="./publish"
+						placeholder={ null }
 						isActive={ this.isActive( 'post' ) }
 						className="masterbar__item-new"
 						tooltip={ translate( 'Create a New Post' ) }
 					>
 						{ translate( 'Write' ) }
-					</Publish>
+					</AsyncLoad>
 				) }
 				<Item
 					tipTarget="me"


### PR DESCRIPTION
This PR changes the `MasterbarItemNew` component to load asynchronously in the logged in masterbar. This seems to shave off ~5% of the main entry point!

`master` branching point: `05b683bfe04ff4144ac49e1896e9f8461fcdf718`

![](https://cldup.com/IH5tK3Xca7.png)

PR: `f2f869f5cf22348244a0661f1e30cad83a0368c6`

![](https://cldup.com/Un_tJPth_K.png)

(@sgomes may want to verify that 😉 )

#### Changes proposed in this Pull Request

* Layout: AsyncLoad MasterbarItemNew

#### Testing instructions

* Checkout this branch.
* Go to any route in Calypso as a logged in user.
* Verify you can see the "Write" item in the masterbar, and it works just like it did before.