### PR TITLE
Migration: add header to confirmation dialog

### DIFF
--- a/client/my-sites/migrate/migrate-button.jsx
+++ b/client/my-sites/migrate/migrate-button.jsx
@@ -29,17 +29,24 @@ class MigrateButton extends Component {
 			return;
 		}
 
-		const message = translate(
-			'Overwrite %(targetDomain)s? All posts, pages,' +
-				' comments and media will be lost on this WordPress.com site.',
-			{
-				args: {
-					targetDomain: this.props.targetSiteDomain,
-				},
-			}
+		const message = (
+			<>
+				<h1>
+					{ translate( 'Import and overwrite everything on %(targetDomain)s?', {
+						args: {
+							targetDomain: this.props.targetSiteDomain,
+						},
+					} ) }
+				</h1>
+				<div>
+					{ translate(
+						'All posts, pages, comments and media will be lost on this WordPress.com site.'
+					) }
+				</div>
+			</>
 		);
 
-		accept( message, this.confirmCallback, translate( 'Overwrite this site' ) );
+		accept( message, this.confirmCallback, translate( 'Import and overwrite' ) );
 	};
 
 	render() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the confirmation modal to include a header

Before: 
![image](https://user-images.githubusercontent.com/363749/75469578-de4dff80-5954-11ea-8bce-4c86cb475577.png)

After:
![image](https://user-images.githubusercontent.com/363749/75469475-afd02480-5954-11ea-913d-32a3f87eeeeb.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on "Import" in the sidebar while a Simple (or Atomic) site is selected.
* Select "WordPress".
* Enter the URL to a Jetpack-connected WordPress site.
* Select "Import Everything".
* Continue through the flow until you see the confirmation dialog.

Fixes #39580
