### PR TITLE
Fix Regression: Renewal Info on My Plan page

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -192,9 +192,12 @@ export class ProductSelector extends Component {
 
 		const expiryMoment = purchase.expiryDate ? moment( purchase.expiryDate ) : null;
 
+		const renewDateMoment = purchase.renewDate ? moment( purchase.renewDate ) : null;
+
 		return (
 			<ProductExpiration
 				expiryDateMoment={ expiryMoment }
+				renewDateMoment={ renewDateMoment }
 				purchaseDateMoment={ subscribedMoment }
 				isRefundable={ purchase.isRefundable }
 			/>

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -28,6 +28,7 @@ import { getSitePlanSlug, isRequestingSitePlans } from 'state/sites/plans/select
 import { getSitePurchases, isFetchingSitePurchases } from 'state/purchases/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getPlan, planHasFeature } from 'lib/plans';
+import { isExpiring } from 'lib/purchases';
 import { isRequestingPlans } from 'state/plans/selectors';
 import { TERM_ANNUALLY, TERM_MONTHLY } from 'lib/plans/constants';
 import { withLocalizedMoment } from 'components/localized-moment';
@@ -192,7 +193,8 @@ export class ProductSelector extends Component {
 
 		const expiryMoment = purchase.expiryDate ? moment( purchase.expiryDate ) : null;
 
-		const renewDateMoment = purchase.renewDate ? moment( purchase.renewDate ) : null;
+		const renewDateMoment =
+			! isExpiring( purchase ) && purchase.renewDate ? moment( purchase.renewDate ) : null;
 
 		return (
 			<ProductExpiration

--- a/client/components/product-expiration/README.md
+++ b/client/components/product-expiration/README.md
@@ -13,6 +13,9 @@ This controls the formatting of the date format, which is passed to a localized 
 #### `expiryDateMoment { moment }`
 This is the expiration date as a `moment` instance, and is required for display.
 
+#### `renewDateMoment { moment }`
+This is the date on which the product will be renewed, as a `moment` instance, and is required for display.
+
 #### `isRefundable { boolean } - default false`
 Controls whether the product is currently in the refund window, which changes the display to the purchase date, if provided.
 
@@ -25,6 +28,7 @@ Optional purchase date, used only when `isRefundable` provided.
 const expiryDateMoment = moment( product.expiry );
 <ProductExpiration
 	expiryDateMoment={ expiryDateMoment }
+	renewDateMoment={ renewDateMoment }
 	isRefundable={ product.isRefundable }
 />
 ```

--- a/client/components/product-expiration/README.md
+++ b/client/components/product-expiration/README.md
@@ -14,7 +14,7 @@ This controls the formatting of the date format, which is passed to a localized 
 This is the expiration date as a `moment` instance, and is required for display.
 
 #### `renewDateMoment { moment }`
-This is the date on which the product will be renewed, as a `moment` instance, and is required for display.
+This is the date on which the product will be renewed, as a `moment` instance, used only when provided.
 
 #### `isRefundable { boolean } - default false`
 Controls whether the product is currently in the refund window, which changes the display to the purchase date, if provided.

--- a/client/components/product-expiration/README.md
+++ b/client/components/product-expiration/README.md
@@ -14,7 +14,7 @@ This controls the formatting of the date format, which is passed to a localized 
 This is the expiration date as a `moment` instance, and is required for display.
 
 #### `renewDateMoment { moment }`
-This is the date on which the product will be renewed, as a `moment` instance, used only when provided.
+This is the date on which the product will be auto-renewed, as a `moment` instance, used only when provided.
 
 #### `isRefundable { boolean } - default false`
 Controls whether the product is currently in the refund window, which changes the display to the purchase date, if provided.
@@ -26,6 +26,7 @@ Optional purchase date, used only when `isRefundable` provided.
 
 ```jsx
 const expiryDateMoment = moment( product.expiry );
+const renewDateMoment = moment( product.renewDate );
 <ProductExpiration
 	expiryDateMoment={ expiryDateMoment }
 	renewDateMoment={ renewDateMoment }

--- a/client/components/product-expiration/docs/example.tsx
+++ b/client/components/product-expiration/docs/example.tsx
@@ -20,6 +20,7 @@ function ProductExpirationExample() {
 					<ProductExpiration
 						purchaseDateMoment={ moment() }
 						expiryDateMoment={ moment() }
+						renewDateMoment={ moment() }
 						isRefundable
 					/>
 				</em>
@@ -35,7 +36,7 @@ function ProductExpirationExample() {
 				Product subscription expires in future:
 				<br />
 				<em>
-					<ProductExpiration expiryDateMoment={ moment().add( 1, 'day' ) } />
+					<ProductExpiration renewDateMoment={ moment().add( 1, 'day' ) } />
 				</em>
 			</p>
 		</>

--- a/client/components/product-expiration/index.tsx
+++ b/client/components/product-expiration/index.tsx
@@ -8,6 +8,7 @@ import { Moment } from 'moment';
 interface Props extends LocalizeProps {
 	dateFormat?: string;
 	expiryDateMoment: Moment;
+	renewDateMoment: Moment;
 	isRefundable?: boolean;
 	purchaseDateMoment?: Moment;
 }
@@ -22,13 +23,14 @@ export class ProductExpiration extends React.PureComponent< Props > {
 		const {
 			dateFormat,
 			expiryDateMoment,
+			renewDateMoment,
 			isRefundable,
 			purchaseDateMoment,
 			translate,
 		} = this.props;
 
 		// Return null if we don't have any dates.
-		if ( ! expiryDateMoment && ! purchaseDateMoment ) {
+		if ( ! expiryDateMoment && ! renewDateMoment && ! purchaseDateMoment ) {
 			return null;
 		}
 
@@ -40,7 +42,7 @@ export class ProductExpiration extends React.PureComponent< Props > {
 			return null;
 		}
 
-		// Return null if date is not parsable.
+		// Return null if expiration date isn't parsable.
 		if ( ! expiryDateMoment.isValid() ) {
 			return null;
 		}
@@ -50,8 +52,12 @@ export class ProductExpiration extends React.PureComponent< Props > {
 			return translate( 'Expired on %s', { args: expiryDateMoment.format( dateFormat ) } );
 		}
 
+		if ( ! renewDateMoment ) {
+			return translate( 'Expires on %s', { args: expiryDateMoment.format( dateFormat ) } );
+		}
+
 		// Lastly, return the renewal date.
-		return translate( 'Renews on %s', { args: expiryDateMoment.format( dateFormat ) } );
+		return translate( 'Renews on %s', { args: renewDateMoment.format( dateFormat ) } );
 	}
 }
 

--- a/client/components/product-expiration/index.tsx
+++ b/client/components/product-expiration/index.tsx
@@ -52,7 +52,7 @@ export class ProductExpiration extends React.PureComponent< Props > {
 			return translate( 'Expired on %s', { args: expiryDateMoment.format( dateFormat ) } );
 		}
 
-		if ( ! renewDateMoment ) {
+		if ( ! renewDateMoment || ! renewDateMoment.isValid() ) {
 			return translate( 'Expires on %s', { args: expiryDateMoment.format( dateFormat ) } );
 		}
 

--- a/client/components/product-expiration/test/index.js
+++ b/client/components/product-expiration/test/index.js
@@ -36,7 +36,11 @@ describe( 'ProductExpiration', () => {
 	it( 'should return the renewal date in when the date is in the future', () => {
 		const date = moment( new Date( 2100, 10, 10 ) );
 		const wrapper = shallow(
-			<ProductExpiration renewDateMoment={ date } translate={ translate } />
+			<ProductExpiration
+				expiryDateMoment={ date }
+				renewDateMoment={ date }
+				translate={ translate }
+			/>
 		);
 		expect( wrapper.text() ).toEqual( 'Renews on November 10, 2100' );
 	} );

--- a/client/components/product-expiration/test/index.js
+++ b/client/components/product-expiration/test/index.js
@@ -36,7 +36,7 @@ describe( 'ProductExpiration', () => {
 	it( 'should return the renewal date in when the date is in the future', () => {
 		const date = moment( new Date( 2100, 10, 10 ) );
 		const wrapper = shallow(
-			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
+			<ProductExpiration renewDateMoment={ date } translate={ translate } />
 		);
 		expect( wrapper.text() ).toEqual( 'Renews on November 10, 2100' );
 	} );

--- a/client/components/product-expiration/test/index.js
+++ b/client/components/product-expiration/test/index.js
@@ -33,12 +33,33 @@ describe( 'ProductExpiration', () => {
 		expect( wrapper.text() ).toEqual( 'Expired on November 10, 2009' );
 	} );
 
-	it( 'should return the renewal date in when the date is in the future', () => {
+	it( 'should return the expiry date in future tense when date is in future', () => {
+		const date = moment( new Date( 2100, 10, 10 ) );
+		const wrapper = shallow(
+			<ProductExpiration expiryDateMoment={ date } translate={ translate } />
+		);
+		expect( wrapper.text() ).toEqual( 'Expires on November 10, 2100' );
+	} );
+
+	it( 'should return the renewal date (same as the expiry date) in when the date is in the future', () => {
 		const date = moment( new Date( 2100, 10, 10 ) );
 		const wrapper = shallow(
 			<ProductExpiration
 				expiryDateMoment={ date }
 				renewDateMoment={ date }
+				translate={ translate }
+			/>
+		);
+		expect( wrapper.text() ).toEqual( 'Renews on November 10, 2100' );
+	} );
+
+	it( 'should return the renewal date in when the date is in the future', () => {
+		const expiryDate = moment( new Date( 2100, 9, 10 ) );
+		const renewDate = moment( new Date( 2100, 10, 10 ) );
+		const wrapper = shallow(
+			<ProductExpiration
+				expiryDateMoment={ expiryDate }
+				renewDateMoment={ renewDate }
 				translate={ translate }
 			/>
 		);

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -136,9 +136,14 @@ class PurchasesListing extends Component {
 
 		const expiryMoment = purchase.expiryDate ? this.props.moment( purchase.expiryDate ) : null;
 
+		// Pass auto-renew information if it is enabled.
+		const renewMoment =
+			purchase.autoRenew && purchase.autoRenewDateMoment ? purchase.autoRenewDateMoment : null;
+
 		return (
 			<ProductExpiration
 				expiryDateMoment={ expiryMoment }
+				renewDateMoment={ renewMoment }
 				purchaseDateMoment={ subscribedMoment }
 				isRefundable={ purchase.isRefundable }
 			/>

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -138,7 +138,9 @@ class PurchasesListing extends Component {
 
 		// Pass auto-renew information if it is enabled.
 		const renewMoment =
-			purchase.autoRenew && purchase.autoRenewDateMoment ? purchase.autoRenewDateMoment : null;
+			purchase.autoRenew && purchase.autoRenewDate
+				? this.props.moment( purchase.autoRenewDate )
+				: null;
 
 		return (
 			<ProductExpiration

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -136,11 +136,17 @@ class PurchasesListing extends Component {
 
 		const expiryMoment = purchase.expiryDate ? this.props.moment( purchase.expiryDate ) : null;
 
+		let renewMoment = null;
+
 		// Pass auto-renew information if it is enabled.
-		const renewMoment =
-			purchase.autoRenew && purchase.autoRenewDate
-				? this.props.moment( purchase.autoRenewDate )
-				: null;
+		if ( 'renewDate' in purchase ) {
+			renewMoment = purchase.renewDate ? this.props.moment( purchase.renewDate ) : null;
+		} else if ( 'autoRenewDate' in purchase ) {
+			renewMoment =
+				purchase.autoRenew && purchase.autoRenewDate
+					? this.props.moment( purchase.autoRenewDate )
+					: null;
+		}
 
 		return (
 			<ProductExpiration

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -138,7 +138,8 @@ class PurchasesListing extends Component {
 
 		let renewMoment = null;
 
-		// Pass auto-renew information if it is enabled.
+		// If a purchase object has been passed into this function, it will contain the `renewDate` property.
+		// Otherwise, if a plan object has been passed into this function, it will contain the `autoRenew` and `autoRenewDate` properties.
 		if ( 'renewDate' in purchase ) {
 			renewMoment = purchase.renewDate ? this.props.moment( purchase.renewDate ) : null;
 		} else if ( 'autoRenewDate' in purchase ) {

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -124,49 +124,18 @@ class PurchasesListing extends Component {
 		return null;
 	}
 
-	getPurchaseByCurrentPlan() {
-		const { currentPlanSlug, purchases } = this.props;
-
-		if ( ! currentPlanSlug ) {
-			return null;
-		}
-
-		return find(
-			purchases,
-			purchase => purchase.active && purchase.productSlug === currentPlanSlug
-		);
-	}
-
 	getExpirationInfoForPlan( plan ) {
-		// No expiration date for free plan or partner site.
-		if ( this.isFreePlan( plan ) || isPartnerPurchase( plan ) ) {
+		// No expiration date for free plans.
+		if ( this.isFreePlan( plan ) ) {
 			return null;
 		}
-
-		const subscribedMoment = plan.subscribedDate ? this.props.moment( plan.subscribedDate ) : null;
 
 		const expiryMoment = plan.expiryDate ? this.props.moment( plan.expiryDate ) : null;
 
 		const renewMoment =
 			plan.autoRenew && plan.autoRenewDate ? this.props.moment( plan.autoRenewDate ) : null;
 
-		let isRefundable = false;
-
-		// we need to find the purchase linked to the current plan to find out if it's refundable or not
-		const purchaseForCurrentPlan = this.getPurchaseByCurrentPlan();
-
-		if ( purchaseForCurrentPlan ) {
-			isRefundable = purchaseForCurrentPlan.isRefundable;
-		}
-
-		return (
-			<ProductExpiration
-				expiryDateMoment={ expiryMoment }
-				renewDateMoment={ renewMoment }
-				purchaseDateMoment={ subscribedMoment }
-				isRefundable={ isRefundable }
-			/>
-		);
+		return <ProductExpiration expiryDateMoment={ expiryMoment } renewDateMoment={ renewMoment } />;
 	}
 
 	getExpirationInfoForPurchase( purchase ) {
@@ -175,22 +144,11 @@ class PurchasesListing extends Component {
 			return null;
 		}
 
-		const subscribedMoment = purchase.subscribedDate
-			? this.props.moment( purchase.subscribedDate )
-			: null;
-
 		const expiryMoment = purchase.expiryDate ? this.props.moment( purchase.expiryDate ) : null;
 
 		const renewMoment = purchase.renewDate ? this.props.moment( purchase.renewDate ) : null;
 
-		return (
-			<ProductExpiration
-				expiryDateMoment={ expiryMoment }
-				renewDateMoment={ renewMoment }
-				purchaseDateMoment={ subscribedMoment }
-				isRefundable={ purchase.isRefundable }
-			/>
-		);
+		return <ProductExpiration expiryDateMoment={ expiryMoment } renewDateMoment={ renewMoment } />;
 	}
 
 	getActionButton( purchase ) {

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -27,7 +27,11 @@ import ProductExpiration from 'components/product-expiration';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { managePurchase } from 'me/purchases/paths';
 import { getPlan } from 'lib/plans';
-import { isPartnerPurchase, shouldAddPaymentSourceInsteadOfRenewingNow } from 'lib/purchases';
+import {
+	isExpiring,
+	isPartnerPurchase,
+	shouldAddPaymentSourceInsteadOfRenewingNow,
+} from 'lib/purchases';
 import {
 	isFreeJetpackPlan,
 	isFreePlan,
@@ -146,7 +150,10 @@ class PurchasesListing extends Component {
 
 		const expiryMoment = purchase.expiryDate ? this.props.moment( purchase.expiryDate ) : null;
 
-		const renewMoment = purchase.renewDate ? this.props.moment( purchase.renewDate ) : null;
+		const renewMoment =
+			! isExpiring( purchase ) && purchase.renewDate
+				? this.props.moment( purchase.renewDate )
+				: null;
 
 		return <ProductExpiration expiryDateMoment={ expiryMoment } renewDateMoment={ renewMoment } />;
 	}

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -138,8 +138,8 @@ class PurchasesListing extends Component {
 
 		let renewMoment = null;
 
-		// If a purchase object has been passed into this function, it will contain the `renewDate` property.
-		// Otherwise, if a plan object has been passed into this function, it will contain the `autoRenew` and `autoRenewDate` properties.
+		// If a purchase object has been passed into this function, the `renewDate` will contain information of renewal.
+		// Otherwise, if a plan object has been passed into this function, the `autoRenew` and `autoRenewDate` properties will contain information of renewals.
 		if ( 'renewDate' in purchase ) {
 			renewMoment = purchase.renewDate ? this.props.moment( purchase.renewDate ) : null;
 		} else if ( 'autoRenewDate' in purchase ) {


### PR DESCRIPTION
**Note:** This is my first Calypso/React PR. Please excuse any silly or serious mistakes since I'm still learning.

This PR does some refactoring to fix an issue caused by: https://github.com/Automattic/wp-calypso/pull/38486/ (see: https://github.com/Automattic/wp-calypso/pull/38486/files#r370240351)

Basically, the new `ProductExpiration` React component assumes that renewals for subscriptions will always happen at the expiration date. However, we renew WordPress.com subscriptions ahead of their expiration. Due to this assumption, Calypso currently shows the wrong renewal date on the `My Plan` page. This PR aims to address this issue.

#### Changes proposed in this Pull Request

* Adds a new `renewDateMoment` property to the `ProductExpiration` component so that separate expiration and renewal dates can be passed to the component. The component's logic is also modified so as to support this change. Along with that, this PR also updates the documentation 

* The `getExpirationInfo()` function in the `PurchasesListing` component is now splitted into separate functions: `getExpirationInfoForPlan()` and `getExpirationInfoForPurchase` since the older function was called both for plan and purchase objects. Both objects have significant differences with the `renewDate/autoRenewDate` and the `isRefundable` properties, so it's better to have different functions operate on these different objects. Let me know if this approach doesn't seem right to you, I'm open to hearing suggestions and refactor it to make it better.

#### Testing instructions

##### Initial Setup

* Check out this pull request on your local environment

##### Test Renewal Info on My Plan page for a WordPress.com subscription

* Create a new site on your WordPress.com account and buy a WordPress.com premium/personal plan subscription on that site.
 * Navigate to `http://calypso.localhost:3000/plans/my-plan/{Your site address}`. Calypso should show the `Renews on {DATE}` text on the `My Plan` block. This will typically be a month before the plan's expiration.
* Now, disable auto renew on the plan subscription from SA.
* Refresh the page and it should now show: `Expires on {DATE}` text. This should be the same date as the plan's expiration.

##### Test Renewal Info on My Plan page for Jetpack Backup

* Set up a fresh test Jetpack site on your WordPress.com account and buy Jetpack Backup for the site.
 * Navigate to `http://calypso.localhost:3000/plans/my-plan/{Your site address}`. Calypso should show the `Renews on {DATE}` text on the `My Plan` block. This will typically be the same date as the product's expiration.
* Now, disable auto renew on the plan subscription from SA.
* Refresh the page and it should now show: `Expires on {DATE}` text. This should be the same date as the plan's expiration.

##### Test Renewal Info on Plans page for Jetpack Backup

* Navigate to `http://calypso.localhost:3000/plans/{Your site address}`. Calypso should show the `Purchased on {DATE}` text for the purchase under the `Solutions` heading (beneath the `Plans` section).
* Edit the code in `client/components/product-expiration/index.tsx` to remove the `|| isRefundable` condition on line 38. This is needed so that we can test out the other conditions.
* Now, refresh the page. It should now show: `Renews on {DATE}`. This date should be equal to the product's expiration date.
* Now, disable auto renew on the Jetpack backup subscription from SA.
* Now, refresh the page. It should now show: `Expires on {DATE}`. This date should be equal to the product's expiration date.
* Now, revert the code change you made in file `client/components/product-expiration/index.tsx`.