### PR TITLE
Site Migration: Automatically update site address when the site is upgraded to WordPress.com Business plan

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -27,7 +27,7 @@ import StepUpgrade from './step-upgrade';
 import { Interval, EVERY_TEN_SECONDS } from 'lib/interval';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import { getSite, getSiteAdminUrl, isJetpackSite } from 'state/sites/selectors';
-import { receiveSite, updateSiteMigrationMeta } from 'state/sites/actions';
+import { receiveSite, updateSiteMigrationMeta, requestSite } from 'state/sites/actions';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { urlToSlug } from 'lib/url';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
@@ -251,7 +251,7 @@ class SectionMigrate extends Component {
 	};
 
 	updateFromAPI = () => {
-		const { targetSiteId } = this.props;
+		const { targetSiteId, targetSiteSlug } = this.props;
 		wpcom
 			.undocumented()
 			.getMigrationStatus( targetSiteId )
@@ -293,6 +293,13 @@ class SectionMigrate extends Component {
 							lastModified,
 						} );
 						return;
+					}
+
+					/**
+					 * Request the site information until the site upgrades to Atomic
+					 */
+					if ( targetSiteSlug.indexOf( 'wpcomstaging' ) === -1 ) {
+						this.props.requestSite( targetSiteId );
 					}
 
 					this.setMigrationState( {
@@ -644,5 +651,5 @@ export default connect(
 			targetSiteSlug: getSelectedSiteSlug( state ),
 		};
 	},
-	{ navigateToSelectedSourceSite, receiveSite, updateSiteMigrationMeta }
+	{ navigateToSelectedSourceSite, receiveSite, updateSiteMigrationMeta, requestSite }
 )( localize( SectionMigrate ) );

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -111,8 +111,8 @@ class SectionMigrate extends Component {
 		const { targetSiteId, targetSiteSlug } = this.props;
 
 		/**
-		 * Request another update after the migration is finishes to update the site title and information
-		 * that will come when the migration is completed.
+		 * Request another update after the migration is finished to
+		 * update the site title and other info that may have changed.
 		 */
 		this.props.requestSite( targetSiteId );
 

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -257,7 +257,7 @@ class SectionMigrate extends Component {
 	};
 
 	updateFromAPI = () => {
-		const { targetSiteId, targetSiteSlug } = this.props;
+		const { targetSiteId, targetSite } = this.props;
 		wpcom
 			.undocumented()
 			.getMigrationStatus( targetSiteId )
@@ -304,7 +304,7 @@ class SectionMigrate extends Component {
 					/**
 					 * Request the site information until the site upgrades to Atomic
 					 */
-					if ( targetSiteSlug.indexOf( 'wpcomstaging' ) === -1 ) {
+					if ( ! get( targetSite, 'options.is_wpcom_atomic', false ) ) {
 						this.props.requestSite( targetSiteId );
 					}
 

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -110,6 +110,12 @@ class SectionMigrate extends Component {
 	finishMigration = () => {
 		const { targetSiteId, targetSiteSlug } = this.props;
 
+		/**
+		 * Request another update after the migration is finishes to update the site title and information
+		 * that will come when the migration is completed.
+		 */
+		this.props.requestSite( targetSiteId );
+
 		wpcom
 			.undocumented()
 			.resetMigration( targetSiteId )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a polling mechanism triggered on each migration status API update to request an update to the site object
* This will refresh the site as soon as it's upgraded to WordPress.com Business plan and update the visible site address in Calypso.

#### Testing instructions

* Start with a WordPress.com Simple site
* Start a migration
* Look at the site addresses shown in the sidebar and on the migration screen and see if they will update when the site is upgraded to WordPress.com Business.
* Check the network logs and make sure there are no additional refresh updates after the site information is updated. 
* Make sure the site title in the sidebar is updated when the migration finishes. 
