### PR TITLE
Marketing Button Options: Update contexts to allow for different translations

### DIFF
--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -117,20 +117,22 @@ class SharingButtonsOptions extends Component {
 		switch ( postType.name ) {
 			case 'index':
 				label = this.props.translate( 'Front Page, Archive Pages, and Search Results', {
-					context: 'jetpack',
+					context: 'Show like and sharing buttons on',
 				} );
 				break;
 			case 'post':
-				label = this.props.translate( 'Posts' );
+				label = this.props.translate( 'Posts', { context: 'Show like and sharing buttons on' } );
 				break;
 			case 'page':
-				label = this.props.translate( 'Pages' );
+				label = this.props.translate( 'Pages', { context: 'Show like and sharing buttons on' } );
 				break;
 			case 'attachment':
-				label = this.props.translate( 'Media' );
+				label = this.props.translate( 'Media', { context: 'Show like and sharing buttons on' } );
 				break;
 			case 'portfolio':
-				label = this.props.translate( 'Portfolio Items' );
+				label = this.props.translate( 'Portfolio Items', {
+					context: 'Show like and sharing buttons on',
+				} );
 				break;
 			default:
 				label = postType.label;


### PR DESCRIPTION
German needs a different translation here (_Beiträgen_):
![grafik (1)](https://user-images.githubusercontent.com/203408/75890113-33df4c00-5e2e-11ea-8350-79116ef50a96.png)

But if this is changed here, it also changes it here which is wrong:
![Screenshot 2020-03-03 at 11 01 26](https://user-images.githubusercontent.com/203408/75890189-4c4f6680-5e2e-11ea-9311-6c729f629ccd.png)
