### PR TITLE
Update login screen for existing logged in user

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -71,9 +71,9 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 				{ translate( 'Not %(userName)s? Log in with {{link}}another account{{/link}}', {
 					components: {
 						link: (
-							<a
-								href="#/"
-								className="continue-as-user__change-user wp-block-button__link"
+							<button
+								type="button"
+								className="continue-as-user__change-user-link"
 								onClick={ handleChangeAccount }
 							/>
 						),

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -71,7 +71,7 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 				className="continue-as-user__change-user-link"
 				onClick={ onChangeAccount }
 			>
-				{ translate( 'Change Account' ) }
+				{ translate( 'Log in with a different account' ) }
 			</button>
 		</div>
 	);

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -51,11 +51,6 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 
 	const userName = currentUser.display_name || currentUser.username;
 
-	const handleChangeAccount = e => {
-		e.preventDefault();
-		onChangeAccount();
-	};
-
 	// Render ContinueAsUser straight away, even before validation.
 	// This helps avoid jarring layout shifts. It's not ideal that the link URL changes transparently
 	// like that, but it is better than the alternative, and in practice it should happen quicker than
@@ -74,7 +69,7 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 							<button
 								type="button"
 								className="continue-as-user__change-user-link"
-								onClick={ handleChangeAccount }
+								onClick={ onChangeAccount }
 							/>
 						),
 					},

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -79,7 +79,7 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 						),
 					},
 					args: { userName },
-					comment: 'Link to continue login as different user ',
+					comment: 'Link to continue login as different user',
 				} ) }
 			</p>
 		</div>

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -72,7 +72,7 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 					components: {
 						link: (
 							<a
-								href="/"
+								href="#/"
 								className="continue-as-user__change-user wp-block-button__link"
 								onClick={ handleChangeAccount }
 							/>

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
+import { Button } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -40,7 +41,7 @@ async function validateUrl( redirectUrl ) {
 	}
 }
 
-function ContinueAsUser( { currentUser, redirectUrlFromQuery } ) {
+function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } ) {
 	const translate = useTranslate();
 	const [ validatedRedirectUrl, setValidatedRedirectUrl ] = useState( null );
 
@@ -50,23 +51,37 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery } ) {
 
 	const userName = currentUser.display_name || currentUser.username;
 
+	const handleChangeAccount = e => {
+		e.preventDefault();
+		onChangeAccount();
+	};
+
 	// Render ContinueAsUser straight away, even before validation.
 	// This helps avoid jarring layout shifts. It's not ideal that the link URL changes transparently
 	// like that, but it is better than the alternative, and in practice it should happen quicker than
 	// the user can notice.
-	const redirectLink = (
-		<a href={ validatedRedirectUrl || '/' }>
-			<Gravatar user={ currentUser } size={ 16 } />
-			{ userName }
-		</a>
-	);
 
 	return (
 		<div className="continue-as-user">
-			{ translate( 'or continue as {{userName/}}', {
-				components: { userName: redirectLink },
-				comment: 'Alternative link under login header, skips login to continue as current user.',
-			} ) }
+			<Gravatar user={ currentUser } imgSize={ 200 } size={ 200 } />
+			<Button primary href={ validatedRedirectUrl || '/' }>
+				{ translate( 'Continue as %(userName)s', { args: { userName } } ) }
+			</Button>
+			<p>
+				{ translate( 'Not %(userName)s? Log in with {{link}}another account{{/link}}', {
+					components: {
+						link: (
+							<a
+								href="/"
+								className="continue-as-user__change-user wp-block-button__link"
+								onClick={ handleChangeAccount }
+							/>
+						),
+					},
+					args: { userName },
+					comment: 'Link to continue login as different user ',
+				} ) }
+			</p>
 		</div>
 	);
 }

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -63,7 +63,7 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 
 	return (
 		<div className="continue-as-user">
-			<Gravatar user={ currentUser } imgSize={ 200 } size={ 200 } />
+			<Gravatar user={ currentUser } imgSize={ 400 } size={ 200 } />
 			<Button primary href={ validatedRedirectUrl || '/' }>
 				{ translate( 'Continue as %(userName)s', { args: { userName } } ) }
 			</Button>

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -68,6 +68,7 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 						link: (
 							<button
 								type="button"
+								id="loginAsAnotherUser"
 								className="continue-as-user__change-user-link"
 								onClick={ onChangeAccount }
 							/>

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -59,25 +59,20 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 	return (
 		<div className="continue-as-user">
 			<Gravatar user={ currentUser } imgSize={ 400 } size={ 200 } />
+			<div className="continue-as-user__username">{ userName }</div>
 			<Button primary href={ validatedRedirectUrl || '/' }>
-				{ translate( 'Continue as %(userName)s', { args: { userName } } ) }
+				{ translate( 'Continue' ) }
 			</Button>
-			<p>
-				{ translate( 'Not %(userName)s? Log in with {{link}}another account{{/link}}', {
-					components: {
-						link: (
-							<button
-								type="button"
-								id="loginAsAnotherUser"
-								className="continue-as-user__change-user-link"
-								onClick={ onChangeAccount }
-							/>
-						),
-					},
-					args: { userName },
-					comment: 'Link to continue login as different user',
-				} ) }
-			</p>
+			<p>{ translate( 'or' ) }</p>
+
+			<button
+				type="button"
+				id="loginAsAnotherUser"
+				className="continue-as-user__change-user-link"
+				onClick={ onChangeAccount }
+			>
+				{ translate( 'Change Account' ) }
+			</button>
 		</div>
 	);
 }

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -2,17 +2,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	flex-direction: column;
 	color: var( --color-text-subtle );
 	font-size: 14px;
-
-	> a {
-		display: inline-flex;
-		align-items: center;
-		// Match avatar height.
-		height: 16px;
-	}
-
-	.gravatar {
-		margin: 0 4px;
-	}
 }

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -5,4 +5,8 @@
 	flex-direction: column;
 	color: var( --color-text-subtle );
 	font-size: 14px;
+
+	& > a.button {
+		margin: 20px 0;
+	}
 }

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -9,4 +9,15 @@
 	& > a.button {
 		margin: 20px 0;
 	}
+
+	.continue-as-user__change-user-link {
+		color: var( --color-link );
+		cursor: pointer;
+
+		&:hover,
+		&:focus,
+		&:active {
+			color: var( --color-link-dark );
+		}
+	}
 }

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -8,7 +8,13 @@
 	font-size: 14px;
 
 	& > a.button {
-		margin: 20px 0;
+		margin: 10px 0 20px;
+	}
+	.continue-as-user__username {
+		font-size: 16px;
+		line-height: 24px;
+		font-weight: 400;
+		margin-top: 20px;
 	}
 
 	.continue-as-user__change-user-link {

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -1,5 +1,6 @@
 .continue-as-user {
 	display: flex;
+	animation: 1s appear 0s ease-in;
 	align-items: center;
 	justify-content: center;
 	flex-direction: column;

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -171,6 +171,10 @@ class Login extends Component {
 		}
 	};
 
+	handleContinueAsAnotherUser = () => {
+		this.setState( { continueAsAnotherUser: true } );
+	};
+
 	rebootAfterLogin = async () => {
 		this.props.recordTracksEvent( 'calypso_login_success', {
 			two_factor_enabled: this.props.twoFactorEnabled,
@@ -417,13 +421,7 @@ class Login extends Component {
 
 		if ( this.showContinueAsUser() ) {
 			// someone is already logged in, offer to proceed to the app without a new login
-			return (
-				<ContinueAsUser
-					onChangeAccount={ () => {
-						this.setState( { continueAsAnotherUser: true } );
-					} }
-				/>
-			);
+			return <ContinueAsUser onChangeAccount={ this.handleContinueAsAnotherUser } />;
 		}
 
 		return (

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -170,7 +170,7 @@
 		color: var( --color-primary );
 	}
 
-	.visit-site, .continue-as-user {
+	.visit-site {
 		margin: -12px 0 24px;
 	}
 }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -194,11 +194,27 @@ export class Login extends React.Component {
 			socialService,
 			socialServiceResponse,
 			fromSite,
+			locale,
+			isLoginView,
+			path,
 		} = this.props;
 
 		if ( privateSite && isLoggedIn ) {
 			return <PrivateSite />;
 		}
+
+		const footer = (
+			<>
+				{ ! socialConnect && (
+					<LoginLinks
+						locale={ locale }
+						privateSite={ privateSite }
+						twoFactorAuthType={ twoFactorAuthType }
+					/>
+				) }
+				{ isLoginView && <TranslatorInvite path={ path } /> }
+			</>
+		);
 
 		return (
 			<LoginBlock
@@ -212,20 +228,13 @@ export class Login extends React.Component {
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
 				fromSite={ fromSite }
+				footer={ footer }
 			/>
 		);
 	}
 
 	render() {
-		const {
-			isLoginView,
-			locale,
-			path,
-			privateSite,
-			socialConnect,
-			translate,
-			twoFactorAuthType,
-		} = this.props;
+		const { locale, translate } = this.props;
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 		return (
 			<div>
@@ -238,18 +247,7 @@ export class Login extends React.Component {
 						meta={ [ { name: 'description', content: 'Log in to WordPress.com' } ] }
 					/>
 
-					<div>
-						<div className="wp-login__container">{ this.renderContent() }</div>
-
-						{ ! socialConnect && (
-							<LoginLinks
-								locale={ locale }
-								privateSite={ privateSite }
-								twoFactorAuthType={ twoFactorAuthType }
-							/>
-						) }
-						{ isLoginView && <TranslatorInvite path={ path } /> }
-					</div>
+					<div className="wp-login__container">{ this.renderContent() }</div>
 				</Main>
 
 				{ this.renderFooter() }

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -26,11 +26,10 @@ export default class LoginPage extends AsyncBaseContainer {
 		const passwordSelector = By.css( '#password' );
 		const changeAccountSelector = By.css( '#loginAsAnotherUser' );
 
-		await driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );
-
 		// await driverHelper.waitTillFocused( driver, userNameSelector );
 		try {
 			// If there is already a logged in user, we display the Gravatar and 'Continue as [user]' button and hide login form
+			await driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );
 			await driverHelper.setWhenSettable( driver, userNameSelector, username );
 		} catch {
 			// In order to display login form, the link to login with another account should be clicked first

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -24,10 +24,20 @@ export default class LoginPage extends AsyncBaseContainer {
 		const driver = this.driver;
 		const userNameSelector = By.css( '#usernameOrEmail' );
 		const passwordSelector = By.css( '#password' );
+		const changeAccountSelector = By.css( '#loginAsAnotherUser' );
 
 		await driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );
+
 		// await driverHelper.waitTillFocused( driver, userNameSelector );
-		await driverHelper.setWhenSettable( driver, userNameSelector, username );
+		try {
+			// If there is already a logged in user, we display the Gravatar and 'Continue as [user]' button and hide login form
+			await driverHelper.setWhenSettable( driver, userNameSelector, username );
+		} catch {
+			// In order to display login form, the link to login with another account should be clicked first
+			await driverHelper.waitTillPresentAndDisplayed( driver, changeAccountSelector );
+			await driverHelper.clickWhenClickable( driver, changeAccountSelector );
+			await driverHelper.setWhenSettable( driver, userNameSelector, username );
+		}
 		await this.driver.sleep( 1000 );
 		await driver.findElement( userNameSelector ).sendKeys( Key.ENTER );
 

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -34,7 +34,6 @@ export default class LoginPage extends AsyncBaseContainer {
 			await driverHelper.setWhenSettable( driver, userNameSelector, username );
 		} catch {
 			// In order to display login form, the link to login with another account should be clicked first
-			await driverHelper.waitTillPresentAndDisplayed( driver, changeAccountSelector );
 			await driverHelper.clickWhenClickable( driver, changeAccountSelector );
 			await driverHelper.setWhenSettable( driver, userNameSelector, username );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* increase the gravatar image size and remove login form and other links from initial view
* display `Log in with another account` text below with a link to show login form and everything else

<img width="1099" alt="image" src="https://user-images.githubusercontent.com/87168/76763481-dfc45800-679b-11ea-9f91-dca08bca44f3.png">


#### Testing instructions
- Stay logged-in 
- Open `/log-in`

Fixes (together with https://github.com/Automattic/wp-calypso/pull/40314): #39988 
Related: #35309