### PR TITLE
Try/functional open menu manage section if domains or email tabs are selected

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'components/gridicon';
@@ -16,95 +16,77 @@ import MaterialIcon from 'components/material-icon';
 import { preload } from 'sections-helper';
 import TranslatableString from 'components/translatable/proptype';
 
-export default class SidebarItem extends React.Component {
-	static propTypes = {
-		label: TranslatableString.isRequired,
-		className: PropTypes.string,
-		link: PropTypes.string.isRequired,
-		onNavigate: PropTypes.func,
-		icon: PropTypes.string,
-		customIcon: PropTypes.object,
-		materialIcon: PropTypes.string,
-		materialIconStyle: PropTypes.string,
-		selected: PropTypes.bool,
-		expandSection: PropTypes.func,
-		preloadSectionName: PropTypes.string,
-		forceInternalLink: PropTypes.bool,
-		testTarget: PropTypes.string,
-		tipTarget: PropTypes.string,
-	};
+export default function SidebarItem( props ) {
+	const isExternalLink = isExternal( props.link );
+	const showAsExternal = isExternalLink && ! props.forceInternalLink;
+	const classes = classnames( props.className, { selected: props.selected } );
+	const { materialIcon, materialIconStyle, icon, customIcon } = props;
 
-	_preloaded = false;
+	let _preloaded = false;
 
-	preload = () => {
-		if ( ! this._preloaded && this.props.preloadSectionName ) {
-			this._preloaded = true;
-			preload( this.props.preloadSectionName );
+	const itemPreload = () => {
+		if ( ! _preloaded && props.preloadSectionName ) {
+			_preloaded = true;
+			preload();
 		}
 	};
 
-	expandSectionIfSelected = () => {
-		const { expandSection, selected } = this.props;
+	const expandSectionIfSelected = () => {
+		const { expandSection, selected } = props;
 
 		if ( selected && isFunction( expandSection ) ) {
 			expandSection();
 		}
 	};
 
-	componentDidMount() {
-		this.expandSectionIfSelected();
-	}
+	useEffect( expandSectionIfSelected, [ props.selected ] );
 
-	componentDidUpdate( prevProps ) {
-		// Expand section if selected state changes from false to true
-		if ( ! prevProps.selected ) {
-			this.expandSectionIfSelected();
-		}
-	}
-
-	render() {
-		const isExternalLink = isExternal( this.props.link );
-		const showAsExternal = isExternalLink && ! this.props.forceInternalLink;
-		const classes = classnames( this.props.className, { selected: this.props.selected } );
-		const { materialIcon, materialIconStyle, icon, customIcon } = this.props;
-
-		return (
-			<li
-				className={ classes }
-				data-tip-target={ this.props.tipTarget }
-				data-post-type={ this.props.postType }
+	return (
+		<li className={ classes } data-tip-target={ props.tipTarget } data-post-type={ props.postType }>
+			<a
+				className="sidebar__menu-link"
+				onClick={ props.onNavigate }
+				href={ props.link }
+				target={ showAsExternal ? '_blank' : null }
+				rel={ isExternalLink ? 'noopener noreferrer' : null }
+				onMouseEnter={ itemPreload }
 			>
-				<a
-					className="sidebar__menu-link"
-					onClick={ this.props.onNavigate }
-					href={ this.props.link }
-					target={ showAsExternal ? '_blank' : null }
-					rel={ isExternalLink ? 'noopener noreferrer' : null }
-					onMouseEnter={ this.preload }
-				>
-					{ icon && <Gridicon className={ 'sidebar__menu-icon' } icon={ icon } size={ 24 } /> }
+				{ icon && <Gridicon className={ 'sidebar__menu-icon' } icon={ icon } size={ 24 } /> }
 
-					{ materialIcon && (
-						<MaterialIcon
-							className={ 'sidebar__menu-icon' }
-							icon={ materialIcon }
-							style={ materialIconStyle }
-						/>
-					) }
+				{ materialIcon && (
+					<MaterialIcon
+						className={ 'sidebar__menu-icon' }
+						icon={ materialIcon }
+						style={ materialIconStyle }
+					/>
+				) }
 
-					{ customIcon && customIcon }
+				{ customIcon && customIcon }
 
-					{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
-					<span
-						className="sidebar__menu-link-text menu-link-text"
-						data-e2e-sidebar={ this.props.label }
-					>
-						{ this.props.label }
-					</span>
-					{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
-					{ this.props.children }
-				</a>
-			</li>
-		);
-	}
+				{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
+				<span className="sidebar__menu-link-text menu-link-text" data-e2e-sidebar={ props.label }>
+					{ props.label }
+				</span>
+				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
+				{ props.children }
+			</a>
+		</li>
+	);
 }
+
+SidebarItem.propTypes = {
+	label: TranslatableString.isRequired,
+	className: PropTypes.string,
+	link: PropTypes.string.isRequired,
+	onNavigate: PropTypes.func,
+	icon: PropTypes.string,
+	customIcon: PropTypes.object,
+	materialIcon: PropTypes.string,
+	materialIconStyle: PropTypes.string,
+	selected: PropTypes.bool,
+	expandSection: PropTypes.func,
+	preloadSectionName: PropTypes.string,
+	forceInternalLink: PropTypes.bool,
+	testTarget: PropTypes.string,
+	tipTarget: PropTypes.string,
+};

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -95,7 +95,7 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/domains/manage/${ site.slug }` }
-								onClick={ this.expandManageSection }
+								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
 								selected={ path === '/domains/manage' || path === '/domains/add' }
 							>
 								{ translate( 'Domains' ) }
@@ -104,7 +104,7 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/email/${ site.slug }` }
-								onClick={ this.expandManageSection }
+								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
 								selected={ path === '/email' }
 							>
 								{ translate( 'Email' ) }
@@ -116,10 +116,6 @@ class PlansNavigation extends React.Component {
 			)
 		);
 	}
-
-	expandManageSection = () => {
-		this.props.expandSection( SIDEBAR_SECTION_MANAGE );
-	};
 
 	toggleCartVisibility = () => {
 		this.setState( { cartVisible: ! this.state.cartVisible } );
@@ -147,7 +143,7 @@ class PlansNavigation extends React.Component {
 	}
 }
 
-const mapStateToProps = state => {
+export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const site = getSite( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
@@ -157,6 +153,4 @@ const mapStateToProps = state => {
 		shouldShowMyPlan: ! isOnFreePlan || isJetpack,
 		site,
 	};
-};
-
-export default connect( mapStateToProps, { expandSection } )( localize( PlansNavigation ) );
+} )( localize( PlansNavigation ) );

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -21,8 +21,6 @@ import { isATEnabled } from 'lib/automated-transfer';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
-import { SIDEBAR_SECTION_MANAGE } from '../sidebar/constants';
-import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 
 class PlansNavigation extends React.Component {
 	static propTypes = {
@@ -95,18 +93,13 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/domains/manage/${ site.slug }` }
-								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
 								selected={ path === '/domains/manage' || path === '/domains/add' }
 							>
 								{ translate( 'Domains' ) }
 							</NavItem>
 						) }
 						{ canManageDomain && (
-							<NavItem
-								path={ `/email/${ site.slug }` }
-								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
-								selected={ path === '/email' }
-							>
+							<NavItem path={ `/email/${ site.slug }` } selected={ path === '/email' }>
 								{ translate( 'Email' ) }
 							</NavItem>
 						) }

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -95,7 +95,7 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/domains/manage/${ site.slug }` }
-								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
+								onClick={ this.expandManageSection }
 								selected={ path === '/domains/manage' || path === '/domains/add' }
 							>
 								{ translate( 'Domains' ) }
@@ -104,7 +104,7 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/email/${ site.slug }` }
-								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
+								onClick={ this.expandManageSection }
 								selected={ path === '/email' }
 							>
 								{ translate( 'Email' ) }
@@ -116,6 +116,10 @@ class PlansNavigation extends React.Component {
 			)
 		);
 	}
+
+	expandManageSection = () => {
+		this.props.expandSection( SIDEBAR_SECTION_MANAGE );
+	};
 
 	toggleCartVisibility = () => {
 		this.setState( { cartVisible: ! this.state.cartVisible } );
@@ -143,7 +147,7 @@ class PlansNavigation extends React.Component {
 	}
 }
 
-export default connect( state => {
+const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const site = getSite( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
@@ -153,4 +157,6 @@ export default connect( state => {
 		shouldShowMyPlan: ! isOnFreePlan || isJetpack,
 		site,
 	};
-} )( localize( PlansNavigation ) );
+};
+
+export default connect( mapStateToProps, { expandSection } )( localize( PlansNavigation ) );

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -21,6 +21,8 @@ import { isATEnabled } from 'lib/automated-transfer';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
+import { SIDEBAR_SECTION_MANAGE } from '../sidebar/constants';
+import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 
 class PlansNavigation extends React.Component {
 	static propTypes = {
@@ -93,13 +95,18 @@ class PlansNavigation extends React.Component {
 						{ canManageDomain && (
 							<NavItem
 								path={ `/domains/manage/${ site.slug }` }
+								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
 								selected={ path === '/domains/manage' || path === '/domains/add' }
 							>
 								{ translate( 'Domains' ) }
 							</NavItem>
 						) }
 						{ canManageDomain && (
-							<NavItem path={ `/email/${ site.slug }` } selected={ path === '/email' }>
+							<NavItem
+								path={ `/email/${ site.slug }` }
+								onClick={ () => this.props.dispatch( expandSection( SIDEBAR_SECTION_MANAGE ) ) }
+								selected={ path === '/email' }
+							>
 								{ translate( 'Email' ) }
 							</NavItem>
 						) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Functional version of modified version of SidebarItem (changes made in https://github.com/Automattic/wp-calypso/pull/39949)

#### Testing instructions

* Same as https://github.com/Automattic/wp-calypso/pull/39949
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


Fixes #39934
@gwwar