### PR TITLE
Links all subpackages to the parent package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,8 +208,7 @@
 			}
 		},
 		"@automattic/calypso-color-schemes": {
-			"version": "file:packages/calypso-color-schemes",
-			"dev": true
+			"version": "file:packages/calypso-color-schemes"
 		},
 		"@automattic/calypso-polyfills": {
 			"version": "file:packages/calypso-polyfills",
@@ -316,6 +315,9 @@
 		"@automattic/material-design-icons": {
 			"version": "file:packages/material-design-icons"
 		},
+		"@automattic/media-library": {
+			"version": "file:packages/media-library"
+		},
 		"@automattic/mini-css-extract-plugin-with-rtl": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/@automattic/mini-css-extract-plugin-with-rtl/-/mini-css-extract-plugin-with-rtl-0.8.0.tgz",
@@ -346,6 +348,24 @@
 					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 					"dev": true
 				}
+			}
+		},
+		"@automattic/notifications": {
+			"version": "file:apps/notifications",
+			"requires": {
+				"@automattic/calypso-color-schemes": "file:packages/calypso-color-schemes",
+				"@automattic/calypso-polyfills": "file:packages/calypso-polyfills"
+			}
+		},
+		"@automattic/o2-blocks": {
+			"version": "file:apps/o2-blocks",
+			"requires": {
+				"@wordpress/blocks": "6.12.0",
+				"@wordpress/components": "9.2.1",
+				"@wordpress/editor": "9.12.1",
+				"@wordpress/element": "2.11.0",
+				"@wordpress/i18n": "3.9.0",
+				"classnames": "2.2.6"
 			}
 		},
 		"@automattic/react-i18n": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
 		"@automattic/full-site-editing": "file:apps/full-site-editing",
 		"@automattic/load-script": "file:packages/load-script",
 		"@automattic/material-design-icons": "file:packages/material-design-icons",
+		"@automattic/media-library": "file:packages/media-library",
+		"@automattic/notifications": "file:apps/notifications",
+		"@automattic/o2-blocks": "file:apps/o2-blocks",
 		"@automattic/react-i18n": "file:packages/react-i18n",
 		"@automattic/tree-select": "file:packages/tree-select",
 		"@automattic/viewport": "file:packages/viewport",
@@ -53,7 +56,8 @@
 		"i18n-calypso": "file:packages/i18n-calypso",
 		"photon": "file:packages/photon",
 		"wp-calypso": "file:client",
-		"wpcom": "file:packages/wpcom.js"
+		"wpcom": "file:packages/wpcom.js",
+		"wpcom-proxy-request": "file:packages/wpcom-proxy-request"
 	},
 	"engines": {
 		"node": "^12.13.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Link all subpackages in `packages/*` and `apps/*` to the parent repo. This is a pre-requisite to be able to use `yarn import` and get a clean tree.

#### Testing instructions

Verify that the build artefacts have not changed. Run these commands before and after the change and check that the output is the same.

* Run `CALYPSO_ENV="production" npm run build`
* List files in `public/` with the file size. In OSX, you can run `find public -type f -print0 | xargs -0 stat -f "%N %z"`. The equivalent command in linux is `find public -type f -print0 | xargs -0 stat -c "%y %s %n"` (untested!)
