### PR TITLE
Add fallback CustomEvent polyfill for IE11

### DIFF
--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -27,20 +27,6 @@ const appleClientUrl =
 const connectUrlPopupFLow =
 	'https://public-api.wordpress.com/connect/?magic=keyring&service=apple&action=request&for=connect';
 
-// polyfill for CustomEvent otherwise Apple login breaks on IE 11
-// see: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
-( function() {
-	if ( typeof window === 'undefined' || typeof window.CustomEvent === 'function' ) return false;
-	function CustomEvent( event, params ) {
-		params = params || { bubbles: false, cancelable: false, detail: null };
-		const evt = document.createEvent( 'CustomEvent' );
-		evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
-		return evt;
-	}
-
-	window.CustomEvent = CustomEvent;
-} )();
-
 class AppleLoginButton extends Component {
 	static propTypes = {
 		clientId: PropTypes.string.isRequired,

--- a/packages/calypso-polyfills/browser-fallback.js
+++ b/packages/calypso-polyfills/browser-fallback.js
@@ -12,4 +12,18 @@ import 'regenerator-runtime/runtime';
 import svg4everybody from 'svg4everybody';
 import 'isomorphic-fetch';
 
+// polyfill for CustomEvent otherwise Apple login breaks on IE 11
+// see: https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+( function() {
+	if ( typeof window === 'undefined' || typeof window.CustomEvent === 'function' ) return false;
+	function CustomEvent( event, params ) {
+		params = params || { bubbles: false, cancelable: false, detail: null };
+		const evt = document.createEvent( 'CustomEvent' );
+		evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+		return evt;
+	}
+
+	window.CustomEvent = CustomEvent;
+} )();
+
 svg4everybody();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move CustomEvent polyfill for IE11 to Calypso Polyfills lib as requested by @sgomes and @simison 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use connect flow in IE 11
* Should no longer see an exception caused by lack of CustomEvent class

Fixes https://github.com/Automattic/wp-calypso/pull/40075#issuecomment-598371778
