### PR TITLE
Adds prettier plugin to eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
 		'wpcalypso/react',
 		'plugin:jsx-a11y/recommended',
 		'plugin:jest/recommended',
-		'prettier',
+		'plugin:prettier/recommended',
 		'prettier/react',
 	],
 	overrides: [

--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
 		"eslint-plugin-jest": "23.6.0",
 		"eslint-plugin-jsdoc": "18.11.0",
 		"eslint-plugin-jsx-a11y": "6.2.3",
+		"eslint-plugin-prettier": "3.1.2",
 		"eslint-plugin-react": "7.18.3",
 		"eslint-plugin-wpcalypso": "file:./packages/eslint-plugin-wpcalypso",
 		"exports-loader": "0.7.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds prettier integration to eslint(https://prettier.io/docs/en/integrating-with-linters.html#use-eslint-to-run-prettier). This allows for a better integration with the editor, as it will display prettier errros and auto-fix them on save like eslint errors.

![Kapture 2020-03-13 at 11 47 03](https://user-images.githubusercontent.com/975703/76614831-1b9fb900-6521-11ea-9502-48008bbf56b8.gif)

#### Testing instructions

* Configure your editor to highlight eslint errors and auto-fix them on save.
* Checkout the branch, open any `.js` file and type anything with formatting errors (eg: extra spaces)
* Check your editor highlights them, and fixes them on save.