### PR TITLE
Jetpack Cloud: Add settings page

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -43,11 +43,13 @@ export class RewindCredentialsForm extends Component {
 		siteUrl: PropTypes.string,
 		labels: PropTypes.object,
 		requirePath: PropTypes.bool,
+		notices: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		labels: {},
 		requirePath: false,
+		notices: true,
 	};
 
 	state = {
@@ -146,22 +148,32 @@ export class RewindCredentialsForm extends Component {
 	}
 
 	render() {
-		const { formIsSubmitting, labels, onCancel, requirePath, siteId, translate } = this.props;
+		const {
+			formIsSubmitting,
+			labels,
+			notices,
+			onCancel,
+			requirePath,
+			siteId,
+			translate,
+		} = this.props;
 		const { showAdvancedSettings, formErrors } = this.state;
 
 		return (
 			<div className="rewind-credentials-form">
 				<QueryRewindState siteId={ siteId } />
-				<div className="rewind-credentials-form__instructions">
-					{ translate(
-						'Your server credentials can be found with your hosting provider. Their website should explain how to get the credentials you need. {{link}}Check out our handy guide for more info{{/link}}.',
-						{
-							components: {
-								link: <a href="https://jetpack.com/support/activating-jetpack-backups/" />,
-							},
-						}
-					) }
-				</div>
+				{ notices && (
+					<div className="rewind-credentials-form__instructions">
+						{ translate(
+							'Your server credentials can be found with your hosting provider. Their website should explain how to get the credentials you need. {{link}}Check out our handy guide for more info{{/link}}.',
+							{
+								components: {
+									link: <a href="https://jetpack.com/support/activating-jetpack-backups/" />,
+								},
+							}
+						) }
+					</div>
+				) }
 				<FormFieldset>
 					<FormLabel htmlFor="protocol-type">{ translate( 'Credential Type' ) }</FormLabel>
 					<FormSelect
@@ -306,11 +318,13 @@ export class RewindCredentialsForm extends Component {
 					) }
 				</FormFieldset>
 
-				<div className="rewind-credentials-form__tos">
-					{ translate(
-						'By adding credentials, you are providing us with access to your server to perform automatic actions (such as backing up or restoring your site), manually access your site in case of an emergency, and troubleshoot your support requests.'
-					) }
-				</div>
+				{ notices && (
+					<div className="rewind-credentials-form__tos">
+						{ translate(
+							'By adding credentials, you are providing us with access to your server to perform automatic actions (such as backing up or restoring your site), manually access your site in case of an emergency, and troubleshoot your support requests.'
+						) }
+					</div>
+				) }
 
 				<FormFieldset>
 					<Button primary disabled={ formIsSubmitting } onClick={ this.handleSubmit }>

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -43,13 +43,13 @@ export class RewindCredentialsForm extends Component {
 		siteUrl: PropTypes.string,
 		labels: PropTypes.object,
 		requirePath: PropTypes.bool,
-		notices: PropTypes.bool,
+		showNotices: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		labels: {},
 		requirePath: false,
-		notices: true,
+		showNotices: true,
 	};
 
 	state = {
@@ -151,7 +151,7 @@ export class RewindCredentialsForm extends Component {
 		const {
 			formIsSubmitting,
 			labels,
-			notices,
+			showNotices,
 			onCancel,
 			requirePath,
 			siteId,
@@ -162,7 +162,7 @@ export class RewindCredentialsForm extends Component {
 		return (
 			<div className="rewind-credentials-form">
 				<QueryRewindState siteId={ siteId } />
-				{ notices && (
+				{ showNotices && (
 					<div className="rewind-credentials-form__instructions">
 						{ translate(
 							'Your server credentials can be found with your hosting provider. Their website should explain how to get the credentials you need. {{link}}Check out our handy guide for more info{{/link}}.',
@@ -318,7 +318,7 @@ export class RewindCredentialsForm extends Component {
 					) }
 				</FormFieldset>
 
-				{ notices && (
+				{ showNotices && (
 					<div className="rewind-credentials-form__tos">
 						{ translate(
 							'By adding credentials, you are providing us with access to your server to perform automatic actions (such as backing up or restoring your site), manually access your site in case of an emergency, and troubleshoot your support requests.'

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -3,22 +3,78 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
+import RewindCredentialsForm from 'components/rewind-credentials-form';
+import { Card } from '@automattic/components';
+import getRewindState from 'state/selectors/get-rewind-state';
+import QueryRewindState from 'components/data/query-rewind-state';
+import Gridicon from 'components/gridicon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class SettingsPage extends Component {
 	render() {
-		return <div>Welcome to the settings page for { this.props.siteId }</div>;
+		const { rewind, siteId, translate } = this.props;
+
+		const connected = 'active' === rewind.state;
+
+		return (
+			<div className="settings">
+				<QueryRewindState siteId={ siteId } />
+				<div className="settings__page-title">{ translate( 'Server connection details' ) }</div>
+				{ connected && (
+					<Card compact={ true } className="settings__connected">
+						<Gridicon icon="checkmark-circle" />
+						<div className="settings__details">
+							<div className="settings__details-head">
+								{ translate( 'Server status: Connected' ) }
+							</div>
+							<div>{ translate( 'One-click restores are enabled.' ) }</div>
+						</div>
+					</Card>
+				) }
+				{ ! connected && (
+					<Card compact={ true } className="settings__disconnected">
+						<Gridicon icon="cross-circle" />
+						<div className="settings__details">
+							<div className="settings__details-head">
+								{ translate( 'Server status: Not connected' ) }
+							</div>
+							<div>
+								{ translate(
+									'Enter your server credentials to enable one-click restores for Backups. Find your server credentials.'
+								) }
+							</div>
+						</div>
+					</Card>
+				) }
+				<RewindCredentialsForm
+					{ ...{
+						allowCancel: false,
+						role: 'main',
+						siteId,
+						notices: false,
+					} }
+				/>
+			</div>
+		);
 	}
 }
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
+	const rewind = getRewindState( state, siteId );
 
 	return {
 		siteId,
+		rewind,
 	};
-} )( SettingsPage );
+} )( localize( SettingsPage ) );

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -24,13 +24,13 @@ class SettingsPage extends Component {
 	render() {
 		const { rewind, siteId, translate } = this.props;
 
-		const connected = 'active' === rewind.state;
+		const isConnected = 'active' === rewind.state;
 
 		return (
 			<div className="settings">
 				<QueryRewindState siteId={ siteId } />
 				<div className="settings__page-title">{ translate( 'Server connection details' ) }</div>
-				{ connected && (
+				{ isConnected && (
 					<Card compact={ true } className="settings__connected">
 						<Gridicon icon="checkmark-circle" />
 						<div className="settings__details">
@@ -41,7 +41,7 @@ class SettingsPage extends Component {
 						</div>
 					</Card>
 				) }
-				{ ! connected && (
+				{ ! isConnected && (
 					<Card compact={ true } className="settings__disconnected">
 						<Gridicon icon="cross-circle" />
 						<div className="settings__details">
@@ -61,7 +61,7 @@ class SettingsPage extends Component {
 						allowCancel: false,
 						role: 'main',
 						siteId,
-						notices: false,
+						showNotices: false,
 					} }
 				/>
 			</div>

--- a/client/landing/jetpack-cloud/sections/settings/style.scss
+++ b/client/landing/jetpack-cloud/sections/settings/style.scss
@@ -1,0 +1,37 @@
+.settings__page-title {
+    font-size: 1.3rem;
+    font-weight: 500;
+    letter-spacing: -0.01rem;
+    margin-bottom: 1rem;
+}
+
+.card.is-compact.settings__connected,
+.card.is-compact.settings__disconnected {
+    margin-bottom: 1.5rem;
+}
+
+.settings__connected .gridicon {
+    display: inline-block;
+    fill: green;
+    width: 4rem;
+    height: 4rem;
+}
+
+.settings__disconnected .gridicon {
+    display: inline-block;
+    fill: red;
+    width: 4rem;
+    height: 4rem;
+}
+
+.settings__details {
+    display: inline-block;
+    vertical-align: top;
+    margin-left: 1rem;
+    margin-top: 0.5rem;
+}
+
+.settings__details-head {
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+}


### PR DESCRIPTION
**_Please remember, this is a minimal changeset that brings in the foundation of this page. It merely  sets the stage for a MVP, and is not yet meant to be an MVP. Additions, fixes, can/should be added as future PRs._**

#### Changes proposed in this Pull Request

* Modifies the `RewindCredentialsForm` component to accept a `notices` boolean, allows us to disable the legal text notices
* Adds a connection status module to the top of the settings page (let's make this it's own component at a later date, perhaps for use on the dashboard as well)
* Adds a contextualized `RewindCredentialsForm` to the settings page
* Adds basic styling for large screens throughout (mobile styles need discussion)

#### Testing instructions

* Test the settings page for a site with valid credentials.
* Test the settings page for a site without credentials. Test adding working credentials.
* Ensure no regression in normal Calypso when using the `RewindCredentialsForm` component in the settings section. Ensure that the text notices are still showing.

