### PR TITLE
Update acorn to 6.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8770,9 +8770,9 @@
 			}
 		},
 		"acorn": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-			"integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw=="
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+			"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
 		},
 		"acorn-dynamic-import": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
 		"@wordpress/jest-preset-default": "5.4.0",
 		"@wordpress/npm-package-json-lint-config": "2.2.0",
 		"@wordpress/scripts": "7.1.0",
-		"acorn": "6.4.0",
+		"acorn": "6.4.1",
 		"babel-eslint": "10.0.3",
 		"babel-jest": "25.1.0",
 		"babel-plugin-add-module-exports": "1.0.2",

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -1123,9 +1123,9 @@
 			}
 		},
 		"acorn": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-			"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
 		},
 		"acorn-jsx": {
 			"version": "5.1.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates acorn 6.4.1 to patch a security vulnerability

Links:
* Github notifications
  * https://github.com/Automattic/wp-calypso/network/alert/package.json/acorn/closed
  * https://github.com/Automattic/wp-calypso/network/alert/test/e2e/package-lock.json/acorn/open
* Synk advisory: https://snyk.io/vuln/SNYK-JS-ACORN-559469
* Changelog https://github.com/acornjs/acorn/blob/master/acorn/CHANGELOG.md

#### Testing instructions

N/A
