### PR TITLE
Use remote connection instead of sending users to wp-admin

### DIFF
--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -106,13 +106,6 @@ export class JetpackConnectMain extends Component {
 	componentDidUpdate() {
 		const { isMobileAppFlow, skipRemoteInstall } = this.props;
 
-		if (
-			this.getStatus() === NOT_CONNECTED_JETPACK &&
-			this.isCurrentUrlFetched() &&
-			! this.state.redirecting
-		) {
-			return this.goToRemoteAuth( this.props.siteHomeUrl );
-		}
 		if ( this.getStatus() === ALREADY_OWNED && ! this.state.redirecting ) {
 			if ( isMobileAppFlow ) {
 				return this.redirectToMobileApp( 'already-connected' );
@@ -126,7 +119,9 @@ export class JetpackConnectMain extends Component {
 			this.checkUrl( this.state.currentUrl );
 		}
 
-		if ( includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], this.getStatus() ) ) {
+		if (
+			includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK, NOT_CONNECTED_JETPACK ], this.getStatus() )
+		) {
 			if (
 				config.isEnabled( 'jetpack/connect/remote-install' ) &&
 				! isMobileAppFlow &&


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This leverages the Jetpack remote connection flow instead of redirecting users to wp-admin, which causes user confusion if they are not logged in to their admin.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a test site with Jetpack installed, but not connected.
* Go to `/jetpack/connect`.
* Input the site URL and click button to continue.
* See remote login screen and input credentials.
* Verify flow continues correctly.

Fixes 1164141197617539-as-1164522491999689
