### PR TITLE
Gutenboarding: Use color variables, remove unused styles

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -140,7 +140,7 @@ const Header: FunctionComponent = () => {
 		>
 			<div className="gutenboarding__header-section">
 				<div className="gutenboarding__header-group">
-					<Icon icon="wordpress-alt" color="#066188" />
+					<Icon icon="wordpress-alt" className="gutenboarding__header-wp-icon" />
 				</div>
 				<div className="gutenboarding__header-group">
 					{ siteTitle ? (

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -29,17 +29,9 @@
 	color: var( --studio-blue-90 );
 }
 
-.gutenboarding__header-section,
-.gutenboarding__header-back-button {
+.gutenboarding__header-section {
 	display: flex;
 	align-items: center;
-}
-
-.gutenboarding__header-back-button {
-	color: inherit;
-	.dashicons-arrow-left-alt {
-		margin-right: 5px;
-	}
 }
 
 .gutenboarding__header-group {

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -25,6 +25,10 @@
 	}
 }
 
+.gutenboarding__header-wp-icon {
+	color: var( --studio-blue-90 );
+}
+
 .gutenboarding__header-section,
 .gutenboarding__header-back-button {
 	display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow-ups to #39950

#### Testing instructions

* Visit [`/gutenboarding`](https://calypso.live/gutenboarding?branch=update/gutenboarding-icon-color)
* Verify the WordPress (W) logo in the header looks correct.