### PR TITLE
Rewind: add tracking events to server credentials updates

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -57,6 +57,7 @@ export const request = action => {
 
 	const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_attempt', {
 		site_id: action.siteId,
+		protocol: action.credentials.protocol,
 	} );
 
 	return [
@@ -93,6 +94,7 @@ export const success = ( action, { rewind_state } ) => [
 	} ),
 	recordTracksEvent( 'calypso_rewind_creds_update_success', {
 		site_id: action.siteId,
+		protocol: action.credentials.protocol,
 	} ),
 	// the API transform could fail and the rewind data might
 	// be unavailable so if that's the case just let it go

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -98,6 +98,16 @@ export const success = ( action, { rewind_state } ) => [
 		duration: 4000,
 		id: action.noticeId,
 	} ),
+	recordTracksEvent( 'calypso_rewind_creds_update_success', {
+		site_id: action.siteId,
+		host: action.credentials.host,
+		kpri: action.credentials.krpi ? 'provided but [omitted here]' : 'not provided',
+		pass: action.credentials.pass ? 'provided but [omitted here]' : 'not provided',
+		path: action.credentials.path,
+		port: action.credentials.port,
+		protocol: action.credentials.protocol,
+		user: action.credentials.user,
+	} ),
 	// the API transform could fail and the rewind data might
 	// be unavailable so if that's the case just let it go
 	// for now. we'll improve our rigor as time goes by.

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -57,13 +57,6 @@ export const request = action => {
 
 	const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_attempt', {
 		site_id: action.siteId,
-		host: action.credentials.host,
-		kpri: action.credentials.krpi ? 'provided but [omitted here]' : 'not provided',
-		pass: action.credentials.pass ? 'provided but [omitted here]' : 'not provided',
-		path: action.credentials.path,
-		port: action.credentials.port,
-		protocol: action.credentials.protocol,
-		user: action.credentials.user,
 	} );
 
 	return [
@@ -100,13 +93,6 @@ export const success = ( action, { rewind_state } ) => [
 	} ),
 	recordTracksEvent( 'calypso_rewind_creds_update_success', {
 		site_id: action.siteId,
-		host: action.credentials.host,
-		kpri: action.credentials.krpi ? 'provided but [omitted here]' : 'not provided',
-		pass: action.credentials.pass ? 'provided but [omitted here]' : 'not provided',
-		path: action.credentials.path,
-		port: action.credentials.port,
-		protocol: action.credentials.protocol,
-		user: action.credentials.user,
 	} ),
 	// the API transform could fail and the rewind data might
 	// be unavailable so if that's the case just let it go

--- a/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
+++ b/client/state/data-layer/wpcom/activity-log/update-credentials/index.js
@@ -55,8 +55,20 @@ export const request = action => {
 	const { path, ...otherCredentials } = action.credentials;
 	const credentials = { ...otherCredentials, abspath: path };
 
+	const tracksEvent = recordTracksEvent( 'calypso_rewind_creds_update_attempt', {
+		site_id: action.siteId,
+		host: action.credentials.host,
+		kpri: action.credentials.krpi ? 'provided but [omitted here]' : 'not provided',
+		pass: action.credentials.pass ? 'provided but [omitted here]' : 'not provided',
+		path: action.credentials.path,
+		port: action.credentials.port,
+		protocol: action.credentials.protocol,
+		user: action.credentials.user,
+	} );
+
 	return [
 		notice,
+		tracksEvent,
 		http(
 			{
 				apiNamespace: 'wpcom/v2',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add tracks event when attempting to add server credentials.
  * `calypso_rewind_creds_update_attempt`
* Add tracks event when successfully adding server credentials.
  * `calypso_rewind_creds_update_success`

#### Testing instructions

* Fire off this PR.
* Open Calypso and enter `localStorage.setItem( 'debug', 'calypso:analytics*' );` on your console.
* Select a Jetpack site and head to `Settings > Security > Backups and security scans`.
* Add correct server credentials and ensure both events are fired correctly.

#### Screenshot

![image](https://user-images.githubusercontent.com/390760/76626199-a50ab780-6530-11ea-8da0-c9b37681ea4d.png)

