### PR TITLE
SPT: Set template title in large preview

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -67,6 +67,26 @@ const copyStylesToIframe = ( srcDocument, targetiFrameDocument ) => {
 };
 
 /**
+ * It tries to set the textarea value of the <PostTitle /> component,
+ * since it isn't possible to do it with the current implementation.
+ * So, in the meanwhile, it uses this DOM manipulation process.
+ *
+ * Here there is a core suggestion to be able to set post title explicitly:
+ * https://github.com/WordPress/gutenberg/pull/20609
+ *
+ * @param   {string}  title Template title.
+ * @param   {object}  body iFrame body DOM reference.
+ * @returns {boolean} True is the textarea value was applied. Otherwise, False.
+ */
+function setTemplateTitle( title, body ) {
+	const templateTitle = body.querySelector( '.editor-post-title .editor-post-title__input' );
+	if ( ! templateTitle ) {
+		return false;
+	}
+	templateTitle.value = title;
+	return true;
+}
+/**
  * Performs a blocks preview using an iFrame.
  *
  * @param {object} props component's props
@@ -128,13 +148,7 @@ const BlockFramePreview = ( {
 		if ( ! iframeBody ) {
 			return;
 		}
-
-		const templateTitle = iframeBody.querySelector(
-			'.editor-post-title .editor-post-title__input'
-		);
-		if ( templateTitle ) {
-			templateTitle.value = title;
-		}
+		setTemplateTitle( title, iframeBody );
 	}, [ recomputeBlockListKey, iframeRef, title ] );
 
 	// Populate iFrame styles.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -67,26 +67,6 @@ const copyStylesToIframe = ( srcDocument, targetiFrameDocument ) => {
 };
 
 /**
- * Temporarily manually set the PostTitle from DOM.
- * It isn't currently possible to manually force the `<PostTitle />` component
- * to render a title provided as a prop. A Core PR will rectify this (see below).
- * Until then we use direct DOM manipulation to set the post title.
- *
- * See: https://github.com/WordPress/gutenberg/pull/20609/
- *
- * @param   {string}  title Template title.
- * @param   {object}  body iFrame body DOM reference.
- * @returns {boolean} True is the textarea value was applied. Otherwise, False.
- */
-function setTemplateTitle( title, body ) {
-	const templateTitle = body.querySelector( '.editor-post-title .editor-post-title__input' );
-	if ( ! templateTitle ) {
-		return false;
-	}
-	templateTitle.value = title;
-	return true;
-}
-/**
  * Performs a blocks preview using an iFrame.
  *
  * @param {object} props component's props
@@ -149,15 +129,15 @@ const BlockFramePreview = ( {
 			return;
 		}
 
-		/*
-		 * Set the template title.
-		 * The setTimeout() hack is needed for the first-rendering cycle,
-		 * since there is a race condition.
-		 * The next one's the title is updated without the delay.
-		 */
-		if ( ! setTemplateTitle( title, iframeBody ) ) {
-			setTimeout( () => setTemplateTitle( title, iframeBody ), 0 );
+		const templateTitle = iframeBody.querySelector(
+			'.editor-post-title .editor-post-title__input'
+		);
+
+		if ( ! templateTitle ) {
+			return;
 		}
+
+		templateTitle.value = title;
 	}, [ recomputeBlockListKey ] );
 
 	// Populate iFrame styles.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -206,13 +206,11 @@ const BlockFramePreview = ( {
 				<div className="edit-post-visual-editor">
 					<div className="editor-styles-wrapper">
 						<div className="editor-writing-flow">
-							{ blocks && blocks.length ? (
-								<CustomBlockPreview
-									blocks={ renderedBlocks }
-									settings={ settings }
-									recomputeBlockListKey={ recomputeBlockListKey }
-								/>
-							) : null }
+							<CustomBlockPreview
+								blocks={ renderedBlocks }
+								settings={ settings }
+								recomputeBlockListKey={ recomputeBlockListKey }
+							/>
 						</div>
 					</div>
 				</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -153,7 +153,7 @@ const BlockFramePreview = ( {
 		 * Set the template title.
 		 * The setTimeout() hack is needed for the first-rendering cycle,
 		 * since there is a race condition.
-		 * The next ones the title is updated without the delay.
+		 * The next one's the title is updated without the delay.
 		 */
 		if ( ! setTemplateTitle( title, iframeBody ) ) {
 			setTimeout( () => setTemplateTitle( title, iframeBody ), 0 );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -148,7 +148,16 @@ const BlockFramePreview = ( {
 		if ( ! iframeBody ) {
 			return;
 		}
-		setTemplateTitle( title, iframeBody );
+
+		/*
+		 * Set the template title.
+		 * The setTimeout() hack is needed for the first-rendering cycle,
+		 * since there is a race condition.
+		 * The next ones the title is updated without the delay.
+		 */
+		if ( ! setTemplateTitle( title, iframeBody ) ) {
+			setTimeout( () => setTemplateTitle( title, iframeBody ), 0 );
+		}
 	}, [ recomputeBlockListKey, iframeRef, title ] );
 
 	// Populate iFrame styles.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -67,12 +67,12 @@ const copyStylesToIframe = ( srcDocument, targetiFrameDocument ) => {
 };
 
 /**
- * It tries to set the textarea value of the <PostTitle /> component,
- * since it isn't possible to do it with the current implementation.
- * So, in the meanwhile, it uses this DOM manipulation process.
+ * Temporarily manually set the PostTitle from DOM.
+ * It isn't currently possible to manually force the `<PostTitle />` component 
+ * to render a title provided as a prop. A Core PR will rectify this (see below).
+ * Until then we use direct DOM manipulation to set the post title.
  *
- * Here there is a core suggestion to be able to set post title explicitly:
- * https://github.com/WordPress/gutenberg/pull/20609
+ * See: https://github.com/WordPress/gutenberg/pull/20609/
  *
  * @param   {string}  title Template title.
  * @param   {object}  body iFrame body DOM reference.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -122,7 +122,14 @@ const BlockFramePreview = ( {
 		} );
 	}, [ viewportWidth ] );
 
-	// Set template title.
+	/*
+	 * Temporarily manually set the PostTitle from DOM.
+	 * It isn't currently possible to manually force the `<PostTitle />` component
+	 * to render a title provided as a prop. A Core PR will rectify this (see below).
+	 * Until then we use direct DOM manipulation to set the post title.
+	 *
+	 * See: https://github.com/WordPress/gutenberg/pull/20609/
+	 */
 	useEffect( () => {
 		const iframeBody = get( iframeRef, [ 'current', 'contentDocument', 'body' ] );
 		if ( ! iframeBody ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -84,6 +84,7 @@ const BlockFramePreview = ( {
 	blocks,
 	settings,
 	setTimeout = noop,
+	title,
 } ) => {
 	const frameContainerRef = useRef();
 	const renderedBlocksRef = useRef();
@@ -120,6 +121,21 @@ const BlockFramePreview = ( {
 			transform: `scale( ${ scale } )`,
 		} );
 	}, [ viewportWidth ] );
+
+	// Set template title.
+	useEffect( () => {
+		const iframeBody = get( iframeRef, [ 'current', 'contentDocument', 'body' ] );
+		if ( ! iframeBody ) {
+			return;
+		}
+
+		const templateTitle = iframeBody.querySelector(
+			'.editor-post-title .editor-post-title__input'
+		);
+		if ( templateTitle ) {
+			templateTitle.value = title;
+		}
+	}, [ recomputeBlockListKey, iframeRef, title ] );
 
 	// Populate iFrame styles.
 	useEffect( () => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -202,7 +202,7 @@ const BlockFramePreview = ( {
 				style={ style }
 			/>
 
-			<div ref={ renderedBlocksRef } className="block-editor" id="rendered-blocks">
+			<div ref={ renderedBlocksRef } className="block-editor">
 				<div className="edit-post-visual-editor">
 					<div className="editor-styles-wrapper">
 						<div className="editor-writing-flow">

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -68,7 +68,7 @@ const copyStylesToIframe = ( srcDocument, targetiFrameDocument ) => {
 
 /**
  * Temporarily manually set the PostTitle from DOM.
- * It isn't currently possible to manually force the `<PostTitle />` component 
+ * It isn't currently possible to manually force the `<PostTitle />` component
  * to render a title provided as a prop. A Core PR will rectify this (see below).
  * Until then we use direct DOM manipulation to set the post title.
  *
@@ -158,7 +158,7 @@ const BlockFramePreview = ( {
 		if ( ! setTemplateTitle( title, iframeBody ) ) {
 			setTimeout( () => setTemplateTitle( title, iframeBody ), 0 );
 		}
-	}, [ recomputeBlockListKey, iframeRef, title ] );
+	}, [ recomputeBlockListKey ] );
 
 	// Populate iFrame styles.
 	useEffect( () => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-preview.js
@@ -23,7 +23,7 @@ export default function( { blocks, settings, recomputeBlockListKey } ) {
 	return (
 		<BlockEditorProvider value={ blocks } settings={ settings }>
 			<Disabled key={ recomputeBlockListKey }>
-				<div className="template-title">
+				<div className="block-iframe-preview__template-title">
 					<PostTitle />
 				</div>
 				<BlockList />

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-preview.js
@@ -11,6 +11,7 @@
  */
 import { BlockEditorProvider, BlockList } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
+import { PostTitle } from '@wordpress/editor';
 
 // Exists as a pass through component to simplify automatted testing of
 // components which need to `BlockEditorProvider`. Setting up JSDom to handle
@@ -21,6 +22,7 @@ export default function( { blocks, settings, recomputeBlockListKey } ) {
 	return (
 		<BlockEditorProvider value={ blocks } settings={ settings }>
 			<Disabled key={ recomputeBlockListKey }>
+				<PostTitle />
 				<BlockList />
 			</Disabled>
 		</BlockEditorProvider>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-preview.js
@@ -19,12 +19,16 @@ import { PostTitle } from '@wordpress/editor';
 // Therefore this component exists to simplify mocking out the Block Editor
 // when under test conditions.
 export default function( { blocks, settings, recomputeBlockListKey } ) {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<BlockEditorProvider value={ blocks } settings={ settings }>
 			<Disabled key={ recomputeBlockListKey }>
-				<PostTitle />
+				<div className="template-title">
+					<PostTitle />
+				</div>
 				<BlockList />
 			</Disabled>
 		</BlockEditorProvider>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  */
 import BlockIframePreview from './block-iframe-preview';
 
-const TemplateSelectorPreview = ( { blocks = [], viewportWidth } ) => {
+const TemplateSelectorPreview = ( { blocks = [], viewportWidth, title } ) => {
 	const noBlocks = ! blocks.length;
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -26,7 +26,7 @@ const TemplateSelectorPreview = ( { blocks = [], viewportWidth } ) => {
 			{ /* Always render preview iframe to ensure it's ready to populate with Blocks. */
 			/* Without this some browsers will experience a noticavle delay
 			/* before Blocks are populated into the iframe. */ }
-			<BlockIframePreview blocks={ blocks } viewportWidth={ viewportWidth } />
+			<BlockIframePreview blocks={ blocks } viewportWidth={ viewportWidth } title={ title } />
 		</div>
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -10,7 +10,7 @@ import { compose } from '@wordpress/compose';
 import { Button, Modal, Spinner, IconButton } from '@wordpress/components';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
-import { parse as parseBlocks, createBlock } from '@wordpress/blocks';
+import { parse as parseBlocks } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -43,21 +43,9 @@ class PageTemplateModal extends Component {
 	getBlocksByTemplateSlugs = memoize( templates =>
 		reduce(
 			templates,
-			( prev, { slug, content, title } ) => {
+			( prev, { slug, content } ) => {
 				prev[ slug ] = content
-					? [
-							/*
-							 * Let's add the page title as a heading block.
-							 * It will be remove when inserting the template
-							 * blocks into the editor.
-							 */
-							createBlock( 'core/heading', {
-								content: title,
-								align: 'center',
-								level: 1,
-							} ),
-							...parseBlocks( replacePlaceholders( content, this.props.siteInformation ) ),
-					  ]
+					? parseBlocks( replacePlaceholders( content, this.props.siteInformation ) )
 					: [];
 				return prev;
 			},
@@ -174,9 +162,6 @@ class PageTemplateModal extends Component {
 
 		// Load content.
 		const blocks = this.getBlocksForSelection( slug );
-
-		// Let's pull the title before to insert blocks in the editor.
-		blocks.shift();
 
 		// Only overwrite the page title if the template is not one of the Homepage Layouts
 		const title = isHomepageTemplate ? null : this.getTitleByTemplateSlug( slug );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -479,10 +479,4 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	.block-iframe-preview__template-title {
 		padding-top: 20px;
 	}
-
-	// Fixes a rendering bug where the margins of the top/bottom blocks weren't contained in the iframe body
-	// For details see issue #39799
-	.block-editor-block-list__layout {
-		overflow: hidden;
-	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -476,7 +476,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	// Tweak template title (post-title) component.
-	.template-title {
+	.block-iframe-preview__template-title {
 		padding-top: 20px;
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -381,7 +381,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .sidebar-modal-opener__warning-options {
 	float: right;
 	margin-top: 20px;
-	
+
 	.components-button {
 		margin-left: 12px;
 	}
@@ -439,14 +439,14 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	// Manual CSS Overrides. Remove after better solutions are in place.
-	
+
 	// Removes empty paragraph placeholders, i.e. "Write Title..."
 	[data-type='core/paragraph'] [data-rich-text-placeholder] {
 		display: none;
 	}
 
 	/*
-	* Fixes jetpack .wp-block-jetpack-slideshow styles, as the /wp-content/plugins/jetpack/_inc/blocks/vendors~swiper.[hash].css 
+	* Fixes jetpack .wp-block-jetpack-slideshow styles, as the /wp-content/plugins/jetpack/_inc/blocks/vendors~swiper.[hash].css
 	* file is loaded on block insert, not on page load. After the iframe is grabbing these styles, we can remove this code.
 	*/
 	.swiper-wrapper {
@@ -473,6 +473,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			margin-top: 0;
 			margin-bottom: 0;
 		}
+	}
+
+	// Tweak template title (post-title) component.
+	.template-title {
+		padding-top: 20px;
 	}
 
 	// Fixes a rendering bug where the margins of the top/bottom blocks weren't contained in the iframe body


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves how the template title is rendered into the preview. Now, it's a core/heading h1 block. What this PR proposes is to use the `<PostTitle />` core editor component.

The only tricky part to deal is that this component gets the title from the post data. This is why we've created this PR in the core. In the meanwhile, however, we can go ahead in setting the template title using DOM manipulation. Once the core PR is ready 🤞, we can update and simplify the current approach.

#### Testing instructions

1) Apply the patch
2) Check how the title is rendered in the large preview box
3) Compare with editor-canvas
4) Test in different themes in order to detect format variations such as alignment, font-size, etc
5) Compare with `master` branch


#### Mayhood

**before**
![image](https://user-images.githubusercontent.com/77539/75811469-3d53b000-5d6b-11ea-858c-86c868c8001f.png)

**after**
![image](https://user-images.githubusercontent.com/77539/75811903-0631ce80-5d6c-11ea-8867-c29cb7178491.png)

<img width="1525" alt="Screen Shot 2020-03-03 at 4 29 27 PM" src="https://user-images.githubusercontent.com/77539/75812053-4bee9700-5d6c-11ea-936f-3d38f1df5220.png">


Fixes https://github.com/Automattic/wp-calypso/issues/39805
