### PR TITLE
Jetpack Cloud: Add DatePicker component

### DIFF
--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { withLocalizedMoment } from 'components/localized-moment';
+import Button from 'components/forms/form-button';
+import DateRangeSelector from 'my-sites/activity/filterbar/date-range-selector';
+import Gridicon from 'components/gridicon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const DATE_FORMAT = 'YYYY-MM-DD';
+
+class DatePicker extends Component {
+	state = {
+		currentSetting: false,
+	};
+
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+		initialDate: PropTypes.instanceOf( Date ).isRequired,
+		onChange: PropTypes.func.isRequired,
+	};
+
+	getFormattedDate = date => this.props.moment( date ).format( DATE_FORMAT );
+
+	getDisplayDate = date => {
+		const word = this.props
+			.moment( date )
+			.calendar()
+			.split( ' ' )[ 0 ];
+		if ( 'Today' === word || 'Yesterday' === word ) {
+			return word;
+		}
+
+		return this.getFormattedDate( date );
+	};
+
+	shuttleLeft = () => {
+		const { initialDate, moment } = this.props;
+		const currentSetting = moment(
+			this.state.currentSetting ? this.state.currentSetting : initialDate
+		).subtract( 1, 'days' );
+		this.setState( { currentSetting } );
+		this.props.onChange( currentSetting.format( DATE_FORMAT ) );
+	};
+
+	shuttleRight = () => {
+		if ( ! this.canShuttleRight() ) {
+			return false;
+		}
+
+		const { initialDate, moment } = this.props;
+		const currentSetting = moment(
+			this.state.currentSetting ? this.state.currentSetting : initialDate
+		).add( 1, 'days' );
+		this.setState( { currentSetting } );
+		this.props.onChange( currentSetting.format( DATE_FORMAT ) );
+	};
+
+	canShuttleRight = () =>
+		this.props.moment().format( DATE_FORMAT ) !==
+		this.props
+			.moment( this.state.currentSetting ? this.state.currentSetting : this.props.initialDate )
+			.format( DATE_FORMAT );
+
+	render() {
+		const { initialDate, siteId } = this.props;
+		const { currentSetting } = this.state;
+
+		const currentDisplayDate = currentSetting
+			? this.getDisplayDate( currentSetting )
+			: this.getDisplayDate( initialDate );
+
+		return (
+			<div className="date-picker">
+				<Button compact borderless onClick={ this.shuttleLeft }>
+					<Gridicon icon="chevron-left" />
+				</Button>
+
+				<div className="date-picker__current-display-date">{ currentDisplayDate }</div>
+
+				<Button compact borderless onClick={ this.shuttleRight }>
+					<Gridicon icon="chevron-right" className={ ! this.canShuttleRight() && 'disabled' } />
+				</Button>
+
+				<DateRangeSelector
+					siteId={ siteId }
+					enabled={ true }
+					customLabel={ <Gridicon icon="calendar" /> }
+				/>
+			</div>
+		);
+	}
+}
+
+export default localize( withLocalizedMoment( DatePicker ) );

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -1,0 +1,10 @@
+.date-picker .button,
+.date-picker__current-display-date,
+.date-picker .date-range {
+    display: inline-block;
+    float: none;
+}
+
+.date-picker .button .gridicon.disabled {
+    fill: #dcdcde;
+}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -10,11 +10,23 @@ import { connect } from 'react-redux';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs } from 'state/data-getters';
 import ActivityList from '../../components/activity-list';
+import DatePicker from '../../components/date-picker';
 
 class BackupsPage extends Component {
+	state = {
+		currentDateSetting: false,
+	};
+
+	dateChange = currentDateSetting => this.setState( { currentDateSetting } );
+
 	render() {
+		const { siteId } = this.props;
+		const initialDate = new Date();
+
 		return (
 			<div>
+				<DatePicker siteId={ siteId } initialDate={ initialDate } onChange={ this.dateChange } />
+
 				<p>Welcome to the backup detail page for site { this.props.siteId }</p>
 				<ActivityList logs={ this.props.logs } />
 			</div>

--- a/client/my-sites/activity/filterbar/date-range-selector.jsx
+++ b/client/my-sites/activity/filterbar/date-range-selector.jsx
@@ -250,7 +250,7 @@ export class DateRangeSelector extends Component {
 	};
 
 	render() {
-		const { isVisible } = this.props;
+		const { customLabel, isVisible } = this.props;
 		const from = this.getFromDate();
 		const to = this.getToDate();
 		const now = new Date();
@@ -275,7 +275,7 @@ export class DateRangeSelector extends Component {
 							onClick={ props.onTriggerClick }
 							ref={ props.buttonRef }
 						>
-							{ this.getFormattedDate( from, to ) }
+							{ customLabel ? customLabel : this.getFormattedDate( from, to ) }
 						</Button>
 						{ ( from || to ) && (
 							<Button


### PR DESCRIPTION
The shape of this component could be different depending on which design we're referring to. This PR puts the most of the needed logic in place for any of the designs, and we can go back and update the design of this component if needed.

#### Changes proposed in this Pull Request

* Adds the `DatePicker` component, which contains buttons for shuttling left/right, the currently selected date, and the `DateRangeSelector` component from the activity log.
* Modifies the DateRangeSelector component with optional `customLabel` prop, to allow us to use an icon in place of the regular text. Defaults to the text used on the activity log.
* Renders our new `DatePicker` components on the `Backups` page, and consume the date change event via Backups page.

#### Testing instructions

1. Check the activity log in a normal Calypso context. The DateRangeSelector should show the text "Date Range". Select a date range and it should now display the date range.
2. From Jetpack Cloud context, ensure that the date picker at the top of the backups page allows shuttling left and right where appropriate, the date displayed moves accurately, and you are stopped from moving further into the future past today's date.
3. Bonus points for checking the localization aspect. Not sure how that looks, but in theory it's all correct.