### PR TITLE
Gutenboarding: Add push 2fa support to auth store

### DIFF
--- a/client/landing/gutenboarding/devtools.ts
+++ b/client/landing/gutenboarding/devtools.ts
@@ -27,9 +27,9 @@ export const setupWpDataDebug = () => {
 				Site.register( clientCreds );
 
 				window.wp.auth = {};
-				let previousState = window.wp?.data.select( AUTH_STORE ).getLoginFlowState();
-				let previousErrors = window.wp?.data.select( AUTH_STORE ).getErrors();
-				window.wp?.data.subscribe( () => {
+				let previousState = window.wp.data.select( AUTH_STORE ).getLoginFlowState();
+				let previousErrors = window.wp.data.select( AUTH_STORE ).getErrors();
+				window.wp.data.subscribe( () => {
 					const newState = window.wp?.data.select( AUTH_STORE ).getLoginFlowState();
 					const newErrors = window.wp?.data.select( AUTH_STORE ).getErrors();
 					if (

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -219,7 +219,7 @@ export function createActions( {
 			}
 
 			try {
-				const response: WpLoginResponse = yield wpLogin( 'two-step-authentication-endpoint', {
+				const response: WpLoginResponse = yield* wpLogin( 'two-step-authentication-endpoint', {
 					remember_me: true,
 					auth_type: 'push',
 					user_id,

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -153,11 +153,11 @@ export function createActions( {
 			} else if ( loginResponse.data.two_step_notification_sent ) {
 				yield receiveWpLogin( loginResponse );
 
-				const twoFactorResonse = yield* handle2fa( loginResponse.data );
-				if ( twoFactorResonse.success ) {
-					yield* handleSuccessfulLogin( twoFactorResonse );
-				} else if ( twoFactorResonse.success === false ) {
-					yield receiveWpLoginFailed( twoFactorResonse );
+				const twoFactorResponse = yield* handle2fa( loginResponse.data );
+				if ( twoFactorResponse.success ) {
+					yield* handleSuccessfulLogin( twoFactorResponse );
+				} else if ( twoFactorResponse.success === false ) {
+					yield receiveWpLoginFailed( twoFactorResponse );
 				} else {
 					// If success is undefined then 2fa polling was canceled
 				}
@@ -192,11 +192,11 @@ export function createActions( {
 	}
 
 	function* handle2fa(
-		loginResonseData: Exclude< WpLoginSuccessResponse[ 'data' ], LoginCompleteData >
+		loginResponseData: Exclude< WpLoginSuccessResponse[ 'data' ], LoginCompleteData >
 	) {
-		switch ( loginResonseData.two_step_notification_sent ) {
+		switch ( loginResponseData.two_step_notification_sent ) {
 			case 'push':
-				return yield* handlePush2fa( loginResonseData );
+				return yield* handlePush2fa( loginResponseData );
 		}
 	}
 

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -14,13 +14,15 @@ import {
 	WpLoginErrorResponse,
 	SendLoginEmailSuccessResponse,
 	SendLoginEmailErrorResponse,
+	WpLoginResponse,
 } from './types';
-import { STORE_KEY } from './constants';
+import { STORE_KEY, POLL_APP_PUSH_INTERVAL_SECONDS } from './constants';
 import {
 	wpcomRequest,
 	fetchAndParse,
 	requestAllBlogsAccess,
 	reloadProxy,
+	wait,
 } from '../wpcom-request-controls';
 import { remoteLoginUser } from './controls';
 import { WpcomClientCredentials } from '../shared-types';
@@ -131,35 +133,25 @@ export function createActions( {
 		const username = yield select( STORE_KEY, 'getUsernameOrEmail' );
 
 		try {
-			const loginResponse = yield fetchAndParse(
-				// TODO Wrap this in `localizeUrl` from lib/i18n-utils
-				'https://wordpress.com/wp-login.php?action=login-endpoint',
-				{
-					credentials: 'include',
-					method: 'POST',
-					headers: {
-						Accept: 'application/json',
-						'Content-Type': 'application/x-www-form-urlencoded',
-					},
-					body: stringify( {
-						remember_me: true,
-						username,
-						password,
-						client_id,
-						client_secret,
-					} ),
+			let loginResponse = yield* wpLogin( 'login-endpoint', {
+				remember_me: true,
+				username,
+				password,
+			} );
+
+			if ( ! loginResponse.success ) {
+				return receiveWpLoginFailed( loginResponse );
+			}
+
+			if ( loginResponse.data.two_step_notification_sent ) {
+				yield receiveWpLogin( loginResponse );
+
+				if ( loginResponse.data.two_step_notification_sent === 'push' ) {
+					loginResponse = yield* handlePush2fa( loginResponse );
 				}
-			);
-
-			if ( ! loginResponse.ok || ! loginResponse.body.success ) {
-				return receiveWpLoginFailed( loginResponse.body );
 			}
 
-			if ( loginResponse.body.two_step_notification_sent === 'push' ) {
-				yield* handlePush2fa( loginResponse.body );
-			}
-
-			yield* handleSuccessfulLogin( loginResponse.body );
+			yield* handleSuccessfulLogin( loginResponse );
 
 			return;
 		} catch ( e ) {
@@ -186,11 +178,33 @@ export function createActions( {
 	}
 
 	function* handlePush2fa( response: WpLoginSuccessResponse ) {
-		const { user_id, two_step_nonce_push, push_web_token } = response.data;
+		const { user_id, push_web_token } = response.data;
+		let { two_step_nonce_push: two_step_nonce } = response.data;
 
-		yield fetchAndParse(
+		while ( ! response.data.token_links ) {
+			response = yield wpLogin( 'two-step-authentication-endpoint', {
+				remember_me: true,
+				auth_type: 'push',
+				user_id,
+				two_step_nonce,
+				two_step_push_token: push_web_token,
+			} );
+
+			if ( ! response.success ) {
+				two_step_nonce = response.data.two_step_nonce;
+				yield wait( POLL_APP_PUSH_INTERVAL_SECONDS * 1000 );
+			}
+		}
+
+		return response;
+	}
+
+	type WpLoginAction = 'two-step-authentication-endpoint' | 'login-endpoint';
+
+	function* wpLogin( action: WpLoginAction, body: object ) {
+		const response = yield fetchAndParse(
 			// TODO Wrap this in `localizeUrl` from lib/i18n-utils
-			'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint',
+			'https://wordpress.com/wp-login.php?action=' + encodeURIComponent( action ),
 			{
 				credentials: 'include',
 				method: 'POST',
@@ -199,16 +213,14 @@ export function createActions( {
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},
 				body: stringify( {
-					remember_me: true,
-					auth_type: 'push',
-					user_id,
-					two_step_nonce: two_step_nonce_push,
-					two_step_push_token: push_web_token,
 					client_id,
 					client_secret,
+					...body,
 				} ),
 			}
 		);
+
+		return response.body as WpLoginResponse;
 	}
 
 	return {

--- a/packages/data-stores/src/auth/constants.ts
+++ b/packages/data-stores/src/auth/constants.ts
@@ -1,1 +1,2 @@
 export const STORE_KEY = 'automattic/auth';
+export const POLL_APP_PUSH_INTERVAL_SECONDS = 5;

--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -42,10 +42,7 @@ const makeRemoteLoginRequest = ( loginLink: string, requestTimeout = 25000 ) => 
 };
 
 export const remoteLoginUser = ( loginLinks: string[] ) =>
-	( {
-		type: 'REMOTE_LOGIN_USER',
-		loginLinks,
-	} as const );
+	( { type: 'REMOTE_LOGIN_USER', loginLinks } as const );
 
 export const controls = {
 	REMOTE_LOGIN_USER: ( { loginLinks }: ReturnType< typeof remoteLoginUser > ) =>

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -9,6 +9,7 @@ import { combineReducers } from '@wordpress/data';
  */
 import { LoginFlowState } from './types';
 import { Action } from './actions';
+import { getNextTaskId } from './utils';
 
 export const loginFlowState: Reducer< LoginFlowState, Action > = (
 	state = 'ENTER_USERNAME_OR_EMAIL',
@@ -85,7 +86,18 @@ export const errors: Reducer< ErrorObject[], Action > = ( state = [], action ) =
 	}
 };
 
-const reducer = combineReducers( { errors, loginFlowState, usernameOrEmail } );
+const pollingTaskId: Reducer< number, Action > = ( state = getNextTaskId(), action ) => {
+	switch ( action.type ) {
+		case 'RESET_LOGIN_FLOW':
+			return getNextTaskId();
+		case 'START_POLLING_TASK':
+			return action.pollingTaskId;
+		default:
+			return state;
+	}
+};
+
+const reducer = combineReducers( { errors, loginFlowState, usernameOrEmail, pollingTaskId } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -34,6 +34,12 @@ export const loginFlowState: Reducer< LoginFlowState, Action > = (
 			}
 			return 'LOGGED_IN';
 
+		case 'RECEIVE_WP_LOGIN_FAILED':
+			if ( state === 'WAITING_FOR_2FA_APP' ) {
+				return 'ENTER_PASSWORD';
+			}
+			return state;
+
 		case 'RECEIVE_SEND_LOGIN_EMAIL':
 			if ( action.response.success ) {
 				return 'LOGIN_LINK_SENT';

--- a/packages/data-stores/src/auth/reducer.ts
+++ b/packages/data-stores/src/auth/reducer.ts
@@ -28,6 +28,9 @@ export const loginFlowState: Reducer< LoginFlowState, Action > = (
 			return state;
 
 		case 'RECEIVE_WP_LOGIN':
+			if ( action.response.data.two_step_notification_sent ) {
+				return 'WAITING_FOR_2FA_APP';
+			}
 			return 'LOGGED_IN';
 
 		case 'RECEIVE_SEND_LOGIN_EMAIL':

--- a/packages/data-stores/src/auth/selectors.ts
+++ b/packages/data-stores/src/auth/selectors.ts
@@ -11,3 +11,5 @@ export const getFirstError = ( state: State ) =>
 export const getLoginFlowState = ( state: State ) => state.loginFlowState;
 
 export const getUsernameOrEmail = ( state: State ) => state.usernameOrEmail;
+
+export const getPollingTaskId = ( state: State ) => state.pollingTaskId;

--- a/packages/data-stores/src/auth/test/flows.ts
+++ b/packages/data-stores/src/auth/test/flows.ts
@@ -149,6 +149,100 @@ describe( 'password login flow', () => {
 			},
 		] );
 	} );
+
+	it( 'logs in using mobile app for 2fa', async () => {
+		const { getLoginFlowState } = select( store );
+		const { submitUsernameOrEmail, submitPassword } = dispatch( store );
+
+		expect( getLoginFlowState() ).toBe( 'ENTER_USERNAME_OR_EMAIL' );
+
+		( wpcomRequest as jest.Mock ).mockResolvedValue( {
+			email_verified: true,
+			passwordless: false,
+		} );
+
+		await submitUsernameOrEmail( 'user1' );
+
+		expect( wpcomRequest ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				path: '/users/user1/auth-options',
+			} )
+		);
+
+		expect( getLoginFlowState() ).toBe( 'ENTER_PASSWORD' );
+
+		const user_id = 12341234;
+		const two_step_nonce = 'secretnonce';
+		const two_step_push_token = 'push:token';
+
+		nock( 'https://wordpress.com' )
+			.post( '/wp-login.php?action=login-endpoint', body => {
+				expect( parse( body ) ).toEqual(
+					expect.objectContaining( {
+						username: 'user1',
+						password: 'passw0rd',
+						remember_me: 'true',
+					} )
+				);
+				return true;
+			} )
+			.reply( 200, {
+				success: true,
+				data: {
+					user_id,
+					two_step_supported_auth_types: [ 'push' ],
+					two_step_notification_sent: 'push',
+					two_step_nonce_push: two_step_nonce,
+					push_web_token: two_step_push_token,
+				},
+			} )
+			.post( '/wp-login.php?action=two-step-authentication-endpoint', body => {
+				expect( parse( body ) ).toEqual(
+					expect.objectContaining( {
+						user_id: user_id.toString( 10 ),
+						auth_type: 'push',
+						two_step_nonce,
+						two_step_push_token,
+					} )
+				);
+				return true;
+			} )
+			.reply( 403, {
+				success: false,
+				data: {
+					two_step_nonce,
+					errors: [
+						{
+							code: 'invalid_two_step_code',
+							message: 'Double check the app and try again',
+						},
+					],
+				},
+			} );
+
+		await submitPassword( 'passw0rd' );
+
+		expect( getLoginFlowState() ).toBe( 'WAITING_FOR_2FA_APP' );
+
+		nock( 'https://wordpress.com' )
+			.post( '/wp-login.php?action=two-step-authentication-endpoint', body => {
+				expect( parse( body ) ).toEqual(
+					expect.objectContaining( {
+						user_id: user_id.toString( 10 ),
+						auth_type: 'push',
+						two_step_nonce,
+						two_step_push_token,
+					} )
+				);
+				return true;
+			} )
+			.reply( 200, {
+				success: true,
+				data: { token_links: [] },
+			} );
+
+		expect( getLoginFlowState() ).toBe( 'LOGGED_IN' );
+	} );
 } );
 
 describe( 'passwordless login flow', () => {

--- a/packages/data-stores/src/auth/types.ts
+++ b/packages/data-stores/src/auth/types.ts
@@ -24,6 +24,7 @@ export interface WpLoginSuccessResponse {
 		token_links?: string[];
 		user_id?: number;
 		two_step_supported_auth_types?: string[];
+		two_step_nonce?: string;
 		two_step_nonce_backup?: string;
 		two_step_nonce_authenticator?: string;
 		two_step_nonce_push?: string;

--- a/packages/data-stores/src/auth/types.ts
+++ b/packages/data-stores/src/auth/types.ts
@@ -21,7 +21,14 @@ export type AuthOptionsResponse = AuthOptionsSuccessResponse | AuthOptionsErrorR
 export interface WpLoginSuccessResponse {
 	success: true;
 	data: {
-		token_links: string[];
+		token_links?: string[];
+		user_id?: number;
+		two_step_supported_auth_types?: string[];
+		two_step_nonce_backup?: string;
+		two_step_nonce_authenticator?: string;
+		two_step_nonce_push?: string;
+		push_web_token?: string;
+		two_step_notification_sent?: string;
 	};
 }
 

--- a/packages/data-stores/src/auth/types.ts
+++ b/packages/data-stores/src/auth/types.ts
@@ -18,19 +18,25 @@ export interface AuthOptionsErrorResponse {
 
 export type AuthOptionsResponse = AuthOptionsSuccessResponse | AuthOptionsErrorResponse;
 
+export interface LoginCompleteData {
+	token_links: string[];
+	two_step_notification_sent: undefined;
+}
+
+export interface PushNotificationSentData {
+	user_id?: number;
+	two_step_supported_auth_types?: string[];
+	two_step_nonce?: string;
+	two_step_nonce_backup?: string;
+	two_step_nonce_authenticator?: string;
+	two_step_nonce_push?: string;
+	push_web_token?: string;
+	two_step_notification_sent: 'push';
+}
+
 export interface WpLoginSuccessResponse {
 	success: true;
-	data: {
-		token_links?: string[];
-		user_id?: number;
-		two_step_supported_auth_types?: string[];
-		two_step_nonce?: string;
-		two_step_nonce_backup?: string;
-		two_step_nonce_authenticator?: string;
-		two_step_nonce_push?: string;
-		push_web_token?: string;
-		two_step_notification_sent?: string;
-	};
+	data: LoginCompleteData | PushNotificationSentData;
 }
 
 export interface WpLoginErrorResponse {
@@ -40,6 +46,7 @@ export interface WpLoginErrorResponse {
 			code: string;
 			message: string;
 		} >;
+		two_step_nonce?: string;
 	};
 }
 

--- a/packages/data-stores/src/auth/utils.ts
+++ b/packages/data-stores/src/auth/utils.ts
@@ -1,0 +1,4 @@
+let nextTaskId = 0;
+export function getNextTaskId() {
+	return nextTaskId++;
+}

--- a/packages/data-stores/src/wpcom-request-controls/index.ts
+++ b/packages/data-stores/src/wpcom-request-controls/index.ts
@@ -39,6 +39,8 @@ export const requestAllBlogsAccess = () =>
 		type: 'REQUEST_ALL_BLOGS_ACCESS',
 	} as const );
 
+export const wait = ( ms: number ) => ( { type: 'WAIT', ms } as const );
+
 export const controls = {
 	WPCOM_REQUEST: ( { request }: ReturnType< typeof wpcomRequest > ) => wpcomProxyRequest( request ),
 	FETCH_AND_PARSE: async ( { resource, options }: ReturnType< typeof fetchAndParse > ) => {
@@ -53,4 +55,6 @@ export const controls = {
 		triggerReloadProxy();
 	},
 	REQUEST_ALL_BLOGS_ACCESS: () => triggerRequestAllBlogsAccess(),
+	WAIT: ( { ms }: ReturnType< typeof wait > ) =>
+		new Promise( resolve => setTimeout( resolve, ms ) ),
 } as const;

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -18,6 +18,7 @@
 
 		"moduleResolution": "node",
 		"esModuleInterop": true,
+		"downlevelIteration": true,
 
 		"forceConsistentCasingInFileNames": true,
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add support for "push" 2nd login factor
* Polls ever 5 seconds to see if push notification has been handed (this is the poll time currently used by `/log-in`)
* Add `downlevelIteration` to TS config so we can use `yield*` in generator functions
* Every time we poll update the nonce that we'll use for the next time we poll

"Push" means when we send a push notification to the WordPress app during login, and you click the button in the app to approve the login. Not the one where you have to end a code for the 2nd factor.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout branch locally
* Install WordPress app on phone (I found I needed to enable notifications for the app, can always disable later 😄)
* In console:
  * `wp.auth.submitUsernameOrEmail('username')` using an account that's logged into the mobile app
  * `wp.auth.submitPassword('correctpassword')`
  * Console will print that it's now waiting for 2FA
  * Go to your phone and approve the push notifcation
  * After a few seconds the console will update to say you're logged in
  * Also try running `wp.auth.reset()` while polling is happening, polling should stop

Should probably try a passwordless account with 2fa. I don't actually know if passwordless accounts can have a second factor 🤔 (we might ask them to pick a password)
