### PR TITLE
Add:  Error style to badge component

### DIFF
--- a/client/components/badge/README.md
+++ b/client/components/badge/README.md
@@ -19,3 +19,9 @@ class MyComponent extends React.Component {
 	}
 }
 ```
+
+## Props
+
+The following props are available to customize the Badge:
+
+- `type`: `'warning'`, `'success'`, `'info'`, `'info-blue'`, `'error'`

--- a/client/components/badge/docs/example.jsx
+++ b/client/components/badge/docs/example.jsx
@@ -20,6 +20,8 @@ BadgeExample.defaultProps = {
 			<Badge type="info">Info Badge</Badge>
 			<Badge type="success">Success Badge</Badge>
 			<Badge type="warning">Warning Badge</Badge>
+			<Badge type="info-blue">Info Blue Badge</Badge>
+			<Badge type="error">Error Badge</Badge>
 		</div>
 	),
 };

--- a/client/components/badge/index.jsx
+++ b/client/components/badge/index.jsx
@@ -13,7 +13,7 @@ import './style.scss';
 
 export default class Badge extends React.Component {
 	static propTypes = {
-		type: PropTypes.oneOf( [ 'warning', 'success', 'info', 'info-blue' ] ).isRequired,
+		type: PropTypes.oneOf( [ 'warning', 'success', 'info', 'info-blue', 'error' ] ).isRequired,
 	};
 
 	static defaultProps = {

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -26,3 +26,8 @@
 	background-color: var( --color-primary );
 	color: var( --color-text-inverted );
 }
+
+.badge--error {
+	background-color: var( --color-error );
+	color: var( --color-text-inverted );
+}

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -23,7 +23,7 @@
 }
 
 .badge--info-blue {
-	background-color: var( --color-primary );
+	background-color: var( --studio-blue-50 );
 	color: var( --color-text-inverted );
 }
 

--- a/client/components/badge/test/index.js
+++ b/client/components/badge/test/index.js
@@ -36,6 +36,11 @@ describe( 'Badge', () => {
 		assert.lengthOf( badge.find( '.badge.badge--info-blue' ), 1 );
 	} );
 
+	test( 'should have proper type class (error)', () => {
+		const badge = shallow( <Badge type="error" /> );
+		assert.lengthOf( badge.find( '.badge.badge--error' ), 1 );
+	} );
+
 	test( 'should have proper type class (default)', () => {
 		const badge = shallow( <Badge /> );
 		assert.lengthOf( badge.find( '.badge.badge--warning' ), 1 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new error style to the badge component. 

New designs.
<img width="1467" alt="Screen Shot 2020-03-17 at 9 55 12 AM" src="https://user-images.githubusercontent.com/115071/76839213-68430700-6835-11ea-8a81-1a3169a0222a.png">

Notice when you switch between the different colour scheme that the badge colours don't change. 


#### Testing instructions

* Checkout the dev docs. http://calypso.localhost:3000/devdocs/design/badge 


