### PR TITLE
Components: Fix popover menu item hover colors

### DIFF
--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -140,7 +140,8 @@
 	min-width: 200px;
 }
 
-.popover__menu-item {
+.popover__menu-item,
+.popover__menu-item.button {
 	position: relative;
 	background: inherit;
 	border: none;
@@ -204,6 +205,7 @@
 		color: var( --color-text-subtle );
 		vertical-align: bottom;
 		margin-right: 8px;
+		position: static;
 	}
 	.gridicons-cloud-download {
 		position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Components: Fix popover menu item hover colors

Before:
![](https://cldup.com/P8koI1obrU.png)

After:
![](https://cldup.com/C7gR8m0bsn.png)

#### Testing instructions

* Checkout this branch.
* Pick a WP.com site.
* Go to Pages.
* Click the `...` menu on the right side.
* Verify the "Copy Link" item looks like the others, both in hover state and regular state.

It might be a bit difficult to repro it locally, as the bug happens only in staging/production. 

Fixes #39255.