### PR TITLE
Sidebar: Move site notices above promotions/upsells

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -82,13 +82,13 @@ class CurrentSite extends Component {
 				) : (
 					<AllSites />
 				) }
+				<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
+				<AsyncLoad require="my-sites/current-site/stale-cart-items-notice" placeholder={ null } />
 				<AsyncLoad
 					require="my-sites/current-site/notice"
 					placeholder={ null }
 					site={ selectedSite }
 				/>
-				<AsyncLoad require="my-sites/current-site/domain-warnings" placeholder={ null } />
-				<AsyncLoad require="my-sites/current-site/stale-cart-items-notice" placeholder={ null } />
 			</Card>
 		);
 	}

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -295,6 +295,7 @@ export class SiteNotice extends React.Component {
 			<div className="current-site__notices">
 				<QueryProductsList />
 				<QueryActivePromotions />
+				{ siteRedirectNotice }
 				{ discountOrFreeToPaid ||
 					( config.isEnabled( 'jitms' ) && (
 						<AsyncLoad
@@ -303,7 +304,6 @@ export class SiteNotice extends React.Component {
 							template="sidebar-banner"
 						/>
 					) ) }
-				{ siteRedirectNotice }
 				<QuerySitePlans siteId={ site.ID } />
 				{ ! hasJITM && domainCreditNotice }
 				{ ! ( hasJITM || discountOrFreeToPaid || domainCreditNotice ) && this.domainUpsellNudge() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Site notices and other urgent requests should come before any type of upsell. This moves the domain warnings and site redirect notice above JITMs/other sidebar upsells.
* Originally brought up by @amamujee in Slack: p1583516414300400-slack-dotcom-manage

**Before**

<img width="345" alt="Screen Shot 2020-03-06 at 12 51 08 PM" src="https://user-images.githubusercontent.com/2124984/76111148-bfcbb200-5fad-11ea-9c0d-65160aed6857.png">

**After**

<img width="334" alt="Screen Shot 2020-03-06 at 12 55 12 PM" src="https://user-images.githubusercontent.com/2124984/76111157-c3f7cf80-5fad-11ea-92e1-f27e6c96358f.png">

#### Testing instructions

* Switch to this PR
* Test on a site that has multiple notices/warnings/upsells displaying in the sidebar at once
* Any site configuration notices should appear above any upsells