### PR TITLE
Site Migrations: Don't refresh migration status for first 30 seconds

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -38,8 +38,11 @@ import wpcom from 'lib/wp';
  */
 import './section-migrate.scss';
 
+const THIRTY_SECONDS = 30 * 1000;
+
 class SectionMigrate extends Component {
 	_startedMigrationFromCart = false;
+	_timeStartedMigrationFromCart = false;
 
 	state = {
 		errorMessage: '',
@@ -58,6 +61,7 @@ class SectionMigrate extends Component {
 	componentDidMount() {
 		if ( true === this.props.startMigration ) {
 			this._startedMigrationFromCart = true;
+			this._timeStartedMigrationFromCart = new Date().getTime();
 			this.setMigrationState( { migrationStatus: 'backing-up' } );
 			this.startMigration();
 		}
@@ -158,10 +162,13 @@ class SectionMigrate extends Component {
 		// and start migration straight away. This condition prevents a response
 		// from the status endpoint accidentally changing the local state
 		// before the server's properly registered that we're backing up.
+		// After 30 seconds, responses from the server are no longer ignored,
+		// this prevents migrations reset from the server from being locked.
 		if (
 			this._startedMigrationFromCart &&
 			'backing-up' === this.state.migrationStatus &&
-			state.migrationStatus === 'inactive'
+			state.migrationStatus === 'inactive' &&
+			new Date().getTime() - this._timeStartedMigrationFromCart < THIRTY_SECONDS
 		) {
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a delay of 30 seconds after a migration is started from the cart before polling results in an update.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start a migration on a site without a business plan.
* Complete the purchase of the business plan in the migration flow.
* After migration starts, reset the migration.
* Verify that the status of the migration updates.
