### PR TITLE
composite-checkout: Redirect to plans page if bundled plan is removed

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -1402,7 +1402,7 @@ function useCachedDomainContactDetails( dispatch ) {
 			reduxDispatch( requestContactDetailsCache() );
 			setHaveRequestedCachedDetails( true );
 		}
-	}, [ haveRequestedCachedDetails ] );
+	}, [ haveRequestedCachedDetails, reduxDispatch ] );
 
 	const cachedContactDetails = useSelector( getContactDetailsCache );
 	if ( cachedContactDetails ) {

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -551,7 +551,7 @@ function useInitializeCartFromServer(
 					if ( couponToAdd ) {
 						updatedResponseCart = addCouponToResponseCart( updatedResponseCart, couponToAdd );
 					}
-					return setServerCart( prepareRequestCart( updatedResponseCart ) );
+					return setServerCart( prepareRequestCart( updatedResponseCart, {} ) );
 				}
 				return response;
 			} )
@@ -599,7 +599,7 @@ function useCartUpdateAndRevalidate(
 
 		hookDispatch( { type: 'REQUEST_UPDATED_RESPONSE_CART' } );
 
-		setServerCart( prepareRequestCart( responseCart ) )
+		setServerCart( prepareRequestCart( responseCart, { is_update: true } ) )
 			.then( response => {
 				debug( 'updated cart is', response );
 				hookDispatch( {

--- a/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/types/backend/shopping-cart-endpoint.ts
@@ -125,6 +125,10 @@ export interface ResponseCartProduct {
 	included_domain_purchase_amount: number;
 }
 
+interface RequestCartOptions {
+	is_update?: boolean;
+}
+
 export const prepareRequestCartProduct: ( ResponseCartProduct ) => RequestCartProduct = ( {
 	product_slug,
 	meta,
@@ -139,14 +143,10 @@ export const prepareRequestCartProduct: ( ResponseCartProduct ) => RequestCartPr
 	} as RequestCartProduct;
 };
 
-export const prepareRequestCart: ( ResponseCart ) => RequestCart = ( {
-	products,
-	currency,
-	locale,
-	coupon,
-	is_coupon_applied,
-	tax,
-}: ResponseCart ) => {
+export const prepareRequestCart: ( ResponseCart, RequestCartOptions ) => RequestCart = (
+	{ products, currency, locale, coupon, is_coupon_applied, tax }: ResponseCart,
+	{ is_update = false }: RequestCartOptions
+) => {
 	return {
 		products: products.map( prepareRequestCartProduct ),
 		currency,
@@ -155,6 +155,7 @@ export const prepareRequestCart: ( ResponseCart ) => RequestCart = ( {
 		is_coupon_applied,
 		temporary: false,
 		tax,
+		is_update,
 		extra: '', // TODO: fix this
 	} as RequestCart;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes it so that composite checkout will empty the cart and redirect to the plans page if a plan that is bundled with a domain is removed from the cart. This is because when that happens the shopping cart backend will automatically add a premium plan to the cart, which is a terrible UX.

Fixes #38979

#### Testing instructions

- Apply D40211-code and sandbox the store.
- Add a plan and a domain to your cart.
- Visit composite checkout.
- In the review step, click to remove _just_ the plan. 
- Verify that you are redirected to the plans page and that your cart is empty (you will not see the red "2" icon on the "cart" button in the upper right of the plans page).
- Add a plan and a domain to your cart again.
- Visit composite checkout.
- In the review step, click to remove _just_ the domain.
- Verify that that's the only thing to be removed and that you are not redirected.