### PR TITLE
Try: Quick prototype for showing page controls on hover

### DIFF
--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -76,7 +76,7 @@ function PageCardInfo( {
 		<div className="page-card-info">
 			{ themeId && <QueryTheme siteId="wpcom" themeId={ themeId } /> }
 			{ siteUrl && <div className="page-card-info__site-url">{ siteUrl }</div> }
-			<div>
+			<>
 				{ showTimestamp && renderTimestamp() }
 				{ isFront && (
 					<span className="page-card-info__badge">
@@ -98,7 +98,7 @@ function PageCardInfo( {
 						</span>
 					</span>
 				) }
-			</div>
+			</>
 		</div>
 	);
 }

--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -2,6 +2,7 @@
 	color: var( --color-text-subtle );
 	font-size: 12px;
 	vertical-align: middle;
+	display: inline;
 }
 
 .page-card-info__item {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -12,7 +12,9 @@ import { flow, get, includes, noop, partial } from 'lodash';
 /**
  * Internal dependencies
  */
-import { CompactCard } from '@automattic/components';
+import { Card } from '@automattic/components';
+import { isMobile } from '@automattic/viewport';
+import MaterialIcon from 'components/material-icon';
 import Gridicon from 'components/gridicon';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
@@ -118,20 +120,18 @@ class Page extends Component {
 		}
 
 		if ( this.props.page.status !== 'publish' ) {
+			return <a onClick={ this.viewPage }>{ this.props.translate( 'Preview' ) }</a>;
+		}
+
+		if ( isMobile() ) {
 			return (
 				<PopoverMenuItem onClick={ this.viewPage }>
-					<Gridicon icon={ isPreviewable ? 'visible' : 'external' } size={ 18 } />
-					{ this.props.translate( 'Preview' ) }
+					{ this.props.translate( 'View' ) }
 				</PopoverMenuItem>
 			);
 		}
 
-		return (
-			<PopoverMenuItem onClick={ this.viewPage }>
-				<Gridicon icon={ isPreviewable ? 'visible' : 'external' } size={ 18 } />
-				{ this.props.translate( 'View Page' ) }
-			</PopoverMenuItem>
-		);
+		return <a onClick={ this.viewPage }>{ this.props.translate( 'View' ) }</a>;
 	}
 
 	childPageInfo() {
@@ -183,12 +183,15 @@ class Page extends Component {
 			return null;
 		}
 
-		return (
-			<PopoverMenuItem onClick={ this.updateStatusPublish }>
-				<Gridicon icon="checkmark" size={ 18 } />
-				{ this.props.translate( 'Publish' ) }
-			</PopoverMenuItem>
-		);
+		if ( isMobile() ) {
+			return (
+				<PopoverMenuItem onClick={ this.updateStatusPublish }>
+					{ this.props.translate( 'Publish' ) }
+				</PopoverMenuItem>
+			);
+		}
+
+		return <a onClick={ this.updateStatusPublish }>{ this.props.translate( 'Publish' ) }</a>;
 	}
 
 	getEditItem() {
@@ -209,15 +212,22 @@ class Page extends Component {
 			);
 		}
 
+		if ( isMobile() ) {
+			return (
+				<PopoverMenuItem
+					onClick={ this.editPage }
+					onMouseOver={ preloadEditor }
+					onFocus={ preloadEditor }
+				>
+					{ this.props.translate( 'Edit' ) }
+				</PopoverMenuItem>
+			);
+		}
+
 		return (
-			<PopoverMenuItem
-				onClick={ this.editPage }
-				onMouseOver={ preloadEditor }
-				onFocus={ preloadEditor }
-			>
-				<Gridicon icon="pencil" size={ 18 } />
+			<a onClick={ this.editPage } onMouseOver={ preloadEditor } onFocus={ preloadEditor }>
 				{ this.props.translate( 'Edit' ) }
-			</PopoverMenuItem>
+			</a>
 		);
 	}
 
@@ -293,14 +303,20 @@ class Page extends Component {
 			return null;
 		}
 
-		if ( this.props.page.status !== 'trash' ) {
-			return [
-				<MenuSeparator key="separator" />,
+		if ( this.props.page.status !== 'trash' && isMobile() ) {
+			return (
 				<PopoverMenuItem key="item" className="page__trash-item" onClick={ this.updateStatusTrash }>
-					<Gridicon icon="trash" size={ 18 } />
 					{ this.props.translate( 'Trash' ) }
-				</PopoverMenuItem>,
-			];
+				</PopoverMenuItem>
+			);
+		}
+
+		if ( this.props.page.status !== 'trash' ) {
+			return (
+				<a key="item" className="page__trash-item" onClick={ this.updateStatusTrash }>
+					{ this.props.translate( 'Trash' ) }
+				</a>
+			);
 		}
 
 		return [
@@ -321,11 +337,20 @@ class Page extends Component {
 		) {
 			return null;
 		}
+
+		if ( isMobile() ) {
+			return (
+				<PopoverMenuItem onClick={ this.copyPage } href={ duplicateUrl }>
+					<Gridicon icon="clipboard" size={ 18 } />
+					{ this.props.translate( 'Duplicate' ) }
+				</PopoverMenuItem>
+			);
+		}
+
 		return (
-			<PopoverMenuItem onClick={ this.copyPage } href={ duplicateUrl }>
-				<Gridicon icon="clipboard" size={ 18 } />
-				{ this.props.translate( 'Copy Page' ) }
-			</PopoverMenuItem>
+			<a onClick={ this.copyPage } href={ duplicateUrl }>
+				{ this.props.translate( 'Duplicate' ) }
+			</a>
 		);
 	}
 
@@ -450,25 +475,33 @@ class Page extends Component {
 			sendToTrashItem ||
 			moreInfoItem;
 
-		const ellipsisMenu = hasMenuItems && (
-			<EllipsisMenu
-				className="page__actions-toggle"
-				position="bottom left"
-				onToggle={ this.handleMenuToggle }
-			>
+		let ellipsisMenu = hasMenuItems && (
+			<div className="page__actions-hover">
 				{ editItem }
 				{ publishItem }
 				{ viewItem }
-				{ statsItem }
 				{ copyPageItem }
-				{ copyLinkItem }
 				{ restoreItem }
-				{ frontPageItem }
-				{ postsPageItem }
 				{ sendToTrashItem }
-				{ moreInfoItem }
-			</EllipsisMenu>
+			</div>
 		);
+
+		if ( isMobile() ) {
+			ellipsisMenu = hasMenuItems && (
+				<EllipsisMenu
+					className="page__actions-toggle"
+					position="bottom left"
+					onToggle={ this.handleMenuToggle }
+				>
+					{ editItem }
+					{ publishItem }
+					{ viewItem }
+					{ copyPageItem }
+					{ restoreItem }
+					{ sendToTrashItem }
+				</EllipsisMenu>
+			);
+		}
 
 		const shadowNotice = shadowStatus && (
 			<ShadowNotice shadowStatus={ shadowStatus } onUndoClick={ this.undoPostStatus } />
@@ -495,7 +528,7 @@ class Page extends Component {
 		);
 
 		return (
-			<CompactCard className={ classNames( cardClasses ) }>
+			<Card className={ classNames( cardClasses ) }>
 				{ hierarchyIndent }
 				{ this.props.multisite ? <SiteIcon siteId={ page.site_ID } size={ 34 } /> : null }
 				<div className="page__main">
@@ -522,15 +555,11 @@ class Page extends Component {
 							</InfoPopover>
 						) }
 					</a>
-					<PageCardInfo
-						page={ page }
-						showTimestamp
-						siteUrl={ this.props.multisite && this.getSiteDomain() }
-					/>
+					<PageCardInfo page={ page } siteUrl={ this.props.multisite && this.getSiteDomain() } />
 				</div>
 				{ ellipsisMenu }
 				{ shadowNotice }
-			</CompactCard>
+			</Card>
 		);
 	}
 

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -31,6 +31,7 @@
 .page {
 	align-items: center;
 	display: flex;
+	margin-bottom: 0;
 
 	.site-icon {
 		display: none;
@@ -129,7 +130,7 @@
 	line-height: 1.2;
 
 	display: inline;
-	margin-right: 33px;
+	margin-right: 16px;
 
 	word-break: break-word;
 
@@ -196,4 +197,28 @@
 	margin-left: auto;
 	margin-right: 24px;
 	animation: shadow-notice-appear 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ); // http://easings.net/#easeOutBack
+}
+
+.page__actions-hover {
+	display: flex;
+	align-items: center;
+	opacity: 0;
+	transition: all 0.1s;
+
+	a {
+		display: flex;
+		align-items: center;
+		margin-left: 16px;
+		cursor: pointer;
+	}
+}
+
+.pages__page-list .page:hover {
+	.page__actions-hover {
+		opacity: 1;
+	}
+}
+
+.page__trash-item {
+	color: var( --color-error );
 }


### PR DESCRIPTION
# DO NOT MERGE

Trying a quick prototype for helping to surface actions within Page management.

* On desktop: Actions are pulled out of ellipsis menu and shown on hover
* On mobile: Actions remain in the ellipsis menu since this is an established pattern on mobile and because hover doesn't play well with mobile

#### Testing instructions

* Checkout this branch or visit calypso.live branch
* Visit Pages
