### PR TITLE
Data stores: Add getVerticalTemplate

### DIFF
--- a/packages/data-stores/src/verticals-templates/actions.ts
+++ b/packages/data-stores/src/verticals-templates/actions.ts
@@ -3,10 +3,23 @@
  */
 import { Template } from './types';
 
-export const receiveTemplates = ( verticalId: string, templates: Template[] ) => ( {
-	type: 'RECEIVE_TEMPLATES' as const,
-	verticalId,
-	templates,
-} );
+export const receiveTemplates = ( verticalId: string, templates: Template[] ) =>
+	( {
+		type: 'RECEIVE_TEMPLATES',
+		verticalId,
+		templates,
+	} as const );
 
-export type Action = ReturnType< typeof receiveTemplates >;
+export const receiveVerticalTemplate = (
+	verticalId: string,
+	templateSlug: string,
+	template: Template
+) =>
+	( {
+		type: 'RECEIVE_VERTICAL_TEMPLATE',
+		verticalId,
+		templateSlug,
+		template,
+	} as const );
+
+export type Action = ReturnType< typeof receiveTemplates | typeof receiveVerticalTemplate >;

--- a/packages/data-stores/src/verticals-templates/reducer.ts
+++ b/packages/data-stores/src/verticals-templates/reducer.ts
@@ -9,6 +9,7 @@ import { combineReducers } from '@wordpress/data';
  */
 import { Template } from './types';
 import { Action } from './actions';
+import { getVerticalTemplateKey } from './utils';
 
 const templates: Reducer< Record< string, Template[] | undefined >, Action > = (
 	state = {},
@@ -23,7 +24,20 @@ const templates: Reducer< Record< string, Template[] | undefined >, Action > = (
 	return state;
 };
 
-const reducer = combineReducers( { templates } );
+const verticalTemplates: Reducer< Record< string, Template | undefined >, Action > = (
+	state = {},
+	action
+) => {
+	if ( action.type === 'RECEIVE_VERTICAL_TEMPLATE' ) {
+		return {
+			...state,
+			[ getVerticalTemplateKey( action.verticalId, action.templateSlug ) ]: action.template,
+		};
+	}
+	return state;
+};
+
+const reducer = combineReducers( { templates, verticalTemplates } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/packages/data-stores/src/verticals-templates/resolvers.ts
+++ b/packages/data-stores/src/verticals-templates/resolvers.ts
@@ -6,15 +6,31 @@ import { apiFetch } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
-import { receiveTemplates } from './actions';
+import { receiveTemplates, receiveVerticalTemplate } from './actions';
 
 export function* getTemplates(
 	// Resolver has the same signature as corresponding selector without the initial state argument
 	verticalId: Parameters< typeof import('./selectors')[ 'getTemplates' ] >[ 1 ]
 ) {
 	const resp = yield apiFetch( {
-		url: `https://public-api.wordpress.com/wpcom/v2/verticals/${ verticalId }/templates`,
+		url: `https://public-api.wordpress.com/wpcom/v2/verticals/${ encodeURIComponent(
+			verticalId
+		) }/templates`,
 	} );
 
 	return receiveTemplates( verticalId, resp.templates );
+}
+
+export function* getVerticalTemplate(
+	// Resolver has the same signature as corresponding selector without the initial state argument
+	verticalId: Parameters< typeof import('./selectors')[ 'getVerticalTemplate' ] >[ 1 ],
+	templateSlug: Parameters< typeof import('./selectors')[ 'getVerticalTemplate' ] >[ 2 ]
+) {
+	const resp = yield apiFetch( {
+		url: `https://public-api.wordpress.com/wpcom/v2/verticals/${ encodeURIComponent(
+			verticalId
+		) }/templates/${ encodeURIComponent( templateSlug ) }`,
+	} );
+
+	return receiveVerticalTemplate( verticalId, templateSlug, resp );
 }

--- a/packages/data-stores/src/verticals-templates/selectors.ts
+++ b/packages/data-stores/src/verticals-templates/selectors.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { State } from './reducer';
+import { getVerticalTemplateKey } from './utils';
 
 /**
  * Get template suggestions
@@ -11,4 +12,15 @@ import { State } from './reducer';
  */
 export const getTemplates = ( state: State, verticalId: string ) => {
 	return state.templates[ verticalId ];
+};
+
+/**
+ * Get template suggestions
+ *
+ * @param state Store state
+ * @param verticalId Vertical ID, e.g. `"p13v1"`
+ * @param templateSlug Template slug, e.g. `"barnsbury"`
+ */
+export const getVerticalTemplate = ( state: State, verticalId: string, templateSlug: string ) => {
+	return state.verticalTemplates[ getVerticalTemplateKey( verticalId, templateSlug ) ];
 };

--- a/packages/data-stores/src/verticals-templates/utils.ts
+++ b/packages/data-stores/src/verticals-templates/utils.ts
@@ -1,0 +1,5 @@
+export function getVerticalTemplateKey( verticalId: string, templateSlug: string ) {
+	// We'll _join_ verticalId and templateSlug to get unique entries into a flat data structure.
+	// Yes, that's `verticalID + joinCharacter + templateSlug`
+	return `${ verticalId }\u2a1d${ templateSlug }`;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Extracted from #40132

Adds `getVerticalTemplate( verticalId, templateSlug )` to the verticals-templates data store.

See #40132 for usage/demo/testing.

#### Testing instructions

Run #40132 and you can see this fetching data on the `/gutenboarding` style-preview step.
Alternatively, run this branch in dev an run `wp.data.select('automattic/verticals/templates').getVerticalTemplate('p8v36','twenty-twenty')` in the console.