### PR TITLE
Enable customers turn off/on auto-renewal on their G Suite subscriptions 

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -29,6 +29,7 @@ import {
 import {
 	isDomainRegistration,
 	isDomainTransfer,
+	isGoogleApps,
 	isConciergeSession,
 	isJetpackPlan,
 	isJetpackProduct,
@@ -328,7 +329,7 @@ class PurchaseMeta extends Component {
 		}
 
 		if (
-			( isDomainRegistration( purchase ) || isPlan( purchase ) ) &&
+			( isDomainRegistration( purchase ) || isPlan( purchase ) || isGoogleApps( purchase ) ) &&
 			isRechargeable( purchase ) &&
 			! isExpired( purchase )
 		) {


### PR DESCRIPTION
Traditionally customers with domains and plans can access the renewal auto-toggle in related product purchase pages, enabling them to turn off, or on the auto-renewal status of the product.

<img width="701" alt="Screenshot 2020-03-14 at 2 47 55 AM" src="https://user-images.githubusercontent.com/277661/76672618-64498780-659e-11ea-80ec-3efd3aab0b95.png">

Customers with G Suite products see this instead:

<img width="699" alt="Screenshot 2020-03-14 at 2 43 23 AM" src="https://user-images.githubusercontent.com/277661/76672649-8fcc7200-659e-11ea-93f6-c71e002531dc.png">

#### Changes proposed in this Pull Request

* The logic to display the auto-toggle is adjusted to include G Suite products as well.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

NOTE: You may need to add a payment method in the production instance as you may not be able to properly add payment methods in purchases page of the dev server.

* Checkout this branch in your development instance, likely http://calypso.localhost:3000
* Ensure you have a valid G Suite subscription 
* Ensure you have a valid payment method associated with that subscription
* Access the related purchase page starting from [here](http://calypso.localhost:3000/me/purchases)
* Confirm that you can now see the toggle.



