### PR TITLE
SPT: Fix Safari Overlapping Layout Issue

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -481,7 +481,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	// flex: 1; and flex-direction: column; in Safari causes a lot of weird overlapping layout issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
-	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type="core/column"] {
+	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] {
         flex-direction: row;
     }
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -480,8 +480,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		padding-top: 20px;
 	}
 
-	// flex: 1; and flex-direction: column; in Safari causes a lot of weird overlapping layout issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
+	// flex: 1; in Safari causes a lot of weird overlapping layout issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
 	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] {
-        flex-direction: row;
+        display: block;
     }
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -480,8 +480,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		padding-top: 20px;
 	}
 
-	// flex: 1; in Safari causes a lot of weird overlapping layout issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
-	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] {
-		height: min-intrinsic;
+	// flex: column; on the parent and flex-basis: 0; on the child in Safari causes a lot of weird overlapping layout 
+	// issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
+	// Using flex-basis: auto; on the child allows the height to be calculated properly
+	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] .block-core-columns {
+		flex-basis: auto;
 	}
 }
+

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -481,7 +481,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	// flex: 1; in Safari causes a lot of weird overlapping layout issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
-	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] .block-core-columns {
-		flex-basis: auto;
+	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] {
+		height: min-intrinsic;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -479,4 +479,9 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	.block-iframe-preview__template-title {
 		padding-top: 20px;
 	}
+
+	// flex: 1; and flex-direction: column; in Safari causes a lot of weird overlapping layout issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
+	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type="core/column"] {
+        flex-direction: row;
+    }
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -487,4 +487,3 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		flex-basis: auto;
 	}
 }
-

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -481,7 +481,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	// flex: 1; in Safari causes a lot of weird overlapping layout issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
-	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] {
-        display: block;
-    }
+	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] .block-core-columns {
+		flex-basis: auto;
+	}
 }


### PR DESCRIPTION
Safari has a severe overlapping layout issue in iframe previews: https://github.com/Automattic/wp-calypso/issues/39874

This PR adds a small CSS override to fix layout previews in Safari.

### Testing Instructions
- Open Safari
- Set-up your FSE dev environment
- Got go Page -> Add New
- Select the effected layouts, such as Menu, Dalton Homepage, 2020 Homepage, etc.
- Test these layouts in Chrome, Firefox to make sure there isn't a regression

### Before
<img width="1616" alt="Screen Shot 2020-03-09 at 2 46 10 PM" src="https://user-images.githubusercontent.com/967608/76255335-03c3ee80-621c-11ea-95ab-e3be87c250b6.png">
<img width="1619" alt="Screen Shot 2020-03-09 at 2 46 35 PM" src="https://user-images.githubusercontent.com/967608/76255397-1a6a4580-621c-11ea-8917-c2ae6530540d.png">
<img width="1615" alt="Screen Shot 2020-03-09 at 2 46 21 PM" src="https://user-images.githubusercontent.com/967608/76255357-0cb4c000-621c-11ea-941b-0fa6542da6b2.png">

### After
<img width="1615" alt="Screen Shot 2020-03-09 at 3 39 01 PM" src="https://user-images.githubusercontent.com/967608/76255613-746b0b00-621c-11ea-957a-4c03bc2dcea3.png">
<img width="1618" alt="Screen Shot 2020-03-09 at 3 39 23 PM" src="https://user-images.githubusercontent.com/967608/76255626-7af98280-621c-11ea-84f4-091fe30317fe.png">
<img width="1615" alt="Screen Shot 2020-03-09 at 3 39 36 PM" src="https://user-images.githubusercontent.com/967608/76255652-8ba9f880-621c-11ea-97ef-9d485b60e1d0.png">

