### PR TITLE
Themes Upsell: Remove Exact Premium Theme Count

### DIFF
--- a/client/my-sites/feature-upsell/themes-upsell.jsx
+++ b/client/my-sites/feature-upsell/themes-upsell.jsx
@@ -115,7 +115,7 @@ class ThemesUpsellComponent extends Component {
 						<Feature
 							icon={ <Gridicon icon="types" size={ 48 } /> }
 							title="Access our Entire Library of Premium Themes"
-							description="Professional site designs can be expensive, so we’ve negotiated deals on your behalf with many of the most prominent WordPress theme designers in the world. As a Business plan customer, you’ll gain access to our entire library of 197 premium site themes for no additional fee."
+							description="Professional site designs can be expensive, so we’ve negotiated deals on your behalf with many of the most prominent WordPress theme designers in the world. As a Business plan customer, you’ll gain access to our entire library of premium themes for no additional fee."
 						/>
 					</div>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the hard-coded number referring to the premium theme count.

#### Testing instructions

I'm not sured where it's used, but checking the phrasing should be enough. cc @lancewillett 

Fixes #40152
