### PR TITLE
Fixes footer to bottom of window

### DIFF
--- a/client/assets/stylesheets/jetpack-cloud.scss
+++ b/client/assets/stylesheets/jetpack-cloud.scss
@@ -29,21 +29,4 @@
 			fill: var( --color-text-subtle );
 		}
 	}
-
-	.layout__primary {
-		box-sizing: border-box;
-		display: flex;
-		flex-direction: column;
-		min-height: calc( 100vh - 47px ); // Padding of .layout__content.
-		padding: 40px 16px 0;
-
-		@include breakpoint ( '>660px' ) {
-			min-height: calc( 100vh - 95px ); // 71px top + 24px bottom padding. 
-			padding: 0;
-		}
-
-		@include breakpoint ( '>960px' ) {
-			min-height: calc( 100vh - 111px ); // 79px top + 32px bottom padding.
-		}
-	}
 }

--- a/client/assets/stylesheets/jetpack-cloud.scss
+++ b/client/assets/stylesheets/jetpack-cloud.scss
@@ -31,11 +31,19 @@
 	}
 
 	.layout__primary {
+		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
+		min-height: calc( 100vh - 47px ); // Padding of .layout__content.
 		padding: 40px 16px 0;
-		max-width: 680px;
 
 		@include breakpoint ( '>660px' ) {
+			min-height: calc( 100vh - 95px ); // 71px top + 24px bottom padding. 
 			padding: 0;
+		}
+
+		@include breakpoint ( '>960px' ) {
+			min-height: calc( 100vh - 111px ); // 79px top + 32px bottom padding.
 		}
 	}
 }

--- a/client/landing/jetpack-cloud/components/stats-footer/style.scss
+++ b/client/landing/jetpack-cloud/components/stats-footer/style.scss
@@ -3,9 +3,13 @@
 	color: var( --color-neutral-80 );
 	display: flex;
 	padding-top: 10px;
-	margin-top: 40px;
+	margin: 40px 0;
 	flex-shrink: 0;
 	flex-wrap: wrap;
+
+	@include breakpoint( '>660px' ) {
+		margin-bottom: 0;
+	}
 }
 
 .stats-footer__header {

--- a/client/landing/jetpack-cloud/components/stats-footer/style.scss
+++ b/client/landing/jetpack-cloud/components/stats-footer/style.scss
@@ -4,6 +4,7 @@
 	display: flex;
 	padding-top: 10px;
 	margin-top: 40px;
+	flex-shrink: 0;
 	flex-wrap: wrap;
 }
 

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -101,8 +101,8 @@ class ScanPage extends Component {
 
 	render() {
 		return (
-			<>
-				<div className="scan__main">{ this.renderScanState() }</div>
+			<div className="scan__main">
+				<div className="scan__content">{ this.renderScanState() }</div>
 				<StatsFooter
 					header="Scan Summary"
 					stats={ [
@@ -113,7 +113,7 @@ class ScanPage extends Component {
 					noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backups has you covered."
 					noticeLink="https://jetpack/upgrade/backups"
 				/>
-			</>
+			</div>
 		);
 	}
 }

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -101,8 +101,8 @@ class ScanPage extends Component {
 
 	render() {
 		return (
-			<div>
-				{ this.renderScanState() }
+			<>
+				<div className="scan__main">{ this.renderScanState() }</div>
 				<StatsFooter
 					header="Scan Summary"
 					stats={ [
@@ -113,7 +113,7 @@ class ScanPage extends Component {
 					noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backups has you covered."
 					noticeLink="https://jetpack/upgrade/backups"
 				/>
-			</div>
+			</>
 		);
 	}
 }

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -1,4 +1,21 @@
 .scan__main {
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	min-height: calc( 100vh - 47px ); // Padding of .layout__content.
+	padding: 40px 16px 0;
+
+	@include breakpoint ( '>660px' ) {
+		min-height: calc( 100vh - 95px ); // 71px top + 24px bottom padding. 
+		padding: 0;
+	}
+
+	@include breakpoint ( '>960px' ) {
+		min-height: calc( 100vh - 111px ); // 79px top + 32px bottom padding.
+	}
+}
+
+.scan__content {
 	flex: 1 0 auto;
 	max-width: 680px;
 }

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -1,3 +1,8 @@
+.scan__main {
+	flex: 1 0 auto;
+	max-width: 680px;
+}
+
 .scan__icon {
 	display: block;
 	margin: 0 auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adjusts the styles and markup of Jetpack Cloud to ensure the footer is stuck to the bottom of the page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to scan section.
* Verify footer position, changing screen width to test various devices.
* Add content to ensure footer is pushed down appropriately.

Screen:
<img width="739" alt="Screen Shot 2020-03-09 at 2 20 30 PM" src="https://user-images.githubusercontent.com/1760168/76244808-2ac8f300-6211-11ea-9d72-7382518d360e.png">

Fixes 1151678672052943-as-1165205423871162.