### PR TITLE
composite-checkout: Filter out falsey values in CheckoutSteps

### DIFF
--- a/client/my-sites/checkout/checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/checkout/types/transaction-endpoint.ts
@@ -155,7 +155,7 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 		cart: createTransactionEndpointCartFromLineItems( {
 			debug,
 			siteId,
-			couponId,
+			couponId: couponId || getCouponIdFromProducts( items ),
 			country,
 			postalCode,
 			subdivisionCode,
@@ -173,6 +173,11 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 			zip: postalCode, // TODO: do we need this in addition to postalCode?
 		},
 	};
+}
+
+function getCouponIdFromProducts( items: WPCOMCartItem[] ): string | undefined {
+	const couponItem = items.find( item => item.type === 'coupon' );
+	return couponItem?.wpcom_meta?.couponCode;
 }
 
 export type WPCOMTransactionEndpointResponse = {

--- a/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
+++ b/packages/composite-checkout-wpcom/src/types/checkout-cart.ts
@@ -38,6 +38,7 @@ export type WPCOMCartItem = CheckoutCartItem & {
 		extra: object;
 		volume?: number;
 		is_domain_registration?: boolean;
+		couponCode?: string;
 	};
 };
 

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -136,7 +136,8 @@ function DefaultCheckoutSteps() {
 export function CheckoutSteps( { children } ) {
 	let stepNumber = 0;
 	let nextStepNumber = 1;
-	const totalSteps = React.Children.count( children );
+	const steps = React.Children.toArray( children ).filter( child => child );
+	const totalSteps = steps.length;
 	const { activeStepNumber, stepCompleteStatus, setTotalSteps } = useContext(
 		CheckoutStepDataContext
 	);
@@ -154,13 +155,14 @@ export function CheckoutSteps( { children } ) {
 		totalSteps
 	);
 
-	return React.Children.map( children, child => {
+	return steps.map( child => {
 		stepNumber = nextStepNumber;
 		nextStepNumber = stepNumber === totalSteps ? null : stepNumber + 1;
 		const isStepActive = activeStepNumber === stepNumber;
 		const isStepComplete = !! stepCompleteStatus[ stepNumber ];
 		return (
 			<CheckoutSingleStepDataContext.Provider
+				key={ 'checkout-step-' + stepNumber }
 				value={ {
 					stepNumber,
 					nextStepNumber,

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -37,7 +37,9 @@ export function Checkout( { children, className } ) {
 	const [ activeStepNumber, setActiveStepNumber ] = useState( 1 );
 	const [ stepCompleteStatus, setStepCompleteStatus ] = useState( {} );
 	const [ totalSteps, setTotalSteps ] = useState( 0 );
-	const isThereAnotherNumberedStep = activeStepNumber < totalSteps;
+	const actualActiveStepNumber =
+		activeStepNumber > totalSteps && totalSteps > 0 ? totalSteps : activeStepNumber;
+	const isThereAnotherNumberedStep = actualActiveStepNumber < totalSteps;
 
 	// Change the step if the url changes
 	useChangeStepNumberForUrl( setActiveStepNumber );
@@ -61,7 +63,7 @@ export function Checkout( { children, className } ) {
 		<ContainerUI className={ joinClasses( [ className, 'composite-checkout' ] ) }>
 			<CheckoutStepDataContext.Provider
 				value={ {
-					activeStepNumber,
+					activeStepNumber: actualActiveStepNumber,
 					stepCompleteStatus,
 					totalSteps,
 					setActiveStepNumber,


### PR DESCRIPTION
React.Children functions include all children, including `null` and `false` which will render as empty. This causes issues with the special children handling of `CheckoutSteps` which counts children and uses the number of the child to render it with its index.

This PR filters out falsey values before having `CheckoutSteps` do the indexing and rendering work.

#### Screenshots
Before:

![Screen Shot 2020-03-03 at 7 39 12 PM](https://user-images.githubusercontent.com/2036909/75833321-b01e5480-5d86-11ea-878f-3869bb72c44c.png)

After:

![Screen Shot 2020-03-03 at 7 36 06 PM](https://user-images.githubusercontent.com/2036909/75833212-574ebc00-5d86-11ea-9fcc-ec636e657dfb.png)

#### Testing instructions

Visit composite checkout with a 100% free purchase. One way to do this is to use a coupon code that provides a 100% discount (see also #39855 which allows removing coupons). Make sure that you can progress through checkout as you'd expect and you can get to the final step successfully. Notably make sure that the step numbers are correct (1, 2 rather than 1, 3).

If you've added the coupon during checkout, also try reloading checkout (the coupon should remain) to verify that the steps still work as expected. The experience before and after reloading will be different.