### PR TITLE
[Private sites] Redirect private atomic users to wp admin classic editor (from URL)

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -8,7 +8,7 @@ import i18n from 'i18n-calypso';
 import page from 'page';
 import { stringify } from 'qs';
 import { isWebUri as isValidUrl } from 'valid-url';
-import { get, has, startsWith } from 'lodash';
+import { get, has, pickBy, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,11 +16,12 @@ import { get, has, startsWith } from 'lodash';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/actions';
 import { addQueryArgs, addSiteFragment } from 'lib/route';
+import wpcom from 'lib/wp';
 import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSite, getSiteAdminUrl } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
@@ -28,6 +29,8 @@ import { requestSelectedEditor, setSelectedEditor } from 'state/selected-editor/
 import { getGutenbergEditorUrl } from 'state/selectors/get-gutenberg-editor-url';
 import { shouldLoadGutenberg } from 'state/selectors/should-load-gutenberg';
 import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isPrivateSite from 'state/selectors/is-private-site';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -54,7 +57,7 @@ function renderEditor( context, props ) {
 	context.primary = React.createElement( PostEditor, props );
 }
 
-function maybeRedirect( context ) {
+async function maybeRedirect( context ) {
 	const postType = determinePostType( context );
 	const postId = getPostID( context );
 
@@ -68,6 +71,39 @@ function maybeRedirect( context ) {
 				path += `?${ context.querystring }`;
 			}
 			page.redirect( path );
+			return true;
+		}
+	}
+
+	const isAtomic = isSiteAutomatedTransfer( state, siteId );
+	const isPrivate = isPrivateSite( state, siteId );
+	if ( isAtomic && isPrivate ) {
+		let currentEditor = get( context.query, 'set-editor', null );
+		if ( ! currentEditor ) {
+			currentEditor = getSelectedEditor( state, siteId );
+		}
+		if ( ! currentEditor ) {
+			await waitForSiteIdAndSelectedEditor( context );
+			currentEditor = getSelectedEditor( state, siteId );
+		}
+
+		if ( currentEditor === 'classic' ) {
+			let queryArgs = pickBy( {
+				post: postId,
+				action: postId && 'edit', // If postId is set, open edit view.
+				post_type: postType !== 'post' && postType, // Use postType if it's different than post.
+				'classic-editor': 1,
+			} );
+
+			// needed for loading the editor in SU sessions
+			if ( wpcom.addSupportParams ) {
+				queryArgs = wpcom.addSupportParams( queryArgs );
+			}
+
+			const siteAdminUrl = getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
+			const wpAdminUrl = addQueryArgs( queryArgs, siteAdminUrl );
+
+			window.location.href = wpAdminUrl;
 			return true;
 		}
 	}
@@ -207,8 +243,8 @@ export default {
 
 		recordPlaceholdersTiming();
 
-		function startEditing( siteId ) {
-			if ( maybeRedirect( context ) ) {
+		async function startEditing( siteId ) {
+			if ( await maybeRedirect( context ) ) {
 				return;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Classic editor in calypso don't support displaying private media files because of CORS issues. Adding a support would be super complex and probably not worth it considering that we're phasing out the classical editor altogether. Classic editor in wp-admin handles private files out of the box so we're redirecting all private+atomic+classic editor users from calypso to wp-admin with `?classic_editor` attached to URL.

This PR triggers the redirect right after classic editor page is open in calypso. An alternative approach is presented in #40122

#### Testing instructions

* Create a new atomic site via `calypso.localhost:3000`, make sure it's private once you go atomic
* Apply related wpcomsh change from this PR **to the site you just created** 412-gh-wpcomsh
* Edit a post, in three dots menu select "Switch to classic editor"
* Confirm you're redirected to corresponding page in wp-admin
* Confirm it works with new existing posts and pages