### PR TITLE
Typography: Change font-weight of /checkout/thank-you

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -65,7 +65,7 @@
 .checkout-thank-you__features-header {
 	color: var( --color-neutral-50 );
 	font-size: 24px;
-	font-weight: 300;
+	font-weight: 400;
 	line-height: 32px;
 	margin: 48px 48px 24px;
 
@@ -177,7 +177,7 @@
 .checkout-thank-you__header-text,
 .checkout-thank-you__success-message-item {
 	font-size: 18px;
-	font-weight: 300;
+	font-weight: 400;
 }
 
 .checkout-thank-you__header.is-placeholder {
@@ -288,7 +288,7 @@
 
 .checkout-thank-you__jetpack-error-heading {
 	font-size: 21px;
-	font-weight: 300;
+	font-weight: 400;
 	line-height: 32px;
 	margin-top: 0;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change font-weight from 300 to 400 for the following SCSS files as mentioned in #39596:

- [x] client/my-sites/checkout/checkout-thank-you/style.scss

#### Testing instructions

- Go to http://calypso.localhost:3000/plans/
- Select a site that is upgradable
- Click on `Upgrade` to upgrade to a higher plan
- Proceed with payment, e.g. using free credits
- Check `font-weight` of header and success message texts

<table>
<tr>
<td>Before:
<br><br>

![39596-02-before](https://user-images.githubusercontent.com/3323310/76277157-7be0f180-62ba-11ea-8f98-80c81767d7da.png)
</td>
<td>After:
<br><br>

![39596-02-after](https://user-images.githubusercontent.com/3323310/76277155-797e9780-62ba-11ea-80a5-1244e31b2567.png)
</td>
</tr>
</table>
