### PR TITLE
Gutenboarding: Add "Start Over" button on design selector page.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -52,7 +52,7 @@ const DesignSelector: FunctionComponent = () => {
 						to={ makePath( Step.IntentGathering ) }
 						isLink
 					>
-						{ NO__( 'Start Over' ) }
+						{ NO__( 'Start over' ) }
 					</Link>
 				</div>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -50,6 +50,7 @@ const DesignSelector: FunctionComponent = () => {
 						className="design-selector__start-over-button"
 						onClick={ handleStartOverButtonClick }
 						to={ makePath( Step.IntentGathering ) }
+						isLink
 					>
 						{ NO__( 'Start Over' ) }
 					</Link>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -14,6 +14,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import designs from './available-designs.json';
 import { usePath, Step } from '../../path';
 import { isEnabled } from '../../../../config';
+import Link from '../../components/link';
 import './style.scss';
 import { SubTitle, Title } from 'landing/gutenboarding/components/titles';
 
@@ -24,7 +25,11 @@ const DesignSelector: FunctionComponent = () => {
 	const { selectedDesign, siteVertical } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
-	const { setSelectedDesign } = useDispatch( ONBOARD_STORE );
+	const { setSelectedDesign, resetOnboardStore } = useDispatch( ONBOARD_STORE );
+
+	const handleStartOverButtonClick = () => {
+		resetOnboardStore();
+	};
 
 	return (
 		<div
@@ -32,12 +37,23 @@ const DesignSelector: FunctionComponent = () => {
 			data-vertical={ siteVertical?.label }
 		>
 			<div className="design-selector__header">
-				<Title>{ NO__( 'Choose a starting design' ) }</Title>
-				<SubTitle>
-					{ NO__(
-						'Get started with one of our top website layouts. You can always change it later'
-					) }
-				</SubTitle>
+				<div className="design-selector__header-section design-selector__header-section--title">
+					<Title>{ NO__( 'Choose a starting design' ) }</Title>
+					<SubTitle>
+						{ NO__(
+							'Get started with one of our top website layouts. You can always change it later'
+						) }
+					</SubTitle>
+				</div>
+				<div className="design-selector__header-section">
+					<Link
+						className="design-selector__start-over-button"
+						onClick={ handleStartOverButtonClick }
+						to={ makePath( Step.IntentGathering ) }
+					>
+						{ NO__( 'Start Over' ) }
+					</Link>
+				</div>
 			</div>
 			<div className="design-selector__design-grid">
 				<div className="design-selector__grid">

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -37,7 +37,7 @@ const DesignSelector: FunctionComponent = () => {
 			data-vertical={ siteVertical?.label }
 		>
 			<div className="design-selector__header">
-				<div className="design-selector__header-section design-selector__header-section--title">
+				<div className="design-selector__heading">
 					<Title>{ NO__( 'Choose a starting design' ) }</Title>
 					<SubTitle>
 						{ NO__(
@@ -45,16 +45,14 @@ const DesignSelector: FunctionComponent = () => {
 						) }
 					</SubTitle>
 				</div>
-				<div className="design-selector__header-section">
-					<Link
-						className="design-selector__start-over-button"
-						onClick={ handleStartOverButtonClick }
-						to={ makePath( Step.IntentGathering ) }
-						isLink
-					>
-						{ NO__( 'Start over' ) }
-					</Link>
-				</div>
+				<Link
+					className="design-selector__start-over-button"
+					onClick={ handleStartOverButtonClick }
+					to={ makePath( Step.IntentGathering ) }
+					isLink
+				>
+					{ NO__( 'Start over' ) }
+				</Link>
 			</div>
 			<div className="design-selector__design-grid">
 				<div className="design-selector__grid">

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -18,7 +18,7 @@
 		margin: 5% 0%;
 	}
 
-	.design-selector__header-section--title {
+	.design-selector__heading {
 		flex-grow: 1;
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -23,10 +23,8 @@
 	}
 
 	.design-selector__start-over-button {
-		text-decoration: underline;
-
-		&:hover {
-			box-shadow: none !important;
+		&.is-link {
+			color: var( --color-text-subtle );
 		}
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -13,8 +13,21 @@
 	left: 0;
 
 	.design-selector__header {
-		width: 100%;
+		display: flex;
+		align-items: center;
 		margin: 5% 0%;
+	}
+
+	.design-selector__header-section--title {
+		flex-grow: 1;
+	}
+
+	.design-selector__start-over-button {
+		text-decoration: underline;
+
+		&:hover {
+			box-shadow: none !important;
+		}
 	}
 
 	.design-selector__grid {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/40006.

#### Changes proposed in this Pull Request

* Add StartOver button on design selector page.

#### Testing instructions

* Go to `/gutenboarding`, set vertical & site name and click continue.
* Now you've reached the design selector page, click **Start Over** button right to the header title.
* It should:
  * Reset vertical & site title.
  * Display the acquire intent page.

![image](https://user-images.githubusercontent.com/1287077/76581410-3ae11b00-650e-11ea-807d-b13aaf789593.png)
