### PR TITLE
Add a custom error message for a compromised account.

### DIFF
--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -71,14 +71,12 @@ export function getErrorFromHTTPError( httpError ) {
 			return {
 				code,
 				message: (
-					<div>
-						<p>
-							{ translate(
-								'Your account has been blocked as a security precaution. To continue, you must {{a}}reset your password{{/a}}.',
-								{ components: { a: <a href={ url } rel="external" /> } }
-							) }
-						</p>
-					</div>
+					<p>
+						{ translate(
+							'Your account has been blocked as a security precaution. To continue, you must {{a}}reset your password{{/a}}.',
+							{ components: { a: <a href={ url } rel="external" /> } }
+						) }
+					</p>
 				),
 				field,
 			};

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -66,6 +66,22 @@ export function getErrorFromHTTPError( httpError ) {
 	if ( code ) {
 		if ( code in errorFields ) {
 			field = errorFields[ code ];
+		} else if ( code === 'compromisable_account' ) {
+			const url = localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' );
+			return {
+				code,
+				message: (
+					<div>
+						<p>
+							{ translate(
+								'Your account has been blocked as a security precaution. To continue, you must {{a}}reset your password{{/a}}.',
+								{ components: { a: <a href={ url } rel="external" /> } }
+							) }
+						</p>
+					</div>
+				),
+				field,
+			};
 		} else if ( code === 'admin_login_attempt' ) {
 			const url = localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' );
 
@@ -150,7 +166,7 @@ export const isRegularAccount = authAccountType => authAccountType === 'regular'
 export const isPasswordlessAccount = authAccountType => authAccountType === 'passwordless';
 
 export async function postLoginRequest( action, bodyObj ) {
-	const response = await fetch(
+	const response = await window.fetch(
 		localizeUrl( `https://wordpress.com/wp-login.php?action=${ action }` ),
 		{
 			method: 'POST',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renders a custom error message when an account is compromised because the html tags returned by the backend are escaped by default.

#### Testing instructions

* Try to log in with a compromised account (MC pastebin: 24382).
* Notice the error message links to the password reset page.