### PR TITLE
BPB: Allow for multiple instances

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
@@ -32,10 +32,6 @@ registerBlockType( blockName, {
 	...settings,
 	title: __( 'Blog Posts', 'full-site-editing' ),
 	category: 'layout',
-	supports: {
-		...settings.supports,
-		multiple: false,
-	},
 } );
 
 registerQueryStore();

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/editor.js
@@ -34,4 +34,4 @@ registerBlockType( blockName, {
 	category: 'layout',
 } );
 
-registerQueryStore();
+registerQueryStore( blockName );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allows for multiple instances of the Blog Posts Block.

This was fixed on the Newspack side a while ago, but it looks like we missed removing this restriction on our side.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and build the blocks with `$ npx lerna run dev --scope='@automattic/full-site-editing' --stream --no-prefix` from the `/apps/full-site-editing` folder.
* In a new or existing post or page, attempt to insert more than one Blog Posts block.

Fixes #39251
