### PR TITLE
Sidebar: add “Activity & Backups” menu option for Atomic and Jetpack-connected sites

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -196,7 +196,22 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const activityLink = '/activity-log' + siteSuffix;
+		let activityLink = '/activity-log' + siteSuffix;
+
+		if ( this.props.isJetpack && isEnabled( 'manage/themes-jetpack' ) ) {
+			activityLink = '/activity-log' + siteSuffix + '?group=rewind';
+			return (
+				<SidebarItem
+					tipTarget="activity"
+					label={ translate( 'Activity & Backups' ) }
+					selected={ itemLinkMatches( activityLink, path ) }
+					link={ activityLink }
+					onNavigate={ this.trackActivityClick }
+					expandSection={ this.expandToolsSection }
+				/>
+			);
+		}
+
 		return (
 			<SidebarItem
 				tipTarget="activity"

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -199,7 +199,7 @@ export class MySitesSidebar extends Component {
 		let activityLink = '/activity-log' + siteSuffix;
 
 		if ( this.props.isJetpack && isEnabled( 'manage/themes-jetpack' ) ) {
-			activityLink = '/activity-log' + siteSuffix + '?group=rewind';
+			activityLink += '?group=rewind';
 			return (
 				<SidebarItem
 					tipTarget="activity"

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -196,26 +196,18 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		let activityLink = '/activity-log' + siteSuffix;
+		let activityLink = '/activity-log' + siteSuffix,
+			activityLabel = translate( 'Activity' );
 
 		if ( this.props.isJetpack && isEnabled( 'manage/themes-jetpack' ) ) {
 			activityLink += '?group=rewind';
-			return (
-				<SidebarItem
-					tipTarget="activity"
-					label={ translate( 'Activity & Backups' ) }
-					selected={ itemLinkMatches( activityLink, path ) }
-					link={ activityLink }
-					onNavigate={ this.trackActivityClick }
-					expandSection={ this.expandToolsSection }
-				/>
-			);
+			activityLabel = translate( 'Activity & Backups' );
 		}
 
 		return (
 			<SidebarItem
 				tipTarget="activity"
-				label={ translate( 'Activity' ) }
+				label={ activityLabel }
 				selected={ itemLinkMatches( [ '/activity-log' ], path ) }
 				link={ activityLink }
 				onNavigate={ this.trackActivityClick }


### PR DESCRIPTION
Fixes #40058

#### Changes proposed in this Pull Request

* When viewing an Atomic or Jetpack-connected site — change the sidebar menu label from "Activity" to "Activity & Backups".
* The link goes to the same page, yet auto-loads the filter for backups rather than all activity

#### Testing instructions

1. Log in, navigate to My Sites, find an Atomic or Jetpack-connected site
2. View the sidebar, verify the label and link destination are changed from current production environment

#### Screenshots

Jetpack-connected Atomic site — updated label:
<img width="1086" alt="Screen Shot 2020-03-13 at 00 34 46" src="https://user-images.githubusercontent.com/66797/76600156-9934dc00-64c3-11ea-9723-9a59d292afce.png">

WordPress.com  Simple site — no label change:
<img width="1086" alt="Screen Shot 2020-03-13 at 00 34 53" src="https://user-images.githubusercontent.com/66797/76600166-9d60f980-64c3-11ea-9aa1-adc369b44ce4.png">

Two small-screen views, Jetpack-connected site (to see how it flows):
<img src="https://user-images.githubusercontent.com/66797/76600172-9f2abd00-64c3-11ea-98fa-9715efe4fb73.png" width="480" />

<img width="480" alt="Screen Shot 2020-03-13 at 00 37 00" src="https://user-images.githubusercontent.com/66797/76600176-a05bea00-64c3-11ea-8d5d-2f07625a12d4.png">
