### PR TITLE
Notification Bubble: Fix Colour with Classic Blue

### DIFF
--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-blue.scss
@@ -32,6 +32,8 @@
 	--color-accent-100-rgb: var( --studio-orange-100-rgb );
 
 	/* Component Properties */
+	--color-masterbar-unread-dot-background: var( --color-accent-30 );
+	
 	--color-sidebar-background: var( --studio-gray-5 );
 	--color-sidebar-background-rgb: var( --studio-gray-5-rgb );
 	--color-sidebar-text-alternative: var( --studio-gray-50 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the notification dot colour with the Classic Blue scheme so that it uses its own accent colour (at the same shade as most the others)

<img width="785" alt="Screenshot 2020-02-27 at 17 56 57" src="https://user-images.githubusercontent.com/43215253/75472351-43bce300-598b-11ea-854b-12d5bbfc70d9.png">

#### Testing instructions

Trigger a notification (which can be done by making a comment on a blog post that needs approval) and verify the dot is now orange.

<img width="1559" alt="Screenshot 2020-02-27 at 18 00 01" src="https://user-images.githubusercontent.com/43215253/75472426-63540b80-598b-11ea-83a3-062c187b1478.png">

Fixes #39660
