### PR TITLE
Gutenberg: Add tracking for error notices

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -145,6 +145,21 @@ const trackGlobalStyles = eventName => options => {
 };
 
 /**
+ * Logs any error notice which is shown to the user so we can determine how often
+ * folks see different errors and what types of sites they occur on.
+ *
+ * @param {string} content The error message. Like "Update failed."
+ * @param {object} options Optional. Extra data logged with the error in Gutenberg.
+ */
+const trackErrorNotices = ( content, options ) => {
+	const logInfo = {
+		errorText: content,
+		errorOptions: options,
+	};
+	tracksRecordEvent( 'wpcom_gutenberg_error_notice', logInfo );
+};
+
+/**
  * Tracker can be
  * - string - which means it is an event name and should be tracked as such automatically
  * - function - in case you need to load additional properties from the action.
@@ -173,6 +188,9 @@ const REDUX_TRACKING = {
 		replaceBlock: trackBlockReplacement,
 		replaceBlocks: trackBlockReplacement,
 		replaceInnerBlocks: trackInnerBlocksReplacement,
+	},
+	'core/notices': {
+		createErrorNotice: trackErrorNotices,
 	},
 };
 


### PR DESCRIPTION
This allows us to see how often users see errors on their site.

This is part of the work to figure out what is causing p9F6qB-4PJ-p2. (i.e. track it to see if we can detect any common threads.)

See deployment diff at D40149-code.

#### Changes proposed in this Pull Request
* Add handler for `createErrorNotice` in the core/notices store.

#### Testing instructions
0. First, apply D40149-code to your sandbox. Also sandbox a test site and `widgets.wp.com`.
1. In the JS console for a post, change the context to the iFrame (`post.php`) instead of the Calypso page. (screenshot shows how to do this for Firefox)
<img width="2558" alt="Screen Shot 2020-03-11 at 4 40 54 PM" src="https://user-images.githubusercontent.com/6265975/76473902-263e3f00-63b7-11ea-8c07-febd6d6ed875.png">

2. In the console, execute `localStorage = "wpcom-block-editor:tracking"`
3. Reload the page, and do step 1 again. You should see some messages in the console saying "wpcom-block-editor:tracking registering tracking handlers".

<img width="545" alt="Screen Shot 2020-03-11 at 4 40 15 PM" src="https://user-images.githubusercontent.com/6265975/76473912-30f8d400-63b7-11ea-914e-bb1f0a72fa5d.png">

This means that the debugger is working for the trackers.

Next, we need to create a situation where the error will display.
1. In the iFrame JS context, execute `wp.data.dispatch( 'core/notices' ).createErrorNotice( 'This is an error.' );`
2. Verify that you see a debug tracking event for `createErrorNotice`.
3. Verify that the error notice appears in the editor.
<img width="1543" alt="Screen Shot 2020-03-11 at 5 03 53 PM" src="https://user-images.githubusercontent.com/6265975/76474941-8aaecd80-63ba-11ea-956f-efca9e2ad7b1.png">


### Questions

Should we send this to Kibana instead of tracks?