### PR TITLE
Types: Fix bad type

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -18,7 +18,7 @@ import MediaListStore from './list-store';
 import MediaValidationStore from './validation-store';
 
 /**
- * @typedef MediaActions
+ * @typedef IMediaActions
  *
  * TODO: Better method types
  *
@@ -27,7 +27,7 @@ import MediaValidationStore from './validation-store';
  */
 
 /**
- * @type {MediaActions} MediaActions
+ * @type {IMediaActions}
  */
 const MediaActions = {
 	_fetching: {},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The overlap of the `MediaActions` type name was causing `tsc` to error with the following cryptic message:

```
…/wp-calypso/node_modules/typescript/lib/tsc.js:78602
                throw e;
                ^

Error: Debug Failure. Unexpected node.
Node 75 was unexpected.
    at getDeclarationSpaces
…
```

Fix the error (and the `typecheck` job/script) by renaming the _type_ to `IMediaActions`.

Introduced in #39057 / #39048

#### Testing instructions

* `typecheck` job works on CI (has type errors as before, but finishes and reports)
* `npm run typecheck` has the same behavior as the job - type errors but completes and reports