### PR TITLE
JITM: JITMs accept is_dismissible value

### DIFF
--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -45,6 +45,7 @@ const transformApiRequest = ( { data: jitms } ) =>
 		action: jitm.action,
 		template: jitm.template,
 		id: jitm.id,
+		isDismissible: jitm.is_dismissible,
 	} ) );
 
 /**

--- a/client/state/data-layer/wpcom/sites/jitm/schema.json
+++ b/client/state/data-layer/wpcom/sites/jitm/schema.json
@@ -77,6 +77,9 @@
 					},
 					"action": {
 						"type": "object"
+					},
+					"is_dismissible": {
+						"type": "boolean"
 					}
 				},
 				"type": "object"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `isDismissible` value to the JITMs state tree.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You may need to install [Redux devtools](https://github.com/reduxjs/redux-devtools).
* Open the Redux devtools and go to stats page of your free site.
* When `Free domain with a plan` banner appears in the sidebar, filter `JITM` actions.
  <img width="521" alt="Stats_and_Insights_‹_FreePlan_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/75549808-ddf85600-5a73-11ea-8b4e-24feeebdc307.png">
* You should be able to `isDismissible` in the raw state.
  <img width="926" alt="Stats_and_Insights_‹_FreePlan_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/75551100-beaef800-5a76-11ea-886c-80a58a36f03d.png">
