### PR TITLE
Jetpack Cloud: Remove inline help

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -101,6 +101,37 @@ class Layout extends Component {
 		// intentionally don't remove these in unmount
 	}
 
+	shouldLoadInlineHelp() {
+		if ( ! config.isEnabled( 'inline-help' ) ) {
+			return false;
+		}
+
+		if (
+			'jetpack-connect' === this.props.sectionName &&
+			'/jetpack/new' !== this.props.currentRoute
+		) {
+			return false;
+		}
+
+		if ( '/log-in/jetpack' === this.props.currentRoute ) {
+			return false;
+		}
+
+		if ( '/me/account/closed' === this.props.currentRoute ) {
+			return false;
+		}
+
+		if ( 'happychat' === this.props.sectionName ) {
+			return false;
+		}
+
+		if ( 'devdocs' === this.props.sectionName ) {
+			return false;
+		}
+
+		return true;
+	}
+
 	renderMasterbar() {
 		const MasterbarComponent = config.isEnabled( 'jetpack-cloud' )
 			? JetpackCloudMasterbar
@@ -196,14 +227,9 @@ class Layout extends Component {
 				{ 'development' === process.env.NODE_ENV && (
 					<AsyncLoad require="components/webpack-build-monitor" placeholder={ null } />
 				) }
-				{ ( 'jetpack-connect' !== this.props.sectionName ||
-					this.props.currentRoute === '/jetpack/new' ) &&
-					this.props.currentRoute !== '/log-in/jetpack' &&
-					'devdocs' !== this.props.sectionName &&
-					this.props.currentRoute !== '/me/account/closed' &&
-					'happychat' !== this.props.sectionName && (
-						<AsyncLoad require="blocks/inline-help" placeholder={ null } />
-					) }
+				{ this.shouldLoadInlineHelp() && (
+					<AsyncLoad require="blocks/inline-help" placeholder={ null } />
+				) }
 				<AsyncLoad require="blocks/support-article-dialog" placeholder={ null } />
 				<AsyncLoad require="blocks/app-banner" placeholder={ null } />
 				{ config.isEnabled( 'gdpr-banner' ) && (

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -40,6 +40,7 @@
 		"gdpr-banner": false,
 		"help": true,
 		"help/courses": true,
+		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -34,6 +34,7 @@
 		"google-my-business": false,
 		"help": true,
 		"help/courses": true,
+		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/development.json
+++ b/config/development.json
@@ -65,6 +65,7 @@
 		"gutenboarding/style-preview": true,
 		"help": true,
 		"help/courses": true,
+		"inline-help": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,
 		"ive/me": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -39,6 +39,7 @@
 		"happychat": false,
 		"help": true,
 		"help/courses": true,
+		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -38,6 +38,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -41,6 +41,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/test.json
+++ b/config/test.json
@@ -37,6 +37,7 @@
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"help": true,
+		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,
 		"ive/use-external-assignment": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -48,6 +48,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removed the inline help bubble for jetpack cloud. 

The help bubble looks like this and can be found on the bottom right cornder of the calypso UI. 
<img width="523" alt="Screen Shot 2020-03-23 at 2 22 06 PM" src="https://user-images.githubusercontent.com/115071/77320944-b793a680-6d11-11ea-8623-c82ecd03256e.png">

#### Testing instructions
1. Load up Jetpack cloud. 
* Notice that the inline help bubble is not there any more. 

2. Load up calypso. 
Notice that on 

http://calypso.localhost:3000/devdocs/
http://calypso.localhost:3000/jetpack/conect
http://calypso.localhost:3000/me/chat 
http://calypso.localhost:3000/log-in/jetpack
http://calypso.localhost:3000/me/account/closed (I wasn't able to test this one because we land on http://calypso.localhost:3000/me/account/close instead)

the help bubble is not present 

but is present on 
http://calypso.localhost:3000/jetpack/new



* Load up calypso. 
* Notice that the bubble is not there for specific sections and route as well. 
[ ] todo firgure out the different places where it shouldn't be shown. 
