### PR TITLE
Site migration: hide part of UI on mobile to make URL input more usable

### DIFF
--- a/client/my-sites/migrate/components/sites-block/index.jsx
+++ b/client/my-sites/migrate/components/sites-block/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -87,14 +88,19 @@ class SitesBlock extends Component {
 	};
 
 	render() {
-		const { targetSite, translate } = this.props;
+		const { targetSite, step, translate } = this.props;
+		const isSourceSelectStep = step === 'sourceSelect';
+		const className = classNames( 'sites-block__sites', {
+			'is-step-source-select': isSourceSelectStep,
+		} );
+
 		return (
-			<div className="sites-block__sites">
-				<div className="sites-block__sites-item">{ this.getSourceSiteOrInput() }</div>
+			<div className={ className }>
+				<div className="sites-block__source-site">{ this.getSourceSiteOrInput() }</div>
 				<div className="sites-block__sites-arrow-wrapper">
 					<Gridicon className="sites-block__sites-arrow" icon="arrow-right" />
 				</div>
-				<div className="sites-block__sites-item">
+				<div className="sites-block__target-site">
 					<Site site={ targetSite } indicator={ false } />
 					<div className="sites-block__sites-labels-container">
 						<Badge type="info">{ translate( 'This Site' ) }</Badge>
@@ -112,6 +118,7 @@ SitesBlock.propTypes = {
 	targetSite: PropTypes.object.isRequired,
 	onUrlChange: PropTypes.func,
 	onSubmit: PropTypes.func,
+	step: PropTypes.string,
 };
 
 export default localize( SitesBlock );

--- a/client/my-sites/migrate/components/sites-block/style.scss
+++ b/client/my-sites/migrate/components/sites-block/style.scss
@@ -40,7 +40,8 @@
 		}
 	}
 
-	.sites-block__sites-item {
+	.sites-block__source-site,
+	.sites-block__target-site {
 		padding: 25px;
 		width: 50%;
 
@@ -49,11 +50,18 @@
 		}
 	}
 
+	@include breakpoint('<660px') {
+		&.is-step-source-select {
+			.sites-block__sites-arrow-wrapper,
+			.sites-block__target-site {
+				display: none;
+			}
+		}
+	}
+
 	.site__content {
 		padding: 0; /* Reduce spacing below the site component, so we can put labels under it */
 	}
-
-
 
 	.sites-block__faux-site-selector {
 		box-sizing: border-box;

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -142,6 +142,7 @@ class StepSourceSelect extends Component {
 					onUrlChange={ this.onUrlChange }
 					onSubmit={ this.handleContinue }
 					url={ this.props.url }
+					step="sourceSelect"
 				/>
 				{ this.state.error && (
 					<Notice className="migrate__error" showDismiss={ false } status="is-error">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Simplifies the UI during the source selection step of migration on small viewports to give the URL input more room and make it more usable.

#### Testing instructions

* Apply the PR and run Calypso locally, or use `calypso.live` (for the latter, add `?flags=tools/migrate` to the end of the URL to enable the feature flag).
* Start a migration: go to the import section of a Simple site and choose the WordPress importer.
* On the next page, on mobile viewports you should see a URL input. On bigger viewports, the input should have a second element next to it to indicate where the migration will go.
* Enter the URL of a Jetpack site and click the "Continue" button. The "from" and "to" elements of the UI should be visible at the top of the page in all viewports.

![image](https://user-images.githubusercontent.com/1647564/75543440-b2488200-5a19-11ea-8c20-f23c43c7d4c7.png)

![image](https://user-images.githubusercontent.com/1647564/75543699-56322d80-5a1a-11ea-98cb-4935f9a64ff8.png)





