### PR TITLE
Enable the new domain status design feature flag on production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -29,6 +29,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"domains/new-status-design": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -38,6 +38,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"domains/new-status-design": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable the new domain status design feature flag on production.

We've tested this on horizon, made some small updates and we're now launching the new domain status designs for everyone.

All details are in p99Zz8-UK-p2

#### Testing instructions

* Check that visiting a registered domain or mapped domain shows the new design on production
