### PR TITLE
SPT: Accommodate Varia styles

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -153,8 +153,11 @@ const BlockFramePreview = ( {
 	useEffect( () => {
 		setTimeout( () => {
 			copyStylesToIframe( window.document, iframeRef.current.contentDocument );
-			iframeRef.current.contentDocument.body.classList.add( bodyClassName );
-			iframeRef.current.contentDocument.body.classList.add( 'editor-styles-wrapper' );
+			iframeRef.current.contentDocument.body.classList.add(
+				bodyClassName,
+				'editor-styles-wrapper',
+				'block-editor__container'
+			);
 			rescale();
 		}, 0 );
 	}, [ setTimeout, bodyClassName, rescale ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `block-editor__container` class to iframe body. Themes seem to rely on it for styling.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In a local install, have the latest Variable and Maywood themes installed with Maywood activated.
* Checkout the PR and build FSE with `$ npx lerna run dev --scope='@automattic/full-site-editing' --stream --no-prefix`
* Publish a new post with a featured image wider than 700px or add a picture like that to an existing post.
* Create a new page and select the blog template in the template selector.
* Make sure the featured image doesn't overflow the content area.

Fixes #39278.
