### PR TITLE
Old checkout: fix layout in non-standard payment methods

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -463,6 +463,16 @@
 		}
 	}
 
+	// Redirect Payment Box
+	// -----------------------------------
+	.redirect-payment-box, .wechat-payment-box {
+		 .checkout__payment-box-section {
+			 .checkout__checkout-field {
+				 padding: 0 15px 15px;
+			 }
+		 }
+	}
+
 	// Credits Payment Box
 	// -----------------------------------
 	.credits-payment-box {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Not sure how long this has been the case, but the checkout form for most of our non-standard payment methods looks bad (notice the lack of padding):

<img width="731" alt="Screen Shot 2020-03-05 at 10 47 28" src="https://user-images.githubusercontent.com/844866/75965217-2a5af000-5ed1-11ea-9119-0c6495eca2bc.png">

This fixes it for all redirect type methods + wechat. Examples:
<img width="748" alt="Screen Shot 2020-03-05 at 11 00 28" src="https://user-images.githubusercontent.com/844866/75965289-42327400-5ed1-11ea-8f47-0e66bfb2498d.png">
<img width="737" alt="Screen Shot 2020-03-05 at 11 01 16" src="https://user-images.githubusercontent.com/844866/75965302-46f72800-5ed1-11ea-9fba-946e6ae6313b.png">


#### Testing instructions

To get access to the payment methods, use the matching currency and IP address:
* Wechat/Alipay: USD, CN
* Bancontact: EUR, BE
* iDEAL: EUR, NL
* Giropay: EUR, DE

You can override the IP detection in the backend, look for `get_allowed_payment_methods()` in the shopping-cart.
