### PR TITLE
composite-checkout: Do not show VAT field for any countries

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -95,7 +95,7 @@ const FieldRow = styled( GridRow )`
 
 function isEligibleForVat( country ) {
 	//TODO: Detect whether people are in EU or AU and return true if they are
-	const countriesWithVAT = [ 'AU' ];
+	const countriesWithVAT = [];
 	return countriesWithVAT.includes( country );
 }
 


### PR DESCRIPTION
Previously we had Australia in this array for testing, but it should not
be live until we are ready to use this field. This PR makes the array empty.

#### Testing instructions

Visit composite checkout _without a domain product_; choose "Australia" in the country field and verify that the VAT field does not appear.