### PR TITLE
Fix spacing on full-width group blocks on iframed SPT previews

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -466,8 +466,9 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		border-radius: 100%;
 	}
 
-	// Fixes cover image spacing
-	.editor-styles-wrapper [data-block][data-type='core/cover'] {
+	// Fixes cover image spacing and full-width group spacing
+	.editor-styles-wrapper [data-block][data-type='core/group'],
+	.editor-styles-wrapper [data-block][data-type='core/cover'][data-align='full'] {
 		margin-top: 0;
 		margin-bottom: 0;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -467,10 +467,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	// Fixes cover image spacing and full-width group spacing
-	.editor-styles-wrapper [data-block][data-type='core/group'],
-	.editor-styles-wrapper [data-block][data-type='core/cover'][data-align='full'] {
-		margin-top: 0;
-		margin-bottom: 0;
+	.editor-styles-wrapper [data-block] {
+		&[data-type='core/group'],
+		&[data-type='core/cover'][data-align='full'] {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
 	}
-
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sets margin top/bottom to `0` on `core/block` in the editor preview. This is only noticeable when there are two full-width backgrounds with color or photo above one another.

Before:
<img width="698" alt="Screen Shot 2020-02-28 at 1 58 19 PM" src="https://user-images.githubusercontent.com/967608/75583011-69e98e00-5a32-11ea-90c6-c7379760762a.png">

After: 
<img width="909" alt="Screen Shot 2020-02-28 at 1 51 24 PM" src="https://user-images.githubusercontent.com/967608/75582936-432b5780-5a32-11ea-9543-e6d69ac2f7ce.png">

#### Testing instructions
* Have FSE installed locally. See existing documentation on how to get this running.
* Add a new page
* Check that previews look correct, specifically Stratford (in the home page templates.
* There should be no gap between full-width group blocks with backgrounds
* There should be no regressions in templates where there should still be a gap
