### PR TITLE
Create the History section of JP Scan

### DIFF
--- a/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
+++ b/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
@@ -77,4 +77,7 @@
 	--color-sidebar-menu-hover-background: var( --studio-gray-5 );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-5-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-gray-70 );
+
+	--color-fixed-threat: var( --studio-jetpack-green-40 );
+	--color-ignored-threat: var( --studio-gray-50 );
 }

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { ReactNode } from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import './style.scss';
 
 export interface Props {
 	children?: ReactNode;
+	className?: string;
 	header: string;
 	subheader?: string | ReactNode;
 	highlight?: 'info' | 'success' | 'warning' | 'error';
@@ -35,9 +37,13 @@ class LogItem extends React.PureComponent< Props > {
 	}
 
 	render() {
-		const { highlight, children } = this.props;
+		const { highlight, children, className } = this.props;
 		return (
-			<FoldableCard header={ this.renderHeader() } className="log-item" highlight={ highlight }>
+			<FoldableCard
+				header={ this.renderHeader() }
+				className={ classnames( 'log-item', className ) }
+				highlight={ highlight }
+			>
 				{ children }
 			</FoldableCard>
 		);

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -31,7 +31,7 @@ class LogItem extends React.PureComponent< Props > {
 				<CardHeading tagName="h2" size={ 18 }>
 					{ header }
 				</CardHeading>
-				{ subheader && <p className="log-item__subheader">{ subheader }</p> }
+				{ subheader && <div className="log-item__subheader">{ subheader }</div> }
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
@@ -38,7 +38,7 @@ class ScanHistoryItem extends Component {
 				<div className="scan-history-item__subheader">
 					<span className="scan-history-item__date">Threat found on { entry.detectionDate }</span>
 					<span className="scan-history-item__date-separator"></span>
-					<span className={ `scan-history-item__date is-${ entry.action }` }>
+					<span className={ classnames( 'scan-history-item__date', this.entryActionClassNames() ) }>
 						Threat { entry.action } on { entry.actionDate }
 					</span>
 				</div>

--- a/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Badge from 'components/badge';
+import LogItem from '../log-item';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ScanHistoryItem extends Component {
+	static propTypes = {
+		object: PropTypes.object,
+	};
+
+	entryActionClassNames( entry ) {
+		return {
+			'is-fixed': entry.action === 'fixed',
+			'is-ignored': entry.action === 'ignored',
+		};
+	}
+
+	renderEntryHeader( entry ) {
+		// React complains because we shouldn't wrap a <div> tag inside <p> tag. This happens
+		// because LogItem surrounds its content by a <p> tag, and the Badge is a <div> tag.
+		// Should we create our own Badge component?
+		return (
+			<>
+				<div className="scan-history-item__subheader">
+					<span className="scan-history-item__date">Threat found on { entry.detectionDate }</span>
+					<span className="scan-history-item__date-separator"></span>
+					<span className={ `scan-history-item__date is-${ entry.action }` }>
+						Threat { entry.action } on { entry.actionDate }
+					</span>
+				</div>
+				<Badge
+					className={ classnames(
+						'scan-history-item__badge',
+						this.entryActionClassNames( entry )
+					) }
+				>
+					<small>{ entry.action }</small>
+				</Badge>
+			</>
+		);
+	}
+
+	renderEntryDetails( entry ) {
+		return (
+			<div className="scan-history-item__details">
+				<strong>{ translate( 'What was the problem?' ) }</strong>
+				<p>{ entry.description.problem }</p>
+				<strong>{ translate( 'How did Jetpack fix it?' ) }</strong>
+				<p>{ entry.description.fix }</p>
+				<strong>{ translate( 'The technical details' ) }</strong>
+				<p>{ entry.description.details }</p>
+			</div>
+		);
+	}
+
+	render() {
+		const { entry } = this.props;
+
+		return (
+			<LogItem
+				className={ classnames( 'scan-history-item', this.entryActionClassNames( entry ) ) }
+				header={ entry.title }
+				subheader={ this.renderEntryHeader( entry ) }
+				key={ entry.id }
+			>
+				{ this.renderEntryDetails( entry ) }
+			</LogItem>
+		);
+	}
+}
+
+export default ScanHistoryItem;

--- a/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
@@ -38,7 +38,12 @@ class ScanHistoryItem extends Component {
 				<div className="scan-history-item__subheader">
 					<span className="scan-history-item__date">Threat found on { entry.detectionDate }</span>
 					<span className="scan-history-item__date-separator"></span>
-					<span className={ classnames( 'scan-history-item__date', this.entryActionClassNames() ) }>
+					<span
+						className={ classnames(
+							'scan-history-item__date',
+							this.entryActionClassNames( entry )
+						) }
+					>
 						Threat { entry.action } on { entry.actionDate }
 					</span>
 				</div>

--- a/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
@@ -30,9 +30,6 @@ class ScanHistoryItem extends Component {
 	}
 
 	renderEntryHeader( entry ) {
-		// React complains because we shouldn't wrap a <div> tag inside <p> tag. This happens
-		// because LogItem surrounds its content by a <p> tag, and the Badge is a <div> tag.
-		// Should we create our own Badge component?
 		return (
 			<>
 				<div className="scan-history-item__subheader">

--- a/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
@@ -36,7 +36,9 @@ class ScanHistoryItem extends Component {
 		return (
 			<>
 				<div className="scan-history-item__subheader">
-					<span className="scan-history-item__date">Threat found on { entry.detectionDate }</span>
+					<span className="scan-history-item__date">
+						{ translate( 'Threat found on %s', { args: entry.detectionDate } ) }
+					</span>
 					<span className="scan-history-item__date-separator"></span>
 					<span
 						className={ classnames(
@@ -44,7 +46,9 @@ class ScanHistoryItem extends Component {
 							this.entryActionClassNames( entry )
 						) }
 					>
-						Threat { entry.action } on { entry.actionDate }
+						{ translate( 'Threat %(action)s on %(actionDate)s', {
+							args: { action: entry.action, actionDate: entry.actionDate },
+						} ) }
 					</span>
 				</div>
 				<Badge

--- a/client/landing/jetpack-cloud/components/scan-history-item/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-history-item/style.scss
@@ -1,0 +1,65 @@
+.scan-history-item {
+	&.is-fixed {
+		border-left: 3px solid var( --studio-jetpack-green-40 );
+	}
+
+	&.is-ignored {
+		border-left: 3px solid var( --studio-gray-50 );
+	}
+
+	&__subheader {
+		color: var( --studio-gray-50 );
+		font-size: 13px;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+
+		@include breakpoint( '>800px' ) {
+			flex-direction: row;
+			align-items: center;
+		}
+	}
+
+	&__date {
+		white-space: nowrap;
+
+		&.is-fixed {
+			color: var( --studio-jetpack-green-40 );
+		}
+	}
+
+	&__date-separator {
+		display: none;
+
+		@include breakpoint( '>800px' ) {
+			display: inline-block;
+			background: var( --studio-gray-50 );
+			margin: 0 20px;
+			width: 4px;
+			height: 4px;
+			border-radius: 50%;
+		}
+	}
+
+	&__badge {
+		width: 60px;
+		margin-top: 10px;
+		letter-spacing: 1px;
+		text-align: center;
+		text-transform: uppercase;
+		border-radius: 3px;
+		color: #fff;
+
+		&.is-fixed {
+			background-color: var( --studio-jetpack-green-40 );
+		}
+
+		&.is-ignored {
+			background-color: var( --studio-gray-50 );
+		}
+	}
+
+	&__details {
+		font-size: 15px;
+	}
+}

--- a/client/landing/jetpack-cloud/components/scan-history-item/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-history-item/style.scss
@@ -8,13 +8,13 @@
 	}
 
 	&__subheader {
-		color: var( --studio-gray-50 );
+		color: var( --color-ignored-threat );
 		font-size: 13px;
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
 
-		@include breakpoint( '>800px' ) {
+		@include breakpoint( '>960px' ) {
 			flex-direction: row;
 			align-items: center;
 		}
@@ -24,16 +24,16 @@
 		white-space: nowrap;
 
 		&.is-fixed {
-			color: var( --studio-jetpack-green-40 );
+			color: var( --color-fixed-threat );
 		}
 	}
 
 	&__date-separator {
 		display: none;
 
-		@include breakpoint( '>800px' ) {
+		@include breakpoint( '>960px' ) {
 			display: inline-block;
-			background: var( --studio-gray-50 );
+			background: var( --color-ignored-threat );
 			margin: 0 20px;
 			width: 4px;
 			height: 4px;
@@ -51,11 +51,11 @@
 		color: #fff;
 
 		&.is-fixed {
-			background-color: var( --studio-jetpack-green-40 );
+			background-color: var( --color-fixed-threat );
 		}
 
 		&.is-ignored {
-			background-color: var( --studio-gray-50 );
+			background-color: var( --color-ignored-threat );
 		}
 	}
 

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -85,7 +85,14 @@ const router = () => {
 		page( '/scan/:site', siteSelection, setupSidebar, scan, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
-			page( '/scan/:site/history', siteSelection, setupSidebar, scanHistory, makeLayout, clientRender );
+			page(
+				'/scan/:site/history',
+				siteSelection,
+				setupSidebar,
+				scanHistory,
+				makeLayout,
+				clientRender
+			);
 		}
 	}
 

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -112,7 +112,6 @@ class ScanHistoryPage extends Component {
 
 	handleOnFilterChange = filter => {
 		// @todo: should we filter in the front end?
-		// eslint-disable-next-line no-console
 		this.setState( {
 			filter,
 		} );

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
@@ -9,9 +8,8 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Badge from 'components/badge';
 import FormattedHeader from 'components/formatted-header';
-import LogItem from '../../../components/log-item';
+import ScanHistoryItem from '../../../components/scan-history-item';
 import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -108,47 +106,29 @@ const scanEntries = [
 ];
 
 class ScanHistoryPage extends Component {
-	handleOnFilterChange( selection ) {
+	state = {
+		filter: filterOptions[ 0 ],
+	};
+
+	handleOnFilterChange = filter => {
 		// @todo: should we filter in the front end?
 		// eslint-disable-next-line no-console
-		console.log( selection );
-	}
+		this.setState( {
+			filter,
+		} );
+	};
 
-	renderEntryHeader( entry ) {
-		// React complains because we shouldn't wrap a <div> tag inside <p> tag. This happens
-		// because LogItem surrounds its content by a <p> tag, and the Badge is a <div> tag.
-		// Should we create our own Badge component?
-		return (
-			<>
-				<small className="history__entry-date">Threat found on { entry.detectionDate }</small>
-				<small className={ `history__entry-date is-${ entry.action }` }>
-					Threat { entry.action } on { entry.actionDate }
-				</small>
-				<Badge
-					className="history__entry-badge"
-					type={ entry.action === 'fixed' ? 'success' : 'info' }
-				>
-					<small>{ entry.action }</small>
-				</Badge>
-			</>
-		);
-	}
-
-	renderEntryDetails( entry ) {
-		return (
-			<div className="history__entry-details">
-				<strong>{ translate( 'What was the problem?' ) }</strong>
-				<p>{ entry.description.problem }</p>
-				<strong>{ translate( 'How did Jetpack fix it?' ) }</strong>
-				<p>{ entry.description.fix }</p>
-				<strong>{ translate( 'The technical details' ) }</strong>
-				<p>{ entry.description.details }</p>
-			</div>
-		);
+	filteredEntries() {
+		const { logEntries } = this.props;
+		const { value: filter } = this.state.filter;
+		if ( filter === 'all' ) {
+			return logEntries;
+		}
+		return logEntries.filter( entry => entry.action === filter );
 	}
 
 	render() {
-		const { logEntries } = this.props;
+		const logEntries = this.filteredEntries();
 		return (
 			<section className="history">
 				<FormattedHeader className="history__title" headerText="History" />
@@ -164,14 +144,7 @@ class ScanHistoryPage extends Component {
 				/>
 				<div className="history__entries">
 					{ logEntries.map( entry => (
-						<LogItem
-							header={ entry.title }
-							subheader={ this.renderEntryHeader( entry ) }
-							highlight="success"
-							key={ entry.id }
-						>
-							{ this.renderEntryDetails( entry ) }
-						</LogItem>
+						<ScanHistoryItem entry={ entry } key={ entry.id } />
 					) ) }
 				</div>
 			</section>

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -110,6 +110,12 @@ class ScanHistoryEntry extends Component {
 		);
 	}
 
+	renderEntryDetails() {
+		const { entry } = this.props;
+
+		return <pre>{ JSON.stringify( entry, null, 2 ) }</pre>;
+	}
+
 	render() {
 		const { entry } = this.props;
 
@@ -120,7 +126,7 @@ class ScanHistoryEntry extends Component {
 				screenReaderText="More"
 				key={ entry.id }
 			>
-				I'm highlighted!
+				{ this.renderEntryDetails() }
 			</FoldableCard>
 		);
 	}

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -4,13 +4,14 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import FoldableCard from 'components/foldable-card';
+import Badge from 'components/badge';
 import FormattedHeader from 'components/formatted-header';
+import LogItem from '../../../components/log-item';
 import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -32,9 +33,13 @@ const scanEntries = [
 		action: 'fixed',
 		detectionDate: '23 September, 2019',
 		actionDate: '1 October, 2019',
-		details: {
+		description: {
 			title: 'Unexpected string was found in: /htdocs/wp-admin/index.php',
-			description: '',
+			problem:
+				'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
+			fix:
+				'To fix this threat, Jetpack deleted the file, since it’s not a part of the original WordPress.',
+			details: 'This threat was found in the file: /htdocs/sx--a4bp.php',
 		},
 	},
 	{
@@ -43,10 +48,14 @@ const scanEntries = [
 		action: 'ignored',
 		detectionDate: '17 September, 2019',
 		actionDate: '24 September, 2019',
-		details: {
+		description: {
 			title:
 				'Unexpected file baaaaaad--file.php contains malicious code and is not part of the Plugin',
-			description: '',
+			problem:
+				'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
+			fix:
+				'To fix this threat, Jetpack deleted the file, since it’s not a part of the original WordPress.',
+			details: 'This threat was found in the file: /htdocs/sx--a4bp.php',
 		},
 	},
 	{
@@ -55,103 +64,116 @@ const scanEntries = [
 		action: 'ignored',
 		detectionDate: '16 September, 2019',
 		actionDate: '24 September, 2019',
-		details: {
+		description: {
 			title:
 				'Unexpected file veryBadFile.php contains malicious code and is not part of the Plugin',
-			description: '',
-		},
-	},
-	{
-		title: 'Infected core file: index.php',
-		action: 'fixed',
-		detectionDate: '16 September, 2019',
-		actionDate: '24 September, 2019',
-		details: {
-			title: 'Unexpected string was found in: /htdocs/wp-admin/index.php',
-			description: '',
+			problem:
+				'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
+			fix:
+				'To fix this threat, Jetpack deleted the file, since it’s not a part of the original WordPress.',
+			details: 'This threat was found in the file: /htdocs/sx--a4bp.php',
 		},
 	},
 	{
 		id: 4,
+		title: 'Infected core file: index.php',
+		action: 'fixed',
+		detectionDate: '16 September, 2019',
+		actionDate: '24 September, 2019',
+		description: {
+			title: 'Unexpected string was found in: /htdocs/wp-admin/index.php',
+			problem:
+				'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
+			fix:
+				'To fix this threat, Jetpack deleted the file, since it’s not a part of the original WordPress.',
+			details: 'This threat was found in the file: /htdocs/sx--a4bp.php',
+		},
+	},
+	{
+		id: 5,
 		title: 'Infected Plugin: Classic Editor',
 		action: 'ignored',
 		detectionDate: '14 September, 2019',
 		actionDate: '14 September, 2019',
-		details: {
+		description: {
 			title:
 				'Unexpected file veryBadFile.php contains malicious code and is not part of the Plugin',
-			description: '',
+			problem:
+				'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
+			fix:
+				'To fix this threat, Jetpack deleted the file, since it’s not a part of the original WordPress.',
+			details: 'This threat was found in the file: /htdocs/sx--a4bp.php',
 		},
 	},
 ];
 
-class ScanHistoryEntry extends Component {
-	static propTypes = {
-		entry: PropTypes.object,
-	};
-
-	renderEntryHeader() {
-		const { entry } = this.props;
-
-		const actionClass = 'entry' + entry.action === 'fixed' ? ' is-fixed' : ' is-ignored';
-
-		return (
-			<div className={ actionClass }>
-				<div className="entry__title">
-					<small className="entry__badge">{ entry.action }</small> { entry.title }{ ' ' }
-				</div>
-				<div className="entry__description">
-					<small>Threat found on { entry.detectionDate }</small>–
-					<small>
-						Threat { entry.action } on { entry.actionDate }
-					</small>
-				</div>
-			</div>
-		);
-	}
-
-	renderEntryDetails() {
-		const { entry } = this.props;
-
-		return <pre>{ JSON.stringify( entry, null, 2 ) }</pre>;
-	}
-
-	render() {
-		const { entry } = this.props;
-
-		return (
-			<FoldableCard
-				className="history__entry"
-				header={ this.renderEntryHeader() }
-				screenReaderText="More"
-				key={ entry.id }
-			>
-				{ this.renderEntryDetails() }
-			</FoldableCard>
-		);
-	}
-}
-
 class ScanHistoryPage extends Component {
-	handleOnSelect( selection ) {
+	handleOnFilterChange( selection ) {
 		// @todo: should we filter in the front end?
 		// eslint-disable-next-line no-console
 		console.log( selection );
 	}
 
+	renderEntryHeader( entry ) {
+		// React complains because we shouldn't wrap a <div> tag inside <p> tag. This happens
+		// because LogItem surrounds its content by a <p> tag, and the Badge is a <div> tag.
+		// Should we create our own Badge component?
+		return (
+			<>
+				<small className="history__entry-date">Threat found on { entry.detectionDate }</small>
+				<small className={ `history__entry-date is-${ entry.action }` }>
+					Threat { entry.action } on { entry.actionDate }
+				</small>
+				<Badge
+					className="history__entry-badge"
+					type={ entry.action === 'fixed' ? 'success' : 'info' }
+				>
+					<small>{ entry.action }</small>
+				</Badge>
+			</>
+		);
+	}
+
+	renderEntryDetails( entry ) {
+		return (
+			<div className="history__entry-details">
+				<strong>{ translate( 'What was the problem?' ) }</strong>
+				<p>{ entry.description.problem }</p>
+				<strong>{ translate( 'How did Jetpack fix it?' ) }</strong>
+				<p>{ entry.description.fix }</p>
+				<strong>{ translate( 'The technical details' ) }</strong>
+				<p>{ entry.description.details }</p>
+			</div>
+		);
+	}
+
 	render() {
+		const { logEntries } = this.props;
 		return (
 			<section className="history">
 				<FormattedHeader className="history__title" headerText="History" />
-				<p>The scanning history contains a record of all previously active threats on your site.</p>
+				<p>
+					{ translate(
+						'The scanning history contains a record of all previously active threats on your site.'
+					) }
+				</p>
 				<SimplifiedSegmentedControl
 					className="history__filters"
 					options={ filterOptions }
-					onSelect={ this.handleOnSelect }
+					onSelect={ this.handleOnFilterChange }
 				/>
-				{ scanEntries.map( entry => (
-					<ScanHistoryEntry entry={ entry } key={ entry.id } />
-				) ) }
+				<div className="history__entries">
+					{ logEntries.map( entry => (
+						<LogItem
+							header={ entry.title }
+							subheader={ this.renderEntryHeader( entry ) }
+							highlight="success"
+							key={ entry.id }
+						>
+							{ this.renderEntryDetails( entry ) }
+						</LogItem>
+					) ) }
+				</div>
 			</section>
 		);
 	}
@@ -160,7 +182,11 @@ class ScanHistoryPage extends Component {
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 
+	// TODO: Get state from actual API.
+	const scanHistoryLogEntries = scanEntries;
+
 	return {
 		siteId,
+		logEntries: scanHistoryLogEntries,
 	};
 } )( ScanHistoryPage );

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -1,17 +1,153 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
+import FoldableCard from 'components/foldable-card';
+import FormattedHeader from 'components/formatted-header';
+import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
-class ScanHistoryPage extends Component {
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const filterOptions = [
+	{ value: 'all', label: 'All' },
+	{ value: 'fixed', label: 'Fixed' },
+	{ value: 'ignored', label: 'Ignored' },
+];
+
+const scanEntries = [
+	{
+		id: 1,
+		title: 'Infected core file: index.php',
+		action: 'fixed',
+		detectionDate: '23 September, 2019',
+		actionDate: '1 October, 2019',
+		details: {
+			title: 'Unexpected string was found in: /htdocs/wp-admin/index.php',
+			description: '',
+		},
+	},
+	{
+		id: 2,
+		title: 'Infected Plugin: Contact Form 7',
+		action: 'ignored',
+		detectionDate: '17 September, 2019',
+		actionDate: '24 September, 2019',
+		details: {
+			title:
+				'Unexpected file baaaaaad--file.php contains malicious code and is not part of the Plugin',
+			description: '',
+		},
+	},
+	{
+		id: 3,
+		title: 'Infected Plugin: Contact Form 7',
+		action: 'ignored',
+		detectionDate: '16 September, 2019',
+		actionDate: '24 September, 2019',
+		details: {
+			title:
+				'Unexpected file veryBadFile.php contains malicious code and is not part of the Plugin',
+			description: '',
+		},
+	},
+	{
+		title: 'Infected core file: index.php',
+		action: 'fixed',
+		detectionDate: '16 September, 2019',
+		actionDate: '24 September, 2019',
+		details: {
+			title: 'Unexpected string was found in: /htdocs/wp-admin/index.php',
+			description: '',
+		},
+	},
+	{
+		id: 4,
+		title: 'Infected Plugin: Classic Editor',
+		action: 'ignored',
+		detectionDate: '14 September, 2019',
+		actionDate: '14 September, 2019',
+		details: {
+			title:
+				'Unexpected file veryBadFile.php contains malicious code and is not part of the Plugin',
+			description: '',
+		},
+	},
+];
+
+class ScanHistoryEntry extends Component {
+	static propTypes = {
+		entry: PropTypes.object,
+	};
+
+	renderEntryHeader() {
+		const { entry } = this.props;
+
+		const actionClass = 'entry' + entry.action === 'fixed' ? ' is-fixed' : ' is-ignored';
+
+		return (
+			<div className={ actionClass }>
+				<div className="entry__title">
+					<small className="entry__badge">{ entry.action }</small> { entry.title }{ ' ' }
+				</div>
+				<div className="entry__description">
+					<small>Threat found on { entry.detectionDate }</small>–
+					<small>
+						Threat { entry.action } on { entry.actionDate }
+					</small>
+				</div>
+			</div>
+		);
+	}
+
 	render() {
-		return ( <div>Welcome to the scan history page for site { this.props.siteId }</div> );
+		const { entry } = this.props;
+
+		return (
+			<FoldableCard
+				className="history__entry"
+				header={ this.renderEntryHeader() }
+				screenReaderText="More"
+				key={ entry.id }
+			>
+				I'm highlighted!
+			</FoldableCard>
+		);
+	}
+}
+
+class ScanHistoryPage extends Component {
+	handleOnSelect( selection ) {
+		// @todo: should we filter in the front end?
+		// eslint-disable-next-line no-console
+		console.log( selection );
+	}
+
+	render() {
+		return (
+			<section className="history">
+				<FormattedHeader className="history__title" headerText="History" />
+				<p>The scanning history contains a record of all previously active threats on your site.</p>
+				<SimplifiedSegmentedControl
+					className="history__filters"
+					options={ filterOptions }
+					onSelect={ this.handleOnSelect }
+				/>
+				{ scanEntries.map( entry => (
+					<ScanHistoryEntry entry={ entry } key={ entry.id } />
+				) ) }
+			</section>
+		);
 	}
 }
 

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -8,7 +8,6 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import FormattedHeader from 'components/formatted-header';
 import ScanHistoryItem from '../../../components/scan-history-item';
 import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -130,7 +129,7 @@ class ScanHistoryPage extends Component {
 		const logEntries = this.filteredEntries();
 		return (
 			<section className="history">
-				<FormattedHeader className="history__title" headerText="History" />
+				<h1 className="history__header">{ translate( 'History' ) }</h1>
 				<p>
 					{ translate(
 						'The scanning history contains a record of all previously active threats on your site.'

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -1,10 +1,4 @@
 .history {
-	/*
-		Overriding colors from Calypso components (Badge and ItemLog).
-	*/
-	--color-success: var( --studio-jetpack-green-40 );
-	--color-success-20: var( --studio-jetpack-green-40 );
-
 	padding: 0 10px;
 
 	&__title {
@@ -18,35 +12,5 @@
 
 	&__entries {
 		font-size: 16px;
-	}
-
-	&__entry-date {
-		display: inline-block;
-		width: 100%;
-
-		&.is-fixed {
-			color: var( --studio-jetpack-green-40 );
-		}
-
-		&.is-ignored {
-			color: var( --studio-gray-50 );
-		}
-	}
-
-	&__entry-badge {
-		width: 60px;
-		margin-top: 10px;
-		letter-spacing: 1px;
-		text-align: center;
-		text-transform: uppercase;
-		border-radius: 3px;
-	}
-
-	&__entry-details {
-		font-size: 15px;
-	}
-
-	.card-heading {
-		color: var( --studio-jetpack-green-40 );
 	}
 }

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -1,4 +1,10 @@
 .history {
+	/*
+		Overriding colors from Calypso components (Badge and ItemLog).
+	*/
+	--color-success: var( --studio-jetpack-green-40 );
+	--color-success-20: var( --studio-jetpack-green-40 );
+
 	padding: 0 10px;
 
 	&__title {
@@ -9,24 +15,38 @@
 	&__filters {
 		margin: 25px 0;
 	}
-}
 
-.entry {
-	&.is-fixed {
-		border-left: 3px solid var( --studio-jetpack-green-40 );
+	&__entries {
+		font-size: 16px;
 	}
 
-	&.is-ignored {
-		border-left: 3px solid var( --studio-gray-50 );
+	&__entry-date {
+		display: inline-block;
+		width: 100%;
+
+		&.is-fixed {
+			color: var( --studio-jetpack-green-40 );
+		}
+
+		&.is-ignored {
+			color: var( --studio-gray-50 );
+		}
 	}
 
-	&__badge {
-		color: white;
-		background: var( --studio-jetpack-green-40 );
-		text-transform: uppercase;
+	&__entry-badge {
 		width: 60px;
-		padding: 5px;
-		letter-spacing: 0.5px;
+		margin-top: 10px;
+		letter-spacing: 1px;
+		text-align: center;
+		text-transform: uppercase;
 		border-radius: 3px;
+	}
+
+	&__entry-details {
+		font-size: 15px;
+	}
+
+	.card-heading {
+		color: var( --studio-jetpack-green-40 );
 	}
 }

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -1,0 +1,32 @@
+.history {
+	padding: 0 10px;
+
+	&__title {
+		text-align: left;
+		margin-left: -10px;
+	}
+
+	&__filters {
+		margin: 25px 0;
+	}
+}
+
+.entry {
+	&.is-fixed {
+		border-left: 3px solid var( --studio-jetpack-green-40 );
+	}
+
+	&.is-ignored {
+		border-left: 3px solid var( --studio-gray-50 );
+	}
+
+	&__badge {
+		color: white;
+		background: var( --studio-jetpack-green-40 );
+		text-transform: uppercase;
+		width: 60px;
+		padding: 5px;
+		letter-spacing: 0.5px;
+		border-radius: 3px;
+	}
+}

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -1,8 +1,14 @@
 .history {
 	padding: 0 10px;
 
-	&__title {
-		text-align: left;
+	&__header {
+		font-size: 28px;
+		line-height: 1;
+		margin: 30px 0;
+
+		@include breakpoint( '>660px' ) {
+			font-size: 48px;
+		}
 	}
 
 	&__filters {

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -3,7 +3,6 @@
 
 	&__title {
 		text-align: left;
-		margin-left: -10px;
 	}
 
 	&__filters {


### PR DESCRIPTION
**Changes proposed in this Pull Request**

- The goal of this is to create the iteration of the UI of the History section. At this point, we don't know if we will have an APIs ready to work with.

See 1151678672052943-as-1164658985934865.

**Testing instructions**

- View Scan page and verify that component matches comps.

**Screenshots**
![Kapture 2020-03-05 at 22 58 33](https://user-images.githubusercontent.com/3418513/76042971-f31e2a80-5f34-11ea-9063-be7a660524a6.gif)

**Desktop**
<img width="1326" alt="image" src="https://user-images.githubusercontent.com/3418513/76178444-2ca1a080-6196-11ea-859d-c849c86e85c4.png">

**Mobile**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/3418513/76178421-1398ef80-6196-11ea-8d25-096423693b3a.png">
