### PR TITLE
Media library: Output types to dist/types

### DIFF
--- a/packages/media-library/package.json
+++ b/packages/media-library/package.json
@@ -20,10 +20,9 @@
 	},
 	"files": [
 		"dist",
-		"types",
 		"src"
 	],
-	"types": "types",
+	"types": "dist/types",
 	"dependencies": {},
 	"scripts": {
 		"clean": "npx rimraf dist types",

--- a/packages/media-library/tsconfig.json
+++ b/packages/media-library/tsconfig.json
@@ -6,7 +6,7 @@
 		"checkJs": false,
 		"jsx": "react",
 		"declaration": true,
-		"declarationDir": "./types",
+		"declarationDir": "dist/types",
 		"emitDeclarationOnly": true,
 		"isolatedModules": true,
 
@@ -23,7 +23,10 @@
 
 		"typeRoots": [ "../../node_modules/@types" ],
 		// "types": [],
-		"lib": [ "ESNext", "DOM" ]
+		"lib": [ "ESNext", "DOM" ],
+
+		"incremental": true,
+		"tsBuildInfoFile": "../../.tsc-cache/media-library"
 	},
 	"include": [ "src" ],
 	"exclude": [ "**/docs/*", "**/test/*" ]


### PR DESCRIPTION
Move generated type output to dist/types, following convention in other packages.
Add TypeScript build caching.