### PR TITLE
Polyfill CustomEvent on IE 11 for Apple login

### DIFF
--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -27,6 +27,20 @@ const appleClientUrl =
 const connectUrlPopupFLow =
 	'https://public-api.wordpress.com/connect/?magic=keyring&service=apple&action=request&for=connect';
 
+// polyfill for CustomEvent otherwise Apple login breaks on IE 11
+// see: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+( function() {
+	if ( typeof window === 'undefined' || typeof window.CustomEvent === 'function' ) return false;
+	function CustomEvent( event, params ) {
+		params = params || { bubbles: false, cancelable: false, detail: null };
+		const evt = document.createEvent( 'CustomEvent' );
+		evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+		return evt;
+	}
+
+	window.CustomEvent = CustomEvent;
+} )();
+
 class AppleLoginButton extends Component {
 	static propTypes = {
 		clientId: PropTypes.string.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix a crash on IE11 loading Jetpack connect login screen

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Connect a Jetpack site in  IE11
* Debugger prompt comes up when login form displays
* With this patch, there should be no debugger prompt
