### PR TITLE
SPT: Track source of opening the selector

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -116,7 +116,7 @@ class PageTemplateModal extends Component {
 
 	componentDidMount() {
 		if ( this.state.isOpen ) {
-			trackView( this.props.segment.id, this.props.vertical.id );
+			this.trackCurrentView();
 		}
 	}
 
@@ -124,13 +124,21 @@ class PageTemplateModal extends Component {
 		// Only track when the modal is first displayed
 		// and if it didn't already happen during componentDidMount.
 		if ( ! prevState.isOpen && this.state.isOpen ) {
-			trackView( this.props.segment.id, this.props.vertical.id );
+			this.trackCurrentView();
 		}
 
 		// Disable welcome guide right away as it collides with the modal window.
 		if ( this.props.isWelcomeGuideActive || this.props.areTipsEnabled ) {
 			this.props.hideWelcomeGuide();
 		}
+	}
+
+	trackCurrentView() {
+		trackView(
+			this.props.segment.id,
+			this.props.vertical.id,
+			this.props.isPromptedFromSidebar ? 'sidebar' : 'add-page'
+		);
 	}
 
 	static getDefaultSelectedTemplate = props => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
@@ -6,13 +6,27 @@ let tracksIdentity = null;
 /**
  * Populate `identity` on WPCOM and ATOMIC to enable tracking.
  * Always disabled for regular self-hosted installations.
+ *
+ * @param {object} identity Info about identity.
+ * @param {number} identity.userid User ID.
+ * @param {string} identity.username Username.
+ * @param {number} identity.blogid Blog ID.
+ * @returns {void}
  */
 export const initializeWithIdentity = identity => {
 	tracksIdentity = identity;
 	window._tkq.push( [ 'identifyUser', identity.userid, identity.username ] );
 };
 
-export const trackView = ( segment_id, vertical_id ) => {
+/**
+ * Track a view of the layout selector.
+ *
+ * @param {string} segment_id Segment ID.
+ * @param {string} vertical_id Vertical ID.
+ * @param {string} source Source triggering the view.
+ * @returns {void}
+ */
+export const trackView = ( segment_id, vertical_id, source ) => {
 	if ( ! tracksIdentity ) {
 		return;
 	}
@@ -23,10 +37,18 @@ export const trackView = ( segment_id, vertical_id ) => {
 			blog_id: tracksIdentity.blogid,
 			segment_id,
 			vertical_id,
+			source,
 		},
 	] );
 };
 
+/**
+ * Track closing of the layout selector.
+ *
+ * @param {string} segment_id Segment ID.
+ * @param {string} vertical_id Vertical ID.
+ * @returns {void}
+ */
 export const trackDismiss = ( segment_id, vertical_id ) => {
 	if ( ! tracksIdentity ) {
 		return;
@@ -42,6 +64,14 @@ export const trackDismiss = ( segment_id, vertical_id ) => {
 	] );
 };
 
+/**
+ * Track layout selection.
+ *
+ * @param {string} segment_id Segment ID.
+ * @param {string} vertical_id Vertical ID.
+ * @param {string} template Template slug.
+ * @returns {void}
+ */
 export const trackSelection = ( segment_id, vertical_id, template ) => {
 	if ( ! tracksIdentity ) {
 		return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new prop `source` to the tracks event `a8c_full_site_editing_template_selector_view` with possible values:
- `add-page` - automatically shown when adding a brand new page (original behavior)
- `sidebar` - triggered from the post editing sidebar (feature added later)

#### Install instructions Local

I have tested this on local WP + FSE setup. Since tracking is intentionally disabled on WP installs outside WordPress.com Simple or Atomic, I recommend adding this snippet:

```
console.log( 'trackView', { segment_id, vertical_id, source } );
```

as the very first line inside `trackView` function in `apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js`

Rebuild code. 

#### Install Instructions Remote

Use the `--sync` param of the build as described in PCYsg-ly5-p2 and test on your real wpcom sandbox. No console.logs need to be added, watch Devtools Network tab for `t.gif` and explore its params.

Sandbox a single wpcom simple site and visit it's wp-admin.

#### Actual Testing Instructions

- Create new page (`/wp-admin/post-new.php?post_type=page`) - console should show the console.log or you should see a t.gif request if testing on the sandbox with `source` value `add-page`
- Select a layout to insert Template into Page
- Navigate to the sidebar to change to a different Layout
- Confirm changing layout
- New event should fire with `source` value `sidebar`

Fixes #39550
