### PR TITLE
Composite Checkout: trim whitespace from coupon value before validating

### DIFF
--- a/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-coupon-field-state.ts
@@ -32,13 +32,15 @@ export default function useCouponFieldState( submitCoupon ): CouponFieldStatePro
 	}, [ couponFieldValue ] );
 
 	const handleCouponSubmit = useCallback( () => {
-		if ( isCouponValid( couponFieldValue ) ) {
+		const trimmedValue = couponFieldValue.trim();
+
+		if ( isCouponValid( trimmedValue ) ) {
 			onEvent( {
 				type: 'a8c_checkout_add_coupon',
-				payload: { coupon: couponFieldValue },
+				payload: { coupon: trimmedValue },
 			} );
 
-			submitCoupon( couponFieldValue );
+			submitCoupon( trimmedValue );
 
 			return;
 		}


### PR DESCRIPTION
This allows coupons to be submitted with leading or trailing whitespace. Fixes #39991.

**To test:**
- visit the new Checkout
- add a coupon with whitespace
- verify that the trimmed coupon value is sent to the /shopping-cart/ endpoint and properly applied to the cart