### PR TITLE
Add strict type checking for `@automattic/data-stores` to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,9 @@ jobs:
       - prepare
       - run:
           name: TypeScript strict typecheck of individual subprojects
-          command: npm run tsc -- --project client/landing/gutenboarding
+          command: |
+            npm run tsc -- --project client/landing/gutenboarding &&
+            npm run tsc -- --project packages/data-stores
 
   lint-and-translate:
     <<: *defaults


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add strict type checking for `@automattic/data-stores` to CI

This package passes strict type checking, seems like adding it to CI will keep it this way.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI passes
