### PR TITLE
Fixes purchase time period to work for products

### DIFF
--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -10,6 +10,8 @@ import { isGSuiteOrExtraLicenseProductSlug } from 'lib/gsuite';
 import {
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
+	JETPACK_BACKUP_PRODUCTS_YEARLY,
+	JETPACK_BACKUP_PRODUCTS_MONTHLY,
 	getJetpackProductsDisplayNames,
 	getJetpackProductsTaglines,
 } from './constants';
@@ -251,6 +253,14 @@ export function isBiennially( rawProduct ) {
 	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_BIENNIAL_PERIOD;
+}
+
+export function isMonthlyFromSlug( productSlug ) {
+	return JETPACK_BACKUP_PRODUCTS_MONTHLY.includes( productSlug );
+}
+
+export function isYearlyFromSlug( productSlug ) {
+	return JETPACK_BACKUP_PRODUCTS_YEARLY.includes( productSlug );
 }
 
 export function isJpphpBundle( product ) {

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -10,11 +10,10 @@ import { isGSuiteOrExtraLicenseProductSlug } from 'lib/gsuite';
 import {
 	JETPACK_BACKUP_PRODUCTS,
 	JETPACK_PRODUCTS_LIST,
-	JETPACK_BACKUP_PRODUCTS_YEARLY,
-	JETPACK_BACKUP_PRODUCTS_MONTHLY,
 	getJetpackProductsDisplayNames,
 	getJetpackProductsTaglines,
 } from './constants';
+import { PRODUCTS_LIST } from './products-list';
 import {
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
@@ -234,6 +233,13 @@ export function isJetpackProduct( product ) {
 	return isJetpackProductSlug( product.product_slug );
 }
 
+export function getProductFromSlug( productSlug ) {
+	if ( PRODUCTS_LIST[ productSlug ] ) {
+		return formatProduct( PRODUCTS_LIST[ productSlug ] );
+	}
+	return productSlug; // Consistent behavior with `getPlan`.
+}
+
 export function isMonthly( rawProduct ) {
 	const product = formatProduct( rawProduct );
 	assertValidProduct( product );
@@ -253,14 +259,6 @@ export function isBiennially( rawProduct ) {
 	assertValidProduct( product );
 
 	return parseInt( product.bill_period, 10 ) === PLAN_BIENNIAL_PERIOD;
-}
-
-export function isMonthlyFromSlug( productSlug ) {
-	return JETPACK_BACKUP_PRODUCTS_MONTHLY.includes( productSlug );
-}
-
-export function isYearlyFromSlug( productSlug ) {
-	return JETPACK_BACKUP_PRODUCTS_YEARLY.includes( productSlug );
 }
 
 export function isJpphpBundle( product ) {

--- a/client/lib/products-values/products-list.ts
+++ b/client/lib/products-values/products-list.ts
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import * as constants from './constants';
+import {
+	TERM_ANNUALLY,
+	TERM_MONTHLY,
+	PLAN_MONTHLY_PERIOD,
+	PLAN_ANNUAL_PERIOD,
+} from 'lib/plans/constants';
+
+const PRODUCT_SHORT_NAMES = constants.getJetpackProductsShortNames();
+
+export const PRODUCTS_LIST = {
+	[ constants.PRODUCT_JETPACK_BACKUP_DAILY ]: {
+		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_BACKUP_DAILY ],
+		product_slug: constants.PRODUCT_JETPACK_BACKUP_DAILY,
+		term: TERM_ANNUALLY,
+		bill_period: PLAN_ANNUAL_PERIOD,
+	},
+	[ constants.PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: {
+		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ],
+		product_slug: constants.PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+		term: TERM_MONTHLY,
+		bill_period: PLAN_MONTHLY_PERIOD,
+	},
+	[ constants.PRODUCT_JETPACK_BACKUP_REALTIME ]: {
+		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_BACKUP_REALTIME ],
+		product_slug: constants.PRODUCT_JETPACK_BACKUP_REALTIME,
+		term: TERM_ANNUALLY,
+		bill_period: PLAN_ANNUAL_PERIOD,
+	},
+	[ constants.PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: {
+		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ],
+		product_slug: constants.PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+		term: TERM_MONTHLY,
+		bill_period: PLAN_MONTHLY_PERIOD,
+	},
+};

--- a/client/lib/products-values/schema.json
+++ b/client/lib/products-values/schema.json
@@ -7,6 +7,8 @@
 		"product_id": { "type": "number" },
 		"product_name": { "type": "string" },
 		"product_slug": { "type": "string" },
-		"is_domain_registration": { "type": "boolean" }
+		"is_domain_registration": { "type": "boolean" },
+		"term": { "type": "string" },
+		"bill_period": { "type": "number" }
 	}
 }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -31,6 +31,8 @@ import {
 	isDomainTransfer,
 	isConciergeSession,
 	isPlan,
+	isJetpackProductSlug,
+	isMonthlyFromSlug,
 } from 'lib/products-values';
 import { getPlan } from 'lib/plans';
 
@@ -90,6 +92,10 @@ class PurchaseMeta extends Component {
 				case TERM_MONTHLY:
 					period = translate( 'month' );
 					break;
+			}
+		} else if ( isJetpackProductSlug( productSlug ) ) {
+			if ( isMonthlyFromSlug( productSlug ) ) {
+				period = translate( 'month' );
 			}
 		}
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -31,8 +31,7 @@ import {
 	isDomainTransfer,
 	isConciergeSession,
 	isPlan,
-	isJetpackProductSlug,
-	isMonthlyFromSlug,
+	getProductFromSlug,
 } from 'lib/products-values';
 import { getPlan } from 'lib/plans';
 
@@ -67,7 +66,7 @@ class PurchaseMeta extends Component {
 	renderPrice() {
 		const { purchase, translate } = this.props;
 		const { priceText, currencyCode, productSlug } = purchase;
-		const plan = getPlan( productSlug );
+		const plan = getPlan( productSlug ) || getProductFromSlug( productSlug );
 		let period = translate( 'year' );
 
 		if ( isOneTimePurchase( purchase ) || isDomainTransfer( purchase ) ) {
@@ -92,10 +91,6 @@ class PurchaseMeta extends Component {
 				case TERM_MONTHLY:
 					period = translate( 'month' );
 					break;
-			}
-		} else if ( isJetpackProductSlug( productSlug ) ) {
-			if ( isMonthlyFromSlug( productSlug ) ) {
-				period = translate( 'month' );
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This resolves a bug where text showed yearly when it was a monthly purchase.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a monthly backup solution.
* Go to Manage Purchases screen.
* Examine product cost text.

Screenshot:
<img width="429" alt="Screen Shot 2020-02-28 at 1 28 51 PM" src="https://user-images.githubusercontent.com/1760168/75576790-9bf8f100-5a2e-11ea-80cd-986b769fecb1.png">


Fixes 1142395350490785-as-1162348084744889.
