### PR TITLE
Update/jetpack cloud backup status with new date management

### DIFF
--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -23,6 +23,7 @@ class DatePicker extends Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
 		selectedDate: PropTypes.instanceOf( Date ).isRequired,
+		oldestDateAvailable: PropTypes.instanceOf( Date ).isRequired,
 		onDateChange: PropTypes.func.isRequired,
 		onDateRangeSelection: PropTypes.func.isRequired,
 	};
@@ -53,6 +54,10 @@ class DatePicker extends Component {
 	};
 
 	shuttleLeft = () => {
+		if ( ! this.canShuttleLeft() ) {
+			return false;
+		}
+
 		const { moment, onDateChange, selectedDate } = this.props;
 
 		const newSelectedDate = moment( selectedDate ).subtract( 1, 'days' );
@@ -70,6 +75,12 @@ class DatePicker extends Component {
 		const newSelectedDate = moment( selectedDate ).add( 1, 'days' );
 
 		onDateChange( newSelectedDate.toDate() );
+	};
+
+	canShuttleLeft = () => {
+		const { moment, selectedDate, oldestDateAvailable } = this.props;
+
+		return !! oldestDateAvailable && ! moment( selectedDate ).isSame( oldestDateAvailable, 'day' );
 	};
 
 	canShuttleRight = () => {
@@ -90,7 +101,7 @@ class DatePicker extends Component {
 		return (
 			<div className="date-picker">
 				<Button compact borderless onClick={ this.shuttleLeft }>
-					<Gridicon icon="chevron-left" />
+					<Gridicon icon="chevron-left" className={ ! this.canShuttleLeft() && 'disabled' } />
 				</Button>
 
 				<div className="date-picker__display-date">{ previousDisplayDate }</div>

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -18,37 +19,45 @@ import Gridicon from 'components/gridicon';
  */
 import './style.scss';
 
-const DATE_FORMAT = 'YYYY-MM-DD';
-
 class DatePicker extends Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
-		selectedDateString: PropTypes.string.isRequired,
-		onChange: PropTypes.func.isRequired,
+		selectedDate: PropTypes.instanceOf( Date ).isRequired,
+		onDateChange: PropTypes.func.isRequired,
+		onDateRangeSelection: PropTypes.func.isRequired,
 	};
 
-	getFormattedDate = dateString => this.props.moment.parseZone( dateString ).format( DATE_FORMAT );
+	getDisplayDate = ( date, showTodayYesterday = true ) => {
+		const { moment, translate } = this.props;
 
-	getDisplayDate = dateString => {
-		const word = this.props.moment
-			.parseZone( dateString )
-			.calendar()
-			.split( ' ' )[ 0 ];
-		if ( 'Today' === word || 'Yesterday' === word ) {
-			return word;
+		const daysDiff = moment().diff( date, 'days' );
+		const yearToday = moment().format( 'YYYY' );
+		const yearDate = moment( date ).format( 'YYYY' );
+
+		let dateFormat = 'MMM D';
+
+		if ( yearToday !== yearDate ) {
+			dateFormat = 'MMM D, YYYY';
 		}
 
-		return this.getFormattedDate( dateString );
+		if ( showTodayYesterday ) {
+			switch ( daysDiff ) {
+				case 0:
+					return translate( 'Today' );
+				case 1:
+					return translate( 'Yesterday' );
+			}
+		}
+
+		return date.format( dateFormat );
 	};
 
 	shuttleLeft = () => {
-		const { moment, onChange, selectedDateString } = this.props;
-		const newDateString = moment
-			.parseZone( selectedDateString )
-			.subtract( 1, 'days' )
-			.toISOString( true );
+		const { moment, onDateChange, selectedDate } = this.props;
 
-		onChange( newDateString );
+		const newSelectedDate = moment( selectedDate ).subtract( 1, 'days' );
+
+		onDateChange( newSelectedDate.getDate() );
 	};
 
 	shuttleRight = () => {
@@ -56,24 +65,27 @@ class DatePicker extends Component {
 			return false;
 		}
 
-		const { moment, onChange, selectedDateString } = this.props;
-		const newDateString = moment
-			.parseZone( selectedDateString )
-			.add( 1, 'days' )
-			.toISOString( true );
+		const { moment, onDateChange, selectedDate } = this.props;
 
-		onChange( newDateString );
+		const newSelectedDate = moment( selectedDate ).add( 1, 'days' );
+
+		onDateChange( newSelectedDate.getDate() );
 	};
 
 	canShuttleRight = () => {
-		const { moment, selectedDateString } = this.props;
-		return ! moment().isSame( moment.parseZone( selectedDateString ), 'day' );
+		const { moment, selectedDate } = this.props;
+
+		return ! moment( selectedDate ).isSame( moment(), 'day' );
 	};
 
 	render() {
-		const { selectedDateString, siteId } = this.props;
+		const { selectedDate, siteId, moment } = this.props;
 
-		const currentDisplayDate = this.getDisplayDate( selectedDateString );
+		const previousDate = moment( selectedDate ).subtract( 1, 'days' );
+		const nextDate = moment( selectedDate ).add( 1, 'days' );
+
+		const previousDisplayDate = this.getDisplayDate( previousDate );
+		const nextDisplayDate = this.getDisplayDate( nextDate, false );
 
 		return (
 			<div className="date-picker">
@@ -81,17 +93,26 @@ class DatePicker extends Component {
 					<Gridicon icon="chevron-left" />
 				</Button>
 
-				<div className="date-picker__current-display-date">{ currentDisplayDate }</div>
-
-				<Button compact borderless onClick={ this.shuttleRight }>
-					<Gridicon icon="chevron-right" className={ ! this.canShuttleRight() && 'disabled' } />
-				</Button>
+				<div className="date-picker__display-date">{ previousDisplayDate }</div>
 
 				<DateRangeSelector
 					siteId={ siteId }
 					enabled={ true }
 					customLabel={ <Gridicon icon="calendar" /> }
 				/>
+
+				<div
+					className={ classNames( 'date-picker__display-date', {
+						disabled: ! this.canShuttleRight(),
+					} ) }
+				>
+					{ nextDisplayDate }
+				</div>
+
+				<Button compact borderless onClick={ this.shuttleRight }>
+					<Gridicon icon="chevron-right" className={ ! this.canShuttleRight() && 'disabled' } />
+				</Button>
+				<div>Date selected: { this.getDisplayDate( selectedDate ) }</div>
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -49,11 +49,10 @@ class DatePicker extends Component {
 		return moment( date ).format( dateFormat );
 	};
 
-	shuttleLeft = () => {
-		if ( ! this.canShuttleLeft() ) {
+	goToPreviousDay = () => {
+		if ( ! this.canGoToPreviousDay() ) {
 			return false;
 		}
-
 		const { moment, onDateChange, selectedDate } = this.props;
 
 		const newSelectedDate = moment( selectedDate ).subtract( 1, 'days' );
@@ -61,11 +60,10 @@ class DatePicker extends Component {
 		onDateChange( newSelectedDate.toDate() );
 	};
 
-	shuttleRight = () => {
-		if ( ! this.canShuttleRight() ) {
+	goToNextDay = () => {
+		if ( ! this.canGoToNextDay() ) {
 			return false;
 		}
-
 		const { moment, onDateChange, selectedDate } = this.props;
 
 		const newSelectedDate = moment( selectedDate ).add( 1, 'days' );
@@ -73,13 +71,13 @@ class DatePicker extends Component {
 		onDateChange( newSelectedDate.toDate() );
 	};
 
-	canShuttleLeft = () => {
+	canGoToPreviousDay = () => {
 		const { moment, selectedDate, oldestDateAvailable } = this.props;
 
 		return !! oldestDateAvailable && ! moment( selectedDate ).isSame( oldestDateAvailable, 'day' );
 	};
 
-	canShuttleRight = () => {
+	canGoToNextDay = () => {
 		const { moment, selectedDate } = this.props;
 
 		return ! moment( selectedDate ).isSame( moment(), 'day' );
@@ -96,8 +94,8 @@ class DatePicker extends Component {
 
 		return (
 			<div className="date-picker">
-				<Button compact borderless onClick={ this.shuttleLeft }>
-					<Gridicon icon="chevron-left" className={ ! this.canShuttleLeft() && 'disabled' } />
+				<Button compact borderless onClick={ this.goToPreviousDay }>
+					<Gridicon icon="chevron-left" className={ ! this.canGoToPreviousDay() && 'disabled' } />
 				</Button>
 
 				<div className="date-picker__display-date">{ previousDisplayDate }</div>
@@ -110,14 +108,14 @@ class DatePicker extends Component {
 
 				<div
 					className={ classNames( 'date-picker__display-date', {
-						disabled: ! this.canShuttleRight(),
+						disabled: ! this.canGoToNextDay(),
 					} ) }
 				>
 					{ nextDisplayDate }
 				</div>
 
-				<Button compact borderless onClick={ this.shuttleRight }>
-					<Gridicon icon="chevron-right" className={ ! this.canShuttleRight() && 'disabled' } />
+				<Button compact borderless onClick={ this.goToNextDay }>
+					<Gridicon icon="chevron-right" className={ ! this.canGoToNextDay() && 'disabled' } />
 				</Button>
 				<div>Date selected: { this.getDisplayDate( selectedDate ) }</div>
 			</div>

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -49,7 +49,7 @@ class DatePicker extends Component {
 			}
 		}
 
-		return date.format( dateFormat );
+		return moment( date ).format( dateFormat );
 	};
 
 	shuttleLeft = () => {
@@ -57,7 +57,7 @@ class DatePicker extends Component {
 
 		const newSelectedDate = moment( selectedDate ).subtract( 1, 'days' );
 
-		onDateChange( newSelectedDate.getDate() );
+		onDateChange( newSelectedDate.toDate() );
 	};
 
 	shuttleRight = () => {
@@ -69,7 +69,7 @@ class DatePicker extends Component {
 
 		const newSelectedDate = moment( selectedDate ).add( 1, 'days' );
 
-		onDateChange( newSelectedDate.getDate() );
+		onDateChange( newSelectedDate.toDate() );
 	};
 
 	canShuttleRight = () => {

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -35,11 +35,7 @@ class DatePicker extends Component {
 		const yearToday = moment().format( 'YYYY' );
 		const yearDate = moment( date ).format( 'YYYY' );
 
-		let dateFormat = 'MMM D';
-
-		if ( yearToday !== yearDate ) {
-			dateFormat = 'MMM D, YYYY';
-		}
+		const dateFormat = yearToday === yearDate ? 'MMM D' : 'MMM D, YYYY';
 
 		if ( showTodayYesterday ) {
 			switch ( daysDiff ) {

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -1,10 +1,10 @@
 .date-picker .button,
-.date-picker__current-display-date,
+.date-picker__display-date,
 .date-picker .date-range {
-    display: inline-block;
-    float: none;
+	display: inline-block;
+	float: none;
 }
 
 .date-picker .button .gridicon.disabled {
-    fill: #dcdcde;
+	fill: #dcdcde;
 }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -10,7 +10,6 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { emptyFilter } from 'state/activity-log/reducer';
-// import { getBackupAttemptsForDate, getDailyBackupDeltas, getEventsInDailyBackup } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
@@ -18,8 +17,6 @@ import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import { applySiteOffset } from 'lib/site/timezone';
 import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
-//import BackupDelta from '../../components/backup-delta';
-//import DailyBackupStatus from '../../components/daily-backup-status';
 import DatePicker from '../../components/date-picker';
 import getRewindState from 'state/selectors/get-rewind-state';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
@@ -90,20 +87,8 @@ class BackupsPage extends Component {
 		//todo: go to the log activity view
 	};
 
-	// hasRealtimeBackups = () =>
-	// 	this.props.sitePurchases &&
-	// 	!! this.props.sitePurchases.filter(
-	// 		purchase => 'jetpack_backup_realtime' === purchase.productSlug
-	// 	).length;
-
 	render() {
-		// const { allowRestore, logs, moment, siteId, siteSlug } = this.props;
 		const { siteId, loading, oldestDateAvailable } = this.props;
-
-		// const hasRealtimeBackups = this.hasRealtimeBackups();
-		// const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
-		// const deltas = getDailyBackupDeltas( logs, selectedDateString );
-		// const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
 
 		return (
 			<div>
@@ -119,7 +104,7 @@ class BackupsPage extends Component {
 					siteId={ siteId }
 				/>
 
-				{ /* The following code is for testing purposes: */ }
+				{ /* The following code is only for testing purposes: */ }
 				<div>{ loading && 'Loading backups...' }</div>
 				<div>
 					{ ! loading && 'Backups on this date: ' + this.state.backupsOnSelectedDate.length }
@@ -130,26 +115,7 @@ class BackupsPage extends Component {
 							<li key={ log.activityId }>{ log.activityTitle }</li>
 						) ) }
 				</ul>
-
-				{ /*<DailyBackupStatus*/ }
-				{ /*allowRestore={ allowRestore }*/ }
-				{ /*date={ this.state.selectedDate }*/ }
-				{ /*backups={ this.state.selectedDateBackups }*/ }
-				{ /*backupAttempts={ backupAttempts }*/ }
-				{ /*siteSlug={ siteSlug }*/ }
-				{ /*/>*/ }
-
-				{ /* Temporaly commented. PR in progress */ }
-				{ /*<BackupDelta*/ }
-				{ /*{ ...{*/ }
-				{ /*deltas,*/ }
-				{ /*backupAttempts,*/ }
-				{ /*hasRealtimeBackups,*/ }
-				{ /*realtimeEvents,*/ }
-				{ /*allowRestore,*/ }
-				{ /*moment,*/ }
-				{ /*} }*/ }
-				{ /*/>*/ }
+				{ /* END of code for testing purposes: */ }
 			</div>
 		);
 	}
@@ -216,7 +182,6 @@ export default connect( state => {
 	return {
 		allowRestore,
 		loading,
-		// rewind,
 		siteId,
 		sitePurchases,
 		siteSlug,

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -53,9 +53,13 @@ class BackupsPage extends Component {
 		oldestDateAvailable: new Date(),
 	};
 
+	componentDidMount() {
+		this.createIndexedLog();
+	}
+
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.logs !== this.props.logs ) {
-			this.createIndexedLog( this.props.logs );
+			this.createIndexedLog();
 		}
 		if ( prevProps.siteId !== this.props.siteId ) {
 			this.resetState();
@@ -73,17 +77,15 @@ class BackupsPage extends Component {
 
 	/**
 	 * Create an indexed log of backups based on the date of the backup and in the site time zone
-	 *
-	 * @param {Array} logs The logs provided by the store.
 	 */
-	createIndexedLog( logs ) {
-		if ( 'success' === logs.state ) {
+	createIndexedLog() {
+		if ( 'success' === this.props.logs.state ) {
 			const { siteTimezone, siteGmtOffset } = this.props;
 
 			const indexedLog = {};
 			let oldestDateAvailable = new Date();
 
-			logs.data.forEach( log => {
+			this.props.logs.data.forEach( log => {
 				const backupDate = applySiteOffset( moment( log.activityTs ), {
 					siteTimezone,
 					siteGmtOffset,
@@ -169,7 +171,9 @@ class BackupsPage extends Component {
 				</div>
 				<ul>
 					{ ! loading &&
-						this.state.backupsOnSelectedDate.map( log => <li>{ log.activityTitle }</li> ) }
+						this.state.backupsOnSelectedDate.map( log => (
+							<li key={ log.activityId }>{ log.activityTitle }</li>
+						) ) }
 				</ul>
 
 				{ /*<DailyBackupStatus*/ }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -3,18 +3,19 @@
  */
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
+import page from 'page';
 
 /**
  * Internal dependencies
  */
 import { emptyFilter } from 'state/activity-log/reducer';
-import { getBackupAttemptsForDate, getDailyBackupDeltas, getEventsInDailyBackup } from './utils';
+// import { getBackupAttemptsForDate, getDailyBackupDeltas, getEventsInDailyBackup } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
-import BackupDelta from '../../components/backup-delta';
-import DailyBackupStatus from '../../components/daily-backup-status';
+// import BackupDelta from '../../components/backup-delta';
+// import DailyBackupStatus from '../../components/daily-backup-status';
 import DatePicker from '../../components/date-picker';
 import getRewindState from 'state/selectors/get-rewind-state';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
@@ -24,53 +25,64 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 class BackupsPage extends Component {
 	constructor( props ) {
 		super( props );
+
 		this.state = {
-			selectedDateString: props.moment().toISOString( true ),
+			selectedDate: new Date(),
 		};
 	}
 
-	dateChange = selectedDateString => this.setState( { selectedDateString } );
+	onDateChange = date => {
+		this.setState( { selectedDate: date } );
+	};
 
-	hasRealtimeBackups = () =>
-		this.props.sitePurchases &&
-		!! this.props.sitePurchases.filter(
-			purchase => 'jetpack_backup_realtime' === purchase.productSlug
-		).length;
+	onDateRangeSelection = () => {
+		//todo: go to the log activity view
+	};
+
+	// hasRealtimeBackups = () =>
+	// 	this.props.sitePurchases &&
+	// 	!! this.props.sitePurchases.filter(
+	// 		purchase => 'jetpack_backup_realtime' === purchase.productSlug
+	// 	).length;
 
 	render() {
-		const { allowRestore, logs, moment, siteId, siteSlug } = this.props;
-		const { selectedDateString } = this.state;
+		// const { allowRestore, logs, moment, siteId, siteSlug } = this.props;
+		const { siteId } = this.props;
 
-		const hasRealtimeBackups = this.hasRealtimeBackups();
-		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
-		const deltas = getDailyBackupDeltas( logs, selectedDateString );
-		const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
+		// const hasRealtimeBackups = this.hasRealtimeBackups();
+		// const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
+		// const deltas = getDailyBackupDeltas( logs, selectedDateString );
+		// const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
 
 		return (
 			<div>
 				<QueryRewindState siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
+
 				<DatePicker
-					onChange={ this.dateChange }
-					selectedDateString={ selectedDateString }
+					onDateChange={ this.onDateChange }
+					onDateRangeSelection={ this.onDateRangeSelection }
+					selectedDate={ this.state.selectedDate }
 					siteId={ siteId }
 				/>
-				<DailyBackupStatus
-					allowRestore={ allowRestore }
-					date={ selectedDateString }
-					backupAttempts={ backupAttempts }
-					siteSlug={ siteSlug }
-				/>
-				<BackupDelta
-					{ ...{
-						deltas,
-						backupAttempts,
-						hasRealtimeBackups,
-						realtimeEvents,
-						allowRestore,
-						moment,
-					} }
-				/>
+				{ /* Temporaly commented for this PR */ }
+				{ /*<DailyBackupStatus*/ }
+				{ /*allowRestore={ allowRestore }*/ }
+				{ /*date={ selectedDateString }*/ }
+				{ /*backupAttempts={ backupAttempts }*/ }
+				{ /*siteSlug={ siteSlug }*/ }
+				{ /*/>*/ }
+
+				{ /*<BackupDelta*/ }
+				{ /*{ ...{*/ }
+				{ /*deltas,*/ }
+				{ /*backupAttempts,*/ }
+				{ /*hasRealtimeBackups,*/ }
+				{ /*realtimeEvents,*/ }
+				{ /*allowRestore,*/ }
+				{ /*moment,*/ }
+				{ /*} }*/ }
+				{ /*/>*/ }
 			</div>
 		);
 	}
@@ -78,10 +90,15 @@ class BackupsPage extends Component {
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
-	const logs = siteId && requestActivityLogs( siteId, emptyFilter );
-	const rewind = getRewindState( state, siteId );
-	const sitePurchases = siteId && getSitePurchases( state, siteId );
 
+	//The section require a valid site, if not, redirect to backups
+	if ( false === !! siteId ) {
+		return page.redirect( '/backups' );
+	}
+
+	const logs = requestActivityLogs( siteId, emptyFilter );
+	const rewind = getRewindState( state, siteId );
+	const sitePurchases = getSitePurchases( state, siteId );
 	const restoreStatus = rewind.rewind && rewind.rewind.status;
 	const allowRestore =
 		'active' === rewind.state && ! ( 'queued' === restoreStatus || 'running' === restoreStatus );

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -4,7 +4,6 @@
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import page from 'page';
 import moment from 'moment';
 
 /**
@@ -39,7 +38,7 @@ const backupActivityNames = [
 class BackupsPage extends Component {
 	//todo: add the rest of the expected propTypes
 	static propTypes = {
-		logs: PropTypes.array,
+		logs: PropTypes.object,
 		loading: PropTypes.bool,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string,
@@ -58,6 +57,18 @@ class BackupsPage extends Component {
 		if ( prevProps.logs !== this.props.logs ) {
 			this.createIndexedLog( this.props.logs );
 		}
+		if ( prevProps.siteId !== this.props.siteId ) {
+			this.resetState();
+		}
+	}
+
+	resetState() {
+		this.setState( {
+			selectedDate: new Date(),
+			backupsOnSelectedDate: [],
+			indexedLog: {},
+			oldestDateAvailable: new Date(),
+		} );
 	}
 
 	/**
@@ -151,7 +162,15 @@ class BackupsPage extends Component {
 					siteId={ siteId }
 				/>
 
+				{ /* The following code is for testing purposes: */ }
 				<div>{ loading && 'Loading backups...' }</div>
+				<div>
+					{ ! loading && 'Backups on this date: ' + this.state.backupsOnSelectedDate.length }
+				</div>
+				<ul>
+					{ ! loading &&
+						this.state.backupsOnSelectedDate.map( log => <li>{ log.activityTitle }</li> ) }
+				</ul>
 
 				{ /*<DailyBackupStatus*/ }
 				{ /*allowRestore={ allowRestore }*/ }
@@ -179,12 +198,6 @@ class BackupsPage extends Component {
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
-
-	//The section require a valid site, if not, redirect to backups
-	if ( false === !! siteId ) {
-		return page.redirect( '/backups' );
-	}
-
 	const siteSlug = getSelectedSiteSlug( state );
 	const siteGmtOffset = getSiteGmtOffset( state, siteId );
 	const siteTimezone = getSiteTimezoneValue( state, siteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a date index to the backup log to facilitate the manipulations of the backups. The backups will work in the site time zone like Activity Log works in Calypso.

When we process all the backups (one time), we'll get the oldest backup available, so we can limit the DatePicker on the left navigation.

**This PR is based on https://github.com/Automattic/wp-calypso/pull/40149 Still in progress...**

#### Testing instructions

- TBD
