### PR TITLE
Update: Async load the sidebar on the cloud and calypso

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -250,6 +250,7 @@ export class SiteNotice extends React.Component {
 							require="blocks/jitm"
 							messagePath={ messagePath }
 							template="sidebar-banner"
+							placeholder={ null }
 						/>
 					) ) }
 				<QuerySitePlans siteId={ site.ID } />

--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -9,8 +9,7 @@ import React from 'react';
  */
 import config from 'config';
 import SitePicker from 'my-sites/picker';
-import Sidebar from 'my-sites/sidebar';
-import JetpackCloudSidebar from 'landing/jetpack-cloud/components/sidebar';
+import AsyncLoad from 'components/async-load';
 
 class MySitesNavigation extends React.Component {
 	static displayName = 'MySitesNavigation';
@@ -21,7 +20,17 @@ class MySitesNavigation extends React.Component {
 	};
 
 	render() {
-		const SidebarComponent = config.isEnabled( 'jetpack-cloud' ) ? JetpackCloudSidebar : Sidebar;
+		const asyncProps = {
+			placeholder: null,
+			path: this.props.path,
+			siteBasePath: this.props.siteBasePath,
+		};
+
+		const asyncSidebar = config.isEnabled( 'jetpack-cloud' ) ? (
+			<AsyncLoad require="landing/jetpack-cloud/components/sidebar" { ...asyncProps } />
+		) : (
+			<AsyncLoad require="my-sites/sidebar" { ...asyncProps } />
+		);
 
 		return (
 			<div>
@@ -30,7 +39,7 @@ class MySitesNavigation extends React.Component {
 					siteBasePath={ this.props.siteBasePath }
 					onClose={ this.preventPickerDefault }
 				/>
-				<SidebarComponent path={ this.props.path } siteBasePath={ this.props.siteBasePath } />
+				{ asyncSidebar }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes so that the sidebar coponent gets loaded async for both calypso and jetpack cloud.

#### Testing instructions

* Load calypso. Notice that the sidebar on sites looks as expected and works like that as well. 
* Load jetpack cloud with `npm run start-jetpack-cloud` notice that the sidebar looks and works as before. 

You shouldn't notice any different in loading as a user.
