### PR TITLE
Updates FAQ text for Jetpack plans

### DIFF
--- a/client/my-sites/plans-features-main/jetpack-faq.jsx
+++ b/client/my-sites/plans-features-main/jetpack-faq.jsx
@@ -45,9 +45,8 @@ const JetpackFAQ = ( { isChatAvailable, translate } ) => {
 			<FAQItem
 				question={ translate( 'Does this work with a multisite network?' ) }
 				answer={ translate(
-					'Yes, Jetpack and all of its premium features are compatible with WordPress Multisite' +
-						' networks. If you manage a Multisite network you will need to make sure you have a' +
-						' subscription for each site you wish to cover with premium features.'
+					"Yes, Jetpack and all of it's paid features are compatible with WordPress Multisite" +
+						' networks, except for Jetpack Backup.'
 				) }
 			/>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This updates the text in the FAQ for Jetpack to indicate Jetpack works for multisite except for backups.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the plans page in Calypso and examine FAQ.

New text:
<img width="373" alt="Screen Shot 2020-02-28 at 2 10 23 PM" src="https://user-images.githubusercontent.com/1760168/75579614-3c9ddf80-5a34-11ea-84ef-f87c330289ba.png">

Fixes 1142395350490785-as-1153599598600715.
