### PR TITLE
Expand "Manage" menu section if plans/emails or plan/email tabs are s…

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -43,11 +43,22 @@ export default class SidebarItem extends React.Component {
 		}
 	};
 
-	componentDidMount() {
+	expandSectionIfSelected = () => {
 		const { expandSection, selected } = this.props;
 
-		if ( isFunction( expandSection ) && selected ) {
+		if ( selected && isFunction( expandSection ) ) {
 			expandSection();
+		}
+	};
+
+	componentDidMount() {
+		this.expandSectionIfSelected();
+	}
+
+	componentDidUpdate( prevProps ) {
+		// Expand section if selected state changes from false to true
+		if ( ! prevProps.selected ) {
+			this.expandSectionIfSelected();
 		}
 	}
 

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -95,7 +95,7 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/domains/manage/${ site.slug }` }
-								onClick={ this.expandManageSection }
+								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
 								selected={ path === '/domains/manage' || path === '/domains/add' }
 							>
 								{ translate( 'Domains' ) }
@@ -104,7 +104,7 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/email/${ site.slug }` }
-								onClick={ this.expandManageSection }
+								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
 								selected={ path === '/email' }
 							>
 								{ translate( 'Email' ) }
@@ -116,10 +116,6 @@ class PlansNavigation extends React.Component {
 			)
 		);
 	}
-
-	expandManageSection = () => {
-		this.props.expandSection( SIDEBAR_SECTION_MANAGE );
-	};
 
 	toggleCartVisibility = () => {
 		this.setState( { cartVisible: ! this.state.cartVisible } );
@@ -147,7 +143,7 @@ class PlansNavigation extends React.Component {
 	}
 }
 
-const mapStateToProps = state => {
+export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const site = getSite( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
@@ -157,6 +153,4 @@ const mapStateToProps = state => {
 		shouldShowMyPlan: ! isOnFreePlan || isJetpack,
 		site,
 	};
-};
-
-export default connect( mapStateToProps, { expandSection } )( localize( PlansNavigation ) );
+} )( localize( PlansNavigation ) );

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -21,8 +21,6 @@ import { isATEnabled } from 'lib/automated-transfer';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
-import { SIDEBAR_SECTION_MANAGE } from '../sidebar/constants';
-import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 
 class PlansNavigation extends React.Component {
 	static propTypes = {
@@ -95,18 +93,13 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/domains/manage/${ site.slug }` }
-								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
 								selected={ path === '/domains/manage' || path === '/domains/add' }
 							>
 								{ translate( 'Domains' ) }
 							</NavItem>
 						) }
 						{ canManageDomain && (
-							<NavItem
-								path={ `/email/${ site.slug }` }
-								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
-								selected={ path === '/email' }
-							>
+							<NavItem path={ `/email/${ site.slug }` } selected={ path === '/email' }>
 								{ translate( 'Email' ) }
 							</NavItem>
 						) }

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -95,7 +95,7 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/domains/manage/${ site.slug }` }
-								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
+								onClick={ this.expandManageSection }
 								selected={ path === '/domains/manage' || path === '/domains/add' }
 							>
 								{ translate( 'Domains' ) }
@@ -104,7 +104,7 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/email/${ site.slug }` }
-								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
+								onClick={ this.expandManageSection }
 								selected={ path === '/email' }
 							>
 								{ translate( 'Email' ) }
@@ -116,6 +116,10 @@ class PlansNavigation extends React.Component {
 			)
 		);
 	}
+
+	expandManageSection = () => {
+		this.props.expandSection( SIDEBAR_SECTION_MANAGE );
+	};
 
 	toggleCartVisibility = () => {
 		this.setState( { cartVisible: ! this.state.cartVisible } );
@@ -143,7 +147,7 @@ class PlansNavigation extends React.Component {
 	}
 }
 
-export default connect( state => {
+const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const site = getSite( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
@@ -153,4 +157,6 @@ export default connect( state => {
 		shouldShowMyPlan: ! isOnFreePlan || isJetpack,
 		site,
 	};
-} )( localize( PlansNavigation ) );
+};
+
+export default connect( mapStateToProps, { expandSection } )( localize( PlansNavigation ) );

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -21,6 +21,8 @@ import { isATEnabled } from 'lib/automated-transfer';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
+import { SIDEBAR_SECTION_MANAGE } from '../sidebar/constants';
+import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 
 class PlansNavigation extends React.Component {
 	static propTypes = {
@@ -93,13 +95,18 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/domains/manage/${ site.slug }` }
+								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
 								selected={ path === '/domains/manage' || path === '/domains/add' }
 							>
 								{ translate( 'Domains' ) }
 							</NavItem>
 						) }
 						{ canManageDomain && (
-							<NavItem path={ `/email/${ site.slug }` } selected={ path === '/email' }>
+							<NavItem
+								path={ `/email/${ site.slug }` }
+								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
+								selected={ path === '/email' }
+							>
 								{ translate( 'Email' ) }
 							</NavItem>
 						) }


### PR DESCRIPTION
…elected

#### Changes proposed in this Pull Request

* Expand "Manage" section when clicking on "domains" and "email" in "Plans" page

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a site
* Click on 'Plan' in the sidebar
* In the 'plans' page, make sure you have access to 'domain' and 'email' tabs
* Make sure the "Manage" menu section is collapsed
* Click on the 'domain' tab
-> The menu 'manage' section should be opened, with 'Domains' highlighted


#### Comments
 * Used `import { expandMySitesSidebarSection as expandSection } ` as done... everywhere!! (6 files). Maybe renaming this method might be considered?
 * I added a onClick on the NavItem. I am not sure if it is the best way or if it should be handled by the router, or even directly within the constructors or ComponentDidMount of DomainWarnings/EmailManagement components... The difference in behaviour is minimal, but it would prevent having the same problem if a another page links to those pages...
 * Although having the section expanding is enough, maybe  highlighting the section header when one of the child is `selected` could also be an option. As you also lose some navigation information when section is manually closed.

Fixes #39934
@gwwar 