### PR TITLE
numberFormat should support blank "thousandsSep"

### DIFF
--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -186,7 +186,10 @@ I18N.prototype.emit = function( ...args ) {
 I18N.prototype.numberFormat = function( number, options = {} ) {
 	const decimals = typeof options === 'number' ? options : options.decimals || 0;
 	const decPoint = options.decPoint || this.state.numberFormatSettings.decimal_point || '.';
-	const thousandsSep = options.thousandsSep || this.state.numberFormatSettings.thousands_sep || ',';
+	const thousandsSep =
+		typeof options.thousandsSep === 'string'
+			? options.thousandsSep
+			: this.state.numberFormatSettings.thousands_sep || ',';
 
 	return numberFormat( number, decimals, decPoint, thousandsSep );
 };

--- a/packages/i18n-calypso/test/index.js
+++ b/packages/i18n-calypso/test/index.js
@@ -247,6 +247,10 @@ describe( 'I18n', function() {
 					} )
 				).toBe( '2*500@330' );
 			} );
+			it( 'should allow empty separators ', function() {
+				expect( numberFormat( 9999 ) ).not.toBe( '9999' );
+				expect( numberFormat( 9999, { thousandsSep: '' } ) ).toBe( '9999' );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Allow numberFormat() to have an 'empty' thousand separator.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
cd path/to/wp-calypso`
npm run build
node
```
```
const { numberFormat } = require('./packages/i18n-calypso/dist/cjs/');
numberFormat(9999, { thousandsSep: '', });
```

* Before: `9.999`
* After: `9999`

Added a unit test in `packages/i18n-calypso`

#### Sidenote

Couldn't find a more "elegant" way to test if `options.thousandsSep` was the empty string... Opened to suggestions...

```
const thousandsSep =
		typeof options.thousandsSep === 'string'
			? options.thousandsSep
			: this.state.numberFormatSettings.thousands_sep || ',';
```

Fixes #39881

