### PR TITLE
JITM: Simplify message path for stats section

### DIFF
--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -139,9 +139,12 @@ export function getStatsPathForTab(
 }
 
 export function getMessagePathForJITM( path: URLString, siteFragment?: SiteSlug | SiteId ): string {
-	return sectionify( path, siteFragment )
-		.replace( /^\/+/, '' )
-		.replace( /\//g, '-' );
+	let messagePath = sectionify( path, siteFragment ).replace( /^\/+/, '' );
+
+	// simplify stats paths
+	messagePath = messagePath.replace( /^(stats)\/\w+/, '$1' );
+
+	return messagePath.replace( /\//g, '-' );
 }
 
 // TODO: Add status enum (see `client/my-sites/pages/main.jsx`).

--- a/client/lib/route/test/index.js
+++ b/client/lib/route/test/index.js
@@ -411,5 +411,13 @@ describe( 'route', function() {
 		test( 'converts internal slashes to dashes', function() {
 			expect( route.getMessagePathForJITM( 'test/path/to/site' ) ).to.equal( 'test-path-to-site' );
 		} );
+
+		test( 'should simplify stats paths', function() {
+			expect( route.getMessagePathForJITM( '/stats/day' ) ).to.equal( 'stats' );
+			expect( route.getMessagePathForJITM( '/stats/week' ) ).to.equal( 'stats' );
+			expect( route.getMessagePathForJITM( '/stats/month' ) ).to.equal( 'stats' );
+			expect( route.getMessagePathForJITM( '/stats/year' ) ).to.equal( 'stats' );
+			expect( route.getMessagePathForJITM( '/stats/insights' ) ).to.equal( 'stats' );
+		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Simplify JITM message path for `/stats` sections, so it won't contain subsection. This PR reduces number of JITM requests called in `/stats` section.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This doesn't need any test plan. Just make sure all test passed.
