### PR TITLE
DateRangeSelector: Set the start date to the start of the day (00:00:00)

### DIFF
--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -43,11 +43,17 @@ export class DateRangeSelector extends Component {
 			enteredToDate: null,
 		} );
 
-		const formattedFromDate = fromDate && moment( fromDate ).format( DATE_FORMAT );
+		const formattedFromDate =
+			fromDate &&
+			moment( fromDate )
+				.startOf( 'day' )
+				.utc()
+				.format( DATE_FORMAT );
 		const formattedToDate =
 			toDate &&
 			moment( toDate )
 				.endOf( 'day' )
+				.utc()
 				.format( DATE_FORMAT );
 		if ( formattedFromDate && formattedToDate && formattedFromDate !== formattedToDate ) {
 			selectDateRange( siteId, formattedFromDate, formattedToDate );
@@ -67,11 +73,13 @@ export class DateRangeSelector extends Component {
 		const formattedStartDate = startDate
 			? moment( startDate )
 					.startOf( 'day' )
+					.utc()
 					.format( DATE_FORMAT )
 			: null;
 		const formattedEndDate = endDate
 			? moment( endDate )
 					.endOf( 'day' )
+					.utc()
 					.format( DATE_FORMAT )
 			: null;
 

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -64,7 +64,11 @@ export class DateRangeSelector extends Component {
 
 	handleDateRangeCommit = ( startDate, endDate ) => {
 		const { moment, selectDateRange } = this.props;
-		const formattedStartDate = startDate ? moment( startDate ).format( DATE_FORMAT ) : null;
+		const formattedStartDate = startDate
+			? moment( startDate )
+					.startOf( 'day' )
+					.format( DATE_FORMAT )
+			: null;
 		const formattedEndDate = endDate
 			? moment( endDate )
 					.endOf( 'day' )


### PR DESCRIPTION
**Changes proposed in this Pull Request**

Set the start date to the start of the day (00:00:00).

**Context**

By default, the start date is set to YYYY-MM-DD 12:00:00. Because of this, we may be inadvertently filtering out entries of things that occurred before 12:00:00 on the selected date.

**Testing instructions**

- Go to Calypso
- Select a site
- Open the Activity Log section
- Select a date in which there are log entries before 12:00:00
- Entries should be missing from the selected date

**Screenshot**
With filtering
<img width="1194" alt="All log entries" src="https://user-images.githubusercontent.com/3418513/75456991-fffdb580-5959-11ea-818e-82d5356f5230.png">

Filtering (one entry is missing)
<img width="1102" alt="Missing a log entry" src="https://user-images.githubusercontent.com/3418513/75457009-055b0000-595a-11ea-9702-badfedeaa6c2.png">




