### PR TITLE
Premium themes: update references to remove exact count

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -117,7 +117,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 						</p>
 						<p>
 							{ translate(
-								"That's exactly why we've partnered with some of the world's greatest designers to offer over 250 high-end designs that you can use to make your site look incredible."
+								"That's exactly why we've partnered with some of the world's greatest designers to offer high-end designs that you can use to make your site look incredible."
 							) }
 						</p>
 						<p>
@@ -148,7 +148,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 						</p>
 						<p>
 							{ translate(
-								'But if you upgrade to a Premium plan with this special offer, you will get our full collection of over 250 premium themes for just an additional %(discountPrice)s!',
+								'But if you upgrade to a Premium plan with this special offer, you will get our full collection premium themes for just an additional %(discountPrice)s!',
 								{
 									args: {
 										discountPrice: formatCurrency( planDiscountedRawPrice, currencyCode, {
@@ -214,7 +214,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 						<p>
 							<b>
 								{ translate(
-									'Upgrade to the Premium plan and access over 250 premium themes for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more.',
+									'Upgrade to the Premium plan and access our full collection of premium themes for just {{del}}%(fullPrice)s{{/del}} %(discountPrice)s more.',
 									{
 										components: { del: <del /> },
 										args: {

--- a/client/my-sites/feature-upsell/plugins-upsell.jsx
+++ b/client/my-sites/feature-upsell/plugins-upsell.jsx
@@ -90,8 +90,8 @@ class PluginsUpsellComponent extends Component {
 						WordPress Plugins are now available on the Business plan
 					</h1>
 					<h2 className="feature-upsell__card-header is-sub">
-						Upgrading to the Business plan unlocks access to more than 50,000 WordPress Plugins and
-						197 premium Themes, making it our most powerful plan ever.
+						Upgrading to the Business plan unlocks access to more thousands of WordPress plugins and
+						themes, making it our most powerful plan ever.
 					</h2>
 
 					<div className="feature-upsell__cta">
@@ -115,7 +115,7 @@ class PluginsUpsellComponent extends Component {
 						<Feature
 							icon={ <Gridicon icon="plugins" size={ 48 } /> }
 							title="Install as Many WordPress Plugins as You Want"
-							description="Plugins are like smartphone apps for WordPress. They improve your site with features like:  SEO and marketing tools, lead generation tools, appointment booking and management, SalesForce and Mailchimp integration, Google Analytics, and much, much more."
+							description="Plugins are like smartphone apps for WordPress. They improve your site with features like: SEO and marketing tools, lead generation tools, appointment booking and management, SalesForce and Mailchimp integration, Google Analytics, and much, much more."
 						/>
 					</div>
 
@@ -123,7 +123,7 @@ class PluginsUpsellComponent extends Component {
 						<Feature
 							icon={ <Gridicon icon="types" size={ 48 } /> }
 							title="Access our Entire Library of Premium Themes"
-							description="Professional site designs can be expensive, so we’ve negotiated deals on your behalf with many of the most prominent WordPress theme designers in the world. As a Business plan customer, you’ll gain access to our entire library of 197 premium site themes for no additional fee."
+							description="Professional site designs can be expensive, so we’ve negotiated deals on your behalf with many of the most prominent WordPress theme designers in the world. As a Business plan customer, you’ll gain access to our entire library of premium themes for no additional fee."
 						/>
 					</div>
 

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -100,7 +100,7 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 					plan={ PLAN_JETPACK_BUSINESS }
 					title={ translate( 'Access all our premium themes with our Professional plan!' ) }
 					description={ translate(
-						'In addition to more than 100 premium themes, ' +
+						'In addition to our collection of premium themes, ' +
 							'get Elasticsearch-powered site search, real-time offsite backups, ' +
 							'and security scanning.'
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix a few references to avoid using exact hard-coded numbers for premium themes. Using instead words that indicate a collection and group instead of precise numbers.

Full context the issue below.

Fixes #40152