### PR TITLE
ContactDetailsFormFields: add optional error message prop

### DIFF
--- a/client/components/domains/contact-details-form-fields/README.md
+++ b/client/components/domains/contact-details-form-fields/README.md
@@ -13,6 +13,7 @@ Its primary purpose for existing is to ensure consistency between the domain che
     <ContactDetailsFormFields
         eventFormName="Edit Contact Info"
         contactDetails={ contactDetailsObject }
+        contactDetailsErrors={ contactDetailsErrorsObject }
         disableSubmitButton={ false }
         getIsFieldDisabled={ customFieldDisabledCheck }
         labelTexts={ labelTextOverridesObjects }
@@ -46,6 +47,28 @@ The form model, consisting of key/value pairs. Keys must be **camelCase**.
     postalCode: '12345',
     countryCode: 'IT',
     fax: '+3398067382',
+},
+
+```
+
+### contactDetailsErrors {object} (optional)
+
+Error messages for each field consisting of key/value pairs. Keys must be **camelCase**.
+
+```js
+{
+    firstName: 'This field is required.',
+    lastName: null,
+    organization: null,
+    email: null,
+    phone: 'This phone number is too short; please include an area code.',
+    address1: null,
+    address2: null,
+    city: null,
+    state: null,
+    postalCode: null,
+    countryCode: 'This country code is invalid.',
+    fax: null,
 },
 
 ```

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/constants.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/constants.js
@@ -1,3 +1,19 @@
+export const CONTACT_DETAILS_FORM_FIELDS = [
+	'firstName',
+	'lastName',
+	'organization',
+	'email',
+	'alternateEmail',
+	'phone',
+	'address1',
+	'address2',
+	'city',
+	'state',
+	'postalCode',
+	'countryCode',
+	'fax',
+];
+
 export const CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES = [ 'GB', 'IE' ];
 
 // We must exclude country codes that return

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -17,13 +17,13 @@ const EuAddressFieldset = props => {
 		<div className="custom-form-fieldsets__address-fields eu-address-fieldset">
 			<Input
 				label={ translate( 'Postal Code' ) }
-				errorMessage={ contactDetailsErrors?.postalCode }
 				{ ...getFieldProps( 'postal-code' ) }
+				errorMessage={ contactDetailsErrors?.postalCode }
 			/>
 			<Input
 				label={ translate( 'City' ) }
-				errorMessage={ contactDetailsErrors?.city }
 				{ ...getFieldProps( 'city' ) }
+				errorMessage={ contactDetailsErrors?.city }
 			/>
 		</div>
 	);

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -12,11 +12,19 @@ import { localize } from 'i18n-calypso';
 import { Input } from 'my-sites/domains/components/form';
 
 const EuAddressFieldset = props => {
-	const { getFieldProps, translate } = props;
+	const { getFieldProps, translate, contactDetailsErrors } = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields eu-address-fieldset">
-			<Input label={ translate( 'Postal Code' ) } { ...getFieldProps( 'postal-code' ) } />
-			<Input label={ translate( 'City' ) } { ...getFieldProps( 'city' ) } />
+			<Input
+				label={ translate( 'Postal Code' ) }
+				errorMessage={ contactDetailsErrors?.postalCode }
+				{ ...getFieldProps( 'postal-code' ) }
+			/>
+			<Input
+				label={ translate( 'City' ) }
+				errorMessage={ contactDetailsErrors?.city }
+				{ ...getFieldProps( 'city' ) }
+			/>
 		</div>
 	);
 };
@@ -24,11 +32,13 @@ const EuAddressFieldset = props => {
 EuAddressFieldset.propTypes = {
 	getFieldProps: PropTypes.func,
 	translate: PropTypes.func,
+	contactDetailsErrors: PropTypes.object,
 };
 
 EuAddressFieldset.defaultProps = {
 	getFieldProps: noop,
 	translate: identity,
+	contactDetailsErrors: {},
 };
 
 export default localize( EuAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -17,13 +17,13 @@ const EuAddressFieldset = props => {
 		<div className="custom-form-fieldsets__address-fields eu-address-fieldset">
 			<Input
 				label={ translate( 'Postal Code' ) }
-				{ ...getFieldProps( 'postal-code' ) }
-				errorMessage={ contactDetailsErrors?.postalCode }
+				{ ...getFieldProps( 'postal-code', {
+					customErrorMessage: contactDetailsErrors?.postalCode,
+				} ) }
 			/>
 			<Input
 				label={ translate( 'City' ) }
-				{ ...getFieldProps( 'city' ) }
-				errorMessage={ contactDetailsErrors?.city }
+				{ ...getFieldProps( 'city', false, { customErrorMessage: contactDetailsErrors?.city } ) }
 			/>
 		</div>
 	);
@@ -38,7 +38,6 @@ EuAddressFieldset.propTypes = {
 EuAddressFieldset.defaultProps = {
 	getFieldProps: noop,
 	translate: identity,
-	contactDetailsErrors: {},
 };
 
 export default localize( EuAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -76,6 +76,7 @@ export class RegionAddressFieldsets extends Component {
 						label={ translate( 'Address' ) }
 						maxLength={ 40 }
 						{ ...getFieldProps( 'address-1' ) }
+						errorMessage={ this.props.contactDetailsErrors?.address1 }
 					/>
 
 					<HiddenInput
@@ -83,6 +84,7 @@ export class RegionAddressFieldsets extends Component {
 						text={ translate( '+ Add Address Line 2' ) }
 						maxLength={ 40 }
 						{ ...getFieldProps( 'address-2', true ) }
+						errorMessage={ this.props.contactDetailsErrors?.address2 }
 					/>
 				</div>
 				{ this.getRegionAddressFieldset() }

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -42,7 +42,6 @@ export class RegionAddressFieldsets extends Component {
 		countryCode: 'US',
 		shouldAutoFocusAddressField: false,
 		hasCountryStates: false,
-		contactDetailsErrors: {},
 	};
 
 	inputRefCallback( input ) {
@@ -75,16 +74,19 @@ export class RegionAddressFieldsets extends Component {
 						ref={ shouldAutoFocusAddressField ? this.inputRefCallback : noop }
 						label={ translate( 'Address' ) }
 						maxLength={ 40 }
-						{ ...getFieldProps( 'address-1' ) }
-						errorMessage={ this.props.contactDetailsErrors?.address1 }
+						{ ...getFieldProps( 'address-1', {
+							customErrorMessage: this.props.contactDetailsErrors?.address1,
+						} ) }
 					/>
 
 					<HiddenInput
 						label={ translate( 'Address Line 2' ) }
 						text={ translate( '+ Add Address Line 2' ) }
 						maxLength={ 40 }
-						{ ...getFieldProps( 'address-2', true ) }
-						errorMessage={ this.props.contactDetailsErrors?.address2 }
+						{ ...getFieldProps( 'address-2', {
+							needsChildRef: true,
+							customErrorMessage: this.props.contactDetailsErrors?.address2,
+						} ) }
 					/>
 				</div>
 				{ this.getRegionAddressFieldset() }

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import {
+	CONTACT_DETAILS_FORM_FIELDS,
 	CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES,
 	CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES,
 } from './constants';
@@ -27,6 +28,12 @@ export class RegionAddressFieldsets extends Component {
 		countryCode: PropTypes.string,
 		shouldAutoFocusAddressField: PropTypes.bool,
 		hasCountryStates: PropTypes.bool,
+		contactDetailsErrors: PropTypes.shape(
+			Object.assign(
+				{},
+				...CONTACT_DETAILS_FORM_FIELDS.map( field => ( { [ field ]: PropTypes.string } ) )
+			)
+		),
 	};
 
 	static defaultProps = {
@@ -35,6 +42,7 @@ export class RegionAddressFieldsets extends Component {
 		countryCode: 'US',
 		shouldAutoFocusAddressField: false,
 		hasCountryStates: false,
+		contactDetailsErrors: {},
 	};
 
 	inputRefCallback( input ) {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -17,13 +17,13 @@ const UkAddressFieldset = props => {
 		<div className="custom-form-fieldsets__address-fields uk-address-fieldset">
 			<Input
 				label={ translate( 'City' ) }
-				{ ...getFieldProps( 'city' ) }
-				errorMessage={ contactDetailsErrors?.city }
+				{ ...getFieldProps( 'city', { customErrorMessage: contactDetailsErrors?.city } ) }
 			/>
 			<Input
 				label={ translate( 'Postal Code' ) }
-				{ ...getFieldProps( 'postal-code' ) }
-				errorMessage={ contactDetailsErrors?.postalCode }
+				{ ...getFieldProps( 'postal-code', {
+					customErrorMessage: contactDetailsErrors?.postalCode,
+				} ) }
 			/>
 		</div>
 	);
@@ -38,6 +38,5 @@ UkAddressFieldset.propTypes = {
 UkAddressFieldset.defaultProps = {
 	getFieldProps: noop,
 	translate: identity,
-	contactDetailsErrors: {},
 };
 export default localize( UkAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -17,13 +17,13 @@ const UkAddressFieldset = props => {
 		<div className="custom-form-fieldsets__address-fields uk-address-fieldset">
 			<Input
 				label={ translate( 'City' ) }
-				errorMessage={ contactDetailsErrors?.city }
 				{ ...getFieldProps( 'city' ) }
+				errorMessage={ contactDetailsErrors?.city }
 			/>
 			<Input
 				label={ translate( 'Postal Code' ) }
-				errorMessage={ contactDetailsErrors?.postalCode }
 				{ ...getFieldProps( 'postal-code' ) }
+				errorMessage={ contactDetailsErrors?.postalCode }
 			/>
 		</div>
 	);

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -12,11 +12,19 @@ import { localize } from 'i18n-calypso';
 import { Input } from 'my-sites/domains/components/form';
 
 const UkAddressFieldset = props => {
-	const { getFieldProps, translate } = props;
+	const { getFieldProps, translate, contactDetailsErrors } = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields uk-address-fieldset">
-			<Input label={ translate( 'City' ) } { ...getFieldProps( 'city' ) } />
-			<Input label={ translate( 'Postal Code' ) } { ...getFieldProps( 'postal-code' ) } />
+			<Input
+				label={ translate( 'City' ) }
+				errorMessage={ contactDetailsErrors?.city }
+				{ ...getFieldProps( 'city' ) }
+			/>
+			<Input
+				label={ translate( 'Postal Code' ) }
+				errorMessage={ contactDetailsErrors?.postalCode }
+				{ ...getFieldProps( 'postal-code' ) }
+			/>
 		</div>
 	);
 };
@@ -24,10 +32,12 @@ const UkAddressFieldset = props => {
 UkAddressFieldset.propTypes = {
 	getFieldProps: PropTypes.func,
 	translate: PropTypes.func,
+	contactDetailsErrors: PropTypes.object,
 };
 
 UkAddressFieldset.defaultProps = {
 	getFieldProps: noop,
 	translate: identity,
+	contactDetailsErrors: {},
 };
 export default localize( UkAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -18,16 +18,21 @@ const UsAddressFieldset = props => {
 		<div className="custom-form-fieldsets__address-fields us-address-fieldset">
 			<Input
 				label={ translate( 'City' ) }
-				errorMessage={ contactDetailsErrors?.city }
 				{ ...getFieldProps( 'city' ) }
+				errorMessage={ contactDetailsErrors?.city }
 			/>
 			<StateSelect
 				label={ getStateLabelText( countryCode ) }
 				countryCode={ countryCode }
 				selectText={ STATE_SELECT_TEXT[ countryCode ] }
 				{ ...getFieldProps( 'state', true ) }
+				errorMessage={ contactDetailsErrors?.state }
 			/>
-			<Input label={ getPostCodeLabelText( countryCode ) } { ...getFieldProps( 'postal-code' ) } />
+			<Input
+				label={ getPostCodeLabelText( countryCode ) }
+				{ ...getFieldProps( 'postal-code' ) }
+				errorMessage={ contactDetailsErrors?.postalCode }
+			/>
 		</div>
 	);
 };

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -18,20 +18,22 @@ const UsAddressFieldset = props => {
 		<div className="custom-form-fieldsets__address-fields us-address-fieldset">
 			<Input
 				label={ translate( 'City' ) }
-				{ ...getFieldProps( 'city' ) }
-				errorMessage={ contactDetailsErrors?.city }
+				{ ...getFieldProps( 'city', { customErrorMessage: contactDetailsErrors?.city } ) }
 			/>
 			<StateSelect
 				label={ getStateLabelText( countryCode ) }
 				countryCode={ countryCode }
 				selectText={ STATE_SELECT_TEXT[ countryCode ] }
-				{ ...getFieldProps( 'state', true ) }
-				errorMessage={ contactDetailsErrors?.state }
+				{ ...getFieldProps( 'state', {
+					needsChildRef: true,
+					customErrorMessage: contactDetailsErrors?.state,
+				} ) }
 			/>
 			<Input
 				label={ getPostCodeLabelText( countryCode ) }
-				{ ...getFieldProps( 'postal-code' ) }
-				errorMessage={ contactDetailsErrors?.postalCode }
+				{ ...getFieldProps( 'postal-code', {
+					customErrorMessage: contactDetailsErrors?.postalCode,
+				} ) }
 			/>
 		</div>
 	);
@@ -48,7 +50,6 @@ UsAddressFieldset.defaultProps = {
 	countryCode: 'US',
 	getFieldProps: noop,
 	translate: identity,
-	contactDetailsErrors: {},
 };
 
 export default localize( UsAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -13,10 +13,14 @@ import { StateSelect, Input } from 'my-sites/domains/components/form';
 import { getStateLabelText, getPostCodeLabelText, STATE_SELECT_TEXT } from './utils.js';
 
 const UsAddressFieldset = props => {
-	const { getFieldProps, translate, countryCode } = props;
+	const { getFieldProps, translate, countryCode, contactDetailsErrors } = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields us-address-fieldset">
-			<Input label={ translate( 'City' ) } { ...getFieldProps( 'city' ) } />
+			<Input
+				label={ translate( 'City' ) }
+				errorMessage={ contactDetailsErrors?.city }
+				{ ...getFieldProps( 'city' ) }
+			/>
 			<StateSelect
 				label={ getStateLabelText( countryCode ) }
 				countryCode={ countryCode }
@@ -32,12 +36,14 @@ UsAddressFieldset.propTypes = {
 	countryCode: PropTypes.string,
 	getFieldProps: PropTypes.func,
 	translate: PropTypes.func,
+	contactDetailsErrors: PropTypes.object,
 };
 
 UsAddressFieldset.defaultProps = {
 	countryCode: 'US',
 	getFieldProps: noop,
 	translate: identity,
+	contactDetailsErrors: {},
 };
 
 export default localize( UsAddressFieldset );

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -41,7 +41,7 @@ import { CALYPSO_CONTACT } from 'lib/url/support';
 import getCountries from 'state/selectors/get-countries';
 import QueryDomainCountries from 'components/data/query-countries/domains';
 import {
-    CONTACT_DETAILS_FORM_FIELDS,
+	CONTACT_DETAILS_FORM_FIELDS,
 	CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES,
 	CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES,
 } from './custom-form-fieldsets/constants';
@@ -61,12 +61,12 @@ export class ContactDetailsFormFields extends Component {
 				...CONTACT_DETAILS_FORM_FIELDS.map( field => ( { [ field ]: PropTypes.string } ) )
 			)
 		).isRequired,
-        contactDetailsErrors: PropTypes.shape(
-            Object.assign(
-                {},
-                ...CONTACT_DETAILS_FORM_FIELDS.map( field => ( { [ field ]: PropTypes.string } ) )
-            )
-        ),
+		contactDetailsErrors: PropTypes.shape(
+			Object.assign(
+				{},
+				...CONTACT_DETAILS_FORM_FIELDS.map( field => ( { [ field ]: PropTypes.string } ) )
+			)
+		),
 		countriesList: PropTypes.array.isRequired,
 		needsFax: PropTypes.bool,
 		getIsFieldDisabled: PropTypes.func,
@@ -90,7 +90,7 @@ export class ContactDetailsFormFields extends Component {
 			{},
 			...CONTACT_DETAILS_FORM_FIELDS.map( field => ( { [ field ]: '' } ) )
 		),
-        contactDetailsErrors: {},
+		contactDetailsErrors: {},
 		needsFax: false,
 		getIsFieldDisabled: noop,
 		onContactDetailsChange: noop,
@@ -385,7 +385,7 @@ export class ContactDetailsFormFields extends Component {
 				<div className="contact-details-form-fields__row">
 					{ this.createField( 'email', Input, {
 						label: translate( 'Email' ),
-                        errorMessage: this.props.contactDetailsErrors?.email,
+						errorMessage: this.props.contactDetailsErrors?.email,
 					} ) }
 
 					{ this.createField(
@@ -397,7 +397,7 @@ export class ContactDetailsFormFields extends Component {
 							countriesList: this.props.countriesList,
 							countryCode: this.state.phoneCountryCode,
 							enableStickyCountry: false,
-                            errorMessage: this.props.contactDetailsErrors?.phone,
+							errorMessage: this.props.contactDetailsErrors?.phone,
 						},
 						true
 					) }
@@ -407,7 +407,7 @@ export class ContactDetailsFormFields extends Component {
 					{ needsFax &&
 						this.createField( 'fax', Input, {
 							label: translate( 'Fax' ),
-                            errorMessage: this.props.contactDetailsErrors?.fax,
+							errorMessage: this.props.contactDetailsErrors?.fax,
 						} ) }
 				</div>
 
@@ -418,7 +418,7 @@ export class ContactDetailsFormFields extends Component {
 						{
 							label: translate( 'Country' ),
 							countriesList: this.props.countriesList,
-                            errorMessage: this.props.contactDetailsErrors?.countryCode,
+							errorMessage: this.props.contactDetailsErrors?.countryCode,
 						},
 						true
 					) }
@@ -430,6 +430,7 @@ export class ContactDetailsFormFields extends Component {
 						countryCode={ countryCode }
 						hasCountryStates={ hasCountryStates }
 						shouldAutoFocusAddressField={ this.shouldAutoFocusAddressField }
+						contactDetailsErrors={ this.props.contactDetailsErrors }
 					/>
 				) }
 			</div>
@@ -443,13 +444,13 @@ export class ContactDetailsFormFields extends Component {
 				<CountrySelect
 					label={ this.props.translate( 'Country' ) }
 					countriesList={ this.props.countriesList }
-                    errorMessage={ this.props.contactDetailsErrors?.countryCode }
+					errorMessage={ this.props.contactDetailsErrors?.countryCode }
 					{ ...this.getFieldProps( 'country-code', true ) }
 				/>
 
 				<Input
 					label={ getPostCodeLabelText( countryCode ) }
-                    errorMessage={ this.props.contactDetailsErrors?.postalCode }
+					errorMessage={ this.props.contactDetailsErrors?.postalCode }
 					{ ...this.getFieldProps( 'postal-code' ) }
 				/>
 			</div>
@@ -461,7 +462,7 @@ export class ContactDetailsFormFields extends Component {
 			<div className="contact-details-form-fields__row">
 				<Input
 					label={ this.props.translate( 'Alternate Email Address' ) }
-                    errorMessage={ this.props.contactDetailsErrors?.alternateEmail }
+					errorMessage={ this.props.contactDetailsErrors?.alternateEmail }
 					{ ...this.getFieldProps( 'alternate-email' ) }
 				/>
 			</div>
@@ -469,7 +470,13 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	render() {
-		const { translate, onCancel, disableSubmitButton, labelTexts, contactDetailsErrors } = this.props;
+		const {
+			translate,
+			onCancel,
+			disableSubmitButton,
+			labelTexts,
+			contactDetailsErrors,
+		} = this.props;
 		const countryCode = this.getCountryCode();
 
 		const isFooterVisible = !! ( this.props.onSubmit || onCancel );
@@ -479,12 +486,12 @@ export class ContactDetailsFormFields extends Component {
 				<div className="contact-details-form-fields__row">
 					{ this.createField( 'first-name', Input, {
 						label: translate( 'First Name' ),
-                        errorMessage: contactDetailsErrors?.firstName,
+						errorMessage: contactDetailsErrors?.firstName,
 					} ) }
 
 					{ this.createField( 'last-name', Input, {
 						label: translate( 'Last Name' ),
-                        errorMessage: contactDetailsErrors?.lastName,
+						errorMessage: contactDetailsErrors?.lastName,
 					} ) }
 				</div>
 				{ this.props.needsAlternateEmailForGSuite && this.renderAlternateEmailFieldForGSuite() }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -355,9 +355,9 @@ export class ContactDetailsFormFields extends Component {
 		};
 	};
 
-	createField = ( name, componentClass, additionalProps, needsChildRef ) => {
+	createField = ( name, componentClass, additionalProps, fieldPropOptions = {} ) => {
 		return createElement( componentClass, {
-			...this.getFieldProps( name, { needsChildRef } ),
+			...this.getFieldProps( name, { ...fieldPropOptions } ),
 			...additionalProps,
 		} );
 	};
@@ -380,15 +380,23 @@ export class ContactDetailsFormFields extends Component {
 							label: translate( 'Organization' ),
 							text: labelTexts.organization || translate( '+ Add organization name' ),
 						},
-						true
+						{
+							needsChildRef: true,
+						}
 					) }
 				</div>
 
 				<div className="contact-details-form-fields__row">
-					{ this.createField( 'email', Input, {
-						label: translate( 'Email' ),
-						errorMessage: this.props.contactDetailsErrors?.email,
-					} ) }
+					{ this.createField(
+						'email',
+						Input,
+						{
+							label: translate( 'Email' ),
+						},
+						{
+							errorMessage: this.props.contactDetailsErrors?.email,
+						}
+					) }
 
 					{ this.createField(
 						'phone',
@@ -399,18 +407,26 @@ export class ContactDetailsFormFields extends Component {
 							countriesList: this.props.countriesList,
 							countryCode: this.state.phoneCountryCode,
 							enableStickyCountry: false,
-							errorMessage: this.props.contactDetailsErrors?.phone,
 						},
-						true
+						{
+							needsChildRef: true,
+							errorMessage: this.props.contactDetailsErrors?.phone,
+						}
 					) }
 				</div>
 
 				<div className="contact-details-form-fields__row">
 					{ needsFax &&
-						this.createField( 'fax', Input, {
-							label: translate( 'Fax' ),
-							errorMessage: this.props.contactDetailsErrors?.fax,
-						} ) }
+						this.createField(
+							'fax',
+							Input,
+							{
+								label: translate( 'Fax' ),
+							},
+							{
+								errorMessage: this.props.contactDetailsErrors?.fax,
+							}
+						) }
 				</div>
 
 				<div className="contact-details-form-fields__row">
@@ -420,9 +436,11 @@ export class ContactDetailsFormFields extends Component {
 						{
 							label: translate( 'Country' ),
 							countriesList: this.props.countriesList,
-							errorMessage: this.props.contactDetailsErrors?.countryCode,
 						},
-						true
+						{
+							errorMessage: this.props.contactDetailsErrors?.countryCode,
+							needsChildRef: true,
+						}
 					) }
 				</div>
 
@@ -490,15 +508,27 @@ export class ContactDetailsFormFields extends Component {
 		return (
 			<FormFieldset className="contact-details-form-fields">
 				<div className="contact-details-form-fields__row">
-					{ this.createField( 'first-name', Input, {
-						label: translate( 'First Name' ),
-						errorMessage: contactDetailsErrors?.firstName,
-					} ) }
+					{ this.createField(
+						'first-name',
+						Input,
+						{
+							label: translate( 'First Name' ),
+						},
+						{
+							errorMessage: contactDetailsErrors?.firstName,
+						}
+					) }
 
-					{ this.createField( 'last-name', Input, {
-						label: translate( 'Last Name' ),
-						errorMessage: contactDetailsErrors?.lastName,
-					} ) }
+					{ this.createField(
+						'last-name',
+						Input,
+						{
+							label: translate( 'Last Name' ),
+						},
+						{
+							errorMessage: contactDetailsErrors?.lastName,
+						}
+					) }
 				</div>
 				{ this.props.needsAlternateEmailForGSuite && this.renderAlternateEmailFieldForGSuite() }
 

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -61,6 +61,12 @@ export class ContactDetailsFormFields extends Component {
 				...CONTACT_DETAILS_FORM_FIELDS.map( field => ( { [ field ]: PropTypes.string } ) )
 			)
 		).isRequired,
+        contactDetailsErrors: PropTypes.shape(
+            Object.assign(
+                {},
+                ...CONTACT_DETAILS_FORM_FIELDS.map( field => ( { [ field ]: PropTypes.string } ) )
+            )
+        ),
 		countriesList: PropTypes.array.isRequired,
 		needsFax: PropTypes.bool,
 		getIsFieldDisabled: PropTypes.func,
@@ -84,6 +90,7 @@ export class ContactDetailsFormFields extends Component {
 			{},
 			...CONTACT_DETAILS_FORM_FIELDS.map( field => ( { [ field ]: '' } ) )
 		),
+        contactDetailsErrors: {},
 		needsFax: false,
 		getIsFieldDisabled: noop,
 		onContactDetailsChange: noop,

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -358,7 +358,7 @@ export class ContactDetailsFormFields extends Component {
 
 	createField = ( name, componentClass, additionalProps, needsChildRef ) => {
 		return createElement( componentClass, {
-			...this.getFieldProps( name, needsChildRef ),
+			...this.getFieldProps( name, { needsChildRef } ),
 			...additionalProps,
 		} );
 	};
@@ -447,14 +447,17 @@ export class ContactDetailsFormFields extends Component {
 				<CountrySelect
 					label={ this.props.translate( 'Country' ) }
 					countriesList={ this.props.countriesList }
-					errorMessage={ this.props.contactDetailsErrors?.countryCode }
-					{ ...this.getFieldProps( 'country-code', true ) }
+					{ ...this.getFieldProps( 'country-code', {
+						customErrorMessage: this.props.contactDetailsErrors?.countryCode,
+						needsChildRef: true,
+					} ) }
 				/>
 
 				<Input
 					label={ getPostCodeLabelText( countryCode ) }
-					errorMessage={ this.props.contactDetailsErrors?.postalCode }
-					{ ...this.getFieldProps( 'postal-code' ) }
+					{ ...this.getFieldProps( 'postal-code', {
+						customErrorMessage: this.props.contactDetailsErrors?.postalCode,
+					} ) }
 				/>
 			</div>
 		);
@@ -465,8 +468,9 @@ export class ContactDetailsFormFields extends Component {
 			<div className="contact-details-form-fields__row">
 				<Input
 					label={ this.props.translate( 'Alternate Email Address' ) }
-					errorMessage={ this.props.contactDetailsErrors?.alternateEmail }
-					{ ...this.getFieldProps( 'alternate-email' ) }
+					{ ...this.getFieldProps( 'alternate-email', {
+						customErrorMessage: this.props.contactDetailsErrors?.alternateEmail,
+					} ) }
 				/>
 			</div>
 		);

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -91,7 +91,6 @@ export class ContactDetailsFormFields extends Component {
 			{},
 			...CONTACT_DETAILS_FORM_FIELDS.map( field => ( { [ field ]: '' } ) )
 		),
-		contactDetailsErrors: {},
 		needsFax: false,
 		getIsFieldDisabled: noop,
 		onContactDetailsChange: noop,

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -82,6 +82,7 @@ export class ContactDetailsFormFields extends Component {
 		needsOnlyGoogleAppsDetails: PropTypes.bool,
 		needsAlternateEmailForGSuite: PropTypes.bool,
 		hasCountryStates: PropTypes.bool,
+		shouldForceRenderOnPropChange: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -105,6 +106,7 @@ export class ContactDetailsFormFields extends Component {
 		hasCountryStates: false,
 		translate: identity,
 		userCountryCode: 'US',
+		shouldForceRenderOnPropChange: false,
 	};
 
 	constructor( props ) {
@@ -125,6 +127,7 @@ export class ContactDetailsFormFields extends Component {
 	// This is an attempt limit the redraws to only what we need.
 	shouldComponentUpdate( nextProps, nextState ) {
 		return (
+			nextProps.shouldForceRenderOnPropChange === true ||
 			( nextProps.isSubmitting === false && this.props.isSubmitting === true ) ||
 			nextState.phoneCountryCode !== this.state.phoneCountryCode ||
 			! isEqual( nextProps.contactDetails, this.props.contactDetails ) ||

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -394,7 +394,7 @@ export class ContactDetailsFormFields extends Component {
 							label: translate( 'Email' ),
 						},
 						{
-							errorMessage: this.props.contactDetailsErrors?.email,
+							customErrorMessage: this.props.contactDetailsErrors?.email,
 						}
 					) }
 
@@ -410,7 +410,7 @@ export class ContactDetailsFormFields extends Component {
 						},
 						{
 							needsChildRef: true,
-							errorMessage: this.props.contactDetailsErrors?.phone,
+							customErrorMessage: this.props.contactDetailsErrors?.phone,
 						}
 					) }
 				</div>
@@ -424,7 +424,7 @@ export class ContactDetailsFormFields extends Component {
 								label: translate( 'Fax' ),
 							},
 							{
-								errorMessage: this.props.contactDetailsErrors?.fax,
+								customErrorMessage: this.props.contactDetailsErrors?.fax,
 							}
 						) }
 				</div>
@@ -438,7 +438,7 @@ export class ContactDetailsFormFields extends Component {
 							countriesList: this.props.countriesList,
 						},
 						{
-							errorMessage: this.props.contactDetailsErrors?.countryCode,
+							customErrorMessage: this.props.contactDetailsErrors?.countryCode,
 							needsChildRef: true,
 						}
 					) }
@@ -515,7 +515,7 @@ export class ContactDetailsFormFields extends Component {
 							label: translate( 'First Name' ),
 						},
 						{
-							errorMessage: contactDetailsErrors?.firstName,
+							customErrorMessage: contactDetailsErrors?.firstName,
 						}
 					) }
 
@@ -526,7 +526,7 @@ export class ContactDetailsFormFields extends Component {
 							label: translate( 'Last Name' ),
 						},
 						{
-							errorMessage: contactDetailsErrors?.lastName,
+							customErrorMessage: contactDetailsErrors?.lastName,
 						}
 					) }
 				</div>

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -41,6 +41,7 @@ import { CALYPSO_CONTACT } from 'lib/url/support';
 import getCountries from 'state/selectors/get-countries';
 import QueryDomainCountries from 'components/data/query-countries/domains';
 import {
+    CONTACT_DETAILS_FORM_FIELDS,
 	CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES,
 	CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES,
 } from './custom-form-fieldsets/constants';
@@ -50,22 +51,6 @@ import { getPostCodeLabelText } from './custom-form-fieldsets/utils';
  * Style dependencies
  */
 import './style.scss';
-
-const CONTACT_DETAILS_FORM_FIELDS = [
-	'firstName',
-	'lastName',
-	'organization',
-	'email',
-	'alternateEmail',
-	'phone',
-	'address1',
-	'address2',
-	'city',
-	'state',
-	'postalCode',
-	'countryCode',
-	'fax',
-];
 
 export class ContactDetailsFormFields extends Component {
 	static propTypes = {

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -385,6 +385,7 @@ export class ContactDetailsFormFields extends Component {
 				<div className="contact-details-form-fields__row">
 					{ this.createField( 'email', Input, {
 						label: translate( 'Email' ),
+                        errorMessage: this.props.contactDetailsErrors?.email,
 					} ) }
 
 					{ this.createField(
@@ -396,6 +397,7 @@ export class ContactDetailsFormFields extends Component {
 							countriesList: this.props.countriesList,
 							countryCode: this.state.phoneCountryCode,
 							enableStickyCountry: false,
+                            errorMessage: this.props.contactDetailsErrors?.phone,
 						},
 						true
 					) }
@@ -405,6 +407,7 @@ export class ContactDetailsFormFields extends Component {
 					{ needsFax &&
 						this.createField( 'fax', Input, {
 							label: translate( 'Fax' ),
+                            errorMessage: this.props.contactDetailsErrors?.fax,
 						} ) }
 				</div>
 
@@ -415,6 +418,7 @@ export class ContactDetailsFormFields extends Component {
 						{
 							label: translate( 'Country' ),
 							countriesList: this.props.countriesList,
+                            errorMessage: this.props.contactDetailsErrors?.countryCode,
 						},
 						true
 					) }
@@ -439,11 +443,13 @@ export class ContactDetailsFormFields extends Component {
 				<CountrySelect
 					label={ this.props.translate( 'Country' ) }
 					countriesList={ this.props.countriesList }
+                    errorMessage={ this.props.contactDetailsErrors?.countryCode }
 					{ ...this.getFieldProps( 'country-code', true ) }
 				/>
 
 				<Input
 					label={ getPostCodeLabelText( countryCode ) }
+                    errorMessage={ this.props.contactDetailsErrors?.postalCode }
 					{ ...this.getFieldProps( 'postal-code' ) }
 				/>
 			</div>
@@ -455,6 +461,7 @@ export class ContactDetailsFormFields extends Component {
 			<div className="contact-details-form-fields__row">
 				<Input
 					label={ this.props.translate( 'Alternate Email Address' ) }
+                    errorMessage={ this.props.contactDetailsErrors?.alternateEmail }
 					{ ...this.getFieldProps( 'alternate-email' ) }
 				/>
 			</div>
@@ -462,7 +469,7 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	render() {
-		const { translate, onCancel, disableSubmitButton, labelTexts } = this.props;
+		const { translate, onCancel, disableSubmitButton, labelTexts, contactDetailsErrors } = this.props;
 		const countryCode = this.getCountryCode();
 
 		const isFooterVisible = !! ( this.props.onSubmit || onCancel );
@@ -472,10 +479,12 @@ export class ContactDetailsFormFields extends Component {
 				<div className="contact-details-form-fields__row">
 					{ this.createField( 'first-name', Input, {
 						label: translate( 'First Name' ),
+                        errorMessage: contactDetailsErrors?.firstName,
 					} ) }
 
 					{ this.createField( 'last-name', Input, {
 						label: translate( 'Last Name' ),
+                        errorMessage: contactDetailsErrors?.lastName,
 					} ) }
 				</div>
 				{ this.props.needsAlternateEmailForGSuite && this.renderAlternateEmailFieldForGSuite() }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -332,7 +332,7 @@ export class ContactDetailsFormFields extends Component {
 		} );
 	};
 
-	getFieldProps = ( name, needsChildRef = false ) => {
+	getFieldProps = ( name, { customErrorMessage = null, needsChildRef = false } ) => {
 		const ref = needsChildRef
 			? { inputRef: this.getRefCallback( name ) }
 			: { ref: this.getRefCallback( name ) };
@@ -344,9 +344,9 @@ export class ContactDetailsFormFields extends Component {
 			additionalClasses: 'contact-details-form-fields__field',
 			disabled: getIsFieldDisabled( name ) || formState.isFieldDisabled( form, name ),
 			isError: formState.isFieldInvalid( form, name ),
-			errorMessage: ( formState.getFieldErrorMessages( form, camelCase( name ) ) || [] ).join(
-				'\n'
-			),
+			errorMessage:
+				customErrorMessage ||
+				( formState.getFieldErrorMessages( form, camelCase( name ) ) || [] ).join( '\n' ),
 			onChange: this.handleFieldChange,
 			onBlur: this.handleBlur,
 			value: formState.getFieldValue( form, name ) || '',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In composite-checkout we are using `ContactDetailsFormFields` as a managed component. This patch adds an optional prop, `contactDetailsErrors`, which can be used to pass in per-field errors through props. These errors have lower precedence than those triggered by the existing validation logic.

#### Testing instructions

* On its own this PR should have no visible effects on the contact details form. Verify that this is the case by interacting with the form in checkout. **Since this touches a shared component you'll need to verify this behavior in both composite checkout and old checkout.**
