### PR TITLE
Disable domains and domain products in composite checkout

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -162,6 +162,16 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		debug( 'shouldShowCompositeCheckout true because testing config is enabled' );
 		return true;
 	}
+	// Disable for domains in the cart
+	if ( cart.products?.find( product => product.is_domain_registration ) ) {
+		debug( 'shouldShowCompositeCheckout false because cart contains domain registration' );
+		return false;
+	}
+	// Disable for domain mapping
+	if ( cart.products?.find( product => product.product_slug.includes( 'domain' ) ) ) {
+		debug( 'shouldShowCompositeCheckout false because cart contains domain item' );
+		return false;
+	}
 	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
 		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
 		return true;


### PR DESCRIPTION
Reverts #40181

#### Testing instructions

- Add a domain using a gTLD without special contact fields (eg: .blog) to your cart.
- Visit checkout.
- Verify that you see regular checkout.
- Add a domain using a ccTLD without special contact fields (eg: .tv) to your cart and return to checkout.
- Verify that you still see regular checkout.
- Add a domain using a TLD that has special contact fields (eg: .co.uk) to your cart and return to checkout.
- Verify that you see regular checkout.