### PR TITLE
Composite checkout: update button width

### DIFF
--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -396,9 +396,17 @@ const SubmitButtonWrapperUI = styled.div`
 	border-top-style: solid;
 	border-top-color: ${props => props.theme.colors.borderColorLight};
 
+	button {
+		width: ${props => ( props.isLastStepActive ? 'calc( 100% - 60px )' : '100%' )};
+	}
+
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		position: relative;
 		border: 0;
+
+		button {
+			width: 100%;
+		}
 	}
 `;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the checkout button so that it doesn't sit under the help icon. This was tested in Chrome, Firefox, and Safari. I will test IE with Calypso.live after this PR is created.

**Before**

![image](https://user-images.githubusercontent.com/6981253/75918133-25426600-5e29-11ea-9345-954386bcb6ca.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/75918230-59b62200-5e29-11ea-9e90-e504aca9068e.png)


**After: desktop initial steps**
![image](https://user-images.githubusercontent.com/6981253/75918173-37bc9f80-5e29-11ea-9380-fc567cd04a69.png)

**After: desktop on last step**
![image](https://user-images.githubusercontent.com/6981253/75918205-4b680600-5e29-11ea-962d-e61db4716c93.png)


#### Testing instructions
* Add any product to your cart and make your way to checkout
* Add `flags=composite-checkout-wpcom` to the url to show the new checkout
* make your way to the last step and confirm the pay button works on desktop and mobile, and that on mobile, the help icon isn't overlapping the pay button.

Fixes #
