### PR TITLE
JITM: Update notice template to render UpsellNudge

### DIFF
--- a/client/blocks/jitm/templates/notice.jsx
+++ b/client/blocks/jitm/templates/notice.jsx
@@ -2,29 +2,43 @@
  * External Dependencies
  */
 import React from 'react';
+import { assign } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
+import UpsellNudge from 'blocks/upsell-nudge';
 
-export default function NoticeTemplate( { icon, CTA, message, onClick, onDismiss, trackImpression } ) {
+export default function NoticeTemplate( { id, CTA, tracks, ...props } ) {
+	const jitmProps = { id, cta_name: id, jitm: true };
+	const tracksProps = {
+		// CTA clicks
+		tracksClickName: tracks?.click?.name ?? `jitm_nudge_click`,
+		tracksClickProperties: assign( {}, jitmProps, tracks?.click?.props ),
+
+		// Impression
+		tracksImpressionName: tracks?.display?.name ?? `jitm_nudge_impression`,
+		tracksImpressionProperties: assign( {}, jitmProps, tracks?.display?.props ),
+
+		// Dismiss
+		tracksDismissName: tracks?.dismiss?.name ?? `jitm_nudge_dismiss`,
+		trackDismissProperties: assign( {}, jitmProps, tracks?.dismiss?.props ),
+	};
+
 	return (
-		<Notice
-			isCompact
-			status="is-success"
-			icon={ icon || "info-outline" }
-			onDismissClick={ onDismiss }
-			showDismiss={ ! CTA && ! CTA.message }
-			text={ message }
-		>
-			{ CTA && CTA.message && (
-				<NoticeAction href={ CTA.link } onClick={ onClick }>
-					{ CTA.message }
-					{ trackImpression && trackImpression() }
-				</NoticeAction>
-			) }
-		</Notice>
+		<UpsellNudge
+			event={ id }
+			title={ props.message }
+			icon={ props.icon || 'info-outline' }
+			showIcon={ !! props.icon }
+			description={ props.description }
+			href={ CTA.link }
+			disableHref={ true }
+			callToAction={ CTA.message }
+			onClick={ props.onClick }
+			onDismissClick={ props.onDismiss }
+			dismissPreferenceName={ props.isDismissible ? id : '' }
+			{ ...tracksProps }
+		/>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update notice template to render UpsellNudge instead of Notice.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/stats/day` of your site.
* In ~~dev mode~~ local Calypso, run the following command to add a JITM for the section.
  ```js
  _jitm.insert(
    'calypso:stats-day:admin_notices', [ {
        "message": "Howdy!",
        "description": "",
        "classes": "",
        "icon": "info-outline",
        "CTA":{
            "message":"Click here!",
            "link": "https://wordpress.com"
        },
        "tracks": {
            "display": {
                "name": "calypso_upgrade_nudge_impression",
                "props": {}
            },
            "click": {
                "name": "calypso_upgrade_nudge_impression",
                "props": {},
            },
            "display": {
                "name": "calypso_upgrade_nudge_impression",
                "props": {},
            }
        },
        "template":"notice",
        "id":"wpcom_calypso_testing",
        "feature_class":"dotcom-welcome",
        "isDismissible": true
    } ]
  );
  ```
* Make sure a nudge appears on the top of the page.
  <img width="1006" alt="Stats_and_Insights_‹_FreePlan_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/75553081-09327380-5a7b-11ea-8faf-0ffcc67261e3.png">
