### PR TITLE
Adds tsconfig.json to each package to speed up VSCode

### DIFF
--- a/apps/full-site-editing/tsconfig.json
+++ b/apps/full-site-editing/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/apps/notifications/tsconfig.json
+++ b/apps/notifications/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/apps/o2-blocks/tsconfig.json
+++ b/apps/o2-blocks/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/apps/wpcom-block-editor/tsconfig.json
+++ b/apps/wpcom-block-editor/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/babel-plugin-i18n-calypso/tsconfig.json
+++ b/packages/babel-plugin-i18n-calypso/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/babel-plugin-transform-wpcalypso-async/tsconfig.json
+++ b/packages/babel-plugin-transform-wpcalypso-async/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/calypso-codemods/tsconfig.json
+++ b/packages/calypso-codemods/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/calypso-color-schemes/tsconfig.json
+++ b/packages/calypso-color-schemes/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/calypso-polyfills/tsconfig.json
+++ b/packages/calypso-polyfills/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/composite-checkout/tsconfig.json
+++ b/packages/composite-checkout/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/eslint-config-wpcalypso/tsconfig.json
+++ b/packages/eslint-config-wpcalypso/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/eslint-plugin-wpcalypso/tsconfig.json
+++ b/packages/eslint-plugin-wpcalypso/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/format-currency/tsconfig.json
+++ b/packages/format-currency/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/i18n-calypso-cli/tsconfig.json
+++ b/packages/i18n-calypso-cli/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/i18n-calypso/tsconfig.json
+++ b/packages/i18n-calypso/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/load-script/tsconfig.json
+++ b/packages/load-script/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/material-design-icons/tsconfig.json
+++ b/packages/material-design-icons/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/photon/tsconfig.json
+++ b/packages/photon/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/tree-select/tsconfig.json
+++ b/packages/tree-select/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/viewport-react/tsconfig.json
+++ b/packages/viewport-react/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/viewport/tsconfig.json
+++ b/packages/viewport/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/webpack-config-flag-plugin/tsconfig.json
+++ b/packages/webpack-config-flag-plugin/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/webpack-extensive-lodash-replacement-plugin/tsconfig.json
+++ b/packages/webpack-extensive-lodash-replacement-plugin/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/webpack-inline-constant-exports-plugin/tsconfig.json
+++ b/packages/webpack-inline-constant-exports-plugin/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/wpcom-proxy-request/tsconfig.json
+++ b/packages/wpcom-proxy-request/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}

--- a/packages/wpcom.js/tsconfig.json
+++ b/packages/wpcom.js/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "@automattic/calypso-build/tsconfig",
+	"exclude": [ "node_modules" ],
+	"compilerOptions": {
+		"allowJs": true
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds `tsconfig.json` files to each package in `./apps` and `./packages`. This speeds up VSCode's JavaScript language services like 'Rename symbol', 'Go to definition', intellisense, etc. It has no effect if the developer is using a different editor.

Startup time for those language services are much faster now (86 seconds -> 3 seconds):
```
// No tsconfig.json
Perf 8    [7:33:52.215] 0::configure: async elapsed time (in milliseconds) 2.7310
Perf 11   [7:33:52.216] 1::compilerOptionsForInferredProjects: elapsed time (in milliseconds) 1.0647
Perf 7542 [7:35:18.539] 2::updateOpen: elapsed time (in milliseconds) 86321.4149

// With tsconfig.json
Perf 8    [7:45:29.863] 0::configure: async elapsed time (in milliseconds) 1.6103
Perf 11   [7:45:29.863] 1::compilerOptionsForInferredProjects: elapsed time (in milliseconds) 0.8481
Perf 218  [7:45:33.58] 2::updateOpen: elapsed time (in milliseconds) 3194.3672
```

The tradeoff is that now we pay those few seconds (the exact time depends on the size of the package) every time we open a file from a new package, while before we were paying 86 seconds upfront.

#### Testing instructions

* Open project in VSCode
* Open any `.js` file in a package.
* Try things like 'Rename symbol', 'Go to definition', 'Peek references'...
* Try importing a package from `@automatic/` and check it autocompletes the name.

#### Conflicts

Potential conflicts with #39786 (cc @sirreal)

#### Notes

There is `tsconfig.json` and `jsconfig.json` in the root of the project, but they are restricted to `./client` package. That's the reason I haven't added `tsconfig.json` to `./client`. Looking at the tssserver logs looks like `jsconfig.json` is ignored if there is a `tsconfig.json`. I'll continue investigating and maybe merging both files and moving them to `client`. 

Why `tsconfig.json` and not `jsconfig.json`? Both files will work. I think that creating a `tsconfig.json` file now (even if the package is not TS) will avoid the problem of someone converting the project to TS in the future, adding a `tsconfig.json` and leaving the `jsconfig.json` file around. Note that, according to the docs, `jsconfig.json` is just `tsconfig.json` with 'allowJs: true`.

#### Relevant docs

* https://code.visualstudio.com/docs/languages/jsconfig
