### PR TITLE
composite-checkout: Disable contact fields when form is not ready

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -660,8 +660,10 @@ export default function CompositeCheckout( {
 		contactDetails,
 		contactDetailsErrors,
 		updateContactDetails,
-		shouldShowContactDetailsValidationErrors
+		shouldShowContactDetailsValidationErrors,
+		isDisabled
 	) => {
+		const getIsFieldDisabled = () => isDisabled;
 		return (
 			<WPCheckoutErrorBoundary>
 				<ContactDetailsFormFields
@@ -672,6 +674,7 @@ export default function CompositeCheckout( {
 					}
 					onContactDetailsChange={ updateContactDetails }
 					shouldForceRenderOnPropChange={ true }
+					getIsFieldDisabled={ getIsFieldDisabled }
 				/>
 			</WPCheckoutErrorBoundary>
 		);

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -129,14 +129,13 @@ function TaxFields( {
 	const isStepActive = useIsStepActive();
 	const isDisabled = ! isStepActive || formStatus !== 'ready';
 
-	const isZip = isZipOrPostal() === 'zip';
 	return (
 		<FieldRow>
 			<LeftColumn>
 				<Field
 					id={ section + '-postal-code' }
 					type="text"
-					label={ isZip ? translate( 'Zip code' ) : translate( 'Postal code' ) }
+					label={ translate( 'Postal code' ) }
 					value={ postalCode.value }
 					disabled={ isDisabled }
 					onChange={ value => {
@@ -171,11 +170,6 @@ TaxFields.propTypes = {
 	updatePostalCode: PropTypes.func.isRequired,
 	updateCountryCode: PropTypes.func.isRequired,
 };
-
-function isZipOrPostal() {
-	//TODO: Add location detection to return "zip" or "postal"
-	return 'postal';
-}
 
 const DomainContactFieldsDescription = styled.p`
 	font-size: 14px;

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -36,6 +36,9 @@ export default function WPContactForm( {
 	const translate = useTranslate();
 	const isDomainFieldsVisible = useHasDomainsInCart();
 	const contactInfo = useSelect( select => select( 'wpcom' ).getContactInfo() );
+	const { formStatus } = useFormStatus();
+	const isStepActive = useIsStepActive();
+	const isDisabled = ! isStepActive || formStatus !== 'ready';
 
 	if ( summary && isComplete ) {
 		return <ContactFormSummary isDomainFieldsVisible={ isDomainFieldsVisible } />;
@@ -57,6 +60,7 @@ export default function WPContactForm( {
 				CountrySelectMenu,
 				countriesList,
 				shouldShowContactDetailsValidationErrors,
+				isDisabled,
 			} ) }
 		</BillingFormFields>
 	);
@@ -122,12 +126,10 @@ function TaxFields( {
 	countriesList,
 	updatePostalCode,
 	updateCountryCode,
+	isDisabled,
 } ) {
 	const translate = useTranslate();
 	const { postalCode, countryCode } = taxInfo;
-	const { formStatus } = useFormStatus();
-	const isStepActive = useIsStepActive();
-	const isDisabled = ! isStepActive || formStatus !== 'ready';
 
 	return (
 		<FieldRow>
@@ -169,6 +171,7 @@ TaxFields.propTypes = {
 	taxInfo: PropTypes.object.isRequired,
 	updatePostalCode: PropTypes.func.isRequired,
 	updateCountryCode: PropTypes.func.isRequired,
+	isDisabled: PropTypes.bool,
 };
 
 const DomainContactFieldsDescription = styled.p`
@@ -258,6 +261,7 @@ function renderContactDetails( {
 	CountrySelectMenu,
 	countriesList,
 	shouldShowContactDetailsValidationErrors,
+	isDisabled,
 } ) {
 	const format = getContactDetailsFormat( isDomainFieldsVisible );
 	const requiresVatId = isEligibleForVat( contactInfo.countryCode.value );
@@ -274,7 +278,8 @@ function renderContactDetails( {
 						prepareDomainContactDetails( contactInfo ),
 						prepareDomainContactDetailsErrors( contactInfo ),
 						updateContactDetails,
-						shouldShowContactDetailsValidationErrors
+						shouldShowContactDetailsValidationErrors,
+						isDisabled
 					) }
 					{ requiresVatId && <VatIdField /> }
 				</React.Fragment>
@@ -289,6 +294,7 @@ function renderContactDetails( {
 						updatePostalCode={ updatePostalCode }
 						CountrySelectMenu={ CountrySelectMenu }
 						countriesList={ countriesList }
+						isDisabled={ isDisabled }
 					/>
 					{ requiresVatId && <VatIdField /> }
 				</React.Fragment>

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -4,7 +4,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { useSelect, useDispatch } from '@automattic/composite-checkout';
+import {
+	useSelect,
+	useDispatch,
+	useFormStatus,
+	useIsStepActive,
+} from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 /**
@@ -120,6 +125,9 @@ function TaxFields( {
 } ) {
 	const translate = useTranslate();
 	const { postalCode, countryCode } = taxInfo;
+	const { formStatus } = useFormStatus();
+	const isStepActive = useIsStepActive();
+	const isDisabled = ! isStepActive || formStatus !== 'ready';
 
 	const isZip = isZipOrPostal() === 'zip';
 	return (
@@ -130,6 +138,7 @@ function TaxFields( {
 					type="text"
 					label={ isZip ? translate( 'Zip code' ) : translate( 'Postal code' ) }
 					value={ postalCode.value }
+					disabled={ isDisabled }
 					onChange={ value => {
 						updatePostalCode( value );
 					} }
@@ -146,7 +155,7 @@ function TaxFields( {
 						updateCountryCode( event.target.value );
 					} }
 					isError={ countryCode.isTouched && ! isValid( countryCode ) }
-					isDisabled={ false } // TODO
+					isDisabled={ isDisabled }
 					errorMessage={ translate( 'This field is required.' ) }
 					currentValue={ countryCode.value }
 					countriesList={ countriesList }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies the contact step form in composite checkout so that the form fields are disabled when the form is not ready (eg: during submit) or when the contact step is not active.

This should not have any noticeable effect, but will prevent the unlikely case that the fields are edited when they should not be.

#### Testing instructions

- Visit composite checkout without a domain and verify that the contact fields are editable as expected.
- Visit composite checkout again with a domain (and the query string `?flags=composite-checkout-testing`) and verify that the contact fields are editable as expected. Click to go to the next step and verify that when the step is pending, the fields are disabled.