### PR TITLE
ProxiedImages: Appropriately show the spinner on the media detail screen

### DIFF
--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -82,7 +82,7 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 				URL.revokeObjectURL( imageObjectUrl );
 			}
 		};
-	}, [ imageObjectUrl, filePath, requestId, siteSlug ] );
+	}, [ imageObjectUrl, filePath, requestId, setSpinner, siteSlug, query ] );
 
 	if ( ! imageObjectUrl ) {
 		return placeholder as React.ReactElement;

--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { useEffect, useState } from 'react';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -42,6 +43,7 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 	filePath,
 	query,
 	placeholder,
+	setSpinner = noop,
 	...rest
 } ) {
 	const [ imageObjectUrl, setImageObjectUrl ] = useState< string >( '' );
@@ -55,6 +57,7 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 				debug( 'set image from cache', { url } );
 			} else {
 				debug( 'requesting image from API', { requestId, imageObjectUrl } );
+				setSpinner( true );
 				wpcom
 					.undocumented()
 					.getAtomicSiteMediaViaProxyRetry(
@@ -66,6 +69,7 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 								cacheResponse( requestId, data );
 								setImageObjectUrl( URL.createObjectURL( data ) );
 								debug( 'got image from API', { requestId, imageObjectUrl, data } );
+								setSpinner( false );
 							}
 						}
 					);

--- a/client/post-editor/media-modal/detail/detail-preview-image.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-image.jsx
@@ -29,7 +29,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 		super( props );
 
 		this.onImagePreloaderLoad = this.onImagePreloaderLoad.bind( this );
-		this.state = { loading: false };
+		this.state = { loading: false, spin: false };
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
@@ -44,6 +44,8 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 		this.setState( { loading: false } );
 		this.props.onLoad();
 	}
+
+	setSpinner = spinner => this.setState( { spin: !! spinner } );
 
 	render() {
 		const src = url( this.props.item, {
@@ -90,6 +92,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 					height={ this.props.item.height }
 					alt={ this.props.item.alt || this.props.item.title }
 					className={ fakeClasses }
+					setSpinner={ this.setSpinner }
 				/>
 
 				<MediaImage
@@ -102,7 +105,7 @@ export default class EditorMediaModalDetailPreviewImage extends Component {
 					className={ classes }
 				/>
 
-				{ ( uploading || loading ) && <Spinner /> }
+				{ ( uploading || loading || this.state.spin ) && <Spinner /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
Targeting branch in #39616

#### Changes proposed in this Pull Request

* Add `<Spinner />` control for proxied images

#### Testing instructions

* Spinner should show when loading the image
* Spinner should hide on image load
* Spinner should hide on error (if supported)