### PR TITLE
[Private media files] Support media library preview modal

### DIFF
--- a/client/my-sites/media-library/media-image.tsx
+++ b/client/my-sites/media-library/media-image.tsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import ImagePreloader from 'components/image-preloader';
 
 /**
  * Internal dependencies
@@ -44,6 +45,7 @@ interface Props {
 	query: string;
 	siteSlug: string;
 	onLoad: () => any;
+	placeholder: React.ReactNode | null;
 	useProxy: boolean;
 	dispatch: any;
 }
@@ -54,15 +56,32 @@ const MediaImage: React.FC< Props > = function MediaImage( {
 	filePath,
 	siteSlug,
 	useProxy = false,
+	placeholder = null,
 	dispatch,
 	...rest
 } ) {
 	if ( useProxy ) {
-		return <ProxiedImage siteSlug={ siteSlug } filePath={ filePath } query={ query } { ...rest } />;
+		return (
+			<ProxiedImage
+				siteSlug={ siteSlug }
+				filePath={ filePath }
+				query={ query }
+				placeholder={ placeholder }
+				{ ...rest }
+			/>
+		);
+	}
+
+	if ( placeholder ) {
+		return <ImagePreloader placeholder={ placeholder } src={ src } { ...rest } />;
 	}
 
 	/* eslint-disable-next-line jsx-a11y/alt-text */
 	return <img src={ src } { ...rest } />;
+};
+
+MediaImage.defaultProps = {
+	placeholder: null,
 };
 
 export default connect( ( state, { src }: Pick< Props, 'src' > ) => {

--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -16,6 +16,7 @@ interface Props {
 	query: string;
 	filePath: string;
 	siteSlug: string;
+	placeholder: React.ReactNode | null;
 
 	[ key: string ]: any;
 }
@@ -40,6 +41,7 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 	siteSlug,
 	filePath,
 	query,
+	placeholder,
 	...rest
 } ) {
 	const [ imageObjectUrl, setImageObjectUrl ] = useState< string >( '' );
@@ -79,11 +81,15 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 	}, [ imageObjectUrl, filePath, requestId, siteSlug ] );
 
 	if ( ! imageObjectUrl ) {
-		return null;
+		return placeholder as React.ReactElement;
 	}
 
 	/* eslint-disable-next-line jsx-a11y/alt-text */
 	return <img src={ imageObjectUrl } { ...rest } />;
+};
+
+ProxiedImage.defaultProps = {
+	placeholder: null,
 };
 
 export default ProxiedImage;

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -10,8 +10,8 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import ImagePreloader from 'components/image-preloader';
 import Spinner from 'components/spinner';
+import MediaImage from 'my-sites/media-library/media-image';
 import { url, isItemBeingUploaded } from 'lib/media/utils';
 
 export default class EditorMediaModalDetailPreviewImage extends Component {
@@ -84,7 +84,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 
 		return (
 			<div>
-				<img
+				<MediaImage
 					src={ src }
 					width={ this.props.item.width }
 					height={ this.props.item.height }
@@ -92,7 +92,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 					className={ fakeClasses }
 				/>
 
-				<ImagePreloader
+				<MediaImage
 					src={ src }
 					width={ this.props.item.width }
 					height={ this.props.item.height }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is related to [private atomic sites project](https://wp.me/paObgF-Ui). It add support for remote private images to Media library preview modal.

#### Testing instructions

* Apply D39236-code (proxy provider script)
* https://github.com/Automattic/wp-calypso/pull/39616
* Sandbox the REST API
* Visit `/media` for a Private Atomic site, select an image, click "edit", confirm the preview modal is displayed correctly.
* Visit `/media` for a regular non-atomic site, select an image, click "edit", confirm the preview modal is displayed correctly. Play with editing image and restoring the original version, confirm the UX is the same as currently in production.