### PR TITLE
Create the ThreatItem component

### DIFF
--- a/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
+++ b/client/assets/stylesheets/_calypso-color-scheme-jetpack-cloud.scss
@@ -78,6 +78,7 @@
 	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-5-rgb );
 	--color-sidebar-menu-hover-text: var( --studio-gray-70 );
 
-	--color-fixed-threat: var( --studio-jetpack-green-40 );
-	--color-ignored-threat: var( --studio-gray-50 );
+	--color-threat-found: var( --studio-red-50 );
+	--color-threat-fixed: var( --studio-jetpack-green-40 );
+	--color-threat-ignored: var( --studio-gray-50 );
 }

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -19,6 +19,9 @@ export interface Props {
 	subheader?: string | ReactNode;
 	highlight?: 'info' | 'success' | 'warning' | 'error';
 	tag?: string;
+	className?: string;
+	summary?: string | ReactNode;
+	expandedSummary?: string | ReactNode;
 }
 
 class LogItem extends React.PureComponent< Props > {
@@ -37,12 +40,14 @@ class LogItem extends React.PureComponent< Props > {
 	}
 
 	render() {
-		const { highlight, children, className } = this.props;
+		const { highlight, children, className, expandedSummary, summary } = this.props;
 		return (
 			<FoldableCard
 				header={ this.renderHeader() }
 				className={ classnames( 'log-item', className ) }
 				highlight={ highlight }
+				expandedSummary={ expandedSummary }
+				summary={ summary }
 			>
 				{ children }
 			</FoldableCard>

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -19,7 +19,6 @@ export interface Props {
 	subheader?: string | ReactNode;
 	highlight?: 'info' | 'success' | 'warning' | 'error';
 	tag?: string;
-	className?: string;
 	summary?: string | ReactNode;
 	expandedSummary?: string | ReactNode;
 }

--- a/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
@@ -71,7 +71,13 @@ class ScanHistoryItem extends Component {
 				subheader={ this.renderEntryHeader( entry ) }
 				key={ entry.id }
 			>
-				<ThreatDescription className="scan-history-item__details" threat={ entry } />
+				<ThreatDescription
+					className="scan-history-item__details"
+					action={ entry.action }
+					details={ entry.description.details }
+					fix={ entry.description.fix }
+					problem={ entry.description.problem }
+				/>
 			</LogItem>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
@@ -72,7 +72,6 @@ class ScanHistoryItem extends Component {
 				key={ entry.id }
 			>
 				<ThreatDescription
-					className="scan-history-item__details"
 					action={ entry.action }
 					details={ entry.description.details }
 					fix={ entry.description.fix }

--- a/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.jsx
@@ -11,6 +11,7 @@ import { translate } from 'i18n-calypso';
  */
 import Badge from 'components/badge';
 import LogItem from '../log-item';
+import ThreatDescription from '../threat-description';
 
 /**
  * Style dependencies
@@ -60,19 +61,6 @@ class ScanHistoryItem extends Component {
 		);
 	}
 
-	renderEntryDetails( entry ) {
-		return (
-			<div className="scan-history-item__details">
-				<strong>{ translate( 'What was the problem?' ) }</strong>
-				<p>{ entry.description.problem }</p>
-				<strong>{ translate( 'How did Jetpack fix it?' ) }</strong>
-				<p>{ entry.description.fix }</p>
-				<strong>{ translate( 'The technical details' ) }</strong>
-				<p>{ entry.description.details }</p>
-			</div>
-		);
-	}
-
 	render() {
 		const { entry } = this.props;
 
@@ -83,7 +71,7 @@ class ScanHistoryItem extends Component {
 				subheader={ this.renderEntryHeader( entry ) }
 				key={ entry.id }
 			>
-				{ this.renderEntryDetails( entry ) }
+				<ThreatDescription className="scan-history-item__details" threat={ entry } />
 			</LogItem>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/scan-history-item/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-history-item/style.scss
@@ -8,7 +8,7 @@
 	}
 
 	&__subheader {
-		color: var( --color-ignored-threat );
+		color: var( --color-threat-ignored );
 		font-size: 13px;
 		display: flex;
 		flex-direction: column;
@@ -24,7 +24,7 @@
 		white-space: nowrap;
 
 		&.is-fixed {
-			color: var( --color-fixed-threat );
+			color: var( --color-threat-fixed );
 		}
 	}
 
@@ -33,7 +33,7 @@
 
 		@include breakpoint( '>960px' ) {
 			display: inline-block;
-			background: var( --color-ignored-threat );
+			background: var( --color-threat-ignored );
 			margin: 0 20px;
 			width: 4px;
 			height: 4px;
@@ -51,11 +51,11 @@
 		color: #fff;
 
 		&.is-fixed {
-			background-color: var( --color-fixed-threat );
+			background-color: var( --color-threat-fixed );
 		}
 
 		&.is-ignored {
-			background-color: var( --color-ignored-threat );
+			background-color: var( --color-threat-ignored );
 		}
 	}
 

--- a/client/landing/jetpack-cloud/components/scan-history-item/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-history-item/style.scss
@@ -58,8 +58,4 @@
 			background-color: var( --color-threat-ignored );
 		}
 	}
-
-	&__details {
-		font-size: 15px;
-	}
 }

--- a/client/landing/jetpack-cloud/components/threat-description/README.md
+++ b/client/landing/jetpack-cloud/components/threat-description/README.md
@@ -1,0 +1,41 @@
+# ThreatDescription
+
+`<ThreatDescription />` is a React component for rendering the description of a Scan threat.
+
+## Usage
+
+```jsx
+import ThreatDescription from 'client/landing/jetpack-cloud/components/threat-description';
+
+export default function MyComponent() {
+	return (
+		<ThreatDescription action="ignored" details="..." fix="..." problem="...">
+			{ content }
+		</ThreatDescription>
+	);
+}
+```
+
+## Props
+
+The following props can be passed to the `<ThreatDescription />` component:
+
+### `children | content`
+
+It can be a string, null, HTML or component to show below everything else inside the description.
+
+### `action`
+
+A string that can take two values: 'fixed' or 'ignored'. If it's undefined, the component will render a different text for that case.
+
+### `details`
+
+The string, HTML element, or component to display in the details section of the description.
+
+### `fix`
+
+The string, HTML element, or component to display in the fix section of the description.
+
+### `problem`
+
+The string, HTML element, or component to display in the problem section of the description.

--- a/client/landing/jetpack-cloud/components/threat-description/index.jsx
+++ b/client/landing/jetpack-cloud/components/threat-description/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ThreatDescription extends Component {
+	static propTypes = {
+		threat: PropTypes.object,
+	};
+
+	render() {
+		const { children, threat } = this.props;
+		const isThreatFixedOrIgnored = !! threat.action;
+		return (
+			<div className="threat-description">
+				<strong>{ translate( 'What was the problem?' ) }</strong>
+				<p>{ threat.description.problem }</p>
+				<strong>
+					{ ! isThreatFixedOrIgnored
+						? translate( 'How we will fix it?' )
+						: translate( 'How did Jetpack fix it?' ) }
+				</strong>
+				<p>{ threat.description.fix }</p>
+				<strong>{ translate( 'The technical details' ) }</strong>
+				<p>{ threat.description.details }</p>
+				{ children }
+			</div>
+		);
+	}
+}
+
+export default ThreatDescription;

--- a/client/landing/jetpack-cloud/components/threat-description/index.jsx
+++ b/client/landing/jetpack-cloud/components/threat-description/index.jsx
@@ -5,31 +5,30 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
 
-/**
- * Style dependencies
- */
-import './style.scss';
-
 class ThreatDescription extends Component {
 	static propTypes = {
-		threat: PropTypes.object,
+		action: PropTypes.string,
+		details: PropTypes.string,
+		fix: PropTypes.string,
+		problem: PropTypes.string,
+		children: PropTypes.node,
 	};
 
 	render() {
-		const { children, threat } = this.props;
-		const isThreatFixedOrIgnored = !! threat.action;
+		const { children, action, details, problem, fix } = this.props;
+		const isThreatFixedOrIgnored = !! action;
 		return (
 			<div className="threat-description">
 				<strong>{ translate( 'What was the problem?' ) }</strong>
-				<p>{ threat.description.problem }</p>
+				<p>{ problem }</p>
 				<strong>
 					{ ! isThreatFixedOrIgnored
 						? translate( 'How we will fix it?' )
 						: translate( 'How did Jetpack fix it?' ) }
 				</strong>
-				<p>{ threat.description.fix }</p>
+				<p>{ fix }</p>
 				<strong>{ translate( 'The technical details' ) }</strong>
-				<p>{ threat.description.details }</p>
+				<p>{ details }</p>
 				{ children }
 			</div>
 		);

--- a/client/landing/jetpack-cloud/components/threat-description/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-description/index.tsx
@@ -1,34 +1,41 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React, { ReactNode } from 'react';
 import { translate } from 'i18n-calypso';
 
-class ThreatDescription extends Component {
-	static propTypes = {
-		action: PropTypes.string,
-		details: PropTypes.string,
-		fix: PropTypes.string,
-		problem: PropTypes.string,
-		children: PropTypes.node,
-	};
+export interface Props {
+	children?: ReactNode;
+	action?: 'ignored' | 'fixed';
+	details: string | ReactNode;
+	fix: string | ReactNode;
+	problem: string | ReactNode;
+}
+
+class ThreatDescription extends React.PureComponent< Props > {
+	renderTextOrNode( content: string | ReactNode ) {
+		if ( typeof content === 'string' ) {
+			return <p>{ content }</p>;
+		}
+		return content;
+	}
 
 	render() {
 		const { children, action, details, problem, fix } = this.props;
 		const isThreatFixedOrIgnored = !! action;
+
 		return (
 			<div className="threat-description">
 				<strong>{ translate( 'What was the problem?' ) }</strong>
-				<p>{ problem }</p>
+				{ this.renderTextOrNode( problem ) }
 				<strong>
 					{ ! isThreatFixedOrIgnored
 						? translate( 'How we will fix it?' )
 						: translate( 'How did Jetpack fix it?' ) }
 				</strong>
-				<p>{ fix }</p>
+				{ this.renderTextOrNode( fix ) }
 				<strong>{ translate( 'The technical details' ) }</strong>
-				<p>{ details }</p>
+				{ this.renderTextOrNode( details ) }
 				{ children }
 			</div>
 		);

--- a/client/landing/jetpack-cloud/components/threat-item/README.md
+++ b/client/landing/jetpack-cloud/components/threat-item/README.md
@@ -1,0 +1,38 @@
+# ThreatItem
+
+`<ThreatItem />` is a React component for rendering a button with an attached loading indicator.
+
+## Usage
+
+```jsx
+import ThreatItem from 'client/landing/jetpack-cloud/components/threat-item';
+
+export default function MyComponent() {
+	return <ThreatItem threat={ threat } />;
+}
+```
+
+## Props
+
+The following props can be passed to the `<ThreatItem />` component:
+
+### `threat`
+
+An object with information about a threat found in the Scan process. It has the following properties:
+
+```js
+{
+    id: 1,
+    title: 'Infected core file: index.php',
+    action: 'fixed',
+    detectionDate: '23 September, 2019',
+    actionDate: '29 September, 2019',
+    description: {
+    title: 'Unexpected string was found in: /htdocs/wp-admin/index.php',
+    problem:
+        'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
+    fix:
+        'To fix this threat, Jetpack will be deleting the file, since it’s not a part of the original WordPress.',
+    details: 'This threat was found in the file: /htdocs/index.php',
+}
+```

--- a/client/landing/jetpack-cloud/components/threat-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.jsx
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { translate } from 'i18n-calypso';
+import classnames from 'classnames';
+import { Button } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import LogItem from '../log-item';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ThreatItem extends Component {
+	static propTypes = {
+		threat: PropTypes.object,
+	};
+
+	handleFixThreat = () => {
+		const { threat } = this.props;
+		// eslint-disable-next-line no-undef
+		alert( `Fixing threat ${ threat.id }` );
+	};
+
+	// This is almost equal to the details of a fixed/ignored threat event,
+	// so we may have to abstract it into its own component
+	renderEntryDetails( threat ) {
+		return (
+			<div className="threat-item__details">
+				<strong>{ translate( 'What was the problem?' ) }</strong>
+				<p>{ threat.description.problem }</p>
+				<strong>{ translate( 'How we will fix it?' ) }</strong>
+				<p>{ threat.description.fix }</p>
+				<strong>{ translate( 'The technical details' ) }</strong>
+				<p>{ threat.description.details }</p>
+				{ this.renderFixThreatCTA( 'is-details' ) }
+			</div>
+		);
+	}
+
+	renderFixThreatCTA( className ) {
+		return (
+			<Button
+				className={ classnames( 'threat-item__fix-cta', className ) }
+				compact
+				onClick={ this.handleFixThreat }
+			>
+				{ translate( 'Fix threat' ) }
+			</Button>
+		);
+	}
+
+	render() {
+		const { threat } = this.props;
+		const fixThreatCTA = this.renderFixThreatCTA( 'is-summary' );
+
+		return (
+			<LogItem
+				className="threat-item"
+				header={ threat.title }
+				subheader={ threat.description.title }
+				summary={ fixThreatCTA }
+				expandedSummary={ fixThreatCTA }
+				key={ threat.id }
+				highlight="error"
+			>
+				{ this.renderEntryDetails( threat ) }
+			</LogItem>
+		);
+	}
+}
+
+export default ThreatItem;

--- a/client/landing/jetpack-cloud/components/threat-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.jsx
@@ -11,6 +11,7 @@ import { Button } from '@automattic/components';
  * Internal dependencies
  */
 import LogItem from '../log-item';
+import ThreatDescription from '../threat-description';
 
 /**
  * Style dependencies
@@ -28,22 +29,13 @@ class ThreatItem extends Component {
 		alert( `Fixing threat ${ threat.id }` );
 	};
 
-	// This is almost equal to the details of a fixed/ignored threat event,
-	// so we may have to abstract it into its own component
-	renderEntryDetails( threat ) {
-		return (
-			<div className="threat-item__details">
-				<strong>{ translate( 'What was the problem?' ) }</strong>
-				<p>{ threat.description.problem }</p>
-				<strong>{ translate( 'How we will fix it?' ) }</strong>
-				<p>{ threat.description.fix }</p>
-				<strong>{ translate( 'The technical details' ) }</strong>
-				<p>{ threat.description.details }</p>
-				{ this.renderFixThreatCTA( 'is-details' ) }
-			</div>
-		);
-	}
-
+	/**
+	 * Render a CTA button. Currently, this button is rendered three
+	 * times: in the details section, and in the `summary` and `extendSummary`
+	 * sections of the header.
+	 *
+	 * @param {string} className A class for the button
+	 */
 	renderFixThreatCTA( className ) {
 		return (
 			<Button
@@ -70,7 +62,9 @@ class ThreatItem extends Component {
 				key={ threat.id }
 				highlight="error"
 			>
-				{ this.renderEntryDetails( threat ) }
+				<ThreatDescription threat={ threat }>
+					{ this.renderFixThreatCTA( 'is-details' ) }
+				</ThreatDescription>
 			</LogItem>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/threat-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.jsx
@@ -36,7 +36,7 @@ class ThreatItem extends Component {
 	 *
 	 * @param {string} className A class for the button
 	 */
-	renderFixThreatCTA( className ) {
+	renderFixThreatButton( className ) {
 		return (
 			<Button
 				className={ classnames( 'threat-item__fix-cta', className ) }
@@ -50,7 +50,7 @@ class ThreatItem extends Component {
 
 	render() {
 		const { threat } = this.props;
-		const fixThreatCTA = this.renderFixThreatCTA( 'is-summary' );
+		const fixThreatCTA = this.renderFixThreatButton( 'is-summary' );
 
 		return (
 			<LogItem
@@ -68,7 +68,7 @@ class ThreatItem extends Component {
 					fix={ threat.description.fix }
 					problem={ threat.description.problem }
 				>
-					{ this.renderFixThreatCTA( 'is-details' ) }
+					{ this.renderFixThreatButton( 'is-details' ) }
 				</ThreatDescription>
 			</LogItem>
 		);

--- a/client/landing/jetpack-cloud/components/threat-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.jsx
@@ -62,7 +62,12 @@ class ThreatItem extends Component {
 				key={ threat.id }
 				highlight="error"
 			>
-				<ThreatDescription threat={ threat }>
+				<ThreatDescription
+					action={ threat.action }
+					details={ threat.description.details }
+					fix={ threat.description.fix }
+					problem={ threat.description.problem }
+				>
 					{ this.renderFixThreatCTA( 'is-details' ) }
 				</ThreatDescription>
 			</LogItem>

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -1,0 +1,36 @@
+.threat-item {
+	// Override the error color to a slightly different red.
+	--color-error-20: var( --color-threat-found );
+
+	&__fix-cta {
+		width: 170px;
+		padding: 10px 30px;
+	}
+
+	&__fix-cta.is-summary {
+		display: none;
+
+		@include breakpoint( '>800px' ) {
+			display: inline-block;
+			margin-left: 20px;
+		}
+	}
+
+	&__fix-cta.is-details {
+		display: inline-block;
+		width: 100%;
+		margin-left: 0;
+
+		@include breakpoint( '>800px' ) {
+			display: none;
+		}
+	}
+}
+
+.button.threat-item__fix-cta.is-compact {
+	color: var( --color-primary-50 );
+	border-color: var( --color-primary-50 );
+	border-width: 1px;
+	border-style: solid;
+	border-radius: 3px;
+}

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -14,8 +14,4 @@
 	&__filters {
 		margin: 25px 0;
 	}
-
-	&__entries {
-		font-size: 16px;
-	}
 }

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -13,6 +13,7 @@ import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
 import SecurityIcon from 'landing/jetpack-cloud/components/security-icon';
 import StatsFooter from 'landing/jetpack-cloud/components/stats-footer';
+import ThreatItem from '../../components/threat-item';
 import { isEnabled } from 'config';
 
 import './style.scss';
@@ -78,6 +79,11 @@ class ScanPage extends Component {
 						}
 					) }
 				</p>
+				<div className="scan__threats">
+					{ threats.map( threat => (
+						<ThreatItem key={ threat.id } threat={ threat } />
+					) ) }
+				</div>
 			</>
 		);
 	}
@@ -129,12 +135,35 @@ export default connect( state => {
 	// TODO: Get threats from actual API.
 	const threats = [
 		{
-			title: 'Infected core file: wp-config.php',
-			details: 'Unexpected string was found in: /htdocs/wp-admin/wp-config.php',
+			id: 1,
+			title: 'Infected core file: index.php',
+			action: null,
+			detectionDate: '23 September, 2019',
+			actionDate: null,
+			description: {
+				title: 'Unexpected string was found in: /htdocs/wp-admin/index.php',
+				problem:
+					'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
+				fix:
+					'To fix this threat, Jetpack will be deleting the file, since it’s not a part of the original WordPress.',
+				details: 'This threat was found in the file: /htdocs/index.php',
+			},
 		},
 		{
-			title: 'Unexpected core file: sx--a4bp.php',
-			details: 'Unexpected file sx--a4bp.php contains malicious code and is not part of WordPress.',
+			id: 2,
+			title: 'Infected Plugin: Contact Form 7',
+			action: null,
+			detectionDate: '17 September, 2019',
+			actionDate: null,
+			description: {
+				title:
+					'Unexpected file baaaaaad--file.php contains malicious code and is not part of the Plugin',
+				problem:
+					'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
+				fix:
+					'To fix this threat, Jetpack will be deleting the file, since it’s not a part of the original WordPress.',
+				details: 'This threat was found in the file: /htdocs/sx--a4bp.php',
+			},
 		},
 	];
 

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -22,6 +22,10 @@
 	color: var( --color-primary-40 );
 }
 
+.scan__threats {
+	margin: 40px 0;
+}
+
 .scan__button {
 	margin: 30px 0;
 	width: 100%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- The goal of this is to create the Threat Card used on the main screen when threats are found.

#### Testing instructions

- Navigate to http://jetpack.cloud.localhost:3000/scan/<yourSiteSlug>?scan-state=threats
- You should see two threat cards
- Compare it with the designs

See 1151678672052943-as-1165217655856094.

#### Screenshots
##### Mobile
<img width="420" alt="image" src="https://user-images.githubusercontent.com/3418513/76278734-17e30c80-626b-11ea-879d-76c538b7083b.png">
<img width="419" alt="image" src="https://user-images.githubusercontent.com/3418513/76278748-24fffb80-626b-11ea-84c4-52b5c3772746.png">

##### Desktop
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/3418513/76278775-35b07180-626b-11ea-93c5-070b910f0df5.png">
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/3418513/76278795-419c3380-626b-11ea-8845-66b7ddf1e4f5.png">

