### PR TITLE
Ads: Update AdsFormSettings to use Redux

### DIFF
--- a/client/state/data-layer/wpcom/wordads/settings/index.js
+++ b/client/state/data-layer/wpcom/wordads/settings/index.js
@@ -60,6 +60,9 @@ export const saveWordadsSettings = action => ( dispatch, getState ) => {
 	const { settings, siteId } = action;
 	const previousSettings = getWordadsSettings( getState(), siteId );
 
+	// Optimistically update settings to the new ones
+	dispatch( updateWordadsSettings( siteId, settings ) );
+
 	dispatch( removeNotice( `wordads-notice-success-${ siteId }` ) );
 	dispatch( removeNotice( `wordads-notice-error-${ siteId }` ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates `AdsFormSettings` to use the Redux store instead of the flux store.

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/earn/ads-settings/:siteSlug where `:siteSlug` is the slug of a site with WordAds enabled.
* Verify the ads settings work like they did before by comparing to staging/production.

Part of #18222. Depends on #39800.
