### PR TITLE
Plans: Revert page view defer after it dropped stats significantly

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -82,14 +82,8 @@ class Plans extends React.Component {
 
 		const partnerName = getPartnerName( purchase );
 
-		const eventProps = {
-			partner_managed: true,
-			partner_slug: purchase.partnerSlug ?? '',
-		};
-
 		return (
 			<div>
-				<TrackComponentView eventName="calypso_plans_view" eventProperties={ eventProps } />
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<Main wideLayout={ true }>
 					<SidebarNavigation />
@@ -140,8 +134,7 @@ class Plans extends React.Component {
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<PageViewTracker path="/plans/:site" title="Plans" />
 				<QueryContactDetailsCache />
-				{ /* We intentionally delay the track event below so that we know whether this is a partner purchase. */ }
-				{ purchase && <TrackComponentView eventName="calypso_plans_view" /> }
+				<TrackComponentView eventName="calypso_plans_view" />
 				<Main wideLayout={ true }>
 					<SidebarNavigation />
 					{ ! canAccessPlans && (


### PR DESCRIPTION
Reverts Automattic/wp-calypso#39714

**Changes proposed in this Pull Request**

In #39714, we ended up deferring the page `calypso_plans_view` event until we had the `purchase` object so that we could add props to the `calypso_plans_view` event. But, that had the effect of significantly dropping the numbers for `calypso_plans_view`. 

At this point, we've already been able to get enough information from the change that it makes sense to just revert this PR so that the stats rebound back to where they were previously.

**Testing instructions**

-Go to http://calypso.localhost:3000/plans/$site
- In the console, run `localStorage.setItem( 'debug', 'calypso:analytics:TrackComponentView' );`
- Refresh the page
- Ensure that the `calypso_plans_view` tracks event fires

