### PR TITLE
Composite Checkout: add busy button

### DIFF
--- a/packages/composite-checkout/src/components/button.js
+++ b/packages/composite-checkout/src/components/button.js
@@ -5,15 +5,46 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
-export default function Button( { children, ...props } ) {
-	return <CallToAction { ...props }>{ children }</CallToAction>;
+/**
+ * Internal Classes
+ */
+import joinClasses from '../lib/join-classes';
+
+export default function Button( {
+	className,
+	buttonState,
+	buttonType,
+	isBusy,
+	children,
+	...props
+} ) {
+	const classNames = joinClasses( [
+		'checkout-button',
+		...( buttonState ? [ 'is-status-' + buttonState ] : [] ),
+		...( buttonType ? [ 'is-type-' + buttonType ] : [] ),
+		...( isBusy ? [ 'is-busy' ] : [] ),
+		...( className ? [ className ] : [] ),
+	] );
+
+	return (
+		<CallToAction
+			buttonState={ buttonState }
+			buttonType={ buttonType }
+			isBusy={ isBusy }
+			className={ classNames }
+			{ ...props }
+		>
+			{ children }
+		</CallToAction>
+	);
 }
 
 Button.propTypes = {
 	buttonState: PropTypes.string, // Either 'disabled', 'primary', 'secondary', 'text-button', 'borderless'.
 	buttonType: PropTypes.string, // Service type (i.e. 'paypal' or 'apple-pay').
-	onClick: PropTypes.func,
 	fullWidth: PropTypes.bool,
+	onClick: PropTypes.func,
+	isBusy: PropTypes.bool,
 };
 
 const CallToAction = styled.button`
@@ -39,8 +70,7 @@ const CallToAction = styled.button`
 		border-bottom-width: ${getBorderElevationWeight};
 		text-decoration: none;
 		color: ${getTextColor};
-		cursor: ${( { buttonState } ) =>
-			buttonState && buttonState.includes( 'disabled' ) ? 'not-allowed' : 'pointer'};
+		cursor: ${props => ( props.buttonState === 'disabled' ? 'not-allowed' : 'pointer' )};
 	}
 
 	:active {
@@ -58,6 +88,26 @@ const CallToAction = styled.button`
 		transform: translateY( 2px );
 		filter: ${getImageFilter};
 		opacity: ${getImageOpacity};
+	}
+
+	&.is-busy {
+		animation: components-button__busy-animation 2500ms infinite linear;
+		background-image: linear-gradient(
+			-45deg,
+			${getBackgroundColor} 28%,
+			${getBackgroundAccentColor} 28%,
+			${getBackgroundAccentColor} 72%,
+			${getBackgroundColor} 72%
+		);
+		background-size: 200px;
+		border-color: ${getRollOverBorderColor};
+		opacity: 1;
+	}
+
+	@keyframes components-button__busy-animation {
+		0% {
+			background-position: 200px 0;
+		}
 	}
 `;
 
@@ -94,6 +144,29 @@ function getRollOverColor( { buttonState, buttonType, theme } ) {
 			return colors.highlightOver;
 		case 'disabled':
 			return colors.disabledPaymentButtons;
+		case 'text-button':
+		case 'borderless':
+			return 'none';
+		default:
+			return 'none';
+	}
+}
+
+function getBackgroundAccentColor( { buttonState, buttonType, theme } ) {
+	const { colors } = theme;
+	switch ( buttonState ) {
+		case 'primary':
+			if ( buttonType === 'apple-pay' ) {
+				return colors.applePayButtonRollOverColor;
+			}
+			if ( buttonType === 'paypal' ) {
+				return colors.paypalGoldHover;
+			}
+			return colors.primaryOver;
+		case 'secondary':
+			return colors.highlightOver;
+		case 'disabled':
+			return colors.disabledButtons;
 		case 'text-button':
 		case 'borderless':
 			return 'none';

--- a/packages/composite-checkout/src/components/button.js
+++ b/packages/composite-checkout/src/components/button.js
@@ -30,55 +30,54 @@ export default function Button( {
 }
 
 Button.propTypes = {
-	buttonState: PropTypes.string,
-	buttonType: PropTypes.string,
+	buttonState: PropTypes.string, // Either 'disabled', 'primary', 'secondary', or 'text-button'.
+	buttonType: PropTypes.string, // Service type (i.e. 'paypal' or 'apple-pay').
 	onClick: PropTypes.func,
 	fullWidth: PropTypes.bool,
 };
 
 const CallToAction = styled.button`
 	display: block;
-	width: ${ props => ( props.fullWidth ? '100%' : 'auto' ) };
+	width: ${props => ( props.fullWidth ? '100%' : 'auto' )};
 	font-size: 16px;
-	border-radius: ${ props => ( props.buttonType === 'paypal' ? '50px' : '3px' ) };
-	padding: ${ props => props.padding };
-	background: ${ getBackgroundColor };
-	border-width: ${ getBorderWeight };
+	border-radius: ${props => ( props.buttonType === 'paypal' ? '50px' : '3px' )};
+	padding: ${props => props.padding};
+	background: ${getBackgroundColor};
+	border-width: ${getBorderWeight};
 	border-style: solid;
-	border-color: ${ getBorderColor };
-	color: ${ getTextColor };
-	border-bottom-width: ${ getBorderElevationWeight };
-	font-weight: ${ getFontWeight };
-	text-decoration: ${ getTextDecoration };
+	border-color: ${getBorderColor};
+	color: ${getTextColor};
+	border-bottom-width: ${getBorderElevationWeight};
+	font-weight: ${getFontWeight};
+	text-decoration: ${getTextDecoration};
 
 	:hover {
-		cursor: pointer;
-		background: ${ getRollOverColor };
-		border-width: ${ getBorderWeight };
+		background: ${getRollOverColor};
+		border-width: ${getBorderWeight};
 		border-style: solid;
-		border-color: ${ getRollOverBorderColor };
-		border-bottom-width: ${ getBorderElevationWeight };
+		border-color: ${getRollOverBorderColor};
+		border-bottom-width: ${getBorderElevationWeight};
 		text-decoration: none;
-		color: ${ getTextColor };
-		cursor: ${ ( { buttonState } ) =>
-			buttonState && buttonState.includes( 'disabled' ) ? 'not-allowed' : 'pointer' };
+		color: ${getTextColor};
+		cursor: ${( { buttonState } ) =>
+			buttonState && buttonState.includes( 'disabled' ) ? 'not-allowed' : 'pointer'};
 	}
 
 	:active {
-		background: ${ getRollOverColor };
-		border-width: ${ getBorderWeight };
+		background: ${getRollOverColor};
+		border-width: ${getBorderWeight};
 		border-style: solid;
-		border-color: ${ getRollOverBorderColor };
-		border-top-width: ${ getBorderElevationWeight };
-		text-decoration: ${ getTextDecoration };
-		color: ${ getTextColor };
+		border-color: ${getRollOverBorderColor};
+		border-top-width: ${getBorderElevationWeight};
+		text-decoration: ${getTextDecoration};
+		color: ${getTextColor};
 	}
 
 	svg {
 		margin-bottom: -1px;
-		transform: translateY(2px);
-		filter: ${ getImageFilter }
-		opacity: ${ getImageOpacity };
+		transform: translateY( 2px );
+		filter: ${getImageFilter};
+		opacity: ${getImageOpacity};
 	}
 `;
 

--- a/packages/composite-checkout/src/components/button.js
+++ b/packages/composite-checkout/src/components/button.js
@@ -5,32 +5,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
-export default function Button( {
-	buttonState,
-	buttonType,
-	onClick,
-	className,
-	fullWidth,
-	children,
-	...props
-} ) {
-	return (
-		<CallToAction
-			buttonState={ buttonState }
-			buttonType={ buttonType }
-			padding={ buttonState === 'text-button' ? '0' : '10px 15px' }
-			onClick={ onClick }
-			className={ className }
-			fullWidth={ fullWidth }
-			{ ...props }
-		>
-			{ children }
-		</CallToAction>
-	);
+export default function Button( { children, ...props } ) {
+	return <CallToAction { ...props }>{ children }</CallToAction>;
 }
 
 Button.propTypes = {
-	buttonState: PropTypes.string, // Either 'disabled', 'primary', 'secondary', or 'text-button'.
+	buttonState: PropTypes.string, // Either 'disabled', 'primary', 'secondary', 'text-button', 'borderless'.
 	buttonType: PropTypes.string, // Service type (i.e. 'paypal' or 'apple-pay').
 	onClick: PropTypes.func,
 	fullWidth: PropTypes.bool,
@@ -41,7 +21,7 @@ const CallToAction = styled.button`
 	width: ${props => ( props.fullWidth ? '100%' : 'auto' )};
 	font-size: 16px;
 	border-radius: ${props => ( props.buttonType === 'paypal' ? '50px' : '3px' )};
-	padding: ${props => props.padding};
+	padding: ${props => ( props.buttonState === 'text-button' ? '0' : '10px 15px' )};
 	background: ${getBackgroundColor};
 	border-width: ${getBorderWeight};
 	border-style: solid;
@@ -82,13 +62,13 @@ const CallToAction = styled.button`
 `;
 
 function getImageFilter( { buttonType, buttonState } ) {
-	return `grayscale( ${ buttonState && buttonState.includes( 'primary' ) ? 0 : 100 } ) invert( ${
-		buttonState === 'primary' && buttonType === 'apple-pay' ? '100%' : 0
+	return `grayscale( ${ buttonState === 'primary' ? '0' : '100' } ) invert( ${
+		buttonState === 'primary' && buttonType === 'apple-pay' ? '100%' : '0'
 	} );`;
 }
 
 function getImageOpacity( { buttonState } ) {
-	return buttonState && buttonState.includes( 'primary' ) ? 1 : '0.5';
+	return buttonState === 'primary' ? '1' : '0.5';
 }
 
 function getBorderWeight( { buttonState } ) {
@@ -115,7 +95,6 @@ function getRollOverColor( { buttonState, buttonType, theme } ) {
 		case 'disabled':
 			return colors.disabledPaymentButtons;
 		case 'text-button':
-			return 'none';
 		case 'borderless':
 			return 'none';
 		default:

--- a/packages/composite-checkout/src/components/button.js
+++ b/packages/composite-checkout/src/components/button.js
@@ -152,29 +152,6 @@ function getRollOverColor( { buttonState, buttonType, theme } ) {
 	}
 }
 
-function getBackgroundAccentColor( { buttonState, buttonType, theme } ) {
-	const { colors } = theme;
-	switch ( buttonState ) {
-		case 'primary':
-			if ( buttonType === 'apple-pay' ) {
-				return colors.applePayButtonRollOverColor;
-			}
-			if ( buttonType === 'paypal' ) {
-				return colors.paypalGoldHover;
-			}
-			return colors.primaryOver;
-		case 'secondary':
-			return colors.highlightOver;
-		case 'disabled':
-			return colors.disabledButtons;
-		case 'text-button':
-		case 'borderless':
-			return 'none';
-		default:
-			return 'none';
-	}
-}
-
 function getRollOverBorderColor( { buttonState, buttonType, theme } ) {
 	const { colors } = theme;
 	switch ( buttonState ) {
@@ -226,6 +203,29 @@ function getBackgroundColor( { buttonType, buttonState, theme } ) {
 			return colors.disabledPaymentButtons;
 		case 'secondary':
 			return colors.highlight;
+		default:
+			return 'none';
+	}
+}
+
+function getBackgroundAccentColor( { buttonState, buttonType, theme } ) {
+	const { colors } = theme;
+	switch ( buttonState ) {
+		case 'primary':
+			if ( buttonType === 'apple-pay' ) {
+				return colors.applePayButtonRollOverColor;
+			}
+			if ( buttonType === 'paypal' ) {
+				return colors.paypalGoldHover;
+			}
+			return colors.primaryOver;
+		case 'secondary':
+			return colors.highlightOver;
+		case 'disabled':
+			return colors.disabledPaymentButtonsAccent;
+		case 'text-button':
+		case 'borderless':
+			return 'none';
 		default:
 			return 'none';
 	}

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -322,6 +322,7 @@ export function CheckoutStepBody( {
 							}
 							buttonState={ formStatus !== 'ready' ? 'disabled' : 'primary' }
 							disabled={ formStatus !== 'ready' }
+							isBusy={ formStatus === 'validating' }
 						/>
 					) }
 				</StepContentUI>

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -313,6 +313,7 @@ function ExistingCardPayButton( { disabled, id, stripeConfiguration } ) {
 				} )
 			}
 			buttonState={ disabled ? 'disabled' : 'primary' }
+			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
 			{ buttonString }

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -151,6 +151,7 @@ function FreePurchaseSubmitButton( { disabled } ) {
 			disabled={ disabled }
 			onClick={ onClick }
 			buttonState={ disabled ? 'disabled' : 'primary' }
+			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
 			{ buttonString }

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -152,6 +152,7 @@ function FullCreditsSubmitButton( { disabled } ) {
 			disabled={ disabled }
 			onClick={ onClick }
 			buttonState={ disabled ? 'disabled' : 'primary' }
+			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
 			{ buttonString }

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -106,6 +106,7 @@ export function PaypalSubmitButton( { disabled } ) {
 			onClick={ onClick }
 			buttonState={ disabled ? 'disabled' : 'primary' }
 			buttonType="paypal"
+			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
 			{ formStatus === 'submitting' ? localize( 'Processing...' ) : <ButtonPayPalIcon /> }

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -568,6 +568,7 @@ function StripePayButton( { disabled, stripe, stripeConfiguration } ) {
 		formStatus === 'submitting'
 			? localize( 'Processing...' )
 			: sprintf( localize( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
+
 	return (
 		<Button
 			disabled={ disabled }
@@ -586,6 +587,7 @@ function StripePayButton( { disabled, stripe, stripeConfiguration } ) {
 				} )
 			}
 			buttonState={ disabled ? 'disabled' : 'primary' }
+			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
 			{ buttonString }

--- a/packages/composite-checkout/src/theme.js
+++ b/packages/composite-checkout/src/theme.js
@@ -16,6 +16,7 @@ const theme = {
 		success: swatches.green50,
 		discount: swatches.green50,
 		disabledPaymentButtons: swatches.gray0,
+		disabledPaymentButtonsAccent: swatches.gray5,
 		disabledButtons: swatches.gray20,
 		borderColor: swatches.gray20,
 		borderColorLight: swatches.gray5,


### PR DESCRIPTION
In order to show the user that the form (or step) is currently validating or submitting, this adds an `isBusy` prop to the button component with an animation similar to Calypso and WordPress core busy buttons.

We should look into using Core's button component in a future PR.

![busy-button](https://user-images.githubusercontent.com/942359/75724470-74af5780-5cac-11ea-9c54-723bce7c0bd2.gif)

**To Test:**
- `npm run composite-checkout-demo`
- visit http://localhost:3000/
- submit the country step and verify that while validating, the button reads "Please wait..." with a busy button animation
- submit the form and verify that while submitting, the form button reads "Processing..." with a busy button animation