### PR TITLE
Fix error message for when expired domain is not renewable and not redeemable

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -231,6 +231,7 @@ class RegisteredDomainType extends React.Component {
 				'{{strong}}Your domain has expired{{/strong}} and is no longer active. {{domainsLink}}Learn more{{/domainsLink}}',
 				{
 					components: {
+						strong: <strong />,
 						domainsLink: domainsLink( DOMAIN_EXPIRATION ),
 					},
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix error message for when expired domain is not renewable and not redeemable - it was not rendered correctly because there was a missing component `strong` in the `translate` options

#### Testing instructions

* You'll need to find a domain that has expired and is not redeemable and check it out
