### PR TITLE
Jetpack Cloud: try icons animation with `react-spring`

### DIFF
--- a/client/assets/stylesheets/jetpack-cloud.scss
+++ b/client/assets/stylesheets/jetpack-cloud.scss
@@ -30,3 +30,8 @@
 		}
 	}
 }
+
+.animations__jpc-icon {
+	width: 80px;
+	height: auto;
+}

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -102,6 +102,16 @@ class JetpackCloudSidebar extends Component {
 				<SidebarFooter>
 					<SidebarMenu>
 						<SidebarItem
+							label={ translate( 'Animations', {
+								comment: 'Jetpack Cloud sidebar navigation item ',
+							} ) }
+							link="/animations"
+							materialIcon="dashboard"
+							materialIconStyle="filled"
+							onNavigate={ this.onNavigate }
+							selected={ this.isSelected( '/animations' ) }
+						/>
+						<SidebarItem
 							label={ translate( 'Support', { comment: 'Jetpack Cloud sidebar navigation item' } ) }
 							link="#" // @todo: Add /support route or change link to other destination
 							materialIcon="help"

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -106,8 +106,8 @@ class JetpackCloudSidebar extends Component {
 								comment: 'Jetpack Cloud sidebar navigation item ',
 							} ) }
 							link="/animations"
-							materialIcon="dashboard"
-							materialIconStyle="filled"
+							materialIcon="offline_bolt"
+							materialIconStyle="outline"
 							onNavigate={ this.onNavigate }
 							selected={ this.isSelected( '/animations' ) }
 						/>

--- a/client/landing/jetpack-cloud/routes.js
+++ b/client/landing/jetpack-cloud/routes.js
@@ -9,6 +9,7 @@ import page from 'page';
 import config from 'config';
 import { normalize } from 'lib/route';
 import { clientRender, makeLayout, setupSidebar, sites, siteSelection } from './controller';
+import { animations } from './sections/animations/controller';
 import { dashboard } from './sections/dashboard/controller';
 import {
 	backups,
@@ -99,6 +100,10 @@ const router = () => {
 	if ( config.isEnabled( 'jetpack-cloud/settings' ) ) {
 		page( '/settings', siteSelection, sites, setupSidebar, makeLayout, clientRender );
 		page( '/settings/:site', siteSelection, setupSidebar, settings, makeLayout, clientRender );
+	}
+
+	if ( config.isEnabled( 'jetpack-cloud/animations' ) ) {
+		page( '/animations', setupSidebar, animations, makeLayout, clientRender );
 	}
 };
 

--- a/client/landing/jetpack-cloud/section.js
+++ b/client/landing/jetpack-cloud/section.js
@@ -1,6 +1,6 @@
 export const JETPACK_CLOUD_SECTION_DEFINITION = {
 	name: 'jetpack-cloud',
-	paths: [ '/', '/scan', '/backups', '/settings' ],
+	paths: [ '/', '/scan', '/backups', '/settings', '/animations' ],
 	module: 'jetpack-cloud',
 	secondary: false,
 	group: 'jetpack-cloud',

--- a/client/landing/jetpack-cloud/sections/animations/controller.js
+++ b/client/landing/jetpack-cloud/sections/animations/controller.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import AnimationsPage from './main';
+
+export function animations( context, next ) {
+	context.primary = <AnimationsPage />;
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/animations/main.jsx
+++ b/client/landing/jetpack-cloud/sections/animations/main.jsx
@@ -26,10 +26,10 @@ export default function() {
 	} );
 
 	const animScanIconHead = useSpring( {
-		from: { y: 0 },
+		from: { transform: 'translateY(0px)' },
 		to: async next => {
 			for (;;) {
-				await next( { y: 260 } );
+				await next( { transform: 'translateY(260px)' } );
 			}
 		},
 		config: { duration: 1800 },
@@ -61,10 +61,11 @@ export default function() {
 						fill="#D0E6B8"
 					/>
 					<animated.line
+						style={ animScanIconHead }
 						x1="0"
 						x2="124"
-						y1={ animScanIconHead.y }
-						y2={ animScanIconHead.y }
+						y1="0"
+						y2="0"
 						stroke="#069E08"
 						strokeWidth="7"
 					/>

--- a/client/landing/jetpack-cloud/sections/animations/main.jsx
+++ b/client/landing/jetpack-cloud/sections/animations/main.jsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useSpring, animated } from 'react-spring';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUserName } from 'state/current-user/selectors';
+
+export default function() {
+	const user = useSelector( state => getCurrentUserName( state ) );
+	const animHello = useSpring( { opacity: 1, from: { opacity: 0 } } );
+
+	return (
+		<div>
+			<animated.p style={ animHello }>Welcome to the animated world of icons, { user }!</animated.p>
+
+		</div>
+	);
+}

--- a/client/landing/jetpack-cloud/sections/animations/main.jsx
+++ b/client/landing/jetpack-cloud/sections/animations/main.jsx
@@ -2,44 +2,41 @@
  * External dependencies
  */
 import React from 'react';
-import { useSelector } from 'react-redux';
-import { useSpring, animated } from 'react-spring';
-
-/**
- * Internal dependencies
- */
-import { getCurrentUserName } from 'state/current-user/selectors';
+import { Keyframes, animated } from 'react-spring/renderprops';
 
 export default function() {
-	const user = useSelector( state => getCurrentUserName( state ) );
-	const animHello = useSpring( { opacity: 1, from: { opacity: 0 } } );
-
-	const animScanIconShield = useSpring( {
-		from: { opacity: 0 },
-		to: async next => {
-			for (;;) {
-				await next( { opacity: 1 } );
-			}
-		},
-		config: { duration: 900 },
-		reset: true,
+	const AnimScanIconShield = Keyframes.Spring( async next => {
+		// eslint-disable-next-line no-constant-condition
+		while ( true ) {
+			await next( {
+				from: { opacity: 0 },
+				opacity: 1,
+				config: { duration: 900 },
+			} );
+			await next( {
+				opacity: 0,
+				config: { duration: 900 },
+			} );
+		}
 	} );
 
-	const animScanIconHead = useSpring( {
-		from: { transform: 'translateY(0px)' },
-		to: async next => {
-			for (;;) {
-				await next( { transform: 'translateY(260px)' } );
-			}
-		},
-		config: { duration: 1800 },
-		reset: true,
+	const AnimScanIconHead = Keyframes.Spring( async next => {
+		// eslint-disable-next-line no-constant-condition
+		while ( true ) {
+			await next( {
+				from: { transform: 'translateY(0px)' },
+				transform: 'translateY(260px)',
+				config: { duration: 1800 },
+			} );
+			await next( {
+				transform: 'translateY(0px)',
+				config: { duration: 0 },
+			} );
+		}
 	} );
 
 	return (
 		<div>
-			<animated.p style={ animHello }>Welcome to the animated world of icons, { user }!</animated.p>
-
 			<svg
 				xmlns="http://www.w3.org/2000/svg"
 				viewBox="0 0 124 150"
@@ -52,23 +49,24 @@ export default function() {
 					/>
 				</mask>
 				<g mask="url(#scan-shield-mask)">
-					<animated.rect
-						style={ animScanIconShield }
-						x="0"
-						y="0"
-						width="124"
-						height="150"
-						fill="#D0E6B8"
-					/>
-					<animated.line
-						style={ animScanIconHead }
-						x1="0"
-						x2="124"
-						y1="0"
-						y2="0"
-						stroke="#069E08"
-						strokeWidth="7"
-					/>
+					<AnimScanIconShield native>
+						{ props => (
+							<animated.rect style={ props } x="0" y="0" width="124" height="150" fill="#D0E6B8" />
+						) }
+					</AnimScanIconShield>
+					<AnimScanIconHead native>
+						{ props => (
+							<animated.line
+								style={ props }
+								x1="0"
+								x2="124"
+								y1="0"
+								y2="0"
+								stroke="#069E08"
+								strokeWidth="7"
+							/>
+						) }
+					</AnimScanIconHead>
 				</g>
 			</svg>
 		</div>

--- a/client/landing/jetpack-cloud/sections/animations/main.jsx
+++ b/client/landing/jetpack-cloud/sections/animations/main.jsx
@@ -14,10 +14,62 @@ export default function() {
 	const user = useSelector( state => getCurrentUserName( state ) );
 	const animHello = useSpring( { opacity: 1, from: { opacity: 0 } } );
 
+	const animScanIconShield = useSpring( {
+		from: { opacity: 0 },
+		to: async next => {
+			for (;;) {
+				await next( { opacity: 1 } );
+			}
+		},
+		config: { duration: 900 },
+		reset: true,
+	} );
+
+	const animScanIconHead = useSpring( {
+		from: { y: 0 },
+		to: async next => {
+			for (;;) {
+				await next( { y: 260 } );
+			}
+		},
+		config: { duration: 1800 },
+		reset: true,
+	} );
+
 	return (
 		<div>
 			<animated.p style={ animHello }>Welcome to the animated world of icons, { user }!</animated.p>
 
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 124 150"
+				className="animations__jpc-icon"
+			>
+				<mask id="scan-shield-mask" maskUnits="userSpaceOnUse" x="0" y="0" width="124" height="150">
+					<path
+						d="M62.115 0L.75 27.273v40.909c0 37.841 26.182 73.227 61.364 81.818 35.181-8.591 61.363-43.977 61.363-81.818v-40.91L62.115 0z"
+						fill="#FFF"
+					/>
+				</mask>
+				<g mask="url(#scan-shield-mask)">
+					<animated.rect
+						style={ animScanIconShield }
+						x="0"
+						y="0"
+						width="124"
+						height="150"
+						fill="#D0E6B8"
+					/>
+					<animated.line
+						x1="0"
+						x2="124"
+						y1={ animScanIconHead.y }
+						y2={ animScanIconHead.y }
+						stroke="#069E08"
+						strokeWidth="7"
+					/>
+				</g>
+			</svg>
 		</div>
 	);
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -12,6 +12,7 @@
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
 	"features": {
 		"jetpack-cloud": true,
+		"jetpack-cloud/animations": true,
 		"jetpack-cloud/backups": true,
 		"jetpack-cloud/backups-restore": true,
 		"jetpack-cloud/settings": true,


### PR DESCRIPTION
*DO NOT MERGE*

#### Changes proposed in this Pull Request

* Trying `react-spring` to power icon animations in Jetpack Cloud.

![jpc-icon-anim-01](https://user-images.githubusercontent.com/390760/76408718-494ffb00-6385-11ea-8772-39735f5edc26.gif)

#### Context and findings

**Update**: animations with `react-spring` _can be_ equally fluid to other animation libraries, but parameters should to be animated manually to achieve good performance — e.g.: https://github.com/Automattic/wp-calypso/pull/40047/commits/71e826975d2ec4638e26018f989ac2f3270cc8ee

Gave `react-spring` a go to see if it's flexible enough for our animated icons on Jetpack Cloud.

My early findings is that this animation framework was never intended to be used for this kind of stuff as is optimized for UI transitions. It's also much less performant than the https://animejs.com/ library we used for all of these animations ([example here](https://codepen.io/scottsweb/pen/bGGYrbp)), requiring a lot more manual work to make it as performant as AnimeJS is out-of-the-box.

My recommendation would be to leave animations out for now and invest a bit more time either including AnimeJS or exploring `react-spring` further.

cc @enejb @ChaosExAnima 

#### Testing instructions

* Fire up this PR with `npm run start-jetpack-cloud`.
* Open Animations page on Jetpack Cloud.
* See animation.
