### PR TITLE
Revert "Site Launch: skip upsell until regression is found"

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -58,7 +58,6 @@ import {
 	TldFilterBar,
 } from 'components/domains/search-filters';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
 import { hasDomainInCart } from 'lib/cart-values/cart-items';
@@ -1441,7 +1440,6 @@ export default connect(
 		return {
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			currentUser: getCurrentUser( state ),
-			selectedSite: getSelectedSite( state ),
 			defaultSuggestions: getDomainsSuggestions( state, queryObject ),
 			defaultSuggestionsError: getDomainsSuggestionsError( state, queryObject ),
 		};

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -190,6 +190,7 @@ class DomainSearch extends Component {
 								onAddTransfer={ this.handleAddTransfer }
 								cart={ this.props.cart }
 								offerUnavailableOption
+								selectedSite={ selectedSite }
 								basePath={ this.props.basePath }
 								products={ this.props.productsList }
 								vendor={ getSuggestionsVendor() }

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -4,6 +4,8 @@
 import { SITE_LAUNCH } from 'state/action-types';
 import 'state/data-layer/wpcom/sites/launch';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { getSiteSlug, isCurrentPlanPaid } from 'state/sites/selectors';
+import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 
 export const launchSite = siteId => ( {
 	type: SITE_LAUNCH,
@@ -20,5 +22,17 @@ export const launchSiteOrRedirectToLaunchSignupFlow = siteId => ( dispatch, getS
 	if ( ! isUnlaunchedSite( getState(), siteId ) ) {
 		return;
 	}
-	dispatch( launchSite( siteId ) );
+
+	if (
+		isCurrentPlanPaid( getState(), siteId ) &&
+		getDomainsBySiteId( getState(), siteId ).length > 1
+	) {
+		dispatch( launchSite( siteId ) );
+		return;
+	}
+
+	const siteSlug = getSiteSlug( getState(), siteId );
+
+	// TODO: consider using the `page` library instead of calling using `location.href` here
+	window.location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
 };


### PR DESCRIPTION
Reverts Automattic/wp-calypso#40129 

Context: p7DVsv-8aJ-p2#comment-27280

The regression was introduced in https://github.com/Automattic/wp-calypso/pull/39664. See p99Zz8-12M-p2 for more context.

The offending line was this: https://github.com/Automattic/wp-calypso/pull/39664/files#diff-37d2382dc9dbc34da496b1cc4c40d0f2L191

I did not realize that we were injecting a selectedSite in a signup step, since, by nature, signup is for signing up for a new site. But seems that it was repurposed for launching private sites as well. As a result the fix was quite simple: 344a11a

#### Testing instructions
Follow the ones from https://github.com/Automattic/wp-calypso/pull/39664 to make sure there are no regressions there (so meta).
Create a new, free site, without domains. It should be in unlaunched state. Try launching it from Home or from Manage -> Settings. The domains step should load with default 2 suggestions.