### PR TITLE
Jetpack Cloud: Update Scan Section Sidebar

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/style.scss
+++ b/client/landing/jetpack-cloud/components/sidebar/style.scss
@@ -4,7 +4,6 @@
 	.sidebar__menu-link {
 		padding-top: 14px;
 		padding-bottom: 14px;
-		font-weight: 600;
 
 		.selected &,
 		.selected &:hover {

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -85,7 +85,7 @@ export default function() {
 
 		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
 			page(
-				'/scan/:site/history',
+				'/scan/history/:site/',
 				siteSelection,
 				navigation,
 				scanHistory,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds history and scanner to the jetpack cloud sidebar. 
* Makes the sidebar work like calypso with the expandable component.
* Update the url of the history view to be more in line with calypso.

Before:
<img width="547" alt="Screen Shot 2020-03-17 at 11 54 52 AM" src="https://user-images.githubusercontent.com/115071/76849678-22426f00-6846-11ea-8044-8fc7b9ee4db5.png">

After:
<img width="529" alt="Screen Shot 2020-03-17 at 11 54 43 AM" src="https://user-images.githubusercontent.com/115071/76849682-25d5f600-6846-11ea-891d-46977a3e3a63.png">


#### Testing instructions
* Load up jetpack cloud 
* Click on the scan section. Does it work like you would expect? 
