### PR TITLE
Changes config to have dev helpers available on staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -23,6 +23,8 @@
 		"catch-js-errors": true,
 		"code-splitting": true,
 		"desktop-promo": true,
+		"dev/test-helper": true,
+		"dev/preferences-helper": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,
 		"domains/cctlds/fr": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This changes the config to allow A/B tests and settings config appear for staging.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to staging or spin up site with staging config.
* Check environment badge.
