### PR TITLE
Add jetpack backup to be remote purchased

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -40,6 +40,13 @@ import {
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 } from 'lib/plans/constants';
 
+import {
+	PRODUCT_JETPACK_BACKUP_DAILY,
+	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+	PRODUCT_JETPACK_BACKUP_REALTIME,
+	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+} from 'lib/products-values/constants';
+
 /**
  * Module variables
  */
@@ -59,11 +66,15 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 			personal: PLAN_JETPACK_PERSONAL,
 			premium: PLAN_JETPACK_PREMIUM,
 			pro: PLAN_JETPACK_BUSINESS,
+			realtimebackup: PRODUCT_JETPACK_BACKUP_REALTIME,
+			backup: PRODUCT_JETPACK_BACKUP_DAILY,
 		},
 		monthly: {
 			personal: PLAN_JETPACK_PERSONAL_MONTHLY,
 			premium: PLAN_JETPACK_PREMIUM_MONTHLY,
 			pro: PLAN_JETPACK_BUSINESS_MONTHLY,
+			realtimebackup: PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+			backup: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 		},
 	};
 

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -25,7 +25,7 @@ export default function() {
 	const locale = getLanguageRouteParam( 'locale' );
 
 	page(
-		'/jetpack/connect/:type(personal|premium|pro)/:interval(yearly|monthly)?',
+		'/jetpack/connect/:type(personal|premium|pro|backup|realtimebackup)/:interval(yearly|monthly)?',
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,
 		controller.connect,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add jetpack backup so that it can be purchased thought the remote install. 

#### Testing instructions

* Visit calypso.localhost:3000/jetpack/connect/backup
Enter a domain that doesn't have jetpack yet. 

Notice that the flow installs/activates jetpack and sends you to the purchase flow for backup yearly

Also test
* Visit calypso.localhost:3000/jetpack/connect/realtimebackup
* Visit calypso.localhost:3000/jetpack/connect/realtimebackup/monthly
* Visit calypso.localhost:3000/jetpack/connect/backup/monthly


