### PR TITLE
Jetpack Search: Display in plans page

### DIFF
--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -17,7 +17,6 @@ export const PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY = 'jetpack_backup_daily_monthl
 export const PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY = 'jetpack_backup_realtime_monthly';
 export const PRODUCT_JETPACK_SEARCH = 'jetpack_search';
 export const PRODUCT_JETPACK_SEARCH_MONTHLY = 'jetpack_search_monthly';
-export const PRODUCT_JETPACK_SEARCH_TRIAL = 'jetpack_search_trial';
 
 export const JETPACK_BACKUP_PRODUCTS_YEARLY = [
 	PRODUCT_JETPACK_BACKUP_DAILY,
@@ -32,11 +31,7 @@ export const JETPACK_BACKUP_PRODUCTS = [
 	...JETPACK_BACKUP_PRODUCTS_MONTHLY,
 ];
 
-export const JETPACK_SEARCH_PRODUCTS = [
-	PRODUCT_JETPACK_SEARCH,
-	PRODUCT_JETPACK_SEARCH_MONTHLY,
-	PRODUCT_JETPACK_SEARCH_TRIAL,
-];
+export const JETPACK_SEARCH_PRODUCTS = [ PRODUCT_JETPACK_SEARCH, PRODUCT_JETPACK_SEARCH_MONTHLY ];
 
 export const JETPACK_PRODUCTS_LIST = [
 	...JETPACK_BACKUP_PRODUCTS,
@@ -69,7 +64,6 @@ export const getJetpackProductsShortNames = () => {
 		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate( 'Real-Time Backups' ),
 		[ PRODUCT_JETPACK_SEARCH ]: translate( 'Search' ),
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
-		[ PRODUCT_JETPACK_SEARCH_TRIAL ]: translate( 'Search (Trial)' ),
 	};
 };
 
@@ -113,7 +107,6 @@ export const getJetpackProductsDisplayNames = () => {
 		),
 		[ PRODUCT_JETPACK_SEARCH ]: translate( 'Jetpack Search' ),
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Jetpack Search' ),
-		[ PRODUCT_JETPACK_SEARCH_TRIAL ]: translate( 'Jetpack Search (Trial)' ),
 	};
 };
 
@@ -134,7 +127,6 @@ export const getJetpackProductsTaglines = () => {
 		),
 		[ PRODUCT_JETPACK_SEARCH ]: searchTagline,
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: searchTagline,
-		[ PRODUCT_JETPACK_SEARCH_TRIAL ]: searchTagline,
 	};
 };
 
@@ -155,7 +147,6 @@ export const getJetpackProductsDescriptions = () => {
 		),
 		[ PRODUCT_JETPACK_SEARCH ]: searchDescription,
 		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: searchDescription,
-		[ PRODUCT_JETPACK_SEARCH_TRIAL ]: searchDescription,
 	};
 };
 
@@ -189,7 +180,6 @@ export const getJetpackProducts = () => {
 			options: {
 				yearly: [ PRODUCT_JETPACK_SEARCH ],
 				monthly: [ PRODUCT_JETPACK_SEARCH_MONTHLY ],
-				trial: [ PRODUCT_JETPACK_SEARCH_TRIAL ],
 			},
 			optionShortNames: getJetpackProductsShortNames(),
 			optionDisplayNames: getJetpackProductsDisplayNames(),

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -4,12 +4,20 @@
 import React, { Fragment } from 'react';
 import { translate } from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import { isEnabled } from 'config';
+
 // Jetpack products constants
 export const PRODUCT_JETPACK_BACKUP = 'jetpack_backup';
 export const PRODUCT_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';
 export const PRODUCT_JETPACK_BACKUP_REALTIME = 'jetpack_backup_realtime';
 export const PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY = 'jetpack_backup_daily_monthly';
 export const PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY = 'jetpack_backup_realtime_monthly';
+export const PRODUCT_JETPACK_SEARCH = 'jetpack_search';
+export const PRODUCT_JETPACK_SEARCH_MONTHLY = 'jetpack_search_monthly';
+export const PRODUCT_JETPACK_SEARCH_TRIAL = 'jetpack_search_trial';
 
 export const JETPACK_BACKUP_PRODUCTS_YEARLY = [
 	PRODUCT_JETPACK_BACKUP_DAILY,
@@ -24,7 +32,16 @@ export const JETPACK_BACKUP_PRODUCTS = [
 	...JETPACK_BACKUP_PRODUCTS_MONTHLY,
 ];
 
-export const JETPACK_PRODUCTS_LIST = [ ...JETPACK_BACKUP_PRODUCTS ];
+export const JETPACK_SEARCH_PRODUCTS = [
+	PRODUCT_JETPACK_SEARCH,
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	PRODUCT_JETPACK_SEARCH_TRIAL,
+];
+
+export const JETPACK_PRODUCTS_LIST = [
+	...JETPACK_BACKUP_PRODUCTS,
+	...( isEnabled( 'jetpack/search-product' ) ? JETPACK_SEARCH_PRODUCTS : [] ),
+];
 
 export const JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/backup/';
 
@@ -37,6 +54,10 @@ export const JETPACK_PRODUCT_PRICE_MATRIX = {
 		relatedProduct: PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
 		ratio: 12,
 	},
+	[ PRODUCT_JETPACK_SEARCH ]: {
+		relatedProduct: PRODUCT_JETPACK_SEARCH_MONTHLY,
+		ratio: 12,
+	},
 };
 
 // Translatable strings
@@ -46,6 +67,9 @@ export const getJetpackProductsShortNames = () => {
 		[ PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY ]: translate( 'Daily Backups' ),
 		[ PRODUCT_JETPACK_BACKUP_REALTIME ]: translate( 'Real-Time Backups' ),
 		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate( 'Real-Time Backups' ),
+		[ PRODUCT_JETPACK_SEARCH ]: translate( 'Search' ),
+		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Search' ),
+		[ PRODUCT_JETPACK_SEARCH_TRIAL ]: translate( 'Search (Trial)' ),
 	};
 };
 
@@ -87,10 +111,14 @@ export const getJetpackProductsDisplayNames = () => {
 				} ) }
 			</Fragment>
 		),
+		[ PRODUCT_JETPACK_SEARCH ]: translate( 'Jetpack Search' ),
+		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: translate( 'Jetpack Search' ),
+		[ PRODUCT_JETPACK_SEARCH_TRIAL ]: translate( 'Jetpack Search (Trial)' ),
 	};
 };
 
 export const getJetpackProductsTaglines = () => {
+	const searchTagline = translate( 'Search your site.' );
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate(
 			'Your data is being securely backed up every day with a 30-day archive.'
@@ -104,10 +132,14 @@ export const getJetpackProductsTaglines = () => {
 		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate(
 			'Your data is being securely backed up as you edit.'
 		),
+		[ PRODUCT_JETPACK_SEARCH ]: searchTagline,
+		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: searchTagline,
+		[ PRODUCT_JETPACK_SEARCH_TRIAL ]: searchTagline,
 	};
 };
 
 export const getJetpackProductsDescriptions = () => {
+	const searchDescription = translate( 'Search your site.' );
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate(
 			'Always-on backups ensure you never lose your site. Your changes are saved every day with a 30-day archive.'
@@ -121,23 +153,49 @@ export const getJetpackProductsDescriptions = () => {
 		[ PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY ]: translate(
 			'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
 		),
+		[ PRODUCT_JETPACK_SEARCH ]: searchDescription,
+		[ PRODUCT_JETPACK_SEARCH_MONTHLY ]: searchDescription,
+		[ PRODUCT_JETPACK_SEARCH_TRIAL ]: searchDescription,
 	};
 };
 
-export const getJetpackProducts = () => [
-	{
-		title: translate( 'Jetpack Backup' ),
-		description: translate(
-			'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
-		),
-		id: PRODUCT_JETPACK_BACKUP,
-		options: {
-			yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
-			monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
+export const getJetpackProducts = () => {
+	const output = [
+		{
+			title: translate( 'Jetpack Backup' ),
+			description: translate(
+				'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
+			),
+			id: PRODUCT_JETPACK_BACKUP,
+			options: {
+				yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
+				monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
+			},
+			optionShortNames: getJetpackProductsShortNames(),
+			optionDisplayNames: getJetpackProductsDisplayNames(),
+			optionDescriptions: getJetpackProductsDescriptions(),
+			optionsLabel: translate( 'Select a backup option:' ),
+			slugs: JETPACK_BACKUP_PRODUCTS,
 		},
-		optionShortNames: getJetpackProductsShortNames(),
-		optionDisplayNames: getJetpackProductsDisplayNames(),
-		optionDescriptions: getJetpackProductsDescriptions(),
-		optionsLabel: translate( 'Select a backup option:' ),
-	},
-];
+	];
+	isEnabled( 'jetpack/search-product' ) &&
+		output.push( {
+			title: translate( 'Jetpack Search' ),
+			// TODO: Add new description copy for Search
+			description: translate(
+				'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
+			),
+			id: PRODUCT_JETPACK_SEARCH,
+			options: {
+				yearly: [ PRODUCT_JETPACK_SEARCH ],
+				monthly: [ PRODUCT_JETPACK_SEARCH_MONTHLY ],
+				trial: [ PRODUCT_JETPACK_SEARCH_TRIAL ],
+			},
+			optionShortNames: getJetpackProductsShortNames(),
+			optionDisplayNames: getJetpackProductsDisplayNames(),
+			optionDescriptions: getJetpackProductsDescriptions(),
+			optionsLabel: translate( 'Select a product option:' ),
+			slugs: JETPACK_SEARCH_PRODUCTS,
+		} );
+	return output;
+};

--- a/client/lib/products-values/products-list.ts
+++ b/client/lib/products-values/products-list.ts
@@ -36,4 +36,16 @@ export const PRODUCTS_LIST = {
 		term: TERM_MONTHLY,
 		bill_period: PLAN_MONTHLY_PERIOD,
 	},
+	[ constants.PRODUCT_JETPACK_SEARCH ]: {
+		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_SEARCH ],
+		product_slug: constants.PRODUCT_JETPACK_SEARCH,
+		term: TERM_ANNUALLY,
+		bill_period: PLAN_ANNUAL_PERIOD,
+	},
+	[ constants.PRODUCT_JETPACK_SEARCH_MONTHLY ]: {
+		product_name: PRODUCT_SHORT_NAMES[ constants.PRODUCT_JETPACK_SEARCH_MONTHLY ],
+		product_slug: constants.PRODUCT_JETPACK_SEARCH_MONTHLY,
+		term: TERM_MONTHLY,
+		bill_period: PLAN_MONTHLY_PERIOD,
+	},
 };

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -29,7 +29,7 @@ import {
 	GROUP_JETPACK,
 } from 'lib/plans/constants';
 import {
-	JETPACK_BACKUP_PRODUCTS,
+	JETPACK_PRODUCTS_LIST,
 	JETPACK_PRODUCT_PRICE_MATRIX,
 	getJetpackProducts,
 } from 'lib/products-values/constants';
@@ -432,19 +432,18 @@ export class PlansFeaturesMain extends Component {
 		}
 
 		const { basePlansPath, intervalType, redirectTo, onUpgradeClick } = this.props;
-		const jetpackProducts = getJetpackProducts();
 
 		return (
-			<div className="plans-features-main__group is-narrow">
+			<div className="plans-features-main__group is-jetpack-products">
 				<PlansFeaturesMainProductsHeader />
 				<AsyncLoad
 					require="blocks/product-plan-overlap-notices"
 					placeholder={ null }
 					plans={ JETPACK_PLANS }
-					products={ JETPACK_BACKUP_PRODUCTS }
+					products={ JETPACK_PRODUCTS_LIST }
 				/>
 				<ProductSelector
-					products={ jetpackProducts }
+					products={ getJetpackProducts() }
 					intervalType={ intervalType }
 					basePlansPath={ basePlansPath }
 					productPriceMatrix={ JETPACK_PRODUCT_PRICE_MATRIX }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -8,11 +8,21 @@
 		margin-top: 20px;
 	}
 
-	&.is-narrow {
-		@include breakpoint( '>960px' ) {
-			max-width: 520px;
-			margin-left: auto;
-			margin-right: auto;
+	&.is-jetpack-products {
+		> .product-selector {
+			display: flex;
+			flex-flow: row wrap;
+
+			.product-card {
+				flex-basis: calc( 50% - 1em );
+				&:first-child:last-child {
+					@include breakpoint( '>960px' ) {
+						margin-left: auto;
+						margin-right: auto;
+						flex-basis: 520px;
+					}
+				}
+			}
 		}
 	}
 }
@@ -40,7 +50,7 @@
 	background: var( --color-surface );
 	border-radius: 3px;
 	padding: 2px 12px;
-	@include elevation ( 2dp );
+	@include elevation( 2dp );
 
 	button.is-borderless {
 		color: var( --color-accent );
@@ -79,7 +89,6 @@
 		font-size: 24px;
 		font-weight: 400;
 	}
-
 }
 
 .plans-features-main__subhead {

--- a/config/development.json
+++ b/config/development.json
@@ -79,6 +79,7 @@
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
+		"jetpack/search-product": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"legal-updates-banner": true,


### PR DESCRIPTION
Partially addressees #39858. Design is not final and will be iterated upon.

#### Changes proposed in this Pull Request

* Add support for showing Jetpack Search product in `/plans` via a feature gate.

#### Testing instructions

1. Spin up this branch locally.

2. Navigate to `/plans` and select a Jetpack site without any plan subscriptions. You should see something like this at the bottom:

<img width="1081" alt="Screen Shot 2020-03-09 at 4 30 33 PM" src="https://user-images.githubusercontent.com/4044428/76262947-50f78e80-6223-11ea-91eb-0c39340b2d6e.png">

3. Navigate to `/plans` and select a Jetpack site with a plan that includes Jetpack Backups. You should see something like this:

<img width="1081" alt="Screen Shot 2020-03-09 at 4 30 00 PM" src="https://user-images.githubusercontent.com/4044428/76262999-6ec4f380-6223-11ea-9ea0-fe597a84c0d1.png">

4. Navigate to [`/plans` in wp-calypso](https://calypso.live/?branch=add/jetpack-search-plans-part-1) for a Jetpack site without any Jetpack plans. Alternatively, you can add a `flags=-jetpack/search-product` query string to the URL. You should see something like this:

<img width="1081" alt="Screen Shot 2020-03-09 at 4 35 22 PM" src="https://user-images.githubusercontent.com/4044428/76263245-01fe2900-6224-11ea-8baf-aadd5dd85659.png">

5. Repeat step 4 for a Jetpack site with a Jetpack plan that includes Backups. It should look like this:

<img width="1081" alt=" Screen Shot 2020-03-09 at 4 34 11 PM" src="https://user-images.githubusercontent.com/4044428/76263270-12ae9f00-6224-11ea-8542-bdd71df1483e.png">
