### PR TITLE
Jetpack Cloud: Daily backup deltas component

### DIFF
--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import Button from 'components/forms/form-button';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class BackupDelta extends Component {
+	render() {
+		const { backupAttempts, deltas } = this.props;
+		const mainBackup = backupAttempts.complete && backupAttempts.complete[ 0 ];
+		const meta = mainBackup && mainBackup.activityDescription[ 2 ].children[ 0 ];
+
+		const media = deltas.mediaCreated.map( item => (
+			<div key={ item.activityId }>
+				<img alt="" src={ item.activityMedia.thumbnail_url } />
+				<div>{ item.activityMedia.name }</div>
+			</div>
+		) );
+
+		const posts = deltas.posts.map( item => {
+			if ( 'post__published' === item.activityName ) {
+				return (
+					<div key={ item.activityId }>
+						<Gridicon icon="pencil" />
+						{ item.activityDescription[ 0 ].children[ 0 ] }
+					</div>
+				);
+			}
+			if ( 'post__trashed' === item.activityName ) {
+				return (
+					<div key={ item.activityId }>
+						<Gridicon icon="cross" />
+						{ item.activityDescription[ 0 ].children[ 0 ].text }
+					</div>
+				);
+			}
+		} );
+
+		return (
+			<div>
+				<div>Backup details</div>
+				<div>Media</div>
+				<div>{ deltas.mediaCreated && media }</div>
+				<div>Posts</div>
+				<div>{ deltas.posts && posts }</div>
+				<div>{ meta }</div>
+				<Button className="backup-delta__view-all-button">View all backup details</Button>
+			</div>
+		);
+	}
+}
+
+export default BackupDelta;

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -1,0 +1,4 @@
+.backup-delta__view-all-button {
+    display: block;
+    float: none;
+}

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -9,3 +9,46 @@ export const getBackupAttemptsForDate = ( logs, date ) => ( {
 			'rewind__backup_error' === item.activityName && item.activityDate.split( 'T' )[ 0 ] === date
 	),
 } );
+
+export const getChangesInRange = ( logs, t1, t2 ) => {
+	return logs.filter( event => {
+		const eventTime = new Date( event.activityDate ).getTime();
+		return eventTime > t1 && eventTime < t2;
+	} );
+};
+
+export const getEventsInDailyBackup = ( logs, date ) => {
+	const d = new Date( date );
+	d.setDate( d.getDate() - 1 );
+	const d1 = d.toISOString().split( 'T' )[ 0 ];
+	const d2 = new Date( date ).toISOString().split( 'T' )[ 0 ];
+	const lastBackup = getBackupAttemptsForDate( logs, d1 );
+	const thisBackup = getBackupAttemptsForDate( logs, d2 );
+
+	if ( ! ( lastBackup.complete.length && thisBackup.complete.length ) ) {
+		return [];
+	}
+
+	const lastBackupDate = new Date( lastBackup.complete[ 0 ].activityDate );
+	const thisBackupDate = new Date( thisBackup.complete[ 0 ].activityDate );
+	const lastBackupTime = lastBackupDate.getTime();
+	const thisBackupTime = thisBackupDate.getTime();
+
+	return getChangesInRange( logs, lastBackupTime, thisBackupTime );
+};
+
+export const getDailyBackupDeltas = ( logs, date ) => {
+	const changes = getEventsInDailyBackup( logs, date );
+
+	const mediaCreated = changes.filter( event => 'attachment__uploaded' === event.activityName );
+	const mediaDeleted = changes.filter( event => 'attachment__deleted' === event.activityName );
+	const posts = changes.filter(
+		event => 'post__published' === event.activityName || 'post__trashed' === event.activityName
+	);
+
+	return {
+		mediaCreated,
+		posts,
+		mediaDeleted,
+	};
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds details about the contents of a daily backup, below the Daily Backup Status component, per the figma designs. It pulls a list of uploaded media, created/deleted posts, and backup meta, and adds them to the section.

#### Testing instructions

Make sure no console errors arise while shuttling days in a variety of states (has backups, no backups, backup errors, different days with different events).

View the backups section for a date that has changes in the form of created posts, deleted posts, and/or uploaded media. You should see those actions represented on that day's backup page. It should look similar to the following screenshot, depending on what the actions were:

<img width="1043" alt="Screen Shot 2020-03-05 at 11 32 41 AM" src="https://user-images.githubusercontent.com/5528445/76003137-a2c3b000-5ed5-11ea-9694-f971b16daf61.png">

As is customary this week, this PR is lacking most styles, pending further foundation work. Please review for function only.