### PR TITLE
CI: Remove tsc caching from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ references:
         "$CIRCLE_TEST_REPORTS/server"           \
         "$CIRCLE_TEST_REPORTS/e2ereports"       \
         "$HOME/jest-cache"                      \
-        "$HOME/wp-calypso/.tsc-cache"           \
         "$HOME/terser-cache"
 
   # Jest cache caching
@@ -58,23 +57,6 @@ references:
     key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/jest-cache
-
-  #
-  # TypeScript compiler (tsc) cache caching
-  #
-  restore-tsc-cache: &restore-tsc-cache
-    name: Restore TypeScript cache
-    keys:
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-tsc-{{ .Branch }}-{{ .Revision }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-tsc-{{ .Branch }}
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-tsc-master
-      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-tsc
-  save-tsc-cache: &save-tsc-cache
-    name: Save TypeScript cache
-    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-tsc-{{ .Branch }}-{{ .Revision }}
-    paths:
-      - ~/wp-calypso/.tsc-cache
-      - ~/wp-calypso/packages/*/dist
 
   #
   # Terser cache caching
@@ -214,12 +196,10 @@ jobs:
       - run: *update-git-master
       - save_cache: *save-git-cache
       # npm dependencies
-      - restore_cache: *restore-tsc-cache
       - restore_cache: *restore-npm-cache
       - run: *npm-install
       - run: *npm-e2e-install
       - save_cache: *save-npm-cache
-      - save_cache: *save-tsc-cache
       - run: npm run build-packages
       - persist_to_workspace:
           root: '~'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* #38903 added TypeScript caching, but didn't do it correctly on CircleCI
* #39786 Attempted to fix TypeScript caching, but introduced a bug. It relied on a glob in the cache path which is unavailable (`packages/*/dist`):
  > Note: Unlike the special step persist_to_workspace, neither save_cache nor restore_cache support globbing for the paths key.
  
  https://circleci.com/docs/2.0/caching/#basic-example-of-dependency-caching

The result is that the cache files (tsbuildinfo) are cached, but the generated output is not. This results in `tsc` not generating any output, similar to #39960.

Remove the tsc caching, which would require listing out the type output path for each package in the CircleCI configuration.

#### Testing instructions

The `typecheck-strict` job should be fixed. Currently broken in https://github.com/Automattic/wp-calypso/pull/39960