### PR TITLE
Gutenboarding: Hide vertical suggestion dropdown when there is only 1 suggestion and it is identical to user input.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/index.tsx
@@ -112,6 +112,15 @@ const VerticalSelect: FunctionComponent< StepProps > = ( {
 			// User-supplied verticals don't have IDs.
 			suggestions.unshift( { label: inputValue.trim() } );
 		}
+
+		// If there is only one suggestion and that suggestion matches the user input value,
+		// do not show any suggestions.
+		if (
+			suggestions.length === 1 &&
+			suggestions[ 0 ].label.toLowerCase() === normalizedInputValue
+		) {
+			suggestions = [];
+		}
 	}
 
 	const handleSelect = ( vertical: SiteVertical ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide vertical suggestion dropdown when there is only 1 suggestion and it is identical to user input.

#### Testing instructions

1. Go to acquire intent `/gutenboarding` page.
2. Enter "American Restaurant" on the vertical input.
3. It should now show a dropdown suggestion.

Fixes #40042
