### PR TITLE
Allow gutenBerg opt-in "button" to be displayed when the user just op…

### DIFF
--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -59,9 +59,10 @@ const updateSelectedEditor = action =>
 
 const setSelectedEditorAndRedirect = (
 	{ siteId, redirectUrl },
-	{ editor_web: editor }
+	{ editor_web: editor, opt_in: optIn, opt_out: optOut }
 ) => dispatch => {
 	dispatch( { type: EDITOR_TYPE_SET, siteId, editor } );
+	dispatch( { type: GUTENBERG_OPT_IN_OUT_SET, siteId, optIn, optOut } );
 
 	if ( ! redirectUrl ) {
 		return;

--- a/client/state/selectors/is-gutenberg-opt-in-enabled.js
+++ b/client/state/selectors/is-gutenberg-opt-in-enabled.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import getSelectedEditor from 'state/selectors/get-selected-editor';
@@ -11,9 +6,7 @@ import isClassicEditorForced from 'state/selectors/is-classic-editor-forced';
 
 export const isGutenbergOptInEnabled = ( state, siteId ) => {
 	return (
-		get( state, [ 'gutenbergOptInOut', siteId, 'optIn' ], false ) &&
-		getSelectedEditor( state, siteId ) === 'classic' &&
-		! isClassicEditorForced( state, siteId )
+		getSelectedEditor( state, siteId ) === 'classic' && ! isClassicEditorForced( state, siteId )
 	);
 };
 

--- a/client/state/selectors/is-gutenberg-opt-in-enabled.js
+++ b/client/state/selectors/is-gutenberg-opt-in-enabled.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import getSelectedEditor from 'state/selectors/get-selected-editor';
@@ -6,7 +11,9 @@ import isClassicEditorForced from 'state/selectors/is-classic-editor-forced';
 
 export const isGutenbergOptInEnabled = ( state, siteId ) => {
 	return (
-		getSelectedEditor( state, siteId ) === 'classic' && ! isClassicEditorForced( state, siteId )
+		get( state, [ 'gutenbergOptInOut', siteId, 'optIn' ], false ) &&
+		getSelectedEditor( state, siteId ) === 'classic' &&
+		! isClassicEditorForced( state, siteId )
 	);
 };
 


### PR DESCRIPTION
…ted out of the block editor

#### Changes proposed in this Pull Request

* Allow Opt-in button for block editor to be displayed when user just opted out of it. This way the user is free to switch editors at his own convenience

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* opt out of the block editor and open the settings menu of the classic editor. You should see the button to opt in.

Fixes #39445 @mmtr @supernovia
