### PR TITLE
New domain status design tweaks

### DIFF
--- a/client/my-sites/domains/domain-management/edit/card/domain-status/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/domain-status/index.jsx
@@ -20,22 +20,12 @@ class DomainStatus extends React.Component {
 		children: PropTypes.any,
 	};
 
-	getHeaderFontSize( header ) {
-		const headerLength = header.length;
-
-		if ( headerLength > 60 ) {
-			return 16;
+	getBreakPoint( headerLength, breakPoints ) {
+		for ( const breakPoint of breakPoints ) {
+			if ( headerLength > breakPoint[ 0 ] ) {
+				return breakPoint[ 1 ];
+			}
 		}
-		if ( headerLength > 51 ) {
-			return 20;
-		}
-		if ( headerLength > 45 ) {
-			return 24;
-		}
-		if ( headerLength > 39 ) {
-			return 28;
-		}
-		return 32;
 	}
 
 	render() {
@@ -43,9 +33,29 @@ class DomainStatus extends React.Component {
 
 		const cardClasses = classNames( 'domain-status__card', statusClass );
 
+		const desktopBreakpoints = [
+			[ 60, 'xxl' ],
+			[ 51, 'xl' ],
+			[ 45, 'l' ],
+			[ 39, 'm' ],
+			[ 0, 's' ],
+		];
+		const mobileBreakpoints = [
+			[ 37, 'xxl' ],
+			[ 31, 'xl' ],
+			[ 26, 'l' ],
+			[ 22, 'm' ],
+			[ 0, 's' ],
+		];
+
+		const headerClasses = classNames(
+			'mobile-' + this.getBreakPoint( header.length, mobileBreakpoints ),
+			'desktop-' + this.getBreakPoint( header.length, desktopBreakpoints )
+		);
+
 		return (
 			<Card compact={ true } className={ cardClasses }>
-				<h2 className={ `font-size-${ this.getHeaderFontSize( header ) }` }>{ header }</h2>
+				<h2 className={ headerClasses }>{ header }</h2>
 				<div className="domain-status__icon">
 					<MaterialIcon icon={ icon } /> { statusText }
 				</div>

--- a/client/my-sites/domains/domain-management/edit/card/domain-status/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/domain-status/index.jsx
@@ -20,6 +20,24 @@ class DomainStatus extends React.Component {
 		children: PropTypes.any,
 	};
 
+	getHeaderFontSize( header ) {
+		const headerLength = header.length;
+
+		if ( headerLength > 60 ) {
+			return 16;
+		}
+		if ( headerLength > 51 ) {
+			return 20;
+		}
+		if ( headerLength > 45 ) {
+			return 24;
+		}
+		if ( headerLength > 39 ) {
+			return 28;
+		}
+		return 32;
+	}
+
 	render() {
 		const { header, icon, statusText, statusClass, children } = this.props;
 
@@ -27,7 +45,7 @@ class DomainStatus extends React.Component {
 
 		return (
 			<Card compact={ true } className={ cardClasses }>
-				<h2>{ header }</h2>
+				<h2 className={ `font-size-${ this.getHeaderFontSize( header ) }` }>{ header }</h2>
 				<div className="domain-status__icon">
 					<MaterialIcon icon={ icon } /> { statusText }
 				</div>

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -68,17 +68,34 @@
 			font-size: 32px;
 			overflow: hidden;
 
-			&.font-size-28 {
-				font-size: 28px;
+			@include breakpoint( '<480px' ) {
+				&.mobile-m {
+					font-size: 28px;
+				}
+				&.mobile-l {
+					font-size: 24px;
+				}
+				&.mobile-xl {
+					font-size: 20px;
+				}
+				&.mobile-xxl {
+					font-size: 16px;
+				}
 			}
-			&.font-size-24 {
-				font-size: 24px;
-			}
-			&.font-size-20 {
-				font-size: 20px;
-			}
-			&.font-size-16 {
-				font-size: 16px;
+
+			@include breakpoint( '>480px' ) {
+				&.desktop-m {
+					font-size: 28px;
+				}
+				&.desktop-l {
+					font-size: 24px;
+				}
+				&.desktop-xl {
+					font-size: 20px;
+				}
+				&.desktop-xxl {
+					font-size: 16px;
+				}
 			}
 		}
 

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -67,6 +67,7 @@
 		h2 {
 			font-size: 32px;
 			overflow: hidden;
+			text-overflow: ellipsis;
 
 			@include breakpoint( '<480px' ) {
 				&.mobile-m {

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -72,6 +72,8 @@
 			font-size: 16px;
 			display: flex;
 			align-items: center;
+			border-bottom: 0;
+			padding-bottom: 0;
 			> svg {
 				margin-right: 5px;
 			}
@@ -79,10 +81,14 @@
 
 		> div {
 			margin-bottom: 1.5em;
+			border-bottom: 1px solid #c3c4c7;
+			padding-bottom: 1.5em;
 		}
 
 		> div:last-child {
 			margin-bottom: 0;
+			border-bottom: 0;
+			padding-bottom: 0.5em;
 		}
 	}
 

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -66,6 +66,20 @@
 	.domain-status__card {
 		h2 {
 			font-size: 32px;
+			overflow: hidden;
+
+			&.font-size-28 {
+				font-size: 28px;
+			}
+			&.font-size-24 {
+				font-size: 24px;
+			}
+			&.font-size-20 {
+				font-size: 20px;
+			}
+			&.font-size-16 {
+				font-size: 16px;
+			}
 		}
 
 		> .domain-status__icon {

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -113,7 +113,7 @@
 
 		> div {
 			margin-bottom: 1.5em;
-			border-bottom: 1px solid #c3c4c7;
+			border-bottom: 1px solid var( --color-border-subtle );
 			padding-bottom: 1.5em;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add border and padding between multiple domain status messages
* Scale the font size of the domain if it's longer

#### Testing instructions

* Open a domain with multiple messages - for example expiring soon and unverified and check if there is a grey line with proper padding
* Open a long domain name and check that it is shown with smaller font size and is not overflowing from the container

The separating line looks like this:

<img width="740" alt="Screenshot 2020-03-02 at 9 54 42" src="https://user-images.githubusercontent.com/1355045/75656094-e74c1300-5c6b-11ea-81a1-a0fae571df8a.png">

And here are some examples of short and long domain names and how they show up on desktop and mobile:

<img width="738" alt="Screenshot 2020-03-02 at 11 35 54" src="https://user-images.githubusercontent.com/1355045/75663948-5e88a380-5c7a-11ea-9cd2-ecf6f59dfe8f.png">

<img width="737" alt="Screenshot 2020-03-02 at 11 34 06" src="https://user-images.githubusercontent.com/1355045/75663957-634d5780-5c7a-11ea-960d-899eebed953e.png">

<img width="441" alt="Screenshot 2020-03-02 at 11 37 00" src="https://user-images.githubusercontent.com/1355045/75663992-6fd1b000-5c7a-11ea-922b-4ed8c8f37a90.png">

<img width="436" alt="Screenshot 2020-03-02 at 11 33 53" src="https://user-images.githubusercontent.com/1355045/75664005-73fdcd80-5c7a-11ea-9bfd-3f5ba1b4d177.png">
