### PR TITLE
Customer Home: make section available to everyone

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,16 +124,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	customerHomeAll: {
-		datestamp: '20200224',
-		variations: {
-			showCustomerHome: 10,
-			control: 90,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	planStepCopyUpdates: {
 		datestamp: '20200221',
 		variations: {

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -31,9 +31,6 @@ import {
 
 jest.mock( 'lib/analytics', () => ( {} ) );
 jest.mock( 'lib/user', () => () => {} );
-jest.mock( 'lib/abtest', () => ( {
-	abtest: () => {},
-} ) );
 jest.mock( 'components/main', () => 'Main' );
 jest.mock( 'components/section-header', () => 'SectionHeader' );
 jest.mock( 'me/sidebar-navigation', () => 'MeSidebarNavigation' );

--- a/client/state/sites/selectors/can-current-user-use-customer-home.js
+++ b/client/state/sites/selectors/can-current-user-use-customer-home.js
@@ -1,19 +1,12 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import canCurrentUser from 'state/selectors/can-current-user';
-import getSiteOptions from 'state/selectors/get-site-options';
 import { isJetpackSite } from 'state/sites/selectors';
 import isVipSite from 'state/selectors/is-vip-site';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getSite from './get-site';
-import { abtest } from 'lib/abtest';
 
 /**
  * Returns true if the current user should be able to use the customer home screen
@@ -33,19 +26,6 @@ export default function canCurrentUserUseCustomerHome( state, siteId = null ) {
 
 	if ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) {
 		return false;
-	}
-
-	if ( abtest( 'customerHomeAll' ) === 'control' ) {
-		const siteOptions = getSiteOptions( state, siteId );
-		const createdAt = get( siteOptions, 'created_at', '' );
-
-		if (
-			! createdAt ||
-			createdAt.substr( 0, 4 ) === '0000' ||
-			new Date( createdAt ) < new Date( '2019-08-06' )
-		) {
-			return false;
-		}
 	}
 
 	const site = getSite( state, siteId );

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -10,6 +10,7 @@ import LoginPage from '../pages/login-page.js';
 import EditorPage from '../pages/editor-page';
 import WPAdminLoginPage from '../pages/wp-admin/wp-admin-logon-page';
 import ReaderPage from '../pages/reader-page.js';
+import StatsPage from '../pages/stats-page';
 import StoreDashboardPage from '../pages/woocommerce/store-dashboard-page';
 import PluginsBrowserPage from '../pages/plugins-browser-page';
 import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
@@ -205,6 +206,9 @@ export default class LoginFlow {
 
 	async loginAndSelectAllSites() {
 		await this.loginAndSelectMySite();
+
+		// visit stats, as home does not have an all sites option
+		await StatsPage.Visit( this.driver );
 
 		const sideBarComponent = await SidebarComponent.Expect( this.driver );
 		await sideBarComponent.selectSiteSwitcher();

--- a/test/e2e/lib/pages/stats-page.js
+++ b/test/e2e/lib/pages/stats-page.js
@@ -10,10 +10,11 @@ import AsyncBaseContainer from '../async-base-container';
 
 import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager';
+import * as dataHelper from '../data-helper';
 
 export default class StatsPage extends AsyncBaseContainer {
-	constructor( driver ) {
-		super( driver, By.css( '.stats-module' ) );
+	constructor( driver, url = dataHelper.getCalypsoURL( 'stats/day' ) ) {
+		super( driver, By.css( '.stats-module' ), url );
 	}
 
 	async openInsights() {


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/issues/39184

This PR makes the Customer Home section available for everyone rather than just sites created after Aug 2019.

<img width="1349" alt="Screen Shot 2020-03-04 at 12 23 49 PM" src="https://user-images.githubusercontent.com/1270189/75919881-32545a80-5e13-11ea-81d2-85299c1a4cfd.png">

### Testing Instructions
- Create a new site
- Customer Home section and the site launch checklist should be available
- With an existing site created before Aug 2019, verify and see if the Customer Home section is available in the sidebar, and by visiting `http://calypso.localhost:3000/home/:site:`