### PR TITLE
WIP:Search across all pages

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -81,24 +81,10 @@ class PagesMain extends React.Component {
 			scheduled: translate( 'Scheduled', { context: 'Filter label for pages list' } ),
 			trashed: translate( 'Trashed', { context: 'Filter label for pages list' } ),
 		};
-		const searchStrings = {
-			published: translate( 'Search Published…', {
-				context: 'Search placeholder for pages list',
-				textOnly: true,
-			} ),
-			drafts: translate( 'Search Drafts…', {
-				context: 'Search placeholder for pages list',
-				textOnly: true,
-			} ),
-			scheduled: translate( 'Search Scheduled…', {
-				context: 'Search placeholder for pages list',
-				textOnly: true,
-			} ),
-			trashed: translate( 'Search Trashed…', {
-				context: 'Search placeholder for pages list',
-				textOnly: true,
-			} ),
-		};
+		const searchPages = translate( 'Search Published…', {
+			context: 'Search placeholder for pages list',
+			textOnly: true,
+		} );
 		return (
 			<Main wideLayout classname="pages">
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
@@ -118,7 +104,7 @@ class PagesMain extends React.Component {
 						fitsContainer
 						onSearch={ doSearch }
 						initialValue={ search }
-						placeholder={ searchStrings[ status ] }
+						placeholder={ searchPages }
 						analyticsGroup="Pages"
 						delaySearch={ true }
 					/>

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -35,6 +35,8 @@ import SectionHeader from 'components/section-header';
 import { Button } from '@automattic/components';
 import { withLocalizedMoment } from 'components/localized-moment';
 
+const PAGES_STATUSES = [ 'publish', 'draft', 'pending', 'private', 'future', 'trash' ];
+
 function preloadEditor() {
 	preload( 'post-editor' );
 }
@@ -75,7 +77,7 @@ export default class PageList extends Component {
 			page: this.state.page,
 			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
 			search,
-			status: mapStatus( status ),
+			status: search ? PAGES_STATUSES.join( ',' ) : mapStatus( status ),
 			type: 'page',
 		};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Search across pages made
* Still missing display the type of pages (trashed,...) in the results, as made in https://github.com/Automattic/wp-calypso/pull/36109

#### Testing instructions
* Will be written later

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



Fixes #36121 