### PR TITLE
Domain status copy updates after internal testing

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -207,7 +207,7 @@ class MappedDomainType extends React.Component {
 
 		if ( isSubdomain( domain.name ) ) {
 			primaryMessage = translate(
-				'Your subdomain mapping has not been setup. You need to create the correct CNAME or NS records at your current DNS provider. {{learnMoreLink}}Learn how to do that in our support guide for mapping subdomains{{/learnMoreLink}}.',
+				'Your subdomain mapping has not been set up. You need to create the correct CNAME or NS records at your current DNS provider. {{learnMoreLink}}Learn how to do that in our support guide for mapping subdomains{{/learnMoreLink}}.',
 				{
 					components: {
 						strong: <strong />,
@@ -225,13 +225,13 @@ class MappedDomainType extends React.Component {
 			);
 		} else {
 			primaryMessage = translate(
-				'Your domain mapping has not been setup. You need to update your nameservers, at the company you purchased your domain, to:',
+				'You domain mapping has not been set up. You need to update your name servers at the company where you purchased the domain to:',
 				{
 					context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
 				}
 			);
 			secondaryMessage = translate(
-				"Please note that it can take up to 72 hours for your changes to become available. If you're still not seeing your site loading at %(domainName)s, please wait a few more hours, clear your browser cache, and try again. {{learnMoreLink}}Learn all about mapping existing domain in our support docs{{/learnMoreLink}}.",
+				"Please note that it can take up to 72 hours for your changes to become available. If you're still not seeing your site loading at %(domainName)s, please wait a few more hours, clear your browser cache, and try again. {{learnMoreLink}}Learn all about mapping an existing domain in our support docs{{/learnMoreLink}}.",
 				{
 					components: { learnMoreLink: learnMoreLink( MAP_EXISTING_DOMAIN ) },
 					args: { domainName: domain.name },
@@ -251,7 +251,7 @@ class MappedDomainType extends React.Component {
 						</ul>
 					) }
 				</div>
-				<div>{ secondaryMessage }</div>
+				<div className="mapped-domain-type__small-message">{ secondaryMessage }</div>
 			</React.Fragment>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -225,7 +225,7 @@ class MappedDomainType extends React.Component {
 			);
 		} else {
 			primaryMessage = translate(
-				'You domain mapping has not been set up. You need to update your name servers at the company where you purchased the domain to:',
+				'Your domain mapping has not been set up. You need to update your name servers at the company where you purchased the domain to:',
 				{
 					context: 'Notice for mapped domain notice with NS records pointing to somewhere else',
 				}

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -156,7 +156,7 @@ class RegisteredDomainType extends React.Component {
 				<div>
 					<p>
 						{ translate(
-							'Your domain will expire in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
+							'{{strong}}Your domain will expire{{/strong}} in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
 							{
 								components: {
 									strong: <strong />,
@@ -200,7 +200,7 @@ class RegisteredDomainType extends React.Component {
 
 		if ( domain.isRenewable ) {
 			message = translate(
-				'Your domain has expired and is no longer active. You have {{strong}}%(days)s{{/strong}} to renew it at the standard rate before an additional %(redemptionCost)s redemption fee is applied. {{domainsLink}}Learn more{{/domainsLink}}',
+				'{{strong}}Your domain has expired{{/strong}} and is no longer active. You have {{strong}}%(days)s{{/strong}} to renew it at the standard rate before an additional %(redemptionCost)s redemption fee is applied. {{domainsLink}}Learn more{{/domainsLink}}',
 				{
 					components: {
 						domainsLink: domainsLink( DOMAIN_EXPIRATION ),
@@ -214,7 +214,7 @@ class RegisteredDomainType extends React.Component {
 			);
 		} else if ( domain.isRedeemable ) {
 			message = translate(
-				'Your domain has expired and is no longer active. You have {{strong}}%(days)s{{/strong}} to reactivate it during this redemption period before someone else can register it. An additional redemption fee of {{strong}}%(redemptionCost)s{{/strong}} will be added to the price of the domain to reactivate it. {{domainsLink}}Learn more{{/domainsLink}}',
+				'{{strong}}Your domain has expired{{/strong}} and is no longer active. You have {{strong}}%(days)s{{/strong}} to reactivate it during this redemption period before someone else can register it. An additional redemption fee of {{strong}}%(redemptionCost)s{{/strong}} will be added to the price of the domain to reactivate it. {{domainsLink}}Learn more{{/domainsLink}}',
 				{
 					components: {
 						domainsLink: domainsLink( DOMAIN_EXPIRATION_REDEMPTION ),
@@ -228,7 +228,7 @@ class RegisteredDomainType extends React.Component {
 			);
 		} else {
 			message = translate(
-				'Your domain has expired and is no longer active. {{domainsLink}}Learn more{{/domainsLink}}',
+				'{{strong}}Your domain has expired{{/strong}} and is no longer active. {{domainsLink}}Learn more{{/domainsLink}}',
 				{
 					components: {
 						domainsLink: domainsLink( DOMAIN_EXPIRATION ),

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -111,6 +111,11 @@
 			}
 		}
 
+		.mapped-domain-type__small-message {
+			font-size: 14px;
+		}
+
+
 		> div {
 			margin-bottom: 1.5em;
 			border-bottom: 1px solid var( --color-border-subtle );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update "You domain mapping has not been set up. You need to update your name servers at the company where you purchased the domain to:"
* Update: "Learn all about mapping an existing domain in our support docs."
* setup -> set up
* For each status that has an action required, can we highlight what state the domain is in. ie: "**Your domain has expired** and is no longer active"
* I updated the font-size for the secondary message "Please note that it can take up to 72 hours..." message

#### Testing instructions

* Verify that the texts are updated for domain mappings and expired domains
* Verify that the mapping not pointing to us secondary message has smaller font-size

