### PR TITLE
composite-checkout: Send coupon from URL to initial cart

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -115,8 +115,7 @@ export default function CompositeCheckout( {
 	plan,
 	purchaseId,
 	cart,
-	// TODO: handle these also
-	// couponCode,
+	couponCode: couponCodeFromUrl,
 } ) {
 	const translate = useTranslate();
 	const planSlug = useSelector( state => getUpgradePlanSlugFromPath( state, siteId, product ) );
@@ -258,6 +257,7 @@ export default function CompositeCheckout( {
 		siteSlug,
 		canInitializeCart,
 		productForCart,
+		couponCodeFromUrl,
 		setCart || wpcomSetCart,
 		getCart || wpcomGetCart,
 		translate,

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -521,22 +521,14 @@ function useInitializeCartFromServer(
 						' or coupon',
 						couponToAdd
 					);
-					let updatedResponseCart;
+					let updatedResponseCart = processRawResponse( response );
 					if ( productToAdd ) {
-						updatedResponseCart = addItemToResponseCart(
-							processRawResponse( response ),
-							productToAdd
-						);
+						updatedResponseCart = addItemToResponseCart( updatedResponseCart, productToAdd );
 					}
 					if ( couponToAdd ) {
-						updatedResponseCart = addCouponToResponseCart(
-							processRawResponse( response ),
-							couponToAdd
-						);
+						updatedResponseCart = addCouponToResponseCart( updatedResponseCart, couponToAdd );
 					}
-					if ( updatedResponseCart ) {
-						return setServerCart( prepareRequestCart( updatedResponseCart ) );
-					}
+					return setServerCart( prepareRequestCart( updatedResponseCart ) );
 				}
 				return response;
 			} )


### PR DESCRIPTION
Just as `CompositeCheckout` can have a `product` provided as an initial product to add to the cart on first load, this adds the `couponCode` prop which adds a coupon to the initial cart.

This enables the behavior (which already exists in the old checkout) that a coupon code can be specified using the URL query string `?coupon=CODEHERE`

#### Testing instructions

- First load composite checkout with just a plan and be sure the cart loads as expected.
- Next load composite checkout with the URL `/checkout/example.wordpress.com/planslughere` and be sure the cart loads with that plan added (use a different plan than the one you added in the first step).
- Finally load composite checkout again with a `coupon=COUPONCODEHERE` in the URL and be sure the cart loads with that coupon applied.

Some valid plan slugs are `business`, `personal`.

To get a valid coupon code, you'll need to sandbox the coupons admin page.