### PR TITLE
Plans: Link to My Plan from plan purchases.

### DIFF
--- a/client/me/purchases/product-link/index.jsx
+++ b/client/me/purchases/product-link/index.jsx
@@ -32,7 +32,7 @@ const ProductLink = ( { productUrl, purchase, selectedSite } ) => {
 	}
 
 	if ( isPlan( purchase ) ) {
-		url = '/plans/compare/' + selectedSite.slug;
+		url = '/plans/my-plan/' + selectedSite.slug;
 		text = i18n.translate( 'View Plan Features' );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Instead of linking to the general Compare Plans view from a plan purchase, link to the My Plan tab instead.

![2020-03-11 12 19 49](https://user-images.githubusercontent.com/349751/76456034-9fc43600-6393-11ea-9632-23ecfc65604d.gif)

#### Testing instructions

* Find a plan purchase under `/me/purchases`.
* Click the View Plan Features link.
* Verify you are sent to the My Plans tab (`/plans/my-plan/:site`, instead of `/plans/:site`).

Fixes #38076
