### PR TITLE
Domain step test: Revert to control

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -13,8 +13,6 @@ import { localize } from 'i18n-calypso';
  */
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import InfoPopover from 'components/info-popover';
-import { getTld } from 'lib/domains';
 
 /**
  * Style dependencies
@@ -36,96 +34,10 @@ class DomainProductPrice extends React.Component {
 		isMappingProduct: false,
 	};
 
-	getDomainPricePopoverElement() {
-		const { price, rule, isFeatured, domain, translate } = this.props;
-
-		let popoverText;
-
-		switch ( rule ) {
-			case 'FREE_DOMAIN':
-				if ( getTld( domain ) === 'blog' ) {
-					popoverText = translate(
-						'Every WordPress.com blog comes with a free .blog address. {{a}}Learn more{{/a}}.',
-						{
-							components: {
-								a: (
-									<a
-										href="https://en.support.wordpress.com/domains/#domain-name-overview"
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={ event => {
-											event.stopPropagation();
-										} }
-									/>
-								),
-							},
-						}
-					);
-				} else {
-					popoverText = translate(
-						'Every WordPress.com site comes with a free WordPress.com address. {{a}}Learn more{{/a}}.',
-						{
-							components: {
-								a: (
-									<a
-										href="https://en.support.wordpress.com/domains/#domain-name-overview"
-										target="_blank"
-										rel="noopener noreferrer"
-										onClick={ event => {
-											event.stopPropagation();
-										} }
-									/>
-								),
-							},
-						}
-					);
-				}
-				break;
-
-			case 'INCLUDED_IN_HIGHER_PLAN':
-				popoverText = translate(
-					'The registration fee for this domain is free for the first year with the purchase of any paid plan. ' +
-						'It will renew for %(cost)s / year after that. {{a}}Learn more{{/a}}.',
-					{
-						args: { cost: price },
-						components: {
-							a: (
-								<a
-									href="https://en.support.wordpress.com/domains/domain-pricing-and-available-tlds/"
-									target="_blank"
-									rel="noopener noreferrer"
-									onClick={ event => {
-										event.stopPropagation();
-									} }
-								/>
-							),
-						},
-					}
-				);
-				break;
-		}
-
-		if ( ! popoverText ) {
-			return;
-		}
-
-		return (
-			! isFeatured && (
-				<InfoPopover
-					iconSize={ 22 }
-					position={ 'left' }
-					className="domain-product-price__free-text-tooltip"
-				>
-					{ popoverText }
-				</InfoPopover>
-			)
-		);
-	}
-
 	renderFreeWithPlanText() {
-		const { isMappingProduct, showDesignUpdate, translate } = this.props;
+		const { isMappingProduct, translate } = this.props;
 
-		let message, popoverElement;
+		let message;
 		switch ( this.props.rule ) {
 			case 'FREE_WITH_PLAN':
 				message = translate( 'First year free with your plan' );
@@ -134,7 +46,7 @@ class DomainProductPrice extends React.Component {
 				}
 				break;
 			case 'INCLUDED_IN_HIGHER_PLAN':
-				if ( this.props.showTestCopy ) {
+				if ( this.props.isEligibleVariantForDomainTest ) {
 					message = translate( 'Registration fee: {{del}}%(cost)s{{/del}} {{span}}Free{{/span}}', {
 						args: { cost: this.props.price },
 						components: {
@@ -142,15 +54,6 @@ class DomainProductPrice extends React.Component {
 							span: <span className="domain-product-price__free-price" />,
 						},
 					} );
-				} else if ( this.props.showDesignUpdate ) {
-					message = translate( '{{del}}%(cost)s{{/del}} {{span}}Free with a paid plan{{/span}}', {
-						args: { cost: this.props.price },
-						components: {
-							del: <del />,
-							span: <span className="domain-product-price__free-price" />,
-						},
-					} );
-					popoverElement = this.getDomainPricePopoverElement();
 				} else {
 					message = translate( 'First year included in paid plans' );
 				}
@@ -164,16 +67,7 @@ class DomainProductPrice extends React.Component {
 				break;
 		}
 
-		const className = classnames( 'domain-product-price__free-text', {
-			'domain-product-price__free-text-domain-step-design-updates': showDesignUpdate,
-		} );
-
-		return (
-			<div className={ className }>
-				{ message }
-				{ popoverElement }
-			</div>
-		);
+		return <div className="domain-product-price__free-text">{ message }</div>;
 	}
 
 	renderFreeWithPlanPrice() {
@@ -181,43 +75,21 @@ class DomainProductPrice extends React.Component {
 			return;
 		}
 
-		let priceText;
-		if ( this.props.showTestCopy ) {
-			priceText = this.props.translate( 'Renews at %(cost)s / year', {
-				args: { cost: this.props.price },
-			} );
-		} else if ( this.props.showDesignUpdate ) {
-			if ( this.props.isFeatured ) {
-				priceText = this.props.translate( 'Renews at %(cost)s / year. {{a}}Learn more{{/a}}.', {
+		const priceText = this.props.isEligibleVariantForDomainTest
+			? this.props.translate( 'Renews at %(cost)s / year', {
 					args: { cost: this.props.price },
-					components: {
-						a: (
-							<a
-								href="https://en.support.wordpress.com/domains/domain-pricing-and-available-tlds/"
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ event => {
-									event.stopPropagation();
-								} }
-							/>
-						),
-					},
-				} );
-			}
-		} else {
-			priceText = this.props.translate( 'Renewal: %(cost)s {{small}}/year{{/small}}', {
-				args: { cost: this.props.price },
-				components: { small: <small /> },
-			} );
-		}
+			  } )
+			: this.props.translate( 'Renewal: %(cost)s {{small}}/year{{/small}}', {
+					args: { cost: this.props.price },
+					components: { small: <small /> },
+			  } );
 
-		return priceText && <div className="domain-product-price__price">{ priceText }</div>;
+		return <div className="domain-product-price__price">{ priceText }</div>;
 	}
 
 	renderFreeWithPlan() {
 		const className = classnames( 'domain-product-price', 'is-free-domain', {
-			'domain-product-price__domain-step-copy-updates': this.props.showTestCopy,
-			'domain-product-price__domain-step-design-updates': this.props.showDesignUpdate,
+			'domain-product-price__domain-step-copy-updates': this.props.isEligibleVariantForDomainTest,
 		} );
 
 		return (
@@ -229,23 +101,20 @@ class DomainProductPrice extends React.Component {
 	}
 
 	renderFree() {
-		const { isEligibleVariantForDomainTest, showDesignUpdate, translate } = this.props;
+		const { isEligibleVariantForDomainTest, translate } = this.props;
 
 		const className = classnames( 'domain-product-price', {
 			'domain-product-price__domain-step-copy-updates': isEligibleVariantForDomainTest,
-			'domain-product-price__domain-step-design-updates': showDesignUpdate,
 		} );
 
 		const productPriceClassName = classnames( 'domain-product-price__price', {
 			'domain-product-price__free-price': isEligibleVariantForDomainTest,
-			'domain-product-price__free-price-domain-step-design-updates': showDesignUpdate,
 		} );
 
 		return (
 			<div className={ className }>
 				<div className={ productPriceClassName }>
 					<span>{ translate( 'Free' ) }</span>
-					{ showDesignUpdate && this.getDomainPricePopoverElement() }
 				</div>
 			</div>
 		);

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -29,11 +29,6 @@
 				padding-left: 0;
 				padding-right: 0;
 			}
-
-			&.domain-product-price__domain-step-design-updates {
-				padding-left: 0;
-				padding-right: 1em;
-			}
 		}
 	}
 
@@ -62,22 +57,6 @@
 	.domain-product-price__sale-price {
 		color: var( --color-neutral-60 );
 		display: block;
-
-		&.domain-product-price__free-text-domain-step-design-updates {
-			display: flex;
-			align-items: center;
-			height: 100%;
-			color: var( --color-neutral-30 );
-
-			& del,
-			& span {
-				margin-right: 0.3em;
-			}
-
-			@include breakpoint( '<480px' ) {
-				margin-top: 5px;
-			}
-		}
 	}
 
 	&.no-price .domain-product-price__free-text,
@@ -97,19 +76,6 @@
 
 	.domain-product-price__free-price {
 		color: var( --color-success );
-
-		&.domain-product-price__free-price-domain-step-design-updates {
-			display: flex;
-			align-items: center;
-
-			& span {
-				margin-right: 0.3em;
-			}
-
-			@include breakpoint( '<480px' ) {
-				margin-top: 5px;
-			}
-		}
 	}
 
 	.domain-product-price__price,
@@ -126,10 +92,6 @@
 		.domain-product-price__renewal-price {
 			font-size: 80%;
 			color: var( --color-text-subtle );
-		}
-
-		&.domain-product-price__domain-step-design-updates .domain-product-price__price {
-			color: var( --color-neutral-60 );
 		}
 
 		@include breakpoint( '>660px' ) {

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -20,15 +20,10 @@
 		}
 	}
 
-	.is-section-signup & {
+	.is-section-signup &:not( .domain-product-price__domain-step-copy-updates ) {
 		@include breakpoint( '>660px' ) {
 			padding-left: 1em;
 			padding-right: 2em;
-
-			&.domain-product-price__domain-step-copy-updates {
-				padding-left: 0;
-				padding-right: 0;
-			}
 		}
 	}
 
@@ -63,14 +58,6 @@
 	&.no-price .domain-product-price__sale-price {
 		@include breakpoint( '>660px' ) {
 			margin-left: 0;
-		}
-	}
-
-	.domain-product-price__free-text-tooltip {
-		display: flex;
-
-		body.is-section-signup .layout & {
-			padding: 0;
 		}
 	}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -30,7 +30,6 @@ import { getDomainPrice, getDomainSalePrice, getTld, isHstsRequired } from 'lib/
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getProductsList } from 'state/products-list/selectors';
 import Badge from 'components/badge';
-import PlanPill from 'components/plans/plan-pill';
 import InfoPopover from 'components/info-popover';
 import { HTTPS_SSL } from 'lib/url/support';
 
@@ -196,9 +195,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		const infoPopoverSize = isFeatured ? 22 : 18;
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain-copy-test':
-				this.props.showTestCopy && ! this.props.isFeatured,
-			'domain-registration-suggestion__title-domain-design-updates':
-				this.props.showDesignUpdate && ! this.props.isFeatured,
+				this.props.isEligibleVariantForDomainTest && ! this.props.isFeatured,
 		} );
 
 		return (
@@ -210,7 +207,6 @@ class DomainRegistrationSuggestion extends React.Component {
 						className="domain-registration-suggestion__hsts-tooltip"
 						iconSize={ infoPopoverSize }
 						position={ 'right' }
-						{ ...( this.props.showDesignUpdate ? { icon: 'help-outline' } : {} ) }
 					>
 						{ translate(
 							'All domains ending in {{strong}}%(tld)s{{/strong}} require an SSL certificate ' +
@@ -273,7 +269,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		}
 
 		if ( title ) {
-			if ( this.props.showTestCopy ) {
+			if ( this.props.isEligibleVariantForDomainTest ) {
 				const badgeClassName = classNames( '', {
 					success: isRecommended,
 					'info-blue': isBestAlternative,
@@ -282,23 +278,6 @@ class DomainRegistrationSuggestion extends React.Component {
 				return (
 					<div className="domain-registration-suggestion__progress-bar">
 						<Badge type={ badgeClassName }>{ title }</Badge>
-					</div>
-				);
-			}
-
-			if ( this.props.showDesignUpdate ) {
-				const pillClassNames = classNames(
-					'domain-registration-suggestion__progress-bar',
-					'domain-registration-suggestion__progress-bar-design-update-test',
-					{
-						'pill-success': isRecommended,
-						'pill-primary': isBestAlternative,
-					}
-				);
-
-				return (
-					<div className={ pillClassNames }>
-						<PlanPill>{ title }</PlanPill>
 					</div>
 				);
 			}
@@ -366,8 +345,6 @@ class DomainRegistrationSuggestion extends React.Component {
 				domainsWithPlansOnly={ domainsWithPlansOnly }
 				onButtonClick={ this.onButtonClick }
 				{ ...this.getButtonProps() }
-				showTestCopy={ this.props.showTestCopy }
-				showDesignUpdate={ this.props.showDesignUpdate }
 				isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 				isFeatured={ isFeatured }
 			>

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -257,7 +257,6 @@ class DomainSearchResults extends React.Component {
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }
 					showTestCopy={ this.props.showTestCopy }
-					showDesignUpdate={ this.props.showDesignUpdate }
 					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 				/>
 			);
@@ -284,7 +283,6 @@ class DomainSearchResults extends React.Component {
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }
 						showTestCopy={ this.props.showTestCopy }
-						showDesignUpdate={ this.props.showDesignUpdate }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				);
@@ -295,7 +293,6 @@ class DomainSearchResults extends React.Component {
 					<DomainTransferSuggestion
 						onButtonClick={ this.props.onClickUseYourDomain }
 						tracksButtonClickSource="search-suggestions-bottom"
-						showDesignUpdate={ this.props.showDesignUpdate }
 					/>
 				);
 			}

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -256,7 +256,6 @@ class DomainSearchResults extends React.Component {
 					selectedSite={ this.props.selectedSite }
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }
-					showTestCopy={ this.props.showTestCopy }
 					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 				/>
 			);
@@ -282,7 +281,6 @@ class DomainSearchResults extends React.Component {
 						onButtonClick={ this.props.onClickResult }
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }
-						showTestCopy={ this.props.showTestCopy }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				);

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -45,8 +45,6 @@ class DomainSuggestion extends React.Component {
 			price,
 			priceRule,
 			salePrice,
-			showTestCopy,
-			showDesignUpdate,
 			isEligibleVariantForDomainTest,
 			isFeatured,
 		} = this.props;
@@ -62,7 +60,7 @@ class DomainSuggestion extends React.Component {
 		);
 
 		const contentClassName = classNames( 'domain-suggestion__content', {
-			'domain-suggestion__content-domain-copy-test': showTestCopy && ! isFeatured,
+			'domain-suggestion__content-domain-copy-test': isEligibleVariantForDomainTest && ! isFeatured,
 		} );
 
 		/* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -83,8 +81,6 @@ class DomainSuggestion extends React.Component {
 							salePrice={ salePrice }
 							rule={ priceRule }
 							isFeatured={ isFeatured }
-							showTestCopy={ showTestCopy }
-							showDesignUpdate={ showDesignUpdate }
 							isEligibleVariantForDomainTest={ isEligibleVariantForDomainTest }
 							domain={ this.props.domain }
 						/>

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -80,9 +80,7 @@ class DomainSuggestion extends React.Component {
 							price={ price }
 							salePrice={ salePrice }
 							rule={ priceRule }
-							isFeatured={ isFeatured }
 							isEligibleVariantForDomainTest={ isEligibleVariantForDomainTest }
-							domain={ this.props.domain }
 						/>
 					) }
 				</div>

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -135,8 +135,7 @@
 	flex-direction: row;
 	flex-wrap: wrap;
 
-	&.domain-registration-suggestion__title-domain-copy-test,
-	&.domain-registration-suggestion__title-domain-design-updates {
+	&.domain-registration-suggestion__title-domain-copy-test {
 		@include breakpoint( '>480px' ) {
 			max-width: 50%;
 			min-width: 50%;
@@ -150,22 +149,10 @@
 		}
 	}
 
-	&.domain-registration-suggestion__title-domain-design-updates {
-		font-size: 18px;
-		font-weight: 600;
-		line-height: 18px;
-	}
-
 	.domain-registration-suggestion__title {
 		width: auto;
 		max-width: 100%;
 		padding-right: 0.2em;
-	}
-
-	&.domain-registration-suggestion__title-domain-design-updates .domain-registration-suggestion__title {
-		font-size: 18px;
-		font-weight: 600;
-		line-height: 18px;
 	}
 
 	.badge {

--- a/client/components/domains/domain-transfer-suggestion/index.jsx
+++ b/client/components/domains/domain-transfer-suggestion/index.jsx
@@ -21,10 +21,6 @@ class DomainTransferSuggestion extends React.Component {
 	};
 
 	render() {
-		if ( this.props.showDesignUpdate ) {
-			return null;
-		}
-
 		const { translate } = this.props;
 		const buttonContent = translate( 'Use a domain I own', {
 			context: 'Domain transfer or mapping suggestion button',

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -121,8 +121,6 @@ export class FeaturedDomainSuggestions extends Component {
 						fetchAlgo={ this.getFetchAlgorithm( primarySuggestion ) }
 						buttonStyles={ { primary: true } }
 						{ ...childProps }
-						showTestCopy={ this.props.showTestCopy }
-						showDesignUpdate={ this.props.showDesignUpdate }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				) }
@@ -135,8 +133,6 @@ export class FeaturedDomainSuggestions extends Component {
 						uiPosition={ 1 }
 						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }
 						{ ...childProps }
-						showTestCopy={ this.props.showTestCopy }
-						showDesignUpdate={ this.props.showDesignUpdate }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				) }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -86,7 +86,6 @@ export class FeaturedDomainSuggestions extends Component {
 		return classNames( 'featured-domain-suggestions', this.getTextSizeClass(), {
 			'featured-domain-suggestions__is-domain-management': ! this.props.isSignupStep,
 			'featured-domain-suggestions--has-match-reasons': this.hasMatchReasons(),
-			'featured-domain-suggestions__domain-step-design-updates': this.props.showDesignUpdate,
 		} );
 	}
 

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -17,12 +17,6 @@
 	.is-section-signup & {
 		@include breakpoint( '>480px' ) {
 			flex-direction: row;
-
-			&.featured-domain-suggestions__domain-step-design-updates .domain-registration-suggestion__title {
-					font-size: 22px;
-					font-weight: 600;
-					line-height: 18px;
-			}
 		}
 	}
 
@@ -117,25 +111,6 @@
 		.progress-bar {
 			width: 25%;
 			margin-right: 1em;
-		}
-
-		&.domain-registration-suggestion__progress-bar-design-update-test {
-			order: 0;
-			margin: 0.7em 0 1em;
-
-			@include breakpoint( '<480px' ) {
-				margin: 0 0 0.5em;
-			}
-			
-			&.pill-success .plan-pill {
-				position: inherit;
-				background-color: var( --color-success );
-			}
-
-			&.pill-primary .plan-pill {
-				position: inherit;
-				background-color: var( --color-primary );
-			}
 		}
 	}
 

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -22,16 +21,12 @@ class FreeDomainExplainer extends React.Component {
 		this.props.onSkip( undefined, hideFreePlan );
 	};
 	render() {
-		const { showDesignUpdate, translate } = this.props;
-
-		const titleClassnames = classNames( 'free-domain-explainer__title', {
-			'free-domain-explainer__title-domain-design-updates': showDesignUpdate,
-		} );
+		const { translate } = this.props;
 
 		return (
 			<div className="free-domain-explainer card is-compact">
 				<header>
-					<h1 className={ titleClassnames }>
+					<h1 className="free-domain-explainer__title">
 						{ translate( 'Get a free one-year domain registration with any paid plan.' ) }
 					</h1>
 					<p className="free-domain-explainer__subtitle">

--- a/client/components/domains/free-domain-explainer/style.scss
+++ b/client/components/domains/free-domain-explainer/style.scss
@@ -6,12 +6,6 @@
     line-height: 1.3;
     margin: 0;
     margin-bottom: 0.7em;
-
-    &.free-domain-explainer__title-domain-design-updates {
-        font-size: 18px;
-        line-height: 18px;
-        font-weight: 600;
-    }
 }
 
 .free-domain-explainer__subtitle {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -141,7 +141,7 @@ class RegisterDomainStep extends React.Component {
 		includeWordPressDotCom: PropTypes.bool,
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
-		isEligibleVariantForDomainTest: PropTypes.func,
+		isEligibleVariantForDomainTest: PropTypes.bool,
 		onSave: PropTypes.func,
 		onAddMapping: PropTypes.func,
 		onAddDomain: PropTypes.func,

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -141,7 +141,7 @@ class RegisterDomainStep extends React.Component {
 		includeWordPressDotCom: PropTypes.bool,
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
-		showTestCopy: PropTypes.bool,
+		isEligibleVariantForDomainTest: PropTypes.func,
 		onSave: PropTypes.func,
 		onAddMapping: PropTypes.func,
 		onAddDomain: PropTypes.func,
@@ -1095,7 +1095,6 @@ class RegisterDomainStep extends React.Component {
 						onButtonClick={ this.onAddDomain }
 						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 						unavailableDomains={ this.state.unavailableDomains }
-						showTestCopy={ this.props.showTestCopy }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				);
@@ -1250,7 +1249,6 @@ class RegisterDomainStep extends React.Component {
 				cart={ this.props.cart }
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 				unavailableDomains={ this.state.unavailableDomains }
-				showTestCopy={ this.props.showTestCopy }
 				isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 			>
 				{ this.props.isEligibleVariantForDomainTest &&

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1191,12 +1191,7 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderFreeDomainExplainer() {
-		return (
-			<FreeDomainExplainer
-				onSkip={ this.props.hideFreePlan }
-				showDesignUpdate={ this.props.showDesignUpdate }
-			/>
-		);
+		return <FreeDomainExplainer onSkip={ this.props.hideFreePlan } />;
 	}
 
 	onAddDomain = suggestion => {

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -142,7 +142,6 @@ class RegisterDomainStep extends React.Component {
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
 		showTestCopy: PropTypes.bool,
-		showDesignUpdate: PropTypes.bool,
 		onSave: PropTypes.func,
 		onAddMapping: PropTypes.func,
 		onAddDomain: PropTypes.func,
@@ -428,7 +427,6 @@ class RegisterDomainStep extends React.Component {
 
 		const searchBoxClassName = classNames( 'register-domain-step__search', {
 			'register-domain-step__search-domain-step-test': this.props.isEligibleVariantForDomainTest,
-			'register-domain-step__search-domain-step-design-updates': this.props.showDesignUpdate,
 		} );
 		return (
 			<div className="register-domain-step">
@@ -474,7 +472,6 @@ class RegisterDomainStep extends React.Component {
 				{ this.renderContent() }
 				{ this.renderFilterResetNotice() }
 				{ this.renderPaginationControls() }
-				{ this.props.showDesignUpdate && this.renderUseYourDomain() }
 				{ queryObject && <QueryDomainsSuggestions { ...queryObject } /> }
 				<QueryContactDetailsCache />
 			</div>
@@ -499,54 +496,9 @@ class RegisterDomainStep extends React.Component {
 					onChange={ this.onFiltersChange }
 					onReset={ this.onFiltersReset }
 					onSubmit={ this.onFiltersSubmit }
-					showDesignUpdate={ this.props.showDesignUpdate }
 				/>
 			)
 		);
-	}
-
-	renderUseYourDomain() {
-		const { translate } = this.props;
-
-		const { searchResults, lastDomainStatus } = this.state;
-
-		if ( searchResults === null ) {
-			return null;
-		}
-
-		const useYourDomainFunction =
-			domainAvailability.MAPPED === lastDomainStatus
-				? this.goToTransferDomainStep
-				: this.goToUseYourDomainStep;
-
-		/* eslint-disable jsx-a11y/click-events-have-key-events */
-		/* eslint-disable jsx-a11y/interactive-supports-focus */
-		return (
-			<div className="register-domain-step__use-your-domain">
-				<h3>
-					{ translate( 'Already own a domain?', {
-						context: 'Upgrades: Register domain header',
-						comment: 'Asks if you already own a domain name.',
-					} ) }{ ' ' }
-					{ translate( "You can use it as your site's address.", {
-						context: 'Upgrades: Register domain description',
-						comment: 'Explains how you could use an existing domain name with your site.',
-					} ) }
-				</h3>
-				<Button
-					borderless
-					className="register-domain-step__use-your-domain-action is-clickable"
-					onClick={ useYourDomainFunction }
-					data-tracks-button-click-source="initial-suggestions-bottom"
-				>
-					{ translate( 'Use a domain I own', {
-						context: 'Domain transfer or mapping suggestion button',
-					} ) }
-				</Button>
-			</div>
-		);
-		/* eslint-enable jsx-a11y/click-events-have-key-events */
-		/* eslint-enable jsx-a11y/interactive-supports-focus */
 	}
 
 	rejectTrademarkClaim = () => {
@@ -1144,7 +1096,6 @@ class RegisterDomainStep extends React.Component {
 						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 						unavailableDomains={ this.state.unavailableDomains }
 						showTestCopy={ this.props.showTestCopy }
-						showDesignUpdate={ this.props.showDesignUpdate }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 					/>
 				);
@@ -1300,7 +1251,6 @@ class RegisterDomainStep extends React.Component {
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 				unavailableDomains={ this.state.unavailableDomains }
 				showTestCopy={ this.props.showTestCopy }
-				showDesignUpdate={ this.props.showDesignUpdate }
 				isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
 			>
 				{ this.props.isEligibleVariantForDomainTest &&
@@ -1317,7 +1267,6 @@ class RegisterDomainStep extends React.Component {
 						onReset={ this.onFiltersReset }
 						onSubmit={ this.onFiltersSubmit }
 						showPlaceholder={ this.state.loadingResults || ! this.getSuggestionsFromProps() }
-						showDesignUpdate={ this.props.showDesignUpdate }
 					/>
 				) }
 			</DomainSearchResults>

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -96,25 +96,3 @@
 		background: var( --color-neutral-0 );
 	}
 }
-
-.register-domain-step__use-your-domain {
-	padding: 16px 24px;
-	text-align: center;
-	color: var( --color-text-inverted );
-
-	.register-domain-step__use-your-domain-action {
-		color: var( --color-text-inverted );
-
-		&.is-clickable {
-			cursor: pointer;
-			text-decoration: underline;
-	
-			// NOTE: easeOutExpo easing function from http://easings.net/#easeOutExpo
-			transition: box-shadow 0.25s cubic-bezier( 0.19, 1, 0.22, 1 );
-	
-			&:hover {
-				color: var( --color-text-inverted );
-			}
-		}
-	}
-}

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -30,12 +30,6 @@
 		}
 	}
 
-	&.register-domain-step__search-domain-step-design-updates .search .search__input:not( :placeholder-shown ) {
-		font-size: 16px;
-		font-weight: 600;
-		line-height: 18px;
-	}
-
 	&.disabled {
 		border-bottom: none; // so that bottom border is not there during google app dialog animation
 		opacity: 0.7;

--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -137,10 +137,6 @@ export class DropdownFilters extends Component {
 	}
 
 	renderFilterIcon() {
-		if ( this.props.showDesignUpdate ) {
-			return <Gridicon icon="filter" size={ 12 } />;
-		}
-
 		return (
 			<>
 				<Gridicon icon="cog" size={ 12 } />

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -91,8 +91,7 @@
 
 
 
-.search-filters__buttons,
-.search-filters__checkboxes {
+.search-filters__buttons {
 	display: flex;
 	flex-flow: row;
 	overflow: hidden;
@@ -121,51 +120,6 @@
 			padding-top: 0.5em;
 			padding-bottom: 0.5em;
 		}
-
-		button.search-filters__popover-button-domain-step-test {
-			flex: 1 0 auto;
-			margin-left: 2em;
-			
-			&.is-active {
-				color: var( --color-accent );
-				background-color: unset;
-				border-width: 1px 1px 2px;
-			}
-		}
-
-		legend.search-filters__filter-by {
-			font-size: 14px;
-			color: var( --color-neutral-30 );
-		}
-	}
-
-	.search-filters__tld-checkbox-filter-bar {
-		display: flex;
-		flex: 1 0 auto;
-		justify-content: space-around;
-		font-size: 14px;
-
-		@include breakpoint( '<480px' ) {
-			flex-grow: 0;
-		}
-
-		.search-filters__tld-checkbox {
-			display: flex;
-			align-items: center;
-			margin-left: 2em;
-
-			&:last-child {
-				margin-right: 0;
-			}
-
-			& .form-checkbox {
-				font-size: 14px;
-			}
-
-			& span {
-				margin-left: 1em;
-			}
-		}
 	}
 
 	@include breakpoint( '<960px' ) {
@@ -177,29 +131,25 @@
 			margin-bottom: 0.5em;
 		}
 
-		.search-filters__tld-button:nth-child( n + 7 ),
-		.search-filters__tld-checkbox:nth-child( n + 7 ) {
+		.search-filters__tld-button:nth-child( n + 7 ) {
 			display: none;
 		}
 	}
 
 	@include breakpoint( '<800px' ) {
-		.search-filters__tld-button:nth-child( n + 5 ),
-		.search-filters__tld-checkbox:nth-child( n + 5 ) {
+		.search-filters__tld-button:nth-child( n + 5 ) {
 			display: none;
 		}
 	}
 
 	@include breakpoint( '<660px' ) {
-		.search-filters__tld-button:nth-child( n + 4 ),
-		.search-filters__tld-checkbox:nth-child( n + 3 ) {
+		.search-filters__tld-button:nth-child( n + 4 ) {
 			display: none;
 		}
 	}
 
 	@include breakpoint( '<480px' ) {
-		.search-filters__tld-button:nth-child( n + 2 ),
-		.search-filters__tld-checkbox:nth-child( n + 2 ) {
+		.search-filters__tld-button:nth-child( n + 2 ) {
 			display: none;
 		}
 	}
@@ -211,14 +161,6 @@
 
 .search-filters__text-input-fieldset .search-filters__label {
 	margin-bottom: 0.25em;
-}
-
-.search-filters__checkboxes-fieldset .search-filters__label {
-	margin-bottom: 1em;
-
-	&:last-of-type {
-		margin-bottom: 0;
-	}
 }
 
 .search-filters__token-field-fieldset {

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -95,7 +95,7 @@
 	display: flex;
 	flex-flow: row;
 	overflow: hidden;
-	align-items: center;
+	justify-content: space-between;
 
 	.button {
 		flex: 1 0 auto;

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import Gridicon from 'components/gridicon';
 import React, { Component } from 'react';
-import { difference, includes, isEqual, pick } from 'lodash';
+import { includes, isEqual, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { isWithinBreakpoint } from '@automattic/viewport';
@@ -15,11 +15,9 @@ import { isWithinBreakpoint } from '@automattic/viewport';
  */
 import { Button, CompactCard } from '@automattic/components';
 import FormFieldset from 'components/forms/form-fieldset';
-import FormCheckbox from 'components/forms/form-checkbox';
 import Popover from 'components/popover';
 import TokenField from 'components/token-field';
 import { recordTldFilterSelected } from './analytics';
-import FormLegend from 'components/forms/form-legend';
 
 const HANDLED_FILTER_KEYS = [ 'tlds' ];
 
@@ -98,30 +96,15 @@ export class TldFilterBar extends Component {
 	}
 
 	render() {
-		const { showDesignUpdate, isSignupStep, showPlaceholder, translate } = this.props;
+		const { showPlaceholder } = this.props;
 
 		if ( showPlaceholder ) {
 			return this.renderPlaceholder();
 		}
 
-		const className = classNames( {
-			'search-filters__buttons': ! showDesignUpdate,
-			'search-filters__checkboxes': showDesignUpdate,
-			'search-filters__tld-filter-bar--is-domain-management': ! isSignupStep,
+		const className = classNames( 'search-filters__buttons', {
+			'search-filters__tld-filter-bar--is-domain-management': ! this.props.isSignupStep,
 		} );
-
-		if ( showDesignUpdate ) {
-			return (
-				<CompactCard className={ className }>
-					<FormLegend className="search-filters__filter-by">
-						{ translate( 'Filter by:' ) }
-					</FormLegend>
-					{ this.renderSuggestedCheckboxes() }
-					{ this.renderPopoverButton() }
-					{ this.state.showPopover && this.renderPopover() }
-				</CompactCard>
-			);
-		}
 
 		return (
 			<CompactCard className={ className }>
@@ -130,31 +113,6 @@ export class TldFilterBar extends Component {
 				{ this.state.showPopover && this.renderPopover() }
 			</CompactCard>
 		);
-	}
-
-	renderSuggestedCheckboxes() {
-		const {
-			lastFilters: { tlds: selectedTlds },
-		} = this.props;
-		const checkboxes = this.props.availableTlds
-			.slice( 0, this.props.numberOfTldsShown )
-			.map( ( tld, index ) => (
-				<div className="search-filters__tld-checkbox" key={ tld }>
-					<FormCheckbox
-						className={ classNames( 'search-filters__tld-button', {
-							'is-active': includes( selectedTlds, tld ),
-						} ) }
-						checked={ includes( selectedTlds, tld ) }
-						data-selected={ includes( selectedTlds, tld ) }
-						data-index={ index }
-						onChange={ this.handleButtonClick }
-						value={ tld }
-					/>
-					<span>.{ tld }</span>
-				</div>
-			) );
-
-		return <div className="search-filters__tld-checkbox-filter-bar">{ checkboxes }</div>;
 	}
 
 	renderSuggestedButtons() {
@@ -201,29 +159,12 @@ export class TldFilterBar extends Component {
 	}
 
 	renderPopoverButton() {
-		const {
-			filters: { tlds = [] } = {},
-			lastFilters: { tlds: lastFilterTlds = [] } = {},
-			availableTlds,
-			translate,
-		} = this.props;
-
-		let isActive;
-		if ( this.props.showDesignUpdate ) {
-			const numberOfTldsShownInViewport = this.getNumberOfTldsShownInViewport();
-			const visibleTldsInFilterBar = availableTlds.slice( 0, numberOfTldsShownInViewport );
-			const isSelectedFiltersNotInFilterBar =
-				difference( lastFilterTlds, visibleTldsInFilterBar ).length > 0;
-			isActive = isSelectedFiltersNotInFilterBar;
-		} else {
-			isActive = tlds.length > 0;
-		}
+		const { filters: { tlds = [] } = {}, translate } = this.props;
 
 		return (
 			<Button
 				className={ classNames( 'search-filters__popover-button', {
-					'is-active': isActive,
-					'search-filters__popover-button-domain-step-test': this.props.showDesignUpdate,
+					'is-active': tlds.length > 0,
 				} ) }
 				onClick={ this.togglePopover }
 				ref={ this.bindButton }

--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -8,7 +8,6 @@ import React, { Component } from 'react';
 import { includes, isEqual, pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { isWithinBreakpoint } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -135,27 +134,6 @@ export class TldFilterBar extends Component {
 					.{ tld }
 				</Button>
 			) );
-	}
-
-	getNumberOfTldsShownInViewport() {
-		// The number of TLDs shown for each breakpoint should match the CSS rule.
-		// e.g. .search-filters__tld-checkbox:nth-child( n + 5 ) is defined as display: none for screen size <800px,
-		// so we return 4 for isWithinBreakpoint( '<800px' ).
-		if ( isWithinBreakpoint( '<480px' ) ) {
-			return 1;
-		}
-
-		if ( isWithinBreakpoint( '<660px' ) ) {
-			return 2;
-		}
-
-		if ( isWithinBreakpoint( '<800px' ) ) {
-			return 4;
-		}
-
-		if ( isWithinBreakpoint( '>800px' ) ) {
-			return this.props.numberOfTldsShown;
-		}
 	}
 
 	renderPopoverButton() {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,15 +106,6 @@ export default {
 		defaultVariation: 'variantShowUpdates',
 		allowExistingUsers: true,
 	},
-	domainStepDesignUpdates: {
-		datestamp: '20201220',
-		variations: {
-			variantDesignUpdates: 0,
-			control: 100,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	planStepCopyUpdates: {
 		datestamp: '20200312',
 		variations: {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -466,7 +466,6 @@ class DomainsStep extends React.Component {
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
-				showTestCopy={ this.showTestCopy }
 				isEligibleVariantForDomainTest={ this.isEligibleVariantForDomainTest() }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -122,7 +122,6 @@ class DomainsStep extends React.Component {
 		}
 
 		this.showTestCopy = false;
-		this.showDesignUpdate = false;
 
 		// Do not assign user to the test if either in the launch flow or in /start/{PLAN_SLUG} flow
 		if (
@@ -130,11 +129,7 @@ class DomainsStep extends React.Component {
 			! props.isPlanStepFulfilled &&
 			'variantShowUpdates' === abtest( 'domainStepCopyUpdates' )
 		) {
-			if ( 'variantDesignUpdates' === abtest( 'domainStepDesignUpdates' ) ) {
-				this.showDesignUpdate = true;
-			} else {
-				this.showTestCopy = true;
-			}
+			this.showTestCopy = true;
 		}
 	}
 
@@ -158,7 +153,7 @@ class DomainsStep extends React.Component {
 	}
 
 	isEligibleVariantForDomainTest() {
-		return this.showTestCopy || this.showDesignUpdate;
+		return this.showTestCopy;
 	}
 
 	getMapDomainUrl = () => {
@@ -472,7 +467,6 @@ class DomainsStep extends React.Component {
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
 				showTestCopy={ this.showTestCopy }
-				showDesignUpdate={ this.showDesignUpdate }
 				isEligibleVariantForDomainTest={ this.isEligibleVariantForDomainTest() }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The domain step test introduced in https://github.com/Automattic/wp-calypso/pull/39276 is being reverted since the variant lost to control. This PR removes all the new code introduced as part of the domains step test.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow at /start
* Assign yourself to _control_ and _variantShowUpdates_ of **domainStepCopyUpdates** test. Verify that the UI for the domain step in both cases is unaffected by this PR. The best way to test this is to compare the domain step UI at https://wordpress.com with the UI in this PR.
* Verify everything works and that you can complete signup.
