### PR TITLE
Gutenboarding: New domain picker design

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -59,10 +59,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 		setUserSelectedDomainSuggestion( selectedDomain );
 	};
 
-	const handleDomainConnect = () => {
-		// TODO: Handle connecting to existing domains
-	};
-
 	const handlePurchaseCancel = () => {
 		setUserSelectedDomainSuggestion( null );
 	};
@@ -100,7 +96,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 						defaultQuery={ defaultQuery }
 						onDomainSelect={ handleDomainSelect }
 						onDomainPurchase={ handlePaidDomainSelect }
-						onDomainConnect={ handleDomainConnect }
 						onClose={ handleClose }
 						queryParameters={ queryParameters }
 						currentDomain={ currentDomain }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -59,6 +59,10 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 		setUserSelectedDomainSuggestion( selectedDomain );
 	};
 
+	const handleDomainConnect = () => {
+		// TODO: Handle connecting to existing domains
+	};
+
 	const handlePurchaseCancel = () => {
 		setUserSelectedDomainSuggestion( null );
 	};
@@ -91,11 +95,13 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				/>
 			) }
 			{ isDomainPopoverVisible && (
-				<Popover onClose={ handleClose } onFocusOutside={ handleClose }>
+				<Popover onClose={ handleClose } onFocusOutside={ handleClose } focusOnMount="container">
 					<DomainPicker
 						defaultQuery={ defaultQuery }
 						onDomainSelect={ handleDomainSelect }
 						onDomainPurchase={ handlePaidDomainSelect }
+						onDomainConnect={ handleDomainConnect }
+						onClose={ handleClose }
 						queryParameters={ queryParameters }
 						currentDomain={ currentDomain }
 					/>

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
-interface Props extends DomainPickerProps, Button.BaseProps {
+interface Props extends Omit< DomainPickerProps, 'onClose' >, Button.BaseProps {
 	className?: string;
 	currentDomain?: DomainSuggestion;
 }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -91,7 +91,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				/>
 			) }
 			{ isDomainPopoverVisible && (
-				<Popover onClose={ handleClose } onFocusOutside={ handleClose } focusOnMount="container">
+				<Popover onClose={ handleClose } onFocusOutside={ handleClose } focusOnMount={ false }>
 					<DomainPicker
 						defaultQuery={ defaultQuery }
 						onDomainSelect={ handleDomainSelect }

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { FunctionComponent, useState } from 'react';
 import { Button, Panel, PanelBody, PanelRow } from '@wordpress/components';
+//  TODO: Extract SearchCard. https://github.com/Automattic/wp-calypso/issues/40323
 import SearchCard from 'components/search-card';
 import { useSelect } from '@wordpress/data';
 import { useDebounce } from 'use-debounce';

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -99,7 +99,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		?.filter( suggestion => ! suggestion.is_free )
 		.slice( 0, PAID_DOMAINS_TO_SHOW );
 
-	// Recommend paid domain with exact site title match with highest relevance score.
+	// Recommend either an exact match or the highest relevance score
 	const recommendedSuggestion = paidSuggestions?.reduce( ( result, suggestion ) => {
 		if ( result.match_reasons?.includes( 'exact-match' ) ) {
 			return result;

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -102,7 +102,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 	// Recommend paid domain with exact site title match with highest relevance score.
 	const recommendedSuggestion = paidSuggestions?.find( suggestion =>
-		suggestion.match_reasons.includes( 'exact-match' )
+		suggestion.match_reasons?.includes( 'exact-match' )
 	);
 
 	return (

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -125,6 +125,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							compact
 							hideClose
 							disableAutocorrect
+							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 						/>
 					</div>
 				</PanelRow>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -163,7 +163,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 									<DomainPickerSuggestionItem
 										suggestion={ suggestion }
 										isRecommended={ suggestion === recommendedSuggestion }
-										isCurrent={ currentDomain.domain_name === suggestion.domain_name }
+										isCurrent={ currentDomain?.domain_name === suggestion.domain_name }
 										onClick={ () => onDomainPurchase( suggestion ) }
 										key={ suggestion.domain_name }
 									/>
@@ -183,7 +183,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							? freeSuggestions.map( suggestion => (
 									<DomainPickerSuggestionItem
 										suggestion={ suggestion }
-										isCurrent={ currentDomain.domain_name === suggestion.domain_name }
+										isCurrent={ currentDomain?.domain_name === suggestion.domain_name }
 										onClick={ () => onDomainSelect( suggestion ) }
 										key={ suggestion.domain_name }
 									/>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -133,7 +133,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							disableAutocorrect
 						/>
 						<div className="domain-picker__connect-domain">
-							<span>{ NO__( 'Already have a domain?' ) }</span>&nbsp;
+							<span>{ NO__( 'Already have a domain?' ) }</span>{ ' ' }
 							<Button
 								className="domain-picker__connect-button"
 								isLink

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -100,9 +100,18 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		.slice( 0, PAID_DOMAINS_TO_SHOW );
 
 	// Recommend paid domain with exact site title match with highest relevance score.
-	const recommendedSuggestion = paidSuggestions?.find( suggestion =>
-		suggestion.match_reasons?.includes( 'exact-match' )
-	);
+	const recommendedSuggestion = paidSuggestions?.reduce( ( result, suggestion ) => {
+		if ( result.match_reasons?.includes( 'exact-match' ) ) {
+			return result;
+		}
+		if ( suggestion.match_reasons?.includes( 'exact-match' ) ) {
+			return suggestion;
+		}
+		if ( suggestion.relevance > result.relevance ) {
+			return suggestion;
+		}
+		return result;
+	} );
 
 	return (
 		<Panel className="domain-picker">

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -2,9 +2,7 @@
  * External dependencies
  */
 import React, { FunctionComponent, useState } from 'react';
-import { Button, Panel, PanelBody, PanelRow } from '@wordpress/components';
-//  TODO: Extract SearchCard. https://github.com/Automattic/wp-calypso/issues/40323
-import SearchCard from 'components/search-card';
+import { Button, Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useDebounce } from 'use-debounce';
 import { times } from 'lodash';
@@ -116,16 +114,12 @@ const DomainPicker: FunctionComponent< Props > = ( {
 						</Button>
 					</div>
 					<div className="domain-picker__search">
-						<SearchCard
-							className="domain-picker__search-field"
-							inputLabel={ label }
+						<TextControl
+							hideLabelFromVision
+							label={ label }
 							placeholder={ label }
-							onSearch={ setDomainSearch }
+							onChange={ setDomainSearch }
 							value={ domainSearch }
-							compact
-							hideClose
-							disableAutocorrect
-							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 						/>
 					</div>
 				</PanelRow>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -56,7 +56,6 @@ export interface Props {
 
 	/**
 	 * Callback that will be invoked when a close button is clicked
-	 *
 	 */
 	onClose: () => void;
 

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -128,7 +128,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				<PanelRow className="domain-picker__panel-row">
 					<div className="domain-picker__suggestion-header">
 						<div className="domain-picker__suggestion-header-title">
-							{ NO__( 'Professional Domain' ) }
+							{ NO__( 'Professional domain' ) }
 						</div>
 						<div className="domain-picker__suggestion-header-description">
 							{ __experimentalCreateInterpolateElement(

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -50,7 +50,6 @@ export interface Props {
 
 	/**
 	 * Callback that will be invoked when user wants to connect an existing domain.
-	 *
 	 */
 	onDomainConnect: () => void;
 

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -50,11 +50,6 @@ export interface Props {
 	onDomainPurchase: ( domainSuggestion: DomainSuggestion ) => void;
 
 	/**
-	 * Callback that will be invoked when user wants to connect an existing domain.
-	 */
-	onDomainConnect: () => void;
-
-	/**
 	 * Callback that will be invoked when a close button is clicked
 	 */
 	onClose: () => void;
@@ -71,7 +66,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	defaultQuery,
 	onDomainSelect,
 	onDomainPurchase,
-	onDomainConnect,
 	onClose,
 	queryParameters,
 	currentDomain,
@@ -132,16 +126,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							hideClose
 							disableAutocorrect
 						/>
-						<div className="domain-picker__connect-domain">
-							<span>{ NO__( 'Already have a domain?' ) }</span>{ ' ' }
-							<Button
-								className="domain-picker__connect-button"
-								isLink
-								onClick={ () => onDomainConnect() }
-							>
-								{ NO__( 'Connect it now' ) }
-							</Button>
-						</div>
 					</div>
 				</PanelRow>
 

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -1,12 +1,14 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
 @import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
+@import '../../mixins';
 
 .domain-picker {
 	min-width: 22em;
 }
 
 .domain-picker__choose-domain-header {
+	@include onboarding-font-recoleta;
 	font-weight: bold;
 	text-align: center;
 	margin-bottom: 20px;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -135,9 +135,21 @@
 
 .domain-picker__badge {
 	display: inline-flex;
+	border-radius: 1000px; // A number large enough to exceed height of any badge to make it look like a pill
+	padding: 2px 11px;
+	line-height: 17px;
+	height: 18px;
 	align-items: center;
 	font-size: 10px;
 	margin-left: 8px;
+
+	background-color: var( --studio-blue-50 );
+	color: var( --color-text-inverted );
+
+	&.is-selected {
+		color: var( --color-text-inverted );
+		background-color: var( --color-success );
+	}
 }
 
 .domain-picker__price {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -87,18 +87,22 @@
 	border: 1px solid var( --color-neutral-5 );
 }
 
+.domain-picker__suggestion-none {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	height: 46px;
+	border-radius: 0;
+	padding: 0 16px;
+	font-size: 14px;
+}
 .domain-picker__suggestion-item {
 	// Increasing specificity because @wordpress/components stylesheets are loaded after gutenboarding stylesheets.
 	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
 	// See https://github.com/WordPress/gutenberg/pull/19535
 	&.components-button {
-		display: flex;
-		justify-content: space-between;
-		width: 100%;
-		height: 46px;
-		border-radius: 0;
-		padding: 0 16px;
-		font-size: 14px;
+		@extend .domain-picker__suggestion-none;
 
 		&.is-tertiary {
 			color: var( --color-text );

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -4,17 +4,71 @@
 @import '../../mixins';
 
 .domain-picker {
-	min-width: 22em;
+	min-width: 530px;
+
+	.components-panel__body.is-opened {
+		padding: 36px;
+	}
 }
 
-.domain-picker__choose-domain-header {
-	@include onboarding-font-recoleta;
-	font-weight: bold;
-	text-align: center;
-	margin-bottom: 20px;
+.domain-picker__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 14px;
 }
-.domain-picker__recommended-header {
-	font-weight: bold;
+
+.domain-picker__header-title {
+	@include onboarding-font-recoleta;
+	font-size: 26px;
+}
+
+.domain-picker__close-button {
+	font-size: 14px;
+	text-transform: lowercase;
+
+	&.components-button.is-tertiary {
+		color: var( --color-neutral-40 );
+		text-decoration: underline;
+	}
+}
+
+.domain-picker__search {
+	// Override styling from @wordpress
+	input[type='search'].search__input {
+		width: 100%;
+		border: none;
+		box-shadow: none;
+		font-size: 16px;
+		font-weight: normal;
+
+		&:focus,
+		&:hover {
+			// Focus outline is provided by parent element in SearchCard.
+			outline: none;
+			box-shadow: none;
+		}
+	}
+}
+
+.domain-picker__search-field {
+	// Override styling from SearchCard
+	&.search-card {
+		margin: 0;
+	}
+}
+
+.domain-picker__connect-domain {
+	text-align: center;
+	margin-top: 14px;
+	color: var( --color-neutral-40 );
+}
+
+.domain-picker__connect-button {
+	&.components-button.is-link {
+		color: var( --color-neutral-40 );
+		text-decoration: underline;
+	}
 }
 
 .domain-picker__panel-row {
@@ -25,6 +79,37 @@
 		flex-direction: column;
 		align-items: stretch;
 	}
+
+	+ .domain-picker__panel-row {
+		margin-top: 36px;
+	}
+}
+
+.domain-picker__suggestion-header {
+	display: flex;
+	justify-content: space-between;
+	padding-bottom: 12px;
+}
+
+.domain-picker__suggestion-header-title {
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: 2px;
+	text-transform: uppercase;
+	color: var( --color-neutral-40 );
+}
+
+.domain-picker__suggestion-header-description {
+	font-size: 12px;
+	color: var( --color-neutral-40 );
+
+	em {
+		font-weight: 600;
+	}
+}
+
+.domain-picker__suggestion-item-group {
+	border: 1px solid $light-gray-500;
 }
 
 .domain-picker__suggestion-item {
@@ -34,23 +119,31 @@
 	&.components-button {
 		display: flex;
 		justify-content: space-between;
-		margin-top: 18px;
+		width: 100%;
+		height: 46px;
+		border-radius: 0;
+		padding: 0 16px;
+		font-size: 14px;
+
+		&.is-tertiary {
+			color: var( --color-text );
+
+			&:not( :disabled ):not( [aria-disabled='true'] ):hover {
+				background: var( --color-surface-backdrop );
+				color: var( --color-text );
+			}
+		}
+	}
+
+	+ .domain-picker__suggestion-item {
+		border-top: 1px solid $light-gray-500;
 	}
 }
 
 .domain-picker__suggestion-item-name {
 	&.placeholder {
 		@include placeholder();
-	}
-}
-
-.domain-picker__suggestion-action {
-	color: var( --studio-blue-40 );
-	text-decoration: none;
-	margin-left: 20px;
-
-	&.placeholder {
-		@include placeholder( --studio-blue-30 );
+		min-width: 30%;
 	}
 }
 
@@ -61,12 +154,23 @@
 	}
 }
 
-.domain-picker__divider {
-	margin-top: 20px;
+.domain-picker__badge {
+	display: inline-flex;
+	align-items: center;
+	font-size: 10px;
+	margin-left: 8px;
 }
 
 .domain-picker__price {
 	color: var( --studio-gray-20 );
-	margin: 0.1em 1em;
 	white-space: nowrap;
+
+	&.is-paid {
+		text-decoration: line-through;
+	}
+
+	&.placeholder {
+		@include placeholder();
+		min-width: 64px;
+	}
 }

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -109,7 +109,7 @@
 }
 
 .domain-picker__suggestion-item-group {
-	border: 1px solid $light-gray-500;
+	border: 1px solid var( --color-neutral-5 );
 }
 
 .domain-picker__suggestion-item {
@@ -136,7 +136,7 @@
 	}
 
 	+ .domain-picker__suggestion-item {
-		border-top: 1px solid $light-gray-500;
+		border-top: 1px solid var( --color-neutral-5 );
 	}
 }
 

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -135,13 +135,11 @@
 
 .domain-picker__badge {
 	display: inline-flex;
-	border-radius: 1000px; // A number large enough to exceed height of any badge to make it look like a pill
-	padding: 2px 11px;
-	line-height: 17px;
-	height: 18px;
+	border-radius: 1000px;
+	padding: 0.3em 1em;
 	align-items: center;
-	font-size: 10px;
-	margin-left: 8px;
+	font-size: 0.75em;
+	margin-left: 1em;
 
 	background-color: var( --studio-blue-50 );
 	color: var( --color-text-inverted );

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -33,31 +33,6 @@
 	}
 }
 
-.domain-picker__search {
-	// Override styling from @wordpress
-	input[type='search'].search__input {
-		width: 100%;
-		border: none;
-		box-shadow: none;
-		font-size: 16px;
-		font-weight: normal;
-
-		&:focus,
-		&:hover {
-			// Focus outline is provided by parent element in SearchCard.
-			outline: none;
-			box-shadow: none;
-		}
-	}
-}
-
-.domain-picker__search-field {
-	// Override styling from SearchCard
-	&.search-card {
-		margin: 0;
-	}
-}
-
 .domain-picker__connect-domain {
 	text-align: center;
 	margin-top: 14px;

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
@@ -8,9 +8,9 @@ import React, { FunctionComponent } from 'react';
  */
 import { Button } from '@wordpress/components';
 
-const DomainPickerSuggestionItemPlaceholder: FunctionComponent< Button.AnchorProps > = props => {
+const DomainPickerSuggestionItemPlaceholder: FunctionComponent = () => {
 	return (
-		<Button className="domain-picker__suggestion-item" isTertiary { ...props }>
+		<Button className="domain-picker__suggestion-item" isTertiary>
 			<div className="domain-picker__suggestion-item-name placeholder"></div>
 			<div className="domain-picker__price placeholder"></div>
 		</Button>

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@wordpress/components';
+
+const DomainPickerSuggestionItemPlaceholder: FunctionComponent< Button.AnchorProps > = props => {
+	return (
+		<Button className="domain-picker__suggestion-item" isTertiary { ...props }>
+			<div className="domain-picker__suggestion-item-name placeholder"></div>
+			<div className="domain-picker__price placeholder"></div>
+		</Button>
+	);
+};
+
+export default DomainPickerSuggestionItemPlaceholder;

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
@@ -2,10 +2,6 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-
-/**
- * Internal dependencies
- */
 import { Button } from '@wordpress/components';
 
 const DomainPickerSuggestionItemPlaceholder: FunctionComponent = () => {

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -5,10 +5,6 @@ import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
 import Badge from 'components/badge';
-
-/**
- * Internal dependencies
- */
 import { DomainSuggestions } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -9,7 +9,7 @@ import { Button } from '@wordpress/components';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
-export interface Props extends Button.AnchorProps {
+interface Props extends Button.AnchorProps {
 	suggestion: DomainSuggestion;
 	isRecommended?: boolean;
 	isCurrent?: boolean;

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import classnames from 'classnames';
+import Badge from 'components/badge';
+
+/**
+ * Internal dependencies
+ */
+import { DomainSuggestions } from '@automattic/data-stores';
+import { Button } from '@wordpress/components';
+
+type DomainSuggestion = DomainSuggestions.DomainSuggestion;
+
+export interface Props extends Button.AnchorProps {
+	suggestion: DomainSuggestion;
+	isRecommended?: boolean;
+	isCurrent?: boolean;
+}
+
+const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
+	suggestion,
+	isRecommended = false,
+	isCurrent = false,
+	...props
+} ) => {
+	const { __: NO__ } = useI18n();
+
+	return (
+		<Button className="domain-picker__suggestion-item" isTertiary { ...props }>
+			<div className="domain-picker__suggestion-item-name">
+				{ suggestion.domain_name }
+				{ isRecommended ? (
+					<Badge type="info-blue" className="domain-picker__badge">
+						{ NO__( 'Recommended' ) }
+					</Badge>
+				) : null }
+				{ isCurrent ? (
+					<Badge type="success" className="domain-picker__badge">
+						{ NO__( 'Selected' ) }
+					</Badge>
+				) : null }
+			</div>
+			<div
+				className={ classnames( 'domain-picker__price', {
+					'is-paid': ! suggestion.is_free,
+				} ) }
+			>
+				{ /* FIXME: What value do we show here for paid domains? */ }
+				{ suggestion.is_free ? NO__( 'Free' ) : NO__( '€4/month' ) }
+			</div>
+		</Button>
+	);
+};
+
+export default DomainPickerSuggestionItem;

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -4,8 +4,6 @@
 import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
-// TODO: Extract Badge component https://github.com/Automattic/wp-calypso/issues/40327.
-import Badge from 'components/badge';
 import { Button } from '@wordpress/components';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
@@ -29,14 +27,10 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 			<div className="domain-picker__suggestion-item-name">
 				{ suggestion.domain_name }
 				{ isRecommended && (
-					<Badge type="info-blue" className="domain-picker__badge">
-						{ NO__( 'Recommended' ) }
-					</Badge>
+					<div className="domain-picker__badge is-recommended">{ NO__( 'Recommended' ) }</div>
 				) }
 				{ isCurrent && (
-					<Badge type="success" className="domain-picker__badge">
-						{ NO__( 'Selected' ) }
-					</Badge>
+					<div className="domain-picker__badge is-selected">{ NO__( 'Selected' ) }</div>
 				) }
 			</div>
 			<div

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -37,11 +37,11 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 						{ NO__( 'Recommended' ) }
 					</Badge>
 				) }
-				{ isCurrent ? (
+				{ isCurrent && (
 					<Badge type="success" className="domain-picker__badge">
 						{ NO__( 'Selected' ) }
 					</Badge>
-				) : null }
+				) }
 			</div>
 			<div
 				className={ classnames( 'domain-picker__price', {

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -4,6 +4,7 @@
 import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
+// TODO: Extract Badge component https://github.com/Automattic/wp-calypso/issues/40327.
 import Badge from 'components/badge';
 import { Button } from '@wordpress/components';
 

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -32,11 +32,11 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 		<Button className="domain-picker__suggestion-item" isTertiary { ...props }>
 			<div className="domain-picker__suggestion-item-name">
 				{ suggestion.domain_name }
-				{ isRecommended ? (
+				{ isRecommended && (
 					<Badge type="info-blue" className="domain-picker__badge">
 						{ NO__( 'Recommended' ) }
 					</Badge>
-				) : null }
+				) }
 				{ isCurrent ? (
 					<Badge type="success" className="domain-picker__badge">
 						{ NO__( 'Selected' ) }

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -5,10 +5,9 @@ import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
 import Badge from 'components/badge';
-import { DomainSuggestions } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 
-type DomainSuggestion = DomainSuggestions.DomainSuggestion;
+type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
 export interface Props extends Button.AnchorProps {
 	suggestion: DomainSuggestion;

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-none.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-none.tsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useI18n } from '@automattic/react-i18n';
+
+const DomainPickerSuggestionItem: FunctionComponent = () => {
+	const { __: NO__ } = useI18n();
+
+	return <div className="domain-picker__suggestion-none">{ NO__( 'No matching domains.' ) }</div>;
+};
+
+export default DomainPickerSuggestionItem;

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -74,7 +74,7 @@ function normalizeDomainSuggestionQuery(
 	return {
 		// Defaults
 		include_wordpressdotcom: queryOptions.only_wordpressdotcom || false,
-		include_dotblogsubdomain: ! queryOptions.only_wordpressdotcom || false,
+		include_dotblogsubdomain: false,
 		only_wordpressdotcom: false,
 		quantity: 5,
 		vendor: 'variation2_front',

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -78,7 +78,7 @@ export interface DomainSuggestion {
 	 *
 	 * @example [ "exact-match" ]
 	 */
-	match_reasons: string[];
+	match_reasons?: string[];
 
 	/**
 	 * Rendered cost with currency


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redesign of domain picker.
* Recommended domain badge is introduced. This is determined by picking domain suggestions with exact-match with highest relevance score. This only appears if there is a domain with exact match. Feel free to discuss change of algorithm.
* (Not from the figma prototype.) A selected domain badge is introduced. I'm only introducing that because I needed to do something with the `currentDomain` prop that was introduced in the DomainPIcker component which was unused.

#### Testing instructions

Here are some things you can test:
- Clicking on domain picker dropdown button should display the domain picker.
- When domain picker appears initially, it should display list of suggestion items as placeholders.
- Entering a value on the domain search input should update the suggestion list with new suggestions.
- While new suggestions are being loaded, the suggestion items should display as placeholders.
- Sometimes **Recommended** badge will appear if there is a domain with exact match with user entered site title.
- Clicking on a free subdomain suggestion item and reopening the domain picker dropdown should show the **Selected** badge on the free subdomain suggestion item.
- Clicking on **Skip for now** button should close the dropdown picker.

#### Known Issues

These issues should be addressed separately in another PR:

- The free subdomain displayed on the domain picker dropdown button does not match the free subdomain on the domain picker free suggestion.
- Clicking on "Connect it now" button does not do anything.
- "More options" button is not added in this PR.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/77141951-96d11400-6ab9-11ea-8b38-ee85a9e3364b.png)

![image](https://user-images.githubusercontent.com/1287077/77142298-a13fdd80-6aba-11ea-9dae-746ca25b59bd.png)

Fixes https://github.com/Automattic/wp-calypso/issues/40163
