### PR TITLE
composite-checkout: Show contact step if domain fields are needed

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-checkout.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-checkout.js
@@ -79,7 +79,8 @@ export default function WPCheckout( {
 	const [ items ] = useLineItems();
 	const firstDomainItem = items.find( isLineItemADomain );
 	const domainName = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
-	const shouldUseDomainContactValidationEndpoint = !! firstDomainItem;
+	const isDomainFieldsVisible = !! firstDomainItem;
+	const shouldShowContactStep = isDomainFieldsVisible || total.amount.value > 0;
 
 	const contactInfo = useSelect( sel => sel( 'wpcom' ).getContactInfo() ) || {};
 	const {
@@ -105,7 +106,7 @@ export default function WPCheckout( {
 		// Touch the fields so they display validation errors
 		touchContactFields();
 
-		if ( shouldUseDomainContactValidationEndpoint ) {
+		if ( isDomainFieldsVisible ) {
 			const hasValidationErrors = await domainContactValidationCallback(
 				activePaymentMethod.id,
 				prepareDomainContactDetails( contactInfo ),
@@ -165,7 +166,7 @@ export default function WPCheckout( {
 					validatingButtonText={ translate( 'Please wait…' ) }
 					validatingButtonAriaLabel={ translate( 'Please wait…' ) }
 				/>
-				{ total.amount.value !== 0 && (
+				{ shouldShowContactStep && (
 					<CheckoutStep
 						stepId={ 'contact-form' }
 						isCompleteCallback={ () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The contact details step currently is not displayed if the cart costs 0 currency, for ease of use.

This change modifies composite checkout so that it will also display the contact step if the domain fields are needed (if there is a domain in the cart).

#### Testing instructions

- Visit composite checkout with a plan, but no domain, in the cart. Verify that the (postal and country code only) contact step is shown.
- Add a coupon code that provides a 100% discount (ask me if you cannot get one yourself) or make sure you have a plan with an unused domain credit available and use a domain in the cart with the `?flags=composite-checkout-testing` query string. 
- Visit composite checkout and verify that the contact step is _not_ shown.
- Add a domain to your cart and visit checkout with the `?flags=composite-checkout-testing` query string. You should see a 0 currency cart, with the "Free" payment method. Verify that you also see the contact step.
- Complete the purchase and verify that it works.