### PR TITLE
Correct spelling and capitalization of Media Library

### DIFF
--- a/client/layout/guided-tours/tours/media-basics-tour/index.js
+++ b/client/layout/guided-tours/tours/media-basics-tour/index.js
@@ -36,7 +36,7 @@ export const MediaBasicsTour = makeTour(
 		>
 			{ ( { translate } ) => (
 				<Fragment>
-					<p>{ translate( 'Welcome to your media libary!' ) }</p>
+					<p>{ translate( 'Welcome to your Media Library!' ) }</p>
 					<p>
 						{ translate(
 							'Upload media — photos, documents, audio files, and more — ' +
@@ -61,7 +61,7 @@ export const MediaBasicsTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							'You can also drag-and-drop image and video files from your computer into your media library.'
+							'You can also drag-and-drop image and video files from your computer into your Media Library.'
 						) }
 					</p>
 					<img


### PR DESCRIPTION
Library was originally misspelled as libary and media library was not capitalized

I do not have local Calypso development environment so was not able to follow https://github.com/Automattic/wp-calypso/blob/master/docs/merge-checklist.md but I do not believe it should be necessary for this small of a change.

#### Changes proposed in this Pull Request

* Fixed spelling and capitalization of Media Library in Guided Tours

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Trigger the Guided Tour on the Media Library as shown in the screenshots on #39981 and see the correct spelling and capitalization of Media Library

Fixes #39981
