### PR TITLE
Site Activity: adds contextual popover menu item to add site credentials

### DIFF
--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -236,11 +236,14 @@ class ActivityLogItem extends Component {
 
 	renderRewindAction() {
 		const {
+			activity,
+			canAutoconfigure,
 			createBackup,
 			createRewind,
 			disableRestore,
 			disableBackup,
-			activity,
+			siteId,
+			siteSlug,
 			translate,
 		} = this.props;
 
@@ -254,6 +257,19 @@ class ActivityLogItem extends Component {
 					<PopoverMenuItem disabled={ disableRestore } icon="history" onClick={ createRewind }>
 						{ translate( 'Restore to this point' ) }
 					</PopoverMenuItem>
+
+					{ disableRestore && (
+						<PopoverMenuItem
+							icon="plus"
+							href={
+								canAutoconfigure
+									? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
+									: `/settings/security/${ siteSlug }`
+							}
+						>
+							{ translate( 'Add server credentials in order to restore your site' ) }
+						</PopoverMenuItem>
+					) }
 
 					<PopoverMenuSeparator />
 

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -244,6 +244,7 @@ class ActivityLogItem extends Component {
 			disableBackup,
 			siteId,
 			siteSlug,
+			trackAddCreds,
 			translate,
 		} = this.props;
 
@@ -266,6 +267,7 @@ class ActivityLogItem extends Component {
 									? `/start/rewind-auto-config/?blogid=${ siteId }&siteSlug=${ siteSlug }`
 									: `/settings/security/${ siteSlug }`
 							}
+							onClick={ trackAddCreds }
 						>
 							{ translate( 'Add server credentials to enable restoring' ) }
 						</PopoverMenuItem>
@@ -487,6 +489,7 @@ const mapDispatchToProps = ( dispatch, { activity: { activityId }, siteId } ) =>
 		dispatch(
 			recordTracksEvent( 'calypso_activitylog_event_get_help', { activity_name: activityName } )
 		),
+	trackAddCreds: () => dispatch( recordTracksEvent( 'calypso_activitylog_event_add_credentials' ) ),
 	trackFixCreds: () => dispatch( recordTracksEvent( 'calypso_activitylog_event_fix_credentials' ) ),
 } );
 

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -267,7 +267,7 @@ class ActivityLogItem extends Component {
 									: `/settings/security/${ siteSlug }`
 							}
 						>
-							{ translate( 'Add server credentials in order to restore your site' ) }
+							{ translate( 'Add server credentials to enable restoring' ) }
 						</PopoverMenuItem>
 					) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds contextual popover menu item to add site credentials in backup events on the site activity.
* Adds new `calypso_activitylog_event_add_credentials` tracks event for this new item.

We’re currently disabling the “Restore to this point” option on the site activity without explaining why, and I’d assume people would not co-relate the banner at the top telling them to add server credentials and the fact that restores are not available.

#### Before

![image](https://user-images.githubusercontent.com/390760/76307820-720ebc80-62c1-11ea-8c04-aadeb8fbb57a.png)

#### After, normal state

![image](https://user-images.githubusercontent.com/390760/76307918-a5514b80-62c1-11ea-88a3-f930e2669c84.png)

#### After, selected state

![image](https://user-images.githubusercontent.com/390760/76307949-b39f6780-62c1-11ea-949a-41fe7204c15f.png)

#### After adding server credentials, the restore option is enabled and this one goes away

![image](https://user-images.githubusercontent.com/390760/76307983-c87bfb00-62c1-11ea-8cd0-6652c93c9961.png)


#### Testing instructions

* Fire up this PR locally or using jurassic.ninja.
* Connect Jetpack.
* Go to your site activity in Calypso; e.g.: `http://calypso.localhost:3000/activity-log/SITE_URL`.
* Ensure you see the new option and that it sends you to the correct place to set up site credentials.
* Validate that the option isn't visible once you've added working credentials.

