### PR TITLE
Stopping Premium bump offer for Personal plan customers

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-thank-you.ts
+++ b/client/my-sites/checkout/checkout/composite-checkout-thank-you.ts
@@ -193,7 +193,6 @@ function getFallbackDestination( {
 }
 
 function getRedirectUrlForConciergeNudge( { pendingOrReceiptId, cart, siteSlug, previousRoute } ) {
-	// For a user purchasing a qualifying plan, show either a plan upgrade upsell or concierge upsell.
 	// If the user has upgraded a plan from seeing our upsell(we find this by checking the previous route is /offer-plan-upgrade),
 	// then skip this section so that we do not show further upsells.
 	if (
@@ -203,10 +202,6 @@ function getRedirectUrlForConciergeNudge( { pendingOrReceiptId, cart, siteSlug, 
 		( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
 		! previousRoute?.includes( `/checkout/${ siteSlug }/offer-plan-upgrade` )
 	) {
-		if ( hasPersonalPlan( cart ) ) {
-			return `/checkout/${ siteSlug }/offer-plan-upgrade/premium/${ pendingOrReceiptId }`;
-		}
-
 		// A user just purchased one of the qualifying plans
 		// Show them the concierge session upsell page
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -445,7 +445,6 @@ export class Checkout extends React.Component {
 
 		const { cart, selectedSiteSlug, previousRoute } = this.props;
 
-		// For a user purchasing a qualifying plan, show either a plan upgrade upsell or concierge upsell.
 		// If the user has upgraded a plan from seeing our upsell (we find this by checking the previous route is /offer-plan-upgrade),
 		// then skip this section so that we do not show further upsells.
 		if (

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -455,10 +455,6 @@ export class Checkout extends React.Component {
 			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
 			! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-plan-upgrade` )
 		) {
-			if ( hasPersonalPlan( cart ) ) {
-				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ pendingOrReceiptId }`;
-			}
-
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Stopping the Premium bump offer for qualified Personal plan customers and showing the QuickStart one instead. More info here pNEWy-cIg.

#### Testing instructions

* Signup for an account and purchase a Personal plan (without domain).
* After completing payment, verify that you are always shown the Quick Start/Concierge upsell offer.

Fixes 295-gh-martech