### PR TITLE
Connect to Simperium instead of polling the API

### DIFF
--- a/apps/notifications/index.jsx
+++ b/apps/notifications/index.jsx
@@ -169,8 +169,8 @@ export class Notifications extends Component {
 
 		const customMiddleware = {
 			APP_RENDER_NOTES: [
-				( store, { newNoteCount } ) => {
-					this.props.setIndicator( newNoteCount );
+				( store, { newNoteCount, hasNewNote } ) => {
+					this.props.setIndicator( newNoteCount, hasNewNote );
 					this.props.setUnseenCount( newNoteCount );
 				},
 			],

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -23,6 +23,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "file:../../packages/calypso-color-schemes",
-		"@automattic/calypso-polyfills": "file:../../packages/calypso-polyfills"
+		"@automattic/calypso-polyfills": "file:../../packages/calypso-polyfills",
+		"simperium": "1.0.4"
 	}
 }

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux';
 import { noop } from 'lodash';
 
 import { init as initStore, store } from './state';
-import { mergeHandlers } from './state/action-middleware/utils';
 import { SET_IS_SHOWING } from './state/action-types';
 import actions from './state/actions';
 
@@ -29,11 +28,6 @@ setGlobalData( globalData );
 
 repliesCache.cleanup();
 
-/**
- * Force a manual refresh of the notes data
- */
-export const refreshNotes = () => client && client.refreshNotes.call( client );
-
 export class Notifications extends PureComponent {
 	static propTypes = {
 		customEnhancer: PropTypes.func,
@@ -55,34 +49,9 @@ export class Notifications extends PureComponent {
 	};
 
 	UNSAFE_componentWillMount() {
-		const {
-			customEnhancer,
-			customMiddleware,
-			isShowing,
-			isVisible,
-			receiveMessage,
-			wpcom,
-		} = this.props;
+		const { customEnhancer, customMiddleware, isShowing, receiveMessage, wpcom } = this.props;
 
-		initStore( {
-			customEnhancer,
-			customMiddleware: mergeHandlers( customMiddleware, {
-				APP_REFRESH_NOTES: [
-					( store, action ) => {
-						if ( ! client ) {
-							return;
-						}
-
-						if ( 'boolean' === typeof action.isVisible ) {
-							client.setVisibility.call( client, { isShowing, isVisible: action.isVisible } );
-						}
-
-						client.refreshNotes.call( client, action.isVisible );
-					},
-				],
-			} ),
-		} );
-
+		initStore( { customEnhancer, customMiddleware } );
 		initAPI( wpcom );
 
 		client = new RestClient();
@@ -96,8 +65,6 @@ export class Notifications extends PureComponent {
 		 * @TODO: Pass this information directly into the Redux initial state
 		 */
 		store.dispatch( { type: SET_IS_SHOWING, isShowing } );
-
-		client.setVisibility( { isShowing, isVisible } );
 	}
 
 	componentDidMount() {
@@ -116,10 +83,6 @@ export class Notifications extends PureComponent {
 
 		if ( isShowing !== this.props.isShowing ) {
 			store.dispatch( { type: SET_IS_SHOWING, isShowing } );
-		}
-
-		if ( isShowing !== this.props.isShowing || isVisible !== this.props.isVisible ) {
-			client.setVisibility( { isShowing, isVisible } );
 		}
 	}
 

--- a/apps/notifications/src/panel/flux/note-actions.js
+++ b/apps/notifications/src/panel/flux/note-actions.js
@@ -14,12 +14,6 @@ function bumpStat( name ) {
 	rawBumpStat( 'notes-click-action', name );
 }
 
-function updateNote( id ) {
-	const globalClient = store.get( 'global' ).client;
-
-	return () => globalClient.getNote( id );
-}
-
 export const setApproveStatus = function( noteId, siteId, commentId, isApproved, type ) {
 	const comment = wpcom()
 		.site( siteId )

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -1,307 +1,68 @@
-/**
- * Module dependencies.
- */
-import { difference, get, pick, property, range } from 'lodash';
-
 import { store } from '../state';
 import actions from '../state/actions';
 
+import getNote from '../state/selectors/get-note';
 import getAllNotes from '../state/selectors/get-all-notes';
-
-import repliesCache from '../comment-replies-cache';
-
-import { fetchNote, listNotes, sendLastSeenTime, subscribeToNoteStream } from './wpcom';
-
-const debug = require( 'debug' )( 'notifications:rest-client' );
-
-const settings = {
-	max_refresh_ms: 180000,
-	refresh_ms: 30000,
-	initial_limit: 10,
-	increment_limit: 10,
-	max_limit: 100,
-};
+import simperium from '../simperium';
 
 export function Client() {
-	this.noteList = [];
-	this.gettingNotes = false;
-	this.timeout = false;
 	this.isVisible = false;
 	this.isShowing = false;
 	this.lastSeenTime = 0;
-	this.hasNewNoteData = false;
-	this.noteRequestLimit = settings.initial_limit;
-	this.retries = 0;
-	this.subscribeTry = 0;
-	this.subscribeTries = 3;
-	this.subscribing = false;
-	this.subscribed = false;
-	this.firstRender = true;
-	this.inbox = [];
 
-	window.addEventListener( 'storage', handleStorageEvent.bind( this ) );
+	store.dispatch( actions.ui.loadNotes() );
+	simperium().then( ( { meta, notifications } ) => {
+		this.meta = meta;
+		this.notifications = notifications;
 
-	this.main( this );
-}
+		meta.on( 'index', async () => {
+			const data = await meta.find();
 
-function main() {
-	// subscribe if possible
-	if ( ! this.subscribed && ! this.subscribing ) {
-		if ( this.subscribeTry < this.subscribeTries ) {
-			debug( 'main: trying to subscribe' );
-			this.subscribing = true;
-			subscribeToNoteStream( pinghubCallback.bind( this ) );
-		} else if ( this.subscribeTry === this.subscribeTries ) {
-			const sub_retry_ms = 120000;
-			debug( 'main: polling until next subscribe attempt', 'sub_retry_ms =', sub_retry_ms );
-			setTimeout(
-				function() {
-					this.subscribeTry = 0;
-				}.bind( this ),
-				sub_retry_ms
-			);
-		}
-		this.subscribeTry++;
-	}
+			if ( ! data.length || ! data[ 0 ].id === 'meta' ) {
+				return;
+			}
 
-	// subscribers call main() when the subscription delivers a message
-	const notes = getAllNotes( store.getState() );
-	if ( notes.length && this.subscribed && ! this.inbox.length ) {
-		return debug( 'main: subscribed, no new messages; sleeping' );
-	}
+			this.lastSeenTime = data[ 0 ].last_seen;
+		} );
 
-	// schedule the next call to main()
-	this.reschedule();
+		meta.on( 'update', ( id, data ) => {
+			this.lastSeenTime = data.last_seen;
+		} );
 
-	// nobody's looking. take a nap until they return.
-	if ( ! this.isVisible ) {
-		return debug( 'main: not visible. sleeping.' );
-	}
+		notifications.on( 'index', async () => {
+			store.dispatch( actions.ui.loadedNotes() );
 
-	if ( this.inbox.length === 1 && this.inbox[ 0 ].action && this.inbox[ 0 ].action === 'push' ) {
-		const note_id = this.inbox[ 0 ].note_id;
-		debug( 'main: have one push message with note_id, calling getNote(%d)', note_id, this.inbox );
-		this.inbox = [];
-		this.getNote( note_id );
-	} else if ( this.inbox.length ) {
-		debug( 'main: have messages, calling getNotes', this.inbox );
-		this.inbox = [];
-		this.getNotes();
-	} else if ( ! notes.length ) {
-		debug( 'main: no notes in local cache, calling getNotes' );
-		this.getNotes();
-	} else {
-		debug( 'main: polling, have notes in local cache, calling getNotesList' );
-		this.getNotesList();
-	}
-}
+			const notes = await notifications.find();
+			store.dispatch( actions.notes.addNotes( notes.map( note => note.data ) ) );
 
-function reschedule( refresh_ms ) {
-	if ( ! refresh_ms ) {
-		refresh_ms = settings.refresh_ms;
-	}
-	if ( this.timeout ) {
-		clearTimeout( this.timeout );
-		this.timeout = false;
-	}
-	if ( this.subscribed ) {
-		debug( 'reschedule', 'subscribed; not polling' );
-	} else {
-		debug( 'reschedule', 'refresh_ms =', refresh_ms );
-		this.timeout = setTimeout( main.bind( this ), refresh_ms );
-	}
-}
+			ready.call( this );
+		} );
 
-function pinghubCallback( err, event ) {
-	const responseType = get( event, 'response.type' );
+		notifications.on( 'update', ( id, notification ) => {
+			store.dispatch( actions.notes.addNotes( [ notification ] ) );
 
-	this.subscribing = false;
+			ready.call( this );
+		} );
 
-	// WebSocket error: costs one try
-	if ( err || ! responseType || responseType === 'error' ) {
-		debug( 'pinghubCallback: error', 'err =', err );
-		this.subscribed = false;
-	} else if ( responseType === 'open' ) {
-		// WebSocket connected: stop polling
-		debug( 'pinghubCallback: connected', event.response );
-		this.subscribeTry = 0;
-		this.subscribed = true;
-	} else if ( responseType === 'close' ) {
-		// WebSocket disconnected: have another try
-		debug( 'pinghubCallback: disconnected', event.response );
-		this.subscribeTry = 0;
-		this.subscribed = false;
-	} else if ( responseType === 'message' ) {
-		// WebSocket message: add to inbox, call main() to trigger API call
-		let message = true;
-		try {
-			message = JSON.parse( get( event, 'response.data' ) );
-		} catch ( e ) {}
-		this.inbox.push( message );
-		debug( 'pinghubCallback: received message', event.response, 'this.inbox =', this.inbox );
-		this.main();
-	} else {
-		// Missed case?
-		debug( 'pinghubCallback: unknown event.response.type', event.response );
-		throw new Error(
-			'notifications:rest-client:pinghubCallback unknown event.response.type: ' + responseType
-		);
-	}
+		notifications.on( 'remove', id => {
+			store.dispatch( actions.notes.removeNotes( [ id ] ) );
 
-	this.reschedule();
-}
-
-function getNote( note_id ) {
-	// initialize the list if it's empty
-	if ( this.noteList.length === 0 ) {
-		this.getNotes();
-	}
-
-	const parameters = {
-		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash',
-	};
-
-	fetchNote( note_id, parameters, ( error, data ) => {
-		if ( error ) {
-			return;
-		}
-		store.dispatch( actions.notes.addNotes( data.notes ) );
-		ready.call( this );
+			ready.call( this );
+		} );
 	} );
 }
 
-function getNotes() {
-	if ( this.gettingNotes ) {
-		return;
-	}
-	this.gettingNotes = true;
+Client.prototype.readNote = function( noteId ) {
+	const note = getNote( store.getState(), noteId );
 
-	const parameters = {
-		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash',
-		number: this.noteRequestLimit,
-	};
+	console.log( note );
 
-	const notes = getAllNotes( store.getState() );
-	if ( ! notes.length || this.noteRequestLimit > notes.length ) {
-		store.dispatch( actions.ui.loadNotes() );
-	}
-
-	listNotes( parameters, ( error, data ) => {
-		this.gettingNotes = false;
-		if ( error ) {
-			/*
-			 * Something failed, so try again and
-			 * reset the local noteList copy. We
-			 * might have optimistically modified
-			 * it when we last compared it to the
-			 * server, but there's been a failure
-			 * here so resetting it will force a
-			 * full refresh.
-			 */
-			this.retries = this.retries + 1;
-			const backoff_ms = Math.min(
-				settings.refresh_ms * ( this.retries + 1 ),
-				settings.max_refresh_ms
-			);
-			debug( 'getNotes error, using backoff_ms=%d', backoff_ms );
-			this.noteList = [];
-			this.reschedule( backoff_ms );
-			return;
-		}
-
-		store.dispatch( actions.ui.loadedNotes() );
-
-		const oldNotes = getAllNotes( store.getState() ).map( property( 'id' ) );
-		const newNotes = data.notes.map( property( 'id' ) );
-		const notesToRemove = difference( oldNotes, newNotes );
-
-		notesToRemove.length && store.dispatch( actions.notes.removeNotes( notesToRemove ) );
-		store.dispatch( actions.notes.addNotes( data.notes ) );
-
-		// Store id/hash pairs for now until properly reduxified
-		// this is used as a network optimization to quickly determine
-		// changes without downloading all the data
-		this.noteList = data.notes.map( note => pick( note, [ 'id', 'note_hash' ] ) );
-
-		this.updateLastSeenTime( Number( data.last_seen_time ) );
-		if ( parameters.number === settings.max_limit ) {
-			/*
-			 * Since we store note data in a local cache,
-			 * we want to purge the data if the notes
-			 * no longer exist, but we only want to do it
-			 * if we have loaded all the notes, otherwise
-			 * we might expunge legitimate entries that
-			 * simply haven't been loaded yet.
-			 */
-			cleanupLocalCache.call( this );
-		}
-		this.retries = 0;
-		ready.call( this );
-	} );
-}
-
-function getNotesList() {
-	const notes = getAllNotes( store.getState() );
-	// make sure we have some notes before we run this
-	if ( ! notes.length ) {
+	if ( ! note ) {
 		return;
 	}
 
-	if ( this.gettingNotes ) {
-		return;
-	}
-	this.gettingNotes = true;
-
-	const parameters = {
-		fields: 'id,note_hash',
-		number: this.noteRequestLimit,
-	};
-
-	listNotes( parameters, ( error, data ) => {
-		debug( 'getNotesList callback:', error, data );
-		this.gettingNotes = false;
-		if ( error ) {
-			this.retries = this.retries + 1;
-			const backoff_ms = Math.min(
-				settings.refresh_ms * ( this.retries + 1 ),
-				settings.max_refresh_ms
-			);
-			debug( 'getNotesList error, using backoff_ms=%d', backoff_ms );
-			return this.reschedule( backoff_ms );
-		}
-
-		this.retries = 0;
-
-		/* Compare list of notes from server to local copy */
-		const newerNoteList = data.notes.map( property( 'id' ) );
-		const localNoteList = this.noteList.map( property( 'id' ) );
-		const notesToRemove = difference( localNoteList, newerNoteList );
-
-		this.hasNewNoteData = difference( newerNoteList, localNoteList ).length;
-
-		const serverHasChanges =
-			this.hasNewNoteData ||
-			difference(
-				data.notes.map( property( 'note_hash' ) ),
-				this.noteList.map( property( 'note_hash' ) )
-			).length > 0;
-
-		/* Actually remove the notes from the local copy */
-		if ( notesToRemove.length ) {
-			store.dispatch( actions.notes.removeNotes( notesToRemove ) );
-		}
-
-		/* Update our local copy of the note list */
-		this.noteList = data.notes;
-		this.updateLastSeenTime( Number( data.last_seen_time ) );
-
-		// Clean out stored reply texts that are older than a day
-		repliesCache.cleanup();
-
-		/* Grab updates/changes from server if they exist */
-		return serverHasChanges ? this.getNotes() : ready.call( this );
-	} );
-}
+	this.notifications.update( noteId, { ...note, read: 1 } );
+};
 
 /**
  * Reports new notification data if available
@@ -312,202 +73,11 @@ function getNotesList() {
  */
 function ready() {
 	const notes = getAllNotes( store.getState() );
+	const timestamps = notes.map( note => Date.parse( note.timestamp ) / 1000 );
+	const newNoteCount = timestamps.filter( time => time > this.lastSeenTime ).length;
+	const latestType = notes.length ? notes.slice( -1 )[ 0 ].type : null;
 
-	const timestamps = notes
-		.map( property( 'timestamp' ) )
-		.map( timestamp => Date.parse( timestamp ) / 1000 );
-
-	let newNoteCount = timestamps.filter( time => time > this.lastSeenTime ).length;
-
-	if ( ! this.firstRender && this.lastSeenTime === 0 ) {
-		newNoteCount = 0;
-	}
-
-	const latestType = get( notes.slice( -1 )[ 0 ], 'type', null );
 	store.dispatch( { type: 'APP_RENDER_NOTES', newNoteCount, latestType } );
-
-	this.hasNewNoteData = false;
-	this.firstRender = false;
 }
-
-/** @type {RegExp} matches keys which may no longer need to exist */
-const obsoleteKeyPattern = /^(note_read_status|reply)_(\d+)/;
-
-const safelyRemoveKey = key => {
-	try {
-		localStorage.removeItem( key );
-	} catch ( e ) {}
-};
-
-const getLocalKeys = () => {
-	try {
-		return range( localStorage.length ).map( index => localStorage.key( index ) );
-	} catch ( e ) {
-		return [];
-	}
-};
-
-function cleanupLocalCache() {
-	const notes = getAllNotes( store.getState() );
-	const currentNoteIds = notes.map( property( 'id' ) );
-
-	getLocalKeys()
-		.map( key => obsoleteKeyPattern.exec( key ) )
-		.filter( match => match && ! currentNoteIds.includes( match[ 1 ] ) )
-		.forEach( safelyRemoveKey );
-}
-
-/**
- * Update lastSeenTime in object instance, localStorage, and remote database.
- * Advance this.lastSeenTime to proposedTime or the latest visible note time.
- * If the timestamp comes from a note, update the remote database.
- *
- * @param {number} proposedTime A proposed update to our lastSeenTime timestamp
- * @param {boolean} fromStorage Whether this call is from handleStorageEvent
- * @returns {boolean} whether or not we will update our lastSeenTime value
- */
-function updateLastSeenTime( proposedTime, fromStorage ) {
-	let fromNote = false;
-	let mostRecentNoteTime = 0;
-
-	// Make sure we aren't getting milliseconds
-	// The check time is Aug 8, 2005 in ms
-	if ( proposedTime > 1123473600000 ) {
-		proposedTime = proposedTime / 1000;
-	}
-
-	debug( 'updateLastSeenTime 0', {
-		proposedTime: proposedTime,
-		fromStorage: fromStorage,
-		lastSeenTime: this.lastSeenTime,
-	} );
-
-	// Event was triggered by another tab's localStorage.setItem; ignore localStorage and remote.
-	if ( fromStorage ) {
-		if ( proposedTime <= this.lastSeenTime ) {
-			return false;
-		}
-		this.lastSeenTime = proposedTime;
-		return true;
-	}
-
-	const notes = getAllNotes( store.getState() );
-	if ( notes.length ) {
-		mostRecentNoteTime = Date.parse( notes[ 0 ].timestamp ) / 1000;
-	}
-
-	debug( 'updateLastSeenTime 1', {
-		proposedTime: proposedTime,
-		showing: this.showing,
-		visible: this.visible,
-		lastSeenTime: this.lastSeenTime,
-		mostRecentNoteTime: mostRecentNoteTime,
-	} );
-
-	// Advance proposedTime to the latest visible note time.
-	if ( this.isShowing && this.isVisible && mostRecentNoteTime > proposedTime ) {
-		proposedTime = mostRecentNoteTime;
-		fromNote = true;
-	}
-
-	debug( 'updateLastSeenTime 2', {
-		proposedTime: proposedTime,
-		fromNote: fromNote,
-		oldNews: proposedTime <= this.lastSeenTime,
-	} );
-
-	// Ignore old news.
-	if ( proposedTime <= this.lastSeenTime ) {
-		return false;
-	}
-
-	this.lastSeenTime = proposedTime;
-
-	try {
-		localStorage.setItem( 'notesLastMarkedSeen', this.lastSeenTime );
-	} catch ( e ) {}
-
-	// Update the database only if an unseen note has become visible.
-	if ( fromNote ) {
-		debug( 'updateLastSeenTime 3', this.lastSeenTime );
-		sendLastSeenTime( this.lastSeenTime );
-	}
-
-	return true;
-}
-
-function refreshNotes() {
-	if ( this.subscribed ) {
-		return;
-	}
-
-	getNotesList.call( this );
-}
-
-function handleStorageEvent( event ) {
-	if ( ! event ) {
-		return;
-	}
-
-	if ( event.key === 'notesLastMarkedSeen' ) {
-		try {
-			const lastSeenTime = Number( event.newValue );
-			if ( updateLastSeenTime.call( this, lastSeenTime, true ) ) {
-				store.dispatch( {
-					type: 'APP_RENDER_NOTES',
-					newNoteCount: 0,
-				} );
-			}
-		} catch ( e ) {}
-		return;
-	}
-
-	if ( 'note_read_status_' === event.key.substring( 0, 17 ) ) {
-		const noteId = parseInt( event.key.slice( 17 ), 10 );
-
-		return store.dispatch( actions.notes.readNote( noteId ) );
-	}
-}
-
-function loadMore() {
-	const notes = getAllNotes( store.getState() );
-	if ( ! notes.length || this.noteRequestLimit > notes.length ) {
-		// we're already attempting to load more notes
-		return;
-	}
-	if ( this.noteRequestLimit >= settings.max_limit ) {
-		return;
-	}
-	this.noteRequestLimit = this.noteRequestLimit + settings.increment_limit;
-	if ( this.noteRequestLimit > settings.max_limit ) {
-		this.noteRequestLimit = settings.max_limit;
-	}
-
-	this.getNotes();
-}
-
-function setVisibility( { isShowing, isVisible } ) {
-	if ( this.isShowing === isShowing && this.isVisible === isVisible ) {
-		return;
-	}
-
-	this.isShowing = isShowing;
-	this.isVisible = isVisible;
-
-	if ( isVisible && isShowing ) {
-		this.updateLastSeenTime( 0 );
-		this.main();
-	}
-}
-
-Client.prototype.main = main;
-Client.prototype.reschedule = reschedule;
-Client.prototype.getNote = getNote;
-Client.prototype.getNotes = getNotes;
-Client.prototype.getNotesList = getNotesList;
-Client.prototype.updateLastSeenTime = updateLastSeenTime;
-Client.prototype.loadMore = loadMore;
-Client.prototype.refreshNotes = refreshNotes;
-Client.prototype.setVisibility = setVisibility;
 
 export default Client;

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -5,28 +5,12 @@ import getNote from '../state/selectors/get-note';
 import getAllNotes from '../state/selectors/get-all-notes';
 import simperium from '../simperium';
 
-const safely = f => {
-	try {
-		return f();
-	} catch ( e ) {
-		return null;
-	}
-};
-
-const load = key => safely( () => localStorage.getItem( key ) );
-const save = ( key, value ) => safely( () => localStorage.setItem( key, value ) );
-
 export function Client() {
 	this.isVisible = false;
 	this.isShowing = false;
 	this.lastSeenTime = null;
 	this.hasIndexed = false;
 	this.initialAnnouncement = null;
-
-	const initialLastSeenTime = load( 'wpnotes_last_seen_time' );
-	if ( null !== initialLastSeenTime ) {
-		this.lastSeenTime = parseInt( initialLastSeenTime, 10 );
-	}
 
 	store.dispatch( actions.ui.loadNotes() );
 	simperium().then( ( { meta, notifications } ) => {
@@ -41,12 +25,10 @@ export function Client() {
 			}
 
 			this.lastSeenTime = data[ 0 ].last_seen;
-			save( 'wpnotes_last_seen_time', this.lastSeenTime );
 		} );
 
 		meta.on( 'update', ( id, data ) => {
 			this.lastSeenTime = data.last_seen;
-			save( 'wpnotes_last_seen_time', this.lastSeenTime );
 
 			this.ready();
 		} );

--- a/apps/notifications/src/panel/simperium/index.ts
+++ b/apps/notifications/src/panel/simperium/index.ts
@@ -1,14 +1,14 @@
 import createClient from './simperium-lib';
 import { wpcom } from '../rest-client/wpcom';
 
-const APP_ID = 'SOME_APP_ID';
+const APP_ID = localStorage.getItem( 'wpnotes_app_id' );
 
 export default async () => {
 	const { token } = await wpcom().req.post( {
 		path: '/me/simperium-tokens/new',
 		apiVersion: 'v1.1',
 		body: {
-			api_key: 'SOME_API_KEY',
+			api_key: localStorage.getItem( 'wpnotes_api_key' ),
 		},
 	} );
 

--- a/apps/notifications/src/panel/simperium/index.ts
+++ b/apps/notifications/src/panel/simperium/index.ts
@@ -1,0 +1,21 @@
+import createClient from './simperium-lib';
+import { wpcom } from '../rest-client/wpcom';
+
+const APP_ID = 'SOME_APP_ID';
+
+export default async () => {
+	const { token } = await wpcom().req.post( {
+		path: '/me/simperium-tokens/new',
+		apiVersion: 'v1.1',
+		body: {
+			api_key: 'SOME_API_KEY',
+		},
+	} );
+
+	const client = createClient( APP_ID, token, {} );
+
+	return {
+		meta: client.bucket( 'meta' ),
+		notifications: client.bucket( 'note20' ),
+	};
+};

--- a/apps/notifications/src/panel/simperium/simperium-lib.js
+++ b/apps/notifications/src/panel/simperium/simperium-lib.js
@@ -1,0 +1,8301 @@
+module.exports = ( function( t ) {
+	var e = {};
+	function n( r ) {
+		if ( e[ r ] ) return e[ r ].exports;
+		var i = ( e[ r ] = { i: r, l: ! 1, exports: {} } );
+		return t[ r ].call( i.exports, i, i.exports, n ), ( i.l = ! 0 ), i.exports;
+	}
+	return (
+		( n.m = t ),
+		( n.c = e ),
+		( n.d = function( t, e, r ) {
+			n.o( t, e ) || Object.defineProperty( t, e, { enumerable: ! 0, get: r } );
+		} ),
+		( n.r = function( t ) {
+			'undefined' != typeof Symbol &&
+				Symbol.toStringTag &&
+				Object.defineProperty( t, Symbol.toStringTag, { value: 'Module' } ),
+				Object.defineProperty( t, '__esModule', { value: ! 0 } );
+		} ),
+		( n.t = function( t, e ) {
+			if ( ( 1 & e && ( t = n( t ) ), 8 & e ) ) return t;
+			if ( 4 & e && 'object' == typeof t && t && t.__esModule ) return t;
+			var r = Object.create( null );
+			if (
+				( n.r( r ),
+				Object.defineProperty( r, 'default', { enumerable: ! 0, value: t } ),
+				2 & e && 'string' != typeof t )
+			)
+				for ( var i in t )
+					n.d(
+						r,
+						i,
+						function( e ) {
+							return t[ e ];
+						}.bind( null, i )
+					);
+			return r;
+		} ),
+		( n.n = function( t ) {
+			var e =
+				t && t.__esModule
+					? function() {
+							return t.default;
+					  }
+					: function() {
+							return t;
+					  };
+			return n.d( e, 'a', e ), e;
+		} ),
+		( n.o = function( t, e ) {
+			return Object.prototype.hasOwnProperty.call( t, e );
+		} ),
+		( n.p = '' ),
+		n( ( n.s = 28 ) )
+	);
+} )( [
+	function( t, e ) {
+		var n;
+		n = ( function() {
+			return this;
+		} )();
+		try {
+			n = n || new Function( 'return this' )();
+		} catch ( t ) {
+			'object' == typeof window && ( n = window );
+		}
+		t.exports = n;
+	},
+	function( t, e ) {
+		'function' == typeof Object.create
+			? ( t.exports = function( t, e ) {
+					( t.super_ = e ),
+						( t.prototype = Object.create( e.prototype, {
+							constructor: { value: t, enumerable: ! 1, writable: ! 0, configurable: ! 0 },
+						} ) );
+			  } )
+			: ( t.exports = function( t, e ) {
+					t.super_ = e;
+					var n = function() {};
+					( n.prototype = e.prototype ), ( t.prototype = new n() ), ( t.prototype.constructor = t );
+			  } );
+	},
+	function( t, e ) {
+		var n,
+			r,
+			i = ( t.exports = {} );
+		function o() {
+			throw new Error( 'setTimeout has not been defined' );
+		}
+		function s() {
+			throw new Error( 'clearTimeout has not been defined' );
+		}
+		function a( t ) {
+			if ( n === setTimeout ) return setTimeout( t, 0 );
+			if ( ( n === o || ! n ) && setTimeout ) return ( n = setTimeout ), setTimeout( t, 0 );
+			try {
+				return n( t, 0 );
+			} catch ( e ) {
+				try {
+					return n.call( null, t, 0 );
+				} catch ( e ) {
+					return n.call( this, t, 0 );
+				}
+			}
+		}
+		! ( function() {
+			try {
+				n = 'function' == typeof setTimeout ? setTimeout : o;
+			} catch ( t ) {
+				n = o;
+			}
+			try {
+				r = 'function' == typeof clearTimeout ? clearTimeout : s;
+			} catch ( t ) {
+				r = s;
+			}
+		} )();
+		var u,
+			f = [],
+			h = ! 1,
+			c = -1;
+		function l() {
+			h && u && ( ( h = ! 1 ), u.length ? ( f = u.concat( f ) ) : ( c = -1 ), f.length && p() );
+		}
+		function p() {
+			if ( ! h ) {
+				var t = a( l );
+				h = ! 0;
+				for ( var e = f.length; e;  ) {
+					for ( u = f, f = []; ++c < e;  ) u && u[ c ].run();
+					( c = -1 ), ( e = f.length );
+				}
+				( u = null ),
+					( h = ! 1 ),
+					( function( t ) {
+						if ( r === clearTimeout ) return clearTimeout( t );
+						if ( ( r === s || ! r ) && clearTimeout )
+							return ( r = clearTimeout ), clearTimeout( t );
+						try {
+							r( t );
+						} catch ( e ) {
+							try {
+								return r.call( null, t );
+							} catch ( e ) {
+								return r.call( this, t );
+							}
+						}
+					} )( t );
+			}
+		}
+		function d( t, e ) {
+			( this.fun = t ), ( this.array = e );
+		}
+		function g() {}
+		( i.nextTick = function( t ) {
+			var e = new Array( arguments.length - 1 );
+			if ( arguments.length > 1 )
+				for ( var n = 1; n < arguments.length; n++ ) e[ n - 1 ] = arguments[ n ];
+			f.push( new d( t, e ) ), 1 !== f.length || h || a( p );
+		} ),
+			( d.prototype.run = function() {
+				this.fun.apply( null, this.array );
+			} ),
+			( i.title = 'browser' ),
+			( i.browser = ! 0 ),
+			( i.env = {} ),
+			( i.argv = [] ),
+			( i.version = '' ),
+			( i.versions = {} ),
+			( i.on = g ),
+			( i.addListener = g ),
+			( i.once = g ),
+			( i.off = g ),
+			( i.removeListener = g ),
+			( i.removeAllListeners = g ),
+			( i.emit = g ),
+			( i.prependListener = g ),
+			( i.prependOnceListener = g ),
+			( i.listeners = function( t ) {
+				return [];
+			} ),
+			( i.binding = function( t ) {
+				throw new Error( 'process.binding is not supported' );
+			} ),
+			( i.cwd = function() {
+				return '/';
+			} ),
+			( i.chdir = function( t ) {
+				throw new Error( 'process.chdir is not supported' );
+			} ),
+			( i.umask = function() {
+				return 0;
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		var r,
+			i = 'object' == typeof Reflect ? Reflect : null,
+			o =
+				i && 'function' == typeof i.apply
+					? i.apply
+					: function( t, e, n ) {
+							return Function.prototype.apply.call( t, e, n );
+					  };
+		r =
+			i && 'function' == typeof i.ownKeys
+				? i.ownKeys
+				: Object.getOwnPropertySymbols
+				? function( t ) {
+						return Object.getOwnPropertyNames( t ).concat( Object.getOwnPropertySymbols( t ) );
+				  }
+				: function( t ) {
+						return Object.getOwnPropertyNames( t );
+				  };
+		var s =
+			Number.isNaN ||
+			function( t ) {
+				return t != t;
+			};
+		function a() {
+			a.init.call( this );
+		}
+		( t.exports = a ),
+			( a.EventEmitter = a ),
+			( a.prototype._events = void 0 ),
+			( a.prototype._eventsCount = 0 ),
+			( a.prototype._maxListeners = void 0 );
+		var u = 10;
+		function f( t ) {
+			if ( 'function' != typeof t )
+				throw new TypeError(
+					'The "listener" argument must be of type Function. Received type ' + typeof t
+				);
+		}
+		function h( t ) {
+			return void 0 === t._maxListeners ? a.defaultMaxListeners : t._maxListeners;
+		}
+		function c( t, e, n, r ) {
+			var i, o, s, a;
+			if (
+				( f( n ),
+				void 0 === ( o = t._events )
+					? ( ( o = t._events = Object.create( null ) ), ( t._eventsCount = 0 ) )
+					: ( void 0 !== o.newListener &&
+							( t.emit( 'newListener', e, n.listener ? n.listener : n ), ( o = t._events ) ),
+					  ( s = o[ e ] ) ),
+				void 0 === s )
+			)
+				( s = o[ e ] = n ), ++t._eventsCount;
+			else if (
+				( 'function' == typeof s
+					? ( s = o[ e ] = r ? [ n, s ] : [ s, n ] )
+					: r
+					? s.unshift( n )
+					: s.push( n ),
+				( i = h( t ) ) > 0 && s.length > i && ! s.warned )
+			) {
+				s.warned = ! 0;
+				var u = new Error(
+					'Possible EventEmitter memory leak detected. ' +
+						s.length +
+						' ' +
+						String( e ) +
+						' listeners added. Use emitter.setMaxListeners() to increase limit'
+				);
+				( u.name = 'MaxListenersExceededWarning' ),
+					( u.emitter = t ),
+					( u.type = e ),
+					( u.count = s.length ),
+					( a = u ),
+					console && console.warn && console.warn( a );
+			}
+			return t;
+		}
+		function l() {
+			if ( ! this.fired )
+				return (
+					this.target.removeListener( this.type, this.wrapFn ),
+					( this.fired = ! 0 ),
+					0 === arguments.length
+						? this.listener.call( this.target )
+						: this.listener.apply( this.target, arguments )
+				);
+		}
+		function p( t, e, n ) {
+			var r = { fired: ! 1, wrapFn: void 0, target: t, type: e, listener: n },
+				i = l.bind( r );
+			return ( i.listener = n ), ( r.wrapFn = i ), i;
+		}
+		function d( t, e, n ) {
+			var r = t._events;
+			if ( void 0 === r ) return [];
+			var i = r[ e ];
+			return void 0 === i
+				? []
+				: 'function' == typeof i
+				? n
+					? [ i.listener || i ]
+					: [ i ]
+				: n
+				? ( function( t ) {
+						for ( var e = new Array( t.length ), n = 0; n < e.length; ++n )
+							e[ n ] = t[ n ].listener || t[ n ];
+						return e;
+				  } )( i )
+				: y( i, i.length );
+		}
+		function g( t ) {
+			var e = this._events;
+			if ( void 0 !== e ) {
+				var n = e[ t ];
+				if ( 'function' == typeof n ) return 1;
+				if ( void 0 !== n ) return n.length;
+			}
+			return 0;
+		}
+		function y( t, e ) {
+			for ( var n = new Array( e ), r = 0; r < e; ++r ) n[ r ] = t[ r ];
+			return n;
+		}
+		Object.defineProperty( a, 'defaultMaxListeners', {
+			enumerable: ! 0,
+			get: function() {
+				return u;
+			},
+			set: function( t ) {
+				if ( 'number' != typeof t || t < 0 || s( t ) )
+					throw new RangeError(
+						'The value of "defaultMaxListeners" is out of range. It must be a non-negative number. Received ' +
+							t +
+							'.'
+					);
+				u = t;
+			},
+		} ),
+			( a.init = function() {
+				( void 0 !== this._events && this._events !== Object.getPrototypeOf( this )._events ) ||
+					( ( this._events = Object.create( null ) ), ( this._eventsCount = 0 ) ),
+					( this._maxListeners = this._maxListeners || void 0 );
+			} ),
+			( a.prototype.setMaxListeners = function( t ) {
+				if ( 'number' != typeof t || t < 0 || s( t ) )
+					throw new RangeError(
+						'The value of "n" is out of range. It must be a non-negative number. Received ' +
+							t +
+							'.'
+					);
+				return ( this._maxListeners = t ), this;
+			} ),
+			( a.prototype.getMaxListeners = function() {
+				return h( this );
+			} ),
+			( a.prototype.emit = function( t ) {
+				for ( var e = [], n = 1; n < arguments.length; n++ ) e.push( arguments[ n ] );
+				var r = 'error' === t,
+					i = this._events;
+				if ( void 0 !== i ) r = r && void 0 === i.error;
+				else if ( ! r ) return ! 1;
+				if ( r ) {
+					var s;
+					if ( ( e.length > 0 && ( s = e[ 0 ] ), s instanceof Error ) ) throw s;
+					var a = new Error( 'Unhandled error.' + ( s ? ' (' + s.message + ')' : '' ) );
+					throw ( ( a.context = s ), a );
+				}
+				var u = i[ t ];
+				if ( void 0 === u ) return ! 1;
+				if ( 'function' == typeof u ) o( u, this, e );
+				else {
+					var f = u.length,
+						h = y( u, f );
+					for ( n = 0; n < f; ++n ) o( h[ n ], this, e );
+				}
+				return ! 0;
+			} ),
+			( a.prototype.addListener = function( t, e ) {
+				return c( this, t, e, ! 1 );
+			} ),
+			( a.prototype.on = a.prototype.addListener ),
+			( a.prototype.prependListener = function( t, e ) {
+				return c( this, t, e, ! 0 );
+			} ),
+			( a.prototype.once = function( t, e ) {
+				return f( e ), this.on( t, p( this, t, e ) ), this;
+			} ),
+			( a.prototype.prependOnceListener = function( t, e ) {
+				return f( e ), this.prependListener( t, p( this, t, e ) ), this;
+			} ),
+			( a.prototype.removeListener = function( t, e ) {
+				var n, r, i, o, s;
+				if ( ( f( e ), void 0 === ( r = this._events ) ) ) return this;
+				if ( void 0 === ( n = r[ t ] ) ) return this;
+				if ( n === e || n.listener === e )
+					0 == --this._eventsCount
+						? ( this._events = Object.create( null ) )
+						: ( delete r[ t ],
+						  r.removeListener && this.emit( 'removeListener', t, n.listener || e ) );
+				else if ( 'function' != typeof n ) {
+					for ( i = -1, o = n.length - 1; o >= 0; o-- )
+						if ( n[ o ] === e || n[ o ].listener === e ) {
+							( s = n[ o ].listener ), ( i = o );
+							break;
+						}
+					if ( i < 0 ) return this;
+					0 === i
+						? n.shift()
+						: ( function( t, e ) {
+								for ( ; e + 1 < t.length; e++ ) t[ e ] = t[ e + 1 ];
+								t.pop();
+						  } )( n, i ),
+						1 === n.length && ( r[ t ] = n[ 0 ] ),
+						void 0 !== r.removeListener && this.emit( 'removeListener', t, s || e );
+				}
+				return this;
+			} ),
+			( a.prototype.off = a.prototype.removeListener ),
+			( a.prototype.removeAllListeners = function( t ) {
+				var e, n, r;
+				if ( void 0 === ( n = this._events ) ) return this;
+				if ( void 0 === n.removeListener )
+					return (
+						0 === arguments.length
+							? ( ( this._events = Object.create( null ) ), ( this._eventsCount = 0 ) )
+							: void 0 !== n[ t ] &&
+							  ( 0 == --this._eventsCount
+									? ( this._events = Object.create( null ) )
+									: delete n[ t ] ),
+						this
+					);
+				if ( 0 === arguments.length ) {
+					var i,
+						o = Object.keys( n );
+					for ( r = 0; r < o.length; ++r )
+						'removeListener' !== ( i = o[ r ] ) && this.removeAllListeners( i );
+					return (
+						this.removeAllListeners( 'removeListener' ),
+						( this._events = Object.create( null ) ),
+						( this._eventsCount = 0 ),
+						this
+					);
+				}
+				if ( 'function' == typeof ( e = n[ t ] ) ) this.removeListener( t, e );
+				else if ( void 0 !== e )
+					for ( r = e.length - 1; r >= 0; r-- ) this.removeListener( t, e[ r ] );
+				return this;
+			} ),
+			( a.prototype.listeners = function( t ) {
+				return d( this, t, ! 0 );
+			} ),
+			( a.prototype.rawListeners = function( t ) {
+				return d( this, t, ! 1 );
+			} ),
+			( a.listenerCount = function( t, e ) {
+				return 'function' == typeof t.listenerCount ? t.listenerCount( e ) : g.call( t, e );
+			} ),
+			( a.prototype.listenerCount = g ),
+			( a.prototype.eventNames = function() {
+				return this._eventsCount > 0 ? r( this._events ) : [];
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		var r = n( 7 ),
+			i =
+				Object.keys ||
+				function( t ) {
+					var e = [];
+					for ( var n in t ) e.push( n );
+					return e;
+				};
+		t.exports = c;
+		var o = n( 6 );
+		o.inherits = n( 1 );
+		var s = n( 22 ),
+			a = n( 25 );
+		o.inherits( c, s );
+		for ( var u = i( a.prototype ), f = 0; f < u.length; f++ ) {
+			var h = u[ f ];
+			c.prototype[ h ] || ( c.prototype[ h ] = a.prototype[ h ] );
+		}
+		function c( t ) {
+			if ( ! ( this instanceof c ) ) return new c( t );
+			s.call( this, t ),
+				a.call( this, t ),
+				t && ! 1 === t.readable && ( this.readable = ! 1 ),
+				t && ! 1 === t.writable && ( this.writable = ! 1 ),
+				( this.allowHalfOpen = ! 0 ),
+				t && ! 1 === t.allowHalfOpen && ( this.allowHalfOpen = ! 1 ),
+				this.once( 'end', l );
+		}
+		function l() {
+			this.allowHalfOpen || this._writableState.ended || r.nextTick( p, this );
+		}
+		function p( t ) {
+			t.end();
+		}
+		Object.defineProperty( c.prototype, 'writableHighWaterMark', {
+			enumerable: ! 1,
+			get: function() {
+				return this._writableState.highWaterMark;
+			},
+		} ),
+			Object.defineProperty( c.prototype, 'destroyed', {
+				get: function() {
+					return (
+						void 0 !== this._readableState &&
+						void 0 !== this._writableState &&
+						this._readableState.destroyed && this._writableState.destroyed
+					);
+				},
+				set: function( t ) {
+					void 0 !== this._readableState &&
+						void 0 !== this._writableState &&
+						( ( this._readableState.destroyed = t ), ( this._writableState.destroyed = t ) );
+				},
+			} ),
+			( c.prototype._destroy = function( t, e ) {
+				this.push( null ), this.end(), r.nextTick( e, t );
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		( function( t ) {
+			/*!
+			 * The buffer module from node.js, for the browser.
+			 *
+			 * @author   Feross Aboukhadijeh <http://feross.org>
+			 * @license  MIT
+			 */
+			var r = n( 52 ),
+				i = n( 53 ),
+				o = n( 18 );
+			function s() {
+				return u.TYPED_ARRAY_SUPPORT ? 2147483647 : 1073741823;
+			}
+			function a( t, e ) {
+				if ( s() < e ) throw new RangeError( 'Invalid typed array length' );
+				return (
+					u.TYPED_ARRAY_SUPPORT
+						? ( ( t = new Uint8Array( e ) ).__proto__ = u.prototype )
+						: ( null === t && ( t = new u( e ) ), ( t.length = e ) ),
+					t
+				);
+			}
+			function u( t, e, n ) {
+				if ( ! ( u.TYPED_ARRAY_SUPPORT || this instanceof u ) ) return new u( t, e, n );
+				if ( 'number' == typeof t ) {
+					if ( 'string' == typeof e )
+						throw new Error( 'If encoding is specified then the first argument must be a string' );
+					return c( this, t );
+				}
+				return f( this, t, e, n );
+			}
+			function f( t, e, n, r ) {
+				if ( 'number' == typeof e ) throw new TypeError( '"value" argument must not be a number' );
+				return 'undefined' != typeof ArrayBuffer && e instanceof ArrayBuffer
+					? ( function( t, e, n, r ) {
+							if ( ( e.byteLength, n < 0 || e.byteLength < n ) )
+								throw new RangeError( "'offset' is out of bounds" );
+							if ( e.byteLength < n + ( r || 0 ) )
+								throw new RangeError( "'length' is out of bounds" );
+							e =
+								void 0 === n && void 0 === r
+									? new Uint8Array( e )
+									: void 0 === r
+									? new Uint8Array( e, n )
+									: new Uint8Array( e, n, r );
+							u.TYPED_ARRAY_SUPPORT ? ( ( t = e ).__proto__ = u.prototype ) : ( t = l( t, e ) );
+							return t;
+					  } )( t, e, n, r )
+					: 'string' == typeof e
+					? ( function( t, e, n ) {
+							( 'string' == typeof n && '' !== n ) || ( n = 'utf8' );
+							if ( ! u.isEncoding( n ) )
+								throw new TypeError( '"encoding" must be a valid string encoding' );
+							var r = 0 | d( e, n ),
+								i = ( t = a( t, r ) ).write( e, n );
+							i !== r && ( t = t.slice( 0, i ) );
+							return t;
+					  } )( t, e, n )
+					: ( function( t, e ) {
+							if ( u.isBuffer( e ) ) {
+								var n = 0 | p( e.length );
+								return 0 === ( t = a( t, n ) ).length || e.copy( t, 0, 0, n ), t;
+							}
+							if ( e ) {
+								if (
+									( 'undefined' != typeof ArrayBuffer && e.buffer instanceof ArrayBuffer ) ||
+									'length' in e
+								)
+									return 'number' != typeof e.length || ( r = e.length ) != r
+										? a( t, 0 )
+										: l( t, e );
+								if ( 'Buffer' === e.type && o( e.data ) ) return l( t, e.data );
+							}
+							var r;
+							throw new TypeError(
+								'First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.'
+							);
+					  } )( t, e );
+			}
+			function h( t ) {
+				if ( 'number' != typeof t ) throw new TypeError( '"size" argument must be a number' );
+				if ( t < 0 ) throw new RangeError( '"size" argument must not be negative' );
+			}
+			function c( t, e ) {
+				if ( ( h( e ), ( t = a( t, e < 0 ? 0 : 0 | p( e ) ) ), ! u.TYPED_ARRAY_SUPPORT ) )
+					for ( var n = 0; n < e; ++n ) t[ n ] = 0;
+				return t;
+			}
+			function l( t, e ) {
+				var n = e.length < 0 ? 0 : 0 | p( e.length );
+				t = a( t, n );
+				for ( var r = 0; r < n; r += 1 ) t[ r ] = 255 & e[ r ];
+				return t;
+			}
+			function p( t ) {
+				if ( t >= s() )
+					throw new RangeError(
+						'Attempt to allocate Buffer larger than maximum size: 0x' +
+							s().toString( 16 ) +
+							' bytes'
+					);
+				return 0 | t;
+			}
+			function d( t, e ) {
+				if ( u.isBuffer( t ) ) return t.length;
+				if (
+					'undefined' != typeof ArrayBuffer &&
+					'function' == typeof ArrayBuffer.isView &&
+					( ArrayBuffer.isView( t ) || t instanceof ArrayBuffer )
+				)
+					return t.byteLength;
+				'string' != typeof t && ( t = '' + t );
+				var n = t.length;
+				if ( 0 === n ) return 0;
+				for ( var r = ! 1; ;  )
+					switch ( e ) {
+						case 'ascii':
+						case 'latin1':
+						case 'binary':
+							return n;
+						case 'utf8':
+						case 'utf-8':
+						case void 0:
+							return q( t ).length;
+						case 'ucs2':
+						case 'ucs-2':
+						case 'utf16le':
+						case 'utf-16le':
+							return 2 * n;
+						case 'hex':
+							return n >>> 1;
+						case 'base64':
+							return F( t ).length;
+						default:
+							if ( r ) return q( t ).length;
+							( e = ( '' + e ).toLowerCase() ), ( r = ! 0 );
+					}
+			}
+			function g( t, e, n ) {
+				var r = ! 1;
+				if ( ( ( void 0 === e || e < 0 ) && ( e = 0 ), e > this.length ) ) return '';
+				if ( ( ( void 0 === n || n > this.length ) && ( n = this.length ), n <= 0 ) ) return '';
+				if ( ( n >>>= 0 ) <= ( e >>>= 0 ) ) return '';
+				for ( t || ( t = 'utf8' ); ;  )
+					switch ( t ) {
+						case 'hex':
+							return T( this, e, n );
+						case 'utf8':
+						case 'utf-8':
+							return k( this, e, n );
+						case 'ascii':
+							return C( this, e, n );
+						case 'latin1':
+						case 'binary':
+							return j( this, e, n );
+						case 'base64':
+							return E( this, e, n );
+						case 'ucs2':
+						case 'ucs-2':
+						case 'utf16le':
+						case 'utf-16le':
+							return M( this, e, n );
+						default:
+							if ( r ) throw new TypeError( 'Unknown encoding: ' + t );
+							( t = ( t + '' ).toLowerCase() ), ( r = ! 0 );
+					}
+			}
+			function y( t, e, n ) {
+				var r = t[ e ];
+				( t[ e ] = t[ n ] ), ( t[ n ] = r );
+			}
+			function m( t, e, n, r, i ) {
+				if ( 0 === t.length ) return -1;
+				if (
+					( 'string' == typeof n
+						? ( ( r = n ), ( n = 0 ) )
+						: n > 2147483647
+						? ( n = 2147483647 )
+						: n < -2147483648 && ( n = -2147483648 ),
+					( n = +n ),
+					isNaN( n ) && ( n = i ? 0 : t.length - 1 ),
+					n < 0 && ( n = t.length + n ),
+					n >= t.length )
+				) {
+					if ( i ) return -1;
+					n = t.length - 1;
+				} else if ( n < 0 ) {
+					if ( ! i ) return -1;
+					n = 0;
+				}
+				if ( ( 'string' == typeof e && ( e = u.from( e, r ) ), u.isBuffer( e ) ) )
+					return 0 === e.length ? -1 : v( t, e, n, r, i );
+				if ( 'number' == typeof e )
+					return (
+						( e &= 255 ),
+						u.TYPED_ARRAY_SUPPORT && 'function' == typeof Uint8Array.prototype.indexOf
+							? i
+								? Uint8Array.prototype.indexOf.call( t, e, n )
+								: Uint8Array.prototype.lastIndexOf.call( t, e, n )
+							: v( t, [ e ], n, r, i )
+					);
+				throw new TypeError( 'val must be string, number or Buffer' );
+			}
+			function v( t, e, n, r, i ) {
+				var o,
+					s = 1,
+					a = t.length,
+					u = e.length;
+				if (
+					void 0 !== r &&
+					( 'ucs2' === ( r = String( r ).toLowerCase() ) ||
+						'ucs-2' === r ||
+						'utf16le' === r ||
+						'utf-16le' === r )
+				) {
+					if ( t.length < 2 || e.length < 2 ) return -1;
+					( s = 2 ), ( a /= 2 ), ( u /= 2 ), ( n /= 2 );
+				}
+				function f( t, e ) {
+					return 1 === s ? t[ e ] : t.readUInt16BE( e * s );
+				}
+				if ( i ) {
+					var h = -1;
+					for ( o = n; o < a; o++ )
+						if ( f( t, o ) === f( e, -1 === h ? 0 : o - h ) ) {
+							if ( ( -1 === h && ( h = o ), o - h + 1 === u ) ) return h * s;
+						} else -1 !== h && ( o -= o - h ), ( h = -1 );
+				} else
+					for ( n + u > a && ( n = a - u ), o = n; o >= 0; o-- ) {
+						for ( var c = ! 0, l = 0; l < u; l++ )
+							if ( f( t, o + l ) !== f( e, l ) ) {
+								c = ! 1;
+								break;
+							}
+						if ( c ) return o;
+					}
+				return -1;
+			}
+			function b( t, e, n, r ) {
+				n = Number( n ) || 0;
+				var i = t.length - n;
+				r ? ( r = Number( r ) ) > i && ( r = i ) : ( r = i );
+				var o = e.length;
+				if ( o % 2 != 0 ) throw new TypeError( 'Invalid hex string' );
+				r > o / 2 && ( r = o / 2 );
+				for ( var s = 0; s < r; ++s ) {
+					var a = parseInt( e.substr( 2 * s, 2 ), 16 );
+					if ( isNaN( a ) ) return s;
+					t[ n + s ] = a;
+				}
+				return s;
+			}
+			function _( t, e, n, r ) {
+				return H( q( e, t.length - n ), t, n, r );
+			}
+			function w( t, e, n, r ) {
+				return H(
+					( function( t ) {
+						for ( var e = [], n = 0; n < t.length; ++n ) e.push( 255 & t.charCodeAt( n ) );
+						return e;
+					} )( e ),
+					t,
+					n,
+					r
+				);
+			}
+			function x( t, e, n, r ) {
+				return w( t, e, n, r );
+			}
+			function O( t, e, n, r ) {
+				return H( F( e ), t, n, r );
+			}
+			function S( t, e, n, r ) {
+				return H(
+					( function( t, e ) {
+						for ( var n, r, i, o = [], s = 0; s < t.length && ! ( ( e -= 2 ) < 0 ); ++s )
+							( n = t.charCodeAt( s ) ), ( r = n >> 8 ), ( i = n % 256 ), o.push( i ), o.push( r );
+						return o;
+					} )( e, t.length - n ),
+					t,
+					n,
+					r
+				);
+			}
+			function E( t, e, n ) {
+				return 0 === e && n === t.length
+					? r.fromByteArray( t )
+					: r.fromByteArray( t.slice( e, n ) );
+			}
+			function k( t, e, n ) {
+				n = Math.min( t.length, n );
+				for ( var r = [], i = e; i < n;  ) {
+					var o,
+						s,
+						a,
+						u,
+						f = t[ i ],
+						h = null,
+						c = f > 239 ? 4 : f > 223 ? 3 : f > 191 ? 2 : 1;
+					if ( i + c <= n )
+						switch ( c ) {
+							case 1:
+								f < 128 && ( h = f );
+								break;
+							case 2:
+								128 == ( 192 & ( o = t[ i + 1 ] ) ) &&
+									( u = ( ( 31 & f ) << 6 ) | ( 63 & o ) ) > 127 &&
+									( h = u );
+								break;
+							case 3:
+								( o = t[ i + 1 ] ),
+									( s = t[ i + 2 ] ),
+									128 == ( 192 & o ) &&
+										128 == ( 192 & s ) &&
+										( u = ( ( 15 & f ) << 12 ) | ( ( 63 & o ) << 6 ) | ( 63 & s ) ) > 2047 &&
+										( u < 55296 || u > 57343 ) &&
+										( h = u );
+								break;
+							case 4:
+								( o = t[ i + 1 ] ),
+									( s = t[ i + 2 ] ),
+									( a = t[ i + 3 ] ),
+									128 == ( 192 & o ) &&
+										128 == ( 192 & s ) &&
+										128 == ( 192 & a ) &&
+										( u =
+											( ( 15 & f ) << 18 ) |
+											( ( 63 & o ) << 12 ) |
+											( ( 63 & s ) << 6 ) |
+											( 63 & a ) ) > 65535 &&
+										u < 1114112 &&
+										( h = u );
+						}
+					null === h
+						? ( ( h = 65533 ), ( c = 1 ) )
+						: h > 65535 &&
+						  ( ( h -= 65536 ),
+						  r.push( ( ( h >>> 10 ) & 1023 ) | 55296 ),
+						  ( h = 56320 | ( 1023 & h ) ) ),
+						r.push( h ),
+						( i += c );
+				}
+				return ( function( t ) {
+					var e = t.length;
+					if ( e <= 4096 ) return String.fromCharCode.apply( String, t );
+					var n = '',
+						r = 0;
+					for ( ; r < e;  ) n += String.fromCharCode.apply( String, t.slice( r, ( r += 4096 ) ) );
+					return n;
+				} )( r );
+			}
+			( e.Buffer = u ),
+				( e.SlowBuffer = function( t ) {
+					+t != t && ( t = 0 );
+					return u.alloc( +t );
+				} ),
+				( e.INSPECT_MAX_BYTES = 50 ),
+				( u.TYPED_ARRAY_SUPPORT =
+					void 0 !== t.TYPED_ARRAY_SUPPORT
+						? t.TYPED_ARRAY_SUPPORT
+						: ( function() {
+								try {
+									var t = new Uint8Array( 1 );
+									return (
+										( t.__proto__ = {
+											__proto__: Uint8Array.prototype,
+											foo: function() {
+												return 42;
+											},
+										} ),
+										42 === t.foo() &&
+											'function' == typeof t.subarray &&
+											0 === t.subarray( 1, 1 ).byteLength
+									);
+								} catch ( t ) {
+									return ! 1;
+								}
+						  } )() ),
+				( e.kMaxLength = s() ),
+				( u.poolSize = 8192 ),
+				( u._augment = function( t ) {
+					return ( t.__proto__ = u.prototype ), t;
+				} ),
+				( u.from = function( t, e, n ) {
+					return f( null, t, e, n );
+				} ),
+				u.TYPED_ARRAY_SUPPORT &&
+					( ( u.prototype.__proto__ = Uint8Array.prototype ),
+					( u.__proto__ = Uint8Array ),
+					'undefined' != typeof Symbol &&
+						Symbol.species &&
+						u[ Symbol.species ] === u &&
+						Object.defineProperty( u, Symbol.species, { value: null, configurable: ! 0 } ) ),
+				( u.alloc = function( t, e, n ) {
+					return ( function( t, e, n, r ) {
+						return (
+							h( e ),
+							e <= 0
+								? a( t, e )
+								: void 0 !== n
+								? 'string' == typeof r
+									? a( t, e ).fill( n, r )
+									: a( t, e ).fill( n )
+								: a( t, e )
+						);
+					} )( null, t, e, n );
+				} ),
+				( u.allocUnsafe = function( t ) {
+					return c( null, t );
+				} ),
+				( u.allocUnsafeSlow = function( t ) {
+					return c( null, t );
+				} ),
+				( u.isBuffer = function( t ) {
+					return ! ( null == t || ! t._isBuffer );
+				} ),
+				( u.compare = function( t, e ) {
+					if ( ! u.isBuffer( t ) || ! u.isBuffer( e ) )
+						throw new TypeError( 'Arguments must be Buffers' );
+					if ( t === e ) return 0;
+					for ( var n = t.length, r = e.length, i = 0, o = Math.min( n, r ); i < o; ++i )
+						if ( t[ i ] !== e[ i ] ) {
+							( n = t[ i ] ), ( r = e[ i ] );
+							break;
+						}
+					return n < r ? -1 : r < n ? 1 : 0;
+				} ),
+				( u.isEncoding = function( t ) {
+					switch ( String( t ).toLowerCase() ) {
+						case 'hex':
+						case 'utf8':
+						case 'utf-8':
+						case 'ascii':
+						case 'latin1':
+						case 'binary':
+						case 'base64':
+						case 'ucs2':
+						case 'ucs-2':
+						case 'utf16le':
+						case 'utf-16le':
+							return ! 0;
+						default:
+							return ! 1;
+					}
+				} ),
+				( u.concat = function( t, e ) {
+					if ( ! o( t ) ) throw new TypeError( '"list" argument must be an Array of Buffers' );
+					if ( 0 === t.length ) return u.alloc( 0 );
+					var n;
+					if ( void 0 === e ) for ( e = 0, n = 0; n < t.length; ++n ) e += t[ n ].length;
+					var r = u.allocUnsafe( e ),
+						i = 0;
+					for ( n = 0; n < t.length; ++n ) {
+						var s = t[ n ];
+						if ( ! u.isBuffer( s ) )
+							throw new TypeError( '"list" argument must be an Array of Buffers' );
+						s.copy( r, i ), ( i += s.length );
+					}
+					return r;
+				} ),
+				( u.byteLength = d ),
+				( u.prototype._isBuffer = ! 0 ),
+				( u.prototype.swap16 = function() {
+					var t = this.length;
+					if ( t % 2 != 0 ) throw new RangeError( 'Buffer size must be a multiple of 16-bits' );
+					for ( var e = 0; e < t; e += 2 ) y( this, e, e + 1 );
+					return this;
+				} ),
+				( u.prototype.swap32 = function() {
+					var t = this.length;
+					if ( t % 4 != 0 ) throw new RangeError( 'Buffer size must be a multiple of 32-bits' );
+					for ( var e = 0; e < t; e += 4 ) y( this, e, e + 3 ), y( this, e + 1, e + 2 );
+					return this;
+				} ),
+				( u.prototype.swap64 = function() {
+					var t = this.length;
+					if ( t % 8 != 0 ) throw new RangeError( 'Buffer size must be a multiple of 64-bits' );
+					for ( var e = 0; e < t; e += 8 )
+						y( this, e, e + 7 ),
+							y( this, e + 1, e + 6 ),
+							y( this, e + 2, e + 5 ),
+							y( this, e + 3, e + 4 );
+					return this;
+				} ),
+				( u.prototype.toString = function() {
+					var t = 0 | this.length;
+					return 0 === t
+						? ''
+						: 0 === arguments.length
+						? k( this, 0, t )
+						: g.apply( this, arguments );
+				} ),
+				( u.prototype.equals = function( t ) {
+					if ( ! u.isBuffer( t ) ) throw new TypeError( 'Argument must be a Buffer' );
+					return this === t || 0 === u.compare( this, t );
+				} ),
+				( u.prototype.inspect = function() {
+					var t = '',
+						n = e.INSPECT_MAX_BYTES;
+					return (
+						this.length > 0 &&
+							( ( t = this.toString( 'hex', 0, n )
+								.match( /.{2}/g )
+								.join( ' ' ) ),
+							this.length > n && ( t += ' ... ' ) ),
+						'<Buffer ' + t + '>'
+					);
+				} ),
+				( u.prototype.compare = function( t, e, n, r, i ) {
+					if ( ! u.isBuffer( t ) ) throw new TypeError( 'Argument must be a Buffer' );
+					if (
+						( void 0 === e && ( e = 0 ),
+						void 0 === n && ( n = t ? t.length : 0 ),
+						void 0 === r && ( r = 0 ),
+						void 0 === i && ( i = this.length ),
+						e < 0 || n > t.length || r < 0 || i > this.length )
+					)
+						throw new RangeError( 'out of range index' );
+					if ( r >= i && e >= n ) return 0;
+					if ( r >= i ) return -1;
+					if ( e >= n ) return 1;
+					if ( this === t ) return 0;
+					for (
+						var o = ( i >>>= 0 ) - ( r >>>= 0 ),
+							s = ( n >>>= 0 ) - ( e >>>= 0 ),
+							a = Math.min( o, s ),
+							f = this.slice( r, i ),
+							h = t.slice( e, n ),
+							c = 0;
+						c < a;
+						++c
+					)
+						if ( f[ c ] !== h[ c ] ) {
+							( o = f[ c ] ), ( s = h[ c ] );
+							break;
+						}
+					return o < s ? -1 : s < o ? 1 : 0;
+				} ),
+				( u.prototype.includes = function( t, e, n ) {
+					return -1 !== this.indexOf( t, e, n );
+				} ),
+				( u.prototype.indexOf = function( t, e, n ) {
+					return m( this, t, e, n, ! 0 );
+				} ),
+				( u.prototype.lastIndexOf = function( t, e, n ) {
+					return m( this, t, e, n, ! 1 );
+				} ),
+				( u.prototype.write = function( t, e, n, r ) {
+					if ( void 0 === e ) ( r = 'utf8' ), ( n = this.length ), ( e = 0 );
+					else if ( void 0 === n && 'string' == typeof e )
+						( r = e ), ( n = this.length ), ( e = 0 );
+					else {
+						if ( ! isFinite( e ) )
+							throw new Error(
+								'Buffer.write(string, encoding, offset[, length]) is no longer supported'
+							);
+						( e |= 0 ),
+							isFinite( n )
+								? ( ( n |= 0 ), void 0 === r && ( r = 'utf8' ) )
+								: ( ( r = n ), ( n = void 0 ) );
+					}
+					var i = this.length - e;
+					if (
+						( ( void 0 === n || n > i ) && ( n = i ),
+						( t.length > 0 && ( n < 0 || e < 0 ) ) || e > this.length )
+					)
+						throw new RangeError( 'Attempt to write outside buffer bounds' );
+					r || ( r = 'utf8' );
+					for ( var o = ! 1; ;  )
+						switch ( r ) {
+							case 'hex':
+								return b( this, t, e, n );
+							case 'utf8':
+							case 'utf-8':
+								return _( this, t, e, n );
+							case 'ascii':
+								return w( this, t, e, n );
+							case 'latin1':
+							case 'binary':
+								return x( this, t, e, n );
+							case 'base64':
+								return O( this, t, e, n );
+							case 'ucs2':
+							case 'ucs-2':
+							case 'utf16le':
+							case 'utf-16le':
+								return S( this, t, e, n );
+							default:
+								if ( o ) throw new TypeError( 'Unknown encoding: ' + r );
+								( r = ( '' + r ).toLowerCase() ), ( o = ! 0 );
+						}
+				} ),
+				( u.prototype.toJSON = function() {
+					return { type: 'Buffer', data: Array.prototype.slice.call( this._arr || this, 0 ) };
+				} );
+			function C( t, e, n ) {
+				var r = '';
+				n = Math.min( t.length, n );
+				for ( var i = e; i < n; ++i ) r += String.fromCharCode( 127 & t[ i ] );
+				return r;
+			}
+			function j( t, e, n ) {
+				var r = '';
+				n = Math.min( t.length, n );
+				for ( var i = e; i < n; ++i ) r += String.fromCharCode( t[ i ] );
+				return r;
+			}
+			function T( t, e, n ) {
+				var r = t.length;
+				( ! e || e < 0 ) && ( e = 0 ), ( ! n || n < 0 || n > r ) && ( n = r );
+				for ( var i = '', o = e; o < n; ++o ) i += B( t[ o ] );
+				return i;
+			}
+			function M( t, e, n ) {
+				for ( var r = t.slice( e, n ), i = '', o = 0; o < r.length; o += 2 )
+					i += String.fromCharCode( r[ o ] + 256 * r[ o + 1 ] );
+				return i;
+			}
+			function R( t, e, n ) {
+				if ( t % 1 != 0 || t < 0 ) throw new RangeError( 'offset is not uint' );
+				if ( t + e > n ) throw new RangeError( 'Trying to access beyond buffer length' );
+			}
+			function P( t, e, n, r, i, o ) {
+				if ( ! u.isBuffer( t ) )
+					throw new TypeError( '"buffer" argument must be a Buffer instance' );
+				if ( e > i || e < o ) throw new RangeError( '"value" argument is out of bounds' );
+				if ( n + r > t.length ) throw new RangeError( 'Index out of range' );
+			}
+			function A( t, e, n, r ) {
+				e < 0 && ( e = 65535 + e + 1 );
+				for ( var i = 0, o = Math.min( t.length - n, 2 ); i < o; ++i )
+					t[ n + i ] = ( e & ( 255 << ( 8 * ( r ? i : 1 - i ) ) ) ) >>> ( 8 * ( r ? i : 1 - i ) );
+			}
+			function I( t, e, n, r ) {
+				e < 0 && ( e = 4294967295 + e + 1 );
+				for ( var i = 0, o = Math.min( t.length - n, 4 ); i < o; ++i )
+					t[ n + i ] = ( e >>> ( 8 * ( r ? i : 3 - i ) ) ) & 255;
+			}
+			function D( t, e, n, r, i, o ) {
+				if ( n + r > t.length ) throw new RangeError( 'Index out of range' );
+				if ( n < 0 ) throw new RangeError( 'Index out of range' );
+			}
+			function L( t, e, n, r, o ) {
+				return o || D( t, 0, n, 4 ), i.write( t, e, n, r, 23, 4 ), n + 4;
+			}
+			function U( t, e, n, r, o ) {
+				return o || D( t, 0, n, 8 ), i.write( t, e, n, r, 52, 8 ), n + 8;
+			}
+			( u.prototype.slice = function( t, e ) {
+				var n,
+					r = this.length;
+				if (
+					( ( t = ~~t ) < 0 ? ( t += r ) < 0 && ( t = 0 ) : t > r && ( t = r ),
+					( e = void 0 === e ? r : ~~e ) < 0 ? ( e += r ) < 0 && ( e = 0 ) : e > r && ( e = r ),
+					e < t && ( e = t ),
+					u.TYPED_ARRAY_SUPPORT )
+				)
+					( n = this.subarray( t, e ) ).__proto__ = u.prototype;
+				else {
+					var i = e - t;
+					n = new u( i, void 0 );
+					for ( var o = 0; o < i; ++o ) n[ o ] = this[ o + t ];
+				}
+				return n;
+			} ),
+				( u.prototype.readUIntLE = function( t, e, n ) {
+					( t |= 0 ), ( e |= 0 ), n || R( t, e, this.length );
+					for ( var r = this[ t ], i = 1, o = 0; ++o < e && ( i *= 256 );  ) r += this[ t + o ] * i;
+					return r;
+				} ),
+				( u.prototype.readUIntBE = function( t, e, n ) {
+					( t |= 0 ), ( e |= 0 ), n || R( t, e, this.length );
+					for ( var r = this[ t + --e ], i = 1; e > 0 && ( i *= 256 );  ) r += this[ t + --e ] * i;
+					return r;
+				} ),
+				( u.prototype.readUInt8 = function( t, e ) {
+					return e || R( t, 1, this.length ), this[ t ];
+				} ),
+				( u.prototype.readUInt16LE = function( t, e ) {
+					return e || R( t, 2, this.length ), this[ t ] | ( this[ t + 1 ] << 8 );
+				} ),
+				( u.prototype.readUInt16BE = function( t, e ) {
+					return e || R( t, 2, this.length ), ( this[ t ] << 8 ) | this[ t + 1 ];
+				} ),
+				( u.prototype.readUInt32LE = function( t, e ) {
+					return (
+						e || R( t, 4, this.length ),
+						( this[ t ] | ( this[ t + 1 ] << 8 ) | ( this[ t + 2 ] << 16 ) ) +
+							16777216 * this[ t + 3 ]
+					);
+				} ),
+				( u.prototype.readUInt32BE = function( t, e ) {
+					return (
+						e || R( t, 4, this.length ),
+						16777216 * this[ t ] +
+							( ( this[ t + 1 ] << 16 ) | ( this[ t + 2 ] << 8 ) | this[ t + 3 ] )
+					);
+				} ),
+				( u.prototype.readIntLE = function( t, e, n ) {
+					( t |= 0 ), ( e |= 0 ), n || R( t, e, this.length );
+					for ( var r = this[ t ], i = 1, o = 0; ++o < e && ( i *= 256 );  ) r += this[ t + o ] * i;
+					return r >= ( i *= 128 ) && ( r -= Math.pow( 2, 8 * e ) ), r;
+				} ),
+				( u.prototype.readIntBE = function( t, e, n ) {
+					( t |= 0 ), ( e |= 0 ), n || R( t, e, this.length );
+					for ( var r = e, i = 1, o = this[ t + --r ]; r > 0 && ( i *= 256 );  )
+						o += this[ t + --r ] * i;
+					return o >= ( i *= 128 ) && ( o -= Math.pow( 2, 8 * e ) ), o;
+				} ),
+				( u.prototype.readInt8 = function( t, e ) {
+					return (
+						e || R( t, 1, this.length ), 128 & this[ t ] ? -1 * ( 255 - this[ t ] + 1 ) : this[ t ]
+					);
+				} ),
+				( u.prototype.readInt16LE = function( t, e ) {
+					e || R( t, 2, this.length );
+					var n = this[ t ] | ( this[ t + 1 ] << 8 );
+					return 32768 & n ? 4294901760 | n : n;
+				} ),
+				( u.prototype.readInt16BE = function( t, e ) {
+					e || R( t, 2, this.length );
+					var n = this[ t + 1 ] | ( this[ t ] << 8 );
+					return 32768 & n ? 4294901760 | n : n;
+				} ),
+				( u.prototype.readInt32LE = function( t, e ) {
+					return (
+						e || R( t, 4, this.length ),
+						this[ t ] | ( this[ t + 1 ] << 8 ) | ( this[ t + 2 ] << 16 ) | ( this[ t + 3 ] << 24 )
+					);
+				} ),
+				( u.prototype.readInt32BE = function( t, e ) {
+					return (
+						e || R( t, 4, this.length ),
+						( this[ t ] << 24 ) | ( this[ t + 1 ] << 16 ) | ( this[ t + 2 ] << 8 ) | this[ t + 3 ]
+					);
+				} ),
+				( u.prototype.readFloatLE = function( t, e ) {
+					return e || R( t, 4, this.length ), i.read( this, t, ! 0, 23, 4 );
+				} ),
+				( u.prototype.readFloatBE = function( t, e ) {
+					return e || R( t, 4, this.length ), i.read( this, t, ! 1, 23, 4 );
+				} ),
+				( u.prototype.readDoubleLE = function( t, e ) {
+					return e || R( t, 8, this.length ), i.read( this, t, ! 0, 52, 8 );
+				} ),
+				( u.prototype.readDoubleBE = function( t, e ) {
+					return e || R( t, 8, this.length ), i.read( this, t, ! 1, 52, 8 );
+				} ),
+				( u.prototype.writeUIntLE = function( t, e, n, r ) {
+					( ( t = +t ), ( e |= 0 ), ( n |= 0 ), r ) ||
+						P( this, t, e, n, Math.pow( 2, 8 * n ) - 1, 0 );
+					var i = 1,
+						o = 0;
+					for ( this[ e ] = 255 & t; ++o < n && ( i *= 256 );  ) this[ e + o ] = ( t / i ) & 255;
+					return e + n;
+				} ),
+				( u.prototype.writeUIntBE = function( t, e, n, r ) {
+					( ( t = +t ), ( e |= 0 ), ( n |= 0 ), r ) ||
+						P( this, t, e, n, Math.pow( 2, 8 * n ) - 1, 0 );
+					var i = n - 1,
+						o = 1;
+					for ( this[ e + i ] = 255 & t; --i >= 0 && ( o *= 256 );  )
+						this[ e + i ] = ( t / o ) & 255;
+					return e + n;
+				} ),
+				( u.prototype.writeUInt8 = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 1, 255, 0 ),
+						u.TYPED_ARRAY_SUPPORT || ( t = Math.floor( t ) ),
+						( this[ e ] = 255 & t ),
+						e + 1
+					);
+				} ),
+				( u.prototype.writeUInt16LE = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 2, 65535, 0 ),
+						u.TYPED_ARRAY_SUPPORT
+							? ( ( this[ e ] = 255 & t ), ( this[ e + 1 ] = t >>> 8 ) )
+							: A( this, t, e, ! 0 ),
+						e + 2
+					);
+				} ),
+				( u.prototype.writeUInt16BE = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 2, 65535, 0 ),
+						u.TYPED_ARRAY_SUPPORT
+							? ( ( this[ e ] = t >>> 8 ), ( this[ e + 1 ] = 255 & t ) )
+							: A( this, t, e, ! 1 ),
+						e + 2
+					);
+				} ),
+				( u.prototype.writeUInt32LE = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 4, 4294967295, 0 ),
+						u.TYPED_ARRAY_SUPPORT
+							? ( ( this[ e + 3 ] = t >>> 24 ),
+							  ( this[ e + 2 ] = t >>> 16 ),
+							  ( this[ e + 1 ] = t >>> 8 ),
+							  ( this[ e ] = 255 & t ) )
+							: I( this, t, e, ! 0 ),
+						e + 4
+					);
+				} ),
+				( u.prototype.writeUInt32BE = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 4, 4294967295, 0 ),
+						u.TYPED_ARRAY_SUPPORT
+							? ( ( this[ e ] = t >>> 24 ),
+							  ( this[ e + 1 ] = t >>> 16 ),
+							  ( this[ e + 2 ] = t >>> 8 ),
+							  ( this[ e + 3 ] = 255 & t ) )
+							: I( this, t, e, ! 1 ),
+						e + 4
+					);
+				} ),
+				( u.prototype.writeIntLE = function( t, e, n, r ) {
+					if ( ( ( t = +t ), ( e |= 0 ), ! r ) ) {
+						var i = Math.pow( 2, 8 * n - 1 );
+						P( this, t, e, n, i - 1, -i );
+					}
+					var o = 0,
+						s = 1,
+						a = 0;
+					for ( this[ e ] = 255 & t; ++o < n && ( s *= 256 );  )
+						t < 0 && 0 === a && 0 !== this[ e + o - 1 ] && ( a = 1 ),
+							( this[ e + o ] = ( ( ( t / s ) >> 0 ) - a ) & 255 );
+					return e + n;
+				} ),
+				( u.prototype.writeIntBE = function( t, e, n, r ) {
+					if ( ( ( t = +t ), ( e |= 0 ), ! r ) ) {
+						var i = Math.pow( 2, 8 * n - 1 );
+						P( this, t, e, n, i - 1, -i );
+					}
+					var o = n - 1,
+						s = 1,
+						a = 0;
+					for ( this[ e + o ] = 255 & t; --o >= 0 && ( s *= 256 );  )
+						t < 0 && 0 === a && 0 !== this[ e + o + 1 ] && ( a = 1 ),
+							( this[ e + o ] = ( ( ( t / s ) >> 0 ) - a ) & 255 );
+					return e + n;
+				} ),
+				( u.prototype.writeInt8 = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 1, 127, -128 ),
+						u.TYPED_ARRAY_SUPPORT || ( t = Math.floor( t ) ),
+						t < 0 && ( t = 255 + t + 1 ),
+						( this[ e ] = 255 & t ),
+						e + 1
+					);
+				} ),
+				( u.prototype.writeInt16LE = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 2, 32767, -32768 ),
+						u.TYPED_ARRAY_SUPPORT
+							? ( ( this[ e ] = 255 & t ), ( this[ e + 1 ] = t >>> 8 ) )
+							: A( this, t, e, ! 0 ),
+						e + 2
+					);
+				} ),
+				( u.prototype.writeInt16BE = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 2, 32767, -32768 ),
+						u.TYPED_ARRAY_SUPPORT
+							? ( ( this[ e ] = t >>> 8 ), ( this[ e + 1 ] = 255 & t ) )
+							: A( this, t, e, ! 1 ),
+						e + 2
+					);
+				} ),
+				( u.prototype.writeInt32LE = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 4, 2147483647, -2147483648 ),
+						u.TYPED_ARRAY_SUPPORT
+							? ( ( this[ e ] = 255 & t ),
+							  ( this[ e + 1 ] = t >>> 8 ),
+							  ( this[ e + 2 ] = t >>> 16 ),
+							  ( this[ e + 3 ] = t >>> 24 ) )
+							: I( this, t, e, ! 0 ),
+						e + 4
+					);
+				} ),
+				( u.prototype.writeInt32BE = function( t, e, n ) {
+					return (
+						( t = +t ),
+						( e |= 0 ),
+						n || P( this, t, e, 4, 2147483647, -2147483648 ),
+						t < 0 && ( t = 4294967295 + t + 1 ),
+						u.TYPED_ARRAY_SUPPORT
+							? ( ( this[ e ] = t >>> 24 ),
+							  ( this[ e + 1 ] = t >>> 16 ),
+							  ( this[ e + 2 ] = t >>> 8 ),
+							  ( this[ e + 3 ] = 255 & t ) )
+							: I( this, t, e, ! 1 ),
+						e + 4
+					);
+				} ),
+				( u.prototype.writeFloatLE = function( t, e, n ) {
+					return L( this, t, e, ! 0, n );
+				} ),
+				( u.prototype.writeFloatBE = function( t, e, n ) {
+					return L( this, t, e, ! 1, n );
+				} ),
+				( u.prototype.writeDoubleLE = function( t, e, n ) {
+					return U( this, t, e, ! 0, n );
+				} ),
+				( u.prototype.writeDoubleBE = function( t, e, n ) {
+					return U( this, t, e, ! 1, n );
+				} ),
+				( u.prototype.copy = function( t, e, n, r ) {
+					if (
+						( n || ( n = 0 ),
+						r || 0 === r || ( r = this.length ),
+						e >= t.length && ( e = t.length ),
+						e || ( e = 0 ),
+						r > 0 && r < n && ( r = n ),
+						r === n )
+					)
+						return 0;
+					if ( 0 === t.length || 0 === this.length ) return 0;
+					if ( e < 0 ) throw new RangeError( 'targetStart out of bounds' );
+					if ( n < 0 || n >= this.length ) throw new RangeError( 'sourceStart out of bounds' );
+					if ( r < 0 ) throw new RangeError( 'sourceEnd out of bounds' );
+					r > this.length && ( r = this.length ), t.length - e < r - n && ( r = t.length - e + n );
+					var i,
+						o = r - n;
+					if ( this === t && n < e && e < r )
+						for ( i = o - 1; i >= 0; --i ) t[ i + e ] = this[ i + n ];
+					else if ( o < 1e3 || ! u.TYPED_ARRAY_SUPPORT )
+						for ( i = 0; i < o; ++i ) t[ i + e ] = this[ i + n ];
+					else Uint8Array.prototype.set.call( t, this.subarray( n, n + o ), e );
+					return o;
+				} ),
+				( u.prototype.fill = function( t, e, n, r ) {
+					if ( 'string' == typeof t ) {
+						if (
+							( 'string' == typeof e
+								? ( ( r = e ), ( e = 0 ), ( n = this.length ) )
+								: 'string' == typeof n && ( ( r = n ), ( n = this.length ) ),
+							1 === t.length )
+						) {
+							var i = t.charCodeAt( 0 );
+							i < 256 && ( t = i );
+						}
+						if ( void 0 !== r && 'string' != typeof r )
+							throw new TypeError( 'encoding must be a string' );
+						if ( 'string' == typeof r && ! u.isEncoding( r ) )
+							throw new TypeError( 'Unknown encoding: ' + r );
+					} else 'number' == typeof t && ( t &= 255 );
+					if ( e < 0 || this.length < e || this.length < n )
+						throw new RangeError( 'Out of range index' );
+					if ( n <= e ) return this;
+					var o;
+					if (
+						( ( e >>>= 0 ),
+						( n = void 0 === n ? this.length : n >>> 0 ),
+						t || ( t = 0 ),
+						'number' == typeof t )
+					)
+						for ( o = e; o < n; ++o ) this[ o ] = t;
+					else {
+						var s = u.isBuffer( t ) ? t : q( new u( t, r ).toString() ),
+							a = s.length;
+						for ( o = 0; o < n - e; ++o ) this[ o + e ] = s[ o % a ];
+					}
+					return this;
+				} );
+			var N = /[^+\/0-9A-Za-z-_]/g;
+			function B( t ) {
+				return t < 16 ? '0' + t.toString( 16 ) : t.toString( 16 );
+			}
+			function q( t, e ) {
+				var n;
+				e = e || 1 / 0;
+				for ( var r = t.length, i = null, o = [], s = 0; s < r; ++s ) {
+					if ( ( n = t.charCodeAt( s ) ) > 55295 && n < 57344 ) {
+						if ( ! i ) {
+							if ( n > 56319 ) {
+								( e -= 3 ) > -1 && o.push( 239, 191, 189 );
+								continue;
+							}
+							if ( s + 1 === r ) {
+								( e -= 3 ) > -1 && o.push( 239, 191, 189 );
+								continue;
+							}
+							i = n;
+							continue;
+						}
+						if ( n < 56320 ) {
+							( e -= 3 ) > -1 && o.push( 239, 191, 189 ), ( i = n );
+							continue;
+						}
+						n = 65536 + ( ( ( i - 55296 ) << 10 ) | ( n - 56320 ) );
+					} else i && ( e -= 3 ) > -1 && o.push( 239, 191, 189 );
+					if ( ( ( i = null ), n < 128 ) ) {
+						if ( ( e -= 1 ) < 0 ) break;
+						o.push( n );
+					} else if ( n < 2048 ) {
+						if ( ( e -= 2 ) < 0 ) break;
+						o.push( ( n >> 6 ) | 192, ( 63 & n ) | 128 );
+					} else if ( n < 65536 ) {
+						if ( ( e -= 3 ) < 0 ) break;
+						o.push( ( n >> 12 ) | 224, ( ( n >> 6 ) & 63 ) | 128, ( 63 & n ) | 128 );
+					} else {
+						if ( ! ( n < 1114112 ) ) throw new Error( 'Invalid code point' );
+						if ( ( e -= 4 ) < 0 ) break;
+						o.push(
+							( n >> 18 ) | 240,
+							( ( n >> 12 ) & 63 ) | 128,
+							( ( n >> 6 ) & 63 ) | 128,
+							( 63 & n ) | 128
+						);
+					}
+				}
+				return o;
+			}
+			function F( t ) {
+				return r.toByteArray(
+					( function( t ) {
+						if (
+							( t = ( function( t ) {
+								return t.trim ? t.trim() : t.replace( /^\s+|\s+$/g, '' );
+							} )( t ).replace( N, '' ) ).length < 2
+						)
+							return '';
+						for ( ; t.length % 4 != 0;  ) t += '=';
+						return t;
+					} )( t )
+				);
+			}
+			function H( t, e, n, r ) {
+				for ( var i = 0; i < r && ! ( i + n >= e.length || i >= t.length ); ++i )
+					e[ i + n ] = t[ i ];
+				return i;
+			}
+		}.call( this, n( 0 ) ) );
+	},
+	function( t, e, n ) {
+		( function( t ) {
+			function n( t ) {
+				return Object.prototype.toString.call( t );
+			}
+			( e.isArray = function( t ) {
+				return Array.isArray ? Array.isArray( t ) : '[object Array]' === n( t );
+			} ),
+				( e.isBoolean = function( t ) {
+					return 'boolean' == typeof t;
+				} ),
+				( e.isNull = function( t ) {
+					return null === t;
+				} ),
+				( e.isNullOrUndefined = function( t ) {
+					return null == t;
+				} ),
+				( e.isNumber = function( t ) {
+					return 'number' == typeof t;
+				} ),
+				( e.isString = function( t ) {
+					return 'string' == typeof t;
+				} ),
+				( e.isSymbol = function( t ) {
+					return 'symbol' == typeof t;
+				} ),
+				( e.isUndefined = function( t ) {
+					return void 0 === t;
+				} ),
+				( e.isRegExp = function( t ) {
+					return '[object RegExp]' === n( t );
+				} ),
+				( e.isObject = function( t ) {
+					return 'object' == typeof t && null !== t;
+				} ),
+				( e.isDate = function( t ) {
+					return '[object Date]' === n( t );
+				} ),
+				( e.isError = function( t ) {
+					return '[object Error]' === n( t ) || t instanceof Error;
+				} ),
+				( e.isFunction = function( t ) {
+					return 'function' == typeof t;
+				} ),
+				( e.isPrimitive = function( t ) {
+					return (
+						null === t ||
+						'boolean' == typeof t ||
+						'number' == typeof t ||
+						'string' == typeof t ||
+						'symbol' == typeof t ||
+						void 0 === t
+					);
+				} ),
+				( e.isBuffer = t.isBuffer );
+		}.call( this, n( 5 ).Buffer ) );
+	},
+	function( t, e, n ) {
+		'use strict';
+		( function( e ) {
+			void 0 === e ||
+			! e.version ||
+			0 === e.version.indexOf( 'v0.' ) ||
+			( 0 === e.version.indexOf( 'v1.' ) && 0 !== e.version.indexOf( 'v1.8.' ) )
+				? ( t.exports = {
+						nextTick: function( t, n, r, i ) {
+							if ( 'function' != typeof t )
+								throw new TypeError( '"callback" argument must be a function' );
+							var o,
+								s,
+								a = arguments.length;
+							switch ( a ) {
+								case 0:
+								case 1:
+									return e.nextTick( t );
+								case 2:
+									return e.nextTick( function() {
+										t.call( null, n );
+									} );
+								case 3:
+									return e.nextTick( function() {
+										t.call( null, n, r );
+									} );
+								case 4:
+									return e.nextTick( function() {
+										t.call( null, n, r, i );
+									} );
+								default:
+									for ( o = new Array( a - 1 ), s = 0; s < o.length;  ) o[ s++ ] = arguments[ s ];
+									return e.nextTick( function() {
+										t.apply( null, o );
+									} );
+							}
+						},
+				  } )
+				: ( t.exports = e );
+		}.call( this, n( 2 ) ) );
+	},
+	function( t, e, n ) {
+		var r = n( 5 ),
+			i = r.Buffer;
+		function o( t, e ) {
+			for ( var n in t ) e[ n ] = t[ n ];
+		}
+		function s( t, e, n ) {
+			return i( t, e, n );
+		}
+		i.from && i.alloc && i.allocUnsafe && i.allocUnsafeSlow
+			? ( t.exports = r )
+			: ( o( r, e ), ( e.Buffer = s ) ),
+			o( i, s ),
+			( s.from = function( t, e, n ) {
+				if ( 'number' == typeof t ) throw new TypeError( 'Argument must not be a number' );
+				return i( t, e, n );
+			} ),
+			( s.alloc = function( t, e, n ) {
+				if ( 'number' != typeof t ) throw new TypeError( 'Argument must be a number' );
+				var r = i( t );
+				return (
+					void 0 !== e ? ( 'string' == typeof n ? r.fill( e, n ) : r.fill( e ) ) : r.fill( 0 ), r
+				);
+			} ),
+			( s.allocUnsafe = function( t ) {
+				if ( 'number' != typeof t ) throw new TypeError( 'Argument must be a number' );
+				return i( t );
+			} ),
+			( s.allocUnsafeSlow = function( t ) {
+				if ( 'number' != typeof t ) throw new TypeError( 'Argument must be a number' );
+				return r.SlowBuffer( t );
+			} );
+	},
+	function( t, e, n ) {
+		( function( t ) {
+			var r =
+					Object.getOwnPropertyDescriptors ||
+					function( t ) {
+						for ( var e = Object.keys( t ), n = {}, r = 0; r < e.length; r++ )
+							n[ e[ r ] ] = Object.getOwnPropertyDescriptor( t, e[ r ] );
+						return n;
+					},
+				i = /%[sdj%]/g;
+			( e.format = function( t ) {
+				if ( ! m( t ) ) {
+					for ( var e = [], n = 0; n < arguments.length; n++ ) e.push( a( arguments[ n ] ) );
+					return e.join( ' ' );
+				}
+				n = 1;
+				for (
+					var r = arguments,
+						o = r.length,
+						s = String( t ).replace( i, function( t ) {
+							if ( '%%' === t ) return '%';
+							if ( n >= o ) return t;
+							switch ( t ) {
+								case '%s':
+									return String( r[ n++ ] );
+								case '%d':
+									return Number( r[ n++ ] );
+								case '%j':
+									try {
+										return JSON.stringify( r[ n++ ] );
+									} catch ( t ) {
+										return '[Circular]';
+									}
+								default:
+									return t;
+							}
+						} ),
+						u = r[ n ];
+					n < o;
+					u = r[ ++n ]
+				)
+					g( u ) || ! _( u ) ? ( s += ' ' + u ) : ( s += ' ' + a( u ) );
+				return s;
+			} ),
+				( e.deprecate = function( n, r ) {
+					if ( void 0 !== t && ! 0 === t.noDeprecation ) return n;
+					if ( void 0 === t )
+						return function() {
+							return e.deprecate( n, r ).apply( this, arguments );
+						};
+					var i = ! 1;
+					return function() {
+						if ( ! i ) {
+							if ( t.throwDeprecation ) throw new Error( r );
+							t.traceDeprecation ? console.trace( r ) : console.error( r ), ( i = ! 0 );
+						}
+						return n.apply( this, arguments );
+					};
+				} );
+			var o,
+				s = {};
+			function a( t, n ) {
+				var r = { seen: [], stylize: f };
+				return (
+					arguments.length >= 3 && ( r.depth = arguments[ 2 ] ),
+					arguments.length >= 4 && ( r.colors = arguments[ 3 ] ),
+					d( n ) ? ( r.showHidden = n ) : n && e._extend( r, n ),
+					v( r.showHidden ) && ( r.showHidden = ! 1 ),
+					v( r.depth ) && ( r.depth = 2 ),
+					v( r.colors ) && ( r.colors = ! 1 ),
+					v( r.customInspect ) && ( r.customInspect = ! 0 ),
+					r.colors && ( r.stylize = u ),
+					h( r, t, r.depth )
+				);
+			}
+			function u( t, e ) {
+				var n = a.styles[ e ];
+				return n ? '[' + a.colors[ n ][ 0 ] + 'm' + t + '[' + a.colors[ n ][ 1 ] + 'm' : t;
+			}
+			function f( t, e ) {
+				return t;
+			}
+			function h( t, n, r ) {
+				if (
+					t.customInspect &&
+					n &&
+					O( n.inspect ) &&
+					n.inspect !== e.inspect &&
+					( ! n.constructor || n.constructor.prototype !== n )
+				) {
+					var i = n.inspect( r, t );
+					return m( i ) || ( i = h( t, i, r ) ), i;
+				}
+				var o = ( function( t, e ) {
+					if ( v( e ) ) return t.stylize( 'undefined', 'undefined' );
+					if ( m( e ) ) {
+						var n =
+							"'" +
+							JSON.stringify( e )
+								.replace( /^"|"$/g, '' )
+								.replace( /'/g, "\\'" )
+								.replace( /\\"/g, '"' ) +
+							"'";
+						return t.stylize( n, 'string' );
+					}
+					if ( y( e ) ) return t.stylize( '' + e, 'number' );
+					if ( d( e ) ) return t.stylize( '' + e, 'boolean' );
+					if ( g( e ) ) return t.stylize( 'null', 'null' );
+				} )( t, n );
+				if ( o ) return o;
+				var s = Object.keys( n ),
+					a = ( function( t ) {
+						var e = {};
+						return (
+							t.forEach( function( t, n ) {
+								e[ t ] = ! 0;
+							} ),
+							e
+						);
+					} )( s );
+				if (
+					( t.showHidden && ( s = Object.getOwnPropertyNames( n ) ),
+					x( n ) && ( s.indexOf( 'message' ) >= 0 || s.indexOf( 'description' ) >= 0 ) )
+				)
+					return c( n );
+				if ( 0 === s.length ) {
+					if ( O( n ) ) {
+						var u = n.name ? ': ' + n.name : '';
+						return t.stylize( '[Function' + u + ']', 'special' );
+					}
+					if ( b( n ) ) return t.stylize( RegExp.prototype.toString.call( n ), 'regexp' );
+					if ( w( n ) ) return t.stylize( Date.prototype.toString.call( n ), 'date' );
+					if ( x( n ) ) return c( n );
+				}
+				var f,
+					_ = '',
+					S = ! 1,
+					E = [ '{', '}' ];
+				( p( n ) && ( ( S = ! 0 ), ( E = [ '[', ']' ] ) ), O( n ) ) &&
+					( _ = ' [Function' + ( n.name ? ': ' + n.name : '' ) + ']' );
+				return (
+					b( n ) && ( _ = ' ' + RegExp.prototype.toString.call( n ) ),
+					w( n ) && ( _ = ' ' + Date.prototype.toUTCString.call( n ) ),
+					x( n ) && ( _ = ' ' + c( n ) ),
+					0 !== s.length || ( S && 0 != n.length )
+						? r < 0
+							? b( n )
+								? t.stylize( RegExp.prototype.toString.call( n ), 'regexp' )
+								: t.stylize( '[Object]', 'special' )
+							: ( t.seen.push( n ),
+							  ( f = S
+									? ( function( t, e, n, r, i ) {
+											for ( var o = [], s = 0, a = e.length; s < a; ++s )
+												j( e, String( s ) )
+													? o.push( l( t, e, n, r, String( s ), ! 0 ) )
+													: o.push( '' );
+											return (
+												i.forEach( function( i ) {
+													i.match( /^\d+$/ ) || o.push( l( t, e, n, r, i, ! 0 ) );
+												} ),
+												o
+											);
+									  } )( t, n, r, a, s )
+									: s.map( function( e ) {
+											return l( t, n, r, a, e, S );
+									  } ) ),
+							  t.seen.pop(),
+							  ( function( t, e, n ) {
+									if (
+										t.reduce( function( t, e ) {
+											return (
+												e.indexOf( '\n' ) >= 0 && 0,
+												t + e.replace( /\u001b\[\d\d?m/g, '' ).length + 1
+											);
+										}, 0 ) > 60
+									)
+										return (
+											n[ 0 ] +
+											( '' === e ? '' : e + '\n ' ) +
+											' ' +
+											t.join( ',\n  ' ) +
+											' ' +
+											n[ 1 ]
+										);
+									return n[ 0 ] + e + ' ' + t.join( ', ' ) + ' ' + n[ 1 ];
+							  } )( f, _, E ) )
+						: E[ 0 ] + _ + E[ 1 ]
+				);
+			}
+			function c( t ) {
+				return '[' + Error.prototype.toString.call( t ) + ']';
+			}
+			function l( t, e, n, r, i, o ) {
+				var s, a, u;
+				if (
+					( ( u = Object.getOwnPropertyDescriptor( e, i ) || { value: e[ i ] } ).get
+						? ( a = u.set
+								? t.stylize( '[Getter/Setter]', 'special' )
+								: t.stylize( '[Getter]', 'special' ) )
+						: u.set && ( a = t.stylize( '[Setter]', 'special' ) ),
+					j( r, i ) || ( s = '[' + i + ']' ),
+					a ||
+						( t.seen.indexOf( u.value ) < 0
+							? ( a = g( n ) ? h( t, u.value, null ) : h( t, u.value, n - 1 ) ).indexOf( '\n' ) >
+									-1 &&
+							  ( a = o
+									? a
+											.split( '\n' )
+											.map( function( t ) {
+												return '  ' + t;
+											} )
+											.join( '\n' )
+											.substr( 2 )
+									: '\n' +
+									  a
+											.split( '\n' )
+											.map( function( t ) {
+												return '   ' + t;
+											} )
+											.join( '\n' ) )
+							: ( a = t.stylize( '[Circular]', 'special' ) ) ),
+					v( s ) )
+				) {
+					if ( o && i.match( /^\d+$/ ) ) return a;
+					( s = JSON.stringify( '' + i ) ).match( /^"([a-zA-Z_][a-zA-Z_0-9]*)"$/ )
+						? ( ( s = s.substr( 1, s.length - 2 ) ), ( s = t.stylize( s, 'name' ) ) )
+						: ( ( s = s
+								.replace( /'/g, "\\'" )
+								.replace( /\\"/g, '"' )
+								.replace( /(^"|"$)/g, "'" ) ),
+						  ( s = t.stylize( s, 'string' ) ) );
+				}
+				return s + ': ' + a;
+			}
+			function p( t ) {
+				return Array.isArray( t );
+			}
+			function d( t ) {
+				return 'boolean' == typeof t;
+			}
+			function g( t ) {
+				return null === t;
+			}
+			function y( t ) {
+				return 'number' == typeof t;
+			}
+			function m( t ) {
+				return 'string' == typeof t;
+			}
+			function v( t ) {
+				return void 0 === t;
+			}
+			function b( t ) {
+				return _( t ) && '[object RegExp]' === S( t );
+			}
+			function _( t ) {
+				return 'object' == typeof t && null !== t;
+			}
+			function w( t ) {
+				return _( t ) && '[object Date]' === S( t );
+			}
+			function x( t ) {
+				return _( t ) && ( '[object Error]' === S( t ) || t instanceof Error );
+			}
+			function O( t ) {
+				return 'function' == typeof t;
+			}
+			function S( t ) {
+				return Object.prototype.toString.call( t );
+			}
+			function E( t ) {
+				return t < 10 ? '0' + t.toString( 10 ) : t.toString( 10 );
+			}
+			( e.debuglog = function( n ) {
+				if ( ( v( o ) && ( o = t.env.NODE_DEBUG || '' ), ( n = n.toUpperCase() ), ! s[ n ] ) )
+					if ( new RegExp( '\\b' + n + '\\b', 'i' ).test( o ) ) {
+						var r = t.pid;
+						s[ n ] = function() {
+							var t = e.format.apply( e, arguments );
+							console.error( '%s %d: %s', n, r, t );
+						};
+					} else s[ n ] = function() {};
+				return s[ n ];
+			} ),
+				( e.inspect = a ),
+				( a.colors = {
+					bold: [ 1, 22 ],
+					italic: [ 3, 23 ],
+					underline: [ 4, 24 ],
+					inverse: [ 7, 27 ],
+					white: [ 37, 39 ],
+					grey: [ 90, 39 ],
+					black: [ 30, 39 ],
+					blue: [ 34, 39 ],
+					cyan: [ 36, 39 ],
+					green: [ 32, 39 ],
+					magenta: [ 35, 39 ],
+					red: [ 31, 39 ],
+					yellow: [ 33, 39 ],
+				} ),
+				( a.styles = {
+					special: 'cyan',
+					number: 'yellow',
+					boolean: 'yellow',
+					undefined: 'grey',
+					null: 'bold',
+					string: 'green',
+					date: 'magenta',
+					regexp: 'red',
+				} ),
+				( e.isArray = p ),
+				( e.isBoolean = d ),
+				( e.isNull = g ),
+				( e.isNullOrUndefined = function( t ) {
+					return null == t;
+				} ),
+				( e.isNumber = y ),
+				( e.isString = m ),
+				( e.isSymbol = function( t ) {
+					return 'symbol' == typeof t;
+				} ),
+				( e.isUndefined = v ),
+				( e.isRegExp = b ),
+				( e.isObject = _ ),
+				( e.isDate = w ),
+				( e.isError = x ),
+				( e.isFunction = O ),
+				( e.isPrimitive = function( t ) {
+					return (
+						null === t ||
+						'boolean' == typeof t ||
+						'number' == typeof t ||
+						'string' == typeof t ||
+						'symbol' == typeof t ||
+						void 0 === t
+					);
+				} ),
+				( e.isBuffer = n( 30 ) );
+			var k = [
+				'Jan',
+				'Feb',
+				'Mar',
+				'Apr',
+				'May',
+				'Jun',
+				'Jul',
+				'Aug',
+				'Sep',
+				'Oct',
+				'Nov',
+				'Dec',
+			];
+			function C() {
+				var t = new Date(),
+					e = [ E( t.getHours() ), E( t.getMinutes() ), E( t.getSeconds() ) ].join( ':' );
+				return [ t.getDate(), k[ t.getMonth() ], e ].join( ' ' );
+			}
+			function j( t, e ) {
+				return Object.prototype.hasOwnProperty.call( t, e );
+			}
+			( e.log = function() {
+				console.log( '%s - %s', C(), e.format.apply( e, arguments ) );
+			} ),
+				( e.inherits = n( 1 ) ),
+				( e._extend = function( t, e ) {
+					if ( ! e || ! _( e ) ) return t;
+					for ( var n = Object.keys( e ), r = n.length; r--;  ) t[ n[ r ] ] = e[ n[ r ] ];
+					return t;
+				} );
+			var T = 'undefined' != typeof Symbol ? Symbol( 'util.promisify.custom' ) : void 0;
+			function M( t, e ) {
+				if ( ! t ) {
+					var n = new Error( 'Promise was rejected with a falsy value' );
+					( n.reason = t ), ( t = n );
+				}
+				return e( t );
+			}
+			( e.promisify = function( t ) {
+				if ( 'function' != typeof t )
+					throw new TypeError( 'The "original" argument must be of type Function' );
+				if ( T && t[ T ] ) {
+					var e;
+					if ( 'function' != typeof ( e = t[ T ] ) )
+						throw new TypeError( 'The "util.promisify.custom" argument must be of type Function' );
+					return (
+						Object.defineProperty( e, T, {
+							value: e,
+							enumerable: ! 1,
+							writable: ! 1,
+							configurable: ! 0,
+						} ),
+						e
+					);
+				}
+				function e() {
+					for (
+						var e,
+							n,
+							r = new Promise( function( t, r ) {
+								( e = t ), ( n = r );
+							} ),
+							i = [],
+							o = 0;
+						o < arguments.length;
+						o++
+					)
+						i.push( arguments[ o ] );
+					i.push( function( t, r ) {
+						t ? n( t ) : e( r );
+					} );
+					try {
+						t.apply( this, i );
+					} catch ( t ) {
+						n( t );
+					}
+					return r;
+				}
+				return (
+					Object.setPrototypeOf( e, Object.getPrototypeOf( t ) ),
+					T &&
+						Object.defineProperty( e, T, {
+							value: e,
+							enumerable: ! 1,
+							writable: ! 1,
+							configurable: ! 0,
+						} ),
+					Object.defineProperties( e, r( t ) )
+				);
+			} ),
+				( e.promisify.custom = T ),
+				( e.callbackify = function( e ) {
+					if ( 'function' != typeof e )
+						throw new TypeError( 'The "original" argument must be of type Function' );
+					function n() {
+						for ( var n = [], r = 0; r < arguments.length; r++ ) n.push( arguments[ r ] );
+						var i = n.pop();
+						if ( 'function' != typeof i )
+							throw new TypeError( 'The last argument must be of type Function' );
+						var o = this,
+							s = function() {
+								return i.apply( o, arguments );
+							};
+						e.apply( this, n ).then(
+							function( e ) {
+								t.nextTick( s, null, e );
+							},
+							function( e ) {
+								t.nextTick( M, e, s );
+							}
+						);
+					}
+					return (
+						Object.setPrototypeOf( n, Object.getPrototypeOf( e ) ),
+						Object.defineProperties( n, r( e ) ),
+						n
+					);
+				} );
+		}.call( this, n( 2 ) ) );
+	},
+	function( t, e, n ) {
+		( function( t ) {
+			var r = ( void 0 !== t && t ) || ( 'undefined' != typeof self && self ) || window,
+				i = Function.prototype.apply;
+			function o( t, e ) {
+				( this._id = t ), ( this._clearFn = e );
+			}
+			( e.setTimeout = function() {
+				return new o( i.call( setTimeout, r, arguments ), clearTimeout );
+			} ),
+				( e.setInterval = function() {
+					return new o( i.call( setInterval, r, arguments ), clearInterval );
+				} ),
+				( e.clearTimeout = e.clearInterval = function( t ) {
+					t && t.close();
+				} ),
+				( o.prototype.unref = o.prototype.ref = function() {} ),
+				( o.prototype.close = function() {
+					this._clearFn.call( r, this._id );
+				} ),
+				( e.enroll = function( t, e ) {
+					clearTimeout( t._idleTimeoutId ), ( t._idleTimeout = e );
+				} ),
+				( e.unenroll = function( t ) {
+					clearTimeout( t._idleTimeoutId ), ( t._idleTimeout = -1 );
+				} ),
+				( e._unrefActive = e.active = function( t ) {
+					clearTimeout( t._idleTimeoutId );
+					var e = t._idleTimeout;
+					e >= 0 &&
+						( t._idleTimeoutId = setTimeout( function() {
+							t._onTimeout && t._onTimeout();
+						}, e ) );
+				} ),
+				n( 33 ),
+				( e.setImmediate =
+					( 'undefined' != typeof self && self.setImmediate ) ||
+					( void 0 !== t && t.setImmediate ) ||
+					( this && this.setImmediate ) ),
+				( e.clearImmediate =
+					( 'undefined' != typeof self && self.clearImmediate ) ||
+					( void 0 !== t && t.clearImmediate ) ||
+					( this && this.clearImmediate ) );
+		}.call( this, n( 0 ) ) );
+	},
+	function( t, e, n ) {
+		'use strict';
+		function r( t ) {
+			return ( r =
+				'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator
+					? function( t ) {
+							return typeof t;
+					  }
+					: function( t ) {
+							return t &&
+								'function' == typeof Symbol &&
+								t.constructor === Symbol &&
+								t !== Symbol.prototype
+								? 'symbol'
+								: typeof t;
+					  } )( t );
+		}
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			Object.defineProperty( e, 'parseMessage', {
+				enumerable: ! 0,
+				get: function() {
+					return o.default;
+				},
+			} ),
+			Object.defineProperty( e, 'parseVersionMessage', {
+				enumerable: ! 0,
+				get: function() {
+					return s.default;
+				},
+			} ),
+			( e.change = void 0 );
+		var i = ( function( t ) {
+			if ( t && t.__esModule ) return t;
+			if ( null === t || ( 'object' !== r( t ) && 'function' != typeof t ) ) return { default: t };
+			var e = u();
+			if ( e && e.has( t ) ) return e.get( t );
+			var n = {},
+				i = Object.defineProperty && Object.getOwnPropertyDescriptor;
+			for ( var o in t )
+				if ( Object.prototype.hasOwnProperty.call( t, o ) ) {
+					var s = i ? Object.getOwnPropertyDescriptor( t, o ) : null;
+					s && ( s.get || s.set ) ? Object.defineProperty( n, o, s ) : ( n[ o ] = t[ o ] );
+				}
+			( n.default = t ), e && e.set( t, n );
+			return n;
+		} )( n( 34 ) );
+		e.change = i;
+		var o = a( n( 38 ) ),
+			s = a( n( 39 ) );
+		function a( t ) {
+			return t && t.__esModule ? t : { default: t };
+		}
+		function u() {
+			if ( 'function' != typeof WeakMap ) return null;
+			var t = new WeakMap();
+			return (
+				( u = function() {
+					return t;
+				} ),
+				t
+			);
+		}
+	},
+	function( t, e, n ) {
+		'use strict';
+		var r = n( 62 ),
+			i = n( 64 );
+		function o() {
+			( this.protocol = null ),
+				( this.slashes = null ),
+				( this.auth = null ),
+				( this.host = null ),
+				( this.port = null ),
+				( this.hostname = null ),
+				( this.hash = null ),
+				( this.search = null ),
+				( this.query = null ),
+				( this.pathname = null ),
+				( this.path = null ),
+				( this.href = null );
+		}
+		( e.parse = b ),
+			( e.resolve = function( t, e ) {
+				return b( t, ! 1, ! 0 ).resolve( e );
+			} ),
+			( e.resolveObject = function( t, e ) {
+				return t ? b( t, ! 1, ! 0 ).resolveObject( e ) : e;
+			} ),
+			( e.format = function( t ) {
+				i.isString( t ) && ( t = b( t ) );
+				return t instanceof o ? t.format() : o.prototype.format.call( t );
+			} ),
+			( e.Url = o );
+		var s = /^([a-z0-9.+-]+:)/i,
+			a = /:[0-9]*$/,
+			u = /^(\/\/?(?!\/)[^\?\s]*)(\?[^\s]*)?$/,
+			f = [ '{', '}', '|', '\\', '^', '`' ].concat( [ '<', '>', '"', '`', ' ', '\r', '\n', '\t' ] ),
+			h = [ "'" ].concat( f ),
+			c = [ '%', '/', '?', ';', '#' ].concat( h ),
+			l = [ '/', '?', '#' ],
+			p = /^[+a-z0-9A-Z_-]{0,63}$/,
+			d = /^([+a-z0-9A-Z_-]{0,63})(.*)$/,
+			g = { javascript: ! 0, 'javascript:': ! 0 },
+			y = { javascript: ! 0, 'javascript:': ! 0 },
+			m = {
+				http: ! 0,
+				https: ! 0,
+				ftp: ! 0,
+				gopher: ! 0,
+				file: ! 0,
+				'http:': ! 0,
+				'https:': ! 0,
+				'ftp:': ! 0,
+				'gopher:': ! 0,
+				'file:': ! 0,
+			},
+			v = n( 65 );
+		function b( t, e, n ) {
+			if ( t && i.isObject( t ) && t instanceof o ) return t;
+			var r = new o();
+			return r.parse( t, e, n ), r;
+		}
+		( o.prototype.parse = function( t, e, n ) {
+			if ( ! i.isString( t ) )
+				throw new TypeError( "Parameter 'url' must be a string, not " + typeof t );
+			var o = t.indexOf( '?' ),
+				a = -1 !== o && o < t.indexOf( '#' ) ? '?' : '#',
+				f = t.split( a );
+			f[ 0 ] = f[ 0 ].replace( /\\/g, '/' );
+			var b = ( t = f.join( a ) );
+			if ( ( ( b = b.trim() ), ! n && 1 === t.split( '#' ).length ) ) {
+				var _ = u.exec( b );
+				if ( _ )
+					return (
+						( this.path = b ),
+						( this.href = b ),
+						( this.pathname = _[ 1 ] ),
+						_[ 2 ]
+							? ( ( this.search = _[ 2 ] ),
+							  ( this.query = e ? v.parse( this.search.substr( 1 ) ) : this.search.substr( 1 ) ) )
+							: e && ( ( this.search = '' ), ( this.query = {} ) ),
+						this
+					);
+			}
+			var w = s.exec( b );
+			if ( w ) {
+				var x = ( w = w[ 0 ] ).toLowerCase();
+				( this.protocol = x ), ( b = b.substr( w.length ) );
+			}
+			if ( n || w || b.match( /^\/\/[^@\/]+@[^@\/]+/ ) ) {
+				var O = '//' === b.substr( 0, 2 );
+				! O || ( w && y[ w ] ) || ( ( b = b.substr( 2 ) ), ( this.slashes = ! 0 ) );
+			}
+			if ( ! y[ w ] && ( O || ( w && ! m[ w ] ) ) ) {
+				for ( var S, E, k = -1, C = 0; C < l.length; C++ ) {
+					-1 !== ( j = b.indexOf( l[ C ] ) ) && ( -1 === k || j < k ) && ( k = j );
+				}
+				-1 !== ( E = -1 === k ? b.lastIndexOf( '@' ) : b.lastIndexOf( '@', k ) ) &&
+					( ( S = b.slice( 0, E ) ),
+					( b = b.slice( E + 1 ) ),
+					( this.auth = decodeURIComponent( S ) ) ),
+					( k = -1 );
+				for ( C = 0; C < c.length; C++ ) {
+					var j;
+					-1 !== ( j = b.indexOf( c[ C ] ) ) && ( -1 === k || j < k ) && ( k = j );
+				}
+				-1 === k && ( k = b.length ),
+					( this.host = b.slice( 0, k ) ),
+					( b = b.slice( k ) ),
+					this.parseHost(),
+					( this.hostname = this.hostname || '' );
+				var T = '[' === this.hostname[ 0 ] && ']' === this.hostname[ this.hostname.length - 1 ];
+				if ( ! T )
+					for ( var M = this.hostname.split( /\./ ), R = ( ( C = 0 ), M.length ); C < R; C++ ) {
+						var P = M[ C ];
+						if ( P && ! P.match( p ) ) {
+							for ( var A = '', I = 0, D = P.length; I < D; I++ )
+								P.charCodeAt( I ) > 127 ? ( A += 'x' ) : ( A += P[ I ] );
+							if ( ! A.match( p ) ) {
+								var L = M.slice( 0, C ),
+									U = M.slice( C + 1 ),
+									N = P.match( d );
+								N && ( L.push( N[ 1 ] ), U.unshift( N[ 2 ] ) ),
+									U.length && ( b = '/' + U.join( '.' ) + b ),
+									( this.hostname = L.join( '.' ) );
+								break;
+							}
+						}
+					}
+				this.hostname.length > 255
+					? ( this.hostname = '' )
+					: ( this.hostname = this.hostname.toLowerCase() ),
+					T || ( this.hostname = r.toASCII( this.hostname ) );
+				var B = this.port ? ':' + this.port : '',
+					q = this.hostname || '';
+				( this.host = q + B ),
+					( this.href += this.host ),
+					T &&
+						( ( this.hostname = this.hostname.substr( 1, this.hostname.length - 2 ) ),
+						'/' !== b[ 0 ] && ( b = '/' + b ) );
+			}
+			if ( ! g[ x ] )
+				for ( C = 0, R = h.length; C < R; C++ ) {
+					var F = h[ C ];
+					if ( -1 !== b.indexOf( F ) ) {
+						var H = encodeURIComponent( F );
+						H === F && ( H = escape( F ) ), ( b = b.split( F ).join( H ) );
+					}
+				}
+			var z = b.indexOf( '#' );
+			-1 !== z && ( ( this.hash = b.substr( z ) ), ( b = b.slice( 0, z ) ) );
+			var Y = b.indexOf( '?' );
+			if (
+				( -1 !== Y
+					? ( ( this.search = b.substr( Y ) ),
+					  ( this.query = b.substr( Y + 1 ) ),
+					  e && ( this.query = v.parse( this.query ) ),
+					  ( b = b.slice( 0, Y ) ) )
+					: e && ( ( this.search = '' ), ( this.query = {} ) ),
+				b && ( this.pathname = b ),
+				m[ x ] && this.hostname && ! this.pathname && ( this.pathname = '/' ),
+				this.pathname || this.search )
+			) {
+				B = this.pathname || '';
+				var W = this.search || '';
+				this.path = B + W;
+			}
+			return ( this.href = this.format() ), this;
+		} ),
+			( o.prototype.format = function() {
+				var t = this.auth || '';
+				t && ( ( t = ( t = encodeURIComponent( t ) ).replace( /%3A/i, ':' ) ), ( t += '@' ) );
+				var e = this.protocol || '',
+					n = this.pathname || '',
+					r = this.hash || '',
+					o = ! 1,
+					s = '';
+				this.host
+					? ( o = t + this.host )
+					: this.hostname &&
+					  ( ( o =
+							t +
+							( -1 === this.hostname.indexOf( ':' ) ? this.hostname : '[' + this.hostname + ']' ) ),
+					  this.port && ( o += ':' + this.port ) ),
+					this.query &&
+						i.isObject( this.query ) &&
+						Object.keys( this.query ).length &&
+						( s = v.stringify( this.query ) );
+				var a = this.search || ( s && '?' + s ) || '';
+				return (
+					e && ':' !== e.substr( -1 ) && ( e += ':' ),
+					this.slashes || ( ( ! e || m[ e ] ) && ! 1 !== o )
+						? ( ( o = '//' + ( o || '' ) ), n && '/' !== n.charAt( 0 ) && ( n = '/' + n ) )
+						: o || ( o = '' ),
+					r && '#' !== r.charAt( 0 ) && ( r = '#' + r ),
+					a && '?' !== a.charAt( 0 ) && ( a = '?' + a ),
+					e +
+						o +
+						( n = n.replace( /[?#]/g, function( t ) {
+							return encodeURIComponent( t );
+						} ) ) +
+						( a = a.replace( '#', '%23' ) ) +
+						r
+				);
+			} ),
+			( o.prototype.resolve = function( t ) {
+				return this.resolveObject( b( t, ! 1, ! 0 ) ).format();
+			} ),
+			( o.prototype.resolveObject = function( t ) {
+				if ( i.isString( t ) ) {
+					var e = new o();
+					e.parse( t, ! 1, ! 0 ), ( t = e );
+				}
+				for ( var n = new o(), r = Object.keys( this ), s = 0; s < r.length; s++ ) {
+					var a = r[ s ];
+					n[ a ] = this[ a ];
+				}
+				if ( ( ( n.hash = t.hash ), '' === t.href ) ) return ( n.href = n.format() ), n;
+				if ( t.slashes && ! t.protocol ) {
+					for ( var u = Object.keys( t ), f = 0; f < u.length; f++ ) {
+						var h = u[ f ];
+						'protocol' !== h && ( n[ h ] = t[ h ] );
+					}
+					return (
+						m[ n.protocol ] && n.hostname && ! n.pathname && ( n.path = n.pathname = '/' ),
+						( n.href = n.format() ),
+						n
+					);
+				}
+				if ( t.protocol && t.protocol !== n.protocol ) {
+					if ( ! m[ t.protocol ] ) {
+						for ( var c = Object.keys( t ), l = 0; l < c.length; l++ ) {
+							var p = c[ l ];
+							n[ p ] = t[ p ];
+						}
+						return ( n.href = n.format() ), n;
+					}
+					if ( ( ( n.protocol = t.protocol ), t.host || y[ t.protocol ] ) ) n.pathname = t.pathname;
+					else {
+						for (
+							var d = ( t.pathname || '' ).split( '/' );
+							d.length && ! ( t.host = d.shift() );
+
+						);
+						t.host || ( t.host = '' ),
+							t.hostname || ( t.hostname = '' ),
+							'' !== d[ 0 ] && d.unshift( '' ),
+							d.length < 2 && d.unshift( '' ),
+							( n.pathname = d.join( '/' ) );
+					}
+					if (
+						( ( n.search = t.search ),
+						( n.query = t.query ),
+						( n.host = t.host || '' ),
+						( n.auth = t.auth ),
+						( n.hostname = t.hostname || t.host ),
+						( n.port = t.port ),
+						n.pathname || n.search )
+					) {
+						var g = n.pathname || '',
+							v = n.search || '';
+						n.path = g + v;
+					}
+					return ( n.slashes = n.slashes || t.slashes ), ( n.href = n.format() ), n;
+				}
+				var b = n.pathname && '/' === n.pathname.charAt( 0 ),
+					_ = t.host || ( t.pathname && '/' === t.pathname.charAt( 0 ) ),
+					w = _ || b || ( n.host && t.pathname ),
+					x = w,
+					O = ( n.pathname && n.pathname.split( '/' ) ) || [],
+					S =
+						( ( d = ( t.pathname && t.pathname.split( '/' ) ) || [] ),
+						n.protocol && ! m[ n.protocol ] );
+				if (
+					( S &&
+						( ( n.hostname = '' ),
+						( n.port = null ),
+						n.host && ( '' === O[ 0 ] ? ( O[ 0 ] = n.host ) : O.unshift( n.host ) ),
+						( n.host = '' ),
+						t.protocol &&
+							( ( t.hostname = null ),
+							( t.port = null ),
+							t.host && ( '' === d[ 0 ] ? ( d[ 0 ] = t.host ) : d.unshift( t.host ) ),
+							( t.host = null ) ),
+						( w = w && ( '' === d[ 0 ] || '' === O[ 0 ] ) ) ),
+					_ )
+				)
+					( n.host = t.host || '' === t.host ? t.host : n.host ),
+						( n.hostname = t.hostname || '' === t.hostname ? t.hostname : n.hostname ),
+						( n.search = t.search ),
+						( n.query = t.query ),
+						( O = d );
+				else if ( d.length )
+					O || ( O = [] ),
+						O.pop(),
+						( O = O.concat( d ) ),
+						( n.search = t.search ),
+						( n.query = t.query );
+				else if ( ! i.isNullOrUndefined( t.search ) ) {
+					if ( S )
+						( n.hostname = n.host = O.shift() ),
+							( T = !! ( n.host && n.host.indexOf( '@' ) > 0 ) && n.host.split( '@' ) ) &&
+								( ( n.auth = T.shift() ), ( n.host = n.hostname = T.shift() ) );
+					return (
+						( n.search = t.search ),
+						( n.query = t.query ),
+						( i.isNull( n.pathname ) && i.isNull( n.search ) ) ||
+							( n.path = ( n.pathname ? n.pathname : '' ) + ( n.search ? n.search : '' ) ),
+						( n.href = n.format() ),
+						n
+					);
+				}
+				if ( ! O.length )
+					return (
+						( n.pathname = null ),
+						n.search ? ( n.path = '/' + n.search ) : ( n.path = null ),
+						( n.href = n.format() ),
+						n
+					);
+				for (
+					var E = O.slice( -1 )[ 0 ],
+						k = ( ( n.host || t.host || O.length > 1 ) && ( '.' === E || '..' === E ) ) || '' === E,
+						C = 0,
+						j = O.length;
+					j >= 0;
+					j--
+				)
+					'.' === ( E = O[ j ] )
+						? O.splice( j, 1 )
+						: '..' === E
+						? ( O.splice( j, 1 ), C++ )
+						: C && ( O.splice( j, 1 ), C-- );
+				if ( ! w && ! x ) for ( ; C--; C ) O.unshift( '..' );
+				! w || '' === O[ 0 ] || ( O[ 0 ] && '/' === O[ 0 ].charAt( 0 ) ) || O.unshift( '' ),
+					k && '/' !== O.join( '/' ).substr( -1 ) && O.push( '' );
+				var T,
+					M = '' === O[ 0 ] || ( O[ 0 ] && '/' === O[ 0 ].charAt( 0 ) );
+				S &&
+					( ( n.hostname = n.host = M ? '' : O.length ? O.shift() : '' ),
+					( T = !! ( n.host && n.host.indexOf( '@' ) > 0 ) && n.host.split( '@' ) ) &&
+						( ( n.auth = T.shift() ), ( n.host = n.hostname = T.shift() ) ) );
+				return (
+					( w = w || ( n.host && O.length ) ) && ! M && O.unshift( '' ),
+					O.length ? ( n.pathname = O.join( '/' ) ) : ( ( n.pathname = null ), ( n.path = null ) ),
+					( i.isNull( n.pathname ) && i.isNull( n.search ) ) ||
+						( n.path = ( n.pathname ? n.pathname : '' ) + ( n.search ? n.search : '' ) ),
+					( n.auth = t.auth || n.auth ),
+					( n.slashes = n.slashes || t.slashes ),
+					( n.href = n.format() ),
+					n
+				);
+			} ),
+			( o.prototype.parseHost = function() {
+				var t = this.host,
+					e = a.exec( t );
+				e &&
+					( ':' !== ( e = e[ 0 ] ) && ( this.port = e.substr( 1 ) ),
+					( t = t.substr( 0, t.length - e.length ) ) ),
+					t && ( this.hostname = t );
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ), ( e.default = u );
+		var r = n( 3 ),
+			i = n( 9 ),
+			o = n( 14 ),
+			s = function( t ) {
+				return new Promise( function( e, n ) {
+					t( function( t, r ) {
+						return t ? n( t ) : e( r );
+					} );
+				} );
+			},
+			a = function( t, e ) {
+				return 'function' == typeof t
+					? e.then(
+							function( e ) {
+								return t( null, e ), e;
+							},
+							function( e ) {
+								return t( e ), e;
+							}
+					  )
+					: e;
+			};
+		function u( t, e, n ) {
+			var i,
+				o = this;
+			r.EventEmitter.call( this ),
+				( this.name = t ),
+				( this.store = e( this ) ),
+				( this.storeAPI =
+					( ( i = this.store ),
+					{
+						get: function( t ) {
+							return s( i.get.bind( i, t ) );
+						},
+						update: function( t, e, n ) {
+							return s( i.update.bind( i, t, e, n ) );
+						},
+						remove: function( t ) {
+							return s( i.remove.bind( i, t ) );
+						},
+						find: function( t ) {
+							return s( i.find.bind( i, t ) );
+						},
+					} ) ),
+				( this.isIndexing = ! 1 ),
+				( this.onChannelIndex = this.emit.bind( this, 'index' ) ),
+				( this.onChannelError = this.emit.bind( this, 'error' ) ),
+				( this.onChannelUpdate = function( t, e, n, r, i ) {
+					o.update( t, e, { original: n, patch: r, isIndexing: i }, { sync: ! 1 } );
+				} ),
+				( this.onChannelIndexingStateChange = function( t ) {
+					( o.isIndexing = t ), t && o.emit( 'indexing' );
+				} ),
+				( this.onChannelRemove = function( t ) {
+					return o.remove( t );
+				} ),
+				n && this.setChannel( n );
+		}
+		( 0, i.inherits )( u, r.EventEmitter ),
+			( u.prototype.setChannel = function( t ) {
+				var e = this;
+				this.channel &&
+					this.channel
+						.removeListener( 'index', this.onChannelIndex )
+						.removeListener( 'error', this.onChannelError )
+						.removeListener( 'update', this.onChannelUpdate )
+						.removeListener( 'indexingStateChange', this.onChannelIndexingStateChange )
+						.removeListener( 'remove', this.onChannelRemove ),
+					( this.channel = t ),
+					t
+						.on( 'index', this.onChannelIndex )
+						.on( 'error', this.onChannelError )
+						.on( 'update', this.onChannelUpdate )
+						.on( 'indexingStateChange', this.onChannelIndexingStateChange )
+						.on( 'remove', this.onChannelRemove );
+				var n = function( t ) {
+					return e.get( t ).then( function( t ) {
+						if ( t ) return t.data;
+					} );
+				};
+				t.beforeNetworkChange( function( t ) {
+					for ( var r = arguments.length, i = new Array( r > 1 ? r - 1 : 0 ), o = 1; o < r; o++ )
+						i[ o - 1 ] = arguments[ o ];
+					var s = e.changeResolver
+						? Promise.resolve( e.changeResolver.apply( e, [ t ].concat( i ) ) )
+						: Promise.resolve( null );
+					return s.then( function( e ) {
+						return e || n( t );
+					} );
+				} );
+			} ),
+			( u.prototype.beforeNetworkChange = function( t ) {
+				this.changeResolver = t;
+			} ),
+			( u.prototype.reload = function() {
+				this.channel.reload();
+			} ),
+			( u.prototype.add = function( t, e ) {
+				var n = ( 0, o.v4 )();
+				return this.update( n, t, e );
+			} ),
+			( u.prototype.get = function( t, e ) {
+				return a( e, this.storeAPI.get( t ) );
+			} ),
+			( u.prototype.update = function( t, e, n, r, i ) {
+				var o = this;
+				'function' == typeof n
+					? ( ( i = n ), ( r = { sync: ! 0 } ) )
+					: 'function' == typeof r && ( ( i = r ), ( r = { sync: ! 0 } ) ),
+					! 1 == !! r && ( r = { sync: ! 0 } );
+				var s = this.storeAPI
+					.update( t, e, this.isIndexing )
+					.then( function( t ) {
+						return o.channel.update( t, r.sync );
+					} )
+					.then( function( e ) {
+						return o.emit( 'update', t, e.data, n ), e;
+					} );
+				return a( i, s );
+			} ),
+			( u.prototype.hasLocalChanges = function( t ) {
+				return a( t, this.channel.hasLocalChanges() );
+			} ),
+			( u.prototype.getVersion = function( t, e ) {
+				return a( e, this.channel.getVersion( t ) );
+			} ),
+			( u.prototype.touch = function( t, e ) {
+				var n = this,
+					r = this.storeAPI.get( t ).then( function( t ) {
+						if ( t ) return n.update( t.id, t.data );
+					} );
+				return a( e, r );
+			} ),
+			( u.prototype.remove = function( t, e ) {
+				var n = this,
+					r = this.storeAPI.remove( t ).then( function( e ) {
+						return n.emit( 'remove', t ), n.channel.remove( t ), e;
+					} );
+				return a( e, r );
+			} ),
+			( u.prototype.find = function( t, e ) {
+				return a( e, this.storeAPI.find( t ) );
+			} ),
+			( u.prototype.getRevisions = function( t, e ) {
+				return a( e, this.channel.getRevisions( t ) );
+			} );
+	},
+	function( t, e, n ) {
+		var r = n( 31 ),
+			i = n( 17 ),
+			o = i;
+		( o.v1 = r ), ( o.v4 = i ), ( t.exports = o );
+	},
+	function( t, e ) {
+		var n =
+			( 'undefined' != typeof crypto &&
+				crypto.getRandomValues &&
+				crypto.getRandomValues.bind( crypto ) ) ||
+			( 'undefined' != typeof msCrypto &&
+				'function' == typeof window.msCrypto.getRandomValues &&
+				msCrypto.getRandomValues.bind( msCrypto ) );
+		if ( n ) {
+			var r = new Uint8Array( 16 );
+			t.exports = function() {
+				return n( r ), r;
+			};
+		} else {
+			var i = new Array( 16 );
+			t.exports = function() {
+				for ( var t, e = 0; e < 16; e++ )
+					0 == ( 3 & e ) && ( t = 4294967296 * Math.random() ),
+						( i[ e ] = ( t >>> ( ( 3 & e ) << 3 ) ) & 255 );
+				return i;
+			};
+		}
+	},
+	function( t, e ) {
+		for ( var n = [], r = 0; r < 256; ++r ) n[ r ] = ( r + 256 ).toString( 16 ).substr( 1 );
+		t.exports = function( t, e ) {
+			var r = e || 0,
+				i = n;
+			return [
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				'-',
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				'-',
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				'-',
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				'-',
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+				i[ t[ r++ ] ],
+			].join( '' );
+		};
+	},
+	function( t, e, n ) {
+		var r = n( 15 ),
+			i = n( 16 );
+		t.exports = function( t, e, n ) {
+			var o = ( e && n ) || 0;
+			'string' == typeof t && ( ( e = 'binary' === t ? new Array( 16 ) : null ), ( t = null ) );
+			var s = ( t = t || {} ).random || ( t.rng || r )();
+			if ( ( ( s[ 6 ] = ( 15 & s[ 6 ] ) | 64 ), ( s[ 8 ] = ( 63 & s[ 8 ] ) | 128 ), e ) )
+				for ( var a = 0; a < 16; ++a ) e[ o + a ] = s[ a ];
+			return e || i( s );
+		};
+	},
+	function( t, e ) {
+		var n = {}.toString;
+		t.exports =
+			Array.isArray ||
+			function( t ) {
+				return '[object Array]' == n.call( t );
+			};
+	},
+	function( t, e, n ) {
+		( function( t ) {
+			( e.fetch = a( t.fetch ) && a( t.ReadableStream ) ),
+				( e.writableStream = a( t.WritableStream ) ),
+				( e.abortController = a( t.AbortController ) ),
+				( e.blobConstructor = ! 1 );
+			try {
+				new Blob( [ new ArrayBuffer( 1 ) ] ), ( e.blobConstructor = ! 0 );
+			} catch ( t ) {}
+			var n;
+			function r() {
+				if ( void 0 !== n ) return n;
+				if ( t.XMLHttpRequest ) {
+					n = new t.XMLHttpRequest();
+					try {
+						n.open( 'GET', t.XDomainRequest ? '/' : 'https://example.com' );
+					} catch ( t ) {
+						n = null;
+					}
+				} else n = null;
+				return n;
+			}
+			function i( t ) {
+				var e = r();
+				if ( ! e ) return ! 1;
+				try {
+					return ( e.responseType = t ), e.responseType === t;
+				} catch ( t ) {}
+				return ! 1;
+			}
+			var o = void 0 !== t.ArrayBuffer,
+				s = o && a( t.ArrayBuffer.prototype.slice );
+			function a( t ) {
+				return 'function' == typeof t;
+			}
+			( e.arraybuffer = e.fetch || ( o && i( 'arraybuffer' ) ) ),
+				( e.msstream = ! e.fetch && s && i( 'ms-stream' ) ),
+				( e.mozchunkedarraybuffer = ! e.fetch && o && i( 'moz-chunked-arraybuffer' ) ),
+				( e.overrideMimeType = e.fetch || ( !! r() && a( r().overrideMimeType ) ) ),
+				( e.vbArray = a( t.VBArray ) ),
+				( n = null );
+		}.call( this, n( 0 ) ) );
+	},
+	function( t, e, n ) {
+		( function( t, r, i ) {
+			var o = n( 19 ),
+				s = n( 1 ),
+				a = n( 21 ),
+				u = ( e.readyStates = { UNSENT: 0, OPENED: 1, HEADERS_RECEIVED: 2, LOADING: 3, DONE: 4 } ),
+				f = ( e.IncomingMessage = function( e, n, s, u ) {
+					var f = this;
+					if (
+						( a.Readable.call( f ),
+						( f._mode = s ),
+						( f.headers = {} ),
+						( f.rawHeaders = [] ),
+						( f.trailers = {} ),
+						( f.rawTrailers = [] ),
+						f.on( 'end', function() {
+							t.nextTick( function() {
+								f.emit( 'close' );
+							} );
+						} ),
+						'fetch' === s )
+					) {
+						if (
+							( ( f._fetchResponse = n ),
+							( f.url = n.url ),
+							( f.statusCode = n.status ),
+							( f.statusMessage = n.statusText ),
+							n.headers.forEach( function( t, e ) {
+								( f.headers[ e.toLowerCase() ] = t ), f.rawHeaders.push( e, t );
+							} ),
+							o.writableStream )
+						) {
+							var h = new WritableStream( {
+								write: function( t ) {
+									return new Promise( function( e, n ) {
+										f._destroyed ? n() : f.push( new r( t ) ) ? e() : ( f._resumeFetch = e );
+									} );
+								},
+								close: function() {
+									i.clearTimeout( u ), f._destroyed || f.push( null );
+								},
+								abort: function( t ) {
+									f._destroyed || f.emit( 'error', t );
+								},
+							} );
+							try {
+								return void n.body.pipeTo( h ).catch( function( t ) {
+									i.clearTimeout( u ), f._destroyed || f.emit( 'error', t );
+								} );
+							} catch ( t ) {}
+						}
+						var c = n.body.getReader();
+						! ( function t() {
+							c.read()
+								.then( function( e ) {
+									if ( ! f._destroyed ) {
+										if ( e.done ) return i.clearTimeout( u ), void f.push( null );
+										f.push( new r( e.value ) ), t();
+									}
+								} )
+								.catch( function( t ) {
+									i.clearTimeout( u ), f._destroyed || f.emit( 'error', t );
+								} );
+						} )();
+					} else {
+						if (
+							( ( f._xhr = e ),
+							( f._pos = 0 ),
+							( f.url = e.responseURL ),
+							( f.statusCode = e.status ),
+							( f.statusMessage = e.statusText ),
+							e
+								.getAllResponseHeaders()
+								.split( /\r?\n/ )
+								.forEach( function( t ) {
+									var e = t.match( /^([^:]+):\s*(.*)/ );
+									if ( e ) {
+										var n = e[ 1 ].toLowerCase();
+										'set-cookie' === n
+											? ( void 0 === f.headers[ n ] && ( f.headers[ n ] = [] ),
+											  f.headers[ n ].push( e[ 2 ] ) )
+											: void 0 !== f.headers[ n ]
+											? ( f.headers[ n ] += ', ' + e[ 2 ] )
+											: ( f.headers[ n ] = e[ 2 ] ),
+											f.rawHeaders.push( e[ 1 ], e[ 2 ] );
+									}
+								} ),
+							( f._charset = 'x-user-defined' ),
+							! o.overrideMimeType )
+						) {
+							var l = f.rawHeaders[ 'mime-type' ];
+							if ( l ) {
+								var p = l.match( /;\s*charset=([^;])(;|$)/ );
+								p && ( f._charset = p[ 1 ].toLowerCase() );
+							}
+							f._charset || ( f._charset = 'utf-8' );
+						}
+					}
+				} );
+			s( f, a.Readable ),
+				( f.prototype._read = function() {
+					var t = this._resumeFetch;
+					t && ( ( this._resumeFetch = null ), t() );
+				} ),
+				( f.prototype._onXHRProgress = function() {
+					var t = this,
+						e = t._xhr,
+						n = null;
+					switch ( t._mode ) {
+						case 'text:vbarray':
+							if ( e.readyState !== u.DONE ) break;
+							try {
+								n = new i.VBArray( e.responseBody ).toArray();
+							} catch ( t ) {}
+							if ( null !== n ) {
+								t.push( new r( n ) );
+								break;
+							}
+						case 'text':
+							try {
+								n = e.responseText;
+							} catch ( e ) {
+								t._mode = 'text:vbarray';
+								break;
+							}
+							if ( n.length > t._pos ) {
+								var o = n.substr( t._pos );
+								if ( 'x-user-defined' === t._charset ) {
+									for ( var s = new r( o.length ), a = 0; a < o.length; a++ )
+										s[ a ] = 255 & o.charCodeAt( a );
+									t.push( s );
+								} else t.push( o, t._charset );
+								t._pos = n.length;
+							}
+							break;
+						case 'arraybuffer':
+							if ( e.readyState !== u.DONE || ! e.response ) break;
+							( n = e.response ), t.push( new r( new Uint8Array( n ) ) );
+							break;
+						case 'moz-chunked-arraybuffer':
+							if ( ( ( n = e.response ), e.readyState !== u.LOADING || ! n ) ) break;
+							t.push( new r( new Uint8Array( n ) ) );
+							break;
+						case 'ms-stream':
+							if ( ( ( n = e.response ), e.readyState !== u.LOADING ) ) break;
+							var f = new i.MSStreamReader();
+							( f.onprogress = function() {
+								f.result.byteLength > t._pos &&
+									( t.push( new r( new Uint8Array( f.result.slice( t._pos ) ) ) ),
+									( t._pos = f.result.byteLength ) );
+							} ),
+								( f.onload = function() {
+									t.push( null );
+								} ),
+								f.readAsArrayBuffer( n );
+					}
+					t._xhr.readyState === u.DONE && 'ms-stream' !== t._mode && t.push( null );
+				} );
+		}.call( this, n( 2 ), n( 5 ).Buffer, n( 0 ) ) );
+	},
+	function( t, e, n ) {
+		( ( e = t.exports = n( 22 ) ).Stream = e ),
+			( e.Readable = e ),
+			( e.Writable = n( 25 ) ),
+			( e.Duplex = n( 4 ) ),
+			( e.Transform = n( 27 ) ),
+			( e.PassThrough = n( 58 ) );
+	},
+	function( t, e, n ) {
+		'use strict';
+		( function( e, r ) {
+			var i = n( 7 );
+			t.exports = b;
+			var o,
+				s = n( 18 );
+			b.ReadableState = v;
+			n( 3 ).EventEmitter;
+			var a = function( t, e ) {
+					return t.listeners( e ).length;
+				},
+				u = n( 23 ),
+				f = n( 8 ).Buffer,
+				h = e.Uint8Array || function() {};
+			var c = n( 6 );
+			c.inherits = n( 1 );
+			var l = n( 54 ),
+				p = void 0;
+			p = l && l.debuglog ? l.debuglog( 'stream' ) : function() {};
+			var d,
+				g = n( 55 ),
+				y = n( 24 );
+			c.inherits( b, u );
+			var m = [ 'error', 'close', 'destroy', 'pause', 'resume' ];
+			function v( t, e ) {
+				t = t || {};
+				var r = e instanceof ( o = o || n( 4 ) );
+				( this.objectMode = !! t.objectMode ),
+					r && ( this.objectMode = this.objectMode || !! t.readableObjectMode );
+				var i = t.highWaterMark,
+					s = t.readableHighWaterMark,
+					a = this.objectMode ? 16 : 16384;
+				( this.highWaterMark = i || 0 === i ? i : r && ( s || 0 === s ) ? s : a ),
+					( this.highWaterMark = Math.floor( this.highWaterMark ) ),
+					( this.buffer = new g() ),
+					( this.length = 0 ),
+					( this.pipes = null ),
+					( this.pipesCount = 0 ),
+					( this.flowing = null ),
+					( this.ended = ! 1 ),
+					( this.endEmitted = ! 1 ),
+					( this.reading = ! 1 ),
+					( this.sync = ! 0 ),
+					( this.needReadable = ! 1 ),
+					( this.emittedReadable = ! 1 ),
+					( this.readableListening = ! 1 ),
+					( this.resumeScheduled = ! 1 ),
+					( this.destroyed = ! 1 ),
+					( this.defaultEncoding = t.defaultEncoding || 'utf8' ),
+					( this.awaitDrain = 0 ),
+					( this.readingMore = ! 1 ),
+					( this.decoder = null ),
+					( this.encoding = null ),
+					t.encoding &&
+						( d || ( d = n( 26 ).StringDecoder ),
+						( this.decoder = new d( t.encoding ) ),
+						( this.encoding = t.encoding ) );
+			}
+			function b( t ) {
+				if ( ( ( o = o || n( 4 ) ), ! ( this instanceof b ) ) ) return new b( t );
+				( this._readableState = new v( t, this ) ),
+					( this.readable = ! 0 ),
+					t &&
+						( 'function' == typeof t.read && ( this._read = t.read ),
+						'function' == typeof t.destroy && ( this._destroy = t.destroy ) ),
+					u.call( this );
+			}
+			function _( t, e, n, r, i ) {
+				var o,
+					s = t._readableState;
+				null === e
+					? ( ( s.reading = ! 1 ),
+					  ( function( t, e ) {
+							if ( e.ended ) return;
+							if ( e.decoder ) {
+								var n = e.decoder.end();
+								n &&
+									n.length &&
+									( e.buffer.push( n ), ( e.length += e.objectMode ? 1 : n.length ) );
+							}
+							( e.ended = ! 0 ), O( t );
+					  } )( t, s ) )
+					: ( i ||
+							( o = ( function( t, e ) {
+								var n;
+								( r = e ),
+									f.isBuffer( r ) ||
+										r instanceof h ||
+										'string' == typeof e ||
+										void 0 === e ||
+										t.objectMode ||
+										( n = new TypeError( 'Invalid non-string/buffer chunk' ) );
+								var r;
+								return n;
+							} )( s, e ) ),
+					  o
+							? t.emit( 'error', o )
+							: s.objectMode || ( e && e.length > 0 )
+							? ( 'string' == typeof e ||
+									s.objectMode ||
+									Object.getPrototypeOf( e ) === f.prototype ||
+									( e = ( function( t ) {
+										return f.from( t );
+									} )( e ) ),
+							  r
+									? s.endEmitted
+										? t.emit( 'error', new Error( 'stream.unshift() after end event' ) )
+										: w( t, s, e, ! 0 )
+									: s.ended
+									? t.emit( 'error', new Error( 'stream.push() after EOF' ) )
+									: ( ( s.reading = ! 1 ),
+									  s.decoder && ! n
+											? ( ( e = s.decoder.write( e ) ),
+											  s.objectMode || 0 !== e.length ? w( t, s, e, ! 1 ) : E( t, s ) )
+											: w( t, s, e, ! 1 ) ) )
+							: r || ( s.reading = ! 1 ) );
+				return ( function( t ) {
+					return ! t.ended && ( t.needReadable || t.length < t.highWaterMark || 0 === t.length );
+				} )( s );
+			}
+			function w( t, e, n, r ) {
+				e.flowing && 0 === e.length && ! e.sync
+					? ( t.emit( 'data', n ), t.read( 0 ) )
+					: ( ( e.length += e.objectMode ? 1 : n.length ),
+					  r ? e.buffer.unshift( n ) : e.buffer.push( n ),
+					  e.needReadable && O( t ) ),
+					E( t, e );
+			}
+			Object.defineProperty( b.prototype, 'destroyed', {
+				get: function() {
+					return void 0 !== this._readableState && this._readableState.destroyed;
+				},
+				set: function( t ) {
+					this._readableState && ( this._readableState.destroyed = t );
+				},
+			} ),
+				( b.prototype.destroy = y.destroy ),
+				( b.prototype._undestroy = y.undestroy ),
+				( b.prototype._destroy = function( t, e ) {
+					this.push( null ), e( t );
+				} ),
+				( b.prototype.push = function( t, e ) {
+					var n,
+						r = this._readableState;
+					return (
+						r.objectMode
+							? ( n = ! 0 )
+							: 'string' == typeof t &&
+							  ( ( e = e || r.defaultEncoding ) !== r.encoding &&
+									( ( t = f.from( t, e ) ), ( e = '' ) ),
+							  ( n = ! 0 ) ),
+						_( this, t, e, ! 1, n )
+					);
+				} ),
+				( b.prototype.unshift = function( t ) {
+					return _( this, t, null, ! 0, ! 1 );
+				} ),
+				( b.prototype.isPaused = function() {
+					return ! 1 === this._readableState.flowing;
+				} ),
+				( b.prototype.setEncoding = function( t ) {
+					return (
+						d || ( d = n( 26 ).StringDecoder ),
+						( this._readableState.decoder = new d( t ) ),
+						( this._readableState.encoding = t ),
+						this
+					);
+				} );
+			function x( t, e ) {
+				return t <= 0 || ( 0 === e.length && e.ended )
+					? 0
+					: e.objectMode
+					? 1
+					: t != t
+					? e.flowing && e.length
+						? e.buffer.head.data.length
+						: e.length
+					: ( t > e.highWaterMark &&
+							( e.highWaterMark = ( function( t ) {
+								return (
+									t >= 8388608
+										? ( t = 8388608 )
+										: ( t--,
+										  ( t |= t >>> 1 ),
+										  ( t |= t >>> 2 ),
+										  ( t |= t >>> 4 ),
+										  ( t |= t >>> 8 ),
+										  ( t |= t >>> 16 ),
+										  t++ ),
+									t
+								);
+							} )( t ) ),
+					  t <= e.length ? t : e.ended ? e.length : ( ( e.needReadable = ! 0 ), 0 ) );
+			}
+			function O( t ) {
+				var e = t._readableState;
+				( e.needReadable = ! 1 ),
+					e.emittedReadable ||
+						( p( 'emitReadable', e.flowing ),
+						( e.emittedReadable = ! 0 ),
+						e.sync ? i.nextTick( S, t ) : S( t ) );
+			}
+			function S( t ) {
+				p( 'emit readable' ), t.emit( 'readable' ), T( t );
+			}
+			function E( t, e ) {
+				e.readingMore || ( ( e.readingMore = ! 0 ), i.nextTick( k, t, e ) );
+			}
+			function k( t, e ) {
+				for (
+					var n = e.length;
+					! e.reading &&
+					! e.flowing &&
+					! e.ended &&
+					e.length < e.highWaterMark &&
+					( p( 'maybeReadMore read 0' ), t.read( 0 ), n !== e.length );
+
+				)
+					n = e.length;
+				e.readingMore = ! 1;
+			}
+			function C( t ) {
+				p( 'readable nexttick read 0' ), t.read( 0 );
+			}
+			function j( t, e ) {
+				e.reading || ( p( 'resume read 0' ), t.read( 0 ) ),
+					( e.resumeScheduled = ! 1 ),
+					( e.awaitDrain = 0 ),
+					t.emit( 'resume' ),
+					T( t ),
+					e.flowing && ! e.reading && t.read( 0 );
+			}
+			function T( t ) {
+				var e = t._readableState;
+				for ( p( 'flow', e.flowing ); e.flowing && null !== t.read();  );
+			}
+			function M( t, e ) {
+				return 0 === e.length
+					? null
+					: ( e.objectMode
+							? ( n = e.buffer.shift() )
+							: ! t || t >= e.length
+							? ( ( n = e.decoder
+									? e.buffer.join( '' )
+									: 1 === e.buffer.length
+									? e.buffer.head.data
+									: e.buffer.concat( e.length ) ),
+							  e.buffer.clear() )
+							: ( n = ( function( t, e, n ) {
+									var r;
+									t < e.head.data.length
+										? ( ( r = e.head.data.slice( 0, t ) ),
+										  ( e.head.data = e.head.data.slice( t ) ) )
+										: ( r =
+												t === e.head.data.length
+													? e.shift()
+													: n
+													? ( function( t, e ) {
+															var n = e.head,
+																r = 1,
+																i = n.data;
+															t -= i.length;
+															for ( ; ( n = n.next );  ) {
+																var o = n.data,
+																	s = t > o.length ? o.length : t;
+																if (
+																	( s === o.length ? ( i += o ) : ( i += o.slice( 0, t ) ),
+																	0 === ( t -= s ) )
+																) {
+																	s === o.length
+																		? ( ++r,
+																		  n.next ? ( e.head = n.next ) : ( e.head = e.tail = null ) )
+																		: ( ( e.head = n ), ( n.data = o.slice( s ) ) );
+																	break;
+																}
+																++r;
+															}
+															return ( e.length -= r ), i;
+													  } )( t, e )
+													: ( function( t, e ) {
+															var n = f.allocUnsafe( t ),
+																r = e.head,
+																i = 1;
+															r.data.copy( n ), ( t -= r.data.length );
+															for ( ; ( r = r.next );  ) {
+																var o = r.data,
+																	s = t > o.length ? o.length : t;
+																if ( ( o.copy( n, n.length - t, 0, s ), 0 === ( t -= s ) ) ) {
+																	s === o.length
+																		? ( ++i,
+																		  r.next ? ( e.head = r.next ) : ( e.head = e.tail = null ) )
+																		: ( ( e.head = r ), ( r.data = o.slice( s ) ) );
+																	break;
+																}
+																++i;
+															}
+															return ( e.length -= i ), n;
+													  } )( t, e ) );
+									return r;
+							  } )( t, e.buffer, e.decoder ) ),
+					  n );
+				var n;
+			}
+			function R( t ) {
+				var e = t._readableState;
+				if ( e.length > 0 ) throw new Error( '"endReadable()" called on non-empty stream' );
+				e.endEmitted || ( ( e.ended = ! 0 ), i.nextTick( P, e, t ) );
+			}
+			function P( t, e ) {
+				t.endEmitted ||
+					0 !== t.length ||
+					( ( t.endEmitted = ! 0 ), ( e.readable = ! 1 ), e.emit( 'end' ) );
+			}
+			function A( t, e ) {
+				for ( var n = 0, r = t.length; n < r; n++ ) if ( t[ n ] === e ) return n;
+				return -1;
+			}
+			( b.prototype.read = function( t ) {
+				p( 'read', t ), ( t = parseInt( t, 10 ) );
+				var e = this._readableState,
+					n = t;
+				if (
+					( 0 !== t && ( e.emittedReadable = ! 1 ),
+					0 === t && e.needReadable && ( e.length >= e.highWaterMark || e.ended ) )
+				)
+					return (
+						p( 'read: emitReadable', e.length, e.ended ),
+						0 === e.length && e.ended ? R( this ) : O( this ),
+						null
+					);
+				if ( 0 === ( t = x( t, e ) ) && e.ended ) return 0 === e.length && R( this ), null;
+				var r,
+					i = e.needReadable;
+				return (
+					p( 'need readable', i ),
+					( 0 === e.length || e.length - t < e.highWaterMark ) &&
+						p( 'length less than watermark', ( i = ! 0 ) ),
+					e.ended || e.reading
+						? p( 'reading or ended', ( i = ! 1 ) )
+						: i &&
+						  ( p( 'do read' ),
+						  ( e.reading = ! 0 ),
+						  ( e.sync = ! 0 ),
+						  0 === e.length && ( e.needReadable = ! 0 ),
+						  this._read( e.highWaterMark ),
+						  ( e.sync = ! 1 ),
+						  e.reading || ( t = x( n, e ) ) ),
+					null === ( r = t > 0 ? M( t, e ) : null )
+						? ( ( e.needReadable = ! 0 ), ( t = 0 ) )
+						: ( e.length -= t ),
+					0 === e.length &&
+						( e.ended || ( e.needReadable = ! 0 ), n !== t && e.ended && R( this ) ),
+					null !== r && this.emit( 'data', r ),
+					r
+				);
+			} ),
+				( b.prototype._read = function( t ) {
+					this.emit( 'error', new Error( '_read() is not implemented' ) );
+				} ),
+				( b.prototype.pipe = function( t, e ) {
+					var n = this,
+						o = this._readableState;
+					switch ( o.pipesCount ) {
+						case 0:
+							o.pipes = t;
+							break;
+						case 1:
+							o.pipes = [ o.pipes, t ];
+							break;
+						default:
+							o.pipes.push( t );
+					}
+					( o.pipesCount += 1 ), p( 'pipe count=%d opts=%j', o.pipesCount, e );
+					var u = ( ! e || ! 1 !== e.end ) && t !== r.stdout && t !== r.stderr ? h : b;
+					function f( e, r ) {
+						p( 'onunpipe' ),
+							e === n &&
+								r &&
+								! 1 === r.hasUnpiped &&
+								( ( r.hasUnpiped = ! 0 ),
+								p( 'cleanup' ),
+								t.removeListener( 'close', m ),
+								t.removeListener( 'finish', v ),
+								t.removeListener( 'drain', c ),
+								t.removeListener( 'error', y ),
+								t.removeListener( 'unpipe', f ),
+								n.removeListener( 'end', h ),
+								n.removeListener( 'end', b ),
+								n.removeListener( 'data', g ),
+								( l = ! 0 ),
+								! o.awaitDrain || ( t._writableState && ! t._writableState.needDrain ) || c() );
+					}
+					function h() {
+						p( 'onend' ), t.end();
+					}
+					o.endEmitted ? i.nextTick( u ) : n.once( 'end', u ), t.on( 'unpipe', f );
+					var c = ( function( t ) {
+						return function() {
+							var e = t._readableState;
+							p( 'pipeOnDrain', e.awaitDrain ),
+								e.awaitDrain && e.awaitDrain--,
+								0 === e.awaitDrain && a( t, 'data' ) && ( ( e.flowing = ! 0 ), T( t ) );
+						};
+					} )( n );
+					t.on( 'drain', c );
+					var l = ! 1;
+					var d = ! 1;
+					function g( e ) {
+						p( 'ondata' ),
+							( d = ! 1 ),
+							! 1 !== t.write( e ) ||
+								d ||
+								( ( ( 1 === o.pipesCount && o.pipes === t ) ||
+									( o.pipesCount > 1 && -1 !== A( o.pipes, t ) ) ) &&
+									! l &&
+									( p( 'false write response, pause', n._readableState.awaitDrain ),
+									n._readableState.awaitDrain++,
+									( d = ! 0 ) ),
+								n.pause() );
+					}
+					function y( e ) {
+						p( 'onerror', e ),
+							b(),
+							t.removeListener( 'error', y ),
+							0 === a( t, 'error' ) && t.emit( 'error', e );
+					}
+					function m() {
+						t.removeListener( 'finish', v ), b();
+					}
+					function v() {
+						p( 'onfinish' ), t.removeListener( 'close', m ), b();
+					}
+					function b() {
+						p( 'unpipe' ), n.unpipe( t );
+					}
+					return (
+						n.on( 'data', g ),
+						( function( t, e, n ) {
+							if ( 'function' == typeof t.prependListener ) return t.prependListener( e, n );
+							t._events && t._events[ e ]
+								? s( t._events[ e ] )
+									? t._events[ e ].unshift( n )
+									: ( t._events[ e ] = [ n, t._events[ e ] ] )
+								: t.on( e, n );
+						} )( t, 'error', y ),
+						t.once( 'close', m ),
+						t.once( 'finish', v ),
+						t.emit( 'pipe', n ),
+						o.flowing || ( p( 'pipe resume' ), n.resume() ),
+						t
+					);
+				} ),
+				( b.prototype.unpipe = function( t ) {
+					var e = this._readableState,
+						n = { hasUnpiped: ! 1 };
+					if ( 0 === e.pipesCount ) return this;
+					if ( 1 === e.pipesCount )
+						return (
+							( t && t !== e.pipes ) ||
+								( t || ( t = e.pipes ),
+								( e.pipes = null ),
+								( e.pipesCount = 0 ),
+								( e.flowing = ! 1 ),
+								t && t.emit( 'unpipe', this, n ) ),
+							this
+						);
+					if ( ! t ) {
+						var r = e.pipes,
+							i = e.pipesCount;
+						( e.pipes = null ), ( e.pipesCount = 0 ), ( e.flowing = ! 1 );
+						for ( var o = 0; o < i; o++ ) r[ o ].emit( 'unpipe', this, n );
+						return this;
+					}
+					var s = A( e.pipes, t );
+					return (
+						-1 === s ||
+							( e.pipes.splice( s, 1 ),
+							( e.pipesCount -= 1 ),
+							1 === e.pipesCount && ( e.pipes = e.pipes[ 0 ] ),
+							t.emit( 'unpipe', this, n ) ),
+						this
+					);
+				} ),
+				( b.prototype.on = function( t, e ) {
+					var n = u.prototype.on.call( this, t, e );
+					if ( 'data' === t ) ! 1 !== this._readableState.flowing && this.resume();
+					else if ( 'readable' === t ) {
+						var r = this._readableState;
+						r.endEmitted ||
+							r.readableListening ||
+							( ( r.readableListening = r.needReadable = ! 0 ),
+							( r.emittedReadable = ! 1 ),
+							r.reading ? r.length && O( this ) : i.nextTick( C, this ) );
+					}
+					return n;
+				} ),
+				( b.prototype.addListener = b.prototype.on ),
+				( b.prototype.resume = function() {
+					var t = this._readableState;
+					return (
+						t.flowing ||
+							( p( 'resume' ),
+							( t.flowing = ! 0 ),
+							( function( t, e ) {
+								e.resumeScheduled || ( ( e.resumeScheduled = ! 0 ), i.nextTick( j, t, e ) );
+							} )( this, t ) ),
+						this
+					);
+				} ),
+				( b.prototype.pause = function() {
+					return (
+						p( 'call pause flowing=%j', this._readableState.flowing ),
+						! 1 !== this._readableState.flowing &&
+							( p( 'pause' ), ( this._readableState.flowing = ! 1 ), this.emit( 'pause' ) ),
+						this
+					);
+				} ),
+				( b.prototype.wrap = function( t ) {
+					var e = this,
+						n = this._readableState,
+						r = ! 1;
+					for ( var i in ( t.on( 'end', function() {
+						if ( ( p( 'wrapped end' ), n.decoder && ! n.ended ) ) {
+							var t = n.decoder.end();
+							t && t.length && e.push( t );
+						}
+						e.push( null );
+					} ),
+					t.on( 'data', function( i ) {
+						( p( 'wrapped data' ),
+						n.decoder && ( i = n.decoder.write( i ) ),
+						n.objectMode && null == i ) ||
+							( ( n.objectMode || ( i && i.length ) ) &&
+								( e.push( i ) || ( ( r = ! 0 ), t.pause() ) ) );
+					} ),
+					t ) )
+						void 0 === this[ i ] &&
+							'function' == typeof t[ i ] &&
+							( this[ i ] = ( function( e ) {
+								return function() {
+									return t[ e ].apply( t, arguments );
+								};
+							} )( i ) );
+					for ( var o = 0; o < m.length; o++ ) t.on( m[ o ], this.emit.bind( this, m[ o ] ) );
+					return (
+						( this._read = function( e ) {
+							p( 'wrapped _read', e ), r && ( ( r = ! 1 ), t.resume() );
+						} ),
+						this
+					);
+				} ),
+				Object.defineProperty( b.prototype, 'readableHighWaterMark', {
+					enumerable: ! 1,
+					get: function() {
+						return this._readableState.highWaterMark;
+					},
+				} ),
+				( b._fromList = M );
+		}.call( this, n( 0 ), n( 2 ) ) );
+	},
+	function( t, e, n ) {
+		t.exports = n( 3 ).EventEmitter;
+	},
+	function( t, e, n ) {
+		'use strict';
+		var r = n( 7 );
+		function i( t, e ) {
+			t.emit( 'error', e );
+		}
+		t.exports = {
+			destroy: function( t, e ) {
+				var n = this,
+					o = this._readableState && this._readableState.destroyed,
+					s = this._writableState && this._writableState.destroyed;
+				return o || s
+					? ( e
+							? e( t )
+							: ! t ||
+							  ( this._writableState && this._writableState.errorEmitted ) ||
+							  r.nextTick( i, this, t ),
+					  this )
+					: ( this._readableState && ( this._readableState.destroyed = ! 0 ),
+					  this._writableState && ( this._writableState.destroyed = ! 0 ),
+					  this._destroy( t || null, function( t ) {
+							! e && t
+								? ( r.nextTick( i, n, t ),
+								  n._writableState && ( n._writableState.errorEmitted = ! 0 ) )
+								: e && e( t );
+					  } ),
+					  this );
+			},
+			undestroy: function() {
+				this._readableState &&
+					( ( this._readableState.destroyed = ! 1 ),
+					( this._readableState.reading = ! 1 ),
+					( this._readableState.ended = ! 1 ),
+					( this._readableState.endEmitted = ! 1 ) ),
+					this._writableState &&
+						( ( this._writableState.destroyed = ! 1 ),
+						( this._writableState.ended = ! 1 ),
+						( this._writableState.ending = ! 1 ),
+						( this._writableState.finished = ! 1 ),
+						( this._writableState.errorEmitted = ! 1 ) );
+			},
+		};
+	},
+	function( t, e, n ) {
+		'use strict';
+		( function( e, r, i ) {
+			var o = n( 7 );
+			function s( t ) {
+				var e = this;
+				( this.next = null ),
+					( this.entry = null ),
+					( this.finish = function() {
+						! ( function( t, e, n ) {
+							var r = t.entry;
+							t.entry = null;
+							for ( ; r;  ) {
+								var i = r.callback;
+								e.pendingcb--, i( n ), ( r = r.next );
+							}
+							e.corkedRequestsFree
+								? ( e.corkedRequestsFree.next = t )
+								: ( e.corkedRequestsFree = t );
+						} )( e, t );
+					} );
+			}
+			t.exports = v;
+			var a,
+				u =
+					! e.browser && [ 'v0.10', 'v0.9.' ].indexOf( e.version.slice( 0, 5 ) ) > -1
+						? r
+						: o.nextTick;
+			v.WritableState = m;
+			var f = n( 6 );
+			f.inherits = n( 1 );
+			var h = { deprecate: n( 57 ) },
+				c = n( 23 ),
+				l = n( 8 ).Buffer,
+				p = i.Uint8Array || function() {};
+			var d,
+				g = n( 24 );
+			function y() {}
+			function m( t, e ) {
+				( a = a || n( 4 ) ), ( t = t || {} );
+				var r = e instanceof a;
+				( this.objectMode = !! t.objectMode ),
+					r && ( this.objectMode = this.objectMode || !! t.writableObjectMode );
+				var i = t.highWaterMark,
+					f = t.writableHighWaterMark,
+					h = this.objectMode ? 16 : 16384;
+				( this.highWaterMark = i || 0 === i ? i : r && ( f || 0 === f ) ? f : h ),
+					( this.highWaterMark = Math.floor( this.highWaterMark ) ),
+					( this.finalCalled = ! 1 ),
+					( this.needDrain = ! 1 ),
+					( this.ending = ! 1 ),
+					( this.ended = ! 1 ),
+					( this.finished = ! 1 ),
+					( this.destroyed = ! 1 );
+				var c = ! 1 === t.decodeStrings;
+				( this.decodeStrings = ! c ),
+					( this.defaultEncoding = t.defaultEncoding || 'utf8' ),
+					( this.length = 0 ),
+					( this.writing = ! 1 ),
+					( this.corked = 0 ),
+					( this.sync = ! 0 ),
+					( this.bufferProcessing = ! 1 ),
+					( this.onwrite = function( t ) {
+						! ( function( t, e ) {
+							var n = t._writableState,
+								r = n.sync,
+								i = n.writecb;
+							if (
+								( ( function( t ) {
+									( t.writing = ! 1 ),
+										( t.writecb = null ),
+										( t.length -= t.writelen ),
+										( t.writelen = 0 );
+								} )( n ),
+								e )
+							)
+								! ( function( t, e, n, r, i ) {
+									--e.pendingcb,
+										n
+											? ( o.nextTick( i, r ),
+											  o.nextTick( S, t, e ),
+											  ( t._writableState.errorEmitted = ! 0 ),
+											  t.emit( 'error', r ) )
+											: ( i( r ),
+											  ( t._writableState.errorEmitted = ! 0 ),
+											  t.emit( 'error', r ),
+											  S( t, e ) );
+								} )( t, n, r, e, i );
+							else {
+								var s = x( n );
+								s || n.corked || n.bufferProcessing || ! n.bufferedRequest || w( t, n ),
+									r ? u( _, t, n, s, i ) : _( t, n, s, i );
+							}
+						} )( e, t );
+					} ),
+					( this.writecb = null ),
+					( this.writelen = 0 ),
+					( this.bufferedRequest = null ),
+					( this.lastBufferedRequest = null ),
+					( this.pendingcb = 0 ),
+					( this.prefinished = ! 1 ),
+					( this.errorEmitted = ! 1 ),
+					( this.bufferedRequestCount = 0 ),
+					( this.corkedRequestsFree = new s( this ) );
+			}
+			function v( t ) {
+				if ( ( ( a = a || n( 4 ) ), ! ( d.call( v, this ) || this instanceof a ) ) )
+					return new v( t );
+				( this._writableState = new m( t, this ) ),
+					( this.writable = ! 0 ),
+					t &&
+						( 'function' == typeof t.write && ( this._write = t.write ),
+						'function' == typeof t.writev && ( this._writev = t.writev ),
+						'function' == typeof t.destroy && ( this._destroy = t.destroy ),
+						'function' == typeof t.final && ( this._final = t.final ) ),
+					c.call( this );
+			}
+			function b( t, e, n, r, i, o, s ) {
+				( e.writelen = r ),
+					( e.writecb = s ),
+					( e.writing = ! 0 ),
+					( e.sync = ! 0 ),
+					n ? t._writev( i, e.onwrite ) : t._write( i, o, e.onwrite ),
+					( e.sync = ! 1 );
+			}
+			function _( t, e, n, r ) {
+				n ||
+					( function( t, e ) {
+						0 === e.length && e.needDrain && ( ( e.needDrain = ! 1 ), t.emit( 'drain' ) );
+					} )( t, e ),
+					e.pendingcb--,
+					r(),
+					S( t, e );
+			}
+			function w( t, e ) {
+				e.bufferProcessing = ! 0;
+				var n = e.bufferedRequest;
+				if ( t._writev && n && n.next ) {
+					var r = e.bufferedRequestCount,
+						i = new Array( r ),
+						o = e.corkedRequestsFree;
+					o.entry = n;
+					for ( var a = 0, u = ! 0; n;  )
+						( i[ a ] = n ), n.isBuf || ( u = ! 1 ), ( n = n.next ), ( a += 1 );
+					( i.allBuffers = u ),
+						b( t, e, ! 0, e.length, i, '', o.finish ),
+						e.pendingcb++,
+						( e.lastBufferedRequest = null ),
+						o.next
+							? ( ( e.corkedRequestsFree = o.next ), ( o.next = null ) )
+							: ( e.corkedRequestsFree = new s( e ) ),
+						( e.bufferedRequestCount = 0 );
+				} else {
+					for ( ; n;  ) {
+						var f = n.chunk,
+							h = n.encoding,
+							c = n.callback;
+						if (
+							( b( t, e, ! 1, e.objectMode ? 1 : f.length, f, h, c ),
+							( n = n.next ),
+							e.bufferedRequestCount--,
+							e.writing )
+						)
+							break;
+					}
+					null === n && ( e.lastBufferedRequest = null );
+				}
+				( e.bufferedRequest = n ), ( e.bufferProcessing = ! 1 );
+			}
+			function x( t ) {
+				return (
+					t.ending && 0 === t.length && null === t.bufferedRequest && ! t.finished && ! t.writing
+				);
+			}
+			function O( t, e ) {
+				t._final( function( n ) {
+					e.pendingcb--,
+						n && t.emit( 'error', n ),
+						( e.prefinished = ! 0 ),
+						t.emit( 'prefinish' ),
+						S( t, e );
+				} );
+			}
+			function S( t, e ) {
+				var n = x( e );
+				return (
+					n &&
+						( ! ( function( t, e ) {
+							e.prefinished ||
+								e.finalCalled ||
+								( 'function' == typeof t._final
+									? ( e.pendingcb++, ( e.finalCalled = ! 0 ), o.nextTick( O, t, e ) )
+									: ( ( e.prefinished = ! 0 ), t.emit( 'prefinish' ) ) );
+						} )( t, e ),
+						0 === e.pendingcb && ( ( e.finished = ! 0 ), t.emit( 'finish' ) ) ),
+					n
+				);
+			}
+			f.inherits( v, c ),
+				( m.prototype.getBuffer = function() {
+					for ( var t = this.bufferedRequest, e = []; t;  ) e.push( t ), ( t = t.next );
+					return e;
+				} ),
+				( function() {
+					try {
+						Object.defineProperty( m.prototype, 'buffer', {
+							get: h.deprecate(
+								function() {
+									return this.getBuffer();
+								},
+								'_writableState.buffer is deprecated. Use _writableState.getBuffer instead.',
+								'DEP0003'
+							),
+						} );
+					} catch ( t ) {}
+				} )(),
+				'function' == typeof Symbol &&
+				Symbol.hasInstance &&
+				'function' == typeof Function.prototype[ Symbol.hasInstance ]
+					? ( ( d = Function.prototype[ Symbol.hasInstance ] ),
+					  Object.defineProperty( v, Symbol.hasInstance, {
+							value: function( t ) {
+								return !! d.call( this, t ) || ( this === v && t && t._writableState instanceof m );
+							},
+					  } ) )
+					: ( d = function( t ) {
+							return t instanceof this;
+					  } ),
+				( v.prototype.pipe = function() {
+					this.emit( 'error', new Error( 'Cannot pipe, not readable' ) );
+				} ),
+				( v.prototype.write = function( t, e, n ) {
+					var r,
+						i = this._writableState,
+						s = ! 1,
+						a = ! i.objectMode && ( ( r = t ), l.isBuffer( r ) || r instanceof p );
+					return (
+						a &&
+							! l.isBuffer( t ) &&
+							( t = ( function( t ) {
+								return l.from( t );
+							} )( t ) ),
+						'function' == typeof e && ( ( n = e ), ( e = null ) ),
+						a ? ( e = 'buffer' ) : e || ( e = i.defaultEncoding ),
+						'function' != typeof n && ( n = y ),
+						i.ended
+							? ( function( t, e ) {
+									var n = new Error( 'write after end' );
+									t.emit( 'error', n ), o.nextTick( e, n );
+							  } )( this, n )
+							: ( a ||
+									( function( t, e, n, r ) {
+										var i = ! 0,
+											s = ! 1;
+										return (
+											null === n
+												? ( s = new TypeError( 'May not write null values to stream' ) )
+												: 'string' == typeof n ||
+												  void 0 === n ||
+												  e.objectMode ||
+												  ( s = new TypeError( 'Invalid non-string/buffer chunk' ) ),
+											s && ( t.emit( 'error', s ), o.nextTick( r, s ), ( i = ! 1 ) ),
+											i
+										);
+									} )( this, i, t, n ) ) &&
+							  ( i.pendingcb++,
+							  ( s = ( function( t, e, n, r, i, o ) {
+									if ( ! n ) {
+										var s = ( function( t, e, n ) {
+											t.objectMode ||
+												! 1 === t.decodeStrings ||
+												'string' != typeof e ||
+												( e = l.from( e, n ) );
+											return e;
+										} )( e, r, i );
+										r !== s && ( ( n = ! 0 ), ( i = 'buffer' ), ( r = s ) );
+									}
+									var a = e.objectMode ? 1 : r.length;
+									e.length += a;
+									var u = e.length < e.highWaterMark;
+									u || ( e.needDrain = ! 0 );
+									if ( e.writing || e.corked ) {
+										var f = e.lastBufferedRequest;
+										( e.lastBufferedRequest = {
+											chunk: r,
+											encoding: i,
+											isBuf: n,
+											callback: o,
+											next: null,
+										} ),
+											f
+												? ( f.next = e.lastBufferedRequest )
+												: ( e.bufferedRequest = e.lastBufferedRequest ),
+											( e.bufferedRequestCount += 1 );
+									} else b( t, e, ! 1, a, r, i, o );
+									return u;
+							  } )( this, i, a, t, e, n ) ) ),
+						s
+					);
+				} ),
+				( v.prototype.cork = function() {
+					this._writableState.corked++;
+				} ),
+				( v.prototype.uncork = function() {
+					var t = this._writableState;
+					t.corked &&
+						( t.corked--,
+						t.writing ||
+							t.corked ||
+							t.finished ||
+							t.bufferProcessing ||
+							! t.bufferedRequest ||
+							w( this, t ) );
+				} ),
+				( v.prototype.setDefaultEncoding = function( t ) {
+					if (
+						( 'string' == typeof t && ( t = t.toLowerCase() ),
+						! (
+							[
+								'hex',
+								'utf8',
+								'utf-8',
+								'ascii',
+								'binary',
+								'base64',
+								'ucs2',
+								'ucs-2',
+								'utf16le',
+								'utf-16le',
+								'raw',
+							].indexOf( ( t + '' ).toLowerCase() ) > -1
+						) )
+					)
+						throw new TypeError( 'Unknown encoding: ' + t );
+					return ( this._writableState.defaultEncoding = t ), this;
+				} ),
+				Object.defineProperty( v.prototype, 'writableHighWaterMark', {
+					enumerable: ! 1,
+					get: function() {
+						return this._writableState.highWaterMark;
+					},
+				} ),
+				( v.prototype._write = function( t, e, n ) {
+					n( new Error( '_write() is not implemented' ) );
+				} ),
+				( v.prototype._writev = null ),
+				( v.prototype.end = function( t, e, n ) {
+					var r = this._writableState;
+					'function' == typeof t
+						? ( ( n = t ), ( t = null ), ( e = null ) )
+						: 'function' == typeof e && ( ( n = e ), ( e = null ) ),
+						null != t && this.write( t, e ),
+						r.corked && ( ( r.corked = 1 ), this.uncork() ),
+						r.ending ||
+							r.finished ||
+							( function( t, e, n ) {
+								( e.ending = ! 0 ),
+									S( t, e ),
+									n && ( e.finished ? o.nextTick( n ) : t.once( 'finish', n ) );
+								( e.ended = ! 0 ), ( t.writable = ! 1 );
+							} )( this, r, n );
+				} ),
+				Object.defineProperty( v.prototype, 'destroyed', {
+					get: function() {
+						return void 0 !== this._writableState && this._writableState.destroyed;
+					},
+					set: function( t ) {
+						this._writableState && ( this._writableState.destroyed = t );
+					},
+				} ),
+				( v.prototype.destroy = g.destroy ),
+				( v.prototype._undestroy = g.undestroy ),
+				( v.prototype._destroy = function( t, e ) {
+					this.end(), e( t );
+				} );
+		}.call( this, n( 2 ), n( 10 ).setImmediate, n( 0 ) ) );
+	},
+	function( t, e, n ) {
+		'use strict';
+		var r = n( 8 ).Buffer,
+			i =
+				r.isEncoding ||
+				function( t ) {
+					switch ( ( t = '' + t ) && t.toLowerCase() ) {
+						case 'hex':
+						case 'utf8':
+						case 'utf-8':
+						case 'ascii':
+						case 'binary':
+						case 'base64':
+						case 'ucs2':
+						case 'ucs-2':
+						case 'utf16le':
+						case 'utf-16le':
+						case 'raw':
+							return ! 0;
+						default:
+							return ! 1;
+					}
+				};
+		function o( t ) {
+			var e;
+			switch (
+				( ( this.encoding = ( function( t ) {
+					var e = ( function( t ) {
+						if ( ! t ) return 'utf8';
+						for ( var e; ;  )
+							switch ( t ) {
+								case 'utf8':
+								case 'utf-8':
+									return 'utf8';
+								case 'ucs2':
+								case 'ucs-2':
+								case 'utf16le':
+								case 'utf-16le':
+									return 'utf16le';
+								case 'latin1':
+								case 'binary':
+									return 'latin1';
+								case 'base64':
+								case 'ascii':
+								case 'hex':
+									return t;
+								default:
+									if ( e ) return;
+									( t = ( '' + t ).toLowerCase() ), ( e = ! 0 );
+							}
+					} )( t );
+					if ( 'string' != typeof e && ( r.isEncoding === i || ! i( t ) ) )
+						throw new Error( 'Unknown encoding: ' + t );
+					return e || t;
+				} )( t ) ),
+				this.encoding )
+			) {
+				case 'utf16le':
+					( this.text = u ), ( this.end = f ), ( e = 4 );
+					break;
+				case 'utf8':
+					( this.fillLast = a ), ( e = 4 );
+					break;
+				case 'base64':
+					( this.text = h ), ( this.end = c ), ( e = 3 );
+					break;
+				default:
+					return ( this.write = l ), void ( this.end = p );
+			}
+			( this.lastNeed = 0 ), ( this.lastTotal = 0 ), ( this.lastChar = r.allocUnsafe( e ) );
+		}
+		function s( t ) {
+			return t <= 127
+				? 0
+				: t >> 5 == 6
+				? 2
+				: t >> 4 == 14
+				? 3
+				: t >> 3 == 30
+				? 4
+				: t >> 6 == 2
+				? -1
+				: -2;
+		}
+		function a( t ) {
+			var e = this.lastTotal - this.lastNeed,
+				n = ( function( t, e, n ) {
+					if ( 128 != ( 192 & e[ 0 ] ) ) return ( t.lastNeed = 0 ), '�';
+					if ( t.lastNeed > 1 && e.length > 1 ) {
+						if ( 128 != ( 192 & e[ 1 ] ) ) return ( t.lastNeed = 1 ), '�';
+						if ( t.lastNeed > 2 && e.length > 2 && 128 != ( 192 & e[ 2 ] ) )
+							return ( t.lastNeed = 2 ), '�';
+					}
+				} )( this, t );
+			return void 0 !== n
+				? n
+				: this.lastNeed <= t.length
+				? ( t.copy( this.lastChar, e, 0, this.lastNeed ),
+				  this.lastChar.toString( this.encoding, 0, this.lastTotal ) )
+				: ( t.copy( this.lastChar, e, 0, t.length ), void ( this.lastNeed -= t.length ) );
+		}
+		function u( t, e ) {
+			if ( ( t.length - e ) % 2 == 0 ) {
+				var n = t.toString( 'utf16le', e );
+				if ( n ) {
+					var r = n.charCodeAt( n.length - 1 );
+					if ( r >= 55296 && r <= 56319 )
+						return (
+							( this.lastNeed = 2 ),
+							( this.lastTotal = 4 ),
+							( this.lastChar[ 0 ] = t[ t.length - 2 ] ),
+							( this.lastChar[ 1 ] = t[ t.length - 1 ] ),
+							n.slice( 0, -1 )
+						);
+				}
+				return n;
+			}
+			return (
+				( this.lastNeed = 1 ),
+				( this.lastTotal = 2 ),
+				( this.lastChar[ 0 ] = t[ t.length - 1 ] ),
+				t.toString( 'utf16le', e, t.length - 1 )
+			);
+		}
+		function f( t ) {
+			var e = t && t.length ? this.write( t ) : '';
+			if ( this.lastNeed ) {
+				var n = this.lastTotal - this.lastNeed;
+				return e + this.lastChar.toString( 'utf16le', 0, n );
+			}
+			return e;
+		}
+		function h( t, e ) {
+			var n = ( t.length - e ) % 3;
+			return 0 === n
+				? t.toString( 'base64', e )
+				: ( ( this.lastNeed = 3 - n ),
+				  ( this.lastTotal = 3 ),
+				  1 === n
+						? ( this.lastChar[ 0 ] = t[ t.length - 1 ] )
+						: ( ( this.lastChar[ 0 ] = t[ t.length - 2 ] ),
+						  ( this.lastChar[ 1 ] = t[ t.length - 1 ] ) ),
+				  t.toString( 'base64', e, t.length - n ) );
+		}
+		function c( t ) {
+			var e = t && t.length ? this.write( t ) : '';
+			return this.lastNeed ? e + this.lastChar.toString( 'base64', 0, 3 - this.lastNeed ) : e;
+		}
+		function l( t ) {
+			return t.toString( this.encoding );
+		}
+		function p( t ) {
+			return t && t.length ? this.write( t ) : '';
+		}
+		( e.StringDecoder = o ),
+			( o.prototype.write = function( t ) {
+				if ( 0 === t.length ) return '';
+				var e, n;
+				if ( this.lastNeed ) {
+					if ( void 0 === ( e = this.fillLast( t ) ) ) return '';
+					( n = this.lastNeed ), ( this.lastNeed = 0 );
+				} else n = 0;
+				return n < t.length ? ( e ? e + this.text( t, n ) : this.text( t, n ) ) : e || '';
+			} ),
+			( o.prototype.end = function( t ) {
+				var e = t && t.length ? this.write( t ) : '';
+				return this.lastNeed ? e + '�' : e;
+			} ),
+			( o.prototype.text = function( t, e ) {
+				var n = ( function( t, e, n ) {
+					var r = e.length - 1;
+					if ( r < n ) return 0;
+					var i = s( e[ r ] );
+					if ( i >= 0 ) return i > 0 && ( t.lastNeed = i - 1 ), i;
+					if ( --r < n || -2 === i ) return 0;
+					if ( ( i = s( e[ r ] ) ) >= 0 ) return i > 0 && ( t.lastNeed = i - 2 ), i;
+					if ( --r < n || -2 === i ) return 0;
+					if ( ( i = s( e[ r ] ) ) >= 0 )
+						return i > 0 && ( 2 === i ? ( i = 0 ) : ( t.lastNeed = i - 3 ) ), i;
+					return 0;
+				} )( this, t, e );
+				if ( ! this.lastNeed ) return t.toString( 'utf8', e );
+				this.lastTotal = n;
+				var r = t.length - ( n - this.lastNeed );
+				return t.copy( this.lastChar, 0, r ), t.toString( 'utf8', e, r );
+			} ),
+			( o.prototype.fillLast = function( t ) {
+				if ( this.lastNeed <= t.length )
+					return (
+						t.copy( this.lastChar, this.lastTotal - this.lastNeed, 0, this.lastNeed ),
+						this.lastChar.toString( this.encoding, 0, this.lastTotal )
+					);
+				t.copy( this.lastChar, this.lastTotal - this.lastNeed, 0, t.length ),
+					( this.lastNeed -= t.length );
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		t.exports = s;
+		var r = n( 4 ),
+			i = n( 6 );
+		function o( t, e ) {
+			var n = this._transformState;
+			n.transforming = ! 1;
+			var r = n.writecb;
+			if ( ! r ) return this.emit( 'error', new Error( 'write callback called multiple times' ) );
+			( n.writechunk = null ), ( n.writecb = null ), null != e && this.push( e ), r( t );
+			var i = this._readableState;
+			( i.reading = ! 1 ),
+				( i.needReadable || i.length < i.highWaterMark ) && this._read( i.highWaterMark );
+		}
+		function s( t ) {
+			if ( ! ( this instanceof s ) ) return new s( t );
+			r.call( this, t ),
+				( this._transformState = {
+					afterTransform: o.bind( this ),
+					needTransform: ! 1,
+					transforming: ! 1,
+					writecb: null,
+					writechunk: null,
+					writeencoding: null,
+				} ),
+				( this._readableState.needReadable = ! 0 ),
+				( this._readableState.sync = ! 1 ),
+				t &&
+					( 'function' == typeof t.transform && ( this._transform = t.transform ),
+					'function' == typeof t.flush && ( this._flush = t.flush ) ),
+				this.on( 'prefinish', a );
+		}
+		function a() {
+			var t = this;
+			'function' == typeof this._flush
+				? this._flush( function( e, n ) {
+						u( t, e, n );
+				  } )
+				: u( this, null, null );
+		}
+		function u( t, e, n ) {
+			if ( e ) return t.emit( 'error', e );
+			if ( ( null != n && t.push( n ), t._writableState.length ) )
+				throw new Error( 'Calling transform done when ws.length != 0' );
+			if ( t._transformState.transforming )
+				throw new Error( 'Calling transform done when still transforming' );
+			return t.push( null );
+		}
+		( i.inherits = n( 1 ) ),
+			i.inherits( s, r ),
+			( s.prototype.push = function( t, e ) {
+				return ( this._transformState.needTransform = ! 1 ), r.prototype.push.call( this, t, e );
+			} ),
+			( s.prototype._transform = function( t, e, n ) {
+				throw new Error( '_transform() is not implemented' );
+			} ),
+			( s.prototype._write = function( t, e, n ) {
+				var r = this._transformState;
+				if (
+					( ( r.writecb = n ), ( r.writechunk = t ), ( r.writeencoding = e ), ! r.transforming )
+				) {
+					var i = this._readableState;
+					( r.needTransform || i.needReadable || i.length < i.highWaterMark ) &&
+						this._read( i.highWaterMark );
+				}
+			} ),
+			( s.prototype._read = function( t ) {
+				var e = this._transformState;
+				null !== e.writechunk && e.writecb && ! e.transforming
+					? ( ( e.transforming = ! 0 ),
+					  this._transform( e.writechunk, e.writeencoding, e.afterTransform ) )
+					: ( e.needTransform = ! 0 );
+			} ),
+			( s.prototype._destroy = function( t, e ) {
+				var n = this;
+				r.prototype._destroy.call( this, t, function( t ) {
+					e( t ), n.emit( 'close' );
+				} );
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		function r( t ) {
+			return ( r =
+				'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator
+					? function( t ) {
+							return typeof t;
+					  }
+					: function( t ) {
+							return t &&
+								'function' == typeof Symbol &&
+								t.constructor === Symbol &&
+								t !== Symbol.prototype
+								? 'symbol'
+								: typeof t;
+					  } )( t );
+		}
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.default = function( t, e, n ) {
+				return new i.default( t, e, n ).on( 'error', function() {} );
+			} ),
+			Object.defineProperty( e, 'Client', {
+				enumerable: ! 0,
+				get: function() {
+					return i.default;
+				},
+			} ),
+			Object.defineProperty( e, 'Bucket', {
+				enumerable: ! 0,
+				get: function() {
+					return o.default;
+				},
+			} ),
+			Object.defineProperty( e, 'Auth', {
+				enumerable: ! 0,
+				get: function() {
+					return s.default;
+				},
+			} ),
+			( e.util = void 0 );
+		var i = f( n( 29 ) ),
+			o = f( n( 13 ) ),
+			s = f( n( 48 ) ),
+			a = ( function( t ) {
+				if ( t && t.__esModule ) return t;
+				if ( null === t || ( 'object' !== r( t ) && 'function' != typeof t ) )
+					return { default: t };
+				var e = u();
+				if ( e && e.has( t ) ) return e.get( t );
+				var n = {},
+					i = Object.defineProperty && Object.getOwnPropertyDescriptor;
+				for ( var o in t )
+					if ( Object.prototype.hasOwnProperty.call( t, o ) ) {
+						var s = i ? Object.getOwnPropertyDescriptor( t, o ) : null;
+						s && ( s.get || s.set ) ? Object.defineProperty( n, o, s ) : ( n[ o ] = t[ o ] );
+					}
+				( n.default = t ), e && e.set( t, n );
+				return n;
+			} )( n( 11 ) );
+		function u() {
+			if ( 'function' != typeof WeakMap ) return null;
+			var t = new WeakMap();
+			return (
+				( u = function() {
+					return t;
+				} ),
+				t
+			);
+		}
+		function f( t ) {
+			return t && t.__esModule ? t : { default: t };
+		}
+		e.util = a;
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.default = h ),
+			( e.Heartbeat = c ),
+			( e.ReconnectionTimer = l ),
+			Object.defineProperty( e, 'Bucket', {
+				enumerable: ! 0,
+				get: function() {
+					return o.default;
+				},
+			} ),
+			Object.defineProperty( e, 'Channel', {
+				enumerable: ! 0,
+				get: function() {
+					return s.default;
+				},
+			} );
+		var r = n( 9 ),
+			i = n( 3 ),
+			o = f( n( 13 ) ),
+			s = f( n( 32 ) ),
+			a = f( n( 41 ) ),
+			u = f( n( 43 ) );
+		function f( t ) {
+			return t && t.__esModule ? t : { default: t };
+		}
+		function h( t, e, n ) {
+			( ( n = n || {} ).ghostStoreProvider = n.ghostStoreProvider || a.default ),
+				( n.objectStoreProvider = n.objectStoreProvider || u.default ),
+				( n.hearbeatInterval = n.heartbeatInterval || 4 ),
+				( n.websocketClientProvider = n.websocketClientProvider || p ),
+				( this.accessToken = e ),
+				( this.open = ! 1 ),
+				( this.options = n ),
+				( this.heartbeat = new c( n.hearbeatInterval, this.sendHeartbeat.bind( this ) ) ),
+				this.heartbeat.on( 'timeout', this.onConnectionTimeout.bind( this ) ),
+				( this.reconnectionTimer = new l( function( t ) {
+					return 3e3 + ( t >= 3 ? 3e3 * ( t - 3 ) : 0 );
+				}, this.onReconnect.bind( this ) ) ),
+				( this.appId = t ),
+				( n.url =
+					n.url || ( 0, r.format )( 'wss://api.simperium.com/sock/1/%s/websocket', this.appId ) ),
+				( this.reconnect = ! 0 ),
+				this.on( 'message:h', this.onHeartbeat.bind( this ) ),
+				( this.buckets = [] ),
+				this.connect();
+		}
+		function c( t, e ) {
+			( this.count = 0 ),
+				( this.seconds = t ),
+				i.EventEmitter.call( this ),
+				e && this.on( 'beat', e );
+		}
+		function l( t, e ) {
+			i.EventEmitter.call( this ),
+				( this.started = ! 1 ),
+				( this.interval =
+					t ||
+					function() {
+						return 1e3;
+					} ),
+				e && this.on( 'tripped', e ),
+				this.reset();
+		}
+		function p( t ) {
+			return new ( 'undefined' != typeof window && window.WebSocket
+				? window.WebSocket
+				: n( 44 ).w3cwebsocket )( t );
+		}
+		( 0, r.inherits )( h, i.EventEmitter ),
+			( h.prototype.bucket = function( t ) {
+				var e = this.buckets.length,
+					n = new o.default( t, this.options.objectStoreProvider ),
+					i = new s.default(
+						this.appId,
+						this.accessToken,
+						this.options.ghostStoreProvider( n ),
+						t
+					),
+					a = this.sendChannelMessage.bind( this, e ),
+					u = i.handleMessage.bind( i );
+				return (
+					n.setChannel( i ),
+					this.buckets.push( n ),
+					i.on( 'unauthorized', this.onUnauthorized.bind( this ) ),
+					i.on( 'send', a ),
+					this.on( 'connect', i.onConnect.bind( i ) ),
+					this.on( ( 0, r.format )( 'channel:%d', e ), u ),
+					this.on( 'access-token', function( t ) {
+						i.access_token = t;
+					} ),
+					this.open && i.onConnect(),
+					n
+				);
+			} ),
+			( h.prototype.onHeartbeat = function( t ) {
+				var e = parseInt( t );
+				this.heartbeat.tick( e );
+			} ),
+			( h.prototype.onConnect = function() {
+				( this.open = ! 0 ),
+					this.heartbeat.start(),
+					this.reconnectionTimer.reset(),
+					this.emit( 'connect' );
+			} ),
+			( h.prototype.onReconnect = function( t ) {
+				this.emit( 'reconnect', t ), this.connect();
+			} ),
+			( h.prototype.onConnectionTimeout = function() {
+				this.disconnect();
+			} ),
+			( h.prototype.onConnectionFailed = function() {
+				this.emit( 'disconnect' ), this.reconnect && this.reconnectionTimer.start();
+			} ),
+			( h.prototype.onMessage = function( t ) {
+				this.parseMessage( t ), this.heartbeat.tick();
+			} ),
+			( h.prototype.onUnauthorized = function( t ) {
+				( this.reconnect = ! 1 ), this.emit( 'unauthorized', t );
+			} ),
+			( h.prototype.parseMessage = function( t ) {
+				var e = t.data,
+					n = e.indexOf( ':' ),
+					i = e.slice( 0, n ),
+					o = parseInt( i ),
+					s = e.slice( n + 1 );
+				this.emit( 'message', e ),
+					isNaN( o )
+						? this.emit( ( 0, r.format )( 'message:%s', i ), s )
+						: this.emit( ( 0, r.format )( 'channel:%d', o ), s );
+			} ),
+			( h.prototype.sendHeartbeat = function( t ) {
+				this.send( ( 0, r.format )( 'h:%d', t ) );
+			} ),
+			( h.prototype.send = function( t ) {
+				this.emit( 'send', t );
+				try {
+					this.socket.send( t );
+				} catch ( t ) {
+					this.emit( 'error', t );
+				}
+			} ),
+			( h.prototype.sendChannelMessage = function( t, e ) {
+				this.send( ( 0, r.format )( '%d:%s', t, e ) );
+			} ),
+			( h.prototype.connect = function() {
+				this.open && this.disconnect(),
+					( this.reconnect = ! 0 ),
+					( this.socket = this.options.websocketClientProvider( this.options.url ) ),
+					( this.socket.onopen = this.onConnect.bind( this ) ),
+					( this.socket.onmessage = this.onMessage.bind( this ) ),
+					( this.socket.onclose = this.onConnectionFailed.bind( this ) );
+			} ),
+			( h.prototype.disconnect = function() {
+				this.open ? this.socket.close() : this.onClose();
+			} ),
+			( h.prototype.end = function() {
+				( this.reconnect = ! 1 ),
+					this.reconnectionTimer.stop(),
+					this.heartbeat.stop(),
+					this.disconnect();
+			} ),
+			( h.prototype.onClose = function() {
+				( this.connection = null ),
+					this.heartbeat.stop(),
+					! 1 !== this.reconnect && this.reconnectionTimer.start(),
+					this.emit( 'close' );
+			} ),
+			( h.prototype.setAccessToken = function( t ) {
+				( this.accessToken = t ), this.emit( 'access-token', t ), this.connect();
+			} ),
+			( 0, r.inherits )( c, i.EventEmitter ),
+			( c.prototype.onBeat = function() {
+				this.count++,
+					( this.timeout = setTimeout( this.onTimeout.bind( this ), 1e3 * this.seconds * 2 ) ),
+					this.emit( 'beat', this.count );
+			} ),
+			( c.prototype.onTimeout = function() {
+				this.emit( 'timeout' ), this.stop();
+			} ),
+			( c.prototype.tick = function( t ) {
+				t > 0 && 'number' == typeof t && ( this.count = t ), this.start();
+			} ),
+			( c.prototype.start = function() {
+				this.stop(),
+					clearTimeout( this.timer ),
+					( this.timer = setTimeout( this.onBeat.bind( this ), 1e3 * this.seconds ) );
+			} ),
+			( c.prototype.stop = function() {
+				clearTimeout( this.timer ), clearTimeout( this.timeout );
+			} ),
+			( 0, r.inherits )( l, i.EventEmitter ),
+			( l.prototype.onInterval = function() {
+				this.emit( 'tripped', this.attempt ), this.attempt++;
+			} ),
+			( l.prototype.start = function() {
+				( this.started = ! 0 ),
+					( this.timer = setTimeout(
+						this.onInterval.bind( this ),
+						this.interval( this.attempt )
+					) );
+			} ),
+			( l.prototype.restart = function() {
+				this.reset(), this.start();
+			} ),
+			( l.prototype.reset = l.prototype.stop = function() {
+				( this.attempt = 0 ), ( this.started = ! 1 ), clearTimeout( this.timer );
+			} ),
+			( h.Bucket = o.default );
+	},
+	function( t, e ) {
+		t.exports = function( t ) {
+			return (
+				t &&
+				'object' == typeof t &&
+				'function' == typeof t.copy &&
+				'function' == typeof t.fill &&
+				'function' == typeof t.readUInt8
+			);
+		};
+	},
+	function( t, e, n ) {
+		var r,
+			i,
+			o = n( 15 ),
+			s = n( 16 ),
+			a = 0,
+			u = 0;
+		t.exports = function( t, e, n ) {
+			var f = ( e && n ) || 0,
+				h = e || [],
+				c = ( t = t || {} ).node || r,
+				l = void 0 !== t.clockseq ? t.clockseq : i;
+			if ( null == c || null == l ) {
+				var p = o();
+				null == c && ( c = r = [ 1 | p[ 0 ], p[ 1 ], p[ 2 ], p[ 3 ], p[ 4 ], p[ 5 ] ] ),
+					null == l && ( l = i = 16383 & ( ( p[ 6 ] << 8 ) | p[ 7 ] ) );
+			}
+			var d = void 0 !== t.msecs ? t.msecs : new Date().getTime(),
+				g = void 0 !== t.nsecs ? t.nsecs : u + 1,
+				y = d - a + ( g - u ) / 1e4;
+			if (
+				( y < 0 && void 0 === t.clockseq && ( l = ( l + 1 ) & 16383 ),
+				( y < 0 || d > a ) && void 0 === t.nsecs && ( g = 0 ),
+				g >= 1e4 )
+			)
+				throw new Error( "uuid.v1(): Can't create more than 10M uuids/sec" );
+			( a = d ), ( u = g ), ( i = l );
+			var m = ( 1e4 * ( 268435455 & ( d += 122192928e5 ) ) + g ) % 4294967296;
+			( h[ f++ ] = ( m >>> 24 ) & 255 ),
+				( h[ f++ ] = ( m >>> 16 ) & 255 ),
+				( h[ f++ ] = ( m >>> 8 ) & 255 ),
+				( h[ f++ ] = 255 & m );
+			var v = ( ( d / 4294967296 ) * 1e4 ) & 268435455;
+			( h[ f++ ] = ( v >>> 8 ) & 255 ),
+				( h[ f++ ] = 255 & v ),
+				( h[ f++ ] = ( ( v >>> 24 ) & 15 ) | 16 ),
+				( h[ f++ ] = ( v >>> 16 ) & 255 ),
+				( h[ f++ ] = ( l >>> 8 ) | 128 ),
+				( h[ f++ ] = 255 & l );
+			for ( var b = 0; b < 6; ++b ) h[ f + b ] = c[ b ];
+			return e || s( h );
+		};
+	},
+	function( t, e, n ) {
+		'use strict';
+		( function( t ) {
+			Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+				( e.default = l ),
+				( e.revisionCache = void 0 );
+			var r,
+				i = n( 9 ),
+				o = n( 3 ),
+				s = n( 11 ),
+				a = n( 14 ),
+				u = ( r = n( 40 ) ) && r.__esModule ? r : { default: r };
+			var f = s.change.type.MODIFY,
+				h = s.change.type.REMOVE,
+				c = {};
+			function l( t, e, n, r ) {
+				var i = this,
+					s = ( this.message = new o.EventEmitter() );
+				( this.name = r ),
+					( this.isIndexing = ! 1 ),
+					( this.appid = t ),
+					( this.store = n ),
+					( this.access_token = e ),
+					( this.session_id = 'node-' + ( 0, a.v4 )() ),
+					s.on( 'auth', this.onAuth.bind( this ) ),
+					s.on( 'i', this.onIndex.bind( this ) ),
+					s.on( 'c', this.onChanges.bind( this ) ),
+					s.on( 'e', this.onVersion.bind( this ) ),
+					s.on( 'cv', this.onChangeVersion.bind( this ) ),
+					s.on( 'o', function() {} ),
+					( this.networkQueue = new p() ),
+					( this.localQueue = new g( this.store ) ),
+					this.localQueue.on( 'send', function( t ) {
+						i.emit( 'send', 'c:'.concat( JSON.stringify( t ) ) );
+					} ),
+					this.localQueue.on( 'error', c.handleChangeError.bind( this ) );
+			}
+			function p() {
+				this.queues = {};
+			}
+			function d() {
+				( this.queue = [] ), ( this.running = ! 1 );
+			}
+			function g( t ) {
+				( this.store = t ), ( this.sent = {} ), ( this.queues = {} ), ( this.ready = ! 1 );
+			}
+			( c.updateChangeVersion = function( t ) {
+				var e = this;
+				return this.store.setChangeVersion( t ).then( function() {
+					return e.emit( 'change-version', t ), t;
+				} );
+			} ),
+				( c.buildModifyChange = function( t, e, n ) {
+					var r,
+						i = s.change.buildChange( s.change.type.MODIFY, t, e, n ),
+						o = ! 0;
+					for ( r in i.v )
+						if ( r ) {
+							o = ! 1;
+							break;
+						}
+					o
+						? this.emit( 'unmodified', t, e, n )
+						: this.localQueue.queue( { type: 'modify', id: t, object: e } );
+				} ),
+				( c.updateObjectVersion = function( t, e, n, r, i, o ) {
+					var a = this,
+						u = function() {
+							return a.store.put( t, e, n );
+						};
+					return o
+						? u().then( function() {
+								c.updateAcknowledged.call( a, o );
+						  } )
+						: this.onBeforeNetworkChange( t, n, r, i ).then( function( e ) {
+								var o = s.change.diff( r, e ),
+									f = s.change.transform( o, i, r );
+								return (
+									a.localQueue.dequeueChangesFor( t ),
+									u().then( function() {
+										var e = n;
+										f &&
+											( ( e = s.change.apply( f, n ) ),
+											a.localQueue.queue( { type: 'modify', id: t, object: e } ) ),
+											a.emit( 'update', t, e, r, i, a.isIndexing );
+									} )
+								);
+						  } );
+				} ),
+				( c.removeObject = function( t, e ) {
+					var n;
+					return (
+						( n = e ? c.updateAcknowledged.bind( this, e ) : this.emit.bind( this, 'remove', t ) ),
+						this.store.remove( t ).then( n )
+					);
+				} ),
+				( c.updateAcknowledged = function( t ) {
+					var e = t.id;
+					this.localQueue.sent[ e ] === t &&
+						( this.localQueue.acknowledge( t ), this.emit( 'acknowledge', e, t ) );
+				} ),
+				( c.findAcknowledgedChange = function( t ) {
+					var e = this.localQueue.sent[ t.id ];
+					if ( e && ( t.ccids || [] ).indexOf( e.ccid ) > -1 ) return e;
+				} ),
+				( c.requestObjectVersion = function( t, e ) {
+					var n = this;
+					return new Promise( function( r ) {
+						n.once( 'version.'.concat( t, '.' ).concat( e ), function( t ) {
+							r( t );
+						} ),
+							n.send( 'e:'.concat( t, '.' ).concat( e ) );
+					} );
+				} ),
+				( c.applyChange = function( t, e ) {
+					var n,
+						r,
+						i,
+						o,
+						a = this,
+						u = c.findAcknowledgedChange.call( this, t ),
+						l = c.updateChangeVersion.bind( this, t.cv );
+					return t.error
+						? ( ( ( n = new Error(
+								''.concat( t.error, ' - Could not apply change to: ' ).concat( e.key )
+						  ) ).code = t.error ),
+						  ( n.change = t ),
+						  ( n.ghost = e ),
+						  void c.handleChangeError.call( this, n, t, u ) )
+						: t.o === f
+						? e && e.version !== t.sv
+							? void c.requestObjectVersion.call( this, t.id, t.sv ).then( function( e ) {
+									c.applyChange.call( a, t, { version: t.sv, data: e } );
+							  } )
+							: ( ( r = e.data ),
+							  ( i = t.v ),
+							  ( o = s.change.apply( i, r ) ),
+							  c.updateObjectVersion.call( this, t.id, t.ev, o, r, i, u ).then( l ) )
+						: t.o === h
+						? c.removeObject
+								.bind( this )( t.id, u )
+								.then( l )
+						: void 0;
+				} ),
+				( c.handleChangeError = function( t, e, n ) {
+					var r = this;
+					switch ( t.code ) {
+						case 405:
+						case 440:
+							n && n.d
+								? this.localQueue.dequeueChangesFor( e.id )
+								: this.store.get( e.id ).then( function( t ) {
+										r.localQueue.queue( { type: 'full', originalChange: n, object: t } );
+								  } );
+							break;
+						case 409:
+						case 412:
+							c.updateAcknowledged.call( this, n );
+							break;
+						default:
+							this.emit( 'error', t, e );
+					}
+				} ),
+				( c.indexingComplete = function() {
+					var t = this;
+					this.setIsIndexing( ! 1 ),
+						c.updateChangeVersion.call( this, this.index_cv ).then( function() {
+							t.localQueue.start();
+						} ),
+						this.emit( 'index', this.index_cv ),
+						( this.index_last_id = null ),
+						( this.index_cv = null ),
+						this.emit( 'ready' );
+				} ),
+				( 0, i.inherits )( l, o.EventEmitter ),
+				( l.prototype.update = function( t ) {
+					var e = this,
+						n = ! ( arguments.length > 1 && void 0 !== arguments[ 1 ] ) || arguments[ 1 ];
+					return (
+						this.onBucketUpdate( t.id ),
+						! 0 === n
+							? this.store
+									.get( t.id )
+									.then( function( n ) {
+										return c.buildModifyChange.call( e, t.id, t.data, n );
+									} )
+									.then( function() {
+										return t;
+									} )
+							: Promise.resolve( t )
+					);
+				} ),
+				( l.prototype.setIsIndexing = function( t ) {
+					( this.isIndexing = t ), this.emit( 'indexingStateChange', this.isIndexing );
+				} ),
+				( l.prototype.remove = function( t ) {
+					var e = this;
+					this.store.get( t ).then( function() {
+						return e.localQueue.queue( { type: 'remove', id: t } );
+					} );
+				} ),
+				( l.prototype.getRevisions = function( t ) {
+					var e = this;
+					return new Promise( function( n, r ) {
+						! ( function( t, e, n ) {
+							var r,
+								i,
+								o = new Set(),
+								s = [];
+							function a( t, e, n ) {
+								y.set( ''.concat( t, '.' ).concat( e ), n ),
+									s.push( { id: t, version: e, data: n } ),
+									s.length !== r
+										? ( f( e ), clearTimeout( i ), ( i = setTimeout( u, 200 ) ) )
+										: u();
+							}
+							function u() {
+								clearTimeout( i ),
+									t.removeListener( 'version.'.concat( e ), a ),
+									n(
+										null,
+										s.sort( function( t, e ) {
+											return e.version - t.version;
+										} )
+									);
+							}
+							function f( n ) {
+								for ( var r = n; r > 0 && o.has( r );  ) r -= 1;
+								r &&
+									( o.add( r ),
+									y.has( ''.concat( e, '.' ).concat( r ) )
+										? a( e, r, y.get( ''.concat( e, '.' ).concat( r ) ) )
+										: t.send( 'e:'.concat( e, '.' ).concat( r ) ) );
+							}
+							t.on( 'version.'.concat( e ), a ),
+								t.store.get( e ).then( function( t ) {
+									var e = t.version;
+									r = e;
+									for ( var n = 0; n < 60 && e - n > 0; n++ ) f( e - n );
+									for (
+										var i = 10 * Math.round( ( e - 60 ) / 10 ) + 1, o = 0;
+										o < 100 && i - 10 * o > 0;
+										o++
+									)
+										f( i - 10 * o );
+								}, n ),
+								( i = setTimeout( u, 800 ) );
+						} )( e, t, function( t, e ) {
+							t ? r( t ) : n( e );
+						} );
+					} );
+				} ),
+				( l.prototype.hasLocalChanges = function() {
+					return Promise.resolve( Object.keys( this.localQueue.queues ).length > 0 );
+				} ),
+				( l.prototype.getVersion = function( t ) {
+					return this.store.get( t ).then( function( t ) {
+						return t && t.version ? t.version : 0;
+					} );
+				} ),
+				( l.prototype.beforeNetworkChange = function( t ) {
+					this.changeResolver = t;
+				} ),
+				( l.prototype.onBeforeNetworkChange = function( t, e, n, r ) {
+					return this.changeResolver
+						? Promise.resolve( this.changeResolver( t, e, n, r ) )
+						: Promise.resolve();
+				} ),
+				( l.prototype.handleMessage = function( t ) {
+					var e = ( 0, s.parseMessage )( t );
+					this.message.emit( e.command, e.data );
+				} ),
+				( l.prototype.send = function( t ) {
+					this.emit( 'send', t );
+				} ),
+				( l.prototype.reload = function() {
+					var t = this;
+					this.store.eachGhost( function( e ) {
+						t.emit( 'update', e.key, e.data );
+					} );
+				} ),
+				( l.prototype.onBucketUpdate = function( t ) {
+					this.isIndexing &&
+						null != this.index_last_id &&
+						null != this.index_cv &&
+						this.index_last_id === t &&
+						c.indexingComplete.call( this );
+				} ),
+				( l.prototype.onAuth = function( t ) {
+					var e,
+						n,
+						r = this;
+					try {
+						return ( e = JSON.parse( t ) ), void this.emit( 'unauthorized', e );
+					} catch ( t ) {
+						return (
+							this.once( 'ready', function() {
+								r.localQueue.resendSentChanges();
+							} ),
+							( n = function( t ) {
+								t ? ( r.localQueue.start(), r.sendChangeVersionRequest( t ) ) : r.startIndexing();
+							} ),
+							void this.store.getChangeVersion().then( n )
+						);
+					}
+				} ),
+				( l.prototype.startIndexing = function() {
+					this.localQueue.pause(), this.setIsIndexing( ! 0 ), this.sendIndexRequest();
+				} ),
+				( l.prototype.onConnect = function() {
+					var t = {
+						name: this.name,
+						clientid: this.session_id,
+						api: '1.1',
+						token: this.access_token,
+						app_id: this.appid,
+						library: 'node-simperium',
+						version: '0.0.1',
+					};
+					this.send( ( 0, i.format )( 'init:%s', JSON.stringify( t ) ) );
+				} ),
+				( l.prototype.onIndex = function( t ) {
+					var e,
+						n = JSON.parse( t ),
+						r = n.index,
+						i = n.mark,
+						o = n.current,
+						s = c.updateObjectVersion.bind( this );
+					r.forEach( function( t ) {
+						( e = t.id ), s( t.id, t.v, t.d );
+					} ),
+						i
+							? this.sendIndexRequest( i )
+							: ( e && ( this.index_last_id = e ),
+							  this.index_last_id || c.indexingComplete.call( this ),
+							  ( this.index_cv = o ) );
+				} ),
+				( l.prototype.sendIndexRequest = function( t ) {
+					this.send( ( 0, i.format )( 'i:1:%s::10', t || '' ) );
+				} ),
+				( l.prototype.sendChangeVersionRequest = function( t ) {
+					this.send( ( 0, i.format )( 'cv:%s', t ) );
+				} ),
+				( l.prototype.onChanges = function( t ) {
+					var e = this;
+					JSON.parse( t ).forEach( function( t ) {
+						e.networkQueue.queueFor( t.id ).add( function( n ) {
+							return e.store
+								.get( t.id )
+								.then( function( n ) {
+									return c.applyChange.call( e, t, n );
+								} )
+								.then( n, n );
+						} );
+					} ),
+						this.emit( 'ready' );
+				} ),
+				( l.prototype.onChangeVersion = function( t ) {
+					var e = this;
+					'?' === t &&
+						this.store.setChangeVersion( null ).then( function() {
+							return e.startIndexing();
+						} );
+				} ),
+				( l.prototype.onVersion = function( t ) {
+					if ( '\n?' !== t.slice( -2 ) ) {
+						var e = ( 0, s.parseVersionMessage )( t );
+						this.emit( 'version', e.id, e.version, e.data ),
+							this.emit( 'version.' + e.id, e.id, e.version, e.data ),
+							this.emit( 'version.' + e.id + '.' + e.version, e.data );
+					}
+				} ),
+				( p.prototype.queueFor = function( t ) {
+					var e = this.queues,
+						n = e[ t ];
+					return (
+						n ||
+							( ( n = new d() ).on( 'finish', function() {
+								delete e[ t ];
+							} ),
+							( e[ t ] = n ) ),
+						n
+					);
+				} ),
+				( 0, i.inherits )( d, o.EventEmitter ),
+				( d.prototype.add = function( t ) {
+					return this.queue.push( t ), this.start(), this;
+				} ),
+				( d.prototype.start = function() {
+					this.running ||
+						( ( this.running = ! 0 ), this.emit( 'start' ), t( this.run.bind( this ) ) );
+				} ),
+				( d.prototype.run = function() {
+					if ( ( ( this.running = ! 0 ), 0 === this.queue.length ) )
+						return ( this.running = ! 1 ), void this.emit( 'finish' );
+					this.queue.shift()( this.run.bind( this ) );
+				} ),
+				( 0, i.inherits )( g, o.EventEmitter ),
+				( g.prototype.start = function() {
+					var t;
+					for ( t in ( ( this.ready = ! 0 ), this.queues ) ) this.processQueue( t );
+				} ),
+				( g.prototype.pause = function() {
+					this.ready = ! 1;
+				} ),
+				( g.prototype.acknowledge = function( t ) {
+					this.sent[ t.id ] === t && delete this.sent[ t.id ], this.processQueue( t.id );
+				} ),
+				( g.prototype.queue = function( t ) {
+					var e = this.queues[ t.id ];
+					e || ( ( e = [] ), ( this.queues[ t.id ] = e ) ),
+						e.push( t ),
+						this.emit( 'queued', t.id, t, e ),
+						this.ready && this.processQueue( t.id );
+				} ),
+				( g.prototype.dequeueChangesFor = function( t ) {
+					var e = [],
+						n = this.sent[ t ],
+						r = this.queues[ t ];
+					return n && e.push( n ), r && ( delete this.queues[ t ], ( e = e.concat( r ) ) ), e;
+				} ),
+				( g.prototype.processQueue = function( t ) {
+					var e = this,
+						n = this.queues[ t ];
+					n &&
+						( 0 !== n.length
+							? this.sent[ t ]
+								? this.emit( 'wait', t )
+								: this.store.get( t ).then( function( n ) {
+										var r = e.queues[ t ];
+										if ( e.sent[ t ] ) e.emit( 'wait', t );
+										else {
+											var i = r.reduce( function( t, e ) {
+													return 'remove' === t.type ? t : e;
+												} ),
+												o = ( 0, u.default )( i, n );
+											( e.queues[ t ] = [] ),
+												s.change.isEmptyChange( o ) || ( ( e.sent[ t ] = o ), e.emit( 'send', o ) );
+										}
+								  } )
+							: delete this.queues[ t ] );
+				} ),
+				( g.prototype.resendSentChanges = function() {
+					for ( var t in this.sent ) this.emit( 'send', this.sent[ t ] );
+				} );
+			var y = new Map();
+			e.revisionCache = y;
+		}.call( this, n( 10 ).setImmediate ) );
+	},
+	function( t, e, n ) {
+		( function( t, e ) {
+			! ( function( t, n ) {
+				'use strict';
+				if ( ! t.setImmediate ) {
+					var r,
+						i,
+						o,
+						s,
+						a,
+						u = 1,
+						f = {},
+						h = ! 1,
+						c = t.document,
+						l = Object.getPrototypeOf && Object.getPrototypeOf( t );
+					( l = l && l.setTimeout ? l : t ),
+						'[object process]' === {}.toString.call( t.process )
+							? ( r = function( t ) {
+									e.nextTick( function() {
+										d( t );
+									} );
+							  } )
+							: ! ( function() {
+									if ( t.postMessage && ! t.importScripts ) {
+										var e = ! 0,
+											n = t.onmessage;
+										return (
+											( t.onmessage = function() {
+												e = ! 1;
+											} ),
+											t.postMessage( '', '*' ),
+											( t.onmessage = n ),
+											e
+										);
+									}
+							  } )()
+							? t.MessageChannel
+								? ( ( ( o = new MessageChannel() ).port1.onmessage = function( t ) {
+										d( t.data );
+								  } ),
+								  ( r = function( t ) {
+										o.port2.postMessage( t );
+								  } ) )
+								: c && 'onreadystatechange' in c.createElement( 'script' )
+								? ( ( i = c.documentElement ),
+								  ( r = function( t ) {
+										var e = c.createElement( 'script' );
+										( e.onreadystatechange = function() {
+											d( t ), ( e.onreadystatechange = null ), i.removeChild( e ), ( e = null );
+										} ),
+											i.appendChild( e );
+								  } ) )
+								: ( r = function( t ) {
+										setTimeout( d, 0, t );
+								  } )
+							: ( ( s = 'setImmediate$' + Math.random() + '$' ),
+							  ( a = function( e ) {
+									e.source === t &&
+										'string' == typeof e.data &&
+										0 === e.data.indexOf( s ) &&
+										d( +e.data.slice( s.length ) );
+							  } ),
+							  t.addEventListener
+									? t.addEventListener( 'message', a, ! 1 )
+									: t.attachEvent( 'onmessage', a ),
+							  ( r = function( e ) {
+									t.postMessage( s + e, '*' );
+							  } ) ),
+						( l.setImmediate = function( t ) {
+							'function' != typeof t && ( t = new Function( '' + t ) );
+							for ( var e = new Array( arguments.length - 1 ), n = 0; n < e.length; n++ )
+								e[ n ] = arguments[ n + 1 ];
+							var i = { callback: t, args: e };
+							return ( f[ u ] = i ), r( u ), u++;
+						} ),
+						( l.clearImmediate = p );
+				}
+				function p( t ) {
+					delete f[ t ];
+				}
+				function d( t ) {
+					if ( h ) setTimeout( d, 0, t );
+					else {
+						var e = f[ t ];
+						if ( e ) {
+							h = ! 0;
+							try {
+								! ( function( t ) {
+									var e = t.callback,
+										n = t.args;
+									switch ( n.length ) {
+										case 0:
+											e();
+											break;
+										case 1:
+											e( n[ 0 ] );
+											break;
+										case 2:
+											e( n[ 0 ], n[ 1 ] );
+											break;
+										case 3:
+											e( n[ 0 ], n[ 1 ], n[ 2 ] );
+											break;
+										default:
+											e.apply( void 0, n );
+									}
+								} )( e );
+							} finally {
+								p( t ), ( h = ! 1 );
+							}
+						}
+					}
+				}
+			} )( 'undefined' == typeof self ? ( void 0 === t ? this : t ) : self );
+		}.call( this, n( 0 ), n( 2 ) ) );
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.buildChange = function( t, e, n, i ) {
+				if ( '-' === t ) return { o: '-', id: e, ccid: ( 0, r.default )() };
+				var o = { o: 'M', id: e, ccid: ( 0, r.default )(), v: u( i.data, n ) };
+				i.version > 0 && ( o.sv = i.version );
+				return o;
+			} ),
+			( e.compressChanges = function( t, e ) {
+				if ( 0 === t.length ) return {};
+				if ( 1 === t.length ) {
+					var n = t[ 0 ];
+					return 'M' === n.o ? n.v : null;
+				}
+				var r = t.reduce( function( t, e ) {
+					return null === t || '-' === e.o ? null : a( t, e.v );
+				}, e );
+				return null === r ? null : u( e, r );
+			} ),
+			( e.transform = function( t, e, n ) {
+				return s( t, e, n );
+			} ),
+			( e.modify = function( t, e, n ) {
+				return { o: 'M', id: t, ccid: ( 0, r.default )(), v: n };
+			} ),
+			( e.apply = function( t, e ) {
+				return a( e, t );
+			} ),
+			( e.isEmptyChange = function( t ) {
+				switch ( t.o ) {
+					case 'M':
+						return 0 === Object.keys( t.v ).length;
+				}
+			} ),
+			( e.diff = e.type = void 0 );
+		var r = o( n( 17 ) ),
+			i = o( n( 35 ) );
+		function o( t ) {
+			return t && t.__esModule ? t : { default: t };
+		}
+		var s = i.default.transform_object_diff,
+			a = i.default.apply_object_diff,
+			u = i.default.object_diff;
+		e.diff = u;
+		e.type = { MODIFY: 'M', REMOVE: '-' };
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ), ( e.default = void 0 );
+		var r = new ( n( 36 ).JSONDiff )( { list_diff: ! 1 } );
+		e.default = r;
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ), ( e.JSONDiff = u );
+		var r = ( function( t ) {
+			if ( t && t.__esModule ) return t;
+			if ( null === t || ( 'object' !== o( t ) && 'function' != typeof t ) ) return { default: t };
+			var e = i();
+			if ( e && e.has( t ) ) return e.get( t );
+			var n = {},
+				r = Object.defineProperty && Object.getOwnPropertyDescriptor;
+			for ( var s in t )
+				if ( Object.prototype.hasOwnProperty.call( t, s ) ) {
+					var a = r ? Object.getOwnPropertyDescriptor( t, s ) : null;
+					a && ( a.get || a.set ) ? Object.defineProperty( n, s, a ) : ( n[ s ] = t[ s ] );
+				}
+			( n.default = t ), e && e.set( t, n );
+			return n;
+		} )( n( 37 ) );
+		function i() {
+			if ( 'function' != typeof WeakMap ) return null;
+			var t = new WeakMap();
+			return (
+				( i = function() {
+					return t;
+				} ),
+				t
+			);
+		}
+		function o( t ) {
+			return ( o =
+				'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator
+					? function( t ) {
+							return typeof t;
+					  }
+					: function( t ) {
+							return t &&
+								'function' == typeof Symbol &&
+								t.constructor === Symbol &&
+								t !== Symbol.prototype
+								? 'symbol'
+								: typeof t;
+					  } )( t );
+		}
+		var s = Object.prototype.hasOwnProperty,
+			a = function( t, e ) {
+				return function() {
+					return t.apply( e, arguments );
+				};
+			};
+		function u( t ) {
+			( this.options = t || { list_diff: ! 0 } ),
+				( this.patch_apply_with_offsets = a( this.patch_apply_with_offsets, this ) ),
+				( this.transform_object_diff = a( this.transform_object_diff, this ) ),
+				( this.transform_list_diff = a( this.transform_list_diff, this ) ),
+				( this.apply_object_diff_with_offsets = a( this.apply_object_diff_with_offsets, this ) ),
+				( this.apply_object_diff = a( this.apply_object_diff, this ) ),
+				( this.apply_list_diff = a( this.apply_list_diff, this ) ),
+				( this.diff = a( this.diff, this ) ),
+				( this.object_diff = a( this.object_diff, this ) ),
+				( this.list_diff = a( this.list_diff, this ) ),
+				( this._common_suffix = a( this._common_suffix, this ) ),
+				( this._common_prefix = a( this._common_prefix, this ) ),
+				( this.object_equals = a( this.object_equals, this ) ),
+				( this.list_equals = a( this.list_equals, this ) ),
+				( this.equals = a( this.equals, this ) ),
+				( this.deepCopy = a( this.deepCopy, this ) ),
+				( this.typeOf = a( this.typeOf, this ) ),
+				( this.entries = a( this.entries, this ) );
+		}
+		( u.dmp = new r.default() ),
+			( u.prototype.entries = function( t ) {
+				var e, n;
+				for ( e in ( ( n = 0 ), t ) ) s.call( t, e ) && ( t[ e ], n++ );
+				return n;
+			} ),
+			( u.prototype.typeOf = function( t ) {
+				var e;
+				return (
+					'object' === ( e = o( t ) ) &&
+						( t
+							? 'number' != typeof t.length ||
+							  'function' != typeof t.splice ||
+							  t.propertyIsEnumerable( 'length' ) ||
+							  ( e = 'array' )
+							: ( e = 'null' ) ),
+					e
+				);
+			} ),
+			( u.prototype.deepCopy = function( t ) {
+				var e, n, r;
+				if ( '[object Array]' === Object.prototype.toString.call( t ) ) {
+					for ( n = [], e = 0, r = t.length; 0 <= r ? e < r : e > r; 0 <= r ? e++ : e-- )
+						n[ e ] = u.prototype.deepCopy( t[ e ] );
+					return n;
+				}
+				if ( 'object' === o( t ) ) {
+					for ( e in ( ( n = {} ), t ) ) n[ e ] = u.prototype.deepCopy( t[ e ] );
+					return n;
+				}
+				return t;
+			} ),
+			( u.prototype.equals = function( t, e ) {
+				var n, r;
+				return (
+					( n = this.typeOf( t ) ),
+					( r = this.typeOf( e ) ),
+					'boolean' === n && 'number' === r
+						? Number( t ) === e
+						: 'number' === n && 'boolean' === n
+						? Number( e ) === t
+						: n === r &&
+						  ( 'array' === n
+								? this.list_equals( t, e )
+								: 'object' === n
+								? this.object_equals( t, e )
+								: t === e )
+				);
+			} ),
+			( u.prototype.list_equals = function( t, e ) {
+				var n, r;
+				if ( ( n = t.length ) !== e.length ) return ! 1;
+				for ( r = 0; 0 <= n ? r < n : r > n; 0 <= n ? r++ : r-- )
+					if ( ! this.equals( t[ r ], e[ r ] ) ) return ! 1;
+				return ! 0;
+			} ),
+			( u.prototype.object_equals = function( t, e ) {
+				var n;
+				for ( n in t )
+					if ( s.call( t, n ) ) {
+						if ( ! ( n in e ) ) return ! 1;
+						if ( ! this.equals( t[ n ], e[ n ] ) ) return ! 1;
+					}
+				for ( n in e ) if ( s.call( e, n ) && ! ( n in t ) ) return ! 1;
+				return ! 0;
+			} ),
+			( u.prototype._common_prefix = function( t, e ) {
+				var n, r;
+				for (
+					r = Math.min( t.length, e.length ), n = 0;
+					0 <= r ? n < r : n > r;
+					0 <= r ? n++ : n--
+				)
+					if ( ! this.equals( t[ n ], e[ n ] ) ) return n;
+				return r;
+			} ),
+			( u.prototype._common_suffix = function( t, e ) {
+				var n, r, i, o;
+				if ( ( ( r = t.length ), ( i = e.length ), 0 === ( o = Math.min( t.length, e.length ) ) ) )
+					return 0;
+				for ( n = 0; 0 <= o ? n < o : n > o; 0 <= o ? n++ : n-- )
+					if ( ! this.equals( t[ r - n - 1 ], e[ i - n - 1 ] ) ) return n;
+				return o;
+			} ),
+			( u.prototype.list_diff = function( t, e ) {
+				var n, r, i, o, s, a, u;
+				for (
+					n = {},
+						i = t.length,
+						o = e.length,
+						a = this._common_prefix( t, e ),
+						u = this._common_suffix( t, e ),
+						t = t.slice( a, i - u ),
+						e = e.slice( a, o - u ),
+						i = t.length,
+						o = e.length,
+						s = Math.max( i, o ),
+						r = 0;
+					0 <= s ? r <= s : r >= s;
+					0 <= s ? r++ : r--
+				)
+					r < i && r < o
+						? this.equals( t[ r ], e[ r ] ) || ( n[ r + a ] = this.diff( t[ r ], e[ r ] ) )
+						: r < i
+						? ( n[ r + a ] = { o: '-' } )
+						: r < o && ( n[ r + a ] = { o: '+', v: e[ r ] } );
+				return n;
+			} ),
+			( u.prototype.object_diff = function( t, e ) {
+				var n, r;
+				if ( ( ( n = {} ), null == t || null == e ) ) return {};
+				for ( r in t )
+					s.call( t, r ) &&
+						( r in e
+							? this.equals( t[ r ], e[ r ] ) || ( n[ r ] = this.diff( t[ r ], e[ r ] ) )
+							: ( n[ r ] = { o: '-' } ) );
+				for ( r in e ) s.call( e, r ) && ( r in t || ( n[ r ] = { o: '+', v: e[ r ] } ) );
+				return n;
+			} ),
+			( u.prototype.diff = function( t, e ) {
+				var n, r;
+				if ( this.equals( t, e ) ) return {};
+				if ( ( r = this.typeOf( t ) ) !== this.typeOf( e ) ) return { o: 'r', v: e };
+				switch ( r ) {
+					case 'boolean':
+					case 'number':
+						return { o: 'r', v: e };
+					case 'array':
+						return this.options.list_diff
+							? { o: 'L', v: this.list_diff( t, e ) }
+							: { o: 'r', v: e };
+					case 'object':
+						return { o: 'O', v: this.object_diff( t, e ) };
+					case 'string':
+						if (
+							( ( n = u.dmp.diff_main( t, e ) ).length > 2 && u.dmp.diff_cleanupEfficiency( n ),
+							n.length > 0 )
+						)
+							return { o: 'd', v: u.dmp.diff_toDelta( n ) };
+				}
+				return {};
+			} ),
+			( u.prototype.apply_list_diff = function( t, e ) {
+				var n, r, i, o, a, f, h, c, l, p, d, g, y, m;
+				for ( h in ( ( l = this.deepCopy( t ) ), ( f = [] ), ( n = [] ), e ) )
+					s.call( e, h ) && ( f.push( h ), f.sort() );
+				for ( y = 0, m = f.length; y < m; y++ )
+					switch (
+						( ( c = e[ ( a = f[ y ] ) ] ),
+						( d = ( function() {
+							var t, e, r;
+							for ( r = [], t = 0, e = n.length; t < e; t++ ) ( g = n[ t ] ) <= a && r.push( g );
+							return r;
+						} )().length ),
+						( p = a - d ),
+						c.o )
+					) {
+						case '+':
+							[].splice.apply( l, [ p, p - p + 1 ].concat( c.v ) );
+							break;
+						case '-':
+							[].splice.apply( l, [ p, p - p + 1 ].concat( [] ) ), ( n[ n.length ] = p );
+							break;
+						case 'r':
+							l[ p ] = c.v;
+							break;
+						case 'I':
+							l[ p ] += c.v;
+							break;
+						case 'L':
+							l[ p ] = this.apply_list_diff( l[ p ], c.v );
+							break;
+						case 'O':
+							l[ p ] = this.apply_object_diff( l[ p ], c.v );
+							break;
+						case 'd':
+							( r = u.dmp.diff_fromDelta( l[ p ], c.v ) ),
+								( i = u.dmp.patch_make( l[ p ], r ) ),
+								( o = u.dmp.patch_apply( i, l[ p ] ) ),
+								( l[ p ] = o[ 0 ] );
+					}
+				return l;
+			} ),
+			( u.prototype.apply_object_diff = function( t, e ) {
+				var n, r, i, o, a, f;
+				for ( o in ( ( f = this.deepCopy( t ) ), e ) )
+					if ( s.call( e, o ) )
+						switch ( ( a = e[ o ] ).o ) {
+							case '+':
+								f[ o ] = a.v;
+								break;
+							case '-':
+								delete f[ o ];
+								break;
+							case 'r':
+								f[ o ] = a.v;
+								break;
+							case 'I':
+								f[ o ] += a.v;
+								break;
+							case 'L':
+								f[ o ] = this.apply_list_diff( f[ o ], a.v );
+								break;
+							case 'O':
+								f[ o ] = this.apply_object_diff( f[ o ], a.v );
+								break;
+							case 'd':
+								( n = u.dmp.diff_fromDelta( f[ o ], a.v ) ),
+									( r = u.dmp.patch_make( f[ o ], n ) ),
+									( i = u.dmp.patch_apply( r, f[ o ] ) ),
+									( f[ o ] = i[ 0 ] );
+						}
+				return f;
+			} ),
+			( u.prototype.apply_object_diff_with_offsets = function( t, e, n, r ) {
+				var i, o, a, f, h, c;
+				for ( f in ( ( c = this.deepCopy( t ) ), e ) )
+					if ( s.call( e, f ) )
+						switch ( ( h = e[ f ] ).o ) {
+							case '+':
+								c[ f ] = h.v;
+								break;
+							case '-':
+								delete c[ f ];
+								break;
+							case 'r':
+								c[ f ] = h.v;
+								break;
+							case 'I':
+								c[ f ] += h.v;
+								break;
+							case 'L':
+								c[ f ] = this.apply_list_diff( c[ f ], h.v );
+								break;
+							case 'O':
+								c[ f ] = this.apply_object_diff( c[ f ], h.v );
+								break;
+							case 'd':
+								( i = u.dmp.diff_fromDelta( c[ f ], h.v ) ),
+									( o = u.dmp.patch_make( c[ f ], i ) ),
+									f === n
+										? ( c[ f ] = this.patch_apply_with_offsets( o, c[ f ], r ) )
+										: ( ( a = u.dmp.patch_apply( o, c[ f ] ) ), ( c[ f ] = a[ 0 ] ) );
+						}
+				return c;
+			} ),
+			( u.prototype.transform_list_diff = function( t, e, n ) {
+				var r, i, o, a, u, f, h, c, l, p;
+				for ( u in ( ( r = {} ), ( o = [] ), ( i = [] ), e ) )
+					s.call( e, u ) && ( '+' === ( f = e[ u ] ).o && o.push( u ), '-' === f.o && i.push( u ) );
+				for ( u in t )
+					if (
+						s.call( t, u ) &&
+						( ( f = t[ u ] ),
+						( c = [
+							( function() {
+								var t, e, n;
+								for ( n = [], t = 0, e = o.length; t < e; t++ ) ( p = o[ t ] ) <= u && n.push( p );
+								return n;
+							} )(),
+						].length ),
+						( h = [
+							( function() {
+								var t, e, n;
+								for ( n = [], t = 0, e = i.length; t < e; t++ ) ( p = i[ t ] ) <= u && n.push( p );
+								return n;
+							} )(),
+						].length ),
+						( u = u + c - h ),
+						( r[ ( l = String( u ) ) ] = f ),
+						u in e )
+					) {
+						if ( '+' === f.o && '+' === e.index.o ) continue;
+						'-' === f.o && '-' === e.index.o
+							? delete r[ l ]
+							: ( ( a = this.transform_object_diff( { sindex: f }, { sindex: e.index }, n ) ),
+							  ( r[ l ] = a[ l ] ) );
+					}
+				return r;
+			} ),
+			( u.prototype.transform_object_diff = function( t, e, n ) {
+				var r, i, o, a, f, h, c, l, p, d, g, y, m;
+				for ( g in ( ( o = this.deepCopy( t ) ), t ) )
+					if ( s.call( t, g ) && ( ( a = t[ g ] ), g in e ) )
+						return (
+							( y = n[ g ] ),
+							( c = e[ g ] ),
+							'+' === a.o && '+' === c.o
+								? this.equals( a.v, c.v )
+									? delete o[ g ]
+									: ( o[ g ] = this.diff( c.v, a.v ) )
+								: '-' === a.o && '-' === c.o
+								? delete o[ g ]
+								: '-' !== c.o || ( 'O' !== ( m = a.o ) && 'L' !== m && 'I' !== m && 'd' !== m )
+								? 'O' === a.o && 'O' === c.o
+									? ( o[ g ] = { o: 'O', v: this.transform_object_diff( a.v, c.v, y ) } )
+									: 'L' === a.o && 'L' === c.o
+									? ( o[ g ] = { o: 'O', v: this.transform_list_diff( a.v, c.v, y ) } )
+									: 'd' === a.o &&
+									  'd' === c.o &&
+									  ( delete o[ g ],
+									  ( r = u.dmp.patch_make( y, u.dmp.diff_fromDelta( y, a.v ) ) ),
+									  ( f = u.dmp.patch_make( y, u.dmp.diff_fromDelta( y, c.v ) ) ),
+									  ( h = u.dmp.patch_apply( f, y )[ 0 ] ),
+									  ( i = u.dmp.patch_apply( r, h )[ 0 ] ) !== h &&
+											( ( l = u.dmp.diff_main( h, i ) ).length > 2 &&
+												u.dmp.diff_cleanupEfficiency( l ),
+											l.length > 0 && ( o[ g ] = { o: 'd', v: u.dmp.diff_toDelta( l ) } ) ) )
+								: ( ( o[ g ] = { o: '+' } ),
+								  'O' === a.o
+										? ( o[ g ].v = this.apply_object_diff( y, a.v ) )
+										: 'L' === a.o
+										? ( o[ g ].v = this.apply_list_diff( y, a.v ) )
+										: 'I' === a.o
+										? ( o[ g ].v = y + a.v )
+										: 'd' === a.o &&
+										  ( ( l = u.dmp.diff_fromDelta( y, a.v ) ),
+										  ( p = u.dmp.patch_make( y, l ) ),
+										  ( d = u.dmp.patch_apply( p, y ) ),
+										  ( o[ g ].v = d[ 0 ] ) ) ),
+							o
+						);
+			} ),
+			( u.prototype.patch_apply_with_offsets = function( t, e, n ) {} ),
+			( u.prototype.patch_apply_with_offsets = function( t, e, n ) {
+				if ( 0 == t.length ) return e;
+				t = u.dmp.patch_deepCopy( t );
+				var i = u.dmp.patch_addPadding( t );
+				( e = i + e + i ), u.dmp.patch_splitMax( t );
+				for ( var o = 0, s = 0; s < t.length; s++ ) {
+					var a,
+						f = t[ s ].start2 + o,
+						h = u.dmp.diff_text1( t[ s ].diffs ),
+						c = -1;
+					if (
+						( h.length > u.dmp.Match_MaxBits
+							? -1 != ( a = u.dmp.match_main( e, h.substring( 0, u.dmp.Match_MaxBits ), f ) ) &&
+							  ( -1 ==
+									( c = u.dmp.match_main(
+										e,
+										h.substring( h.length - u.dmp.Match_MaxBits ),
+										f + h.length - u.dmp.Match_MaxBits
+									) ) ||
+									a >= c ) &&
+							  ( a = -1 )
+							: ( a = u.dmp.match_main( e, h, f ) ),
+						-1 == a )
+					)
+						o -= t[ s ].length2 - t[ s ].length1;
+					else {
+						var l;
+						( o = a - f ),
+							( l =
+								-1 == c
+									? e.substring( a, a + h.length )
+									: e.substring( a, c + u.dmp.Match_MaxBits ) );
+						var p = u.dmp.diff_main( h, l, ! 1 );
+						if (
+							h.length > u.dmp.Match_MaxBits &&
+							u.dmp.diff_levenshtein( p ) / h.length > u.dmp.Patch_DeleteThreshold
+						);
+						else
+							for ( var d, g = 0, y = 0; y < t[ s ].diffs.length; y++ ) {
+								var m = t[ s ].diffs[ y ];
+								if (
+									( m[ 0 ] !== r.DIFF_EQUAL && ( d = u.dmp.diff_xIndex( p, g ) ),
+									m[ 0 ] === r.DIFF_INSERT )
+								) {
+									e = e.substring( 0, a + d ) + m[ 1 ] + e.substring( a + d );
+									for ( var v = 0; v < n.length; v++ )
+										n[ v ] + i.length > a + d && ( n[ v ] += m[ 1 ].length );
+								} else if ( m[ 0 ] === r.DIFF_DELETE ) {
+									var b = a + d,
+										_ = a + u.dmp.diff_xIndex( p, g + m[ 1 ].length );
+									e = e.substring( 0, b ) + e.substring( _ );
+									for ( v = 0; v < n.length; v++ )
+										n[ v ] + i.length > b &&
+											( n[ v ] + i.length < _ ? ( n[ v ] = b - i.length ) : ( n[ v ] -= _ - b ) );
+								}
+								m[ 0 ] !== r.DIFF_DELETE && ( g += m[ 1 ].length );
+							}
+					}
+				}
+				return ( e = e.substring( i.length, e.length - i.length ) );
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		function r( t ) {
+			return ( r =
+				'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator
+					? function( t ) {
+							return typeof t;
+					  }
+					: function( t ) {
+							return t &&
+								'function' == typeof Symbol &&
+								t.constructor === Symbol &&
+								t !== Symbol.prototype
+								? 'symbol'
+								: typeof t;
+					  } )( t );
+		}
+		function i() {
+			( this.Diff_Timeout = 1 ),
+				( this.Diff_EditCost = 4 ),
+				( this.Match_Threshold = 0.5 ),
+				( this.Match_Distance = 1e3 ),
+				( this.Patch_DeleteThreshold = 0.5 ),
+				( this.Patch_Margin = 4 ),
+				( this.Match_MaxBits = 32 );
+		}
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.default = i ),
+			( e.DIFF_EQUAL = e.DIFF_INSERT = e.DIFF_DELETE = void 0 );
+		e.DIFF_DELETE = -1;
+		e.DIFF_INSERT = 1;
+		( e.DIFF_EQUAL = 0 ),
+			( i.Diff = function( t, e ) {
+				( this[ 0 ] = t ), ( this[ 1 ] = e );
+			} ),
+			( i.Diff.prototype.length = 2 ),
+			( i.Diff.prototype.toString = function() {
+				return this[ 0 ] + ',' + this[ 1 ];
+			} ),
+			( i.prototype.diff_main = function( t, e, n, r ) {
+				void 0 === r &&
+					( r =
+						this.Diff_Timeout <= 0
+							? Number.MAX_VALUE
+							: new Date().getTime() + 1e3 * this.Diff_Timeout );
+				var o = r;
+				if ( null == t || null == e ) throw new Error( 'Null input. (diff_main)' );
+				if ( t == e ) return t ? [ new i.Diff( 0, t ) ] : [];
+				void 0 === n && ( n = ! 0 );
+				var s = n,
+					a = this.diff_commonPrefix( t, e ),
+					u = t.substring( 0, a );
+				( t = t.substring( a ) ), ( e = e.substring( a ) ), ( a = this.diff_commonSuffix( t, e ) );
+				var f = t.substring( t.length - a );
+				( t = t.substring( 0, t.length - a ) ), ( e = e.substring( 0, e.length - a ) );
+				var h = this.diff_compute_( t, e, s, o );
+				return (
+					u && h.unshift( new i.Diff( 0, u ) ),
+					f && h.push( new i.Diff( 0, f ) ),
+					this.diff_cleanupMerge( h ),
+					h
+				);
+			} ),
+			( i.prototype.diff_compute_ = function( t, e, n, r ) {
+				var o;
+				if ( ! t ) return [ new i.Diff( 1, e ) ];
+				if ( ! e ) return [ new i.Diff( -1, t ) ];
+				var s = t.length > e.length ? t : e,
+					a = t.length > e.length ? e : t,
+					u = s.indexOf( a );
+				if ( -1 != u )
+					return (
+						( o = [
+							new i.Diff( 1, s.substring( 0, u ) ),
+							new i.Diff( 0, a ),
+							new i.Diff( 1, s.substring( u + a.length ) ),
+						] ),
+						t.length > e.length && ( o[ 0 ][ 0 ] = o[ 2 ][ 0 ] = -1 ),
+						o
+					);
+				if ( 1 == a.length ) return [ new i.Diff( -1, t ), new i.Diff( 1, e ) ];
+				var f = this.diff_halfMatch_( t, e );
+				if ( f ) {
+					var h = f[ 0 ],
+						c = f[ 1 ],
+						l = f[ 2 ],
+						p = f[ 3 ],
+						d = f[ 4 ],
+						g = this.diff_main( h, l, n, r ),
+						y = this.diff_main( c, p, n, r );
+					return g.concat( [ new i.Diff( 0, d ) ], y );
+				}
+				return n && t.length > 100 && e.length > 100
+					? this.diff_lineMode_( t, e, r )
+					: this.diff_bisect_( t, e, r );
+			} ),
+			( i.prototype.diff_lineMode_ = function( t, e, n ) {
+				var r = this.diff_linesToChars_( t, e );
+				( t = r.chars1 ), ( e = r.chars2 );
+				var o = r.lineArray,
+					s = this.diff_main( t, e, ! 1, n );
+				this.diff_charsToLines_( s, o ),
+					this.diff_cleanupSemantic( s ),
+					s.push( new i.Diff( 0, '' ) );
+				for ( var a = 0, u = 0, f = 0, h = '', c = ''; a < s.length;  ) {
+					switch ( s[ a ][ 0 ] ) {
+						case 1:
+							f++, ( c += s[ a ][ 1 ] );
+							break;
+						case -1:
+							u++, ( h += s[ a ][ 1 ] );
+							break;
+						case 0:
+							if ( u >= 1 && f >= 1 ) {
+								s.splice( a - u - f, u + f ), ( a = a - u - f );
+								for ( var l = this.diff_main( h, c, ! 1, n ), p = l.length - 1; p >= 0; p-- )
+									s.splice( a, 0, l[ p ] );
+								a += l.length;
+							}
+							( f = 0 ), ( u = 0 ), ( h = '' ), ( c = '' );
+					}
+					a++;
+				}
+				return s.pop(), s;
+			} ),
+			( i.prototype.diff_bisect_ = function( t, e, n ) {
+				for (
+					var r = t.length,
+						o = e.length,
+						s = Math.ceil( ( r + o ) / 2 ),
+						a = s,
+						u = 2 * s,
+						f = new Array( u ),
+						h = new Array( u ),
+						c = 0;
+					c < u;
+					c++
+				)
+					( f[ c ] = -1 ), ( h[ c ] = -1 );
+				( f[ a + 1 ] = 0 ), ( h[ a + 1 ] = 0 );
+				for (
+					var l = r - o, p = l % 2 != 0, d = 0, g = 0, y = 0, m = 0, v = 0;
+					v < s && ! ( new Date().getTime() > n );
+					v++
+				) {
+					for ( var b = -v + d; b <= v - g; b += 2 ) {
+						for (
+							var _ = a + b,
+								w =
+									( k =
+										b == -v || ( b != v && f[ _ - 1 ] < f[ _ + 1 ] )
+											? f[ _ + 1 ]
+											: f[ _ - 1 ] + 1 ) - b;
+							k < r && w < o && t.charAt( k ) == e.charAt( w );
+
+						)
+							k++, w++;
+						if ( ( ( f[ _ ] = k ), k > r ) ) g += 2;
+						else if ( w > o ) d += 2;
+						else if ( p ) {
+							if ( ( S = a + l - b ) >= 0 && S < u && -1 != h[ S ] )
+								if ( k >= ( O = r - h[ S ] ) ) return this.diff_bisectSplit_( t, e, k, w, n );
+						}
+					}
+					for ( var x = -v + y; x <= v - m; x += 2 ) {
+						for (
+							var O,
+								S = a + x,
+								E =
+									( O =
+										x == -v || ( x != v && h[ S - 1 ] < h[ S + 1 ] )
+											? h[ S + 1 ]
+											: h[ S - 1 ] + 1 ) - x;
+							O < r && E < o && t.charAt( r - O - 1 ) == e.charAt( o - E - 1 );
+
+						)
+							O++, E++;
+						if ( ( ( h[ S ] = O ), O > r ) ) m += 2;
+						else if ( E > o ) y += 2;
+						else if ( ! p ) {
+							if ( ( _ = a + l - x ) >= 0 && _ < u && -1 != f[ _ ] ) {
+								var k;
+								w = a + ( k = f[ _ ] ) - _;
+								if ( k >= ( O = r - O ) ) return this.diff_bisectSplit_( t, e, k, w, n );
+							}
+						}
+					}
+				}
+				return [ new i.Diff( -1, t ), new i.Diff( 1, e ) ];
+			} ),
+			( i.prototype.diff_bisectSplit_ = function( t, e, n, r, i ) {
+				var o = t.substring( 0, n ),
+					s = e.substring( 0, r ),
+					a = t.substring( n ),
+					u = e.substring( r ),
+					f = this.diff_main( o, s, ! 1, i ),
+					h = this.diff_main( a, u, ! 1, i );
+				return f.concat( h );
+			} ),
+			( i.prototype.diff_linesToChars_ = function( t, e ) {
+				var n = [],
+					r = {};
+				function i( t ) {
+					for ( var e = '', i = 0, s = -1, a = n.length; s < t.length - 1;  ) {
+						-1 == ( s = t.indexOf( '\n', i ) ) && ( s = t.length - 1 );
+						var u = t.substring( i, s + 1 );
+						( r.hasOwnProperty
+						? r.hasOwnProperty( u )
+						: void 0 !== r[ u ] )
+							? ( e += String.fromCharCode( r[ u ] ) )
+							: ( a == o && ( ( u = t.substring( i ) ), ( s = t.length ) ),
+							  ( e += String.fromCharCode( a ) ),
+							  ( r[ u ] = a ),
+							  ( n[ a++ ] = u ) ),
+							( i = s + 1 );
+					}
+					return e;
+				}
+				n[ 0 ] = '';
+				var o = 4e4,
+					s = i( t );
+				return ( o = 65535 ), { chars1: s, chars2: i( e ), lineArray: n };
+			} ),
+			( i.prototype.diff_charsToLines_ = function( t, e ) {
+				for ( var n = 0; n < t.length; n++ ) {
+					for ( var r = t[ n ][ 1 ], i = [], o = 0; o < r.length; o++ )
+						i[ o ] = e[ r.charCodeAt( o ) ];
+					t[ n ][ 1 ] = i.join( '' );
+				}
+			} ),
+			( i.prototype.diff_commonPrefix = function( t, e ) {
+				if ( ! t || ! e || t.charAt( 0 ) != e.charAt( 0 ) ) return 0;
+				for ( var n = 0, r = Math.min( t.length, e.length ), i = r, o = 0; n < i;  )
+					t.substring( o, i ) == e.substring( o, i ) ? ( o = n = i ) : ( r = i ),
+						( i = Math.floor( ( r - n ) / 2 + n ) );
+				return i;
+			} ),
+			( i.prototype.diff_commonSuffix = function( t, e ) {
+				if ( ! t || ! e || t.charAt( t.length - 1 ) != e.charAt( e.length - 1 ) ) return 0;
+				for ( var n = 0, r = Math.min( t.length, e.length ), i = r, o = 0; n < i;  )
+					t.substring( t.length - i, t.length - o ) == e.substring( e.length - i, e.length - o )
+						? ( o = n = i )
+						: ( r = i ),
+						( i = Math.floor( ( r - n ) / 2 + n ) );
+				return i;
+			} ),
+			( i.prototype.diff_commonOverlap_ = function( t, e ) {
+				var n = t.length,
+					r = e.length;
+				if ( 0 == n || 0 == r ) return 0;
+				n > r ? ( t = t.substring( n - r ) ) : n < r && ( e = e.substring( 0, n ) );
+				var i = Math.min( n, r );
+				if ( t == e ) return i;
+				for ( var o = 0, s = 1; ;  ) {
+					var a = t.substring( i - s ),
+						u = e.indexOf( a );
+					if ( -1 == u ) return o;
+					( s += u ),
+						( 0 != u && t.substring( i - s ) != e.substring( 0, s ) ) || ( ( o = s ), s++ );
+				}
+			} ),
+			( i.prototype.diff_halfMatch_ = function( t, e ) {
+				if ( this.Diff_Timeout <= 0 ) return null;
+				var n = t.length > e.length ? t : e,
+					r = t.length > e.length ? e : t;
+				if ( n.length < 4 || 2 * r.length < n.length ) return null;
+				var i = this;
+				function o( t, e, n ) {
+					for (
+						var r, o, s, a, u = t.substring( n, n + Math.floor( t.length / 4 ) ), f = -1, h = '';
+						-1 != ( f = e.indexOf( u, f + 1 ) );
+
+					) {
+						var c = i.diff_commonPrefix( t.substring( n ), e.substring( f ) ),
+							l = i.diff_commonSuffix( t.substring( 0, n ), e.substring( 0, f ) );
+						h.length < l + c &&
+							( ( h = e.substring( f - l, f ) + e.substring( f, f + c ) ),
+							( r = t.substring( 0, n - l ) ),
+							( o = t.substring( n + c ) ),
+							( s = e.substring( 0, f - l ) ),
+							( a = e.substring( f + c ) ) );
+					}
+					return 2 * h.length >= t.length ? [ r, o, s, a, h ] : null;
+				}
+				var s,
+					a,
+					u,
+					f,
+					h,
+					c = o( n, r, Math.ceil( n.length / 4 ) ),
+					l = o( n, r, Math.ceil( n.length / 2 ) );
+				return c || l
+					? ( ( s = l ? ( c && c[ 4 ].length > l[ 4 ].length ? c : l ) : c ),
+					  t.length > e.length
+							? ( ( a = s[ 0 ] ), ( u = s[ 1 ] ), ( f = s[ 2 ] ), ( h = s[ 3 ] ) )
+							: ( ( f = s[ 0 ] ), ( h = s[ 1 ] ), ( a = s[ 2 ] ), ( u = s[ 3 ] ) ),
+					  [ a, u, f, h, s[ 4 ] ] )
+					: null;
+			} ),
+			( i.prototype.diff_cleanupSemantic = function( t ) {
+				for (
+					var e = ! 1, n = [], r = 0, o = null, s = 0, a = 0, u = 0, f = 0, h = 0;
+					s < t.length;
+
+				)
+					0 == t[ s ][ 0 ]
+						? ( ( n[ r++ ] = s ), ( a = f ), ( u = h ), ( f = 0 ), ( h = 0 ), ( o = t[ s ][ 1 ] ) )
+						: ( 1 == t[ s ][ 0 ] ? ( f += t[ s ][ 1 ].length ) : ( h += t[ s ][ 1 ].length ),
+						  o &&
+								o.length <= Math.max( a, u ) &&
+								o.length <= Math.max( f, h ) &&
+								( t.splice( n[ r - 1 ], 0, new i.Diff( -1, o ) ),
+								( t[ n[ r - 1 ] + 1 ][ 0 ] = 1 ),
+								r--,
+								( s = --r > 0 ? n[ r - 1 ] : -1 ),
+								( a = 0 ),
+								( u = 0 ),
+								( f = 0 ),
+								( h = 0 ),
+								( o = null ),
+								( e = ! 0 ) ) ),
+						s++;
+				for (
+					e && this.diff_cleanupMerge( t ), this.diff_cleanupSemanticLossless( t ), s = 1;
+					s < t.length;
+
+				) {
+					if ( -1 == t[ s - 1 ][ 0 ] && 1 == t[ s ][ 0 ] ) {
+						var c = t[ s - 1 ][ 1 ],
+							l = t[ s ][ 1 ],
+							p = this.diff_commonOverlap_( c, l ),
+							d = this.diff_commonOverlap_( l, c );
+						p >= d
+							? ( p >= c.length / 2 || p >= l.length / 2 ) &&
+							  ( t.splice( s, 0, new i.Diff( 0, l.substring( 0, p ) ) ),
+							  ( t[ s - 1 ][ 1 ] = c.substring( 0, c.length - p ) ),
+							  ( t[ s + 1 ][ 1 ] = l.substring( p ) ),
+							  s++ )
+							: ( d >= c.length / 2 || d >= l.length / 2 ) &&
+							  ( t.splice( s, 0, new i.Diff( 0, c.substring( 0, d ) ) ),
+							  ( t[ s - 1 ][ 0 ] = 1 ),
+							  ( t[ s - 1 ][ 1 ] = l.substring( 0, l.length - d ) ),
+							  ( t[ s + 1 ][ 0 ] = -1 ),
+							  ( t[ s + 1 ][ 1 ] = c.substring( d ) ),
+							  s++ ),
+							s++;
+					}
+					s++;
+				}
+			} ),
+			( i.prototype.diff_cleanupSemanticLossless = function( t ) {
+				function e( t, e ) {
+					if ( ! t || ! e ) return 6;
+					var n = t.charAt( t.length - 1 ),
+						r = e.charAt( 0 ),
+						o = n.match( i.nonAlphaNumericRegex_ ),
+						s = r.match( i.nonAlphaNumericRegex_ ),
+						a = o && n.match( i.whitespaceRegex_ ),
+						u = s && r.match( i.whitespaceRegex_ ),
+						f = a && n.match( i.linebreakRegex_ ),
+						h = u && r.match( i.linebreakRegex_ ),
+						c = f && t.match( i.blanklineEndRegex_ ),
+						l = h && e.match( i.blanklineStartRegex_ );
+					return c || l ? 5 : f || h ? 4 : o && ! a && u ? 3 : a || u ? 2 : o || s ? 1 : 0;
+				}
+				for ( var n = 1; n < t.length - 1;  ) {
+					if ( 0 == t[ n - 1 ][ 0 ] && 0 == t[ n + 1 ][ 0 ] ) {
+						var r = t[ n - 1 ][ 1 ],
+							o = t[ n ][ 1 ],
+							s = t[ n + 1 ][ 1 ],
+							a = this.diff_commonSuffix( r, o );
+						if ( a ) {
+							var u = o.substring( o.length - a );
+							( r = r.substring( 0, r.length - a ) ),
+								( o = u + o.substring( 0, o.length - a ) ),
+								( s = u + s );
+						}
+						for (
+							var f = r, h = o, c = s, l = e( r, o ) + e( o, s );
+							o.charAt( 0 ) === s.charAt( 0 );
+
+						) {
+							( r += o.charAt( 0 ) ),
+								( o = o.substring( 1 ) + s.charAt( 0 ) ),
+								( s = s.substring( 1 ) );
+							var p = e( r, o ) + e( o, s );
+							p >= l && ( ( l = p ), ( f = r ), ( h = o ), ( c = s ) );
+						}
+						t[ n - 1 ][ 1 ] != f &&
+							( f ? ( t[ n - 1 ][ 1 ] = f ) : ( t.splice( n - 1, 1 ), n-- ),
+							( t[ n ][ 1 ] = h ),
+							c ? ( t[ n + 1 ][ 1 ] = c ) : ( t.splice( n + 1, 1 ), n-- ) );
+					}
+					n++;
+				}
+			} ),
+			( i.nonAlphaNumericRegex_ = /[^a-zA-Z0-9]/ ),
+			( i.whitespaceRegex_ = /\s/ ),
+			( i.linebreakRegex_ = /[\r\n]/ ),
+			( i.blanklineEndRegex_ = /\n\r?\n$/ ),
+			( i.blanklineStartRegex_ = /^\r?\n\r?\n/ ),
+			( i.prototype.diff_cleanupEfficiency = function( t ) {
+				for (
+					var e = ! 1, n = [], r = 0, o = null, s = 0, a = ! 1, u = ! 1, f = ! 1, h = ! 1;
+					s < t.length;
+
+				)
+					0 == t[ s ][ 0 ]
+						? ( t[ s ][ 1 ].length < this.Diff_EditCost && ( f || h )
+								? ( ( n[ r++ ] = s ), ( a = f ), ( u = h ), ( o = t[ s ][ 1 ] ) )
+								: ( ( r = 0 ), ( o = null ) ),
+						  ( f = h = ! 1 ) )
+						: ( -1 == t[ s ][ 0 ] ? ( h = ! 0 ) : ( f = ! 0 ),
+						  o &&
+								( ( a && u && f && h ) ||
+									( o.length < this.Diff_EditCost / 2 && a + u + f + h == 3 ) ) &&
+								( t.splice( n[ r - 1 ], 0, new i.Diff( -1, o ) ),
+								( t[ n[ r - 1 ] + 1 ][ 0 ] = 1 ),
+								r--,
+								( o = null ),
+								a && u
+									? ( ( f = h = ! 0 ), ( r = 0 ) )
+									: ( ( s = --r > 0 ? n[ r - 1 ] : -1 ), ( f = h = ! 1 ) ),
+								( e = ! 0 ) ) ),
+						s++;
+				e && this.diff_cleanupMerge( t );
+			} ),
+			( i.prototype.diff_cleanupMerge = function( t ) {
+				t.push( new i.Diff( 0, '' ) );
+				for ( var e, n = 0, r = 0, o = 0, s = '', a = ''; n < t.length;  )
+					switch ( t[ n ][ 0 ] ) {
+						case 1:
+							o++, ( a += t[ n ][ 1 ] ), n++;
+							break;
+						case -1:
+							r++, ( s += t[ n ][ 1 ] ), n++;
+							break;
+						case 0:
+							r + o > 1
+								? ( 0 !== r &&
+										0 !== o &&
+										( 0 !== ( e = this.diff_commonPrefix( a, s ) ) &&
+											( n - r - o > 0 && 0 == t[ n - r - o - 1 ][ 0 ]
+												? ( t[ n - r - o - 1 ][ 1 ] += a.substring( 0, e ) )
+												: ( t.splice( 0, 0, new i.Diff( 0, a.substring( 0, e ) ) ), n++ ),
+											( a = a.substring( e ) ),
+											( s = s.substring( e ) ) ),
+										0 !== ( e = this.diff_commonSuffix( a, s ) ) &&
+											( ( t[ n ][ 1 ] = a.substring( a.length - e ) + t[ n ][ 1 ] ),
+											( a = a.substring( 0, a.length - e ) ),
+											( s = s.substring( 0, s.length - e ) ) ) ),
+								  ( n -= r + o ),
+								  t.splice( n, r + o ),
+								  s.length && ( t.splice( n, 0, new i.Diff( -1, s ) ), n++ ),
+								  a.length && ( t.splice( n, 0, new i.Diff( 1, a ) ), n++ ),
+								  n++ )
+								: 0 !== n && 0 == t[ n - 1 ][ 0 ]
+								? ( ( t[ n - 1 ][ 1 ] += t[ n ][ 1 ] ), t.splice( n, 1 ) )
+								: n++,
+								( o = 0 ),
+								( r = 0 ),
+								( s = '' ),
+								( a = '' );
+					}
+				'' === t[ t.length - 1 ][ 1 ] && t.pop();
+				var u = ! 1;
+				for ( n = 1; n < t.length - 1;  )
+					0 == t[ n - 1 ][ 0 ] &&
+						0 == t[ n + 1 ][ 0 ] &&
+						( t[ n ][ 1 ].substring( t[ n ][ 1 ].length - t[ n - 1 ][ 1 ].length ) ==
+						t[ n - 1 ][ 1 ]
+							? ( ( t[ n ][ 1 ] =
+									t[ n - 1 ][ 1 ] +
+									t[ n ][ 1 ].substring( 0, t[ n ][ 1 ].length - t[ n - 1 ][ 1 ].length ) ),
+							  ( t[ n + 1 ][ 1 ] = t[ n - 1 ][ 1 ] + t[ n + 1 ][ 1 ] ),
+							  t.splice( n - 1, 1 ),
+							  ( u = ! 0 ) )
+							: t[ n ][ 1 ].substring( 0, t[ n + 1 ][ 1 ].length ) == t[ n + 1 ][ 1 ] &&
+							  ( ( t[ n - 1 ][ 1 ] += t[ n + 1 ][ 1 ] ),
+							  ( t[ n ][ 1 ] = t[ n ][ 1 ].substring( t[ n + 1 ][ 1 ].length ) + t[ n + 1 ][ 1 ] ),
+							  t.splice( n + 1, 1 ),
+							  ( u = ! 0 ) ) ),
+						n++;
+				u && this.diff_cleanupMerge( t );
+			} ),
+			( i.prototype.diff_xIndex = function( t, e ) {
+				var n,
+					r = 0,
+					i = 0,
+					o = 0,
+					s = 0;
+				for (
+					n = 0;
+					n < t.length &&
+					( 1 !== t[ n ][ 0 ] && ( r += t[ n ][ 1 ].length ),
+					-1 !== t[ n ][ 0 ] && ( i += t[ n ][ 1 ].length ),
+					! ( r > e ) );
+					n++
+				)
+					( o = r ), ( s = i );
+				return t.length != n && -1 === t[ n ][ 0 ] ? s : s + ( e - o );
+			} ),
+			( i.prototype.diff_prettyHtml = function( t ) {
+				for ( var e = [], n = /&/g, r = /</g, i = />/g, o = /\n/g, s = 0; s < t.length; s++ ) {
+					var a = t[ s ][ 0 ],
+						u = t[ s ][ 1 ]
+							.replace( n, '&amp;' )
+							.replace( r, '&lt;' )
+							.replace( i, '&gt;' )
+							.replace( o, '&para;<br>' );
+					switch ( a ) {
+						case 1:
+							e[ s ] = '<ins style="background:#e6ffe6;">' + u + '</ins>';
+							break;
+						case -1:
+							e[ s ] = '<del style="background:#ffe6e6;">' + u + '</del>';
+							break;
+						case 0:
+							e[ s ] = '<span>' + u + '</span>';
+					}
+				}
+				return e.join( '' );
+			} ),
+			( i.prototype.diff_text1 = function( t ) {
+				for ( var e = [], n = 0; n < t.length; n++ ) 1 !== t[ n ][ 0 ] && ( e[ n ] = t[ n ][ 1 ] );
+				return e.join( '' );
+			} ),
+			( i.prototype.diff_text2 = function( t ) {
+				for ( var e = [], n = 0; n < t.length; n++ ) -1 !== t[ n ][ 0 ] && ( e[ n ] = t[ n ][ 1 ] );
+				return e.join( '' );
+			} ),
+			( i.prototype.diff_levenshtein = function( t ) {
+				for ( var e = 0, n = 0, r = 0, i = 0; i < t.length; i++ ) {
+					var o = t[ i ][ 0 ],
+						s = t[ i ][ 1 ];
+					switch ( o ) {
+						case 1:
+							n += s.length;
+							break;
+						case -1:
+							r += s.length;
+							break;
+						case 0:
+							( e += Math.max( n, r ) ), ( n = 0 ), ( r = 0 );
+					}
+				}
+				return ( e += Math.max( n, r ) );
+			} ),
+			( i.prototype.isHighSurrogate = function( t ) {
+				var e = t.charCodeAt( 0 );
+				return e >= 55296 && e <= 56319;
+			} ),
+			( i.prototype.isLowSurrogate = function( t ) {
+				var e = t.charCodeAt( 0 );
+				return e >= 56320 && e <= 57343;
+			} ),
+			( i.prototype.diff_toDelta = function( t ) {
+				for ( var e, n = [], r = 0; r < t.length; r++ ) {
+					var i = t[ r ],
+						o = i[ 1 ][ 0 ],
+						s = i[ 1 ][ i[ 1 ].length - 1 ];
+					if (
+						0 !== i[ 1 ].length &&
+						( s && this.isHighSurrogate( s ) && ( ( e = s ), ( i[ 1 ] = i[ 1 ].slice( 0, -1 ) ) ),
+						e &&
+							o &&
+							this.isHighSurrogate( e ) &&
+							this.isLowSurrogate( o ) &&
+							( i[ 1 ] = e + i[ 1 ] ),
+						0 !== i[ 1 ].length )
+					)
+						switch ( i[ 0 ] ) {
+							case 1:
+								n.push( '+' + encodeURI( i[ 1 ] ) );
+								break;
+							case -1:
+								n.push( '-' + i[ 1 ].length );
+								break;
+							case 0:
+								n.push( '=' + i[ 1 ].length );
+						}
+				}
+				return n.join( '\t' ).replace( /%20/g, ' ' );
+			} ),
+			( i.prototype.digit16 = function( t ) {
+				switch ( t ) {
+					case '0':
+						return 0;
+					case '1':
+						return 1;
+					case '2':
+						return 2;
+					case '3':
+						return 3;
+					case '4':
+						return 4;
+					case '5':
+						return 5;
+					case '6':
+						return 6;
+					case '7':
+						return 7;
+					case '8':
+						return 8;
+					case '9':
+						return 9;
+					case 'A':
+					case 'a':
+						return 10;
+					case 'B':
+					case 'b':
+						return 11;
+					case 'C':
+					case 'c':
+						return 12;
+					case 'D':
+					case 'd':
+						return 13;
+					case 'E':
+					case 'e':
+						return 14;
+					case 'F':
+					case 'f':
+						return 15;
+					default:
+						throw new Error( 'Invalid hex-code' );
+				}
+			} ),
+			( i.prototype.decodeURI = function( t ) {
+				try {
+					return decodeURI( t );
+				} catch ( u ) {
+					for ( var e = 0, n = ''; e < t.length;  )
+						if ( '%' === t[ e ] ) {
+							var r = ( this.digit16( t[ e + 1 ] ) << 4 ) + this.digit16( t[ e + 2 ] );
+							if ( 0 != ( 128 & r ) ) {
+								if ( '%' !== t[ e + 3 ] ) throw new URIError( 'URI malformed' );
+								var i = ( this.digit16( t[ e + 4 ] ) << 4 ) + this.digit16( t[ e + 5 ] );
+								if ( 128 != ( 192 & i ) ) throw new URIError( 'URI malformed' );
+								if ( ( ( i &= 63 ), 192 != ( 224 & r ) ) ) {
+									if ( '%' !== t[ e + 6 ] ) throw new URIError( 'URI malformed' );
+									var o = ( this.digit16( t[ e + 7 ] ) << 4 ) + this.digit16( t[ e + 8 ] );
+									if ( 128 != ( 192 & o ) ) throw new URIError( 'URI malformed' );
+									if ( ( ( o &= 63 ), 224 != ( 240 & r ) ) ) {
+										if ( '%' !== t[ e + 9 ] ) throw new URIError( 'URI malformed' );
+										var s = ( this.digit16( t[ e + 10 ] ) << 4 ) + this.digit16( t[ e + 11 ] );
+										if ( 128 != ( 192 & s ) ) throw new URIError( 'URI malformed' );
+										if ( ( ( s &= 63 ), 240 == ( 248 & r ) ) ) {
+											var a = ( ( 7 & r ) << 18 ) | ( i << 12 ) | ( o << 6 ) | s;
+											if ( a >= 65536 && a <= 1114111 ) {
+												( n += String.fromCharCode( ( ( ( 65535 & a ) >>> 10 ) & 1023 ) | 55296 ) ),
+													( n += String.fromCharCode( 56320 | ( 1023 & a ) ) ),
+													( e += 12 );
+												continue;
+											}
+										}
+										throw new URIError( 'URI malformed' );
+									}
+									( n += String.fromCharCode( ( ( 15 & r ) << 12 ) | ( i << 6 ) | o ) ), ( e += 9 );
+								} else ( n += String.fromCharCode( ( ( 31 & r ) << 6 ) | i ) ), ( e += 6 );
+							} else ( n += String.fromCharCode( r ) ), ( e += 3 );
+						} else n += t[ e++ ];
+					return n;
+				}
+			} ),
+			( i.prototype.diff_fromDelta = function( t, e ) {
+				for ( var n = [], r = 0, o = 0, s = e.split( /\t/g ), a = 0; a < s.length; a++ ) {
+					var u = s[ a ].substring( 1 );
+					switch ( s[ a ].charAt( 0 ) ) {
+						case '+':
+							try {
+								n[ r++ ] = new i.Diff( 1, this.decodeURI( u ) );
+							} catch ( t ) {
+								throw new Error( 'Illegal escape in diff_fromDelta: ' + u );
+							}
+							break;
+						case '-':
+						case '=':
+							var f = parseInt( u, 10 );
+							if ( isNaN( f ) || f < 0 )
+								throw new Error( 'Invalid number in diff_fromDelta: ' + u );
+							var h = t.substring( o, ( o += f ) );
+							'=' == s[ a ].charAt( 0 )
+								? ( n[ r++ ] = new i.Diff( 0, h ) )
+								: ( n[ r++ ] = new i.Diff( -1, h ) );
+							break;
+						default:
+							if ( s[ a ] )
+								throw new Error( 'Invalid diff operation in diff_fromDelta: ' + s[ a ] );
+					}
+				}
+				if ( o != t.length )
+					throw new Error(
+						'Delta length (' + o + ') does not equal source text length (' + t.length + ').'
+					);
+				return n;
+			} ),
+			( i.prototype.match_main = function( t, e, n ) {
+				if ( null == t || null == e || null == n ) throw new Error( 'Null input. (match_main)' );
+				return (
+					( n = Math.max( 0, Math.min( n, t.length ) ) ),
+					t == e
+						? 0
+						: t.length
+						? t.substring( n, n + e.length ) == e
+							? n
+							: this.match_bitap_( t, e, n )
+						: -1
+				);
+			} ),
+			( i.prototype.match_bitap_ = function( t, e, n ) {
+				if ( e.length > this.Match_MaxBits )
+					throw new Error( 'Pattern too long for this browser.' );
+				var r = this.match_alphabet_( e ),
+					i = this;
+				function o( t, r ) {
+					var o = t / e.length,
+						s = Math.abs( n - r );
+					return i.Match_Distance ? o + s / i.Match_Distance : s ? 1 : o;
+				}
+				var s = this.Match_Threshold,
+					a = t.indexOf( e, n );
+				-1 != a &&
+					( ( s = Math.min( o( 0, a ), s ) ),
+					-1 != ( a = t.lastIndexOf( e, n + e.length ) ) && ( s = Math.min( o( 0, a ), s ) ) );
+				var u,
+					f,
+					h = 1 << ( e.length - 1 );
+				a = -1;
+				for ( var c, l = e.length + t.length, p = 0; p < e.length; p++ ) {
+					for ( u = 0, f = l; u < f;  )
+						o( p, n + f ) <= s ? ( u = f ) : ( l = f ), ( f = Math.floor( ( l - u ) / 2 + u ) );
+					l = f;
+					var d = Math.max( 1, n - f + 1 ),
+						g = Math.min( n + f, t.length ) + e.length,
+						y = Array( g + 2 );
+					y[ g + 1 ] = ( 1 << p ) - 1;
+					for ( var m = g; m >= d; m-- ) {
+						var v = r[ t.charAt( m - 1 ) ];
+						if (
+							( ( y[ m ] =
+								0 === p
+									? ( ( y[ m + 1 ] << 1 ) | 1 ) & v
+									: ( ( ( y[ m + 1 ] << 1 ) | 1 ) & v ) |
+									  ( ( c[ m + 1 ] | c[ m ] ) << 1 ) |
+									  1 |
+									  c[ m + 1 ] ),
+							y[ m ] & h )
+						) {
+							var b = o( p, m - 1 );
+							if ( b <= s ) {
+								if ( ( ( s = b ), ! ( ( a = m - 1 ) > n ) ) ) break;
+								d = Math.max( 1, 2 * n - a );
+							}
+						}
+					}
+					if ( o( p + 1, n ) > s ) break;
+					c = y;
+				}
+				return a;
+			} ),
+			( i.prototype.match_alphabet_ = function( t ) {
+				for ( var e = {}, n = 0; n < t.length; n++ ) e[ t.charAt( n ) ] = 0;
+				for ( n = 0; n < t.length; n++ ) e[ t.charAt( n ) ] |= 1 << ( t.length - n - 1 );
+				return e;
+			} ),
+			( i.prototype.patch_addContext_ = function( t, e ) {
+				if ( 0 != e.length ) {
+					if ( null === t.start2 ) throw Error( 'patch not initialized' );
+					for (
+						var n = e.substring( t.start2, t.start2 + t.length1 ), r = 0;
+						e.indexOf( n ) != e.lastIndexOf( n ) &&
+						n.length < this.Match_MaxBits - this.Patch_Margin - this.Patch_Margin;
+
+					)
+						( r += this.Patch_Margin ),
+							( n = e.substring( t.start2 - r, t.start2 + t.length1 + r ) );
+					r += this.Patch_Margin;
+					var o = e.substring( t.start2 - r, t.start2 );
+					o && t.diffs.unshift( new i.Diff( 0, o ) );
+					var s = e.substring( t.start2 + t.length1, t.start2 + t.length1 + r );
+					s && t.diffs.push( new i.Diff( 0, s ) ),
+						( t.start1 -= o.length ),
+						( t.start2 -= o.length ),
+						( t.length1 += o.length + s.length ),
+						( t.length2 += o.length + s.length );
+				}
+			} ),
+			( i.prototype.patch_make = function( t, e, n ) {
+				var o, s;
+				if ( 'string' == typeof t && 'string' == typeof e && void 0 === n )
+					( o = t ),
+						( s = this.diff_main( o, e, ! 0 ) ).length > 2 &&
+							( this.diff_cleanupSemantic( s ), this.diff_cleanupEfficiency( s ) );
+				else if ( t && 'object' == r( t ) && void 0 === e && void 0 === n )
+					( s = t ), ( o = this.diff_text1( s ) );
+				else if ( 'string' == typeof t && e && 'object' == r( e ) && void 0 === n )
+					( o = t ), ( s = e );
+				else {
+					if ( 'string' != typeof t || 'string' != typeof e || ! n || 'object' != r( n ) )
+						throw new Error( 'Unknown call format to patch_make.' );
+					( o = t ), ( s = n );
+				}
+				if ( 0 === s.length ) return [];
+				for (
+					var a = [], u = new i.patch_obj(), f = 0, h = 0, c = 0, l = o, p = o, d = 0;
+					d < s.length;
+					d++
+				) {
+					var g = s[ d ][ 0 ],
+						y = s[ d ][ 1 ];
+					switch ( ( f || 0 === g || ( ( u.start1 = h ), ( u.start2 = c ) ), g ) ) {
+						case 1:
+							( u.diffs[ f++ ] = s[ d ] ),
+								( u.length2 += y.length ),
+								( p = p.substring( 0, c ) + y + p.substring( c ) );
+							break;
+						case -1:
+							( u.length1 += y.length ),
+								( u.diffs[ f++ ] = s[ d ] ),
+								( p = p.substring( 0, c ) + p.substring( c + y.length ) );
+							break;
+						case 0:
+							y.length <= 2 * this.Patch_Margin && f && s.length != d + 1
+								? ( ( u.diffs[ f++ ] = s[ d ] ),
+								  ( u.length1 += y.length ),
+								  ( u.length2 += y.length ) )
+								: y.length >= 2 * this.Patch_Margin &&
+								  f &&
+								  ( this.patch_addContext_( u, l ),
+								  a.push( u ),
+								  ( u = new i.patch_obj() ),
+								  ( f = 0 ),
+								  ( l = p ),
+								  ( h = c ) );
+					}
+					1 !== g && ( h += y.length ), -1 !== g && ( c += y.length );
+				}
+				return f && ( this.patch_addContext_( u, l ), a.push( u ) ), a;
+			} ),
+			( i.prototype.patch_deepCopy = function( t ) {
+				for ( var e = [], n = 0; n < t.length; n++ ) {
+					var r = t[ n ],
+						o = new i.patch_obj();
+					o.diffs = [];
+					for ( var s = 0; s < r.diffs.length; s++ )
+						o.diffs[ s ] = new i.Diff( r.diffs[ s ][ 0 ], r.diffs[ s ][ 1 ] );
+					( o.start1 = r.start1 ),
+						( o.start2 = r.start2 ),
+						( o.length1 = r.length1 ),
+						( o.length2 = r.length2 ),
+						( e[ n ] = o );
+				}
+				return e;
+			} ),
+			( i.prototype.patch_apply = function( t, e ) {
+				if ( 0 == t.length ) return [ e, [] ];
+				t = this.patch_deepCopy( t );
+				var n = this.patch_addPadding( t );
+				( e = n + e + n ), this.patch_splitMax( t );
+				for ( var r = 0, i = [], o = 0; o < t.length; o++ ) {
+					var s,
+						a,
+						u = t[ o ].start2 + r,
+						f = this.diff_text1( t[ o ].diffs ),
+						h = -1;
+					if (
+						( f.length > this.Match_MaxBits
+							? -1 != ( s = this.match_main( e, f.substring( 0, this.Match_MaxBits ), u ) ) &&
+							  ( -1 ==
+									( h = this.match_main(
+										e,
+										f.substring( f.length - this.Match_MaxBits ),
+										u + f.length - this.Match_MaxBits
+									) ) ||
+									s >= h ) &&
+							  ( s = -1 )
+							: ( s = this.match_main( e, f, u ) ),
+						-1 == s )
+					)
+						( i[ o ] = ! 1 ), ( r -= t[ o ].length2 - t[ o ].length1 );
+					else if (
+						( ( i[ o ] = ! 0 ),
+						( r = s - u ),
+						f ==
+							( a =
+								-1 == h
+									? e.substring( s, s + f.length )
+									: e.substring( s, h + this.Match_MaxBits ) ) )
+					)
+						e = e.substring( 0, s ) + this.diff_text2( t[ o ].diffs ) + e.substring( s + f.length );
+					else {
+						var c = this.diff_main( f, a, ! 1 );
+						if (
+							f.length > this.Match_MaxBits &&
+							this.diff_levenshtein( c ) / f.length > this.Patch_DeleteThreshold
+						)
+							i[ o ] = ! 1;
+						else {
+							this.diff_cleanupSemanticLossless( c );
+							for ( var l, p = 0, d = 0; d < t[ o ].diffs.length; d++ ) {
+								var g = t[ o ].diffs[ d ];
+								0 !== g[ 0 ] && ( l = this.diff_xIndex( c, p ) ),
+									1 === g[ 0 ]
+										? ( e = e.substring( 0, s + l ) + g[ 1 ] + e.substring( s + l ) )
+										: -1 === g[ 0 ] &&
+										  ( e =
+												e.substring( 0, s + l ) +
+												e.substring( s + this.diff_xIndex( c, p + g[ 1 ].length ) ) ),
+									-1 !== g[ 0 ] && ( p += g[ 1 ].length );
+							}
+						}
+					}
+				}
+				return [ ( e = e.substring( n.length, e.length - n.length ) ), i ];
+			} ),
+			( i.prototype.patch_addPadding = function( t ) {
+				for ( var e = this.Patch_Margin, n = '', r = 1; r <= e; r++ ) n += String.fromCharCode( r );
+				for ( r = 0; r < t.length; r++ ) ( t[ r ].start1 += e ), ( t[ r ].start2 += e );
+				var o = t[ 0 ],
+					s = o.diffs;
+				if ( 0 == s.length || 0 != s[ 0 ][ 0 ] )
+					s.unshift( new i.Diff( 0, n ) ),
+						( o.start1 -= e ),
+						( o.start2 -= e ),
+						( o.length1 += e ),
+						( o.length2 += e );
+				else if ( e > s[ 0 ][ 1 ].length ) {
+					var a = e - s[ 0 ][ 1 ].length;
+					( s[ 0 ][ 1 ] = n.substring( s[ 0 ][ 1 ].length ) + s[ 0 ][ 1 ] ),
+						( o.start1 -= a ),
+						( o.start2 -= a ),
+						( o.length1 += a ),
+						( o.length2 += a );
+				}
+				if ( 0 == ( s = ( o = t[ t.length - 1 ] ).diffs ).length || 0 != s[ s.length - 1 ][ 0 ] )
+					s.push( new i.Diff( 0, n ) ), ( o.length1 += e ), ( o.length2 += e );
+				else if ( e > s[ s.length - 1 ][ 1 ].length ) {
+					a = e - s[ s.length - 1 ][ 1 ].length;
+					( s[ s.length - 1 ][ 1 ] += n.substring( 0, a ) ), ( o.length1 += a ), ( o.length2 += a );
+				}
+				return n;
+			} ),
+			( i.prototype.patch_splitMax = function( t ) {
+				for ( var e = this.Match_MaxBits, n = 0; n < t.length; n++ )
+					if ( ! ( t[ n ].length1 <= e ) ) {
+						var r = t[ n ];
+						t.splice( n--, 1 );
+						for ( var o = r.start1, s = r.start2, a = ''; 0 !== r.diffs.length;  ) {
+							var u = new i.patch_obj(),
+								f = ! 0;
+							for (
+								u.start1 = o - a.length,
+									u.start2 = s - a.length,
+									'' !== a &&
+										( ( u.length1 = u.length2 = a.length ), u.diffs.push( new i.Diff( 0, a ) ) );
+								0 !== r.diffs.length && u.length1 < e - this.Patch_Margin;
+
+							) {
+								var h = r.diffs[ 0 ][ 0 ],
+									c = r.diffs[ 0 ][ 1 ];
+								1 === h
+									? ( ( u.length2 += c.length ),
+									  ( s += c.length ),
+									  u.diffs.push( r.diffs.shift() ),
+									  ( f = ! 1 ) )
+									: -1 === h && 1 == u.diffs.length && 0 == u.diffs[ 0 ][ 0 ] && c.length > 2 * e
+									? ( ( u.length1 += c.length ),
+									  ( o += c.length ),
+									  ( f = ! 1 ),
+									  u.diffs.push( new i.Diff( h, c ) ),
+									  r.diffs.shift() )
+									: ( ( c = c.substring( 0, e - u.length1 - this.Patch_Margin ) ),
+									  ( u.length1 += c.length ),
+									  ( o += c.length ),
+									  0 === h ? ( ( u.length2 += c.length ), ( s += c.length ) ) : ( f = ! 1 ),
+									  u.diffs.push( new i.Diff( h, c ) ),
+									  c == r.diffs[ 0 ][ 1 ]
+											? r.diffs.shift()
+											: ( r.diffs[ 0 ][ 1 ] = r.diffs[ 0 ][ 1 ].substring( c.length ) ) );
+							}
+							a = ( a = this.diff_text2( u.diffs ) ).substring( a.length - this.Patch_Margin );
+							var l = this.diff_text1( r.diffs ).substring( 0, this.Patch_Margin );
+							'' !== l &&
+								( ( u.length1 += l.length ),
+								( u.length2 += l.length ),
+								0 !== u.diffs.length && 0 === u.diffs[ u.diffs.length - 1 ][ 0 ]
+									? ( u.diffs[ u.diffs.length - 1 ][ 1 ] += l )
+									: u.diffs.push( new i.Diff( 0, l ) ) ),
+								f || t.splice( ++n, 0, u );
+						}
+					}
+			} ),
+			( i.prototype.patch_toText = function( t ) {
+				for ( var e = [], n = 0; n < t.length; n++ ) e[ n ] = t[ n ];
+				return e.join( '' );
+			} ),
+			( i.prototype.patch_fromText = function( t ) {
+				var e = [];
+				if ( ! t ) return e;
+				for (
+					var n = t.split( '\n' ), r = 0, o = /^@@ -(\d+),?(\d*) \+(\d+),?(\d*) @@$/;
+					r < n.length;
+
+				) {
+					var s = n[ r ].match( o );
+					if ( ! s ) throw new Error( 'Invalid patch string: ' + n[ r ] );
+					var a = new i.patch_obj();
+					for (
+						e.push( a ),
+							a.start1 = parseInt( s[ 1 ], 10 ),
+							'' === s[ 2 ]
+								? ( a.start1--, ( a.length1 = 1 ) )
+								: '0' == s[ 2 ]
+								? ( a.length1 = 0 )
+								: ( a.start1--, ( a.length1 = parseInt( s[ 2 ], 10 ) ) ),
+							a.start2 = parseInt( s[ 3 ], 10 ),
+							'' === s[ 4 ]
+								? ( a.start2--, ( a.length2 = 1 ) )
+								: '0' == s[ 4 ]
+								? ( a.length2 = 0 )
+								: ( a.start2--, ( a.length2 = parseInt( s[ 4 ], 10 ) ) ),
+							r++;
+						r < n.length;
+
+					) {
+						var u = n[ r ].charAt( 0 );
+						try {
+							var f = decodeURI( n[ r ].substring( 1 ) );
+						} catch ( t ) {
+							throw new Error( 'Illegal escape in patch_fromText: ' + f );
+						}
+						if ( '-' == u ) a.diffs.push( new i.Diff( -1, f ) );
+						else if ( '+' == u ) a.diffs.push( new i.Diff( 1, f ) );
+						else if ( ' ' == u ) a.diffs.push( new i.Diff( 0, f ) );
+						else {
+							if ( '@' == u ) break;
+							if ( '' !== u ) throw new Error( 'Invalid patch mode "' + u + '" in: ' + f );
+						}
+						r++;
+					}
+				}
+				return e;
+			} ),
+			( i.patch_obj = function() {
+				( this.diffs = [] ),
+					( this.start1 = null ),
+					( this.start2 = null ),
+					( this.length1 = 0 ),
+					( this.length2 = 0 );
+			} ),
+			( i.patch_obj.prototype.toString = function() {
+				for (
+					var t,
+						e = [
+							'@@ -' +
+								( 0 === this.length1
+									? this.start1 + ',0'
+									: 1 == this.length1
+									? this.start1 + 1
+									: this.start1 + 1 + ',' + this.length1 ) +
+								' +' +
+								( 0 === this.length2
+									? this.start2 + ',0'
+									: 1 == this.length2
+									? this.start2 + 1
+									: this.start2 + 1 + ',' + this.length2 ) +
+								' @@\n',
+						],
+						n = 0;
+					n < this.diffs.length;
+					n++
+				) {
+					switch ( this.diffs[ n ][ 0 ] ) {
+						case 1:
+							t = '+';
+							break;
+						case -1:
+							t = '-';
+							break;
+						case 0:
+							t = ' ';
+					}
+					e[ n + 1 ] = t + encodeURI( this.diffs[ n ][ 1 ] ) + '\n';
+				}
+				return e.join( '' ).replace( /%20/g, ' ' );
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.default = function( t ) {
+				var e = t.indexOf( ':' );
+				return { command: t.slice( 0, e ), data: t.slice( e + 1 ) };
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.default = function( t ) {
+				var e = t.indexOf( '\n' ),
+					n = t.indexOf( '.' ),
+					r = t.slice( 0, n ),
+					i = parseInt( t.slice( n + 1, e ) );
+				return { data: JSON.parse( t.slice( e + 1 ) ).data, id: r, version: i };
+			} );
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.default = function( t, e ) {
+				switch ( t.type ) {
+					case 'modify':
+						return r.change.buildChange( 'M', t.id, t.object, e );
+					case 'remove':
+						return r.change.buildChange( '-', t.id, {}, e );
+					case 'full':
+						return ( function( t ) {
+							for ( var e = 1; e < arguments.length; e++ ) {
+								var n = null != arguments[ e ] ? arguments[ e ] : {};
+								e % 2
+									? i( Object( n ), ! 0 ).forEach( function( e ) {
+											o( t, e, n[ e ] );
+									  } )
+									: Object.getOwnPropertyDescriptors
+									? Object.defineProperties( t, Object.getOwnPropertyDescriptors( n ) )
+									: i( Object( n ) ).forEach( function( e ) {
+											Object.defineProperty( t, e, Object.getOwnPropertyDescriptor( n, e ) );
+									  } );
+							}
+							return t;
+						} )( {}, t.originalChange, { d: t.object } );
+					default:
+						throw ( t.type, new Error( 'Unknown operation type ' + JSON.stringify( t ) ) );
+				}
+			} );
+		var r = n( 11 );
+		function i( t, e ) {
+			var n = Object.keys( t );
+			if ( Object.getOwnPropertySymbols ) {
+				var r = Object.getOwnPropertySymbols( t );
+				e &&
+					( r = r.filter( function( e ) {
+						return Object.getOwnPropertyDescriptor( t, e ).enumerable;
+					} ) ),
+					n.push.apply( n, r );
+			}
+			return n;
+		}
+		function o( t, e, n ) {
+			return (
+				e in t
+					? Object.defineProperty( t, e, {
+							value: n,
+							enumerable: ! 0,
+							configurable: ! 0,
+							writable: ! 0,
+					  } )
+					: ( t[ e ] = n ),
+				t
+			);
+		}
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.default = function( t ) {
+				return new i.default( t );
+			} );
+		var r,
+			i = ( r = n( 42 ) ) && r.__esModule ? r : { default: r };
+	},
+	function( t, e, n ) {
+		'use strict';
+		( function( t ) {
+			function n( t ) {
+				( this.bucket = t ), ( this.index = {} );
+			}
+			Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+				( e.default = n ),
+				( n.prototype.getChangeVersion = function() {
+					var e = this;
+					return new Promise( function( n ) {
+						t( function() {
+							n( e.cv );
+						} );
+					} );
+				} ),
+				( n.prototype.setChangeVersion = function( e ) {
+					var n = this;
+					return new Promise( function( r ) {
+						t( function() {
+							( n.cv = e ), r( e );
+						} );
+					} );
+				} ),
+				( n.prototype.put = function( e, n, r ) {
+					var i = this;
+					return new Promise( function( o ) {
+						t( function() {
+							( i.index[ e ] = JSON.stringify( { version: n, data: r } ) ), o( ! 0 );
+						} );
+					} );
+				} ),
+				( n.prototype.get = function( e ) {
+					var n = this;
+					return new Promise( function( r ) {
+						t( function() {
+							var t = n.index[ e ];
+							t
+								? ( t = JSON.parse( t ) )
+								: ( ( ( t = { data: {} } ).key = e ), ( n.index[ e ] = JSON.stringify( t ) ) ),
+								r( t );
+						} );
+					} );
+				} ),
+				( n.prototype.remove = function( e ) {
+					var n = this;
+					return new Promise( function( r ) {
+						t( function() {
+							delete n.index[ e ], r();
+						} );
+					} );
+				} );
+		}.call( this, n( 10 ).setImmediate ) );
+	},
+	function( t, e, n ) {
+		'use strict';
+		function r() {
+			this.objects = {};
+		}
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.default = function() {
+				return new r();
+			} ),
+			( r.prototype.get = function( t, e ) {
+				e( null, { id: t, data: this.objects[ t ] } );
+			} ),
+			( r.prototype.update = function( t, e, n, r ) {
+				( this.objects[ t ] = e ), r( null, { id: t, data: e, isIndexing: n } );
+			} ),
+			( r.prototype.remove = function( t, e ) {
+				delete this.objects[ t ], e( null );
+			} ),
+			( r.prototype.find = function( t, e ) {
+				var n,
+					r = [];
+				for ( n in this.objects ) r.push( { id: n, data: this.objects[ n ] } );
+				e( null, r );
+			} );
+	},
+	function( t, e, n ) {
+		var r;
+		try {
+			r = n( 45 );
+		} catch ( t ) {
+		} finally {
+			if ( ( r || 'undefined' == typeof window || ( r = window ), ! r ) )
+				throw new Error( 'Could not determine global this' );
+		}
+		var i = r.WebSocket || r.MozWebSocket,
+			o = n( 46 );
+		function s( t, e ) {
+			return e ? new i( t, e ) : new i( t );
+		}
+		i &&
+			[ 'CONNECTING', 'OPEN', 'CLOSING', 'CLOSED' ].forEach( function( t ) {
+				Object.defineProperty( s, t, {
+					get: function() {
+						return i[ t ];
+					},
+				} );
+			} ),
+			( t.exports = { w3cwebsocket: i ? s : null, version: o } );
+	},
+	function( t, e ) {
+		var n = function() {
+			if ( 'object' == typeof self && self ) return self;
+			if ( 'object' == typeof window && window ) return window;
+			throw new Error( 'Unable to resolve global `this`' );
+		};
+		t.exports = ( function() {
+			if ( this ) return this;
+			if ( 'object' == typeof globalThis && globalThis ) return globalThis;
+			try {
+				Object.defineProperty( Object.prototype, '__global__', {
+					get: function() {
+						return this;
+					},
+					configurable: ! 0,
+				} );
+			} catch ( t ) {
+				return n();
+			}
+			try {
+				return __global__ || n();
+			} finally {
+				delete Object.prototype.__global__;
+			}
+		} )();
+	},
+	function( t, e, n ) {
+		t.exports = n( 47 ).version;
+	},
+	function( t ) {
+		t.exports = JSON.parse(
+			'{"_args":[["websocket@1.0.31","/Users/dmsnell/PhpstormProjects/node-simperium"]],"_from":"websocket@1.0.31","_id":"websocket@1.0.31","_inBundle":false,"_integrity":"sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==","_location":"/websocket","_phantomChildren":{},"_requested":{"type":"version","registry":true,"raw":"websocket@1.0.31","name":"websocket","escapedName":"websocket","rawSpec":"1.0.31","saveSpec":null,"fetchSpec":"1.0.31"},"_requiredBy":["/"],"_resolved":"https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz","_spec":"1.0.31","_where":"/Users/dmsnell/PhpstormProjects/node-simperium","author":{"name":"Brian McKelvey","email":"theturtle32@gmail.com","url":"https://github.com/theturtle32"},"browser":"lib/browser.js","bugs":{"url":"https://github.com/theturtle32/WebSocket-Node/issues"},"config":{"verbose":false},"contributors":[{"name":"Iñaki Baz Castillo","email":"ibc@aliax.net","url":"http://dev.sipdoc.net"}],"dependencies":{"debug":"^2.2.0","es5-ext":"^0.10.50","nan":"^2.14.0","typedarray-to-buffer":"^3.1.5","yaeti":"^0.0.6"},"description":"Websocket Client & Server Library implementing the WebSocket protocol as specified in RFC 6455.","devDependencies":{"buffer-equal":"^1.0.0","faucet":"^0.0.1","gulp":"^4.0.2","gulp-jshint":"^2.0.4","jshint":"^2.0.0","jshint-stylish":"^2.2.1","tape":"^4.9.1"},"directories":{"lib":"./lib"},"engines":{"node":">=0.10.0"},"homepage":"https://github.com/theturtle32/WebSocket-Node","keywords":["websocket","websockets","socket","networking","comet","push","RFC-6455","realtime","server","client"],"license":"Apache-2.0","main":"index","name":"websocket","repository":{"type":"git","url":"git+https://github.com/theturtle32/WebSocket-Node.git"},"scripts":{"gulp":"gulp","install":"(node-gyp rebuild 2> builderror.log) || (exit 0)","test":"faucet test/unit"},"version":"1.0.31"}'
+		);
+	},
+	function( t, e, n ) {
+		'use strict';
+		Object.defineProperty( e, '__esModule', { value: ! 0 } ),
+			( e.default = e.Auth = e.AuthError = void 0 );
+		var r = s( n( 3 ) ),
+			i = n( 49 ),
+			o = s( n( 12 ) );
+		function s( t ) {
+			return t && t.__esModule ? t : { default: t };
+		}
+		function a( t ) {
+			return ( a =
+				'function' == typeof Symbol && 'symbol' == typeof Symbol.iterator
+					? function( t ) {
+							return typeof t;
+					  }
+					: function( t ) {
+							return t &&
+								'function' == typeof Symbol &&
+								t.constructor === Symbol &&
+								t !== Symbol.prototype
+								? 'symbol'
+								: typeof t;
+					  } )( t );
+		}
+		function u( t, e ) {
+			var n = Object.keys( t );
+			if ( Object.getOwnPropertySymbols ) {
+				var r = Object.getOwnPropertySymbols( t );
+				e &&
+					( r = r.filter( function( e ) {
+						return Object.getOwnPropertyDescriptor( t, e ).enumerable;
+					} ) ),
+					n.push.apply( n, r );
+			}
+			return n;
+		}
+		function f( t, e, n ) {
+			return (
+				e in t
+					? Object.defineProperty( t, e, {
+							value: n,
+							enumerable: ! 0,
+							configurable: ! 0,
+							writable: ! 0,
+					  } )
+					: ( t[ e ] = n ),
+				t
+			);
+		}
+		function h( t, e ) {
+			if ( null == t ) return {};
+			var n,
+				r,
+				i = ( function( t, e ) {
+					if ( null == t ) return {};
+					var n,
+						r,
+						i = {},
+						o = Object.keys( t );
+					for ( r = 0; r < o.length; r++ )
+						( n = o[ r ] ), e.indexOf( n ) >= 0 || ( i[ n ] = t[ n ] );
+					return i;
+				} )( t, e );
+			if ( Object.getOwnPropertySymbols ) {
+				var o = Object.getOwnPropertySymbols( t );
+				for ( r = 0; r < o.length; r++ )
+					( n = o[ r ] ),
+						e.indexOf( n ) >= 0 ||
+							( Object.prototype.propertyIsEnumerable.call( t, n ) && ( i[ n ] = t[ n ] ) );
+			}
+			return i;
+		}
+		function c( t, e ) {
+			for ( var n = 0; n < e.length; n++ ) {
+				var r = e[ n ];
+				( r.enumerable = r.enumerable || ! 1 ),
+					( r.configurable = ! 0 ),
+					'value' in r && ( r.writable = ! 0 ),
+					Object.defineProperty( t, r.key, r );
+			}
+		}
+		function l( t, e ) {
+			if ( ! ( t instanceof e ) ) throw new TypeError( 'Cannot call a class as a function' );
+		}
+		function p( t, e ) {
+			return ! e || ( 'object' !== a( e ) && 'function' != typeof e )
+				? ( function( t ) {
+						if ( void 0 === t )
+							throw new ReferenceError(
+								"this hasn't been initialised - super() hasn't been called"
+							);
+						return t;
+				  } )( t )
+				: e;
+		}
+		function d( t, e ) {
+			if ( 'function' != typeof e && null !== e )
+				throw new TypeError( 'Super expression must either be null or a function' );
+			( t.prototype = Object.create( e && e.prototype, {
+				constructor: { value: t, writable: ! 0, configurable: ! 0 },
+			} ) ),
+				e && v( t, e );
+		}
+		function g( t ) {
+			var e = 'function' == typeof Map ? new Map() : void 0;
+			return ( g = function( t ) {
+				if (
+					null === t ||
+					( ( n = t ), -1 === Function.toString.call( n ).indexOf( '[native code]' ) )
+				)
+					return t;
+				var n;
+				if ( 'function' != typeof t )
+					throw new TypeError( 'Super expression must either be null or a function' );
+				if ( void 0 !== e ) {
+					if ( e.has( t ) ) return e.get( t );
+					e.set( t, r );
+				}
+				function r() {
+					return m( t, arguments, b( this ).constructor );
+				}
+				return (
+					( r.prototype = Object.create( t.prototype, {
+						constructor: { value: r, enumerable: ! 1, writable: ! 0, configurable: ! 0 },
+					} ) ),
+					v( r, t )
+				);
+			} )( t );
+		}
+		function y() {
+			if ( 'undefined' == typeof Reflect || ! Reflect.construct ) return ! 1;
+			if ( Reflect.construct.sham ) return ! 1;
+			if ( 'function' == typeof Proxy ) return ! 0;
+			try {
+				return Date.prototype.toString.call( Reflect.construct( Date, [], function() {} ) ), ! 0;
+			} catch ( t ) {
+				return ! 1;
+			}
+		}
+		function m( t, e, n ) {
+			return ( m = y()
+				? Reflect.construct
+				: function( t, e, n ) {
+						var r = [ null ];
+						r.push.apply( r, e );
+						var i = new ( Function.bind.apply( t, r ) )();
+						return n && v( i, n.prototype ), i;
+				  } ).apply( null, arguments );
+		}
+		function v( t, e ) {
+			return ( v =
+				Object.setPrototypeOf ||
+				function( t, e ) {
+					return ( t.__proto__ = e ), t;
+				} )( t, e );
+		}
+		function b( t ) {
+			return ( b = Object.setPrototypeOf
+				? Object.getPrototypeOf
+				: function( t ) {
+						return t.__proto__ || Object.getPrototypeOf( t );
+				  } )( t );
+		}
+		var _ = r.default.EventEmitter,
+			w = ( function( t ) {
+				function e( t ) {
+					var n;
+					return (
+						l( this, e ),
+						( ( n = p(
+							this,
+							b( e ).call( this, 'Failed to authenticate user.' )
+						) ).underlyingError = t ),
+						n
+					);
+				}
+				return d( e, t ), e;
+			} )( g( Error ) );
+		e.AuthError = w;
+		var x = ( function( t ) {
+			function e( t, n ) {
+				var r;
+				return (
+					l( this, e ), ( ( r = p( this, b( e ).call( this ) ) ).appId = t ), ( r.appSecret = n ), r
+				);
+			}
+			var n, r, s;
+			return (
+				d( e, t ),
+				( n = e ),
+				( r = [
+					{
+						key: 'authorize',
+						value: function( t, e ) {
+							var n = JSON.stringify( { username: t, password: e } );
+							return this.request( 'authorize/', n );
+						},
+					},
+					{
+						key: 'create',
+						value: function( t, e, n ) {
+							var r = { username: t, password: e };
+							n && ( r.provider = n );
+							var i = JSON.stringify( r );
+							return this.request( 'create/', i );
+						},
+					},
+					{
+						key: 'getUrlOptions',
+						value: function( t ) {
+							var e = o.default.parse(
+									''
+										.concat( 'https://auth.simperium.com/1', '/' )
+										.concat( this.appId, '/' )
+										.concat( t )
+								),
+								n = e.port;
+							return ( function( t ) {
+								for ( var e = 1; e < arguments.length; e++ ) {
+									var n = null != arguments[ e ] ? arguments[ e ] : {};
+									e % 2
+										? u( Object( n ), ! 0 ).forEach( function( e ) {
+												f( t, e, n[ e ] );
+										  } )
+										: Object.getOwnPropertyDescriptors
+										? Object.defineProperties( t, Object.getOwnPropertyDescriptors( n ) )
+										: u( Object( n ) ).forEach( function( e ) {
+												Object.defineProperty( t, e, Object.getOwnPropertyDescriptor( n, e ) );
+										  } );
+								}
+								return t;
+							} )( {}, h( e, [ 'port' ] ), {
+								port: n ? Number( n ) : void 0,
+								method: 'POST',
+								headers: { 'X-Simperium-API-Key': this.appSecret },
+							} );
+						},
+					},
+					{
+						key: 'request',
+						value: function( t, e ) {
+							var n = this;
+							return new Promise( function( r, o ) {
+								var s = ( 0, i.request )( n.getUrlOptions( t ), function( t ) {
+									var e = '';
+									t.on( 'data', function( t ) {
+										e += t.toString();
+									} ),
+										t.on( 'end', function() {
+											try {
+												var t = ( function( t ) {
+													var e = JSON.parse( t );
+													if ( ! e.access_token && 'string' != typeof e.access_token )
+														throw new Error( 'access_token not present' );
+													return {
+														options: e,
+														access_token: new String( e.access_token ).toString(),
+													};
+												} )( e );
+												r( t ), n.emit( 'authorize', t );
+											} catch ( t ) {
+												return o( new w( t ) );
+											}
+										} );
+								} );
+								s.on( 'error', function( t ) {
+									o( t );
+								} ),
+									s.end( e );
+							} );
+						},
+					},
+				] ) && c( n.prototype, r ),
+				s && c( n, s ),
+				e
+			);
+		} )( _ );
+		e.Auth = x;
+		e.default = function( t, e ) {
+			return new x( t, e );
+		};
+	},
+	function( t, e, n ) {
+		var r = n( 50 ),
+			i = n( 12 ),
+			o = t.exports;
+		for ( var s in r ) r.hasOwnProperty( s ) && ( o[ s ] = r[ s ] );
+		function a( t ) {
+			if (
+				( 'string' == typeof t && ( t = i.parse( t ) ),
+				t.protocol || ( t.protocol = 'https:' ),
+				'https:' !== t.protocol )
+			)
+				throw new Error( 'Protocol "' + t.protocol + '" not supported. Expected "https:"' );
+			return t;
+		}
+		( o.request = function( t, e ) {
+			return ( t = a( t ) ), r.request.call( this, t, e );
+		} ),
+			( o.get = function( t, e ) {
+				return ( t = a( t ) ), r.get.call( this, t, e );
+			} );
+	},
+	function( t, e, n ) {
+		( function( t ) {
+			var r = n( 51 ),
+				i = n( 20 ),
+				o = n( 60 ),
+				s = n( 61 ),
+				a = n( 12 ),
+				u = e;
+			( u.request = function( e, n ) {
+				e = 'string' == typeof e ? a.parse( e ) : o( e );
+				var i = -1 === t.location.protocol.search( /^https?:$/ ) ? 'http:' : '',
+					s = e.protocol || i,
+					u = e.hostname || e.host,
+					f = e.port,
+					h = e.path || '/';
+				u && -1 !== u.indexOf( ':' ) && ( u = '[' + u + ']' ),
+					( e.url = ( u ? s + '//' + u : '' ) + ( f ? ':' + f : '' ) + h ),
+					( e.method = ( e.method || 'GET' ).toUpperCase() ),
+					( e.headers = e.headers || {} );
+				var c = new r( e );
+				return n && c.on( 'response', n ), c;
+			} ),
+				( u.get = function( t, e ) {
+					var n = u.request( t, e );
+					return n.end(), n;
+				} ),
+				( u.ClientRequest = r ),
+				( u.IncomingMessage = i.IncomingMessage ),
+				( u.Agent = function() {} ),
+				( u.Agent.defaultMaxSockets = 4 ),
+				( u.globalAgent = new u.Agent() ),
+				( u.STATUS_CODES = s ),
+				( u.METHODS = [
+					'CHECKOUT',
+					'CONNECT',
+					'COPY',
+					'DELETE',
+					'GET',
+					'HEAD',
+					'LOCK',
+					'M-SEARCH',
+					'MERGE',
+					'MKACTIVITY',
+					'MKCOL',
+					'MOVE',
+					'NOTIFY',
+					'OPTIONS',
+					'PATCH',
+					'POST',
+					'PROPFIND',
+					'PROPPATCH',
+					'PURGE',
+					'PUT',
+					'REPORT',
+					'SEARCH',
+					'SUBSCRIBE',
+					'TRACE',
+					'UNLOCK',
+					'UNSUBSCRIBE',
+				] );
+		}.call( this, n( 0 ) ) );
+	},
+	function( t, e, n ) {
+		( function( e, r, i ) {
+			var o = n( 19 ),
+				s = n( 1 ),
+				a = n( 20 ),
+				u = n( 21 ),
+				f = n( 59 ),
+				h = a.IncomingMessage,
+				c = a.readyStates;
+			var l = ( t.exports = function( t ) {
+				var n,
+					r = this;
+				u.Writable.call( r ),
+					( r._opts = t ),
+					( r._body = [] ),
+					( r._headers = {} ),
+					t.auth && r.setHeader( 'Authorization', 'Basic ' + new e( t.auth ).toString( 'base64' ) ),
+					Object.keys( t.headers ).forEach( function( e ) {
+						r.setHeader( e, t.headers[ e ] );
+					} );
+				var i = ! 0;
+				if ( 'disable-fetch' === t.mode || ( 'requestTimeout' in t && ! o.abortController ) )
+					( i = ! 1 ), ( n = ! 0 );
+				else if ( 'prefer-streaming' === t.mode ) n = ! 1;
+				else if ( 'allow-wrong-content-type' === t.mode ) n = ! o.overrideMimeType;
+				else {
+					if ( t.mode && 'default' !== t.mode && 'prefer-fast' !== t.mode )
+						throw new Error( 'Invalid value for opts.mode' );
+					n = ! 0;
+				}
+				( r._mode = ( function( t, e ) {
+					return o.fetch && e
+						? 'fetch'
+						: o.mozchunkedarraybuffer
+						? 'moz-chunked-arraybuffer'
+						: o.msstream
+						? 'ms-stream'
+						: o.arraybuffer && t
+						? 'arraybuffer'
+						: o.vbArray && t
+						? 'text:vbarray'
+						: 'text';
+				} )( n, i ) ),
+					( r._fetchTimer = null ),
+					r.on( 'finish', function() {
+						r._onFinish();
+					} );
+			} );
+			s( l, u.Writable ),
+				( l.prototype.setHeader = function( t, e ) {
+					var n = t.toLowerCase();
+					-1 === p.indexOf( n ) && ( this._headers[ n ] = { name: t, value: e } );
+				} ),
+				( l.prototype.getHeader = function( t ) {
+					var e = this._headers[ t.toLowerCase() ];
+					return e ? e.value : null;
+				} ),
+				( l.prototype.removeHeader = function( t ) {
+					delete this._headers[ t.toLowerCase() ];
+				} ),
+				( l.prototype._onFinish = function() {
+					var t = this;
+					if ( ! t._destroyed ) {
+						var n = t._opts,
+							s = t._headers,
+							a = null;
+						'GET' !== n.method &&
+							'HEAD' !== n.method &&
+							( a = o.arraybuffer
+								? f( e.concat( t._body ) )
+								: o.blobConstructor
+								? new r.Blob(
+										t._body.map( function( t ) {
+											return f( t );
+										} ),
+										{ type: ( s[ 'content-type' ] || {} ).value || '' }
+								  )
+								: e.concat( t._body ).toString() );
+						var u = [];
+						if (
+							( Object.keys( s ).forEach( function( t ) {
+								var e = s[ t ].name,
+									n = s[ t ].value;
+								Array.isArray( n )
+									? n.forEach( function( t ) {
+											u.push( [ e, t ] );
+									  } )
+									: u.push( [ e, n ] );
+							} ),
+							'fetch' === t._mode )
+						) {
+							var h = null;
+							if ( o.abortController ) {
+								var l = new AbortController();
+								( h = l.signal ),
+									( t._fetchAbortController = l ),
+									'requestTimeout' in n &&
+										0 !== n.requestTimeout &&
+										( t._fetchTimer = r.setTimeout( function() {
+											t.emit( 'requestTimeout' ),
+												t._fetchAbortController && t._fetchAbortController.abort();
+										}, n.requestTimeout ) );
+							}
+							r.fetch( t._opts.url, {
+								method: t._opts.method,
+								headers: u,
+								body: a || void 0,
+								mode: 'cors',
+								credentials: n.withCredentials ? 'include' : 'same-origin',
+								signal: h,
+							} ).then(
+								function( e ) {
+									( t._fetchResponse = e ), t._connect();
+								},
+								function( e ) {
+									r.clearTimeout( t._fetchTimer ), t._destroyed || t.emit( 'error', e );
+								}
+							);
+						} else {
+							var p = ( t._xhr = new r.XMLHttpRequest() );
+							try {
+								p.open( t._opts.method, t._opts.url, ! 0 );
+							} catch ( e ) {
+								return void i.nextTick( function() {
+									t.emit( 'error', e );
+								} );
+							}
+							'responseType' in p && ( p.responseType = t._mode.split( ':' )[ 0 ] ),
+								'withCredentials' in p && ( p.withCredentials = !! n.withCredentials ),
+								'text' === t._mode &&
+									'overrideMimeType' in p &&
+									p.overrideMimeType( 'text/plain; charset=x-user-defined' ),
+								'requestTimeout' in n &&
+									( ( p.timeout = n.requestTimeout ),
+									( p.ontimeout = function() {
+										t.emit( 'requestTimeout' );
+									} ) ),
+								u.forEach( function( t ) {
+									p.setRequestHeader( t[ 0 ], t[ 1 ] );
+								} ),
+								( t._response = null ),
+								( p.onreadystatechange = function() {
+									switch ( p.readyState ) {
+										case c.LOADING:
+										case c.DONE:
+											t._onXHRProgress();
+									}
+								} ),
+								'moz-chunked-arraybuffer' === t._mode &&
+									( p.onprogress = function() {
+										t._onXHRProgress();
+									} ),
+								( p.onerror = function() {
+									t._destroyed || t.emit( 'error', new Error( 'XHR error' ) );
+								} );
+							try {
+								p.send( a );
+							} catch ( e ) {
+								return void i.nextTick( function() {
+									t.emit( 'error', e );
+								} );
+							}
+						}
+					}
+				} ),
+				( l.prototype._onXHRProgress = function() {
+					( function( t ) {
+						try {
+							var e = t.status;
+							return null !== e && 0 !== e;
+						} catch ( t ) {
+							return ! 1;
+						}
+					} )( this._xhr ) &&
+						! this._destroyed &&
+						( this._response || this._connect(), this._response._onXHRProgress() );
+				} ),
+				( l.prototype._connect = function() {
+					var t = this;
+					t._destroyed ||
+						( ( t._response = new h( t._xhr, t._fetchResponse, t._mode, t._fetchTimer ) ),
+						t._response.on( 'error', function( e ) {
+							t.emit( 'error', e );
+						} ),
+						t.emit( 'response', t._response ) );
+				} ),
+				( l.prototype._write = function( t, e, n ) {
+					this._body.push( t ), n();
+				} ),
+				( l.prototype.abort = l.prototype.destroy = function() {
+					( this._destroyed = ! 0 ),
+						r.clearTimeout( this._fetchTimer ),
+						this._response && ( this._response._destroyed = ! 0 ),
+						this._xhr
+							? this._xhr.abort()
+							: this._fetchAbortController && this._fetchAbortController.abort();
+				} ),
+				( l.prototype.end = function( t, e, n ) {
+					'function' == typeof t && ( ( n = t ), ( t = void 0 ) ),
+						u.Writable.prototype.end.call( this, t, e, n );
+				} ),
+				( l.prototype.flushHeaders = function() {} ),
+				( l.prototype.setTimeout = function() {} ),
+				( l.prototype.setNoDelay = function() {} ),
+				( l.prototype.setSocketKeepAlive = function() {} );
+			var p = [
+				'accept-charset',
+				'accept-encoding',
+				'access-control-request-headers',
+				'access-control-request-method',
+				'connection',
+				'content-length',
+				'cookie',
+				'cookie2',
+				'date',
+				'dnt',
+				'expect',
+				'host',
+				'keep-alive',
+				'origin',
+				'referer',
+				'te',
+				'trailer',
+				'transfer-encoding',
+				'upgrade',
+				'via',
+			];
+		}.call( this, n( 5 ).Buffer, n( 0 ), n( 2 ) ) );
+	},
+	function( t, e, n ) {
+		'use strict';
+		( e.byteLength = function( t ) {
+			var e = f( t ),
+				n = e[ 0 ],
+				r = e[ 1 ];
+			return ( 3 * ( n + r ) ) / 4 - r;
+		} ),
+			( e.toByteArray = function( t ) {
+				var e,
+					n,
+					r = f( t ),
+					s = r[ 0 ],
+					a = r[ 1 ],
+					u = new o(
+						( function( t, e, n ) {
+							return ( 3 * ( e + n ) ) / 4 - n;
+						} )( 0, s, a )
+					),
+					h = 0,
+					c = a > 0 ? s - 4 : s;
+				for ( n = 0; n < c; n += 4 )
+					( e =
+						( i[ t.charCodeAt( n ) ] << 18 ) |
+						( i[ t.charCodeAt( n + 1 ) ] << 12 ) |
+						( i[ t.charCodeAt( n + 2 ) ] << 6 ) |
+						i[ t.charCodeAt( n + 3 ) ] ),
+						( u[ h++ ] = ( e >> 16 ) & 255 ),
+						( u[ h++ ] = ( e >> 8 ) & 255 ),
+						( u[ h++ ] = 255 & e );
+				2 === a &&
+					( ( e = ( i[ t.charCodeAt( n ) ] << 2 ) | ( i[ t.charCodeAt( n + 1 ) ] >> 4 ) ),
+					( u[ h++ ] = 255 & e ) );
+				1 === a &&
+					( ( e =
+						( i[ t.charCodeAt( n ) ] << 10 ) |
+						( i[ t.charCodeAt( n + 1 ) ] << 4 ) |
+						( i[ t.charCodeAt( n + 2 ) ] >> 2 ) ),
+					( u[ h++ ] = ( e >> 8 ) & 255 ),
+					( u[ h++ ] = 255 & e ) );
+				return u;
+			} ),
+			( e.fromByteArray = function( t ) {
+				for ( var e, n = t.length, i = n % 3, o = [], s = 0, a = n - i; s < a; s += 16383 )
+					o.push( h( t, s, s + 16383 > a ? a : s + 16383 ) );
+				1 === i
+					? ( ( e = t[ n - 1 ] ), o.push( r[ e >> 2 ] + r[ ( e << 4 ) & 63 ] + '==' ) )
+					: 2 === i &&
+					  ( ( e = ( t[ n - 2 ] << 8 ) + t[ n - 1 ] ),
+					  o.push( r[ e >> 10 ] + r[ ( e >> 4 ) & 63 ] + r[ ( e << 2 ) & 63 ] + '=' ) );
+				return o.join( '' );
+			} );
+		for (
+			var r = [],
+				i = [],
+				o = 'undefined' != typeof Uint8Array ? Uint8Array : Array,
+				s = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/',
+				a = 0,
+				u = s.length;
+			a < u;
+			++a
+		)
+			( r[ a ] = s[ a ] ), ( i[ s.charCodeAt( a ) ] = a );
+		function f( t ) {
+			var e = t.length;
+			if ( e % 4 > 0 ) throw new Error( 'Invalid string. Length must be a multiple of 4' );
+			var n = t.indexOf( '=' );
+			return -1 === n && ( n = e ), [ n, n === e ? 0 : 4 - ( n % 4 ) ];
+		}
+		function h( t, e, n ) {
+			for ( var i, o, s = [], a = e; a < n; a += 3 )
+				( i =
+					( ( t[ a ] << 16 ) & 16711680 ) +
+					( ( t[ a + 1 ] << 8 ) & 65280 ) +
+					( 255 & t[ a + 2 ] ) ),
+					s.push(
+						r[ ( ( o = i ) >> 18 ) & 63 ] +
+							r[ ( o >> 12 ) & 63 ] +
+							r[ ( o >> 6 ) & 63 ] +
+							r[ 63 & o ]
+					);
+			return s.join( '' );
+		}
+		( i[ '-'.charCodeAt( 0 ) ] = 62 ), ( i[ '_'.charCodeAt( 0 ) ] = 63 );
+	},
+	function( t, e ) {
+		( e.read = function( t, e, n, r, i ) {
+			var o,
+				s,
+				a = 8 * i - r - 1,
+				u = ( 1 << a ) - 1,
+				f = u >> 1,
+				h = -7,
+				c = n ? i - 1 : 0,
+				l = n ? -1 : 1,
+				p = t[ e + c ];
+			for (
+				c += l, o = p & ( ( 1 << -h ) - 1 ), p >>= -h, h += a;
+				h > 0;
+				o = 256 * o + t[ e + c ], c += l, h -= 8
+			);
+			for (
+				s = o & ( ( 1 << -h ) - 1 ), o >>= -h, h += r;
+				h > 0;
+				s = 256 * s + t[ e + c ], c += l, h -= 8
+			);
+			if ( 0 === o ) o = 1 - f;
+			else {
+				if ( o === u ) return s ? NaN : ( 1 / 0 ) * ( p ? -1 : 1 );
+				( s += Math.pow( 2, r ) ), ( o -= f );
+			}
+			return ( p ? -1 : 1 ) * s * Math.pow( 2, o - r );
+		} ),
+			( e.write = function( t, e, n, r, i, o ) {
+				var s,
+					a,
+					u,
+					f = 8 * o - i - 1,
+					h = ( 1 << f ) - 1,
+					c = h >> 1,
+					l = 23 === i ? Math.pow( 2, -24 ) - Math.pow( 2, -77 ) : 0,
+					p = r ? 0 : o - 1,
+					d = r ? 1 : -1,
+					g = e < 0 || ( 0 === e && 1 / e < 0 ) ? 1 : 0;
+				for (
+					e = Math.abs( e ),
+						isNaN( e ) || e === 1 / 0
+							? ( ( a = isNaN( e ) ? 1 : 0 ), ( s = h ) )
+							: ( ( s = Math.floor( Math.log( e ) / Math.LN2 ) ),
+							  e * ( u = Math.pow( 2, -s ) ) < 1 && ( s--, ( u *= 2 ) ),
+							  ( e += s + c >= 1 ? l / u : l * Math.pow( 2, 1 - c ) ) * u >= 2 &&
+									( s++, ( u /= 2 ) ),
+							  s + c >= h
+									? ( ( a = 0 ), ( s = h ) )
+									: s + c >= 1
+									? ( ( a = ( e * u - 1 ) * Math.pow( 2, i ) ), ( s += c ) )
+									: ( ( a = e * Math.pow( 2, c - 1 ) * Math.pow( 2, i ) ), ( s = 0 ) ) );
+					i >= 8;
+					t[ n + p ] = 255 & a, p += d, a /= 256, i -= 8
+				);
+				for ( s = ( s << i ) | a, f += i; f > 0; t[ n + p ] = 255 & s, p += d, s /= 256, f -= 8 );
+				t[ n + p - d ] |= 128 * g;
+			} );
+	},
+	function( t, e ) {},
+	function( t, e, n ) {
+		'use strict';
+		var r = n( 8 ).Buffer,
+			i = n( 56 );
+		( t.exports = ( function() {
+			function t() {
+				! ( function( t, e ) {
+					if ( ! ( t instanceof e ) ) throw new TypeError( 'Cannot call a class as a function' );
+				} )( this, t ),
+					( this.head = null ),
+					( this.tail = null ),
+					( this.length = 0 );
+			}
+			return (
+				( t.prototype.push = function( t ) {
+					var e = { data: t, next: null };
+					this.length > 0 ? ( this.tail.next = e ) : ( this.head = e ),
+						( this.tail = e ),
+						++this.length;
+				} ),
+				( t.prototype.unshift = function( t ) {
+					var e = { data: t, next: this.head };
+					0 === this.length && ( this.tail = e ), ( this.head = e ), ++this.length;
+				} ),
+				( t.prototype.shift = function() {
+					if ( 0 !== this.length ) {
+						var t = this.head.data;
+						return (
+							1 === this.length ? ( this.head = this.tail = null ) : ( this.head = this.head.next ),
+							--this.length,
+							t
+						);
+					}
+				} ),
+				( t.prototype.clear = function() {
+					( this.head = this.tail = null ), ( this.length = 0 );
+				} ),
+				( t.prototype.join = function( t ) {
+					if ( 0 === this.length ) return '';
+					for ( var e = this.head, n = '' + e.data; ( e = e.next );  ) n += t + e.data;
+					return n;
+				} ),
+				( t.prototype.concat = function( t ) {
+					if ( 0 === this.length ) return r.alloc( 0 );
+					if ( 1 === this.length ) return this.head.data;
+					for ( var e, n, i, o = r.allocUnsafe( t >>> 0 ), s = this.head, a = 0; s;  )
+						( e = s.data ),
+							( n = o ),
+							( i = a ),
+							e.copy( n, i ),
+							( a += s.data.length ),
+							( s = s.next );
+					return o;
+				} ),
+				t
+			);
+		} )() ),
+			i &&
+				i.inspect &&
+				i.inspect.custom &&
+				( t.exports.prototype[ i.inspect.custom ] = function() {
+					var t = i.inspect( { length: this.length } );
+					return this.constructor.name + ' ' + t;
+				} );
+	},
+	function( t, e ) {},
+	function( t, e, n ) {
+		( function( e ) {
+			function n( t ) {
+				try {
+					if ( ! e.localStorage ) return ! 1;
+				} catch ( t ) {
+					return ! 1;
+				}
+				var n = e.localStorage[ t ];
+				return null != n && 'true' === String( n ).toLowerCase();
+			}
+			t.exports = function( t, e ) {
+				if ( n( 'noDeprecation' ) ) return t;
+				var r = ! 1;
+				return function() {
+					if ( ! r ) {
+						if ( n( 'throwDeprecation' ) ) throw new Error( e );
+						n( 'traceDeprecation' ) ? console.trace( e ) : console.warn( e ), ( r = ! 0 );
+					}
+					return t.apply( this, arguments );
+				};
+			};
+		}.call( this, n( 0 ) ) );
+	},
+	function( t, e, n ) {
+		'use strict';
+		t.exports = o;
+		var r = n( 27 ),
+			i = n( 6 );
+		function o( t ) {
+			if ( ! ( this instanceof o ) ) return new o( t );
+			r.call( this, t );
+		}
+		( i.inherits = n( 1 ) ),
+			i.inherits( o, r ),
+			( o.prototype._transform = function( t, e, n ) {
+				n( null, t );
+			} );
+	},
+	function( t, e, n ) {
+		var r = n( 5 ).Buffer;
+		t.exports = function( t ) {
+			if ( t instanceof Uint8Array ) {
+				if ( 0 === t.byteOffset && t.byteLength === t.buffer.byteLength ) return t.buffer;
+				if ( 'function' == typeof t.buffer.slice )
+					return t.buffer.slice( t.byteOffset, t.byteOffset + t.byteLength );
+			}
+			if ( r.isBuffer( t ) ) {
+				for ( var e = new Uint8Array( t.length ), n = t.length, i = 0; i < n; i++ ) e[ i ] = t[ i ];
+				return e.buffer;
+			}
+			throw new Error( 'Argument must be a Buffer' );
+		};
+	},
+	function( t, e ) {
+		t.exports = function() {
+			for ( var t = {}, e = 0; e < arguments.length; e++ ) {
+				var r = arguments[ e ];
+				for ( var i in r ) n.call( r, i ) && ( t[ i ] = r[ i ] );
+			}
+			return t;
+		};
+		var n = Object.prototype.hasOwnProperty;
+	},
+	function( t, e ) {
+		t.exports = {
+			100: 'Continue',
+			101: 'Switching Protocols',
+			102: 'Processing',
+			200: 'OK',
+			201: 'Created',
+			202: 'Accepted',
+			203: 'Non-Authoritative Information',
+			204: 'No Content',
+			205: 'Reset Content',
+			206: 'Partial Content',
+			207: 'Multi-Status',
+			208: 'Already Reported',
+			226: 'IM Used',
+			300: 'Multiple Choices',
+			301: 'Moved Permanently',
+			302: 'Found',
+			303: 'See Other',
+			304: 'Not Modified',
+			305: 'Use Proxy',
+			307: 'Temporary Redirect',
+			308: 'Permanent Redirect',
+			400: 'Bad Request',
+			401: 'Unauthorized',
+			402: 'Payment Required',
+			403: 'Forbidden',
+			404: 'Not Found',
+			405: 'Method Not Allowed',
+			406: 'Not Acceptable',
+			407: 'Proxy Authentication Required',
+			408: 'Request Timeout',
+			409: 'Conflict',
+			410: 'Gone',
+			411: 'Length Required',
+			412: 'Precondition Failed',
+			413: 'Payload Too Large',
+			414: 'URI Too Long',
+			415: 'Unsupported Media Type',
+			416: 'Range Not Satisfiable',
+			417: 'Expectation Failed',
+			418: "I'm a teapot",
+			421: 'Misdirected Request',
+			422: 'Unprocessable Entity',
+			423: 'Locked',
+			424: 'Failed Dependency',
+			425: 'Unordered Collection',
+			426: 'Upgrade Required',
+			428: 'Precondition Required',
+			429: 'Too Many Requests',
+			431: 'Request Header Fields Too Large',
+			451: 'Unavailable For Legal Reasons',
+			500: 'Internal Server Error',
+			501: 'Not Implemented',
+			502: 'Bad Gateway',
+			503: 'Service Unavailable',
+			504: 'Gateway Timeout',
+			505: 'HTTP Version Not Supported',
+			506: 'Variant Also Negotiates',
+			507: 'Insufficient Storage',
+			508: 'Loop Detected',
+			509: 'Bandwidth Limit Exceeded',
+			510: 'Not Extended',
+			511: 'Network Authentication Required',
+		};
+	},
+	function( t, e, n ) {
+		( function( t, r ) {
+			var i;
+			/*! https://mths.be/punycode v1.4.1 by @mathias */ ! ( function( o ) {
+				e && e.nodeType, t && t.nodeType;
+				var s = 'object' == typeof r && r;
+				s.global !== s && s.window !== s && s.self;
+				var a,
+					u = 2147483647,
+					f = /^xn--/,
+					h = /[^\x20-\x7E]/,
+					c = /[\x2E\u3002\uFF0E\uFF61]/g,
+					l = {
+						overflow: 'Overflow: input needs wider integers to process',
+						'not-basic': 'Illegal input >= 0x80 (not a basic code point)',
+						'invalid-input': 'Invalid input',
+					},
+					p = Math.floor,
+					d = String.fromCharCode;
+				function g( t ) {
+					throw new RangeError( l[ t ] );
+				}
+				function y( t, e ) {
+					for ( var n = t.length, r = []; n--;  ) r[ n ] = e( t[ n ] );
+					return r;
+				}
+				function m( t, e ) {
+					var n = t.split( '@' ),
+						r = '';
+					return (
+						n.length > 1 && ( ( r = n[ 0 ] + '@' ), ( t = n[ 1 ] ) ),
+						r + y( ( t = t.replace( c, '.' ) ).split( '.' ), e ).join( '.' )
+					);
+				}
+				function v( t ) {
+					for ( var e, n, r = [], i = 0, o = t.length; i < o;  )
+						( e = t.charCodeAt( i++ ) ) >= 55296 && e <= 56319 && i < o
+							? 56320 == ( 64512 & ( n = t.charCodeAt( i++ ) ) )
+								? r.push( ( ( 1023 & e ) << 10 ) + ( 1023 & n ) + 65536 )
+								: ( r.push( e ), i-- )
+							: r.push( e );
+					return r;
+				}
+				function b( t ) {
+					return y( t, function( t ) {
+						var e = '';
+						return (
+							t > 65535 &&
+								( ( e += d( ( ( ( t -= 65536 ) >>> 10 ) & 1023 ) | 55296 ) ),
+								( t = 56320 | ( 1023 & t ) ) ),
+							( e += d( t ) )
+						);
+					} ).join( '' );
+				}
+				function _( t, e ) {
+					return t + 22 + 75 * ( t < 26 ) - ( ( 0 != e ) << 5 );
+				}
+				function w( t, e, n ) {
+					var r = 0;
+					for ( t = n ? p( t / 700 ) : t >> 1, t += p( t / e ); t > 455; r += 36 ) t = p( t / 35 );
+					return p( r + ( 36 * t ) / ( t + 38 ) );
+				}
+				function x( t ) {
+					var e,
+						n,
+						r,
+						i,
+						o,
+						s,
+						a,
+						f,
+						h,
+						c,
+						l,
+						d = [],
+						y = t.length,
+						m = 0,
+						v = 128,
+						_ = 72;
+					for ( ( n = t.lastIndexOf( '-' ) ) < 0 && ( n = 0 ), r = 0; r < n; ++r )
+						t.charCodeAt( r ) >= 128 && g( 'not-basic' ), d.push( t.charCodeAt( r ) );
+					for ( i = n > 0 ? n + 1 : 0; i < y;  ) {
+						for (
+							o = m, s = 1, a = 36;
+							i >= y && g( 'invalid-input' ),
+								( ( f =
+									( l = t.charCodeAt( i++ ) ) - 48 < 10
+										? l - 22
+										: l - 65 < 26
+										? l - 65
+										: l - 97 < 26
+										? l - 97
+										: 36 ) >= 36 ||
+									f > p( ( u - m ) / s ) ) &&
+									g( 'overflow' ),
+								( m += f * s ),
+								! ( f < ( h = a <= _ ? 1 : a >= _ + 26 ? 26 : a - _ ) );
+							a += 36
+						)
+							s > p( u / ( c = 36 - h ) ) && g( 'overflow' ), ( s *= c );
+						( _ = w( m - o, ( e = d.length + 1 ), 0 == o ) ),
+							p( m / e ) > u - v && g( 'overflow' ),
+							( v += p( m / e ) ),
+							( m %= e ),
+							d.splice( m++, 0, v );
+					}
+					return b( d );
+				}
+				function O( t ) {
+					var e,
+						n,
+						r,
+						i,
+						o,
+						s,
+						a,
+						f,
+						h,
+						c,
+						l,
+						y,
+						m,
+						b,
+						x,
+						O = [];
+					for ( y = ( t = v( t ) ).length, e = 128, n = 0, o = 72, s = 0; s < y; ++s )
+						( l = t[ s ] ) < 128 && O.push( d( l ) );
+					for ( r = i = O.length, i && O.push( '-' ); r < y;  ) {
+						for ( a = u, s = 0; s < y; ++s ) ( l = t[ s ] ) >= e && l < a && ( a = l );
+						for (
+							a - e > p( ( u - n ) / ( m = r + 1 ) ) && g( 'overflow' ),
+								n += ( a - e ) * m,
+								e = a,
+								s = 0;
+							s < y;
+							++s
+						)
+							if ( ( ( l = t[ s ] ) < e && ++n > u && g( 'overflow' ), l == e ) ) {
+								for (
+									f = n, h = 36;
+									! ( f < ( c = h <= o ? 1 : h >= o + 26 ? 26 : h - o ) );
+									h += 36
+								)
+									( x = f - c ),
+										( b = 36 - c ),
+										O.push( d( _( c + ( x % b ), 0 ) ) ),
+										( f = p( x / b ) );
+								O.push( d( _( f, 0 ) ) ), ( o = w( n, m, r == i ) ), ( n = 0 ), ++r;
+							}
+						++n, ++e;
+					}
+					return O.join( '' );
+				}
+				( a = {
+					version: '1.4.1',
+					ucs2: { decode: v, encode: b },
+					decode: x,
+					encode: O,
+					toASCII: function( t ) {
+						return m( t, function( t ) {
+							return h.test( t ) ? 'xn--' + O( t ) : t;
+						} );
+					},
+					toUnicode: function( t ) {
+						return m( t, function( t ) {
+							return f.test( t ) ? x( t.slice( 4 ).toLowerCase() ) : t;
+						} );
+					},
+				} ),
+					void 0 ===
+						( i = function() {
+							return a;
+						}.call( e, n, e, t ) ) || ( t.exports = i );
+			} )();
+		}.call( this, n( 63 )( t ), n( 0 ) ) );
+	},
+	function( t, e ) {
+		t.exports = function( t ) {
+			return (
+				t.webpackPolyfill ||
+					( ( t.deprecate = function() {} ),
+					( t.paths = [] ),
+					t.children || ( t.children = [] ),
+					Object.defineProperty( t, 'loaded', {
+						enumerable: ! 0,
+						get: function() {
+							return t.l;
+						},
+					} ),
+					Object.defineProperty( t, 'id', {
+						enumerable: ! 0,
+						get: function() {
+							return t.i;
+						},
+					} ),
+					( t.webpackPolyfill = 1 ) ),
+				t
+			);
+		};
+	},
+	function( t, e, n ) {
+		'use strict';
+		t.exports = {
+			isString: function( t ) {
+				return 'string' == typeof t;
+			},
+			isObject: function( t ) {
+				return 'object' == typeof t && null !== t;
+			},
+			isNull: function( t ) {
+				return null === t;
+			},
+			isNullOrUndefined: function( t ) {
+				return null == t;
+			},
+		};
+	},
+	function( t, e, n ) {
+		'use strict';
+		( e.decode = e.parse = n( 66 ) ), ( e.encode = e.stringify = n( 67 ) );
+	},
+	function( t, e, n ) {
+		'use strict';
+		function r( t, e ) {
+			return Object.prototype.hasOwnProperty.call( t, e );
+		}
+		t.exports = function( t, e, n, o ) {
+			( e = e || '&' ), ( n = n || '=' );
+			var s = {};
+			if ( 'string' != typeof t || 0 === t.length ) return s;
+			var a = /\+/g;
+			t = t.split( e );
+			var u = 1e3;
+			o && 'number' == typeof o.maxKeys && ( u = o.maxKeys );
+			var f = t.length;
+			u > 0 && f > u && ( f = u );
+			for ( var h = 0; h < f; ++h ) {
+				var c,
+					l,
+					p,
+					d,
+					g = t[ h ].replace( a, '%20' ),
+					y = g.indexOf( n );
+				y >= 0
+					? ( ( c = g.substr( 0, y ) ), ( l = g.substr( y + 1 ) ) )
+					: ( ( c = g ), ( l = '' ) ),
+					( p = decodeURIComponent( c ) ),
+					( d = decodeURIComponent( l ) ),
+					r( s, p )
+						? i( s[ p ] )
+							? s[ p ].push( d )
+							: ( s[ p ] = [ s[ p ], d ] )
+						: ( s[ p ] = d );
+			}
+			return s;
+		};
+		var i =
+			Array.isArray ||
+			function( t ) {
+				return '[object Array]' === Object.prototype.toString.call( t );
+			};
+	},
+	function( t, e, n ) {
+		'use strict';
+		var r = function( t ) {
+			switch ( typeof t ) {
+				case 'string':
+					return t;
+				case 'boolean':
+					return t ? 'true' : 'false';
+				case 'number':
+					return isFinite( t ) ? t : '';
+				default:
+					return '';
+			}
+		};
+		t.exports = function( t, e, n, a ) {
+			return (
+				( e = e || '&' ),
+				( n = n || '=' ),
+				null === t && ( t = void 0 ),
+				'object' == typeof t
+					? o( s( t ), function( s ) {
+							var a = encodeURIComponent( r( s ) ) + n;
+							return i( t[ s ] )
+								? o( t[ s ], function( t ) {
+										return a + encodeURIComponent( r( t ) );
+								  } ).join( e )
+								: a + encodeURIComponent( r( t[ s ] ) );
+					  } ).join( e )
+					: a
+					? encodeURIComponent( r( a ) ) + n + encodeURIComponent( r( t ) )
+					: ''
+			);
+		};
+		var i =
+			Array.isArray ||
+			function( t ) {
+				return '[object Array]' === Object.prototype.toString.call( t );
+			};
+		function o( t, e ) {
+			if ( t.map ) return t.map( e );
+			for ( var n = [], r = 0; r < t.length; r++ ) n.push( e( t[ r ], r ) );
+			return n;
+		}
+		var s =
+			Object.keys ||
+			function( t ) {
+				var e = [];
+				for ( var n in t ) Object.prototype.hasOwnProperty.call( t, n ) && e.push( n );
+				return e;
+			};
+	},
+] );

--- a/apps/notifications/src/panel/state/action-middleware/notes/read-status.js
+++ b/apps/notifications/src/panel/state/action-middleware/notes/read-status.js
@@ -3,22 +3,9 @@ import * as types from '../../action-types';
 import getIsNoteRead from '../../selectors/get-is-note-read';
 import getNote from '../../selectors/get-note';
 
-import { markReadStatus } from '../../../rest-client/wpcom';
+import store from '../../../flux/store';
+
 import { bumpStat } from '../../../rest-client/bump-stat';
-
-const clearLocalReadCache = noteId => {
-	try {
-		localStorage.removeItem( `note_read_status_${ noteId }` );
-	} catch ( e ) {}
-};
-
-// Clear the local cache of read status
-// if we get updated data from the server
-export const clearReadCache = ( store, action ) => {
-	const noteIds = action.notes ? action.notes.map( ( { id } ) => id ) : action.noteIds;
-
-	noteIds.forEach( clearLocalReadCache );
-};
 
 export const markAsRead = ( { getState }, { noteId } ) => {
 	const state = getState();
@@ -29,27 +16,15 @@ export const markAsRead = ( { getState }, { noteId } ) => {
 	}
 
 	// If the note hasn't yet been marked as read then mark it
+	store.get( 'global' ).client.readNote( noteId );
+
 	try {
 		localStorage.setItem( `note_read_status_${ noteId }`, '1' );
 	} catch ( e ) {}
 
 	bumpStat( 'notes-read-type', note.type );
-
-	markReadStatus( noteId, true, ( error, data ) => {
-		if ( error || ! data.success ) {
-			try {
-				return localStorage.removeItem( `note_read_status_${ noteId }` );
-			} catch ( e ) {}
-		}
-
-		try {
-			localStorage.setItem( `note_read_status_${ noteId }`, '1' );
-		} catch ( e ) {}
-	} );
 };
 
 export default {
-	[ types.NOTES_ADD ]: [ clearReadCache ],
-	[ types.NOTES_REMOVE ]: [ clearReadCache ],
 	[ types.SELECT_NOTE ]: [ markAsRead ],
 };

--- a/apps/notifications/src/panel/templates/comment-reply-input.jsx
+++ b/apps/notifications/src/panel/templates/comment-reply-input.jsx
@@ -236,7 +236,6 @@ const CommentReplyInput = createReactClass( {
 			if ( component.props.note.meta.ids.comment ) {
 				// pre-emptively approve the comment if it wasn't already
 				component.props.approveNote( component.props.note.id, true );
-				component.props.global.client.getNote( component.props.note.id );
 			}
 
 			// remove focus from textarea so we can resume using keyboard

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -74,16 +74,6 @@ export class NoteList extends React.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.noteList && ! this.props.isLoading ) {
-			const element = ReactDOM.findDOMNode( this.scrollableContainer );
-			if (
-				element.clientHeight > 0 &&
-				element.scrollTop + element.clientHeight >= this.noteList.clientHeight - 300
-			) {
-				this.props.client.loadMore();
-			}
-		}
-
 		if ( prevProps.selectedNoteId !== this.props.selectedNoteId ) {
 			this.ensureSelectedNoteVisibility();
 		}

--- a/apps/notifications/src/panel/templates/summary-in-list.jsx
+++ b/apps/notifications/src/panel/templates/summary-in-list.jsx
@@ -11,7 +11,6 @@ import ImagePreloader from './image-loader';
 
 import { html } from '../indices-to-html';
 
-var debug = require( 'debug' )( 'notifications:summary-in-list' );
 var { recordTracksEvent } = require( '../helpers/stats' );
 
 export class SummaryInList extends React.Component {

--- a/client/layout/masterbar/notifications.jsx
+++ b/client/layout/masterbar/notifications.jsx
@@ -87,14 +87,14 @@ class MasterbarItemNotifications extends Component {
 	 *
 	 * @param {number} currentUnseenCount Number of reported unseen notifications
 	 */
-	setNotesIndicator = currentUnseenCount => {
+	setNotesIndicator = ( currentUnseenCount, hasNewNote = false ) => {
 		const existingUnseenCount = store.get( 'wpnotes_unseen_count' );
 		let newAnimationState = this.state.animationState;
 
 		if ( 0 === currentUnseenCount ) {
 			// If we don't have new notes at load-time, remove the `-1` "init" status
 			newAnimationState = 0;
-		} else if ( currentUnseenCount > existingUnseenCount ) {
+		} else if ( hasNewNote || currentUnseenCount > existingUnseenCount ) {
 			// Animate the indicator bubble by swapping CSS classes through the animation state
 			// Note that we could have an animation state of `-1` indicating the initial load
 			newAnimationState = 1 - Math.abs( this.state.animationState );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1424,6 +1424,22 @@
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
+		"@babel/polyfill": {
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
+			"integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
+			"requires": {
+				"core-js": "^2.6.5",
+				"regenerator-runtime": "^0.13.2"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+				}
+			}
+		},
 		"@babel/preset-env": {
 			"version": "7.8.4",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
@@ -10046,28 +10062,28 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"dev": true,
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"dev": true,
 							"optional": true,
@@ -10078,14 +10094,14 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 							"dev": true,
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"dev": true,
 							"optional": true,
@@ -10096,42 +10112,42 @@
 						},
 						"chownr": {
 							"version": "1.1.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
 							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 							"dev": true,
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 							"dev": true,
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 							"dev": true,
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "3.2.6",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 							"dev": true,
 							"optional": true,
@@ -10141,28 +10157,28 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.7",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 							"dev": true,
 							"optional": true,
@@ -10172,14 +10188,14 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"dev": true,
 							"optional": true,
@@ -10196,7 +10212,7 @@
 						},
 						"glob": {
 							"version": "7.1.6",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 							"dev": true,
 							"optional": true,
@@ -10211,14 +10227,14 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"dev": true,
 							"optional": true,
@@ -10228,7 +10244,7 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
 							"dev": true,
 							"optional": true,
@@ -10238,7 +10254,7 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"dev": true,
 							"optional": true,
@@ -10249,21 +10265,21 @@
 						},
 						"inherits": {
 							"version": "2.0.4",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 							"dev": true,
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"optional": true,
@@ -10273,14 +10289,14 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"dev": true,
 							"optional": true,
@@ -10290,14 +10306,14 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 							"dev": true,
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.9.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 							"dev": true,
 							"optional": true,
@@ -10308,7 +10324,7 @@
 						},
 						"minizlib": {
 							"version": "1.3.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 							"dev": true,
 							"optional": true,
@@ -10318,7 +10334,7 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"dev": true,
 							"optional": true,
@@ -10328,14 +10344,14 @@
 						},
 						"ms": {
 							"version": "2.1.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.4.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
 							"dev": true,
 							"optional": true,
@@ -10347,7 +10363,7 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.14.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
 							"dev": true,
 							"optional": true,
@@ -10366,7 +10382,7 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"dev": true,
 							"optional": true,
@@ -10377,7 +10393,7 @@
 						},
 						"npm-bundled": {
 							"version": "1.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
 							"dev": true,
 							"optional": true,
@@ -10387,14 +10403,14 @@
 						},
 						"npm-normalize-package-bin": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.7",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
 							"dev": true,
 							"optional": true,
@@ -10405,7 +10421,7 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"dev": true,
 							"optional": true,
@@ -10418,21 +10434,21 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 							"dev": true,
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"dev": true,
 							"optional": true,
@@ -10442,21 +10458,21 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"dev": true,
 							"optional": true,
@@ -10467,21 +10483,21 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"dev": true,
 							"optional": true,
@@ -10494,7 +10510,7 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"resolved": false,
+									"resolved": "",
 									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"dev": true,
 									"optional": true
@@ -10503,7 +10519,7 @@
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"optional": true,
@@ -10519,7 +10535,7 @@
 						},
 						"rimraf": {
 							"version": "2.7.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 							"dev": true,
 							"optional": true,
@@ -10529,49 +10545,49 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 							"dev": true,
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"optional": true,
@@ -10583,7 +10599,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"optional": true,
@@ -10593,7 +10609,7 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"optional": true,
@@ -10603,14 +10619,14 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.13",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 							"dev": true,
 							"optional": true,
@@ -10626,14 +10642,14 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"dev": true,
 							"optional": true,
@@ -10643,14 +10659,14 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"dev": true,
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 							"dev": true,
 							"optional": true
@@ -12708,7 +12724,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
 			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-			"dev": true,
 			"requires": {
 				"es5-ext": "^0.10.50",
 				"type": "^1.0.1"
@@ -14205,7 +14220,6 @@
 			"version": "0.10.53",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
 			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-			"dev": true,
 			"requires": {
 				"es6-iterator": "~2.0.3",
 				"es6-symbol": "~3.1.3",
@@ -14227,7 +14241,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"dev": true,
 			"requires": {
 				"d": "1",
 				"es5-ext": "^0.10.35",
@@ -14259,7 +14272,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
 			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-			"dev": true,
 			"requires": {
 				"d": "^1.0.1",
 				"ext": "^1.1.2"
@@ -15350,7 +15362,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
 			"integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-			"dev": true,
 			"requires": {
 				"type": "^2.0.0"
 			},
@@ -15358,8 +15369,7 @@
 				"type": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
-					"dev": true
+					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
 				}
 			}
 		},
@@ -18233,6 +18243,11 @@
 				"sshpk": "^1.7.0"
 			}
 		},
+		"https": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+			"integrity": "sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q="
+		},
 		"https-browserify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -19444,8 +19459,7 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-upper-case": {
 			"version": "1.1.2",
@@ -20053,28 +20067,28 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"dev": true,
 							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"dev": true,
 							"optional": true,
@@ -20085,14 +20099,14 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 							"dev": true,
 							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"dev": true,
 							"optional": true,
@@ -20103,42 +20117,42 @@
 						},
 						"chownr": {
 							"version": "1.1.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
 							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 							"dev": true,
 							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 							"dev": true,
 							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 							"dev": true,
 							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "3.2.6",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 							"dev": true,
 							"optional": true,
@@ -20148,28 +20162,28 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.7",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 							"dev": true,
 							"optional": true,
@@ -20179,14 +20193,14 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"dev": true,
 							"optional": true,
@@ -20203,7 +20217,7 @@
 						},
 						"glob": {
 							"version": "7.1.6",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 							"dev": true,
 							"optional": true,
@@ -20218,14 +20232,14 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"dev": true,
 							"optional": true,
@@ -20235,7 +20249,7 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
 							"dev": true,
 							"optional": true,
@@ -20245,7 +20259,7 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"dev": true,
 							"optional": true,
@@ -20256,21 +20270,21 @@
 						},
 						"inherits": {
 							"version": "2.0.4",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 							"dev": true,
 							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"optional": true,
@@ -20280,14 +20294,14 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"dev": true,
 							"optional": true,
@@ -20297,14 +20311,14 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 							"dev": true,
 							"optional": true
 						},
 						"minipass": {
 							"version": "2.9.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 							"dev": true,
 							"optional": true,
@@ -20315,7 +20329,7 @@
 						},
 						"minizlib": {
 							"version": "1.3.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 							"dev": true,
 							"optional": true,
@@ -20325,7 +20339,7 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"dev": true,
 							"optional": true,
@@ -20335,14 +20349,14 @@
 						},
 						"ms": {
 							"version": "2.1.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.4.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
 							"dev": true,
 							"optional": true,
@@ -20354,7 +20368,7 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.14.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
 							"dev": true,
 							"optional": true,
@@ -20373,7 +20387,7 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"dev": true,
 							"optional": true,
@@ -20384,7 +20398,7 @@
 						},
 						"npm-bundled": {
 							"version": "1.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
 							"dev": true,
 							"optional": true,
@@ -20394,14 +20408,14 @@
 						},
 						"npm-normalize-package-bin": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.7",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
 							"dev": true,
 							"optional": true,
@@ -20412,7 +20426,7 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"dev": true,
 							"optional": true,
@@ -20425,21 +20439,21 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 							"dev": true,
 							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"dev": true,
 							"optional": true,
@@ -20449,21 +20463,21 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"dev": true,
 							"optional": true,
@@ -20474,21 +20488,21 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"dev": true,
 							"optional": true,
@@ -20501,7 +20515,7 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"resolved": false,
+									"resolved": "",
 									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"dev": true,
 									"optional": true
@@ -20510,7 +20524,7 @@
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"optional": true,
@@ -20526,7 +20540,7 @@
 						},
 						"rimraf": {
 							"version": "2.7.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 							"dev": true,
 							"optional": true,
@@ -20536,49 +20550,49 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 							"dev": true,
 							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"optional": true,
@@ -20590,7 +20604,7 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"optional": true,
@@ -20600,7 +20614,7 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"optional": true,
@@ -20610,14 +20624,14 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.13",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 							"dev": true,
 							"optional": true,
@@ -20633,14 +20647,14 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"dev": true,
 							"optional": true,
@@ -20650,14 +20664,14 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"dev": true,
 							"optional": true
 						},
 						"yallist": {
 							"version": "3.1.1",
-							"resolved": false,
+							"resolved": "",
 							"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 							"dev": true,
 							"optional": true
@@ -23171,8 +23185,7 @@
 		"nan": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-			"dev": true
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -23246,8 +23259,7 @@
 		"next-tick": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-			"dev": true
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -32808,6 +32820,23 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
+		"simperium": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/simperium/-/simperium-1.0.4.tgz",
+			"integrity": "sha512-kMnq/f+8D3+1WJD1smXdN79LCpFs9IYpL37/xHsBGtQcd8zJeoDI3MD4CCNiy9vQxZiOVMC9LICtvgiZ7vCZXw==",
+			"requires": {
+				"@babel/polyfill": "7.7.0",
+				"uuid": "3.3.3",
+				"websocket": "1.0.31"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+					"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+				}
+			}
+		},
 		"simple-html-tokenizer": {
 			"version": "0.5.9",
 			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.9.tgz",
@@ -35837,8 +35866,7 @@
 		"type": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-			"dev": true
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -35879,6 +35907,14 @@
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
 		},
 		"typescript": {
 			"version": "3.7.5",
@@ -37652,6 +37688,33 @@
 				}
 			}
 		},
+		"websocket": {
+			"version": "1.0.31",
+			"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
+			"integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
+			"requires": {
+				"debug": "^2.2.0",
+				"es5-ext": "^0.10.50",
+				"nan": "^2.14.0",
+				"typedarray-to-buffer": "^3.1.5",
+				"yaeti": "^0.0.6"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
 		"websocket-driver": {
 			"version": "0.7.3",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
@@ -38363,6 +38426,11 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+		},
+		"yaeti": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+			"integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
 		},
 		"yallist": {
 			"version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
 		"@automattic/wpcom-block-editor": "file:apps/wpcom-block-editor",
 		"@wordpress/e2e-test-utils": "4.3.0",
 		"browserslist": "4.8.6",
+		"https": "1.0.0",
 		"i18n-calypso": "file:packages/i18n-calypso",
 		"photon": "file:packages/photon",
+		"simperium": "1.0.4",
 		"wp-calypso": "file:client",
 		"wpcom": "file:packages/wpcom.js"
 	},


### PR DESCRIPTION
 - Get the real `node-simperium` working
 - ✅ Hook up the bell icon
 - <del>Move into a `ServiceWorker` if possible</del> Prevent multiple tabs from doing the same redundant work. `ServiceWorker` may have too transitory of a lifetime to support background syncing across tabs and `SharedWorker` isn't available in Safari 👎 but we can approximate its behavior with faux-locking
 - Persist notes so that we don't have to
   perform full indexing on every load

## Testing

It's not currently possible to test this live. You'll need to clone the branch
and run locally with `npm start`. Once you do that, paste in the notifications
app id and api key into `localStorage`.

```js
// in the browser console
localStorage.setItem('wpnotes_app_id', 'SOME_APP_ID');
localStorage.setItem('wpnotes_api_key', 'SOME_API_KEY');
```

This is bad, and the keys are probably safe to share publicly, but I'm not
confident in that at this time.

Further, you're going to need to add your user id to the Simperium-sync
whitelist in the backend. Basically if you want to test this then you're going
to need to reach out to me. 😉