### PR TITLE
Jetpack Cloud: Add user gravatar to the Jetpack Cloud masterbar

### DIFF
--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -13,7 +13,6 @@ import Item from 'layout/masterbar/item';
 import JetpackLogo from 'components/jetpack-logo';
 import Masterbar from 'layout/masterbar/masterbar';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { preload } from 'sections-helper';
 
 /**
  * Style dependencies
@@ -23,7 +22,6 @@ import './style.scss';
 export default function() {
 	const translate = useTranslate();
 	const user = useSelector( state => getCurrentUser( state ) );
-	const preloadMe = () => preload( 'me' );
 
 	return (
 		<Masterbar>
@@ -41,7 +39,6 @@ export default function() {
 				url="#" // @todo: add a correct URL
 				icon="user-circle"
 				className="masterbar__item-me"
-				preloadSection={ preloadMe }
 				tooltip={ translate( 'Update your profile, personal settings, and more' ) }
 			>
 				<Gravatar user={ user } alt={ translate( 'My Profile' ) } size={ 18 } />

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -2,14 +2,18 @@
  * External dependencies
  */
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Gravatar from 'components/gravatar';
 import Item from 'layout/masterbar/item';
 import JetpackLogo from 'components/jetpack-logo';
 import Masterbar from 'layout/masterbar/masterbar';
+import { getCurrentUser } from 'state/current-user/selectors';
+import { preload } from 'sections-helper';
 
 /**
  * Style dependencies
@@ -18,6 +22,8 @@ import './style.scss';
 
 export default function() {
 	const translate = useTranslate();
+	const user = useSelector( state => getCurrentUser( state ) );
+	const preloadMe = () => preload( 'me' );
 
 	return (
 		<Masterbar>
@@ -29,6 +35,19 @@ export default function() {
 				} ) }
 			>
 				<JetpackLogo size={ 28 } full monochrome />
+			</Item>
+			<Item
+				tipTarget="me"
+				url="#" // @todo: add a correct URL
+				icon="user-circle"
+				className="masterbar__item-me"
+				preloadSection={ preloadMe }
+				tooltip={ translate( 'Update your profile, personal settings, and more' ) }
+			>
+				<Gravatar user={ user } alt={ translate( 'My Profile' ) } size={ 18 } />
+				<span className="masterbar__item-me-label">
+					{ translate( 'My Profile', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
+				</span>
 			</Item>
 		</Masterbar>
 	);

--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -24,7 +24,9 @@ export default function() {
 	const user = useSelector( state => getCurrentUser( state ) );
 
 	return (
-		<Masterbar>
+		<Masterbar
+			className="is-jetpack-cloud-masterbar" // eslint-disable-line wpcalypso/jsx-classname-namespace
+		>
 			<Item
 				className="masterbar__item-home"
 				url="/"

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -1,4 +1,8 @@
 // Masterbar - home link
+.masterbar {
+	justify-content: space-between;
+}
+
 .masterbar__item-home {
 	width: $sidebar-width-max;
 	padding: 0;

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -1,9 +1,9 @@
 // Masterbar - home link
-.masterbar {
+.masterbar.is-jetpack-cloud-masterbar {
 	justify-content: space-between;
 }
 
-.masterbar__item-home {
+.is-jetpack-cloud-masterbar .masterbar__item-home {
 	width: $sidebar-width-max;
 	padding: 0;
 	border-right: 1px solid var( --color-masterbar-border );

--- a/client/layout/masterbar/masterbar.jsx
+++ b/client/layout/masterbar/masterbar.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -9,16 +10,15 @@ import React from 'react';
  */
 import './style.scss';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
-const Masterbar = ( { children } ) => (
-	<header id="header" className="masterbar">
+const Masterbar = ( { children, className } ) => (
+	<header id="header" className={ classNames( 'masterbar', className ) }>
 		{ children }
 	</header>
 );
-/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 Masterbar.propTypes = {
 	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
 };
 
 export default Masterbar;


### PR DESCRIPTION
This PR adds a user gravatar to the top right corner of the Jetpack Cloud Masterbar. It's based on the default Calypso's Masterbar.

<img width="752" alt="Screenshot 2020-02-27 at 14 09 31" src="https://user-images.githubusercontent.com/478735/75448146-f466ba80-596a-11ea-8889-ff1db2e24a68.png">

#### Changes proposed in this Pull Request

* Add user gravatar and link to the Jetpack Cloud Masterbar

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://jetpack.cloud.localhost:3000/ while being logged in to WordPress.com
* Confirm that you can see your gravatar in the right-hand side of the Masterbar

Fixes 1156570014567299-as-1163908948789809