### PR TITLE
Themes: do not display search counts, until counts are correct

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -13,7 +13,6 @@ import { compact, includes, isEqual, property, snakeCase } from 'lodash';
 import { trackClick } from './helpers';
 import QueryThemes from 'components/data/query-themes';
 import ThemesList from 'components/themes-list';
-import ThemesSelectionHeader from './themes-selection-header';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
@@ -158,16 +157,11 @@ class ThemesSelection extends Component {
 	};
 
 	render() {
-		const { source, query, listLabel, themesCount, upsellUrl } = this.props;
+		const { source, query, upsellUrl } = this.props;
 
 		return (
 			<div className="themes__selection">
-				{ ! this.props.recommendedThemes && (
-					<>
-						<QueryThemes query={ query } siteId={ source } />
-						<ThemesSelectionHeader label={ listLabel } count={ themesCount } />
-					</>
-				) }
+				<QueryThemes query={ query } siteId={ source } />
 				<ThemesList
 					upsellUrl={ upsellUrl }
 					themes={ this.props.recommendedThemes || this.props.themes }


### PR DESCRIPTION
Temporary Fix for https://github.com/Automattic/wp-calypso/issues/39898

Theme search counts don't appear accurate so as a first step let's stop displaying theme counts until we get to the root cause.

**Logged in** WordPress.com/themes

| Before  | After |
| ------------- | ------------- |
| <img width="1331" alt="Screen Shot 2020-03-09 at 3 48 45 PM" src="https://user-images.githubusercontent.com/1270189/76264312-a4b3a900-621e-11ea-8c5e-947495e41714.png"> | <img width="1331" alt="Screen Shot 2020-03-09 at 3 49 19 PM" src="https://user-images.githubusercontent.com/1270189/76264327-b1d09800-621e-11ea-8d9d-9de35d24e3ac.png"> |

**Logged out** WordPress.com/themes

| Before  | After |
| ------------- | ------------- |
| <img width="1449" alt="Screen Shot 2020-03-09 at 3 46 30 PM" src="https://user-images.githubusercontent.com/1270189/76264249-78982800-621e-11ea-8c1d-a88f2b7e6762.png"> |  <img width="1444" alt="Screen Shot 2020-03-09 at 3 46 14 PM" src="https://user-images.githubusercontent.com/1270189/76264264-82ba2680-621e-11ea-9897-c67592d226bb.png"> |

### Testing Instructions
- **Stop** any local branches
- Checkout this branch
- Visit calypso.localhost:3000/themes while not logged in. Verify that counts do not appear, even when applying filters.
- Visit calypso.localhost:3000/themes while logged in. Scroll down and click on "show all themes":
<img width="1113" alt="Screen Shot 2020-03-09 at 4 00 50 PM" src="https://user-images.githubusercontent.com/1270189/76264482-302d3a00-621f-11ea-88e3-b65f2e9909df.png">
- Verify that counts do not appear, even when applying filters.


