### PR TITLE
Domains: Update DNS setup required language to be more user-friendly

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -222,10 +222,10 @@ export class DomainWarnings extends React.PureComponent {
 		};
 		let children;
 		if ( this.props.isCompact ) {
-			noticeProps.text = translate( 'DNS configuration required' );
+			noticeProps.text = translate( 'Set up your domain' );
 			children = (
 				<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
-					{ translate( 'Fix' ) }
+					{ translate( 'Go' ) }
 				</NoticeAction>
 			);
 		} else {

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -222,7 +222,7 @@ export class DomainWarnings extends React.PureComponent {
 		};
 		let children;
 		if ( this.props.isCompact ) {
-			noticeProps.text = translate( 'Set up your domain' );
+			noticeProps.text = translate( 'Complete domain setup' );
 			children = (
 				<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
 					{ translate( 'Go' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Average user probably doesn't know what DNS means right off. We can make this language more user-friendly with a quick copy update.

**Before**

<img src="https://user-images.githubusercontent.com/2124984/76111878-27cec800-5faf-11ea-9509-3c2f0a4dc77a.png" style="max-width: 100%; height: auto;">

**After**

<img width="241" alt="Screen Shot 2020-03-16 at 1 23 50 PM" src="https://user-images.githubusercontent.com/349751/76796892-a4209280-6789-11ea-8090-99e838ec02be.png" style="max-width: 100%; height: auto;">


#### Testing instructions

* Switch to this PR.
* Add a subdomain to a domain that is not yet set up properly. You can add any random domain to an account to do this (and just don't set up any DNS for it).
* Note the copy changes.

Fixes #39939 
