### PR TITLE
Site Editor: move to top level menu item

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
@@ -29,11 +29,42 @@ function initialize_site_editor() {
 	// Force enable required Gutenberg experiments if they are not already active.
 	add_filter( 'option_gutenberg-experiments', __NAMESPACE__ . '\enable_site_editor_experiment' );
 
-	// TODO: Currently this action is removed on Dotcom. Circle back and find a cleaner way to deal with this.
-	add_action( 'admin_menu', 'gutenberg_menu' );
-
 	// Dotcom-specific overrides for API requests and similar.
 	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_override_scripts' );
+
+	// Add top level Site Editor menu item.
+	add_action( 'admin_menu', __NAMESPACE__ . '\add_site_editor_menu_item' );
+}
+
+/**
+ * Add top level Site Editor menu item.
+ */
+function add_site_editor_menu_item() {
+	// Allow Site Editor to be loaded on top level menu page.
+	add_filter( 'site_editor_allowed_hooks', __NAMESPACE__ . '\override_allowed_paths' );
+
+	add_menu_page(
+		__( 'Site Editor (beta)', 'full-site-editing' ),
+		__( 'Site Editor (beta)', 'full-site-editing' ),
+		'edit_theme_options',
+		'gutenberg-edit-site',
+		'gutenberg_edit_site_page',
+		'dashicons-edit'
+	);
+}
+
+/**
+ * Overrides Site Editor allowed paths so that it can be loaded as top level page.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/a38de905717f5fd3bd57b0a71fb27826b819eb91/lib/edit-site-page.php#L41
+ *
+ * @param array $allowed_paths Array of currently allowed paths.
+ *
+ * @return array Array of currently allowed paths with top level page path appended.
+ */
+function override_allowed_paths( $allowed_paths ) {
+	$allowed_paths[] = 'toplevel_page_gutenberg-edit-site';
+	return $allowed_paths;
 }
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
@@ -40,9 +40,6 @@ function initialize_site_editor() {
  * Add top level Site Editor menu item.
  */
 function add_site_editor_menu_item() {
-	// Allow Site Editor to be loaded on top level menu page.
-	add_filter( 'site_editor_allowed_hooks', __NAMESPACE__ . '\override_allowed_paths' );
-
 	add_menu_page(
 		__( 'Site Editor (beta)', 'full-site-editing' ),
 		__( 'Site Editor (beta)', 'full-site-editing' ),
@@ -51,20 +48,6 @@ function add_site_editor_menu_item() {
 		'gutenberg_edit_site_page',
 		'dashicons-edit'
 	);
-}
-
-/**
- * Overrides Site Editor allowed paths so that it can be loaded as top level page.
- *
- * @see https://github.com/WordPress/gutenberg/blob/a38de905717f5fd3bd57b0a71fb27826b819eb91/lib/edit-site-page.php#L41
- *
- * @param array $allowed_paths Array of currently allowed paths.
- *
- * @return array Array of currently allowed paths with top level page path appended.
- */
-function override_allowed_paths( $allowed_paths ) {
-	$allowed_paths[] = 'toplevel_page_gutenberg-edit-site';
-	return $allowed_paths;
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Exposes Site Editor as top level wp-admin menu item and allows it to boot in that context.

<img width="189" alt="Screenshot 2020-03-13 at 17 13 19" src="https://user-images.githubusercontent.com/1182160/76639177-f7a69c80-654d-11ea-8c73-8256abcb1bc3.png">


#### Testing instructions

Local testing:

1. Change the filter [here](https://github.com/Automattic/wp-calypso/blob/c017679608b650cd12e529e4947148e252b819fb/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php#L96) to return true, since Site Editor is disabled by default.
2. Verify that the Site Editor item is present in the menu and that the editor loads.

Sandbox testing:

1. Sync plugin changes to your sandbox.
2. Make sure that the test site has `gutenberg-edge` sticker applied.
3. Verify that the Site Editor item is present in the menu and that the editor loads. 