### PR TITLE
Fix Flow For Jetpack Backups from `jetpack/connect`

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -60,6 +60,7 @@ export class ProductSelector extends Component {
 			ratio: PropTypes.number,
 		} ),
 		siteId: PropTypes.number,
+		onUpgradeClick: PropTypes.func,
 
 		// Connected props
 		availableProducts: PropTypes.object,
@@ -262,7 +263,7 @@ export class ProductSelector extends Component {
 	}
 
 	handleCheckoutForProduct = productObject => {
-		const { currentPlanSlug, intervalType, selectedSiteSlug } = this.props;
+		const { currentPlanSlug, intervalType, selectedSiteSlug, onUpgradeClick } = this.props;
 
 		return () => {
 			this.props.recordTracksEvent( 'calypso_plan_features_upgrade_click', {
@@ -270,6 +271,10 @@ export class ProductSelector extends Component {
 				product_name: productObject.product_slug,
 				billing_cycle: intervalType,
 			} );
+			if ( onUpgradeClick ) {
+				onUpgradeClick( productObject );
+				return;
+			}
 			page( '/checkout/' + selectedSiteSlug + '/' + productObject.product_slug );
 		};
 	};

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -116,7 +116,7 @@ export function connect( context, next ) {
 	const { type = false, interval } = params;
 	const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
 
-	debug( 'entered connect flow with params %o', params );
+	console.log( 'entered connect flow with params %o', params );
 
 	const planSlug = getPlanSlugFromFlowType( type, interval );
 

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -115,9 +115,6 @@ export function connect( context, next ) {
 	const { path, pathname, params, query } = context;
 	const { type = false, interval } = params;
 	const analyticsPageTitle = get( type, analyticsPageTitleByType, 'Jetpack Connect' );
-
-	console.log( 'entered connect flow with params %o', params );
-
 	const planSlug = getPlanSlugFromFlowType( type, interval );
 
 	// Not clearing the plan here, because other flows can set the cookie before arriving here.

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -75,7 +75,6 @@ class PlansLanding extends Component {
 		storePlan( cartItem ? cartItem.product_slug : PLAN_JETPACK_FREE );
 
 		setTimeout( () => {
-			console.log( 'Redirecting to', redirectUrl, cartItem );
 			page.redirect( redirectUrl );
 		}, 25 );
 	};

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -75,6 +75,7 @@ class PlansLanding extends Component {
 		storePlan( cartItem ? cartItem.product_slug : PLAN_JETPACK_FREE );
 
 		setTimeout( () => {
+			console.log( 'Redirecting to', redirectUrl, cartItem );
 			page.redirect( redirectUrl );
 		}, 25 );
 	};

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -19,6 +19,7 @@ import Placeholder from './plans-placeholder';
 import PlansGrid from './plans-grid';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
+import QueryProductsList from 'components/data/query-products-list';
 import { addItem } from 'lib/cart/actions';
 import { addQueryArgs } from 'lib/route';
 import { clearPlan, isCalypsoStartedConnection, retrievePlan } from './persistence-utils';
@@ -26,6 +27,7 @@ import { completeFlow } from 'state/jetpack-connect/actions';
 import { externalRedirect } from 'lib/route/path';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getPlanBySlug } from 'state/plans/selectors';
+import { getProductBySlug } from 'state/products-list/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 import { JPC_PATH_PLANS } from './constants';
@@ -36,6 +38,7 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { persistSignupDestination } from 'signup/utils';
+import { isJetpackBackupSlug as getIsJetpackBackupSlug } from 'lib/products-values';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
 const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
@@ -197,6 +200,7 @@ class Plans extends Component {
 			return (
 				<Fragment>
 					<QueryPlans />
+					<QueryProductsList />
 					<Placeholder />
 				</Fragment>
 			);
@@ -240,7 +244,12 @@ const connectComponent = connect(
 		const selectedSiteSlug = selectedSite ? selectedSite.slug : '';
 
 		const selectedPlanSlug = retrievePlan();
-		const selectedPlan = getPlanBySlug( state, selectedPlanSlug );
+		const isJetpackBackupSlug = getIsJetpackBackupSlug( selectedPlanSlug );
+
+		const selectedPlan = isJetpackBackupSlug
+			? getProductBySlug( state, selectedPlanSlug )
+			: getPlanBySlug( state, selectedPlanSlug );
+
 		return {
 			calypsoStartedConnection: isCalypsoStartedConnection( selectedSiteSlug ),
 			canPurchasePlans: selectedSite

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -171,7 +171,6 @@ class Plans extends Component {
 		addItem( cartItem );
 		this.props.completeFlow();
 		persistSignupDestination( this.getMyPlansDestination() );
-		console.log( 'Checking out with', cartItem );
 
 		this.redirect( '/checkout/' );
 	};

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -168,6 +168,8 @@ class Plans extends Component {
 		addItem( cartItem );
 		this.props.completeFlow();
 		persistSignupDestination( this.getMyPlansDestination() );
+		console.log( 'Checking out with', cartItem );
+
 		this.redirect( '/checkout/' );
 	};
 

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -3,6 +3,7 @@
 exports[`Plans should render placeholder when shouldShowPlaceholder is true 1`] = `
 <Fragment>
   <Connect(QueryPlans) />
+  <QueryProductsList />
   <PlansPlaceholder />
 </Fragment>
 `;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -431,7 +431,7 @@ export class PlansFeaturesMain extends Component {
 			return null;
 		}
 
-		const { basePlansPath, intervalType, redirectTo } = this.props;
+		const { basePlansPath, intervalType, redirectTo, onUpgradeClick } = this.props;
 		const jetpackProducts = getJetpackProducts();
 
 		return (
@@ -449,6 +449,7 @@ export class PlansFeaturesMain extends Component {
 					basePlansPath={ basePlansPath }
 					productPriceMatrix={ JETPACK_PRODUCT_PRICE_MATRIX }
 					redirectTo={ redirectTo }
+					onUpgradeClick={ onUpgradeClick }
 				/>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

See p1HpG7-8CV-p2 for a discussion of the issue

* Fix Jetpack store flow so that user can arrive on the checkout page with a Backup product

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. In a fresh private window, navigate to `/jetpack/connect/store`
2.  Make note of the selected product ( Daily vs Real-Time )  then click the "Get Real-Time Backups" button near the bottom
3. Confirm you are taken to a Jetpack-branded page `/jetpack/connect`
4. proceed through the flow with a test Jetpack site and WordPress.com user, until you reach the checkout page
5. Confirm you have the backup product that corresponds to what you chose in step 2

