### PR TITLE
Block editor: Add document titles

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -37,12 +37,13 @@ import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 import { setEditorIframeLoaded, startEditingPost } from 'state/ui/editor/actions';
 import { Placeholder } from './placeholder';
 import WebPreview from 'components/web-preview';
-import { trashPost } from 'state/posts/actions';
+import { editPost, trashPost } from 'state/posts/actions';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { protectForm, ProtectedFormProps } from 'lib/protect-form';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ConvertToBlocksDialog from 'components/convert-to-blocks';
 import config from 'config';
+import EditorDocumentHead from 'post-editor/editor-document-head';
 
 /**
  * Types
@@ -230,7 +231,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 		if ( EditorActions.SetDraftId === action && ! this.props.postId ) {
 			const { postId } = payload;
-			const { siteId, currentRoute } = this.props;
+			const { siteId, currentRoute, postType } = this.props;
 
 			if ( ! endsWith( currentRoute, `/${ postId }` ) ) {
 				this.props.replaceHistory( `${ currentRoute }/${ postId }`, true );
@@ -238,6 +239,9 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 				//set postId on state.ui.editor.postId, so components like editor revisions can read from it
 				this.props.startEditingPost( siteId, postId );
+
+				//set post type on state.posts.[ id ].type, so components like document head can read from it
+				this.props.editPost( siteId, postId, { type: postType } );
 			}
 		}
 
@@ -562,6 +566,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 					title={ this.getStatsTitle() }
 					properties={ this.getStatsProps() }
 				/>
+				<EditorDocumentHead />
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<ConvertToBlocksDialog
 					showDialog={ isConversionPromptVisible }
@@ -684,6 +689,7 @@ const mapDispatchToProps = {
 	openPostRevisionsDialog,
 	setEditorIframeLoaded,
 	startEditingPost,
+	editPost,
 	trashPost,
 	updateSiteFrontPage,
 };

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -10,7 +10,7 @@ import { get, has, isInteger, noop } from 'lodash';
  */
 import { shouldLoadGutenberg } from 'state/selectors/should-load-gutenberg';
 import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
-import { EDITOR_START } from 'state/action-types';
+import { EDITOR_START, POST_EDIT } from 'state/action-types';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import CalypsoifyIframe from './calypsoify-iframe';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
@@ -95,12 +95,12 @@ export const authenticate = ( context, next ) => {
 	const storageKey = `gutenframe_${ siteId }_is_authenticated`;
 
 	const isAuthenticated =
-		sessionStorage.getItem( storageKey ) || // Previously authenticated.
+		globalThis.sessionStorage.getItem( storageKey ) || // Previously authenticated.
 		! isSiteWpcomAtomic( state, siteId ) || // Simple sites users are always authenticated.
 		isEnabled( 'desktop' ) || // The desktop app can store third-party cookies.
 		context.query.authWpAdmin; // Redirect back from the WP Admin login page to Calypso.
 	if ( isAuthenticated ) {
-		sessionStorage.setItem( storageKey, 'true' );
+		globalThis.sessionStorage.setItem( storageKey, 'true' );
 		return next();
 	}
 
@@ -176,6 +176,9 @@ export const post = ( context, next ) => {
 
 	// Set postId on state.ui.editor.postId, so components like editor revisions can read from it.
 	context.store.dispatch( { type: EDITOR_START, siteId, postId } );
+
+	// Set post type on state.posts.[ id ].type, so components like document head can read from it.
+	context.store.dispatch( { type: POST_EDIT, post: { type: postType }, siteId, postId } );
 
 	context.primary = (
 		<CalypsoifyIframe


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Replaces the document title with specific titles when using the block editor rather than keeping the title of the previous page (which was causing some confusing labels such as "Customer Home" when opening the block editor from "My Home", as originally reported by @amamujee in p1583412425219600-slack-manage).

Before | After
--- | ---
<img width="606" alt="Screen Shot 2020-03-05 at 16 14 50" src="https://user-images.githubusercontent.com/1233880/75995521-d2d27980-5efc-11ea-80d7-1f92e50833bc.png"> | <img width="641" alt="Screen Shot 2020-03-05 at 16 16 00" src="https://user-images.githubusercontent.com/1233880/75995524-d8c85a80-5efc-11ea-9735-a8d5ab435cbc.png">

It reuses the existing `EditorDocumentHead` component, so titles handle new/existing post and different post types:

<img width="230" alt="Screen Shot 2020-03-05 at 16 03 47" src="https://user-images.githubusercontent.com/1233880/75995850-52f8df00-5efd-11ea-9a64-0c0b8f58ae56.png">
<img width="229" alt="Screen Shot 2020-03-05 at 16 03 56" src="https://user-images.githubusercontent.com/1233880/75995862-555b3900-5efd-11ea-98dd-e57dfe56a432.png">
<img width="238" alt="Screen Shot 2020-03-05 at 16 04 18" src="https://user-images.githubusercontent.com/1233880/75995870-57bd9300-5efd-11ea-851f-17dbbb984823.png">
<img width="234" alt="Screen Shot 2020-03-05 at 16 04 27" src="https://user-images.githubusercontent.com/1233880/75995876-5a1fed00-5efd-11ea-8a8a-5cbd86027240.png">
<img width="232" alt="Screen Shot 2020-03-05 at 16 05 50" src="https://user-images.githubusercontent.com/1233880/75995884-5c824700-5efd-11ea-9be4-a6737c756bdb.png">
<img width="227" alt="Screen Shot 2020-03-05 at 16 05 57" src="https://user-images.githubusercontent.com/1233880/75995893-5f7d3780-5efd-11ea-8812-c0b63383a008.png">

#### Testing instructions

Load the block editor from different sections (Site > Posts, Site > Pages, My Home, Tools > Activity) and make sure it uses a document title that's aligned with the post status (new/existing) and type (post, page, portfolio, ...).
