### PR TITLE
Dialog: Improve line height of h1

### DIFF
--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -56,7 +56,6 @@
 		color: var( --color-neutral-70 );
 		font-size: 1.375em;
 		font-weight: 600;
-		line-height: 2em;
 		margin-bottom: 0.5em;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adjusts the line height of h1 in Dialog, so that things look better.

Before:

<img width="572" alt="ScreenCapture at Thu Feb 27 14:56:09 EST 2020" src="https://user-images.githubusercontent.com/2098816/75482562-106e5a00-5973-11ea-9b75-ab8ae04edcdc.png">

After:

<img width="570" alt="ScreenCapture at Thu Feb 27 14:56:26 EST 2020" src="https://user-images.githubusercontent.com/2098816/75482567-12d0b400-5973-11ea-8fb3-4fc6eeaedefe.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run branch
* Go to a part of the UI where a Dialog is shown with an h1 heading, such the confirmation modal in the WP Import migration flow
* Verify that the dialog's style is updated and looks better

Fixes #39748
