### PR TITLE
Update text on migration progress screen

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -320,9 +320,11 @@ class SectionMigrate extends Component {
 	};
 
 	renderLoading() {
+		const { translate } = this.props;
+
 		return (
 			<CompactCard>
-				<span className="migrate__placeholder">Loading...</span>
+				<span className="migrate__placeholder">{ translate( 'Loading…' ) }</span>
 			</CompactCard>
 		);
 	}
@@ -484,7 +486,7 @@ class SectionMigrate extends Component {
 
 	renderProgressItem( progressState ) {
 		const { migrationStatus } = this.state;
-		const { sourceSite, targetSite } = this.props;
+		const { sourceSite, targetSite, translate } = this.props;
 		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
 
@@ -493,13 +495,27 @@ class SectionMigrate extends Component {
 			case 'backing-up':
 				progressItemText = (
 					<span>
-						Backup of <span className="migrate__domain">{ sourceSiteDomain } completed</span>
+						{ translate( 'Backup of {{sp}}%(sourceSiteDomain)s{{/sp}} completed', {
+							args: {
+								sourceSiteDomain,
+							},
+							components: {
+								sp: <span className="migrate__domain" />,
+							},
+						} ) }
 					</span>
 				);
 				if ( migrationStatus === 'backing-up' ) {
 					progressItemText = (
 						<span>
-							Backing up <span className="migrate__domain">{ sourceSiteDomain }</span>
+							{ translate( 'Backing up {{sp}}%(sourceSiteDomain)s{{/sp}}', {
+								args: {
+									sourceSiteDomain,
+								},
+								components: {
+									sp: <span className="migrate__domain" />,
+								},
+							} ) }
 						</span>
 					);
 				}
@@ -507,7 +523,14 @@ class SectionMigrate extends Component {
 			case 'restoring':
 				progressItemText = (
 					<span>
-						Restoring to <span className="migrate__domain">{ targetSiteDomain }</span>
+						{ translate( 'Restoring to {{sp}}%(targetSiteDomain)s{{/sp}}', {
+							args: {
+								targetSiteDomain,
+							},
+							components: {
+								sp: <span className="migrate__domain" />,
+							},
+						} ) }
 					</span>
 				);
 				break;

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -493,13 +493,13 @@ class SectionMigrate extends Component {
 			case 'backing-up':
 				progressItemText = (
 					<span>
-						Backed up from <span className="migrate__domain">{ sourceSiteDomain }</span>
+						Backup of <span className="migrate__domain">{ sourceSiteDomain } completed</span>
 					</span>
 				);
 				if ( migrationStatus === 'backing-up' ) {
 					progressItemText = (
 						<span>
-							Backing up from <span className="migrate__domain">{ sourceSiteDomain }</span>
+							Backing up <span className="migrate__domain">{ sourceSiteDomain }</span>
 						</span>
 					);
 				}


### PR DESCRIPTION
#### Changes

This PR updates the wording on the migration progress screen.

##### Before

<img width="514" alt="ScreenCapture at Tue Mar 10 23:04:22 EDT 2020" src="https://user-images.githubusercontent.com/2098816/76378853-ef1f4d80-6324-11ea-84ba-56d25324f576.png">

<img width="532" alt="ScreenCapture at Tue Mar 10 23:04:33 EDT 2020" src="https://user-images.githubusercontent.com/2098816/76378861-f5152e80-6324-11ea-93f3-52bb9797cff2.png">

##### After

<img width="561" alt="ScreenCapture at Tue Mar 10 23:07:20 EDT 2020" src="https://user-images.githubusercontent.com/2098816/76378871-fba3a600-6324-11ea-8919-19e04b24bc05.png">

<img width="531" alt="ScreenCapture at Tue Mar 10 23:07:32 EDT 2020" src="https://user-images.githubusercontent.com/2098816/76378879-ff372d00-6324-11ea-81b5-45f6e5a0abaa.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Perform a migration
* Verify that text on progress screen is updated
