### PR TITLE
Composite checkout: Add delete product event

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -840,6 +840,20 @@ function getCheckoutEventHandler( dispatch ) {
 					} )
 				);
 
+			case 'a8c_checkout_delete_product':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_delete_product', {
+						product_name: action.payload.product_name,
+					} )
+				);
+
+			case 'a8c_checkout_delete_product_press':
+				return dispatch(
+					recordTracksEvent( 'calypso_checkout_composite_delete_product_press', {
+						product_name: action.payload.product_name,
+					} )
+				);
+
 			case 'a8c_checkout_add_coupon_error':
 				return dispatch(
 					recordTracksEvent( 'calypso_checkout_composite_coupon_add_error', {

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -8,6 +8,7 @@ import {
 	renderDisplayValueMarkdown,
 	CheckoutModal,
 	useFormStatus,
+	useEvents,
 } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
@@ -52,6 +53,7 @@ function WPLineItem( {
 	const deleteButtonId = `checkout-delete-button-${ item.id }`;
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const modalCopy = returnModalCopy( item.type, translate, hasDomainsInCart );
+	const onEvent = useEvents();
 
 	const shouldShowVariantSelector = item.wpcom_meta && item.wpcom_meta.extra?.context === 'signup';
 
@@ -67,6 +69,12 @@ function WPLineItem( {
 						buttonState="borderless"
 						onClick={ () => {
 							setIsModalVisible( true );
+							onEvent( {
+								type: 'a8c_checkout_delete_product_press',
+								payload: {
+									product_name: item.label,
+								},
+							} );
 						} }
 					>
 						<DeleteIcon uniqueID={ deleteButtonId } product={ item.label } />
@@ -79,6 +87,12 @@ function WPLineItem( {
 						} }
 						primaryAction={ () => {
 							removeItem( item.wpcom_meta.uuid );
+							onEvent( {
+								type: 'a8c_checkout_delete_product',
+								payload: {
+									product_name: item.label,
+								},
+							} );
 						} }
 						title={ modalCopy.title }
 						copy={ modalCopy.description }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a tracks event to measure when people remove products from our cart. I have an event for people that click the button and then another one for when the product is removed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get calypso running locally or visit the calypso.live link
* Open the console and enter this command: "localStorage.setItem( 'debug', 'calypso:analytics*' );"
* See that you have events tracking in the console.
* Add a product to the cart
* Visit the checkout and append the following string to the end of your url: "?flags=composite-checkout-wpcom"
* Make your way to the review step and see if the events fire when you press the trash icon to remove the product and after you delete the product. 

