### PR TITLE
Auth store logs into remote services

### DIFF
--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -105,28 +105,22 @@ export const receiveWpLoginFailed = ( response: WpLoginErrorResponse ) =>
 
 type WpLoginAction = 'login-endpoint' | 'two-step-authentication-endpoint';
 
-export interface FetchWpLoginAction {
-	type: 'FETCH_WP_LOGIN';
-	action: WpLoginAction;
-	params: object;
-}
-
-const fetchWpLogin = ( action: WpLoginAction, params: object ): FetchWpLoginAction =>
+const fetchWpLogin = ( action: WpLoginAction, params: object ) =>
 	( {
 		type: 'FETCH_WP_LOGIN',
 		action,
 		params,
 	} as const );
 
-export interface RemoteLoginUserAction {
-	type: 'REMOTE_LOGIN_USER';
-	loginLinks: string[];
-}
+export type FetchWpLoginAction = ReturnType< typeof fetchWpLogin >;
 
-const remoteLoginUser = ( loginLinks: string[] ): RemoteLoginUserAction => ( {
-	type: 'REMOTE_LOGIN_USER',
-	loginLinks,
-} );
+const remoteLoginUser = ( loginLinks: string[] ) =>
+	( {
+		type: 'REMOTE_LOGIN_USER',
+		loginLinks,
+	} as const );
+
+export type RemoteLoginUserAction = ReturnType< typeof remoteLoginUser >;
 
 export function* submitPassword( password: string ) {
 	yield clearErrors();

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -118,6 +118,16 @@ const fetchWpLogin = ( action: WpLoginAction, params: object ): FetchWpLoginActi
 		params,
 	} as const );
 
+export interface RemoteLoginUserAction {
+	type: 'REMOTE_LOGIN_USER';
+	loginLinks: string[];
+}
+
+const remoteLoginUser = ( loginLinks: string[] ): RemoteLoginUserAction => ( {
+	type: 'REMOTE_LOGIN_USER',
+	loginLinks,
+} );
+
 export function* submitPassword( password: string ) {
 	yield clearErrors();
 	const username = yield { type: 'SELECT_USERNAME_OR_EMAIL' };
@@ -126,6 +136,7 @@ export function* submitPassword( password: string ) {
 		const loginResponse = yield fetchWpLogin( 'login-endpoint', { username, password } );
 
 		if ( loginResponse.ok && loginResponse.body.success ) {
+			yield remoteLoginUser( loginResponse.body.data.token_links );
 			yield receiveWpLogin( loginResponse.body );
 		} else {
 			yield receiveWpLoginFailed( loginResponse.body );

--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -8,9 +8,57 @@ import wpcomRequest, { requestAllBlogsAccess } from 'wpcom-proxy-request';
 /**
  * Internal dependencies
  */
-import { FetchAuthOptionsAction, FetchWpLoginAction, SendLoginEmailAction } from './actions';
+import {
+	FetchAuthOptionsAction,
+	FetchWpLoginAction,
+	RemoteLoginUserAction,
+	SendLoginEmailAction,
+} from './actions';
 import { STORE_KEY } from './constants';
 import { WpcomClientCredentials } from '../shared-types';
+
+/**
+ * Creates a promise that will be rejected after a given timeout
+ *
+ * @param ms amount of milliseconds till reject the promise
+ * @returns a promise that will be rejected after ms milliseconds
+ */
+const createTimingOutPromise = ( ms: number ) =>
+	new Promise( ( _, reject ) => {
+		setTimeout( () => reject( new Error( `timeout of ${ ms } reached` ) ), ms );
+	} );
+
+/**
+ * Makes a request to a given link in an iframe
+ *
+ * @param loginLink the login link to load
+ * @param requestTimeout amount of time to allow the link to load, default 25s
+ * @returns a promise that will be resolved if the link was successfully loaded
+ */
+const makeRemoteLoginRequest = ( loginLink: string, requestTimeout = 25000 ) => {
+	if ( typeof document === 'undefined' ) {
+		return Promise.reject();
+	}
+
+	let iframe: HTMLIFrameElement | undefined;
+	const iframeLoadPromise = new Promise( resolve => {
+		iframe = document.createElement( 'iframe' );
+		iframe.style.display = 'none';
+		iframe.setAttribute( 'scrolling', 'no' );
+		iframe.onload = resolve;
+		iframe.src = loginLink;
+		document.body.appendChild( iframe );
+	} );
+
+	const removeIframe = () => {
+		iframe?.parentElement?.removeChild( iframe );
+	};
+
+	return Promise.race( [ iframeLoadPromise, createTimingOutPromise( requestTimeout ) ] ).then(
+		removeIframe,
+		removeIframe
+	);
+};
 
 export function createControls( clientCreds: WpcomClientCredentials ) {
 	requestAllBlogsAccess().catch( () => {
@@ -68,5 +116,12 @@ export function createControls( clientCreds: WpcomClientCredentials ) {
 				},
 			} );
 		},
+		REMOTE_LOGIN_USER: ( { loginLinks }: RemoteLoginUserAction ) =>
+			Promise.all(
+				loginLinks
+					.map( loginLink => makeRemoteLoginRequest( loginLink ) )
+					// make sure we continue even when a remote login fails
+					.map( promise => promise.catch( () => undefined ) )
+			),
 	};
 }

--- a/packages/data-stores/src/auth/test/actions.ts
+++ b/packages/data-stores/src/auth/test/actions.ts
@@ -4,6 +4,35 @@
 import { submitPassword } from '../actions';
 
 describe( 'submitPassword', () => {
+	it( 'logins in to remote services on successful login', async () => {
+		const password = 'passw0rd';
+		const generator = submitPassword( password );
+
+		expect( generator.next().value ).toEqual( {
+			type: 'CLEAR_ERRORS',
+		} );
+
+		expect( generator.next().value ).toEqual( {
+			type: 'SELECT_USERNAME_OR_EMAIL',
+		} );
+
+		const username = 'user1';
+		expect( generator.next( username ).value ).toEqual( {
+			type: 'FETCH_WP_LOGIN',
+			action: 'login-endpoint',
+			params: { username, password },
+		} );
+
+		const token_links = [ 'https://gravator.com?login-url', 'https://jetpack.com?login-url' ];
+
+		expect(
+			generator.next( { ok: true, body: { success: true, data: { token_links } } } ).value
+		).toEqual( {
+			type: 'REMOTE_LOGIN_USER',
+			loginLinks: token_links,
+		} );
+	} );
+
 	it( 'dispatches failed action if exception is thrown by fetch', async () => {
 		const password = 'passw0rd';
 		const generator = submitPassword( password );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Logging in at `/log-in` logs into a number of services (depending on your account) e.g. `jetpack.com`, `gravatar.com`, etc.

This PR ensures that logging in with the auth store also logs into these services.

Code was copied from `client/state/login.js`, particularly `makeRemoteLoginRequest()`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/gutenboarding`
* Open network tab and console
* `wp.auth.submitUsernameOrPassword('validuser')`
* `wp.auth.submitPassword('correctpassword')`
* Look in network tab for request to `https://jetpack.com/remote-login.php` and see it responds with lots of precious precious cookies 🍪 

You should notice that the `remote-login.php` request is a iframe/subdocument request.