### PR TITLE
UpsellNudge: Remove A/B test and update instances in favor of the variant

### DIFF
--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -2,13 +2,11 @@
  * External dependencies
  */
 import React from 'react';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
 import UpsellNudge from 'blocks/upsell-nudge';
-import { abtest } from 'lib/abtest';
 import { preventWidows } from 'lib/formatting';
 
 /**
@@ -17,57 +15,37 @@ import { preventWidows } from 'lib/formatting';
 import './sidebar-banner.scss';
 
 export default function SidebarBannerTemplate( {
-	icon,
 	CTA,
 	message,
 	id,
 	dismissPreferenceName,
-	onClick,
 	onDismissClick,
-	trackImpression,
 	tracks,
 	tracksDismissName,
 	tracksDismissProperties,
 } ) {
-	if ( abtest( 'sidebarUpsellNudgeUnification' ) === 'variantShowUnifiedUpsells' ) {
-		const clickName = tracks?.click?.name ?? `jitm_nudge_click_${ id }`;
-		const clickProps = tracks?.click?.props;
-		const displayName = tracks?.display?.name ?? `jitm_nudge_impression_${ id }`;
-		const displayProps = tracks?.display?.props;
-		const jitmProps = { id: id, jitm: true };
-
-		return (
-			<UpsellNudge
-				callToAction={ CTA.message }
-				compact
-				event={ displayName }
-				forceHref={ true }
-				dismissPreferenceName={ dismissPreferenceName }
-				href={ CTA.link }
-				onDismissClick={ onDismissClick }
-				title={ preventWidows( message ) }
-				tracksClickName={ clickName }
-				tracksClickProperties={ { ...jitmProps, ...clickProps } }
-				tracksImpressionName={ displayName }
-				tracksImpressionProperties={ { ...jitmProps, ...displayProps } }
-				tracksDismissName={ tracksDismissName }
-				tracksDismissProperties={ { ...jitmProps, ...tracksDismissProperties } }
-			/>
-		);
-	}
+	const clickName = tracks?.click?.name ?? `jitm_nudge_click_${ id }`;
+	const clickProps = tracks?.click?.props;
+	const displayName = tracks?.display?.name ?? `jitm_nudge_impression_${ id }`;
+	const displayProps = tracks?.display?.props;
+	const jitmProps = { id: id, jitm: true };
 
 	return (
-		<div className="sidebar-banner">
-			{ trackImpression && trackImpression() }
-			<a className="sidebar-banner__link" onClick={ onClick } href={ CTA.link }>
-				<span className="sidebar-banner__icon-wrapper">
-					<Gridicon className="sidebar-banner__icon" icon={ icon || 'info-outline' } size={ 18 } />
-				</span>
-				<span className="sidebar-banner__content">
-					<span className="sidebar-banner__text">{ preventWidows( message ) }</span>
-				</span>
-				<span className="sidebar-banner__cta">{ CTA.message }</span>
-			</a>
-		</div>
+		<UpsellNudge
+			callToAction={ CTA.message }
+			compact
+			event={ displayName }
+			forceHref={ true }
+			dismissPreferenceName={ dismissPreferenceName }
+			href={ CTA.link }
+			onDismissClick={ onDismissClick }
+			title={ preventWidows( message ) }
+			tracksClickName={ clickName }
+			tracksClickProperties={ { ...jitmProps, ...clickProps } }
+			tracksImpressionName={ displayName }
+			tracksImpressionProperties={ { ...jitmProps, ...displayProps } }
+			tracksDismissName={ tracksDismissName }
+			tracksDismissProperties={ { ...jitmProps, ...tracksDismissProperties } }
+		/>
 	);
 }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,15 +106,6 @@ export default {
 		defaultVariation: 'variantShowUpdates',
 		allowExistingUsers: true,
 	},
-	sidebarUpsellNudgeUnification: {
-		datestamp: '20200221',
-		variations: {
-			variantShowUnifiedUpsells: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	domainStepDesignUpdates: {
 		datestamp: '20201220',
 		variations: {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -13,7 +13,6 @@ import { get, reject, transform } from 'lodash';
 /**
  * Internal dependencies
  */
-import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import getActiveDiscount from 'state/selectors/get-active-discount';
@@ -25,7 +24,6 @@ import isEligibleForFreeToPaidUpsell from 'state/selectors/is-eligible-for-free-
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QueryActivePromotions from 'components/data/query-active-promotions';
-import TrackComponentView from 'lib/analytics/track-component-view';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import { getProductsList } from 'state/products-list/selectors';
 import QueryProductsList from 'components/data/query-products-list';
@@ -39,7 +37,6 @@ import { getSectionName } from 'state/ui/selectors';
 import { getTopJITM } from 'state/jitm/selectors';
 import AsyncLoad from 'components/async-load';
 import UpsellNudge from 'blocks/upsell-nudge';
-import { abtest } from 'lib/abtest';
 import { preventWidows } from 'lib/formatting';
 
 const DOMAIN_UPSELL_NUDGE_DISMISS_KEY = 'domain_upsell_nudge_dismiss';
@@ -89,33 +86,19 @@ export class SiteNotice extends React.Component {
 		const noticeText = preventWidows( translate( 'Free domain available' ) );
 		const ctaText = translate( 'Claim' );
 
-		if ( abtest( 'sidebarUpsellNudgeUnification' ) === 'variantShowUnifiedUpsells' ) {
-			return (
-				<UpsellNudge
-					callToAction={ ctaText }
-					compact
-					event={ eventName }
-					forceHref={ true }
-					href={ `/domains/add/${ this.props.site.slug }` }
-					title={ noticeText }
-					tracksClickName="calypso_domain_credit_reminder_click"
-					tracksClickProperties={ eventProperties }
-					tracksImpressionName={ eventName }
-					tracksImpressionProperties={ eventProperties }
-				/>
-			);
-		}
-
 		return (
-			<Notice isCompact status="is-success" icon="info-outline" text={ noticeText }>
-				<NoticeAction
-					onClick={ this.props.clickClaimDomainNotice }
-					href={ `/domains/add/${ this.props.site.slug }` }
-				>
-					{ ctaText }
-					<TrackComponentView eventName={ eventName } eventProperties={ eventProperties } />
-				</NoticeAction>
-			</Notice>
+			<UpsellNudge
+				callToAction={ ctaText }
+				compact
+				event={ eventName }
+				forceHref={ true }
+				href={ `/domains/add/${ this.props.site.slug }` }
+				title={ noticeText }
+				tracksClickName="calypso_domain_credit_reminder_click"
+				tracksClickProperties={ eventProperties }
+				tracksImpressionName={ eventName }
+				tracksImpressionProperties={ eventProperties }
+			/>
 		);
 	}
 
@@ -189,45 +172,22 @@ export class SiteNotice extends React.Component {
 			} );
 		}
 
-		if ( abtest( 'sidebarUpsellNudgeUnification' ) === 'variantShowUnifiedUpsells' ) {
-			return (
-				<UpsellNudge
-					callToAction={ translate( 'Add' ) }
-					compact
-					href={ `/domains/add/${ site.slug }` }
-					onDismissClick={ this.props.clickDomainUpsellDismiss }
-					dismissPreferenceName="calypso_upgrade_nudge_cta_click"
-					event="calypso_upgrade_nudge_impression"
-					title={ preventWidows( noticeText ) }
-					tracksClickName="calypso_upgrade_nudge_cta_click"
-					tracksClickProperties={ { cta_name: 'domain-upsell-nudge' } }
-					tracksImpressionName="calypso_upgrade_nudge_impression"
-					tracksImpressionProperties={ { cta_name: 'domain-upsell-nudge' } }
-					tracksDismissName="calypso_upgrade_nudge_cta_click"
-					tracksDismissProperties={ { cta_name: 'domain-upsell-nudge-dismiss' } }
-				/>
-			);
-		}
-
 		return (
-			<Notice
-				isCompact
-				status="is-success"
-				icon="info-outline"
+			<UpsellNudge
+				callToAction={ translate( 'Add' ) }
+				compact
+				href={ `/domains/add/${ site.slug }` }
 				onDismissClick={ this.props.clickDomainUpsellDismiss }
-				showDismiss={ true }
-			>
-				<NoticeAction
-					onClick={ this.props.clickDomainUpsellGo }
-					href={ `/domains/add/${ site.slug }` }
-				>
-					{ noticeText }
-					<TrackComponentView
-						eventName="calypso_upgrade_nudge_impression"
-						eventProperties={ { cta_name: 'domain-upsell-nudge' } }
-					/>
-				</NoticeAction>
-			</Notice>
+				dismissPreferenceName="calypso_upgrade_nudge_cta_click"
+				event="calypso_upgrade_nudge_impression"
+				title={ preventWidows( noticeText ) }
+				tracksClickName="calypso_upgrade_nudge_cta_click"
+				tracksClickProperties={ { cta_name: 'domain-upsell-nudge' } }
+				tracksImpressionName="calypso_upgrade_nudge_impression"
+				tracksImpressionProperties={ { cta_name: 'domain-upsell-nudge' } }
+				tracksDismissName="calypso_upgrade_nudge_cta_click"
+				tracksDismissProperties={ { cta_name: 'domain-upsell-nudge-dismiss' } }
+			/>
 		);
 	}
 
@@ -248,29 +208,17 @@ export class SiteNotice extends React.Component {
 			return null;
 		}
 
-		if ( abtest( 'sidebarUpsellNudgeUnification' ) === 'variantShowUnifiedUpsells' ) {
-			const eventProperties = { cta_name: 'active-discount-sidebar' };
-			return (
-				<UpsellNudge
-					event="calypso_upgrade_nudge_impression"
-					tracksClickName="calypso_upgrade_nudge_cta_click"
-					tracksClickProperties={ eventProperties }
-					tracksImpressionName="calypso_upgrade_nudge_impression"
-					tracksImpressionProperties={ eventProperties }
-					callToAction={ ctaText || 'Upgrade' }
-					href={ `/plans/${ site.slug }?discount=${ name }` }
-					title={ bannerText }
-				/>
-			);
-		}
-
+		const eventProperties = { cta_name: 'active-discount-sidebar' };
 		return (
-			<SidebarBanner
-				ctaName="active-discount-sidebar"
-				ctaText={ ctaText || 'Upgrade' }
+			<UpsellNudge
+				event="calypso_upgrade_nudge_impression"
+				tracksClickName="calypso_upgrade_nudge_cta_click"
+				tracksClickProperties={ eventProperties }
+				tracksImpressionName="calypso_upgrade_nudge_impression"
+				tracksImpressionProperties={ eventProperties }
+				callToAction={ ctaText || 'Upgrade' }
 				href={ `/plans/${ site.slug }?discount=${ name }` }
-				icon="info-outline"
-				text={ bannerText }
+				title={ bannerText }
 			/>
 		);
 	}
@@ -350,14 +298,6 @@ export default connect(
 				),
 			clickDomainUpsellDismiss: () => {
 				dispatch( savePreference( DOMAIN_UPSELL_NUDGE_DISMISS_KEY, new Date().toISOString() ) );
-
-				if ( abtest( 'sidebarUpsellNudgeUnification' ) !== 'variantShowUnifiedUpsells' ) {
-					dispatch(
-						recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
-							cta_name: 'domain-upsell-nudge-dismiss',
-						} )
-					);
-				}
 			},
 		};
 	}

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -10,7 +10,6 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import QuerySitePlans from 'components/data/query-site-plans';
-import SidebarBanner from 'my-sites/current-site/sidebar-banner';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import isEligibleForFreeToPaidUpsell from 'state/selectors/is-eligible-for-free-to-paid-upsell';
@@ -20,35 +19,21 @@ import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
 import { clickUpgradeNudge } from 'state/marketing/actions';
 import UpsellNudge from 'blocks/upsell-nudge';
-import { abtest } from 'lib/abtest';
 
 const debug = debugFactory( 'calypso:reader:sidebar-nudges' );
 
 function renderFreeToPaidPlanNudge( { siteId, siteSlug, translate }, dispatch ) {
-	if ( abtest( 'sidebarUpsellNudgeUnification' ) === 'variantShowUnifiedUpsells' ) {
-		return (
-			<UpsellNudge
-				event={ 'free-to-paid-sidebar-reader' }
-				forceHref={ true }
-				callToAction={ translate( 'Upgrade' ) }
-				compact
-				href={ '/plans/' + siteSlug }
-				title={ translate( 'Free domain with a plan' ) }
-				onClick={ () => dispatch( clickUpgradeNudge( siteId ) ) }
-				tracksClickName={ 'calypso_upgrade_nudge_cta_click' }
-				tracksImpressionName={ 'calypso_upgrade_nudge_impression' }
-			/>
-		);
-	}
-
 	return (
-		<SidebarBanner
-			ctaName={ 'free-to-paid-sidebar-reader' }
-			ctaText={ translate( 'Upgrade' ) }
+		<UpsellNudge
+			event={ 'free-to-paid-sidebar-reader' }
+			forceHref={ true }
+			callToAction={ translate( 'Upgrade' ) }
+			compact
 			href={ '/plans/' + siteSlug }
-			icon="info-outline"
-			text={ translate( 'Free domain with a plan' ) }
+			title={ translate( 'Free domain with a plan' ) }
 			onClick={ () => dispatch( clickUpgradeNudge( siteId ) ) }
+			tracksClickName={ 'calypso_upgrade_nudge_cta_click' }
+			tracksImpressionName={ 'calypso_upgrade_nudge_impression' }
 		/>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove UpsellNudge A/B test introduced in #38881
* Update sidebar nudges in favor of the variant to display to 100% of users, as per results in p8Eqe3-12G-p2

<img width="330" alt="Screen Shot 2020-03-10 at 1 28 36 PM" src="https://user-images.githubusercontent.com/2124984/76341255-282ed200-62d3-11ea-8803-ddfa6eecc042.png">

#### Testing instructions

* Switch to this PR
* Check all UpsellNudge instances in the sidebar (use list/screenshots in #38881 for reference)
* Double-check all Tracks events (impression, click, dismiss) are firing as expected (use event names in #38881 for reference)