### PR TITLE
My Home: Show Quick Links in two columns for all screens > 480px

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -147,20 +147,23 @@
 
 	&__box-action {
 		margin-bottom: 16px;
-		width: 48%;
+		width: 100%;
 
 		@include breakpoint( '>480px' ) {
+			width: 48%;
 			margin-bottom: 24px;
 		}
 
 		.button {
 			border-width: 1px;
+			display: flex;
 			height: 100%;
 			min-width: 100%;
 			padding: 16px;
 			text-align: center;
 
 			@include breakpoint( '>480px' ) {
+				display: block;
 				min-height: 85px;
 				padding: 24px;
 			}
@@ -173,7 +176,7 @@
 			display: block;
 
 			@include breakpoint( '<480px' ) {
-				margin: 0;
+				margin: auto 14px;
 			}
 		}
 	}

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -147,18 +147,20 @@
 
 	&__box-action {
 		margin-bottom: 16px;
-		width: 100%;
+		width: 48%;
+
+		@include breakpoint( '>480px' ) {
+			margin-bottom: 24px;
+		}
 
 		.button {
 			border-width: 1px;
-			display: flex;
 			height: 100%;
 			min-width: 100%;
 			padding: 16px;
 			text-align: center;
 
 			@include breakpoint( '>480px' ) {
-				display: block;
 				min-height: 85px;
 				padding: 24px;
 			}
@@ -171,25 +173,8 @@
 			display: block;
 
 			@include breakpoint( '<480px' ) {
-				margin: auto 14px;
+				margin: 0;
 			}
-		}
-
-		@mixin box-action-two-col {
-			margin-bottom: 24px;
-			width: 48%;
-
-			.button {
-				flex: 1;
-				margin: 0 auto;
-				padding: 30px 24px;
-			}
-		}
-		@include breakpoint( '>1280px' ) {
-			@include box-action-two-col;
-		}
-		@include breakpoint( '800px-960px' ) {
-			@include box-action-two-col;
 		}
 	}
 	&__card-checklist-heading {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Always show Quick Links in two columns on screens > 480px, rather than going back and forth between single and two column layouts as the screen narrows. There will be a lot of variation depending on translations, of course.

Video demo of how the quick links scale with this PR on resize: https://cloudup.com/coEXQS8T5rJ

**Before**

<img width="595" alt="Screen Shot 2020-03-09 at 11 35 34 AM" src="https://user-images.githubusercontent.com/2124984/76230454-21805c00-61fa-11ea-9191-bbddecb6274d.png">

**After**

<img width="590" alt="Screen Shot 2020-03-09 at 11 35 20 AM" src="https://user-images.githubusercontent.com/2124984/76230468-25ac7980-61fa-11ea-92d9-7c92b0ac64b6.png">

#### Testing instructions

* Switch to this PR
* Navigate to a site with Customer Home that shows quick links (or complete the site's checklist)
* Check the display of the quick links at various screen sizes; look for visual bugs.

Fixes #39918
