### PR TITLE
Gutenboarding: Update the domains picker to make domain upgrades available

### DIFF
--- a/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
@@ -1,0 +1,85 @@
+/*
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { Card } from '@automattic/components';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const ConfirmPurchaseModal: FunctionComponent = props => {
+	const { __: NO__ } = useI18n();
+
+	const handleCancel = () => {
+		props.onCancel();
+	};
+
+	const handlePurchase = () => {
+		props.onAccept();
+	};
+
+	const handleESC = event => {
+		if ( event.keyCode === 27 ) {
+			props.onCancel();
+		}
+	};
+
+	return (
+		<div className="confirm-purchase-modal">
+			<div
+				className="confirm-purchase-modal__background"
+				onClick={ handleCancel }
+				onKeyPress={ handleESC }
+				role="dialog"
+			/>
+			<Card className="confirm-purchase-modal__content">
+				<div className="confirm-purchase-modal__header">
+					{ NO__( 'You are about to register your new domain!' ) }
+				</div>
+				<div className="confirm-purchase-modal__items">
+					{ NO__(
+						'To be able to complete the registration of %s, you need to take some extra steps: ',
+						props.selectedDomain
+					) }
+					<ul>
+						{ ! props.isLogged && <li>{ NO__( 'Create an account' ) }</li> }
+						<li>{ NO__( 'Create your site' ) }</li>
+						<li>{ NO__( 'Purchase a paid plan' ) }</li>
+					</ul>
+					{ NO__(
+						'Every paid plan include a domain registration. Once you have completed the purchase of your new plan, we will continue with the set up of your site.'
+					) }
+				</div>
+				<div className="confirm-purchase-modal__buttons">
+					<Button
+						isLarge
+						type="button"
+						className="confirm-purchase-modal__buttons-cancel"
+						onClick={ handleCancel }
+					>
+						{ NO__( 'Do it later' ) }
+					</Button>
+					<Button
+						isLarge
+						isPrimary
+						type="button"
+						className="confirm-purchase-modal__buttons-accept"
+						onClick={ handlePurchase }
+					>
+						{ NO__( 'Create your site and register your new domain' ) }
+					</Button>
+				</div>
+			</Card>
+		</div>
+	);
+};
+
+export default ConfirmPurchaseModal;

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
@@ -4,7 +4,7 @@
 import React, { FunctionComponent } from 'react';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
-import { Button } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 
 /**
@@ -17,31 +17,22 @@ import { Card } from '@automattic/components';
  */
 import './style.scss';
 
-const ConfirmPurchaseModal: FunctionComponent = props => {
+interface Props {
+	onCancel: () => void;
+	onAccept: () => void;
+	isLogged: boolean;
+	selectedDomain: import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
+}
+const ConfirmPurchaseModal: FunctionComponent< Props > = props => {
 	const { __: NO__ } = useI18n();
 
-	const handleCancel = () => {
-		props.onCancel();
-	};
-
-	const handlePurchase = () => {
-		props.onAccept();
-	};
-
-	const handleESC = event => {
-		if ( event.keyCode === 27 ) {
-			props.onCancel();
-		}
-	};
-
 	return (
-		<div className="confirm-purchase-modal">
-			<div
-				className="confirm-purchase-modal__background"
-				onClick={ handleCancel }
-				onKeyPress={ handleESC }
-				role="dialog"
-			/>
+		<Modal
+			title={ NO__( 'You are about to register your new domain!' ) }
+			className="confirm-purchase-modal"
+			isDismissible={ false }
+			onRequestClose={ props.onCancel }
+		>
 			<Card className="confirm-purchase-modal__content">
 				<div className="confirm-purchase-modal__header">
 					{ NO__( 'You are about to register your new domain!' ) }
@@ -62,7 +53,7 @@ const ConfirmPurchaseModal: FunctionComponent = props => {
 						<li>{ NO__( 'Purchase a paid plan' ) }</li>
 					</ul>
 					{ NO__(
-						'Every paid plan include a domain registration. Once you have completed the purchase of your new plan, we will continue with the set up of your site.'
+						'Every paid plan includes a domain registration. Once you have completed the purchase of your new plan, we will continue with the set up of your site.'
 					) }
 				</div>
 				<div className="confirm-purchase-modal__buttons">
@@ -70,7 +61,7 @@ const ConfirmPurchaseModal: FunctionComponent = props => {
 						isLarge
 						type="button"
 						className="confirm-purchase-modal__buttons-cancel"
-						onClick={ handleCancel }
+						onClick={ props.onCancel }
 					>
 						{ NO__( 'Do it later' ) }
 					</Button>
@@ -79,13 +70,13 @@ const ConfirmPurchaseModal: FunctionComponent = props => {
 						isPrimary
 						type="button"
 						className="confirm-purchase-modal__buttons-accept"
-						onClick={ handlePurchase }
+						onClick={ props.onAccept }
 					>
 						{ NO__( 'Create your site and register your new domain' ) }
 					</Button>
 				</div>
 			</Card>
-		</div>
+		</Modal>
 	);
 };
 

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
@@ -61,19 +61,10 @@ const ConfirmPurchaseModal: FunctionComponent< Props > = props => {
 					) }
 				</div>
 				<div className="confirm-purchase-modal__buttons">
-					<Button
-						isLarge
-						className="confirm-purchase-modal__buttons-cancel"
-						onClick={ props.onCancel }
-					>
+					<Button isLarge onClick={ props.onCancel }>
 						{ NO__( 'Do it later' ) }
 					</Button>
-					<Button
-						isLarge
-						isPrimary
-						className="confirm-purchase-modal__buttons-accept"
-						onClick={ props.onAccept }
-					>
+					<Button isLarge isPrimary onClick={ props.onAccept }>
 						{ NO__( 'Create your site and register your new domain' ) }
 					</Button>
 				</div>

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
@@ -45,7 +45,7 @@ const ConfirmPurchaseModal: FunctionComponent< Props > = props => {
 					{ __experimentalCreateInterpolateElement(
 						sprintf(
 							NO__(
-								'To be able to complete the registration of <DomainName>%s</DomainName>, you need to take some extra steps: '
+								'To be able to complete the registration of <DomainName>%s</DomainName>, you need to take some extra steps:'
 							),
 							props.selectedDomain.domain_name
 						),

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import { Button } from '@wordpress/components';
+import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,9 +47,14 @@ const ConfirmPurchaseModal: FunctionComponent = props => {
 					{ NO__( 'You are about to register your new domain!' ) }
 				</div>
 				<div className="confirm-purchase-modal__items">
-					{ NO__(
-						'To be able to complete the registration of %s, you need to take some extra steps: ',
-						props.selectedDomain
+					{ __experimentalCreateInterpolateElement(
+						sprintf(
+							NO__(
+								'To be able to complete the registration of <DomainName>%s</DomainName>, you need to take some extra steps: '
+							),
+							props.selectedDomain.domain_name
+						),
+						{ DomainName: <em /> }
 					) }
 					<ul>
 						{ ! props.isLogged && <li>{ NO__( 'Create an account' ) }</li> }

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
@@ -11,7 +11,6 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { Card } from '@automattic/components';
 import { USER_STORE } from '../../stores/user';
 
 /**
@@ -32,43 +31,41 @@ const ConfirmPurchaseModal: FunctionComponent< Props > = props => {
 
 	return (
 		<Modal
-			title={ NO__( 'You are about to register your new domain!' ) }
+			title={ NO__( "You're about to register your new domain!" ) }
 			className="confirm-purchase-modal"
 			isDismissible={ false }
 			onRequestClose={ props.onCancel }
 		>
-			<Card className="confirm-purchase-modal__content">
-				<div className="confirm-purchase-modal__header">
-					{ NO__( 'You are about to register your new domain!' ) }
-				</div>
-				<div className="confirm-purchase-modal__items">
-					{ __experimentalCreateInterpolateElement(
-						sprintf(
-							NO__(
-								'To be able to complete the registration of <DomainName>%s</DomainName>, you need to take some extra steps:'
-							),
-							props.selectedDomain.domain_name
+			<div className="confirm-purchase-modal__header">
+				{ NO__( "You're about to register your new domain!" ) }
+			</div>
+			<div className="confirm-purchase-modal__items">
+				{ __experimentalCreateInterpolateElement(
+					sprintf(
+						NO__(
+							'To be able to complete the registration of <DomainName>%s</DomainName>, you need to take some extra steps:'
 						),
-						{ DomainName: <em /> }
-					) }
-					<ul>
-						{ isLoggedIn && <li>{ NO__( 'Create an account' ) }</li> }
-						<li>{ NO__( 'Create your site' ) }</li>
-						<li>{ NO__( 'Purchase a paid plan' ) }</li>
-					</ul>
-					{ NO__(
-						'Every paid plan includes a domain registration. Once you have completed the purchase of your new plan, we will continue with the set up of your site.'
-					) }
-				</div>
-				<div className="confirm-purchase-modal__buttons">
-					<Button isLarge onClick={ props.onCancel }>
-						{ NO__( 'Do it later' ) }
-					</Button>
-					<Button isLarge isPrimary onClick={ props.onAccept }>
-						{ NO__( 'Create your site and register your new domain' ) }
-					</Button>
-				</div>
-			</Card>
+						props.selectedDomain.domain_name
+					),
+					{ DomainName: <em /> }
+				) }
+				<ul>
+					{ isLoggedIn && <li>{ NO__( 'Create an account' ) }</li> }
+					<li>{ NO__( 'Create your site' ) }</li>
+					<li>{ NO__( 'Purchase a paid plan' ) }</li>
+				</ul>
+				{ NO__(
+					'Every paid plan includes a domain registration. Once you have completed the purchase of your new plan, we will continue with the set up of your site.'
+				) }
+			</div>
+			<div className="confirm-purchase-modal__buttons">
+				<Button isLarge onClick={ props.onCancel }>
+					{ NO__( 'Do it later' ) }
+				</Button>
+				<Button isLarge isPrimary onClick={ props.onAccept }>
+					{ NO__( 'Create your site and register your new domain' ) }
+				</Button>
+			</div>
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
@@ -63,7 +63,6 @@ const ConfirmPurchaseModal: FunctionComponent< Props > = props => {
 				<div className="confirm-purchase-modal__buttons">
 					<Button
 						isLarge
-						type="button"
 						className="confirm-purchase-modal__buttons-cancel"
 						onClick={ props.onCancel }
 					>
@@ -72,7 +71,6 @@ const ConfirmPurchaseModal: FunctionComponent< Props > = props => {
 					<Button
 						isLarge
 						isPrimary
-						type="button"
 						className="confirm-purchase-modal__buttons-accept"
 						onClick={ props.onAccept }
 					>

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/index.tsx
@@ -6,25 +6,29 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import { Button, Modal } from '@wordpress/components';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
+import { USER_STORE } from '../../stores/user';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
+type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
+
 interface Props {
 	onCancel: () => void;
 	onAccept: () => void;
-	isLogged: boolean;
-	selectedDomain: import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
+	selectedDomain: DomainSuggestion;
 }
 const ConfirmPurchaseModal: FunctionComponent< Props > = props => {
 	const { __: NO__ } = useI18n();
+	const isLoggedIn = useSelect( select => select( USER_STORE ).isCurrentUserLoggedIn() );
 
 	return (
 		<Modal
@@ -48,7 +52,7 @@ const ConfirmPurchaseModal: FunctionComponent< Props > = props => {
 						{ DomainName: <em /> }
 					) }
 					<ul>
-						{ ! props.isLogged && <li>{ NO__( 'Create an account' ) }</li> }
+						{ isLoggedIn && <li>{ NO__( 'Create an account' ) }</li> }
 						<li>{ NO__( 'Create your site' ) }</li>
 						<li>{ NO__( 'Purchase a paid plan' ) }</li>
 					</ul>

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
@@ -1,0 +1,60 @@
+.confirm-purchase-modal {
+	width: 100%;
+	height: 100%;
+	display: flex;
+		justify-content: center;
+		align-items: center;
+	position: fixed;
+		top: 0;
+		left: 0;
+}
+
+.confirm-purchase-modal__background {
+	width: 100%;
+	height: 100%;
+	background-color: 
+		var( --studio-gray-5 );
+	z-index: -1;
+	opacity: 0.8;
+	position: fixed;
+		top: 0;
+		left: 0;
+}
+
+.confirm-purchase-modal__content {
+	padding: 32px;
+	max-width: 560px;
+}
+
+.confirm-purchase-modal__header {
+	font-family: 'Recoleta-Regular', 'Recoleta', serif;
+	font-size: 40px;
+	color: var( --studio-blue-40 );
+	margin: 0 0 16px;
+	text-align: center;
+}
+
+.confirm-purchase-modal__items {
+	font-size: 16px;
+	color: 
+		var( --studio-gray-60 );
+	font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+	line-height: 1.5em;
+	padding: 32px;
+
+	ul {
+		list-style: circle;
+		margin-top: 16px;
+		margin-bottom: 32px;
+	}
+	li {
+		margin-left: 64px;
+	}
+}
+
+.confirm-purchase-modal__buttons {
+	width: 100%;
+	margin-top: 32px;
+	display: flex;
+		justify-content: space-between;
+}

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
@@ -1,3 +1,4 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins';
 
 .confirm-purchase-modal__header {
@@ -11,8 +12,7 @@
 .confirm-purchase-modal__items {
 	font-size: 16px;
 	color: var( --studio-gray-60 );
-	font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
-		sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+	font-family: $default-font;
 	line-height: 1.5em;
 	padding: 32px;
 

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
@@ -1,25 +1,25 @@
-.confirm-purchase-modal {
-	width: 100%;
-	height: 100%;
-	display: flex;
-		justify-content: center;
-		align-items: center;
-	position: fixed;
-		top: 0;
-		left: 0;
-}
+// .confirm-purchase-modal {
+// 	width: 100%;
+// 	height: 100%;
+// 	display: flex;
+// 		justify-content: center;
+// 		align-items: center;
+// 	position: fixed;
+// 		top: 0;
+// 		left: 0;
+// }
 
-.confirm-purchase-modal__background {
-	width: 100%;
-	height: 100%;
-	background-color: 
-		var( --studio-gray-5 );
-	z-index: -1;
-	opacity: 0.8;
-	position: fixed;
-		top: 0;
-		left: 0;
-}
+// .confirm-purchase-modal__background {
+// 	width: 100%;
+// 	height: 100%;
+// 	background-color:
+// 		var( --studio-gray-5 );
+// 	z-index: -1;
+// 	opacity: 0.8;
+// 	position: fixed;
+// 		top: 0;
+// 		left: 0;
+// }
 
 .confirm-purchase-modal__content {
 	padding: 32px;
@@ -36,9 +36,9 @@
 
 .confirm-purchase-modal__items {
 	font-size: 16px;
-	color: 
-		var( --studio-gray-60 );
-	font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+	color: var( --studio-gray-60 );
+	font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+		sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 	line-height: 1.5em;
 	padding: 32px;
 
@@ -56,5 +56,5 @@
 	width: 100%;
 	margin-top: 32px;
 	display: flex;
-		justify-content: space-between;
+	justify-content: space-between;
 }

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
@@ -1,26 +1,3 @@
-// .confirm-purchase-modal {
-// 	width: 100%;
-// 	height: 100%;
-// 	display: flex;
-// 		justify-content: center;
-// 		align-items: center;
-// 	position: fixed;
-// 		top: 0;
-// 		left: 0;
-// }
-
-// .confirm-purchase-modal__background {
-// 	width: 100%;
-// 	height: 100%;
-// 	background-color:
-// 		var( --studio-gray-5 );
-// 	z-index: -1;
-// 	opacity: 0.8;
-// 	position: fixed;
-// 		top: 0;
-// 		left: 0;
-// }
-
 .confirm-purchase-modal__content {
 	padding: 32px;
 	max-width: 560px;

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
@@ -1,10 +1,12 @@
+@import '../../mixins';
+
 .confirm-purchase-modal__content {
 	padding: 32px;
 	max-width: 560px;
 }
 
 .confirm-purchase-modal__header {
-	font-family: 'Recoleta-Regular', 'Recoleta', serif;
+	@include onboarding-font-recoleta;
 	font-size: 40px;
 	color: var( --studio-blue-40 );
 	margin: 0 0 16px;

--- a/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
+++ b/client/landing/gutenboarding/components/confirm-purchase-modal/style.scss
@@ -1,10 +1,5 @@
 @import '../../mixins';
 
-.confirm-purchase-modal__content {
-	padding: 32px;
-	max-width: 560px;
-}
-
 .confirm-purchase-modal__header {
 	@include onboarding-font-recoleta;
 	font-size: 40px;
@@ -32,8 +27,10 @@
 }
 
 .confirm-purchase-modal__buttons {
-	width: 100%;
-	margin-top: 32px;
+	margin-top: 0.8em;
 	display: flex;
-	justify-content: space-between;
+	justify-content: flex-end;
+	.components-button + .components-button {
+		margin-left: 0.4em;
+	}
 }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
-import ConfirmPurchaseModal from '../confirmPurchaseModal';
+import ConfirmPurchaseModal from '../confirm-purchase-modal';
 
 /**
  * Style dependencies

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
+import ConfirmPurchaseModal from '../confirmPurchaseModal';
 
 /**
  * Style dependencies
@@ -23,13 +24,18 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	children,
 	className,
 	onDomainSelect,
+	onDomainPurchase,
 	defaultQuery,
 	queryParameters,
+	currentUser,
+	currentDomain,
 	...buttonProps
 } ) => {
 	const buttonRef = createRef< HTMLButtonElement >();
 
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
+	const [ isPurchaseDomainVisible, setPurchaseDomainVisibility ] = useState( false );
+	const [ userSelectedDomain, setUserSelectedDomain ] = useState( '' );
 
 	const handleClose = ( e?: React.FocusEvent ) => {
 		// Don't collide with button toggling
@@ -42,6 +48,22 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	const handleDomainSelect: typeof onDomainSelect = selectedDomain => {
 		setDomainPopoverVisibility( false );
 		onDomainSelect( selectedDomain );
+	};
+
+	const handlePaidDomainSelect: typeof onDomainPurchase = selectedDomain => {
+		setDomainPopoverVisibility( false );
+		setPurchaseDomainVisibility( true );
+		setUserSelectedDomain( selectedDomain );
+	};
+
+	const handlePurchaseCancel = () => {
+		setPurchaseDomainVisibility( false );
+		setUserSelectedDomain( '' );
+	};
+
+	const handleDomainPurchase = () => {
+		onDomainSelect( userSelectedDomain );
+		onDomainPurchase( userSelectedDomain );
 	};
 
 	return (
@@ -60,12 +82,22 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<span>{ children }</span>
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
+			{ isPurchaseDomainVisible && (
+				<ConfirmPurchaseModal
+					onCancel={ handlePurchaseCancel }
+					onAccept={ handleDomainPurchase }
+					selectedDomain={ userSelectedDomain }
+					isLogged={ !! currentUser }
+				/>
+			) }
 			{ isDomainPopoverVisible && (
 				<Popover onClose={ handleClose } onFocusOutside={ handleClose }>
 					<DomainPicker
 						defaultQuery={ defaultQuery }
 						onDomainSelect={ handleDomainSelect }
+						onDomainPurchase={ handlePaidDomainSelect }
 						queryParameters={ queryParameters }
+						currentDomain={ currentDomain }
 					/>
 				</Popover>
 			) }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -16,8 +16,11 @@ import ConfirmPurchaseModal from '../confirm-purchase-modal';
  */
 import './style.scss';
 
+type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
+
 interface Props extends DomainPickerProps, Button.BaseProps {
 	className?: string;
+	currentDomain?: DomainSuggestion;
 }
 
 const DomainPickerButton: FunctionComponent< Props > = ( {
@@ -27,15 +30,16 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	onDomainPurchase,
 	defaultQuery,
 	queryParameters,
-	currentUser,
 	currentDomain,
 	...buttonProps
 } ) => {
 	const buttonRef = createRef< HTMLButtonElement >();
 
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
-	const [ isPurchaseDomainVisible, setPurchaseDomainVisibility ] = useState( false );
-	const [ userSelectedDomain, setUserSelectedDomain ] = useState( '' );
+	const [
+		userSelectedDomainSuggestion,
+		setUserSelectedDomainSuggestion,
+	] = useState< DomainSuggestion | null >( null );
 
 	const handleClose = ( e?: React.FocusEvent ) => {
 		// Don't collide with button toggling
@@ -50,20 +54,13 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 		onDomainSelect( selectedDomain );
 	};
 
-	const handlePaidDomainSelect: typeof onDomainPurchase = selectedDomain => {
+	const handlePaidDomainSelect = ( selectedDomain: DomainSuggestion ) => {
 		setDomainPopoverVisibility( false );
-		setPurchaseDomainVisibility( true );
-		setUserSelectedDomain( selectedDomain );
+		setUserSelectedDomainSuggestion( selectedDomain );
 	};
 
 	const handlePurchaseCancel = () => {
-		setPurchaseDomainVisibility( false );
-		setUserSelectedDomain( '' );
-	};
-
-	const handleDomainPurchase = () => {
-		onDomainSelect( userSelectedDomain );
-		onDomainPurchase( userSelectedDomain );
+		setUserSelectedDomainSuggestion( null );
 	};
 
 	return (
@@ -82,12 +79,15 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<span>{ children }</span>
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
-			{ isPurchaseDomainVisible && (
+			{ userSelectedDomainSuggestion && (
 				<ConfirmPurchaseModal
 					onCancel={ handlePurchaseCancel }
-					onAccept={ handleDomainPurchase }
-					selectedDomain={ userSelectedDomain }
-					isLogged={ !! currentUser }
+					onAccept={ () => {
+						onDomainSelect( userSelectedDomainSuggestion );
+						onDomainPurchase( userSelectedDomainSuggestion );
+						setUserSelectedDomainSuggestion( null );
+					} }
+					selectedDomain={ userSelectedDomainSuggestion }
 				/>
 			) }
 			{ isDomainPopoverVisible && (

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -20,7 +20,6 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import { DomainSuggestions } from '@automattic/data-stores';
 import { selectorDebounce } from '../../constants';
-
 /**
  * Style dependencies
  */
@@ -42,6 +41,13 @@ export interface Props {
 	onDomainSelect: ( domainSuggestion: DomainSuggestions.DomainSuggestion ) => void;
 
 	/**
+	 * Callback that will be invoked when a paid domain is selected.
+	 *
+	 * @param domainSuggestion The selected domain.
+	 */
+	onDomainPurchase: ( domainSuggestion: DomainSuggestions.DomainSuggestion ) => void;
+
+	/**
 	 * Additional parameters for the domain suggestions query.
 	 */
 	queryParameters?: Partial< DomainSuggestions.DomainSuggestionQuery >;
@@ -50,22 +56,26 @@ export interface Props {
 const DomainPicker: FunctionComponent< Props > = ( {
 	defaultQuery,
 	onDomainSelect,
+	onDomainPurchase,
 	queryParameters,
+	currentDomain,
 } ) => {
 	const { __: NO__ } = useI18n();
 	const label = NO__( 'Search for a domain' );
 
 	const [ domainSearch, setDomainSearch ] = useState( '' );
 
+	const placeholderAmount = 5;
+
 	const [ search ] = useDebounce( domainSearch.trim() || defaultQuery || '', selectorDebounce );
 	const searchOptions = {
 		include_wordpressdotcom: true,
 		include_dotblogsubdomain: true,
-		quantity: 4,
+		quantity: 15,
 		...queryParameters,
 	};
 
-	const suggestions = useSelect(
+	const allSuggestions = useSelect(
 		select => {
 			if ( search ) {
 				return select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( search, searchOptions );
@@ -74,9 +84,29 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		[ search, queryParameters ]
 	);
 
-	const handleHasDomain = () => {
-		// eslint-disable-next-line no-console
-		console.log( 'Already has a domain.' );
+	let numberOfFreeDomains = 0;
+	let numberOfPaidDomains = 0;
+	const suggestions = allSuggestions?.filter( suggestion => {
+		if (
+			suggestion.cost === 'Free' &&
+			! numberOfFreeDomains &&
+			suggestion.domain_name !== currentDomain.domain_name
+		) {
+			numberOfFreeDomains++;
+			return suggestion;
+		}
+		if ( suggestion.cost !== 'Free' && numberOfPaidDomains < 5 ) {
+			numberOfPaidDomains++;
+			return suggestion;
+		}
+	} );
+
+	const handleDomainClick = suggestion => {
+		if ( suggestion.is_free ) {
+			onDomainSelect( suggestion );
+		} else {
+			onDomainPurchase( suggestion );
+		}
 	};
 
 	return (
@@ -102,28 +132,29 @@ const DomainPicker: FunctionComponent< Props > = ( {
 					{ suggestions?.length
 						? suggestions.map( suggestion => (
 								<Button
-									onClick={ () => onDomainSelect( suggestion ) }
+									onClick={ () => handleDomainClick( suggestion ) }
 									className="domain-picker__suggestion-item"
 									key={ suggestion.domain_name }
 								>
 									<span className="domain-picker__suggestion-item-name">
 										{ suggestion.domain_name }
 									</span>
-									{ suggestion.is_free ? (
-										<span className="domain-picker__suggestion-action">{ NO__( 'Select' ) }</span>
-									) : (
-										<a
-											className="domain-picker__suggestion-action"
-											href={ `http://wordpress.com/start/domain?new=${ suggestion.domain_name }` }
-											target="_blank"
-											rel="noopener noreferrer"
-										>
-											{ NO__( 'Upgrade' ) }
-										</a>
-									) }
+									<span className="domain-picker__suggestion-action">
+										{ suggestion.is_free ? (
+											<span>
+												<span className="domain-picker__price">{ NO__( 'Free' ) }</span>
+												{ NO__( 'Select' ) }
+											</span>
+										) : (
+											<span>
+												<span className="domain-picker__price">{ NO__( 'from €4/month' ) }</span>
+												{ NO__( 'Upgrade' ) }
+											</span>
+										) }
+									</span>
 								</Button>
 						  ) )
-						: times( searchOptions.quantity, i => (
+						: times( placeholderAmount, i => (
 								<Button className="domain-picker__suggestion-item" key={ i }>
 									<span className="domain-picker__suggestion-item-name placeholder">
 										example.wordpress.com
@@ -133,10 +164,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 									</span>
 								</Button>
 						  ) ) }
-				</PanelRow>
-
-				<PanelRow className="domain-picker__has-domain domain-picker__panel-row">
-					<Button onClick={ handleHasDomain }>{ NO__( 'I already have a domain' ) }</Button>
 				</PanelRow>
 			</PanelBody>
 		</Panel>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -152,6 +152,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 											</span>
 										) : (
 											<span>
+												{ /* FIXME: What value do we show here? */ }
 												<span className="domain-picker__price">{ NO__( 'from €4/month' ) }</span>
 												{ NO__( 'Upgrade' ) }
 											</span>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -25,6 +25,9 @@ import { selectorDebounce } from '../../constants';
  */
 import './style.scss';
 
+type DomainSuggestion = DomainSuggestions.DomainSuggestion;
+0;
+
 const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
 
 export interface Props {
@@ -38,19 +41,21 @@ export interface Props {
 	 *
 	 * @param domainSuggestion The selected domain.
 	 */
-	onDomainSelect: ( domainSuggestion: DomainSuggestions.DomainSuggestion ) => void;
+	onDomainSelect: ( domainSuggestion: DomainSuggestion ) => void;
 
 	/**
 	 * Callback that will be invoked when a paid domain is selected.
 	 *
 	 * @param domainSuggestion The selected domain.
 	 */
-	onDomainPurchase: ( domainSuggestion: DomainSuggestions.DomainSuggestion ) => void;
+	onDomainPurchase: ( domainSuggestion: DomainSuggestion ) => void;
 
 	/**
 	 * Additional parameters for the domain suggestions query.
 	 */
 	queryParameters?: Partial< DomainSuggestions.DomainSuggestionQuery >;
+
+	currentDomain?: DomainSuggestion;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -90,7 +95,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		if (
 			suggestion.is_free &&
 			! numberOfFreeDomains &&
-			suggestion.domain_name !== currentDomain.domain_name
+			suggestion.domain_name !== currentDomain?.domain_name
 		) {
 			numberOfFreeDomains++;
 			return suggestion;
@@ -101,7 +106,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		}
 	} );
 
-	const handleDomainClick = suggestion => {
+	const handleDomainClick = ( suggestion: DomainSuggestion ) => {
 		if ( suggestion.is_free ) {
 			onDomainSelect( suggestion );
 		} else {

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -88,14 +88,14 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	let numberOfPaidDomains = 0;
 	const suggestions = allSuggestions?.filter( suggestion => {
 		if (
-			suggestion.cost === 'Free' &&
+			suggestion.is_free &&
 			! numberOfFreeDomains &&
 			suggestion.domain_name !== currentDomain.domain_name
 		) {
 			numberOfFreeDomains++;
 			return suggestion;
 		}
-		if ( suggestion.cost !== 'Free' && numberOfPaidDomains < 5 ) {
+		if ( ! suggestion.is_free && numberOfPaidDomains < 5 ) {
 			numberOfPaidDomains++;
 			return suggestion;
 		}

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -62,3 +62,11 @@
 .domain-picker__divider {
 	margin-top: 20px;
 }
+
+
+.domain-picker__price {
+	color: var( --studio-gray-20 );
+	size: 0.8em;
+	margin: 0.1em 1em;
+	white-space: nowrap;
+}

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -18,7 +18,7 @@
 .domain-picker__panel-row {
 	// Increasing specificity because @wordpress/components stylesheets are loaded after gutenboarding stylesheets.
 	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
-	// See https://github.com/WordPress/gutenberg/pull/19535 
+	// See https://github.com/WordPress/gutenberg/pull/19535
 	&.components-panel__row {
 		flex-direction: column;
 		align-items: stretch;
@@ -28,7 +28,7 @@
 .domain-picker__suggestion-item {
 	// Increasing specificity because @wordpress/components stylesheets are loaded after gutenboarding stylesheets.
 	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
-	// See https://github.com/WordPress/gutenberg/pull/19535 	
+	// See https://github.com/WordPress/gutenberg/pull/19535
 	&.components-button {
 		display: flex;
 		justify-content: space-between;
@@ -63,10 +63,8 @@
 	margin-top: 20px;
 }
 
-
 .domain-picker__price {
 	color: var( --studio-gray-20 );
-	size: 0.8em;
 	margin: 0.1em 1em;
 	white-space: nowrap;
 }

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -144,9 +144,8 @@ const Header: FunctionComponent = () => {
 	};
 
 	const handleSignupForDomains = () => {
+		setShowSignupDialog( true );
 		setDomainFlow( true );
-		setShouldCreate( true );
-		history.push( makePath( Step.Signup ) );
 	};
 
 	useEffect( () => {
@@ -163,7 +162,7 @@ const Header: FunctionComponent = () => {
 				: `/block-editor/page/${ newSite.blogid }/home?is-gutenboarding`;
 			window.location.href = location;
 		}
-	}, [ newSite, resetOnboardStore ] );
+	}, [ isDomainFlow, newSite, resetOnboardStore ] );
 
 	return (
 		<div

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -158,7 +158,7 @@ const Header: FunctionComponent = () => {
 		if ( newSite ) {
 			! isDomainFlow && resetOnboardStore();
 			const location = isDomainFlow
-				? `/checkout/${ newSite.blogid }/personal?redirect_to=%2Fgutenboarding%2Fdesign` //%2F%3FsiteId%3D${ newSite.blogid }`
+				? `/checkout/${ newSite.blogid }/personal?redirect_to=%2Fgutenboarding%2Fdesign`
 				: `/block-editor/page/${ newSite.blogid }/home?is-gutenboarding`;
 			window.location.href = location;
 		}

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -189,7 +189,6 @@ const Header: FunctionComponent = () => {
 									: handleSignupForDomains()
 							}
 							queryParameters={ { vertical: siteVertical?.id } }
-							currentUser={ currentUser }
 						>
 							{ siteTitleElement }
 							{ domainElement }

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -108,7 +108,7 @@ const Header: FunctionComponent = () => {
 						title: siteTitle,
 					},
 					site_creation_flow: 'gutenboarding',
-					theme: `pub/${ selectedDesign?.slug }`,
+					...( selectedDesign && { theme: `pub/${ selectedDesign?.slug }` } ),
 				},
 				...( bearerToken && { authToken: bearerToken } ),
 			} );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -108,7 +108,7 @@ const Header: FunctionComponent = () => {
 						title: siteTitle,
 					},
 					site_creation_flow: 'gutenboarding',
-					...( selectedDesign && { theme: `pub/${ selectedDesign?.slug }` } ),
+					theme: `pub/${ selectedDesign?.slug || 'twentytwenty' }`,
 				},
 				...( bearerToken && { authToken: bearerToken } ),
 			} );
@@ -116,28 +116,10 @@ const Header: FunctionComponent = () => {
 		[ createSite, currentDomain, selectedDesign, siteTitle, siteVertical ]
 	);
 
-	const handleCreateSiteForDomains = useCallback(
-		( username: string, bearerToken?: string ) => {
-			setDomainFlow( true );
-			const siteUrl = currentDomain?.domain_name || siteTitle || username;
-			const themeSlug = 'twentytwenty';
-			createSite( {
-				blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
-				blog_title: siteTitle,
-				options: {
-					site_vertical: siteVertical?.id,
-					site_vertical_name: siteVertical?.label,
-					site_information: {
-						title: siteTitle,
-					},
-					site_creation_flow: 'gutenboarding',
-					theme: `pub/${ themeSlug }`,
-				},
-				...( bearerToken && { authToken: bearerToken } ),
-			} );
-		},
-		[ createSite, currentDomain, siteTitle, siteVertical ]
-	);
+	const handleCreateSiteForDomains: typeof handleCreateSite = ( ...args ) => {
+		setDomainFlow( true );
+		handleCreateSite( ...args );
+	};
 
 	const handleSignup = () => {
 		setShowSignupDialog( true );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -136,7 +136,7 @@ const Header: FunctionComponent = () => {
 				...( bearerToken && { authToken: bearerToken } ),
 			} );
 		},
-		[ createSite, currentDomain, selectedDesign, siteTitle, siteVertical ]
+		[ createSite, currentDomain, siteTitle, siteVertical ]
 	);
 
 	const handleSignup = () => {


### PR DESCRIPTION
This PR re-introduce paid domains in the gutenboarding domain picker, linking them to a sub-flow that actually ask the user to create an account, creates the site, and send them through the calypso checkout so they can pay for a personal plan before they are redirected back to the design section of gutenboarding. 

How to test:
--------------

1. Go to http://calypso.localhost:3000/gutenboarding (or https://calypso.live/gutenboarding?branch=update/gutenboarding-domains-flow )
1. Select a vertical and enter a site title: you should get a domain showing up in the top bar
1. Click it and choose one of the paid domains in the list (or look for a new term and choose one) 
1. You should see a modal dialog telling you what happens next. Make sure you can close it by clicking 'do it later' or clicking outside of the modal
  ![image](https://user-images.githubusercontent.com/1554855/76072460-4d040c00-5f98-11ea-9964-e1f613230726.png)
1. Choose a paid domain again, and this time click on the "create your site and..." button
1. (optional). If you are unlogged, you should get a new dialog asking you to enter your email to create an account. Create one (trick: where we are going you don't need to verify your email, so you can totally make up a non-existent email address)
1. You should see a placeholder-full screen telling you your site is being created. 
1. You should land on the checkout page, with a personal plan already on the cart. Purchase it (give your new fake account some credits first, if that's the case)
  ![image](https://user-images.githubusercontent.com/1554855/76072507-63aa6300-5f98-11ea-962a-5420c43001ec.png)
1. You should land on /gutenboarding/design. The new 'paid' domain should be selected in the domains component in the top bar


