### PR TITLE
Site Editor iframe integration

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -60,6 +60,7 @@ interface Props {
 	duplicatePostId: T.PostId;
 	postId: T.PostId;
 	postType: T.PostType;
+	editorType: string;
 	pressThis: any;
 	siteAdminUrl: T.URL | null;
 	fseParentPageId: T.PostId;
@@ -619,7 +620,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 const mapStateToProps = (
 	state: T.AppState,
-	{ postId, postType, duplicatePostId, fseParentPageId, creatingNewHomepage }: Props
+	{ postId, postType, duplicatePostId, fseParentPageId, creatingNewHomepage, editorType }: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
@@ -646,7 +647,7 @@ const mapStateToProps = (
 	}
 
 	const siteAdminUrl =
-		postType === 'site'
+		editorType === 'site'
 			? getSiteAdminUrl( state, siteId, 'admin.php?page=gutenberg-edit-site' )
 			: getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -534,10 +534,10 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	};
 
 	onIframeLoaded = ( iframeUrl: string ) => {
-		// if ( ! this.successfulIframeLoad ) {
-		// 	window.location.replace( iframeUrl );
-		// 	return;
-		// }
+		if ( ! this.successfulIframeLoad ) {
+			window.location.replace( iframeUrl );
+			return;
+		}
 		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
 	};
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -534,10 +534,10 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	};
 
 	onIframeLoaded = ( iframeUrl: string ) => {
-		if ( ! this.successfulIframeLoad ) {
-			window.location.replace( iframeUrl );
-			return;
-		}
+		// if ( ! this.successfulIframeLoad ) {
+		// 	window.location.replace( iframeUrl );
+		// 	return;
+		// }
 		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
 	};
 
@@ -640,14 +640,28 @@ const mapStateToProps = (
 		'new-homepage': creatingNewHomepage,
 	} );
 
+	let siteEditorQueryArgs = pickBy( {
+		calypsoify: 1,
+		'block-editor': 1,
+		'frame-nonce': getSiteOption( state, siteId, siteOption ) || '',
+		'environment-id': config( 'env_id' ),
+	} );
+
 	// needed for loading the editor in SU sessions
 	if ( wpcom.addSupportParams ) {
 		queryArgs = wpcom.addSupportParams( queryArgs );
+		siteEditorQueryArgs = wpcom.addSupportParams( siteEditorQueryArgs );
 	}
 
-	const siteAdminUrl = getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
+	const siteAdminUrl =
+		postType === 'site'
+			? getSiteAdminUrl( state, siteId, 'admin.php?page=gutenberg-edit-site' )
+			: getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
 
-	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl );
+	const iframeUrl =
+		postType === 'site'
+			? addQueryArgs( siteEditorQueryArgs, siteAdminUrl )
+			: addQueryArgs( queryArgs, siteAdminUrl );
 
 	// Prevents the iframe from loading using a cached frame nonce.
 	const shouldLoadIframe = ! isRequestingSites( state ) && ! isRequestingSite( state, siteId );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -640,17 +640,9 @@ const mapStateToProps = (
 		'new-homepage': creatingNewHomepage,
 	} );
 
-	let siteEditorQueryArgs = pickBy( {
-		calypsoify: 1,
-		'block-editor': 1,
-		'frame-nonce': getSiteOption( state, siteId, siteOption ) || '',
-		'environment-id': config( 'env_id' ),
-	} );
-
 	// needed for loading the editor in SU sessions
 	if ( wpcom.addSupportParams ) {
 		queryArgs = wpcom.addSupportParams( queryArgs );
-		siteEditorQueryArgs = wpcom.addSupportParams( siteEditorQueryArgs );
 	}
 
 	const siteAdminUrl =
@@ -658,10 +650,7 @@ const mapStateToProps = (
 			? getSiteAdminUrl( state, siteId, 'admin.php?page=gutenberg-edit-site' )
 			: getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
 
-	const iframeUrl =
-		postType === 'site'
-			? addQueryArgs( siteEditorQueryArgs, siteAdminUrl )
-			: addQueryArgs( queryArgs, siteAdminUrl );
+	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl );
 
 	// Prevents the iframe from loading using a cached frame nonce.
 	const shouldLoadIframe = ! isRequestingSites( state ) && ! isRequestingSite( state, siteId );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -60,7 +60,7 @@ interface Props {
 	duplicatePostId: T.PostId;
 	postId: T.PostId;
 	postType: T.PostType;
-	editorType: string;
+	editorType: 'site' | 'post'; // Note: a page or other CPT is a type of post.
 	pressThis: any;
 	siteAdminUrl: T.URL | null;
 	fseParentPageId: T.PostId;

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -620,7 +620,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 const mapStateToProps = (
 	state: T.AppState,
-	{ postId, postType, duplicatePostId, fseParentPageId, creatingNewHomepage, editorType }: Props
+	{ postId, postType, duplicatePostId, fseParentPageId, creatingNewHomepage, editorType = 'post' }: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -202,7 +202,7 @@ export const post = ( context, next ) => {
 };
 
 export const siteEditor = ( context, next ) => {
-	context.primary = <CalypsoifyIframe postType={ 'site' } />;
+	context.primary = <CalypsoifyIframe editorType={ 'site' } />;
 
 	return next();
 };

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -202,7 +202,17 @@ export const post = ( context, next ) => {
 };
 
 export const siteEditor = ( context, next ) => {
-	context.primary = <CalypsoifyIframe editorType={ 'site' } />;
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
+	context.primary = (
+		<CalypsoifyIframe
+			// This key is added as a precaution due to it's oberserved necessity in the above post editor.
+			// It will force the component to remount completely when the Id changes.
+			key={ siteId }
+			editorType={ 'site' }
+		/>
+	);
 
 	return next();
 };

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -196,17 +196,7 @@ export const post = ( context, next ) => {
 };
 
 export const siteEditor = ( context, next ) => {
-	context.primary = (
-		<CalypsoifyIframe
-			key={ 'site-editor' }
-			postId={ null }
-			postType={ 'site' }
-			// duplicatePostId={ null }
-			// pressThis={ pressThis }
-			// fseParentPageId={ fseParentPageId }
-			// creatingNewHomepage={ postType === 'page' && has( context, 'query.new-homepage' ) }
-		/>
-	);
+	context.primary = <CalypsoifyIframe postType={ 'site' } />;
 
 	return next();
 };

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -22,6 +22,8 @@ import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
 import { isEnabled } from 'config';
 import { Placeholder } from './placeholder';
 import { makeLayout, render } from 'controller';
+import isSiteUsingCoreSiteEditor from 'state/selectors/is-site-using-core-site-editor';
+import getSiteEditorUrl from 'state/selectors/get-site-editor-url';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {
@@ -142,7 +144,11 @@ export const redirect = async ( context, next ) => {
 	if ( shouldRedirectGutenberg( state, siteId ) ) {
 		const postType = determinePostType( context );
 		const postId = getPostID( context );
-		const url = getGutenbergEditorUrl( state, siteId, postId, postType );
+
+		const url =
+			postId || ! isSiteUsingCoreSiteEditor( state, siteId )
+				? getGutenbergEditorUrl( state, siteId, postId, postType )
+				: getSiteEditorUrl( state, siteId );
 		// pass along parameters, for example press-this
 		return window.location.replace( addQueryArgs( context.query, url ) );
 	}

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -194,3 +194,19 @@ export const post = ( context, next ) => {
 
 	return next();
 };
+
+export const siteEditor = ( context, next ) => {
+	context.primary = (
+		<CalypsoifyIframe
+			key={ 'site-editor' }
+			postId={ null }
+			postType={ 'site' }
+			// duplicatePostId={ null }
+			// pressThis={ pressThis }
+			// fseParentPageId={ fseParentPageId }
+			// creatingNewHomepage={ postType === 'page' && has( context, 'query.new-homepage' ) }
+		/>
+	);
+
+	return next();
+};

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -146,7 +146,7 @@ export const redirect = async ( context, next ) => {
 		const postId = getPostID( context );
 
 		const url =
-			postId || ! isSiteUsingCoreSiteEditor( state, siteId )
+			postType || ! isSiteUsingCoreSiteEditor( state, siteId )
 				? getGutenbergEditorUrl( state, siteId, postId, postType )
 				: getSiteEditorUrl( state, siteId );
 		// pass along parameters, for example press-this

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -7,12 +7,22 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from 'my-sites/controller';
-import { authenticate, post, redirect } from './controller';
+import { authenticate, post, redirect, siteEditor } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page( '/block-editor', '/block-editor/post' );
+
+	page(
+		'/site-editor/:site?',
+		siteSelection,
+		redirect,
+		authenticate,
+		siteEditor,
+		makeLayout,
+		clientRender
+	);
 
 	page( '/block-editor/post', siteSelection, sites, makeLayout, clientRender );
 	page(

--- a/client/sections.js
+++ b/client/sections.js
@@ -418,7 +418,7 @@ const sections = [
 	},
 	{
 		name: 'gutenberg-editor',
-		paths: [ '/block-editor' ],
+		paths: [ '/block-editor', '/site-editor' ],
 		module: 'gutenberg/editor',
 		group: 'gutenberg',
 		secondary: false,

--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -20,7 +20,6 @@ export const getSiteEditorUrl = ( state, siteId ) => {
 
 	const siteSlug = getSiteSlug( state, siteId );
 
-	// @TODO Update this to be URL for the iframe route.
 	return `/site-editor/${ siteSlug }`;
 };
 

--- a/client/state/selectors/get-site-editor-url.js
+++ b/client/state/selectors/get-site-editor-url.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
-import { getSiteAdminUrl } from 'state/sites/selectors';
+import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
 
 /**
  * Retrieves url for site editor.
@@ -18,8 +18,10 @@ export const getSiteEditorUrl = ( state, siteId ) => {
 		return `${ siteAdminUrl }admin.php?page=gutenberg-edit-site`;
 	}
 
+	const siteSlug = getSiteSlug( state, siteId );
+
 	// @TODO Update this to be URL for the iframe route.
-	return `${ siteAdminUrl }admin.php?page=gutenberg-edit-site`;
+	return `/site-editor/${ siteSlug }`;
 };
 
 export default getSiteEditorUrl;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Loads the Site Editor through an Iframe instead of directing to wp-admin.  

Must be used along with - D40421 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR on Calypso and patch D40421 to your sandbox.
* Select a site with the `core-site-editor-enabled` sticker (may also require `gutenberg-edge` sticker to be enabled).
* Click the "Site Editor" button and ensure this is now loaded in an iframe.
* Smoke test the standard Page / Posts editors.

Fixes #39886 
