### PR TITLE
Fix: Post checkout upsell not shown + eCommerce site not setup in the new checkout flow

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -59,6 +59,7 @@ export default function CheckoutSystemDecider( {
 					redirectTo={ redirectTo }
 					feature={ selectedFeature }
 					plan={ plan }
+					cart={ cart }
 				/>
 			</StripeHookProvider>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Post checkout upsells - Premium plan bump offer and the Quick Start offer - are not shown when user is in the composite checkout flow. This PR fixes the issue.

**With a Personal plan in cart**

**BEFORE**

![checkout1](https://user-images.githubusercontent.com/1269602/76420555-4d513c80-63c8-11ea-9db1-b5035a553d3f.gif)

**AFTER**

![checkout1_fixed](https://user-images.githubusercontent.com/1269602/76420124-9fde2900-63c7-11ea-962e-8eaeadc76354.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Proxy through a US IP address and have your browser language set to `en`. Assign yourself to the `composite` variation of `showCompositeCheckout` AB test. 
* In the signup flow, add a Personal plan to cart, complete payment, and verify that you see the Premium plan bump offer.
* In the signup flow, add a Premium plan to cart, complete payment, and verify that you see the Quick Start offer.
* Purchase an eCommerce plan and verify that the store gets provisioned