### PR TITLE
Force theme annotation when theme is sent as a query prop

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -302,8 +302,9 @@ export function generateSteps( {
 				'domainItem',
 				'themeItem',
 				'shouldHideFreePlan',
+				'useThemeHeadstart',
 			],
-			optionalDependencies: [ 'shouldHideFreePlan' ],
+			optionalDependencies: [ 'shouldHideFreePlan', 'useThemeHeadstart' ],
 			props: {
 				isDomainOnly: false,
 			},

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -243,6 +243,10 @@ class DomainsStep extends React.Component {
 		const shouldHideFreePlanItem = this.isEligibleVariantForDomainTest()
 			? { shouldHideFreePlan }
 			: {};
+		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
+		const useThemeHeadstartItem = shouldUseThemeAnnotation
+			? { useThemeHeadstart: shouldUseThemeAnnotation }
+			: {};
 
 		if ( shouldHideFreePlan ) {
 			let domainItem, isPurchasingItem, siteUrl;
@@ -259,9 +263,7 @@ class DomainsStep extends React.Component {
 					},
 					this.getThemeArgs()
 				),
-				Object.assign( { domainItem }, shouldHideFreePlanItem, {
-					useThemeHeadstart: this.shouldUseThemeAnnotation(),
-				} )
+				Object.assign( { domainItem }, shouldHideFreePlanItem, useThemeHeadstartItem )
 			);
 
 			this.props.goToNextStep();
@@ -300,9 +302,7 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			Object.assign( { domainItem }, shouldHideFreePlanItem, {
-				useThemeHeadstart: this.shouldUseThemeAnnotation(),
-			} )
+			Object.assign( { domainItem }, shouldHideFreePlanItem, useThemeHeadstartItem )
 		);
 
 		this.props.setDesignType( this.getDesignType() );
@@ -315,6 +315,10 @@ class DomainsStep extends React.Component {
 	handleAddMapping = ( sectionName, domain, state ) => {
 		const domainItem = domainMapping( { domain } );
 		const isPurchasingItem = true;
+		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
+		const useThemeHeadstartItem = shouldUseThemeAnnotation
+			? { useThemeHeadstart: shouldUseThemeAnnotation }
+			: {};
 
 		this.props.recordAddDomainButtonClickInMapDomain( domain, this.getAnalyticsSection() );
 
@@ -330,7 +334,7 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			Object.assign( { domainItem }, { useThemeHeadstart: this.shouldUseThemeAnnotation() } )
+			Object.assign( { domainItem }, useThemeHeadstartItem )
 		);
 
 		this.props.goToNextStep();
@@ -345,6 +349,10 @@ class DomainsStep extends React.Component {
 			},
 		} );
 		const isPurchasingItem = true;
+		const shouldUseThemeAnnotation = this.shouldUseThemeAnnotation();
+		const useThemeHeadstartItem = shouldUseThemeAnnotation
+			? { useThemeHeadstart: shouldUseThemeAnnotation }
+			: {};
 
 		this.props.recordAddDomainButtonClickInTransferDomain( domain, this.getAnalyticsSection() );
 
@@ -360,7 +368,7 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			Object.assign( { domainItem }, { useThemeHeadstart: this.shouldUseThemeAnnotation() } )
+			Object.assign( { domainItem }, useThemeHeadstartItem )
 		);
 
 		this.props.goToNextStep();

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -216,6 +216,10 @@ class DomainsStep extends React.Component {
 		return `${ repo }/${ themeSlug }`;
 	};
 
+	shouldUseThemeAnnotation() {
+		return this.getThemeSlug() ? true : false;
+	}
+
 	handleSkip = ( googleAppsCartItem, shouldHideFreePlan = false ) => {
 		const hideFreePlanTracksProp = this.isEligibleVariantForDomainTest()
 			? { should_hide_free_plan: shouldHideFreePlan }
@@ -255,7 +259,9 @@ class DomainsStep extends React.Component {
 					},
 					this.getThemeArgs()
 				),
-				Object.assign( { domainItem }, shouldHideFreePlanItem )
+				Object.assign( { domainItem }, shouldHideFreePlanItem, {
+					useThemeHeadstart: this.shouldUseThemeAnnotation(),
+				} )
 			);
 
 			this.props.goToNextStep();
@@ -294,7 +300,9 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			Object.assign( { domainItem }, shouldHideFreePlanItem )
+			Object.assign( { domainItem }, shouldHideFreePlanItem, {
+				useThemeHeadstart: this.shouldUseThemeAnnotation(),
+			} )
 		);
 
 		this.props.setDesignType( this.getDesignType() );
@@ -322,7 +330,7 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			{ domainItem }
+			Object.assign( { domainItem }, { useThemeHeadstart: this.shouldUseThemeAnnotation() } )
 		);
 
 		this.props.goToNextStep();
@@ -352,7 +360,7 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			{ domainItem }
+			Object.assign( { domainItem }, { useThemeHeadstart: this.shouldUseThemeAnnotation() } )
 		);
 
 		this.props.goToNextStep();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the `with-theme` flow i.e signup flow at /start/with-theme, the selected theme's annotation should be applied to the headstarted site instead of the default annotation.
* We send the selected theme as a query param to the domain step, e.g. : `https://wordpress.com/start/with-theme/domains-theme-preselected?ref=calypshowcase&theme=twentytwenty` 
If the theme is present as a query prop, then we should force the theme annotation during headstart.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**

* Check the normal signup flow - begin signup at /start and verify that you are able to complete signup.
* Verify that your site gets the Hever theme and a default starter content that matches https://qq1455758.wordpress.com/.

**Scenario 2**

Check the `with-theme` flow:

* While logged out of wpcom, go to https://wordpress.com/themes and select any random theme. Click "Pick this design".
* Switch out the https://wordpress.com/ with http://calypso.localhost:3000/ in your browser address bar, and proceed with the signup flow.
* After completing signup, verify that your site gets the selected theme and the theme's annotation.

**Scenario 3**

Check domain transfer in the `with-theme` flow:

* While logged out of wpcom, go to https://wordpress.com/themes and select any random theme. Click "Pick this design".
* Switch out the https://wordpress.com/ with http://calypso.localhost:3000/ in your browser address bar, and proceed with the signup flow.
* In the domain step, select to transfer a domain and add domain transfer item to cart.
* Complete purchase and verify that that your site gets the selected theme and the theme's annotation.
* Repeat all steps and verify for Domain mapping too.

After completing signup, verify that your site gets the selected theme and the theme's annotation.


Fixes the `with-theme` signup flow issue [described by](https://github.com/Automattic/wp-calypso/pull/39795#issuecomment-595059141) @andrewserong.
