### PR TITLE
Pages: Expand search scope for pages from one tab to all tabs

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -81,24 +81,10 @@ class PagesMain extends React.Component {
 			scheduled: translate( 'Scheduled', { context: 'Filter label for pages list' } ),
 			trashed: translate( 'Trashed', { context: 'Filter label for pages list' } ),
 		};
-		const searchStrings = {
-			published: translate( 'Search Published…', {
-				context: 'Search placeholder for pages list',
-				textOnly: true,
-			} ),
-			drafts: translate( 'Search Drafts…', {
-				context: 'Search placeholder for pages list',
-				textOnly: true,
-			} ),
-			scheduled: translate( 'Search Scheduled…', {
-				context: 'Search placeholder for pages list',
-				textOnly: true,
-			} ),
-			trashed: translate( 'Search Trashed…', {
-				context: 'Search placeholder for pages list',
-				textOnly: true,
-			} ),
-		};
+		const searchPlaceholder = translate( 'Search Pages…', {
+			context: 'Search placeholder for pages list',
+			textOnly: true,
+		} );
 		return (
 			<Main wideLayout classname="pages">
 				<PageViewTracker path={ this.getAnalyticsPath() } title={ this.getAnalyticsTitle() } />
@@ -118,7 +104,7 @@ class PagesMain extends React.Component {
 						fitsContainer
 						onSearch={ doSearch }
 						initialValue={ search }
-						placeholder={ searchStrings[ status ] }
+						placeholder={ searchPlaceholder }
 						analyticsGroup="Pages"
 						delaySearch={ true }
 					/>

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -42,6 +42,7 @@ const ICON_SIZE = 12;
 function PageCardInfo( {
 	page,
 	showTimestamp,
+	showPublishedStatus,
 	isFront,
 	isPosts,
 	siteUrl,
@@ -53,13 +54,14 @@ function PageCardInfo( {
 	const moment = useLocalizedMoment();
 
 	const renderTimestamp = function() {
-		if ( page.status === 'future' ) {
+		if ( showPublishedStatus ) {
 			return (
 				<PostRelativeTimeStatus
 					post={ page }
 					link={ contentLink.contentLinkURL }
 					target={ contentLink.contentLinkTarget }
 					gridiconSize={ ICON_SIZE }
+					includeBasicStatus={ true }
 				/>
 			);
 		}

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -21,6 +21,7 @@ import EmptyContent from 'components/empty-content';
 import NoResults from 'my-sites/no-results';
 import Placeholder from './placeholder';
 import { mapPostStatus as mapStatus } from 'lib/route';
+import { POST_STATUSES } from 'state/posts/constants';
 import { sortPagesHierarchically } from './helpers';
 import BlogPostsPage from './blog-posts-page';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
@@ -75,14 +76,27 @@ export default class PageList extends Component {
 			page: this.state.page,
 			number: 20, // all-sites mode, i.e the /me/posts endpoint, only supports up to 20 results at a time
 			search,
-			status: mapStatus( status ),
+			// When searching, search across all statuses so the user can
+			// always find what they are looking for, regardless of what tab
+			// the search was initiated from. Use POST_STATUSES rather than
+			// "any" to do this, since the latter excludes trashed posts.
+			status: search ? POST_STATUSES.join( ',' ) : mapStatus( status ),
 			type: 'page',
 		};
+
+		// Since searches are across all statuses, the status needs to be shown
+		// next to each post.
+		const showPublishedStatus = Boolean( search );
 
 		return (
 			<div>
 				<QueryPosts siteId={ siteId } query={ query } />
-				<ConnectedPages incrementPage={ this.incrementPage } query={ query } siteId={ siteId } />
+				<ConnectedPages
+					incrementPage={ this.incrementPage }
+					query={ query }
+					siteId={ siteId }
+					showPublishedStatus={ showPublishedStatus }
+				/>
 			</div>
 		);
 	}
@@ -101,6 +115,7 @@ class Pages extends Component {
 		hasSites: PropTypes.bool.isRequired,
 		trackScrollPage: PropTypes.func.isRequired,
 		query: PropTypes.object,
+		showPublishedStatus: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -111,6 +126,7 @@ class Pages extends Component {
 		pages: [],
 		trackScrollPage: function() {},
 		query: {},
+		showPublishedStatus: false,
 	};
 
 	state = {
@@ -306,7 +322,7 @@ class Pages extends Component {
 	}
 
 	renderPagesList( { pages } ) {
-		const { site, lastPage, query } = this.props;
+		const { site, lastPage, query, showPublishedStatus } = this.props;
 
 		// Pages only display hierarchically for published pages on single-sites when
 		// there are 100 or fewer pages and no more pages to load (last page).
@@ -319,11 +335,11 @@ class Pages extends Component {
 			! query.search;
 
 		return showHierarchical
-			? this.renderHierarchical( { pages, site } )
-			: this.renderChronological( { pages, site } );
+			? this.renderHierarchical( { pages, site, showPublishedStatus } )
+			: this.renderChronological( { pages, site, showPublishedStatus } );
 	}
 
-	renderHierarchical( { pages, site } ) {
+	renderHierarchical( { pages, site, showPublishedStatus } ) {
 		pages = sortPagesHierarchically( pages );
 		const rows = pages.map( function( page ) {
 			return (
@@ -335,6 +351,7 @@ class Pages extends Component {
 					multisite={ false }
 					hierarchical={ true }
 					hierarchyLevel={ page.indentLevel || 0 }
+					showPublishedStatus={ showPublishedStatus }
 				/>
 			);
 		}, this );
@@ -349,7 +366,7 @@ class Pages extends Component {
 		);
 	}
 
-	renderChronological( { pages, site } ) {
+	renderChronological( { pages, site, showPublishedStatus } ) {
 		const { search, status } = this.props.query;
 
 		if ( ! search ) {
@@ -369,6 +386,7 @@ class Pages extends Component {
 					onShadowStatusChange={ this.updateShadowStatus }
 					page={ page }
 					multisite={ this.props.siteId === null }
+					showPublishedStatus={ showPublishedStatus }
 				/>
 			);
 		} );

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -85,6 +85,7 @@ class Page extends Component {
 
 	static defaultProps = {
 		onShadowStatusChange: noop,
+		showPublishedStatus: false,
 	};
 
 	// Construct a link to the Site the page belongs too
@@ -424,7 +425,14 @@ class Page extends Component {
 	undoPostStatus = () => this.updatePostStatus( this.props.shadowStatus.undo );
 
 	render() {
-		const { editorUrl, page, shadowStatus, translate, isPostsPage: latestPostsPage } = this.props;
+		const {
+			editorUrl,
+			page,
+			shadowStatus,
+			showPublishedStatus,
+			translate,
+			isPostsPage: latestPostsPage,
+		} = this.props;
 		const title = page.title || translate( 'Untitled' );
 		const canEdit = utils.userCan( 'edit_post', page ) && ! latestPostsPage;
 		const depthIndicator = ! this.props.hierarchical && page.parent && '— ';
@@ -525,6 +533,7 @@ class Page extends Component {
 					<PageCardInfo
 						page={ page }
 						showTimestamp
+						showPublishedStatus={ showPublishedStatus }
 						siteUrl={ this.props.multisite && this.getSiteDomain() }
 					/>
 				</div>


### PR DESCRIPTION
This was work in progress for https://github.com/Automattic/wp-calypso/issues/36121 from back in September 2019 (that I never pushed).... I rebased it now just to push it up to GitHub, but didn't make any other changes.

I don't remember exactly what the status of this was or what work was left to do, but it probably needs some work and updates, certainly.

Note there is a newer in-progress pull request at https://github.com/Automattic/wp-calypso/pull/40137.