### PR TITLE
Domain step test: Set variant allocation to zero

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -116,10 +116,10 @@ export default {
 		allowExistingUsers: true,
 	},
 	domainStepDesignUpdates: {
-		datestamp: '20200220',
+		datestamp: '20201220',
 		variations: {
-			variantDesignUpdates: 50,
-			control: 50,
+			variantDesignUpdates: 0,
+			control: 100,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The results for the domain step design update test, introduced in https://github.com/Automattic/wp-calypso/pull/39276, have come in. The control group remains the winner, analysis is in p8Eqe3-15t-p2.
* The test is being reverted in https://github.com/Automattic/wp-calypso/pull/39832. As an interim measure, we will set the control to 100% and assign test to a future date so that users will no longer be assigned to the test.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow at /start.
* At the domain step, verify that you are not assigned to `domainStepDesignUpdates` test.
* Verify that you can complete signup.
