### PR TITLE
Adds missing dependencies to @automattic/babel-plugin-transform-wpcalypso-async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,7 +173,10 @@
 		},
 		"@automattic/babel-plugin-transform-wpcalypso-async": {
 			"version": "file:packages/babel-plugin-transform-wpcalypso-async",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"lodash": "4.17.15"
+			}
 		},
 		"@automattic/calypso-analytics": {
 			"version": "file:packages/calypso-analytics",

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,7 +175,7 @@
 			"version": "file:packages/babel-plugin-transform-wpcalypso-async",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.15"
+				"lodash": "^4.17.15"
 			}
 		},
 		"@automattic/calypso-analytics": {

--- a/packages/babel-plugin-transform-wpcalypso-async/package.json
+++ b/packages/babel-plugin-transform-wpcalypso-async/package.json
@@ -9,5 +9,8 @@
 		"type": "git",
 		"url": "git://github.com/Automattic/wp-calypso.git",
 		"directory": "packages/babel-plugin-transform-wpcalypso-async"
+	},
+	"dependencies": {
+		"lodash": "4.17.15"
 	}
 }

--- a/packages/babel-plugin-transform-wpcalypso-async/package.json
+++ b/packages/babel-plugin-transform-wpcalypso-async/package.json
@@ -11,6 +11,6 @@
 		"directory": "packages/babel-plugin-transform-wpcalypso-async"
 	},
 	"dependencies": {
-		"lodash": "4.17.15"
+		"lodash": "^4.17.15"
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds missing dependencies (`lodash`) to this package. Missing dependency found via https://www.npmjs.com/package/dependency-check.

The version used for `lodash` is the same version used in the root of the project, so nothing should change.

#### Testing instructions

* N/A
