### PR TITLE
Site Migration: Show wp-admin link for non-atomic Jetpack sites

### DIFF
--- a/client/my-sites/importer/jetpack-importer.jsx
+++ b/client/my-sites/importer/jetpack-importer.jsx
@@ -7,14 +7,12 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import { localize } from 'i18n-calypso';
 import { getSelectedSite } from 'state/ui/selectors';
-import { CompactCard } from '@automattic/components';
 import EmptyContent from 'components/empty-content';
 
 class JetpackImporter extends PureComponent {
-	renderUnsupportedCard = () => {
+	render() {
 		const { site, translate } = this.props;
 		const {
 			options: { admin_url: adminUrl },
@@ -33,26 +31,6 @@ class JetpackImporter extends PureComponent {
 				actionURL={ adminUrl + 'import.php' }
 				actionTarget="_blank"
 			/>
-		);
-	};
-	render() {
-		if ( ! isEnabled( 'manage/import-to-jetpack' ) ) {
-			return this.renderUnsupportedCard();
-		}
-
-		return (
-			<CompactCard>
-				<h2>
-					A8C NOTICE: Jetpack Importing is currently in development -- please use wp-admin / wp-cli
-					tooling in the meantime
-				</h2>
-				<hr />
-				{ '<JetpackFileImporter /> would go here' }
-				<hr />
-				<div>@TODO URL Importer here</div>
-				<hr />
-				<div>@TODO Info / Icons for supported services here</div>
-			</CompactCard>
 		);
 	}
 }

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -56,6 +56,10 @@ class SectionMigrate extends Component {
 	};
 
 	componentDidMount() {
+		if ( this.isNonAtomicJetpack() ) {
+			return page( `/import/${ this.props.targetSiteSlug }` );
+		}
+
 		if ( true === this.props.startMigration ) {
 			this._startedMigrationFromCart = true;
 			this.setMigrationState( { migrationStatus: 'backing-up' } );
@@ -67,6 +71,10 @@ class SectionMigrate extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		if ( this.isNonAtomicJetpack() ) {
+			return page( `/import/${ this.props.targetSiteSlug }` );
+		}
+
 		if ( this.props.sourceSiteId !== prevProps.sourceSiteId ) {
 			this.fetchSourceSitePluginsAndThemes();
 		}
@@ -330,6 +338,10 @@ class SectionMigrate extends Component {
 
 	isFinished = () => {
 		return includes( [ 'done', 'error', 'unknown' ], this.state.migrationStatus );
+	};
+
+	isNonAtomicJetpack = () => {
+		return ! this.props.isTargetSiteAtomic && this.props.isTargetSiteJetpack;
 	};
 
 	renderLoading() {

--- a/config/development.json
+++ b/config/development.json
@@ -92,7 +92,6 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/import-to-jetpack": true,
 		"manage/import/site-importer-endpoints": true,
 		"manage/payment-methods": true,
 		"manage/plugins": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If migration is navigated to for sites that don't support it (non-Atomic Jetpack sites), redirect to the `/import` page for that site.
* Remove an unused feature-flag, `manage/import-to-jetpack`, so that the Import experience is consistent across all environments for non-Atomic Jetpack sites:

![image](https://user-images.githubusercontent.com/363749/76801180-236e9000-67a3-11ea-95a6-4d4d4a2dce9f.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate directly to `/migrate/:siteSlug`, where `:siteSlug` is the slug for a non-Atomic Jetpack site. Verify that you are redirected to `/import/:siteSlug` and that the message about visiting wp-admin is displayed.
* Navigate to a migration page for a supported site. Use the site-selector to switch to a non-Atomic Jetpack site. Verify the redirection mentioned above occurs.


