### PR TITLE
Checkout: add contextual help links

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -931,6 +931,31 @@ const contextLinksForSection = {
 			),
 		},
 	],
+	checkout: [
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/plan-features/' ),
+			post_id: 140323,
+			title: translate( 'WordPress.com Plan Details' ),
+			description: translate( "We'll help you pick the best fit for your needs and goals." ),
+		},
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/manage-purchases/#refund-policy' ),
+			post_id: 111349,
+			title: translate( 'Refund Policy' ),
+			description: translate(
+				'Have a question or need to change something about a purchase you have made? Learn how.'
+			),
+		},
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/auto-renewal/' ),
+			post_id: 110924,
+			title: translate( 'Subscriptions for Plans and Domains' ),
+			description: translate(
+				'Your WordPress.com plans and any domains you add to your sites are based ' +
+					'on a yearly subscription that renews automatically.'
+			),
+		},
+	],
 };
 
 /*

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -934,14 +934,24 @@ const contextLinksForSection = {
 	checkout: [
 		{
 			link: localizeUrl( 'https://en.support.wordpress.com/plan-features/' ),
-			post_id: 140323,
-			title: translate( 'WordPress.com Plan Details' ),
-			description: translate( "We'll help you pick the best fit for your needs and goals." ),
+			post_id: 134698,
+			title: translate( 'WordPress.com Plans' ),
+			description: translate(
+				'Learn about the capabilities and features that the different plans unlock for your site.'
+			),
 		},
 		{
-			link: localizeUrl( 'https://en.support.wordpress.com/manage-purchases/#refund-policy' ),
+			link: localizeUrl( 'https://en.support.wordpress.com/jetpack-add-ons/' ),
+			post_id: 115025,
+			title: translate( 'Jetpack Plans' ),
+			description: translate(
+				'Learn about the free Jetpack plugin, its benefits, and the useful capabilities and features that a Jetpack plan unlocks.'
+			),
+		},
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/manage-purchases/' ),
 			post_id: 111349,
-			title: translate( 'Refund Policy' ),
+			title: translate( 'Manage Purchases and Refund Policy' ),
 			description: translate(
 				'Have a question or need to change something about a purchase you have made? Learn how.'
 			),
@@ -951,8 +961,8 @@ const contextLinksForSection = {
 			post_id: 110924,
 			title: translate( 'Subscriptions for Plans and Domains' ),
 			description: translate(
-				'Your WordPress.com plans and any domains you add to your sites are based ' +
-					'on a yearly subscription that renews automatically.'
+				'Your WordPress.com plans and any domains you add to your sites are based on a yearly ' +
+					'subscription that renews automatically.'
 			),
 		},
 	],

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -245,7 +245,13 @@ class InlineHelpPopover extends Component {
 			showOptIn,
 			showOptOut,
 			onClose,
+			isCheckout,
 		} = this.props;
+
+		// Don't show additional items inside Checkout.
+		if ( isCheckout ) {
+			return null;
+		}
 
 		return (
 			<>
@@ -377,6 +383,7 @@ function mapStateToProps( state ) {
 		showOptOut: isGutenbergOptOutEnabled( state, siteId ),
 		showOptIn: optInEnabled && isCalypsoClassic,
 		gutenbergUrl,
+		isCheckout: section.name && section.name === 'checkout',
 	};
 }
 


### PR DESCRIPTION
From user testing Checkout, we've seen that customers want more information about our plans, refund policy, and subscriptions. This adds links to relevant support docs to the inline-help bubble.

There's room for 1 or 2 more links if we want them. Maybe G-suite or domains?

<img width="348" alt="Screen Shot 2020-03-06 at 6 12 39 PM" src="https://user-images.githubusercontent.com/942359/76129909-c4f12700-5fd6-11ea-8975-8632c52c2322.png">

**To Test:**
- visit any route with `/checkout/`
- click the inline help button
- check the link and clickthrough explanation copy
- clicking "learn more" should open an inline help modal with the correct documentation