### PR TITLE
Boot: setup JS exception reporter for all sections and some other patches

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -207,7 +207,7 @@ function setupErrorLogger( reduxStore ) {
 	// Save errorLogger to a singleton for use in arbitrary logging.
 	require( 'lib/catch-js-errors/log' ).registerLogger( errorLogger );
 
-	//Save data to JS error logger
+	// Save data to JS error logger
 	errorLogger.saveDiagnosticData( {
 		user_id: getCurrentUserId( reduxStore.getState() ),
 		calypso_env: config( 'env_id' ),

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -378,7 +378,7 @@ function renderLayout( reduxStore ) {
 	debug( 'Main layout rendered.' );
 }
 
-const boot = ( currentUser, router ) => {
+const boot = ( currentUser, registerRoutes ) => {
 	utils();
 	loadAllState().then( () => {
 		const initialState = getInitialState( initialReducer );
@@ -389,8 +389,8 @@ const boot = ( currentUser, router ) => {
 		configureReduxStore( currentUser, reduxStore );
 		setupMiddlewares( currentUser, reduxStore );
 		detectHistoryNavigation.start();
-		if ( router ) {
-			router();
+		if ( registerRoutes ) {
+			registerRoutes();
 		}
 
 		// Render initial `<Layout>` for non-isomorphic sections.

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -403,10 +403,10 @@ const boot = ( currentUser, registerRoutes ) => {
 	} );
 };
 
-export const bootApp = ( appName, router ) => {
+export const bootApp = ( appName, registerRoutes ) => {
 	const user = userFactory();
 	user.initialize().then( () => {
 		debug( `Starting ${ appName }. Let's do this.` );
-		boot( user, router );
+		boot( user, registerRoutes );
 	} );
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -249,12 +249,6 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 	// The analytics module requires user (when logged in) and superProps objects. Inject these here.
 	analytics.initialize( currentUser ? currentUser.get() : undefined, getSuperProps( reduxStore ) );
 
-	// Render Layout only for non-isomorphic sections.
-	// Isomorphic sections will take care of rendering their Layout last themselves.
-	if ( ! document.getElementById( 'primary' ) ) {
-		renderLayout( reduxStore );
-	}
-
 	setupErrorLogger( reduxStore );
 
 	// If `?sb` or `?sp` are present on the path set the focus of layout
@@ -398,6 +392,13 @@ const boot = ( currentUser, router ) => {
 		if ( router ) {
 			router();
 		}
+
+		// Render initial `<Layout>` for non-isomorphic sections.
+		// Isomorphic sections will take care of rendering their `<Layout>` themselves.
+		if ( ! document.getElementById( 'primary' ) ) {
+			renderLayout( reduxStore );
+		}
+
 		page.start( { decodeURLComponents: false } );
 	} );
 };

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -204,7 +204,7 @@ function setupErrorLogger( reduxStore ) {
 
 	const errorLogger = new Logger();
 
-	//Save errorLogger to a singleton for use in arbitrary logging.
+	// Save errorLogger to a singleton for use in arbitrary logging.
 	require( 'lib/catch-js-errors/log' ).registerLogger( errorLogger );
 
 	//Save data to JS error logger

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -103,9 +103,6 @@ const setupContextMiddleware = reduxStore => {
 	} );
 };
 
-// We need to require sections to load React with i18n mixin
-const loadSectionsMiddleware = () => setupRoutes();
-
 const oauthTokenMiddleware = () => {
 	if ( config.isEnabled( 'oauth' ) ) {
 		const loggedOutRoutes = [
@@ -205,7 +202,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 	installPerfmonPageHandlers();
 	setupContextMiddleware( reduxStore );
 	oauthTokenMiddleware();
-	loadSectionsMiddleware();
+	setupRoutes();
 	setRouteMiddleware();
 	clearNoticesMiddleware();
 	unsavedFormsMiddleware();


### PR DESCRIPTION
A little cleanup of Calypso boot code, done when I reviewed the recent work on Jetpack Cloud entrypoint.

- initialize JS exception reporter in a separate function and do it for all sections, including SSR-ed ones. We discussed that with @ockham several months ago and came to a conclusion that there's no real reason to exclude SSR sections. Someone simply did it that way 4 years ago and nobody fixed it yet.
- render initial (non-SSR) layout markup outside `setupMiddlewares` function, which should only install page.js handers.
- rename the custom parameter that @tyxla recently introduced from `router` to `registerRoutes`. It's a custom callback that registers page.js routes by calling `page( ... )`.

**How to test:**
Verify that both Calypso and Jetpack Cloud boot correctly.