### PR TITLE
Make backup download error dismissal permanent

### DIFF
--- a/client/my-sites/activity/activity-log-banner/error-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/error-banner.jsx
@@ -16,7 +16,10 @@ import HappychatButton from 'components/happychat/button';
 import Gridicon from 'components/gridicon';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { dismissRewindRestoreProgress as dismissRewindRestoreProgressAction } from 'state/activity-log/actions';
+import {
+	dismissRewindBackupProgress,
+	dismissRewindRestoreProgress as dismissRewindRestoreProgressAction,
+} from 'state/activity-log/actions';
 
 class ErrorBanner extends PureComponent {
 	static propTypes = {
@@ -57,7 +60,7 @@ class ErrorBanner extends PureComponent {
 	handleDismiss = () =>
 		isUndefined( this.props.downloadId )
 			? this.props.closeDialog( 'restore' )
-			: this.props.closeDialog( 'backup' );
+			: this.props.dismissDownloadError( this.props.siteId, this.props.downloadId );
 
 	render() {
 		const {
@@ -120,6 +123,7 @@ class ErrorBanner extends PureComponent {
 
 export default connect( null, {
 	dismissRewindRestoreProgress: dismissRewindRestoreProgressAction,
+	dismissDownloadError: dismissRewindBackupProgress,
 	trackHappyChatBackup: () => recordTracksEvent( 'calypso_activitylog_error_banner_backup' ),
 	trackHappyChatRestore: () => recordTracksEvent( 'calypso_activitylog_error_banner_restore' ),
 } )( localize( ErrorBanner ) );


### PR DESCRIPTION
<img width="1257" alt="Screenshot 2020-03-04 at 16 09 59" src="https://user-images.githubusercontent.com/7767559/75898934-bc5feb80-5e32-11ea-99ce-bc1113d6bb33.png">

The above error banner displays when there has been some error generating a downloadable archive of a backup. Previously, clicking the X would dismiss the banner, but the error would remain on the back-end, meaning the error would display on subsequent page loads, forever.

This PR hooks up the X to the existing action to clear the error on the back-end.


#### Testing instructions

From a VaultPress sandbox, generate an archive for a test site that will fail by supplying an invalid timestamp:
`node bbin/prepare-download.js -s 256285 --types uploads --timestamp 6453`

On this branch, go to the Activity Log for the site and click the X on the download error banner. You should see an network request, and reloading the page will not bring back the error banner.

