### PR TITLE
Enable `upgrades/domain-search` flag in horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -108,6 +108,7 @@
 		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
+		"upgrades/domain-search": true,
 		"upgrades/in-app-purchase": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,


### PR DESCRIPTION
This allows adding domains in the Horizon testing environment.

![add-domain-button](https://user-images.githubusercontent.com/2036909/76800156-6af81a80-67a9-11ea-9bba-eecdf004304f.png)

#### Testing instructions

None, but once this is enabled, visit https://horizon.wordpress.com/domains/manage/example.com (for your site address) and verify that you see a "Add domain" button.