### PR TITLE
FSE: update version to 0.24

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 0.23
+ * Version: 0.24
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -35,7 +35,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '0.23' );
+define( 'PLUGIN_VERSION', '0.24' );
 
 // Always include these helper files for dotcom FSE.
 require_once __DIR__ . '/dotcom-fse/helpers.php';

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -3,7 +3,7 @@ Contributors: alexislloyd, allancole, automattic, bartkalisz, codebykat, copons,
 Tags: block, blocks, editor, gutenberg, page
 Requires at least: 5.0
 Tested up to: 5.3
-Stable tag: 0.23
+Stable tag: 0.24
 Requires PHP: 5.6.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -41,6 +41,11 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 
 == Changelog ==
+
+= 0.24 =
+
+* Starter Page Templates: fix overflow issue with feature image in blog posts.
+* Global Styles: add new font (Raleway).
 
 = 0.23 =
 * Dotcom Block Editor NUX: disable by default


### PR DESCRIPTION
**Changes proposed in this Pull Request**

Updates the FSE plugin to version 0.16, which includes two changes:

- Adds a new font to Global Styles https://github.com/Automattic/wp-calypso/pull/40087
- Fixes an overflow issue with features images in the blog SPT template https://github.com/Automattic/wp-calypso/pull/39944

**Testing instructions**

- Have the Maywood theme active (use latest release).
- Have FSE active (this PR).

Global Styles change:

- Go to a post, open the Global Styles sidebar and check that the Raleway font is present.
- Select Raleway for base or heading and publish styles.
- Go to the front end and make sure the fonts are properly set.

SPT change:

- Go to a post, and add a featured image larger than 700px. Publish.
- Enable Jetpack and under "Settings > Discussion" activate the subscription module.
- Create a new page. You should see the list of SPT templates.
- Choose the blog template and check that the featured image from the post doesn't overflow.
