### PR TITLE
[Private media files] Support woocommerce extension

### DIFF
--- a/client/extensions/woocommerce/app/product-categories/form.js
+++ b/client/extensions/woocommerce/app/product-categories/form.js
@@ -17,7 +17,8 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
-import ImagePreloader from 'components/image-preloader';
+import MediaImage from 'my-sites/media-library/media-image';
+
 import ProductImageUploader from 'woocommerce/components/product-image-uploader';
 import Spinner from 'components/spinner';
 import TermTreeSelectorTerms from 'blocks/term-tree-selector/terms';
@@ -169,7 +170,7 @@ class ProductCategoryForm extends Component {
 		if ( src && ! isUploading ) {
 			image = (
 				<figure>
-					<ImagePreloader
+					<MediaImage
 						src={ src }
 						alt={ translate( 'Category thumbnail' ) }
 						placeholder={ placeholder ? <img src={ placeholder } alt="" /> : <span /> }

--- a/client/extensions/woocommerce/app/products/product-form-images.js
+++ b/client/extensions/woocommerce/app/products/product-form-images.js
@@ -13,7 +13,7 @@ import { isNumber, noop } from 'lodash';
  */
 import { Button } from '@automattic/components';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
-import ImagePreloader from 'components/image-preloader';
+import MediaImage from 'my-sites/media-library/media-image';
 import ProductImageUploader from 'woocommerce/components/product-image-uploader';
 import Spinner from 'components/spinner';
 
@@ -125,7 +125,7 @@ class ProductFormImages extends Component {
 
 		return (
 			<figure>
-				<ImagePreloader
+				<MediaImage
 					src={ src }
 					alt={ thumb ? translate( 'Product thumbnail' ) : translate( 'Featured product image' ) }
 					placeholder={ placeholder ? <img src={ placeholder } alt="" /> : <span /> }

--- a/client/extensions/woocommerce/app/products/product-form-variations-row.js
+++ b/client/extensions/woocommerce/app/products/product-form-variations-row.js
@@ -16,7 +16,7 @@ import { Button } from '@automattic/components';
 import FormDimensionsInput from 'woocommerce/components/form-dimensions-input';
 import FormTextInput from 'components/forms/form-text-input';
 import FormWeightInput from 'woocommerce/components/form-weight-input';
-import ImagePreloader from 'components/image-preloader';
+import MediaImage from 'my-sites/media-library/media-image';
 import PriceInput from 'woocommerce/components/price-input';
 import ProductImageUploader from 'woocommerce/components/product-image-uploader';
 import Spinner from 'components/spinner';
@@ -129,7 +129,7 @@ class ProductFormVariationsRow extends Component {
 		if ( src && ! isUploading ) {
 			image = (
 				<figure>
-					<ImagePreloader
+					<MediaImage
 						src={ src }
 						alt={ translate( 'Variation thumbnail' ) }
 						placeholder={ placeholder ? <img src={ placeholder } alt="" /> : <span /> }

--- a/client/extensions/woocommerce/components/image-thumb/index.js
+++ b/client/extensions/woocommerce/components/image-thumb/index.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import MediaImage from 'my-sites/media-library/media-image';
 
 const ImageThumb = ( { width, height, src, alt, placeholder, ...props } ) => {
 	const style = {
@@ -30,7 +31,7 @@ const ImageThumb = ( { width, height, src, alt, placeholder, ...props } ) => {
 
 	return (
 		<div className={ imageClasses } style={ style }>
-			<img src={ src } alt={ alt } { ...props } />
+			<MediaImage src={ src } alt={ alt } { ...props } />
 		</div>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is related to [private atomic sites project](https://wp.me/paObgF-Ui). It add support for remote private images to Woocommerce extension.

<img width="976" alt="Zrzut ekranu 2020-03-9 o 14 33 31" src="https://user-images.githubusercontent.com/205419/76217589-f9512700-6212-11ea-82b4-1787ef5a130f.png">

#### Testing instructions

* Test on calypso.localhost
* Apply D39236-code (proxy provider script)
* Sandbox the REST API
* Create a new store site
* Go to Calypso > Store
* Make the site public
* Create a new product, upload an image, save it
* Make the site private in another tab
* Go to products list, inspect thumbnails, confirm the `src` is set to `blob: <identifier>`
* Edit the product, inspect images, confirm the `src` is set to `blob: <identifier>`
* Confirm the images are being displayed properly
