### PR TITLE
Jetpack Cloud: Add header and paragraph content for the Scan Threats page

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -56,6 +56,7 @@ class ScanPage extends Component {
 				<h1 className="scan__header">{ translate( 'Your site may be at risk' ) }</h1>
 				<p>
 					{ translate(
+						'The scan found {{strong}}%(threatCount)s{{/strong}} potential threat with {{strong}}%(siteName)s{{/strong}}.',
 						'The scan found {{strong}}%(threatCount)s{{/strong}} potential threats with {{strong}}%(siteName)s{{/strong}}.',
 						{
 							args: {
@@ -65,6 +66,7 @@ class ScanPage extends Component {
 							components: { strong: <strong /> },
 							comment:
 								'%(threatCount)s represents the number of threats currently identified on the site, and $(siteName)s is the name of the site.',
+							count: threats.length,
 						}
 					) }
 					<br />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the header and first paragraph content to the Scan Threats page.

Overall design:
<img width="886" alt="image" src="https://user-images.githubusercontent.com/42627630/76108841-f4853c80-5fa0-11ea-80c5-6f91877cf264.png">

Part added by this PR:
<img width="565" alt="image" src="https://user-images.githubusercontent.com/42627630/76109024-48902100-5fa1-11ea-8280-b6c9900c34f5.png">

Note that the design shows the number of threats being spelled out, i.e. "two" instead of "2". Due to the technical difficulties of doing that in an I18N environment the number value is displayed instead.

#### Testing instructions
1. Checkout the branch and start Calypso with `CALYPSO_ENV=jetpack-cloud-development npm start`.
2. Visit `http://calypso.localhost:3000/scan/$site_slug?scan-state=threats`.
3. Verify that the design of the header and paragraph content matches the Figma file.
