### PR TITLE
Gutenboarding: Add style-preview step (feat-flag)

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -5,17 +5,21 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
 import classnames from 'classnames';
 import { useI18n } from '@automattic/react-i18n';
+import { useHistory } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import designs from './available-designs.json';
-
+import { usePath, Step } from '../../path';
+import { isEnabled } from '../../../../config';
 import './style.scss';
 
 const DesignSelector: FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
+	const { push } = useHistory();
+	const makePath = usePath();
 	const { selectedDesign, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
@@ -45,6 +49,9 @@ const DesignSelector: FunctionComponent = () => {
 							) }
 							onClick={ () => {
 								setSelectedDesign( design );
+								if ( isEnabled( 'gutenboarding/style-preview' ) ) {
+									push( makePath( Step.Style ) );
+								}
 							} }
 						>
 							<div className="design-selector__image-frame">

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -17,11 +17,14 @@ import LoginForm from './login-form';
 import CreateSite from './create-site';
 import { Attributes } from './types';
 import { Step, usePath } from '../path';
-import './style.scss';
 import AcquireIntent from './acquire-intent';
+import StylePreview from './style-preview';
+import { isEnabled } from '../../../config';
+
+import './style.scss';
 
 const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => {
-	const { siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
+	const { siteVertical, selectedDesign } = useSelect( select => select( STORE_KEY ).getState() );
 	const isCreatingSite = useSelect( select => select( SITE_STORE ).isFetchingSite() );
 
 	const makePath = usePath();
@@ -39,6 +42,18 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 						<Redirect to={ makePath( Step.IntentGathering ) } />
 					) : (
 						<DesignSelector />
+					) }
+				</Route>
+
+				<Route path={ makePath( Step.Style ) }>
+					{ // Disable reason: Leave me alone, my nested ternaries are amazing ✨
+					// eslint-disable-next-line no-nested-ternary
+					! selectedDesign ? (
+						<Redirect to={ makePath( Step.DesignSelection ) } />
+					) : isEnabled( 'gutenboarding/style-preview' ) ? (
+						<StylePreview />
+					) : (
+						<Redirect to={ makePath( Step.DesignSelection ) } />
 					) }
 				</Route>
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useSelect } from '@wordpress/data';
+
+import './style.scss';
+import Link from '../../components/link';
+import { usePath, Step } from '../../path';
+import { useI18n } from '@automattic/react-i18n';
+import { STORE_KEY } from '../../stores/onboard';
+
+const StylePreview: React.FunctionComponent = () => {
+	const { __: NO__ } = useI18n();
+	const makePath = usePath();
+	const { selectedDesign } = useSelect( select => select( STORE_KEY ).getState() );
+	return (
+		<>
+			<div>
+				<Link to={ makePath( Step.DesignSelection ) }>{ NO__( 'Choose another design' ) }</Link>
+			</div>
+			<div>You picked { selectedDesign?.title } design.</div>
+			<p>Hi, I'm a style preview. I'm under construction</p>
+		</>
+	);
+};
+
+export default StylePreview;

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -11,6 +11,7 @@ import { ValuesType } from 'utility-types';
 export const Step = {
 	IntentGathering: undefined,
 	DesignSelection: 'design',
+	Style: 'style',
 	Signup: 'signup',
 	Login: 'login',
 	CreateSite: 'create-site',

--- a/config/development.json
+++ b/config/development.json
@@ -63,6 +63,7 @@
 		"google-my-business": true,
 		"google-drive": true,
 		"gutenboarding": true,
+		"gutenboarding/style-preview": true,
 		"help": true,
 		"help/courses": true,
 		"i18n/community-translator": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add `gutenboarding/style-preview` feature flag and enable it in development.
Add style-preview step with simple placeholder.

#### Testing instructions

- No change in other environments ([calypso.live](https://calypso.live/gutenboarding?branch=gutenboarding/add-styles-step)).
- In development, after selecting a design you move to another placeholder step.