### PR TITLE
FSE: filter out templates that have missing Blocks

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -313,7 +313,7 @@ class PageTemplateModal extends Component {
 		}
 
 		const blocksByTemplateSlug = this.getBlocksByTemplateSlugs( this.props.templates );
-		const templatesWithMissingBlocks = Object.keys( blocksByTemplateSlug );
+		const templatesWithoutMissingBlocks = Object.keys( blocksByTemplateSlug );
 
 		const removeTemplatesWithMissingBlocks = ( templatesToFilter, filterIn ) => {
 			return templatesToFilter.filter( template => filterIn.includes( template.slug ) );
@@ -326,7 +326,7 @@ class PageTemplateModal extends Component {
 					label={ __( 'Layout', 'full-site-editing' ) }
 					templates={ removeTemplatesWithMissingBlocks(
 						templatesList,
-						templatesWithMissingBlocks
+						templatesWithoutMissingBlocks
 					) }
 					blocksByTemplates={ this.getBlocksByTemplateSlugs( this.props.templates ) }
 					onTemplateSelect={ this.previewTemplate }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -40,8 +40,8 @@ class PageTemplateModal extends Component {
 	);
 
 	// Parse templates blocks and memoize them.
-	getBlocksByTemplateSlugs = memoize( templates =>
-		reduce(
+	getBlocksByTemplateSlugs = memoize( templates => {
+		let rtn = reduce(
 			templates,
 			( prev, { slug, content, title } ) => {
 				prev[ slug ] = content
@@ -62,8 +62,29 @@ class PageTemplateModal extends Component {
 				return prev;
 			},
 			{}
-		)
-	);
+		);
+
+		const MISSING_BLOCK_NAME = 'core/spacer';
+
+		// Remove templates that include a missing block
+		rtn = reduce(
+			rtn,
+			( acc, templateBlocks, slug ) => {
+				// We will need to flatten the blocks by `innerBlocks` to ensure we
+				// catch nested Blocks
+				const hasMissingBlocks = templateBlocks.find( block => block.name === MISSING_BLOCK_NAME );
+
+				if ( ! hasMissingBlocks || slug === 'blank' ) {
+					acc[ slug ] = templateBlocks;
+				}
+
+				return acc;
+			},
+			{}
+		);
+
+		return rtn;
+	} );
 
 	getBlocksForPreview = memoize( previewedTemplate => {
 		const blocks = this.getBlocksByTemplateSlug( previewedTemplate );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -309,7 +309,7 @@ class PageTemplateModal extends Component {
 	};
 
 	renderTemplatesList = ( templatesList, legendLabel ) => {
-		if ( 0 === templatesList.length ) {
+		if ( ! templatesList.length ) {
 			return null;
 		}
 
@@ -325,15 +325,21 @@ class PageTemplateModal extends Component {
 			return templatesToFilter.filter( template => filterIn.includes( template.slug ) );
 		};
 
+		const filteredTemplatesList = filterOutTemplatesWithMissingBlocks(
+			templatesList,
+			templatesWithoutMissingBlocks
+		);
+
+		if ( ! filteredTemplatesList.length ) {
+			return null;
+		}
+
 		return (
 			<fieldset className="page-template-modal__list">
 				<legend className="page-template-modal__form-title">{ legendLabel }</legend>
 				<TemplateSelectorControl
 					label={ __( 'Layout', 'full-site-editing' ) }
-					templates={ filterOutTemplatesWithMissingBlocks(
-						templatesList,
-						templatesWithoutMissingBlocks
-					) }
+					templates={ filteredTemplatesList }
 					blocksByTemplates={ blocksByTemplateSlug }
 					onTemplateSelect={ this.previewTemplate }
 					useDynamicPreview={ false }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -315,6 +315,11 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
+		// The raw `templates` prop is not filtered to remove Templates that
+		// contain missing Blocks. Therefore we compare with the keys of the
+		// filtered templates from `getBlocksByTemplateSlugs()` and filter this
+		// list to match. This ensures that the list of Template thumbnails is
+		// filtered so that it does not include Templates that have missing Blocks.
 		const blocksByTemplateSlug = this.getBlocksByTemplateSlugs( this.props.templates );
 		const templatesWithoutMissingBlocks = Object.keys( blocksByTemplateSlug );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -22,36 +22,10 @@ import { trackDismiss, trackSelection, trackView } from './utils/tracking';
 import replacePlaceholders from './utils/replace-placeholders';
 import ensureAssets from './utils/ensure-assets';
 import mapBlocksRecursively from './utils/map-blocks-recursively';
+import containsMissingBlock from './utils/contains-missing-block';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const DEFAULT_HOMEPAGE_TEMPLATE = 'maywood';
-
-/**
- * Determines whether the provided collection of Blocks contains any "missing"
- * blocks as determined by the presence of the `core/missing` block type.
- *
- * @param {Array} blocks the collection of block objects to check for "missing" block .
- * @returns {boolean} whether the collection blocks contains any missing blocks.
- */
-function containsMissingBlock( blocks ) {
-	// Once parsed, missing Blocks have a name prop of `core/missing`.
-	// see: https://github.com/WordPress/gutenberg/tree/742dbf2ef0e37481a3c14c29f3688aa0cd3cf887/packages/block-library/src/missing
-	const MISSING_BLOCK_NAME = 'core/missing';
-
-	return blocks.find( block => {
-		// If we found a missing block the bale out immediately
-		if ( block.name === MISSING_BLOCK_NAME ) {
-			return true;
-		}
-
-		// If there are innerblocks then recurse down into them...
-		if ( block.innerBlocks && block.innerBlocks.length ) {
-			return containsMissingBlock( block.innerBlocks );
-		}
-
-		return false;
-	} );
-}
 
 class PageTemplateModal extends Component {
 	state = {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -42,7 +42,7 @@ class PageTemplateModal extends Component {
 
 	// Parse templates blocks and memoize them.
 	getBlocksByTemplateSlugs = memoize( templates => {
-		let rtn = reduce(
+		const blocksByTemplateSlugs = reduce(
 			templates,
 			( prev, { slug, content, title } ) => {
 				prev[ slug ] = content
@@ -66,9 +66,7 @@ class PageTemplateModal extends Component {
 		);
 
 		// Remove templates that include a missing block
-		rtn = this.filterTemplatesWithMissingBlocks( rtn );
-
-		return rtn;
+		return this.filterTemplatesWithMissingBlocks( blocksByTemplateSlugs );
 	} );
 
 	filterTemplatesWithMissingBlocks( templates ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -315,7 +315,7 @@ class PageTemplateModal extends Component {
 		const blocksByTemplateSlug = this.getBlocksByTemplateSlugs( this.props.templates );
 		const templatesWithoutMissingBlocks = Object.keys( blocksByTemplateSlug );
 
-		const removeTemplatesWithMissingBlocks = ( templatesToFilter, filterIn ) => {
+		const filterOutTemplatesWithMissingBlocks = ( templatesToFilter, filterIn ) => {
 			return templatesToFilter.filter( template => filterIn.includes( template.slug ) );
 		};
 
@@ -324,7 +324,7 @@ class PageTemplateModal extends Component {
 				<legend className="page-template-modal__form-title">{ legendLabel }</legend>
 				<TemplateSelectorControl
 					label={ __( 'Layout', 'full-site-editing' ) }
-					templates={ removeTemplatesWithMissingBlocks(
+					templates={ filterOutTemplatesWithMissingBlocks(
 						templatesList,
 						templatesWithoutMissingBlocks
 					) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -64,7 +64,7 @@ class PageTemplateModal extends Component {
 			{}
 		);
 
-		const MISSING_BLOCK_NAME = 'core/spacer';
+		const MISSING_BLOCK_NAME = 'core/group';
 
 		// Remove templates that include a missing block
 		rtn = reduce(
@@ -74,7 +74,9 @@ class PageTemplateModal extends Component {
 				// catch nested Blocks
 				const hasMissingBlocks = templateBlocks.find( block => block.name === MISSING_BLOCK_NAME );
 
-				if ( ! hasMissingBlocks || slug === 'blank' ) {
+				// If we don't have any missing blocks, or there are no block at
+				// all then retain in collection.
+				if ( ! hasMissingBlocks || ! templateBlocks.length ) {
 					acc[ slug ] = templateBlocks;
 				}
 
@@ -158,7 +160,7 @@ class PageTemplateModal extends Component {
 		const blankTemplate = get( props.templates, [ 0, 'slug' ] );
 		let previouslyChosenTemplate = props._starter_page_template;
 
-		// Usally the "new page" case.
+		// Usally the "new page" case
 		if ( ! props.isFrontPage && ! previouslyChosenTemplate ) {
 			return blankTemplate;
 		}
@@ -310,12 +312,22 @@ class PageTemplateModal extends Component {
 			return null;
 		}
 
+		const blocksByTemplateSlug = this.getBlocksByTemplateSlugs( this.props.templates );
+		const templatesWithMissingBlocks = Object.keys( blocksByTemplateSlug );
+
+		const removeTemplatesWithMissingBlocks = ( templatesToFilter, filterIn ) => {
+			return templatesToFilter.filter( template => filterIn.includes( template.slug ) );
+		};
+
 		return (
 			<fieldset className="page-template-modal__list">
 				<legend className="page-template-modal__form-title">{ legendLabel }</legend>
 				<TemplateSelectorControl
 					label={ __( 'Layout', 'full-site-editing' ) }
-					templates={ templatesList }
+					templates={ removeTemplatesWithMissingBlocks(
+						templatesList,
+						templatesWithMissingBlocks
+					) }
 					blocksByTemplates={ this.getBlocksByTemplateSlugs( this.props.templates ) }
 					onTemplateSelect={ this.previewTemplate }
 					useDynamicPreview={ false }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -64,7 +64,9 @@ class PageTemplateModal extends Component {
 			{}
 		);
 
-		const MISSING_BLOCK_NAME = 'core/group';
+		// Once parsed, missing Blocks have a name prop of `core/missing`.
+		// see: https://github.com/WordPress/gutenberg/tree/742dbf2ef0e37481a3c14c29f3688aa0cd3cf887/packages/block-library/src/missing
+		const MISSING_BLOCK_NAME = 'core/missing';
 
 		// Remove templates that include a missing block
 		rtn = reduce(

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -328,7 +328,7 @@ class PageTemplateModal extends Component {
 						templatesList,
 						templatesWithoutMissingBlocks
 					) }
-					blocksByTemplates={ this.getBlocksByTemplateSlugs( this.props.templates ) }
+					blocksByTemplates={ blocksByTemplateSlug }
 					onTemplateSelect={ this.previewTemplate }
 					useDynamicPreview={ false }
 					siteInformation={ this.props.siteInformation }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/contains-missing-block.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/contains-missing-block.js
@@ -10,7 +10,7 @@ const MISSING_BLOCK_NAME = 'core/missing';
  * @returns {boolean} whether the collection blocks contains any missing blocks.
  */
 function containsMissingBlock( blocks ) {
-	return blocks.find( block => {
+	return !! blocks.find( block => {
 		// If we found a missing block the bale out immediately
 		if ( block.name === MISSING_BLOCK_NAME ) {
 			return true;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/contains-missing-block.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/contains-missing-block.js
@@ -1,0 +1,28 @@
+// Once parsed, missing Blocks have a name prop of `core/missing`.
+// see: https://github.com/WordPress/gutenberg/tree/742dbf2ef0e37481a3c14c29f3688aa0cd3cf887/packages/block-library/src/missing
+const MISSING_BLOCK_NAME = 'core/missing';
+
+/**
+ * Determines whether the provided collection of Blocks contains any "missing"
+ * blocks as determined by the presence of the `core/missing` block type.
+ *
+ * @param {Array} blocks the collection of block objects to check for "missing" block .
+ * @returns {boolean} whether the collection blocks contains any missing blocks.
+ */
+function containsMissingBlock( blocks ) {
+	return blocks.find( block => {
+		// If we found a missing block the bale out immediately
+		if ( block.name === MISSING_BLOCK_NAME ) {
+			return true;
+		}
+
+		// If there are innerblocks then recurse down into them...
+		if ( block.innerBlocks && block.innerBlocks.length ) {
+			return containsMissingBlock( block.innerBlocks );
+		}
+
+		return false;
+	} );
+}
+
+export default containsMissingBlock;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Short term solution for https://github.com/Automattic/wp-calypso/issues/39293 whilst we work on [improved longer term solutions](https://github.com/Automattic/wp-calypso/issues/39293#issuecomment-595147085).

[Recent Issues](https://github.com/Automattic/wp-calypso/issues/39293) have shown that users are seeing missing block messages in Templates when these Templates are using blocks that are not registered.

The missing blocks are likely due to certain blocks being used which are not directly a part of the FSE plugin (eg: [`layout-grid`](https://github.com/Automattic/wp-calypso/issues/39293)).

This PR proposes a solution whereby we dynamically remove any Templates from SPT which contain unsupported Blocks. 

## Todo

- [x] Flatten Blocks before checking for missing in order to catch nested Blocks
- [x] Update testing `MISSING` block with actually missing block name `core/missing`(?)
- [x] Work out why thumbnails are still showing even when filtered out (try clicking them - you'll see they don't load cos template is not available!)

## Testing instructions

You will need to be able to build and then sync the FSE Plugin over to a WP install. Full instructions can be found at `PaYJgx-sW-p2`.

### Testing Setup

* Disable Jetpack.
* Create a new Page 
* Open developer tools and open the `Console` tab.
* Type the following and hit ENTER:
```
Boolean(wp.blocks.getBlockTypes().find(block => block.name === "jetpack/layout-grid"));
``` 
* You should see `false` if the experimental block `jetpack/layout-grid` is not available.

**Warning**: if you see `true` then disable the "Block Experiments" Plugin from your env and rerun the command.

### On Master

* Switch to `master` branch.
* Build FSE and sync to your WP install.
* Create a new Page and see the SPT Template Selector appear.
* You should see the About template showing warning notices about the missing `jetpack/layout-grid` Plugin (see screenshot below): 
<img width="1272" alt="Screen Shot 2020-03-04 at 16 48 13" src="https://user-images.githubusercontent.com/444434/75902473-f5e72580-5e37-11ea-8fc1-37157f7b46fd.png">

### On this PR's branch

* Checkout this PR's branch.
* Build FSE and sync to your WP install.
* Create a new Page and see the SPT Template Selector appear.
* You should no longer see the "About" template which uses the `jetpack/layout-grid` Block. 
<img width="1119" alt="Screen Shot 2020-03-04 at 16 50 21" src="https://user-images.githubusercontent.com/444434/75902681-50808180-5e38-11ea-80d2-2f2e7bd7dab8.png">

* Check all the other templates that use the `jetpack/layout-grid` Block do not show up in the Template selector (you can [use @marekhrabe's analysus to see which Templates use the Block](https://gist.github.com/marekhrabe/1ca4d5f436040afbced1123444088d7d#file-stats-json-L55))
* Click through all the templates that do show and make sure none are showing the "missing blocks" warnings. 

Fixes https://github.com/Automattic/wp-calypso/issues/39293