### PR TITLE
Layout: AsyncLoad GdprBanner for logged out users

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -21,7 +21,6 @@ import { getCurrentRoute } from 'state/selectors/get-current-route';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
-import GdprBanner from 'blocks/gdpr-banner';
 import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 
 /**
@@ -128,7 +127,9 @@ const LayoutLoggedOut = ( {
 					{ secondary }
 				</div>
 			</div>
-			{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
+			{ config.isEnabled( 'gdpr-banner' ) && (
+				<AsyncLoad require="blocks/gdpr-banner" placeholder={ null } />
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Layout: AsyncLoad GdprBanner for logged out users

#### Testing instructions

* Checkout this branch.
* Go to https://hash-5345abf4d9ce28eb1831be4ecc77f638c0bb4517.calypso.live/ while logged out.
* Make sure you're in one of the [GDPR countries](https://github.com/Automattic/wp-calypso/blob/master/client/lib/analytics/utils/is-current-user-maybe-in-gdpr-zone.js#L20), proxied into one of them or just alter your `country_code` cookie to be one of those countries
* Verify you can see the GDPR popup at the bottom:

![](https://cldup.com/Kk9GTZT8Or.png)
