### PR TITLE
Domains: Don't show free domains with plans upsell to non-DWPO users

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -20,7 +20,6 @@ import { domainManagementList } from 'my-sites/domains/paths';
 import { hasDomainCredit, isCurrentUserCurrentPlanOwner } from 'state/sites/plans/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
-import isEligibleForFreeToPaidUpsell from 'state/selectors/is-eligible-for-free-to-paid-upsell';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QueryActivePromotions from 'components/data/query-active-promotions';
@@ -268,7 +267,6 @@ export default connect(
 
 		return {
 			isDomainOnly: isDomainOnlySite( state, siteId ),
-			isEligibleForFreeToPaidUpsell: isEligibleForFreeToPaidUpsell( state, siteId ),
 			activeDiscount: getActiveDiscount( state ),
 			hasDomainCredit: hasDomainCredit( state, siteId ),
 			canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),

--- a/client/reader/sidebar/reader-sidebar-nudges/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-nudges/index.jsx
@@ -10,10 +10,8 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import QuerySitePlans from 'components/data/query-site-plans';
-import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import isEligibleForFreeToPaidUpsell from 'state/selectors/is-eligible-for-free-to-paid-upsell';
-import { isJetpackSite } from 'state/sites/selectors';
 import getSites from 'state/selectors/get-sites';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
@@ -73,8 +71,6 @@ function mapStateToProps( state ) {
 		siteSlug,
 		isEligibleForFreeToPaidUpsellNudge:
 			siteCount === 1 && // available when a user owns one site only
-			! isJetpackSite( state, siteId ) && // not for Jetpack sites
-			! isDomainOnlySite( state, siteId ) && // not for domain only sites
 			isEligibleForFreeToPaidUpsell( state, siteId ) &&
 			// This nudge only shows up to US EN users.
 			isEnglish &&

--- a/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
+++ b/client/state/selectors/is-eligible-for-free-to-paid-upsell.js
@@ -4,10 +4,13 @@
 
 import canCurrentUser from 'state/selectors/can-current-user';
 
+import { currentUserHasFlag } from 'state/current-user/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import isMappedDomainSite from 'state/selectors/is-mapped-domain-site';
 import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import isVipSite from 'state/selectors/is-vip-site';
+import isDomainOnlySite from 'state/selectors/is-domain-only-site';
+import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 /**
  * Returns true if the current user is eligible to participate in the free to paid plan upsell for the site
  *
@@ -21,13 +24,17 @@ const isEligibleForFreeToPaidUpsell = ( state, siteId ) => {
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const siteIsOnFreePlan = isSiteOnFreePlan( state, siteId );
 	const siteIsVipSite = isVipSite( state, siteId );
+	const siteIsDomainOnly = isDomainOnlySite( state, siteId );
+	const domainsWithPlansOnly = currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY );
 
 	return (
 		userCanManageOptions &&
 		! siteHasMappedDomain &&
 		siteIsOnFreePlan &&
 		! siteIsVipSite &&
-		! siteIsJetpack
+		! siteIsJetpack &&
+		! siteIsDomainOnly &&
+		domainsWithPlansOnly
 	);
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Seems that for non-DWPO (domains with plans only) users, we show this upsell:

<img width="258" alt="Screenshot 2020-03-12 at 00 00 17" src="https://user-images.githubusercontent.com/3392497/76474747-7ab3df80-63f4-11ea-9490-0f80bbdb4a49.png">

It does not make sense in the context of a user that does not have a paid plan enforced by the `DOMAINS_WITH_PLANS_ONLY` flag - the plan is not added automatically, the domain is not free, etc. This also conflicts with the `NON_PRIMARY_DOMAINS_TO_FREE_USERS` test.

#### Testing instructions

Get a user that has `DOMAINS_WITH_PLANS_ONLY` flag, make sure they see the above upsell on their Free site, but not on one that has a paid plan or domain mapping (or the user is not an admin, etc.).

Now, do the same with a user that does not have this flag.