### PR TITLE
Gutenboarding: Cleanup page selector removal

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -13,11 +13,8 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import designs from './available-designs.json';
 
 import './style.scss';
-interface Props {
-	showPageSelector?: true;
-}
 
-const DesignSelector: FunctionComponent< Props > = () => {
+const DesignSelector: FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const { selectedDesign, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -21,7 +21,7 @@ import './style.scss';
 import AcquireIntent from './acquire-intent';
 
 const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => {
-	const { siteVertical, selectedDesign } = useSelect( select => select( STORE_KEY ).getState() );
+	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 	const isCreatingSite = useSelect( select => select( SITE_STORE ).isFetchingSite() );
 
 	const makePath = usePath();
@@ -39,14 +39,6 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 						<Redirect to={ makePath( Step.IntentGathering ) } />
 					) : (
 						<DesignSelector />
-					) }
-				</Route>
-
-				<Route path={ makePath( Step.PageSelection ) }>
-					{ ! selectedDesign ? (
-						<Redirect to={ makePath( Step.DesignSelection ) } />
-					) : (
-						<DesignSelector showPageSelector />
 					) }
 				</Route>
 

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -15,7 +15,6 @@ import { Verticals } from '@automattic/data-stores';
 import { SiteVertical } from '../../stores/onboard/types';
 import { StepProps } from '../stepper-wizard';
 import Question from '../question';
-import { __TodoAny__ } from '../../../../types';
 import AnimatedPlaceholder from '../animated-placeholder';
 
 /**
@@ -53,7 +52,7 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 	 *
 	 * Using `Suggestions` here would effectively be `any`.
 	 */
-	const suggestionRef = createRef< __TodoAny__ >();
+	const suggestionRef = createRef< any >();
 
 	const verticals = useSelect( select =>
 		select( VERTICALS_STORE )

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -11,7 +11,6 @@ import { ValuesType } from 'utility-types';
 export const Step = {
 	IntentGathering: undefined,
 	DesignSelection: 'design',
-	PageSelection: 'pages',
 	Signup: 'signup',
 	Login: 'login',
 	CreateSite: 'create-site',

--- a/client/landing/gutenboarding/tsconfig.json
+++ b/client/landing/gutenboarding/tsconfig.json
@@ -4,7 +4,6 @@
 		"composite": false,
 		"noEmit": true,
 		"emitDeclarationOnly": false,
-		"rootDir": ".",
 		"tsBuildInfoFile": null
 	},
 	"files": [ "index.tsx" ],


### PR DESCRIPTION
Removes unused code after from page selector removal in https://github.com/Automattic/wp-calypso/pull/39972

## Testing
- [`/gutenboarding`](https://calypso.live/gutenboarding?branch=remove/gutenboarding-page-selector-leftovers) flow should work as expected.

