### PR TITLE
[Private sites] Redirect private atomic users to wp admin classic editor (from modal)

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -8,7 +8,7 @@ import i18n from 'i18n-calypso';
 import page from 'page';
 import { stringify } from 'qs';
 import { isWebUri as isValidUrl } from 'valid-url';
-import { get, has, startsWith } from 'lodash';
+import { get, has, pickBy, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,11 +16,12 @@ import { get, has, startsWith } from 'lodash';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/actions';
 import { addQueryArgs, addSiteFragment } from 'lib/route';
+import wpcom from 'lib/wp';
 import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSite, getSiteAdminUrl } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
@@ -28,6 +29,8 @@ import { requestSelectedEditor, setSelectedEditor } from 'state/selected-editor/
 import { getGutenbergEditorUrl } from 'state/selectors/get-gutenberg-editor-url';
 import { shouldLoadGutenberg } from 'state/selectors/should-load-gutenberg';
 import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isPrivateSite from 'state/selectors/is-private-site';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -54,7 +57,7 @@ function renderEditor( context, props ) {
 	context.primary = React.createElement( PostEditor, props );
 }
 
-function maybeRedirect( context ) {
+async function maybeRedirect( context ) {
 	const postType = determinePostType( context );
 	const postId = getPostID( context );
 
@@ -68,6 +71,39 @@ function maybeRedirect( context ) {
 				path += `?${ context.querystring }`;
 			}
 			page.redirect( path );
+			return true;
+		}
+	}
+
+	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+	const isPrivate = isPrivateSite( state, siteId );
+	if ( isAtomic && isPrivate ) {
+		let currentEditor = get( context.query, 'set-editor', null );
+		if ( ! currentEditor ) {
+			currentEditor = getSelectedEditor( state, siteId );
+		}
+		if ( ! currentEditor ) {
+			await waitForSiteIdAndSelectedEditor( context );
+			currentEditor = getSelectedEditor( state, siteId );
+		}
+
+		if ( currentEditor === 'classic' ) {
+			let queryArgs = pickBy( {
+				post: postId,
+				action: postId && 'edit', // If postId is set, open edit view.
+				post_type: postType !== 'post' && postType, // Use postType if it's different than post.
+				'classic-editor': 1,
+			} );
+
+			// needed for loading the editor in SU sessions
+			if ( wpcom.addSupportParams ) {
+				queryArgs = wpcom.addSupportParams( queryArgs );
+			}
+
+			const siteAdminUrl = getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
+			const wpAdminUrl = addQueryArgs( queryArgs, siteAdminUrl );
+
+			window.location.href = wpAdminUrl;
 			return true;
 		}
 	}
@@ -207,8 +243,8 @@ export default {
 
 		recordPlaceholdersTiming();
 
-		function startEditing( siteId ) {
-			if ( maybeRedirect( context ) ) {
+		async function startEditing( siteId ) {
+			if ( await maybeRedirect( context ) ) {
 				return;
 			}
 

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -39,7 +39,6 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 		isPrivateAtomic: PropTypes.bool,
 		translate: PropTypes.func,
 		siteId: PropTypes.number,
-		postId: PropTypes.number,
 		postType: PropTypes.string,
 		gutenbergUrl: PropTypes.string,
 		switchToGutenberg: PropTypes.func,
@@ -206,8 +205,6 @@ export default connect( state => {
 
 	return {
 		siteId,
-		postId,
-		postType,
 		gutenbergUrl,
 		optInEnabled,
 		isPrivateAtomic,

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -112,7 +112,6 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 		}
 
 		const { isDialogVisible } = this.state;
-
 		const buttons = [
 			{
 				action: 'gutenberg',

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -39,7 +39,6 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 		isPrivateAtomic: PropTypes.bool,
 		translate: PropTypes.func,
 		siteId: PropTypes.number,
-		postType: PropTypes.string,
 		gutenbergUrl: PropTypes.string,
 		switchToGutenberg: PropTypes.func,
 		openPostRevisionsDialog: PropTypes.func,

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -134,21 +134,19 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 				buttons={ buttons }
 				onClose={ this.useClassicEditor }
 			>
-				<>
-					<h1>{ translate( 'This post uses blocks from the new editor' ) }</h1>
+				<h1>{ translate( 'This post uses blocks from the new editor' ) }</h1>
 
-					<p>
-						{ translate(
-							'You can continue to edit this post in the Classic Editor, but you may lose some data and formatting. You can also check the {{a}}document history{{/a}} and restore a version of the page from earlier.',
-							{
-								components: {
-									//eslint-disable-next-line jsx-a11y/anchor-is-valid
-									a: <a href="#" onClick={ this.showDocumentHistory } />,
-								},
-							}
-						) }
-					</p>
-				</>
+				<p>
+					{ translate(
+						'You can continue to edit this post in the Classic Editor, but you may lose some data and formatting. You can also check the {{a}}document history{{/a}} and restore a version of the page from earlier.',
+						{
+							components: {
+								//eslint-disable-next-line jsx-a11y/anchor-is-valid
+								a: <a href="#" onClick={ this.showDocumentHistory } />,
+							},
+						}
+					) }
+				</p>
 			</Dialog>
 		);
 	}

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -43,7 +43,7 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 		switchToGutenberg: PropTypes.func,
 		openPostRevisionsDialog: PropTypes.func,
 		optInEnabled: PropTypes.bool,
-		useClassic: PropTypes.func,
+		logClassicEditorUsed: PropTypes.func,
 		buildSiteAdminUrl: PropTypes.func,
 		wpAdminRedirectionUrl: PropTypes.string,
 	};
@@ -55,7 +55,7 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 		switchToGutenberg: noop,
 		openPostRevisionsDialog: noop,
 		optInEnabled: false,
-		useClassic: noop,
+		logClassicEditorUsed: noop,
 	};
 
 	state = {
@@ -77,12 +77,11 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 	}
 
 	useClassicEditor = () => {
-		const { useClassic, isPrivateAtomic, wpAdminRedirectionUrl } = this.props;
-		useClassic();
+		const { logClassicEditorUsed, isPrivateAtomic, wpAdminRedirectionUrl } = this.props;
+		logClassicEditorUsed();
+		this.hideDialog();
 		if ( isPrivateAtomic ) {
 			window.location.href = wpAdminRedirectionUrl;
-		} else {
-			this.hideDialog();
 		}
 	};
 
@@ -170,7 +169,7 @@ const mapDispatchToProps = dispatch => ( {
 			)
 		);
 	},
-	useClassic: () => {
+	logClassicEditorUsed: () => {
 		dispatch(
 			withAnalytics(
 				composeAnalytics(

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/index.jsx
@@ -94,29 +94,34 @@ class EditorGutenbergBlocksWarningDialog extends Component {
 
 	useClassicEditor = () => {
 		this.props.useClassic();
-		this.redirectToWpAdmin();
+		const { isAtomic, isPrivate } = this.props;
+		if ( isAtomic && isPrivate ) {
+			this.redirectToWpAdmin();
+		} else {
+			this.setState( {
+				forceClassic: true,
+			} );
+		}
 	};
 
 	redirectToWpAdmin = () => {
-		const { isAtomic, isPrivate, postId, postType, buildSiteAdminUrl } = this.props;
-		if ( isAtomic && isPrivate ) {
-			let queryArgs = pickBy( {
-				post: postId,
-				action: postId && 'edit', // If postId is set, open edit view.
-				post_type: postType !== 'post' && postType, // Use postType if it's different than post.
-				'classic-editor': 1,
-			} );
+		const { postId, postType, buildSiteAdminUrl } = this.props;
+		let queryArgs = pickBy( {
+			post: postId,
+			action: postId && 'edit', // If postId is set, open edit view.
+			post_type: postType !== 'post' && postType, // Use postType if it's different than post.
+			'classic-editor': 1,
+		} );
 
-			// needed for loading the editor in SU sessions
-			if ( wpcom.addSupportParams ) {
-				queryArgs = wpcom.addSupportParams( queryArgs );
-			}
-
-			const siteAdminUrl = buildSiteAdminUrl( postId ? 'post.php' : 'post-new.php' );
-			const wpAdminUrl = addQueryArgs( queryArgs, siteAdminUrl );
-
-			window.location.href = wpAdminUrl;
+		// needed for loading the editor in SU sessions
+		if ( wpcom.addSupportParams ) {
+			queryArgs = wpcom.addSupportParams( queryArgs );
 		}
+
+		const siteAdminUrl = buildSiteAdminUrl( postId ? 'post.php' : 'post-new.php' );
+		const wpAdminUrl = addQueryArgs( queryArgs, siteAdminUrl );
+
+		window.location.href = wpAdminUrl;
 	};
 
 	switchToGutenberg = () => {

--- a/client/post-editor/editor-gutenberg-dialogs/index.tsx
+++ b/client/post-editor/editor-gutenberg-dialogs/index.tsx
@@ -44,6 +44,7 @@ const EditorGutenbergDialogs: React.FC< {} > = () => {
 				dispatch( showGutenbergOptInDialog() );
 			}
 		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[ dispatch, isPrivateAtomic, isPostContentLoaded, postContent ]
 	);
 

--- a/client/post-editor/editor-gutenberg-dialogs/index.tsx
+++ b/client/post-editor/editor-gutenberg-dialogs/index.tsx
@@ -44,6 +44,8 @@ const EditorGutenbergDialogs: React.FC< {} > = () => {
 				dispatch( showGutenbergOptInDialog() );
 			}
 		},
+		// Disabling eslint check because hasGutenbergContent is only set inside this effect
+		// and we don't want to rerun it once it's updated
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[ dispatch, isPrivateAtomic, isPostContentLoaded, postContent ]
 	);

--- a/client/post-editor/editor-gutenberg-dialogs/index.tsx
+++ b/client/post-editor/editor-gutenberg-dialogs/index.tsx
@@ -44,7 +44,7 @@ const EditorGutenbergDialogs: React.FC< {} > = () => {
 				dispatch( showGutenbergOptInDialog() );
 			}
 		},
-		[ isPrivateAtomic, isPostContentLoaded, postContent ]
+		[ dispatch, isPrivateAtomic, isPostContentLoaded, postContent ]
 	);
 
 	return (

--- a/client/post-editor/editor-gutenberg-dialogs/index.tsx
+++ b/client/post-editor/editor-gutenberg-dialogs/index.tsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { showGutenbergOptInDialog } from 'state/ui/gutenberg-opt-in-dialog/actions';
+import EditorGutenbergOptInDialog from 'post-editor/editor-gutenberg-opt-in-dialog';
+import EditorGutenbergBlocksWarningDialog from 'post-editor/editor-gutenberg-blocks-warning-dialog';
+import { getEditorRawContent, isEditorLoading } from 'state/ui/editor/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isPrivateSite from 'state/selectors/is-private-site';
+
+const EditorGutenbergDialogs: React.FC< {} > = () => {
+	const [ hasGutenbergBlocks, setHasGutenbergBlocks ] = useState< boolean | null >( null );
+
+	const siteId = useSelector( getSelectedSiteId ) as number;
+	const isAtomic = useSelector( state => isSiteAutomatedTransfer( state, siteId ) );
+	const isPrivate = useSelector( state => isPrivateSite( state, siteId ) );
+	const isPrivateAtomic = isAtomic && isPrivate;
+
+	const postContent = useSelector( getEditorRawContent );
+	const isLoading = useSelector( isEditorLoading );
+	const isPostContentLoaded = ! isLoading && postContent !== null;
+
+	const dispatch = useDispatch();
+
+	useEffect(
+		function() {
+			if ( hasGutenbergBlocks !== null || ! isPostContentLoaded ) {
+				return;
+			}
+			const hasGutenbergContent = ( postContent || '' ).indexOf( '<!-- wp:' ) !== -1;
+			setHasGutenbergBlocks( hasGutenbergContent );
+
+			// If a private atomic site uses classic editor, we want to always show some dialog, even
+			// if it doesn't have any Gutenberg blocks. Instead of saying "you may lose some data and formatting",
+			// let's just show the opt in dialog instead.
+			if ( ! hasGutenbergContent && isPrivateAtomic ) {
+				dispatch( showGutenbergOptInDialog() );
+			}
+		},
+		[ isPrivateAtomic, isPostContentLoaded, postContent ]
+	);
+
+	return (
+		<>
+			<EditorGutenbergOptInDialog />
+			<EditorGutenbergBlocksWarningDialog hasGutenbergBlocks={ !! hasGutenbergBlocks } />
+		</>
+	);
+};
+EditorGutenbergDialogs.displayName = 'EditorGutenbergDialogs';
+
+export default EditorGutenbergDialogs;

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -13,6 +13,7 @@ import Gridicon from 'components/gridicon';
 import isGutenbergOptInDialogShowing from 'state/selectors/is-gutenberg-opt-in-dialog-showing';
 import { hideGutenbergOptInDialog } from 'state/ui/gutenberg-opt-in-dialog/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import getWpAdminClassicEditorRedirectionUrl from 'state/selectors/get-wp-admin-classic-editor-redirection-url';
 import { setSelectedEditor } from 'state/selected-editor/actions';
 import { localize } from 'i18n-calypso';
 import { Button, Dialog } from '@automattic/components';
@@ -26,6 +27,8 @@ import {
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isPrivateSite from 'state/selectors/is-private-site';
 
 /**
  * Style dependencies
@@ -42,10 +45,16 @@ class EditorGutenbergOptInDialog extends Component {
 		optIn: PropTypes.func,
 		useClassic: PropTypes.func,
 		siteId: PropTypes.number,
+		wpAdminRedirectionUrl: PropTypes.string,
 	};
 
 	onCloseDialog = () => {
-		this.props.hideDialog();
+		const { isPrivateAtomic, wpAdminRedirectionUrl } = this.props;
+		if ( isPrivateAtomic ) {
+			window.location.href = wpAdminRedirectionUrl;
+		} else {
+			this.props.hideDialog();
+		}
 	};
 
 	optInToGutenberg = () => {
@@ -138,12 +147,15 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const postId = getEditorPostId( state );
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );
-
 	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
+	const isPrivateAtomic =
+		isSiteAutomatedTransfer( state, siteId ) && isPrivateSite( state, siteId );
+	const wpAdminRedirectionUrl = getWpAdminClassicEditorRedirectionUrl( state, siteId );
 
 	return {
 		gutenbergUrl,
 		isDialogVisible,
-		siteId,
+		isPrivateAtomic,
+		wpAdminRedirectionUrl,
 	};
 }, mapDispatchToProps )( localize( EditorGutenbergOptInDialog ) );

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -29,6 +29,7 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isPrivateSite from 'state/selectors/is-private-site';
+import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled';
 
 /**
  * Style dependencies
@@ -43,6 +44,7 @@ class EditorGutenbergOptInDialog extends Component {
 		isDialogVisible: PropTypes.bool,
 		hideDialog: PropTypes.func,
 		optIn: PropTypes.func,
+		optInEnabled: PropTypes.bool,
 		logClassicEditorUsed: PropTypes.func,
 		siteId: PropTypes.number,
 		wpAdminRedirectionUrl: PropTypes.string,
@@ -64,7 +66,11 @@ class EditorGutenbergOptInDialog extends Component {
 	};
 
 	render() {
-		const { translate, isDialogVisible } = this.props;
+		const { translate, isDialogVisible, optInEnabled } = this.props;
+		if ( ! optInEnabled ) {
+			return null;
+		}
+
 		const buttons = [
 			<Button key="gutenberg" onClick={ this.optInToGutenberg } primary>
 				{ translate( 'Try the block editor' ) }
@@ -150,12 +156,14 @@ export default connect( state => {
 	const postId = getEditorPostId( state );
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );
 	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
+	const optInEnabled = isGutenbergOptInEnabled( state, siteId );
 	const isPrivateAtomic =
 		isSiteAutomatedTransfer( state, siteId ) && isPrivateSite( state, siteId );
 	const wpAdminRedirectionUrl = getWpAdminClassicEditorRedirectionUrl( state, siteId );
 
 	return {
 		gutenbergUrl,
+		optInEnabled,
 		isDialogVisible,
 		isPrivateAtomic,
 		wpAdminRedirectionUrl,

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -43,17 +43,17 @@ class EditorGutenbergOptInDialog extends Component {
 		isDialogVisible: PropTypes.bool,
 		hideDialog: PropTypes.func,
 		optIn: PropTypes.func,
-		useClassic: PropTypes.func,
+		logClassicEditorUsed: PropTypes.func,
 		siteId: PropTypes.number,
 		wpAdminRedirectionUrl: PropTypes.string,
 	};
 
-	onCloseDialog = () => {
-		const { isPrivateAtomic, wpAdminRedirectionUrl } = this.props;
+	useClassicEditor = () => {
+		const { logClassicEditorUsed, hideDialog, isPrivateAtomic, wpAdminRedirectionUrl } = this.props;
+		logClassicEditorUsed();
+		hideDialog();
 		if ( isPrivateAtomic ) {
 			window.location.href = wpAdminRedirectionUrl;
-		} else {
-			this.props.hideDialog();
 		}
 	};
 
@@ -64,7 +64,7 @@ class EditorGutenbergOptInDialog extends Component {
 	};
 
 	render() {
-		const { translate, isDialogVisible, useClassic } = this.props;
+		const { translate, isDialogVisible } = this.props;
 		const buttons = [
 			<Button key="gutenberg" onClick={ this.optInToGutenberg } primary>
 				{ translate( 'Try the block editor' ) }
@@ -72,7 +72,7 @@ class EditorGutenbergOptInDialog extends Component {
 			{
 				action: 'cancel',
 				label: translate( 'Use the current editor' ),
-				onClick: useClassic,
+				onClick: this.useClassicEditor,
 			},
 		];
 		return (
@@ -80,12 +80,15 @@ class EditorGutenbergOptInDialog extends Component {
 				additionalClassNames="editor-gutenberg-opt-in-dialog"
 				isVisible={ isDialogVisible }
 				buttons={ buttons }
-				onClose={ this.onCloseDialog }
+				onClose={ this.useClassicEditor }
 			>
 				<div className="editor-gutenberg-opt-in-dialog__illustration" />
 
 				<header>
-					<button onClick={ this.onCloseDialog } className="editor-gutenberg-opt-in-dialog__close">
+					<button
+						onClick={ this.useClassicEditor }
+						className="editor-gutenberg-opt-in-dialog__close"
+					>
 						<Gridicon icon="cross" />
 					</button>
 				</header>
@@ -122,7 +125,7 @@ const mapDispatchToProps = dispatch => ( {
 			)
 		);
 	},
-	useClassic: () => {
+	logClassicEditorUsed: () => {
 		dispatch(
 			withAnalytics(
 				composeAnalytics(
@@ -134,8 +137,7 @@ const mapDispatchToProps = dispatch => ( {
 					),
 					recordTracksEvent( 'calypso_gutenberg_use_classic_editor' ),
 					bumpStat( 'selected-editor', 'calypso-gutenberg-use-classic-editor' )
-				),
-				hideGutenbergOptInDialog()
+				)
 			)
 		);
 	},

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/index.jsx
@@ -162,6 +162,7 @@ export default connect( state => {
 	const wpAdminRedirectionUrl = getWpAdminClassicEditorRedirectionUrl( state, siteId );
 
 	return {
+		siteId,
 		gutenbergUrl,
 		optInEnabled,
 		isDialogVisible,

--- a/client/post-editor/editor-sidebar/index.jsx
+++ b/client/post-editor/editor-sidebar/index.jsx
@@ -11,7 +11,6 @@ import EditorDrawer from 'post-editor/editor-drawer';
 import EditorSidebarHeader from './header';
 import SidebarFooter from 'layout/sidebar/footer';
 import EditorDeletePost from 'post-editor/editor-delete-post';
-import EditorGutenbergOptInDialog from 'post-editor/editor-gutenberg-opt-in-dialog';
 import EditorGutenbergOptInSidebar from 'post-editor/editor-gutenberg-opt-in-sidebar';
 
 /**
@@ -51,7 +50,6 @@ export class EditorSidebar extends Component {
 					confirmationSidebarStatus={ confirmationSidebarStatus }
 				/>
 				<EditorGutenbergOptInSidebar />
-				<EditorGutenbergOptInDialog />
 				<SidebarFooter>
 					<EditorDeletePost onTrashingPost={ onTrashingPost } />
 				</SidebarFooter>

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -66,6 +66,7 @@ import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported'
 import EditorForbidden from 'post-editor/editor-forbidden';
 import EditorNotice from 'post-editor/editor-notice';
 import EditorGutenbergOptInNotice from 'post-editor/editor-gutenberg-opt-in-notice';
+import EditorGutenbergDialogs from 'post-editor/editor-gutenberg-dialogs';
 import EditorWordCount from 'post-editor/editor-word-count';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
@@ -83,7 +84,6 @@ import QuickSaveButtons from 'post-editor/editor-ground-control/quick-save-butto
 import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { pauseGuidedTour } from 'state/ui/guided-tours/actions';
-import EditorGutenbergBlocksWarningDialog from './editor-gutenberg-blocks-warning-dialog';
 
 /**
  * Style dependencies
@@ -299,7 +299,7 @@ export class PostEditor extends React.Component {
 				<EditorPostTypeUnsupported />
 				<EditorForbidden />
 				<EditorRevisionsDialog loadRevision={ this.loadRevision } />
-				<EditorGutenbergBlocksWarningDialog />
+				<EditorGutenbergDialogs />
 				<div className="post-editor__inner">
 					<EditorGroundControl
 						setPostDate={ this.setPostDate }

--- a/client/state/selectors/get-wp-admin-classic-editor-redirection-url.ts
+++ b/client/state/selectors/get-wp-admin-classic-editor-redirection-url.ts
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { pickBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { AppState } from 'types';
+import { getSiteAdminUrl } from 'state/sites/selectors';
+import { addQueryArgs } from 'lib/route';
+import { getEditorPostId } from 'state/ui/editor/selectors';
+import { getEditedPostValue } from 'state/posts/selectors/get-edited-post-value';
+import wpcom from 'lib/wp';
+
+export default function getWpAdminClassicEditorRedirectionUrl( state: AppState, siteId: number ) {
+	const postId = getEditorPostId( state ) as number;
+	const postType = getEditedPostValue( state, siteId, postId, 'type' );
+
+	let queryArgs = pickBy( {
+		post: postId,
+		action: postId && 'edit', // If postId is set, open edit view.
+		post_type: postType !== 'post' && postType, // Use postType if it's different than post.
+		'classic-editor': 1,
+	} );
+
+	// needed for loading the editor in SU sessions
+	if ( wpcom.addSupportParams ) {
+		queryArgs = wpcom.addSupportParams( queryArgs );
+	}
+
+	const siteAdminUrl = getSiteAdminUrl(
+		state,
+		siteId,
+		postId ? 'post.php' : 'post-new.php'
+	) as string;
+	const wpAdminUrl = addQueryArgs( queryArgs, siteAdminUrl );
+	return wpAdminUrl;
+}

--- a/client/state/selectors/is-private-site.ts
+++ b/client/state/selectors/is-private-site.ts
@@ -4,6 +4,7 @@
 
 import getRawSite from 'state/selectors/get-raw-site';
 import { getSiteSettings } from 'state/site-settings/selectors';
+import { AppState } from "types";
 
 /**
  * Returns true if the site is private
@@ -12,7 +13,7 @@ import { getSiteSettings } from 'state/site-settings/selectors';
  * @param {object} siteId Site ID
  * @returns {boolean} True if site is private
  */
-export default function isPrivateSite( state, siteId ) {
+export default function isPrivateSite( state : AppState, siteId : number ) : boolean | null {
 	const site = getRawSite( state, siteId );
 
 	if ( site ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Problem**

Classic editor in calypso does not support displaying private media files because of CORS issues. Adding a support would be super complex and probably not worth it, especially considering that we're phasing out the classic editor altogether. Classic editor in wp-admin handles private files out of the box so we're redirecting all private+atomic+classic editor users from calypso to wp-admin with `?classic_editor` attached to URL.

**Proposed solution**

We do have some dialog windows in place when user uses classic editor in Calypso:

Gutenberg content warning:

<img width="1090" alt="Zrzut ekranu 2020-03-13 o 16 32 06" src="https://user-images.githubusercontent.com/205419/76635769-3cc7d000-6548-11ea-8e48-ddbed3e6d744.png">

Gutenberg opt-in:

<img width="963" alt="Zrzut ekranu 2020-03-17 o 16 02 19" src="https://user-images.githubusercontent.com/205419/76869487-b291ab80-6868-11ea-965b-2156ecba5f6d.png">

My proposal is that for v1 we:
* Ensure that private+atomic user always sees one of these two modals when visiting classic editor. If no Gutenberg blocks are found in post content, let's display opt-in dialog.
* Ensure that choosing Classic editor redirects to corresponding editor in WP admin (ensured by 412-gh-wpcomsh).
* Make sure nothing changes for users who are not private+atomic+classic editor

#### Testing instructions

* Create a new private atomic site using a8c account and `calypso.localhost:3000` (start with simple site then go atomic - it should stay private)
* Apply related wpcomsh change from this PR **to the site you just created** 412-gh-wpcomsh
* Create a Gutenberg-based post, save it, in three dots menu select "Switch to classic editor"
* You should see Gutenberg content warning modal as on the screenshot above. Confirm that classic editor redirects to classic editor in wp-admin.
* Go back to calypso, create new page
* You should see Gutenberg opt-in modal as on the screenshot above. Confirm that choosing classic editor redirects to classic editor in wp-admin.
* Try on a non-private atomic site and confirm the behavior is the same as currently in production, e.g. you're not getting redirected to `wp-admin` and you're not getting opt-in modal every single time 