### PR TITLE
Add the webauthn route to the Jetpack login endpoint

### DIFF
--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -70,7 +70,7 @@ export default router => {
 				`/log-in/:flow(social-connect|private-site)/${ lang }`,
 				`/log-in/:socialService(google|apple)/callback/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/${ lang }`,
-				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push)/${ lang }`,
+				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 				`/log-in/${ lang }`,
 			],
 			redirectJetpack,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This enables webauthn support for the Jetpack login endpoint.

#### Testing instructions

* Add a security key to a test WP.com account
* On a private tab, navigate to `https://calypso.localhost:3000/log-in/jetpack/webauthn`
* Make sure you are able to log in using a security key