### PR TITLE
Gutenboarding: Add error handling for password flow to auth store

### DIFF
--- a/client/landing/gutenboarding/devtools.ts
+++ b/client/landing/gutenboarding/devtools.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 interface MagicWindow extends Window {
 	wp: undefined | Record< string, any >;
 }
@@ -30,7 +32,6 @@ export const setupWpDataDebug = () => {
 				) ) {
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					window.wp.auth[ actionName ] = async ( ...args: any[] ) => {
-						/* eslint-disable no-console */
 						await ( actionFn as any )( ...args ); // eslint-disable-line @typescript-eslint/no-explicit-any
 						const loginFlowState = window.wp?.data.select( AUTH_STORE ).getLoginFlowState();
 						const errors = window.wp?.data.select( AUTH_STORE ).getErrors();
@@ -40,7 +41,6 @@ export const setupWpDataDebug = () => {
 						} else {
 							console.log( 'No Errors!' );
 						}
-						/* eslint-enable no-console */
 					};
 				}
 			}

--- a/client/landing/gutenboarding/devtools.ts
+++ b/client/landing/gutenboarding/devtools.ts
@@ -30,9 +30,17 @@ export const setupWpDataDebug = () => {
 				) ) {
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					window.wp.auth[ actionName ] = async ( ...args: any[] ) => {
+						/* eslint-disable no-console */
 						await ( actionFn as any )( ...args ); // eslint-disable-line @typescript-eslint/no-explicit-any
 						const loginFlowState = window.wp?.data.select( AUTH_STORE ).getLoginFlowState();
-						console.log( 'New loginFlowState =', loginFlowState ); // eslint-disable-line no-console
+						const errors = window.wp?.data.select( AUTH_STORE ).getErrors();
+						console.log( 'New loginFlowState =', loginFlowState );
+						if ( errors.length ) {
+							console.log( 'Errors =', JSON.stringify( errors, null, 2 ) );
+						} else {
+							console.log( 'No Errors!' );
+						}
+						/* eslint-enable no-console */
 					};
 				}
 			}

--- a/packages/data-stores/.eslintrc.js
+++ b/packages/data-stores/.eslintrc.js
@@ -5,4 +5,15 @@ module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
 	},
+	overrides: [
+		{
+			files: [ '**/test/**/*' ],
+			rules: {
+				'import/no-extraneous-dependencies': [
+					'error',
+					{ packageDir: [ __dirname, __dirname + '/../..' ] },
+				],
+			},
+		},
+	],
 };

--- a/packages/data-stores/.eslintrc.js
+++ b/packages/data-stores/.eslintrc.js
@@ -1,3 +1,5 @@
+const path = require( 'path' );
+
 module.exports = {
 	env: {
 		browser: true,
@@ -11,7 +13,7 @@ module.exports = {
 			rules: {
 				'import/no-extraneous-dependencies': [
 					'error',
-					{ packageDir: [ __dirname, __dirname + '/../..' ] },
+					{ packageDir: [ __dirname, path.join( __dirname, '..', '..' ) ] },
 				],
 			},
 		},

--- a/packages/data-stores/jest.config.js
+++ b/packages/data-stores/jest.config.js
@@ -1,1 +1,5 @@
-module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };
+module.exports = {
+	preset: '@automattic/calypso-build',
+	rootDir: __dirname,
+	setupFiles: [ 'regenerator-runtime/runtime' ],
+};

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -107,3 +107,9 @@ export type Action =
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost
 	| { type: 'TEST_ACTION' };
+
+export const publicActions = {
+	reset,
+	submitUsernameOrEmail,
+	submitPassword,
+};

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -87,12 +87,24 @@ export function* submitPassword( password: string ) {
 	yield clearErrors();
 	const username = yield { type: 'SELECT_USERNAME_OR_EMAIL' };
 
-	const loginResponse = yield fetchWpLogin( 'login-endpoint', { username, password } );
+	try {
+		const loginResponse = yield fetchWpLogin( 'login-endpoint', { username, password } );
 
-	if ( loginResponse.ok && loginResponse.body.success ) {
-		yield receiveWpLogin( loginResponse.body );
-	} else {
-		yield receiveWpLoginFailed( loginResponse.body );
+		if ( loginResponse.ok && loginResponse.body.success ) {
+			yield receiveWpLogin( loginResponse.body );
+		} else {
+			yield receiveWpLoginFailed( loginResponse.body );
+		}
+	} catch ( e ) {
+		const error = {
+			code: e.name,
+			message: e.message,
+		};
+
+		yield receiveWpLoginFailed( {
+			success: false,
+			data: { errors: [ error ] },
+		} );
 	}
 }
 

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -29,6 +29,11 @@ export const receiveAuthOptionsFailed = ( response: AuthOptionsErrorResponse ) =
 		response,
 	} as const );
 
+export const clearErrors = () =>
+	( {
+		type: 'CLEAR_ERRORS',
+	} as const );
+
 export interface FetchAuthOptionsAction {
 	type: 'FETCH_AUTH_OPTIONS';
 	usernameOrEmail: string;
@@ -40,6 +45,8 @@ const fetchAuthOptions = ( usernameOrEmail: string ): FetchAuthOptionsAction => 
 } );
 
 export function* submitUsernameOrEmail( usernameOrEmail: string ) {
+	yield clearErrors();
+
 	try {
 		const authOptions = yield fetchAuthOptions( usernameOrEmail );
 
@@ -77,6 +84,7 @@ const fetchWpLogin = ( action: WpLoginAction, params: object ): FetchWpLoginActi
 	} as const );
 
 export function* submitPassword( password: string ) {
+	yield clearErrors();
 	const username = yield { type: 'SELECT_USERNAME_OR_EMAIL' };
 
 	const loginResponse = yield fetchWpLogin( 'login-endpoint', { username, password } );
@@ -91,6 +99,7 @@ export function* submitPassword( password: string ) {
 export type Action =
 	| ReturnType<
 			| typeof reset
+			| typeof clearErrors
 			| typeof receiveAuthOptions
 			| typeof receiveAuthOptionsFailed
 			| typeof receiveWpLogin

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -79,12 +79,12 @@ const fetchWpLogin = ( action: WpLoginAction, params: object ): FetchWpLoginActi
 export function* submitPassword( password: string ) {
 	const username = yield { type: 'SELECT_USERNAME_OR_EMAIL' };
 
-	try {
-		const loginResponse = yield fetchWpLogin( 'login-endpoint', { username, password } );
+	const loginResponse = yield fetchWpLogin( 'login-endpoint', { username, password } );
 
-		yield receiveWpLogin( loginResponse );
-	} catch ( err ) {
-		yield receiveWpLoginFailed( err );
+	if ( loginResponse.ok && loginResponse.body.success ) {
+		yield receiveWpLogin( loginResponse.body );
+	} else {
+		yield receiveWpLoginFailed( loginResponse.body );
 	}
 }
 

--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -47,7 +47,10 @@ export function createControls( clientCreds: WpcomClientCredentials ) {
 				}
 			);
 
-			return await response.json();
+			return {
+				ok: response.ok,
+				body: await response.json(),
+			};
 		},
 	};
 }

--- a/packages/data-stores/src/auth/index.ts
+++ b/packages/data-stores/src/auth/index.ts
@@ -8,7 +8,7 @@ import { registerStore } from '@wordpress/data';
  */
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
-import * as actions from './actions';
+import { publicActions } from './actions';
 import { createControls } from './controls';
 import * as selectors from './selectors';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
@@ -22,7 +22,7 @@ export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KE
 	if ( ! isRegistered ) {
 		isRegistered = true;
 		registerStore< State >( STORE_KEY, {
-			actions,
+			actions: publicActions,
 			controls: createControls( clientCreds ) as any,
 			reducer,
 			selectors,
@@ -32,6 +32,6 @@ export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KE
 }
 
 declare module '@wordpress/data' {
-	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof publicActions >;
 	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
 }

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -45,7 +45,33 @@ export const usernameOrEmail: Reducer< string, Action > = ( state = '', action )
 	}
 };
 
-const reducer = combineReducers( { loginFlowState, usernameOrEmail } );
+export interface ErrorObject {
+	code: string;
+	message: string;
+}
+
+export const errors: Reducer< ErrorObject[], Action > = ( state = [], action ) => {
+	switch ( action.type ) {
+		case 'RESET_LOGIN_FLOW':
+			return [];
+
+		case 'RECEIVE_WP_LOGIN_FAILED':
+			return action.response.data.errors;
+
+		case 'RECEIVE_AUTH_OPTIONS_FAILED':
+			return [
+				{
+					code: action.response.error,
+					message: action.response.message,
+				},
+			];
+
+		default:
+			return state;
+	}
+};
+
+const reducer = combineReducers( { errors, loginFlowState, usernameOrEmail } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -53,6 +53,7 @@ export interface ErrorObject {
 export const errors: Reducer< ErrorObject[], Action > = ( state = [], action ) => {
 	switch ( action.type ) {
 		case 'RESET_LOGIN_FLOW':
+		case 'CLEAR_ERRORS':
 			return [];
 
 		case 'RECEIVE_WP_LOGIN_FAILED':

--- a/packages/data-stores/src/auth/selectors.ts
+++ b/packages/data-stores/src/auth/selectors.ts
@@ -3,6 +3,11 @@
  */
 import { State } from './reducer';
 
+export const getErrors = ( state: State ) => state.errors;
+
+export const getFirstError = ( state: State ) =>
+	state.errors.length ? state.errors[ 0 ] : undefined;
+
 export const getLoginFlowState = ( state: State ) => state.loginFlowState;
 
 export const getUsernameOrEmail = ( state: State ) => state.usernameOrEmail;

--- a/packages/data-stores/src/auth/test/actions.ts
+++ b/packages/data-stores/src/auth/test/actions.ts
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import { submitPassword } from '../actions';
+
+describe( 'submitPassword', () => {
+	it( 'dispatches failed action if exception is thrown by fetch', async () => {
+		const password = 'passw0rd';
+		const generator = submitPassword( password );
+
+		expect( generator.next().value ).toEqual( {
+			type: 'CLEAR_ERRORS',
+		} );
+
+		expect( generator.next().value ).toEqual( {
+			type: 'SELECT_USERNAME_OR_EMAIL',
+		} );
+
+		const username = 'user1';
+		expect( generator.next( username ).value ).toEqual( {
+			type: 'FETCH_WP_LOGIN',
+			action: 'login-endpoint',
+			params: { username, password },
+		} );
+
+		const errorMessage = 'Error!!1';
+		expect( generator.throw( new Error( errorMessage ) ).value ).toEqual( {
+			type: 'RECEIVE_WP_LOGIN_FAILED',
+			response: {
+				success: false,
+				data: {
+					errors: [ { code: 'Error', message: 'Error!!1' } ],
+				},
+			},
+		} );
+	} );
+} );

--- a/packages/data-stores/src/auth/test/flows.ts
+++ b/packages/data-stores/src/auth/test/flows.ts
@@ -12,6 +12,8 @@
 import { dispatch, select } from '@wordpress/data';
 import { parse } from 'qs';
 import wpcomRequest from 'wpcom-proxy-request';
+import 'jest-fetch-mock';
+import nock from 'nock';
 
 /**
  * Internal dependencies
@@ -24,23 +26,19 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
 } ) );
 
-const fetch = jest.fn();
-
+let store: ReturnType< typeof register >;
 beforeAll( () => {
-	( global as any ).fetch = fetch;
+	store = register( { client_id: '', client_secret: '' } );
 } );
 
-let store: ReturnType< typeof register >;
 beforeEach( () => {
-	store = register( { client_id: '', client_secret: '' } );
-
-	fetch.mockReset();
+	dispatch( store ).reset();
 	( wpcomRequest as jest.Mock ).mockReset();
 } );
 
 describe( 'password login flow', () => {
 	it( 'logs in with correct credentials', async () => {
-		const { getLoginFlowState } = select( store );
+		const { getErrors, getLoginFlowState } = select( store );
 		const { submitUsernameOrEmail, submitPassword } = dispatch( store );
 
 		expect( getLoginFlowState() ).toBe( 'ENTER_USERNAME_OR_EMAIL' );
@@ -60,33 +58,95 @@ describe( 'password login flow', () => {
 
 		expect( getLoginFlowState() ).toBe( 'ENTER_PASSWORD' );
 
-		fetch.mockResolvedValue( {
-			json: () =>
-				Promise.resolve( {
-					success: true,
-					data: { token_links: [] },
-				} ),
-		} );
+		nock( 'https://wordpress.com' )
+			.post( '/wp-login.php?action=login-endpoint', body => {
+				expect( parse( body ) ).toEqual(
+					expect.objectContaining( {
+						username: 'user1',
+						password: 'passw0rd',
+						remember_me: 'true',
+					} )
+				);
+				return true;
+			} )
+			.reply( 200, {
+				success: true,
+				data: { token_links: [] },
+			} );
 
 		await submitPassword( 'passw0rd' );
 
-		expect( fetch ).toHaveBeenLastCalledWith(
-			'https://wordpress.com/wp-login.php?action=login-endpoint',
-			expect.objectContaining( {
-				method: 'POST',
-				body: expect.any( String ),
-			} )
-		);
-
-		const requestBody = fetch.mock.calls[ 0 ][ 1 ].body;
-		expect( parse( requestBody ) ).toEqual(
-			expect.objectContaining( {
-				username: 'user1',
-				password: 'passw0rd',
-				remember_me: 'true',
-			} )
-		);
-
 		expect( getLoginFlowState() ).toBe( 'LOGGED_IN' );
+		expect( getErrors() ).toEqual( [] );
+	} );
+
+	it( 'errors for unknown users', async () => {
+		const { getErrors, getLoginFlowState } = select( store );
+		const { submitUsernameOrEmail } = dispatch( store );
+
+		expect( getLoginFlowState() ).toBe( 'ENTER_USERNAME_OR_EMAIL' );
+
+		( wpcomRequest as jest.Mock ).mockRejectedValue( {
+			error: 'unknown_user',
+			message: 'User does not exist',
+		} );
+
+		await submitUsernameOrEmail( 'unknown' );
+
+		expect( wpcomRequest ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				path: '/users/unknown/auth-options',
+			} )
+		);
+
+		expect( getLoginFlowState() ).toBe( 'ENTER_USERNAME_OR_EMAIL' );
+		expect( getErrors() ).toEqual( [
+			{
+				code: 'unknown_user',
+				message: 'User does not exist',
+			},
+		] );
+	} );
+
+	it( "doesn't log in with incorrect passord", async () => {
+		const { getErrors, getLoginFlowState } = select( store );
+		const { submitUsernameOrEmail, submitPassword } = dispatch( store );
+
+		expect( getLoginFlowState() ).toBe( 'ENTER_USERNAME_OR_EMAIL' );
+
+		( wpcomRequest as jest.Mock ).mockResolvedValue( {
+			email_verified: true,
+			passwordless: false,
+		} );
+
+		await submitUsernameOrEmail( 'user1' );
+
+		expect( getLoginFlowState() ).toBe( 'ENTER_PASSWORD' );
+
+		nock( 'https://wordpress.com' )
+			.post( '/wp-login.php?action=login-endpoint', body => {
+				expect( parse( body ) ).toEqual(
+					expect.objectContaining( {
+						username: 'user1',
+						password: 'wrongpassword',
+						remember_me: 'true',
+					} )
+				);
+				return true;
+			} )
+			.reply( 400, {
+				success: false,
+				data: { errors: [ { code: 'incorrect_password', message: 'message for user' } ] },
+			} );
+
+		await submitPassword( 'wrongpassword' );
+
+		expect( getLoginFlowState() ).toBe( 'ENTER_PASSWORD' );
+		expect( getErrors() ).toEqual( [
+			{
+				code: 'incorrect_password',
+				message: 'message for user',
+			},
+		] );
 	} );
 } );

--- a/packages/data-stores/src/auth/test/reducer.ts
+++ b/packages/data-stores/src/auth/test/reducer.ts
@@ -9,8 +9,8 @@
 /**
  * Internal dependencies
  */
-import { loginFlowState, usernameOrEmail } from '../reducer';
-import { reset, receiveAuthOptions } from '../actions';
+import { errors, loginFlowState, usernameOrEmail } from '../reducer';
+import { reset, receiveAuthOptions, clearErrors } from '../actions';
 
 describe( 'login flow state', () => {
 	it( 'returns the correct default state', () => {
@@ -45,5 +45,24 @@ describe( 'usernameOrEmail', () => {
 			receiveAuthOptions( { passwordless: true, email_verified: true }, 'new username' )
 		);
 		expect( state ).toBe( 'new username' );
+	} );
+} );
+
+describe( 'errors', () => {
+	it( 'defaults to empty', () => {
+		const state = errors( undefined, { type: 'TEST_ACTION' } );
+		expect( state ).toEqual( [] );
+	} );
+
+	it( 'is returned to the default state by the reset action', () => {
+		const defaultState = errors( undefined, { type: 'TEST_ACTION' } );
+
+		const state = errors( [ { code: 'code', message: '' } ], reset() );
+		expect( state ).toEqual( defaultState );
+	} );
+
+	it( 'is emptied by the clearErrors action', () => {
+		const state = errors( [ { code: 'code', message: '' } ], clearErrors() );
+		expect( state ).toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Handle errors that come up in the standard username/password flow
* Add `getErrors()` and `getFirstError()` selectors to get the lastest error code and message returned by the server
* Don't expose actions in the public api that users of the store shouldn't use e.g. `receiveWpLogin()`
* Switch to `nock` for mocking fetch calls
* Update `no-extraneous-dependencies` lint rule for test files (they're allowed to use dev dependencies from the root of the repo

I couldn't figure out how to use `nock` to mock the calls made using `wpcom-proxy-request`, probably something to do with it making an iframe under the hood instead of sending an xhr. I see other examples in the codebase doing it though.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/gutenboarding` and open network tab and console
* Use the following to test the auth store. State transitions and errors will be printed to the console
  * `wp.auth.submitUsernameOrEmail('')`
  * `wp.auth.submitPassword('')`
  * `wp.reset()`
