### PR TITLE
Global styles: add Raleway font

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
@@ -78,7 +78,7 @@ class Global_Styles {
 	 */
 	private $plugin_name = 'jetpack-global-styles';
 
-	const VERSION = '1909241817';
+	const VERSION = '2003121439';
 
 	const SYSTEM_FONT     = '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif';
 	const AVAILABLE_FONTS = [

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/class-global-styles.php
@@ -103,6 +103,7 @@ class Global_Styles {
 		'Open Sans',
 		'Playfair Display',
 		'Poppins',
+		'Raleway',
 		'Roboto',
 		'Roboto Slab',
 		'Rubik',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  Adds `Raleway` font to the list

Extracted from https://github.com/Automattic/wp-calypso/pull/38896


## Testing instructions

Install the FSE plugin locally:

* `npm install`
* `npx lerna run build --scope='@automattic/full-site-editing'`
* Move the `<local-path-to-calypso>/apps/full-site-editing/full-site-editing-plugin/` under  `wp-content/plugins` in your local WordPress install.

Install a theme that uses Global Styles:

* Clone the [themes](https://github.com/automattic/themes) repo locally.
* `cd varia`
* `npm install`
* `npm run build`
* Move `<local-path-to-themes>/varia` under `wp-content/themes` in your local WordPress install.

Test:

* Activate the Full Site Editing plugin and the Varia theme
* Go to a post.
* Open the Global Styles sidebar and verify that fonts work.