### PR TITLE
Gutenboarding: Add paid domain to cart

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -171,9 +171,6 @@ const Header: FunctionComponent = () => {
 	}, [ newUser, handleCreateSite ] );
 
 	useEffect( () => {
-		// TODO: Cancellable?
-		// let cancel = () => undefined;
-
 		if ( newSite ) {
 			if ( isDomainFlow ) {
 				// I'd rather not make my own product, but this works.
@@ -204,9 +201,6 @@ const Header: FunctionComponent = () => {
 			resetOnboardStore();
 			window.location.href = `/block-editor/page/${ newSite.site_slug }/home?is-gutenboarding`;
 		}
-
-		// TODO: Cancellable?
-		// return cancel;
 	}, [ domain, isDomainFlow, newSite, resetOnboardStore ] );
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When selecting a paid domain from the domain picker, add it to the cart before sending the user to checkout.

#### Testing instructions

* [`/gutenboarding`](https://calypso.live/gutenboarding?branch=gutenboarding/domain-purchase)
* Enter a vertical and title.
* Click the domain dropdown and select a paid domain.
* Continue from the modal.
* Your site should be created, then you'll be sent to checkout with a plan and a domain in the cart ready for checkout.

