### PR TITLE
Jetpack Cloud: Add backup search view to backups page

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import Button from 'components/forms/form-button';
+import { Card } from '@automattic/components';
+import ActivityActor from 'my-sites/activity/activity-log-item/activity-actor';
+import ActivityDescription from 'my-sites/activity/activity-log-item/activity-description';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ActivityCard extends Component {
+	render() {
+		const { activity, moment, allowRestore } = this.props;
+
+		return (
+			<div className="activity-card">
+				<div className="activity-card__time">
+					<Gridicon icon="cloud-upload" />
+					{ moment( activity.activityDate ).format( 'LT' ) }
+				</div>
+				<Card>
+					<ActivityActor
+						{ ...{
+							actorAvatarUrl: activity.actorAvatarUrl,
+							actorName: activity.actorName,
+							actorRole: activity.actorRole,
+							actorType: activity.actorType,
+						} }
+					/>
+					<ActivityDescription activity={ activity } rewindIsActive={ allowRestore } />
+					<div>{ activity.activityTitle }</div>
+					<div>
+						<Button compact borderless>
+							See content <Gridicon icon="chevron-down" />
+						</Button>
+						<Button compact borderless>
+							Actions <Gridicon icon="add" />
+						</Button>
+					</div>
+				</Card>
+			</div>
+		);
+	}
+}
+
+export default ActivityCard;

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -1,0 +1,8 @@
+.activity-card .activity-log-item__actor {
+    margin-left: 0;
+}
+
+.activity-card .button.is-borderless.is-primary {
+    float: none;
+    display: inline-block;
+}

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -9,9 +9,7 @@ import { localize } from 'i18n-calypso';
  */
 import Gridicon from 'components/gridicon';
 import Button from 'components/forms/form-button';
-import { Card } from '@automattic/components';
-import ActivityActor from 'my-sites/activity/activity-log-item/activity-actor';
-import ActivityDescription from 'my-sites/activity/activity-log-item/activity-description';
+import ActivityCard from '../../components/activity-card';
 
 /**
  * Style dependencies
@@ -20,47 +18,24 @@ import './style.scss';
 
 class BackupDelta extends Component {
 	renderRealtime() {
-		const { allowRestore, translate } = this.props;
+		const { allowRestore, moment, translate } = this.props;
 
 		const realtimeEvents = this.props.realtimeEvents.filter( event => event.activityIsRewindable );
 
-		const events = realtimeEvents.map( event => (
-			<Fragment key={ event.activityId }>
-				<div className="backup-delta__time">
-					<Gridicon icon="cloud-upload" />
-					{ this.props.moment( event.activityDate ).format( 'LT' ) }
-				</div>
-				<Card>
-					<ActivityActor
-						{ ...{
-							actorAvatarUrl: event.actorAvatarUrl,
-							actorName: event.actorName,
-							actorRole: event.actorRole,
-							actorType: event.actorType,
-						} }
-					/>
-					<ActivityDescription activity={ event } rewindIsActive={ allowRestore } />
-					<div>{ event.activityTitle }</div>
-					<div>
-						<Button compact borderless>
-							{ translate( 'See content' ) } <Gridicon icon="chevron-down" />
-						</Button>
-						<Button compact borderless>
-							{ translate( 'Actions' ) } <Gridicon icon="add" />
-						</Button>
-					</div>
-				</Card>
-			</Fragment>
+		const cards = realtimeEvents.map( activity => (
+			<ActivityCard
+				{ ...{
+					moment,
+					activity,
+					allowRestore,
+				} }
+			/>
 		) );
 
 		return (
 			<div className="backup-delta__realtime">
 				<div>{ translate( 'More backups from today' ) }</div>
-				{ events.length ? (
-					events
-				) : (
-					<div>{ translate( 'you have no more backups for this day' ) }</div>
-				) }
+				{ cards.length ? cards : <div>{ translate( 'you have no more backups for this day' ) }</div> }
 			</div>
 		);
 	}
@@ -120,9 +95,11 @@ class BackupDelta extends Component {
 	}
 
 	render() {
+		const { hasRealtimeBackups } = this.props;
+
 		return (
 			<div className="backup-delta">
-				{ this.props.hasRealtimeBackups ? this.renderRealtime() : this.renderDaily() }
+				{ hasRealtimeBackups ? this.renderRealtime() : this.renderDaily() }
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -3,15 +3,15 @@
  */
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
+import { isMobile } from '@automattic/viewport';
 
 /**
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
-import { emptyFilter } from 'state/activity-log/reducer';
+import { updateFilter } from 'state/activity-log/actions';
 import { getBackupAttemptsForDate, getDailyBackupDeltas, getEventsInDailyBackup } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePurchases } from 'state/purchases/selectors';
 import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
 import BackupDelta from '../../components/backup-delta';
@@ -23,6 +23,18 @@ import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
+import Filterbar from 'my-sites/activity/filterbar';
+import ActivityCard from '../../components/activity-card';
+import siteSupportsRealtimeBackup from 'state/selectors/site-supports-realtime-backup';
+import Pagination from 'components/pagination';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const PAGE_SIZE = 10;
 
 class BackupsPage extends Component {
 	constructor( props ) {
@@ -34,17 +46,23 @@ class BackupsPage extends Component {
 
 	dateChange = selectedDateString => this.setState( { selectedDateString } );
 
-	hasRealtimeBackups = () =>
-		this.props.sitePurchases &&
-		!! this.props.sitePurchases.filter(
-			purchase => 'jetpack_backup_realtime' === purchase.productSlug
-		).length;
+	isEmptyFilter = filter => {
+		if ( ! filter ) {
+			return true;
+		}
+		if ( filter.group || filter.on || filter.before || filter.after ) {
+			return false;
+		}
+		if ( filter.page !== 1 ) {
+			return false;
+		}
+		return true;
+	};
 
-	render() {
-		const { allowRestore, logs, moment, siteId, siteSlug } = this.props;
+	renderMain() {
+		const { allowRestore, hasRealtimeBackups, logs, moment, siteId, siteSlug } = this.props;
 		const { selectedDateString } = this.state;
 
-		const hasRealtimeBackups = this.hasRealtimeBackups();
 		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );
 		const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
@@ -79,24 +97,108 @@ class BackupsPage extends Component {
 			</Main>
 		);
 	}
+
+	changePage = pageNumber => {
+		this.props.selectPage( this.props.siteId, pageNumber );
+		window.scrollTo( 0, 0 );
+	};
+
+	renderActivityLog() {
+		const { allowRestore, filter, logs, moment, siteId } = this.props;
+		const { page: requestedPage } = filter;
+
+		const actualPage = Math.max(
+			1,
+			Math.min( requestedPage, Math.ceil( logs.length / PAGE_SIZE ) )
+		);
+		const theseLogs = logs.slice( ( actualPage - 1 ) * PAGE_SIZE, actualPage * PAGE_SIZE );
+
+		const cards = theseLogs.map( activity => (
+			<ActivityCard
+				{ ...{
+					key: activity.activityId,
+					moment,
+					activity,
+					allowRestore,
+				} }
+			/>
+		) );
+
+		return (
+			<div>
+				<div>Find a backup or restore point</div>
+				<div>
+					This is the complete event history for your site. Filter by date range and/ or activity
+					type.
+				</div>
+				<Filterbar
+					{ ...{
+						siteId,
+						filter,
+						isLoading: false,
+						isVisible: true,
+					} }
+				/>
+				<Pagination
+					compact={ isMobile() }
+					className="backups__pagination"
+					key="backups__pagination-top"
+					nextLabel={ 'Older' }
+					page={ actualPage }
+					pageClick={ this.changePage }
+					perPage={ PAGE_SIZE }
+					prevLabel={ 'Newer' }
+					total={ logs.length }
+				/>
+				{ cards }
+				<Pagination
+					compact={ isMobile() }
+					className="backups__pagination"
+					key="backups__pagination-bottom"
+					nextLabel={ 'Older' }
+					page={ actualPage }
+					pageClick={ this.changePage }
+					perPage={ PAGE_SIZE }
+					prevLabel={ 'Newer' }
+					total={ logs.length }
+				/>
+			</div>
+		);
+	}
+
+	render() {
+		const { filter } = this.props;
+
+		return (
+			<div className="backups__page">
+				{ ! this.isEmptyFilter( filter ) ? this.renderActivityLog() : this.renderMain() }
+			</div>
+		);
+	}
 }
 
-export default connect( state => {
+const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
-	const logs = siteId && requestActivityLogs( siteId, emptyFilter );
+	const filter = getActivityLogFilter( state, siteId );
+	const logs = siteId && requestActivityLogs( siteId, filter );
 	const rewind = getRewindState( state, siteId );
-	const sitePurchases = siteId && getSitePurchases( state, siteId );
-
 	const restoreStatus = rewind.rewind && rewind.rewind.status;
 	const allowRestore =
 		'active' === rewind.state && ! ( 'queued' === restoreStatus || 'running' === restoreStatus );
 
 	return {
 		allowRestore,
+		filter,
+		hasRealtimeBackups: siteSupportsRealtimeBackup( state, siteId ),
 		logs: logs?.data ?? [],
 		rewind,
 		siteId,
-		sitePurchases,
 		siteSlug: getSelectedSiteSlug( state ),
 	};
-} )( withLocalizedMoment( BackupsPage ) );
+};
+
+const mapDispatchToProps = dispatch => ( {
+	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) ),
+} );
+
+export default connect( mapStateToProps, mapDispatchToProps )( withLocalizedMoment( BackupsPage ) );

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -1,0 +1,3 @@
+.backups__page .filterbar .filterbar__wrap.card {
+    display: inline-block;
+}

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -7,6 +7,7 @@ import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
+
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a date range is selected on the backup page, switch to the "Activity Log view" and show a list of appropriate events, along with working filtering and pagination.
* Break out `ActivityCard` into it's own component, retrofit into `BackupDelta` and use in the Activity Log view of the Backup page.
* A few misc improvements/fixes/advancements over a few other related areas.

As usual, **this is not pretty**, but in theory it should be fully functional.

<img width="1122" alt="Screen Shot 2020-03-11 at 3 17 41 PM" src="https://user-images.githubusercontent.com/5528445/76454795-921aaa80-63ab-11ea-82cf-2bebeeaaff13.png">


#### Testing instructions

* View the backups page as a daily site, ensure the view still works as expected.
* View the backups page as a realtime site, ensure the view still works as expected.
* Click the calendar icon at the top of the backups page, select a date range. Ensure that the proper data is displayed, that further filtering works, that pagination works, and that you are able to exit back to the backups page view by clearing filters.
