### PR TITLE
Jetpack Cloud: Daily backup status component

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { withLocalizedMoment } from 'components/localized-moment';
+import Gridicon from 'components/gridicon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class DailyBackupStatus extends Component {
+	renderGoodBackup() {
+		const { backupAttempts, moment, translate } = this.props;
+
+		const displayDate = moment( backupAttempts.complete[ 0 ].activityDate ).format(
+			'MMMM Do YYYY, h:mm:ss a'
+		);
+
+		return (
+			<Fragment>
+				<Gridicon icon="cloud-upload" />
+				<div className="daily-backup-status__label">
+					{ translate( 'Latest backup completed:' ) }
+				</div>
+				<div className="daily-backup-status__date">{ displayDate }</div>
+			</Fragment>
+		);
+	}
+
+	renderFailedBackup() {
+		const { backupAttempts, translate } = this.props;
+
+		const hasBackupError = backupAttempts.error.length;
+		const errorMessage =
+			hasBackupError && backupAttempts.error[ 0 ].activityDescription[ 0 ].children[ 0 ].text;
+
+		return (
+			<Fragment>
+				<Gridicon icon="cross-circle" className="daily-backup-status__gridicon-error-state" />
+
+				<div className="daily-backup-status__date">{ translate( 'Backup error' ) }</div>
+				<div className="daily-backup-status__label">
+					{ hasBackupError ? errorMessage : translate( 'This day has no backups.' ) }
+				</div>
+			</Fragment>
+		);
+	}
+
+	render() {
+		const { backupAttempts } = this.props;
+		const dateHasGoodBackup = backupAttempts.complete.length;
+
+		return (
+			<div className="daily-backup-status">
+				{ dateHasGoodBackup ? this.renderGoodBackup() : this.renderFailedBackup() }
+			</div>
+		);
+	}
+}
+
+export default localize( withLocalizedMoment( DailyBackupStatus ) );

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import { withLocalizedMoment } from 'components/localized-moment';
 import Gridicon from 'components/gridicon';
+import Button from 'components/forms/form-button';
 
 /**
  * Style dependencies
@@ -30,6 +31,8 @@ class DailyBackupStatus extends Component {
 					{ translate( 'Latest backup completed:' ) }
 				</div>
 				<div className="daily-backup-status__date">{ displayDate }</div>
+				<Button className="daily-backup-status__download-button">Download backup</Button>
+				<Button className="daily-backup-status__restore-button">Restore to this point</Button>
 			</Fragment>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -1,0 +1,17 @@
+.daily-backup-status .gridicon {
+	width: 150px !important;
+	height: 150px !important;
+	fill: green !important;
+}
+
+.daily-backup-status .gridicon.daily-backup-status__gridicon-error-state {
+	fill: red !important;
+}
+
+.daily-backup-status__label {
+	color: grey;
+}
+
+.daily-backup-status__date {
+	font-size: 1.5rem;
+}

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -15,3 +15,9 @@
 .daily-backup-status__date {
 	font-size: 1.5rem;
 }
+
+.daily-backup-status .form-button.daily-backup-status__restore-button,
+.daily-backup-status .form-button.daily-backup-status__download-button {
+	float: none;
+	display: block;
+}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -11,6 +11,8 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs } from 'state/data-getters';
 import ActivityList from '../../components/activity-list';
 import DatePicker from '../../components/date-picker';
+import DailyBackupStatus from '../../components/daily-backup-status';
+import { getBackupAttemptsForDate } from './utils';
 
 class BackupsPage extends Component {
 	state = {
@@ -20,14 +22,18 @@ class BackupsPage extends Component {
 	dateChange = currentDateSetting => this.setState( { currentDateSetting } );
 
 	render() {
-		const { siteId } = this.props;
+		const { logs, siteId } = this.props;
 		const initialDate = new Date();
+		const currentDateSetting = this.state.currentDateSetting
+			? this.state.currentDateSetting
+			: new Date().toISOString().split( 'T' )[ 0 ];
+
+		const backupAttempts = getBackupAttemptsForDate( logs, currentDateSetting );
 
 		return (
 			<div>
 				<DatePicker siteId={ siteId } initialDate={ initialDate } onChange={ this.dateChange } />
-
-				<p>Welcome to the backup detail page for site { this.props.siteId }</p>
+				<DailyBackupStatus date={ currentDateSetting } backupAttempts={ backupAttempts } />
 				<ActivityList logs={ this.props.logs } />
 			</div>
 		);
@@ -36,10 +42,10 @@ class BackupsPage extends Component {
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
-	const logs = requestActivityLogs( siteId, { group: 'rewind' } );
+	const logs = siteId && requestActivityLogs( siteId, { group: 'rewind' } );
 
 	return {
 		siteId,
-		logs,
+		logs: logs?.data ?? [],
 	};
 } )( BackupsPage );

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs } from 'state/data-getters';
-import ActivityList from '../../components/activity-list';
 import DatePicker from '../../components/date-picker';
 import DailyBackupStatus from '../../components/daily-backup-status';
 import { getBackupAttemptsForDate } from './utils';
@@ -34,7 +33,6 @@ class BackupsPage extends Component {
 			<div>
 				<DatePicker siteId={ siteId } initialDate={ initialDate } onChange={ this.dateChange } />
 				<DailyBackupStatus date={ currentDateSetting } backupAttempts={ backupAttempts } />
-				<ActivityList logs={ this.props.logs } />
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -1,0 +1,11 @@
+export const getBackupAttemptsForDate = ( logs, date ) => ( {
+	complete: logs.filter(
+		item =>
+			'rewind__backup_complete_full' === item.activityName &&
+			item.activityDate.split( 'T' )[ 0 ] === date
+	),
+	error: logs.filter(
+		item =>
+			'rewind__backup_error' === item.activityName && item.activityDate.split( 'T' )[ 0 ] === date
+	),
+} );

--- a/packages/media-library/types/index.d.ts
+++ b/packages/media-library/types/index.d.ts
@@ -1,2 +1,0 @@
-declare const _default: () => void;
-export default _default;

--- a/packages/media-library/types/index.d.ts
+++ b/packages/media-library/types/index.d.ts
@@ -1,0 +1,2 @@
+declare const _default: () => void;
+export default _default;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the DailyBackupStatus component to Jetpack Cloud components, and utilizes it on the Backup page under the date picker.

PLEASE NOTE: The styles are intentionally left bare, and the restore/download buttons are intentionally left disconnected at this time. We'll fix all that in a subsequent PR.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load up this PR and make sure the component appears for each day that can be selected, and that there are no console errors related to this component
* Ensure that shuttling back and forth with the date picker changes the date for the backup status component, and that dates with missing backups explain what went wrong in the error message.

<img width="495" alt="Screen Shot 2020-03-04 at 1 28 58 PM" src="https://user-images.githubusercontent.com/5528445/75910767-7435ce80-5e1c-11ea-8eb9-bffd976d188d.png">
<img width="385" alt="Screen Shot 2020-03-04 at 1 28 50 PM" src="https://user-images.githubusercontent.com/5528445/75910770-7566fb80-5e1c-11ea-97e9-b74e4fe4360e.png">

