### PR TITLE
Downgrade react-stripe-elements in composite-checkout

### DIFF
--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -41,7 +41,7 @@
 		"emotion-theming": "^10.0.27",
 		"interpolate-components": "^1.1.1",
 		"prop-types": "^15.7.2",
-		"react-stripe-elements": "^5.1.0"
+		"react-stripe-elements": "4.0.2"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^4.6",


### PR DESCRIPTION
This makes it match the version we are using in Calypso. There is no
need for the upgraded version here.

#### Testing instructions

- Run `npm run composite-checkout-demo`.
- Verify that the credit card fields load correctly.