### PR TITLE
Removes reference to backups when purchased

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -673,9 +673,6 @@ export const PLANS_LIST = {
 			switch ( feature ) {
 				case constants.FEATURE_JETPACK_BACKUP_DAILY:
 				case constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY:
-					return i18n.translate(
-						'Upgrade your site to access additional features, including spam protection and priority support.'
-					);
 				case constants.FEATURE_JETPACK_BACKUP_REALTIME:
 				case constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY:
 					return i18n.translate(

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -674,16 +674,16 @@ export const PLANS_LIST = {
 				case constants.FEATURE_JETPACK_BACKUP_DAILY:
 				case constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY:
 					return i18n.translate(
-						'Upgrade your site to access additional features, including spam protection, and priority support.'
+						'Upgrade your site to access additional features, including spam protection and priority support.'
 					);
 				case constants.FEATURE_JETPACK_BACKUP_REALTIME:
 				case constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY:
 					return i18n.translate(
-						'Upgrade your site to access additional features, including spam protection, and priority support.'
+						'Upgrade your site to access additional features, including spam protection and priority support.'
 					);
 				default:
 					return i18n.translate(
-						'Upgrade your site to access additional features, including spam protection, and priority support.'
+						'Upgrade your site to access additional features, including spam protection, backups, and priority support.'
 					);
 			}
 		},

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -674,7 +674,7 @@ export const PLANS_LIST = {
 				case constants.FEATURE_JETPACK_BACKUP_DAILY:
 				case constants.FEATURE_JETPACK_BACKUP_DAILY_MONTHLY:
 					return i18n.translate(
-						'Upgrade your site to access additional features, including spam protection, real-time backups, and priority support.'
+						'Upgrade your site to access additional features, including spam protection, and priority support.'
 					);
 				case constants.FEATURE_JETPACK_BACKUP_REALTIME:
 				case constants.FEATURE_JETPACK_BACKUP_REALTIME_MONTHLY:
@@ -683,7 +683,7 @@ export const PLANS_LIST = {
 					);
 				default:
 					return i18n.translate(
-						'Upgrade your site to access additional features, including spam protection, backups, and priority support.'
+						'Upgrade your site to access additional features, including spam protection, and priority support.'
 					);
 			}
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjusting wording to remove reference to backups if product is purchased.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a Jetpack site with a Free plan.
* View My Plan.
* Purchase a backup solution.
* View My Plan again.

Should say backups is an option if backups isn't present, otherwise strike references.

Screens:
<img width="1066" alt="Screen Shot 2020-03-02 at 3 19 47 PM" src="https://user-images.githubusercontent.com/1760168/75714930-93a4ee00-5c9a-11ea-9b40-cb52cd266330.png">
<img width="442" alt="Screen Shot 2020-03-02 at 3 23 32 PM" src="https://user-images.githubusercontent.com/1760168/75714939-97387500-5c9a-11ea-9a8f-8b7e004d8c6a.png">

Fixes #38035.