### PR TITLE
Fix a 404 error when navigating to /log-in/jetpack/webauthn

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -145,6 +145,21 @@ const trackGlobalStyles = eventName => options => {
 };
 
 /**
+ * Logs any error notice which is shown to the user so we can determine how often
+ * folks see different errors and what types of sites they occur on.
+ *
+ * @param {string} content The error message. Like "Update failed."
+ * @param {object} options Optional. Extra data logged with the error in Gutenberg.
+ */
+const trackErrorNotices = ( content, options ) => {
+	const logInfo = {
+		errorText: content,
+		errorOptions: options,
+	};
+	tracksRecordEvent( 'wpcom_gutenberg_error_notice', logInfo );
+};
+
+/**
  * Tracker can be
  * - string - which means it is an event name and should be tracked as such automatically
  * - function - in case you need to load additional properties from the action.
@@ -173,6 +188,9 @@ const REDUX_TRACKING = {
 		replaceBlock: trackBlockReplacement,
 		replaceBlocks: trackBlockReplacement,
 		replaceInnerBlocks: trackInnerBlocksReplacement,
+	},
+	'core/notices': {
+		createErrorNotice: trackErrorNotices,
 	},
 };
 

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -70,7 +70,7 @@ export default router => {
 				`/log-in/:flow(social-connect|private-site)/${ lang }`,
 				`/log-in/:socialService(google|apple)/callback/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/${ lang }`,
-				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(webauthn|authenticator|backup|sms|push)/${ lang }`,
 				`/log-in/${ lang }`,
 			],
 			redirectJetpack,

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -70,7 +70,7 @@ export default router => {
 				`/log-in/:flow(social-connect|private-site)/${ lang }`,
 				`/log-in/:socialService(google|apple)/callback/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/${ lang }`,
-				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push)/${ lang }`,
+				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 				`/log-in/${ lang }`,
 			],
 			redirectJetpack,

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -59,6 +59,7 @@ export default function CheckoutSystemDecider( {
 					redirectTo={ redirectTo }
 					feature={ selectedFeature }
 					plan={ plan }
+					cart={ cart }
 				/>
 			</StripeHookProvider>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This enables webauthn support for the Jetpack login endpoint.

#### Testing instructions

* Add a security key to a test WP.com account
* On a private tab, navigate to `https://calypso.localhost:3000/log-in/jetpack/webauthn`
* Make sure you are able to log in using a security key