### PR TITLE
New domain mapping status refactoring

### DIFF
--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
@@ -53,7 +53,12 @@ class RenewButton extends React.Component {
 			redemptionProduct,
 			reactivate,
 			customLabel,
+			subscriptionId,
 		} = this.props;
+
+		if ( ! subscriptionId ) {
+			return null;
+		}
 
 		let formattedPrice = '...';
 		let loading = true;

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -28,6 +28,8 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { isSubdomain } from 'lib/domains';
 import { MAP_EXISTING_DOMAIN, MAP_SUBDOMAIN } from 'lib/url/support';
 import RenewButton from 'my-sites/domains/domain-management/edit/card/renew-button';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'state/sites/selectors';
 
 class MappedDomainType extends React.Component {
 	getVerticalNavigation() {
@@ -188,11 +190,8 @@ class MappedDomainType extends React.Component {
 	}
 
 	renderSettingUpNameservers() {
-		const { domain, selectedSite, translate } = this.props;
-		if (
-			selectedSite.jetpack ||
-			( selectedSite.options && selectedSite.options.is_automated_transfer )
-		) {
+		const { domain, translate } = this.props;
+		if ( this.props.isJetpackSite || this.props.isAutomatedTransferSite ) {
 			return null;
 		}
 
@@ -356,6 +355,14 @@ class MappedDomainType extends React.Component {
 	}
 }
 
-export default connect( null, {
-	recordPaymentSettingsClick,
-} )( withLocalizedMoment( localize( MappedDomainType ) ) );
+export default connect(
+	( state, ownProps ) => {
+		return {
+			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, ownProps.selectedSite.ID ),
+			isJetpackSite: isJetpackSite( state, ownProps.selectedSite.ID ),
+		};
+	},
+	{
+		recordPaymentSettingsClick,
+	}
+)( withLocalizedMoment( localize( MappedDomainType ) ) );

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -136,52 +136,52 @@ class MappedDomainType extends React.Component {
 			return null;
 		}
 
+		let noticeText;
+		let subscriptionId;
+		let customLabel;
+		let tracksProps;
+
 		if ( domain.bundledPlanSubscriptionId ) {
-			return (
-				<div>
-					<p>
-						{ translate(
-							'Your domain mapping will expire with your plan in {{strong}}%(days)s{{/strong}}. Please renew your plan before it expires or it will stop working.',
-							{
-								components: {
-									strong: <strong />,
-								},
-								args: {
-									days: moment.utc( expiry ).fromNow( true ),
-								},
-							}
-						) }
-					</p>
-					<RenewButton
-						primary={ true }
-						selectedSite={ this.props.selectedSite }
-						subscriptionId={ parseInt( domain.bundledPlanSubscriptionId, 10 ) }
-						customLabel={ translate( 'Renew your plan ' ) }
-						tracksProps={ { source: 'mapped-domain-status', mapping_status: 'expiring-soon-plan' } }
-					/>
-				</div>
+			noticeText = translate(
+				'Your domain mapping will expire with your plan in {{strong}}%(days)s{{/strong}}. Please renew your plan before it expires or it will stop working.',
+				{
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						days: moment.utc( expiry ).fromNow( true ),
+					},
+				}
 			);
+			subscriptionId = domain.bundledPlanSubscriptionId;
+			customLabel = translate( 'Renew your plan ' );
+			tracksProps = { source: 'mapped-domain-status', mapping_status: 'expiring-soon-plan' };
+		} else {
+			noticeText = translate(
+				'Your domain mapping will expire in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
+				{
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						days: moment.utc( expiry ).fromNow( true ),
+					},
+				}
+			);
+			subscriptionId = domain.subscriptionId;
+			customLabel = null;
+			tracksProps = { source: 'mapped-domain-status', mapping_status: 'expiring-soon' };
 		}
+
 		return (
 			<div>
-				<p>
-					{ translate(
-						'Your domain mapping will expire in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
-						{
-							components: {
-								strong: <strong />,
-							},
-							args: {
-								days: moment.utc( expiry ).fromNow( true ),
-							},
-						}
-					) }
-				</p>
+				<p>{ noticeText }</p>
 				<RenewButton
 					primary={ true }
 					selectedSite={ this.props.selectedSite }
-					subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
-					tracksProps={ { source: 'mapped-domain-status', mapping_status: 'expiring-soon' } }
+					subscriptionId={ parseInt( subscriptionId, 10 ) }
+					customLabel={ customLabel }
+					tracksProps={ tracksProps }
 				/>
 			</div>
 		);
@@ -264,18 +264,18 @@ class MappedDomainType extends React.Component {
 			return null;
 		}
 
+		let subscriptionId;
+		let customLabel;
+		let tracksProps;
+
 		if ( domain.bundledPlanSubscriptionId ) {
-			return (
-				<div>
-					<RenewButton
-						compact={ true }
-						selectedSite={ this.props.selectedSite }
-						subscriptionId={ parseInt( domain.bundledPlanSubscriptionId, 10 ) }
-						customLabel={ translate( 'Renew your plan' ) }
-						tracksProps={ { source: 'mapped-domain-status', mapping_status: 'active-plan' } }
-					/>
-				</div>
-			);
+			subscriptionId = domain.bundledPlanSubscriptionId;
+			customLabel = translate( 'Renew your plan' );
+			tracksProps = { source: 'mapped-domain-status', mapping_status: 'active-plan' };
+		} else {
+			subscriptionId = domain.subscriptionId;
+			customLabel = null;
+			tracksProps = { source: 'mapped-domain-status', mapping_status: 'active' };
 		}
 
 		return (
@@ -283,8 +283,9 @@ class MappedDomainType extends React.Component {
 				<RenewButton
 					compact={ true }
 					selectedSite={ this.props.selectedSite }
-					subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
-					tracksProps={ { source: 'mapped-domain-status', mapping_status: 'active' } }
+					subscriptionId={ parseInt( subscriptionId, 10 ) }
+					customLabel={ customLabel }
+					tracksProps={ tracksProps }
 				/>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -156,7 +156,7 @@ class MappedDomainType extends React.Component {
 				}
 			);
 			subscriptionId = domain.bundledPlanSubscriptionId;
-			customLabel = translate( 'Renew your plan ' );
+			customLabel = translate( 'Renew your plan' );
 			tracksProps = { source: 'mapped-domain-status', mapping_status: 'expiring-soon-plan' };
 		} else {
 			noticeText = translate(

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -309,6 +309,23 @@ class MappedDomainType extends React.Component {
 		const { statusText, statusClass, icon } = this.resolveStatus();
 
 		const newStatusDesignAutoRenew = config.isEnabled( 'domains/new-status-design/auto-renew' );
+		let expiresText;
+
+		if ( ! domain.expiry ) {
+			expiresText = translate( 'Expires: Never' );
+		} else if ( domain.bundledPlanSubscriptionId ) {
+			expiresText = translate( 'Expires with your plan on %(expiry_date)s', {
+				args: {
+					expiry_date: moment.utc( domain.expiry ).format( 'LL' ),
+				},
+			} );
+		} else {
+			expiresText = translate( 'Expires: %(expiry_date)s', {
+				args: {
+					expiry_date: moment.utc( domain.expiry ).format( 'LL' ),
+				},
+			} );
+		}
 
 		return (
 			<div className="domain-types__container">
@@ -322,21 +339,9 @@ class MappedDomainType extends React.Component {
 					{ this.renderExpiringSoon() }
 				</DomainStatus>
 				<Card compact={ true } className="domain-types__expiration-row">
-					<div>
-						{ domain.bundledPlanSubscriptionId
-							? translate( 'Expires with your plan on %(expiry_date)s', {
-									args: {
-										expiry_date: moment( domain.expiry ).format( 'LL' ),
-									},
-							  } )
-							: translate( 'Expires: %(expiry_date)s', {
-									args: {
-										expiry_date: moment( domain.expiry ).format( 'LL' ),
-									},
-							  } ) }
-					</div>
+					<div>{ expiresText }</div>
 					{ this.renderDefaultRenewButton() }
-					{ ! newStatusDesignAutoRenew && (
+					{ ! newStatusDesignAutoRenew && domain.subscriptionId && (
 						<div>
 							<SubscriptionSettings
 								type={ domain.type }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a follow up for https://github.com/Automattic/wp-calypso/pull/39701 and @klimeryk comments in there.

* Don't show renew/payment settings button if there is not subscriptionId
* Use UTC to format the expiry date
* Display "Expires: Never" if the expiry date is empty
* Don't duplicate some rendered code

So for VIP users mapped domains would look like this:
<img width="745" alt="Screenshot 2020-03-04 at 15 07 28" src="https://user-images.githubusercontent.com/1355045/75882495-f8428300-5e29-11ea-9e84-d92d5453048b.png">


#### Testing instructions

* Test that everything works as it was for normal users
* Test with a VIP user mapped domain
