### PR TITLE
Images: Use webpack loader for fireworks

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -269,7 +269,7 @@ class Home extends Component {
 				{ isRecentlyMigratedSite && (
 					<Card className="customer-home__migrate-card" highlight="info">
 						<img
-							src="/calypso/images/illustrations/fireworks.svg"
+							src={ fireworksIllustration }
 							aria-hidden="true"
 							className="customer-home__migrate-fireworks"
 							alt=""


### PR DESCRIPTION
Migrate static image regression to file-loader.

#38356 migrated this image to webpack file loader. #39642 restored the
image to prevent possible 404s, #39632 introduced a legacy static URL.

Use file-loader to allow removal in #39643.

cc: @Aurorum 

### Testing instructions

- Ensure the affected image is correctly displayed on the customer home page. See #39632