### PR TITLE
Revert "Jetpack Cloud: Use calypso entrypoint"

### DIFF
--- a/client/landing/jetpack-cloud/components/current-site/index.tsx
+++ b/client/landing/jetpack-cloud/components/current-site/index.tsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { useSelector } from 'react-redux';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+import { getSelectedSite } from 'state/ui/selectors';
+import Site from 'blocks/site';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const CurrentSite = () => {
+	const selectedSite = useSelector( state => getSelectedSite( state ) );
+
+	return selectedSite ? (
+		<Card className="current-site">
+			<Site showHomeIcon={ false } site={ selectedSite } />
+		</Card>
+	) : null;
+};
+
+export default CurrentSite;

--- a/client/landing/jetpack-cloud/components/current-site/style.scss
+++ b/client/landing/jetpack-cloud/components/current-site/style.scss
@@ -1,0 +1,46 @@
+.current-site.card {
+	margin: 0;
+	padding: 0;
+	box-shadow: none;
+	background: transparent;
+
+	&.is-loading {
+		.site-icon {
+			animation: pulse-light 0.8s ease-in-out infinite;
+		}
+
+		.site__title {
+			color: var( --color-sidebar-text );
+			line-height: 35px;
+		}
+
+		.current-site__switch-sites {
+			cursor: default;
+
+			&::before {
+				visibility: hidden;
+			}
+		}
+	}
+}
+
+.current-site .site {
+	transition: opacity 0.15s ease-in-out;
+
+	.site__info {
+		animation: appear 0.3s ease-in-out;
+	}
+
+	.focus-sites & {
+		opacity: 0.2;
+		pointer-events: none;
+	}
+}
+
+.current-site {
+	.site,
+	.all-sites {
+		background: var( --color-sidebar-background );
+		border-bottom: 1px solid var( --color-sidebar-border );
+	}
+}

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  */
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import config from 'config';
-import CurrentSite from 'my-sites/current-site';
+import CurrentSite from '../current-site';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
@@ -48,11 +48,9 @@ class JetpackCloudSidebar extends Component {
 		const { selectedSiteSlug, translate } = this.props;
 
 		return (
-			<Sidebar
-				className="is-jetpack-cloud-sidebar" // eslint-disable-line wpcalypso/jsx-classname-namespace
-			>
+			<Sidebar>
+				<CurrentSite />
 				<SidebarRegion>
-					<CurrentSite />
 					<SidebarMenu>
 						<SidebarItem
 							link="/"

--- a/client/landing/jetpack-cloud/components/sidebar/style.scss
+++ b/client/landing/jetpack-cloud/components/sidebar/style.scss
@@ -1,44 +1,42 @@
-.is-jetpack-cloud-sidebar {
-	// Menu links
-	.sidebar__menu-link {
-		padding-top: 14px;
-		padding-bottom: 14px;
-		font-weight: 600;
+// Menu links
+.sidebar__menu-link {
+	padding-top: 14px;
+	padding-bottom: 14px;
+	font-weight: 600;
 
-		.selected &,
-		.selected &:hover {
-			background-color: rgba( var( --color-sidebar-menu-selected-background-rgb ), 0.12 );
-		}
+	.selected &,
+	.selected &:hover {
+		background-color: rgba( var( --color-sidebar-menu-selected-background-rgb ), 0.12 );
+	}
+}
+
+// Expandables
+.sidebar__menu.is-togglable {
+	.sidebar__heading {
+		padding-top: 15px;
+		padding-bottom: 15px;
 	}
 
-	// Expandables
-	.sidebar__menu.is-togglable {
+	&.is-toggle-open {
 		.sidebar__heading {
-			padding-top: 15px;
-			padding-bottom: 15px;
-		}
-
-		&.is-toggle-open {
-			.sidebar__heading {
-				background-color: var( --studio-white );
-			}
+			background-color: var( --studio-white );
 		}
 	}
+}
 
-	.sidebar__expandable-content {
-		.sidebar__menu-link {
-			padding-top: 10px;
-			padding-bottom: 10px;
-			font-weight: 400;
-		}
+.sidebar__expandable-content {
+	.sidebar__menu-link {
+		padding-top: 10px;
+		padding-bottom: 10px;
+		font-weight: 400;
 	}
+}
 
-	// Footer
-	.sidebar__footer {
-		margin-top: auto;
+// Footer
+.sidebar__footer {
+	margin-top: auto;
 
-		.sidebar__menu-link {
-			border-top: 1px solid var( --color-sidebar-border );
-		}
+	.sidebar__menu-link {
+		border-top: 1px solid var( --color-sidebar-border );
 	}
 }

--- a/client/landing/jetpack-cloud/controller.js
+++ b/client/landing/jetpack-cloud/controller.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { Provider as ReduxProvider } from 'react-redux';
+import page from 'page';
+import React from 'react';
+import ReactDom from 'react-dom';
+
+/**
+ * Internal Dependencies
+ */
+import { getSiteFragment, sectionify } from 'lib/route';
+import { requestSites } from 'state/sites/actions';
+import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+import { setSelectedSiteId } from 'state/ui/actions';
+import getSites from 'state/selectors/get-sites';
+import hasLoadedSites from 'state/selectors/has-loaded-sites';
+import JetpackCloudLayout from './layout';
+import JetpackCloudSidebar from './components/sidebar';
+import JetpackCloudSitePicker from './components/site-picker';
+import { MomentProvider } from 'components/localized-moment/context';
+
+export const makeLayout = ( context, next ) => {
+	const { primary, secondary, store } = context;
+
+	context.layout = (
+		<ReduxProvider store={ store }>
+			<MomentProvider>
+				<JetpackCloudLayout primary={ primary } secondary={ secondary } />
+			</MomentProvider>
+		</ReduxProvider>
+	);
+
+	next();
+};
+
+export const clientRender = context => {
+	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
+};
+
+export function setupSidebar( context, next ) {
+	context.secondary = <JetpackCloudSidebar path={ context.path } />;
+	next();
+}
+
+export async function siteSelection( context, next ) {
+	const getState = () => context.store.getState();
+	const dispatch = action => context.store.dispatch( action );
+
+	const siteFragment = context.params.site || getSiteFragment( context.path );
+
+	// 1. request all sites ( or get them if they already are present)
+	const allSites = await ( async () => {
+		if ( hasLoadedSites( getState() ) ) {
+			return getSites( getState() );
+		}
+
+		return dispatch( requestSites() ).then( () => {
+			return getSites( getState() );
+		} );
+	} )();
+
+	// 2. filter to our preferred list ( non-atomic, jetpack )
+	const eligibleSites = allSites.filter(
+		site => site.jetpack && ! site.options.is_automated_transfer
+	);
+
+	// 3. use that list to determine the correct way to render ( 0, 1, or a list )
+	if ( eligibleSites.length === 1 && ! siteFragment ) {
+		const { slug } = eligibleSites[ 0 ];
+
+		let redirectPath = `${ context.pathname }/${ slug }`;
+		if ( context.querystring ) {
+			redirectPath += `?${ context.querystring }`;
+		}
+		page.redirect( redirectPath );
+	} else if ( eligibleSites.length > 0 ) {
+		// figure out if the siteFragment matched one of the eligible sites
+
+		for ( const { ID, slug } of eligibleSites ) {
+			if ( siteFragment === ID || siteFragment === slug ) {
+				dispatch( setSelectedSiteId( ID ) );
+			}
+		}
+	}
+
+	next();
+}
+
+/**
+ * Middleware that adds the site selector screen to the layout.
+ * extended from my-sites/controller to only allow non-atomic jetpack sites
+ *
+ * @param {object} context -- Middleware context
+ * @param {Function} next -- Call next middleware in chain
+ */
+export function sites( context, next ) {
+	context.store.dispatch( setLayoutFocus( 'content' ) );
+	context.primary = <JetpackCloudSitePicker siteBasePath={ sectionify( context.path ) } />;
+	next();
+}

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -1,92 +1,25 @@
 /**
  * External dependencies
  */
-import page from 'page';
-import config from 'config';
+import config from '../../config';
 
 /**
  * Internal dependencies
  */
-import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { makeLayout, render as clientRender } from 'controller';
+import initJetpackCloudRoutes from './routes';
+import { bootApp } from 'boot/common';
 
-import { dashboard } from 'landing/jetpack-cloud/sections/dashboard/controller';
-import {
-	backups,
-	backupDetail,
-	backupDownload,
-	backupRestore,
-} from 'landing/jetpack-cloud/sections/backups/controller';
-import { scan, scanHistory } from 'landing/jetpack-cloud/sections/scan/controller';
-import { settings } from 'landing/jetpack-cloud/sections/settings/controller';
+/**
+ * Style dependencies
+ */
+import 'components/environment-badge/style.scss';
+import 'layout/style.scss';
+import 'assets/stylesheets/jetpack-cloud.scss';
 
-export default function() {
-	page( '/', siteSelection, navigation, dashboard, makeLayout, clientRender );
-
-	if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
-		page( '/backups', siteSelection, sites, navigation, makeLayout, clientRender );
-
-		page( '/backups/:site', siteSelection, navigation, backups, makeLayout, clientRender );
-		page(
-			'/backups/:site/detail/',
-			siteSelection,
-			navigation,
-			backupDetail,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/backups/:site/detail/:backupId',
-			siteSelection,
-			navigation,
-			backupDetail,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/backups/:site/download',
-			siteSelection,
-			navigation,
-			backupDownload,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/backups/:site/backups/download/:downloadId',
-			navigation,
-			backupDownload,
-			makeLayout,
-			clientRender
-		);
+window.AppBoot = () => {
+	if ( ! config.isEnabled( 'jetpack-cloud' ) ) {
+		window.location.href = '/';
+	} else {
+		bootApp( 'Jetpack Cloud', initJetpackCloudRoutes );
 	}
-	if ( config.isEnabled( 'jetpack-cloud/backups-restore' ) ) {
-		page( '/backups/restore', siteSelection, sites, navigation, makeLayout, clientRender );
-		page(
-			'/backups/:site/restore/',
-			siteSelection,
-			navigation,
-			backupRestore,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/backups/restore/:site/:restoreId',
-			siteSelection,
-			navigation,
-			backupRestore,
-			makeLayout,
-			clientRender
-		);
-	}
-	if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
-		page( '/scan', siteSelection, sites, navigation, makeLayout, clientRender );
-		page( '/scan/:site', siteSelection, navigation, scan, makeLayout, clientRender );
-	}
-	if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
-		page( '/scan/:site/history', siteSelection, navigation, scanHistory, makeLayout, clientRender );
-	}
-	if ( config.isEnabled( 'jetpack-cloud/settings' ) ) {
-		page( '/settings', siteSelection, sites, navigation, makeLayout, clientRender );
-		page( '/settings/:site', siteSelection, navigation, settings, makeLayout, clientRender );
-	}
-}
+};

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { normalize } from 'lib/route';
+import { clientRender, makeLayout, setupSidebar, sites, siteSelection } from './controller';
+import { dashboard } from './sections/dashboard/controller';
+import {
+	backups,
+	backupDetail,
+	backupDownload,
+	backupRestore,
+} from './sections/backups/controller';
+import { scan, scanHistory } from './sections/scan/controller';
+import { settings } from './sections/settings/controller';
+
+const router = () => {
+	page( '*', normalize );
+
+	page( '/', siteSelection, setupSidebar, dashboard, makeLayout, clientRender );
+
+	if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
+		page( '/backups', siteSelection, sites, setupSidebar, makeLayout, clientRender );
+		page( '/backups/:site', siteSelection, setupSidebar, backups, makeLayout, clientRender );
+		page(
+			'/backups/:site/detail',
+			siteSelection,
+			setupSidebar,
+			backupDetail,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/backups/:site/detail/:backupId',
+			siteSelection,
+			setupSidebar,
+			backupDetail,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/backups/:site/download',
+			siteSelection,
+			setupSidebar,
+			backupDownload,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/site/:site/backups/backups/download/:downloadId',
+			setupSidebar,
+			backupDownload,
+			makeLayout,
+			clientRender
+		);
+
+		if ( config.isEnabled( 'jetpack-cloud/backups-restore' ) ) {
+			page( '/backups/restore', siteSelection, sites, setupSidebar, makeLayout, clientRender );
+			page(
+				'/backups/:site/restore',
+				siteSelection,
+				setupSidebar,
+				backupRestore,
+				makeLayout,
+				clientRender
+			);
+			page(
+				'/backups/:site/restore/:restoreId',
+				siteSelection,
+				setupSidebar,
+				backupRestore,
+				makeLayout,
+				clientRender
+			);
+		}
+	}
+
+	if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
+		page( '/scan', siteSelection, sites, setupSidebar, makeLayout, clientRender );
+		page( '/scan/:site', siteSelection, setupSidebar, scan, makeLayout, clientRender );
+
+		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
+			page( '/scan/:site/history', siteSelection, setupSidebar, scanHistory, makeLayout, clientRender );
+		}
+	}
+
+	if ( config.isEnabled( 'jetpack-cloud/settings' ) ) {
+		page( '/settings', siteSelection, sites, setupSidebar, makeLayout, clientRender );
+		page( '/settings/:site', siteSelection, setupSidebar, settings, makeLayout, clientRender );
+	}
+};
+
+export default router;

--- a/client/landing/jetpack-cloud/section.js
+++ b/client/landing/jetpack-cloud/section.js
@@ -1,0 +1,8 @@
+export const JETPACK_CLOUD_SECTION_DEFINITION = {
+	name: 'jetpack-cloud',
+	paths: [ '/', '/scan', '/backups', '/settings' ],
+	module: 'jetpack-cloud',
+	secondary: false,
+	group: 'jetpack-cloud',
+	enableLoggedOut: true,
+};

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -13,7 +13,6 @@ import classnames from 'classnames';
  */
 import AsyncLoad from 'components/async-load';
 import MasterbarLoggedIn from 'layout/masterbar/logged-in';
-import JetpackCloudMasterbar from 'landing/jetpack-cloud/components/masterbar';
 import GlobalNotices from 'components/global-notices';
 import HtmlIsIframeClassname from 'layout/html-is-iframe-classname';
 import notices from 'notices';
@@ -101,19 +100,6 @@ class Layout extends Component {
 		// intentionally don't remove these in unmount
 	}
 
-	renderMasterbar() {
-		const MasterbarComponent = config.isEnabled( 'jetpack-cloud' )
-			? JetpackCloudMasterbar
-			: MasterbarLoggedIn;
-
-		return (
-			<MasterbarComponent
-				section={ this.props.sectionGroup }
-				isCheckout={ this.props.sectionName === 'checkout' }
-			/>
-		);
-	}
-
 	render() {
 		const sectionClass = classnames(
 			'layout',
@@ -164,7 +150,10 @@ class Layout extends Component {
 				<AsyncLoad require="layout/guided-tours" placeholder={ null } />
 				{ ! isE2ETest() && <AsyncLoad require="layout/nps-survey-notice" placeholder={ null } /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
-				{ this.renderMasterbar() }
+				<MasterbarLoggedIn
+					section={ this.props.sectionGroup }
+					isCheckout={ this.props.sectionName === 'checkout' }
+				/>
 				{ config.isEnabled( 'support-user' ) && <SupportUser /> }
 				<LayoutLoader />
 				{ this.props.isOffline && <OfflineStatus /> }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -54,8 +54,6 @@ import {
 	emailManagementNewGSuiteAccount,
 } from 'my-sites/email/paths';
 import SitesComponent from 'my-sites/sites';
-import Sidebar from 'my-sites/sidebar';
-import JetpackCloudSidebar from 'landing/jetpack-cloud/components/sidebar';
 import { warningNotice } from 'state/notices/actions';
 import { makeLayout, render as clientRender } from 'controller';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
@@ -89,11 +87,9 @@ function createNavigation( context ) {
 		basePath = sectionify( context.pathname );
 	}
 
-	const SidebarComponent = config.isEnabled( 'jetpack-cloud' ) ? JetpackCloudSidebar : Sidebar;
-
 	return (
 		<NavigationComponent
-			sidebar={ <SidebarComponent path={ context.path } siteBasePath={ basePath } /> }
+			path={ context.path }
 			allSitesPath={ basePath }
 			siteBasePath={ basePath }
 		/>

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+
 import React from 'react';
 
 /**
  * Internal dependencies
  */
 import SitePicker from 'my-sites/picker';
+import Sidebar from 'my-sites/sidebar';
 
 class MySitesNavigation extends React.Component {
 	static displayName = 'MySitesNavigation';
@@ -24,7 +26,7 @@ class MySitesNavigation extends React.Component {
 					siteBasePath={ this.props.siteBasePath }
 					onClose={ this.preventPickerDefault }
 				/>
-				{ this.props.sidebar }
+				<Sidebar path={ this.props.path } siteBasePath={ this.props.siteBasePath } />
 			</div>
 		);
 	}

--- a/client/sections.js
+++ b/client/sections.js
@@ -472,14 +472,6 @@ const sections = [
 		secondary: true,
 		group: 'sites',
 	},
-	{
-		name: 'jetpack-cloud',
-		paths: [ '/', '/scan', '/backups', '/settings' ], // TODO: Split this up into its own sections
-		module: 'landing/jetpack-cloud',
-		secondary: true,
-		group: 'jetpack-cloud',
-		enableLoggedOut: true,
-	},
 ];
 
 for ( const extension of require( './extensions' ) ) {

--- a/client/server/bundler/sections-loader.js
+++ b/client/server/bundler/sections-loader.js
@@ -1,13 +1,5 @@
-/**
- * External dependecies
- */
-const { getOptions } = require( 'loader-utils' ); // eslint-disable-line import/no-extraneous-dependencies
-
-/**
- * Internal dependecies
- */
 const config = require( '../config' );
-const utils = require( './utils.js' );
+const { getOptions } = require( 'loader-utils' );
 
 /*
  * This sections-loader has one responsibility: adding import statements for the section modules.
@@ -60,7 +52,7 @@ const loader = function() {
 	const options = getOptions( this ) || {};
 	const { forceRequire, onlyIsomorphic } = options;
 	let { include } = options;
-	let sections = require( this.resourcePath ).filter( utils.filterSections );
+	let sections = require( this.resourcePath );
 
 	if ( include ) {
 		if ( ! Array.isArray( include ) ) {
@@ -75,9 +67,6 @@ const loader = function() {
 			console.warn( `[sections-loader] Available sections are:` );
 			printSectionsAndPaths( allSections );
 		}
-	} else {
-		console.log( `[sections-loader] created ${ sections.length } of section.` );
-		printSectionsAndPaths( sections );
 	}
 
 	return addModuleImportToSections( {

--- a/client/server/bundler/utils.js
+++ b/client/server/bundler/utils.js
@@ -5,11 +5,6 @@ const crypto = require( 'crypto' );
 const fs = require( 'fs' );
 const qs = require( 'qs' );
 
-/**
- * Internal dependecies
- */
-const config = require( '../config' );
-
 const HASH_LENGTH = 10;
 const URL_BASE_PATH = '/calypso';
 
@@ -41,18 +36,7 @@ function getUrl( filename, hash ) {
 	);
 }
 
-const activeSections = config( 'sections' );
-const byDefaultEnableSection = config( 'enable_all_sections' );
-
-function filterSections( section ) {
-	if ( activeSections && typeof activeSections[ section.name ] !== 'undefined' ) {
-		return activeSections[ section.name ];
-	}
-	return byDefaultEnableSection;
-}
-
 module.exports = {
 	hashFile: hashFile,
 	getUrl: getUrl,
-	filterSections: filterSections,
 };

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -136,6 +136,7 @@ const webpackConfig = {
 	entry: filterEntrypoints( {
 		'entry-main': [ path.join( __dirname, 'boot', 'app' ) ],
 		'entry-domains-landing': [ path.join( __dirname, 'landing', 'domains' ) ],
+		'entry-jetpack-cloud': [ path.join( __dirname, 'landing', 'jetpack-cloud' ) ],
 		'entry-login': [ path.join( __dirname, 'landing', 'login' ) ],
 		'entry-gutenboarding': [ path.join( __dirname, 'landing', 'gutenboarding' ) ],
 	} ),

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -129,9 +129,5 @@
 	"wpcom_signup_key": false,
 	"statsd_analytics_response_time_max_logs_per_second": 50,
 	"google_maps_and_places_api_key": "AIzaSyAJN-ceOpTLP1CSQdyoRLS4VT9Zlsibkeg",
-	"push_notification_vapid_key": "BDQlTOrVTrxRM0i-gCsrxjxOyul281c5WVdfstXaqZqTSpjSI9M-E99CvwwJRWDkZ0goa8VSqUCgwiexxcDuXCs",
-	"enable_all_sections": true,
-	"sections": {
-		"jetpack-cloud": false
-	}
+	"push_notification_vapid_key": "BDQlTOrVTrxRM0i-gCsrxjxOyul281c5WVdfstXaqZqTSpjSI9M-E99CvwwJRWDkZ0goa8VSqUCgwiexxcDuXCs"
 }

--- a/config/development.json
+++ b/config/development.json
@@ -70,6 +70,7 @@
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,
+		"jetpack-cloud": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/concierge-sessions": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -17,9 +17,5 @@
 		"jetpack-cloud/settings": true,
 		"jetpack-cloud/scan": true,
 		"jetpack-cloud/scan-history": true
-	},
-	"enable_all_sections": false,
-	"sections": {
-		"jetpack-cloud": true
 	}
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -15,9 +15,5 @@
 		"jetpack-cloud/settings": true,
 		"jetpack-cloud/scan": true,
 		"jetpack-cloud/scan-history": true
-	},
-	"enable_all_sections": false,
-	"sections": {
-		"jetpack-cloud": true
 	}
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -15,9 +15,5 @@
 		"jetpack-cloud/settings": true,
 		"jetpack-cloud/scan": true,
 		"jetpack-cloud/scan-history": true
-	},
-	"enable_all_sections": false,
-	"sections": {
-		"jetpack-cloud": true
 	}
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#39708

The commit (Automattic/wp-calypso#39708) broke cloud.jetpack.com (staging). 

To tests
---
Start up calypso (npm start) 
Visit calypso.localhost:3000/
Does it look and work as expected?

Start up jetpack cloud (`npm run run start-jetpack-cloud`) 
visit jetpack.cloud.localhost:3000/
Does it look and work as expected?

