### PR TITLE
Composite Checkout: UI updates for domains

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
@@ -84,13 +84,14 @@ const CouponField = styled( Coupon )`
 
 const CheckoutTermsUI = styled.div`
 	& > * {
-		margin: 16px 0;
+		margin: 16px 16px 16px -26px;
 		padding-left: 26px;
 		position: relative;
 	}
 
-	& div:first-child {
+	& div:first-of-type {
 		padding-left: 0;
+		margin-left: 0;
 	}
 
 	& > * > svg {
@@ -104,6 +105,7 @@ const CheckoutTermsUI = styled.div`
 	& > * > p {
 		font-size: 12px;
 		margin: 0;
+		word-break: break-word;
 	}
 
 	& > * > p a {

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
@@ -84,8 +84,8 @@ const CouponField = styled( Coupon )`
 
 const CheckoutTermsUI = styled.div`
 	& > * {
-		margin: 16px 16px 16px -26px;
-		padding-left: 26px;
+		margin: 16px 16px 16px -24px;
+		padding-left: 24px;
 		position: relative;
 	}
 
@@ -95,10 +95,10 @@ const CheckoutTermsUI = styled.div`
 	}
 
 	& > * > svg {
-		width: 18px;
-		height: 18px;
+		width: 16px;
+		height: 16px;
 		position: absolute;
-		top: 2px;
+		top: 0;
 		left: 0;
 	}
 

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-review.js
@@ -94,7 +94,7 @@ const CheckoutTermsUI = styled.div`
 		margin-left: 0;
 	}
 
-	& > * > svg {
+	svg {
 		width: 16px;
 		height: 16px;
 		position: absolute;
@@ -102,17 +102,17 @@ const CheckoutTermsUI = styled.div`
 		left: 0;
 	}
 
-	& > * > p {
+	p {
 		font-size: 12px;
 		margin: 0;
 		word-break: break-word;
 	}
 
-	& > * > p a {
+	a {
 		text-decoration: underline;
 	}
 
-	& > * > p a:hover {
+	a:hover {
 		text-decoration: none;
 	}
 `;

--- a/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout-order-summary.js
@@ -90,6 +90,7 @@ const CheckoutSummaryTotal = styled.span`
 
 const DomainURL = styled.div`
 	margin-top: -12px;
+	word-break: break-word;
 `;
 
 const SummaryContent = styled.div`

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -146,14 +146,17 @@ function LineItemTitle( { item, id } ) {
 }
 
 function LineItemPrice( { lineItem } ) {
-	if ( lineItem.amount.value < lineItem.wpcom_meta?.product_cost_integer ) {
-		return (
-			<span>
-				<s>{ lineItem.wpcom_meta.product_cost_display }</s> { lineItem.amount.displayValue }
-			</span>
-		);
-	}
-	return renderDisplayValueMarkdown( lineItem.amount.displayValue );
+	return (
+		<LineItemPriceUI>
+			{ lineItem.amount.value < lineItem.wpcom_meta?.product_cost_integer ? (
+				<>
+					<s>{ lineItem.wpcom_meta.product_cost_display }</s> { lineItem.amount.displayValue }
+				</>
+			) : (
+				renderDisplayValueMarkdown( lineItem.amount.displayValue )
+			) }
+		</LineItemPriceUI>
+	);
 }
 
 const LineItemUI = styled( WPLineItem )`
@@ -172,6 +175,11 @@ const LineItemUI = styled( WPLineItem )`
 
 const LineItemTitleUI = styled.div`
 	flex: 1;
+	word-break: break-word;
+`;
+
+const LineItemPriceUI = styled.span`
+	margin-left: 12px;
 `;
 
 const BundledDomainFreeUI = styled.div`

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -73,7 +73,7 @@ export function Checkout( { children, className } ) {
 			>
 				<MainContentUI
 					className={ joinClasses( [ className, 'checkout__content' ] ) }
-					isLastStepActive={ isThereAnotherNumberedStep }
+					isLastStepActive={ ! isThereAnotherNumberedStep }
 				>
 					{ children || getDefaultCheckoutSteps() }
 
@@ -373,7 +373,7 @@ const MainContentUI = styled.div`
 	background: ${props => props.theme.colors.surface};
 	width: 100%;
 	box-sizing: border-box;
-	margin-bottom: ${props => ( props.isLastStepActive ? '89px' : 0 )};
+	margin-bottom: ${props => ( props.isLastStepActive ? '100px' : 0 )};
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		border: 1px solid ${props => props.theme.colors.borderColorLight};


### PR DESCRIPTION
This fixes some styling issues uncovered from adding domain support to Checkout.

**Included:**
- prevent fixed submit button from overlapping domain TOS
- allow for wrapping of long domains in order summary, pricing line item, and domain TOS
- small visual tweaks to TOS

Before | After
------------ | -------------
<img width="388" alt="before-summary" src="https://user-images.githubusercontent.com/942359/76659540-1a848100-654d-11ea-9f7c-becfc6d5cd79.png"> | <img width="400" alt="after-summary" src="https://user-images.githubusercontent.com/942359/76659545-1bb5ae00-654d-11ea-8a05-0f72973c6641.png">
<img width="409" alt="before-line-item" src="https://user-images.githubusercontent.com/942359/76659542-1b1d1780-654d-11ea-9448-2dd64a527b7b.png"> | <img width="294" alt="after-line-item" src="https://user-images.githubusercontent.com/942359/76659544-1b1d1780-654d-11ea-9c12-e37801969854.png">
<img width="297" alt="before-tos" src="https://user-images.githubusercontent.com/942359/76659550-1ce6db00-654d-11ea-92c1-6e8c4a8c49fa.png"> | <img width="298" alt="after-tos" src="https://user-images.githubusercontent.com/942359/76659549-1c4e4480-654d-11ea-87cd-f279c829314c.png">
<img width="567" alt="before-tos-alignment" src="https://user-images.githubusercontent.com/942359/76659548-1c4e4480-654d-11ea-9511-8ca71b74172d.png"> | <img width="569" alt="after-tos-alignment" src="https://user-images.githubusercontent.com/942359/76659547-1bb5ae00-654d-11ea-9b88-7d5c893c1c75.png">

**To test:**
- add multiple domains of varying lengths (with and without hyphens) to your site
- visit checkout
- verify that the styling looks like the screenshots, there aren't any broken wrapping elements, etc.