### PR TITLE
Update the reconnect to renew message on the Manage Purchase page

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -40,7 +40,7 @@ import { getUser } from 'state/users/selectors';
 import { managePurchase } from '../paths';
 import AutoRenewToggle from './auto-renew-toggle';
 import PaymentLogo from 'components/payment-logo';
-import { CALYPSO_CONTACT } from 'lib/url/support';
+import { JETPACK_SUPPORT } from 'lib/url/support';
 import UserItem from 'components/user';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
@@ -247,7 +247,7 @@ class PurchaseMeta extends Component {
 		);
 	}
 
-	renderContactSupportToRenewMessage() {
+	renderReconnectToRenewMessage() {
 		const { purchase, translate } = this.props;
 
 		if ( this.props.site ) {
@@ -255,18 +255,24 @@ class PurchaseMeta extends Component {
 		}
 
 		return (
-			<div className="manage-purchase__contact-support">
+			<div className="manage-purchase__footnotes">
 				{ translate(
-					'You are the owner of %(purchaseName)s but because you are no longer a user on %(siteSlug)s, ' +
-						'renewing it will require staff assistance. Please {{contactSupportLink}}contact support{{/contactSupportLink}}, ' +
-						'and consider transferring this purchase to another active user on %(siteSlug)s to avoid this issue in the future.',
+					'You are the owner of %(purchaseName)s, but your site %(siteSlug)s is no longer connected to WordPress.com. ' +
+						'To renew %(purchaseName)s, you have to reconnect the site to your WordPress.com account first. ' +
+						'Please, check out this {{supportPageLink}}support page{{/supportPageLink}} to get more help.',
 					{
 						args: {
 							purchaseName: getName( purchase ),
 							siteSlug: this.props.purchase.domain,
 						},
 						components: {
-							contactSupportLink: <a href={ CALYPSO_CONTACT } />,
+							supportPageLink: (
+								<a
+									href={
+										JETPACK_SUPPORT + 'reconnecting-reinstalling-jetpack/#reconnecting-jetpack'
+									}
+								/>
+							),
 						},
 					}
 				) }
@@ -381,7 +387,7 @@ class PurchaseMeta extends Component {
 					{ this.renderExpiration() }
 					{ this.renderPaymentDetails() }
 				</ul>
-				{ this.renderContactSupportToRenewMessage() }
+				{ this.renderReconnectToRenewMessage() }
 			</>
 		);
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -259,7 +259,7 @@ class PurchaseMeta extends Component {
 				{ translate(
 					'You are the owner of %(purchaseName)s, but your site %(siteSlug)s is no longer connected to WordPress.com. ' +
 						'To renew %(purchaseName)s, you have to reconnect the site to your WordPress.com account first. ' +
-						'Please, check out this {{supportPageLink}}support page{{/supportPageLink}} to get more help.',
+						'Please, check out this {{supportPageLink}}support page{{/supportPageLink}} for information on how to reconnect.',
 					{
 						args: {
 							purchaseName: getName( purchase ),

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -11,7 +11,6 @@ import { times } from 'lodash';
  * Internal Dependencies
  */
 import {
-	getName,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,
@@ -248,7 +247,7 @@ class PurchaseMeta extends Component {
 	}
 
 	renderReconnectToRenewMessage() {
-		const { purchase, translate } = this.props;
+		const { translate } = this.props;
 
 		if ( this.props.site ) {
 			return null;
@@ -257,12 +256,11 @@ class PurchaseMeta extends Component {
 		return (
 			<div className="manage-purchase__footnotes">
 				{ translate(
-					'You are the owner of %(purchaseName)s, but your site %(siteSlug)s is no longer connected to WordPress.com. ' +
-						'To renew %(purchaseName)s, you have to reconnect the site to your WordPress.com account first. ' +
-						'Please, check out this {{supportPageLink}}support page{{/supportPageLink}} for information on how to reconnect.',
+					'The Jetpack Plan for %(siteSlug)s is expired, and the site is no longer connected to WordPress.com. ' +
+						'To renew this plan, please reconnect %(siteSlug)s to your WordPress.com account, then complete your purchase. ' +
+						'Now sure how to reconnect? {{supportPageLink}}Here are the instructions{{/supportPageLink}}.',
 					{
 						args: {
-							purchaseName: getName( purchase ),
 							siteSlug: this.props.purchase.domain,
 						},
 						components: {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -31,6 +31,7 @@ import {
 	isDomainTransfer,
 	isConciergeSession,
 	isJetpackPlan,
+	isJetpackProduct,
 	isPlan,
 } from 'lib/products-values';
 import { getPlan } from 'lib/plans';
@@ -259,11 +260,12 @@ class PurchaseMeta extends Component {
 			return (
 				<div className="manage-purchase__footnotes">
 					{ translate(
-						'The Jetpack Plan for %(siteSlug)s is expired, and the site is no longer connected to WordPress.com. ' +
-							'To renew this plan, please reconnect %(siteSlug)s to your WordPress.com account, then complete your purchase. ' +
+						'%(purchaseName)s expired on %(siteSlug)s, and the site is no longer connected to WordPress.com. ' +
+							'To renew this purchase, please reconnect %(siteSlug)s to your WordPress.com account, then complete your purchase. ' +
 							'Now sure how to reconnect? {{supportPageLink}}Here are the instructions{{/supportPageLink}}.',
 						{
 							args: {
+								purchaseName: getName( purchase ),
 								siteSlug: this.props.purchase.domain,
 							},
 							components: {
@@ -424,6 +426,6 @@ export default connect( ( state, { purchaseId } ) => {
 		site: purchase ? getSite( state, purchase.siteId ) : null,
 		owner: purchase ? getUser( state, purchase.userId ) : null,
 		isAutorenewalEnabled: purchase ? ! isExpiring( purchase ) : null,
-		isJetpack: purchase && isJetpackPlan( purchase ),
+		isJetpack: purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) ),
 	};
 } )( localize( withLocalizedMoment( PurchaseMeta ) ) );

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -294,7 +294,7 @@
 	}
 }
 
-.manage-purchase__contact-support {
+.manage-purchase__footnotes {
 	color: var( --color-text-subtle );
 	border-top: solid 1px var( --color-neutral-0 );
 	margin: 0 auto;

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -25,6 +25,7 @@ import {
 	isDomainTransfer,
 	isGoogleApps,
 	isJetpackPlan,
+	isJetpackProduct,
 	isPlan,
 } from 'lib/products-values';
 import notices from 'notices';
@@ -321,7 +322,7 @@ class RemovePurchase extends Component {
 
 export default connect(
 	( state, { purchase } ) => {
-		const isJetpack = purchase && isJetpackPlan( purchase );
+		const isJetpack = purchase && ( isJetpackPlan( purchase ) || isJetpackProduct( purchase ) );
 		return {
 			isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, purchase.siteId ),


### PR DESCRIPTION
This PR updates the message on the Manage Purchase page for expired *and* disconnected sites. Instead of recommending contacting the support, it now informs that the site has to be reconnected to WordPress.com in order to be renewed.

<img width="738" alt="Screenshot 2020-03-02 at 10 17 19" src="https://user-images.githubusercontent.com/478735/75662401-55dea000-5c6f-11ea-92e4-780ffb3ffcdc.png">

This should resolve the issue described in pbtFFM-5K-p2

#### Changes proposed in this Pull Request

* Update the footer message copy for expired and disconnected sites
* Use a more semantic and content-agnostic class name for the message container

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a Jetpack site (e.g. Jurassic Ninja) with one of the paid plans
* In SA, manually adjust the "expires" date, so that the plan is expired
* Disconnect the site from WordPress.com
* Go to http://calypso.localhost:3000/me/purchases and select the site with the expired plan
* Confirm that the message on the https://wordpress.com/me/purchases/:siteSlug/:purchaseId is now updated and clearly communicates the next step

Fixes n/a
