### PR TITLE
uuid: Update dependency to v7

### DIFF
--- a/client/components/date-range/inputs.tsx
+++ b/client/components/date-range/inputs.tsx
@@ -3,7 +3,7 @@
  */
 import React, { FunctionComponent, useRef, useCallback } from 'react';
 import { noop } from 'lodash';
-import uuidv4 from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -41,6 +41,7 @@ const DateRangeInputs: FunctionComponent< Props > = ( {
 	/**
 	 * Handles input focus events with fixed arguments
 	 * for consistency via partial application
+	 *
 	 * @param  startOrEnd one of "Start" or "End"
 	 * @returns the partially applied function ready to receive event data
 	 */
@@ -55,6 +56,7 @@ const DateRangeInputs: FunctionComponent< Props > = ( {
 	/**
 	 * Handles input blur events with fixed arguments
 	 * for consistency via partial application
+	 *
 	 * @param  startOrEnd one of "Start" or "End"
 	 * @returns the partially applied function ready to receive event data
 	 */
@@ -69,6 +71,7 @@ const DateRangeInputs: FunctionComponent< Props > = ( {
 	/**
 	 * Handles input change events with fixed arguments
 	 * for consistency via partial application
+	 *
 	 * @param  startOrEnd one of "Start" or "End"
 	 * @returns the partially applied function ready to receive event data
 	 */

--- a/client/package.json
+++ b/client/package.json
@@ -158,7 +158,7 @@
 		"use-debounce": "3.1.0",
 		"use-subscription": "1.3.0",
 		"utility-types": "3.10.0",
-		"uuid": "3.3.3",
+		"uuid": "7.0.1",
 		"valid-url": "1.0.9",
 		"wpcom": "file:../packages/wpcom.js",
 		"wpcom-proxy-request": "file:../packages/wpcom-proxy-request",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37855,7 +37855,7 @@
 				"use-debounce": "3.1.0",
 				"use-subscription": "1.3.0",
 				"utility-types": "3.10.0",
-				"uuid": "3.3.3",
+				"uuid": "7.0.1",
 				"valid-url": "1.0.9",
 				"wpcom": "file:packages/wpcom.js",
 				"wpcom-proxy-request": "file:packages/wpcom-proxy-request",
@@ -37916,9 +37916,9 @@
 					"integrity": "sha512-sQsgKYcn+OthBkvKz+TeHlYZq2SF5ZP9RutHg7O67GI+sdYqf0BVy6VeTe28TG4Vui6hoMheiMnZqhidOtN7EA=="
 				},
 				"uuid": {
-					"version": "3.3.3",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-					"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.1.tgz",
+					"integrity": "sha512-yqjRXZzSJm9Dbl84H2VDHpM3zMjzSJQ+hn6C4zqd5ilW+7P4ZmLEEqwho9LjP+tGuZlF4xrHQXT0h9QZUS/pWA=="
 				}
 			}
 		},


### PR DESCRIPTION
With #39735, we're using `uuid@7` in `wpcom-proxy-request` and `uuid@3` in the Calypso client. This makes using a consistent type definition (`@types/uuid@7`) in the root devDependencies impossible.

Update `uuid` to version 7 in the Calypso client. It seems that all usage of `uuid` was already compatible, namely using the version as a named import rather than via package path.

```js
// Ok 👍 
import { v4 as uuid } from 'uuid';
// Not
import uuid from 'uuid/v4'; 👎 
```

See [v7 breaking changes](https://github.com/uuidjs/uuid/blob/master/CHANGELOG.md#-breaking-changes).

#### Testing instructions

* e2e works
* Visually inspect `uuid` usage in code and confirm it is consistent and compatible for v7.