### PR TITLE
Plans: Show ability to set custom domain as primary under plan benefits

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -5,6 +5,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { head } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,11 +19,18 @@ import { hasCustomDomain } from 'lib/site/utils';
  */
 import customDomainImage from 'assets/images/illustrations/custom-domain.svg';
 import customDomainBloggerImage from 'assets/images/illustrations/custom-domain-blogger.svg';
+import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getDomainsBySiteId } from 'state/sites/domains/selectors';
+import { getRegisteredDomains } from 'lib/domains';
 
 const CustomDomainPurchaseDetail = ( {
 	selectedSite,
 	hasDomainCredit,
+	hasNonPrimaryDomainsFlag,
 	onlyBlogDomain,
+	registeredDomain,
 	translate,
 } ) => {
 	const customDomainIcon = onlyBlogDomain ? customDomainBloggerImage : customDomainImage;
@@ -65,6 +74,24 @@ const CustomDomainPurchaseDetail = ( {
 				{ ...actionButton }
 			/>
 		);
+	} else if ( hasNonPrimaryDomainsFlag && registeredDomain ) {
+		const actionButton = {};
+		actionButton.buttonText = translate( 'Change primary domain' );
+		actionButton.href = `/domains/manage/${ selectedSite.slug }`;
+		return (
+			<PurchaseDetail
+				icon={ <img alt="" src={ customDomainIcon } /> }
+				title={ translate( 'Make your new domain your primary address' ) }
+				description={ translate(
+					'Make {{em}}%(domain)s{{/em}} the primary address that your visitors see when they come to your site.',
+					{
+						args: { domain: registeredDomain.name },
+						components: { em: <em /> },
+					}
+				) }
+				{ ...actionButton }
+			/>
+		);
 	}
 	return null;
 };
@@ -73,6 +100,19 @@ CustomDomainPurchaseDetail.propTypes = {
 	onlyBlogDomain: PropTypes.bool,
 	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
 	hasDomainCredit: PropTypes.bool,
+	hasNonPrimaryDomainsFlag: PropTypes.bool,
+	siteDomains: PropTypes.array,
 };
 
-export default localize( CustomDomainPurchaseDetail );
+export default connect( state => {
+	const siteId = getSelectedSiteId( state );
+	const siteDomains = getDomainsBySiteId( state, siteId );
+	const registeredDomains = getRegisteredDomains( siteDomains );
+
+	return {
+		hasNonPrimaryDomainsFlag: getCurrentUser( state )
+			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+			: false,
+		registeredDomain: head( registeredDomains ),
+	};
+} )( localize( CustomDomainPurchaseDetail ) );

--- a/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/custom-domain-purchase-detail.jsx
@@ -81,7 +81,7 @@ const CustomDomainPurchaseDetail = ( {
 		return (
 			<PurchaseDetail
 				icon={ <img alt="" src={ customDomainIcon } /> }
-				title={ translate( 'Make your new domain your primary address' ) }
+				title={ translate( 'Make your domain your primary address' ) }
 				description={ translate(
 					'Make {{em}}%(domain)s{{/em}} the primary address that your visitors see when they come to your site.',
 					{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR emphasizes the ability to set a domain as primary under plan benefits after upgrading, as part of this test: p99Zz8-10j-p2

<img width="526" alt="Screenshot 2020-03-04 at 4 02 39 PM" src="https://user-images.githubusercontent.com/13062352/75892808-3cd21c80-5e32-11ea-9c0e-c7ca9df07cc6.png">

#### Testing instructions

* Purchase a plan for a site
* Make sure the card is not shown before purchasing a domain
* Claim your free domain
* Click Plan on your sidebar
* Verify that the card is shown like in the screenshot above after you register the domain under plan features, and that the button sends you to the right place
* Make sure that the card is not shown if a custom domain is set as primary
* Verify that nothing gets broken