### PR TITLE
Site migration: don't show checklist completed banner if we're showing site recently migrated banner

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -316,6 +316,7 @@ class Home extends Component {
 			isChecklistComplete,
 			siteIsUnlaunched,
 			isEstablishedSite,
+			isRecentlyMigratedSite,
 			displayWelcomeBanner,
 		} = this.props;
 
@@ -328,7 +329,9 @@ class Home extends Component {
 				/>
 			);
 		}
-		const renderChecklistCompleteBanner = 'render' === this.state.renderChecklistCompleteBanner;
+
+		const renderChecklistCompleteBanner =
+			'render' === this.state.renderChecklistCompleteBanner && ! isRecentlyMigratedSite;
 
 		return (
 			<Main className="customer-home__main is-wide-layout">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* With this PR, the banner congratulating the user for completing every item in their checklist should never appear at the same time as the "Your site has been imported!" banner.

#### Testing instructions

* Apply the PR, or use `calypso.live`.
* Have a new Simple site you've completed all the checklist items on.
* Open the site in Calypso, go to `/import/[ SITE ]` and click WordPress.
* Enter the URL of a Jetpack site to import from.
* Follow the steps and complete the migration.
* At the end of the process you should be redirected to the customer home. You should only see the "Your site has been imported!" banner, not the banner congratulating you for completing every item in your checklist.

<img width="2108" alt="image" src="https://user-images.githubusercontent.com/1647564/76785351-31291300-67ad-11ea-89c4-3d3dc186691b.png">

