### PR TITLE
Server: Fix allmoji URL

### DIFF
--- a/client/server/bundler/index.js
+++ b/client/server/bundler/index.js
@@ -85,7 +85,7 @@ function middleware( app ) {
 					</p>
 					<p>
 						In the meantime, try to follow all the emotions of the allmoji:
-						<img src="https://emoji.slack-edge.com/T024FN1V2/allmoji/fa5781cf7a8c5685.gif"
+						<img src="https://emoji.slack-edge.com/T024FN1V2/allmoji/15b93529a828705f.gif"
 							width="36" style="vertical-align: middle;">
 				</body>
 			` );


### PR DESCRIPTION
It is a sad day for Calypso! The allmoji on the server bundler page is broken 😓 This PR fixes it.

#### Changes proposed in this Pull Request

* Server: Fix allmoji URL

#### Preview

Before:
![](https://cldup.com/Co1LNH7_xP.png)
After:
![](https://cldup.com/deyIPT6N6h.png)

#### Testing instructions

* Checkout this branch.
* Start building Calypso.
* When you get to the Webpack part, visit http://calypso.localhost:3000/
* Verify the allmoji is loaded and it looks well.
* Optional: try to follow all the emotions from the allmoji.