### PR TITLE
CartItem: refactor as functional component

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -35,32 +35,8 @@ import { localize } from 'i18n-calypso';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans';
 
 export class CartItem extends React.Component {
-	getProductInfo() {
-		const { cartItem, selectedSite } = this.props;
-		const domain =
-			cartItem.meta ||
-			get( cartItem, 'extra.domain_to_bundle' ) ||
-			( selectedSite && selectedSite.domain );
-		let info = null;
-
-		if ( isGoogleApps( cartItem ) && cartItem.extra.google_apps_users ) {
-			info = cartItem.extra.google_apps_users.map( user => (
-				<div key={ `user-${ user.email }` }>{ user.email }</div>
-			) );
-		} else if ( isCredits( cartItem ) ) {
-			info = null;
-		} else if ( getIncludedDomain( cartItem ) ) {
-			info = getIncludedDomain( cartItem );
-		} else if ( isTheme( cartItem ) ) {
-			info = selectedSite && selectedSite.domain;
-		} else {
-			info = domain;
-		}
-		return info;
-	}
-
 	render() {
-		const { cart, cartItem, translate, domainsWithPlansOnly, moment } = this.props;
+		const { cart, cartItem, translate, domainsWithPlansOnly, selectedSite, moment } = this.props;
 
 		let name = this.getProductName();
 		const subscriptionLength = this.getSubscriptionLength();
@@ -79,7 +55,9 @@ export class CartItem extends React.Component {
 					<span className="product-name" data-e2e-product-slug={ cartItem.product_slug }>
 						{ name || translate( 'Loading…' ) }
 					</span>
-					<span className="product-domain">{ this.getProductInfo() }</span>
+					<span className="product-domain">
+						<ProductInfo cartItem={ cartItem } selectedSite={ selectedSite } />
+					</span>
 					<DomainRenewalExpiryDate
 						moment={ moment }
 						translate={ translate }
@@ -371,6 +349,29 @@ function getDomainRenewalExpiryDate( cartItem ) {
 		get( cartItem, 'is_renewal' ) &&
 		get( cartItem, 'domain_post_renewal_expiration_date' )
 	);
+}
+
+function ProductInfo( { cartItem, selectedSite } ) {
+	const domain =
+		cartItem.meta ||
+		get( cartItem, 'extra.domain_to_bundle' ) ||
+		( selectedSite && selectedSite.domain );
+	let info = null;
+
+	if ( isGoogleApps( cartItem ) && cartItem.extra.google_apps_users ) {
+		info = cartItem.extra.google_apps_users.map( user => (
+			<div key={ `user-${ user.email }` }>{ user.email }</div>
+		) );
+	} else if ( isCredits( cartItem ) ) {
+		info = null;
+	} else if ( getIncludedDomain( cartItem ) ) {
+		info = getIncludedDomain( cartItem );
+	} else if ( isTheme( cartItem ) ) {
+		info = selectedSite && selectedSite.domain;
+	} else {
+		info = domain;
+	}
+	return info;
 }
 
 export default connect( state => ( {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -34,55 +34,54 @@ import { removeItem } from 'lib/cart/actions';
 import { localize } from 'i18n-calypso';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans';
 
-export class CartItem extends React.Component {
-	render() {
-		const { cart, cartItem, translate, domainsWithPlansOnly, selectedSite, moment } = this.props;
-
-		let name = getProductName( cartItem, translate );
-		const subscriptionLength = getSubscriptionLength( cartItem, translate );
-		if ( subscriptionLength ) {
-			name += ' - ' + subscriptionLength;
-		}
-
-		if ( isTheme( cartItem ) ) {
-			name += ' - ' + translate( 'never expires' );
-		}
-
-		/*eslint-disable wpcalypso/jsx-classname-namespace*/
-		return (
-			<li className="cart-item">
-				<div className="primary-details">
-					<span className="product-name" data-e2e-product-slug={ cartItem.product_slug }>
-						{ name || translate( 'Loading…' ) }
-					</span>
-					<span className="product-domain">
-						<ProductInfo cartItem={ cartItem } selectedSite={ selectedSite } />
-					</span>
-					<DomainRenewalExpiryDate
-						moment={ moment }
-						translate={ translate }
-						cartItem={ cartItem }
-					/>
-				</div>
-
-				<div className="secondary-details">
-					<span className="product-price">
-						<ProductPrice cart={ cart } cartItem={ cartItem } translate={ translate } />
-					</span>
-					<span className="product-monthly-price">
-						<MonthlyPrice cartItem={ cartItem } translate={ translate } />
-					</span>
-					<RemoveButton
-						cart={ cart }
-						cartItem={ cartItem }
-						translate={ translate }
-						domainsWithPlansOnly={ domainsWithPlansOnly }
-					/>
-				</div>
-			</li>
-		);
-		/*eslint-enable wpcalypso/jsx-classname-namespace*/
+export function CartItem( {
+	cart,
+	cartItem,
+	translate,
+	domainsWithPlansOnly,
+	selectedSite,
+	moment,
+} ) {
+	let name = getProductName( cartItem, translate );
+	const subscriptionLength = getSubscriptionLength( cartItem, translate );
+	if ( subscriptionLength ) {
+		name += ' - ' + subscriptionLength;
 	}
+
+	if ( isTheme( cartItem ) ) {
+		name += ' - ' + translate( 'never expires' );
+	}
+
+	/*eslint-disable wpcalypso/jsx-classname-namespace*/
+	return (
+		<li className="cart-item">
+			<div className="primary-details">
+				<span className="product-name" data-e2e-product-slug={ cartItem.product_slug }>
+					{ name || translate( 'Loading…' ) }
+				</span>
+				<span className="product-domain">
+					<ProductInfo cartItem={ cartItem } selectedSite={ selectedSite } />
+				</span>
+				<DomainRenewalExpiryDate moment={ moment } translate={ translate } cartItem={ cartItem } />
+			</div>
+
+			<div className="secondary-details">
+				<span className="product-price">
+					<ProductPrice cart={ cart } cartItem={ cartItem } translate={ translate } />
+				</span>
+				<span className="product-monthly-price">
+					<MonthlyPrice cartItem={ cartItem } translate={ translate } />
+				</span>
+				<RemoveButton
+					cart={ cart }
+					cartItem={ cartItem }
+					translate={ translate }
+					domainsWithPlansOnly={ domainsWithPlansOnly }
+				/>
+			</div>
+		</li>
+	);
+	/*eslint-enable wpcalypso/jsx-classname-namespace*/
 }
 
 CartItem.propTypes = {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -59,37 +59,8 @@ export class CartItem extends React.Component {
 		return info;
 	}
 
-	getDomainRenewalExpiryDate() {
-		const { cartItem } = this.props;
-
-		return (
-			get( cartItem, 'is_domain_registration' ) &&
-			get( cartItem, 'is_renewal' ) &&
-			get( cartItem, 'domain_post_renewal_expiration_date' )
-		);
-	}
-
-	renderDomainRenewalExpiryDate() {
-		const domainRenewalExpiryDate = this.getDomainRenewalExpiryDate();
-
-		if ( ! domainRenewalExpiryDate ) {
-			return null;
-		}
-
-		const { moment, translate } = this.props;
-		const domainRenewalExpiryDateText = translate( 'Renew until %(renewalDate)s', {
-			args: {
-				renewalDate: moment( domainRenewalExpiryDate ).format( 'LL' ),
-			},
-		} );
-
-		/*eslint-disable wpcalypso/jsx-classname-namespace*/
-		return <span className="product-domain-renewal-date">{ domainRenewalExpiryDateText }</span>;
-		/*eslint-enable wpcalypso/jsx-classname-namespace*/
-	}
-
 	render() {
-		const { cart, cartItem, translate, domainsWithPlansOnly } = this.props;
+		const { cart, cartItem, translate, domainsWithPlansOnly, moment } = this.props;
 
 		let name = this.getProductName();
 		const subscriptionLength = this.getSubscriptionLength();
@@ -109,7 +80,11 @@ export class CartItem extends React.Component {
 						{ name || translate( 'Loading…' ) }
 					</span>
 					<span className="product-domain">{ this.getProductInfo() }</span>
-					{ this.renderDomainRenewalExpiryDate() }
+					<DomainRenewalExpiryDate
+						moment={ moment }
+						translate={ translate }
+						cartItem={ cartItem }
+					/>
 				</div>
 
 				<div className="secondary-details">
@@ -370,6 +345,32 @@ function DomainPlanPrice( { cartItem, translate } ) {
 	}
 
 	return <em>{ translate( 'First year free with your plan' ) }</em>;
+}
+
+function DomainRenewalExpiryDate( { moment, translate, cartItem } ) {
+	const domainRenewalExpiryDate = getDomainRenewalExpiryDate( cartItem );
+
+	if ( ! domainRenewalExpiryDate ) {
+		return null;
+	}
+
+	const domainRenewalExpiryDateText = translate( 'Renew until %(renewalDate)s', {
+		args: {
+			renewalDate: moment( domainRenewalExpiryDate ).format( 'LL' ),
+		},
+	} );
+
+	/*eslint-disable wpcalypso/jsx-classname-namespace*/
+	return <span className="product-domain-renewal-date">{ domainRenewalExpiryDateText }</span>;
+	/*eslint-enable wpcalypso/jsx-classname-namespace*/
+}
+
+function getDomainRenewalExpiryDate( cartItem ) {
+	return (
+		get( cartItem, 'is_domain_registration' ) &&
+		get( cartItem, 'is_renewal' ) &&
+		get( cartItem, 'domain_post_renewal_expiration_date' )
+	);
 }
 
 export default connect( state => ( {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -38,8 +38,8 @@ export class CartItem extends React.Component {
 	render() {
 		const { cart, cartItem, translate, domainsWithPlansOnly, selectedSite, moment } = this.props;
 
-		let name = this.getProductName();
-		const subscriptionLength = this.getSubscriptionLength();
+		let name = getProductName( cartItem, translate );
+		const subscriptionLength = getSubscriptionLength( cartItem, translate );
 		if ( subscriptionLength ) {
 			name += ' - ' + subscriptionLength;
 		}
@@ -82,78 +82,6 @@ export class CartItem extends React.Component {
 			</li>
 		);
 		/*eslint-enable wpcalypso/jsx-classname-namespace*/
-	}
-
-	getSubscriptionLength() {
-		const { cartItem, translate } = this.props;
-		if ( this.isDomainProductDiscountedTo0() ) {
-			return false;
-		}
-
-		const hasBillPeriod = cartItem.bill_period && parseInt( cartItem.bill_period ) !== -1;
-		if ( ! hasBillPeriod ) {
-			return false;
-		}
-
-		if ( isMonthly( cartItem ) ) {
-			return translate( 'monthly subscription' );
-		} else if ( isYearly( cartItem ) ) {
-			return translate( 'annual subscription' );
-		} else if ( isBiennially( cartItem ) ) {
-			return translate( 'two year subscription' );
-		}
-
-		return false;
-	}
-
-	isDomainProductDiscountedTo0() {
-		const { cartItem } = this.props;
-		return isDomainProduct( cartItem ) && isBundled( cartItem ) && cartItem.cost === 0;
-	}
-
-	getProductName() {
-		const { cartItem, translate } = this.props;
-		const options = {
-			count: cartItem.volume,
-			args: {
-				volume: cartItem.volume,
-				productName: cartItem.product_name,
-			},
-		};
-
-		if ( ! cartItem.volume ) {
-			return cartItem.product_name;
-		} else if ( cartItem.volume === 1 ) {
-			switch ( cartItem.product_slug ) {
-				case GSUITE_BASIC_SLUG:
-				case GSUITE_BUSINESS_SLUG:
-					return translate( '%(productName)s (1 User)', {
-						args: {
-							productName: cartItem.product_name,
-						},
-					} );
-
-				default:
-					return cartItem.product_name;
-			}
-		} else {
-			switch ( cartItem.product_slug ) {
-				case GSUITE_BASIC_SLUG:
-				case GSUITE_BUSINESS_SLUG:
-					return translate(
-						'%(productName)s (%(volume)s User)',
-						'%(productName)s (%(volume)s Users)',
-						options
-					);
-
-				default:
-					return translate(
-						'%(productName)s (%(volume)s Item)',
-						'%(productName)s (%(volume)s Items)',
-						options
-					);
-			}
-		}
 	}
 }
 
@@ -372,6 +300,75 @@ function ProductInfo( { cartItem, selectedSite } ) {
 		info = domain;
 	}
 	return info;
+}
+
+function getProductName( cartItem, translate ) {
+	const options = {
+		count: cartItem.volume,
+		args: {
+			volume: cartItem.volume,
+			productName: cartItem.product_name,
+		},
+	};
+
+	if ( ! cartItem.volume ) {
+		return cartItem.product_name;
+	} else if ( cartItem.volume === 1 ) {
+		switch ( cartItem.product_slug ) {
+			case GSUITE_BASIC_SLUG:
+			case GSUITE_BUSINESS_SLUG:
+				return translate( '%(productName)s (1 User)', {
+					args: {
+						productName: cartItem.product_name,
+					},
+				} );
+
+			default:
+				return cartItem.product_name;
+		}
+	} else {
+		switch ( cartItem.product_slug ) {
+			case GSUITE_BASIC_SLUG:
+			case GSUITE_BUSINESS_SLUG:
+				return translate(
+					'%(productName)s (%(volume)s User)',
+					'%(productName)s (%(volume)s Users)',
+					options
+				);
+
+			default:
+				return translate(
+					'%(productName)s (%(volume)s Item)',
+					'%(productName)s (%(volume)s Items)',
+					options
+				);
+		}
+	}
+}
+
+function getSubscriptionLength( cartItem, translate ) {
+	if ( isDomainProductDiscountedTo0( cartItem ) ) {
+		return false;
+	}
+
+	const hasBillPeriod = cartItem.bill_period && parseInt( cartItem.bill_period ) !== -1;
+	if ( ! hasBillPeriod ) {
+		return false;
+	}
+
+	if ( isMonthly( cartItem ) ) {
+		return translate( 'monthly subscription' );
+	} else if ( isYearly( cartItem ) ) {
+		return translate( 'annual subscription' );
+	} else if ( isBiennially( cartItem ) ) {
+		return translate( 'two year subscription' );
+	}
+
+	return false;
+}
+
+function isDomainProductDiscountedTo0( cartItem ) {
+	return isDomainProduct( cartItem ) && isBundled( cartItem ) && cartItem.cost === 0;
 }
 
 export default connect( state => ( {

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -35,6 +35,7 @@ import { localize } from 'i18n-calypso';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans';
 
 export function CartItem( {
+	removeItemFromCart,
 	cart,
 	cartItem,
 	translate,
@@ -72,12 +73,15 @@ export function CartItem( {
 				<span className="product-monthly-price">
 					<MonthlyPrice cartItem={ cartItem } translate={ translate } />
 				</span>
-				<RemoveButton
-					cart={ cart }
-					cartItem={ cartItem }
-					translate={ translate }
-					domainsWithPlansOnly={ domainsWithPlansOnly }
-				/>
+				{ removeItemFromCart && (
+					<RemoveButton
+						removeItemFromCart={ removeItemFromCart }
+						cart={ cart }
+						cartItem={ cartItem }
+						translate={ translate }
+						domainsWithPlansOnly={ domainsWithPlansOnly }
+					/>
+				) }
 			</div>
 		</li>
 	);
@@ -85,6 +89,7 @@ export function CartItem( {
 }
 
 CartItem.propTypes = {
+	removeItemFromCart: PropTypes.func,
 	cartItem: PropTypes.shape( {
 		product_id: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
 		cost: PropTypes.number,
@@ -102,7 +107,7 @@ CartItem.propTypes = {
 	moment: PropTypes.func.isRequired,
 };
 
-function RemoveButton( { cart, cartItem, translate, domainsWithPlansOnly } ) {
+function RemoveButton( { removeItemFromCart, cart, cartItem, translate, domainsWithPlansOnly } ) {
 	const labelText = translate( 'Remove item' );
 	const removeFromCart = event => {
 		event.preventDefault();
@@ -112,7 +117,7 @@ function RemoveButton( { cart, cartItem, translate, domainsWithPlansOnly } ) {
 			'Product ID',
 			cartItem.product_id
 		);
-		removeItem( cartItem, domainsWithPlansOnly );
+		removeItemFromCart( cartItem, domainsWithPlansOnly );
 	};
 
 	if ( canRemoveFromCart( cart, cartItem ) ) {
@@ -127,6 +132,7 @@ function RemoveButton( { cart, cartItem, translate, domainsWithPlansOnly } ) {
 			</button>
 		);
 	}
+	return null;
 }
 
 function MonthlyPrice( { cartItem, translate } ) {
@@ -372,4 +378,5 @@ function isDomainProductDiscountedTo0( cartItem ) {
 
 export default connect( state => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),
+	removeItemFromCart: removeItem,
 } ) )( localize( withLocalizedMoment( CartItem ) ) );

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -86,11 +86,11 @@ export function CartItem( {
 
 CartItem.propTypes = {
 	cartItem: PropTypes.shape( {
-		product_id: PropTypes.string.isRequired,
+		product_id: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,
 		cost: PropTypes.number,
 		free_trial: PropTypes.bool,
 		volume: PropTypes.number,
-		currency: PropTypes.string.isRequired,
+		currency: PropTypes.string,
 		product_slug: PropTypes.string,
 		cost_before_coupon: PropTypes.number,
 		is_sale_coupon_applied: PropTypes.bool,
@@ -130,7 +130,7 @@ function RemoveButton( { cart, cartItem, translate, domainsWithPlansOnly } ) {
 }
 
 function MonthlyPrice( { cartItem, translate } ) {
-	const { currency } = cartItem;
+	const { currency = 'USD' } = cartItem;
 
 	if ( ! monthlyPriceApplies( cartItem ) ) {
 		return null;
@@ -208,7 +208,7 @@ function ProductPrice( { cart, cartItem, translate } ) {
 					<span className="cart__gsuite-discount-regular-price">{ costBeforeCoupon }</span>
 
 					<span className="cart__gsuite-discount-discounted-price">
-						{ cost } { cartItem.currency }
+						{ cost } { cartItem.currency || 'USD' }
 					</span>
 
 					<span className="cart__gsuite-discount-text">
@@ -224,7 +224,7 @@ function ProductPrice( { cart, cartItem, translate } ) {
 	return translate( '%(cost)s %(currency)s', {
 		args: {
 			cost: cost,
-			currency: cartItem.currency,
+			currency: cartItem.currency || 'USD',
 		},
 	} );
 }
@@ -242,7 +242,7 @@ function DomainPlanPrice( { cartItem, translate } ) {
 		return (
 			<span>
 				<span className="cart__free-with-plan">
-					{ cartItem.product_cost } { cartItem.currency }
+					{ cartItem.product_cost } { cartItem.currency || 'USD' }
 				</span>
 				<span className="cart__free-text">{ translate( 'First year free with your plan' ) }</span>
 			</span>

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -35,18 +35,6 @@ import { localize } from 'i18n-calypso';
 import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans';
 
 export class CartItem extends React.Component {
-	removeFromCart = event => {
-		event.preventDefault();
-		const { cartItem, domainsWithPlansOnly } = this.props;
-		analytics.ga.recordEvent(
-			'Upgrades',
-			'Clicked Remove From Cart Icon',
-			'Product ID',
-			cartItem.product_id
-		);
-		removeItem( cartItem, domainsWithPlansOnly );
-	};
-
 	price() {
 		const { cart, cartItem, translate } = this.props;
 
@@ -234,7 +222,7 @@ export class CartItem extends React.Component {
 	}
 
 	render() {
-		const { cartItem, translate } = this.props;
+		const { cart, cartItem, translate, domainsWithPlansOnly } = this.props;
 
 		let name = this.getProductName();
 		const subscriptionLength = this.getSubscriptionLength();
@@ -260,7 +248,12 @@ export class CartItem extends React.Component {
 				<div className="secondary-details">
 					<span className="product-price">{ this.price() }</span>
 					<span className="product-monthly-price">{ this.monthlyPrice() }</span>
-					{ this.removeButton() }
+					<RemoveButton
+						cart={ cart }
+						cartItem={ cartItem }
+						translate={ translate }
+						domainsWithPlansOnly={ domainsWithPlansOnly }
+					/>
 				</div>
 			</li>
 		);
@@ -338,24 +331,6 @@ export class CartItem extends React.Component {
 			}
 		}
 	}
-
-	removeButton() {
-		const { cart, cartItem, translate } = this.props;
-		const labelText = translate( 'Remove item' );
-
-		if ( canRemoveFromCart( cart, cartItem ) ) {
-			return (
-				<button
-					className="cart__remove-item"
-					onClick={ this.removeFromCart }
-					aria-label={ labelText }
-					title={ labelText }
-				>
-					<Gridicon icon="trash" size={ 24 } />
-				</button>
-			);
-		}
-	}
 }
 
 CartItem.propTypes = {
@@ -375,6 +350,33 @@ CartItem.propTypes = {
 	selectedSite: PropTypes.object,
 	moment: PropTypes.func.isRequired,
 };
+
+function RemoveButton( { cart, cartItem, translate, domainsWithPlansOnly } ) {
+	const labelText = translate( 'Remove item' );
+	const removeFromCart = event => {
+		event.preventDefault();
+		analytics.ga.recordEvent(
+			'Upgrades',
+			'Clicked Remove From Cart Icon',
+			'Product ID',
+			cartItem.product_id
+		);
+		removeItem( cartItem, domainsWithPlansOnly );
+	};
+
+	if ( canRemoveFromCart( cart, cartItem ) ) {
+		return (
+			<button
+				className="cart__remove-item"
+				onClick={ removeFromCart }
+				aria-label={ labelText }
+				title={ labelText }
+			>
+				<Gridicon icon="trash" size={ 24 } />
+			</button>
+		);
+	}
+}
 
 export default connect( state => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
@@ -36,13 +37,14 @@ import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans
 export class CartItem extends React.Component {
 	removeFromCart = event => {
 		event.preventDefault();
+		const { cartItem, domainsWithPlansOnly } = this.props;
 		analytics.ga.recordEvent(
 			'Upgrades',
 			'Clicked Remove From Cart Icon',
 			'Product ID',
-			this.props.cartItem.product_id
+			cartItem.product_id
 		);
-		removeItem( this.props.cartItem, this.props.domainsWithPlansOnly );
+		removeItem( cartItem, domainsWithPlansOnly );
 	};
 
 	price() {
@@ -144,7 +146,8 @@ export class CartItem extends React.Component {
 	}
 
 	calcMonthlyBillingDetails() {
-		const { cost, product_slug } = this.props.cartItem;
+		const { cartItem } = this.props;
+		const { cost, product_slug } = cartItem;
 		return {
 			monthlyPrice: calculateMonthlyPriceForPlan( product_slug, cost ),
 			months: getBillingMonthsForPlan( product_slug ),
@@ -169,7 +172,8 @@ export class CartItem extends React.Component {
 	}
 
 	getFreeTrialPrice() {
-		const freeTrialText = this.props.translate( 'Free %(days)s Day Trial', {
+		const { translate } = this.props;
+		const freeTrialText = translate( 'Free %(days)s Day Trial', {
 			args: { days: '14' },
 		} );
 
@@ -353,6 +357,24 @@ export class CartItem extends React.Component {
 		}
 	}
 }
+
+CartItem.propTypes = {
+	cartItem: PropTypes.shape( {
+		product_id: PropTypes.string.isRequired,
+		cost: PropTypes.number,
+		free_trial: PropTypes.bool,
+		volume: PropTypes.number,
+		currency: PropTypes.string.isRequired,
+		product_slug: PropTypes.string,
+		cost_before_coupon: PropTypes.number,
+		is_sale_coupon_applied: PropTypes.bool,
+	} ).isRequired,
+	domainsWithPlansOnly: PropTypes.bool,
+	translate: PropTypes.func.isRequired,
+	cart: PropTypes.object.isRequired,
+	selectedSite: PropTypes.object,
+	moment: PropTypes.func.isRequired,
+};
 
 export default connect( state => ( {
 	domainsWithPlansOnly: currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This refactors the `CartItem` component as a functional component to clarify its props, how it functions, and to make the remove button optional which should make it easier to insert into other components that might not want to display the button.

**Before and After**

![Screen Shot 2020-03-05 at 7 51 13 PM](https://user-images.githubusercontent.com/2036909/76040044-3a4bf180-5f1c-11ea-94a3-0ef5753f7408.png)


#### Testing instructions

**Reviewing this PR is probably easiest to do by going through each commit separately. I've tried to keep them each small and sensible to their purpose.**

Load the (non-composite) version of the checkout screen and make sure you see it rendered the same as production.