### PR TITLE
[Private media files] Support audio and video files

### DIFF
--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -618,3 +618,38 @@ export function validateMediaItem( site, item ) {
 
 	return itemErrors;
 }
+
+/**
+ * Given a media file URL (possibly served through photon) and site slug, returns information
+ * required to correctly proxy the asset through the media proxy. Specifically, it returns
+ * an object with the following keys:
+ * - query: query string extracted from url
+ * - filePath: path of the file on remote site, even if url is photon url
+ * - isRelativeToSiteRoot: true if the file come from remote site identified by siteSlug, false otherwise
+ *
+ * @param {string} mediaUrl Media file URL.
+ * @param {string} siteSlug Slug of the site this file belongs to.
+ * @returns {object}	Dictionary
+ */
+export function mediaURLToProxyConfig( mediaUrl, siteSlug ) {
+	const { pathname, search: query, hostname } = getUrlParts( mediaUrl );
+	let filePath = pathname;
+	let isRelativeToSiteRoot = true;
+	if (
+		hostname !== siteSlug &&
+		( hostname.endsWith( 'wp.com' ) || hostname.endsWith( 'wordpress.com' ) )
+	) {
+		const [ first, ...rest ] = filePath.substr( 1 ).split( '/' );
+		filePath = '/' + rest.join( '/' );
+
+		if ( first !== siteSlug ) {
+			isRelativeToSiteRoot = false;
+		}
+	}
+
+	return {
+		query,
+		filePath,
+		isRelativeToSiteRoot,
+	};
+}

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -7,35 +7,12 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getUrlParts } from 'lib/url/url-parts';
 import isPrivateSite from 'state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
 import ProxiedImage, { RenderedComponent } from './proxied-image';
-
-const parseMediaURL = ( url: string, siteSlug: string ) => {
-	const { pathname, search: query, hostname } = getUrlParts( url );
-	let filePath = pathname;
-	let isRelativeToSiteRoot = true;
-	if (
-		hostname !== siteSlug &&
-		( hostname.endsWith( 'wp.com' ) || hostname.endsWith( 'wordpress.com' ) )
-	) {
-		const [ first, ...rest ] = filePath.substr( 1 ).split( '/' );
-		filePath = '/' + rest.join( '/' );
-
-		if ( first !== siteSlug ) {
-			isRelativeToSiteRoot = false;
-		}
-	}
-
-	return {
-		query,
-		filePath,
-		isRelativeToSiteRoot,
-	};
-};
+import { mediaURLToProxyConfig } from 'lib/media/utils';
 
 export interface MediaFileProps {
 	src: string;
@@ -90,7 +67,7 @@ export default connect( ( state, { src }: Pick< MediaFileProps, 'src' > ) => {
 	const siteSlug = getSelectedSiteSlug( state ) as string;
 	const isAtomic = !! isSiteAutomatedTransfer( state, siteId as number );
 	const isPrivate = !! isPrivateSite( state, siteId );
-	const { filePath, query, isRelativeToSiteRoot } = parseMediaURL( src, siteSlug );
+	const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
 	const useProxy = ( isAtomic && isPrivate && filePath && isRelativeToSiteRoot ) as boolean;
 
 	return {

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { getUrlParts } from 'lib/url/url-parts';
+import isPrivateSite from 'state/selectors/is-private-site';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
+import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
+import ProxiedImage, { RenderedComponent } from './proxied-image';
+
+const parseMediaURL = ( url: string, siteSlug: string ) => {
+	const { pathname, search: query, hostname } = getUrlParts( url );
+	let filePath = pathname;
+	let isRelativeToSiteRoot = true;
+	if (
+		hostname !== siteSlug &&
+		( hostname.endsWith( 'wp.com' ) || hostname.endsWith( 'wordpress.com' ) )
+	) {
+		const [ first, ...rest ] = filePath.substr( 1 ).split( '/' );
+		filePath = '/' + rest.join( '/' );
+
+		if ( first !== siteSlug ) {
+			isRelativeToSiteRoot = false;
+		}
+	}
+
+	return {
+		query,
+		filePath,
+		isRelativeToSiteRoot,
+	};
+};
+
+export interface MediaFileProps {
+	src: string;
+
+	component: RenderedComponent;
+	proxiedComponent?: RenderedComponent;
+	filePath: string;
+	query: string;
+	siteSlug: string;
+	onLoad: () => any;
+	placeholder: React.ReactNode | null;
+	useProxy: boolean;
+	dispatch: any;
+}
+
+const MediaFile: React.FC< MediaFileProps > = function MediaFile( {
+	src,
+	query,
+	filePath,
+	siteSlug,
+	useProxy = false,
+	placeholder = null,
+	dispatch,
+	component: Component,
+	proxiedComponent,
+	...rest
+} ) {
+	if ( useProxy ) {
+		return (
+			<ProxiedImage
+				siteSlug={ siteSlug }
+				filePath={ filePath }
+				query={ query }
+				component={ proxiedComponent || Component }
+				placeholder={ placeholder }
+				{ ...rest }
+			/>
+		);
+	}
+
+	/* eslint-disable-next-line jsx-a11y/alt-text */
+	return <Component src={ src } { ...rest } />;
+};
+
+MediaFile.defaultProps = {
+	placeholder: null,
+	component: 'img',
+};
+
+export default connect( ( state, { src }: Pick< MediaFileProps, 'src' > ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state ) as string;
+	const isAtomic = !! isSiteAutomatedTransfer( state, siteId as number );
+	const isPrivate = !! isPrivateSite( state, siteId );
+	const { filePath, query, isRelativeToSiteRoot } = parseMediaURL( src, siteSlug );
+	const useProxy = ( isAtomic && isPrivate && filePath && isRelativeToSiteRoot ) as boolean;
+
+	return {
+		query,
+		siteSlug,
+		useProxy,
+		filePath,
+	};
+} )( MediaFile );

--- a/client/my-sites/media-library/media-image.tsx
+++ b/client/my-sites/media-library/media-image.tsx
@@ -2,104 +2,26 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import ImagePreloader from 'components/image-preloader';
 
 /**
  * Internal dependencies
  */
-import { getUrlParts } from 'lib/url/url-parts';
-import isPrivateSite from 'state/selectors/is-private-site';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
-import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
-import ProxiedImage, { RenderedComponent } from './proxied-image';
+import ImagePreloader from 'components/image-preloader';
+import MediaFile, { MediaFileProps } from './media-file';
+import { RenderedComponent } from './proxied-image';
 
-const parseMediaURL = ( url: string, siteSlug: string ) => {
-	const { pathname, search: query, hostname } = getUrlParts( url );
-	let filePath = pathname;
-	let isRelativeToSiteRoot = true;
-	if (
-		hostname !== siteSlug &&
-		( hostname.endsWith( 'wp.com' ) || hostname.endsWith( 'wordpress.com' ) )
-	) {
-		const [ first, ...rest ] = filePath.substr( 1 ).split( '/' );
-		filePath = '/' + rest.join( '/' );
-
-		if ( first !== siteSlug ) {
-			isRelativeToSiteRoot = false;
-		}
+const MediaImage: React.FC< MediaFileProps > = function MediaImage( props: MediaFileProps ) {
+	let component: RenderedComponent = props.component;
+	if ( component === 'img' && props.placeholder ) {
+		component = ImagePreloader;
 	}
 
-	return {
-		query,
-		filePath,
-		isRelativeToSiteRoot,
-	};
-};
-
-interface Props {
-	src: string;
-
-	component: RenderedComponent;
-	filePath: string;
-	query: string;
-	siteSlug: string;
-	onLoad: () => any;
-	placeholder: React.ReactNode | null;
-	useProxy: boolean;
-	dispatch: any;
-}
-
-const MediaImage: React.FC< Props > = function MediaImage( {
-	src,
-	query,
-	filePath,
-	siteSlug,
-	useProxy = false,
-	placeholder = null,
-	dispatch,
-	component: Component,
-	...rest
-} ) {
-	if ( useProxy ) {
-		return (
-			<ProxiedImage
-				siteSlug={ siteSlug }
-				filePath={ filePath }
-				query={ query }
-				component={ Component }
-				placeholder={ placeholder }
-				{ ...rest }
-			/>
-		);
-	}
-
-	if ( placeholder ) {
-		return <ImagePreloader placeholder={ placeholder } src={ src } { ...rest } />;
-	}
-
-	/* eslint-disable-next-line jsx-a11y/alt-text */
-	return <Component src={ src } { ...rest } />;
+	return <MediaFile { ...props } component={ component } />;
 };
 
 MediaImage.defaultProps = {
-	placeholder: null,
 	component: 'img',
+	proxiedComponent: 'img',
 };
 
-export default connect( ( state, { src }: Pick< Props, 'src' > ) => {
-	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSelectedSiteSlug( state ) as string;
-	const isAtomic = !! isSiteAutomatedTransfer( state, siteId as number );
-	const isPrivate = !! isPrivateSite( state, siteId );
-	const { filePath, query, isRelativeToSiteRoot } = parseMediaURL( src, siteSlug );
-	const useProxy = ( isAtomic && isPrivate && filePath && isRelativeToSiteRoot ) as boolean;
-
-	return {
-		query,
-		siteSlug,
-		useProxy,
-		filePath,
-	};
-} )( MediaImage );
+export default MediaImage;

--- a/client/post-editor/media-modal/detail/detail-preview-audio.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-audio.jsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { url } from 'lib/media/utils';
+import MediaFile from 'my-sites/media-library/media-file';
 
 export default class extends React.Component {
 	static displayName = 'EditorMediaModalDetailPreviewAudio';
@@ -22,6 +23,8 @@ export default class extends React.Component {
 	render() {
 		const classes = classNames( this.props.className, 'is-audio' );
 
-		return <audio src={ url( this.props.item ) } controls className={ classes } />;
+		return (
+			<MediaFile component="audio" src={ url( this.props.item ) } controls className={ classes } />
+		);
 	}
 }

--- a/client/post-editor/media-modal/detail/detail-preview-video.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-video.jsx
@@ -11,6 +11,7 @@ import classNames from 'classnames';
  */
 import { isVideoPressItem, url } from 'lib/media/utils';
 import EditorMediaModalDetailItemVideoPress from './detail-preview-videopress';
+import MediaFile from 'my-sites/media-library/media-file';
 
 export default class extends React.Component {
 	static displayName = 'EditorMediaModalDetailPreviewVideo';
@@ -27,6 +28,8 @@ export default class extends React.Component {
 
 		const classes = classNames( this.props.className, 'is-video' );
 
-		return <video src={ url( this.props.item ) } controls className={ classes } />;
+		return (
+			<MediaFile component="video" src={ url( this.props.item ) } controls className={ classes } />
+		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is related to [private atomic sites project](https://wp.me/paObgF-Ui). It add support for remote private video and audio files

<img width="985" alt="Zrzut ekranu 2020-03-9 o 16 25 36" src="https://user-images.githubusercontent.com/205419/76229508-9ff0f400-6222-11ea-9022-019a4d865f27.png">

**Known limitations:**
Currently this uses XHR and downloads the entire file before presenting it. This is less than perfect, ideally we'd switch to `fetch` whenever `responseType="blob"` is requested, and use a blob based on `ReadableStream` as soon as it's available (see https://developer.mozilla.org/en-US/docs/Web/API/Streams_API/Using_readable_streams)

#### Testing instructions

* Test on calypso.localhost
* Apply D39236-code (proxy provider script)
* Sandbox the REST API
* Create a new private atomic site
* Go to wp admin > media and upload a video and audio file
* Go to media in Calypso, select both files, click edit, confirm you get proper preview
* Confirm simple sites don't use `src="blob: <id>"` but direct file URLs instead
