### PR TITLE
[Private media files] Use <MediaImage /> component to display post thumbnails

### DIFF
--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -17,6 +17,7 @@ import { getNormalizedPost } from 'state/posts/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import canCurrentUserEditPost from 'state/selectors/can-current-user-edit-post';
 import { isMultiSelectEnabled } from 'state/ui/post-type-list/selectors';
+import MediaImage from 'my-sites/media-library/media-image';
 
 function PostTypeListPostThumbnail( { onClick, thumbnail, postLink } ) {
 	const classes = classnames( 'post-type-list__post-thumbnail-wrapper', {
@@ -27,7 +28,7 @@ function PostTypeListPostThumbnail( { onClick, thumbnail, postLink } ) {
 		<div className={ classes }>
 			{ thumbnail && (
 				<a href={ postLink } className="post-type-list__post-thumbnail-link">
-					<img //eslint-disable-line
+					<MediaImage //eslint-disable-line
 						src={ resizeImageUrl( safeImageUrl( thumbnail ), { h: 80 } ) }
 						className="post-type-list__post-thumbnail"
 						onClick={ onClick }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is related to [private atomic sites project](https://wp.me/paObgF-Ui). It add support for private remote post thumbnails.

**Before**

<img width="1103" alt="Zrzut ekranu 2020-03-9 o 13 48 49" src="https://user-images.githubusercontent.com/205419/76214306-b9874100-620c-11ea-8133-d9687cd111a4.png">

**After**

<img width="1101" alt="Zrzut ekranu 2020-03-9 o 13 48 43" src="https://user-images.githubusercontent.com/205419/76214302-b8561400-620c-11ea-9e64-f679f7f4713c.png">
#### Testing instructions

* Test locally as calypso.live won't work for this patch
* Apply D39236-code (proxy provider script)
* Sandbox the REST API
* Go to one of your private atomic sites, make it public, upload a media image, make it private again
* Create a new post and use the image you just uploaded as featured image, save the post
* Go to posts list, confirm the thumbnail shows and it's src is `blob: <identifier>` instead of an actual URL
* Checkout master branch, refresh, confirm the thumbnail src is an actual URL