### PR TITLE
Adds scanner route for Cloud

### DIFF
--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -16,7 +16,7 @@ import {
 	backupDownload,
 	backupRestore,
 } from './sections/backups/controller';
-import { scan, scanHistory } from './sections/scan/controller';
+import { scan, scanner, scanHistory } from './sections/scan/controller';
 import { settings } from './sections/settings/controller';
 
 const router = () => {
@@ -85,7 +85,18 @@ const router = () => {
 		page( '/scan/:site', siteSelection, setupSidebar, scan, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
-			page( '/scan/:site/history', siteSelection, setupSidebar, scanHistory, makeLayout, clientRender );
+			page(
+				'/scan/:site/history',
+				siteSelection,
+				setupSidebar,
+				scanHistory,
+				makeLayout,
+				clientRender
+			);
+		}
+
+		if ( config.isEnabled( 'jetpack-cloud/scan-scanner' ) ) {
+			page( '/scan/:site/scanner', siteSelection, setupSidebar, scanner, makeLayout, clientRender );
 		}
 	}
 

--- a/client/landing/jetpack-cloud/sections/scan/controller.js
+++ b/client/landing/jetpack-cloud/sections/scan/controller.js
@@ -7,6 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import ScanPage from './main';
+import ScanScannerPage from './scanner';
 import ScanHistoryPage from './history';
 
 export function scan( context, next ) {
@@ -14,9 +15,10 @@ export function scan( context, next ) {
 	next();
 }
 
-/**
- * Internal dependencies
- */
+export function scanner( context, next ) {
+	context.primary = <ScanScannerPage />;
+	next();
+}
 
 export function scanHistory( context, next ) {
 	context.primary = <ScanHistoryPage />;

--- a/client/landing/jetpack-cloud/sections/scan/scanner/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/scanner/index.jsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+class ScanScannerPage extends Component {
+	render() {
+		return <div>Welcome to the scanner page for site { this.props.siteId }</div>;
+	}
+}
+
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId,
+	};
+} )( ScanScannerPage );

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -16,6 +16,7 @@
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/settings": true,
 		"jetpack-cloud/scan": true,
+		"jetpack-cloud/scan-scanner": true,
 		"jetpack-cloud/scan-history": true
 	}
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -14,6 +14,7 @@
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/settings": true,
 		"jetpack-cloud/scan": true,
+		"jetpack-cloud/scan-scanner": true,
 		"jetpack-cloud/scan-history": true
 	}
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -14,6 +14,7 @@
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/settings": true,
 		"jetpack-cloud/scan": true,
+		"jetpack-cloud/scan-scanner": true,
 		"jetpack-cloud/scan-history": true
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds scanner route and basic page for JP Cloud.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit Cloud.
* Go to `/scan/:site/scanner`.

Ticket: 1151678672052943-as-1164779035398550.