### PR TITLE
composite-checkout: add new composite checkout flag for testing domains

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -141,7 +141,10 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		return false;
 	}
 
-	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
+	if (
+		config.isEnabled( 'composite-checkout-testing' ) ||
+		abtest( 'showCompositeCheckout' ) === 'composite'
+	) {
 		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
 		return true;
 	}

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -85,7 +85,7 @@ export default function CheckoutSystemDecider( {
 
 function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, isJetpack ) {
 	if ( config.isEnabled( 'composite-checkout-force' ) ) {
-		debug( 'shouldShowCompositeCheckout true because config is enabled' );
+		debug( 'shouldShowCompositeCheckout true because force config is enabled' );
 		return true;
 	}
 	// Disable if this is a jetpack site
@@ -93,31 +93,9 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		debug( 'shouldShowCompositeCheckout false because jetpack site' );
 		return false;
 	}
-	// If the URL is adding a product, only allow wpcom plans
-	const slugFragmentsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
-	if (
-		productSlug &&
-		! slugFragmentsToAllow.find( fragment => productSlug.includes( fragment ) )
-	) {
-		debug(
-			'shouldShowCompositeCheckout false because product does not match whitelist',
-			productSlug
-		);
-		return false;
-	}
 	// Disable for non-USD
 	if ( cart.currency !== 'USD' ) {
 		debug( 'shouldShowCompositeCheckout false because currency is not USD' );
-		return false;
-	}
-	// Disable for domains in the cart
-	if ( cart.products?.find( product => product.is_domain_registration ) ) {
-		debug( 'shouldShowCompositeCheckout false because cart contains domain registration' );
-		return false;
-	}
-	// Disable for domain mapping
-	if ( cart.products?.find( product => product.product_slug.includes( 'domain' ) ) ) {
-		debug( 'shouldShowCompositeCheckout false because cart contains domain item' );
 		return false;
 	}
 	// Disable for GSuite plans
@@ -140,11 +118,34 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		debug( 'shouldShowCompositeCheckout false because country is not US' );
 		return false;
 	}
-
+	if ( config.isEnabled( 'composite-checkout-testing' ) ) {
+		debug( 'shouldShowCompositeCheckout true because testing config is enabled' );
+		return true;
+	}
+	// If the URL is adding a product, only allow wpcom plans
+	const slugFragmentsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
 	if (
-		config.isEnabled( 'composite-checkout-testing' ) ||
-		abtest( 'showCompositeCheckout' ) === 'composite'
+		productSlug &&
+		! slugFragmentsToAllow.find( fragment => productSlug.includes( fragment ) )
 	) {
+		debug(
+			'shouldShowCompositeCheckout false because product does not match whitelist',
+			productSlug
+		);
+		return false;
+	}
+	// Disable for domains in the cart
+	if ( cart.products?.find( product => product.is_domain_registration ) ) {
+		debug( 'shouldShowCompositeCheckout false because cart contains domain registration' );
+		return false;
+	}
+	// Disable for domain mapping
+	if ( cart.products?.find( product => product.product_slug.includes( 'domain' ) ) ) {
+		debug( 'shouldShowCompositeCheckout false because cart contains domain item' );
+		return false;
+	}
+
+	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
 		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
 		return true;
 	}

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -84,7 +84,7 @@ export default function CheckoutSystemDecider( {
 }
 
 function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, isJetpack ) {
-	if ( config.isEnabled( 'composite-checkout-wpcom' ) ) {
+	if ( config.isEnabled( 'composite-checkout-force' ) ) {
 		debug( 'shouldShowCompositeCheckout true because config is enabled' );
 		return true;
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -37,7 +37,6 @@
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,
-		"composite-checkout-wpcom": false,
 		"coming-soon": true,
 		"desktop-promo": true,
 		"devdocs": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,7 +21,7 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
-		"composite-checkout-wpcom": true,
+		"composite-checkout-testing": true,
 		"devdocs": false,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In production, composite checkout is displayed if a user passes all the product guards (checks for products that composite checkout does not yet support) and is assigned as part of the abtest. We have a config flag, `composite-checkout-wpcom`, which skips all the product guards and the abtest if enabled, but while this makes it easy to test the behavior on products that would be excluded by the guards, it makes it hard to test new upcoming changes to those guards like the upcoming support for domains.

This PR adds a new flag, `composite-checkout-testing`, which replaces the other flag that's enabled on Horizon. The new flag can be used to conditionally enable certain features for testing to larger audiences. This PR also uses the flag to simulate the upcoming domains release.

In order to continue to develop new features easily, this also renames the old flag to `composite-checkout-force`, to make it clear that it skips all the product guards.

#### Testing instructions

- Add a plan and a domain to your cart.
- Visit checkout in development and be sure that you see regular checkout.
- Add `?flags=composite-checkout-force` to the URL and be sure that you see composite checkout.
- Add `?flags=composite-checkout-testing` to the URL and be sure that you see composite checkout.
- Add GSuite to your cart.
- Visit checkout with `?flags=composite-checkout-force` and be sure that you see composite checkout.
- Visit checkout with `?flags=composite-checkout-testing` and be sure that you see regular checkout.
- Use a special url to add a product to the cart, like `/checkout/example.com/premium`.
- Verify that a logstash log appears for that product with the text "CheckoutSystemDecider saw productSlug to add" and the product slug ("premium" in the above example). Ask me if you don't know how to search logstash for that string.