### PR TITLE
Build: Clean tsbuildinfo files on package clean

### DIFF
--- a/packages/calypso-analytics/package.json
+++ b/packages/calypso-analytics/package.json
@@ -25,7 +25,7 @@
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "npx rimraf dist \"../../.tsc-cache/packages__calypso-analytics*\"",
 		"prepublish": "npm run clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,7 @@
 		"react-dom": "^16.8"
 	},
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "npx rimraf dist \"../../.tsc-cache/packages__components*\"",
 		"prepublish": "npm run clean",
 		"prepare": "transpile && tsc && copy-assets"
 	}

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -7,7 +7,7 @@
 	"types": "dist/types",
 	"sideEffects": false,
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "npx rimraf dist \"../../.tsc-cache/packages__composite-checkout-wpcom*\"",
 		"prepublish": "npm run clean",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"typecheck": "tsc --project ./tsconfig.json --noEmit"

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -26,7 +26,7 @@
 	],
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "npx rimraf dist \"../../.tsc-cache/packages__data-stores*\"",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"prepublish": "npm run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"

--- a/packages/media-library/package.json
+++ b/packages/media-library/package.json
@@ -25,7 +25,7 @@
 	"types": "dist/types",
 	"dependencies": {},
 	"scripts": {
-		"clean": "npx rimraf dist types",
+		"clean": "npx rimraf dist types \"../../.tsc-cache/packages__media-library*\"",
 		"prepublish": "npm run clean",
 		"prepare": "transpile && tsc && copy-assets"
 	}

--- a/packages/react-i18n/package.json
+++ b/packages/react-i18n/package.json
@@ -25,7 +25,7 @@
 	],
 	"types": "dist/types",
 	"scripts": {
-		"clean": "npx rimraf dist",
+		"clean": "npx rimraf dist ../../.tsc-cache/packages__react-i18n*",
 		"prepare": "tsc --project ./tsconfig.json && tsc --project ./tsconfig-cjs.json",
 		"prepublish": "npm run clean",
 		"watch": "tsc --project ./tsconfig.json --watch"


### PR DESCRIPTION
If tsbuildinfo (TypeScript cache) files are not cleaned, `tsc` will skip work even if declaration
files are missing and need to be generated.

Ensure that with package clean, the tsbuildinfo files are also removed.

Follow up to #39786

#### Testing instructions

When running this sequence of commands, tsbuildinfo files must be removed with generated types or they will not be regenterated.

On master, the following will error with missing types. On this branch is succeeds because the tsbuildinfo are removed which forces regeneration of declaration files.

```sh
npm run build-packages  # Build packages, declaration files, tsbuildinfo cache files
npm run clean:packages # Remove `dist`, should also remove `tsbuildinfo`
npm run build-packages # Rebuild packages…
npm run tsc -- -p client/landing/gutenboarding/ # Requires some type declarations
```