### PR TITLE
Add product_slugs and receipt_id to calypso_checkout_composite_payment_complete

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -840,6 +840,10 @@ function getCheckoutEventHandler( dispatch ) {
 						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
 						total: action.payload.total.amount.value,
 						currency: action.payload.total.amount.currency,
+						product_slugs: action.payload.responseCart.products
+							.map( product => product.product_slug )
+							.join( ',' ),
+						receipt_id: transactionResult.receipt_id,
 						payment_method:
 							translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
 								?.name || '',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies our Tracks logging for the `calypso_checkout_composite_payment_complete` event so that it also includes `product_slugs` (a comma-separated list of products in the cart that was purchased) and `receipt_id` (the transaction receipt id).

#### Testing instructions

Complete a purchase using composite checkout. Verify that you see the above properties in the Tracks log for that event.