### PR TITLE
Improving the DatePicker component to match the specification

### DIFF
--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -18,37 +19,45 @@ import Gridicon from 'components/gridicon';
  */
 import './style.scss';
 
-const DATE_FORMAT = 'YYYY-MM-DD';
-
 class DatePicker extends Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
-		selectedDateString: PropTypes.string.isRequired,
-		onChange: PropTypes.func.isRequired,
+		selectedDate: PropTypes.instanceOf( Date ).isRequired,
+		onDateChange: PropTypes.func.isRequired,
+		onDateRangeSelection: PropTypes.func.isRequired,
 	};
 
-	getFormattedDate = dateString => this.props.moment.parseZone( dateString ).format( DATE_FORMAT );
+	getDisplayDate = ( date, showTodayYesterday = true ) => {
+		const { moment, translate } = this.props;
 
-	getDisplayDate = dateString => {
-		const word = this.props.moment
-			.parseZone( dateString )
-			.calendar()
-			.split( ' ' )[ 0 ];
-		if ( 'Today' === word || 'Yesterday' === word ) {
-			return word;
+		const daysDiff = moment().diff( date, 'days' );
+		const yearToday = moment().format( 'YYYY' );
+		const yearDate = moment( date ).format( 'YYYY' );
+
+		let dateFormat = 'MMM D';
+
+		if ( yearToday !== yearDate ) {
+			dateFormat = 'MMM D, YYYY';
 		}
 
-		return this.getFormattedDate( dateString );
+		if ( showTodayYesterday ) {
+			switch ( daysDiff ) {
+				case 0:
+					return translate( 'Today' );
+				case 1:
+					return translate( 'Yesterday' );
+			}
+		}
+
+		return date.format( dateFormat );
 	};
 
 	shuttleLeft = () => {
-		const { moment, onChange, selectedDateString } = this.props;
-		const newDateString = moment
-			.parseZone( selectedDateString )
-			.subtract( 1, 'days' )
-			.toISOString( true );
+		const { moment, onDateChange, selectedDate } = this.props;
 
-		onChange( newDateString );
+		const newSelectedDate = moment( selectedDate ).subtract( 1, 'days' );
+
+		onDateChange( newSelectedDate.getDate() );
 	};
 
 	shuttleRight = () => {
@@ -56,24 +65,27 @@ class DatePicker extends Component {
 			return false;
 		}
 
-		const { moment, onChange, selectedDateString } = this.props;
-		const newDateString = moment
-			.parseZone( selectedDateString )
-			.add( 1, 'days' )
-			.toISOString( true );
+		const { moment, onDateChange, selectedDate } = this.props;
 
-		onChange( newDateString );
+		const newSelectedDate = moment( selectedDate ).add( 1, 'days' );
+
+		onDateChange( newSelectedDate.getDate() );
 	};
 
 	canShuttleRight = () => {
-		const { moment, selectedDateString } = this.props;
-		return ! moment().isSame( moment.parseZone( selectedDateString ), 'day' );
+		const { moment, selectedDate } = this.props;
+
+		return ! moment( selectedDate ).isSame( moment(), 'day' );
 	};
 
 	render() {
-		const { selectedDateString, siteId } = this.props;
+		const { selectedDate, siteId, moment } = this.props;
 
-		const currentDisplayDate = this.getDisplayDate( selectedDateString );
+		const previousDate = moment( selectedDate ).subtract( 1, 'days' );
+		const nextDate = moment( selectedDate ).add( 1, 'days' );
+
+		const previousDisplayDate = this.getDisplayDate( previousDate );
+		const nextDisplayDate = this.getDisplayDate( nextDate, false );
 
 		return (
 			<div className="date-picker">
@@ -81,17 +93,26 @@ class DatePicker extends Component {
 					<Gridicon icon="chevron-left" />
 				</Button>
 
-				<div className="date-picker__current-display-date">{ currentDisplayDate }</div>
-
-				<Button compact borderless onClick={ this.shuttleRight }>
-					<Gridicon icon="chevron-right" className={ ! this.canShuttleRight() && 'disabled' } />
-				</Button>
+				<div className="date-picker__display-date">{ previousDisplayDate }</div>
 
 				<DateRangeSelector
 					siteId={ siteId }
 					enabled={ true }
 					customLabel={ <Gridicon icon="calendar" /> }
 				/>
+
+				<div
+					className={ classNames( 'date-picker__display-date', {
+						disabled: ! this.canShuttleRight(),
+					} ) }
+				>
+					{ nextDisplayDate }
+				</div>
+
+				<Button compact borderless onClick={ this.shuttleRight }>
+					<Gridicon icon="chevron-right" className={ ! this.canShuttleRight() && 'disabled' } />
+				</Button>
+				<div>Date selected: { this.getDisplayDate( selectedDate ) }</div>
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -49,7 +49,7 @@ class DatePicker extends Component {
 			}
 		}
 
-		return date.format( dateFormat );
+		return moment( date ).format( dateFormat );
 	};
 
 	shuttleLeft = () => {
@@ -57,7 +57,7 @@ class DatePicker extends Component {
 
 		const newSelectedDate = moment( selectedDate ).subtract( 1, 'days' );
 
-		onDateChange( newSelectedDate.getDate() );
+		onDateChange( newSelectedDate.toDate() );
 	};
 
 	shuttleRight = () => {
@@ -69,7 +69,7 @@ class DatePicker extends Component {
 
 		const newSelectedDate = moment( selectedDate ).add( 1, 'days' );
 
-		onDateChange( newSelectedDate.getDate() );
+		onDateChange( newSelectedDate.toDate() );
 	};
 
 	canShuttleRight = () => {

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -1,10 +1,10 @@
 .date-picker .button,
-.date-picker__current-display-date,
+.date-picker__display-date,
 .date-picker .date-range {
-    display: inline-block;
-    float: none;
+	display: inline-block;
+	float: none;
 }
 
 .date-picker .button .gridicon.disabled {
-    fill: #dcdcde;
+	fill: #dcdcde;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The goal is to improve the manipulation of the dates using a`Date` object instead of a text format, as the ActivityLog component does in Calypso. 

* Keep the component neutral, working directly with the `Date` object
* Show the appropriate date format, Today or Yesterday and if a date is in the last year, show the year.
* Applied the expected date selection behavior. Show the previous and the next date from the current selected date: < previous  [current date]  next >. If today is Mar 11, the previous date would be Mar 10 and the next date would be Mar 12.

**Note:** The existing code has been commented intentionally to allow the review of this PR. In the next PR will be uncommented.

#### Testing instructions

Notes: This PR is only to check the functionality, no styles applied.

1. Go to `/backups/:siteSlug` for a site with Jetpack
2. Check if it shows your current date (Today) as the selected date and you can see Yesterday on the left navigator and the tomorrow date on the right navigation. And the rest of the dates it's shown in the expected format.
![](https://cldup.com/kfpcGoTO7E.gif)
3. Check if we jump to last year, the year show up
![](https://cldup.com/3hcJXRKubZ.gif)
4. Verify that no errors are showing up in the console.