### PR TITLE
Add auto-renew toggle on the new registered domain screen

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -390,6 +390,16 @@ function creditCardExpiresBeforeSubscription( purchase ) {
 	);
 }
 
+function creditCardHasAlreadyExpired( purchase ) {
+	const creditCard = purchase?.payment?.creditCard;
+
+	return (
+		isPaidWithCreditCard( purchase ) &&
+		hasCreditCardData( purchase ) &&
+		moment( creditCard.expiryDate, 'MM/YY' ).isBefore( moment.now(), 'months' )
+	);
+}
+
 function shouldRenderExpiringCreditCard( purchase ) {
 	return (
 		! isExpired( purchase ) &&
@@ -480,6 +490,7 @@ function getDomainRegistrationAgreementUrl( purchase ) {
 export {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
+	creditCardHasAlreadyExpired,
 	getDomainRegistrationAgreementUrl,
 	getIncludedDomain,
 	getName,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -390,6 +390,16 @@ function creditCardExpiresBeforeSubscription( purchase ) {
 	);
 }
 
+function shouldRenderExpiringCreditCard( purchase ) {
+	return (
+		! isExpired( purchase ) &&
+		! isExpiring( purchase ) &&
+		! isOneTimePurchase( purchase ) &&
+		! isIncludedWithPlan( purchase ) &&
+		creditCardExpiresBeforeSubscription( purchase )
+	);
+}
+
 function monthsUntilCardExpires( purchase ) {
 	const creditCard = purchase.payment.creditCard;
 	const expiry = moment( creditCard.expiryDate, 'MM/YY' );
@@ -506,4 +516,5 @@ export {
 	showCreditCardExpiringWarning,
 	subscribedWithinPastWeek,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
+	shouldRenderExpiringCreditCard,
 };

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -32,7 +32,6 @@ class AutoRenewToggle extends Component {
 		recordTracksEvent: PropTypes.func.isRequired,
 		compact: PropTypes.bool,
 		withTextStatus: PropTypes.bool,
-		withPlan: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -144,11 +143,7 @@ class AutoRenewToggle extends Component {
 	}
 
 	renderTextStatus() {
-		const { translate, isEnabled, withPlan } = this.props;
-
-		if ( withPlan ) {
-			return isEnabled ? translate( 'Plan auto-renew (on)' ) : translate( 'Plan auto-renew (off)' );
-		}
+		const { translate, isEnabled } = this.props;
 
 		return isEnabled ? translate( 'Auto-renew (on)' ) : translate( 'Auto-renew (off)' );
 	}

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -32,6 +32,7 @@ class AutoRenewToggle extends Component {
 		recordTracksEvent: PropTypes.func.isRequired,
 		compact: PropTypes.bool,
 		withTextStatus: PropTypes.bool,
+		withPlan: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -143,7 +144,11 @@ class AutoRenewToggle extends Component {
 	}
 
 	renderTextStatus() {
-		const { translate, isEnabled } = this.props;
+		const { translate, isEnabled, withPlan } = this.props;
+
+		if ( withPlan ) {
+			return isEnabled ? translate( 'Plan auto-renew (on)' ) : translate( 'Plan auto-renew (off)' );
+		}
 
 		return isEnabled ? translate( 'Auto-renew (on)' ) : translate( 'Auto-renew (off)' );
 	}

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -31,6 +31,7 @@ class AutoRenewToggle extends Component {
 		fetchingUserPurchases: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
 		compact: PropTypes.bool,
+		withTextStatus: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -141,8 +142,14 @@ class AutoRenewToggle extends Component {
 		return this.props.isEnabled;
 	}
 
+	renderTextStatus() {
+		const { translate, isEnabled } = this.props;
+
+		return isEnabled ? translate( 'Auto-renew (on)' ) : translate( 'Auto-renew (off)' );
+	}
+
 	render() {
-		const { planName, siteDomain, purchase, compact } = this.props;
+		const { planName, siteDomain, purchase, compact, withTextStatus } = this.props;
 
 		const ToggleComponent = compact ? CompactFormToggle : FormToggle;
 
@@ -151,8 +158,11 @@ class AutoRenewToggle extends Component {
 				<ToggleComponent
 					checked={ this.getToggleUiStatus() }
 					disabled={ this.isUpdatingAutoRenew() }
+					toggling={ this.isUpdatingAutoRenew() }
 					onChange={ this.onToggleAutoRenew }
-				/>
+				>
+					{ withTextStatus && this.renderTextStatus() }
+				</ToggleComponent>
 				<AutoRenewDisablingDialog
 					isVisible={ this.state.showAutoRenewDisablingDialog }
 					planName={ planName }

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -19,6 +19,7 @@ import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
 import { createNotice } from 'state/notices/actions';
 import AutoRenewDisablingDialog from './auto-renew-disabling-dialog';
 import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 
 class AutoRenewToggle extends Component {
 	static propTypes = {
@@ -29,6 +30,7 @@ class AutoRenewToggle extends Component {
 		isAtomicSite: PropTypes.bool.isRequired,
 		fetchingUserPurchases: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
+		compact: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -140,11 +142,13 @@ class AutoRenewToggle extends Component {
 	}
 
 	render() {
-		const { planName, siteDomain, purchase } = this.props;
+		const { planName, siteDomain, purchase, compact } = this.props;
+
+		const ToggleComponent = compact ? CompactFormToggle : FormToggle;
 
 		return (
 			<>
-				<FormToggle
+				<ToggleComponent
 					checked={ this.getToggleUiStatus() }
 					disabled={ this.isUpdatingAutoRenew() }
 					onChange={ this.onToggleAutoRenew }

--- a/client/my-sites/domains/domain-management/edit/card/notices/expiring-credit-card.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/notices/expiring-credit-card.jsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import { Button } from '@automattic/components';
+import { shouldRenderExpiringCreditCard, creditCardHasAlreadyExpired } from 'lib/purchases';
+import { getEditCardDetailsPath } from 'me/purchases/utils';
+import { type as domainTypes } from 'lib/domains/constants';
+
+function ExpiringCreditCard( props ) {
+	const { selectedSite, purchase, domain } = props;
+	const translate = useTranslate();
+
+	if ( ! selectedSite || ! purchase ) {
+		return null;
+	}
+
+	if ( ! shouldRenderExpiringCreditCard( purchase ) ) {
+		return null;
+	}
+
+	const editCardDetailsPath = getEditCardDetailsPath( selectedSite.slug, purchase );
+
+	let messageText;
+
+	if ( domain.type === domainTypes.MAPPED ) {
+		if ( domain.bundledPlanSubscriptionId ) {
+			return null;
+		}
+
+		if ( creditCardHasAlreadyExpired( purchase ) ) {
+			messageText = translate(
+				'Your credit card {{strong}}has expired before your domain mapping renewal date{{/strong}}. Please update your payment information on your account to avoid any disruptions to your service. Turn off auto-renew if you don’t want to see this message anymore.',
+				{
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			messageText = translate(
+				'Your credit card is {{strong}}set to expire before your domain mapping renewal date{{/strong}}. Please update your payment information on your account to avoid any disruptions to your service. Turn off auto-renew if you don’t want to see this message anymore.',
+				{
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		}
+	} else if ( domain.type === domainTypes.REGISTERED ) {
+		if ( creditCardHasAlreadyExpired( purchase ) ) {
+			messageText = translate(
+				'Your credit card {{strong}}has expired before your domain renewal date{{/strong}}. Please update your payment information on your account to avoid any disruptions to your service. Turn off auto-renew if you don’t want to see this message anymore.',
+				{
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		} else {
+			messageText = translate(
+				'Your credit card is {{strong}}set to expire before your domain renewal date{{/strong}}. Please update your payment information on your account to avoid any disruptions to your service. Turn off auto-renew if you don’t want to see this message anymore.',
+				{
+					components: {
+						strong: <strong />,
+					},
+				}
+			);
+		}
+	}
+
+	return (
+		<div>
+			<p>{ messageText }</p>
+			<Button primary={ true } href={ editCardDetailsPath }>
+				{ translate( 'Add a new credit card' ) }
+			</Button>
+		</div>
+	);
+}
+
+export default ExpiringCreditCard;

--- a/client/my-sites/domains/domain-management/edit/card/notices/expiring-credit-card.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/notices/expiring-credit-card.jsx
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { useTranslate } from 'i18n-calypso';
 import { Button } from '@automattic/components';
 import { shouldRenderExpiringCreditCard, creditCardHasAlreadyExpired } from 'lib/purchases';
 import { getEditCardDetailsPath } from 'me/purchases/utils';

--- a/client/my-sites/domains/domain-management/edit/card/notices/expiring-soon.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/notices/expiring-soon.jsx
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'components/localized-moment';
+
+/**
+ * Internal dependencies
+ */
+import { isExpiringSoon } from 'lib/domains/utils';
+import RenewButton from 'my-sites/domains/domain-management/edit/card/renew-button';
+import { type as domainTypes } from 'lib/domains/constants';
+
+function ExpiringSoon( props ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
+	const { domain, purchase, selectedSite } = props;
+	const { expiry } = domain;
+
+	if ( ! isExpiringSoon( domain, 30 ) ) {
+		return null;
+	}
+
+	let noticeText;
+	let subscriptionId;
+	let customLabel;
+	let tracksProps;
+
+	if ( domain.type === domainTypes.MAPPED ) {
+		if ( ! domain.currentUserCanManage ) {
+			noticeText = translate(
+				'{{strong}}The domain mapping will expire{{/strong}} in {{strong}}%(days)s{{/strong}}. Please contact the domain mapping owner %(owner)s to renew it.',
+				{
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						days: moment.utc( expiry ).fromNow( true ),
+						owner: domain.owner,
+					},
+				}
+			);
+		} else if ( domain.bundledPlanSubscriptionId ) {
+			noticeText = translate(
+				'Your domain mapping will expire with your plan in {{strong}}%(days)s{{/strong}}. Please renew your plan before it expires or it will stop working.',
+				{
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						days: moment.utc( expiry ).fromNow( true ),
+					},
+				}
+			);
+			subscriptionId = domain.bundledPlanSubscriptionId;
+			customLabel = translate( 'Renew your plan' );
+			tracksProps = { source: 'mapped-domain-status', mapping_status: 'expiring-soon-plan' };
+		} else {
+			noticeText = translate(
+				'Your domain mapping will expire in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
+				{
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						days: moment.utc( expiry ).fromNow( true ),
+					},
+				}
+			);
+			subscriptionId = domain.subscriptionId;
+			customLabel = null;
+			tracksProps = { source: 'mapped-domain-status', mapping_status: 'expiring-soon' };
+		}
+	} else if ( domain.type === domainTypes.REGISTERED ) {
+		if ( ! domain.currentUserCanManage ) {
+			noticeText = translate(
+				'{{strong}}The domain will expire{{/strong}} in {{strong}}%(days)s{{/strong}}. Please contact the domain owner %(owner)s to renew it.',
+				{
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						days: moment.utc( expiry ).fromNow( true ),
+						owner: domain.owner,
+					},
+				}
+			);
+		} else {
+			noticeText = translate(
+				'{{strong}}Your domain will expire{{/strong}} in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
+				{
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						days: moment.utc( expiry ).fromNow( true ),
+					},
+				}
+			);
+			subscriptionId = domain.subscriptionId;
+			customLabel = null;
+			tracksProps = { source: 'registered-domain-status', mapping_status: 'expiring-soon' };
+		}
+	}
+
+	return (
+		<div>
+			<p>{ noticeText }</p>
+			{ domain.currentUserCanManage && (
+				<RenewButton
+					primary={ true }
+					purchase={ purchase }
+					selectedSite={ selectedSite }
+					subscriptionId={ parseInt( subscriptionId, 10 ) }
+					customLabel={ customLabel }
+					tracksProps={ tracksProps }
+				/>
+			) }
+		</div>
+	);
+}
+
+export default ExpiringSoon;

--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.jsx
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -13,8 +12,6 @@ import classNames from 'classnames';
 import formatCurrency from '@automattic/format-currency';
 import { Button } from '@automattic/components';
 import { handleRenewNowClick, getRenewalPrice } from 'lib/purchases';
-import { getByPurchaseId } from 'state/purchases/selectors';
-import QuerySitePurchases from 'components/data/query-site-purchases';
 
 /**
  * Style dependencies
@@ -31,6 +28,7 @@ class RenewButton extends React.Component {
 		reactivate: PropTypes.bool,
 		customLabel: PropTypes.string,
 		tracksProps: PropTypes.object,
+		purchase: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -87,8 +85,6 @@ class RenewButton extends React.Component {
 
 		return (
 			<React.Fragment>
-				{ selectedSite.ID && <QuerySitePurchases siteId={ selectedSite.ID } /> }
-
 				<Button
 					compact={ this.props.compact }
 					primary={ this.props.primary }
@@ -102,8 +98,4 @@ class RenewButton extends React.Component {
 	}
 }
 
-export default connect( ( state, ownProps ) => {
-	return {
-		purchase: getByPurchaseId( state, ownProps.subscriptionId ),
-	};
-} )( localize( RenewButton ) );
+export default localize( RenewButton );

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import { Card, Button } from '@automattic/components';
+import { Card } from '@automattic/components';
 import VerticalNav from 'components/vertical-nav';
 import { withLocalizedMoment } from 'components/localized-moment';
 import DomainStatus from '../card/domain-status';
@@ -32,8 +32,8 @@ import RenewButton from 'my-sites/domains/domain-management/edit/card/renew-butt
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'state/sites/selectors';
 import { getByPurchaseId } from 'state/purchases/selectors';
-import { isRechargeable, isExpired, shouldRenderExpiringCreditCard } from 'lib/purchases';
-import { getEditCardDetailsPath } from 'me/purchases/utils';
+import { isRechargeable, isExpired } from 'lib/purchases';
+import ExpiringCreditCard from '../card/notices/expiring-credit-card';
 
 class MappedDomainType extends React.Component {
 	getVerticalNavigation() {
@@ -261,38 +261,6 @@ class MappedDomainType extends React.Component {
 		);
 	}
 
-	renderExpiringCreditCard() {
-		const { selectedSite, purchase, translate } = this.props;
-
-		if ( ! selectedSite || ! purchase ) {
-			return null;
-		}
-
-		if ( ! shouldRenderExpiringCreditCard( purchase ) ) {
-			return null;
-		}
-
-		const editCardDetailsPath = getEditCardDetailsPath( selectedSite.slug, purchase );
-
-		return (
-			<div>
-				<p>
-					{ translate(
-						'Your credit card is {{strong}}set to expire before your domain mapping renewal date{{/strong}}. Please update your payment information on your account to avoid any disruptions to your service. Turn off auto-renew if you don’t want to see this message anymore.',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					) }
-				</p>
-				<Button primary={ true } href={ editCardDetailsPath }>
-					{ translate( 'Update your payment information' ) }
-				</Button>
-			</div>
-		);
-	}
-
 	renderDefaultRenewButton() {
 		const { domain, purchase, translate } = this.props;
 
@@ -395,7 +363,11 @@ class MappedDomainType extends React.Component {
 					statusClass={ statusClass }
 					icon={ icon }
 				>
-					{ this.renderExpiringCreditCard() }
+					<ExpiringCreditCard
+						selectedSite={ selectedSite }
+						purchase={ purchase }
+						domain={ domain }
+					/>
 					{ this.renderSettingUpNameservers() }
 					{ this.renderExpiringSoon() }
 				</DomainStatus>

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -34,6 +34,7 @@ import { isJetpackSite } from 'state/sites/selectors';
 import { getByPurchaseId } from 'state/purchases/selectors';
 import { isRechargeable, isExpired } from 'lib/purchases';
 import ExpiringCreditCard from '../card/notices/expiring-credit-card';
+import ExpiringSoon from '../card/notices/expiring-soon';
 
 class MappedDomainType extends React.Component {
 	getVerticalNavigation() {
@@ -132,66 +133,6 @@ class MappedDomainType extends React.Component {
 			statusClass: 'status-success',
 			icon: 'check_circle',
 		};
-	}
-
-	renderExpiringSoon() {
-		const { domain, translate, purchase, moment } = this.props;
-		const { expiry } = domain;
-
-		if ( ! isExpiringSoon( domain, 30 ) ) {
-			return null;
-		}
-
-		let noticeText;
-		let subscriptionId;
-		let customLabel;
-		let tracksProps;
-
-		if ( domain.bundledPlanSubscriptionId ) {
-			noticeText = translate(
-				'Your domain mapping will expire with your plan in {{strong}}%(days)s{{/strong}}. Please renew your plan before it expires or it will stop working.',
-				{
-					components: {
-						strong: <strong />,
-					},
-					args: {
-						days: moment.utc( expiry ).fromNow( true ),
-					},
-				}
-			);
-			subscriptionId = domain.bundledPlanSubscriptionId;
-			customLabel = translate( 'Renew your plan' );
-			tracksProps = { source: 'mapped-domain-status', mapping_status: 'expiring-soon-plan' };
-		} else {
-			noticeText = translate(
-				'Your domain mapping will expire in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
-				{
-					components: {
-						strong: <strong />,
-					},
-					args: {
-						days: moment.utc( expiry ).fromNow( true ),
-					},
-				}
-			);
-			subscriptionId = domain.subscriptionId;
-			customLabel = null;
-			tracksProps = { source: 'mapped-domain-status', mapping_status: 'expiring-soon' };
-		}
-
-		return (
-			<div>
-				<p>{ noticeText }</p>
-				<RenewButton
-					primary={ true }
-					purchase={ purchase }
-					selectedSite={ this.props.selectedSite }
-					subscriptionId={ parseInt( subscriptionId, 10 ) }
-					customLabel={ customLabel }
-					tracksProps={ tracksProps }
-				/>
-			</div>
-		);
 	}
 
 	renderSettingUpNameservers() {
@@ -369,7 +310,7 @@ class MappedDomainType extends React.Component {
 						domain={ domain }
 					/>
 					{ this.renderSettingUpNameservers() }
-					{ this.renderExpiringSoon() }
+					<ExpiringSoon selectedSite={ selectedSite } purchase={ purchase } domain={ domain } />
 				</DomainStatus>
 				<Card compact={ true } className="domain-types__expiration-row">
 					<div>{ expiresText }</div>

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -120,7 +120,11 @@ class MappedDomainType extends React.Component {
 			};
 		}
 
-		if ( ! domain.pointsToWpcom ) {
+		if (
+			! this.props.isJetpackSite &&
+			! this.props.isAutomatedTransferSite &&
+			! domain.pointsToWpcom
+		) {
 			return {
 				statusText: translate( 'Action required' ),
 				statusClass: 'status-error',

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -246,7 +246,7 @@ class MappedDomainType extends React.Component {
 	}
 
 	renderAutoRenewToggle() {
-		const { selectedSite, domain, purchase } = this.props;
+		const { selectedSite, purchase } = this.props;
 
 		if ( ! purchase ) {
 			return null;
@@ -263,13 +263,16 @@ class MappedDomainType extends React.Component {
 				purchase={ purchase }
 				compact={ true }
 				withTextStatus={ true }
-				withPlan={ !! domain.bundledPlanSubscriptionId }
 			/>
 		);
 	}
 
 	renderAutoRenew() {
-		const { isLoadingPurchase } = this.props;
+		const { isLoadingPurchase, domain } = this.props;
+
+		if ( domain && domain.bundledPlanSubscriptionId ) {
+			return <div />;
+		}
 
 		if ( isLoadingPurchase ) {
 			return (

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -31,7 +31,11 @@ import { MAP_EXISTING_DOMAIN, MAP_SUBDOMAIN } from 'lib/url/support';
 import RenewButton from 'my-sites/domains/domain-management/edit/card/renew-button';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'state/sites/selectors';
-import { getByPurchaseId } from 'state/purchases/selectors';
+import {
+	getByPurchaseId,
+	isFetchingSitePurchases,
+	hasLoadedSitePurchasesFromServer,
+} from 'state/purchases/selectors';
 import { isRechargeable, isExpired } from 'lib/purchases';
 import ExpiringCreditCard from '../card/notices/expiring-credit-card';
 import ExpiringSoon from '../card/notices/expiring-soon';
@@ -244,6 +248,10 @@ class MappedDomainType extends React.Component {
 	renderAutoRenewToggle() {
 		const { selectedSite, domain, purchase } = this.props;
 
+		if ( ! purchase ) {
+			return null;
+		}
+
 		if ( ! isRechargeable( purchase ) || isExpired( purchase ) ) {
 			return null;
 		}
@@ -261,10 +269,14 @@ class MappedDomainType extends React.Component {
 	}
 
 	renderAutoRenew() {
-		const { purchase } = this.props;
+		const { isLoadingPurchase } = this.props;
 
-		if ( ! purchase ) {
-			return <div />;
+		if ( isLoadingPurchase ) {
+			return (
+				<div className="domain-types__auto-renew-placeholder">
+					<p />
+				</div>
+			);
 		}
 
 		return <div>{ this.renderAutoRenewToggle() }</div>;
@@ -348,6 +360,8 @@ export default connect(
 			purchase: purchaseSubscriptionId
 				? getByPurchaseId( state, parseInt( purchaseSubscriptionId, 10 ) )
 				: null,
+			isLoadingPurchase:
+				isFetchingSitePurchases( state ) && ! hasLoadedSitePurchasesFromServer( state ),
 			isSiteAutomatedTransfer: isSiteAutomatedTransfer( state, ownProps.selectedSite.ID ),
 			isJetpackSite: isJetpackSite( state, ownProps.selectedSite.ID ),
 		};

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -38,14 +38,7 @@ import NonPrimaryDomainPlanUpsell from '../../components/domain/non-primary-doma
 import RenewButton from 'my-sites/domains/domain-management/edit/card/renew-button';
 import AutoRenewToggle from 'me/purchases/manage-purchase/auto-renew-toggle';
 import QuerySitePurchases from 'components/data/query-site-purchases';
-import {
-	isExpired,
-	isExpiring,
-	isRechargeable,
-	creditCardExpiresBeforeSubscription,
-	isOneTimePurchase,
-	isIncludedWithPlan,
-} from 'lib/purchases';
+import { isExpired, shouldRenderExpiringCreditCard, isRechargeable } from 'lib/purchases';
 import { getEditCardDetailsPath } from 'me/purchases/utils';
 
 class RegisteredDomainType extends React.Component {
@@ -106,7 +99,7 @@ class RegisteredDomainType extends React.Component {
 		const { domain, translate, purchase, moment } = this.props;
 		const { registrationDate, expiry } = domain;
 
-		if ( purchase && this.shouldRenderExpiringCreditCard( purchase ) ) {
+		if ( purchase && shouldRenderExpiringCreditCard( purchase ) ) {
 			return {
 				statusText: translate( 'Action required' ),
 				statusClass: 'status-error',
@@ -362,16 +355,6 @@ class RegisteredDomainType extends React.Component {
 		);
 	}
 
-	shouldRenderExpiringCreditCard( purchase ) {
-		return (
-			! isExpired( purchase ) &&
-			! isExpiring( purchase ) &&
-			! isOneTimePurchase( purchase ) &&
-			! isIncludedWithPlan( purchase ) &&
-			creditCardExpiresBeforeSubscription( purchase )
-		);
-	}
-
 	renderExpiringCreditCard() {
 		const { selectedSite, purchase, translate } = this.props;
 
@@ -379,7 +362,7 @@ class RegisteredDomainType extends React.Component {
 			return null;
 		}
 
-		if ( ! this.shouldRenderExpiringCreditCard( purchase ) ) {
+		if ( ! shouldRenderExpiringCreditCard( purchase ) ) {
 			return null;
 		}
 

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -356,6 +356,7 @@ class RegisteredDomainType extends React.Component {
 				siteDomain={ selectedSite.domain }
 				purchase={ purchase }
 				compact={ true }
+				withTextStatus={ true }
 			/>
 		);
 	}
@@ -364,10 +365,14 @@ class RegisteredDomainType extends React.Component {
 		const { selectedSite, purchase } = this.props;
 
 		if ( ! purchase ) {
-			return <QuerySitePurchases siteId={ selectedSite.ID } />;
+			return (
+				<div>
+					<QuerySitePurchases siteId={ selectedSite.ID } />
+				</div>
+			);
 		}
 
-		return <Card compact={ true }>{ this.renderAutoRenewToggle() }</Card>;
+		return <div>{ this.renderAutoRenewToggle() }</div>;
 	}
 
 	planUpsellForNonPrimaryDomain() {
@@ -458,8 +463,9 @@ class RegisteredDomainType extends React.Component {
 							/>
 						</div>
 					) }
+					{ newStatusDesignAutoRenew && domain.currentUserCanManage && this.renderAutoRenew() }
 				</Card>
-				{ newStatusDesignAutoRenew && this.renderAutoRenew() }
+
 				{ this.getVerticalNavigation() }
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -40,6 +40,7 @@ import AutoRenewToggle from 'me/purchases/manage-purchase/auto-renew-toggle';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { isExpired, shouldRenderExpiringCreditCard, isRechargeable } from 'lib/purchases';
 import ExpiringCreditCard from '../card/notices/expiring-credit-card';
+import ExpiringSoon from '../card/notices/expiring-soon';
 
 class RegisteredDomainType extends React.Component {
 	getVerticalNavigation() {
@@ -158,58 +159,6 @@ class RegisteredDomainType extends React.Component {
 			statusClass: 'status-success',
 			icon: 'check_circle',
 		};
-	}
-
-	renderExpiringSoon() {
-		const { domain, purchase, translate, moment } = this.props;
-		const { expiry } = domain;
-
-		if ( isExpiringSoon( domain, 30 ) ) {
-			let message;
-			if ( domain.currentUserCanManage ) {
-				message = translate(
-					'{{strong}}Your domain will expire{{/strong}} in {{strong}}%(days)s{{/strong}}. Please renew it before it expires or it will stop working.',
-					{
-						components: {
-							strong: <strong />,
-						},
-						args: {
-							days: moment.utc( expiry ).fromNow( true ),
-						},
-					}
-				);
-			} else {
-				message = translate(
-					'{{strong}}The domain will expire{{/strong}} in {{strong}}%(days)s{{/strong}}. Please contact the domain owner %(owner)s to renew it.',
-					{
-						components: {
-							strong: <strong />,
-						},
-						args: {
-							days: moment.utc( expiry ).fromNow( true ),
-							owner: domain.owner,
-						},
-					}
-				);
-			}
-
-			return (
-				<div>
-					<p>{ message }</p>
-					{ domain.currentUserCanManage && (
-						<RenewButton
-							primary={ true }
-							purchase={ purchase }
-							selectedSite={ this.props.selectedSite }
-							subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
-							tracksProps={ { source: 'registered-domain-status', domain_status: 'expiring-soon' } }
-						/>
-					) }
-				</div>
-			);
-		}
-
-		return null;
 	}
 
 	renderExpired() {
@@ -447,7 +396,7 @@ class RegisteredDomainType extends React.Component {
 						purchase={ purchase }
 						domain={ domain }
 					/>
-					{ this.renderExpiringSoon() }
+					<ExpiringSoon selectedSite={ selectedSite } purchase={ purchase } domain={ domain } />
 					{ this.renderExpired() }
 					{ this.renderRecentlyRegistered() }
 				</DomainStatus>

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -9,7 +9,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import { Card, Button } from '@automattic/components';
+import { Card } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import VerticalNav from 'components/vertical-nav';
 import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
@@ -39,7 +39,7 @@ import RenewButton from 'my-sites/domains/domain-management/edit/card/renew-butt
 import AutoRenewToggle from 'me/purchases/manage-purchase/auto-renew-toggle';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import { isExpired, shouldRenderExpiringCreditCard, isRechargeable } from 'lib/purchases';
-import { getEditCardDetailsPath } from 'me/purchases/utils';
+import ExpiringCreditCard from '../card/notices/expiring-credit-card';
 
 class RegisteredDomainType extends React.Component {
 	getVerticalNavigation() {
@@ -355,38 +355,6 @@ class RegisteredDomainType extends React.Component {
 		);
 	}
 
-	renderExpiringCreditCard() {
-		const { selectedSite, purchase, translate } = this.props;
-
-		if ( ! selectedSite || ! purchase ) {
-			return null;
-		}
-
-		if ( ! shouldRenderExpiringCreditCard( purchase ) ) {
-			return null;
-		}
-
-		const editCardDetailsPath = getEditCardDetailsPath( selectedSite.slug, purchase );
-
-		return (
-			<div>
-				<p>
-					{ translate(
-						'Your credit card is {{strong}}set to expire before your domain renewal date{{/strong}}. Please update your payment information on your account to avoid any disruptions to your service. Turn off auto-renew if you don’t want to see this message anymore.',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					) }
-				</p>
-				<Button primary={ true } href={ editCardDetailsPath }>
-					{ translate( 'Update your payment information' ) }
-				</Button>
-			</div>
-		);
-	}
-
 	renderAutoRenewToggle() {
 		const { selectedSite, purchase } = this.props;
 
@@ -474,7 +442,11 @@ class RegisteredDomainType extends React.Component {
 							compact={ true }
 						/>
 					) }
-					{ this.renderExpiringCreditCard() }
+					<ExpiringCreditCard
+						selectedSite={ selectedSite }
+						purchase={ purchase }
+						domain={ domain }
+					/>
 					{ this.renderExpiringSoon() }
 					{ this.renderExpired() }
 					{ this.renderRecentlyRegistered() }

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -152,7 +152,7 @@ class RegisteredDomainType extends React.Component {
 	}
 
 	renderExpiringSoon() {
-		const { domain, translate, moment } = this.props;
+		const { domain, purchase, translate, moment } = this.props;
 		const { expiry } = domain;
 
 		if ( isExpiringSoon( domain, 30 ) ) {
@@ -190,6 +190,7 @@ class RegisteredDomainType extends React.Component {
 					{ domain.currentUserCanManage && (
 						<RenewButton
 							primary={ true }
+							purchase={ purchase }
 							selectedSite={ this.props.selectedSite }
 							subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
 							tracksProps={ { source: 'registered-domain-status', domain_status: 'expiring-soon' } }
@@ -203,7 +204,7 @@ class RegisteredDomainType extends React.Component {
 	}
 
 	renderExpired() {
-		const { domain, translate, moment } = this.props;
+		const { domain, purchase, translate, moment } = this.props;
 		const domainsLink = link => <a href={ link } target="_blank" rel="noopener noreferrer" />;
 
 		if ( ! domain.expired ) {
@@ -278,6 +279,7 @@ class RegisteredDomainType extends React.Component {
 				{ domain.currentUserCanManage && ( domain.isRenewable || domain.isRedeemable ) && (
 					<RenewButton
 						primary={ true }
+						purchase={ purchase }
 						selectedSite={ this.props.selectedSite }
 						subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
 						redemptionProduct={ domain.isRedeemable ? this.props.redemptionProduct : null }
@@ -321,7 +323,7 @@ class RegisteredDomainType extends React.Component {
 	}
 
 	renderDefaultRenewButton() {
-		const { domain } = this.props;
+		const { domain, purchase } = this.props;
 
 		if ( ! domain.currentUserCanManage ) {
 			return null;
@@ -335,6 +337,7 @@ class RegisteredDomainType extends React.Component {
 			<div>
 				<RenewButton
 					compact={ true }
+					purchase={ purchase }
 					selectedSite={ this.props.selectedSite }
 					subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
 					tracksProps={ { source: 'registered-domain-status', domain_status: 'active' } }
@@ -362,14 +365,10 @@ class RegisteredDomainType extends React.Component {
 	}
 
 	renderAutoRenew() {
-		const { selectedSite, purchase } = this.props;
+		const { purchase } = this.props;
 
 		if ( ! purchase ) {
-			return (
-				<div>
-					<QuerySitePurchases siteId={ selectedSite.ID } />
-				</div>
-			);
+			return <div />;
 		}
 
 		return <div>{ this.renderAutoRenewToggle() }</div>;
@@ -408,7 +407,7 @@ class RegisteredDomainType extends React.Component {
 	};
 
 	render() {
-		const { domain, moment } = this.props;
+		const { domain, selectedSite, purchase, moment } = this.props;
 		const { name: domain_name } = domain;
 
 		const { statusText, statusClass, icon } = this.resolveStatus();
@@ -417,6 +416,7 @@ class RegisteredDomainType extends React.Component {
 
 		return (
 			<div className="domain-types__container">
+				{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 				{ this.planUpsellForNonPrimaryDomain() }
 				{ this.domainWarnings() }
 				<DomainStatus

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -33,7 +33,11 @@ import {
 import SubscriptionSettings from '../card/subscription-settings';
 import { recordPaymentSettingsClick } from '../payment-settings-analytics';
 import { getProductBySlug } from 'state/products-list/selectors';
-import { getByPurchaseId } from 'state/purchases/selectors';
+import {
+	getByPurchaseId,
+	isFetchingSitePurchases,
+	hasLoadedSitePurchasesFromServer,
+} from 'state/purchases/selectors';
 import NonPrimaryDomainPlanUpsell from '../../components/domain/non-primary-domain-plan-upsell';
 import RenewButton from 'my-sites/domains/domain-management/edit/card/renew-button';
 import AutoRenewToggle from 'me/purchases/manage-purchase/auto-renew-toggle';
@@ -307,6 +311,10 @@ class RegisteredDomainType extends React.Component {
 	renderAutoRenewToggle() {
 		const { selectedSite, purchase } = this.props;
 
+		if ( ! purchase ) {
+			return null;
+		}
+
 		if ( ! isRechargeable( purchase ) || isExpired( purchase ) ) {
 			return null;
 		}
@@ -323,10 +331,14 @@ class RegisteredDomainType extends React.Component {
 	}
 
 	renderAutoRenew() {
-		const { purchase } = this.props;
+		const { isLoadingPurchase } = this.props;
 
-		if ( ! purchase ) {
-			return <div />;
+		if ( isLoadingPurchase ) {
+			return (
+				<div className="domain-types__auto-renew-placeholder">
+					<p />
+				</div>
+			);
 		}
 
 		return <div>{ this.renderAutoRenewToggle() }</div>;
@@ -441,6 +453,8 @@ export default connect(
 
 		return {
 			purchase: subscriptionId ? getByPurchaseId( state, parseInt( subscriptionId, 10 ) ) : null,
+			isLoadingPurchase:
+				isFetchingSitePurchases( state ) && ! hasLoadedSitePurchasesFromServer( state ),
 			redemptionProduct: getProductBySlug( state, 'domain_redemption' ),
 		};
 	},

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -146,4 +146,12 @@
 	.subscription-settings {
 		margin-top: 0;
 	}
+
+	.domain-types__auto-renew-placeholder {
+		width: 20%;
+		p {
+			@include placeholder( --color-neutral-5 );
+			margin: 0 auto;
+		}
+	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -55,7 +55,7 @@
 		"domains/kracken-ui/max-characters-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
-		"domains/new-status-design/auto-renew": false,
+		"domains/new-status-design/auto-renew": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -39,6 +39,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/new-status-design/auto-renew": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display the auto-renew toggle on the registered domain screen
* Display "expiring credit card" message for cases where the credit card expires/expired before renewal time

Here's how it looks with credit card that is expiring before the domain renewal:

<img width="742" alt="Screenshot 2020-03-18 at 0 09 40" src="https://user-images.githubusercontent.com/1355045/76906738-4e450b00-68ad-11ea-9e43-c922163dfe3e.png">

![Screenshot 2020-03-18 at 0 10 29](https://user-images.githubusercontent.com/1355045/76906803-69b01600-68ad-11ea-9ec7-65794af7b2f9.png)

<img width="553" alt="Screenshot 2020-03-18 at 0 10 35" src="https://user-images.githubusercontent.com/1355045/76906765-59983680-68ad-11ea-8584-dcb3ee7b2783.png">

<img width="755" alt="Screenshot 2020-03-18 at 0 10 43" src="https://user-images.githubusercontent.com/1355045/76906782-6157db00-68ad-11ea-8347-ab4ca3c5499d.png">

#### Testing instructions

* Open a registered/mapped domain paid with a credit card and verify that you can enable/disable the auto-renew toggle
* Verify that the expiring credit card notification is shown
* Verify that the message is correct in the expiring soon notification for mapped domains/registered domains
* Verify that domain purchased with credits looks okay - there should be no auto-renew toggle

Also fixes #40067