### PR TITLE
Jetpack Connect: Remove url from AuthFormHeader

### DIFF
--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import urlModule from 'url';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -139,8 +138,8 @@ export class AuthFormHeader extends Component {
 		const safeIconUrl = siteIcon ? safeImageUrl( siteIcon ) : false;
 		const icon = safeIconUrl ? { img: safeIconUrl } : false;
 		const url = decodeEntities( homeUrl );
-		const parsedUrl = urlModule.parse( url );
-		const path = parsedUrl.path === '/' ? '' : parsedUrl.path;
+		const parsedUrl = new URL( url );
+		const path = parsedUrl.pathname === '/' ? '' : parsedUrl.pathname;
 		const site = {
 			admin_url: decodeEntities( siteUrl + '/wp-admin' ),
 			domain: parsedUrl.host + path,


### PR DESCRIPTION
This PR removes the single usage of `url` in the Jetpack Connect section.

#### Changes proposed in this Pull Request

* Jetpack Connect: Remove `url` module from `AuthFormHeader`

#### Testing instructions

* Create a JN Site from https://jurassic.ninja/create?shortlived
* Click the Jetpack sidebar menu item if you don't get presented with the Jetpack connection screen.
* Copy the "Set up Jetpack" button URL. Add `&calypso_env=development` to it.
* Open the resulting URL.
* Look out for console errors.
* Verify that on the authorization page, the site card looks well and displays the site URL properly:

![](https://cldup.com/cWtFpFY0Ti.png)
