### PR TITLE
[e2e] Attempt to improve flaky tests

### DIFF
--- a/test/e2e/lib/pages/editor-page.js
+++ b/test/e2e/lib/pages/editor-page.js
@@ -219,7 +219,7 @@ export default class EditorPage extends AsyncBaseContainer {
 		return await driverHelper.waitTillNotPresent(
 			this.driver,
 			by.css( '.editor-simple-payments-modal' ),
-			this.explicitWaitMS * 3
+			this.explicitWaitMS * 7
 		);
 	}
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1206,7 +1206,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			await this.loginFlow.login();
-			return this.loginFlow.checkForDevDocsAndRedirectToReader();
+			return await this.loginFlow.checkForDevDocsAndRedirectToReader();
 		} );
 
 		step( 'Find a post to share (press this)', async function() {
@@ -1219,20 +1219,20 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 		step( 'Block Editor loads with shared content', async function() {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			await gEditorComponent.initEditor();
+			return await gEditorComponent.initEditor();
 		} );
 
 		step( 'Can publish and view content', async function() {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			await gEditorComponent.publish( { visit: true } );
+			return await gEditorComponent.publish( { visit: true } );
 		} );
 
 		step( 'Can see a post title and post content', async function() {
 			const viewPostPage = await ViewPostPage.Expect( driver );
 			const postTitle = await viewPostPage.postTitle();
 			const postContent = await viewPostPage.postContent();
-			assert.ok( postTitle.length > 0, 'Press This did not copy a post title!' );
-			assert.ok( postContent.length > 0, 'Press This did not copy any post content!' );
+			assert( postTitle.length > 0, 'Press This did not copy a post title!' );
+			return assert( postContent.length > 0, 'Press This did not copy any post content!' );
 		} );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

1) Improve `Can Share Posts From Reader (PressThis)!` test stability - I noticed this test is failing very often and on different steps. I assume that missing `await` [here](https://github.com/Automattic/wp-calypso/pull/40174/files#diff-38fc5aa5d43ce62fb9ec7c17b4ba4406R1209) was causing these random failures. 

2) Improve `Insert a payment button:` stability - while testing locally, I noticed that sometimes it takes much longer than 60s for payment modal to disappear. Hopefully, the [increased timeout](https://github.com/Automattic/wp-calypso/pull/40174/files#diff-7c87841d595d7dee6dd22c8e7f3b2e3eR222) will reduce the number of failures. 

#### Changes proposed in this Pull Request

Make sure that tests are passing. 