### PR TITLE
Add color output to FSE e2e tests

### DIFF
--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -48,7 +48,7 @@
 		"test:js:help": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --help --colors",
 		"test:js:watch": "npx wp-scripts test-unit-js --config='bin/js-unit-config.js' --watch --colors",
 		"test:js:update-snapshots": "npx wp-scripts test-unit-js -u --config='bin/js-unit-config.js' --colors",
-		"test:e2e": "npx wp-scripts test-e2e --wordpress-base-url='http://localhost:4013'",
+		"test:e2e": "npx wp-scripts test-e2e --wordpress-base-url='http://localhost:4013' --colors",
 		"test:e2e:watch": "npm run test-e2e -- --watch",
 		"clean": "npx rimraf dist full-site-editing-plugin/*/dist",
 		"prebuild": "npm run clean",


### PR DESCRIPTION
### Changes proposed in this Pull Request
Based on #39806, adds color output to e2e tests as well.

Before:

<img width="1017" alt="Screen Shot 2020-03-02 at 4 10 11 PM" src="https://user-images.githubusercontent.com/6265975/75730059-9571b000-5ca0-11ea-9411-cc8c99403346.png">

After:

<img width="1013" alt="Screen Shot 2020-03-02 at 4 11 05 PM" src="https://user-images.githubusercontent.com/6265975/75730058-94408300-5ca0-11ea-9e1f-67c6de1aee1d.png">

### Testing:

Run `npx lerna run test:e2e --scope='@automattic/full-site-editing' --stream` and look at the colors :)
