### PR TITLE
Add better tracking for the Renew button in the new domain status screen

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -99,8 +99,9 @@ function getSubscriptionEndDate( purchase ) {
  *
  * @param {object} purchase - the purchase to be renewed
  * @param {string} siteSlug - the site slug to renew the purchase for
+ * @param {object} tracksProps - where was the renew button clicked from
  */
-function handleRenewNowClick( purchase, siteSlug ) {
+function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 	const renewItem = getRenewalItemFromProduct( purchase, {
 		domain: purchase.meta,
 	} );
@@ -109,6 +110,7 @@ function handleRenewNowClick( purchase, siteSlug ) {
 	// Track the renew now submit.
 	analytics.tracks.recordEvent( 'calypso_purchases_renew_now_click', {
 		product_slug: purchase.productSlug,
+		...tracksProps,
 	} );
 
 	addItems( renewItems );

--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
@@ -29,10 +29,19 @@ class RenewButton extends React.Component {
 		subscriptionId: PropTypes.number,
 		redemptionProduct: PropTypes.object,
 		reactivate: PropTypes.bool,
+		tracksProps: PropTypes.object,
+	};
+
+	static defaultProps = {
+		tracksProps: {},
 	};
 
 	handleRenew = () => {
-		handleRenewNowClick( this.props.purchase, this.props.selectedSite.slug );
+		handleRenewNowClick(
+			this.props.purchase,
+			this.props.selectedSite.slug,
+			this.props.tracksProps
+		);
 	};
 
 	render() {

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -166,6 +166,7 @@ class RegisteredDomainType extends React.Component {
 						primary={ true }
 						selectedSite={ this.props.selectedSite }
 						subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
+						tracksProps={ { source: 'registered-domain-status', domain_status: 'expiring-soon' } }
 					/>
 				</div>
 			);
@@ -241,6 +242,7 @@ class RegisteredDomainType extends React.Component {
 						subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
 						redemptionProduct={ domain.isRedeemable ? this.props.redemptionProduct : null }
 						reactivate={ ! domain.isRenewable && domain.isRedeemable }
+						tracksProps={ { source: 'registered-domain-status', domain_status: 'expired' } }
 					/>
 				) }
 			</div>
@@ -289,6 +291,7 @@ class RegisteredDomainType extends React.Component {
 					compact={ true }
 					selectedSite={ this.props.selectedSite }
 					subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
+					tracksProps={ { source: 'registered-domain-status', domain_status: 'active' } }
 				/>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We've added some additional properties for the renew action on the new domain status screen. We want to verify how often those buttons would be used.

#### Testing instructions

* Open the new domain status screen and click on the Renew for XXX button. In your browser dev tools verify in the Network tab that a call is made to the tracks pixel including both `source` and `domain_status` properties
