### PR TITLE
Fix dotcom Welcome Guide to be safe for atomic.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -229,16 +229,6 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_blog_posts_block' );
  * Load WPCOM Block Editor NUX
  */
 function load_wpcom_block_editor_nux() {
-	/**
-	 * Can be used to enable Dotcom editor guide.
-	 *
-	 * @since 0.23
-	 *
-	 * @param bool true if Dotcom editor nux should be enabled, false otherwise.
-	 */
-	if ( ! apply_filters( 'a8c_enable_dotcom_editor_nux', false ) ) {
-		return;
-	}
 
 	require_once __DIR__ . '/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php';
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -111,6 +111,8 @@ function WpcomNux() {
 	);
 }
 
-registerPlugin( 'wpcom-block-editor-nux', {
-	render: () => <WpcomNux />,
-} );
+if ( __experimentalCreateInterpolateElement ) {
+	registerPlugin( 'wpcom-block-editor-nux', {
+		render: () => <WpcomNux />,
+	} );
+}

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -111,7 +111,7 @@ function WpcomNux() {
 	);
 }
 
-if ( __experimentalCreateInterpolateElement ) {
+if ( __experimentalCreateInterpolateElement && Guide && GuidePage ) {
 	registerPlugin( 'wpcom-block-editor-nux', {
 		render: () => <WpcomNux />,
 	} );

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -111,6 +111,9 @@ function WpcomNux() {
 	);
 }
 
+// Only register plugin if these features are available.
+// If registered without this check, atomic sites without gutenberg enabled will error when loading the editor.
+// These seem to be the only dependencies here that are not supported there.
 if ( __experimentalCreateInterpolateElement && Guide && GuidePage ) {
 	registerPlugin( 'wpcom-block-editor-nux', {
 		render: () => <WpcomNux />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A potential solution for bringing this back into atomic.  Essentially we only register the nux plugin if the experimental function is available.  This is the most recent addition to the dependencies in this file so if it is available, everything should be.  Similarly, if this function name gets changed as it gets determined to be a full feature and not an experiment, we will have a back up check to prevent this from breaking on simple sites as well.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this FSE build on Atomic development sites.
* Test loading the editor with and without gutenberg enabled.

Fixes #
