### PR TITLE
Gutenboarding: auth store sends login email when use logs in with passwordless account

### DIFF
--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -8,7 +8,7 @@ import wpcomRequest, { requestAllBlogsAccess } from 'wpcom-proxy-request';
 /**
  * Internal dependencies
  */
-import { FetchAuthOptionsAction, FetchWpLoginAction } from './actions';
+import { FetchAuthOptionsAction, FetchWpLoginAction, SendLoginEmailAction } from './actions';
 import { STORE_KEY } from './constants';
 import { WpcomClientCredentials } from '../shared-types';
 
@@ -51,6 +51,22 @@ export function createControls( clientCreds: WpcomClientCredentials ) {
 				ok: response.ok,
 				body: await response.json(),
 			};
+		},
+		SEND_LOGIN_EMAIL: async ( { email }: SendLoginEmailAction ) => {
+			return await wpcomRequest( {
+				path: `/auth/send-login-email`,
+				apiVersion: '1.2',
+				method: 'post',
+				body: {
+					email,
+
+					// TODO Send the correct locale
+					lang_id: 1,
+					locale: 'en',
+
+					...clientCreds,
+				},
+			} );
 		},
 	};
 }

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -27,6 +27,12 @@ export const loginFlowState: Reducer< LoginFlowState, Action > = (
 		case 'RECEIVE_WP_LOGIN':
 			return 'LOGGED_IN';
 
+		case 'RECEIVE_SEND_LOGIN_EMAIL':
+			if ( action.success ) {
+				return 'LOGIN_LINK_SENT';
+			}
+			return state;
+
 		default:
 			return state;
 	}

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -28,7 +28,7 @@ export const loginFlowState: Reducer< LoginFlowState, Action > = (
 			return 'LOGGED_IN';
 
 		case 'RECEIVE_SEND_LOGIN_EMAIL':
-			if ( action.success ) {
+			if ( action.response.success ) {
 				return 'LOGIN_LINK_SENT';
 			}
 			return state;
@@ -66,6 +66,7 @@ export const errors: Reducer< ErrorObject[], Action > = ( state = [], action ) =
 			return action.response.data.errors;
 
 		case 'RECEIVE_AUTH_OPTIONS_FAILED':
+		case 'RECEIVE_SEND_LOGIN_EMAIL_FAILED':
 			return [
 				{
 					code: action.response.error,

--- a/packages/data-stores/src/auth/types.ts
+++ b/packages/data-stores/src/auth/types.ts
@@ -36,3 +36,14 @@ export interface WpLoginErrorResponse {
 }
 
 export type WpLoginResponse = WpLoginSuccessResponse | WpLoginErrorResponse;
+
+export interface SendLoginEmailSuccessResponse {
+	success: true;
+}
+
+export interface SendLoginEmailErrorResponse {
+	error: string;
+	message: string;
+}
+
+export type SendLoginEmailResponse = SendLoginEmailSuccessResponse | SendLoginEmailErrorResponse;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Handle cases where the user has a passwordless account
* Doesn't handle errors yet, that's being added in #39819

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/gutenboarding` and open network tab and console
* Use the following to test the auth store. State transitions and errors will be printed to the console
  * `wp.auth.submitUsernameOrEmail('')`
  * `wp.auth.submitPassword('')`
  * `wp.reset()`
* Test using a passwordless account (you can make one at `/gutenboarding/signup`)
* Check inbox for the login email
