### PR TITLE
Gutenboarding: auth store can reload proxy after login

### DIFF
--- a/client/landing/gutenboarding/devtools.ts
+++ b/client/landing/gutenboarding/devtools.ts
@@ -23,7 +23,7 @@ export const setupWpDataDebug = () => {
 				};
 
 				const { Auth, Site } = require( '@automattic/data-stores' );
-				const AUTH_STORE = Auth.register( clientCreds );
+				const AUTH_STORE = Auth.register( { ...clientCreds, loadCookiesAfterLogin: true } );
 				Site.register( clientCreds );
 
 				window.wp.auth = {};

--- a/client/landing/gutenboarding/devtools.ts
+++ b/client/landing/gutenboarding/devtools.ts
@@ -23,7 +23,7 @@ export const setupWpDataDebug = () => {
 				};
 
 				const { Auth, Site } = require( '@automattic/data-stores' );
-				const AUTH_STORE = Auth.register( { ...clientCreds, loadCookiesAfterLogin: true } );
+				const AUTH_STORE = Auth.register( clientCreds );
 				Site.register( clientCreds );
 
 				window.wp.auth = {};

--- a/packages/data-stores/src/auth/README.md
+++ b/packages/data-stores/src/auth/README.md
@@ -85,7 +85,7 @@ function MyComponent() {
 
 ### `loadCookiesAfterLogin` config
 
-After login is complete (`loginFlowState === 'LOGGED_IN'`) the user will have a session on the server, but the client won't have the cookies for that session yet.
+After login is complete (`loginFlowState === 'LOGGED_IN'`) the user will have a session on the server, but the client won't have all the cookies for that session yet. In particular it won't have the cookies needed by `wpcom-proxy-request` to talk to `public-api.wordpress.com`.
 
 This could be fine under some circumstances. If, after a successful login, the browser navigates to another page then the cookies will be loaded as part of that page navigation. It would be a waste for the auth store to retrieve them. In this case use `loadCookiesAfterLogin = false`.
 

--- a/packages/data-stores/src/auth/README.md
+++ b/packages/data-stores/src/auth/README.md
@@ -14,6 +14,7 @@ import { Auth } from '@automattic/data-stores';
 const AUTH_STORE = Auth.register( {
 	client_id: 'MY_CLIENT_ID', // ⚠️Replace with your app's ID
 	client_secret: 'MY_CLIENT_SECRET', // ⚠️Replace with your app's secret
+	loadCookiesAfterLogin: true, // Read more below
 } );
 ```
 
@@ -81,3 +82,15 @@ function MyComponent() {
 	}
 }
 ```
+
+### `loadCookiesAfterLogin` config
+
+After login is complete (`loginFlowState === 'LOGGED_IN'`) the user will have a session on the server, but the client won't have the cookies for that session yet.
+
+This could be fine under some circumstances. If, after a successful login, the browser navigates to another page then the cookies will be loaded as part of that page navigation. It would be a waste for the auth store to retrieve them. In this case use `loadCookiesAfterLogin = false`.
+
+If however the user will continue to work and make more requests on the same page after logging in, then we want the store to make the required request to get cookies. In this case use `loadCookiesAfterLogin = true`.
+
+This config flag doesn't have a default as it depends on your situation.
+
+*Implementation detail:* under the hood, if `loadCookiesAfterLogin === true` then the store will reload the iframe used by `wpcom-proxy-request` to send requests to `public-api.wordpress.com`. Because it's only the iframe that reloads the user won't see a browser refresh happen.

--- a/packages/data-stores/src/auth/README.md
+++ b/packages/data-stores/src/auth/README.md
@@ -91,6 +91,6 @@ This could be fine under some circumstances. If, after a successful login, the b
 
 If however the user will continue to work and make more requests on the same page after logging in, then we want the store to make the required request to get cookies. In this case use `loadCookiesAfterLogin = true`.
 
-This config flag doesn't have a default as it depends on your situation.
+The flag defaults to `true`.
 
 *Implementation detail:* under the hood, if `loadCookiesAfterLogin === true` then the store will reload the iframe used by `wpcom-proxy-request` to send requests to `public-api.wordpress.com`. Because it's only the iframe that reloads the user won't see a browser refresh happen.

--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -3,7 +3,7 @@
  */
 import { createRegistryControl } from '@wordpress/data';
 import { stringify } from 'qs';
-import wpcomRequest, { requestAllBlogsAccess } from 'wpcom-proxy-request';
+import wpcomRequest, { reloadProxy, requestAllBlogsAccess } from 'wpcom-proxy-request';
 
 /**
  * Internal dependencies
@@ -60,7 +60,11 @@ const makeRemoteLoginRequest = ( loginLink: string, requestTimeout = 25000 ) => 
 	);
 };
 
-export function createControls( clientCreds: WpcomClientCredentials ) {
+export interface ControlsConfig extends WpcomClientCredentials {
+	loadCookiesAfterLogin: boolean;
+}
+
+export function createControls( clientCreds: ControlsConfig ) {
 	requestAllBlogsAccess().catch( () => {
 		throw new Error( 'Could not get all blog access.' );
 	} );
@@ -77,6 +81,8 @@ export function createControls( clientCreds: WpcomClientCredentials ) {
 			} );
 		},
 		FETCH_WP_LOGIN: async ( { action, params }: FetchWpLoginAction ) => {
+			const { client_id, client_secret, loadCookiesAfterLogin } = clientCreds;
+
 			const response = await fetch(
 				// TODO Wrap this in `localizeUrl` from lib/i18n-utils
 				'https://wordpress.com/wp-login.php?action=' + encodeURIComponent( action ),
@@ -89,11 +95,16 @@ export function createControls( clientCreds: WpcomClientCredentials ) {
 					},
 					body: stringify( {
 						remember_me: true,
-						...clientCreds,
+						client_id,
+						client_secret,
 						...params,
 					} ),
 				}
 			);
+
+			if ( loadCookiesAfterLogin && response.ok ) {
+				reloadProxy();
+			}
 
 			return {
 				ok: response.ok,

--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -61,6 +61,10 @@ const makeRemoteLoginRequest = ( loginLink: string, requestTimeout = 25000 ) => 
 };
 
 export interface ControlsConfig extends WpcomClientCredentials {
+	/**
+	 * True if user needs immediate access to cookies after logging in.
+	 * See README.md for details.
+	 */
 	loadCookiesAfterLogin: boolean;
 }
 

--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -116,6 +116,8 @@ export function createControls( config: ControlsConfig ) {
 			};
 		},
 		SEND_LOGIN_EMAIL: async ( { email }: SendLoginEmailAction ) => {
+			const { client_id, client_secret } = config;
+
 			return await wpcomRequest( {
 				path: `/auth/send-login-email`,
 				apiVersion: '1.2',
@@ -127,7 +129,8 @@ export function createControls( config: ControlsConfig ) {
 					lang_id: 1,
 					locale: 'en',
 
-					...clientCreds,
+					client_id,
+					client_secret,
 				},
 			} );
 		},

--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -64,8 +64,9 @@ export interface ControlsConfig extends WpcomClientCredentials {
 	/**
 	 * True if user needs immediate access to cookies after logging in.
 	 * See README.md for details.
+	 * Default: true
 	 */
-	loadCookiesAfterLogin: boolean;
+	loadCookiesAfterLogin?: boolean;
 }
 
 export function createControls( config: ControlsConfig ) {
@@ -85,7 +86,7 @@ export function createControls( config: ControlsConfig ) {
 			} );
 		},
 		FETCH_WP_LOGIN: async ( { action, params }: FetchWpLoginAction ) => {
-			const { client_id, client_secret, loadCookiesAfterLogin } = config;
+			const { client_id, client_secret, loadCookiesAfterLogin = true } = config;
 
 			const response = await fetch(
 				// TODO Wrap this in `localizeUrl` from lib/i18n-utils

--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -64,7 +64,7 @@ export interface ControlsConfig extends WpcomClientCredentials {
 	loadCookiesAfterLogin: boolean;
 }
 
-export function createControls( clientCreds: ControlsConfig ) {
+export function createControls( config: ControlsConfig ) {
 	requestAllBlogsAccess().catch( () => {
 		throw new Error( 'Could not get all blog access.' );
 	} );
@@ -81,7 +81,7 @@ export function createControls( clientCreds: ControlsConfig ) {
 			} );
 		},
 		FETCH_WP_LOGIN: async ( { action, params }: FetchWpLoginAction ) => {
-			const { client_id, client_secret, loadCookiesAfterLogin } = clientCreds;
+			const { client_id, client_secret, loadCookiesAfterLogin } = config;
 
 			const response = await fetch(
 				// TODO Wrap this in `localizeUrl` from lib/i18n-utils

--- a/packages/data-stores/src/auth/index.ts
+++ b/packages/data-stores/src/auth/index.ts
@@ -12,14 +12,9 @@ import { publicActions } from './actions';
 import { createControls, ControlsConfig } from './controls';
 import * as selectors from './selectors';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
-import { WpcomClientCredentials } from '../shared-types';
 
 export * from './types';
 export { State };
-
-export interface StoreConfig extends WpcomClientCredentials {
-	loadCookiesAfterLogin: boolean;
-}
 
 let isRegistered = false;
 export function register( config: ControlsConfig ): typeof STORE_KEY {

--- a/packages/data-stores/src/auth/index.ts
+++ b/packages/data-stores/src/auth/index.ts
@@ -9,7 +9,7 @@ import { registerStore } from '@wordpress/data';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import { publicActions } from './actions';
-import { createControls } from './controls';
+import { createControls, ControlsConfig } from './controls';
 import * as selectors from './selectors';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { WpcomClientCredentials } from '../shared-types';
@@ -17,13 +17,17 @@ import { WpcomClientCredentials } from '../shared-types';
 export * from './types';
 export { State };
 
+export interface StoreConfig extends WpcomClientCredentials {
+	loadCookiesAfterLogin: boolean;
+}
+
 let isRegistered = false;
-export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KEY {
+export function register( config: ControlsConfig ): typeof STORE_KEY {
 	if ( ! isRegistered ) {
 		isRegistered = true;
 		registerStore< State >( STORE_KEY, {
 			actions: publicActions,
-			controls: createControls( clientCreds ) as any,
+			controls: createControls( config ) as any,
 			reducer,
 			selectors,
 		} );

--- a/packages/data-stores/src/auth/test/flows.ts
+++ b/packages/data-stores/src/auth/test/flows.ts
@@ -24,11 +24,12 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 	default: jest.fn(),
 	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
+	reloadProxy: jest.fn(),
 } ) );
 
 let store: ReturnType< typeof register >;
 beforeAll( () => {
-	store = register( { client_id: '', client_secret: '' } );
+	store = register( { client_id: '', client_secret: '', loadCookiesAfterLogin: true } );
 } );
 
 beforeEach( () => {

--- a/packages/data-stores/src/auth/test/flows.ts
+++ b/packages/data-stores/src/auth/test/flows.ts
@@ -24,12 +24,11 @@ jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
 	default: jest.fn(),
 	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
-	reloadProxy: jest.fn(),
 } ) );
 
 let store: ReturnType< typeof register >;
 beforeAll( () => {
-	store = register( { client_id: '', client_secret: '', loadCookiesAfterLogin: true } );
+	store = register( { client_id: '', client_secret: '', loadCookiesAfterLogin: false } );
 } );
 
 beforeEach( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `loadCookiesAfterLogin` config flag to auth store
* Reloads proxy iframe after successful login if `loadCookiesAfterLogin`

See changes to `README.md` for more details.

For gutenboarding `loadCookiesAfterLogin` should be `true`. If on `/log-in` then it should be `false`, because the entire page is about to reload anyway.

Making the boolean part of the config doesn't feel very natrual. I think it'd be nicer if it were like: `submitPassword('p@ssw0rd', { loadCookies: true })`. But there's lots of ways the user could be logged in. It might not even be in response to an action being sent.

This config flag doesn't work very well if sometimes we should get the iframe to reload and sometimes we don't. I guess we'll cross that bridge when we get to it.

Alternative idea: don't do this in the auth store at all and require gutenboarding to reload the iframe. Reasons I don't like that:
1) It's not obvious to the dev that that's what they need to do (as @roo2 found)
2) If we change sometimes about how proxied requests work (maybe because of changes to 3rd party cookies) then it can all be fixed up in the auth store rather than in all the places that use the auth store.

Alternative config flag names: `reloadProxyAfterLogin`, `pageWillNeedCookies`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/gutenboarding`
* Open network and console in console devtools
* In console run
  * `wp.auth.submitUsernameOrEmail('validuser')`
  * `wp.auth.submitPassword('correctpassword')`
  * `wp.data.dispatch('automattic/site').createSite({ blog_name: 'my new site' })`
* Before this change:
  * Request to `/sites/new` will error because the user doesn't have permission
* After this change:
  * Request to `/sites/new` succeeds

