### PR TITLE
Play store badge: load from https instead of http

### DIFF
--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -37,7 +37,7 @@ const APP_STORE_BADGE_URLS = {
 	android: {
 		defaultSrc: '/calypso/images/me/get-apps-google-play.png',
 		src:
-			'http://play.google.com/intl/en_us/badges/images/generic/{localeSlug}_badge_web_generic.png',
+			'https://play.google.com/intl/en_us/badges/images/generic/{localeSlug}_badge_web_generic.png',
 		tracksEvent: 'calypso_app_download_android_click',
 		getLocaleSlug,
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use https instead of http to load app store badge in different locales than English.

Fixes https://github.com/Automattic/wp-calypso/issues/39810

#### Testing instructions

I haven't actually confirmed this fixes it, just seemed obvious when reading the code.

See https://github.com/Automattic/wp-calypso/issues/39810
