### PR TITLE
Disconnect Jetpack Highlight: Fix Colour Contrast

### DIFF
--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -15,7 +15,7 @@
 }
 
 .disconnect-jetpack__highlight {
-	color: var( --color-neutral-40 );
+	color: var( --color-text-subtle );
 	margin-bottom: 1.5em;
 	font-size: 16px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When disconnecting Jetpack, I noticed the colour variable used is `--color-neutral-40`. This doesn't pass colour contrast requirements, so a while ago, a whole bunch of these were updated to `--color-text-subtle`. I guess this one was missed.

#### Testing instructions

Visit `/settings/disconnect-site/confirm/site` on a Jetpack site and compare the title.

**Before:**
<img width="776" alt="Screenshot 2020-03-09 at 19 24 22" src="https://user-images.githubusercontent.com/43215253/76249754-e868db80-623b-11ea-828a-b97fb093a0df.png">

**After:**
<img width="804" alt="Screenshot 2020-03-09 at 19 24 34" src="https://user-images.githubusercontent.com/43215253/76249800-fa4a7e80-623b-11ea-8a4b-919d59733012.png">

cc @tyxla 
