### PR TITLE
SPT: Re implement template post title.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -10,7 +10,12 @@ import { compose } from '@wordpress/compose';
 import { Button, Modal, Spinner, IconButton } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
-import { parse as parseBlocks, createBlock, registerBlockType } from '@wordpress/blocks';
+import {
+	parse as parseBlocks,
+	createBlock,
+	registerBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -165,6 +170,10 @@ class PageTemplateModal extends Component {
 		}
 	}
 
+	componentWillUnmount() {
+		unregisterBlockType( 'a8c/spt-template-post-title' );
+	}
+
 	static getDefaultSelectedTemplate = props => {
 		const blankTemplate = get( props.templates, [ 0, 'slug' ] );
 		let previouslyChosenTemplate = props._starter_page_template;
@@ -193,6 +202,8 @@ class PageTemplateModal extends Component {
 		// Track selection and mark post as using a template in its postmeta.
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 		this.props.saveTemplateChoice( slug );
+
+		unregisterBlockType( 'a8c/spt-template-post-title' );
 
 		// Check to see if this is a blank template selection
 		// and reset the template if so.
@@ -279,6 +290,8 @@ class PageTemplateModal extends Component {
 	};
 
 	closeModal = event => {
+		unregisterBlockType( 'a8c/spt-template-post-title' );
+
 		// Check to see if the Blur event occurred on the buttons inside of the Modal.
 		// If it did then we don't want to dismiss the Modal for this type of Blur.
 		if ( event.target.matches( 'button.template-selector-item__label' ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -171,7 +171,9 @@ class PageTemplateModal extends Component {
 	}
 
 	componentWillUnmount() {
-		unregisterBlockType( 'a8c/spt-template-post-title' );
+		if ( this.props.isPostTitleBlockRegistered ) {
+			unregisterBlockType( 'a8c/spt-template-post-title' );
+		}
 	}
 
 	static getDefaultSelectedTemplate = props => {
@@ -203,7 +205,9 @@ class PageTemplateModal extends Component {
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 		this.props.saveTemplateChoice( slug );
 
-		unregisterBlockType( 'a8c/spt-template-post-title' );
+		if ( this.props.isPostTitleBlockRegistered ) {
+			unregisterBlockType( 'a8c/spt-template-post-title' );
+		}
 
 		// Check to see if this is a blank template selection
 		// and reset the template if so.
@@ -290,7 +294,9 @@ class PageTemplateModal extends Component {
 	};
 
 	closeModal = event => {
-		unregisterBlockType( 'a8c/spt-template-post-title' );
+		if ( this.props.isPostTitleBlockRegistered ) {
+			unregisterBlockType( 'a8c/spt-template-post-title' );
+		}
 
 		// Check to see if the Blur event occurred on the buttons inside of the Modal.
 		// If it did then we don't want to dismiss the Modal for this type of Blur.
@@ -508,6 +514,9 @@ export const PageTemplatesPlugin = compose(
 				.find( block => block.name === 'a8c/post-content' ),
 			isWelcomeGuideActive: select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' ), // Gutenberg 7.2.0 or higher
 			areTipsEnabled: select( 'core/nux' ) ? select( 'core/nux' ).areTipsEnabled() : false, // Gutenberg 7.1.0 or lower
+			isPostTitleBlockRegistered: !! select( 'core/blocks' ).getBlockType(
+				'a8c/spt-template-post-title'
+			),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -10,7 +10,7 @@ import { compose } from '@wordpress/compose';
 import { Button, Modal, Spinner, IconButton } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
-import { parse as parseBlocks, createBlock } from '@wordpress/blocks';
+import { parse as parseBlocks, createBlock, registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -25,6 +25,40 @@ import mapBlocksRecursively from './utils/map-blocks-recursively';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
+
+/*
+ * Register a `a8c/spt-template-post-title` used only
+ * for the Large Preview of the template.
+ * This block will be unregistered once the template is inserted,
+ * the component unmounted, modal closed, etc...
+ */
+registerBlockType( 'a8c/spt-template-post-title', {
+	title: __( 'SPT Template post title' ),
+	description: __( 'Template post title.' ),
+	category: 'layout',
+	attributes: {
+		title: {
+			type: 'string',
+			default: '',
+		},
+	},
+	edit: ( { attributes } ) => {
+		const { title } = attributes;
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<div className="editor-post-title">
+				<div className="wp-block editor-post-title__block">
+					<div>
+						<textarea className="editor-post-title__input" defaultValue={ title } />
+					</div>
+				</div>
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	},
+	save: () => null,
+} );
 
 class PageTemplateModal extends Component {
 	state = {
@@ -51,10 +85,8 @@ class PageTemplateModal extends Component {
 							 * It will be remove when inserting the template
 							 * blocks into the editor.
 							 */
-							createBlock( 'core/heading', {
-								content: title,
-								align: 'center',
-								level: 1,
+							createBlock( 'a8c/spt-template-post-title', {
+								title,
 							} ),
 							...parseBlocks( replacePlaceholders( content, this.props.siteInformation ) ),
 					  ]

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -381,7 +381,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .sidebar-modal-opener__warning-options {
 	float: right;
 	margin-top: 20px;
-	
+
 	.components-button {
 		margin-left: 12px;
 	}
@@ -439,14 +439,14 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	// Manual CSS Overrides. Remove after better solutions are in place.
-	
+
 	// Removes empty paragraph placeholders, i.e. "Write Title..."
 	[data-type='core/paragraph'] [data-rich-text-placeholder] {
 		display: none;
 	}
 
 	/*
-	* Fixes jetpack .wp-block-jetpack-slideshow styles, as the /wp-content/plugins/jetpack/_inc/blocks/vendors~swiper.[hash].css 
+	* Fixes jetpack .wp-block-jetpack-slideshow styles, as the /wp-content/plugins/jetpack/_inc/blocks/vendors~swiper.[hash].css
 	* file is loaded on block insert, not on page load. After the iframe is grabbing these styles, we can remove this code.
 	*/
 	.swiper-wrapper {
@@ -473,5 +473,13 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			margin-top: 0;
 			margin-bottom: 0;
 		}
+	}
+
+	// Adjust template title.
+	.editor-post-title__input {
+		overflow: hidden;
+		overflow-wrap: break-word;
+		resize: none;
+		height: 135px;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -480,6 +480,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		overflow: hidden;
 		overflow-wrap: break-word;
 		resize: none;
-		height: 135px;
+		max-height: 80px;
+		box-sizing: border-box;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A few days ago we changed the way to render the template title, inserting a `core/heading` block among all templates blocks there. It simplifies the way to compute the scaling for the title.
This PR keeps iterating over the same feature, creating a new `a8c/spt-template-post-title` and using it instead of the `core/heading` one. It allows inheriting theme styles such as font-size, alignment, etc.
For instance, testing with `Mayland` theme:

**Editor Canvas**
![image](https://user-images.githubusercontent.com/77539/75677825-12823280-5c6b-11ea-9e47-fa9024b39cbd.png)

**After (correct title alignment)**
<img width="933" alt="Screen Shot 2020-03-02 at 9 49 40 AM" src="https://user-images.githubusercontent.com/77539/75677999-6725ad80-5c6b-11ea-81ed-93c251c01ce6.png">

**Before (wrong title alignment)**
<img width="933" alt="Screen Shot 2020-03-02 at 9 50 20 AM" src="https://user-images.githubusercontent.com/77539/75678014-6db42500-5c6b-11ea-8920-04baabd970a2.png">


#### Testing instructions

* Apply these changes in your testing environment.
* Test how the template post title looks compared one the template is inserted in the editor-canvas.

Fixes https://github.com/Automattic/wp-calypso/issues/39805
