### PR TITLE
WooCommerce login: fix 2FA button alignment

### DIFF
--- a/client/blocks/login/two-factor-authentication/verification-code-form.scss
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.scss
@@ -4,8 +4,17 @@
 	padding: 1em 0;
 }
 
+.woo .two-factor-authentication__verification-code-form {
+	text-align: center;
+}
+
 .two-factor-authentication__verification-code-form .button {
 	width: 100%;
+}
+
+.woo .two-factor-authentication__verification-code-form .form-button {
+	float: none;
+	margin: 0;
 }
 
 .security-key-form__add-wait-for-key {

--- a/client/blocks/login/two-factor-authentication/verification-code-form.scss
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.scss
@@ -4,12 +4,12 @@
 	padding: 1em 0;
 }
 
-.woo .two-factor-authentication__verification-code-form {
-	text-align: center;
-}
-
 .two-factor-authentication__verification-code-form .button {
 	width: 100%;
+}
+
+.woo .two-factor-authentication__verification-code-form {
+	text-align: center;
 }
 
 .woo .two-factor-authentication__verification-code-form .form-button {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -647,9 +647,8 @@
 	.login__social,
 	.two-factor-authentication__actions {
 		border-top: 1px solid #e6e6e6;
-		margin: 0 -16px;
 		padding-top: 44px;
-		width: calc( 100% + ( #{$woo-form-whitespace} * 2 ) );
+		text-align: left;
 
 		@include breakpoint( '>480px' ) {
 			margin: 0 -24px;

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -648,7 +648,7 @@
 	.two-factor-authentication__actions {
 		border-top: 1px solid #e6e6e6;
 		padding-top: 44px;
-		text-align: left;
+		text-align: center;
 
 		@include breakpoint( '>480px' ) {
 			margin: 0 -24px;


### PR DESCRIPTION
Moved from #38581 props @Aurorum 

#### Changes proposed in this Pull Request

* Center the 2FA button on the WooCommerce login form
* Extra fix for smallest screen centering

#### Testing instructions

Follow the instructions in #38580 and verify the buttons now appear centered.

**Before:**
<img width="1225" alt="Screen Shot 2020-03-12 at 22 28 52" src="https://user-images.githubusercontent.com/66797/76592569-fffcca00-64b0-11ea-9451-cb946c9c8caa.png">
<img width="1225" alt="Screen Shot 2020-03-12 at 22 28 59" src="https://user-images.githubusercontent.com/66797/76592576-02f7ba80-64b1-11ea-8829-0191381c23bb.png">
<img width="1225" alt="Screen Shot 2020-03-12 at 22 29 13" src="https://user-images.githubusercontent.com/66797/76592577-03905100-64b1-11ea-8f82-c1dc60ce3270.png">
<img width="1225" alt="Screen Shot 2020-03-12 at 22 29 32" src="https://user-images.githubusercontent.com/66797/76592579-04c17e00-64b1-11ea-8dbe-963f169d7f8c.png">

**After:**
<img width="1225" alt="Screen Shot 2020-03-12 at 22 47 19" src="https://user-images.githubusercontent.com/66797/76593412-7e5a6b80-64b3-11ea-84eb-267f627474b5.png">
<img width="1225" alt="Screen Shot 2020-03-12 at 22 47 33" src="https://user-images.githubusercontent.com/66797/76593418-82868900-64b3-11ea-91f5-ff7cb2204596.png">

Fixes #38580
