### PR TITLE
[Private media files] Support SiteIcon

### DIFF
--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -13,6 +13,7 @@ import Gridicon from 'components/gridicon';
  * Internal dependencies
  */
 import Image from 'components/image';
+import MediaImage from 'my-sites/media-library/media-image';
 import Spinner from 'components/spinner';
 import QuerySites from 'components/data/query-sites';
 import { getSite } from 'state/sites/selectors';
@@ -45,7 +46,7 @@ function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {
 		<div className={ classes } style={ style }>
 			{ ! site && siteId > 0 && <QuerySites siteId={ siteId } /> }
 			{ iconSrc ? (
-				<Image className="site-icon__img" src={ iconSrc } alt="" />
+				<MediaImage component={ Image } className="site-icon__img" src={ iconSrc } alt="" />
 			) : (
 				<Gridicon icon="site" size={ Math.round( size / 1.3 ) } />
 			) }

--- a/client/my-sites/media-library/media-image.tsx
+++ b/client/my-sites/media-library/media-image.tsx
@@ -13,7 +13,7 @@ import isPrivateSite from 'state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
-import ProxiedImage from './proxied-image';
+import ProxiedImage, { RenderedComponent } from './proxied-image';
 
 const parseMediaURL = ( url: string, siteSlug: string ) => {
 	const { pathname, search: query, hostname } = getUrlParts( url );
@@ -41,6 +41,7 @@ const parseMediaURL = ( url: string, siteSlug: string ) => {
 interface Props {
 	src: string;
 
+	component: RenderedComponent;
 	filePath: string;
 	query: string;
 	siteSlug: string;
@@ -58,6 +59,7 @@ const MediaImage: React.FC< Props > = function MediaImage( {
 	useProxy = false,
 	placeholder = null,
 	dispatch,
+	component: Component,
 	...rest
 } ) {
 	if ( useProxy ) {
@@ -66,6 +68,7 @@ const MediaImage: React.FC< Props > = function MediaImage( {
 				siteSlug={ siteSlug }
 				filePath={ filePath }
 				query={ query }
+				component={ Component }
 				placeholder={ placeholder }
 				{ ...rest }
 			/>
@@ -77,11 +80,12 @@ const MediaImage: React.FC< Props > = function MediaImage( {
 	}
 
 	/* eslint-disable-next-line jsx-a11y/alt-text */
-	return <img src={ src } { ...rest } />;
+	return <Component src={ src } { ...rest } />;
 };
 
 MediaImage.defaultProps = {
 	placeholder: null,
+	component: 'img',
 };
 
 export default connect( ( state, { src }: Pick< Props, 'src' > ) => {

--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -12,11 +12,18 @@ import wpcom from 'lib/wp';
 const debug = debugFactory( 'calypso:my-sites:media-library:proxied-image' );
 const { Blob } = globalThis; // The linter complains if I don't do this...?
 
+type RenderedComponentProps = {
+	src: string;
+	[ key: string ]: any;
+};
+export type RenderedComponent = string | React.ComponentType< RenderedComponentProps >;
+
 interface Props {
 	query: string;
 	filePath: string;
 	siteSlug: string;
 	placeholder: React.ReactNode | null;
+	component: RenderedComponent;
 
 	[ key: string ]: any;
 }
@@ -42,6 +49,7 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 	filePath,
 	query,
 	placeholder,
+	component: Component,
 	...rest
 } ) {
 	const [ imageObjectUrl, setImageObjectUrl ] = useState< string >( '' );
@@ -85,7 +93,7 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 	}
 
 	/* eslint-disable-next-line jsx-a11y/alt-text */
-	return <img src={ imageObjectUrl } { ...rest } />;
+	return <Component src={ imageObjectUrl } { ...rest } />;
 };
 
 ProxiedImage.defaultProps = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is related to [private atomic sites project](https://wp.me/paObgF-Ui). It add support for remote private images to <SiteIcon /> component.

<img width="279" alt="Zrzut ekranu 2020-03-9 o 14 55 19" src="https://user-images.githubusercontent.com/205419/76219638-6c0fd180-6216-11ea-9f6a-07b417254061.png">


#### Testing instructions

* Test on calypso.localhost
* Apply D39236-code (proxy provider script)
* Sandbox the REST API
* Create a new store site
* Go to Calypso > Store
* Make the site public
* Upload a new site icon
* Make the site private
* Refresh calypso
* Inspect the site icon in the sidebar, confirm the `src` is set to `blob: <identifier>`
* Confirm the images are being displayed properly
