### PR TITLE
Enable the new domain status feature flag on staging too

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -32,6 +32,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"domains/new-status-design": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable the new domain status feature flag on staging too ( forgot to do that in https://github.com/Automattic/wp-calypso/pull/39958 )

We've tested this on horizon, made some small updates and we're now launching the new domain status designs for everyone.

All details are in p99Zz8-UK-p2

#### Testing instructions

* Verify that the new domain status screens are visible on staging too

