### PR TITLE
Plans: Update descriptions and pricing styling for Jetpack

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -611,7 +611,9 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.plan-features .plan-price.is-discounted {
+		display: block;
 		margin-right: 0;
+		font-size: 24px;
 	}
 
 	.plan-pill {
@@ -676,10 +678,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		.plan-features__graphic {
 			display: none;
-		}
-
-		.plan-features__pricing {
-			padding-top: 16px;
 		}
 	}
 }

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -17,6 +17,12 @@ const WPComGetBillingTimeframe = annualPriceText =>
 		: i18n.translate( 'per month, billed annually' );
 const WPComGetBiennialBillingTimeframe = () => i18n.translate( '/month, billed every two years' );
 
+const plansDescriptionHeadingComponent = {
+	components: {
+		strong: <strong className="plans__features plan-features__targeted-description-heading" />,
+	},
+};
+
 const getPlanBloggerDetails = () => ( {
 	group: constants.GROUP_WPCOM,
 	type: constants.TYPE_BLOGGER,
@@ -29,13 +35,7 @@ const getPlanBloggerDetails = () => ( {
 	getDescription: () =>
 		i18n.translate(
 			'{{strong}}Best for Bloggers:{{/strong}} Brand your blog with a custom .blog domain name, and remove all WordPress.com advertising. Receive additional storage space and email support.',
-			{
-				components: {
-					strong: (
-						<strong className="plans__features plan-features__targeted-description-heading" />
-					),
-				},
-			}
+			plansDescriptionHeadingComponent
 		),
 	getShortDescription: () =>
 		i18n.translate(
@@ -89,13 +89,7 @@ const getPlanPersonalDetails = () => ( {
 			'{{strong}}Best for Personal Use:{{/strong}} Boost your' +
 				' website with a custom domain name, and remove all WordPress.com advertising. ' +
 				'Get access to high-quality email and live chat support.',
-			{
-				components: {
-					strong: (
-						<strong className="plans__features plan-features__targeted-description-heading" />
-					),
-				},
-			}
+			plansDescriptionHeadingComponent
 		),
 	getShortDescription: isEligibleForPlanStepUpdates =>
 		isEligibleForPlanStepUpdates
@@ -151,13 +145,7 @@ const getPlanEcommerceDetails = () => ( {
 			'{{strong}}Best for Online Stores:{{/strong}} Sell products or services with this powerful, ' +
 				'all-in-one online store experience. This plan includes premium integrations and is extendable, ' +
 				'so it’ll grow with you as your business grows.',
-			{
-				components: {
-					strong: (
-						<strong className="plans__features plan-features__targeted-description-heading" />
-					),
-				},
-			}
+			plansDescriptionHeadingComponent
 		);
 	},
 	getShortDescription: isEligibleForPlanStepUpdates =>
@@ -249,13 +237,7 @@ const getPlanPremiumDetails = () => ( {
 				' Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
 				' Google Analytics support,' +
 				' and the ability to monetize your site with ads.',
-			{
-				components: {
-					strong: (
-						<strong className="plans__features plan-features__targeted-description-heading" />
-					),
-				},
-			}
+			plansDescriptionHeadingComponent
 		),
 	getShortDescription: isEligibleForPlanStepUpdates =>
 		isEligibleForPlanStepUpdates
@@ -325,13 +307,7 @@ const getPlanBusinessDetails = () => ( {
 			'{{strong}}Best for Small Businesses:{{/strong}} Power your' +
 				' business website with custom plugins and themes, unlimited premium and business theme templates,' +
 				' 200 GB storage, and the ability to remove WordPress.com branding.',
-			{
-				components: {
-					strong: (
-						<strong className="plans__features plan-features__targeted-description-heading" />
-					),
-				},
-			}
+			plansDescriptionHeadingComponent
 		),
 	getShortDescription: isEligibleForPlanStepUpdates =>
 		isEligibleForPlanStepUpdates
@@ -734,13 +710,7 @@ export const PLANS_LIST = {
 				'{{strong}}Best for Small Businesses:{{/strong}}' +
 					'Comprehensive, automated scanning for security vulnerabilities, ' +
 					'fast video hosting, and marketing automation.',
-				{
-					components: {
-						strong: (
-							<strong className="plans__features plan-features__targeted-description-heading" />
-						),
-					},
-				}
+				plansDescriptionHeadingComponent
 			),
 		getTagline: () =>
 			i18n.translate(
@@ -805,13 +775,7 @@ export const PLANS_LIST = {
 				'{{strong}}Best for Small Businesses:{{/strong}}' +
 					'Comprehensive, automated scanning for security vulnerabilities, ' +
 					'fast video hosting, and marketing automation.',
-				{
-					components: {
-						strong: (
-							<strong className="plans__features plan-features__targeted-description-heading" />
-						),
-					},
-				}
+				plansDescriptionHeadingComponent
 			),
 		getTagline: () =>
 			i18n.translate(
@@ -869,13 +833,7 @@ export const PLANS_LIST = {
 				'{{strong}}Best for Personal Use:{{/strong}}' +
 					'Security essentials for your WordPress site, including ' +
 					'automated backups and priority support.',
-				{
-					components: {
-						strong: (
-							<strong className="plans__features plan-features__targeted-description-heading" />
-						),
-					},
-				}
+				plansDescriptionHeadingComponent
 			),
 		getTagline: () =>
 			i18n.translate(
@@ -922,13 +880,7 @@ export const PLANS_LIST = {
 				'{{strong}}Best for Personal Use:{{/strong}}' +
 					'Security essentials for your WordPress site, including ' +
 					'automated backups and priority support.',
-				{
-					components: {
-						strong: (
-							<strong className="plans__features plan-features__targeted-description-heading" />
-						),
-					},
-				}
+				plansDescriptionHeadingComponent
 			),
 		getTagline: () =>
 			i18n.translate(
@@ -986,13 +938,7 @@ export const PLANS_LIST = {
 				'{{strong}}Best for Organizations:{{/strong}}' +
 					'The most powerful WordPress sites: real-time backups, ' +
 					'enhanced search, and unlimited premium themes.',
-				{
-					components: {
-						strong: (
-							<strong className="plans__features plan-features__targeted-description-heading" />
-						),
-					},
-				}
+				plansDescriptionHeadingComponent
 			),
 		getTagline: () =>
 			i18n.translate( 'You have the full suite of security and performance tools.' ),
@@ -1062,13 +1008,7 @@ export const PLANS_LIST = {
 				'{{strong}}Best for Organizations:{{/strong}}' +
 					'The most powerful WordPress sites: real-time backups, ' +
 					'enhanced search, and unlimited premium themes.',
-				{
-					components: {
-						strong: (
-							<strong className="plans__features plan-features__targeted-description-heading" />
-						),
-					},
-				}
+				plansDescriptionHeadingComponent
 			),
 		getTagline: () =>
 			i18n.translate( 'You have the full suite of security and performance tools.' ),

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -858,7 +858,7 @@ export const PLANS_LIST = {
 		type: constants.TYPE_PERSONAL,
 		term: constants.TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Personal' ),
-		getAudience: () => i18n.translate( 'Best for Hobbyists' ),
+		getAudience: () => i18n.translate( 'Best for Personal Use' ),
 		getProductId: () => 2005,
 		getStoreSlug: () => constants.PLAN_JETPACK_PERSONAL,
 		availableFor: plan =>
@@ -866,7 +866,7 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'jetpack-personal',
 		getDescription: () =>
 			i18n.translate(
-				'{{strong}}Best for Hobbyists:{{/strong}}' +
+				'{{strong}}Best for Personal Use:{{/strong}}' +
 					'Security essentials for your WordPress site, including ' +
 					'automated backups and priority support.',
 				{
@@ -912,14 +912,14 @@ export const PLANS_LIST = {
 		type: constants.TYPE_PERSONAL,
 		term: constants.TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Personal' ),
-		getAudience: () => i18n.translate( 'Best for Hobbyists' ),
+		getAudience: () => i18n.translate( 'Best for Personal Use' ),
 		getStoreSlug: () => constants.PLAN_JETPACK_PERSONAL_MONTHLY,
 		getProductId: () => 2006,
 		getPathSlug: () => 'jetpack-personal-monthly',
 		availableFor: plan => includes( [ constants.PLAN_JETPACK_FREE ], plan ),
 		getDescription: () =>
 			i18n.translate(
-				'{{strong}}Best for Hobbyists:{{/strong}}' +
+				'{{strong}}Best for Personal Use:{{/strong}}' +
 					'Security essentials for your WordPress site, including ' +
 					'automated backups and priority support.',
 				{

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -666,7 +666,7 @@ export const PLANS_LIST = {
 		group: constants.GROUP_JETPACK,
 		type: constants.TYPE_FREE,
 		getTitle: () => i18n.translate( 'Free' ),
-		getAudience: () => i18n.translate( 'Best for students' ),
+		getAudience: () => i18n.translate( 'Best for Students' ),
 		getProductId: () => 2002,
 		getStoreSlug: () => constants.PLAN_JETPACK_FREE,
 		getTagline: feature => {
@@ -714,7 +714,7 @@ export const PLANS_LIST = {
 		type: constants.TYPE_PREMIUM,
 		term: constants.TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Premium' ),
-		getAudience: () => i18n.translate( 'Best for small businesses' ),
+		getAudience: () => i18n.translate( 'Best for Small Businesses' ),
 		getSubtitle: () => i18n.translate( 'Protection, speed, and revenue.' ),
 		getProductId: () => 2000,
 		getStoreSlug: () => constants.PLAN_JETPACK_PREMIUM,
@@ -731,8 +731,16 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'premium',
 		getDescription: () =>
 			i18n.translate(
-				'Comprehensive, automated scanning for security vulnerabilities, ' +
-					'fast video hosting, and marketing automation.'
+				'{{strong}}Best for Small Businesses:{{/strong}}' +
+					'Comprehensive, automated scanning for security vulnerabilities, ' +
+					'fast video hosting, and marketing automation.',
+				{
+					components: {
+						strong: (
+							<strong className="plans__features plan-features__targeted-description-heading" />
+						),
+					},
+				}
 			),
 		getTagline: () =>
 			i18n.translate(
@@ -779,7 +787,7 @@ export const PLANS_LIST = {
 		type: constants.TYPE_PREMIUM,
 		term: constants.TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Premium' ),
-		getAudience: () => i18n.translate( 'Best for small businesses' ),
+		getAudience: () => i18n.translate( 'Best for Small Businesses' ),
 		getProductId: () => 2003,
 		getStoreSlug: () => constants.PLAN_JETPACK_PREMIUM_MONTHLY,
 		getPathSlug: () => 'premium-monthly',
@@ -794,8 +802,16 @@ export const PLANS_LIST = {
 			),
 		getDescription: () =>
 			i18n.translate(
-				'Comprehensive, automated scanning for security vulnerabilities, ' +
-					'fast video hosting, and marketing automation.'
+				'{{strong}}Best for Small Businesses:{{/strong}}' +
+					'Comprehensive, automated scanning for security vulnerabilities, ' +
+					'fast video hosting, and marketing automation.',
+				{
+					components: {
+						strong: (
+							<strong className="plans__features plan-features__targeted-description-heading" />
+						),
+					},
+				}
 			),
 		getTagline: () =>
 			i18n.translate(
@@ -842,7 +858,7 @@ export const PLANS_LIST = {
 		type: constants.TYPE_PERSONAL,
 		term: constants.TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Personal' ),
-		getAudience: () => i18n.translate( 'Best for hobbyists' ),
+		getAudience: () => i18n.translate( 'Best for Hobbyists' ),
 		getProductId: () => 2005,
 		getStoreSlug: () => constants.PLAN_JETPACK_PERSONAL,
 		availableFor: plan =>
@@ -850,8 +866,16 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'jetpack-personal',
 		getDescription: () =>
 			i18n.translate(
-				'Security essentials for your WordPress site, including ' +
-					'automated backups and priority support.'
+				'{{strong}}Best for Hobbyists:{{/strong}}' +
+					'Security essentials for your WordPress site, including ' +
+					'automated backups and priority support.',
+				{
+					components: {
+						strong: (
+							<strong className="plans__features plan-features__targeted-description-heading" />
+						),
+					},
+				}
 			),
 		getTagline: () =>
 			i18n.translate(
@@ -888,15 +912,23 @@ export const PLANS_LIST = {
 		type: constants.TYPE_PERSONAL,
 		term: constants.TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Personal' ),
-		getAudience: () => i18n.translate( 'Best for hobbyists' ),
+		getAudience: () => i18n.translate( 'Best for Hobbyists' ),
 		getStoreSlug: () => constants.PLAN_JETPACK_PERSONAL_MONTHLY,
 		getProductId: () => 2006,
 		getPathSlug: () => 'jetpack-personal-monthly',
 		availableFor: plan => includes( [ constants.PLAN_JETPACK_FREE ], plan ),
 		getDescription: () =>
 			i18n.translate(
-				'Security essentials for your WordPress site, including ' +
-					'automated backups and priority support.'
+				'{{strong}}Best for Hobbyists:{{/strong}}' +
+					'Security essentials for your WordPress site, including ' +
+					'automated backups and priority support.',
+				{
+					components: {
+						strong: (
+							<strong className="plans__features plan-features__targeted-description-heading" />
+						),
+					},
+				}
 			),
 		getTagline: () =>
 			i18n.translate(
@@ -933,7 +965,7 @@ export const PLANS_LIST = {
 		type: constants.TYPE_BUSINESS,
 		term: constants.TERM_ANNUALLY,
 		getTitle: () => i18n.translate( 'Professional' ),
-		getAudience: () => i18n.translate( 'Best for organizations' ),
+		getAudience: () => i18n.translate( 'Best for Organizations' ),
 		getStoreSlug: () => constants.PLAN_JETPACK_BUSINESS,
 		getProductId: () => 2001,
 		availableFor: plan =>
@@ -951,8 +983,16 @@ export const PLANS_LIST = {
 		getPathSlug: () => 'professional',
 		getDescription: () =>
 			i18n.translate(
-				'The most powerful WordPress sites: real-time backups, ' +
-					'enhanced search, and unlimited premium themes.'
+				'{{strong}}Best for Organizations:{{/strong}}' +
+					'The most powerful WordPress sites: real-time backups, ' +
+					'enhanced search, and unlimited premium themes.',
+				{
+					components: {
+						strong: (
+							<strong className="plans__features plan-features__targeted-description-heading" />
+						),
+					},
+				}
 			),
 		getTagline: () =>
 			i18n.translate( 'You have the full suite of security and performance tools.' ),
@@ -1001,7 +1041,7 @@ export const PLANS_LIST = {
 		type: constants.TYPE_BUSINESS,
 		term: constants.TERM_MONTHLY,
 		getTitle: () => i18n.translate( 'Professional' ),
-		getAudience: () => i18n.translate( 'Best for organizations' ),
+		getAudience: () => i18n.translate( 'Best for Organizations' ),
 		getSubtitle: () => i18n.translate( 'Ultimate security and traffic tools.' ),
 		getProductId: () => 2004,
 		getStoreSlug: () => constants.PLAN_JETPACK_BUSINESS_MONTHLY,
@@ -1019,8 +1059,16 @@ export const PLANS_LIST = {
 			),
 		getDescription: () =>
 			i18n.translate(
-				'The most powerful WordPress sites: real-time backups, ' +
-					'enhanced search, and unlimited premium themes.'
+				'{{strong}}Best for Organizations:{{/strong}}' +
+					'The most powerful WordPress sites: real-time backups, ' +
+					'enhanced search, and unlimited premium themes.',
+				{
+					components: {
+						strong: (
+							<strong className="plans__features plan-features__targeted-description-heading" />
+						),
+					},
+				}
 			),
 		getTagline: () =>
 			i18n.translate( 'You have the full suite of security and performance tools.' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates Jetpack plans tables according to the latest pattern in Calypso; adds audience highlight.
* Updates pricing section in signup plans tables.

#### Before, Calypso > Plans

![image](https://user-images.githubusercontent.com/390760/76520101-2b07ff00-645a-11ea-8f91-b5411bc9d57d.png)

#### After, Calypso > Plans

![image](https://user-images.githubusercontent.com/390760/76520136-3c510b80-645a-11ea-8b25-43e98249beba.png)

#### Before, JP Connect > Store

![image](https://user-images.githubusercontent.com/390760/76520368-a9fd3780-645a-11ea-9081-a6c5b66aa21f.png)

#### After, JP Connect > Store

![image](https://user-images.githubusercontent.com/390760/76520405-c00af800-645a-11ea-8766-fb857b86cf8b.png)


#### Testing instructions

* Fire up this PR.
* Visit `http://calypso.localhost:3000/plans/SITE_URL` and ensure the audience highlight is visible (on both mobile and desktop).
* Visit `http://calypso.localhost:3000/jetpack/connect/store/` and ensure the pricing section looks good on desktop (mobile is unchanged).
