### PR TITLE
Gutenboarding: Prefill domain search input from user entered site title.

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -20,6 +20,8 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import { DomainSuggestions } from '@automattic/data-stores';
 import { selectorDebounce } from '../../constants';
+import { STORE_KEY } from '../../stores/onboard';
+
 /**
  * Style dependencies
  */
@@ -68,7 +70,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	const { __: NO__ } = useI18n();
 	const label = NO__( 'Search for a domain' );
 
-	const [ domainSearch, setDomainSearch ] = useState( '' );
+	const { siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
+
+	const [ domainSearch, setDomainSearch ] = useState( siteTitle );
 
 	const placeholderAmount = 5;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/40159

#### Changes proposed in this Pull Request

* Prefill domain picker's search input with site title entered by user.

#### Testing instructions

1. Go to `/gutenboarding`.
2. Enter your site vertical and site title.
3. Click on the domain picker dropdown.
4. The domain search input field should be prefilled with what you entered on your site title.


#### Known Issues

1. Once user has selected a domain from the domain picker, changing the site title again would cause another new domain to be automatically suggested, discarding what the domain that the user originally chose. We need to introduce another state to store what domain user has explicitly chosen, and maintain that domain. We could fix this in another PR, or we could do it in this PR. Please discuss what to do in comments of this PR! Thanks!