### PR TITLE
Layout: AsyncLoad SitesPopover

### DIFF
--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -13,9 +13,9 @@ import { connect } from 'react-redux';
 /**
  * Internal Dependencies
  */
+import AsyncLoad from 'components/async-load';
 import { translate } from 'i18n-calypso';
 import { preload } from 'sections-helper';
-import SitesPopover from 'components/sites-popover';
 import { Button } from '@automattic/components';
 import { markPostSeen } from 'state/reader/posts/actions';
 import { recordGaEvent, recordAction, recordTrackForPost } from 'reader/stats';
@@ -135,7 +135,9 @@ export class DailyPostButton extends React.Component {
 	renderSitesPopover = () => {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<SitesPopover
+			<AsyncLoad
+				require="components/sites-popover"
+				placeholder={ null }
 				key="menu"
 				header={ <div> { translate( 'Post on' ) } </div> }
 				context={ this.dailyPostButtonRef.current }

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -10,9 +10,9 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import AsyncLoad from 'components/async-load';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import MasterbarItem from './item';
-import SitesPopover from 'components/sites-popover';
 import { preload } from 'sections-helper';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
@@ -76,7 +76,9 @@ class MasterbarItemNew extends React.Component {
 		}
 
 		return (
-			<SitesPopover
+			<AsyncLoad
+				require="components/sites-popover"
+				placeholder={ null }
 				id="popover__sites-popover-masterbar"
 				visible
 				groups


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the logged in layout to async load SitesPopover and prevent the popover component from being included in the main entry point.

#### Testing instructions

* Checkout this branch.
* Open the reader - `/read`.
* Click the "Write" button in the masterbar.
* Verify you can see the site selection dropdown and it works well.
