### PR TITLE
Add/data stores methods for dealing with duplicate sites

### DIFF
--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -67,7 +67,7 @@ export const resetOnboardStore = () => ( {
 	type: 'RESET_ONBOARD_STORE' as const,
 } );
 
-export const setSelectedSite = ( selectedSite: string ) => ( {
+export const setSelectedSite = ( selectedSite: number ) => ( {
 	type: 'SET_SELECTED_SITE' as const,
 	selectedSite,
 } );

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -67,6 +67,11 @@ export const resetOnboardStore = () => ( {
 	type: 'RESET_ONBOARD_STORE' as const,
 } );
 
+export const setSelectedSite = ( selectedSite: string ) => ( {
+	type: 'SET_SELECTED_SITE' as const,
+	selectedSite,
+} );
+
 export function* createSite(
 	username: string,
 	freeDomainSuggestion?: DomainSuggestion,
@@ -119,6 +124,7 @@ export type OnboardAction = ReturnType<
 	| typeof setDomainSearch
 	| typeof setFonts
 	| typeof setSelectedDesign
+	| typeof setSelectedSite
 	| typeof setSiteTitle
 	| typeof setSiteVertical
 	| typeof togglePageLayout

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -31,6 +31,7 @@ registerStore< State >( STORE_KEY, {
 		'pageLayouts',
 		'selectedDesign',
 		'selectedFonts',
+		'selectedSite',
 	],
 } );
 

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -81,6 +81,19 @@ const pageLayouts: Reducer< string[], OnboardAction > = ( state = [], action ) =
 	return state;
 };
 
+const selectedSite: Reducer< string | undefined, OnboardAction > = (
+	state = undefined,
+	action
+) => {
+	if ( action.type === 'SET_SELECTED_SITE' ) {
+		return action.selectedSite;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return undefined;
+	}
+	return state;
+};
+
 const selectedFonts: Reducer< FontPair | undefined, OnboardAction > = (
 	state = undefined,
 	action
@@ -102,6 +115,7 @@ const reducer = combineReducers( {
 	siteTitle,
 	siteVertical,
 	pageLayouts,
+	selectedSite,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -81,7 +81,7 @@ const pageLayouts: Reducer< string[], OnboardAction > = ( state = [], action ) =
 	return state;
 };
 
-const selectedSite: Reducer< string | undefined, OnboardAction > = (
+const selectedSite: Reducer< number | undefined, OnboardAction > = (
 	state = undefined,
 	action
 ) => {

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -4,3 +4,4 @@
 import { State } from './reducer';
 
 export const getState = ( state: State ) => state;
+export const getSelectedSite = ( state: State ) => state.selectedSite;

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -1,7 +1,13 @@
 /**
  * Internal dependencies
  */
-import { CreateSiteParams, NewSiteErrorResponse, NewSiteSuccessResponse } from './types';
+import {
+	CreateSiteParams,
+	NewSiteErrorResponse,
+	NewSiteSuccessResponse,
+	ExistingSiteDetails,
+	ExistingSiteError,
+} from './types';
 import { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
 
@@ -57,18 +63,43 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		}
 	}
 
+	const receiveExistingSite = ( slug: string, response: ExistingSiteDetails | undefined ) => ( {
+		type: 'RECEIVE_EXISTING_SITE' as const,
+		slug,
+		response,
+	} );
+
+	const receiveExistingSiteFailed = ( slug: string, response: ExistingSiteError | undefined ) => ( {
+		type: 'RECEIVE_EXISTING_SITE_FAILED' as const,
+		slug,
+		response,
+	} );
+
+	const reset = () => ( {
+		type: 'RESET_SITE_STORE' as const,
+	} );
+
 	return {
 		fetchNewSite,
 		receiveNewSite,
 		receiveNewSiteFailed,
 		createSite,
+		receiveExistingSite,
+		receiveExistingSiteFailed,
+		reset,
 	};
 }
 
-type ActionCreators = ReturnType< typeof createActions >;
+export type ActionCreators = ReturnType< typeof createActions >;
 
-export type Action = ReturnType<
-	| ActionCreators[ 'fetchNewSite' ]
-	| ActionCreators[ 'receiveNewSite' ]
-	| ActionCreators[ 'receiveNewSiteFailed' ]
->;
+export type Action =
+	| ReturnType<
+			| ActionCreators[ 'fetchNewSite' ]
+			| ActionCreators[ 'receiveNewSite' ]
+			| ActionCreators[ 'receiveNewSiteFailed' ]
+			| ActionCreators[ 'receiveExistingSite' ]
+			| ActionCreators[ 'receiveExistingSiteFailed' ]
+			| ActionCreators[ 'reset' ]
+	  >
+	// Type added so we can dispatch actions in tests, but has no runtime cost
+	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -5,8 +5,8 @@ import {
 	CreateSiteParams,
 	NewSiteErrorResponse,
 	NewSiteSuccessResponse,
-	ExistingSiteDetails,
-	ExistingSiteError,
+	SiteDetails,
+	SiteError,
 } from './types';
 import { WpcomClientCredentials } from '../shared-types';
 import { wpcomRequest } from '../wpcom-request-controls';
@@ -63,15 +63,15 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		}
 	}
 
-	const receiveExistingSite = ( slug: string, response: ExistingSiteDetails | undefined ) => ( {
-		type: 'RECEIVE_EXISTING_SITE' as const,
-		slug,
+	const receiveSite = ( siteId: number, response: SiteDetails | undefined ) => ( {
+		type: 'RECEIVE_SITE' as const,
+		siteId,
 		response,
 	} );
 
-	const receiveExistingSiteFailed = ( slug: string, response: ExistingSiteError | undefined ) => ( {
-		type: 'RECEIVE_EXISTING_SITE_FAILED' as const,
-		slug,
+	const receiveSiteFailed = ( siteId: number, response: SiteError | undefined ) => ( {
+		type: 'RECEIVE_SITE_FAILED' as const,
+		siteId,
 		response,
 	} );
 
@@ -84,8 +84,8 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		receiveNewSite,
 		receiveNewSiteFailed,
 		createSite,
-		receiveExistingSite,
-		receiveExistingSiteFailed,
+		receiveSite,
+		receiveSiteFailed,
 		reset,
 	};
 }
@@ -97,8 +97,8 @@ export type Action =
 			| ActionCreators[ 'fetchNewSite' ]
 			| ActionCreators[ 'receiveNewSite' ]
 			| ActionCreators[ 'receiveNewSiteFailed' ]
-			| ActionCreators[ 'receiveExistingSite' ]
-			| ActionCreators[ 'receiveExistingSiteFailed' ]
+			| ActionCreators[ 'receiveSite' ]
+			| ActionCreators[ 'receiveSiteFailed' ]
 			| ActionCreators[ 'reset' ]
 	  >
 	// Type added so we can dispatch actions in tests, but has no runtime cost

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -9,10 +9,12 @@ import { registerStore } from '@wordpress/data';
 import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import { createActions } from './actions';
+import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { WpcomClientCredentials } from '../shared-types';
 import { controls } from '../wpcom-request-controls';
+import { MetadataDispatch, MetadataSelect } from './types';
 
 export * from './types';
 export { State };
@@ -25,6 +27,7 @@ export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KE
 			actions: createActions( clientCreds ),
 			controls: controls as any,
 			reducer,
+			resolvers,
 			selectors,
 		} );
 	}
@@ -32,6 +35,8 @@ export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KE
 }
 
 declare module '@wordpress/data' {
-	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< ReturnType< typeof createActions > >;
-	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+	function dispatch(
+		key: typeof STORE_KEY
+	): DispatchFromMap< ReturnType< typeof createActions > > & MetadataDispatch;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors > & MetadataSelect;
 }

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -14,7 +14,6 @@ import * as selectors from './selectors';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { WpcomClientCredentials } from '../shared-types';
 import { controls } from '../wpcom-request-controls';
-import { MetadataDispatch, MetadataSelect } from './types';
 
 export * from './types';
 export { State };
@@ -35,8 +34,6 @@ export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KE
 }
 
 declare module '@wordpress/data' {
-	function dispatch(
-		key: typeof STORE_KEY
-	): DispatchFromMap< ReturnType< typeof createActions > > & MetadataDispatch;
-	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors > & MetadataSelect;
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< ReturnType< typeof createActions > >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
 }

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -7,24 +7,29 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { NewSiteBlogDetails, NewSiteErrorResponse } from './types';
+import { NewSiteBlogDetails, NewSiteErrorResponse, ExistingSiteDetails } from './types';
 import { Action } from './actions';
 
-const newSiteData: Reducer< NewSiteBlogDetails | undefined, Action > = ( state, action ) => {
+export const newSiteData: Reducer< NewSiteBlogDetails | undefined, Action > = ( state, action ) => {
 	if ( action.type === 'RECEIVE_NEW_SITE' ) {
 		const { response } = action;
 		return response.blog_details;
 	} else if ( action.type === 'RECEIVE_NEW_SITE_FAILED' ) {
 		return undefined;
+	} else if ( action.type === 'RESET_SITE_STORE' ) {
+		return undefined;
 	}
 	return state;
 };
 
-const newSiteError: Reducer< NewSiteErrorResponse | undefined, Action > = ( state, action ) => {
+export const newSiteError: Reducer< NewSiteErrorResponse | undefined, Action > = (
+	state,
+	action
+) => {
 	switch ( action.type ) {
 		case 'FETCH_NEW_SITE':
-			return undefined;
 		case 'RECEIVE_NEW_SITE':
+		case 'RESET_SITE_STORE':
 			return undefined;
 		case 'RECEIVE_NEW_SITE_FAILED':
 			return {
@@ -38,14 +43,29 @@ const newSiteError: Reducer< NewSiteErrorResponse | undefined, Action > = ( stat
 	return state;
 };
 
-const isFetchingSite: Reducer< boolean | undefined, Action > = ( state = false, action ) => {
+export const isFetchingSite: Reducer< boolean | undefined, Action > = ( state = false, action ) => {
 	switch ( action.type ) {
 		case 'FETCH_NEW_SITE':
 			return true;
 		case 'RECEIVE_NEW_SITE':
-			return false;
 		case 'RECEIVE_NEW_SITE_FAILED':
+		case 'RESET_SITE_STORE':
 			return false;
+	}
+	return state;
+};
+
+export const existingSite: Reducer<
+	{ [ key: string ]: ExistingSiteDetails | undefined },
+	Action
+> = ( state = {}, action ) => {
+	if ( action.type === 'RECEIVE_EXISTING_SITE' ) {
+		return { ...state, [ action.slug ]: action.response };
+	} else if ( action.type === 'RECEIVE_EXISTING_SITE_FAILED' ) {
+		const { [ action.slug ]: slugToBeRemoved, ...remainingState } = state;
+		return { ...remainingState };
+	} else if ( action.type === 'RESET_SITE_STORE' ) {
+		return {};
 	}
 	return state;
 };
@@ -56,7 +76,7 @@ const newSite = combineReducers( {
 	isFetching: isFetchingSite,
 } );
 
-const reducer = combineReducers( { newSite } );
+const reducer = combineReducers( { newSite, existingSite } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -55,7 +55,7 @@ export const isFetchingSite: Reducer< boolean | undefined, Action > = ( state = 
 	return state;
 };
 
-export const sites: Reducer< { [ key: string ]: SiteDetails | undefined }, Action > = (
+export const sites: Reducer< { [ key: number ]: SiteDetails | undefined }, Action > = (
 	state = {},
 	action
 ) => {

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -7,7 +7,7 @@ import { combineReducers } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { NewSiteBlogDetails, NewSiteErrorResponse, ExistingSiteDetails } from './types';
+import { NewSiteBlogDetails, NewSiteErrorResponse, SiteDetails } from './types';
 import { Action } from './actions';
 
 export const newSiteData: Reducer< NewSiteBlogDetails | undefined, Action > = ( state, action ) => {
@@ -55,14 +55,14 @@ export const isFetchingSite: Reducer< boolean | undefined, Action > = ( state = 
 	return state;
 };
 
-export const existingSite: Reducer<
-	{ [ key: string ]: ExistingSiteDetails | undefined },
-	Action
-> = ( state = {}, action ) => {
-	if ( action.type === 'RECEIVE_EXISTING_SITE' ) {
-		return { ...state, [ action.slug ]: action.response };
-	} else if ( action.type === 'RECEIVE_EXISTING_SITE_FAILED' ) {
-		const { [ action.slug ]: slugToBeRemoved, ...remainingState } = state;
+export const sites: Reducer< { [ key: string ]: SiteDetails | undefined }, Action > = (
+	state = {},
+	action
+) => {
+	if ( action.type === 'RECEIVE_SITE' ) {
+		return { ...state, [ action.siteId ]: action.response };
+	} else if ( action.type === 'RECEIVE_SITE_FAILED' ) {
+		const { [ action.siteId ]: idToBeRemoved, ...remainingState } = state;
 		return { ...remainingState };
 	} else if ( action.type === 'RESET_SITE_STORE' ) {
 		return {};
@@ -76,7 +76,7 @@ const newSite = combineReducers( {
 	isFetching: isFetchingSite,
 } );
 
-const reducer = combineReducers( { newSite, existingSite } );
+const reducer = combineReducers( { newSite, sites } );
 
 export type State = ReturnType< typeof reducer >;
 

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { wpcomRequest } from '../wpcom-request-controls';
+import { STORE_KEY } from './constants';
+
+/**
+ * Attempt to find an existing site based on its domain, and if not return undefined.
+ * We are currently ignoring error messages and silently failing if we can't find an
+ * existing site. This could be extended in the future by retrieving the `error` and
+ * `message` strings returned by the API.
+ *
+ * @param slug {string}	The domain to search for
+ */
+export function* getSite( slug: string ) {
+	try {
+		const existingSite = yield wpcomRequest( {
+			path: '/sites/' + encodeURIComponent( slug ),
+			apiVersion: '1.1',
+		} );
+		yield dispatch( STORE_KEY ).receiveExistingSite( slug, existingSite );
+	} catch ( err ) {
+		yield dispatch( STORE_KEY ).receiveExistingSiteFailed( slug, undefined );
+	}
+}

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -10,21 +10,21 @@ import { wpcomRequest } from '../wpcom-request-controls';
 import { STORE_KEY } from './constants';
 
 /**
- * Attempt to find an existing site based on its domain, and if not return undefined.
- * We are currently ignoring error messages and silently failing if we can't find an
- * existing site. This could be extended in the future by retrieving the `error` and
+ * Attempt to find a site based on its id, and if not return undefined.
+ * We are currently ignoring error messages and silently failing if we can't find a
+ * site. This could be extended in the future by retrieving the `error` and
  * `message` strings returned by the API.
  *
- * @param slug {string}	The domain to search for
+ * @param siteId {number}	The site to look up
  */
-export function* getSite( slug: string ) {
+export function* getSite( siteId: number ) {
 	try {
 		const existingSite = yield wpcomRequest( {
-			path: '/sites/' + encodeURIComponent( slug ),
+			path: '/sites/' + encodeURIComponent( siteId ),
 			apiVersion: '1.1',
 		} );
-		yield dispatch( STORE_KEY ).receiveExistingSite( slug, existingSite );
+		yield dispatch( STORE_KEY ).receiveSite( siteId, existingSite );
 	} catch ( err ) {
-		yield dispatch( STORE_KEY ).receiveExistingSiteFailed( slug, undefined );
+		yield dispatch( STORE_KEY ).receiveSiteFailed( siteId, undefined );
 	}
 }

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -2,6 +2,8 @@
  * Internal dependencies
  */
 import { State } from './reducer';
+import { dispatch } from '@wordpress/data';
+import { STORE_KEY } from './constants';
 
 export const getState = ( state: State ) => state;
 
@@ -9,3 +11,19 @@ export const getNewSite = ( state: State ) => state.newSite.data;
 export const getNewSiteError = ( state: State ) => state.newSite.error;
 export const isFetchingSite = ( state: State ) => state.newSite.isFetching;
 export const isNewSite = ( state: State ) => !! state.newSite.data;
+
+/**
+ * Get an existing site matched by domain string. This selector has a matching
+ * resolver that uses the `slug` parameter to fetch an existing site. If the
+ * existingSite cannot be found, invalidate the resolution cache.
+ *
+ * @param state {State}		state object
+ * @param slug {string}		domain string
+ */
+export const getSite = ( state: State, slug: string ) => {
+	const existingSite = state.existingSite[ slug ];
+	if ( ! existingSite ) {
+		dispatch( STORE_KEY ).invalidateResolution( 'getSite', [ slug ] );
+	}
+	return existingSite;
+};

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -13,17 +13,17 @@ export const isFetchingSite = ( state: State ) => state.newSite.isFetching;
 export const isNewSite = ( state: State ) => !! state.newSite.data;
 
 /**
- * Get an existing site matched by domain string. This selector has a matching
- * resolver that uses the `slug` parameter to fetch an existing site. If the
- * existingSite cannot be found, invalidate the resolution cache.
+ * Get a site matched by id. This selector has a matching
+ * resolver that uses the `siteId` parameter to fetch an existing site. If the
+ * site cannot be found, invalidate the resolution cache.
  *
  * @param state {State}		state object
- * @param slug {string}		domain string
+ * @param siteId {number}	id of the site to look up
  */
-export const getSite = ( state: State, slug: string ) => {
-	const existingSite = state.existingSite[ slug ];
-	if ( ! existingSite ) {
-		dispatch( 'core/data' ).invalidateResolution( STORE_KEY, 'getSite', [ slug ] );
+export const getSite = ( state: State, siteId: number ) => {
+	const site = state.sites[ siteId ];
+	if ( ! site ) {
+		dispatch( 'core/data' ).invalidateResolution( STORE_KEY, 'getSite', [ siteId ] );
 	}
-	return existingSite;
+	return site;
 };

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -23,7 +23,7 @@ export const isNewSite = ( state: State ) => !! state.newSite.data;
 export const getSite = ( state: State, slug: string ) => {
 	const existingSite = state.existingSite[ slug ];
 	if ( ! existingSite ) {
-		dispatch( STORE_KEY ).invalidateResolution( 'getSite', [ slug ] );
+		dispatch( 'core/data' ).invalidateResolution( STORE_KEY, 'getSite', [ slug ] );
 	}
 	return existingSite;
 };

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -1,0 +1,63 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { existingSite } from '../reducer';
+import { createActions } from '../actions';
+import { ExistingSiteDetails, ExistingSiteError } from '../types';
+
+const { receiveExistingSite, receiveExistingSiteFailed } = createActions( {
+	client_id: '',
+	client_secret: '',
+} );
+
+describe( 'existingSite', () => {
+	const existingSiteDetails: ExistingSiteDetails = {
+		ID: 1,
+		name: 'My test site',
+		description: '',
+		URL: 'http://mytestsite12345.wordpress.com',
+	};
+
+	const existingSiteError: ExistingSiteError = {
+		error: 'unknown_blog',
+		message: 'Unknown blog',
+	};
+
+	it( 'returns the correct default state', () => {
+		const state = existingSite( undefined, { type: 'TEST_ACTION' } );
+		expect( state ).toEqual( {} );
+	} );
+
+	it( 'returns site data keyed by slug', () => {
+		const state = existingSite(
+			undefined,
+			receiveExistingSite( 'mytestsite12345.wordpress.com', existingSiteDetails )
+		);
+		expect( state ).toEqual( {
+			'mytestsite12345.wordpress.com': existingSiteDetails,
+		} );
+	} );
+
+	it( 'clears existing data keyed by slug, and no other data is affected', () => {
+		const originalState = {
+			'mytestsite12345.wordpress.com': existingSiteDetails,
+			'myothertestsite12345.wordpress.com': existingSiteDetails,
+		};
+		const updatedState = existingSite(
+			originalState,
+			receiveExistingSiteFailed( 'myothertestsite12345.wordpress.com', existingSiteError )
+		);
+
+		expect( updatedState ).toEqual( {
+			'mytestsite12345.wordpress.com': existingSiteDetails,
+		} );
+	} );
+} );

--- a/packages/data-stores/src/site/test/reducer.ts
+++ b/packages/data-stores/src/site/test/reducer.ts
@@ -9,55 +9,51 @@
 /**
  * Internal dependencies
  */
-import { existingSite } from '../reducer';
-import { createActions } from '../actions';
-import { ExistingSiteDetails, ExistingSiteError } from '../types';
+import { sites } from '../reducer';
+import { SiteDetails, SiteError } from '../types';
 
-const { receiveExistingSite, receiveExistingSiteFailed } = createActions( {
-	client_id: '',
-	client_secret: '',
-} );
-
-describe( 'existingSite', () => {
-	const existingSiteDetails: ExistingSiteDetails = {
-		ID: 1,
+describe( 'Site', () => {
+	const siteDetailsResponse: SiteDetails = {
+		ID: 12345,
 		name: 'My test site',
 		description: '',
 		URL: 'http://mytestsite12345.wordpress.com',
 	};
 
-	const existingSiteError: ExistingSiteError = {
+	const siteErrorResponse: SiteError = {
 		error: 'unknown_blog',
 		message: 'Unknown blog',
 	};
 
 	it( 'returns the correct default state', () => {
-		const state = existingSite( undefined, { type: 'TEST_ACTION' } );
+		const state = sites( undefined, { type: 'TEST_ACTION' } );
 		expect( state ).toEqual( {} );
 	} );
 
-	it( 'returns site data keyed by slug', () => {
-		const state = existingSite(
-			undefined,
-			receiveExistingSite( 'mytestsite12345.wordpress.com', existingSiteDetails )
-		);
+	it( 'returns site data keyed by id', () => {
+		const state = sites( undefined, {
+			type: 'RECEIVE_SITE',
+			siteId: 12345,
+			response: siteDetailsResponse,
+		} );
 		expect( state ).toEqual( {
-			'mytestsite12345.wordpress.com': existingSiteDetails,
+			12345: siteDetailsResponse,
 		} );
 	} );
 
-	it( 'clears existing data keyed by slug, and no other data is affected', () => {
+	it( 'clears data keyed by id, and no other data is affected', () => {
 		const originalState = {
-			'mytestsite12345.wordpress.com': existingSiteDetails,
-			'myothertestsite12345.wordpress.com': existingSiteDetails,
+			12345: siteDetailsResponse,
+			23456: siteDetailsResponse,
 		};
-		const updatedState = existingSite(
-			originalState,
-			receiveExistingSiteFailed( 'myothertestsite12345.wordpress.com', existingSiteError )
-		);
+		const updatedState = sites( originalState, {
+			type: 'RECEIVE_SITE_FAILED',
+			siteId: 23456,
+			response: siteErrorResponse,
+		} );
 
 		expect( updatedState ).toEqual( {
-			'mytestsite12345.wordpress.com': existingSiteDetails,
+			12345: siteDetailsResponse,
 		} );
 	} );
 } );

--- a/packages/data-stores/src/site/test/resolvers.ts
+++ b/packages/data-stores/src/site/test/resolvers.ts
@@ -1,0 +1,72 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getSite } from '../resolvers';
+import { register } from '../';
+
+beforeAll( () => {
+	register( { client_id: '', client_secret: '' } );
+} );
+
+describe( 'getSite', () => {
+	it( 'should return a receiveExistingSite action object on success', async () => {
+		const slug = 'mytestsite12345.wordpress.com';
+		const apiResponse = {
+			ID: 1,
+			name: 'My test site',
+			description: '',
+			URL: 'http://mytestsite12345.wordpress.com',
+		};
+
+		const generator = getSite( slug );
+
+		expect( generator.next().value ).toEqual( {
+			type: 'WPCOM_REQUEST',
+			request: expect.objectContaining( {
+				path: `/sites/${ slug }`,
+			} ),
+		} );
+
+		expect( await generator.next( apiResponse ).value ).toEqual( {
+			type: 'RECEIVE_EXISTING_SITE',
+			slug,
+			response: apiResponse,
+		} );
+
+		expect( generator.next().done ).toBe( true );
+	} );
+
+	it( 'should return a receiveExistingSiteFailed action object on fail', async () => {
+		const slug = 'mytestsite12345.wordpress.com';
+		const apiResponse = {
+			status: 404,
+			error: 'unknown_blog',
+			message: 'Unknown blog',
+		};
+
+		const generator = getSite( slug );
+
+		expect( generator.next().value ).toEqual( {
+			type: 'WPCOM_REQUEST',
+			request: expect.objectContaining( {
+				path: `/sites/${ slug }`,
+			} ),
+		} );
+
+		expect( await generator.throw( apiResponse ).value ).toEqual( {
+			type: 'RECEIVE_EXISTING_SITE_FAILED',
+			slug,
+			response: undefined,
+		} );
+
+		expect( generator.next().done ).toBe( true );
+	} );
+} );

--- a/packages/data-stores/src/site/test/resolvers.ts
+++ b/packages/data-stores/src/site/test/resolvers.ts
@@ -18,7 +18,7 @@ beforeAll( () => {
 
 describe( 'getSite', () => {
 	it( 'should return a receiveExistingSite action object on success', async () => {
-		const slug = 'mytestsite12345.wordpress.com';
+		const siteId = 123456;
 		const apiResponse = {
 			ID: 1,
 			name: 'My test site',
@@ -26,18 +26,18 @@ describe( 'getSite', () => {
 			URL: 'http://mytestsite12345.wordpress.com',
 		};
 
-		const generator = getSite( slug );
+		const generator = getSite( siteId );
 
 		expect( generator.next().value ).toEqual( {
 			type: 'WPCOM_REQUEST',
 			request: expect.objectContaining( {
-				path: `/sites/${ slug }`,
+				path: `/sites/${ siteId }`,
 			} ),
 		} );
 
 		expect( await generator.next( apiResponse ).value ).toEqual( {
-			type: 'RECEIVE_EXISTING_SITE',
-			slug,
+			type: 'RECEIVE_SITE',
+			siteId,
 			response: apiResponse,
 		} );
 
@@ -45,25 +45,25 @@ describe( 'getSite', () => {
 	} );
 
 	it( 'should return a receiveExistingSiteFailed action object on fail', async () => {
-		const slug = 'mytestsite12345.wordpress.com';
+		const siteId = 12345;
 		const apiResponse = {
 			status: 404,
 			error: 'unknown_blog',
 			message: 'Unknown blog',
 		};
 
-		const generator = getSite( slug );
+		const generator = getSite( siteId );
 
 		expect( generator.next().value ).toEqual( {
 			type: 'WPCOM_REQUEST',
 			request: expect.objectContaining( {
-				path: `/sites/${ slug }`,
+				path: `/sites/${ siteId }`,
 			} ),
 		} );
 
 		expect( await generator.throw( apiResponse ).value ).toEqual( {
-			type: 'RECEIVE_EXISTING_SITE_FAILED',
-			slug,
+			type: 'RECEIVE_SITE_FAILED',
+			siteId,
 			response: undefined,
 		} );
 

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -1,0 +1,118 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { dispatch, select, subscribe } from '@wordpress/data';
+import wpcomRequest from 'wpcom-proxy-request';
+
+/**
+ * Internal dependencies
+ */
+import { register } from '..';
+import { STORE_KEY } from '../constants';
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	requestAllBlogsAccess: jest.fn( () => Promise.resolve() ),
+} ) );
+
+let store: ReturnType< typeof register >;
+
+beforeAll( () => {
+	store = register( { client_id: '', client_secret: '' } );
+} );
+
+beforeEach( () => {
+	( wpcomRequest as jest.Mock ).mockReset();
+	dispatch( store ).reset();
+} );
+
+describe( 'getSite', () => {
+	it( 'resolves the state via an API call and caches the resolver on success', async () => {
+		const slug = 'mytestsite12345.wordpress.com';
+		const apiResponse = {
+			ID: 1,
+			name: 'My test site',
+			description: '',
+			URL: 'http://mytestsite12345.wordpress.com',
+		};
+
+		( wpcomRequest as jest.Mock ).mockResolvedValue( apiResponse );
+
+		const listenForStateUpdate = () => {
+			return new Promise( resolve => {
+				const unsubscribe = subscribe( () => {
+					unsubscribe();
+					resolve();
+				} );
+			} );
+		};
+
+		// First call returns undefined
+		expect( select( store ).getSite( slug ) ).toEqual( undefined );
+		await listenForStateUpdate();
+
+		// By the second call, the resolver will have resolved
+		expect( select( store ).getSite( slug ) ).toEqual( apiResponse );
+		await listenForStateUpdate();
+
+		// The resolver should now be cached with an `isStarting` value of false
+
+		expect( select( store ).getIsResolving( 'getSite', [ slug ] ) ).toStrictEqual( false );
+	} );
+
+	it( 'resolves the state via an API call and invalidates the resolver cache on fail', async () => {
+		const slug = 'mytestsite12345.wordpress.com';
+		const apiResponse = {
+			status: 404,
+			error: 'unknown_blog',
+			message: 'Unknown blog',
+		};
+
+		( wpcomRequest as jest.Mock ).mockRejectedValue( apiResponse );
+		const spy = jest.spyOn( dispatch( STORE_KEY ), 'invalidateResolution' );
+		spy.mockClear();
+
+		const listenForStateUpdate = () => {
+			// The subscribe function in wordpress/data stores only updates when state changes,
+			// so for this test (where state remains the same), use setTimeout instead.
+			return new Promise( resolve => {
+				setTimeout( () => {
+					resolve();
+				}, 0 );
+			} );
+		};
+
+		// After the first call, the resolver's cache will be invalidated
+		expect( select( store ).getSite( slug ) ).toEqual( undefined );
+		await listenForStateUpdate();
+
+		expect( select( store ).getIsResolving( 'getSite', [ slug ] ) ).toStrictEqual( undefined );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( spy ).toHaveBeenCalledWith( 'getSite', [ slug ] );
+
+		// After the second call, the resolver's cache will be valid
+		expect( select( store ).getSite( slug ) ).toEqual( undefined );
+		await listenForStateUpdate();
+
+		expect( select( store ).getIsResolving( 'getSite', [ slug ] ) ).toStrictEqual( false );
+		expect( spy ).toHaveBeenCalledTimes( 2 );
+
+		// After the third call, the resolver's cache will be invalidated again
+		expect( select( store ).getSite( slug ) ).toEqual( undefined );
+		await listenForStateUpdate();
+
+		// The resolver should now be cached with an `isStarting` value of false
+		expect( select( store ).getIsResolving( 'getSite', [ slug ] ) ).toStrictEqual( undefined );
+		expect( spy ).toHaveBeenCalledTimes( 3 );
+		spy.mockClear();
+	} );
+} );

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -16,7 +16,6 @@ import wpcomRequest from 'wpcom-proxy-request';
  * Internal dependencies
  */
 import { register } from '..';
-import { STORE_KEY } from '../constants';
 
 jest.mock( 'wpcom-proxy-request', () => ( {
 	__esModule: true,
@@ -66,7 +65,9 @@ describe( 'getSite', () => {
 
 		// The resolver should now be cached with an `isStarting` value of false
 
-		expect( select( store ).getIsResolving( 'getSite', [ slug ] ) ).toStrictEqual( false );
+		expect( select( 'core/data' ).getIsResolving( store, 'getSite', [ slug ] ) ).toStrictEqual(
+			false
+		);
 	} );
 
 	it( 'resolves the state via an API call and invalidates the resolver cache on fail', async () => {
@@ -78,8 +79,6 @@ describe( 'getSite', () => {
 		};
 
 		( wpcomRequest as jest.Mock ).mockRejectedValue( apiResponse );
-		const spy = jest.spyOn( dispatch( STORE_KEY ), 'invalidateResolution' );
-		spy.mockClear();
 
 		const listenForStateUpdate = () => {
 			// The subscribe function in wordpress/data stores only updates when state changes,
@@ -95,24 +94,25 @@ describe( 'getSite', () => {
 		expect( select( store ).getSite( slug ) ).toEqual( undefined );
 		await listenForStateUpdate();
 
-		expect( select( store ).getIsResolving( 'getSite', [ slug ] ) ).toStrictEqual( undefined );
-		expect( spy ).toHaveBeenCalledTimes( 1 );
-		expect( spy ).toHaveBeenCalledWith( 'getSite', [ slug ] );
+		expect( select( 'core/data' ).getIsResolving( store, 'getSite', [ slug ] ) ).toStrictEqual(
+			undefined
+		);
 
 		// After the second call, the resolver's cache will be valid
 		expect( select( store ).getSite( slug ) ).toEqual( undefined );
 		await listenForStateUpdate();
 
-		expect( select( store ).getIsResolving( 'getSite', [ slug ] ) ).toStrictEqual( false );
-		expect( spy ).toHaveBeenCalledTimes( 2 );
+		expect( select( 'core/data' ).getIsResolving( store, 'getSite', [ slug ] ) ).toStrictEqual(
+			false
+		);
 
 		// After the third call, the resolver's cache will be invalidated again
 		expect( select( store ).getSite( slug ) ).toEqual( undefined );
 		await listenForStateUpdate();
 
 		// The resolver should now be cached with an `isStarting` value of false
-		expect( select( store ).getIsResolving( 'getSite', [ slug ] ) ).toStrictEqual( undefined );
-		expect( spy ).toHaveBeenCalledTimes( 3 );
-		spy.mockClear();
+		expect( select( 'core/data' ).getIsResolving( store, 'getSite', [ slug ] ) ).toStrictEqual(
+			undefined
+		);
 	} );
 } );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -48,3 +48,28 @@ export interface CreateSiteParams {
 		font_base?: string;
 	};
 }
+
+export interface ExistingSiteDetails {
+	ID: number;
+	name: string;
+	description: string;
+	URL: string;
+}
+
+export interface ExistingSiteError {
+	error: string;
+	message: string;
+}
+
+export type ExistingSiteResponse = ExistingSiteDetails | ExistingSiteError;
+
+export type MetadataDispatch = {
+	invalidateResolution: (
+		selectorName: string,
+		args: Array< any >
+	) => { type: string; selectorName: string; args: any };
+};
+
+export type MetadataSelect = {
+	getIsResolving: ( selectorName: string, args: Array< any > ) => boolean | undefined;
+};

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -49,16 +49,16 @@ export interface CreateSiteParams {
 	};
 }
 
-export interface ExistingSiteDetails {
+export interface SiteDetails {
 	ID: number;
 	name: string;
 	description: string;
 	URL: string;
 }
 
-export interface ExistingSiteError {
+export interface SiteError {
 	error: string;
 	message: string;
 }
 
-export type ExistingSiteResponse = ExistingSiteDetails | ExistingSiteError;
+export type SiteResponse = SiteDetails | SiteError;

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -62,14 +62,3 @@ export interface ExistingSiteError {
 }
 
 export type ExistingSiteResponse = ExistingSiteDetails | ExistingSiteError;
-
-export type MetadataDispatch = {
-	invalidateResolution: (
-		selectorName: string,
-		args: Array< any >
-	) => { type: string; selectorName: string; args: any };
-};
-
-export type MetadataSelect = {
-	getIsResolving: ( selectorName: string, args: Array< any > ) => boolean | undefined;
-};


### PR DESCRIPTION
Adds in a `getSite` selector and resolver to the `site` data store for fetching details about an existing site, and also adds a selectedSite reducer to the `onboard` store.

This PR splits out changes to the data stores from PR #39794 so that this PR is just about adding the ability to deal with duplicate sites, but doesn't implement a solution yet. The goal here is to advance our ability to deal with potential duplicate sites while the discussion on how best to do so continues separately.

Broadly, the behaviour this PR enables is to store a string of the domain slug for a site that's just been created (setting it to be the `selectedSite` after resetting the onboard store), and perform an API call to see if that site exists and is accessible to the current user when a user returns to the Gutenboarding flow (more discussion of a potential approach in [the comments](https://github.com/Automattic/wp-calypso/pull/40158#issuecomment-603689686) below).

#### Changes proposed in this Pull Request

* Add `getSite` selector and resolver to the `site` data store, to fetch an existing site by slug (domain).
* Automatically invalidate resolver cache for the `getSite` selector if there is no value, so that failed network requests etc don't leave an existing site "stuck" in an empty state.
* Add `selectedSite` reducer to onboard store, for storing a simple string (slug of the site's domain).

Note that this PR incorporates using a couple of the metadata methods in the `core/data` package, which are proxied in to our stores. In this case I've added `invalidateResolution` and `getIsResolved` and added simple types for these methods for the `site` store. Longer term, we might want to add in the remaining selectors and actions to our type definitions.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run tests from the command line (probably don't need to do this manually as they're covered in CI):

```
npm run test-packages ./packages/data-stores/src/site/test/
```

##### Test the `getSite` selector

1. Create a private site (or use an existing one)
2. While logged in go to http://calypso.localhost:3000/gutenboarding
3. Open up the console and enter the following:

```
console.log( wp.data.select( 'automattic/site' ).getSite( 'myfakesite.movie.blog' ) );
```

The first time you run this, it should log `undefined`, and you should see a network request to fetch the site details.
4. Run the line above again, and it should log the site object.
5. Continue to call this, and it should display the same data, and it shouldn't create additonal network requests. 

##### Test the `getSite` selector cache invalidation

Observe that calling `getSite` repeatedly when the network request fails for some reason (404, etc) will trigger a network request every _second_ time it's called.

1. Using the same private site, open an inCognito / private browsing window and navigate to http://calypso.localhost:3000/gutenboarding
2. Enter the same line as above into the console.
3. The first time you run this, it should log `undefined`, and you should see a network request to fetch the site details.
4. The second time you run this, it should return `undefined` and there won't be another network request.
5. The third time you run this (or every _other_ time), it should return `undefined` and there will be another network request.

##### Test the onboard store methods

Test that the changes to the onboard store work as expected:

1. Navigate to `http://calypso.localhost:3000/gutenboarding`
2. Pass in a fake last created site `slug` to the `setSelectedSite` action:

```
wp.data.dispatch( 'automattic/onboard' ).setSelectedSite( 'myfakesite.movie.blog' );
```

3. Check that this string is returned from the matching selector:

```
console.log( wp.data.select( 'automattic/onboard' ).getSelectedSite() );
```

Related to #39268
