### PR TITLE
Plans: update "WordPress powers ..." phrase to 36% from 35%

### DIFF
--- a/client/my-sites/plan-testimonials/index.jsx
+++ b/client/my-sites/plan-testimonials/index.jsx
@@ -18,7 +18,7 @@ export class PlanTestimonials extends Component {
 				</div>
 				<div className="plan-testimonials__content-right-container">
 					<div className="plan-testimonials__content-right">
-						Did you know that WordPress powers 35% of the entire internet? WordPress.com is the best
+						Did you know that WordPress powers 36% of the entire internet? WordPress.com is the best
 						WordPress solution out there, as trusted by:
 					</div>
 					<div className="plan-testimonials__content-testimonial-image"></div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the plan selection page's phrasing of "WordPress powers 35%" to "WordPress powers 36%". 

#### Testing instructions

* Launch Calypso.live, create a new site, and on the plans chooser ensure the string has been updated. 

