### PR TITLE
Adds Scan submenu items

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/heading.tsx
+++ b/client/landing/jetpack-cloud/components/sidebar/heading.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import MaterialIcon from 'components/material-icon';
+
+interface Props {
+	title: string;
+	materialIcon?: string;
+	materialIconStyle?: string;
+	tag?: string;
+	onClick?: CallableFunction;
+	link?: string;
+}
+
+function StaticSidebarHeading( props: Props ): ReactElement {
+	const { materialIcon, materialIconStyle, title, link } = props;
+
+	const InnerTag = link ? 'a' : 'span';
+
+	return (
+		<li>
+			<InnerTag href={ link } className="sidebar__menu-link">
+				{ materialIcon && (
+					<MaterialIcon
+						className="sidebar__menu-icon"
+						icon={ materialIcon }
+						style={ materialIconStyle }
+					/>
+				) }
+				{ title }
+			</InnerTag>
+		</li>
+	);
+}
+
+export default StaticSidebarHeading;

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -23,11 +23,14 @@ import StaticSidebarMenu from './menu';
  * Style dependencies
  */
 import './style.scss';
+import Badge from 'components/badge';
 
 class JetpackCloudSidebar extends Component {
 	static propTypes = {
 		path: PropTypes.string.isRequired,
 		selectedSiteSlug: PropTypes.string,
+		badgeText: PropTypes.string,
+		badgeType: PropTypes.oneOf( [ 'success', 'error' ] ),
 	};
 
 	/**
@@ -46,7 +49,12 @@ class JetpackCloudSidebar extends Component {
 	};
 
 	scanMenu = () => {
-		const { selectedSiteSlug, translate } = this.props;
+		const {
+			selectedSiteSlug,
+			translate,
+			badgeText, // TODO: Get from state.
+			badgeType,
+		} = this.props;
 
 		const isHistory = this.isSelected( `/scan/${ selectedSiteSlug }/history` );
 		return (
@@ -58,8 +66,9 @@ class JetpackCloudSidebar extends Component {
 					} ) }
 					onNavigate={ this.onNavigate }
 					selected={ ! isHistory }
-					showAsExternal
-				/>
+				>
+					{ badgeText && <Badge type={ badgeType }>{ badgeText }</Badge> }
+				</SidebarItem>
 				{ config.isEnabled( 'jetpack-cloud/scan-history' ) && selectedSiteSlug && (
 					<SidebarItem
 						link={ `/scan/${ selectedSiteSlug }/history` }

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -17,6 +17,7 @@ import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
+import StaticSidebarMenu from './menu';
 
 /**
  * Style dependencies
@@ -42,6 +43,35 @@ class JetpackCloudSidebar extends Component {
 
 	onNavigate = () => {
 		window.scrollTo( 0, 0 );
+	};
+
+	scanMenu = () => {
+		const { selectedSiteSlug, translate } = this.props;
+
+		const isHistory = this.isSelected( `/scan/${ selectedSiteSlug }/history` );
+		return (
+			<ul>
+				<SidebarItem
+					link={ selectedSiteSlug ? `/scan/${ selectedSiteSlug }` : '/scan' }
+					label={ translate( 'Scanner', {
+						comment: 'Jetpack Cloud / Scan sidebar navigation item',
+					} ) }
+					onNavigate={ this.onNavigate }
+					selected={ ! isHistory }
+					showAsExternal
+				/>
+				{ config.isEnabled( 'jetpack-cloud/scan-history' ) && selectedSiteSlug && (
+					<SidebarItem
+						link={ `/scan/${ selectedSiteSlug }/history` }
+						label={ translate( 'History', {
+							comment: 'Jetpack Cloud / Scan sidebar navigation item',
+						} ) }
+						onNavigate={ this.onNavigate }
+						selected={ isHistory }
+					/>
+				) }
+			</ul>
+		);
 	};
 
 	render() {
@@ -75,7 +105,7 @@ class JetpackCloudSidebar extends Component {
 						/>
 					) }
 					{ config.isEnabled( 'jetpack-cloud/scan' ) && (
-						<SidebarItem
+						<StaticSidebarMenu
 							label={ translate( 'Scan', {
 								comment: 'Jetpack Cloud / Scan sidebar navigation item',
 							} ) }
@@ -83,8 +113,10 @@ class JetpackCloudSidebar extends Component {
 							onNavigate={ this.onNavigate }
 							materialIcon="security" // @todo: The Scan logo differs from the Material Icon used here
 							materialIconStyle="filled"
-							selected={ this.isSelected( '/scan' ) }
-						/>
+							expanded={ this.isSelected( '/scan' ) }
+						>
+							{ this.scanMenu() }
+						</StaticSidebarMenu>
 					) }
 					{ config.isEnabled( 'jetpack-cloud/settings' ) && (
 						<SidebarItem

--- a/client/landing/jetpack-cloud/components/sidebar/menu.tsx
+++ b/client/landing/jetpack-cloud/components/sidebar/menu.tsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React, { ReactElement, ReactChildren } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SidebarMenu from 'layout/sidebar/menu';
+import StaticSidebarHeading from './heading';
+
+interface Props {
+	label: string;
+	className?: string;
+	materialIcon?: string;
+	materialIconStyle?: string;
+	onClick?: CallableFunction;
+	children: ReactChildren;
+	expanded: boolean;
+	link?: string;
+}
+
+function StaticSidebarMenu( props: Props ): ReactElement {
+	return (
+		<SidebarMenu className={ props.className }>
+			<StaticSidebarHeading
+				title={ props.label }
+				materialIcon={ props.materialIcon }
+				materialIconStyle={ props.materialIconStyle }
+				onClick={ props.onClick }
+				link={ props.link }
+			/>
+			<div role="region" className="sidebar__menu-content" hidden={ ! props.expanded }>
+				{ props.children }
+			</div>
+		</SidebarMenu>
+	);
+}
+
+export default StaticSidebarMenu;

--- a/client/landing/jetpack-cloud/components/sidebar/style.scss
+++ b/client/landing/jetpack-cloud/components/sidebar/style.scss
@@ -34,6 +34,13 @@
 		}
 	}
 
+	// Static menu items.
+	.sidebar__menu-content {
+		.sidebar__menu-link-text {
+			margin-left: 35px; // 24px for SVG, 11px margin.
+		}
+	}
+
 	// Footer
 	.sidebar__footer {
 		margin-top: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Creates submenu items for Scan nav.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load Jetpack Cloud.
* Click Scan.
* Note sidebar change.
* Select a site.
* Note History available and selectable.

Screenshot:
<img width="272" alt="Screen Shot 2020-03-10 at 4 11 11 PM" src="https://user-images.githubusercontent.com/1760168/76354961-cb8ae180-62e9-11ea-90b1-120807ff30b1.png">

Fixes 1151678672052943-as-1165787355206375.