### PR TITLE
Add Site Editor to calypso sidebar

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -58,6 +58,7 @@ import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
 import isVipSite from 'state/selectors/is-vip-site';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import isSiteUsingCoreSiteEditor from 'state/selectors/is-site-using-core-site-editor';
+import getSiteEditorUrl from 'state/selectors/get-site-editor-url';
 import {
 	SIDEBAR_SECTION_SITE,
 	SIDEBAR_SECTION_DESIGN,
@@ -306,10 +307,10 @@ export class MySitesSidebar extends Component {
 					<SidebarItem
 						label={ translate( 'Site Editor (beta)' ) }
 						// selected={ itemLinkMatches( '/customize', path ) }
-						// link={ this.props.customizeUrl }
+						link={ this.props.siteEditorUrl }
 						// onNavigate={ this.trackCustomizeClick }
-						// preloadSectionName="customize"
-						// forceInternalLink
+						preloadSectionName="site editor"
+						forceInternalLink
 						// expandSection={ this.expandDesignSection }
 					/>
 				) }
@@ -802,6 +803,7 @@ function mapStateToProps( state ) {
 			isSiteUsingCoreSiteEditor( state, selectedSiteId )
 		),
 		showSiteEditor: isSiteUsingCoreSiteEditor( state, selectedSiteId ),
+		siteEditorUrl: getSiteEditorUrl( state, selectedSiteId ),
 		siteId,
 		site,
 		siteSuffix: site ? '/' + site.slug : '',

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -306,12 +306,9 @@ export class MySitesSidebar extends Component {
 				{ showSiteEditor && (
 					<SidebarItem
 						label={ translate( 'Site Editor (beta)' ) }
-						// selected={ itemLinkMatches( '/customize', path ) }
 						link={ this.props.siteEditorUrl }
-						// onNavigate={ this.trackCustomizeClick }
 						preloadSectionName="site editor"
 						forceInternalLink
-						// expandSection={ this.expandDesignSection }
 					/>
 				) }
 				<SidebarItem

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -57,6 +57,7 @@ import {
 import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
 import isVipSite from 'state/selectors/is-vip-site';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import isSiteUsingCoreSiteEditor from 'state/selectors/is-site-using-core-site-editor';
 import {
 	SIDEBAR_SECTION_SITE,
 	SIDEBAR_SECTION_DESIGN,
@@ -265,7 +266,14 @@ export class MySitesSidebar extends Component {
 	}
 
 	design() {
-		const { path, site, translate, canUserEditThemeOptions, showCustomizerLink } = this.props,
+		const {
+				path,
+				site,
+				translate,
+				canUserEditThemeOptions,
+				showCustomizerLink,
+				showSiteEditor,
+			} = this.props,
 			jetpackEnabled = isEnabled( 'manage/themes-jetpack' );
 		let themesLink;
 
@@ -292,6 +300,17 @@ export class MySitesSidebar extends Component {
 						preloadSectionName="customize"
 						forceInternalLink
 						expandSection={ this.expandDesignSection }
+					/>
+				) }
+				{ showSiteEditor && (
+					<SidebarItem
+						label={ translate( 'Site Editor (beta)' ) }
+						// selected={ itemLinkMatches( '/customize', path ) }
+						// link={ this.props.customizeUrl }
+						// onNavigate={ this.trackCustomizeClick }
+						// preloadSectionName="customize"
+						// forceInternalLink
+						// expandSection={ this.expandDesignSection }
 					/>
 				) }
 				<SidebarItem
@@ -778,7 +797,11 @@ function mapStateToProps( state ) {
 		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		isMigrationInProgress: !! isSiteMigrationInProgress( state, selectedSiteId ),
 		isVip: isVipSite( state, selectedSiteId ),
-		showCustomizerLink: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
+		showCustomizerLink: ! (
+			isSiteUsingFullSiteEditing( state, selectedSiteId ) ||
+			isSiteUsingCoreSiteEditor( state, selectedSiteId )
+		),
+		showSiteEditor: isSiteUsingCoreSiteEditor( state, selectedSiteId ),
 		siteId,
 		site,
 		siteSuffix: site ? '/' + site.slug : '',

--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
-import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
+import { getSiteAdminUrl } from 'state/sites/selectors';
 
 /**
  * Retrieves url for site editor.
@@ -14,13 +14,9 @@ import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
 export const getSiteEditorUrl = ( state, siteId ) => {
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 
-	// I'm not sure if we will want this here?
 	if ( shouldRedirectGutenberg( state, siteId ) ) {
 		return `${ siteAdminUrl }admin.php?page=gutenberg-edit-site`;
 	}
-
-	// const siteSlug = getSiteSlug( state, siteId );
-	// return `/site-editor/${ siteSlug }`;
 
 	// @TODO Update this to be URL for the iframe route.
 	return `${ siteAdminUrl }admin.php?page=gutenberg-edit-site`;

--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
+import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
+
+/**
+ * Retrieves url for site editor.
+ *
+ * @param {object} state  Global state tree
+ * @param {object} siteId Site ID
+ * @returns {string} Url of site editor instance for calypso or wp-admin.
+ */
+export const getSiteEditorUrl = ( state, siteId ) => {
+	const siteAdminUrl = getSiteAdminUrl( state, siteId );
+
+	// I'm not sure if we will want this here?
+	if ( shouldRedirectGutenberg( state, siteId ) ) {
+		return `${ siteAdminUrl }admin.php?page=gutenberg-edit-site`;
+	}
+
+	// const siteSlug = getSiteSlug( state, siteId );
+	// return `/site-editor/${ siteSlug }`;
+
+	// @TODO Update this to be URL for the iframe route.
+	return `${ siteAdminUrl }admin.php?page=gutenberg-edit-site`;
+};
+
+export default getSiteEditorUrl;

--- a/client/state/selectors/is-site-using-core-site-editor.js
+++ b/client/state/selectors/is-site-using-core-site-editor.js
@@ -17,6 +17,5 @@ import getRawSite from 'state/selectors/get-raw-site';
  */
 export default function isSiteUsingCoreSiteEditor( state, siteId ) {
 	const site = getRawSite( state, siteId );
-	const isActive = get( site, 'is_core_site_editor_enabled', false );
-	return isActive;
+	return get( site, 'is_core_site_editor_enabled', false );
 }

--- a/client/state/selectors/is-site-using-core-site-editor.js
+++ b/client/state/selectors/is-site-using-core-site-editor.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getRawSite from 'state/selectors/get-raw-site';
+
+/**
+ * Checks if a site is using the core Site Editor
+ *
+ * @param {object} state  Global state tree
+ * @param {object} siteId Site ID
+ * @returns {boolean} True if the site is using core Site Editor, otherwise false
+ */
+export default function isSiteUsingCoreSiteEditor( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	const isActive = get( site, 'is_core_site_editor_enabled', false );
+	return isActive;
+}

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -19,6 +19,7 @@ export const SITE_REQUEST_FIELDS = [
 	'site_migration',
 	'is_fse_active',
 	'is_fse_eligible',
+	'is_core_site_editor_enabled',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a 'Site Editor' button in place of the 'customizer' button when the 'core-site-editor-enabled' blog sticker is present on a site (dependent on D40145).  

![Screen Shot 2020-03-11 at 12 26 17 PM](https://user-images.githubusercontent.com/28742426/76439944-8e7b2980-6393-11ea-9682-88e09e107f56.png)

This button redirects to the wp-admin site editor, and future plans (follow-up PRs) are to bring this into an iframe.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch D40145
* Run this PR on calypso.
* Verify the 'Customize' button becomes a 'Site Editor' button when using a site with the `core-site-editor-enabled` sticker.
* Verify button leads to wp-admin site editor screen.

First step in addressing #39886 
