### PR TITLE
Adds scan footer

### DIFF
--- a/client/landing/jetpack-cloud/components/stats-footer/index.tsx
+++ b/client/landing/jetpack-cloud/components/stats-footer/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+import './style.scss';
+
+type Stat = {
+	name: string;
+	number: number;
+};
+
+interface FooterProps {
+	header?: string;
+	noticeText?: string;
+	noticeLink?: string;
+	stats?: Stat[];
+}
+
+interface NoticeProps {
+	text: string;
+	link?: string;
+}
+
+const Notice = ( props: NoticeProps ): ReactElement => (
+	<div className="stats-footer__notice">
+		<Gridicon icon="info" className="stats-footer__notice-icon" />
+		{ props.text }
+		{ props.link && (
+			<>
+				&nbsp;<a href={ props.link }>Learn more &raquo;</a>
+			</>
+		) }
+	</div>
+);
+
+const Stat = ( props: Stat ): ReactElement => (
+	<div className="stats-footer__stat">
+		<span className="stats-footer__stat-number">{ props.number }</span>
+		&nbsp;
+		<span className="stats-footer__stat-name">{ props.name }</span>
+	</div>
+);
+
+const StatsFooter = ( props: FooterProps ): ReactElement => (
+	<div className="stats-footer">
+		{ props.header && <h3 className="stats-footer__header">{ props.header }</h3> }
+		{ props.stats && props.stats.map( ( stat, index ) => <Stat key={ index } { ...stat } /> ) }
+		{ props.noticeText && <Notice text={ props.noticeText } link={ props.noticeLink } /> }
+	</div>
+);
+
+export default StatsFooter;

--- a/client/landing/jetpack-cloud/components/stats-footer/style.scss
+++ b/client/landing/jetpack-cloud/components/stats-footer/style.scss
@@ -20,6 +20,7 @@
 	font-size: 20px;
 	margin-right: 24px;
 	flex: 1;
+	max-width: 150px;
 }
 
 .stats-footer > div:last-child {

--- a/client/landing/jetpack-cloud/components/stats-footer/style.scss
+++ b/client/landing/jetpack-cloud/components/stats-footer/style.scss
@@ -18,7 +18,7 @@
 
 .stats-footer__stat {
 	font-size: 20px;
-	margin-right: 24px;
+	margin: 0 24px 20px 0;
 	flex: 1;
 	max-width: 150px;
 }
@@ -35,7 +35,11 @@
 .stats-footer__notice {
 	position: relative;
 	padding-left: 40px;
-	flex: 1;
+	flex-basis: 100%;
+
+	@include breakpoint( '>660px' ) {
+		flex: 1;
+	}
 }
 
 .stats-footer__notice-icon {

--- a/client/landing/jetpack-cloud/components/stats-footer/style.scss
+++ b/client/landing/jetpack-cloud/components/stats-footer/style.scss
@@ -1,0 +1,44 @@
+.stats-footer {
+	border-top: 1px solid var( --color-neutral-5 );
+	color: var( --color-neutral-80 );
+	display: flex;
+	padding-top: 10px;
+	margin-top: 40px;
+	flex-wrap: wrap;
+}
+
+.stats-footer__header {
+	color: var( --color-neutral-50 );
+	font-size: 13px;
+	font-weight: normal;
+	text-transform: uppercase;
+	margin: 0 0 20px;
+	flex-basis: 100%;
+}
+
+.stats-footer__stat {
+	font-size: 20px;
+	margin-right: 24px;
+	flex: 1;
+}
+
+.stats-footer > div:last-child {
+	margin-right: 0;
+}
+
+.stats-footer__stat-number {
+	font-size: 28px;
+	display: block;
+}
+
+.stats-footer__notice {
+	position: relative;
+	padding-left: 40px;
+	flex: 1;
+}
+
+.stats-footer__notice-icon {
+	fill: var( --color-neutral-50 );
+	position: absolute;
+	left: 0;
+}

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -7,11 +7,26 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import StatsFooter from 'landing/jetpack-cloud/components/stats-footer';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 class ScanPage extends Component {
 	render() {
-		return <div>Welcome to the scan page for site { this.props.siteId }</div>;
+		return (
+			<div>
+				Welcome to the scan page for site { this.props.siteId }
+				<StatsFooter
+					header="Scan Summary"
+					stats={ [
+						{ name: 'Files', number: 1201 },
+						{ name: 'Plugins', number: 4 },
+						{ name: 'Themes', number: 3 },
+					] }
+					noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backups has you covered."
+					noticeLink="https://jetpack/upgrade/backups"
+				/>
+			</div>
+		);
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds footer to Jetpack Scan page. This has static data only as API is not implemented.

See 1151678672052943-as-1164621024668349.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* View Scan page and verify that component matches comps.

Desktop:
<img width="815" alt="Screen Shot 2020-03-04 at 11 31 11 AM" src="https://user-images.githubusercontent.com/1760168/75900958-c3bfce80-5e0b-11ea-9b75-f98db756cd08.png">

Mobile:
<img width="376" alt="Screen Shot 2020-03-04 at 11 32 12 AM" src="https://user-images.githubusercontent.com/1760168/75900999-d6d29e80-5e0b-11ea-8e69-fd60a0b5a17c.png">
