### PR TITLE
Republicize: reword error messages when scheduling fails

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -21,6 +21,7 @@ import { Button } from '@automattic/components';
 import ButtonGroup from 'components/button-group';
 import NoticeAction from 'components/notice/notice-action';
 import { withLocalizedMoment } from 'components/localized-moment';
+import { CALYPSO_CONTACT, JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
 import getPostSharePublishedActions from 'state/selectors/get-post-share-published-actions';
 import getPostShareScheduledActions from 'state/selectors/get-post-share-scheduled-actions';
 import getScheduledPublicizeShareActionTime from 'state/selectors/get-scheduled-publicize-share-action-time';
@@ -105,6 +106,12 @@ class PostShare extends Component {
 		showTooltip: false,
 		tooltipContext: null,
 		eventsByDay: [],
+	};
+
+	trackContactSupport = reason => {
+		analytics.tracks.recordEvent( 'calypso_publicize_share_contact_support', {
+			reason,
+		} );
 	};
 
 	hasConnections() {
@@ -404,7 +411,17 @@ class PostShare extends Component {
 	}
 
 	renderRequestSharingNotice() {
-		const { failure, requesting, success, translate, moment } = this.props;
+		const {
+			failure,
+			isJetpack,
+			requesting,
+			schedulingFailed,
+			success,
+			translate,
+			moment,
+		} = this.props;
+
+		const supportUrl = isJetpack ? JETPACK_CONTACT_SUPPORT : CALYPSO_CONTACT;
 
 		if ( this.props.scheduling ) {
 			return (
@@ -423,10 +440,20 @@ class PostShare extends Component {
 			);
 		}
 
-		if ( this.props.schedulingFailed ) {
+		if ( schedulingFailed ) {
 			return (
-				<Notice status="is-error" onDismissClick={ this.dismiss }>
-					{ translate( "Scheduling share failed. Please don't be mad." ) }
+				<Notice
+					status="is-error"
+					onDismissClick={ this.dismiss }
+					text={ translate( 'Scheduling share failed.' ) }
+				>
+					<NoticeAction
+						href={ supportUrl }
+						onClick={ this.trackContactSupport( 'schedulingFailed' ) }
+						external={ isJetpack }
+					>
+						{ translate( 'Please contact our support team for help.' ) }
+					</NoticeAction>
 				</Notice>
 			);
 		}
@@ -449,8 +476,18 @@ class PostShare extends Component {
 
 		if ( failure ) {
 			return (
-				<Notice status="is-error" onDismissClick={ this.dismiss }>
-					{ translate( "Something went wrong. Please don't be mad." ) }
+				<Notice
+					status="is-error"
+					onDismissClick={ this.dismiss }
+					text={ translate( 'Something went wrong.' ) }
+				>
+					<NoticeAction
+						href={ supportUrl }
+						onClick={ this.trackContactSupport( 'failure' ) }
+						external={ isJetpack }
+					>
+						{ translate( 'Please contact our support team for help.' ) }
+					</NoticeAction>
 				</Notice>
 			);
 		}


### PR DESCRIPTION
Fixes #28766

#### Changes proposed in this Pull Request

- Wording should now be a bit better.
- Added link to contact support, either wpcom or Jetpack.
- Added tracking on link.
- Link opens in a new window when Jetpack support link.

#### Testing instructions

I could not find a way to reliably reproduce the issue, so this is going to be a bit hard to test unless you can force `scheduledAt` and `schedulingFailed`.

Here are how the messages look like now:

- On a WordPress.com site (first error message):
<img width="1103" alt="screenshot 2020-03-09 at 12 34 02" src="https://user-images.githubusercontent.com/426388/76209843-24cc1580-6203-11ea-8746-d9d1524a603d.png">

- On a Jetpack site (second error message):
![image](https://user-images.githubusercontent.com/426388/76209891-43321100-6203-11ea-83e7-970384ae368c.png)

