### PR TITLE
Adds missing dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,12 +264,12 @@
 		"@automattic/composite-checkout": {
 			"version": "file:packages/composite-checkout",
 			"requires": {
+				"@babel/runtime": "^7.8.4",
 				"@emotion/core": "^10.0.27",
 				"@emotion/styled": "^10.0.27",
 				"@wordpress/i18n": "^3.9.0",
 				"debug": "^4.1.1",
 				"emotion-theming": "^10.0.27",
-				"interpolate-components": "^1.1.1",
 				"prop-types": "^15.7.2",
 				"react-stripe-elements": "4.0.2"
 			},
@@ -287,14 +287,14 @@
 		"@automattic/composite-checkout-wpcom": {
 			"version": "file:packages/composite-checkout-wpcom",
 			"requires": {
+				"@automattic/calypso-polyfills": "file:packages/calypso-polyfills",
 				"@automattic/composite-checkout": "file:packages/composite-checkout",
 				"@emotion/core": "^10.0.27",
 				"@emotion/styled": "^10.0.27",
 				"debug": "^4.1.1",
 				"emotion-theming": "^10.0.27",
 				"i18n-calypso": "file:packages/i18n-calypso",
-				"prop-types": "^15.7.2",
-				"react-stripe-elements": "^5.1.0"
+				"prop-types": "^15.7.2"
 			}
 		},
 		"@automattic/data-stores": {
@@ -302,7 +302,6 @@
 			"requires": {
 				"@wordpress/data-controls": "^1.4.0",
 				"@wordpress/url": "^2.8.2",
-				"debug": "^4.1.1",
 				"fast-json-stable-stringify": "^2.1.0",
 				"qs": "^6.9.1",
 				"redux": "^4.0.4",
@@ -460,6 +459,7 @@
 		"@automattic/format-currency": {
 			"version": "file:packages/format-currency",
 			"requires": {
+				"@babel/runtime": "^7.8.4",
 				"i18n-calypso": "file:packages/i18n-calypso"
 			}
 		},
@@ -558,6 +558,7 @@
 			"version": "file:packages/viewport-react",
 			"requires": {
 				"@automattic/viewport": "file:packages/viewport",
+				"@babel/runtime": "^7.8.4",
 				"@wordpress/compose": "^3.7.0"
 			}
 		},
@@ -20359,6 +20360,7 @@
 		"i18n-calypso": {
 			"version": "file:packages/i18n-calypso",
 			"requires": {
+				"@babel/runtime": "^7.8.4",
 				"@tannin/sprintf": "^1.1.0",
 				"@wordpress/compose": "^3.7.2",
 				"debug": "^4.0.0",
@@ -31798,6 +31800,7 @@
 		"photon": {
 			"version": "file:packages/photon",
 			"requires": {
+				"@babel/runtime": "^7.8.4",
 				"crc32": "0.2.2",
 				"debug": "^4.0.0",
 				"seed-random": "2.2.0"
@@ -36530,14 +36533,6 @@
 			"requires": {
 				"@babel/runtime": "^7.3.1",
 				"prop-types": "^15.5.8"
-			}
-		},
-		"react-stripe-elements": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-5.1.0.tgz",
-			"integrity": "sha512-4UlzOLNdbJsZr4JwbTdJjxhedAfalDDtfEYLHEBo0MKG0KgSLRAeIJup0/6NSpKtBLK4ieOMAwvyln9ICOSilQ==",
-			"requires": {
-				"prop-types": "15.7.2"
 			}
 		},
 		"react-syntax-highlighter": {
@@ -44317,6 +44312,7 @@
 		"wpcom-proxy-request": {
 			"version": "file:packages/wpcom-proxy-request",
 			"requires": {
+				"@babel/runtime": "^7.8.4",
 				"debug": "^4.1.1",
 				"progress-event": "^1.0.0",
 				"uuid": "^7.0.1",

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -36,14 +36,14 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/composite-checkout-wpcom#readme",
 	"dependencies": {
+		"@automattic/calypso-polyfills": "file:../calypso-polyfills",
 		"@automattic/composite-checkout": "file:../composite-checkout",
 		"@emotion/core": "^10.0.27",
 		"@emotion/styled": "^10.0.27",
 		"debug": "^4.1.1",
 		"emotion-theming": "^10.0.27",
 		"i18n-calypso": "file:../i18n-calypso",
-		"prop-types": "^15.7.2",
-		"react-stripe-elements": "^5.1.0"
+		"prop-types": "^15.7.2"
 	},
 	"peerDependencies": {
 		"@wordpress/data": "^4",

--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -34,12 +34,12 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/composite-checkout#readme",
 	"dependencies": {
+		"@babel/runtime": "^7.8.4",
 		"@emotion/core": "^10.0.27",
 		"@emotion/styled": "^10.0.27",
 		"@wordpress/i18n": "^3.9.0",
 		"debug": "^4.1.1",
 		"emotion-theming": "^10.0.27",
-		"interpolate-components": "^1.1.1",
 		"prop-types": "^15.7.2",
 		"react-stripe-elements": "4.0.2"
 	},

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -34,7 +34,6 @@
 	"dependencies": {
 		"@wordpress/data-controls": "^1.4.0",
 		"@wordpress/url": "^2.8.2",
-		"debug": "^4.1.1",
 		"fast-json-stable-stringify": "^2.1.0",
 		"qs": "^6.9.1",
 		"redux": "^4.0.4",

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -24,6 +24,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"dependencies": {
+		"@babel/runtime": "^7.8.4",
 		"i18n-calypso": "file:../i18n-calypso"
 	},
 	"scripts": {

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -18,6 +18,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/i18n-calypso#readme",
 	"dependencies": {
+		"@babel/runtime": "^7.8.4",
 		"@tannin/sprintf": "^1.1.0",
 		"@wordpress/compose": "^3.7.2",
 		"debug": "^4.0.0",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -31,6 +31,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"dependencies": {
+		"@babel/runtime": "^7.8.4",
 		"crc32": "0.2.2",
 		"debug": "^4.0.0",
 		"seed-random": "2.2.0"

--- a/packages/viewport-react/package.json
+++ b/packages/viewport-react/package.json
@@ -17,6 +17,7 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/viewport-react#readme",
 	"dependencies": {
+		"@babel/runtime": "^7.8.4",
 		"@automattic/viewport": "file:../viewport",
 		"@wordpress/compose": "^3.7.0"
 	},

--- a/packages/wpcom-proxy-request/package.json
+++ b/packages/wpcom-proxy-request/package.json
@@ -41,6 +41,7 @@
 		"prepare": "transpile"
 	},
 	"dependencies": {
+		"@babel/runtime": "^7.8.4",
 		"debug": "^4.1.1",
 		"progress-event": "^1.0.0",
 		"uuid": "^7.0.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds missing dependencies to `package.json`, and removes unused deps.
* Detected by https://www.npmjs.com/package/dependency-check (running `for file in $(find packages -type d -depth 1 | sort); do (cd $file; echo $file; dependency-check --no-peer --no-dev --missing package.json dist/**/*.js; echo) ; done`

Before:
```
packages/babel-plugin-i18n-calypso

packages/babel-plugin-transform-wpcalypso-async

packages/calypso-analytics

packages/calypso-build

packages/calypso-codemods

packages/calypso-color-schemes

packages/calypso-polyfills

packages/components
Fail! Dependencies not listed in package.json: @storybook/addon-actions, components, devdocs

packages/composite-checkout
Fail! Dependencies not listed in package.json: @babel/runtime

packages/composite-checkout-wpcom
Fail! Dependencies not listed in package.json: @automattic/calypso-polyfills

packages/data-stores

packages/effective-module-tree

packages/eslint-config-wpcalypso

packages/eslint-plugin-wpcalypso

packages/format-currency
Fail! Dependencies not listed in package.json: @babel/runtime

packages/i18n-calypso
Fail! Dependencies not listed in package.json: @babel/runtime

packages/i18n-calypso-cli

packages/load-script

packages/material-design-icons

packages/media-library

packages/photon
Fail! Dependencies not listed in package.json: @babel/runtime

packages/react-i18n

packages/tree-select

packages/viewport

packages/viewport-react
Fail! Dependencies not listed in package.json: @babel/runtime

packages/webpack-config-flag-plugin

packages/webpack-extensive-lodash-replacement-plugin

packages/webpack-inline-constant-exports-plugin

packages/wpcom-proxy-request
Fail! Dependencies not listed in package.json: @babel/runtime

packages/wpcom.js
```


After:
```
packages/babel-plugin-i18n-calypso

packages/babel-plugin-transform-wpcalypso-async

packages/calypso-analytics

packages/calypso-build

packages/calypso-codemods

packages/calypso-color-schemes

packages/calypso-polyfills

packages/components
Fail! Dependencies not listed in package.json: @storybook/addon-actions, components, devdocs

packages/composite-checkout

packages/composite-checkout-wpcom

packages/data-stores

packages/effective-module-tree

packages/eslint-config-wpcalypso

packages/eslint-plugin-wpcalypso

packages/format-currency

packages/i18n-calypso

packages/i18n-calypso-cli

packages/load-script

packages/material-design-icons

packages/media-library

packages/photon

packages/react-i18n

packages/tree-select

packages/viewport

packages/viewport-react

packages/webpack-config-flag-plugin

packages/webpack-extensive-lodash-replacement-plugin

packages/webpack-inline-constant-exports-plugin

packages/wpcom-proxy-request

packages/wpcom.js
```

#### Testing instructions

* Validate that all* dependencies are satisfied now (`for file in $(find packages -type d -depth 1 | sort); do (cd $file; echo $file; dependency-check --no-peer --no-dev --missing package.json dist/**/*.js; echo) ; done`)

* Validate that no new dependencies are actually introduced (there are no new packages in `package-lock.json`), just re-linking existing packages.
