### PR TITLE
Add/gutenboarding login page part 2

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -212,11 +212,11 @@ const Header: FunctionComponent = () => {
 				</div>
 			</div>
 			{ showSignupDialog && (
-				<SignupForm onRequestClose={ () => closeAuthDialog() } onOpenLogin={ handleLogin } />
+				<SignupForm onRequestClose={ closeAuthDialog } onOpenLogin={ handleLogin } />
 			) }
 			{ showLoginDialog && (
 				<LoginForm
-					onRequestClose={ () => closeAuthDialog() }
+					onRequestClose={ closeAuthDialog }
 					onOpenSignup={ handleSignup }
 					onLogin={ handleCreateSite }
 				/>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -9,7 +9,6 @@ import { useDebounce } from 'use-debounce';
 import classnames from 'classnames';
 import { DomainSuggestions } from '@automattic/data-stores';
 import { useHistory } from 'react-router-dom';
-import { reloadProxy } from 'wpcom-proxy-request';
 
 /**
  * Internal dependencies
@@ -101,11 +100,6 @@ const Header: FunctionComponent = () => {
 
 	const handleCreateSite = useCallback(
 		( username: string, bearerToken?: string ) => {
-			// If bearer token wasn't passed, reload the proxy
-			// so that the user's logged in authentication cookie will be used
-			if ( ! bearerToken ) {
-				reloadProxy();
-			}
 			const siteUrl = currentDomain?.domain_name || siteTitle || username;
 
 			createSite( {

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -146,9 +146,6 @@ const Header: FunctionComponent = () => {
 	};
 
 	useEffect( () => {
-		// make login a part of this
-		// we need to add something to determine if the user exists I think, and then just redirect.
-		// the user was logged in with cookies so it's fine
 		if ( newUser && newUser.bearerToken && newUser.username ) {
 			handleCreateSite( newUser.username, newUser.bearerToken );
 		}

--- a/client/landing/gutenboarding/components/login-form/enter-password/index.scss
+++ b/client/landing/gutenboarding/components/login-form/enter-password/index.scss
@@ -1,0 +1,19 @@
+
+.enter-password__change-username {
+    color: var( --color-link );
+    font-weight: inherit;
+    text-decoration: none;
+    display: inline-block;
+    margin-bottom: 5px;
+    font-size: 14px;
+
+    &:hover,
+    &:focus,
+    &:active {
+        color: var( --color-link-dark );
+    }
+    .dashicon {
+        margin-right: 3px;
+        vertical-align: text-bottom;
+    }
+}

--- a/client/landing/gutenboarding/components/login-form/enter-password/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/enter-password/index.tsx
@@ -1,0 +1,75 @@
+import React, { useState, ReactNode } from 'react';
+import { Button, TextControl, Icon } from '@wordpress/components';
+import { useI18n } from '@automattic/react-i18n';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { AUTH_STORE } from '../../../stores/auth';
+import ModalSubmitButton from '../../modal-submit-button';
+
+interface Props {
+	tos: ReactNode;
+	errorNotifications: ReactNode;
+}
+
+const EnterPasswordForm = ( props: Props ) => {
+	const { __: NO__ } = useI18n();
+
+	const [ passwordVal, setPasswordVal ] = useState( '' );
+	const { reset } = useDispatch( AUTH_STORE );
+	const { submitPassword } = useDispatch( AUTH_STORE );
+	const usernameOrEmail = useSelect( select => select( AUTH_STORE ).getUsernameOrEmail() );
+
+	const onSubmitPassword = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		submitPassword( passwordVal );
+	};
+
+	const changeEmailAddress = ( e: React.MouseEvent< HTMLElement > ) => {
+		reset();
+		e.preventDefault;
+	};
+
+	const changeEmailOrUsernameLinkText = includes( usernameOrEmail, '@' )
+		? NO__( 'Change Email Address' )
+		: NO__( 'Change Username' );
+
+	return (
+		<form onSubmit={ onSubmitPassword }>
+			<Button
+				className="enter-password__change-username"
+				isLink={ true }
+				onClick={ changeEmailAddress }
+			>
+				<Icon icon="arrow-left-alt" size={ 18 } />
+				{ changeEmailOrUsernameLinkText }
+			</Button>
+			<TextControl
+				label={ '' }
+				value={ usernameOrEmail }
+				disabled={ true }
+				onChange={ setPasswordVal }
+			/>
+			<TextControl
+				label={ NO__( 'Password' ) }
+				type="password"
+				// focusing on the field causes 1password to autofill the password.
+				// eslint-disable-next-line
+				autoFocus={ true }
+				value={ passwordVal }
+				onChange={ setPasswordVal }
+			/>
+			{ props.errorNotifications }
+			<div>
+				{ props.tos }
+
+				<ModalSubmitButton>{ NO__( 'Login' ) }</ModalSubmitButton>
+			</div>
+		</form>
+	);
+};
+
+export default EnterPasswordForm;

--- a/client/landing/gutenboarding/components/login-form/enter-username-or-email/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/enter-username-or-email/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const EnterUsernameOrEmailForm = ( props: Props ) => {
-	const { __: NO__, _x: NO_x } = useI18n();
+	const { __: NO__ } = useI18n();
 
 	const [ usernameOrEmailVal, setUsernameOrEmailVal ] = useState( '' );
 	const { submitUsernameOrEmail } = useDispatch( AUTH_STORE );
@@ -32,10 +32,6 @@ const EnterUsernameOrEmailForm = ( props: Props ) => {
 				value={ usernameOrEmailVal }
 				// todo loading state
 				onChange={ setUsernameOrEmailVal }
-				placeholder={ NO_x(
-					'E.g., yourname@email.com',
-					"An example of a person's email, use something appropriate for the locale"
-				) }
 				required
 			/>
 			{ props.errorNotifications }

--- a/client/landing/gutenboarding/components/login-form/enter-username-or-email/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/enter-username-or-email/index.tsx
@@ -1,0 +1,51 @@
+import React, { useState, ReactNode } from 'react';
+import { TextControl } from '@wordpress/components';
+import { useI18n } from '@automattic/react-i18n';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { AUTH_STORE } from '../../../stores/auth';
+import ModalSubmitButton from '../../modal-submit-button';
+
+interface Props {
+	tos: ReactNode;
+	errorNotifications: ReactNode;
+}
+
+const EnterUsernameOrEmailForm = ( props: Props ) => {
+	const { __: NO__, _x: NO_x } = useI18n();
+
+	const [ usernameOrEmailVal, setUsernameOrEmailVal ] = useState( '' );
+	const { submitUsernameOrEmail } = useDispatch( AUTH_STORE );
+
+	const onSubmitUsernameOrEmail = ( event: React.FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		submitUsernameOrEmail( usernameOrEmailVal );
+	};
+
+	return (
+		<form onSubmit={ onSubmitUsernameOrEmail }>
+			<TextControl
+				label={ NO__( 'Email Address or Username' ) }
+				value={ usernameOrEmailVal }
+				// todo loading state
+				onChange={ setUsernameOrEmailVal }
+				placeholder={ NO_x(
+					'E.g., yourname@email.com',
+					"An example of a person's email, use something appropriate for the locale"
+				) }
+				required
+			/>
+			{ props.errorNotifications }
+			<div>
+				{ props.tos }
+
+				<ModalSubmitButton>{ NO__( 'Login' ) }</ModalSubmitButton>
+			</div>
+		</form>
+	);
+};
+
+export default EnterUsernameOrEmailForm;

--- a/client/landing/gutenboarding/components/login-form/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/index.tsx
@@ -116,6 +116,12 @@ const LoginForm = () => {
 					</Button>
 				</div>
 			</form>
+			<div className="login-form__signup-links">
+				<a href="signup">
+					{NO__( 'Create account.' )}
+				</a>
+				{/* todo: add a link to other login flow for social logins */}
+			</div>
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/login-form/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/index.tsx
@@ -37,7 +37,7 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 	const { submitPassword } = useDispatch( AUTH_STORE );
 	const loginFlowState = useSelect( select => select( AUTH_STORE ).getLoginFlowState() );
 	const errors = useSelect( select => select( AUTH_STORE ).getErrors() );
-
+	const { reset } = useDispatch( AUTH_STORE );
 	// todo: either reset the auth store state on load here or in the header/index.tsx
 	// todo: loading state like isFetchingNewUser
 
@@ -48,15 +48,20 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 		if ( loginFlowState === 'ENTER_USERNAME_OR_EMAIL' ) {
 			submitUsernameOrEmail( usernameOrEmailVal );
 		} else if ( loginFlowState === 'ENTER_PASSWORD' ) {
+			submitUsernameOrEmail( usernameOrEmailVal );
 			submitPassword( passwordVal );
 		}
+	};
+
+	const closeModal = () => {
+		reset();
+		onRequestClose();
 	};
 
 	useEffect( () => {
 		// this is triggered on successful submitPassword
 		if ( loginFlowState === 'LOGGED_IN' ) {
-			onRequestClose();
-			// todo: use value from store
+			closeModal();
 			onLogin( usernameOrEmailVal );
 		}
 	}, [ loginFlowState ] );
@@ -76,7 +81,7 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 			className="login-form"
 			isDismissible={ false }
 			title={ NO__( 'Log in to save your changes' ) }
-			onRequestClose={ onRequestClose }
+			onRequestClose={ closeModal }
 		>
 			<form onSubmit={ handleLogin }>
 				<TextControl

--- a/client/landing/gutenboarding/components/login-form/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/index.tsx
@@ -43,7 +43,6 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 
 	const handleLogin = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
-
 		// todo: record analytics.
 		if ( loginFlowState === 'ENTER_USERNAME_OR_EMAIL' ) {
 			submitUsernameOrEmail( usernameOrEmailVal );
@@ -53,6 +52,7 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 	};
 
 	const openSignup = ( e: React.MouseEvent< HTMLElement > ) => {
+		reset();
 		onOpenSignup();
 		e.preventDefault();
 	};
@@ -73,6 +73,7 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 			closeModal();
 			onLogin( usernameOrEmailVal );
 		}
+		// todo: handle users with passwordless login.
 	}, [ loginFlowState ] );
 
 	const tos = __experimentalCreateInterpolateElement(
@@ -84,9 +85,11 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 
 	// todo: may need to be updated as more states are handled
 	const shouldShowPasswordField = loginFlowState === 'ENTER_PASSWORD';
+
 	const changeEmailOrUsernameLinkText = includes( usernameOrEmailVal, '@' )
 		? NO__( 'Change Email Address' )
 		: NO__( 'Change Username' );
+
 	return (
 		<Modal
 			className="login-form"

--- a/client/landing/gutenboarding/components/login-form/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/index.tsx
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
+import Gridicon from 'components/gridicon';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -38,7 +39,6 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 	const loginFlowState = useSelect( select => select( AUTH_STORE ).getLoginFlowState() );
 	const errors = useSelect( select => select( AUTH_STORE ).getErrors() );
 	const { reset } = useDispatch( AUTH_STORE );
-	// todo: either reset the auth store state on load here or in the header/index.tsx
 	// todo: loading state like isFetchingNewUser
 
 	const handleLogin = ( event: React.FormEvent< HTMLFormElement > ) => {
@@ -48,9 +48,18 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 		if ( loginFlowState === 'ENTER_USERNAME_OR_EMAIL' ) {
 			submitUsernameOrEmail( usernameOrEmailVal );
 		} else if ( loginFlowState === 'ENTER_PASSWORD' ) {
-			submitUsernameOrEmail( usernameOrEmailVal );
 			submitPassword( passwordVal );
 		}
+	};
+
+	const openSignup = ( e: React.MouseEvent< HTMLElement > ) => {
+		onOpenSignup();
+		e.preventDefault();
+	};
+
+	const changeEmailAddress = ( e: React.MouseEvent< HTMLElement > ) => {
+		reset();
+		e.preventDefault;
 	};
 
 	const closeModal = () => {
@@ -75,7 +84,9 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 
 	// todo: may need to be updated as more states are handled
 	const shouldShowPasswordField = loginFlowState === 'ENTER_PASSWORD';
-
+	const changeEmailOrUsernameLinkText = includes( usernameOrEmailVal, '@' )
+		? NO__( 'Change Email Address' )
+		: NO__( 'Change Username' );
 	return (
 		<Modal
 			className="login-form"
@@ -84,10 +95,20 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 			onRequestClose={ closeModal }
 		>
 			<form onSubmit={ handleLogin }>
+				{ shouldShowPasswordField && (
+					<Button
+						className="login-form__change-username"
+						isLink={ true }
+						onClick={ changeEmailAddress }
+					>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ changeEmailOrUsernameLinkText }
+					</Button>
+				) }
 				<TextControl
-					label={ NO__( 'Email Address or Username' ) }
+					label={ ! shouldShowPasswordField ? NO__( 'Email Address or Username' ) : '' }
 					value={ usernameOrEmailVal }
-					// disabled={ isLoading }
+					disabled={ shouldShowPasswordField }
 					onChange={ setUsernameOrEmailVal }
 					placeholder={ NO_x(
 						'E.g., yourname@email.com',
@@ -134,15 +155,9 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 				</div>
 			</form>
 			<div className="login-form__signup-links">
-				<Link
-					to=""
-					onClick={ e => {
-						onOpenSignup();
-						e.preventDefault();
-					} }
-				>
+				<Button isLink={ true } onClick={ openSignup }>
 					{ NO__( 'Create account.' ) }
-				</Link>
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/client/landing/gutenboarding/components/login-form/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/index.tsx
@@ -2,11 +2,10 @@
  * External dependencies
  */
 import React, { useState, useEffect } from 'react';
-import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
+import { Button, ExternalLink, TextControl, Modal, Notice, Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
-import Gridicon from 'components/gridicon';
 import { includes } from 'lodash';
 
 /**
@@ -104,7 +103,7 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 						isLink={ true }
 						onClick={ changeEmailAddress }
 					>
-						<Gridicon icon="arrow-left" size={ 18 } />
+						<Icon icon="arrow-left-alt" size={ 18 } />
 						{ changeEmailOrUsernameLinkText }
 					</Button>
 				) }

--- a/client/landing/gutenboarding/components/login-form/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/index.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
@@ -22,7 +23,13 @@ declare module '@wordpress/element' {
 	): ReactNode;
 }
 
-const LoginForm = () => {
+interface Props {
+	onRequestClose: () => void;
+	onOpenSignup: () => void;
+	onLogin: ( username: string ) => void;
+}
+
+const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 	const { __: NO__, _x: NO_x } = useI18n();
 	const [ usernameOrEmailVal, setUsernameOrEmailVal ] = useState( '' );
 	const [ passwordVal, setPasswordVal ] = useState( '' );
@@ -31,6 +38,7 @@ const LoginForm = () => {
 	const loginFlowState = useSelect( select => select( AUTH_STORE ).getLoginFlowState() );
 	const errors = useSelect( select => select( AUTH_STORE ).getErrors() );
 
+	// todo: either reset the auth store state on load here or in the header/index.tsx
 	// todo: loading state like isFetchingNewUser
 
 	const handleLogin = ( event: React.FormEvent< HTMLFormElement > ) => {
@@ -41,13 +49,17 @@ const LoginForm = () => {
 			submitUsernameOrEmail( usernameOrEmailVal );
 		} else if ( loginFlowState === 'ENTER_PASSWORD' ) {
 			submitPassword( passwordVal );
-			//todo: handle success
 		}
 	};
 
-	const handleClose = () => {
-		// todo
-	};
+	useEffect( () => {
+		// this is triggered on successful submitPassword
+		if ( loginFlowState === 'LOGGED_IN' ) {
+			onRequestClose();
+			// todo: use value from store
+			onLogin( usernameOrEmailVal );
+		}
+	}, [ loginFlowState ] );
 
 	const tos = __experimentalCreateInterpolateElement(
 		NO__( 'By continuing you agree to our <link_to_tos>Terms of Service</link_to_tos>.' ),
@@ -64,7 +76,7 @@ const LoginForm = () => {
 			className="login-form"
 			isDismissible={ false }
 			title={ NO__( 'Log in to save your changes' ) }
-			onRequestClose={ handleClose }
+			onRequestClose={ onRequestClose }
 		>
 			<form onSubmit={ handleLogin }>
 				<TextControl
@@ -117,10 +129,15 @@ const LoginForm = () => {
 				</div>
 			</form>
 			<div className="login-form__signup-links">
-				<a href="signup">
-					{NO__( 'Create account.' )}
-				</a>
-				{/* todo: add a link to other login flow for social logins */}
+				<Link
+					to=""
+					onClick={ e => {
+						onOpenSignup();
+						e.preventDefault();
+					} }
+				>
+					{ NO__( 'Create account.' ) }
+				</Link>
 			</div>
 		</Modal>
 	);

--- a/client/landing/gutenboarding/components/login-form/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/index.tsx
@@ -1,17 +1,18 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect } from 'react';
-import { Button, ExternalLink, TextControl, Modal, Notice, Icon } from '@wordpress/components';
+import React, { useEffect } from 'react';
+import { Button, ExternalLink, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
-import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { AUTH_STORE } from '../../stores/auth';
+import EnterUsernameOrEmailForm from './enter-username-or-email';
+import EnterPasswordForm from './enter-password';
 import './style.scss';
 
 // TODO: deploy this change to @types/wordpress__element
@@ -30,35 +31,17 @@ interface Props {
 }
 
 const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
-	const { __: NO__, _x: NO_x } = useI18n();
-	const [ usernameOrEmailVal, setUsernameOrEmailVal ] = useState( '' );
-	const [ passwordVal, setPasswordVal ] = useState( '' );
-	const { submitUsernameOrEmail } = useDispatch( AUTH_STORE );
-	const { submitPassword } = useDispatch( AUTH_STORE );
+	const { __: NO__ } = useI18n();
 	const loginFlowState = useSelect( select => select( AUTH_STORE ).getLoginFlowState() );
 	const errors = useSelect( select => select( AUTH_STORE ).getErrors() );
 	const { reset } = useDispatch( AUTH_STORE );
-	// todo: loading state like isFetchingNewUser
 
-	const handleLogin = ( event: React.FormEvent< HTMLFormElement > ) => {
-		event.preventDefault();
-		// todo: record analytics.
-		if ( loginFlowState === 'ENTER_USERNAME_OR_EMAIL' ) {
-			submitUsernameOrEmail( usernameOrEmailVal );
-		} else if ( loginFlowState === 'ENTER_PASSWORD' ) {
-			submitPassword( passwordVal );
-		}
-	};
+	const usernameOrEmail = useSelect( select => select( AUTH_STORE ).getUsernameOrEmail() );
 
 	const openSignup = ( e: React.MouseEvent< HTMLElement > ) => {
 		reset();
 		onOpenSignup();
 		e.preventDefault();
-	};
-
-	const changeEmailAddress = ( e: React.MouseEvent< HTMLElement > ) => {
-		reset();
-		e.preventDefault;
 	};
 
 	const closeModal = () => {
@@ -70,92 +53,50 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 		// this is triggered on successful submitPassword
 		if ( loginFlowState === 'LOGGED_IN' ) {
 			closeModal();
-			onLogin( usernameOrEmailVal );
+			onLogin( usernameOrEmail );
 		}
 		// todo: handle users with passwordless login.
 	}, [ loginFlowState ] );
 
-	const tos = __experimentalCreateInterpolateElement(
-		NO__( 'By continuing you agree to our <link_to_tos>Terms of Service</link_to_tos>.' ),
-		{
-			link_to_tos: <ExternalLink href="https://wordpress.com/tos/" />,
-		}
+	const tos = (
+		<p className="login-form__terms-of-service-link">
+			{ __experimentalCreateInterpolateElement(
+				NO__( 'By continuing you agree to our <link_to_tos>Terms of Service</link_to_tos>.' ),
+				{
+					link_to_tos: <ExternalLink href="https://wordpress.com/tos/" />,
+				}
+			) }
+		</p>
 	);
 
+	const errorNotifications = errors.map( ( error, i ) => (
+		<Notice
+			className="login-form__error-notice"
+			status="error"
+			isDismissible={ false }
+			key={ error.code + i }
+		>
+			{ error.message }
+		</Notice>
+	) );
 	// todo: may need to be updated as more states are handled
-	const shouldShowPasswordField = loginFlowState === 'ENTER_PASSWORD';
-
-	const changeEmailOrUsernameLinkText = includes( usernameOrEmailVal, '@' )
-		? NO__( 'Change Email Address' )
-		: NO__( 'Change Username' );
 
 	return (
 		<Modal
 			className="login-form"
-			isDismissible={ false }
+			isDismissible={ true }
+			// set to false so that 1password's autofill doesn't automatically close the modal
+			shouldCloseOnClickOutside={ false }
 			title={ NO__( 'Log in to save your changes' ) }
 			onRequestClose={ closeModal }
 		>
-			<form onSubmit={ handleLogin }>
-				{ shouldShowPasswordField && (
-					<Button
-						className="login-form__change-username"
-						isLink={ true }
-						onClick={ changeEmailAddress }
-					>
-						<Icon icon="arrow-left-alt" size={ 18 } />
-						{ changeEmailOrUsernameLinkText }
-					</Button>
-				) }
-				<TextControl
-					label={ ! shouldShowPasswordField ? NO__( 'Email Address or Username' ) : '' }
-					value={ usernameOrEmailVal }
-					disabled={ shouldShowPasswordField }
-					onChange={ setUsernameOrEmailVal }
-					placeholder={ NO_x(
-						'E.g., yourname@email.com',
-						"An example of a person's email, use something appropriate for the locale"
-					) }
-					required
-				/>
-				<div
-					className={ `login-form__password-section ${
-						! shouldShowPasswordField ? 'is-hidden' : ''
-					}` }
-				>
-					<TextControl
-						label={ NO__( 'Password' ) }
-						// disabled={ isLoading }
-						type="password"
-						value={ passwordVal }
-						onChange={ setPasswordVal }
-					/>
-				</div>
-				{ errors &&
-					errors.map( ( error, i ) => (
-						<Notice
-							className="login-form__error-notice"
-							status="error"
-							isDismissible={ false }
-							key={ error.code + i }
-						>
-							{ error.message }
-						</Notice>
-					) ) }
-				<div className="login-form__footer">
-					<p className="login-form__terms-of-service-link">{ tos }</p>
+			{ loginFlowState === 'ENTER_USERNAME_OR_EMAIL' && (
+				<EnterUsernameOrEmailForm tos={ tos } errorNotifications={ errorNotifications } />
+			) }
+			{ loginFlowState === 'ENTER_PASSWORD' && (
+				<EnterPasswordForm tos={ tos } errorNotifications={ errorNotifications } />
+			) }
 
-					<Button
-						type="submit"
-						className="login-form__submit"
-						// disabled={ isLoading }
-						// isBusy={ isLoading }
-						isPrimary
-					>
-						{ NO__( 'Login' ) }
-					</Button>
-				</div>
-			</form>
 			<div className="login-form__signup-links">
 				<Button isLink={ true } onClick={ openSignup }>
 					{ NO__( 'Create account.' ) }

--- a/client/landing/gutenboarding/components/login-form/style.scss
+++ b/client/landing/gutenboarding/components/login-form/style.scss
@@ -3,7 +3,8 @@
 .login-form.components-modal__frame {
 	border: none;
 	border-radius: 3px;
-
+	min-width: 450px;
+	
 	.components-modal__header {
 		.components-modal__header-heading {
 			font-size: 20px;
@@ -45,5 +46,23 @@
 	.login-form__signup-links {
 		margin-top: 20px;
 		text-align: center;
+	}
+	.login-form__change-username {
+		color: var( --color-link );
+		font-weight: inherit;
+		text-decoration: none;
+		display: inline-block;
+		margin-bottom: 5px;
+		font-size: 14px;
+	
+		&:hover,
+		&:focus,
+		&:active {
+			color: var( --color-link-dark );
+		}
+		.gridicon {
+			margin-right: 3px;
+			vertical-align: text-bottom;
+		}
 	}
 }

--- a/client/landing/gutenboarding/components/login-form/style.scss
+++ b/client/landing/gutenboarding/components/login-form/style.scss
@@ -42,4 +42,8 @@
 	.login-form__error-notice {
 		margin: 0;
 	}
+	.login-form__signup-links {
+		margin-top: 20px;
+		text-align: center;
+	}
 }

--- a/client/landing/gutenboarding/components/login-form/style.scss
+++ b/client/landing/gutenboarding/components/login-form/style.scss
@@ -60,7 +60,7 @@
 		&:active {
 			color: var( --color-link-dark );
 		}
-		.gridicon {
+		.dashicon {
 			margin-right: 3px;
 			vertical-align: text-bottom;
 		}

--- a/client/landing/gutenboarding/components/login-form/style.scss
+++ b/client/landing/gutenboarding/components/login-form/style.scss
@@ -11,33 +11,17 @@
 			font-weight: normal;
 		}
 	}
+
 	.components-text-control__input {
 		padding: 7px 14px;
 		font-size: 16px;
 		line-height: 1.5;
 	}
-	.login-form__password-section.is-hidden {
-		// hide the password field in a way that still makes it "visible" for password managers.
-		// 1Password doesn't fill the field if it has display:none or visibility:hidden.
-		position: fixed;
-		bottom: 0;
-		height: 0;
-		width: 0;
-		overflow: hidden;
-		opacity: 0;
-	}
+
 	.login-form__terms-of-service-link {
 		text-align: center;
 		color: var( --color-text-subtle );
 		margin: 20px 0 40px;
-	}
-
-	.components-button.login-form__submit {
-		display: block;
-		width: 100%;
-		text-align: center;
-		font-size: 16px;
-		height: 40px;
 	}
 
 	.login-form__error-notice {
@@ -46,23 +30,5 @@
 	.login-form__signup-links {
 		margin-top: 20px;
 		text-align: center;
-	}
-	.login-form__change-username {
-		color: var( --color-link );
-		font-weight: inherit;
-		text-decoration: none;
-		display: inline-block;
-		margin-bottom: 5px;
-		font-size: 14px;
-	
-		&:hover,
-		&:focus,
-		&:active {
-			color: var( --color-link-dark );
-		}
-		.dashicon {
-			margin-right: 3px;
-			vertical-align: text-bottom;
-		}
 	}
 }

--- a/client/landing/gutenboarding/components/modal-submit-button/index.tsx
+++ b/client/landing/gutenboarding/components/modal-submit-button/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const ModalSubmitButton = ( props: Button.Props ): any => {
+	return (
+		<Button type="submit" className="modal-submit-button" isPrimary { ...props }>
+			{ props.children }
+		</Button>
+	);
+};
+
+export default ModalSubmitButton;

--- a/client/landing/gutenboarding/components/modal-submit-button/style.scss
+++ b/client/landing/gutenboarding/components/modal-submit-button/style.scss
@@ -1,0 +1,8 @@
+
+.components-button.modal-submit-button {
+    display: block;
+    width: 100%;
+    text-align: center;
+    font-size: 16px;
+    height: 40px;
+}

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
@@ -29,9 +30,10 @@ declare module '@wordpress/element' {
 
 interface Props {
 	onRequestClose: () => void;
+	onOpenLogin: () => void;
 }
 
-const SignupForm = ( { onRequestClose }: Props ) => {
+const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 	const { __: NO__, _x: NO_x } = useI18n();
 	const [ emailVal, setEmailVal ] = useState( '' );
 	const { createAccount } = useDispatch( USER_STORE );
@@ -132,8 +134,15 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 				</div>
 			</form>
 			<div className="signup-form__login-links">
-				<a href="login">{ NO__( 'Log in to create a site for your existing account.' ) }</a>
-				{ /* todo: add a link to other signup flow for social logins */ }
+				<Link
+					to=""
+					onClick={ e => {
+						onOpenLogin();
+						e.preventDefault();
+					} }
+				>
+					{ NO__( 'Log in to create a site for your existing account.' ) }
+				</Link>
 			</div>
 		</Modal>
 	);

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
@@ -66,6 +65,11 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 		if ( success ) {
 			onRequestClose();
 		}
+	};
+
+	const openLogin = ( e: React.MouseEvent< HTMLElement > ) => {
+		onOpenLogin();
+		e.preventDefault();
 	};
 
 	const tos = __experimentalCreateInterpolateElement(
@@ -134,15 +138,9 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 				</div>
 			</form>
 			<div className="signup-form__login-links">
-				<Link
-					to=""
-					onClick={ e => {
-						onOpenLogin();
-						e.preventDefault();
-					} }
-				>
+				<Button isLink={ true } onClick={ openLogin }>
 					{ NO__( 'Log in to create a site for your existing account.' ) }
-				</Link>
+				</Button>
 			</div>
 		</Modal>
 	);

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -131,6 +131,10 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 					</Button>
 				</div>
 			</form>
+			<div className="signup-form__login-links">
+				<a href="login">{ NO__( 'Log in to create a site for your existing account.' ) }</a>
+				{ /* todo: add a link to other signup flow for social logins */ }
+			</div>
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -15,6 +15,7 @@ import { USER_STORE } from '../../stores/user';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { useLangRouteParam } from '../../path';
 import './style.scss';
+import ModalSubmitButton from '../modal-submit-button';
 
 type NewUserErrorResponse = import('@automattic/data-stores').User.NewUserErrorResponse;
 
@@ -103,6 +104,8 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 			onRequestClose={ onRequestClose }
 			focusOnMount={ false }
 			isDismissible={ ! isFetchingNewUser }
+			// set to false so that 1password's autofill doesn't automatically close the modal
+			shouldCloseOnClickOutside={ false }
 		>
 			<form onSubmit={ handleSignUp }>
 				<TextControl
@@ -126,15 +129,9 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 				<div className="signup-form__footer">
 					<p className="signup-form__terms-of-service-link">{ tos }</p>
 
-					<Button
-						type="submit"
-						className="signup-form__submit"
-						disabled={ isFetchingNewUser }
-						isBusy={ isFetchingNewUser }
-						isPrimary
-					>
+					<ModalSubmitButton disabled={ isFetchingNewUser } isBusy={ isFetchingNewUser }>
 						{ NO__( 'Create your account' ) }
-					</Button>
+					</ModalSubmitButton>
 				</div>
 			</form>
 			<div className="signup-form__login-links">

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -3,6 +3,7 @@
 .signup-form.components-modal__frame {
 	border: none;
 	border-radius: 3px;
+	min-width: 450px;
 
 	.components-modal__header {
 		.components-modal__header-heading {

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -33,4 +33,9 @@
 	.signup-form__error-notice {
 		margin: 0;
 	}
+
+	.signup-form__login-links {
+		margin-top: 20px;
+		text-align: center;
+	}
 }

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -23,14 +23,6 @@
 		margin: 20px 0 40px;
 	}
 
-	.components-button.signup-form__submit {
-		display: block;
-		width: 100%;
-		text-align: center;
-		font-size: 16px;
-		height: 40px;
-	}
-
 	.signup-form__error-notice {
 		margin: 0;
 	}

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -13,7 +13,7 @@ import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
 import DesignSelector from './design-selector';
 import SignupForm from '../components/signup-form';
-import LoginForm from './login-form';
+import LoginForm from '../components/login-form';
 import CreateSite from './create-site';
 import { Attributes } from './types';
 import { Step, usePath } from '../path';

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -12,8 +12,6 @@ import { Redirect, Switch, Route } from 'react-router-dom';
 import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
 import DesignSelector from './design-selector';
-import SignupForm from '../components/signup-form';
-import LoginForm from '../components/login-form';
 import CreateSite from './create-site';
 import { Attributes } from './types';
 import { Step, usePath } from '../path';
@@ -48,14 +46,6 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 					) : (
 						<DesignSelector showPageSelector />
 					) }
-				</Route>
-
-				<Route path={ makePath( Step.Signup ) }>
-					<SignupForm onRequestClose={ () => undefined } />;
-				</Route>
-
-				<Route path={ makePath( Step.Login ) }>
-					<LoginForm />;
 				</Route>
 
 				<Route path={ makePath( Step.CreateSite ) }>

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -38,3 +38,19 @@ $admin-sidebar-width-collapsed: 0;
 .components-button.is-link {
 	text-decoration: none;
 }
+
+input:disabled {
+	background: var( --color-neutral-0 );
+	border-color: var( --color-neutral-0 );
+	color: var( --color-neutral-20 );
+	opacity: 1;
+	-webkit-text-fill-color: var( --color-neutral-20 );
+
+	&:hover {
+		cursor: default;
+	}
+
+	&::placeholder {
+		color: var( --color-neutral-20 );
+	}
+}

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -34,3 +34,7 @@ $admin-sidebar-width-collapsed: 0;
 .wp-block {
 	max-width: 1100px; // Overrides default $content-width
 }
+
+.components-button.is-link {
+	text-decoration: none;
+}

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -18,6 +18,9 @@ export const loginFlowState: Reducer< LoginFlowState, Action > = (
 		case 'RESET_LOGIN_FLOW':
 			return 'ENTER_USERNAME_OR_EMAIL';
 
+		case 'RECEIVE_AUTH_OPTIONS_FAILED':
+			return 'ENTER_USERNAME_OR_EMAIL';
+
 		case 'RECEIVE_AUTH_OPTIONS':
 			if ( ! action.response.passwordless ) {
 				return 'ENTER_PASSWORD';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Link login dialog into the gutenboarding flow.
Handle different states of the login page.
Remove `/gutenboarding/signup` and `gutenboarding/login/` routes which are now unused and don't work correctly when accessed directly

#### Planned but not included in this PR
* Handling 2FA users correctly
* Handling passwordles users correctly ([Issue link](https://github.com/Automattic/wp-calypso/issues/40004))

#### Testing instructions

Go through the `/gutenboarding` flow until you get to the *Create Site* button
Click *create site* to open the signup modal.
* There should be a login link
* The login link should take you to a login form ( in a way that's acceptably smooth )
NOTE: I've implemented this as two modals but do you think that the transition from one modal to the other is smooth enough or should I look to combine the two for a smoother transition
* Use your password manager to autofill the username and password (I tested 1password in FF so far)
* Fill in an incorrect username -> should show an error
* Fill in a correct username -> should clear the error and show the password field
* Fill in an incorrect password -> should show an error
* Click *Change username* link -> should make username editable again
* Enter correct username and password -> should now log you in, take you to the `create-site` route and on to edit your new site!