### PR TITLE
Site Migration: Fixes the upsell as proposed by design

### DIFF
--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -81,6 +81,7 @@
 		padding: 16px 0;
 		justify-content: space-between;
 		border-top: none;
+		border-bottom: none;
 
 	}
 
@@ -101,7 +102,7 @@
 		display: flex;
 		border-top: 1px solid var( --color-neutral-10 );
 
-		margin: 16px 0 0;
+		margin: 24px 0 0;
 		padding: 16px 0 0;
 
 		flex-direction: row;

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -31,14 +31,15 @@
 
 .migrate__plan-upsell {
 	display: flex;
+	flex-direction: row-reverse;
+	flex-wrap: nowrap;
 	border-top: 1px solid var( --color-neutral-10 );
 	border-bottom: 1px solid var( --color-neutral-10 );
 	margin: 16px 0;
 	padding: 16px 0;
 }
 
-.migrate__plan-upsell-icon,
-.migrate__plan-upsell-info,
+.migrate__plan-upsell-container,
 .migrate__plan-upsell-themes,
 .migrate__plan-upsell-plugins {
 	display: flex;
@@ -46,21 +47,85 @@
 	margin-right: 16px;
 }
 
-.migrate__plan-upsell-icon {
-	min-width: 64px;
-	min-height: 64px;
-	max-width: 64px;
-	max-height: 64px;
-}
-
-.migrate__plan-upsell-info {
+.migrate__plan-upsell-container {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap;
 	flex-basis: 40%;
+
+	.migrate__plan-upsell-icon {
+		width: 64px;
+		height: 64px;
+		flex-grow: 0;
+		flex-shrink: 0;
+		margin-right: 16px;
+	}
+
+	.migrate__plan-upsell-info {
+		flex-grow: 1;
+		flex-shrink: 1;
+		max-width: 175px; /** To force the text to go on the next line in English */
+	}
 }
 
 .migrate__plan-upsell-themes,
 .migrate__plan-upsell-plugins {
 	flex-basis: 25%;
 }
+
+
+@include breakpoint('<800px') {
+	&.migrate__plan-upsell {
+		flex-wrap: wrap;
+		margin: 16px 0;
+		padding: 16px 0;
+		justify-content: space-between;
+		border-top: none;
+
+	}
+
+	&.migrate__plan-upsell-container,
+	&.migrate__plan-upsell-themes,
+	&.migrate__plan-upsell-plugins {
+		display: flex;
+		flex-wrap: wrap;
+	}
+
+
+	&.migrate__plan-upsell-themes,
+	&.migrate__plan-upsell-plugins {
+		flex-basis: 45%;
+	}
+
+	&.migrate__plan-upsell-container {
+		display: flex;
+		border-top: 1px solid var( --color-neutral-10 );
+
+		margin: 16px 0 0;
+		padding: 16px 0 0;
+
+		flex-direction: row;
+		flex-wrap: nowrap;
+		flex-basis: 100%;
+
+		.migrate__plan-upsell-icon {
+			width: 64px;
+			height: 64px;
+			flex-grow: 0;
+			flex-shrink: 0;
+			margin-right: 16px;
+		}
+
+		.migrate__plan-upsell-info {
+			flex-grow: 1;
+			flex-shrink: 1;
+			max-width: none;
+		}
+	}
+
+
+}
+
 
 .migrate__plan-name,
 .migrate__plan-price,

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -92,12 +92,6 @@
 		flex-wrap: wrap;
 	}
 
-
-	&.migrate__plan-upsell-themes,
-	&.migrate__plan-upsell-plugins {
-		flex-basis: 45%;
-	}
-
 	&.migrate__plan-upsell-container {
 		display: flex;
 		border-top: 1px solid var( --color-neutral-10 );

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -67,15 +67,25 @@ class StepUpgrade extends Component {
 						) }
 					</div>
 					<div className="migrate__plan-upsell">
-						<div className="migrate__plan-upsell-icon">
-							<ProductIcon slug="business-bundle" />
-						</div>
-						<div className="migrate__plan-upsell-info">
-							<div className="migrate__plan-name">{ translate( 'WordPress.com Business' ) }</div>
-							<div className="migrate__plan-price">
-								<PlanPrice rawPrice={ planPrice } currencyCode={ currency } />
-							</div>
-							<div className="migrate__plan-billing-time-frame">{ billingTimeFrame }</div>
+						{ /** The child elements here are in reverse order due to having flex-direction: row-reverse in CSS */ }
+						<div className="migrate__plan-upsell-plugins">
+							<h4 className="migrate__plan-feature-header">
+								{ translate( 'Your active plugins' ) }
+							</h4>
+							{ plugins.slice( 0, 2 ).map( ( plugin, index ) => (
+								<div className="migrate__plan-upsell-item" key={ index }>
+									<Gridicon size={ 18 } icon="checkmark" />
+									<div className="migrate__plan-upsell-item-label">{ plugin.name }</div>
+								</div>
+							) ) }
+							{ plugins.length > 2 && (
+								<div className="migrate__plan-upsell-item">
+									<Gridicon size={ 18 } icon="plus" />
+									<div className="migrate__plan-upsell-item-label">
+										{ translate( '%(number)d more', { args: { number: plugins.length - 2 } } ) }
+									</div>
+								</div>
+							) }
 						</div>
 						<div className="migrate__plan-upsell-themes">
 							<h4 className="migrate__plan-feature-header">
@@ -96,24 +106,17 @@ class StepUpgrade extends Component {
 								</div>
 							) }
 						</div>
-						<div className="migrate__plan-upsell-plugins">
-							<h4 className="migrate__plan-feature-header">
-								{ translate( 'Your active plugins' ) }
-							</h4>
-							{ plugins.slice( 0, 2 ).map( ( plugin, index ) => (
-								<div className="migrate__plan-upsell-item" key={ index }>
-									<Gridicon size={ 18 } icon="checkmark" />
-									<div className="migrate__plan-upsell-item-label">{ plugin.name }</div>
+						<div className="migrate__plan-upsell-container">
+							<div className="migrate__plan-upsell-icon">
+								<ProductIcon slug="business-bundle" />
+							</div>
+							<div className="migrate__plan-upsell-info">
+								<div className="migrate__plan-name">{ translate( 'WordPress.com Business' ) }</div>
+								<div className="migrate__plan-price">
+									<PlanPrice rawPrice={ planPrice } currencyCode={ currency } />
 								</div>
-							) ) }
-							{ plugins.length > 2 && (
-								<div className="migrate__plan-upsell-item">
-									<Gridicon size={ 18 } icon="plus" />
-									<div className="migrate__plan-upsell-item-label">
-										{ translate( '%(number)d more', { args: { number: plugins.length - 2 } } ) }
-									</div>
-								</div>
-							) }
+								<div className="migrate__plan-billing-time-frame">{ billingTimeFrame }</div>
+							</div>
 						</div>
 					</div>
 					<MigrateButton


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR changes a bit the layout and styling on the upsell step of site migration to make it a bit better looking on mobile
* More information in #39576

#### Testing instructions

* Use Calypso.live link
* Start migration on a WordPress.com Simple site
* Reach the upsell page where you have to buy the Business plan
* Change the page width to less than 800px
* Make sure it looks well
* Try switching to different device screens in developers tools (Chrome or Firefox) 
* Again make sure it looks good on both small screens and desktop sizes.

Fixes #39576
