### PR TITLE
Jetpack Remote Install: Update copy and style on remote credentials page

### DIFF
--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -46,6 +46,7 @@ import {
 	INVALID_PERMISSIONS,
 	UNKNOWN_REMOTE_INSTALL_ERROR,
 } from './connection-notice-types';
+import WordPressLogo from 'components/wordpress-logo';
 
 export class OrgCredentialsForm extends Component {
 	state = {
@@ -133,15 +134,13 @@ export class OrgCredentialsForm extends Component {
 	getHeaderText() {
 		const { translate } = this.props;
 
-		return translate( 'Add your website credentials' );
+		return translate( 'Add your self-hosted WordPress credentials' );
 	}
 
 	getSubHeaderText() {
 		const { translate } = this.props;
 		const subheader = translate(
-			'Add your WordPress administrator credentials ' +
-				'for this site. Your credentials will not be stored and are used for the purpose ' +
-				'of installing Jetpack securely. You can also skip this step entirely and install Jetpack manually.'
+			'Your log in credentials are used for the purpose of securely auto-installing Jetpack and will not be stored.'
 		);
 		return <span>{ subheader }</span>;
 	}
@@ -200,10 +199,19 @@ export class OrgCredentialsForm extends Component {
 		const passwordClassName = classnames( 'jetpack-connect__password-form-input', {
 			'is-error': this.isInvalidPassword(),
 		} );
-
+		const removedProtocolURL = this.props.siteToConnect.replace( /(^\w+:|^)\/\//, '' );
 		return (
 			<Fragment>
-				<FormLabel htmlFor="username">{ translate( 'Username' ) }</FormLabel>
+				<div className="jetpack-connect__site-address">
+					<div className="jetpack-connect__globe">
+						<Gridicon size={ 24 } icon="globe" />
+					</div>{ ' ' }
+					{ removedProtocolURL }
+				</div>
+				<div className="jetpack-connect__wordpress-logo">
+					<WordPressLogo size="72" />
+				</div>
+				<FormLabel htmlFor="username">{ translate( 'WordPress username or esmail' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
 					<Gridicon size={ 24 } icon="user" />
 					<FormTextInput
@@ -219,12 +227,12 @@ export class OrgCredentialsForm extends Component {
 					{ this.isInvalidUsername() && (
 						<FormInputValidation
 							isError
-							text={ translate( 'Username does not exist. Please try again.' ) }
+							text={ translate( 'Username or email does not exist. Please try again.' ) }
 						/>
 					) }
 				</div>
 				<div className="jetpack-connect__password-container">
-					<FormLabel htmlFor="password">{ translate( 'Password' ) }</FormLabel>
+					<FormLabel htmlFor="password">{ translate( 'WordPress password' ) }</FormLabel>
 					<div className="jetpack-connect__password-form">
 						<Gridicon size={ 24 } icon="lock" />
 						<FormPasswordInput
@@ -242,6 +250,11 @@ export class OrgCredentialsForm extends Component {
 							/>
 						) }
 					</div>
+				</div>
+				<div className="jetpack-connect__note">
+					{ translate(
+						'Note: Your WordPress credentials are different than your WordPress.com credentials.'
+					) }
 				</div>
 			</Fragment>
 		);

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -134,7 +134,7 @@ export class OrgCredentialsForm extends Component {
 	getHeaderText() {
 		const { translate } = this.props;
 
-		return translate( 'Add your self-hosted WordPress credentials' );
+		return translate( 'Add your self-hosted WordPress credentials (wp-admin)' );
 	}
 
 	getSubHeaderText() {

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -253,7 +253,7 @@ export class OrgCredentialsForm extends Component {
 				</div>
 				<div className="jetpack-connect__note">
 					{ translate(
-						'Note: Your WordPress credentials can be different than your WordPress.com credentials.'
+						'Note: Your WordPress credentials are different than your WordPress.com credentials.'
 					) }
 				</div>
 			</Fragment>

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -140,7 +140,7 @@ export class OrgCredentialsForm extends Component {
 	getSubHeaderText() {
 		const { translate } = this.props;
 		const subheader = translate(
-			'Your log in credentials are used for the purpose of securely auto-installing Jetpack and will not be stored.'
+			'Your login credentials are used for the purpose of securely auto-installing Jetpack and will not be stored.'
 		);
 		return <span>{ subheader }</span>;
 	}

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -253,7 +253,8 @@ export class OrgCredentialsForm extends Component {
 				</div>
 				<div className="jetpack-connect__note">
 					{ translate(
-						'Note: Your WordPress credentials are different than your WordPress.com credentials.'
+						'Note: WordPress credentials are not the same as WordPress.com credentials. ' +
+						'Be sure to enter the username and password for your self-hosted WordPress site.'
 					) }
 				</div>
 			</Fragment>

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -211,7 +211,7 @@ export class OrgCredentialsForm extends Component {
 				<div className="jetpack-connect__wordpress-logo">
 					<WordPressLogo size="72" />
 				</div>
-				<FormLabel htmlFor="username">{ translate( 'WordPress username or esmail' ) }</FormLabel>
+				<FormLabel htmlFor="username">{ translate( 'WordPress username or email' ) }</FormLabel>
 				<div className="jetpack-connect__site-address-container">
 					<Gridicon size={ 24 } icon="user" />
 					<FormTextInput

--- a/client/jetpack-connect/remote-credentials.js
+++ b/client/jetpack-connect/remote-credentials.js
@@ -253,7 +253,7 @@ export class OrgCredentialsForm extends Component {
 				</div>
 				<div className="jetpack-connect__note">
 					{ translate(
-						'Note: Your WordPress credentials are different than your WordPress.com credentials.'
+						'Note: Your WordPress credentials can be different than your WordPress.com credentials.'
 					) }
 				</div>
 			</Fragment>

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -128,7 +128,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 .jetpack-connect__site-url-entry-container {
 	margin: 0 auto;
 	max-width: 400px;
+
+	.formatted-header {
+		text-align: center;
+	}
 }
+
 
 .jetpack-connect__wp-admin-dialog.dialog.card {
 	max-width: 400px;
@@ -169,6 +174,40 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		margin-top: 16px;
 		word-wrap: nowrap;
 	}
+}
+
+.jetpack-connect__site-address {
+		padding: 0 24px 24px;
+		margin: 0 -24px;
+		border-bottom: 1px solid var( --color-border-subtle );
+		display: flex;
+}
+
+.jetpack-connect__globe {
+		width: 32px;
+		height: 28px;
+		margin-top: -4px;
+		background-color: var( --color-neutral );
+		margin-right: 8px;
+		padding-top: 4px;
+		text-align: center;
+
+		.gridicons-globe {
+			fill: var( --color-neutral-0 );
+		}
+}
+.jetpack-connect__wordpress-logo {
+	margin: 32px auto;
+	text-align: center;
+
+	.wordpress-logo {
+			fill: var( --color-neutral );
+	}
+}
+
+.jetpack-connect__note {
+	font-size: 12px;
+	text-align: center;
 }
 
 .jetpack-connect__authorize-form {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -776,8 +776,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__creds-form-spinner {
-	margin-top: -10px;
-	margin-bottom: -10px;
+	margin-top: 0;
+	margin-bottom: -20px;
 }
 
 .jetpack-connect__navigation {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -201,7 +201,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	text-align: center;
 
 	.wordpress-logo {
-			fill: var( --color-neutral );
+		margin: 0;
+		fill: var( --color-neutral );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the copy and styles on the remote install self hosted credentials page.

Before:
<img width="538" alt="Screen Shot 2020-03-13 at 3 37 47 PM" src="https://user-images.githubusercontent.com/115071/76630893-06d31d80-6541-11ea-8bd1-189b94794f7c.png">

After:

![image](https://user-images.githubusercontent.com/390760/76636140-74327e80-6540-11ea-8189-c20b9f04f55d.png)



#### Testing instructions
* Start Calypso `npm start`
* Visit http://calypso.localhost:3000/jetpack/connect/install
* Type in a wordpress site such as `https://cool-beaver.jurassic.ninja`
* Notice that there are no errors on that page and you can proceed to the nest step. 
* Type in a wrong username and password. The error message is what you expected. 


Fixes https://github.com/Automattic/wp-calypso/issues/40091
