### PR TITLE
Migration: Set backHref for HeaderCake on business plan page

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -535,6 +535,7 @@ class SectionMigrate extends Component {
 
 	render() {
 		const { step, sourceSite, targetSite, targetSiteSlug, translate } = this.props;
+		const sourceSiteSlug = get( sourceSite, 'slug' );
 
 		let migrationElement;
 
@@ -568,8 +569,10 @@ class SectionMigrate extends Component {
 							<StepUpgrade
 								plugins={ this.state.sourceSitePlugins }
 								sourceSite={ sourceSite }
+								sourceSiteSlug={ sourceSiteSlug }
 								startMigration={ this.startMigration }
 								targetSite={ targetSite }
+								targetSiteSlug={ targetSiteSlug }
 								themes={ this.state.sourceSiteThemes }
 							/>
 						);

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -42,17 +42,20 @@ class StepUpgrade extends Component {
 			planPrice,
 			plugins,
 			sourceSite,
+			sourceSiteSlug,
 			targetSite,
+			targetSiteSlug,
 			themes,
 			translate,
 		} = this.props;
 		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
+		const backHref = `/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }`;
 
 		return (
 			<>
 				<QueryPlans />
-				<HeaderCake>{ translate( 'Import Everything' ) }</HeaderCake>
+				<HeaderCake backHref={ backHref }>{ translate( 'Import Everything' ) }</HeaderCake>
 
 				<CompactCard>
 					<CardHeading>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `backHref` to the `HeaderCake` on the business plan page

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a simple site, click "Import" in the sidebar.
* Select "WordPress".
* Enter a URL and continue in the flow until you arrive at the business plan page.
* Click the back button in the header cake. Verify that you are taken to the previous page.

Fixes #39574 
