### PR TITLE
Add missing warnings component for the new domain status screen

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -15,6 +15,7 @@ import VerticalNav from 'components/vertical-nav';
 import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
 import { withLocalizedMoment } from 'components/localized-moment';
 import DomainStatus from '../card/domain-status';
+import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import VerticalNavItem from 'components/vertical-nav/item';
 import { emailManagement } from 'my-sites/email/paths';
 import {
@@ -324,6 +325,22 @@ class RegisteredDomainType extends React.Component {
 		);
 	}
 
+	domainWarnings() {
+		return (
+			<DomainWarnings
+				domain={ this.props.domain }
+				position="registered-domain"
+				selectedSite={ this.props.selectedSite }
+				ruleWhiteList={ [
+					'pendingGSuiteTosAcceptanceDomains',
+					'pendingTransfer',
+					'newTransfersWrongNS',
+					'pendingConsent',
+				] }
+			/>
+		);
+	}
+
 	handlePaymentSettingsClick = () => {
 		this.props.recordPaymentSettingsClick( this.props.domain );
 	};
@@ -339,6 +356,7 @@ class RegisteredDomainType extends React.Component {
 		return (
 			<div className="domain-types__container">
 				{ this.planUpsellForNonPrimaryDomain() }
+				{ this.domainWarnings() }
 				<DomainStatus
 					header={ domain_name }
 					statusText={ statusText }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the DomainWarnings component since we're not handling some of the cases and specificaly - `pendingGSuiteTosAcceptanceDomains`, `pendingTransfer`, `newTransfersWrongNS` and `pendingConsent`


The notifications look like those:

<img width="738" alt="Screenshot 2020-03-06 at 0 04 17" src="https://user-images.githubusercontent.com/1355045/76030897-485f3980-5f3f-11ea-9add-6eb69ec7b1d5.png">

<img width="738" alt="Screenshot 2020-03-06 at 0 12 36" src="https://user-images.githubusercontent.com/1355045/76030899-4a28fd00-5f3f-11ea-9e2d-070e9a247571.png">

#### Testing instructions

* I have no idea how to test the above cases but I've short-circuited the component to show other warnings and it worked so I assume it'll work with the above too 

