### PR TITLE
Disable composite checkout for TLDs with special contact forms

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -18,6 +18,8 @@ import { getCurrentUserLocale, getCurrentUserCountryCode } from 'state/current-u
 import { isJetpackSite } from 'state/sites/selectors';
 import { abtest } from 'lib/abtest';
 import { logToLogstash } from 'state/logstash/actions';
+import { getTlds } from 'lib/cart-values/cart-items';
+import { tldsWithAdditionalDetailsForms } from 'components/domains/registrant-extra-info';
 
 const debug = debugFactory( 'calypso:checkout-system-decider' );
 const wpcom = wp.undocumented();
@@ -135,10 +137,10 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		debug( 'shouldShowCompositeCheckout false because country is not US' );
 		return false;
 	}
-	// Disable for ccTLDs that have special contact forms
-	if ( cart.products?.find( product => !! product.product_slug.match( /dot(fr|ca|uk)_domain/ ) ) ) {
+	// Disable for TLDs that have special contact forms
+	if ( getTlds( cart ).find( tld => tldsWithAdditionalDetailsForms.includes( tld ) ) ) {
 		debug(
-			'shouldShowCompositeCheckout false because cart contains ccTLD with special contact form'
+			'shouldShowCompositeCheckout false because cart contains TLD with special contact form'
 		);
 		return false;
 	}

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -135,6 +135,14 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		debug( 'shouldShowCompositeCheckout false because country is not US' );
 		return false;
 	}
+	// Disable for ccTLDs that have special contact forms
+	if ( cart.products?.find( product => !! product.product_slug.match( /dot(fr|ca|uk)_domain/ ) ) ) {
+		debug(
+			'shouldShowCompositeCheckout false because cart contains ccTLD with special contact form'
+		);
+		return false;
+	}
+
 	if ( config.isEnabled( 'composite-checkout-testing' ) ) {
 		debug( 'shouldShowCompositeCheckout true because testing config is enabled' );
 		return true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For our initial launch of supporting domains in composite checkout, we are going to exclude TLDs which require special contact forms. These include .fr, .ca, and *.uk. This PR adds a guard for those products in `CheckoutSystemDecider`.

#### Testing instructions

- Add a domain using a gTLD without special contact fields (eg: .blog) to your cart.
- Visit checkout.
- Add the `?flags=composite-checkout-testing` to your URL to simulate the domain launch.
- Verify that you see composite checkout.
- Add a domain using a ccTLD without special contact fields (eg: .tv) to your cart and return to checkout _with the same flag_.
- Verify that you still see composite checkout.
- Add a domain using a TLD that has special contact fields (eg: .co.uk) to your cart and return to checkout _with the same flag_.
- Verify that you see regular checkout instead.