### PR TITLE
Update the new domain status messages for non-owners

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -152,27 +152,45 @@ class RegisteredDomainType extends React.Component {
 		const { expiry } = domain;
 
 		if ( isExpiringSoon( domain, 30 ) ) {
+			let message;
+			if ( domain.currentUserCanManage ) {
+				message = translate(
+					'{{strong}}Your domain will expire{{/strong}} in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
+					{
+						components: {
+							strong: <strong />,
+						},
+						args: {
+							days: moment.utc( expiry ).fromNow( true ),
+						},
+					}
+				);
+			} else {
+				message = translate(
+					'{{strong}}The domain will expire{{/strong}} in {{strong}}%(days)s{{/strong}}. Please contact the domain owner %(owner)s to renew it.',
+					{
+						components: {
+							strong: <strong />,
+						},
+						args: {
+							days: moment.utc( expiry ).fromNow( true ),
+							owner: domain.owner,
+						},
+					}
+				);
+			}
+
 			return (
 				<div>
-					<p>
-						{ translate(
-							'{{strong}}Your domain will expire{{/strong}} in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
-							{
-								components: {
-									strong: <strong />,
-								},
-								args: {
-									days: moment.utc( expiry ).fromNow( true ),
-								},
-							}
-						) }
-					</p>
-					<RenewButton
-						primary={ true }
-						selectedSite={ this.props.selectedSite }
-						subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
-						tracksProps={ { source: 'registered-domain-status', domain_status: 'expiring-soon' } }
-					/>
+					<p>{ message }</p>
+					{ domain.currentUserCanManage && (
+						<RenewButton
+							primary={ true }
+							selectedSite={ this.props.selectedSite }
+							subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
+							tracksProps={ { source: 'registered-domain-status', domain_status: 'expiring-soon' } }
+						/>
+					) }
 				</div>
 			);
 		}
@@ -198,7 +216,20 @@ class RegisteredDomainType extends React.Component {
 			  )
 			: null;
 
-		if ( domain.isRenewable ) {
+		if ( ! domain.currentUserCanManage ) {
+			message = translate(
+				'The domain has expired and is no longer active. Please contact the domain owner (%(owner)s) to restore it. {{domainsLink}}Learn more{{/domainsLink}}',
+				{
+					components: {
+						strong: <strong />,
+						domainsLink: domainsLink( DOMAIN_EXPIRATION ),
+					},
+					args: {
+						owner: domain.owner,
+					},
+				}
+			);
+		} else if ( domain.isRenewable ) {
 			message = translate(
 				'{{strong}}Your domain has expired{{/strong}} and is no longer active. You have {{strong}}%(days)s{{/strong}} to renew it at the standard rate before an additional %(redemptionCost)s redemption fee is applied. {{domainsLink}}Learn more{{/domainsLink}}',
 				{
@@ -240,7 +271,7 @@ class RegisteredDomainType extends React.Component {
 		return (
 			<div>
 				<p>{ message }</p>
-				{ ( domain.isRenewable || domain.isRedeemable ) && (
+				{ domain.currentUserCanManage && ( domain.isRenewable || domain.isRedeemable ) && (
 					<RenewButton
 						primary={ true }
 						selectedSite={ this.props.selectedSite }
@@ -287,6 +318,10 @@ class RegisteredDomainType extends React.Component {
 
 	renderDefaultRenewButton() {
 		const { domain } = this.props;
+
+		if ( ! domain.currentUserCanManage ) {
+			return null;
+		}
 
 		if ( domain.expired || isExpiringSoon( domain, 30 ) ) {
 			return null;
@@ -372,7 +407,7 @@ class RegisteredDomainType extends React.Component {
 							  } ) }
 					</div>
 					{ this.renderDefaultRenewButton() }
-					{ ! newStatusDesignAutoRenew && (
+					{ ! newStatusDesignAutoRenew && domain.currentUserCanManage && (
 						<div>
 							<SubscriptionSettings
 								type={ domain.type }

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -218,7 +218,7 @@ class RegisteredDomainType extends React.Component {
 
 		if ( ! domain.currentUserCanManage ) {
 			message = translate(
-				'The domain has expired and is no longer active. Please contact the domain owner (%(owner)s) to restore it. {{domainsLink}}Learn more{{/domainsLink}}',
+				'{{strong}}The domain has expired{{/strong}} and is no longer active. Please contact the domain owner %(owner)s to restore it. {{domainsLink}}Learn more{{/domainsLink}}',
 				{
 					components: {
 						strong: <strong />,

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -120,6 +120,9 @@
 			margin-bottom: 1.5em;
 			border-bottom: 1px solid var( --color-border-subtle );
 			padding-bottom: 1.5em;
+			> p:last-child {
+				margin-bottom: 0;
+			}
 		}
 
 		> div:last-child {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update the expiring/expired messages for non-owners
* don't show the renew and payment settings buttons for non-owners

#### Testing instructions

* You'll need to set up a second account as administrator for a site with multiple domains in different statuses

Active domain viewed by another user:

<img width="738" alt="Screenshot 2020-03-05 at 13 22 43" src="https://user-images.githubusercontent.com/1355045/75977414-07d2d200-5ee5-11ea-8744-2da64c423891.png">

Expiring soon domain viewed by another user:

<img width="742" alt="Screenshot 2020-03-05 at 13 21 53" src="https://user-images.githubusercontent.com/1355045/75977443-19b47500-5ee5-11ea-918e-e08048aa74f6.png">

