### PR TITLE
Site Launch: skip upsell until regression is found

### DIFF
--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -4,8 +4,6 @@
 import { SITE_LAUNCH } from 'state/action-types';
 import 'state/data-layer/wpcom/sites/launch';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { getSiteSlug, isCurrentPlanPaid } from 'state/sites/selectors';
-import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 
 export const launchSite = siteId => ( {
 	type: SITE_LAUNCH,
@@ -22,17 +20,5 @@ export const launchSiteOrRedirectToLaunchSignupFlow = siteId => ( dispatch, getS
 	if ( ! isUnlaunchedSite( getState(), siteId ) ) {
 		return;
 	}
-
-	if (
-		isCurrentPlanPaid( getState(), siteId ) &&
-		getDomainsBySiteId( getState(), siteId ).length > 1
-	) {
-		dispatch( launchSite( siteId ) );
-		return;
-	}
-
-	const siteSlug = getSiteSlug( getState(), siteId );
-
-	// TODO: consider using the `page` library instead of calling using `location.href` here
-	window.location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
+	dispatch( launchSite( siteId ) );
 };


### PR DESCRIPTION
Temporary patch until signup regression is found. This PR skips the domain upsell step when trying to launch a site.

### Testing Instructions
- Create a new site
- Follow Site Setup List in My Home
- Click on Launch Site. We should launch the site directly instead of going to a domain upsell.