### PR TITLE
Site migration: change wording of Jetpack install link and text about WordPress content imports

### DIFF
--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -83,7 +83,10 @@ class StepImportOrMigrate extends Component {
 			return (
 				<p>
 					{ translate(
-						'You need to have {{jetpackInstallLink}}Jetpack{{/jetpackInstallLink}} installed on your site to be able to import everything.',
+						'You need to have Jetpack installed on your site to' +
+							' be able to import everything.' +
+							' {{jetpackInstallLink}}Install' +
+							' Jetpack{{/jetpackInstallLink}}',
 						{
 							components: {
 								jetpackInstallLink: (

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -86,7 +86,7 @@ class StepImportOrMigrate extends Component {
 						'You need to have Jetpack installed on your site to' +
 							' be able to import everything.' +
 							' {{jetpackInstallLink}}Install' +
-							' Jetpack{{/jetpackInstallLink}}',
+							' Jetpack{{/jetpackInstallLink}}.',
 						{
 							components: {
 								jetpackInstallLink: (

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -133,7 +133,8 @@ class StepSourceSelect extends Component {
 					<div className="migrate__explain">
 						{ translate(
 							"Enter a URL and we'll help you move your site to WordPress.com. If you already have a " +
-								'backup file, you can {{uploadFileLink}}upload it to import content{{/uploadFileLink}}.',
+								'WordPress export file, you can' +
+								' {{uploadFileLink}}upload it to import content{{/uploadFileLink}}.',
 							{
 								components: {
 									uploadFileLink: <a className="migrate__import-link" href={ uploadFileLink } />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR slightly changes the wording in two steps of the site migration flow. The link to the Jetpack install is given an explicit "Install Jetpack" call to action to make it clearer what it does. The text about uploading WordPress imports is changed to refer to a "WordPress export file" to communicate the fact that we're expecting a WXR file.

#### Testing instructions

* Apply the PR or use `calypso.live`.
* Go to `/import/[ SITE ]` in a Simple or Atomic site, and click on WordPress.
* Note the new wording on the "What WordPress site do you want to import?" page.
* Enter the URL of a WordPress site without a Jetpack connection, like `lost-skink.jurassic.ninja`.
* Note the new position and wording of the "Install Jetpack" link.

<img width="728" alt="image" src="https://user-images.githubusercontent.com/1647564/76783474-d3df9280-67a9-11ea-8055-0011808f479d.png">

<img width="727" alt="image" src="https://user-images.githubusercontent.com/1647564/76783583-0e492f80-67aa-11ea-83dd-ff1a99f573e0.png">

