### PR TITLE
Composite Checkout: add autofill attribute to Stripe cardholder name

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -370,6 +370,7 @@ function StripeCreditCardFields() {
 				<CreditCardField
 					id="cardholderName"
 					type="Text"
+					autoComplete="cc-name"
 					label={ localize( 'Cardholder name' ) }
 					description={ localize( "Enter your name as it's written on the card" ) }
 					value={ cardholderName?.value ?? '' }


### PR DESCRIPTION
This adds a missing `cc-name` attribute to the Stripe cardholder name field, but due to the way Stripe fields are embedded within iframes and browsers parse those fields, autofill will still only work for the CC number and expiration date. 

Adding the attribute in case this is fixed in the future.

Discussion: https://github.com/stripe/react-stripe-elements/issues/199#issuecomment-513280766
Broken example in Stripe Elements docs: https://stripe.dev/elements-examples/