### PR TITLE
[Private sites] Don't attempt to display preview for media files larger than 20MB

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2463,29 +2463,46 @@ Undocumented.prototype.startMigration = function( sourceSiteId, targetSiteId ) {
 	} );
 };
 
-Undocumented.prototype.getAtomicSiteMediaViaProxy = function( siteIdOrSlug, mediaPath, query, fn ) {
-	return this.wpcom.req.get(
-		{
-			path: `/sites/${ siteIdOrSlug }/atomic-auth-proxy/file${ mediaPath }${ query }`,
-			apiNamespace: 'wpcom/v2',
-			responseType: 'blob',
-		},
-		fn
-	);
+Undocumented.prototype.getAtomicSiteMediaViaProxy = function(
+	siteIdOrSlug,
+	mediaPath,
+	{ query = '', maxSize },
+	fn
+) {
+	const params = {
+		path: `/sites/${ siteIdOrSlug }/atomic-auth-proxy/file${ mediaPath }${ query }`,
+		apiNamespace: 'wpcom/v2',
+	};
+
+	const fetchMedia = () => this.wpcom.req.get( { ...params, responseType: 'blob' }, fn );
+
+	if ( ! maxSize ) {
+		return fetchMedia();
+	}
+
+	return this.wpcom.req.get( { ...params, method: 'HEAD' }, ( err, data, headers ) => {
+		if ( headers[ 'Content-Length' ] > maxSize ) {
+			fn( { message: 'exceeded_max_size' }, null );
+			return;
+		}
+
+		fetchMedia();
+	} );
 };
 
 Undocumented.prototype.getAtomicSiteMediaViaProxyRetry = function(
 	siteIdOrSlug,
 	mediaPath,
-	query,
+	options,
 	fn
 ) {
-	return this.getAtomicSiteMediaViaProxy( siteIdOrSlug, mediaPath, query, ( err, data ) => {
-		if ( err || ! ( data instanceof Blob ) ) {
-			return this.getAtomicSiteMediaViaProxy( siteIdOrSlug, mediaPath, query, fn );
+	return this.getAtomicSiteMediaViaProxy( siteIdOrSlug, mediaPath, options, ( err, data ) => {
+		if ( data instanceof Blob || ( err && err.message === 'exceeded_max_size' ) ) {
+			fn( err, data );
+			return;
 		}
 
-		fn( err, data );
+		return this.getAtomicSiteMediaViaProxy( siteIdOrSlug, mediaPath, options, fn );
 	} );
 };
 

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -32,6 +32,7 @@ const MediaFile: React.FC< MediaFileProps > = function MediaFile( {
 	siteSlug,
 	useProxy = false,
 	placeholder = null,
+	maxSize,
 	dispatch,
 	component: Component,
 	proxiedComponent,
@@ -45,6 +46,7 @@ const MediaFile: React.FC< MediaFileProps > = function MediaFile( {
 				query={ query }
 				component={ proxiedComponent || Component }
 				placeholder={ placeholder }
+				maxSize={ maxSize }
 				{ ...rest }
 			/>
 		);

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -11,19 +11,16 @@ import isPrivateSite from 'state/selectors/is-private-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
-import ProxiedImage, { RenderedComponent } from './proxied-image';
+import ProxiedImage, { ProxiedImageProps, RenderedComponent } from './proxied-image';
 import { mediaURLToProxyConfig } from 'lib/media/utils';
 
-export interface MediaFileProps {
+export interface MediaFileProps extends ProxiedImageProps {
 	src: string;
 
 	component: RenderedComponent;
 	proxiedComponent?: RenderedComponent;
-	filePath: string;
-	query: string;
-	siteSlug: string;
+
 	onLoad: () => any;
-	placeholder: React.ReactNode | null;
 	useProxy: boolean;
 	dispatch: any;
 }

--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -25,7 +25,7 @@ export interface ProxiedImageProps {
 	placeholder: React.ReactNode | null;
 	component: RenderedComponent;
 	maxSize: number | null;
-	onMaxSizeExceeded: () => any;
+	onError?: ( err: Error ) => any;
 
 	[ key: string ]: any;
 }
@@ -52,7 +52,7 @@ const ProxiedImage: React.FC< ProxiedImageProps > = function ProxiedImage( {
 	query,
 	placeholder,
 	maxSize,
-	onMaxSizeExceeded,
+	onError,
 	component: Component,
 	...rest
 } ) {
@@ -82,8 +82,8 @@ const ProxiedImage: React.FC< ProxiedImageProps > = function ProxiedImage( {
 								cacheResponse( requestId, data );
 								setImageObjectUrl( URL.createObjectURL( data ) );
 								debug( 'got image from API', { requestId, imageObjectUrl, data } );
-							} else if ( err.message === 'exceeded_max_size' ) {
-								onMaxSizeExceeded();
+							} else if ( onError ) {
+								onError( err );
 							}
 						}
 					);

--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -18,12 +18,14 @@ type RenderedComponentProps = {
 };
 export type RenderedComponent = string | React.ComponentType< RenderedComponentProps >;
 
-interface Props {
+export interface ProxiedImageProps {
 	query: string;
 	filePath: string;
 	siteSlug: string;
 	placeholder: React.ReactNode | null;
 	component: RenderedComponent;
+	maxSize: number | null;
+	onMaxSizeExceeded: () => any;
 
 	[ key: string ]: any;
 }
@@ -44,11 +46,13 @@ const cacheResponse = ( requestId: string, blob: Blob, freshness = 60000 ) => {
 	}, freshness );
 };
 
-const ProxiedImage: React.FC< Props > = function ProxiedImage( {
+const ProxiedImage: React.FC< ProxiedImageProps > = function ProxiedImage( {
 	siteSlug,
 	filePath,
 	query,
 	placeholder,
+	maxSize,
+	onMaxSizeExceeded,
 	component: Component,
 	...rest
 } ) {
@@ -63,17 +67,23 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 				debug( 'set image from cache', { url } );
 			} else {
 				debug( 'requesting image from API', { requestId, imageObjectUrl } );
+				const options = { query };
+				if ( maxSize !== null ) {
+					options.maxSize = maxSize;
+				}
 				wpcom
 					.undocumented()
 					.getAtomicSiteMediaViaProxyRetry(
 						siteSlug,
 						filePath,
-						query,
+						options,
 						( err: Error, data: Blob | null ) => {
 							if ( data instanceof Blob ) {
 								cacheResponse( requestId, data );
 								setImageObjectUrl( URL.createObjectURL( data ) );
 								debug( 'got image from API', { requestId, imageObjectUrl, data } );
+							} else if ( err.message === 'exceeded_max_size' ) {
+								onMaxSizeExceeded();
 							}
 						}
 					);

--- a/client/post-editor/media-modal/detail/detail-preview-audio.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-audio.jsx
@@ -9,8 +9,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { url } from 'lib/media/utils';
-import MediaFile from 'my-sites/media-library/media-file';
+import EditorMediaModalDetailPreviewMediaFile from './detail-preview-media-file';
 
 export default class extends React.Component {
 	static displayName = 'EditorMediaModalDetailPreviewAudio';
@@ -18,13 +17,17 @@ export default class extends React.Component {
 	static propTypes = {
 		className: PropTypes.string,
 		item: PropTypes.object.isRequired,
+		site: PropTypes.object.isRequired,
 	};
 
 	render() {
-		const classes = classNames( this.props.className, 'is-audio' );
-
+		const { className, ...props } = this.props;
 		return (
-			<MediaFile component="audio" src={ url( this.props.item ) } controls className={ classes } />
+			<EditorMediaModalDetailPreviewMediaFile
+				component="audio"
+				className={ classNames( className, 'is-audio' ) }
+				{ ...props }
+			/>
 		);
 	}
 }

--- a/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
+++ b/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
@@ -13,8 +13,8 @@ import MediaFile from 'my-sites/media-library/media-file';
 interface Props {
 	className: string;
 	component: string;
-	item: any;
-	site: any;
+	item: { URL: string };
+	site: { URL: string };
 }
 
 const EditorMediaModalDetailPreviewMediaFile: React.FC< Props & LocalizeProps > = ( {

--- a/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
+++ b/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
@@ -34,7 +34,7 @@ const EditorMediaModalDetailPreviewMediaFile: React.FC< Props & LocalizeProps > 
 			<div className="editor-media-modal-detail__preview is-too-large">
 				{ translate( 'Preview unavailable, {{a}}click here to open the file directly{{/a}}.', {
 					components: {
-						a: <a href={ fileUrl } />,
+						a: <a target="_blank" href={ fileUrl } />,
 					},
 				} ) }
 			</div>

--- a/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
+++ b/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
@@ -45,7 +45,7 @@ const EditorMediaModalDetailPreviewMediaFile: React.FC< Props & LocalizeProps > 
 		<MediaFile
 			component={ component }
 			src={ url( item, {} ) }
-			maxSize={ 20000 }
+			maxSize={ 20 * 1024 * 1024 }
 			onMaxSizeExceeded={ () => setTooLargeToDisplay( true ) }
 			controls
 			className={ className }

--- a/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
+++ b/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import { localize, LocalizeProps } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { url } from 'lib/media/utils';
+import MediaFile from 'my-sites/media-library/media-file';
+
+interface Props {
+	className: string;
+	component: string;
+	item: any;
+	site: any;
+}
+
+const EditorMediaModalDetailPreviewMediaFile: React.FC< Props & LocalizeProps > = ( {
+	className,
+	component,
+	item,
+	site,
+	translate,
+} ) => {
+	const [ tooLargeToDisplay, setTooLargeToDisplay ] = useState( false );
+	if ( tooLargeToDisplay ) {
+		// User may or may not be authenticated against their remote site - we need to go through the login page
+		// to trigger SSO when available
+		const fileUrl = `${ site.URL }/wp-login.php?${ item.URL }`;
+		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<div className="editor-media-modal-detail__preview is-too-large">
+				{ translate( 'Preview unavailable, {{a}}click here to open the file directly{{/a}}.', {
+					components: {
+						a: <a href={ fileUrl } />,
+					},
+				} ) }
+			</div>
+		);
+	}
+
+	return (
+		<MediaFile
+			component={ component }
+			src={ url( item, {} ) }
+			maxSize={ 20000 }
+			onMaxSizeExceeded={ () => setTooLargeToDisplay( true ) }
+			controls
+			className={ className }
+		/>
+	);
+};
+
+export default localize( EditorMediaModalDetailPreviewMediaFile );

--- a/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
+++ b/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
@@ -24,8 +24,8 @@ const EditorMediaModalDetailPreviewMediaFile: React.FC< Props & LocalizeProps > 
 	site,
 	translate,
 } ) => {
-	const [ tooLargeToDisplay, setTooLargeToDisplay ] = useState( false );
-	if ( tooLargeToDisplay ) {
+	const [ previewUnavailable, setPreviewUnavailable ] = useState( false );
+	if ( previewUnavailable ) {
 		// User may or may not be authenticated against their remote site - we need to go through the login page
 		// to trigger SSO when available
 		const fileUrl = `${ site.URL }/wp-login.php?redirect_to=${ item.URL }`;
@@ -46,7 +46,7 @@ const EditorMediaModalDetailPreviewMediaFile: React.FC< Props & LocalizeProps > 
 			component={ component }
 			src={ url( item, {} ) }
 			maxSize={ 20 * 1024 * 1024 }
-			onMaxSizeExceeded={ () => setTooLargeToDisplay( true ) }
+			onError={ () => setPreviewUnavailable( true ) }
 			controls
 			className={ className }
 		/>

--- a/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
+++ b/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
@@ -28,7 +28,7 @@ const EditorMediaModalDetailPreviewMediaFile: React.FC< Props & LocalizeProps > 
 	if ( tooLargeToDisplay ) {
 		// User may or may not be authenticated against their remote site - we need to go through the login page
 		// to trigger SSO when available
-		const fileUrl = `${ site.URL }/wp-login.php?${ item.URL }`;
+		const fileUrl = `${ site.URL }/wp-login.php?redirect_to=${ item.URL }`;
 		return (
 			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<div className="editor-media-modal-detail__preview is-too-large">

--- a/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
+++ b/client/post-editor/media-modal/detail/detail-preview-media-file.tsx
@@ -34,7 +34,7 @@ const EditorMediaModalDetailPreviewMediaFile: React.FC< Props & LocalizeProps > 
 			<div className="editor-media-modal-detail__preview is-too-large">
 				{ translate( 'Preview unavailable, {{a}}click here to open the file directly{{/a}}.', {
 					components: {
-						a: <a target="_blank" href={ fileUrl } />,
+						a: <a rel="noopener noreferrer" target="_blank" href={ fileUrl } />,
 					},
 				} ) }
 			</div>

--- a/client/post-editor/media-modal/detail/detail-preview-video.jsx
+++ b/client/post-editor/media-modal/detail/detail-preview-video.jsx
@@ -9,16 +9,17 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import { isVideoPressItem, url } from 'lib/media/utils';
+import { isVideoPressItem } from 'lib/media/utils';
 import EditorMediaModalDetailItemVideoPress from './detail-preview-videopress';
-import MediaFile from 'my-sites/media-library/media-file';
+import EditorMediaModalDetailPreviewMediaFile from './detail-preview-media-file';
 
 export default class extends React.Component {
-	static displayName = 'EditorMediaModalDetailPreviewVideo';
+	static displayName = 'EditorMediaModalDetailPreviewAudio';
 
 	static propTypes = {
 		className: PropTypes.string,
 		item: PropTypes.object.isRequired,
+		site: PropTypes.object.isRequired,
 	};
 
 	render() {
@@ -26,10 +27,13 @@ export default class extends React.Component {
 			return <EditorMediaModalDetailItemVideoPress { ...this.props } />;
 		}
 
-		const classes = classNames( this.props.className, 'is-video' );
-
+		const { className, ...props } = this.props;
 		return (
-			<MediaFile component="video" src={ url( this.props.item ) } controls className={ classes } />
+			<EditorMediaModalDetailPreviewMediaFile
+				component="video"
+				className={ classNames( className, 'is-video' ) }
+				{ ...props }
+			/>
 		);
 	}
 }

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -59,6 +59,10 @@
 	&.is-loading {
 		opacity: 0.5;
 	}
+
+	&.is-too-large {
+		font-size: 2em;
+	}
 }
 
 .editor-media-modal-detail__previous,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On private atomic sites we use media proxy endpoint to pull private media files. Streaming is not supported yet and so an entire media file needs to be downloaded in order to display it. For large files it's not a good user experience - this PRs sets a limit to 20MB.

#### Testing instructions

* Test locally, calypso.live won't work
* Create a new private atomic site using a8c account
* Upload two video files (in /wp-admin !) - larger than 20mb and smaller than 20mb
* Go to media in calypso and edit both
* The smaller one should be displayed
* The larger one shouldn't be displayed, instead you should see a direct link to that file
