### PR TITLE
Site Migration: My Sites should reset failed migration state

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -34,6 +34,7 @@ import { domainManagementList } from 'my-sites/domains/paths';
 import WordPressWordmark from 'components/wordpress-wordmark';
 
 import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
+import { updateSiteMigrationMeta } from 'state/sites/actions';
 import wpcom from 'lib/wp';
 
 class MasterbarLoggedIn extends React.Component {
@@ -64,6 +65,7 @@ class MasterbarLoggedIn extends React.Component {
 
 			if ( currentSelectedSiteId && migrationStatus === 'error' ) {
 				wpcom.undocumented().resetMigration( currentSelectedSiteId );
+				this.props.updateSiteMigrationMeta( currentSelectedSiteId, 'inactive', null );
 			}
 		}
 	};
@@ -226,5 +228,5 @@ export default connect(
 			currentSelectedSiteId,
 		};
 	},
-	{ setNextLayoutFocus, recordTracksEvent }
+	{ setNextLayoutFocus, recordTracksEvent, updateSiteMigrationMeta }
 )( localize( MasterbarLoggedIn ) );

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -35,7 +35,8 @@ import WordPressWordmark from 'components/wordpress-wordmark';
 
 import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
 import { updateSiteMigrationMeta } from 'state/sites/actions';
-import wpcom from 'lib/wp';
+import { requestHttpData } from 'state/data-layer/http-data';
+import { http } from 'state/data-layer/wpcom-http/actions';
 
 class MasterbarLoggedIn extends React.Component {
 	static propTypes = {
@@ -64,8 +65,20 @@ class MasterbarLoggedIn extends React.Component {
 			const { migrationStatus, currentSelectedSiteId } = this.props;
 
 			if ( currentSelectedSiteId && migrationStatus === 'error' ) {
-				wpcom.undocumented().resetMigration( currentSelectedSiteId );
-				this.props.updateSiteMigrationMeta( currentSelectedSiteId, 'inactive', null );
+				requestHttpData(
+					'site-migration',
+					http( {
+						apiNamespace: 'wpcom/v2',
+						method: 'POST',
+						path: `/sites/${ currentSelectedSiteId }/reset-migration`,
+						body: {},
+						onSuccess: () => {},
+					} ),
+					{
+						fromApi: () => {},
+						freshness: -Infinity,
+					}
+				);
 			}
 		}
 	};

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -32,7 +32,6 @@ import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-use
 import { getStatsPathForTab } from 'lib/route';
 import { domainManagementList } from 'my-sites/domains/paths';
 import WordPressWordmark from 'components/wordpress-wordmark';
-
 import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
 import { updateSiteMigrationMeta } from 'state/sites/actions';
 import wpcom from 'lib/wp';

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -79,11 +79,9 @@ class MasterbarLoggedIn extends React.Component {
 						method: 'POST',
 						path: `/sites/${ currentSelectedSiteId }/reset-migration`,
 						body: {},
-						onSuccess: () => {},
 					} ),
 					{
-						fromApi: () => {},
-						freshness: -Infinity,
+						freshness: 0,
 					}
 				);
 			}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -64,6 +64,14 @@ class MasterbarLoggedIn extends React.Component {
 			const { migrationStatus, currentSelectedSiteId } = this.props;
 
 			if ( currentSelectedSiteId && migrationStatus === 'error' ) {
+				/**
+				 * Reset the in-memory site lock for the currently selected site
+				 */
+				this.props.updateSiteMigrationMeta( currentSelectedSiteId, 'inactive', null );
+
+				/**
+				 * Reset the migration on the backend
+				 */
 				requestHttpData(
 					'site-migration',
 					http( {

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -33,6 +33,9 @@ import { getStatsPathForTab } from 'lib/route';
 import { domainManagementList } from 'my-sites/domains/paths';
 import WordPressWordmark from 'components/wordpress-wordmark';
 
+import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
+import wpcom from 'lib/wp';
+
 class MasterbarLoggedIn extends React.Component {
 	static propTypes = {
 		user: PropTypes.object.isRequired,
@@ -47,6 +50,22 @@ class MasterbarLoggedIn extends React.Component {
 	clickMySites = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_my_sites_clicked' );
 		this.props.setNextLayoutFocus( 'sidebar' );
+
+		/**
+		 * Site Migration: Reset a failed migration when clicking on My Sites
+		 *
+		 * If the site migration has failed, clicking on My Sites sends the customer in a loop
+		 * until they click the Try Again button on the migration screen.
+		 *
+		 * This code makes it possible to reset the failed migration state when clicking My Sites too.
+		 */
+		if ( config.isEnabled( 'tools/migrate' ) ) {
+			const { migrationStatus, currentSelectedSiteId } = this.props;
+
+			if ( currentSelectedSiteId && migrationStatus === 'error' ) {
+				wpcom.undocumented().resetMigration( currentSelectedSiteId );
+			}
+		}
 	};
 
 	clickReader = () => {
@@ -191,7 +210,8 @@ export default connect(
 	state => {
 		// Falls back to using the user's primary site if no site has been selected
 		// by the user yet
-		const siteId = getSelectedSiteId( state ) || getPrimarySiteId( state );
+		const currentSelectedSiteId = getSelectedSiteId( state );
+		const siteId = currentSelectedSiteId || getPrimarySiteId( state );
 
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
@@ -201,7 +221,9 @@ export default connect(
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 			user: getCurrentUser( state ),
 			isSupportSession: isSupportSession( state ),
-			isMigrationInProgress: !! isSiteMigrationInProgress( state, siteId ),
+			isMigrationInProgress: !! isSiteMigrationInProgress( state, currentSelectedSiteId ),
+			migrationStatus: getSiteMigrationStatus( state, currentSelectedSiteId ),
+			currentSelectedSiteId,
 		};
 	},
 	{ setNextLayoutFocus, recordTracksEvent }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR makes the My Sites button reset the migration state to `inactive` if there's a failed migration for the current site.
* This will unlock the site, similar to the Try Again button

#### Testing instructions

* Apply diff or use the Calypso.live link
* Start a migration
* Cause it to fail in some way (to be added)
* Click My Sites
* You should be back to unlocked state

