### PR TITLE
Update @automattic/color-studio to 2.2.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/calypso-analytics": "file:../packages/calypso-analytics",
 		"@automattic/calypso-polyfills": "file:../packages/calypso-polyfills",
-		"@automattic/color-studio": "2.2.0",
+		"@automattic/color-studio": "2.2.1",
 		"@automattic/components": "file:../packages/components",
 		"@automattic/composite-checkout": "file:../packages/composite-checkout",
 		"@automattic/composite-checkout-wpcom": "file:../packages/composite-checkout-wpcom",

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,9 +246,9 @@
 			}
 		},
 		"@automattic/color-studio": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@automattic/color-studio/-/color-studio-2.2.0.tgz",
-			"integrity": "sha512-ttIF8rPSRJ5hKkDxKESDXyGmbqV3Eg4WCVUmKJp5BQXlbQOtwZ1EqUHmZo+IofXXpO2ngn2GiFz+KGt56C5WMA=="
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@automattic/color-studio/-/color-studio-2.2.1.tgz",
+			"integrity": "sha512-doMeOR5ly+qviYgWhWStByZHnnv3AFBC4Tj6aZLTrw8voulIu9AUv3Z9eit8a68uzCI77VkN7fUFadOiYIYBWg=="
 		},
 		"@automattic/components": {
 			"version": "file:packages/components",
@@ -44076,7 +44076,7 @@
 			"requires": {
 				"@automattic/calypso-analytics": "file:packages/calypso-analytics",
 				"@automattic/calypso-polyfills": "file:packages/calypso-polyfills",
-				"@automattic/color-studio": "2.2.0",
+				"@automattic/color-studio": "2.2.1",
 				"@automattic/components": "file:packages/components",
 				"@automattic/composite-checkout": "file:packages/composite-checkout",
 				"@automattic/composite-checkout-wpcom": "file:packages/composite-checkout-wpcom",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
 		"@automattic/babel-plugin-transform-wpcalypso-async": "file:./packages/babel-plugin-transform-wpcalypso-async",
 		"@automattic/calypso-build": "file:./packages/calypso-build",
 		"@automattic/calypso-color-schemes": "file:./packages/calypso-color-schemes",
-		"@automattic/color-studio": "2.2.0",
+		"@automattic/color-studio": "2.2.1",
 		"@automattic/webpack-config-flag-plugin": "file:packages/webpack-config-flag-plugin",
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "file:./packages/webpack-extensive-lodash-replacement-plugin",
 		"@automattic/webpack-inline-constant-exports-plugin": "file:./packages/webpack-inline-constant-exports-plugin",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates `@automattic/color-studio` from 2.2.0 to 2.2.1. No real differences between those two versions, just change `engines` constrain in `package.json` (https://github.com/Automattic/color-studio/blob/master/CHANGELOG.md)

This change is a prerequisite for a clean migration to `yarn`

#### Testing instructions

* Checkout two copies of this repo: one in master, one in this branch. Install them and build the client (run `npm ci && npm run build-client` in each copy). Then do a diff between static files (`diff -u --recursive repo1 repo2`). Inspect the output and see there are no relevant changes (just comments with the version of @automatic/color-studio and commit hash)
