### PR TITLE
Fix spacing on name server list

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -244,7 +244,7 @@ class MappedDomainType extends React.Component {
 				<div>
 					<p>{ primaryMessage }</p>
 					{ ! isSubdomain( domain.name ) && (
-						<ul>
+						<ul className="mapped-domain-type__name-server-list">
 							{ WPCOM_DEFAULTS.map( nameServer => {
 								return <li key={ nameServer }>{ nameServer }</li>;
 							} ) }

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -111,6 +111,10 @@
 			}
 		}
 
+		.mapped-domain-type__name-server-list {
+			margin-bottom: 0.5em;
+		}
+
 		.mapped-domain-type__small-message {
 			font-size: 14px;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a spacing issue on the domain mapping status message.

**Before**
![image](https://user-images.githubusercontent.com/6981253/76044555-bcdaae00-5f28-11ea-9f6d-e3add0e82467.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/76044726-31ade800-5f29-11ea-9bb7-8d50aa544e2e.png)


#### Testing instructions
- Get calypso running locally or visit calypso.live
- Find a mapped domain that hasn't updated it's name servers to point to us.
- Append this string to the end of the url: "?flags=domains/new-status-design"
- Confirm the space under the list matches the space above it.