### PR TITLE
composite-checkout: Use a default registry to replace custom registry (4)

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
+++ b/client/my-sites/checkout/checkout/composite-checkout-payment-methods.tsx
@@ -61,7 +61,6 @@ export async function submitExistingCardPayment(
 ): Promise< WPCOMTransactionEndpointResponse > {
 	debug( 'formatting existing card transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		debug,
 		...transactionData,
 		paymentMethodType: 'WPCOM_Billing_MoneyPress_Stored',
 	} );
@@ -75,7 +74,6 @@ export async function submitApplePayPayment(
 ): Promise< WPCOMTransactionEndpointResponse > {
 	debug( 'formatting apple-pay transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		debug,
 		...transactionData,
 		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',
 		paymentPartnerProcessorId: transactionData.stripeConfiguration.processor_id,
@@ -89,7 +87,6 @@ export async function makePayPalExpressRequest(
 	submit: PayPalExpressEndpoint
 ): Promise< WPCOMTransactionEndpointResponse > {
 	const formattedTransactionData = createPayPalExpressEndpointRequestPayloadFromLineItems( {
-		debug,
 		...transactionData,
 	} );
 	debug( 'sending paypal transaction', formattedTransactionData );
@@ -110,7 +107,6 @@ export async function sendStripeTransaction(
 	submit: WPCOMTransactionEndpoint
 ): Promise< WPCOMTransactionEndpointResponse > {
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		debug,
 		...transactionData,
 		paymentMethodToken: transactionData.paymentMethodToken.id,
 		paymentMethodType: 'WPCOM_Billing_Stripe_Payment_Method',
@@ -126,7 +122,6 @@ export function submitCreditsTransaction(
 ): Promise< WPCOMTransactionEndpointResponse > {
 	debug( 'formatting full credits transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		debug,
 		...transactionData,
 		paymentMethodType: 'WPCOM_Billing_WPCOM',
 	} );
@@ -140,7 +135,6 @@ export function submitFreePurchaseTransaction(
 ): Promise< WPCOMTransactionEndpointResponse > {
 	debug( 'formatting free transaction', transactionData );
 	const formattedTransactionData = createTransactionEndpointRequestPayloadFromLineItems( {
-		debug,
 		...transactionData,
 		paymentMethodType: 'WPCOM_Billing_WPCOM',
 	} );

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -870,7 +870,9 @@ function getCheckoutEventHandler( reduxDispatch ) {
 				);
 
 			case 'a8c_checkout_cancel_delete_product':
-				return dispatch( recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' ) );
+				return reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' )
+				);
 
 			case 'a8c_checkout_delete_product':
 				return reduxDispatch(

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -23,7 +23,6 @@ import {
 } from '@automattic/composite-checkout-wpcom';
 import {
 	CheckoutProvider,
-	createRegistry,
 	createPayPalMethod,
 	createStripeMethod,
 	createStripePaymentMethodStore,
@@ -31,6 +30,7 @@ import {
 	createFreePaymentMethod,
 	createApplePayMethod,
 	createExistingCardMethod,
+	defaultRegistry,
 } from '@automattic/composite-checkout';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { format as formatUrl, parse as parseUrl } from 'url';
@@ -94,8 +94,7 @@ import CheckoutTerms from './checkout-terms.jsx';
 
 const debug = debugFactory( 'calypso:composite-checkout' );
 
-const registry = createRegistry();
-const { select, dispatch } = registry;
+const { select, dispatch, registerStore } = defaultRegistry;
 
 const wpcom = wp.undocumented();
 
@@ -287,7 +286,6 @@ export default function CompositeCheckout( {
 		[ recordEvent, getThankYouUrl, total, couponItem, responseCart ]
 	);
 
-	const { registerStore } = registry;
 	useWpcomStore(
 		registerStore,
 		recordEvent,
@@ -316,7 +314,7 @@ export default function CompositeCheckout( {
 			return null;
 		}
 		return createPayPalMethod( { registerStore } );
-	}, [ registerStore, shouldLoadPayPalMethod ] );
+	}, [ shouldLoadPayPalMethod ] );
 	if ( paypalMethod ) {
 		paypalMethod.id = 'paypal';
 		// This is defined afterward so that getThankYouUrl can be dynamic without having to re-create payment method
@@ -421,7 +419,7 @@ export default function CompositeCheckout( {
 				return pending;
 			},
 		} );
-	}, [ registerStore, shouldLoadFullCreditsMethod ] );
+	}, [ shouldLoadFullCreditsMethod ] );
 	if ( fullCreditsPaymentMethod ) {
 		fullCreditsPaymentMethod.label = <WordPressCreditsLabel credits={ credits } />;
 		fullCreditsPaymentMethod.inactiveContent = <WordPressCreditsSummary />;
@@ -456,7 +454,7 @@ export default function CompositeCheckout( {
 				return pending;
 			},
 		} );
-	}, [ registerStore, shouldLoadFreePaymentMethod ] );
+	}, [ shouldLoadFreePaymentMethod ] );
 	if ( freePaymentMethod ) {
 		freePaymentMethod.label = <WordPressFreePurchaseLabel />;
 		freePaymentMethod.inactiveContent = <WordPressFreePurchaseSummary />;
@@ -507,7 +505,6 @@ export default function CompositeCheckout( {
 	}, [
 		shouldLoadApplePay,
 		isApplePayLoading,
-		registerStore,
 		stripe,
 		stripeConfiguration,
 		isStripeLoading,
@@ -555,7 +552,7 @@ export default function CompositeCheckout( {
 				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 			} )
 		);
-	}, [ registerStore, stripeConfiguration, storedCards, shouldLoadExistingCardsMethods ] );
+	}, [ stripeConfiguration, storedCards, shouldLoadExistingCardsMethods ] );
 
 	const isPurchaseFree = ! isLoadingCart && total.amount.value === 0;
 	debug( 'is purchase free?', isPurchaseFree );
@@ -703,7 +700,7 @@ export default function CompositeCheckout( {
 				showSuccessMessage={ showSuccessMessage }
 				onEvent={ recordEvent }
 				paymentMethods={ paymentMethods }
-				registry={ registry }
+				registry={ defaultRegistry }
 				isLoading={
 					isLoadingCart || isLoadingStoredCards || paymentMethods.length < 1 || items.length < 1
 				}

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -292,7 +292,7 @@ export default function CompositeCheckout( {
 		updateContactDetailsCache
 	);
 
-	useCachedDomainContactDetails( dispatch );
+	useCachedDomainContactDetails();
 
 	useDisplayErrors( errors, showErrorMessage );
 

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -94,7 +94,7 @@ import CheckoutTerms from './checkout-terms.jsx';
 const debug = debugFactory( 'calypso:composite-checkout' );
 
 const registry = createRegistry();
-const { select } = registry;
+const { select, dispatch } = registry;
 
 const wpcom = wp.undocumented();
 
@@ -286,7 +286,7 @@ export default function CompositeCheckout( {
 		[ recordEvent, getThankYouUrl, total, couponItem, responseCart ]
 	);
 
-	const { registerStore, dispatch } = registry;
+	const { registerStore } = registry;
 	useWpcomStore(
 		registerStore,
 		recordEvent,
@@ -430,7 +430,7 @@ export default function CompositeCheckout( {
 				return pending;
 			},
 		} );
-	}, [ registerStore, dispatch, shouldLoadFullCreditsMethod ] );
+	}, [ registerStore, shouldLoadFullCreditsMethod ] );
 	if ( fullCreditsPaymentMethod ) {
 		fullCreditsPaymentMethod.label = <WordPressCreditsLabel credits={ credits } />;
 		fullCreditsPaymentMethod.inactiveContent = <WordPressCreditsSummary />;
@@ -465,7 +465,7 @@ export default function CompositeCheckout( {
 				return pending;
 			},
 		} );
-	}, [ registerStore, dispatch, shouldLoadFreePaymentMethod ] );
+	}, [ registerStore, shouldLoadFreePaymentMethod ] );
 	if ( freePaymentMethod ) {
 		freePaymentMethod.label = <WordPressFreePurchaseLabel />;
 		freePaymentMethod.inactiveContent = <WordPressFreePurchaseSummary />;
@@ -516,7 +516,6 @@ export default function CompositeCheckout( {
 	}, [
 		shouldLoadApplePay,
 		isApplePayLoading,
-		dispatch,
 		registerStore,
 		stripe,
 		stripeConfiguration,
@@ -569,7 +568,6 @@ export default function CompositeCheckout( {
 		registerStore,
 		stripeConfiguration,
 		storedCards,
-		dispatch,
 		shouldLoadExistingCardsMethods,
 	] );
 
@@ -818,17 +816,17 @@ function createItemToAddToCart( { planSlug, plan, isJetpackNotAtomic } ) {
 	return cartItem;
 }
 
-function getCheckoutEventHandler( dispatch ) {
+function getCheckoutEventHandler( reduxDispatch ) {
 	return function recordEvent( action ) {
 		debug( 'heard checkout event', action );
 		switch ( action.type ) {
 			case 'CHECKOUT_LOADED':
-				return dispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
+				return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_loaded', {} ) );
 
 			case 'PAYMENT_COMPLETE': {
 				const total_cost = action.payload.total.amount.value / 100; // TODO: This conversion only works for USD! We have to localize this or get it from the server directly (or better yet, just force people to use the integer version).
 
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_success', {
 						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
 						currency: action.payload.total.amount.currency,
@@ -850,7 +848,7 @@ function getCheckoutEventHandler( dispatch ) {
 					orderId: transactionResult.receipt_id,
 				} );
 
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_complete', {
 						redirect_url: action.payload.url,
 						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
@@ -864,7 +862,7 @@ function getCheckoutEventHandler( dispatch ) {
 			}
 
 			case 'CART_ERROR':
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_cart_error', {
 						error_type: action.payload.type,
 						error_message: String( action.payload.message ),
@@ -872,7 +870,7 @@ function getCheckoutEventHandler( dispatch ) {
 				);
 
 			case 'a8c_checkout_error':
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_error', {
 						error_type: action.payload.type,
 						error_field: action.payload.field,
@@ -881,7 +879,7 @@ function getCheckoutEventHandler( dispatch ) {
 				);
 
 			case 'a8c_checkout_add_coupon':
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {
 						coupon: action.payload.coupon,
 					} )
@@ -891,32 +889,32 @@ function getCheckoutEventHandler( dispatch ) {
 				return dispatch( recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' ) );
 
 			case 'a8c_checkout_delete_product':
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_delete_product', {
 						product_name: action.payload.product_name,
 					} )
 				);
 
 			case 'a8c_checkout_delete_product_press':
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_delete_product_press', {
 						product_name: action.payload.product_name,
 					} )
 				);
 
 			case 'a8c_checkout_add_coupon_error':
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_coupon_add_error', {
 						error_type: action.payload.type,
 					} )
 				);
 
 			case 'a8c_checkout_add_coupon_button_clicked':
-				return dispatch( recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} ) );
+				return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} ) );
 
 			case 'STEP_NUMBER_CHANGED':
 				if ( action.payload.stepNumber === 2 && action.payload.previousStepNumber === 1 ) {
-					dispatch(
+					reduxDispatch(
 						recordTracksEvent( 'calypso_checkout_composite_first_step_complete', {
 							payment_method:
 								translateCheckoutPaymentMethodToWpcomPaymentMethod( action.payload.paymentMethodId )
@@ -924,45 +922,45 @@ function getCheckoutEventHandler( dispatch ) {
 						} )
 					);
 				}
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_step_changed', {
 						step: action.payload.stepNumber,
 					} )
 				);
 
 			case 'STRIPE_TRANSACTION_BEGIN': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_stripe_submit_clicked', {} )
 				);
 			}
 
 			case 'STRIPE_TRANSACTION_ERROR': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
 						error_code: null,
 						reason: String( action.payload ),
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 						error_code: null,
 						payment_method: 'WPCOM_Billing_Stripe_Payment_Method',
 						reason: String( action.payload ),
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_stripe_transaction_error', {
 						error_message: String( action.payload ),
 					} )
@@ -970,38 +968,38 @@ function getCheckoutEventHandler( dispatch ) {
 			}
 
 			case 'FREE_TRANSACTION_BEGIN': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_WPCOM',
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_WPCOM',
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_free_purchase_submit_clicked', {} )
 				);
 			}
 
 			case 'FREE_PURCHASE_TRANSACTION_ERROR': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
 						error_code: null,
 						reason: String( action.payload ),
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 						error_code: null,
 						payment_method: 'WPCOM_Billing_WPCOM',
 						reason: String( action.payload ),
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_free_purchase_transaction_error', {
 						error_message: String( action.payload ),
 					} )
@@ -1009,39 +1007,39 @@ function getCheckoutEventHandler( dispatch ) {
 			}
 
 			case 'PAYPAL_TRANSACTION_BEGIN': {
-				dispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
-				dispatch(
+				reduxDispatch( recordTracksEvent( 'calypso_checkout_form_redirect', {} ) );
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_PayPal_Express',
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_PayPal_Express',
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_paypal_submit_clicked', {} )
 				);
 			}
 
 			case 'PAYPAL_TRANSACTION_ERROR': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
 						error_code: null,
 						reason: String( action.payload ),
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 						error_code: null,
 						payment_method: 'WPCOM_Billing_PayPal_Express',
 						reason: String( action.payload ),
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_paypal_transaction_error', {
 						error_message: String( action.payload ),
 					} )
@@ -1049,38 +1047,38 @@ function getCheckoutEventHandler( dispatch ) {
 			}
 
 			case 'FULL_CREDITS_TRANSACTION_BEGIN': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_WPCOM',
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_WPCOM',
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_full_credits_submit_clicked', {} )
 				);
 			}
 
 			case 'FULL_CREDITS_TRANSACTION_ERROR': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
 						error_code: null,
 						reason: String( action.payload ),
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 						error_code: null,
 						payment_method: 'WPCOM_Billing_WPCOM',
 						reason: String( action.payload ),
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_full_credits_error', {
 						error_message: String( action.payload ),
 					} )
@@ -1088,38 +1086,38 @@ function getCheckoutEventHandler( dispatch ) {
 			}
 
 			case 'EXISTING_CARD_TRANSACTION_BEGIN': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_MoneyPress_Stored',
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_MoneyPress_Stored',
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_existing_card_submit_clicked', {} )
 				);
 			}
 
 			case 'EXISTING_CARD_TRANSACTION_ERROR': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
 						error_code: null,
 						reason: String( action.payload ),
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 						error_code: null,
 						payment_method: 'WPCOM_Billing_MoneyPress_Stored',
 						reason: String( action.payload ),
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_existing_card_error', {
 						error_message: String( action.payload ),
 					} )
@@ -1127,25 +1125,25 @@ function getCheckoutEventHandler( dispatch ) {
 			}
 
 			case 'APPLE_PAY_TRANSACTION_BEGIN': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_Web_Payment',
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_form_submit', {
 						credits: null,
 						payment_method: 'WPCOM_Billing_Web_Payment',
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_apple_pay_submit_clicked', {} )
 				);
 			}
 
 			case 'APPLE_PAY_LOADING_ERROR':
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
 						error_message: String( action.payload ),
 						is_loading_error: true,
@@ -1153,19 +1151,19 @@ function getCheckoutEventHandler( dispatch ) {
 				);
 
 			case 'APPLE_PAY_TRANSACTION_ERROR': {
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_payment_error', {
 						error_code: null,
 						reason: String( action.payload ),
 					} )
 				);
-				dispatch(
+				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_error', {
 						error_code: null,
 						reason: String( action.payload ),
 					} )
 				);
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_apple_pay_error', {
 						error_message: String( action.payload ),
 					} )
@@ -1178,12 +1176,12 @@ function getCheckoutEventHandler( dispatch ) {
 			}
 
 			case 'SHOW_MODAL_AUTHORIZATION': {
-				return dispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
+				return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 			}
 
 			default:
 				debug( 'unknown checkout event', action );
-				return dispatch(
+				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_unknown_event', {
 						error_type: String( action.type ),
 					} )
@@ -1219,7 +1217,7 @@ function useCountryList( overrideCountryList ) {
 
 	const [ countriesList, setCountriesList ] = useState( overrideCountryList );
 
-	const dispatch = useDispatch();
+	const reduxDispatch = useDispatch();
 	const globalCountryList = useSelector( state => getCountries( state, 'payments' ) );
 
 	// Has the global list been populated?
@@ -1231,10 +1229,10 @@ function useCountryList( overrideCountryList ) {
 				setCountriesList( globalCountryList );
 			} else {
 				debug( 'countries list is empty; dispatching request for data' );
-				dispatch( fetchPaymentCountries() );
+				reduxDispatch( fetchPaymentCountries() );
 			}
 		}
-	}, [ shouldFetchList, isListFetched, globalCountryList, dispatch ] );
+	}, [ shouldFetchList, isListFetched, globalCountryList, reduxDispatch ] );
 
 	return countriesList;
 }
@@ -1301,7 +1299,7 @@ function localizeCurrency( amount ) {
 
 function useWpcomProductVariants( { siteId, productSlug, credits, couponDiscounts } ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
+	const reduxDispatch = useDispatch();
 
 	const availableVariants = useVariantWpcomPlanProductSlugs( productSlug );
 
@@ -1323,11 +1321,11 @@ function useWpcomProductVariants( { siteId, productSlug, credits, couponDiscount
 		debug( 'deciding whether to request product variant data' );
 		if ( shouldFetchProducts && ! haveFetchedProducts ) {
 			debug( 'dispatching request for product variant data' );
-			dispatch( requestPlans() );
-			dispatch( requestProductsList() );
+			reduxDispatch( requestPlans() );
+			reduxDispatch( requestProductsList() );
 			setHaveFetchedProducts( true );
 		}
-	}, [ shouldFetchProducts, haveFetchedProducts, dispatch ] );
+	}, [ shouldFetchProducts, haveFetchedProducts, reduxDispatch ] );
 
 	return anyProductSlug => {
 		if ( anyProductSlug !== productSlug ) {
@@ -1376,7 +1374,7 @@ function useWpcomProductVariants( { siteId, productSlug, credits, couponDiscount
 }
 
 function useVariantWpcomPlanProductSlugs( productSlug ) {
-	const dispatch = useDispatch();
+	const reduxDispatch = useDispatch();
 
 	const chosenPlan = getPlan( productSlug );
 
@@ -1388,11 +1386,11 @@ function useVariantWpcomPlanProductSlugs( productSlug ) {
 		debug( 'deciding whether to request plan variant data' );
 		if ( shouldFetchPlans && ! haveFetchedPlans ) {
 			debug( 'dispatching request for plan variant data' );
-			dispatch( requestPlans() );
-			dispatch( requestProductsList() );
+			reduxDispatch( requestPlans() );
+			reduxDispatch( requestProductsList() );
 			setHaveFetchedPlans( true );
 		}
-	}, [ haveFetchedPlans, shouldFetchPlans, dispatch ] );
+	}, [ haveFetchedPlans, shouldFetchPlans, reduxDispatch ] );
 
 	if ( ! chosenPlan ) {
 		return [];
@@ -1410,7 +1408,7 @@ function useVariantWpcomPlanProductSlugs( productSlug ) {
 	} );
 }
 
-function useCachedDomainContactDetails( dispatch ) {
+function useCachedDomainContactDetails() {
 	const reduxDispatch = useDispatch();
 	const [ haveRequestedCachedDetails, setHaveRequestedCachedDetails ] = useState( false );
 

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -26,6 +26,7 @@ import {
 	createRegistry,
 	createPayPalMethod,
 	createStripeMethod,
+	createStripePaymentMethodStore,
 	createFullCreditsMethod,
 	createFreePaymentMethod,
 	createApplePayMethod,
@@ -351,52 +352,42 @@ export default function CompositeCheckout( {
 		};
 	}
 
-	const shouldLoadStripeMethod = onlyLoadPaymentMethods
+	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
+	const isStripeMethodAllowed = onlyLoadPaymentMethods
 		? onlyLoadPaymentMethods.includes( 'card' )
-		: true;
-	const stripeMethod = useMemo( () => {
-		if (
-			isStripeLoading ||
-			stripeLoadingError ||
-			! stripe ||
-			! stripeConfiguration ||
-			! shouldLoadStripeMethod
-		) {
-			return null;
-		}
-		return createStripeMethod( {
-			getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-			getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-			registerStore,
-			stripe,
-			stripeConfiguration,
-			submitTransaction: submitData => {
-				const pending = sendStripeTransaction(
-					{
-						...submitData,
-						siteId: select( 'wpcom' )?.getSiteId?.(),
-						domainDetails: getDomainDetails( select ),
-					},
-					wpcomTransaction
-				);
-				// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
-				pending.then( result => {
-					debug( 'saving transaction response', result );
-					dispatch( 'wpcom' ).setTransactionResponse( result );
-				} );
-				return pending;
-			},
-		} );
-	}, [
-		shouldLoadStripeMethod,
-		registerStore,
-		dispatch,
-		stripe,
-		stripeConfiguration,
-		isStripeLoading,
-		stripeLoadingError,
-	] );
+		: isPaymentMethodEnabled( 'card', allowedPaymentMethods || serverAllowedPaymentMethods );
+	const shouldLoadStripeMethod = isStripeMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+	const stripePaymentMethodStore = useMemo(
+		() =>
+			createStripePaymentMethodStore( {
+				getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+				getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+				getSiteId: select( 'wpcom' )?.getSiteId?.(),
+				getDomainDetails: () => getDomainDetails( select ),
+				submitTransaction: submitData => {
+					const pending = sendStripeTransaction( submitData, wpcomTransaction );
+					// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
+					pending.then( result => {
+						debug( 'saving transaction response', result );
+						dispatch( 'wpcom' ).setTransactionResponse( result );
+					} );
+					return pending;
+				},
+			} ),
+		[]
+	);
+	const stripeMethod = useMemo(
+		() =>
+			shouldLoadStripeMethod
+				? createStripeMethod( {
+						store: stripePaymentMethodStore,
+						stripe,
+						stripeConfiguration,
+				  } )
+				: null,
+		[ shouldLoadStripeMethod, stripePaymentMethodStore, stripe, stripeConfiguration ]
+	);
 	if ( stripeMethod ) {
 		stripeMethod.id = 'card';
 	}
@@ -564,12 +555,7 @@ export default function CompositeCheckout( {
 				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
 			} )
 		);
-	}, [
-		registerStore,
-		stripeConfiguration,
-		storedCards,
-		shouldLoadExistingCardsMethods,
-	] );
+	}, [ registerStore, stripeConfiguration, storedCards, shouldLoadExistingCardsMethods ] );
 
 	const isPurchaseFree = ! isLoadingCart && total.amount.value === 0;
 	debug( 'is purchase free?', isPurchaseFree );
@@ -910,7 +896,9 @@ function getCheckoutEventHandler( reduxDispatch ) {
 				);
 
 			case 'a8c_checkout_add_coupon_button_clicked':
-				return reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} ) );
+				return reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_composite_add_coupon_clicked', {} )
+				);
 
 			case 'STEP_NUMBER_CHANGED':
 				if ( action.payload.stepNumber === 2 && action.payload.previousStepNumber === 1 ) {

--- a/client/my-sites/checkout/checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/checkout/types/transaction-endpoint.ts
@@ -5,6 +5,9 @@ import {
 	WPCOMCartItem,
 	getNonProductWPCOMCartItemTypes,
 } from '@automattic/composite-checkout-wpcom';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:transaction-endpoint' );
 
 export type WPCOMTransactionEndpoint = (
 	_: WPCOMTransactionEndpointRequestPayload
@@ -68,7 +71,6 @@ export type WPCOMTransactionEndpointDomainDetails = {
 // Create cart object as required by the WPCOM transactions endpoint
 // '/me/transactions/': WPCOM_JSON_API_Transactions_Endpoint
 export function createTransactionEndpointCartFromLineItems( {
-	debug,
 	siteId,
 	couponId,
 	country,
@@ -76,7 +78,6 @@ export function createTransactionEndpointCartFromLineItems( {
 	subdivisionCode,
 	items,
 }: {
-	debug: ( _0: string, _1: any ) => void;
 	siteId: string;
 	couponId?: string;
 	country: string;
@@ -123,7 +124,6 @@ export function createTransactionEndpointCartFromLineItems( {
 }
 
 export function createTransactionEndpointRequestPayloadFromLineItems( {
-	debug,
 	siteId,
 	couponId,
 	country,
@@ -137,7 +137,6 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 	storedDetailsId,
 	name,
 }: {
-	debug: ( _0: string, _1: any ) => void;
 	siteId: string;
 	couponId?: string;
 	country: string;
@@ -153,7 +152,6 @@ export function createTransactionEndpointRequestPayloadFromLineItems( {
 } ): WPCOMTransactionEndpointRequestPayload {
 	return {
 		cart: createTransactionEndpointCartFromLineItems( {
-			debug,
 			siteId,
 			couponId: couponId || getCouponIdFromProducts( items ),
 			country,

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -87,7 +87,7 @@ Each Payment Method or component can create a Redux-like data store by using the
 
 In addition to the features of that package, we provide a `useRegisterStore` hook which takes the same arguments as `registerStore` and will allow creating a new store just before a component first renders.
 
-The registry used for these stores is created by default in `CheckoutProvider` but you can use a custom one by including the `registry` prop on that component.
+The registry used for these stores is created by default but you can use a custom one by including the `registry` prop on `CheckoutProvider`. If you want to use the default registry, you can import it directly from this package using [#defaultRegistry](defaultRegistry), and for convenience, [#registerStore](registerStore).
 
 ## API
 
@@ -115,7 +115,7 @@ It has the following props.
 - `showSuccessMessage: (string) => null`. A function that will display a message with a "success" type.
 - `onEvent?: (action) => null`. A function called for all sorts of events in the code. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action).
 - `paymentMethods: object[]`: An array of [Payment Method objects](#payment-methods).
-- `registry?: object`. An object returned by [createRegistry](#createRegistry). If not provided, a default registry will be created.
+- `registry?: object`. An object returned by [createRegistry](#createRegistry). If not provided, the default registry will be used.
 - `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder.
 
 The line items are for display purposes only. They should also include subtotals, discounts, and taxes. No math will be performed on the line items. Instead, the amount to be charged will be specified by the required prop `total`, which is another line item.
@@ -251,6 +251,10 @@ Creates a [Payment Method](#payment-methods) object. Requires passing an object 
 - `stripe: object`. The configured stripe object.
 - `stripeConfiguration: object`. The stripe configuration object.
 
+### defaultRegistry
+
+The default registry. See [#data-stores](Data Stores) for more details.
+
 ### getDefaultOrderReviewStep
 
 Returns a step object whose properties can be added to a [CheckoutStep](CheckoutStep) (and customized) to display an itemized order review.
@@ -262,6 +266,10 @@ Returns a step object whose properties can be added to a [CheckoutStep](Checkout
 ### getDefaultPaymentMethodStep
 
 Returns a step object whose properties can be added to a [CheckoutStep](CheckoutStep) (and customized) to display a way to select a payment method. The payment methods displayed are those provided to the [CheckoutProvider](#checkoutprovider).
+
+### registerStore
+
+The `registerStore` function on the [#defaultRegistry](default registry). Don't use this if you create a custom registry.
 
 ### formatValueForCurrency
 
@@ -326,7 +334,7 @@ A React Hook that can be used to create a @wordpress/data store. This is the sam
 
 ### useRegistry
 
-A React Hook that returns the @wordpress/data registry. Only works within [CheckoutProvider](#CheckoutProvider).
+A React Hook that returns the `@wordpress/data` registry being used. Only works within [CheckoutProvider](#CheckoutProvider).
 
 ### useSelect
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -15,8 +15,8 @@ import {
 	CheckoutProvider,
 	createApplePayMethod,
 	createPayPalMethod,
-	createRegistry,
 	createStripeMethod,
+	defaultRegistry,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
@@ -90,8 +90,7 @@ async function makePayPalExpressRequest( data ) {
 	return window.location.href;
 }
 
-const registry = createRegistry();
-const { registerStore, select } = registry;
+const { registerStore, select } = defaultRegistry;
 
 registerStore( 'demo', {
 	actions: {
@@ -370,7 +369,7 @@ function MyCheckout() {
 			showErrorMessage={ showErrorMessage }
 			showInfoMessage={ showInfoMessage }
 			showSuccessMessage={ showSuccessMessage }
-			registry={ registry }
+			registry={ defaultRegistry }
 			isLoading={ isLoading }
 			paymentMethods={ [ applePayMethod, stripeMethod, paypalMethod ].filter( Boolean ) }
 		>

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -13,7 +13,7 @@ import CheckoutContext from '../lib/checkout-context';
 import CheckoutErrorBoundary from './checkout-error-boundary';
 import { LocalizeProvider } from '../lib/localize';
 import { LineItemsProvider } from '../lib/line-items';
-import { RegistryProvider, createRegistry } from '../lib/registry';
+import { RegistryProvider, defaultRegistry } from '../lib/registry';
 import { useFormStatusManager } from '../lib/form-status';
 import defaultTheme from '../theme';
 import {
@@ -65,7 +65,7 @@ export const CheckoutProvider = props => {
 
 	// Create the registry automatically if it's not a prop
 	const registryRef = useRef( registry );
-	registryRef.current = registryRef.current || createRegistry();
+	registryRef.current = registryRef.current || defaultRegistry;
 
 	const value = useMemo(
 		() => ( {

--- a/packages/composite-checkout/src/lib/registry.js
+++ b/packages/composite-checkout/src/lib/registry.js
@@ -13,9 +13,15 @@ import useConstructor from './use-constructor';
 
 export { createRegistry, RegistryProvider, useRegistry, useDispatch, useSelect };
 
+export const defaultRegistry = createRegistry();
+
+export function registerStore( ...args ) {
+	return defaultRegistry.registerStore( ...args );
+}
+
 export function useRegisterStore( id, store ) {
-	const { registerStore } = useRegistry();
-	useConstructor( () => registerStore( id, store ) );
+	const registry = useRegistry();
+	useConstructor( () => registry.registerStore( id, store ) );
 }
 
 const primaryStoreId = 'checkout';

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -22,6 +22,8 @@ import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './li
 import { useLineItems, useTotal } from './lib/line-items';
 import {
 	createRegistry,
+	defaultRegistry,
+	registerStore,
 	useDispatch,
 	useRegisterStore,
 	useRegistry,
@@ -64,9 +66,11 @@ export {
 	createPayPalMethod,
 	createRegistry,
 	createStripeMethod,
+	defaultRegistry,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
+	registerStore,
 	renderDisplayValueMarkdown,
 	useAllPaymentMethods,
 	useDispatch,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This refactor is the first step toward making it less risky to create payment methods within a component. Primarily it creates a new default `@wordpress/data` registry in the `composite-checkout` package, which is exported along with its `registerStore` function (which is part of the registry but should be more convenient in some cases). 

This registry (and its `registerStore`, `select`, and `dispatch` functions) can be imported directly by components that use the package, removing the need to create a registry and pass it throughout the component tree which, while not a bad idea, creates additional overhead for code using `composite-checkout` because it forces them to have to think about and manage a data layer even if they don't need one themselves.

Assuming this works well, it shouldn't have any notable effects and the code should continue to run as expected. After this is in place it will be easier to refactor the payment methods themselves to reduce and split up their dependencies, preventing the possibility of recreating them unnecessarily.

#### Testing instructions

- First run the demo with `npm run composite-checkout-demo` and verify that it works as it did before.
- Then run calypso and verify that everything works as it did before in composite checkout (you can use the `?flags=composite-checkout-force` query string to force the composite checkout view).