### PR TITLE
Try: Move checklist progress from inline help to sidebar item

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -236,16 +236,7 @@ class InlineHelpPopover extends Component {
 	};
 
 	renderPrimaryView = () => {
-		const {
-			translate,
-			showNotification,
-			siteId,
-			setNotification,
-			setStoredTask,
-			showOptIn,
-			showOptOut,
-			onClose,
-		} = this.props;
+		const { translate, siteId, showOptIn, showOptOut } = this.props;
 
 		return (
 			<>
@@ -267,14 +258,6 @@ class InlineHelpPopover extends Component {
 						{ translate( 'Switch to Block Editor' ) }
 					</Button>
 				) }
-
-				<WpcomChecklist
-					viewMode="navigation"
-					closePopover={ onClose }
-					showNotification={ showNotification }
-					setNotification={ setNotification }
-					setStoredTask={ setStoredTask }
-				/>
 			</>
 		);
 	};

--- a/client/my-sites/checklist/wpcom-checklist/checklist-navigation/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-navigation/index.jsx
@@ -4,13 +4,12 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { Button, ProgressBar } from '@automattic/components';
+import { ProgressBar } from '@automattic/components';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -25,64 +24,24 @@ export class ChecklistNavigation extends Component {
 	static propTypes = {
 		siteSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
-		setStoredTask: PropTypes.func.isRequired,
-		setNotification: PropTypes.func.isRequired,
-		showNotification: PropTypes.bool,
-		closePopover: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 	};
 
-	handleClick = () => {
-		const task = this.props.taskList.getFirstIncompleteTask();
-
-		if ( task ) {
-			this.props.setStoredTask( task.id );
-		}
-		this.props.setNotification( false );
-		this.props.closePopover();
-		this.props.recordTracksEvent( 'calypso_inlinehelp_checklist_click' );
-	};
-
 	render() {
-		const { isLoading, siteSlug, translate, showNotification, taskList } = this.props;
+		const { isLoading, translate, taskList } = this.props;
 		const { total, completed } = taskList.getCompletionStatus();
 
 		if ( total === completed || isLoading ) {
 			return null;
 		}
 
-		const buttonClasses = classNames( 'checklist-navigation__count', {
-			'has-notification': showNotification,
-		} );
-
-		const checklistLink = '/checklist/' + siteSlug;
-
 		return (
 			<div className="checklist-navigation">
-				<Button
-					onClick={ this.handleClick }
-					href={ checklistLink }
-					className="checklist-navigation__button"
-					borderless
-				>
-					<span className="checklist-navigation__label">
-						{ translate( 'Continue Site Setup' ) }
-					</span>
+				<span className="checklist-navigation__label">{ translate( 'Finish setup' ) }</span>
 
-					<span className={ buttonClasses }>
-						{ translate( '%(complete)d/%(total)d', {
-							comment: 'Numerical progress indicator, like 5/9',
-							args: {
-								complete: completed,
-								total: total,
-							},
-						} ) }
-					</span>
-
-					<div className="checklist-navigation__progress-bar-margin">
-						<ProgressBar total={ total } value={ completed } compact />
-					</div>
-				</Button>
+				<div className="checklist-navigation__progress-bar-margin">
+					<ProgressBar total={ total } value={ completed } compact />
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/checklist/wpcom-checklist/checklist-navigation/style.scss
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-navigation/style.scss
@@ -1,37 +1,11 @@
 .checklist-navigation {
-	border-top: 1px solid var( --color-neutral-10 );
-}
-
-.checklist-navigation .button.is-borderless.checklist-navigation__button {
-	display: flex;
-	justify-content: space-between;
-	flex-wrap: wrap;
-	font-weight: bold;
-	width: 100%;
-	padding: 12px 20px 14px 17px;
-
-	&:hover,
-	&:focus {
-		color: var( --color-primary );
-	}
+	min-width: 80px;
 }
 
 .checklist-navigation__label {
-	margin-bottom: 8px;
-	position: relative;
-}
-
-.checklist-navigation__count {
-	margin-bottom: 8px;
-	&.has-notification::before {
-		display: inline-block;
-		background-color: var( --color-accent-30 );
-		content: '';
-		border-radius: 50%;
-		margin-right: 6px;
-		width: 8px;
-		height: 8px;
-	}
+	display: block;
+	font-size: 12px;
+	margin-bottom: 4px;
 }
 
 .checklist-navigation .progress-bar {
@@ -39,7 +13,7 @@
 }
 
 .checklist-navigation .progress-bar__progress {
-	background-color: var( --color-success );
+	background-color: var( --color-primary );
 }
 
 .checklist-navigation .checklist-navigation__progress-bar-margin {

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -18,6 +18,7 @@ import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import ExternalLink from 'components/external-link';
 import JetpackLogo from 'components/jetpack-logo';
+import MaterialIcon from 'components/material-icon';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
@@ -26,6 +27,7 @@ import SidebarRegion from 'layout/sidebar/region';
 import SiteMenu from './site-menu';
 import StatsSparkline from 'blocks/stats-sparkline';
 import ToolsMenu from './tools-menu';
+import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 import { isFreeTrial, isPersonal, isPremium, isBusiness, isEcommerce } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -166,15 +168,31 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		const myHomeLink = '/home' + siteSuffix;
+
+		const linkClass = classNames( {
+			selected: itemLinkMatches( [ '/home' ], path ),
+		} );
+
+		const tipTarget = 'myhome';
+
 		return (
-			<SidebarItem
-				materialIcon="home"
-				tipTarget="myhome"
-				onNavigate={ this.trackCustomerHomeClick }
-				label={ translate( 'My Home' ) }
-				selected={ itemLinkMatches( [ '/home' ], path ) }
-				link={ '/home' + siteSuffix }
-			/>
+			<li className={ linkClass } data-tip-target={ tipTarget }>
+				<a
+					className="sidebar__menu-link"
+					onClick={ this.trackCustomerHomeClick }
+					href={ myHomeLink }
+				>
+					<MaterialIcon className="sidebar__menu-icon" icon="home" />
+					<span className="sidebar__menu-link-text" data-e2e-sidebar="My Home">
+						{ translate( 'My Home' ) }
+					</span>
+
+					<span className="sidebar__menu-link-secondary-text">
+						<WpcomChecklist viewMode="navigation" />
+					</span>
+				</a>
+			</li>
 		);
 	}
 
@@ -395,7 +413,7 @@ export class MySitesSidebar extends Component {
 			<li className={ linkClass } data-tip-target={ tipTarget }>
 				<a className="sidebar__menu-link" onClick={ this.trackPlanClick } href={ planLink }>
 					<JetpackLogo className="sidebar__menu-icon" size={ 24 } />
-					<span className="menu-link-text" data-e2e-sidebar="Plan">
+					<span className="sidebar__menu-link-text" data-e2e-sidebar="Plan">
 						{ translate( 'Plan', { context: 'noun' } ) }
 					</span>
 					{ displayPlanName && (
@@ -595,7 +613,9 @@ export class MySitesSidebar extends Component {
 							onClick={ this.trackWpadminClick }
 						>
 							<Gridicon className={ 'sidebar__menu-icon' } icon="my-sites" size={ 24 } />
-							<span className="menu-link-text">{ this.props.translate( 'WP Admin' ) }</span>
+							<span className="sidebar__menu-link-text">
+								{ this.props.translate( 'WP Admin' ) }
+							</span>
 						</ExternalLink>
 					</li>
 				</ul>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the pre-launch checklist is incomplete, highlight that in the sidebar. We currently have it in the inline help dot but it's hidden. Right now it's easy to get lost and be confused about where to go to edit your site or what to do next as a new user.

Before | After
------------ | -------------
<img width="374" alt="Screen Shot 2020-02-29 at 5 20 05 PM" src="https://user-images.githubusercontent.com/448298/75611107-c377b880-5b17-11ea-82d1-5351977a12b8.png"> | <img width="376" alt="Screen Shot 2020-02-29 at 5 12 43 PM" src="https://user-images.githubusercontent.com/448298/75611094-a216cc80-5b17-11ea-9019-33506f984e61.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* Look in the sidebar to make sure the progress bar is shown in the sidebar
* Make sure the inline help dot popover works as expected and does not include the checklist progress
* Check a site that has My Home with a completed checklist to make sure the progress bar isn't shown and works as expected
