### PR TITLE
Add/gutenboarding login page

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -13,6 +13,7 @@ import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
 import DesignSelector from './design-selector';
 import SignupForm from '../components/signup-form';
+import LoginForm from './login-form';
 import CreateSite from './create-site';
 import { Attributes } from './types';
 import { Step, usePath } from '../path';
@@ -53,6 +54,10 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 
 				<Route path={ makePath( Step.Signup ) }>
 					<SignupForm onRequestClose={ () => undefined } />;
+				</Route>
+
+				<Route path={ makePath( Step.Login ) }>
+					<LoginForm />;
 				</Route>
 
 				<Route path={ makePath( Step.CreateSite ) }>

--- a/client/landing/gutenboarding/onboarding-block/login-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/login-form/index.tsx
@@ -1,0 +1,144 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
+import { useDispatch, useSelect, dispatch } from '@wordpress/data';
+import { __experimentalCreateInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@automattic/react-i18n';
+/**
+ * Internal dependencies
+ */
+import { USER_STORE } from '../../stores/user';
+import './style.scss';
+import { useHistory } from 'react-router-dom';
+
+// TODO: deploy this change to @types/wordpress__element
+declare module '@wordpress/element' {
+	// eslint-disable-next-line no-shadow
+	export function __experimentalCreateInterpolateElement(
+		interpolatedString: string,
+		conversionMap: Record< string, ReactElement >
+	): ReactNode;
+}
+
+const SignupForm = () => {
+	const { __: NO__, _x: NO_x } = useI18n();
+	const [ usernameOrEmailVal, setUsernameOrEmailVal ] = useState( '' );
+	const [ passwordVal, setPasswordVal ] = useState( '' );
+
+	// dispatch action for logging in
+	// some kind of loading state like isFetchingNewUser
+	// useSelect to get login errors from user store
+
+	const history = useHistory();
+
+	let hasAccountTypeLoaded = false;
+
+	const handleLogin = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+
+		// TODO: check if the account exists and what auth method it uses
+
+		// todo: record analytics.
+
+		// createAccount( { email: usernameOrEmailVal, is_passwordless: true, signup_flow_name: 'gutenboarding' } );
+		// Login dispatch here
+	};
+
+	const handleClose = () => {
+		// work out the equivilant of this code
+		// if ( shouldCreate ) {
+		// 	setShouldCreate( false );
+		// 	history.goBack();
+		// }
+	};
+
+	const tos = __experimentalCreateInterpolateElement(
+		NO__( 'By continuing you agree to our <link_to_tos>Terms of Service</link_to_tos>.' ),
+		{
+			link_to_tos: <ExternalLink href="https://wordpress.com/tos/" />,
+		}
+	);
+
+	let errorMessage: string | undefined;
+
+	// handle error messages like this:
+	// if ( newUserError ) {
+	// 	switch ( newUserError.error ) {
+	// 		case 'already_taken':
+	// 		case 'already_active':
+	// 		case 'email_exists':
+	// 			errorMessage = NO__( 'An account with this email address already exists.' );
+	// 			break;
+
+	// 		default:
+	// 			errorMessage = NO__(
+	// 				'Sorry, something went wrong when trying to create your account. Please try again.'
+	// 			);
+	// 			break;
+	// 	}
+	// }
+
+	return (
+		<Modal
+			className="login-form"
+			isDismissible={ false }
+			title={ NO__( 'Log in to save your changes' ) }
+			onRequestClose={ handleClose }
+		>
+			<form onSubmit={ handleLogin }>
+				<TextControl
+					label={ NO__( 'Email Address or Username' ) }
+					value={ usernameOrEmailVal }
+					// todo: dissable when saving
+					// disabled={ isFetchingNewUser }
+					onChange={ setUsernameOrEmailVal }
+					placeholder={ NO_x(
+						'E.g., yourname@email.com',
+						"An example of a person's email, use something appropriate for the locale"
+					) }
+					required
+				/>
+
+				<div
+					className={ `login-form__password-section ${
+						! hasAccountTypeLoaded ? 'is-hidden' : ''
+					}` }
+				>
+					<TextControl
+						label={ NO__( 'Password' ) }
+						// disabled={ isFormDisabled }
+						type="password"
+						value={ passwordVal }
+						onChange={ setPasswordVal }
+					/>
+
+					{ /* { requestError && requestError.field === 'password' && (
+								<FormInputValidation isError text={ requestError.message } />
+							) } */ }
+				</div>
+				{ errorMessage && (
+					<Notice className="login-form__error-notice" status="error" isDismissible={ false }>
+						{ errorMessage }
+					</Notice>
+				) }
+				<div className="login-form__footer">
+					<p className="login-form__terms-of-service-link">{ tos }</p>
+
+					<Button
+						type="submit"
+						className="login-form__submit"
+						// disabled={ isFetchingNewUser }
+						// isBusy={ isFetchingNewUser }
+						isPrimary
+					>
+						{ NO__( 'Login' ) }
+					</Button>
+				</div>
+			</form>
+		</Modal>
+	);
+};
+
+export default SignupForm;

--- a/client/landing/gutenboarding/onboarding-block/login-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/login-form/index.tsx
@@ -3,15 +3,14 @@
  */
 import React, { useState } from 'react';
 import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
-import { useDispatch, useSelect, dispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
 /**
  * Internal dependencies
  */
-import { USER_STORE } from '../../stores/user';
+import { AUTH_STORE } from '../../stores/auth';
 import './style.scss';
-import { useHistory } from 'react-router-dom';
 
 // TODO: deploy this change to @types/wordpress__element
 declare module '@wordpress/element' {
@@ -26,24 +25,23 @@ const SignupForm = () => {
 	const { __: NO__, _x: NO_x } = useI18n();
 	const [ usernameOrEmailVal, setUsernameOrEmailVal ] = useState( '' );
 	const [ passwordVal, setPasswordVal ] = useState( '' );
+	const { submitUsernameOrEmail } = useDispatch( AUTH_STORE );
+	const { submitPassword } = useDispatch( AUTH_STORE );
+	const loginFlowState = useSelect( select => select( AUTH_STORE ).getLoginFlowState() );
 
-	// dispatch action for logging in
 	// some kind of loading state like isFetchingNewUser
-	// useSelect to get login errors from user store
-
-	const history = useHistory();
-
-	let hasAccountTypeLoaded = false;
+	// todo: useSelect to get login errors from auth store
 
 	const handleLogin = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 
-		// TODO: check if the account exists and what auth method it uses
-
 		// todo: record analytics.
-
-		// createAccount( { email: usernameOrEmailVal, is_passwordless: true, signup_flow_name: 'gutenboarding' } );
-		// Login dispatch here
+		if ( loginFlowState === 'ENTER_USERNAME_OR_EMAIL' ) {
+			submitUsernameOrEmail( usernameOrEmailVal );
+		} else if ( loginFlowState === 'ENTER_PASSWORD' ) {
+			submitPassword( passwordVal );
+			//todo: handle success?
+		}
 	};
 
 	const handleClose = () => {
@@ -63,7 +61,7 @@ const SignupForm = () => {
 
 	let errorMessage: string | undefined;
 
-	// handle error messages like this:
+	// todo: handle error messages like this:
 	// if ( newUserError ) {
 	// 	switch ( newUserError.error ) {
 	// 		case 'already_taken':
@@ -80,6 +78,9 @@ const SignupForm = () => {
 	// 	}
 	// }
 
+	// todo: may need to be updated as more states are handled
+	const shouldShowPasswordField = loginFlowState === 'ENTER_PASSWORD';
+
 	return (
 		<Modal
 			className="login-form"
@@ -92,7 +93,6 @@ const SignupForm = () => {
 					label={ NO__( 'Email Address or Username' ) }
 					value={ usernameOrEmailVal }
 					// todo: dissable when saving
-					// disabled={ isFetchingNewUser }
 					onChange={ setUsernameOrEmailVal }
 					placeholder={ NO_x(
 						'E.g., yourname@email.com',
@@ -100,15 +100,14 @@ const SignupForm = () => {
 					) }
 					required
 				/>
-
 				<div
 					className={ `login-form__password-section ${
-						! hasAccountTypeLoaded ? 'is-hidden' : ''
+						! shouldShowPasswordField ? 'is-hidden' : ''
 					}` }
 				>
 					<TextControl
 						label={ NO__( 'Password' ) }
-						// disabled={ isFormDisabled }
+						// todo: dissable when saving
 						type="password"
 						value={ passwordVal }
 						onChange={ setPasswordVal }
@@ -129,8 +128,7 @@ const SignupForm = () => {
 					<Button
 						type="submit"
 						className="login-form__submit"
-						// disabled={ isFetchingNewUser }
-						// isBusy={ isFetchingNewUser }
+						// todo: dissable and set `isBusy` when saving
 						isPrimary
 					>
 						{ NO__( 'Login' ) }

--- a/client/landing/gutenboarding/onboarding-block/login-form/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/login-form/index.tsx
@@ -6,6 +6,7 @@ import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/com
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
+
 /**
  * Internal dependencies
  */
@@ -21,16 +22,16 @@ declare module '@wordpress/element' {
 	): ReactNode;
 }
 
-const SignupForm = () => {
+const LoginForm = () => {
 	const { __: NO__, _x: NO_x } = useI18n();
 	const [ usernameOrEmailVal, setUsernameOrEmailVal ] = useState( '' );
 	const [ passwordVal, setPasswordVal ] = useState( '' );
 	const { submitUsernameOrEmail } = useDispatch( AUTH_STORE );
 	const { submitPassword } = useDispatch( AUTH_STORE );
 	const loginFlowState = useSelect( select => select( AUTH_STORE ).getLoginFlowState() );
+	const errors = useSelect( select => select( AUTH_STORE ).getErrors() );
 
-	// some kind of loading state like isFetchingNewUser
-	// todo: useSelect to get login errors from auth store
+	// todo: loading state like isFetchingNewUser
 
 	const handleLogin = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
@@ -40,16 +41,12 @@ const SignupForm = () => {
 			submitUsernameOrEmail( usernameOrEmailVal );
 		} else if ( loginFlowState === 'ENTER_PASSWORD' ) {
 			submitPassword( passwordVal );
-			//todo: handle success?
+			//todo: handle success
 		}
 	};
 
 	const handleClose = () => {
-		// work out the equivilant of this code
-		// if ( shouldCreate ) {
-		// 	setShouldCreate( false );
-		// 	history.goBack();
-		// }
+		// todo
 	};
 
 	const tos = __experimentalCreateInterpolateElement(
@@ -58,25 +55,6 @@ const SignupForm = () => {
 			link_to_tos: <ExternalLink href="https://wordpress.com/tos/" />,
 		}
 	);
-
-	let errorMessage: string | undefined;
-
-	// todo: handle error messages like this:
-	// if ( newUserError ) {
-	// 	switch ( newUserError.error ) {
-	// 		case 'already_taken':
-	// 		case 'already_active':
-	// 		case 'email_exists':
-	// 			errorMessage = NO__( 'An account with this email address already exists.' );
-	// 			break;
-
-	// 		default:
-	// 			errorMessage = NO__(
-	// 				'Sorry, something went wrong when trying to create your account. Please try again.'
-	// 			);
-	// 			break;
-	// 	}
-	// }
 
 	// todo: may need to be updated as more states are handled
 	const shouldShowPasswordField = loginFlowState === 'ENTER_PASSWORD';
@@ -92,7 +70,7 @@ const SignupForm = () => {
 				<TextControl
 					label={ NO__( 'Email Address or Username' ) }
 					value={ usernameOrEmailVal }
-					// todo: dissable when saving
+					// disabled={ isLoading }
 					onChange={ setUsernameOrEmailVal }
 					placeholder={ NO_x(
 						'E.g., yourname@email.com',
@@ -107,28 +85,31 @@ const SignupForm = () => {
 				>
 					<TextControl
 						label={ NO__( 'Password' ) }
-						// todo: dissable when saving
+						// disabled={ isLoading }
 						type="password"
 						value={ passwordVal }
 						onChange={ setPasswordVal }
 					/>
-
-					{ /* { requestError && requestError.field === 'password' && (
-								<FormInputValidation isError text={ requestError.message } />
-							) } */ }
 				</div>
-				{ errorMessage && (
-					<Notice className="login-form__error-notice" status="error" isDismissible={ false }>
-						{ errorMessage }
-					</Notice>
-				) }
+				{ errors &&
+					errors.map( ( error, i ) => (
+						<Notice
+							className="login-form__error-notice"
+							status="error"
+							isDismissible={ false }
+							key={ error.code + i }
+						>
+							{ error.message }
+						</Notice>
+					) ) }
 				<div className="login-form__footer">
 					<p className="login-form__terms-of-service-link">{ tos }</p>
 
 					<Button
 						type="submit"
 						className="login-form__submit"
-						// todo: dissable and set `isBusy` when saving
+						// disabled={ isLoading }
+						// isBusy={ isLoading }
 						isPrimary
 					>
 						{ NO__( 'Login' ) }
@@ -139,4 +120,4 @@ const SignupForm = () => {
 	);
 };
 
-export default SignupForm;
+export default LoginForm;

--- a/client/landing/gutenboarding/onboarding-block/login-form/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/login-form/style.scss
@@ -1,0 +1,45 @@
+@import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+
+.login-form.components-modal__frame {
+	border: none;
+	border-radius: 3px;
+
+	.components-modal__header {
+		.components-modal__header-heading {
+			font-size: 20px;
+			font-weight: normal;
+		}
+	}
+	.components-text-control__input {
+		padding: 7px 14px;
+		font-size: 16px;
+		line-height: 1.5;
+	}
+	.login-form__password-section.is-hidden {
+		// hide the password field in a way that still makes it "visible" for password managers.
+		// 1Password doesn't fill the field if it has display:none or visibility:hidden.
+		position: fixed;
+		bottom: 0;
+		height: 0;
+		width: 0;
+		overflow: hidden;
+		opacity: 0;
+	}
+	.login-form__terms-of-service-link {
+		text-align: center;
+		color: var( --color-text-subtle );
+		margin: 20px 0 40px;
+	}
+
+	.components-button.login-form__submit {
+		display: block;
+		width: 100%;
+		text-align: center;
+		font-size: 16px;
+		height: 40px;
+	}
+
+	.login-form__error-notice {
+		margin: 0;
+	}
+}

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -13,6 +13,7 @@ export const Step = {
 	DesignSelection: 'design',
 	PageSelection: 'pages',
 	Signup: 'signup',
+	Login: 'login',
 	CreateSite: 'create-site',
 } as const;
 

--- a/client/landing/gutenboarding/stores/auth/index.ts
+++ b/client/landing/gutenboarding/stores/auth/index.ts
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { Auth } from '@automattic/data-stores';
+
+/**
+ * Internal dependencies
+ */
+import config from '../../../../config';
+
+export const AUTH_STORE = Auth.register( {
+	client_id: config( 'wpcom_signup_id' ),
+	client_secret: config( 'wpcom_signup_key' ),
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add Login page to gutenboarding
Making use of the new auth store

*Included in this PR:*
* UI for login page
* Making calls to the Auth store to check account type and submit the password.

*Planned but not included in this pr:*
* Analytics
* Loading state
* Handling passwordless login
* Handling 2FA
* Actually "Logging in" the user by setting the token
* Closing the Modal
* Changing the username

#### Testing instructions
Navigate to `gutenboarding/signup` 
Click the new "Log in to create a site for your existing account."
TOS link should work
Errors conditions should be handled and error messages displayed
Successful calls should be made to the `auth-options` and `wp-login.php` endpoints


Resolves #39426