### PR TITLE
FSE: add filter for enabling Dotcom editor nux

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -229,6 +229,17 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_blog_posts_block' );
  * Load WPCOM Block Editor NUX
  */
 function load_wpcom_block_editor_nux() {
+	/**
+	 * Can be used to enable Dotcom editor guide.
+	 *
+	 * @since 0.23
+	 *
+	 * @param bool true if Dotcom editor nux should be enabled, false otherwise.
+	 */
+	if ( ! apply_filters( 'a8c_enable_dotcom_editor_nux', false ) ) {
+		return;
+	}
+
 	require_once __DIR__ . '/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php';
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_block_editor_nux' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Running the Dotcom custom welcome guide caused the editor to crash on sites that don't have Gutenberg plugin enabled. Let's keep it off by default and only enable it in environments where we know that the required Gutenberg plugin version is running - these activation filters will be added in separate repos and PRs afterwards.

paYE8P-lx-p2

#### Testing instructions

1. Run this PR in your local wp-env environment.
2. Make sure that the editor nux code is no longer being required by default.
3. Deactivate Gutenberg plugin on your test site.
4. Load the editor and verify that it's no longer crashing.