### PR TITLE
My Home: Update  doc title to "My Home" for consistency

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -329,8 +329,8 @@ class Home extends Component {
 
 		return (
 			<Main className="customer-home__main is-wide-layout">
-				<PageViewTracker path={ `/home/:site` } title={ translate( 'Customer Home' ) } />
-				<DocumentHead title={ translate( 'Customer Home' ) } />
+				<PageViewTracker path={ `/home/:site` } title={ translate( 'My Home' ) } />
+				<DocumentHead title={ translate( 'My Home' ) } />
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				<SidebarNavigation />
 				<div className="customer-home__page-heading">{ this.renderCustomerHomeHeader() }</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the document head/title to "My Home" from "Customer Home" to match the labels in the heading and the sidebar.
* We shouldn't need to worry about string freeze here since we're already using "My Home" elsewhere in the app.

**Before**

<img width="209" alt="Screen Shot 2020-03-05 at 8 45 08 AM" src="https://user-images.githubusercontent.com/2124984/75987415-e3afca80-5ebd-11ea-8c3a-3d6c24548776.png">

**After**

<img width="205" alt="Screen Shot 2020-03-05 at 8 44 46 AM" src="https://user-images.githubusercontent.com/2124984/75987429-e90d1500-5ebd-11ea-9079-9d7b2159542e.png">

#### Testing instructions

* Switch to this PR and navigate to a site with Customer Home active
* Note the document title in your browser tab/window; it should read "My Home" rather than "Customer Home"
