### PR TITLE
Quick Links: Make post options aware of editor preferences

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -62,6 +62,7 @@ import WelcomeBanner from './welcome-banner';
 import StatsCard from './stats-card';
 import FreePhotoLibraryCard from './free-photo-library-card';
 import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 
 /**
  * Style dependencies
@@ -650,6 +651,7 @@ const connectHome = connect(
 		const user = getCurrentUser( state );
 		const displayWelcomeBanner =
 			! isNewlyCreatedSite && user.date && new Date( user.date ) < new Date( '2019-08-06' );
+		const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
 
 		return {
 			displayChecklist:
@@ -665,7 +667,8 @@ const connectHome = connect(
 			isChecklistComplete,
 			isAtomic,
 			needsEmailVerification: ! isCurrentUserEmailVerified( state ),
-			isStaticHomePage: 'page' === getSiteOption( state, siteId, 'show_on_front' ),
+			isStaticHomePage:
+				! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 			siteHasPaidPlan: isSiteOnPaidPlan( state, siteId ),
 			isNewlyCreatedSite,
 			isEstablishedSite: moment().isAfter( moment( createdAt ).add( 2, 'days' ) ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/40108 where attempting to edit the homepage would instead create a new page when the classic editor was selected.

When the classic editor is set as the default preference, we should see the following for page/post editing options:

| Classic  | Block-Editor |
| ------------- | ------------- |
| <img width="1019" alt="Screen Shot 2020-03-13 at 2 18 01 PM" src="https://user-images.githubusercontent.com/1270189/76660389-0da86300-6536-11ea-9f82-87d67bb01799.png"> | <img width="1023" alt="Screen Shot 2020-03-13 at 2 17 33 PM" src="https://user-images.githubusercontent.com/1270189/76660412-1ac55200-6536-11ea-9be8-e8fa87c0403a.png"> |

### Testing Instructions
<img width="368" alt="76578880-5ce38a80-6487-11ea-8b73-f74a32c9385b" src="https://user-images.githubusercontent.com/1270189/76660532-5b24d000-6536-11ea-8f28-d84e9976bd17.png">

- With a user account created before December 16, 2019, click on "Switch to Classic Editor"
- Verify that links match the Classic image above in My Home (WordPress.com/home)
- Switch back to the block-editor 
- Verify that links match the Block-Editor image above in My Home (WordPress.com/home)


