### PR TITLE
Add jetpack cloud colour scheme

### DIFF
--- a/client/document/404.jsx
+++ b/client/document/404.jsx
@@ -4,6 +4,8 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -13,12 +15,18 @@ import EmptyContent from 'components/empty-content';
 import { chunkCssLinks } from './utils';
 
 function NotFound( { faviconURL, entrypoint } ) {
+	const theme = config( 'theme' );
+
 	return (
 		<html lang="en">
 			<Head faviconURL={ faviconURL } cdn={ '//s1.wp.com' }>
 				{ chunkCssLinks( entrypoint ) }
 			</Head>
-			<body>
+			<body
+				className={ classNames( {
+					[ 'theme-' + theme ]: theme,
+				} ) }
+			>
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace*/ }
 				<div id="wpcom" className="wpcom-site">
 					<div className="wp has-no-sidebar">

--- a/client/document/500.jsx
+++ b/client/document/500.jsx
@@ -4,6 +4,8 @@
  */
 
 import React from 'react';
+import classNames from 'classnames';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -13,12 +15,18 @@ import EmptyContent from 'components/empty-content';
 import { chunkCssLinks } from './utils';
 
 function ServerError( { faviconURL, entrypoint } ) {
+	const theme = config( 'theme' );
+
 	return (
 		<html lang="en">
 			<Head faviconURL={ faviconURL } cdn={ '//s1.wp.com' }>
 				{ chunkCssLinks( entrypoint ) }
 			</Head>
-			<body>
+			<body
+				className={ classNames( {
+					[ 'theme-' + theme ]: theme,
+				} ) }
+			>
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace*/ }
 				<div id="wpcom" className="wpcom-site">
 					<div className="wp has-no-sidebar">

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -81,6 +81,8 @@ class Document extends React.Component {
 			'jetpack-connect' === sectionName &&
 			'woocommerce-onboarding' === requestFrom;
 
+		const theme = config( 'theme' );
+
 		return (
 			<html
 				lang={ lang }
@@ -107,6 +109,7 @@ class Document extends React.Component {
 					className={ classNames( {
 						rtl: isRTL,
 						'color-scheme': config.isEnabled( 'me/account/color-scheme-picker' ),
+						[ 'theme-' + theme ]: theme,
 						[ 'is-group-' + sectionGroup ]: sectionGroup,
 						[ 'is-section-' + sectionName ]: sectionName,
 					} ) }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -132,5 +132,6 @@
 	"enable_all_sections": true,
 	"sections": {
 		"jetpack-cloud": false
-	}
+	},
+	"theme": "default"
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -21,5 +21,6 @@
 	"enable_all_sections": false,
 	"sections": {
 		"jetpack-cloud": true
-	}
+	},
+	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -19,5 +19,6 @@
 	"enable_all_sections": false,
 	"sections": {
 		"jetpack-cloud": true
-	}
+	},
+	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -19,5 +19,6 @@
 	"enable_all_sections": false,
 	"sections": {
 		"jetpack-cloud": true
-	}
+	},
+	"theme": "jetpack-cloud"
 }

--- a/packages/calypso-color-schemes/src/calypso-color-schemes.scss
+++ b/packages/calypso-color-schemes/src/calypso-color-schemes.scss
@@ -12,3 +12,4 @@
 @import 'shared/color-schemes/powder-snow';
 @import 'shared/color-schemes/sakura';
 @import 'shared/color-schemes/sunset';
+@import 'shared/color-schemes/jetpack-cloud';

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
@@ -2,19 +2,69 @@
 .color-scheme.is-jetpack-cloud {
 	/* Theme Properties */
 	--color-primary: var( --studio-jetpack-green );
+	--color-primary-rgb: var( --studio-jetpack-green-rgb );
+	--color-primary-dark: var( --studio-jetpack-green-70 );
+	--color-primary-dark-rgb: var( --studio-jetpack-green-70-rgb );
+	--color-primary-light: var( --studio-jetpack-green-30 );
+	--color-primary-light-rgb: var( --studio-jetpack-green-30-rgb );
 	--color-primary-0: var( --studio-jetpack-green-0 );
+	--color-primary-0-rgb: var( --studio-jetpack-green-0-rgb );
 	--color-primary-5: var( --studio-jetpack-green-5 );
+	--color-primary-5-rgb: var( --studio-jetpack-green-5-rgb );
 	--color-primary-10: var( --studio-jetpack-green-10 );
+	--color-primary-10-rgb: var( --studio-jetpack-green-10-rgb );
 	--color-primary-20: var( --studio-jetpack-green-20 );
+	--color-primary-20-rgb: var( --studio-jetpack-green-20-rgb );
 	--color-primary-30: var( --studio-jetpack-green-30 );
+	--color-primary-30-rgb: var( --studio-jetpack-green-30-rgb );
 	--color-primary-40: var( --studio-jetpack-green-40 );
+	--color-primary-40-rgb: var( --studio-jetpack-green-40-rgb );
 	--color-primary-50: var( --studio-jetpack-green-50 );
+	--color-primary-50-rgb: var( --studio-jetpack-green-50-rgb );
 	--color-primary-60: var( --studio-jetpack-green-60 );
+	--color-primary-60-rgb: var( --studio-jetpack-green-60-rgb );
 	--color-primary-70: var( --studio-jetpack-green-70 );
+	--color-primary-70-rgb: var( --studio-jetpack-green-70-rgb );
 	--color-primary-80: var( --studio-jetpack-green-80 );
+	--color-primary-80-rgb: var( --studio-jetpack-green-80-rgb );
 	--color-primary-90: var( --studio-jetpack-green-90 );
+	--color-primary-90-rgb: var( --studio-jetpack-green-90-rgb );
 	--color-primary-100: var( --studio-jetpack-green-100 );
+	--color-primary-100-rgb: var( --studio-jetpack-green-100-rgb );
 
+	/* Theme Properties */
+	--color-accent: var( --studio-jetpack-green );
+	--color-accent-rgb: var( --studio-jetpack-green-rgb );
+	--color-accent-dark: var( --studio-jetpack-green-70 );
+	--color-accent-dark-rgb: var( --studio-jetpack-green-70-rgb );
+	--color-accent-light: var( --studio-jetpack-green-30 );
+	--color-accent-light-rgb: var( --studio-jetpack-green-30-rgb );
+	--color-accent-0: var( --studio-jetpack-green-0 );
+	--color-accent-0-rgb: var( --studio-jetpack-green-0-rgb );
+	--color-accent-5: var( --studio-jetpack-green-5 );
+	--color-accent-5-rgb: var( --studio-jetpack-green-5-rgb );
+	--color-accent-10: var( --studio-jetpack-green-10 );
+	--color-accent-10-rgb: var( --studio-jetpack-green-10-rgb );
+	--color-accent-20: var( --studio-jetpack-green-20 );
+	--color-accent-20-rgb: var( --studio-jetpack-green-20-rgb );
+	--color-accent-30: var( --studio-jetpack-green-30 );
+	--color-accent-30-rgb: var( --studio-jetpack-green-30-rgb );
+	--color-accent-40: var( --studio-jetpack-green-40 );
+	--color-accent-40-rgb: var( --studio-jetpack-green-40-rgb );
+	--color-accent-50: var( --studio-jetpack-green-50 );
+	--color-accent-50-rgb: var( --studio-jetpack-green-50-rgb );
+	--color-accent-60: var( --studio-jetpack-green-60 );
+	--color-accent-60-rgb: var( --studio-jetpack-green-60-rgb );
+	--color-accent-70: var( --studio-jetpack-green-70 );
+	--color-accent-70-rgb: var( --studio-jetpack-green-70-rgb );
+	--color-accent-80: var( --studio-jetpack-green-80 );
+	--color-accent-80-rgb: var( --studio-jetpack-green-80-rgb );
+	--color-accent-90: var( --studio-jetpack-green-90 );
+	--color-accent-90-rgb: var( --studio-jetpack-green-90-rgb );
+	--color-accent-100: var( --studio-jetpack-green-100 );
+	--color-accent-100-rgb: var( --studio-jetpack-green-100-rgb );
+
+	/* Theme Properties */
 	--color-link: var( --studio-jetpack-green-40 );
 	--color-link-rgb: var( --studio-jetpack-green-40-rgb );
 	--color-link-dark: var( --studio-jetpack-green-60 );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
@@ -1,0 +1,74 @@
+.theme-jetpack-cloud,
+.color-scheme.is-jetpack-cloud {
+	/* Theme Properties */
+	--color-primary: var( --studio-jetpack-green );
+	--color-primary-0: var( --studio-jetpack-green-0 );
+	--color-primary-5: var( --studio-jetpack-green-5 );
+	--color-primary-10: var( --studio-jetpack-green-10 );
+	--color-primary-20: var( --studio-jetpack-green-20 );
+	--color-primary-30: var( --studio-jetpack-green-30 );
+	--color-primary-40: var( --studio-jetpack-green-40 );
+	--color-primary-50: var( --studio-jetpack-green-50 );
+	--color-primary-60: var( --studio-jetpack-green-60 );
+	--color-primary-70: var( --studio-jetpack-green-70 );
+	--color-primary-80: var( --studio-jetpack-green-80 );
+	--color-primary-90: var( --studio-jetpack-green-90 );
+	--color-primary-100: var( --studio-jetpack-green-100 );
+
+	--color-link: var( --studio-jetpack-green-40 );
+	--color-link-rgb: var( --studio-jetpack-green-40-rgb );
+	--color-link-dark: var( --studio-jetpack-green-60 );
+	--color-link-dark-rgb: var( --studio-jetpack-green-60-rgb );
+	--color-link-light: var( --studio-jetpack-green-20 );
+	--color-link-light-rgb: var( --studio-jetpack-green-20-rgb );
+	--color-link-0: var( --studio-jetpack-green-0 );
+	--color-link-0-rgb: var( --studio-jetpack-green-0-rgb );
+	--color-link-5: var( --studio-jetpack-green-5 );
+	--color-link-5-rgb: var( --studio-jetpack-green-5-rgb );
+	--color-link-10: var( --studio-jetpack-green-10 );
+	--color-link-10-rgb: var( --studio-jetpack-green-10-rgb );
+	--color-link-20: var( --studio-jetpack-green-20 );
+	--color-link-20-rgb: var( --studio-jetpack-green-20-rgb );
+	--color-link-30: var( --studio-jetpack-green-30 );
+	--color-link-30-rgb: var( --studio-jetpack-green-30-rgb );
+	--color-link-40: var( --studio-jetpack-green-40 );
+	--color-link-40-rgb: var( --studio-jetpack-green-40-rgb );
+	--color-link-50: var( --studio-jetpack-green-50 );
+	--color-link-50-rgb: var( --studio-jetpack-green-50-rgb );
+	--color-link-60: var( --studio-jetpack-green-60 );
+	--color-link-60-rgb: var( --studio-jetpack-green-60-rgb );
+	--color-link-70: var( --studio-jetpack-green-70 );
+	--color-link-70-rgb: var( --studio-jetpack-green-70-rgb );
+	--color-link-80: var( --studio-jetpack-green-80 );
+	--color-link-80-rgb: var( --studio-jetpack-green-80-rgb );
+	--color-link-90: var( --studio-jetpack-green-90 );
+	--color-link-90-rgb: var( --studio-jetpack-green-90-rgb );
+	--color-link-100: var( --studio-jetpack-green-100 );
+	--color-link-100-rgb: var( --studio-jetpack-green-100-rgb );
+
+	/* Component Properties */
+	--color-masterbar-background: var( --studio-white );
+	--color-masterbar-border: var( --studio-gray-5 );
+	--color-masterbar-text: var( --studio-gray-50 );
+	--color-masterbar-item-hover-background: var( --studio-white );
+	--color-masterbar-item-active-background: var( --studio-white );
+	--color-masterbar-item-new-editor-background: var( --studio-white );
+	--color-masterbar-item-new-editor-hover-background: var( --studio-white );
+	--color-masterbar-unread-dot-background: var( --color-accent-30 );
+	--color-masterbar-toggle-drafts-editor-background: var( --studio-gray-60 );
+	--color-masterbar-toggle-drafts-editor-hover-background: var( --studio-gray-40 );
+	--color-masterbar-toggle-drafts-editor-border: var( --studio-gray-10 );
+
+	--color-sidebar-background: var( --studio-white );
+	--color-sidebar-background-rgb: var( --studio-blue-60-rgb );
+	--color-sidebar-border: var( --studio-gray-5-rga );
+	--color-sidebar-text: var( --studio-gray-60 );
+	--color-sidebar-text-alternative: var( --studio-jetpack-green-20 );
+	--color-sidebar-gridicon-fill: var( --studio-jetpack-green-20 );
+	--color-sidebar-menu-selected-background: var( --studio-jetpack-green-10 );
+	--color-sidebar-menu-selected-background-rgb: var( --studio-jetpack-green-10-rgb );
+	--color-sidebar-menu-selected-text: var( --studio-jetpack-green-50 );
+	--color-sidebar-menu-hover-background: var( --studio-jetpack-green-20 );
+	--color-sidebar-menu-hover-background-rgb: var( --studio-jetpack-green-20-rgb );
+	--color-sidebar-menu-hover-text: var( --studio-jetpack-green-50 );
+}

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
@@ -60,15 +60,15 @@
 	--color-masterbar-toggle-drafts-editor-border: var( --studio-gray-10 );
 
 	--color-sidebar-background: var( --studio-white );
-	--color-sidebar-background-rgb: var( --studio-blue-60-rgb );
-	--color-sidebar-border: var( --studio-gray-5-rga );
+	--color-sidebar-background-rgb: var( --studio-white-rgb );
+	--color-sidebar-border: var( --studio-gray-5 );
 	--color-sidebar-text: var( --studio-gray-60 );
 	--color-sidebar-text-alternative: var( --studio-jetpack-green-20 );
-	--color-sidebar-gridicon-fill: var( --studio-jetpack-green-20 );
-	--color-sidebar-menu-selected-background: var( --studio-jetpack-green-10 );
-	--color-sidebar-menu-selected-background-rgb: var( --studio-jetpack-green-10-rgb );
+	--color-sidebar-gridicon-fill: var( --studio-gray-60 );
 	--color-sidebar-menu-selected-text: var( --studio-jetpack-green-50 );
-	--color-sidebar-menu-hover-background: var( --studio-jetpack-green-20 );
-	--color-sidebar-menu-hover-background-rgb: var( --studio-jetpack-green-20-rgb );
-	--color-sidebar-menu-hover-text: var( --studio-jetpack-green-50 );
+	--color-sidebar-menu-selected-background: var( --studio-jetpack-green-5 );
+	--color-sidebar-menu-selected-background-rgb: var( --studio-jetpack-green-5-rgb );
+	--color-sidebar-menu-hover-text: var( --studio-gray-90 );
+	--color-sidebar-menu-hover-background: var( --studio-gray-5 );
+	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-5-rgb );
 }

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
@@ -113,7 +113,7 @@
 	--color-sidebar-background-rgb: var( --studio-white-rgb );
 	--color-sidebar-border: var( --studio-gray-5 );
 	--color-sidebar-text: var( --studio-gray-60 );
-	--color-sidebar-text-alternative: var( --studio-jetpack-green-20 );
+	--color-sidebar-text-alternative: var( --studio-gray-60 );
 	--color-sidebar-gridicon-fill: var( --studio-gray-60 );
 	--color-sidebar-menu-selected-text: var( --studio-jetpack-green-50 );
 	--color-sidebar-menu-selected-background: var( --studio-jetpack-green-5 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Jetpack cloud theme to calypso color theme.
Before:
<img width="847" alt="Screen Shot 2020-03-16 at 5 03 01 PM" src="https://user-images.githubusercontent.com/115071/76777139-08524f00-67a8-11ea-9f60-b6a35ca5d9ba.png">


After:
![image](https://user-images.githubusercontent.com/115071/76777073-f2448e80-67a7-11ea-8fbf-606ec0b0cf3d.png)


#### Testing instructions
* Load up calypso. Does it work as before? 
* load up jetpack cloud `npm run start-jetpack-cloud`. 

Does it look like you expected? 

