### PR TITLE
wpcom-proxy-request: Use uuid rather than uid dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35522,11 +35522,6 @@
 				}
 			}
 		},
-		"uid": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz",
-			"integrity": "sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM="
-		},
 		"uid-number": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
@@ -37736,8 +37731,15 @@
 			"requires": {
 				"debug": "^4.1.1",
 				"progress-event": "^1.0.0",
-				"uid": "^0.0.2",
+				"uuid": "^7.0.1",
 				"wp-error": "^1.3.0"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.1.tgz",
+					"integrity": "sha512-yqjRXZzSJm9Dbl84H2VDHpM3zMjzSJQ+hn6C4zqd5ilW+7P4ZmLEEqwho9LjP+tGuZlF4xrHQXT0h9QZUS/pWA=="
+				}
 			}
 		},
 		"wpcom-xhr-request": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -460,9 +460,9 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.8.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.5.tgz",
-			"integrity": "sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
+			"integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
 			"dev": true,
 			"requires": {
 				"browserslist": "^4.8.5",
@@ -525,12 +525,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-			"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
+			"integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.3",
+				"@babel/types": "^7.8.6",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
@@ -591,12 +591,12 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz",
-			"integrity": "sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.6.tgz",
+			"integrity": "sha512-UrJdk27hKVJSnibFcUWYLkCL0ZywTUoot8yii1lsHJcvwrypagmYKjHLMWivQPm4s6GdyygCL8fiH5EYLxhQwQ==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.8.4",
+				"@babel/compat-data": "^7.8.6",
 				"browserslist": "^4.8.5",
 				"invariant": "^2.2.4",
 				"levenary": "^1.1.1",
@@ -612,25 +612,26 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.3.tgz",
-			"integrity": "sha512-qmp4pD7zeTxsv0JNecSBsEmG1ei2MqwJq4YQcK3ZWm/0t07QstWfvuV/vm3Qt5xNMFETn2SZqpMx2MQzbtq+KA==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.6.tgz",
+			"integrity": "sha512-klTBDdsr+VFFqaDHm5rR69OpEQtO2Qv8ECxHS1mNhJJvaHArR6a1xTf5K/eZW7eZpJbhCx3NW1Yt/sKsLXLblg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
 				"@babel/helper-split-export-declaration": "^7.8.3"
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.3.tgz",
-			"integrity": "sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.6.tgz",
+			"integrity": "sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==",
 			"dev": true,
 			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-regex": "^7.8.3",
 				"regexpu-core": "^4.6.0"
 			}
@@ -703,16 +704,17 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.3.tgz",
-			"integrity": "sha512-C7NG6B7vfBa/pwCOshpMbOYUmrYQDfCpVL/JCRu0ek8B5p8kue1+BCXpg2vOYs7w5ACB9GTOBYQ5U6NwrMg+3Q==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.6.tgz",
+			"integrity": "sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
 				"@babel/helper-simple-access": "^7.8.3",
 				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.8.3",
+				"@babel/template": "^7.8.6",
+				"@babel/types": "^7.8.6",
 				"lodash": "^4.17.13"
 			}
 		},
@@ -754,15 +756,15 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
-			"integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/traverse": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/traverse": "^7.8.6",
+				"@babel/types": "^7.8.6"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -830,9 +832,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-			"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
+			"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -1065,9 +1067,9 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.3.tgz",
-			"integrity": "sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz",
+			"integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.8.3",
@@ -1075,7 +1077,7 @@
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
 				"@babel/helper-split-export-declaration": "^7.8.3",
 				"globals": "^11.1.0"
 			}
@@ -1138,9 +1140,9 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
-			"integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz",
+			"integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -1530,9 +1532,9 @@
 			}
 		},
 		"@babel/register": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.8.3.tgz",
-			"integrity": "sha512-t7UqebaWwo9nXWClIPLPloa5pN33A2leVs8Hf0e9g9YwUP8/H9NeR7DJU+4CXo23QtjChQv5a3DjEtT83ih1rg==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.8.6.tgz",
+			"integrity": "sha512-7IDO93fuRsbyml7bAafBQb3RcBGlCpU4hh5wADA2LJEEcYk92WkwFZ0pHyIi2fb5Auoz1714abETdZKCOxN0CQ==",
 			"dev": true,
 			"requires": {
 				"find-cache-dir": "^2.0.0",
@@ -1575,37 +1577,37 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-			"integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
-				"@babel/parser": "^7.8.3",
-				"@babel/types": "^7.8.3"
+				"@babel/parser": "^7.8.6",
+				"@babel/types": "^7.8.6"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-			"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
+			"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.8.4",
+				"@babel/generator": "^7.8.6",
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.8.4",
-				"@babel/types": "^7.8.3",
+				"@babel/parser": "^7.8.6",
+				"@babel/types": "^7.8.6",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-			"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
+			"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
@@ -1886,13 +1888,6 @@
 				"@emotion/serialize": "^0.11.15",
 				"@emotion/utils": "0.11.3",
 				"babel-plugin-emotion": "^10.0.27"
-			},
-			"dependencies": {
-				"@emotion/utils": {
-					"version": "0.11.3",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-				}
 			}
 		},
 		"@emotion/hash": {
@@ -1939,13 +1934,6 @@
 				"@emotion/unitless": "0.7.5",
 				"@emotion/utils": "0.11.3",
 				"csstype": "^2.5.7"
-			},
-			"dependencies": {
-				"@emotion/utils": {
-					"version": "0.11.3",
-					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
-				}
 			}
 		},
 		"@emotion/sheet": {
@@ -4243,14 +4231,25 @@
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "5.5.2",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.2.tgz",
-			"integrity": "sha512-ICDcRA0C2vtTZZGud1nXRrBLXZqFayodXAKZfo3dkdcLNqcHsgaz3YSTupbURusYeucSVRjjG+RTcQhx6HPPcg==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.3.tgz",
+			"integrity": "sha512-EzKwkwcxeegYYah5ukEeAI/gYRLv2Y9U5PpIsseGSFDk+G3RbipQGBs8GuYS1TLCtQaqoO66+aQGtITPalxsNQ==",
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^2.0.0",
 				"is-plain-object": "^3.0.0",
-				"universal-user-agent": "^4.0.0"
+				"universal-user-agent": "^5.0.0"
+			},
+			"dependencies": {
+				"universal-user-agent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+					"integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+					"dev": true,
+					"requires": {
+						"os-name": "^3.1.0"
+					}
+				}
 			}
 		},
 		"@octokit/plugin-enterprise-rest": {
@@ -4285,9 +4284,9 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
-			"integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.2.tgz",
+			"integrity": "sha512-7NPJpg19wVQy1cs2xqXjjRq/RmtSomja/VSWnptfYwuBxLdbYh2UjhGi0Wx7B1v5Iw5GKhfFDQL7jM7SSp7K2g==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^5.5.0",
@@ -4297,7 +4296,7 @@
 				"is-plain-object": "^3.0.0",
 				"node-fetch": "^2.3.0",
 				"once": "^1.4.0",
-				"universal-user-agent": "^4.0.0"
+				"universal-user-agent": "^5.0.0"
 			},
 			"dependencies": {
 				"node-fetch": {
@@ -4305,6 +4304,15 @@
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
 					"dev": true
+				},
+				"universal-user-agent": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
+					"integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
+					"dev": true,
+					"requires": {
+						"os-name": "^3.1.0"
+					}
 				}
 			}
 		},
@@ -4344,9 +4352,9 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.1.1.tgz",
-			"integrity": "sha512-89LOYH+d/vsbDX785NOfLxTW88GjNd0lWRz1DVPVsZgg9Yett5O+3MOvwo7iHgvUwbFz0mf/yPIjBkUbs4kxoQ==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.3.1.tgz",
+			"integrity": "sha512-rvJP1Y9A/+Cky2C3var1vsw3Lf5Rjn/0sojNl2AjCX+WbpIHYccaJ46abrZoIxMYnOToul6S9tPytUVkFI7CXQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": ">= 8"
@@ -4541,6 +4549,12 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
 					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 					"dev": true
 				}
 			}
@@ -5512,9 +5526,9 @@
 			}
 		},
 		"@types/babel__core": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.4.tgz",
-			"integrity": "sha512-c/5MuRz5HM4aizqL5ViYfW4iEnmfPcfbH4Xa6GgLT21dMc1NGeNnuS6egHheOmP+kCJ9CAzC4pv4SDCWTnRkbg==",
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
+			"integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -5544,9 +5558,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.8",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
-			"integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.9.tgz",
+			"integrity": "sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -5685,9 +5699,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.7.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
-			"integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
+			"version": "13.7.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.6.tgz",
+			"integrity": "sha512-eyK7MWD0R1HqVTp+PtwRgFeIsemzuj4gBFSQxfPHY5iMjS7474e5wq+VFgTcdpyHeNxyKSaetYAjdMLJlKoWqA==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6366,6 +6380,12 @@
 						"ansi-regex": "^3.0.0"
 					}
 				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				},
 				"webpack-log": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
@@ -6458,14 +6478,14 @@
 			}
 		},
 		"@wordpress/block-directory": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-directory/-/block-directory-1.5.1.tgz",
-			"integrity": "sha512-YdlatnSHjw0dKxr4mqKT10awrVYC//kHrwtRrfg2z98+O+4uVsWN9E0mtHzFmYQHRFK3Ep/+GqIgp2RyH8TMgQ==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-directory/-/block-directory-1.5.2.tgz",
+			"integrity": "sha512-PDj01re70kfj1eYlxWPqttHgswXwl3XQSrGWyaCAElywanb6h+vuVt7uWZ0cW0MuMRTJn/bLQVWrGYH05wl8dQ==",
 			"requires": {
 				"@wordpress/api-fetch": "^3.11.0",
-				"@wordpress/block-editor": "^3.7.1",
+				"@wordpress/block-editor": "^3.7.2",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.1",
+				"@wordpress/components": "^9.2.2",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/data": "^4.14.0",
 				"@wordpress/element": "^2.11.0",
@@ -6476,15 +6496,15 @@
 			}
 		},
 		"@wordpress/block-editor": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-3.7.1.tgz",
-			"integrity": "sha512-joZBiYY4iqSpyFJBsPvEJQjILxdywESTu4ACAKb8SGQ19DIa3vkuS6FTEsmdy+YfkRiohhPAsd17mLZAv0tb1g==",
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-3.7.2.tgz",
+			"integrity": "sha512-S+tE0dn+hitSZ1zKggCIQ8LW3cfrWM+ilH01cy7IyG9NRyyNl6V5O8+EMDwO0uI+GSeP65y4MqvLUSoRGM0KKQ==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/a11y": "^2.7.0",
 				"@wordpress/blob": "^2.7.0",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.1",
+				"@wordpress/components": "^9.2.2",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/data": "^4.14.0",
 				"@wordpress/deprecated": "^2.7.0",
@@ -6518,25 +6538,25 @@
 			}
 		},
 		"@wordpress/block-library": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.14.1.tgz",
-			"integrity": "sha512-gq+PKbnnQr/kFm29Cqh5n9EABL1V/Ey79eItfNhzCle92r79kgUwfDjRvoVbzikNU5F1j392ojpZK8EQCn+T8w==",
+			"version": "2.14.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.14.2.tgz",
+			"integrity": "sha512-HL6KaZ6cwWK/ea9MBA/tPjheEOt1ilD/OTHZ9TAaRmc/rALGRy5B4HNzOfbz4D8tnRCkyu5BMGy+5yV5oGPNrw==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/a11y": "^2.7.0",
 				"@wordpress/api-fetch": "^3.11.0",
 				"@wordpress/autop": "^2.6.0",
 				"@wordpress/blob": "^2.7.0",
-				"@wordpress/block-editor": "^3.7.1",
+				"@wordpress/block-editor": "^3.7.2",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.1",
+				"@wordpress/components": "^9.2.2",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/core-data": "^2.12.0",
 				"@wordpress/data": "^4.14.0",
 				"@wordpress/date": "^3.8.0",
 				"@wordpress/deprecated": "^2.7.0",
 				"@wordpress/dom": "^2.8.0",
-				"@wordpress/editor": "^9.12.1",
+				"@wordpress/editor": "^9.12.2",
 				"@wordpress/element": "^2.11.0",
 				"@wordpress/escape-html": "^1.7.0",
 				"@wordpress/i18n": "^3.9.0",
@@ -6545,7 +6565,7 @@
 				"@wordpress/keycodes": "^2.9.0",
 				"@wordpress/primitives": "^1.1.0",
 				"@wordpress/rich-text": "^3.12.0",
-				"@wordpress/server-side-render": "^1.8.1",
+				"@wordpress/server-side-render": "^1.8.2",
 				"@wordpress/url": "^2.11.0",
 				"@wordpress/viewport": "^2.13.0",
 				"classnames": "^2.2.5",
@@ -6590,6 +6610,13 @@
 				"simple-html-tokenizer": "^0.5.7",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+				}
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -6599,9 +6626,9 @@
 			"dev": true
 		},
 		"@wordpress/components": {
-			"version": "9.2.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.2.1.tgz",
-			"integrity": "sha512-OAfibZccphrOmQyc8PF4Y5b5iAGCrzrySh9tgCP1tgYkzY9RwULmYnAFDtrYjfCF9najPTI6Snvea5z7huwlJg==",
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.2.2.tgz",
+			"integrity": "sha512-WSOZUyUh3PWpBl+Q7nr3MFyBlZCfNeTdUv4tcyHIJlm5msXNgvJQIUM53dUnFlJFmdbP/vyOl71XaDs75gWR3A==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@emotion/core": "^10.0.22",
@@ -6637,6 +6664,13 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+				}
 			}
 		},
 		"@wordpress/compose": {
@@ -6759,28 +6793,28 @@
 			}
 		},
 		"@wordpress/edit-post": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-3.13.1.tgz",
-			"integrity": "sha512-ypHBgc+tO7N2Syyqxe/aHh2AlJ1qXNQ01IIeeESATpwlrLpAap+QrSbdALri3p9L1mHVWPRVbwdB42usfzshRw==",
+			"version": "3.13.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-3.13.2.tgz",
+			"integrity": "sha512-BFZ+cQ+czSqJ48XSjyiKLIQ29lPNMTxPRBn7q6nSqwI433/q63G/K9D/PYdVR81gg6WsYMGXoQmnHTaV3yHNaQ==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/a11y": "^2.7.0",
 				"@wordpress/api-fetch": "^3.11.0",
-				"@wordpress/block-editor": "^3.7.1",
-				"@wordpress/block-library": "^2.14.1",
+				"@wordpress/block-editor": "^3.7.2",
+				"@wordpress/block-library": "^2.14.2",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.1",
+				"@wordpress/components": "^9.2.2",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/core-data": "^2.12.0",
 				"@wordpress/data": "^4.14.0",
-				"@wordpress/editor": "^9.12.1",
+				"@wordpress/editor": "^9.12.2",
 				"@wordpress/element": "^2.11.0",
 				"@wordpress/hooks": "^2.7.0",
 				"@wordpress/i18n": "^3.9.0",
 				"@wordpress/icons": "^1.1.0",
 				"@wordpress/keyboard-shortcuts": "^1.1.0",
 				"@wordpress/keycodes": "^2.9.0",
-				"@wordpress/media-utils": "^1.7.1",
+				"@wordpress/media-utils": "^1.7.2",
 				"@wordpress/notices": "^2.0.0",
 				"@wordpress/plugins": "^2.12.0",
 				"@wordpress/url": "^2.11.0",
@@ -6793,18 +6827,18 @@
 			}
 		},
 		"@wordpress/editor": {
-			"version": "9.12.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.12.1.tgz",
-			"integrity": "sha512-WjwQV+vESD63HBgi7ueBXzPt0enEZBi2SGzrfj/zPI1mLskNZTC0Ep6iKhU+PCLBJC6W/OoYct5PeMd2BjbuVA==",
+			"version": "9.12.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.12.2.tgz",
+			"integrity": "sha512-arSWRTtg7F9+ndukeNDnIOtkg7jOaA2R7AwsM2eEnj+WVikAucMR4E/c4TovEwc3JwNycjPcY0qD63iJBo6ZTQ==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/api-fetch": "^3.11.0",
 				"@wordpress/autop": "^2.6.0",
 				"@wordpress/blob": "^2.7.0",
-				"@wordpress/block-directory": "^1.5.1",
-				"@wordpress/block-editor": "^3.7.1",
+				"@wordpress/block-directory": "^1.5.2",
+				"@wordpress/block-editor": "^3.7.2",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.1",
+				"@wordpress/components": "^9.2.2",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/core-data": "^2.12.0",
 				"@wordpress/data": "^4.14.0",
@@ -6819,10 +6853,10 @@
 				"@wordpress/is-shallow-equal": "^1.8.0",
 				"@wordpress/keyboard-shortcuts": "^1.1.0",
 				"@wordpress/keycodes": "^2.9.0",
-				"@wordpress/media-utils": "^1.7.1",
+				"@wordpress/media-utils": "^1.7.2",
 				"@wordpress/notices": "^2.0.0",
 				"@wordpress/rich-text": "^3.12.0",
-				"@wordpress/server-side-render": "^1.8.1",
+				"@wordpress/server-side-render": "^1.8.2",
 				"@wordpress/url": "^2.11.0",
 				"@wordpress/viewport": "^2.13.0",
 				"@wordpress/wordcount": "^2.7.0",
@@ -7074,9 +7108,9 @@
 			}
 		},
 		"@wordpress/media-utils": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-1.7.1.tgz",
-			"integrity": "sha512-cfcCAvhrCUMjYjBhbtKO1Y5GqFvxFqosYykkbDifbwj8DA+P8+Fh2Q9aWKieVh8d7RAES3DqFVY7qvINkKiYMw==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-1.7.2.tgz",
+			"integrity": "sha512-EUlC5wg2XjNbkV/5lMrv3xRXNrR9FPzZjVdVMOvL+pNup9uXSIoyU44xjnlU6FNI0pB2iJb7R0xypPMav1UoUA==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/api-fetch": "^3.11.0",
@@ -7388,13 +7422,13 @@
 			}
 		},
 		"@wordpress/server-side-render": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.8.1.tgz",
-			"integrity": "sha512-JLLwyY6W/KxALMc72R1KgrtTaiHoyNzCjNI8bVD192z+gFTFdBg8d7F3CUMwaCzkfKxf09Y0zn7955c0S6k3Ew==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.8.2.tgz",
+			"integrity": "sha512-uxXkelD0+hFKivOPoVQXrGkqTwITKl5I8rYwV83YjBsl9b2vkXzII+C+0EXbTolvLmLsYDgu224WHcU4JgRZBw==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/api-fetch": "^3.11.0",
-				"@wordpress/components": "^9.2.1",
+				"@wordpress/components": "^9.2.2",
 				"@wordpress/data": "^4.14.0",
 				"@wordpress/deprecated": "^2.7.0",
 				"@wordpress/element": "^2.11.0",
@@ -7532,9 +7566,9 @@
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
 		},
 		"acorn-walk": {
 			"version": "6.2.0",
@@ -7629,9 +7663,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-			"integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -7976,12 +8010,12 @@
 			"dev": true
 		},
 		"array.prototype.find": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
-			"integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
+			"integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.13.0"
+				"es-abstract": "^1.17.4"
 			}
 		},
 		"array.prototype.flat": {
@@ -8941,16 +8975,6 @@
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
 		"blob": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -9274,9 +9298,9 @@
 			},
 			"dependencies": {
 				"caniuse-lite": {
-					"version": "1.0.30001028",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001028.tgz",
-					"integrity": "sha512-Vnrq+XMSHpT7E+LWoIYhs3Sne8h9lx9YJV3acH3THNCwU/9zV93/ta4xVfzTtnqd3rvnuVpVjE3DFqf56tr3aQ=="
+					"version": "1.0.30001030",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001030.tgz",
+					"integrity": "sha512-QGK0W4Ft/Ac+zTjEiRJfwDNATvS3fodDczBXrH42784kcfqcDKpEPfN08N0HQjrAp8He/Jw8QiSS9QRn7XAbUw=="
 				}
 			}
 		},
@@ -10014,7 +10038,6 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"bindings": "^1.5.0",
 						"nan": "^2.12.1",
 						"node-pre-gyp": "*"
 					},
@@ -12733,9 +12756,9 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.9.0.tgz",
-			"integrity": "sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.10.0.tgz",
+			"integrity": "sha512-EhfEKevYGWhWlZbNeplfhIU/+N+x0iCIx7VzKlXma2EdQyznVlZhCptXUY+BegNpPW2kjdx15Rvq503YcXXrcA==",
 			"dev": true
 		},
 		"dateformat": {
@@ -13604,9 +13627,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.355",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.355.tgz",
-			"integrity": "sha512-zKO/wS+2ChI/jz9WAo647xSW8t2RmgRLFdbUb/77cORkUTargO+SCj4ctTHjBn2VeNFrsLgDT7IuDVrd3F8mLQ=="
+			"version": "1.3.362",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.362.tgz",
+			"integrity": "sha512-xdU5VCoZyMPMOWtCaMgbr48OwWZHrMLbGnAOlEqibXiIGsb4kiCGWEHK5NOghcVLdBVIbr/BW+yuKxVuGTtzEg=="
 		},
 		"element-resize-detector": {
 			"version": "1.2.1",
@@ -14399,9 +14422,9 @@
 			},
 			"dependencies": {
 				"eslint-plugin-react-hooks": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.4.0.tgz",
-					"integrity": "sha512-bH5DOCP6WpuOqNaux2BlaDCrSgv8s5BitP90bTgtZ1ZsRn2bdIfeMDY5F2RnJVnyKDy6KRQRDbipPLZ1y77QtQ==",
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.0.tgz",
+					"integrity": "sha512-bzvdX47Jx847bgAYf0FPX3u1oxU+mKU8tqrpj4UX9A96SbAmj/HVEefEy6rJUog5u8QIlOPTKZcBpGn5kkKfAQ==",
 					"dev": true
 				}
 			}
@@ -15721,13 +15744,6 @@
 				}
 			}
 		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true,
-			"optional": true
-		},
 		"filesize": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -16016,9 +16032,9 @@
 			"dev": true
 		},
 		"flow-parser": {
-			"version": "0.119.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.119.0.tgz",
-			"integrity": "sha512-P49kGSnCII6c5/P4QsVDtoam83zrXrdq4EUJDVOpbeURy48RM8BOboKcEfFHS1xnNID01UXu8Hf60b+m23T81w==",
+			"version": "0.119.1",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.119.1.tgz",
+			"integrity": "sha512-yFd4z6ZBXq//TJo/gtSzGKhz6wEVeI2m+6JB25JzXuRAOhM5Ze4xFkc3FSIStbYjrAx4H1IUiUTI/yy30oKp8A==",
 			"dev": true
 		},
 		"flush-write-stream": {
@@ -16279,9 +16295,9 @@
 			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"formidable": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-			"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+			"integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -17137,16 +17153,17 @@
 					}
 				},
 				"fast-glob": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
-					"integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
+					"integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
 					"dev": true,
 					"requires": {
 						"@nodelib/fs.stat": "^2.0.2",
 						"@nodelib/fs.walk": "^1.2.3",
 						"glob-parent": "^5.1.0",
 						"merge2": "^1.3.0",
-						"micromatch": "^4.0.2"
+						"micromatch": "^4.0.2",
+						"picomatch": "^2.2.1"
 					}
 				},
 				"fill-range": {
@@ -17671,9 +17688,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.7.tgz",
+			"integrity": "sha512-ChkjQtKJ3GI6SsI4O5jwr8q8EPrWCnxuc4Tbx+vRI5x6mDOpjKKltNo1lRlszw3xwgTOSns1ZRBiMmmwpcvLxg=="
 		},
 		"hpack.js": {
 			"version": "2.1.6",
@@ -18800,9 +18817,9 @@
 			"dev": true
 		},
 		"ipaddr.js": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
 		},
 		"irregular-plurals": {
 			"version": "2.0.0",
@@ -19939,7 +19956,6 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"bindings": "^1.5.0",
 						"nan": "^2.12.1",
 						"node-pre-gyp": "*"
 					},
@@ -20540,6 +20556,14 @@
 				"strip-ansi": "^5.2.0",
 				"uuid": "^3.3.3",
 				"xml": "^1.0.1"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				}
 			}
 		},
 		"jest-leak-detector": {
@@ -21132,9 +21156,9 @@
 			}
 		},
 		"jsonc-parser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.0.tgz",
-			"integrity": "sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+			"integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
 			"dev": true
 		},
 		"jsonfile": {
@@ -21186,9 +21210,9 @@
 			"dev": true
 		},
 		"just-extend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
-			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
 			"dev": true
 		},
 		"keymaster": {
@@ -22817,13 +22841,13 @@
 			},
 			"dependencies": {
 				"find-cache-dir": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
+					"integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
 					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
-						"make-dir": "^3.0.0",
+						"make-dir": "^3.0.2",
 						"pkg-dir": "^4.1.0"
 					}
 				},
@@ -23384,9 +23408,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.49",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
-			"integrity": "sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==",
+			"version": "1.1.50",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.50.tgz",
+			"integrity": "sha512-lgAmPv9eYZ0bGwUYAKlr8MG6K4CvWliWqnkcT2P8mMAgVrH3lqfBPorFlxiG1pHQnqmavJZ9vbMXUTNyMLbrgQ==",
 			"requires": {
 				"semver": "^6.3.0"
 			}
@@ -28865,12 +28889,12 @@
 			}
 		},
 		"proxy-addr": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+			"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
 			"requires": {
 				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.0"
+				"ipaddr.js": "1.9.1"
 			}
 		},
 		"proxy-from-env": {
@@ -29171,9 +29195,9 @@
 			}
 		},
 		"react": {
-			"version": "16.12.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-			"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+			"version": "16.13.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
+			"integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -29716,9 +29740,9 @@
 			}
 		},
 		"react-docgen": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.2.1.tgz",
-			"integrity": "sha512-3nvsiDKN/KIlgRyHCdkLrm8ajjSMZ4NIHuwYTAdBvQF3O7A2tmCBB3gwTjJ4zXH8aUpIjFwlVIjffzkJHIZ5/Q==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.3.0.tgz",
+			"integrity": "sha512-hUrv69k6nxazOuOmdGeOpC/ldiKy7Qj/UFpxaQi0eDMrUFUTIPGtY5HJu7BggSmiyAMfREaESbtBL9UzdQ+hyg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.7.5",
@@ -29766,14 +29790,14 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.12.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-			"integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+			"version": "16.13.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.0.tgz",
+			"integrity": "sha512-y09d2c4cG220DzdlFkPTnVvGTszVvNpC73v+AaLGLHbkpy3SSgvYq8x0rNwPJ/Rk/CicTNgk0hbHNw1gMEZAXg==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.18.0"
+				"scheduler": "^0.19.0"
 			}
 		},
 		"react-draggable": {
@@ -29856,9 +29880,9 @@
 			}
 		},
 		"react-is": {
-			"version": "16.12.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+			"version": "16.13.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+			"integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
 		},
 		"react-lazily-render": {
 			"version": "1.2.0",
@@ -29914,9 +29938,9 @@
 			}
 		},
 		"react-modal": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.1.tgz",
-			"integrity": "sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==",
+			"version": "3.11.2",
+			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.2.tgz",
+			"integrity": "sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==",
 			"requires": {
 				"exenv": "^1.2.0",
 				"prop-types": "^15.5.10",
@@ -30100,6 +30124,18 @@
 				"prop-types": "^15.6.2",
 				"react-is": "^16.8.6",
 				"scheduler": "^0.18.0"
+			},
+			"dependencies": {
+				"scheduler": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+					"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				}
 			}
 		},
 		"react-textarea-autosize": {
@@ -31270,6 +31306,12 @@
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 					"dev": true
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -31567,9 +31609,9 @@
 			}
 		},
 		"run-async": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+			"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
 			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
@@ -31963,9 +32005,9 @@
 			"dev": true
 		},
 		"scheduler": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-			"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.0.tgz",
+			"integrity": "sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -32751,6 +32793,12 @@
 					"requires": {
 						"websocket-driver": ">=0.5.1"
 					}
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -33387,6 +33435,12 @@
 					"requires": {
 						"rimraf": "^2.6.3"
 					}
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
 				}
 			}
 		},
@@ -34592,6 +34646,14 @@
 				"pify": "^3.0.0",
 				"temp-dir": "^1.0.0",
 				"uuid": "^3.0.1"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				}
 			}
 		},
 		"term-size": {
@@ -34670,13 +34732,13 @@
 					}
 				},
 				"find-cache-dir": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
-					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
+					"integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
 					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
-						"make-dir": "^3.0.0",
+						"make-dir": "^3.0.2",
 						"pkg-dir": "^4.1.0"
 					}
 				},
@@ -35350,9 +35412,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
+			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
 		},
 		"tsutils": {
 			"version": "3.17.1",
@@ -35521,11 +35583,6 @@
 					"dev": true
 				}
 			}
-		},
-		"uid": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz",
-			"integrity": "sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM="
 		},
 		"uid-number": {
 			"version": "0.0.6",
@@ -35781,9 +35838,9 @@
 			}
 		},
 		"universal-user-agent": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
-			"integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+			"integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
 			"dev": true,
 			"requires": {
 				"os-name": "^3.1.0"
@@ -36047,9 +36104,9 @@
 			}
 		},
 		"use-subscription": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.3.0.tgz",
-			"integrity": "sha512-buZV7FUtnbOr+65dN7PHK7chHhQGfk/yjgqfpRLoWuHIAc4klAD/rdot2FsPNtFthN1ZydvA8tR/mWBMQ+/fDQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.4.0.tgz",
+			"integrity": "sha512-R7P7JWpeHp+dtEYsgDzIIgOmVqRfJjRjLOO0YIYk6twctUkUYe6Tz0pcabyTDGcMMRt9uMbFMfwBfxKHg9gCSw==",
 			"requires": {
 				"object-assign": "^4.1.1"
 			}
@@ -36123,9 +36180,9 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.1.tgz",
+			"integrity": "sha512-yqjRXZzSJm9Dbl84H2VDHpM3zMjzSJQ+hn6C4zqd5ilW+7P4ZmLEEqwho9LjP+tGuZlF4xrHQXT0h9QZUS/pWA=="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
@@ -37151,6 +37208,14 @@
 			"requires": {
 				"ansi-colors": "^3.0.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				}
 			}
 		},
 		"webpack-node-externals": {
@@ -37655,6 +37720,230 @@
 				"yamlparser": "0.0.2"
 			},
 			"dependencies": {
+				"@wordpress/block-editor": {
+					"version": "3.7.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-3.7.1.tgz",
+					"integrity": "sha512-joZBiYY4iqSpyFJBsPvEJQjILxdywESTu4ACAKb8SGQ19DIa3vkuS6FTEsmdy+YfkRiohhPAsd17mLZAv0tb1g==",
+					"requires": {
+						"@babel/runtime": "^7.8.3",
+						"@wordpress/a11y": "^2.7.0",
+						"@wordpress/blob": "^2.7.0",
+						"@wordpress/blocks": "^6.12.0",
+						"@wordpress/components": "^9.2.1",
+						"@wordpress/compose": "^3.11.0",
+						"@wordpress/data": "^4.14.0",
+						"@wordpress/deprecated": "^2.7.0",
+						"@wordpress/dom": "^2.8.0",
+						"@wordpress/element": "^2.11.0",
+						"@wordpress/hooks": "^2.7.0",
+						"@wordpress/html-entities": "^2.6.0",
+						"@wordpress/i18n": "^3.9.0",
+						"@wordpress/icons": "^1.1.0",
+						"@wordpress/is-shallow-equal": "^1.8.0",
+						"@wordpress/keyboard-shortcuts": "^1.1.0",
+						"@wordpress/keycodes": "^2.9.0",
+						"@wordpress/rich-text": "^3.12.0",
+						"@wordpress/token-list": "^1.9.0",
+						"@wordpress/url": "^2.11.0",
+						"@wordpress/viewport": "^2.13.0",
+						"@wordpress/wordcount": "^2.7.0",
+						"classnames": "^2.2.5",
+						"diff": "^3.5.0",
+						"dom-scroll-into-view": "^1.2.1",
+						"inherits": "^2.0.3",
+						"lodash": "^4.17.15",
+						"memize": "^1.0.5",
+						"react-autosize-textarea": "^3.0.2",
+						"react-spring": "^8.0.19",
+						"redux-multi": "^0.1.12",
+						"refx": "^3.0.0",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1",
+						"traverse": "^0.6.6"
+					},
+					"dependencies": {
+						"diff": {
+							"version": "3.5.0",
+							"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+							"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+						}
+					}
+				},
+				"@wordpress/block-library": {
+					"version": "2.14.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.14.1.tgz",
+					"integrity": "sha512-gq+PKbnnQr/kFm29Cqh5n9EABL1V/Ey79eItfNhzCle92r79kgUwfDjRvoVbzikNU5F1j392ojpZK8EQCn+T8w==",
+					"requires": {
+						"@babel/runtime": "^7.8.3",
+						"@wordpress/a11y": "^2.7.0",
+						"@wordpress/api-fetch": "^3.11.0",
+						"@wordpress/autop": "^2.6.0",
+						"@wordpress/blob": "^2.7.0",
+						"@wordpress/block-editor": "^3.7.1",
+						"@wordpress/blocks": "^6.12.0",
+						"@wordpress/components": "^9.2.1",
+						"@wordpress/compose": "^3.11.0",
+						"@wordpress/core-data": "^2.12.0",
+						"@wordpress/data": "^4.14.0",
+						"@wordpress/date": "^3.8.0",
+						"@wordpress/deprecated": "^2.7.0",
+						"@wordpress/dom": "^2.8.0",
+						"@wordpress/editor": "^9.12.1",
+						"@wordpress/element": "^2.11.0",
+						"@wordpress/escape-html": "^1.7.0",
+						"@wordpress/i18n": "^3.9.0",
+						"@wordpress/icons": "^1.1.0",
+						"@wordpress/is-shallow-equal": "^1.8.0",
+						"@wordpress/keycodes": "^2.9.0",
+						"@wordpress/primitives": "^1.1.0",
+						"@wordpress/rich-text": "^3.12.0",
+						"@wordpress/server-side-render": "^1.8.1",
+						"@wordpress/url": "^2.11.0",
+						"@wordpress/viewport": "^2.13.0",
+						"classnames": "^2.2.5",
+						"fast-average-color": "4.3.0",
+						"lodash": "^4.17.15",
+						"memize": "^1.0.5",
+						"moment": "^2.22.1",
+						"tinycolor2": "^1.4.1",
+						"url": "^0.11.0"
+					}
+				},
+				"@wordpress/components": {
+					"version": "9.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.2.1.tgz",
+					"integrity": "sha512-OAfibZccphrOmQyc8PF4Y5b5iAGCrzrySh9tgCP1tgYkzY9RwULmYnAFDtrYjfCF9najPTI6Snvea5z7huwlJg==",
+					"requires": {
+						"@babel/runtime": "^7.8.3",
+						"@emotion/core": "^10.0.22",
+						"@emotion/css": "^10.0.22",
+						"@emotion/native": "^10.0.22",
+						"@emotion/styled": "^10.0.23",
+						"@wordpress/a11y": "^2.7.0",
+						"@wordpress/compose": "^3.11.0",
+						"@wordpress/deprecated": "^2.7.0",
+						"@wordpress/dom": "^2.8.0",
+						"@wordpress/element": "^2.11.0",
+						"@wordpress/hooks": "^2.7.0",
+						"@wordpress/i18n": "^3.9.0",
+						"@wordpress/icons": "^1.1.0",
+						"@wordpress/is-shallow-equal": "^1.8.0",
+						"@wordpress/keycodes": "^2.9.0",
+						"@wordpress/primitives": "^1.1.0",
+						"@wordpress/rich-text": "^3.12.0",
+						"@wordpress/warning": "^1.0.0",
+						"classnames": "^2.2.5",
+						"clipboard": "^2.0.1",
+						"dom-scroll-into-view": "^1.2.1",
+						"downshift": "^4.0.5",
+						"gradient-parser": "^0.1.5",
+						"lodash": "^4.17.15",
+						"memize": "^1.0.5",
+						"moment": "^2.22.1",
+						"re-resizable": "^6.0.0",
+						"react-dates": "^17.1.1",
+						"react-resize-aware": "^3.0.0",
+						"react-spring": "^8.0.20",
+						"reakit": "^1.0.0-beta.12",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@wordpress/edit-post": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-3.13.1.tgz",
+					"integrity": "sha512-ypHBgc+tO7N2Syyqxe/aHh2AlJ1qXNQ01IIeeESATpwlrLpAap+QrSbdALri3p9L1mHVWPRVbwdB42usfzshRw==",
+					"requires": {
+						"@babel/runtime": "^7.8.3",
+						"@wordpress/a11y": "^2.7.0",
+						"@wordpress/api-fetch": "^3.11.0",
+						"@wordpress/block-editor": "^3.7.1",
+						"@wordpress/block-library": "^2.14.1",
+						"@wordpress/blocks": "^6.12.0",
+						"@wordpress/components": "^9.2.1",
+						"@wordpress/compose": "^3.11.0",
+						"@wordpress/core-data": "^2.12.0",
+						"@wordpress/data": "^4.14.0",
+						"@wordpress/editor": "^9.12.1",
+						"@wordpress/element": "^2.11.0",
+						"@wordpress/hooks": "^2.7.0",
+						"@wordpress/i18n": "^3.9.0",
+						"@wordpress/icons": "^1.1.0",
+						"@wordpress/keyboard-shortcuts": "^1.1.0",
+						"@wordpress/keycodes": "^2.9.0",
+						"@wordpress/media-utils": "^1.7.1",
+						"@wordpress/notices": "^2.0.0",
+						"@wordpress/plugins": "^2.12.0",
+						"@wordpress/url": "^2.11.0",
+						"@wordpress/viewport": "^2.13.0",
+						"classnames": "^2.2.5",
+						"lodash": "^4.17.15",
+						"memize": "^1.0.5",
+						"refx": "^3.0.0",
+						"rememo": "^3.0.0"
+					}
+				},
+				"@wordpress/editor": {
+					"version": "9.12.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.12.1.tgz",
+					"integrity": "sha512-WjwQV+vESD63HBgi7ueBXzPt0enEZBi2SGzrfj/zPI1mLskNZTC0Ep6iKhU+PCLBJC6W/OoYct5PeMd2BjbuVA==",
+					"requires": {
+						"@babel/runtime": "^7.8.3",
+						"@wordpress/api-fetch": "^3.11.0",
+						"@wordpress/autop": "^2.6.0",
+						"@wordpress/blob": "^2.7.0",
+						"@wordpress/block-directory": "^1.5.1",
+						"@wordpress/block-editor": "^3.7.1",
+						"@wordpress/blocks": "^6.12.0",
+						"@wordpress/components": "^9.2.1",
+						"@wordpress/compose": "^3.11.0",
+						"@wordpress/core-data": "^2.12.0",
+						"@wordpress/data": "^4.14.0",
+						"@wordpress/data-controls": "^1.8.0",
+						"@wordpress/date": "^3.8.0",
+						"@wordpress/deprecated": "^2.7.0",
+						"@wordpress/element": "^2.11.0",
+						"@wordpress/hooks": "^2.7.0",
+						"@wordpress/html-entities": "^2.6.0",
+						"@wordpress/i18n": "^3.9.0",
+						"@wordpress/icons": "^1.1.0",
+						"@wordpress/is-shallow-equal": "^1.8.0",
+						"@wordpress/keyboard-shortcuts": "^1.1.0",
+						"@wordpress/keycodes": "^2.9.0",
+						"@wordpress/media-utils": "^1.7.1",
+						"@wordpress/notices": "^2.0.0",
+						"@wordpress/rich-text": "^3.12.0",
+						"@wordpress/server-side-render": "^1.8.1",
+						"@wordpress/url": "^2.11.0",
+						"@wordpress/viewport": "^2.13.0",
+						"@wordpress/wordcount": "^2.7.0",
+						"classnames": "^2.2.5",
+						"equivalent-key-map": "^0.2.2",
+						"lodash": "^4.17.15",
+						"memize": "^1.0.5",
+						"react-autosize-textarea": "^3.0.2",
+						"redux-optimist": "^1.0.0",
+						"refx": "^3.0.0",
+						"rememo": "^3.0.0"
+					}
+				},
+				"@wordpress/server-side-render": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.8.1.tgz",
+					"integrity": "sha512-JLLwyY6W/KxALMc72R1KgrtTaiHoyNzCjNI8bVD192z+gFTFdBg8d7F3CUMwaCzkfKxf09Y0zn7955c0S6k3Ew==",
+					"requires": {
+						"@babel/runtime": "^7.8.3",
+						"@wordpress/api-fetch": "^3.11.0",
+						"@wordpress/components": "^9.2.1",
+						"@wordpress/data": "^4.14.0",
+						"@wordpress/deprecated": "^2.7.0",
+						"@wordpress/element": "^2.11.0",
+						"@wordpress/i18n": "^3.9.0",
+						"@wordpress/url": "^2.11.0",
+						"lodash": "^4.17.15"
+					}
+				},
 				"diff": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -37676,6 +37965,38 @@
 					"integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
 					"requires": {
 						"moment": ">= 2.9.0"
+					}
+				},
+				"react": {
+					"version": "16.12.0",
+					"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+					"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.2"
+					}
+				},
+				"react-dom": {
+					"version": "16.12.0",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
+					"integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.2",
+						"scheduler": "^0.18.0"
+					}
+				},
+				"react-modal": {
+					"version": "3.11.1",
+					"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.1.tgz",
+					"integrity": "sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==",
+					"requires": {
+						"exenv": "^1.2.0",
+						"prop-types": "^15.5.10",
+						"react-lifecycles-compat": "^3.0.0",
+						"warning": "^4.0.3"
 					}
 				},
 				"react-stripe-elements": {
@@ -37707,6 +38028,23 @@
 					"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.7.3.tgz",
 					"integrity": "sha512-sQsgKYcn+OthBkvKz+TeHlYZq2SF5ZP9RutHg7O67GI+sdYqf0BVy6VeTe28TG4Vui6hoMheiMnZqhidOtN7EA=="
 				},
+				"scheduler": {
+					"version": "0.18.0",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+					"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"use-subscription": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.3.0.tgz",
+					"integrity": "sha512-buZV7FUtnbOr+65dN7PHK7chHhQGfk/yjgqfpRLoWuHIAc4klAD/rdot2FsPNtFthN1ZydvA8tR/mWBMQ+/fDQ==",
+					"requires": {
+						"object-assign": "^4.1.1"
+					}
+				},
 				"uuid": {
 					"version": "3.3.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
@@ -37736,7 +38074,7 @@
 			"requires": {
 				"debug": "^4.1.1",
 				"progress-event": "^1.0.0",
-				"uid": "^0.0.2",
+				"uuid": "^7.0.1",
 				"wp-error": "^1.3.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -460,9 +460,9 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
-			"integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.5.tgz",
+			"integrity": "sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==",
 			"dev": true,
 			"requires": {
 				"browserslist": "^4.8.5",
@@ -525,12 +525,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
-			"integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+			"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.8.6",
+				"@babel/types": "^7.8.3",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
@@ -591,12 +591,12 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.6.tgz",
-			"integrity": "sha512-UrJdk27hKVJSnibFcUWYLkCL0ZywTUoot8yii1lsHJcvwrypagmYKjHLMWivQPm4s6GdyygCL8fiH5EYLxhQwQ==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz",
+			"integrity": "sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.8.6",
+				"@babel/compat-data": "^7.8.4",
 				"browserslist": "^4.8.5",
 				"invariant": "^2.2.4",
 				"levenary": "^1.1.1",
@@ -612,26 +612,25 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.6.tgz",
-			"integrity": "sha512-klTBDdsr+VFFqaDHm5rR69OpEQtO2Qv8ECxHS1mNhJJvaHArR6a1xTf5K/eZW7eZpJbhCx3NW1Yt/sKsLXLblg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.3.tgz",
+			"integrity": "sha512-qmp4pD7zeTxsv0JNecSBsEmG1ei2MqwJq4YQcK3ZWm/0t07QstWfvuV/vm3Qt5xNMFETn2SZqpMx2MQzbtq+KA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-replace-supers": "^7.8.3",
 				"@babel/helper-split-export-declaration": "^7.8.3"
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.6.tgz",
-			"integrity": "sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.3.tgz",
+			"integrity": "sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.8.3",
 				"@babel/helper-regex": "^7.8.3",
 				"regexpu-core": "^4.6.0"
 			}
@@ -704,17 +703,16 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.6.tgz",
-			"integrity": "sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.3.tgz",
+			"integrity": "sha512-C7NG6B7vfBa/pwCOshpMbOYUmrYQDfCpVL/JCRu0ek8B5p8kue1+BCXpg2vOYs7w5ACB9GTOBYQ5U6NwrMg+3Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
 				"@babel/helper-simple-access": "^7.8.3",
 				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/template": "^7.8.6",
-				"@babel/types": "^7.8.6",
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.8.3",
 				"lodash": "^4.17.13"
 			}
 		},
@@ -756,15 +754,15 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
+			"integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/traverse": "^7.8.6",
-				"@babel/types": "^7.8.6"
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -832,9 +830,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
-			"integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+			"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -1067,9 +1065,9 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz",
-			"integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.3.tgz",
+			"integrity": "sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.8.3",
@@ -1077,7 +1075,7 @@
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-replace-supers": "^7.8.3",
 				"@babel/helper-split-export-declaration": "^7.8.3",
 				"globals": "^11.1.0"
 			}
@@ -1140,9 +1138,9 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz",
-			"integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
+			"integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -1532,9 +1530,9 @@
 			}
 		},
 		"@babel/register": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.8.6.tgz",
-			"integrity": "sha512-7IDO93fuRsbyml7bAafBQb3RcBGlCpU4hh5wADA2LJEEcYk92WkwFZ0pHyIi2fb5Auoz1714abETdZKCOxN0CQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.8.3.tgz",
+			"integrity": "sha512-t7UqebaWwo9nXWClIPLPloa5pN33A2leVs8Hf0e9g9YwUP8/H9NeR7DJU+4CXo23QtjChQv5a3DjEtT83ih1rg==",
 			"dev": true,
 			"requires": {
 				"find-cache-dir": "^2.0.0",
@@ -1577,37 +1575,37 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+			"integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
-				"@babel/parser": "^7.8.6",
-				"@babel/types": "^7.8.6"
+				"@babel/parser": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-			"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+			"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.8.6",
+				"@babel/generator": "^7.8.4",
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.8.6",
-				"@babel/types": "^7.8.6",
+				"@babel/parser": "^7.8.4",
+				"@babel/types": "^7.8.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
-			"integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+			"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
@@ -1888,6 +1886,13 @@
 				"@emotion/serialize": "^0.11.15",
 				"@emotion/utils": "0.11.3",
 				"babel-plugin-emotion": "^10.0.27"
+			},
+			"dependencies": {
+				"@emotion/utils": {
+					"version": "0.11.3",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+				}
 			}
 		},
 		"@emotion/hash": {
@@ -1934,6 +1939,13 @@
 				"@emotion/unitless": "0.7.5",
 				"@emotion/utils": "0.11.3",
 				"csstype": "^2.5.7"
+			},
+			"dependencies": {
+				"@emotion/utils": {
+					"version": "0.11.3",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+				}
 			}
 		},
 		"@emotion/sheet": {
@@ -4231,25 +4243,14 @@
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.3.tgz",
-			"integrity": "sha512-EzKwkwcxeegYYah5ukEeAI/gYRLv2Y9U5PpIsseGSFDk+G3RbipQGBs8GuYS1TLCtQaqoO66+aQGtITPalxsNQ==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.2.tgz",
+			"integrity": "sha512-ICDcRA0C2vtTZZGud1nXRrBLXZqFayodXAKZfo3dkdcLNqcHsgaz3YSTupbURusYeucSVRjjG+RTcQhx6HPPcg==",
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^2.0.0",
 				"is-plain-object": "^3.0.0",
-				"universal-user-agent": "^5.0.0"
-			},
-			"dependencies": {
-				"universal-user-agent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-					"integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-					"dev": true,
-					"requires": {
-						"os-name": "^3.1.0"
-					}
-				}
+				"universal-user-agent": "^4.0.0"
 			}
 		},
 		"@octokit/plugin-enterprise-rest": {
@@ -4284,9 +4285,9 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.2.tgz",
-			"integrity": "sha512-7NPJpg19wVQy1cs2xqXjjRq/RmtSomja/VSWnptfYwuBxLdbYh2UjhGi0Wx7B1v5Iw5GKhfFDQL7jM7SSp7K2g==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
+			"integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^5.5.0",
@@ -4296,7 +4297,7 @@
 				"is-plain-object": "^3.0.0",
 				"node-fetch": "^2.3.0",
 				"once": "^1.4.0",
-				"universal-user-agent": "^5.0.0"
+				"universal-user-agent": "^4.0.0"
 			},
 			"dependencies": {
 				"node-fetch": {
@@ -4304,15 +4305,6 @@
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
 					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
 					"dev": true
-				},
-				"universal-user-agent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-					"integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-					"dev": true,
-					"requires": {
-						"os-name": "^3.1.0"
-					}
 				}
 			}
 		},
@@ -4352,9 +4344,9 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.3.1.tgz",
-			"integrity": "sha512-rvJP1Y9A/+Cky2C3var1vsw3Lf5Rjn/0sojNl2AjCX+WbpIHYccaJ46abrZoIxMYnOToul6S9tPytUVkFI7CXQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.1.1.tgz",
+			"integrity": "sha512-89LOYH+d/vsbDX785NOfLxTW88GjNd0lWRz1DVPVsZgg9Yett5O+3MOvwo7iHgvUwbFz0mf/yPIjBkUbs4kxoQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": ">= 8"
@@ -4549,12 +4541,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
 					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-					"dev": true
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 					"dev": true
 				}
 			}
@@ -4835,13 +4821,13 @@
 					}
 				},
 				"find-cache-dir": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
-					"integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
 					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
-						"make-dir": "^3.0.2",
+						"make-dir": "^3.0.0",
 						"pkg-dir": "^4.1.0"
 					}
 				},
@@ -5526,9 +5512,9 @@
 			}
 		},
 		"@types/babel__core": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
-			"integrity": "sha512-tTnhWszAqvXnhW7m5jQU9PomXSiKXk2sFxpahXvI20SZKu9ylPi8WtIxueZ6ehDWikPT0jeFujMj3X4ZHuf3Tg==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.4.tgz",
+			"integrity": "sha512-c/5MuRz5HM4aizqL5ViYfW4iEnmfPcfbH4Xa6GgLT21dMc1NGeNnuS6egHheOmP+kCJ9CAzC4pv4SDCWTnRkbg==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -5558,9 +5544,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.9.tgz",
-			"integrity": "sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==",
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.8.tgz",
+			"integrity": "sha512-yGeB2dHEdvxjP0y4UbRtQaSkXJ9649fYCmIdRoul5kfAoGCwxuCbMhag0k3RPfnuh9kPGm8x89btcfDEXdVWGw==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -5699,9 +5685,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "13.7.6",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.6.tgz",
-			"integrity": "sha512-eyK7MWD0R1HqVTp+PtwRgFeIsemzuj4gBFSQxfPHY5iMjS7474e5wq+VFgTcdpyHeNxyKSaetYAjdMLJlKoWqA==",
+			"version": "13.7.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.4.tgz",
+			"integrity": "sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -6380,12 +6366,6 @@
 						"ansi-regex": "^3.0.0"
 					}
 				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
-				},
 				"webpack-log": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
@@ -6478,14 +6458,14 @@
 			}
 		},
 		"@wordpress/block-directory": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-directory/-/block-directory-1.5.2.tgz",
-			"integrity": "sha512-PDj01re70kfj1eYlxWPqttHgswXwl3XQSrGWyaCAElywanb6h+vuVt7uWZ0cW0MuMRTJn/bLQVWrGYH05wl8dQ==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-directory/-/block-directory-1.5.1.tgz",
+			"integrity": "sha512-YdlatnSHjw0dKxr4mqKT10awrVYC//kHrwtRrfg2z98+O+4uVsWN9E0mtHzFmYQHRFK3Ep/+GqIgp2RyH8TMgQ==",
 			"requires": {
 				"@wordpress/api-fetch": "^3.11.0",
-				"@wordpress/block-editor": "^3.7.2",
+				"@wordpress/block-editor": "^3.7.1",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.2",
+				"@wordpress/components": "^9.2.1",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/data": "^4.14.0",
 				"@wordpress/element": "^2.11.0",
@@ -6496,15 +6476,15 @@
 			}
 		},
 		"@wordpress/block-editor": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-3.7.2.tgz",
-			"integrity": "sha512-S+tE0dn+hitSZ1zKggCIQ8LW3cfrWM+ilH01cy7IyG9NRyyNl6V5O8+EMDwO0uI+GSeP65y4MqvLUSoRGM0KKQ==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-3.7.1.tgz",
+			"integrity": "sha512-joZBiYY4iqSpyFJBsPvEJQjILxdywESTu4ACAKb8SGQ19DIa3vkuS6FTEsmdy+YfkRiohhPAsd17mLZAv0tb1g==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/a11y": "^2.7.0",
 				"@wordpress/blob": "^2.7.0",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.2",
+				"@wordpress/components": "^9.2.1",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/data": "^4.14.0",
 				"@wordpress/deprecated": "^2.7.0",
@@ -6538,25 +6518,25 @@
 			}
 		},
 		"@wordpress/block-library": {
-			"version": "2.14.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.14.2.tgz",
-			"integrity": "sha512-HL6KaZ6cwWK/ea9MBA/tPjheEOt1ilD/OTHZ9TAaRmc/rALGRy5B4HNzOfbz4D8tnRCkyu5BMGy+5yV5oGPNrw==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.14.1.tgz",
+			"integrity": "sha512-gq+PKbnnQr/kFm29Cqh5n9EABL1V/Ey79eItfNhzCle92r79kgUwfDjRvoVbzikNU5F1j392ojpZK8EQCn+T8w==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/a11y": "^2.7.0",
 				"@wordpress/api-fetch": "^3.11.0",
 				"@wordpress/autop": "^2.6.0",
 				"@wordpress/blob": "^2.7.0",
-				"@wordpress/block-editor": "^3.7.2",
+				"@wordpress/block-editor": "^3.7.1",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.2",
+				"@wordpress/components": "^9.2.1",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/core-data": "^2.12.0",
 				"@wordpress/data": "^4.14.0",
 				"@wordpress/date": "^3.8.0",
 				"@wordpress/deprecated": "^2.7.0",
 				"@wordpress/dom": "^2.8.0",
-				"@wordpress/editor": "^9.12.2",
+				"@wordpress/editor": "^9.12.1",
 				"@wordpress/element": "^2.11.0",
 				"@wordpress/escape-html": "^1.7.0",
 				"@wordpress/i18n": "^3.9.0",
@@ -6565,7 +6545,7 @@
 				"@wordpress/keycodes": "^2.9.0",
 				"@wordpress/primitives": "^1.1.0",
 				"@wordpress/rich-text": "^3.12.0",
-				"@wordpress/server-side-render": "^1.8.2",
+				"@wordpress/server-side-render": "^1.8.1",
 				"@wordpress/url": "^2.11.0",
 				"@wordpress/viewport": "^2.13.0",
 				"classnames": "^2.2.5",
@@ -6610,13 +6590,6 @@
 				"simple-html-tokenizer": "^0.5.7",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-				}
 			}
 		},
 		"@wordpress/browserslist-config": {
@@ -6626,9 +6599,9 @@
 			"dev": true
 		},
 		"@wordpress/components": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.2.2.tgz",
-			"integrity": "sha512-WSOZUyUh3PWpBl+Q7nr3MFyBlZCfNeTdUv4tcyHIJlm5msXNgvJQIUM53dUnFlJFmdbP/vyOl71XaDs75gWR3A==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.2.1.tgz",
+			"integrity": "sha512-OAfibZccphrOmQyc8PF4Y5b5iAGCrzrySh9tgCP1tgYkzY9RwULmYnAFDtrYjfCF9najPTI6Snvea5z7huwlJg==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@emotion/core": "^10.0.22",
@@ -6664,13 +6637,6 @@
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-				}
 			}
 		},
 		"@wordpress/compose": {
@@ -6793,28 +6759,28 @@
 			}
 		},
 		"@wordpress/edit-post": {
-			"version": "3.13.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-3.13.2.tgz",
-			"integrity": "sha512-BFZ+cQ+czSqJ48XSjyiKLIQ29lPNMTxPRBn7q6nSqwI433/q63G/K9D/PYdVR81gg6WsYMGXoQmnHTaV3yHNaQ==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-3.13.1.tgz",
+			"integrity": "sha512-ypHBgc+tO7N2Syyqxe/aHh2AlJ1qXNQ01IIeeESATpwlrLpAap+QrSbdALri3p9L1mHVWPRVbwdB42usfzshRw==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/a11y": "^2.7.0",
 				"@wordpress/api-fetch": "^3.11.0",
-				"@wordpress/block-editor": "^3.7.2",
-				"@wordpress/block-library": "^2.14.2",
+				"@wordpress/block-editor": "^3.7.1",
+				"@wordpress/block-library": "^2.14.1",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.2",
+				"@wordpress/components": "^9.2.1",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/core-data": "^2.12.0",
 				"@wordpress/data": "^4.14.0",
-				"@wordpress/editor": "^9.12.2",
+				"@wordpress/editor": "^9.12.1",
 				"@wordpress/element": "^2.11.0",
 				"@wordpress/hooks": "^2.7.0",
 				"@wordpress/i18n": "^3.9.0",
 				"@wordpress/icons": "^1.1.0",
 				"@wordpress/keyboard-shortcuts": "^1.1.0",
 				"@wordpress/keycodes": "^2.9.0",
-				"@wordpress/media-utils": "^1.7.2",
+				"@wordpress/media-utils": "^1.7.1",
 				"@wordpress/notices": "^2.0.0",
 				"@wordpress/plugins": "^2.12.0",
 				"@wordpress/url": "^2.11.0",
@@ -6827,18 +6793,18 @@
 			}
 		},
 		"@wordpress/editor": {
-			"version": "9.12.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.12.2.tgz",
-			"integrity": "sha512-arSWRTtg7F9+ndukeNDnIOtkg7jOaA2R7AwsM2eEnj+WVikAucMR4E/c4TovEwc3JwNycjPcY0qD63iJBo6ZTQ==",
+			"version": "9.12.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.12.1.tgz",
+			"integrity": "sha512-WjwQV+vESD63HBgi7ueBXzPt0enEZBi2SGzrfj/zPI1mLskNZTC0Ep6iKhU+PCLBJC6W/OoYct5PeMd2BjbuVA==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/api-fetch": "^3.11.0",
 				"@wordpress/autop": "^2.6.0",
 				"@wordpress/blob": "^2.7.0",
-				"@wordpress/block-directory": "^1.5.2",
-				"@wordpress/block-editor": "^3.7.2",
+				"@wordpress/block-directory": "^1.5.1",
+				"@wordpress/block-editor": "^3.7.1",
 				"@wordpress/blocks": "^6.12.0",
-				"@wordpress/components": "^9.2.2",
+				"@wordpress/components": "^9.2.1",
 				"@wordpress/compose": "^3.11.0",
 				"@wordpress/core-data": "^2.12.0",
 				"@wordpress/data": "^4.14.0",
@@ -6853,10 +6819,10 @@
 				"@wordpress/is-shallow-equal": "^1.8.0",
 				"@wordpress/keyboard-shortcuts": "^1.1.0",
 				"@wordpress/keycodes": "^2.9.0",
-				"@wordpress/media-utils": "^1.7.2",
+				"@wordpress/media-utils": "^1.7.1",
 				"@wordpress/notices": "^2.0.0",
 				"@wordpress/rich-text": "^3.12.0",
-				"@wordpress/server-side-render": "^1.8.2",
+				"@wordpress/server-side-render": "^1.8.1",
 				"@wordpress/url": "^2.11.0",
 				"@wordpress/viewport": "^2.13.0",
 				"@wordpress/wordcount": "^2.7.0",
@@ -7108,9 +7074,9 @@
 			}
 		},
 		"@wordpress/media-utils": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-1.7.2.tgz",
-			"integrity": "sha512-EUlC5wg2XjNbkV/5lMrv3xRXNrR9FPzZjVdVMOvL+pNup9uXSIoyU44xjnlU6FNI0pB2iJb7R0xypPMav1UoUA==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-1.7.1.tgz",
+			"integrity": "sha512-cfcCAvhrCUMjYjBhbtKO1Y5GqFvxFqosYykkbDifbwj8DA+P8+Fh2Q9aWKieVh8d7RAES3DqFVY7qvINkKiYMw==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/api-fetch": "^3.11.0",
@@ -7422,13 +7388,13 @@
 			}
 		},
 		"@wordpress/server-side-render": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.8.2.tgz",
-			"integrity": "sha512-uxXkelD0+hFKivOPoVQXrGkqTwITKl5I8rYwV83YjBsl9b2vkXzII+C+0EXbTolvLmLsYDgu224WHcU4JgRZBw==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.8.1.tgz",
+			"integrity": "sha512-JLLwyY6W/KxALMc72R1KgrtTaiHoyNzCjNI8bVD192z+gFTFdBg8d7F3CUMwaCzkfKxf09Y0zn7955c0S6k3Ew==",
 			"requires": {
 				"@babel/runtime": "^7.8.3",
 				"@wordpress/api-fetch": "^3.11.0",
-				"@wordpress/components": "^9.2.2",
+				"@wordpress/components": "^9.2.1",
 				"@wordpress/data": "^4.14.0",
 				"@wordpress/deprecated": "^2.7.0",
 				"@wordpress/element": "^2.11.0",
@@ -7566,9 +7532,9 @@
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
 		},
 		"acorn-walk": {
 			"version": "6.2.0",
@@ -7663,9 +7629,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
-			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+			"integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -8010,12 +7976,12 @@
 			"dev": true
 		},
 		"array.prototype.find": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
-			"integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+			"integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.4"
+				"es-abstract": "^1.13.0"
 			}
 		},
 		"array.prototype.flat": {
@@ -8975,6 +8941,16 @@
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"blob": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -9298,9 +9274,9 @@
 			},
 			"dependencies": {
 				"caniuse-lite": {
-					"version": "1.0.30001030",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001030.tgz",
-					"integrity": "sha512-QGK0W4Ft/Ac+zTjEiRJfwDNATvS3fodDczBXrH42784kcfqcDKpEPfN08N0HQjrAp8He/Jw8QiSS9QRn7XAbUw=="
+					"version": "1.0.30001028",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001028.tgz",
+					"integrity": "sha512-Vnrq+XMSHpT7E+LWoIYhs3Sne8h9lx9YJV3acH3THNCwU/9zV93/ta4xVfzTtnqd3rvnuVpVjE3DFqf56tr3aQ=="
 				}
 			}
 		},
@@ -10038,6 +10014,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1",
 						"node-pre-gyp": "*"
 					},
@@ -11740,9 +11717,9 @@
 			"dev": true
 		},
 		"copy-to-clipboard": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-			"integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.1.tgz",
+			"integrity": "sha512-btru1Q6RD9wbonIvEU5EfnhIRGHLo//BGXQ1hNAD2avIs/nBZlpbOeKtv3mhoUByN4DB9Cb6/vXBymj1S43KmA==",
 			"dev": true,
 			"requires": {
 				"toggle-selection": "^1.0.6"
@@ -12756,9 +12733,9 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.10.0.tgz",
-			"integrity": "sha512-EhfEKevYGWhWlZbNeplfhIU/+N+x0iCIx7VzKlXma2EdQyznVlZhCptXUY+BegNpPW2kjdx15Rvq503YcXXrcA==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.9.0.tgz",
+			"integrity": "sha512-khbFLu/MlzLjEzy9Gh8oY1hNt/Dvxw3J6Rbc28cVoYWQaC1S3YI4xwkF9ZWcjDLscbZlY9hISMr66RFzZagLsA==",
 			"dev": true
 		},
 		"dateformat": {
@@ -13627,9 +13604,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.362",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.362.tgz",
-			"integrity": "sha512-xdU5VCoZyMPMOWtCaMgbr48OwWZHrMLbGnAOlEqibXiIGsb4kiCGWEHK5NOghcVLdBVIbr/BW+yuKxVuGTtzEg=="
+			"version": "1.3.355",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.355.tgz",
+			"integrity": "sha512-zKO/wS+2ChI/jz9WAo647xSW8t2RmgRLFdbUb/77cORkUTargO+SCj4ctTHjBn2VeNFrsLgDT7IuDVrd3F8mLQ=="
 		},
 		"element-resize-detector": {
 			"version": "1.2.1",
@@ -14422,9 +14399,9 @@
 			},
 			"dependencies": {
 				"eslint-plugin-react-hooks": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.0.tgz",
-					"integrity": "sha512-bzvdX47Jx847bgAYf0FPX3u1oxU+mKU8tqrpj4UX9A96SbAmj/HVEefEy6rJUog5u8QIlOPTKZcBpGn5kkKfAQ==",
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.4.0.tgz",
+					"integrity": "sha512-bH5DOCP6WpuOqNaux2BlaDCrSgv8s5BitP90bTgtZ1ZsRn2bdIfeMDY5F2RnJVnyKDy6KRQRDbipPLZ1y77QtQ==",
 					"dev": true
 				}
 			}
@@ -15744,6 +15721,13 @@
 				}
 			}
 		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
+		},
 		"filesize": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -16032,9 +16016,9 @@
 			"dev": true
 		},
 		"flow-parser": {
-			"version": "0.119.1",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.119.1.tgz",
-			"integrity": "sha512-yFd4z6ZBXq//TJo/gtSzGKhz6wEVeI2m+6JB25JzXuRAOhM5Ze4xFkc3FSIStbYjrAx4H1IUiUTI/yy30oKp8A==",
+			"version": "0.119.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.119.0.tgz",
+			"integrity": "sha512-P49kGSnCII6c5/P4QsVDtoam83zrXrdq4EUJDVOpbeURy48RM8BOboKcEfFHS1xnNID01UXu8Hf60b+m23T81w==",
 			"dev": true
 		},
 		"flush-write-stream": {
@@ -16295,9 +16279,9 @@
 			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"formidable": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-			"integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+			"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -17153,17 +17137,16 @@
 					}
 				},
 				"fast-glob": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-					"integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
+					"integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
 					"dev": true,
 					"requires": {
 						"@nodelib/fs.stat": "^2.0.2",
 						"@nodelib/fs.walk": "^1.2.3",
 						"glob-parent": "^5.1.0",
 						"merge2": "^1.3.0",
-						"micromatch": "^4.0.2",
-						"picomatch": "^2.2.1"
+						"micromatch": "^4.0.2"
 					}
 				},
 				"fill-range": {
@@ -17688,9 +17671,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.7.tgz",
-			"integrity": "sha512-ChkjQtKJ3GI6SsI4O5jwr8q8EPrWCnxuc4Tbx+vRI5x6mDOpjKKltNo1lRlszw3xwgTOSns1ZRBiMmmwpcvLxg=="
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
 		},
 		"hpack.js": {
 			"version": "2.1.6",
@@ -17938,9 +17921,9 @@
 					"dev": true
 				},
 				"terser": {
-					"version": "4.6.4",
-					"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.4.tgz",
-					"integrity": "sha512-5fqgBPLgVHZ/fVvqRhhUp9YUiGXhFJ9ZkrZWD9vQtFBR4QIGTnbsb+/kKqSqfgp3WnBwGWAFnedGTtmX1YTn0w==",
+					"version": "4.6.3",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+					"integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
 					"dev": true,
 					"requires": {
 						"commander": "^2.20.0",
@@ -18817,9 +18800,9 @@
 			"dev": true
 		},
 		"ipaddr.js": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
 		},
 		"irregular-plurals": {
 			"version": "2.0.0",
@@ -19956,6 +19939,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1",
 						"node-pre-gyp": "*"
 					},
@@ -20556,14 +20540,6 @@
 				"strip-ansi": "^5.2.0",
 				"uuid": "^3.3.3",
 				"xml": "^1.0.1"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
-				}
 			}
 		},
 		"jest-leak-detector": {
@@ -21156,9 +21132,9 @@
 			}
 		},
 		"jsonc-parser": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
-			"integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.0.tgz",
+			"integrity": "sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA==",
 			"dev": true
 		},
 		"jsonfile": {
@@ -21210,9 +21186,9 @@
 			"dev": true
 		},
 		"just-extend": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
 			"dev": true
 		},
 		"keymaster": {
@@ -22841,13 +22817,13 @@
 			},
 			"dependencies": {
 				"find-cache-dir": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
-					"integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
 					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
-						"make-dir": "^3.0.2",
+						"make-dir": "^3.0.0",
 						"pkg-dir": "^4.1.0"
 					}
 				},
@@ -23408,9 +23384,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.50",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.50.tgz",
-			"integrity": "sha512-lgAmPv9eYZ0bGwUYAKlr8MG6K4CvWliWqnkcT2P8mMAgVrH3lqfBPorFlxiG1pHQnqmavJZ9vbMXUTNyMLbrgQ==",
+			"version": "1.1.49",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
+			"integrity": "sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==",
 			"requires": {
 				"semver": "^6.3.0"
 			}
@@ -28889,12 +28865,12 @@
 			}
 		},
 		"proxy-addr": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
-			"integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
 			"requires": {
 				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.1"
+				"ipaddr.js": "1.9.0"
 			}
 		},
 		"proxy-from-env": {
@@ -29195,9 +29171,9 @@
 			}
 		},
 		"react": {
-			"version": "16.13.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
-			"integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+			"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -29740,9 +29716,9 @@
 			}
 		},
 		"react-docgen": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.3.0.tgz",
-			"integrity": "sha512-hUrv69k6nxazOuOmdGeOpC/ldiKy7Qj/UFpxaQi0eDMrUFUTIPGtY5HJu7BggSmiyAMfREaESbtBL9UzdQ+hyg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-5.2.1.tgz",
+			"integrity": "sha512-3nvsiDKN/KIlgRyHCdkLrm8ajjSMZ4NIHuwYTAdBvQF3O7A2tmCBB3gwTjJ4zXH8aUpIjFwlVIjffzkJHIZ5/Q==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.7.5",
@@ -29790,14 +29766,14 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.13.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.0.tgz",
-			"integrity": "sha512-y09d2c4cG220DzdlFkPTnVvGTszVvNpC73v+AaLGLHbkpy3SSgvYq8x0rNwPJ/Rk/CicTNgk0hbHNw1gMEZAXg==",
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
+			"integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.0"
+				"scheduler": "^0.18.0"
 			}
 		},
 		"react-draggable": {
@@ -29880,9 +29856,9 @@
 			}
 		},
 		"react-is": {
-			"version": "16.13.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-			"integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA=="
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
 		},
 		"react-lazily-render": {
 			"version": "1.2.0",
@@ -29938,9 +29914,9 @@
 			}
 		},
 		"react-modal": {
-			"version": "3.11.2",
-			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.2.tgz",
-			"integrity": "sha512-o8gvvCOFaG1T7W6JUvsYjRjMVToLZgLIsi5kdhFIQCtHxDkA47LznX62j+l6YQkpXDbvQegsDyxe/+JJsFQN7w==",
+			"version": "3.11.1",
+			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.1.tgz",
+			"integrity": "sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==",
 			"requires": {
 				"exenv": "^1.2.0",
 				"prop-types": "^15.5.10",
@@ -30124,18 +30100,6 @@
 				"prop-types": "^15.6.2",
 				"react-is": "^16.8.6",
 				"scheduler": "^0.18.0"
-			},
-			"dependencies": {
-				"scheduler": {
-					"version": "0.18.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-					"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
-				}
 			}
 		},
 		"react-textarea-autosize": {
@@ -31306,12 +31270,6 @@
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 					"dev": true
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
 				}
 			}
 		},
@@ -31609,9 +31567,9 @@
 			}
 		},
 		"run-async": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-			"integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"dev": true,
 			"requires": {
 				"is-promise": "^2.1.0"
@@ -32005,9 +31963,9 @@
 			"dev": true
 		},
 		"scheduler": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.0.tgz",
-			"integrity": "sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==",
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+			"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -32793,12 +32751,6 @@
 					"requires": {
 						"websocket-driver": ">=0.5.1"
 					}
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
 				}
 			}
 		},
@@ -33435,12 +33387,6 @@
 					"requires": {
 						"rimraf": "^2.6.3"
 					}
-				},
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
 				}
 			}
 		},
@@ -34646,14 +34592,6 @@
 				"pify": "^3.0.0",
 				"temp-dir": "^1.0.0",
 				"uuid": "^3.0.1"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
-				}
 			}
 		},
 		"term-size": {
@@ -34732,13 +34670,13 @@
 					}
 				},
 				"find-cache-dir": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
-					"integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+					"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
 					"dev": true,
 					"requires": {
 						"commondir": "^1.0.1",
-						"make-dir": "^3.0.2",
+						"make-dir": "^3.0.0",
 						"pkg-dir": "^4.1.0"
 					}
 				},
@@ -35412,9 +35350,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-			"integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
 		},
 		"tsutils": {
 			"version": "3.17.1",
@@ -35583,6 +35521,11 @@
 					"dev": true
 				}
 			}
+		},
+		"uid": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz",
+			"integrity": "sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM="
 		},
 		"uid-number": {
 			"version": "0.0.6",
@@ -35838,9 +35781,9 @@
 			}
 		},
 		"universal-user-agent": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
-			"integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+			"integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
 			"dev": true,
 			"requires": {
 				"os-name": "^3.1.0"
@@ -36104,9 +36047,9 @@
 			}
 		},
 		"use-subscription": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.4.0.tgz",
-			"integrity": "sha512-R7P7JWpeHp+dtEYsgDzIIgOmVqRfJjRjLOO0YIYk6twctUkUYe6Tz0pcabyTDGcMMRt9uMbFMfwBfxKHg9gCSw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.3.0.tgz",
+			"integrity": "sha512-buZV7FUtnbOr+65dN7PHK7chHhQGfk/yjgqfpRLoWuHIAc4klAD/rdot2FsPNtFthN1ZydvA8tR/mWBMQ+/fDQ==",
 			"requires": {
 				"object-assign": "^4.1.1"
 			}
@@ -36180,9 +36123,9 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.1.tgz",
-			"integrity": "sha512-yqjRXZzSJm9Dbl84H2VDHpM3zMjzSJQ+hn6C4zqd5ilW+7P4ZmLEEqwho9LjP+tGuZlF4xrHQXT0h9QZUS/pWA=="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
@@ -37208,14 +37151,6 @@
 			"requires": {
 				"ansi-colors": "^3.0.0",
 				"uuid": "^3.3.2"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-					"dev": true
-				}
 			}
 		},
 		"webpack-node-externals": {
@@ -37720,230 +37655,6 @@
 				"yamlparser": "0.0.2"
 			},
 			"dependencies": {
-				"@wordpress/block-editor": {
-					"version": "3.7.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-3.7.1.tgz",
-					"integrity": "sha512-joZBiYY4iqSpyFJBsPvEJQjILxdywESTu4ACAKb8SGQ19DIa3vkuS6FTEsmdy+YfkRiohhPAsd17mLZAv0tb1g==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/a11y": "^2.7.0",
-						"@wordpress/blob": "^2.7.0",
-						"@wordpress/blocks": "^6.12.0",
-						"@wordpress/components": "^9.2.1",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/data": "^4.14.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/dom": "^2.8.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/hooks": "^2.7.0",
-						"@wordpress/html-entities": "^2.6.0",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/icons": "^1.1.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/keyboard-shortcuts": "^1.1.0",
-						"@wordpress/keycodes": "^2.9.0",
-						"@wordpress/rich-text": "^3.12.0",
-						"@wordpress/token-list": "^1.9.0",
-						"@wordpress/url": "^2.11.0",
-						"@wordpress/viewport": "^2.13.0",
-						"@wordpress/wordcount": "^2.7.0",
-						"classnames": "^2.2.5",
-						"diff": "^3.5.0",
-						"dom-scroll-into-view": "^1.2.1",
-						"inherits": "^2.0.3",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"react-autosize-textarea": "^3.0.2",
-						"react-spring": "^8.0.19",
-						"redux-multi": "^0.1.12",
-						"refx": "^3.0.0",
-						"rememo": "^3.0.0",
-						"tinycolor2": "^1.4.1",
-						"traverse": "^0.6.6"
-					},
-					"dependencies": {
-						"diff": {
-							"version": "3.5.0",
-							"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-							"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-						}
-					}
-				},
-				"@wordpress/block-library": {
-					"version": "2.14.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.14.1.tgz",
-					"integrity": "sha512-gq+PKbnnQr/kFm29Cqh5n9EABL1V/Ey79eItfNhzCle92r79kgUwfDjRvoVbzikNU5F1j392ojpZK8EQCn+T8w==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/a11y": "^2.7.0",
-						"@wordpress/api-fetch": "^3.11.0",
-						"@wordpress/autop": "^2.6.0",
-						"@wordpress/blob": "^2.7.0",
-						"@wordpress/block-editor": "^3.7.1",
-						"@wordpress/blocks": "^6.12.0",
-						"@wordpress/components": "^9.2.1",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/core-data": "^2.12.0",
-						"@wordpress/data": "^4.14.0",
-						"@wordpress/date": "^3.8.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/dom": "^2.8.0",
-						"@wordpress/editor": "^9.12.1",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/escape-html": "^1.7.0",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/icons": "^1.1.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/keycodes": "^2.9.0",
-						"@wordpress/primitives": "^1.1.0",
-						"@wordpress/rich-text": "^3.12.0",
-						"@wordpress/server-side-render": "^1.8.1",
-						"@wordpress/url": "^2.11.0",
-						"@wordpress/viewport": "^2.13.0",
-						"classnames": "^2.2.5",
-						"fast-average-color": "4.3.0",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"moment": "^2.22.1",
-						"tinycolor2": "^1.4.1",
-						"url": "^0.11.0"
-					}
-				},
-				"@wordpress/components": {
-					"version": "9.2.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.2.1.tgz",
-					"integrity": "sha512-OAfibZccphrOmQyc8PF4Y5b5iAGCrzrySh9tgCP1tgYkzY9RwULmYnAFDtrYjfCF9najPTI6Snvea5z7huwlJg==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@emotion/core": "^10.0.22",
-						"@emotion/css": "^10.0.22",
-						"@emotion/native": "^10.0.22",
-						"@emotion/styled": "^10.0.23",
-						"@wordpress/a11y": "^2.7.0",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/dom": "^2.8.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/hooks": "^2.7.0",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/icons": "^1.1.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/keycodes": "^2.9.0",
-						"@wordpress/primitives": "^1.1.0",
-						"@wordpress/rich-text": "^3.12.0",
-						"@wordpress/warning": "^1.0.0",
-						"classnames": "^2.2.5",
-						"clipboard": "^2.0.1",
-						"dom-scroll-into-view": "^1.2.1",
-						"downshift": "^4.0.5",
-						"gradient-parser": "^0.1.5",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"moment": "^2.22.1",
-						"re-resizable": "^6.0.0",
-						"react-dates": "^17.1.1",
-						"react-resize-aware": "^3.0.0",
-						"react-spring": "^8.0.20",
-						"reakit": "^1.0.0-beta.12",
-						"rememo": "^3.0.0",
-						"tinycolor2": "^1.4.1",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@wordpress/edit-post": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-3.13.1.tgz",
-					"integrity": "sha512-ypHBgc+tO7N2Syyqxe/aHh2AlJ1qXNQ01IIeeESATpwlrLpAap+QrSbdALri3p9L1mHVWPRVbwdB42usfzshRw==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/a11y": "^2.7.0",
-						"@wordpress/api-fetch": "^3.11.0",
-						"@wordpress/block-editor": "^3.7.1",
-						"@wordpress/block-library": "^2.14.1",
-						"@wordpress/blocks": "^6.12.0",
-						"@wordpress/components": "^9.2.1",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/core-data": "^2.12.0",
-						"@wordpress/data": "^4.14.0",
-						"@wordpress/editor": "^9.12.1",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/hooks": "^2.7.0",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/icons": "^1.1.0",
-						"@wordpress/keyboard-shortcuts": "^1.1.0",
-						"@wordpress/keycodes": "^2.9.0",
-						"@wordpress/media-utils": "^1.7.1",
-						"@wordpress/notices": "^2.0.0",
-						"@wordpress/plugins": "^2.12.0",
-						"@wordpress/url": "^2.11.0",
-						"@wordpress/viewport": "^2.13.0",
-						"classnames": "^2.2.5",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"refx": "^3.0.0",
-						"rememo": "^3.0.0"
-					}
-				},
-				"@wordpress/editor": {
-					"version": "9.12.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.12.1.tgz",
-					"integrity": "sha512-WjwQV+vESD63HBgi7ueBXzPt0enEZBi2SGzrfj/zPI1mLskNZTC0Ep6iKhU+PCLBJC6W/OoYct5PeMd2BjbuVA==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/api-fetch": "^3.11.0",
-						"@wordpress/autop": "^2.6.0",
-						"@wordpress/blob": "^2.7.0",
-						"@wordpress/block-directory": "^1.5.1",
-						"@wordpress/block-editor": "^3.7.1",
-						"@wordpress/blocks": "^6.12.0",
-						"@wordpress/components": "^9.2.1",
-						"@wordpress/compose": "^3.11.0",
-						"@wordpress/core-data": "^2.12.0",
-						"@wordpress/data": "^4.14.0",
-						"@wordpress/data-controls": "^1.8.0",
-						"@wordpress/date": "^3.8.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/hooks": "^2.7.0",
-						"@wordpress/html-entities": "^2.6.0",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/icons": "^1.1.0",
-						"@wordpress/is-shallow-equal": "^1.8.0",
-						"@wordpress/keyboard-shortcuts": "^1.1.0",
-						"@wordpress/keycodes": "^2.9.0",
-						"@wordpress/media-utils": "^1.7.1",
-						"@wordpress/notices": "^2.0.0",
-						"@wordpress/rich-text": "^3.12.0",
-						"@wordpress/server-side-render": "^1.8.1",
-						"@wordpress/url": "^2.11.0",
-						"@wordpress/viewport": "^2.13.0",
-						"@wordpress/wordcount": "^2.7.0",
-						"classnames": "^2.2.5",
-						"equivalent-key-map": "^0.2.2",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"react-autosize-textarea": "^3.0.2",
-						"redux-optimist": "^1.0.0",
-						"refx": "^3.0.0",
-						"rememo": "^3.0.0"
-					}
-				},
-				"@wordpress/server-side-render": {
-					"version": "1.8.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.8.1.tgz",
-					"integrity": "sha512-JLLwyY6W/KxALMc72R1KgrtTaiHoyNzCjNI8bVD192z+gFTFdBg8d7F3CUMwaCzkfKxf09Y0zn7955c0S6k3Ew==",
-					"requires": {
-						"@babel/runtime": "^7.8.3",
-						"@wordpress/api-fetch": "^3.11.0",
-						"@wordpress/components": "^9.2.1",
-						"@wordpress/data": "^4.14.0",
-						"@wordpress/deprecated": "^2.7.0",
-						"@wordpress/element": "^2.11.0",
-						"@wordpress/i18n": "^3.9.0",
-						"@wordpress/url": "^2.11.0",
-						"lodash": "^4.17.15"
-					}
-				},
 				"diff": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
@@ -37965,38 +37676,6 @@
 					"integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
 					"requires": {
 						"moment": ">= 2.9.0"
-					}
-				},
-				"react": {
-					"version": "16.12.0",
-					"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-					"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2"
-					}
-				},
-				"react-dom": {
-					"version": "16.12.0",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-					"integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2",
-						"scheduler": "^0.18.0"
-					}
-				},
-				"react-modal": {
-					"version": "3.11.1",
-					"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.1.tgz",
-					"integrity": "sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==",
-					"requires": {
-						"exenv": "^1.2.0",
-						"prop-types": "^15.5.10",
-						"react-lifecycles-compat": "^3.0.0",
-						"warning": "^4.0.3"
 					}
 				},
 				"react-stripe-elements": {
@@ -38028,23 +37707,6 @@
 					"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.7.3.tgz",
 					"integrity": "sha512-sQsgKYcn+OthBkvKz+TeHlYZq2SF5ZP9RutHg7O67GI+sdYqf0BVy6VeTe28TG4Vui6hoMheiMnZqhidOtN7EA=="
 				},
-				"scheduler": {
-					"version": "0.18.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-					"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
-				},
-				"use-subscription": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.3.0.tgz",
-					"integrity": "sha512-buZV7FUtnbOr+65dN7PHK7chHhQGfk/yjgqfpRLoWuHIAc4klAD/rdot2FsPNtFthN1ZydvA8tR/mWBMQ+/fDQ==",
-					"requires": {
-						"object-assign": "^4.1.1"
-					}
-				},
 				"uuid": {
 					"version": "3.3.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
@@ -38074,7 +37736,7 @@
 			"requires": {
 				"debug": "^4.1.1",
 				"progress-event": "^1.0.0",
-				"uuid": "^7.0.1",
+				"uid": "^0.0.2",
 				"wp-error": "^1.3.0"
 			}
 		},

--- a/packages/wpcom-proxy-request/History.md
+++ b/packages/wpcom-proxy-request/History.md
@@ -3,6 +3,7 @@
 - Move the published `build/` folder to `dist/` to align with other Calypso packages
 - Upgrade dependency 'debug' to 4.1.1
 - Remove `component-event` dependency, use `addEventListener`/`removeEventListener` directly
+- Replace unmaintained `uid` dependency by well-maintained `uuid`
 
 # 5.0.2 / 2018-10-30
 

--- a/packages/wpcom-proxy-request/History.md
+++ b/packages/wpcom-proxy-request/History.md
@@ -1,8 +1,8 @@
 # 6.0.0 / TBD
 
-- Remove `component-event` dependency, use `addEventListener`/`removeEventListener` directly
 - Move the published `build/` folder to `dist/` to align with other Calypso packages
 - Upgrade dependency 'debug' to 4.1.1
+- Remove `component-event` dependency, use `addEventListener`/`removeEventListener` directly
 
 # 5.0.2 / 2018-10-30
 

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -41,7 +41,7 @@
 	"dependencies": {
 		"debug": "^4.1.1",
 		"progress-event": "^1.0.0",
-		"uid": "^0.0.2",
+		"uuid": "^7.0.1",
 		"wp-error": "^1.3.0"
 	}
 }

--- a/packages/wpcom-proxy-request/src/index.js
+++ b/packages/wpcom-proxy-request/src/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import uid from 'uid';
+import { v4 as uuidv4 } from 'uuid';
 import WPError from 'wp-error';
 import ProgressEvent from 'progress-event';
 import debugFactory from 'debug';
@@ -111,8 +111,8 @@ const request = ( originalParams, fn ) => {
 		install();
 	}
 
-	// generate a uid for this API request
-	const id = uid();
+	// generate a uuid for this API request
+	const id = uuidv4();
 	params.callback = id;
 	params.supports_args = true; // supports receiving variable amount of arguments
 	params.supports_error_obj = true; // better Error object info


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Similar to #39734. Replace the unmaintained [`uid`](https://www.npmjs.com/package/uid) dependency by the well-maintained [`uuid`](https://www.npmjs.com/package/uuid). (We really just use this to generate random IDs for network requests.)

#### Testing instructions

Since this affects the network layer, a casual bit of smoke testing of Calypso should be sufficient to make sure that `wpcom-proxy-request` still works.