### PR TITLE
Site Editor: initialize core FSE on Dotcom sites

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -41,6 +41,15 @@ define( 'PLUGIN_VERSION', '0.21' );
 require_once __DIR__ . '/dotcom-fse/helpers.php';
 
 /**
+ * Load Core Site Editor.
+ */
+function load_core_site_editor() {
+	require_once __DIR__ . '/site-editor/index.php';
+	initialize_site_editor();
+}
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_core_site_editor' );
+
+/**
  * Load Full Site Editing.
  */
 function load_full_site_editing() {

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
@@ -1,6 +1,17 @@
 <?php
 /**
- * Site Editor experiment file.
+ * WP.com Site Editor.
+ *
+ * The purpose of this code is to allow us to use core's Site Editor experiment
+ * on Dotcom and Atomic. The corresponding core functionality is initialized here:
+ * https://github.com/WordPress/gutenberg/blob/master/lib/edit-site-page.php
+ *
+ * We should aim to reuse as much of the core code as possible and use this to adjust it to some
+ * specifics of our platforms, or in cases when we want to extend the default experience.
+ *
+ * It's end goal is somewhat similar to the dotcom-fse project that's also part of this plugin.
+ * The difference being that that was a custom Dotcom solution and this one is being built on
+ * top of core FSE. When ready, it should completely replace the existing dotcom-fse functionality.
  *
  * @package A8C\FSE
  */
@@ -16,29 +27,57 @@ function initialize_site_editor() {
 	}
 
 	// Force enable required Gutenberg experiments if they are not already active.
-	add_filter(
-		'option_gutenberg-experiments',
-		function( $experiments_option ) {
-			if ( empty( $experiments_option['gutenberg-full-site-editing'] ) ) {
-				$experiments_option['gutenberg-full-site-editing'] = 1;
-			}
+	add_filter( 'option_gutenberg-experiments', __NAMESPACE__ . '\enable_site_editor_experiment' );
 
-			if ( empty( $experiments_option['gutenberg-full-site-editing-demo'] ) ) {
-				$experiments_option['gutenberg-full-site-editing-demo'] = 1;
-			}
-
-			return $experiments_option;
-		}
-	);
-
+	// TODO: Currently this action is removed on Dotcom. Circle back and find a cleaner way to deal with this.
 	add_action( 'admin_menu', 'gutenberg_menu' );
 
-	add_action(
-		'admin_enqueue_scripts',
-		function() {
-			do_action( 'enqueue_block_editor_assets' );
-		}
-	);
+	// Dotcom-specific overrides for API requests and similar.
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_override_scripts' );
+}
+
+/**
+ * Used to filter corresponding Site Editor experiment options.
+ *
+ * These need to be toggled on for the Site Editor to work properly.
+ * Furthermore, it's not enough to set them just on a given site.
+ * In WP.com context this needs to be enabled in API context too,
+ * and since we want to have it selectively enabled for some subset of
+ * sites initially, we can't set this option for the whole API.
+ * Instead we'll intercept it with it options filter (option_gutenberg-experiments)
+ * and override its values for certain sites.
+ *
+ * @param array $experiments_option Default experiments option array.
+ *
+ * @return array Experiments option array with FSE values enabled.
+ */
+function enable_site_editor_experiment( $experiments_option ) {
+	if ( ! is_array( $experiments_option ) ) {
+		$experiments_option = array();
+	}
+
+	if ( empty( $experiments_option['gutenberg-full-site-editing'] ) ) {
+		$experiments_option['gutenberg-full-site-editing'] = 1;
+	}
+
+	if ( empty( $experiments_option['gutenberg-full-site-editing-demo'] ) ) {
+		$experiments_option['gutenberg-full-site-editing-demo'] = 1;
+	}
+
+	return $experiments_option;
+}
+
+/**
+ * We need to load Dotcom scripts to override default behavior.
+ *
+ * One example is routing API requests to public-api.
+ */
+function enqueue_override_scripts() {
+	/*
+	 * TODO: clean up this workaround later if possible.
+	 * Currently this works because the required Dotcom overrides are hooked to this action.
+	 */
+	do_action( 'enqueue_block_editor_assets' );
 }
 
 /**
@@ -48,27 +87,11 @@ function initialize_site_editor() {
  */
 function is_site_editor_active() {
 	/**
-	 * There are times when this function is called from the WordPress.com public
-	 * API context. In this case, we need to switch to the correct blog so that
-	 * the functions reference the correct blog context.
-	 */
-	$multisite_id  = apply_filters( 'a8c_fse_get_multisite_id', false );
-	$should_switch = is_multisite() && $multisite_id;
-	if ( $should_switch ) {
-		switch_to_blog( $multisite_id );
-	}
-
-	/**
-	 * Can be used to disable Site Editor functionality.
+	 * Can be used to enable Site Editor functionality.
 	 *
 	 * @since 0.22
 	 *
-	 * @param bool true if Site Editor should be disabled, false otherwise.
+	 * @param bool true if Site Editor should be enabled, false otherwise.
 	 */
-	$is_active = ! apply_filters( 'a8c_disable_core_site_editor', false );
-
-	if ( $should_switch ) {
-		restore_current_blog();
-	}
-	return $is_active;
+	return apply_filters( 'a8c_enable_core_site_editor', false );
 }

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
@@ -32,7 +32,13 @@ function initialize_site_editor() {
 	);
 
 	add_action( 'admin_menu', 'gutenberg_menu' );
-	do_action( 'enqueue_block_editor_assets' );
+
+	add_action(
+		'admin_enqueue_scripts',
+		function() {
+			do_action( 'enqueue_block_editor_assets' );
+		}
+	);
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Site Editor experiment file.
+ *
+ * @package A8C\FSE
+ */
+
+namespace A8C\FSE;
+
+/**
+ * Enables/Disables site editor experiment per blog sticker.
+ */
+function initialize_site_editor() {
+	if ( ! is_site_editor_active() ) {
+		return;
+	}
+
+	// Force enable required Gutenberg experiments if they are not already active.
+	add_filter(
+		'option_gutenberg-experiments',
+		function( $experiments_option ) {
+			if ( empty( $experiments_option['gutenberg-full-site-editing'] ) ) {
+				$experiments_option['gutenberg-full-site-editing'] = 1;
+			}
+
+			if ( empty( $experiments_option['gutenberg-full-site-editing-demo'] ) ) {
+				$experiments_option['gutenberg-full-site-editing-demo'] = 1;
+			}
+
+			return $experiments_option;
+		}
+	);
+
+	add_action( 'admin_menu', 'gutenberg_menu' );
+	do_action( 'enqueue_block_editor_assets' );
+}
+
+/**
+ * Whether or not core Site Editor is active.
+ *
+ * @returns bool True if Site Editor is active, false otherwise.
+ */
+function is_site_editor_active() {
+	/**
+	 * There are times when this function is called from the WordPress.com public
+	 * API context. In this case, we need to switch to the correct blog so that
+	 * the functions reference the correct blog context.
+	 */
+	$multisite_id  = apply_filters( 'a8c_fse_get_multisite_id', false );
+	$should_switch = is_multisite() && $multisite_id;
+	if ( $should_switch ) {
+		switch_to_blog( $multisite_id );
+	}
+
+	/**
+	 * Can be used to disable Site Editor functionality.
+	 *
+	 * @since 0.22
+	 *
+	 * @param bool true if Site Editor should be disabled, false otherwise.
+	 */
+	$is_active = ! apply_filters( 'a8c_disable_core_site_editor', false );
+
+	if ( $should_switch ) {
+		restore_current_blog();
+	}
+	return $is_active;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

An experiment that attempts to enable and initialize core FSE editor for Dotcom sites via FSE plugin.

Alternative take at https://github.com/Automattic/wp-calypso/pull/39713

#### Testing instructions

1. Sync the FSE plugin to your site.
2. Sandbox the API and your test site.
3. Apply D39899-code to your sandbox.
4. Add `core-site-editor-experiment` sticker to your test site.
3. Navigate to `wp-admin/admin.php?page=gutenberg-edit-site` and verify that the editor loads on your simple site.