### PR TITLE
Purchases: Stop description text from jumping on page transition.

### DIFF
--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -171,6 +171,10 @@
 	display: block;
 }
 
+.plan-features__targeted-description-heading {
+	display: inline;
+}
+
 .manage-purchase__settings-link {
 	display: block;
 	margin-top: 16px;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -169,10 +169,10 @@
 .manage-purchase__description {
 	color: var( --color-text-subtle );
 	display: block;
-}
 
-.plan-features__targeted-description-heading {
-	display: inline;
+	.plan-features__targeted-description-heading {
+		display: inline;
+	}
 }
 
 .manage-purchase__settings-link {


### PR DESCRIPTION
When clicking the View Plan Features link on `/me/purchases`, the incoming stylesheet can make the plan description title jump as it becomes `display: block` from its browser default of `inline`. By setting an explicit style for the title on the Manage Purchase page, we can avoid the visual glitch.

<img width="754" alt="Screen Shot 2020-03-12 at 11 18 32 AM" src="https://user-images.githubusercontent.com/349751/76554841-c8ac0000-6453-11ea-8f59-9d7c8af16dda.png">


#### Testing instructions

* Find a plan purchase under `/me/purchases`.
* Click the View Plan Features link, and verify the plan description content doesn't jump from the title becoming `display: block`.
* Click the browser Back button, and verify the description title is still inline.

Fixes #40100 
