### PR TITLE
FSE: Update to 0.21

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 0.20
+ * Version: 0.21
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '0.20' );
+define( 'PLUGIN_VERSION', '0.21' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, codebykat, copons, dmsnell, ge
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.3
-Stable tag: 0.20
+Stable tag: 0.21
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -41,6 +41,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 0.21 =
+* Linting fixes and page layout selector improvements.
 
 = 0.20 =
 * Fix text domain for i18n for Event Countdown and Timeline

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/full-site-editing",
-	"version": "0.20.0",
+	"version": "0.21.0",
 	"description": "Plugin for full site editing with the block editor.",
 	"sideEffects": true,
 	"repository": {


### PR DESCRIPTION
### Changes proposed in this Pull Request
Since the latest FSE update on dotcom (D39601-code) didn't bump the constant versions of the plugin, we need to:
1. Get those versions on .com
2. Make sure the code on .com includes the latest changes in FSE (since it is possible the update happened with code on a stale branch).

### Testing instructions
1. Test the attached diff
2. Deploy to dotcom
3. Deploy to dotorg
4 Merge this PR