### PR TITLE
Buttons: More sentence-casing for button labels

### DIFF
--- a/client/blocks/conversations/empty.jsx
+++ b/client/blocks/conversations/empty.jsx
@@ -34,7 +34,7 @@ class ConversationsEmptyContent extends React.Component {
 					onClick={ this.recordAction }
 					href="/read/search"
 				>
-					{ this.props.translate( 'Find Posts to Follow' ) }
+					{ this.props.translate( 'Find posts to follow' ) }
 				</a>
 			),
 			secondaryAction = null;

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -382,7 +382,7 @@ class UseYourDomainStep extends React.Component {
 			translate( "Requires changes to the domain's DNS" ),
 			this.getMappingPriceText(),
 		];
-		const buttonText = translate( 'Map Your Domain' );
+		const buttonText = translate( 'Map your domain' );
 		const learnMore = translate( '{{a}}Learn more about domain mapping{{/a}}', {
 			components: {
 				a: <a href={ MAP_EXISTING_DOMAIN } rel="noopener noreferrer" target="_blank" />,

--- a/client/my-sites/checkout/cart/cart-empty.jsx
+++ b/client/my-sites/checkout/cart/cart-empty.jsx
@@ -14,11 +14,14 @@ class CartEmpty extends React.Component {
 				<div className="cart-empty">
 					{ this.props.translate( 'There are no items in your cart.' ) }
 				</div>
-				<div className="cart-buttons">
-					<button className="cart-checkout-button button is-primary" onClick={ this.handleClick }>
+				<div className="cart-empty__buttons cart-buttons">
+					<button
+						className="cart-empty__checkout-button cart-checkout-button button is-primary"
+						onClick={ this.handleClick }
+					>
 						{ this.shouldShowPlanButton()
-							? this.props.translate( 'Add a Plan' )
-							: this.props.translate( 'Add a Domain' ) }
+							? this.props.translate( 'Add a plan' )
+							: this.props.translate( 'Add a domain' ) }
 					</button>
 				</div>
 			</div>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -264,7 +264,7 @@ class Home extends Component {
 					{ ! siteIsUnlaunched && (
 						<div className="customer-home__view-site-button">
 							<Button href={ site.URL } onClick={ () => trackAction( 'my_site', 'view_site' ) }>
-								{ translate( 'View Site' ) }
+								{ translate( 'View site' ) }
 							</Button>
 						</div>
 					) }

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -78,7 +78,7 @@ class ContactsPrivacy extends React.PureComponent {
 							this.props.selectedDomainName
 						) }
 					>
-						{ translate( 'Edit Contact Info' ) }
+						{ translate( 'Edit contact info' ) }
 					</VerticalNavItem>
 
 					{ canManageConsent && (

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -168,7 +168,7 @@ class EditContactInfoFormCard extends React.Component {
 				</FormLabel>
 				<DesignatedAgentNotice
 					domainRegistrationAgreementUrl={ domainRegistrationAgreementUrl }
-					saveButtonLabel={ translate( 'Save Contact Info' ) }
+					saveButtonLabel={ translate( 'Save contact info' ) }
 				/>
 			</div>
 		);
@@ -419,7 +419,7 @@ class EditContactInfoFormCard extends React.Component {
 						onContactDetailsChange={ this.handleContactDetailsChange }
 						onSubmit={ this.handleSubmitButtonClick }
 						onValidate={ this.validate }
-						labelTexts={ { submitButton: translate( 'Save Contact Info' ) } }
+						labelTexts={ { submitButton: translate( 'Save contact info' ) } }
 						disableSubmitButton={ this.shouldDisableSubmitButton() }
 						isSubmitting={ this.state.formSubmitting }
 					>

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -53,7 +53,7 @@ class MappedDomainType extends React.Component {
 		const path = domainManagementDns( this.props.selectedSite.slug, this.props.domain.name );
 
 		return (
-			<VerticalNavItem path={ path }>{ this.props.translate( 'DNS Records' ) }</VerticalNavItem>
+			<VerticalNavItem path={ path }>{ this.props.translate( 'DNS records' ) }</VerticalNavItem>
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -68,7 +68,7 @@ class RegisteredDomainType extends React.Component {
 
 		return (
 			<VerticalNavItem path={ path }>
-				{ this.props.translate( 'Name Servers and DNS' ) }
+				{ this.props.translate( 'Name servers and DNS' ) }
 			</VerticalNavItem>
 		);
 	}
@@ -80,14 +80,14 @@ class RegisteredDomainType extends React.Component {
 			this.props.domain.name
 		);
 
-		return <VerticalNavItem path={ path }>{ translate( 'Contacts and Privacy' ) }</VerticalNavItem>;
+		return <VerticalNavItem path={ path }>{ translate( 'Contacts and privacy' ) }</VerticalNavItem>;
 	}
 
 	transferNavItem() {
 		const path = domainManagementTransfer( this.props.selectedSite.slug, this.props.domain.name );
 
 		return (
-			<VerticalNavItem path={ path }>{ this.props.translate( 'Transfer Domain' ) }</VerticalNavItem>
+			<VerticalNavItem path={ path }>{ this.props.translate( 'Transfer domain' ) }</VerticalNavItem>
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/edit/domain-types/wpcom-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/wpcom-domain-type.jsx
@@ -111,8 +111,8 @@ class WpcomDomainType extends React.Component {
 				}
 			>
 				{ isWpcomDomain
-					? this.props.translate( 'Change Site Address' )
-					: this.props.translate( 'Edit Site Address' ) }
+					? this.props.translate( 'Change site address' )
+					: this.props.translate( 'Edit site address' ) }
 			</VerticalNavItem>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/mapped-domain.jsx
@@ -131,7 +131,7 @@ export class MappedDomain extends React.Component {
 		const path = domainManagementDns( this.props.selectedSite.slug, this.props.domain.name );
 
 		return (
-			<VerticalNavItem path={ path }>{ this.props.translate( 'DNS Records' ) }</VerticalNavItem>
+			<VerticalNavItem path={ path }>{ this.props.translate( 'DNS records' ) }</VerticalNavItem>
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/registered-domain.jsx
@@ -137,7 +137,7 @@ class RegisteredDomain extends React.Component {
 
 		return (
 			<VerticalNavItem path={ path }>
-				{ this.props.translate( 'Name Servers and DNS' ) }
+				{ this.props.translate( 'Name servers and DNS' ) }
 			</VerticalNavItem>
 		);
 	}
@@ -149,14 +149,14 @@ class RegisteredDomain extends React.Component {
 			this.props.domain.name
 		);
 
-		return <VerticalNavItem path={ path }>{ translate( 'Contacts and Privacy' ) }</VerticalNavItem>;
+		return <VerticalNavItem path={ path }>{ translate( 'Contacts and privacy' ) }</VerticalNavItem>;
 	}
 
 	transferNavItem() {
 		const path = domainManagementTransfer( this.props.selectedSite.slug, this.props.domain.name );
 
 		return (
-			<VerticalNavItem path={ path }>{ this.props.translate( 'Transfer Domain' ) }</VerticalNavItem>
+			<VerticalNavItem path={ path }>{ this.props.translate( 'Transfer domain' ) }</VerticalNavItem>
 		);
 	}
 

--- a/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/wpcom-domain.jsx
@@ -114,8 +114,8 @@ class WpcomDomain extends React.Component {
 				}
 			>
 				{ isWpcomDomain
-					? this.props.translate( 'Change Site Address' )
-					: this.props.translate( 'Edit Site Address' ) }
+					? this.props.translate( 'Change site address' )
+					: this.props.translate( 'Edit site address' ) }
 			</VerticalNavItem>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -56,11 +56,11 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 			<EmptyContent
 				title={ translate( '%(domainName)s is ready when you are.', { args: { domainName } } ) }
 				line={ translate( 'Start a site now to unlock everything WordPress.com can offer.' ) }
-				action={ translate( 'Create Site' ) }
+				action={ translate( 'Create site' ) }
 				actionURL={ `/start/site-selected/?siteSlug=${ encodeURIComponent(
 					slug
 				) }&siteId=${ encodeURIComponent( siteId ) }` }
-				secondaryAction={ translate( 'Manage Domain' ) }
+				secondaryAction={ translate( 'Manage domain' ) }
 				secondaryActionURL={ domainManagementEdit( slug, domainName ) }
 				illustration={ '/calypso/images/drake/drake-browser.svg' }
 			>
@@ -70,7 +70,7 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 					primary={ ! domainHasGSuiteWithUs }
 					onClick={ recordEmailClick }
 				>
-					{ domainHasGSuiteWithUs ? translate( 'Manage Email' ) : translate( 'Add Email' ) }
+					{ domainHasGSuiteWithUs ? translate( 'Manage email' ) : translate( 'Add email' ) }
 				</Button>
 			</EmptyContent>
 

--- a/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/custom-nameservers-form.jsx
@@ -120,11 +120,11 @@ class CustomNameserversForm extends React.PureComponent {
 							onClick={ this.handleSubmit }
 							disabled={ this.props.submitDisabled }
 						>
-							{ translate( 'Save Custom Name Servers' ) }
+							{ translate( 'Save custom name servers' ) }
 						</FormButton>
 
 						<FormButton type="button" isPrimary={ false } onClick={ this.handleReset }>
-							{ translate( 'Reset to Defaults' ) }
+							{ translate( 'Reset to defaults' ) }
 						</FormButton>
 					</FormFooter>
 				</form>

--- a/client/my-sites/domains/domain-management/name-servers/index.jsx
+++ b/client/my-sites/domains/domain-management/name-servers/index.jsx
@@ -299,7 +299,7 @@ class NameServers extends React.Component {
 				isPlaceholder={ this.isLoading() }
 				path={ domainManagementDns( this.props.selectedSite.slug, this.props.selectedDomainName ) }
 			>
-				{ this.props.translate( 'DNS Records' ) }
+				{ this.props.translate( 'DNS records' ) }
 			</VerticalNavItem>
 		);
 	}

--- a/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/locked.jsx
@@ -80,7 +80,7 @@ class Locked extends React.Component {
 						primary
 						disabled={ this.state.submitting }
 					>
-						{ translate( 'Update Settings And Continue' ) }
+						{ translate( 'Update settings and continue' ) }
 					</Button>
 				</Card>
 			</div>

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/index.jsx
@@ -181,7 +181,7 @@ class TransferOtherUser extends React.Component {
 				},
 				{
 					action: 'confirm',
-					label: this.props.translate( 'Confirm Transfer' ),
+					label: this.props.translate( 'Confirm transfer' ),
 					onClick: this.handleConfirmTransferDomain,
 					disabled: this.state.disableDialogButtons,
 					isPrimary: true,
@@ -215,7 +215,7 @@ class TransferOtherUser extends React.Component {
 		const { selectedDomainName: domainName, translate, users, selectedSite } = this.props,
 			availableUsers = this.filterAvailableUsers( users ),
 			{ currentUserCanManage, domainRegistrationAgreementUrl } = getSelectedDomain( this.props ),
-			saveButtonLabel = translate( 'Transfer Domain' );
+			saveButtonLabel = translate( 'Transfer domain' );
 
 		if ( ! currentUserCanManage ) {
 			return <NonOwnerCard { ...omit( this.props, [ 'children' ] ) } />;

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -195,7 +195,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		}
 
 		const cta: CtaButton = {
-			text: translate( 'Earn Free Credits' ) as string,
+			text: translate( 'Earn free credits' ) as string,
 			action: () => {
 				trackCtaButton( 'peer-referral-wpcom' );
 				onPeerReferralCtaClick();

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -148,7 +148,7 @@ class EmailManagement extends React.Component {
 
 		const defaultEmptyContentProps = {
 			illustration: customDomainImage,
-			action: translate( 'Add a Custom Domain' ),
+			action: translate( 'Add a custom domain' ),
 			actionURL: '/domains/add/' + selectedSiteSlug,
 		};
 
@@ -172,7 +172,7 @@ class EmailManagement extends React.Component {
 		}
 
 		const emailForwardingAction = {
-			secondaryAction: translate( 'Add Email Forwarding' ),
+			secondaryAction: translate( 'Add email forwarding' ),
 			secondaryActionURL: emailManagementForwarding( selectedSiteSlug, selectedDomainName ),
 		};
 

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -85,7 +85,7 @@ export class PeopleInviteDetails extends React.PureComponent {
 					scary={ isPending }
 					onClick={ this.handleDelete }
 				>
-					{ isPending ? translate( 'Revoke Invite' ) : translate( 'Clear Invite' ) }
+					{ isPending ? translate( 'Revoke invite' ) : translate( 'Clear invite' ) }
 				</Button>
 			</div>
 		);

--- a/client/my-sites/people/people-invite-details/test/index.jsx
+++ b/client/my-sites/people/people-invite-details/test/index.jsx
@@ -91,7 +91,7 @@ describe( 'PeopleInviteDetails', () => {
 		const revokeInviteButton = inviteDetails.find( 'Button' );
 		expect( revokeInviteButton ).toHaveLength( 1 );
 		expect( revokeInviteButton.children() ).toHaveLength( 1 );
-		expect( revokeInviteButton.children().text() ).toEqual( 'Revoke Invite' );
+		expect( revokeInviteButton.children().text() ).toEqual( 'Revoke invite' );
 
 		expect( mockDeleteInvite ).not.toHaveBeenCalled();
 		revokeInviteButton.simulate( 'click' );
@@ -120,7 +120,7 @@ describe( 'PeopleInviteDetails', () => {
 		const clearInviteButton = inviteDetails.find( 'Button' );
 		expect( clearInviteButton ).toHaveLength( 1 );
 		expect( clearInviteButton.children() ).toHaveLength( 1 );
-		expect( clearInviteButton.children().text() ).toEqual( 'Clear Invite' );
+		expect( clearInviteButton.children().text() ).toEqual( 'Clear invite' );
 
 		expect( mockDeleteInvite ).not.toHaveBeenCalled();
 		clearInviteButton.simulate( 'click' );

--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -140,16 +140,16 @@ class DeleteSite extends Component {
 		const deleteButtons = [
 			<Button onClick={ this.closeConfirmDialog }>{ translate( 'Cancel' ) }</Button>,
 			<Button primary scary disabled={ deleteDisabled } onClick={ this._deleteSite }>
-				{ translate( 'Delete this Site' ) }
+				{ translate( 'Delete this site' ) }
 			</Button>,
 		];
 
 		const strings = {
-			confirmDeleteSite: translate( 'Confirm Delete Site' ),
-			contactSupport: translate( 'Contact Support' ),
-			deleteSite: translate( 'Delete Site' ),
-			exportContent: translate( 'Export Content' ),
-			exportContentFirst: translate( 'Export Content First' ),
+			confirmDeleteSite: translate( 'Confirm delete site' ),
+			contactSupport: translate( 'Contact support' ),
+			deleteSite: translate( 'Delete site' ),
+			exportContent: translate( 'Export content' ),
+			exportContentFirst: translate( 'Export content first' ),
 		};
 
 		return (

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -47,7 +47,7 @@ class FeedError extends React.Component {
 					onClick={ this.recordSecondaryAction }
 					href="/discover"
 				>
-					{ this.props.translate( 'Explore Discover' ) }
+					{ this.props.translate( 'Explore' ) }
 				</a>
 			);
 

--- a/client/reader/feed-error/index.jsx
+++ b/client/reader/feed-error/index.jsx
@@ -38,7 +38,7 @@ class FeedError extends React.Component {
 					onClick={ this.recordAction }
 					href="/read/search"
 				>
-					{ this.props.translate( 'Find Sites to Follow' ) }
+					{ this.props.translate( 'Find sites to follow' ) }
 				</a>
 			),
 			secondaryAction = (

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -31,7 +31,7 @@ class FeedEmptyContent extends React.PureComponent {
 					onClick={ this.recordAction }
 					href="/read/search"
 				>
-					{ translate( 'Find Sites to Follow' ) }
+					{ translate( 'Find sites to follow' ) }
 				</a>
 			),
 			secondaryAction = (

--- a/client/reader/feed-stream/empty.jsx
+++ b/client/reader/feed-stream/empty.jsx
@@ -40,7 +40,7 @@ class FeedEmptyContent extends React.PureComponent {
 					onClick={ this.recordSecondaryAction }
 					href="/discover"
 				>
-					{ translate( 'Explore Discover' ) }
+					{ translate( 'Explore' ) }
 				</a>
 			);
 

--- a/client/reader/following-manage/empty.jsx
+++ b/client/reader/following-manage/empty.jsx
@@ -29,7 +29,7 @@ class FollowingManageEmptyContent extends React.Component {
 				onClick={ this.recordAction }
 				href="/discover"
 			>
-				{ this.props.translate( 'Explore Discover' ) }
+				{ this.props.translate( 'Explore' ) }
 			</a>
 		);
 

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -36,7 +36,7 @@ class TagEmptyContent extends React.Component {
 					onClick={ this.recordAction }
 					href="/read"
 				>
-					{ this.props.translate( 'Back to Following' ) }
+					{ this.props.translate( 'Back to following' ) }
 				</a>
 			),
 			secondaryAction = isDiscoverEnabled() ? (

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -36,7 +36,7 @@ class TagEmptyContent extends React.Component {
 					onClick={ this.recordAction }
 					href="/read"
 				>
-					{ this.props.translate( 'Back to following' ) }
+					{ this.props.translate( 'Back to Following' ) }
 				</a>
 			),
 			secondaryAction = isDiscoverEnabled() ? (
@@ -51,7 +51,7 @@ class TagEmptyContent extends React.Component {
 
 		return (
 			<EmptyContent
-				title={ this.props.translate( 'No Likes Yet' ) }
+				title={ this.props.translate( 'No likes yet' ) }
 				line={ this.props.translate( 'Posts that you like will appear here.' ) }
 				action={ action }
 				secondaryAction={ secondaryAction }

--- a/client/reader/liked-stream/empty.jsx
+++ b/client/reader/liked-stream/empty.jsx
@@ -45,7 +45,7 @@ class TagEmptyContent extends React.Component {
 					onClick={ this.recordSecondaryAction }
 					href="/discover"
 				>
-					{ this.props.translate( 'Explore Discover' ) }
+					{ this.props.translate( 'Explore' ) }
 				</a>
 			) : null;
 

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -45,7 +45,7 @@ class ListEmptyContent extends React.Component {
 					onClick={ this.recordSecondaryAction }
 					href="/discover"
 				>
-					{ this.props.translate( 'Explore Discover' ) }
+					{ this.props.translate( 'Explore' ) }
 				</a>
 			) : null;
 

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -36,7 +36,7 @@ class ListEmptyContent extends React.Component {
 					onClick={ this.recordAction }
 					href="/read"
 				>
-					{ this.props.translate( 'Back to Following' ) }
+					{ this.props.translate( 'Back to following' ) }
 				</a>
 			),
 			secondaryAction = isDiscoverEnabled() ? (

--- a/client/reader/list-stream/empty.jsx
+++ b/client/reader/list-stream/empty.jsx
@@ -36,7 +36,7 @@ class ListEmptyContent extends React.Component {
 					onClick={ this.recordAction }
 					href="/read"
 				>
-					{ this.props.translate( 'Back to following' ) }
+					{ this.props.translate( 'Back to Following' ) }
 				</a>
 			),
 			secondaryAction = isDiscoverEnabled() ? (

--- a/client/reader/list-stream/missing.jsx
+++ b/client/reader/list-stream/missing.jsx
@@ -48,7 +48,7 @@ class ListMissing extends React.Component {
 					onClick={ this.recordSecondaryAction }
 					href="/discover"
 				>
-					{ this.props.translate( 'Explore Discover' ) }
+					{ this.props.translate( 'Explore' ) }
 				</a>
 			) : null;
 

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -41,7 +41,7 @@ class SearchEmptyContent extends React.Component {
 				onClick={ this.recordAction }
 				href="/read"
 			>
-				{ this.props.translate( 'Back to following' ) }
+				{ this.props.translate( 'Back to Following' ) }
 			</a>
 		);
 
@@ -63,7 +63,7 @@ class SearchEmptyContent extends React.Component {
 
 		return (
 			<EmptyContent
-				title={ this.props.translate( 'No Results' ) }
+				title={ this.props.translate( 'No results' ) }
 				line={ message }
 				action={ action }
 				secondaryAction={ secondaryAction }

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -51,7 +51,7 @@ class SearchEmptyContent extends React.Component {
 				onClick={ this.recordSecondaryAction }
 				href="/discover"
 			>
-				{ this.props.translate( 'Explore Discover' ) }
+				{ this.props.translate( 'Explore' ) }
 			</a>
 		) : null;
 

--- a/client/reader/search-stream/empty.jsx
+++ b/client/reader/search-stream/empty.jsx
@@ -41,7 +41,7 @@ class SearchEmptyContent extends React.Component {
 				onClick={ this.recordAction }
 				href="/read"
 			>
-				{ this.props.translate( 'Back to Following' ) }
+				{ this.props.translate( 'Back to following' ) }
 			</a>
 		);
 

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -34,7 +34,7 @@ const SiteEmptyContent = ( { translate } ) => {
 				onClick={ recordAction }
 				href="/discover"
 			>
-				{ translate( 'Explore Discover' ) }
+				{ translate( 'Explore' ) }
 			</a>
 		);
 	}

--- a/client/reader/site-stream/empty.jsx
+++ b/client/reader/site-stream/empty.jsx
@@ -45,7 +45,7 @@ const SiteEmptyContent = ( { translate } ) => {
 			onClick={ recordSecondaryAction }
 			href="/read/search"
 		>
-			{ translate( 'Find Sites to Follow' ) }
+			{ translate( 'Find sites to follow' ) }
 		</a>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/reader/stream/empty.jsx
+++ b/client/reader/stream/empty.jsx
@@ -34,7 +34,7 @@ class FollowingEmptyContent extends React.Component {
 					onClick={ this.recordAction }
 					href="/read/search"
 				>
-					{ this.props.translate( 'Find Sites to Follow' ) }
+					{ this.props.translate( 'Find sites to follow' ) }
 				</a>
 			),
 			secondaryAction = null;

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -51,7 +51,7 @@ class TagEmptyContent extends React.Component {
 				onClick={ this.recordSecondaryAction }
 				href="/discover"
 			>
-				{ this.props.translate( 'Explore Discover' ) }
+				{ this.props.translate( 'Explore' ) }
 			</a>
 		) : null;
 

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -41,7 +41,7 @@ class TagEmptyContent extends React.Component {
 				onClick={ this.recordAction }
 				href="/read"
 			>
-				{ this.props.translate( 'Back to Following' ) }
+				{ this.props.translate( 'Back to following' ) }
 			</a>
 		);
 

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -41,7 +41,7 @@ class TagEmptyContent extends React.Component {
 				onClick={ this.recordAction }
 				href="/read"
 			>
-				{ this.props.translate( 'Back to following' ) }
+				{ this.props.translate( 'Back to Following' ) }
 			</a>
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixing a few stray uses of `Title Case` button labels to use `Sentence casing`

#### Testing instructions

* Checkout this branch locally or use https://calypso.live/?branch=update/more-button-sentence-casing
* Visit the pages listed below to check the buttons have proper casing.

**My Home**
<img width="120" alt="Screen Shot 2020-03-16 at 11 20 47 AM" src="https://user-images.githubusercontent.com/448298/76773033-34ee7280-6778-11ea-8454-28b149ca84f9.png">

**Domains > { registered domain } > Contacts and Privacy**
![image](https://user-images.githubusercontent.com/448298/76773160-65cea780-6778-11ea-9ad3-82b1c7d9f352.png)

**Domains > { registered domain } > Contacts and Privacy > Edit contact info**
![image](https://user-images.githubusercontent.com/448298/76773190-754df080-6778-11ea-8a05-00161fd922cd.png)

**Domains > { registered domain } > Transfer Domain > Transfer to another registrar**
![image](https://user-images.githubusercontent.com/448298/76773270-99113680-6778-11ea-9a43-c3dd06915ae5.png)

**Domains > { registered domain } > Transfer Domain > Transfer to another user**
![image](https://user-images.githubusercontent.com/448298/76773323-ab8b7000-6778-11ea-9eba-4a2979dabbf7.png)

**Domains (with empty cart) > Cart button in section header**
![image](https://user-images.githubusercontent.com/448298/76773404-c6f67b00-6778-11ea-91fb-f2de088f17b9.png)

**People > Invites > Invite Details**
![image](https://user-images.githubusercontent.com/448298/76773437-d5dd2d80-6778-11ea-8a55-aaf3ae8c8387.png)

**Settings > Delete your site permanently**
![image](https://user-images.githubusercontent.com/448298/76773492-edb4b180-6778-11ea-8ae8-ce02ee947703.png)

**Settings > Delete your site permanently > click `Delete site`**
![image](https://user-images.githubusercontent.com/448298/76773540-03c27200-6779-11ea-9e98-7d9e012e3fd7.png)


Fixes #40120
