### PR TITLE
Site migration: fix typo in error for WordPress.com hosted source sites

### DIFF
--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -75,7 +75,7 @@ class StepSourceSelect extends Component {
 						case 'wordpress':
 							if ( result.site_meta.wpcom_site ) {
 								return this.setState( {
-									error: translate( 'This is site is already hosted on WordPress.com' ),
+									error: translate( 'This site is already hosted on WordPress.com' ),
 									isLoading: false,
 								} );
 							}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a small typo in the error message `This is site is`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR or use Calypso.live.
* Go to `import/[ site ]`, select WordPress and enter the URL of a site that's already hosted on WordPress.com.
* You should see the corrected error message.

<img width="741" alt="image" src="https://user-images.githubusercontent.com/1647564/76614677-7a146980-6518-11ea-8235-cb74593e333a.png">

