### PR TITLE
Add test for the current branch

### DIFF
--- a/.github/workflows/send-calypso-app-build-trigger.sh
+++ b/.github/workflows/send-calypso-app-build-trigger.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -Eeuo pipefail
 
+if [ $GITHUB_REF -eq 'refs/heads/master'] ; then
+	echo "Do not generate a diff for the merge commit."
+	exit 0;
+fi
+
 trigger_payload=`cat $GITHUB_EVENT_PATH`
 
 workflow_data="{

--- a/.github/workflows/send-calypso-app-build-trigger.sh
+++ b/.github/workflows/send-calypso-app-build-trigger.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 if [ $GITHUB_REF -eq 'refs/heads/master'] ; then
 	echo "Do not generate a diff for the merge commit."
-	exit 0;
+	exit 0
 fi
 
 trigger_payload=`cat $GITHUB_EVENT_PATH`

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -14,7 +14,7 @@ Enhances your page creation workflow within the Block Editor.
 == Description ==
 
 This plugin comes with a custom block to display a list of your most recent blog posts, as well as a template selector
-to give you a head start on creating new pages for your site.
+to give you a head start on creating new pages for your site. It also includes the "Timeline" and "Countdown" blocks.
 
 
 == Installation ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Previously, any merge to master which affected the FSE plugin folder would fail. This is because the autogenerated diff build trigger fails if there is no PR data. This adds a check which skips the autogenerated diff step if we are on the master branch. 

#### Testing instructions
- [x] It should trigger the autogenerated diff in the Pull Request
- [ ] It should not trigger the diff in the merge commit to master