### PR TITLE
composite-checkout: Prepopulate contact details with cached data

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -288,7 +288,8 @@ export default function CompositeCheckout( {
 	useWpcomStore(
 		registerStore,
 		recordEvent,
-		areDomainsInLineItems( items ) ? domainManagedContactDetails : taxManagedContactDetails
+		areDomainsInLineItems( items ) ? domainManagedContactDetails : taxManagedContactDetails,
+		updateContactDetailsCache
 	);
 
 	useDisplayErrors( errors, showErrorMessage );

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -1405,7 +1405,9 @@ function useCachedDomainContactDetails( dispatch ) {
 	}, [ haveRequestedCachedDetails ] );
 
 	const cachedContactDetails = useSelector( getContactDetailsCache );
-	dispatch( 'wpcom' ).loadDomainContactDetailsFromCache( cachedContactDetails );
+	if ( cachedContactDetails ) {
+		dispatch( 'wpcom' ).loadDomainContactDetailsFromCache( cachedContactDetails );
+	}
 }
 
 function getPlanProductSlugs(

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -68,6 +68,8 @@ import notices from 'notices';
 import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-from-path';
 import { isJetpackSite, isNewSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
+import { updateContactDetailsCache } from 'state/domains/management/actions';
 import { FormCountrySelect } from 'components/forms/form-country-select';
 import getCountries from 'state/selectors/get-countries';
 import { fetchPaymentCountries } from 'state/countries/actions';
@@ -281,6 +283,7 @@ export default function CompositeCheckout( {
 		[ recordEvent, getThankYouUrl, total, couponItem, responseCart ]
 	);
 
+	const cachedDomainContactDetails = useCachedDomainContactDetails();
 	const { registerStore, dispatch } = registry;
 	useWpcomStore(
 		registerStore,
@@ -1381,6 +1384,11 @@ function useVariantWpcomPlanProductSlugs( productSlug ) {
 		group: chosenPlan.group,
 		type: chosenPlan.type,
 	} );
+}
+
+function useCachedDomainContactDetails() {
+	const cachedDomainContactDetails = useSelector( getContactDetailsCache );
+	return cachedDomainContactDetails;
 }
 
 function getPlanProductSlugs(

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -33,7 +33,7 @@ export default function WPContactForm( {
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
 
 	if ( summary && isComplete ) {
-		return <ContactFormSummary />;
+		return <ContactFormSummary isDomainFieldsVisible={ isDomainFieldsVisible } />;
 	}
 	if ( ! isActive ) {
 		return null;
@@ -174,9 +174,11 @@ const DomainContactFieldsDescription = styled.p`
 	margin: 0 0 16px;
 `;
 
-function ContactFormSummary() {
+function ContactFormSummary( { isDomainFieldsVisible } ) {
 	const translate = useTranslate();
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
+
+	const showDomainContactSummary = isDomainFieldsVisible;
 
 	// Check if paymentData is empty
 	if ( Object.entries( contactInfo ).length === 0 ) {
@@ -199,17 +201,19 @@ function ContactFormSummary() {
 		<GridRow>
 			<div>
 				<SummaryDetails>
-					{ fullName && <SummaryLine>{ fullName }</SummaryLine> }
+					{ showDomainContactSummary && fullName && <SummaryLine>{ fullName }</SummaryLine> }
 
-					{ contactInfo.email.value?.length > 0 && (
+					{ showDomainContactSummary && contactInfo.email.value?.length > 0 && (
 						<SummarySpacerLine>{ contactInfo.email.value }</SummarySpacerLine>
 					) }
 
-					{ contactInfo.address1.value?.length > 0 && (
+					{ showDomainContactSummary && contactInfo.address1.value?.length > 0 && (
 						<SummaryLine>{ contactInfo.address1.value } </SummaryLine>
 					) }
 
-					{ cityAndState && <SummaryLine>{ cityAndState }</SummaryLine> }
+					{ showDomainContactSummary && cityAndState && (
+						<SummaryLine>{ cityAndState }</SummaryLine>
+					) }
 
 					{ postalAndCountry && <SummaryLine>{ postalAndCountry }</SummaryLine> }
 				</SummaryDetails>

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -178,7 +178,7 @@ function ContactFormSummary() {
 	const translate = useTranslate();
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
 
-	//Check if paymentData is empty
+	// Check if paymentData is empty
 	if ( Object.entries( contactInfo ).length === 0 ) {
 		return null;
 	}
@@ -201,11 +201,11 @@ function ContactFormSummary() {
 				<SummaryDetails>
 					{ fullName && <SummaryLine>{ fullName }</SummaryLine> }
 
-					{ contactInfo.email.value.length > 0 && (
+					{ contactInfo.email.value?.length > 0 && (
 						<SummarySpacerLine>{ contactInfo.email.value }</SummarySpacerLine>
 					) }
 
-					{ contactInfo.address1.value.length > 0 && (
+					{ contactInfo.address1.value?.length > 0 && (
 						<SummaryLine>{ contactInfo.address1.value } </SummaryLine>
 					) }
 
@@ -214,9 +214,9 @@ function ContactFormSummary() {
 					{ postalAndCountry && <SummaryLine>{ postalAndCountry }</SummaryLine> }
 				</SummaryDetails>
 
-				{ contactInfo.vatId.value.length > 0 && (
+				{ contactInfo.vatId.value?.length > 0 && (
 					<SummaryDetails>
-						{ contactInfo.vatId.value.length > 0 && (
+						{ contactInfo.vatId.value?.length > 0 && (
 							<SummaryLine>
 								{ translate( 'VAT indentification number:' ) }
 								{ contactInfo.vatId.value }
@@ -230,7 +230,7 @@ function ContactFormSummary() {
 }
 
 function joinNonEmptyValues( joinString, ...values ) {
-	return values.filter( value => value.length > 0 ).join( joinString );
+	return values.filter( value => value?.length > 0 ).join( joinString );
 }
 
 function getContactDetailsFormat( isDomainFieldsVisible ) {

--- a/packages/composite-checkout-wpcom/src/hooks/wpcom-store.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/wpcom-store.ts
@@ -28,7 +28,11 @@ type WpcomStoreAction =
 	| { type: 'UPDATE_PHONE_NUMBER_COUNTRY'; payload: string }
 	| { type: 'UPDATE_POSTAL_CODE'; payload: string }
 	| { type: 'TOUCH_CONTACT_DETAILS' }
-	| { type: 'UPDATE_COUNTRY_CODE'; payload: string };
+	| { type: 'UPDATE_COUNTRY_CODE'; payload: string }
+	| {
+			type: 'LOAD_DOMAIN_CONTACT_DETAILS_FROM_CACHE';
+			payload: DomainContactDetails;
+	  };
 
 export function useWpcomStore(
 	registerStore,
@@ -66,6 +70,8 @@ export function useWpcomStore(
 				return updaters.setErrorMessages( state, action.payload );
 			case 'TOUCH_CONTACT_DETAILS':
 				return updaters.touchContactFields( state );
+			case 'LOAD_DOMAIN_CONTACT_DETAILS_FROM_CACHE':
+				return updaters.populateDomainFieldsFromCache( state, action.payload );
 			default:
 				return state;
 		}
@@ -155,6 +161,10 @@ export function useWpcomStore(
 
 			updateVatId( payload: string ): WpcomStoreAction {
 				return { type: 'UPDATE_VAT_ID', payload: payload };
+			},
+
+			loadDomainContactDetailsFromCache( payload: DomainContactDetails ): WpcomStoreAction {
+				return { type: 'LOAD_DOMAIN_CONTACT_DETAILS_FROM_CACHE', payload };
 			},
 		},
 

--- a/packages/composite-checkout-wpcom/src/hooks/wpcom-store.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/wpcom-store.ts
@@ -33,7 +33,8 @@ type WpcomStoreAction =
 export function useWpcomStore(
 	registerStore,
 	onEvent,
-	managedContactDetails: ManagedContactDetails
+	managedContactDetails: ManagedContactDetails,
+	updateContactDetailsCache: ( DomainContactDetails ) => void
 ) {
 	// Only register once
 	const registerIsComplete = useRef< boolean >( false );
@@ -47,8 +48,10 @@ export function useWpcomStore(
 		action: WpcomStoreAction
 	): ManagedContactDetails {
 		switch ( action.type ) {
-			case 'UPDATE_CONTACT_DETAILS':
+			case 'UPDATE_CONTACT_DETAILS': {
+				updateContactDetailsCache( action.payload );
 				return updaters.updateDomainFields( state, action.payload );
+			}
 			case 'UPDATE_VAT_ID':
 				return updaters.updateVatId( state, action.payload );
 			case 'UPDATE_PHONE':

--- a/packages/composite-checkout-wpcom/src/types/wpcom-store-state.ts
+++ b/packages/composite-checkout-wpcom/src/types/wpcom-store-state.ts
@@ -81,7 +81,9 @@ export function isTouched( details: ManagedContactDetails ): boolean {
 
 export function areRequiredFieldsNotEmpty( details: ManagedContactDetails ): boolean {
 	const values = Object.values( details );
-	return values.length > 0 && values.every( value => value.value.length > 0 || ! value.isRequired );
+	return (
+		values.length > 0 && values.every( value => value.value?.length > 0 || ! value.isRequired )
+	);
 }
 
 /*

--- a/packages/composite-checkout-wpcom/src/types/wpcom-store-state.ts
+++ b/packages/composite-checkout-wpcom/src/types/wpcom-store-state.ts
@@ -41,6 +41,10 @@ function touchIfDifferent( newValue: string, oldData: ManagedValue ): ManagedVal
 		: { ...oldData, value: newValue, isTouched: true, errors: [] };
 }
 
+function setValueUnlessTouched( newValue: string, oldData: ManagedValue ): ManagedValue {
+	return oldData.isTouched ? oldData : { ...oldData, value: newValue, errors: [] };
+}
+
 function setErrors( errors: string[] | undefined, oldData: ManagedValue ): ManagedValue {
 	return undefined === errors ? { ...oldData, errors: [] } : { ...oldData, errors };
 }
@@ -226,6 +230,10 @@ export type ManagedContactDetailsUpdaters = {
 	touchContactFields: ( ManagedContactDetails ) => ManagedContactDetails;
 	updateVatId: ( ManagedContactDetails, string ) => ManagedContactDetails;
 	setErrorMessages: ( ManagedContactDetails, ManagedContactDetailsErrors ) => ManagedContactDetails;
+	populateDomainFieldsFromCache: (
+		ManagedContactDetails,
+		DomainContactDetails
+	) => ManagedContactDetails;
 };
 
 export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
@@ -306,6 +314,28 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 		errors: ManagedContactDetailsErrors
 	): ManagedContactDetails => {
 		return setManagedContactDetailsErrors( errors, oldDetails );
+	},
+
+	populateDomainFieldsFromCache: (
+		oldDetails: ManagedContactDetails,
+		newDetails: DomainContactDetails
+	): ManagedContactDetails => {
+		return {
+			...oldDetails,
+			firstName: setValueUnlessTouched( newDetails.firstName, oldDetails.firstName ),
+			lastName: setValueUnlessTouched( newDetails.lastName, oldDetails.lastName ),
+			organization: setValueUnlessTouched( newDetails.organization, oldDetails.organization ),
+			email: setValueUnlessTouched( newDetails.email, oldDetails.email ),
+			alternateEmail: setValueUnlessTouched( newDetails.alternateEmail, oldDetails.alternateEmail ),
+			phone: setValueUnlessTouched( newDetails.phone, oldDetails.phone ),
+			address1: setValueUnlessTouched( newDetails.address1, oldDetails.address1 ),
+			address2: setValueUnlessTouched( newDetails.address2, oldDetails.address2 ),
+			city: setValueUnlessTouched( newDetails.city, oldDetails.city ),
+			state: setValueUnlessTouched( newDetails.state, oldDetails.state ),
+			postalCode: setValueUnlessTouched( newDetails.postalCode, oldDetails.postalCode ),
+			countryCode: setValueUnlessTouched( newDetails.countryCode, oldDetails.countryCode ),
+			fax: setValueUnlessTouched( newDetails.fax, oldDetails.fax ),
+		};
 	},
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pulls the existing domain contact details cache into composite checkout to prepopulate the contact fields.

#### Testing instructions

Proceed to checkout with a domain in your cart and with a full contact details cache (Note- I assume this is filled if your user account already has at least one domain, but am not sure.)
Check that at the "billing details" step the fields are prepopulated with sensible data, and that you can proceed to the review order step.