### PR TITLE
Gutenboarding: Color and style updates

### DIFF
--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -7,3 +7,26 @@
  * @see https://stackoverflow.com/a/44755058/1432801
  */
 export const selectorDebounce = 300;
+
+export const fontPairings = [
+	[
+		{ title: 'Cabin', fontFamily: 'Cabin' },
+		{ title: 'Raleway', fontFamily: 'Raleway' },
+	],
+	[
+		{ title: 'Chivo', fontFamily: 'Chivo' },
+		{ title: 'Open Sans', fontFamily: 'Open Sans' },
+	],
+	[
+		{ title: 'Playfair', fontFamily: 'Playfair Display' },
+		{ title: 'Fira Sans', fontFamily: 'Fira Sans' },
+	],
+	[
+		{ title: 'Arvo', fontFamily: 'Arvo' },
+		{ title: 'Montserrat', fontFamily: 'Montserrat' },
+	],
+	[
+		{ title: 'Space Mono', fontFamily: 'Space Mono' },
+		{ title: 'Roboto', fontFamily: 'Roboto' },
+	],
+] as const;

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -21,6 +21,7 @@ import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytic
 import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import './style.scss';
+import { fontPairings } from './constants';
 
 registerBlockType( name, settings );
 
@@ -35,6 +36,25 @@ const BlockList = ( props: BlockListProps ) => <OriginalBlockList { ...props } /
 
 export function Gutenboard() {
 	const { __: NO__ } = useI18n();
+
+	// TODO: Explore alternatives for loading fonts and optimizations
+	// TODO: Don't load like this
+	useEffect( () => {
+		fontPairings.forEach( pair =>
+			pair.forEach(
+				( { title, fontFamily }: { title: string; fontFamily: string }, index: number ) => {
+					const isPrimary = index === 0;
+					const l = document.createElement( 'link' );
+					l.href = `https://fonts.googleapis.com/css?family=${ encodeURI( fontFamily ) }${
+						isPrimary ? ':bold' : ''
+					}&text=${ encodeURI( title + '\u00a0/' ) }&display=swap`;
+					l.rel = 'stylesheet';
+					l.type = 'text/css';
+					document.head.appendChild( l );
+				}
+			)
+		);
+	}, [] );
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)
 	// for the 'Back' and 'Next' buttons in the header. If we remove those (and move navigation

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -47,7 +47,7 @@ export function Gutenboard() {
 					const l = document.createElement( 'link' );
 					l.href = `https://fonts.googleapis.com/css?family=${ encodeURI( fontFamily ) }${
 						isPrimary ? ':bold' : ''
-					}&text=${ encodeURI( title + '\u00a0/' ) }&display=swap`;
+					}&text=${ encodeURI( title ) }&display=swap`;
 					l.rel = 'stylesheet';
 					l.type = 'text/css';
 					document.head.appendChild( l );

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -21,6 +21,7 @@ import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytic
 import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import './style.scss';
+import { fontPairings } from './constants';
 
 registerBlockType( name, settings );
 
@@ -39,12 +40,20 @@ export function Gutenboard() {
 	// TODO: Explore alternatives for loading fonts and optimizations
 	// TODO: Don't load like this
 	useEffect( () => {
-		const l = document.createElement( 'link' );
-		l.href =
-			'https://fonts.googleapis.com/css?family=Arvo|Cabin|Chivo|Fira+Sans|Montserrat|Open+Sans|Playfair+Display|Raleway|Roboto|Space+Mono&display=swap';
-		l.rel = 'stylesheet';
-		l.type = 'text/css';
-		document.head.appendChild( l );
+		fontPairings.forEach( pair =>
+			pair.forEach(
+				( { title, fontFamily }: { title: string; fontFamily: string }, index: number ) => {
+					const isPrimary = index === 0;
+					const l = document.createElement( 'link' );
+					l.href = `https://fonts.googleapis.com/css?family=${ encodeURI( fontFamily ) }${
+						isPrimary ? ':bold' : ''
+					}&text=${ encodeURI( title + '\u00a0/' ) }&display=swap`;
+					l.rel = 'stylesheet';
+					l.type = 'text/css';
+					document.head.appendChild( l );
+				}
+			)
+		);
 	}, [] );
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -45,9 +45,9 @@ export function Gutenboard() {
 				( { title, fontFamily }: { title: string; fontFamily: string }, index: number ) => {
 					const isPrimary = index === 0;
 					const l = document.createElement( 'link' );
-					l.href = `https://fonts.googleapis.com/css?family=${ encodeURI( fontFamily ) }${
-						isPrimary ? ':bold' : ''
-					}&text=${ encodeURI( title ) }&display=swap`;
+					l.href = `https://fonts.googleapis.com/css2?family=${ encodeURI(
+						`${ fontFamily }${ isPrimary ? ':wght@700' : '' }`
+					) }&text=${ encodeURI( title ) }&display=swap`;
 					l.rel = 'stylesheet';
 					l.type = 'text/css';
 					document.head.appendChild( l );

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -21,7 +21,6 @@ import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytic
 import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import './style.scss';
-import { fontPairings } from './constants';
 
 registerBlockType( name, settings );
 
@@ -40,20 +39,12 @@ export function Gutenboard() {
 	// TODO: Explore alternatives for loading fonts and optimizations
 	// TODO: Don't load like this
 	useEffect( () => {
-		fontPairings.forEach( pair =>
-			pair.forEach(
-				( { title, fontFamily }: { title: string; fontFamily: string }, index: number ) => {
-					const isPrimary = index === 0;
-					const l = document.createElement( 'link' );
-					l.href = `https://fonts.googleapis.com/css?family=${ encodeURI( fontFamily ) }${
-						isPrimary ? ':bold' : ''
-					}&text=${ encodeURI( title + '\u00a0/' ) }&display=swap`;
-					l.rel = 'stylesheet';
-					l.type = 'text/css';
-					document.head.appendChild( l );
-				}
-			)
-		);
+		const l = document.createElement( 'link' );
+		l.href =
+			'https://fonts.googleapis.com/css?family=Arvo|Cabin|Chivo|Fira+Sans|Montserrat|Open+Sans|Playfair+Display|Raleway|Roboto|Space+Mono&display=swap';
+		l.rel = 'stylesheet';
+		l.type = 'text/css';
+		document.head.appendChild( l );
 	}, [] );
 
 	// @TODO: This is currently needed in addition to the routing (inside the Onboarding Block)

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent.tsx
@@ -22,7 +22,7 @@ const AcquireIntent: FunctionComponent = () => {
 	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 	const makePath = usePath();
 	return (
-		<div className="onboarding-block__acquire-intent" data-vertical={ siteVertical?.label }>
+		<div className="onboarding-block__acquire-intent">
 			<div className="onboarding-block__questions">
 				<StepperWizard
 					stepComponents={ [ VerticalSelect, ( siteVertical || siteTitle ) && SiteTitle ] }

--- a/client/landing/gutenboarding/onboarding-block/colors.scss
+++ b/client/landing/gutenboarding/onboarding-block/colors.scss
@@ -1,10 +1,14 @@
 .onboarding-block {
 	// Basics and "opted-out" steps
-	&,
+	--contrastColor: var( --studio-white );
+	--mainColor: var( --studio-blue-40 );
+	--highlightColor: var( --studio-blue-20 );
+
 	.design-selector,
 	.style-preview {
 		--contrastColor: var( --studio-white );
-		--mainColor: var( --studio-blue-40 );
+		// TODO: This should be Gutenberg's main color
+		--mainColor: var( --studio-gray-100 );
 		--highlightColor: var( --studio-blue-20 );
 	}
 

--- a/client/landing/gutenboarding/onboarding-block/colors.scss
+++ b/client/landing/gutenboarding/onboarding-block/colors.scss
@@ -1,95 +1,100 @@
 .onboarding-block {
-	--contrastColor: var( --studio-white );
-	--mainColor: var( --studio-blue-40 );
-	--highlightColor: var( --studio-blue-20 );
-}
+	// Basics and "opted-out" steps
+	&,
+	.design-selector,
+	.style-preview {
+		--contrastColor: var( --studio-white );
+		--mainColor: var( --studio-blue-40 );
+		--highlightColor: var( --studio-blue-20 );
+	}
 
-.onboarding-block[data-vertical*='football'] {
-	--contrastColor: var( --studio-green-40 );
-	--mainColor: var( --studio-gray-0 );
-	--highlightColor: var( --studio-green-20 );
-}
+	&[data-vertical*='football'] {
+		--contrastColor: var( --studio-green-40 );
+		--mainColor: var( --studio-gray-0 );
+		--highlightColor: var( --studio-green-20 );
+	}
 
-.onboarding-block[data-vertical*='web'] {
-	--contrastColor: var( --studio-blue-40 );
-	--mainColor: var( --studio-blue-0 );
-	--highlightColor: var( --studio-blue-20 );
-}
+	&[data-vertical*='web'] {
+		--contrastColor: var( --studio-blue-40 );
+		--mainColor: var( --studio-blue-0 );
+		--highlightColor: var( --studio-blue-20 );
+	}
 
-.onboarding-block[data-vertical*='animals'] {
-	--contrastColor: var( --studio-blue-40 );
-	--mainColor: var( --studio-blue-0 );
-	--highlightColor: var( --studio-blue-20 );
-}
+	&[data-vertical*='animals'] {
+		--contrastColor: var( --studio-blue-40 );
+		--mainColor: var( --studio-blue-0 );
+		--highlightColor: var( --studio-blue-20 );
+	}
 
-.onboarding-block[data-vertical*='coffee'] {
-	--contrastColor: #4a2512;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
-}
+	&[data-vertical*='coffee'] {
+		--contrastColor: #4a2512;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 
-.onboarding-block[data-vertical*='cats'] {
-	--contrastColor: #1382d2;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
-}
+	&[data-vertical*='cats'] {
+		--contrastColor: #1382d2;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 
-.onboarding-block[data-vertical*='car'] {
-	--contrastColor: #c33939;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
-}
+	&[data-vertical*='car'] {
+		--contrastColor: #c33939;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 
-.onboarding-block[data-vertical*='doctor'] {
-	--contrastColor: #1382d2;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
-}
+	&[data-vertical*='doctor'] {
+		--contrastColor: #1382d2;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 
-.onboarding-block[data-vertical*='dogs'] {
-	--contrastColor: #f3e4be;
-	--mainColor: #a68b46;
-	--highlightColor: #a68b46;
-}
+	&[data-vertical*='dogs'] {
+		--contrastColor: #f3e4be;
+		--mainColor: #a68b46;
+		--highlightColor: #a68b46;
+	}
 
-.onboarding-block[data-vertical*='food'] {
-	--contrastColor: #e35f27;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
-}
+	&[data-vertical*='food'] {
+		--contrastColor: #e35f27;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 
-.onboarding-block[data-vertical*='fashion'] {
-	--contrastColor: #000;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
-}
+	&[data-vertical*='fashion'] {
+		--contrastColor: #000;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 
-.onboarding-block[data-vertical*='football'] {
-	--contrastColor: #47b845;
-	--mainColor: #0e390d;
-	--highlightColor: #0e390d;
-}
+	&[data-vertical*='football'] {
+		--contrastColor: #47b845;
+		--mainColor: #0e390d;
+		--highlightColor: #0e390d;
+	}
 
-.onboarding-block[data-vertical*='movies'] {
-	--contrastColor: #1382d2;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
-}
+	&[data-vertical*='movies'] {
+		--contrastColor: #1382d2;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 
-.onboarding-block[data-vertical*='photo'] {
-	--contrastColor: #1382d2;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
-}
+	&[data-vertical*='photo'] {
+		--contrastColor: #1382d2;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 
-.onboarding-block[data-vertical*='tv'] {
-	--contrastColor: #1382d2;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
-}
+	&[data-vertical*='tv'] {
+		--contrastColor: #1382d2;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 
-.onboarding-block[data-vertical*='jersey'] {
-	--contrastColor: #1382d2;
-	--mainColor: var( --studio-white );
-	--highlightColor: var( --studio-gray-0 );
+	&[data-vertical*='jersey'] {
+		--contrastColor: #1382d2;
+		--mainColor: var( --studio-white );
+		--highlightColor: var( --studio-gray-0 );
+	}
 }

--- a/client/landing/gutenboarding/onboarding-block/colors.scss
+++ b/client/landing/gutenboarding/onboarding-block/colors.scss
@@ -1,94 +1,94 @@
-.onboarding-block__acquire-intent {
+.onboarding-block {
 	--contrastColor: var( --studio-white );
 	--mainColor: var( --studio-blue-40 );
 	--highlightColor: var( --studio-blue-20 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=football] {
+.onboarding-block[data-vertical*='football'] {
 	--contrastColor: var( --studio-green-40 );
 	--mainColor: var( --studio-gray-0 );
 	--highlightColor: var( --studio-green-20 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=web] {
+.onboarding-block[data-vertical*='web'] {
 	--contrastColor: var( --studio-blue-40 );
 	--mainColor: var( --studio-blue-0 );
 	--highlightColor: var( --studio-blue-20 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=animals] {
+.onboarding-block[data-vertical*='animals'] {
 	--contrastColor: var( --studio-blue-40 );
 	--mainColor: var( --studio-blue-0 );
 	--highlightColor: var( --studio-blue-20 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=coffee] {
+.onboarding-block[data-vertical*='coffee'] {
 	--contrastColor: #4a2512;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=cats] {
+.onboarding-block[data-vertical*='cats'] {
 	--contrastColor: #1382d2;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=car] {
+.onboarding-block[data-vertical*='car'] {
 	--contrastColor: #c33939;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=doctor] {
+.onboarding-block[data-vertical*='doctor'] {
 	--contrastColor: #1382d2;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=dogs] {
+.onboarding-block[data-vertical*='dogs'] {
 	--contrastColor: #f3e4be;
 	--mainColor: #a68b46;
 	--highlightColor: #a68b46;
 }
 
-.onboarding-block__acquire-intent[data-vertical*=food] {
+.onboarding-block[data-vertical*='food'] {
 	--contrastColor: #e35f27;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=fashion] {
+.onboarding-block[data-vertical*='fashion'] {
 	--contrastColor: #000;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=football] {
+.onboarding-block[data-vertical*='football'] {
 	--contrastColor: #47b845;
 	--mainColor: #0e390d;
 	--highlightColor: #0e390d;
 }
 
-.onboarding-block__acquire-intent[data-vertical*=movies] {
+.onboarding-block[data-vertical*='movies'] {
 	--contrastColor: #1382d2;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=photo] {
+.onboarding-block[data-vertical*='photo'] {
 	--contrastColor: #1382d2;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=tv] {
+.onboarding-block[data-vertical*='tv'] {
 	--contrastColor: #1382d2;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );
 }
 
-.onboarding-block__acquire-intent[data-vertical*=jersey] {
+.onboarding-block[data-vertical*='jersey'] {
 	--contrastColor: #1382d2;
 	--mainColor: var( --studio-white );
 	--highlightColor: var( --studio-gray-0 );

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -22,9 +22,7 @@ const DesignSelector: FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const { push } = useHistory();
 	const makePath = usePath();
-	const { selectedDesign, siteVertical } = useSelect( select =>
-		select( ONBOARD_STORE ).getState()
-	);
+	const { selectedDesign } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { setSelectedDesign, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const handleStartOverButtonClick = () => {
@@ -32,10 +30,7 @@ const DesignSelector: FunctionComponent = () => {
 	};
 
 	return (
-		<div
-			className="design-selector gutenboarding-color-coded"
-			data-vertical={ siteVertical?.label }
-		>
+		<div className="design-selector">
 			<div className="design-selector__header">
 				<div className="design-selector__heading">
 					<Title>{ NO__( 'Choose a starting design' ) }</Title>

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -28,7 +28,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 	const makePath = usePath();
 
 	return (
-		<>
+		<div className="onboarding-block" data-vertical={ siteVertical?.label }>
 			{ isCreatingSite && <Redirect push to={ makePath( Step.CreateSite ) } /> }
 			<Switch>
 				<Route exact path={ makePath( Step.IntentGathering ) }>
@@ -59,7 +59,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 					<CreateSite />
 				</Route>
 			</Switch>
-		</>
+		</div>
 	);
 };
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -3,19 +3,12 @@
  */
 import * as React from 'react';
 import { Button } from '@wordpress/components';
+import { ValuesType } from 'utility-types';
 
 /**
  * Internal dependencies
  */
-import { ValuesType } from 'utility-types';
-
-export const fontPairings = [
-	[ 'Cabin', 'Raleway' ],
-	[ 'Chivo', 'OpenSans' ],
-	[ 'Playfair', 'FiraSans' ],
-	[ 'Arvo', 'Montserrat' ],
-	[ 'SpaceMono', 'Roboto' ],
-] as const;
+import { fontPairings } from '../../constants';
 
 interface Props {
 	onSelect: ( selection: ValuesType< typeof fontPairings > ) => void;
@@ -25,13 +18,18 @@ const FontSelect: React.FunctionComponent< Props > = ( { onSelect, selected } ) 
 	<div className="style-preview__font-options">
 		<ul>
 			{ fontPairings.map( fonts => {
-				const [ a, b ] = fonts;
+				const [
+					{ title: a, fontFamily: fontFamilyA },
+					{ title: b, fontFamily: fontFamilyB },
+				] = fonts;
 				const isSelected = fonts === selected;
+
 				return (
 					<li key={ a + b }>
 						<Button onClick={ () => onSelect( fonts ) }>
-							<b>{ a }</b>&nbsp;/&nbsp;{ b }
-							{ isSelected && ' *' }
+							<span style={ { fontFamily: fontFamilyA, fontWeight: 700 } }>{ a }&nbsp;/</span>
+							<span style={ { fontFamily: fontFamilyB } }>&nbsp;{ b }</span>
+							{ isSelected && '\u00a0*' }
 						</Button>
 					</li>
 				);

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -27,8 +27,9 @@ const FontSelect: React.FunctionComponent< Props > = ( { onSelect, selected } ) 
 				return (
 					<li key={ a + b }>
 						<Button onClick={ () => onSelect( fonts ) }>
-							<span style={ { fontFamily: fontFamilyA, fontWeight: 700 } }>{ a }&nbsp;/</span>
-							<span style={ { fontFamily: fontFamilyB } }>&nbsp;{ b }</span>
+							<span style={ { fontFamily: fontFamilyA, fontWeight: 700 } }>{ a }</span>
+							&nbsp;/&nbsp;
+							<span style={ { fontFamily: fontFamilyB } }>{ b }</span>
 							{ isSelected && '\u00a0*' }
 						</Button>
 					</li>

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -33,7 +33,6 @@ const FontSelect: React.FunctionComponent< Props > = ( { onSelect, selected } ) 
 					<span style={ { fontFamily: fontFamilyA, fontWeight: 700 } }>{ a }</span>
 					&nbsp;/&nbsp;
 					<span style={ { fontFamily: fontFamilyB } }>{ b }</span>
-					{ isSelected && '\u00a0*' }
 				</Button>
 			);
 		} ) }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { Button } from '@wordpress/components';
 import { ValuesType } from 'utility-types';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -16,26 +17,26 @@ interface Props {
 }
 const FontSelect: React.FunctionComponent< Props > = ( { onSelect, selected } ) => (
 	<div className="style-preview__font-options">
-		<ul>
-			{ fontPairings.map( fonts => {
-				const [
-					{ title: a, fontFamily: fontFamilyA },
-					{ title: b, fontFamily: fontFamilyB },
-				] = fonts;
-				const isSelected = fonts === selected;
+		{ fontPairings.map( fonts => {
+			const isSelected = fonts === selected;
+			const [
+				{ title: a, fontFamily: fontFamilyA },
+				{ title: b, fontFamily: fontFamilyB },
+			] = fonts;
 
-				return (
-					<li key={ a + b }>
-						<Button onClick={ () => onSelect( fonts ) }>
-							<span style={ { fontFamily: fontFamilyA, fontWeight: 700 } }>{ a }</span>
-							&nbsp;/&nbsp;
-							<span style={ { fontFamily: fontFamilyB } }>{ b }</span>
-							{ isSelected && '\u00a0*' }
-						</Button>
-					</li>
-				);
-			} ) }
-		</ul>
+			return (
+				<Button
+					className={ classnames( 'style-preview__font-option', { 'is-selected': isSelected } ) }
+					onClick={ () => onSelect( fonts ) }
+					key={ a + b }
+				>
+					<span style={ { fontFamily: fontFamilyA, fontWeight: 700 } }>{ a }</span>
+					&nbsp;/&nbsp;
+					<span style={ { fontFamily: fontFamilyB } }>{ b }</span>
+					{ isSelected && '\u00a0*' }
+				</Button>
+			);
+		} ) }
 	</div>
 );
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -13,8 +13,9 @@ import Preview from './preview';
 import Link from '../../components/link';
 import { usePath, Step } from '../../path';
 import ViewportSelect from './viewport-select';
-import FontSelect, { fontPairings } from './font-select';
+import FontSelect from './font-select';
 import { Title, SubTitle } from '../../components/titles';
+import { fontPairings } from '../../constants';
 import * as T from './types';
 
 import './style.scss';
@@ -57,7 +58,3 @@ const StylePreview: React.FunctionComponent = () => {
 };
 
 export default StylePreview;
-
-interface ViewProps {
-	isSelected: boolean;
-}

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -17,12 +17,15 @@ interface Props {
 }
 const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 	const { selectedDesign } = useSelect( select => select( STORE_KEY ).getState() );
+	const [ { title: fontA }, { title: fontB } ] = fonts;
 	return (
 		<div className="style-preview__preview">
 			<p>Preview to be implemented.</p>
 			<p>You picked { selectedDesign?.title ?? 'unknown' } design.</p>
 			<p>Showing { viewport } display.</p>
-			<p>With { fonts.join( ' / ' ) } display.</p>
+			<p>
+				With { fontA }&nbsp;/&nbsp;{ fontB } display.
+			</p>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -20,6 +20,11 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 	const [ { title: fontA }, { title: fontB } ] = fonts;
 	return (
 		<div className="style-preview__preview">
+			<div role="presentation" className="style-preview__preview-bar">
+				<div role="presentation" className="style-preview__preview-bar-dot" />
+				<div role="presentation" className="style-preview__preview-bar-dot" />
+				<div role="presentation" className="style-preview__preview-bar-dot" />
+			</div>
 			<p>Preview to be implemented.</p>
 			<p>You picked { selectedDesign?.title ?? 'unknown' } design.</p>
 			<p>Showing { viewport } display.</p>

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -13,7 +13,7 @@ import { ValuesType } from 'utility-types';
 
 interface Props {
 	viewport: T.Viewport;
-	fonts: ValuesType< typeof import('./font-select').fontPairings >;
+	fonts: ValuesType< typeof import('../../constants').fontPairings >;
 }
 const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 	const { selectedDesign } = useSelect( select => select( STORE_KEY ).getState() );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -47,5 +47,10 @@
 		svg {
 			fill: none;
 		}
+
+		color: var( --studio-gray-10 );
+		&.is-selected {
+			color: #000;
+		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -33,13 +33,36 @@
 	height: 3.2em;
 
 	&.is-selected {
-		border-color: var( --contrastColor );
-		color: var( --contrastColor );
+		border-color: var( --highlightColor );
+		color: var( --highlightColor );
 	}
 }
 
 .style-preview__preview {
 	grid-area: preview;
+
+	border: 1px solid var( --studio-gray-5 );
+	box-shadow: 0 4px 14px rgba( 0, 0, 0, 0.25 );
+	border-radius: 4px;
+	overflow: hidden;
+}
+.style-preview__preview-bar {
+	width: 100%;
+	height: 30px;
+
+	background: #fff;
+	border-bottom: 1px solid var( --studio-gray-5 );
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	padding: 10px;
+}
+.style-preview__preview-bar-dot {
+	background: var( --studio-gray-5 );
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	margin: 0 2px;
 }
 
 .style-preview__viewport-select {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -27,9 +27,10 @@
 
 // Extra specificity to override core component border
 .style-preview__font-option.components-button {
-	border: 1px solid gray;
+	border: 1px solid var( --studio-gray-10 );
+
 	&.is-selected {
-		border-color: var( --mainColor );
+		border-color: var( --contrastColor );
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -21,7 +21,18 @@
 }
 .style-preview__font-options {
 	grid-area: fonts;
+	display: grid;
+	grid-template-columns: 100%;
 }
+
+// Extra specificity to override core component border
+.style-preview__font-option.components-button {
+	border: 1px solid gray;
+	&.is-selected {
+		border-color: var( --mainColor );
+	}
+}
+
 .style-preview__preview {
 	grid-area: preview;
 }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -28,6 +28,7 @@
 // Extra specificity to override core component border
 .style-preview__font-option.components-button {
 	border: 1px solid var( --studio-gray-10 );
+	justify-content: center;
 
 	&.is-selected {
 		border-color: var( --contrastColor );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -23,15 +23,18 @@
 	grid-area: fonts;
 	display: grid;
 	grid-template-columns: 100%;
+	row-gap: 1em;
 }
 
 // Extra specificity to override core component border
 .style-preview__font-option.components-button {
 	border: 1px solid var( --studio-gray-10 );
 	justify-content: center;
+	height: 3.2em;
 
 	&.is-selected {
 		border-color: var( --contrastColor );
+		color: var( --contrastColor );
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/viewport-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/viewport-select.tsx
@@ -18,20 +18,26 @@ interface Props {
 }
 const ViewportSelect: React.FunctionComponent< Props > = ( { onSelect, selected } ) => (
 	<div className="style-preview__viewport-select">
-		<Button onClick={ () => onSelect( 'desktop' ) }>
+		<Button
+			onClick={ () => onSelect( 'desktop' ) }
+			className={ selected === 'desktop' ? 'is-selected' : undefined }
+		>
 			<SVG width="55" height="55" viewBox="0 0 55 55">
 				<Path
 					d="M10.4258 15.75C10.4258 15.0596 10.9854 14.5 11.6758 14.5H43.3239C44.0143 14.5 44.5739 15.0596 44.5739 15.75V38.463H10.4258V15.75Z"
-					stroke={ selected === 'desktop' ? '#000' : '#BCBCBC' }
+					stroke="currentColor"
 					strokeWidth="1.5"
 				/>
 				<Path
 					d="M4.58301 38.667C4.58301 37.5624 5.47844 36.667 6.58301 36.667H48.4163C49.5209 36.667 50.4163 37.5624 50.4163 38.667V40.1045H4.58301V38.667Z"
-					fill={ selected === 'desktop' ? '#000' : '#BCBCBC' }
+					fill="currentColor"
 				/>
 			</SVG>
 		</Button>
-		<Button onClick={ () => onSelect( 'tablet' ) }>
+		<Button
+			onClick={ () => onSelect( 'tablet' ) }
+			className={ selected === 'tablet' ? 'is-selected' : undefined }
+		>
 			<SVG width="48" height="48" viewBox="0 0 48 48">
 				<Rect
 					x="10.75"
@@ -39,19 +45,16 @@ const ViewportSelect: React.FunctionComponent< Props > = ( { onSelect, selected 
 					width="26.5"
 					height="30.5"
 					rx="1.25"
-					stroke={ selected === 'tablet' ? '#000' : '#BCBCBC' }
+					stroke="currentColor"
 					strokeWidth="1.5"
 				/>
-				<Rect
-					x="20"
-					y="32"
-					width="8"
-					height="3"
-					fill={ selected === 'tablet' ? '#000' : '#BCBCBC' }
-				/>
+				<Rect x="20" y="32" width="8" height="3" fill="currentColor" />
 			</SVG>
 		</Button>
-		<Button onClick={ () => onSelect( 'mobile' ) }>
+		<Button
+			onClick={ () => onSelect( 'mobile' ) }
+			className={ selected === 'mobile' ? 'is-selected' : undefined }
+		>
 			<SVG width="40" height="40" viewBox="0 0 40 40">
 				<Rect
 					x="12.417"
@@ -59,16 +62,10 @@ const ViewportSelect: React.FunctionComponent< Props > = ( { onSelect, selected 
 					width="16"
 					height="25.1667"
 					rx="1.25"
-					stroke={ selected === 'mobile' ? '#000' : '#BCBCBC' }
+					stroke="currentColor"
 					strokeWidth="1.5"
 				/>
-				<Rect
-					x="18.333"
-					y="26.667"
-					width="5"
-					height="2.5"
-					fill={ selected === 'mobile' ? '#000' : '#BCBCBC' }
-				/>
+				<Rect x="18.333" y="26.667" width="5" height="2.5" fill="currentColor" />
 			</SVG>
 		</Button>
 	</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Reworks slightly to make them available for other steps.
- Fixed, although  #40201 is a pain point.
  ~This slightly regresses the designs (some colors are applied unecessarily) and highlights the need for iteration on the color system (#40201). For example, the title should not be blue here:~
  ![Screen Shot 2020-03-17 at 11 20 21](https://user-images.githubusercontent.com/841763/76846772-523b4380-6841-11ea-9075-52f76c4839ee.png)
- Adds style for the preview frame
  ![Screen Shot 2020-03-17 at 11 19 29](https://user-images.githubusercontent.com/841763/76846704-38016580-6841-11ea-9573-08d6da8fb4b8.png)
- Loads fonts for the font picker buttons
- Style and layout for the font-picker buttons
  ![Screen Shot 2020-03-17 at 11 19 06](https://user-images.githubusercontent.com/841763/76846717-3d5eb000-6841-11ea-8fc6-4964350a96c4.png)

#### Demo

This is slightly outdated. The title colors in design and font selection steps are now black as before.

![demo](https://user-images.githubusercontent.com/841763/76846485-dccf7300-6840-11ea-9e3c-eed632fd9c8b.gif)


#### Testing instructions

* Visit gutenboarding in dev environment [`/gutenboarding`](http://calypso.localhost:3000/gutenboarding)
