### PR TITLE
Jetpack Cloud: Create Fix all threats - add credentials modal

### DIFF
--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -11,6 +12,7 @@ import { translate } from 'i18n-calypso';
 import { Dialog } from '@automattic/components';
 import Gridicon from 'components/gridicon';
 import ServerCredentialsForm from '../server-credentials-form';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Style dependencies
@@ -18,8 +20,9 @@ import ServerCredentialsForm from '../server-credentials-form';
 import './style.scss';
 
 interface Props {
-	showDialog: boolean;
 	onCloseDialog: Function;
+	showDialog: boolean;
+	siteId: number | null;
 }
 
 class FixAllThreatsDialog extends React.PureComponent< Props > {
@@ -29,7 +32,7 @@ class FixAllThreatsDialog extends React.PureComponent< Props > {
 	};
 
 	render() {
-		const { onCloseDialog, showDialog } = this.props;
+		const { onCloseDialog, showDialog, siteId } = this.props;
 
 		return (
 			<Dialog
@@ -56,10 +59,10 @@ class FixAllThreatsDialog extends React.PureComponent< Props > {
 				</div>
 				<ServerCredentialsForm
 					className="fix-all-threats-dialog__form"
-					onCancel={ () => console.log( 'Canceled' ) }
+					onCancel={ onCloseDialog }
 					onComplete={ () => console.log( 'Completed' ) }
 					role="main"
-					siteId={ 28393212 }
+					siteId={ siteId }
 					labels={ {
 						cancel: translate( 'Go back' ),
 						save: translate( 'Save credentials and fix' ),
@@ -70,4 +73,11 @@ class FixAllThreatsDialog extends React.PureComponent< Props > {
 	}
 }
 
-export default FixAllThreatsDialog;
+const mapStateToProps = ( state: object ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId,
+	};
+};
+
+export default connect( mapStateToProps )( FixAllThreatsDialog );

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * External dependencies
  */
@@ -9,6 +10,7 @@ import { translate } from 'i18n-calypso';
  */
 import { Button, Dialog } from '@automattic/components';
 import Gridicon from 'components/gridicon';
+import RewindCredentialsForm from 'components/rewind-credentials-form';
 
 /**
  * Style dependencies
@@ -62,6 +64,14 @@ class FixAllThreatsDialog extends React.PureComponent< Props > {
 						) }
 					</p>
 				</div>
+				<RewindCredentialsForm
+					allowCancel={ false }
+					allowDelete={ false }
+					onCancel={ () => console.log( 'Canceled' ) }
+					onComplete={ () => console.log( 'Completed' ) }
+					role="main"
+					siteId={ 28393212 }
+				/>
 			</Dialog>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Dialog } from '@automattic/components';
+import Gridicon from 'components/gridicon';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	showDialog: boolean;
+	onCloseDialog: Function;
+}
+
+class FixAllThreatsDialog extends React.PureComponent< Props > {
+	fixAll = () => {
+		window.alert( `Fixing all threats!` );
+		this.props.onCloseDialog();
+	};
+
+	render() {
+		const { onCloseDialog, showDialog } = this.props;
+		const buttons = [
+			<Button
+				className="fix-all-threats-dialog__btn fix-all-threats-dialog__btn--fix"
+				onClick={ onCloseDialog }
+			>
+				{ translate( 'Go back' ) }
+			</Button>,
+			<Button onClick={ this.fixAll }>{ translate( 'Save credentials and fix' ) }</Button>,
+		];
+
+		return (
+			<Dialog
+				additionalClassNames="fix-all-threats-dialog"
+				isVisible={ showDialog }
+				onClose={ onCloseDialog }
+				buttons={ buttons }
+			>
+				<h1 className="fix-all-threats-dialog__header">Fix all threats</h1>
+				<h3 className="fix-all-threats-dialog__threat-title">
+					{ translate( 'You have selected to fix all discovered threats' ) }
+				</h3>
+				<div className="fix-all-threats-dialog__warning">
+					<Gridicon className="fix-all-threats-dialog__warning-icon" icon="info" size={ 36 } />
+					<p className="fix-all-threats-dialog__warning-message">
+						{ translate(
+							"Jetpack is unable to auto fix these threats as we currently do not have access to your website's server. Please supply your SFTP/SSH credentials to enable auto fixing. Alternatively, you will need go back and {{strong}}fix the threats manually{{/strong}}.",
+							{
+								components: {
+									strong: <strong />,
+								},
+							}
+						) }
+					</p>
+				</div>
+			</Dialog>
+		);
+	}
+}
+
+export default FixAllThreatsDialog;

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -8,9 +8,9 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { Button, Dialog } from '@automattic/components';
+import { Dialog } from '@automattic/components';
 import Gridicon from 'components/gridicon';
-import RewindCredentialsForm from 'components/rewind-credentials-form';
+import ServerCredentialsForm from '../server-credentials-form';
 
 /**
  * Style dependencies
@@ -30,22 +30,12 @@ class FixAllThreatsDialog extends React.PureComponent< Props > {
 
 	render() {
 		const { onCloseDialog, showDialog } = this.props;
-		const buttons = [
-			<Button
-				className="fix-all-threats-dialog__btn fix-all-threats-dialog__btn--fix"
-				onClick={ onCloseDialog }
-			>
-				{ translate( 'Go back' ) }
-			</Button>,
-			<Button onClick={ this.fixAll }>{ translate( 'Save credentials and fix' ) }</Button>,
-		];
 
 		return (
 			<Dialog
 				additionalClassNames="fix-all-threats-dialog"
 				isVisible={ showDialog }
 				onClose={ onCloseDialog }
-				buttons={ buttons }
 			>
 				<h1 className="fix-all-threats-dialog__header">Fix all threats</h1>
 				<h3 className="fix-all-threats-dialog__threat-title">
@@ -64,13 +54,16 @@ class FixAllThreatsDialog extends React.PureComponent< Props > {
 						) }
 					</p>
 				</div>
-				<RewindCredentialsForm
-					allowCancel={ false }
-					allowDelete={ false }
+				<ServerCredentialsForm
+					className="fix-all-threats-dialog__form"
 					onCancel={ () => console.log( 'Canceled' ) }
 					onComplete={ () => console.log( 'Completed' ) }
 					role="main"
 					siteId={ 28393212 }
+					labels={ {
+						cancel: translate( 'Go back' ),
+						save: translate( 'Save credentials and fix' ),
+					} }
 				/>
 			</Dialog>
 		);

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -41,11 +41,7 @@ const FixAllThreatsDialog = ( {
 	const [ currentStep, setCurrentStep ] = React.useState< ProcessStep >( firstStep );
 
 	return (
-		<Dialog
-			additionalClassNames="fix-all-threats-dialog"
-			isVisible={ showDialog }
-			onClose={ onCloseDialog }
-		>
+		<Dialog additionalClassNames="fix-all-threats-dialog" isVisible={ showDialog }>
 			<h1 className="fix-all-threats-dialog__header">Fix all threats</h1>
 			{ currentStep === 'server-credentials' && (
 				<>

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -20,15 +20,25 @@ import './style.scss';
 
 interface Props {
 	onCloseDialog: Function;
+	onConfirmation: Function;
 	showDialog: boolean;
 	siteId: number;
 	threats: Array< Threat >;
+	userHasCredentials: boolean;
 }
 
 type ProcessStep = 'server-credentials' | 'confirmation';
 
-const FixAllThreatsDialog = ( { onCloseDialog, showDialog, siteId, threats }: Props ) => {
-	const [ step, setStep ] = React.useState< ProcessStep >( 'server-credentials' );
+const FixAllThreatsDialog = ( {
+	onConfirmation,
+	onCloseDialog,
+	showDialog,
+	siteId,
+	threats,
+	userHasCredentials = true,
+}: Props ) => {
+	const firstStep = userHasCredentials ? 'confirmation' : 'server-credentials';
+	const [ currentStep, setCurrentStep ] = React.useState< ProcessStep >( firstStep );
 
 	return (
 		<Dialog
@@ -37,13 +47,17 @@ const FixAllThreatsDialog = ( { onCloseDialog, showDialog, siteId, threats }: Pr
 			onClose={ onCloseDialog }
 		>
 			<h1 className="fix-all-threats-dialog__header">Fix all threats</h1>
-			{ step === 'server-credentials' && (
+			{ currentStep === 'server-credentials' && (
 				<>
 					<h3 className="fix-all-threats-dialog__threat-title">
 						{ translate( 'You have selected to fix all discovered threats' ) }
 					</h3>
 					<div className="fix-all-threats-dialog__warning">
-						<Gridicon className="fix-all-threats-dialog__warning-icon" icon="info" size={ 36 } />
+						<Gridicon
+							className="fix-all-threats-dialog__icon fix-all-threats-dialog__icon--warning"
+							icon="info"
+							size={ 36 }
+						/>
 						<p className="fix-all-threats-dialog__warning-message">
 							{ translate(
 								"Jetpack is unable to auto fix these threats as we currently do not have access to your website's server. Please supply your SFTP/SSH credentials to enable auto fixing. Alternatively, you will need go back and {{strong}}fix the threats manually{{/strong}}.",
@@ -59,7 +73,7 @@ const FixAllThreatsDialog = ( { onCloseDialog, showDialog, siteId, threats }: Pr
 					<ServerCredentialsForm
 						className="fix-all-threats-dialog__form"
 						onCancel={ onCloseDialog }
-						onComplete={ () => setStep( 'confirmation' ) }
+						onComplete={ () => setCurrentStep( 'confirmation' ) }
 						role="main"
 						siteId={ siteId }
 						labels={ {
@@ -69,7 +83,7 @@ const FixAllThreatsDialog = ( { onCloseDialog, showDialog, siteId, threats }: Pr
 					/>
 				</>
 			) }
-			{ step === 'confirmation' && (
+			{ currentStep === 'confirmation' && (
 				<>
 					<h3 className="fix-all-threats-dialog__threat-title">
 						{ translate( 'Please confirm you want to fix all %(threatCount)d active threats', {
@@ -82,19 +96,35 @@ const FixAllThreatsDialog = ( { onCloseDialog, showDialog, siteId, threats }: Pr
 						{ translate( 'Jetpack will be fixing all the detected active threats.' ) }
 					</p>
 					<div className="fix-all-threats-dialog__warning">
-						<Gridicon className="fix-all-threats-dialog__warning-icon" icon="info" size={ 36 } />
+						<Gridicon
+							className="fix-all-threats-dialog__icon fix-all-threats-dialog__icon--confirmation"
+							icon="info"
+							size={ 36 }
+						/>
 						<div className="fix-all-threats-dialog__warning-message">
 							{ translate( 'To fix this threat, Jetpack will be:' ) }
 							<ul>
 								{ threats.map( threat => (
-									<li>{ threat.title }</li>
+									<li key={ threat.id }>{ threat.title }</li>
 								) ) }
 							</ul>
 						</div>
 					</div>
-					<div>
-						<Button>Go back</Button>
-						<Button>Fix all threats</Button>
+					<div className="fix-all-threats-dialog__buttons">
+						{ firstStep !== currentStep && (
+							<Button
+								className="fix-all-threats-dialog__btn fix-all-threats-dialog__btn--cancel"
+								onClick={ () => setCurrentStep( 'server-credentials' ) }
+							>
+								Go back
+							</Button>
+						) }
+						<Button
+							className="fix-all-threats-dialog__btn fix-all-threats-dialog__btn--fix"
+							onClick={ onConfirmation }
+						>
+							Fix all threats
+						</Button>
 					</div>
 				</>
 			) }

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -30,29 +30,5 @@
 			color: var( --color-text-subtle );
 			font-size: 14px;
 		}
-
-		&__btn {
-			width: 100%;
-
-			@include breakpoint( '>480px' ) {
-				width: 140px;
-			}
-		}
-
-		&__btn--fix {
-			background: var( --color-primary-40 );
-			color: #fff;
-			border: 1px solid var( --studio-gray-0 );
-		}
-
-		&__btn--cancel {
-			background: #fff;
-			color: var( --color-primary-40 );
-			border: 1px solid var( --color-primary-40 );
-		}
-	}
-
-	.dialog__action-buttons {
-		background: var( --studio-gray-0 );
 	}
 }

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -1,0 +1,58 @@
+.dialog.fix-all-threats-dialog {
+	max-width: 676px;
+
+	.fix-all-threats-dialog {
+		&__header {
+			font-size: 18px;
+			border-bottom: 1px solid #dcdcde;
+			margin: -8px -24px 16px;
+			padding: 0 24px 16px;
+			color: var( --color-primary-40 );
+		}
+
+		&__threat-title {
+			font-weight: bold;
+			margin: 8px 0;
+		}
+
+		&__warning {
+			display: flex;
+		}
+
+		&__warning-icon {
+			flex: 0 0 24px;
+			margin-top: -5px;
+			margin-right: 8px;
+			fill: var( --color-threat-found );
+		}
+
+		&__warning-message {
+			color: var( --color-text-subtle );
+			font-size: 14px;
+		}
+
+		&__btn {
+			width: 100%;
+
+			@include breakpoint( '>480px' ) {
+				width: 140px;
+			}
+		}
+
+		&__btn--fix {
+			background: var( --color-primary-40 );
+			color: #fff;
+			border: 1px solid var( --studio-gray-0 );
+		}
+
+		&__btn--cancel {
+			background: #fff;
+			color: var( --color-primary-40 );
+			border: 1px solid var( --color-primary-40 );
+		}
+	}
+
+	.dialog__action-buttons {
+		background: var( --studio-gray-0 );
+	}
+}

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -19,16 +19,49 @@
 			display: flex;
 		}
 
-		&__warning-icon {
+		&__icon {
 			flex: 0 0 24px;
 			margin-top: -5px;
 			margin-right: 8px;
+		}
+
+		&__icon--warning {
 			fill: var( --color-threat-found );
+		}
+
+		&__icon--confirmation {
+			fill: var( --color-primary-40 );
 		}
 
 		&__warning-message {
 			color: var( --color-text-subtle );
 			font-size: 14px;
+		}
+
+		&__buttons {
+			display: flex;
+			justify-content: center;
+		}
+
+		&__btn {
+			width: 100%;
+
+			@include breakpoint( '>480px' ) {
+				width: 200px;
+			}
+		}
+
+		&__btn--fix {
+			background: var( --color-primary-40 );
+			color: #fff;
+			border: 1px solid var( --studio-gray-0 );
+		}
+
+		&__btn--cancel {
+			background: #fff;
+			color: var( --color-primary-40 );
+			border: 1px solid var( --color-primary-40 );
+			margin-right: 16px;
 		}
 	}
 }

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -54,6 +54,11 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		closeDialog();
 	};
 
+	const confirmFixAllThreats = () => {
+		window.alert( `Starting to fix ${ threats.length } threats found...` );
+		setShowFixAllThreatsDialog( false );
+	};
+
 	return (
 		<>
 			<h1 className="scan-threats scan__header">{ translate( 'Your site may be at risk' ) }</h1>
@@ -118,6 +123,8 @@ const ScanThreats = ( { site, threats }: Props ) => {
 				showDialog={ showFixAllThreatsDialog }
 				siteId={ site.ID }
 				onCloseDialog={ () => setShowFixAllThreatsDialog( false ) }
+				onConfirmation={ confirmFixAllThreats }
+				userHasCredentials={ false }
 			/>
 		</>
 	);

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -7,6 +7,8 @@ import { numberFormat, translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { Button } from '@automattic/components';
+import FixAllThreatsDialog from '../../components/fix-all-threats-dialog';
 import ThreatDialog from 'landing/jetpack-cloud/components/threat-dialog';
 import ThreatItem from 'landing/jetpack-cloud/components/threat-item';
 import { Threat, ThreatAction } from 'landing/jetpack-cloud/components/threat-item/types';
@@ -18,6 +20,7 @@ import './style.scss';
 
 interface Props {
 	site: {
+		ID: number;
 		name: string;
 	};
 	threats: Array< Threat >;
@@ -26,7 +29,12 @@ interface Props {
 const ScanThreats = ( { site, threats }: Props ) => {
 	const [ selectedThreat, setSelectedThreat ] = React.useState< Threat | undefined >();
 	const [ showThreatDialog, setShowThreatDialog ] = React.useState( false );
+	const [ showFixAllThreatsDialog, setShowFixAllThreatsDialog ] = React.useState( false );
 	const [ actionToPerform, setActionToPerform ] = React.useState< ThreatAction >( 'fix' );
+
+	const openFixAllThreatsDialog = () => {
+		setShowFixAllThreatsDialog( true );
+	};
 
 	const openDialog = ( action: ThreatAction, threat: Threat ) => {
 		setSelectedThreat( threat );
@@ -74,6 +82,17 @@ const ScanThreats = ( { site, threats }: Props ) => {
 				) }
 			</p>
 			<div className="scan-threats__threats">
+				<div className="scan-threats__buttons">
+					<Button
+						className="scan-threats__fix-all-threats-button"
+						onClick={ openFixAllThreatsDialog }
+					>
+						{ translate( 'Fix all' ) }
+					</Button>
+					<Button className="scan-threats__options-button" onClick={ openFixAllThreatsDialog }>
+						...
+					</Button>
+				</div>
 				{ threats.map( threat => (
 					<ThreatItem
 						key={ threat.id }
@@ -94,6 +113,12 @@ const ScanThreats = ( { site, threats }: Props ) => {
 					action={ actionToPerform }
 				/>
 			) }
+			<FixAllThreatsDialog
+				threats={ threats }
+				showDialog={ showFixAllThreatsDialog }
+				siteId={ site.ID }
+				onCloseDialog={ () => setShowFixAllThreatsDialog( false ) }
+			/>
 		</>
 	);
 };

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { numberFormat, translate } from 'i18n-calypso';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,6 +14,7 @@ import FixAllThreatsDialog from '../../components/fix-all-threats-dialog';
 import ThreatDialog from 'landing/jetpack-cloud/components/threat-dialog';
 import ThreatItem from 'landing/jetpack-cloud/components/threat-item';
 import { Threat, ThreatAction } from 'landing/jetpack-cloud/components/threat-item/types';
+import getJetpackCredentials from 'state/selectors/get-jetpack-credentials';
 
 /**
  * Style dependencies
@@ -24,9 +27,10 @@ interface Props {
 		name: string;
 	};
 	threats: Array< Threat >;
+	userHasCredentials: boolean;
 }
 
-const ScanThreats = ( { site, threats }: Props ) => {
+const ScanThreats = ( { site, threats, userHasCredentials }: Props ) => {
 	const [ selectedThreat, setSelectedThreat ] = React.useState< Threat | undefined >();
 	const [ showThreatDialog, setShowThreatDialog ] = React.useState( false );
 	const [ showFixAllThreatsDialog, setShowFixAllThreatsDialog ] = React.useState( false );
@@ -124,10 +128,16 @@ const ScanThreats = ( { site, threats }: Props ) => {
 				siteId={ site.ID }
 				onCloseDialog={ () => setShowFixAllThreatsDialog( false ) }
 				onConfirmation={ confirmFixAllThreats }
-				userHasCredentials={ false }
+				userHasCredentials={ userHasCredentials }
 			/>
 		</>
 	);
 };
 
-export default ScanThreats;
+const mapStateToProps = ( state, { site } ) => {
+	return {
+		userHasCredentials: ! isEmpty( getJetpackCredentials( state, site.ID, 'main' ) ),
+	};
+};
+
+export default connect( mapStateToProps )( ScanThreats );

--- a/client/landing/jetpack-cloud/components/scan-threats/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-threats/style.scss
@@ -2,4 +2,35 @@
 	&__threats {
 		margin: 40px 0;
 	}
+
+	&__buttons {
+		display: flex;
+		justify-content: space-between;
+		margin-bottom: 16px;
+
+		@include breakpoint( '>800px' ) {
+			justify-content: flex-end;
+		}
+	}
+
+	&__fix-all-threats-button {
+		flex: 1 1 75%;
+		padding: 10px 30px;
+		background: var( --color-primary-40 );
+		color: #fff;
+		border-color: var( --color-primary-40 );
+
+		@include breakpoint( '>800px' ) {
+			flex: 0 0 170px;
+		}
+	}
+
+	&__options-button {
+		flex: 0 0 50px;
+		padding: 10px 0;
+		margin-left: 16px;
+		color: var( --color-primary-40 );
+		background: #fff;
+		border-color: var( --color-primary-40 );
+	}
 }

--- a/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
@@ -195,6 +195,7 @@ ServerCredentialsForm.propTypes = {
 	form: PropTypes.object,
 	formErrors: PropTypes.object,
 	formIsSubmitting: PropTypes.bool,
+	formSubmissionStatus: PropTypes.string,
 	handleFieldChange: PropTypes.func,
 	handleSubmit: PropTypes.func,
 	handleDelete: PropTypes.func,

--- a/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
@@ -26,9 +26,10 @@ import './style.scss';
 const ServerCredentialsForm = ( {
 	formIsSubmitting,
 	onCancel,
+	onComplete,
 	translate,
 	handleFieldChange,
-	handleSubmit,
+	// handleSubmit,
 	form,
 	formErrors,
 	labels = {},
@@ -129,7 +130,7 @@ const ServerCredentialsForm = ( {
 			<Button
 				className="server-credentials-form__btn server-credentials-form__btn--fix"
 				disabled={ formIsSubmitting }
-				onClick={ handleSubmit }
+				onClick={ onComplete }
 			>
 				{ labels.save || translate( 'Save' ) }
 			</Button>

--- a/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
@@ -31,145 +31,155 @@ const ServerCredentialsForm = ( {
 	onComplete,
 	translate,
 	handleFieldChange,
-	// handleSubmit,
+	handleSubmit,
 	form,
 	formErrors,
 	labels = {},
-} ) => (
-	<div className="server-credentials-form">
-		<FormFieldset>
-			<FormLabel htmlFor="protocol-type">{ translate( 'Credential Type' ) }</FormLabel>
-			<FormSelect
-				name="protocol"
-				id="protocol-type"
-				value={ get( form, 'protocol', 'ssh' ) }
-				onChange={ handleFieldChange }
-				disabled={ formIsSubmitting }
-			>
-				<option value="ssh">{ translate( 'SSH/SFTP' ) }</option>
-				<option value="ftp">{ translate( 'FTP' ) }</option>
-			</FormSelect>
-		</FormFieldset>
+} ) => {
+	const handleSubmitAndComplete = React.useCallback(
+		( ...args ) => {
+			handleSubmit( ...args );
+			onComplete && onComplete( ...args );
+		},
+		[ handleSubmit, onComplete ]
+	);
 
-		<div className="server-credentials-form__row">
-			<FormFieldset className="server-credentials-form__server-address">
-				<FormLabel htmlFor="host-address">
-					{ labels.host || translate( 'Server Address' ) }
-				</FormLabel>
-				<FormTextInput
-					name="host"
-					id="host-address"
-					placeholder={ translate( 'YourGroovyDomain.com' ) }
-					value={ get( form, 'host', '' ) }
+	return (
+		<div className="server-credentials-form">
+			<FormFieldset>
+				<FormLabel htmlFor="protocol-type">{ translate( 'Credential Type' ) }</FormLabel>
+				<FormSelect
+					name="protocol"
+					id="protocol-type"
+					value={ get( form, 'protocol', 'ssh' ) }
 					onChange={ handleFieldChange }
 					disabled={ formIsSubmitting }
-					isError={ !! formErrors.host }
-				/>
-				{ formErrors.host && <FormInputValidation isError={ true } text={ formErrors.host } /> }
+				>
+					<option value="ssh">{ translate( 'SSH/SFTP' ) }</option>
+					<option value="ftp">{ translate( 'FTP' ) }</option>
+				</FormSelect>
 			</FormFieldset>
 
-			<FormFieldset className="server-credentials-form__port-number">
-				<FormLabel htmlFor="server-port">{ labels.port || translate( 'Port Number' ) }</FormLabel>
+			<div className="server-credentials-form__row">
+				<FormFieldset className="server-credentials-form__server-address">
+					<FormLabel htmlFor="host-address">
+						{ labels.host || translate( 'Server Address' ) }
+					</FormLabel>
+					<FormTextInput
+						name="host"
+						id="host-address"
+						placeholder={ translate( 'YourGroovyDomain.com' ) }
+						value={ get( form, 'host', '' ) }
+						onChange={ handleFieldChange }
+						disabled={ formIsSubmitting }
+						isError={ !! formErrors.host }
+					/>
+					{ formErrors.host && <FormInputValidation isError={ true } text={ formErrors.host } /> }
+				</FormFieldset>
+
+				<FormFieldset className="server-credentials-form__port-number">
+					<FormLabel htmlFor="server-port">{ labels.port || translate( 'Port Number' ) }</FormLabel>
+					<FormTextInput
+						name="port"
+						id="server-port"
+						placeholder="22"
+						value={ get( form, 'port', '' ) }
+						onChange={ handleFieldChange }
+						disabled={ formIsSubmitting }
+						isError={ !! formErrors.port }
+					/>
+					{ formErrors.port && <FormInputValidation isError={ true } text={ formErrors.port } /> }
+				</FormFieldset>
+			</div>
+
+			<div className="server-credentials-form__row server-credentials-form__user-pass">
+				<FormFieldset className="server-credentials-form__username">
+					<FormLabel htmlFor="server-username">
+						{ labels.user || translate( 'Server username' ) }
+					</FormLabel>
+					<FormTextInput
+						name="user"
+						id="server-username"
+						placeholder={ translate( 'username' ) }
+						value={ get( form, 'user', '' ) }
+						onChange={ handleFieldChange }
+						disabled={ formIsSubmitting }
+						isError={ !! formErrors.user }
+						// Hint to LastPass not to attempt autofill
+						data-lpignore="true"
+					/>
+					{ formErrors.user && <FormInputValidation isError={ true } text={ formErrors.user } /> }
+				</FormFieldset>
+
+				<FormFieldset className="server-credentials-form__password">
+					<FormLabel htmlFor="server-password">
+						{ labels.pass || translate( 'Server password' ) }
+					</FormLabel>
+					<FormPasswordInput
+						name="pass"
+						id="server-password"
+						placeholder={ translate( 'password' ) }
+						value={ get( form, 'pass', '' ) }
+						onChange={ handleFieldChange }
+						disabled={ formIsSubmitting }
+						isError={ !! formErrors.pass }
+						// Hint to LastPass not to attempt autofill
+						data-lpignore="true"
+					/>
+					{ formErrors.pass && <FormInputValidation isError={ true } text={ formErrors.pass } /> }
+				</FormFieldset>
+			</div>
+
+			<FormFieldset className="server-credentials-form__path">
+				<FormLabel htmlFor="wordpress-path">
+					{ labels.path || translate( 'WordPress installation path' ) }
+				</FormLabel>
 				<FormTextInput
-					name="port"
-					id="server-port"
-					placeholder="22"
-					value={ get( form, 'port', '' ) }
+					name="path"
+					id="wordpress-path"
+					placeholder="/public_html/wordpress-site/"
+					value={ get( form, 'path', '' ) }
 					onChange={ handleFieldChange }
 					disabled={ formIsSubmitting }
-					isError={ !! formErrors.port }
+					isError={ !! formErrors.path }
 				/>
-				{ formErrors.port && <FormInputValidation isError={ true } text={ formErrors.port } /> }
+				{ formErrors.path && <FormInputValidation isError={ true } text={ formErrors.path } /> }
+			</FormFieldset>
+
+			<FormFieldset className="server-credentials-form__kpri">
+				<FormLabel htmlFor="private-key">{ labels.kpri || translate( 'Private Key' ) }</FormLabel>
+				<FormTextArea
+					name="kpri"
+					id="private-key"
+					value={ get( form, 'kpri', '' ) }
+					onChange={ handleFieldChange }
+					disabled={ formIsSubmitting }
+					className="server-credentials-form__private-key"
+				/>
+				<FormSettingExplanation>
+					{ translate( 'Only non-encrypted private keys are supported.' ) }
+				</FormSettingExplanation>
+			</FormFieldset>
+
+			<FormFieldset className="server-credentials-form__buttons">
+				<Button
+					disabled={ formIsSubmitting }
+					onClick={ onCancel }
+					className="server-credentials-form__btn server-credentials-form__btn--cancel"
+				>
+					{ labels.cancel || translate( 'Cancel' ) }
+				</Button>
+				<Button
+					className="server-credentials-form__btn server-credentials-form__btn--fix"
+					disabled={ formIsSubmitting }
+					onClick={ handleSubmitAndComplete }
+				>
+					{ labels.save || translate( 'Save' ) }
+				</Button>
 			</FormFieldset>
 		</div>
-
-		<div className="server-credentials-form__row server-credentials-form__user-pass">
-			<FormFieldset className="server-credentials-form__username">
-				<FormLabel htmlFor="server-username">
-					{ labels.user || translate( 'Server username' ) }
-				</FormLabel>
-				<FormTextInput
-					name="user"
-					id="server-username"
-					placeholder={ translate( 'username' ) }
-					value={ get( form, 'user', '' ) }
-					onChange={ handleFieldChange }
-					disabled={ formIsSubmitting }
-					isError={ !! formErrors.user }
-					// Hint to LastPass not to attempt autofill
-					data-lpignore="true"
-				/>
-				{ formErrors.user && <FormInputValidation isError={ true } text={ formErrors.user } /> }
-			</FormFieldset>
-
-			<FormFieldset className="server-credentials-form__password">
-				<FormLabel htmlFor="server-password">
-					{ labels.pass || translate( 'Server password' ) }
-				</FormLabel>
-				<FormPasswordInput
-					name="pass"
-					id="server-password"
-					placeholder={ translate( 'password' ) }
-					value={ get( form, 'pass', '' ) }
-					onChange={ handleFieldChange }
-					disabled={ formIsSubmitting }
-					isError={ !! formErrors.pass }
-					// Hint to LastPass not to attempt autofill
-					data-lpignore="true"
-				/>
-				{ formErrors.pass && <FormInputValidation isError={ true } text={ formErrors.pass } /> }
-			</FormFieldset>
-		</div>
-
-		<FormFieldset className="server-credentials-form__path">
-			<FormLabel htmlFor="wordpress-path">
-				{ labels.path || translate( 'WordPress installation path' ) }
-			</FormLabel>
-			<FormTextInput
-				name="path"
-				id="wordpress-path"
-				placeholder="/public_html/wordpress-site/"
-				value={ get( form, 'path', '' ) }
-				onChange={ handleFieldChange }
-				disabled={ formIsSubmitting }
-				isError={ !! formErrors.path }
-			/>
-			{ formErrors.path && <FormInputValidation isError={ true } text={ formErrors.path } /> }
-		</FormFieldset>
-
-		<FormFieldset className="server-credentials-form__kpri">
-			<FormLabel htmlFor="private-key">{ labels.kpri || translate( 'Private Key' ) }</FormLabel>
-			<FormTextArea
-				name="kpri"
-				id="private-key"
-				value={ get( form, 'kpri', '' ) }
-				onChange={ handleFieldChange }
-				disabled={ formIsSubmitting }
-				className="server-credentials-form__private-key"
-			/>
-			<FormSettingExplanation>
-				{ translate( 'Only non-encrypted private keys are supported.' ) }
-			</FormSettingExplanation>
-		</FormFieldset>
-
-		<FormFieldset className="server-credentials-form__buttons">
-			<Button
-				disabled={ formIsSubmitting }
-				onClick={ onCancel }
-				className="server-credentials-form__btn server-credentials-form__btn--cancel"
-			>
-				{ labels.cancel || translate( 'Cancel' ) }
-			</Button>
-			<Button
-				className="server-credentials-form__btn server-credentials-form__btn--fix"
-				disabled={ formIsSubmitting }
-				onClick={ onComplete }
-			>
-				{ labels.save || translate( 'Save' ) }
-			</Button>
-		</FormFieldset>
-	</div>
-);
+	);
+};
 ServerCredentialsForm.propTypes = {
 	allowCancel: PropTypes.bool,
 	allowDelete: PropTypes.bool,

--- a/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
@@ -44,7 +44,7 @@ const ServerCredentialsForm = ( {
 		if ( formSubmissionStatus === 'failed' || formSubmissionStatus === 'success' ) {
 			onComplete && onComplete();
 		}
-	}, [ formSubmissionStatus ] );
+	}, [ formSubmissionStatus, onComplete ] );
 
 	return (
 		<div className="server-credentials-form">

--- a/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
@@ -1,0 +1,157 @@
+/**
+ * External dependendies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import withServerCredentialsForm from '../with-server-credentials-form';
+import { Button } from '@automattic/components';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormSelect from 'components/forms/form-select';
+import FormTextInput from 'components/forms/form-text-input';
+import FormLabel from 'components/forms/form-label';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormPasswordInput from 'components/forms/form-password-input';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const ServerCredentialsForm = ( {
+	formIsSubmitting,
+	onCancel,
+	translate,
+	handleFieldChange,
+	handleSubmit,
+	form,
+	formErrors,
+	labels = {},
+} ) => (
+	<div className="server-credentials-form">
+		<FormFieldset>
+			<FormLabel htmlFor="protocol-type">{ translate( 'Credential Type' ) }</FormLabel>
+			<FormSelect
+				name="protocol"
+				id="protocol-type"
+				value={ get( form, 'protocol', 'ssh' ) }
+				onChange={ handleFieldChange }
+				disabled={ formIsSubmitting }
+			>
+				<option value="ssh">{ translate( 'SSH/SFTP' ) }</option>
+				<option value="ftp">{ translate( 'FTP' ) }</option>
+			</FormSelect>
+		</FormFieldset>
+
+		<div className="server-credentials-form__row">
+			<FormFieldset className="server-credentials-form__server-address">
+				<FormLabel htmlFor="host-address">
+					{ labels.host || translate( 'Server Address' ) }
+				</FormLabel>
+				<FormTextInput
+					name="host"
+					id="host-address"
+					placeholder={ translate( 'YourGroovyDomain.com' ) }
+					value={ get( form, 'host', '' ) }
+					onChange={ handleFieldChange }
+					disabled={ formIsSubmitting }
+					isError={ !! formErrors.host }
+				/>
+				{ formErrors.host && <FormInputValidation isError={ true } text={ formErrors.host } /> }
+			</FormFieldset>
+
+			<FormFieldset className="server-credentials-form__port-number">
+				<FormLabel htmlFor="server-port">{ labels.port || translate( 'Port Number' ) }</FormLabel>
+				<FormTextInput
+					name="port"
+					id="server-port"
+					placeholder="22"
+					value={ get( form, 'port', '' ) }
+					onChange={ handleFieldChange }
+					disabled={ formIsSubmitting }
+					isError={ !! formErrors.port }
+				/>
+				{ formErrors.port && <FormInputValidation isError={ true } text={ formErrors.port } /> }
+			</FormFieldset>
+		</div>
+
+		<div className="server-credentials-form__row server-credentials-form__user-pass">
+			<FormFieldset className="server-credentials-form__username">
+				<FormLabel htmlFor="server-username">
+					{ labels.user || translate( 'Server username' ) }
+				</FormLabel>
+				<FormTextInput
+					name="user"
+					id="server-username"
+					placeholder={ translate( 'username' ) }
+					value={ get( form, 'user', '' ) }
+					onChange={ handleFieldChange }
+					disabled={ formIsSubmitting }
+					isError={ !! formErrors.user }
+					// Hint to LastPass not to attempt autofill
+					data-lpignore="true"
+				/>
+				{ formErrors.user && <FormInputValidation isError={ true } text={ formErrors.user } /> }
+			</FormFieldset>
+
+			<FormFieldset className="server-credentials-form__password">
+				<FormLabel htmlFor="server-password">
+					{ labels.pass || translate( 'Server password' ) }
+				</FormLabel>
+				<FormPasswordInput
+					name="pass"
+					id="server-password"
+					placeholder={ translate( 'password' ) }
+					value={ get( form, 'pass', '' ) }
+					onChange={ handleFieldChange }
+					disabled={ formIsSubmitting }
+					isError={ !! formErrors.pass }
+					// Hint to LastPass not to attempt autofill
+					data-lpignore="true"
+				/>
+				{ formErrors.pass && <FormInputValidation isError={ true } text={ formErrors.pass } /> }
+			</FormFieldset>
+		</div>
+
+		<FormFieldset className="server-credentials-form__buttons">
+			<Button
+				disabled={ formIsSubmitting }
+				onClick={ onCancel }
+				className="server-credentials-form__btn server-credentials-form__btn--cancel"
+			>
+				{ labels.cancel || translate( 'Cancel' ) }
+			</Button>
+			<Button
+				className="server-credentials-form__btn server-credentials-form__btn--fix"
+				disabled={ formIsSubmitting }
+				onClick={ handleSubmit }
+			>
+				{ labels.save || translate( 'Save' ) }
+			</Button>
+		</FormFieldset>
+	</div>
+);
+ServerCredentialsForm.propTypes = {
+	allowCancel: PropTypes.bool,
+	allowDelete: PropTypes.bool,
+	onCancel: PropTypes.func,
+	onComplete: PropTypes.func,
+	labels: PropTypes.object,
+	showAdvancedSettings: PropTypes.bool,
+	toggleAdvancedSettings: PropTypes.func,
+	// The following props are provided by the withServerCredentials HOC
+	requirePath: PropTypes.bool,
+	form: PropTypes.object,
+	formErrors: PropTypes.object,
+	formIsSubmitting: PropTypes.bool,
+	handleFieldChange: PropTypes.func,
+	handleSubmit: PropTypes.func,
+	handleDelete: PropTypes.func,
+};
+
+export default withServerCredentialsForm( localize( ServerCredentialsForm ) );

--- a/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
@@ -27,6 +27,7 @@ import './style.scss';
 
 const ServerCredentialsForm = ( {
 	formIsSubmitting,
+	formSubmissionStatus,
 	onCancel,
 	onComplete,
 	translate,
@@ -36,13 +37,14 @@ const ServerCredentialsForm = ( {
 	formErrors,
 	labels = {},
 } ) => {
-	const handleSubmitAndComplete = React.useCallback(
-		( ...args ) => {
-			handleSubmit( ...args );
-			onComplete && onComplete( ...args );
-		},
-		[ handleSubmit, onComplete ]
-	);
+	React.useEffect( () => {
+		// I'm letting the user jump to the next step even if the submission failed
+		// so one can test the UI without having to enter real credentials. On the next
+		// iteration we should fix this.
+		if ( formSubmissionStatus === 'failed' || formSubmissionStatus === 'success' ) {
+			onComplete && onComplete();
+		}
+	}, [ formSubmissionStatus ] );
 
 	return (
 		<div className="server-credentials-form">
@@ -172,7 +174,7 @@ const ServerCredentialsForm = ( {
 				<Button
 					className="server-credentials-form__btn server-credentials-form__btn--fix"
 					disabled={ formIsSubmitting }
-					onClick={ handleSubmitAndComplete }
+					onClick={ handleSubmit }
 				>
 					{ labels.save || translate( 'Save' ) }
 				</Button>

--- a/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
@@ -17,6 +17,8 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
+import FormTextArea from 'components/forms/form-textarea';
 
 /**
  * Style dependencies
@@ -118,6 +120,37 @@ const ServerCredentialsForm = ( {
 				{ formErrors.pass && <FormInputValidation isError={ true } text={ formErrors.pass } /> }
 			</FormFieldset>
 		</div>
+
+		<FormFieldset className="server-credentials-form__path">
+			<FormLabel htmlFor="wordpress-path">
+				{ labels.path || translate( 'WordPress installation path' ) }
+			</FormLabel>
+			<FormTextInput
+				name="path"
+				id="wordpress-path"
+				placeholder="/public_html/wordpress-site/"
+				value={ get( form, 'path', '' ) }
+				onChange={ handleFieldChange }
+				disabled={ formIsSubmitting }
+				isError={ !! formErrors.path }
+			/>
+			{ formErrors.path && <FormInputValidation isError={ true } text={ formErrors.path } /> }
+		</FormFieldset>
+
+		<FormFieldset className="server-credentials-form__kpri">
+			<FormLabel htmlFor="private-key">{ labels.kpri || translate( 'Private Key' ) }</FormLabel>
+			<FormTextArea
+				name="kpri"
+				id="private-key"
+				value={ get( form, 'kpri', '' ) }
+				onChange={ handleFieldChange }
+				disabled={ formIsSubmitting }
+				className="server-credentials-form__private-key"
+			/>
+			<FormSettingExplanation>
+				{ translate( 'Only non-encrypted private keys are supported.' ) }
+			</FormSettingExplanation>
+		</FormFieldset>
 
 		<FormFieldset className="server-credentials-form__buttons">
 			<Button

--- a/client/landing/jetpack-cloud/components/server-credentials-form/style.scss
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/style.scss
@@ -1,0 +1,63 @@
+.server-credentials-form {
+	margin-top: 24px;
+	margin-bottom: -24px;
+
+	.form-fieldset {
+		width: 100%;
+	}
+
+	&__buttons {
+		background: var( --studio-gray-0 );
+		margin: 0 -24px;
+		padding: 16px 24px;
+		text-align: right;
+		box-sizing: content-box;
+	}
+
+	&__btn {
+		width: 100%;
+
+		@include breakpoint( '>480px' ) {
+			width: 200px;
+		}
+	}
+
+	&__btn--fix {
+		background: var( --color-primary-40 );
+		color: #fff;
+		border: 1px solid var( --studio-gray-0 );
+	}
+
+	&__btn--cancel {
+		background: #fff;
+		color: var( --color-primary-40 );
+		border: 1px solid var( --color-primary-40 );
+		margin-right: 16px;
+	}
+}
+
+.server-credentials-form__row {
+	display: flex;
+	flex-wrap: wrap;
+
+	.form-fieldset:last-child {
+		margin-bottom: 24px;
+	}
+}
+
+@include breakpoint( '>960px' ) {
+	.server-credentials-form__server-address,
+	.server-credentials-form__username,
+	.server-credentials-form__password {
+		flex: 1 0 240px;
+	}
+
+	.server-credentials-form__server-address,
+	.server-credentials-form__username {
+		margin-right: 16px;
+	}
+
+	.server-credentials-form__port-number {
+		flex: 0 0 160px;
+	}
+}

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -22,6 +22,7 @@ interface Props {
 	threat: Threat;
 	onFixThreat: Function;
 	onIgnoreThreat: Function;
+	isFixing: boolean;
 }
 
 class ThreatItem extends Component< Props > {
@@ -32,12 +33,14 @@ class ThreatItem extends Component< Props > {
 	 *
 	 * @param {string} className A class for the button
 	 */
-	renderFixThreatButton( className ) {
+	renderFixThreatButton( className: string ) {
+		const { onFixThreat, isFixing } = this.props;
 		return (
 			<Button
-				className={ classnames( 'threat-item__fix-button', className ) }
 				compact
-				onClick={ this.props.onFixThreat }
+				className={ classnames( 'threat-item__fix-button', className ) }
+				onClick={ onFixThreat }
+				disabled={ isFixing }
 			>
 				{ translate( 'Fix threat' ) }
 			</Button>
@@ -45,7 +48,7 @@ class ThreatItem extends Component< Props > {
 	}
 
 	render() {
-		const { threat, onIgnoreThreat } = this.props;
+		const { threat, onIgnoreThreat, isFixing } = this.props;
 		const fixThreatCTA = this.renderFixThreatButton( 'is-summary' );
 
 		return (
@@ -67,7 +70,12 @@ class ThreatItem extends Component< Props > {
 
 				<div className="threat-item__buttons">
 					{ this.renderFixThreatButton( 'is-details' ) }
-					<Button className="threat-item__ignore-button" compact onClick={ onIgnoreThreat }>
+					<Button
+						className="threat-item__ignore-button"
+						compact
+						onClick={ onIgnoreThreat }
+						disabled={ isFixing }
+					>
 						{ translate( 'Ignore threat' ) }
 					</Button>
 				</div>

--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
@@ -27,7 +27,7 @@ function withServerCredentialsForm( WrappedComponent ) {
 			siteUrl: PropTypes.string,
 			requirePath: PropTypes.bool,
 			formIsSubmitting: PropTypes.bool,
-			formSubmissionStatus: PropTypes.object,
+			formSubmissionStatus: PropTypes.string,
 		};
 
 		static defaultProps = {
@@ -113,7 +113,6 @@ function withServerCredentialsForm( WrappedComponent ) {
 		UNSAFE_componentWillReceiveProps( nextProps ) {
 			const { rewindState, role, siteSlug } = nextProps;
 			const credentials = find( rewindState.credentials, { role: role } );
-
 			const nextForm = Object.assign( {}, this.state.form );
 
 			// Populate the fields with data from state if credentials are already saved

--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
@@ -12,7 +12,6 @@ import { find, isEmpty } from 'lodash';
  */
 import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
 import { getSiteSlug } from 'state/sites/selectors';
-import getJetpackCredentials from 'state/selectors/get-jetpack-credentials';
 import getJetpackCredentialsUpdateStatus from 'state/selectors/get-jetpack-credentials-update-status';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
@@ -156,10 +155,6 @@ function withServerCredentialsForm( WrappedComponent ) {
 	const mapStateToProps = ( state, { siteId } ) => {
 		// I should pass the state of the form update to the child component
 		const formSubmissionStatus = getJetpackCredentialsUpdateStatus( state, siteId );
-
-		// eslint-disable-next-line no-console
-		console.log( getJetpackCredentials( state, siteId, 'main' ) );
-
 		// eslint-disable-next-line no-console
 		console.log( 'formSubmissionStatus', formSubmissionStatus );
 		return {

--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
@@ -27,6 +27,7 @@ function withServerCredentialsForm( WrappedComponent ) {
 			siteUrl: PropTypes.string,
 			requirePath: PropTypes.bool,
 			formIsSubmitting: PropTypes.bool,
+			formSubmissionStatus: PropTypes.object,
 		};
 
 		static defaultProps = {
@@ -131,7 +132,13 @@ function withServerCredentialsForm( WrappedComponent ) {
 
 		render() {
 			const { form, formErrors, showAdvancedSettings } = this.state;
-			const { formIsSubmitting, requirePath, siteId, ...otherProps } = this.props;
+			const {
+				formIsSubmitting,
+				formSubmissionStatus,
+				requirePath,
+				siteId,
+				...otherProps
+			} = this.props;
 			return (
 				<>
 					<QueryRewindState siteId={ siteId } />
@@ -139,6 +146,7 @@ function withServerCredentialsForm( WrappedComponent ) {
 						form={ form }
 						formErrors={ formErrors }
 						formIsSubmitting={ formIsSubmitting }
+						formSubmissionStatus={ formSubmissionStatus }
 						requirePath={ requirePath }
 						handleFieldChange={ this.handleFieldChange }
 						handleSubmit={ this.handleSubmit }
@@ -153,10 +161,7 @@ function withServerCredentialsForm( WrappedComponent ) {
 	};
 
 	const mapStateToProps = ( state, { siteId } ) => {
-		// I should pass the state of the form update to the child component
 		const formSubmissionStatus = getJetpackCredentialsUpdateStatus( state, siteId );
-		// eslint-disable-next-line no-console
-		console.log( 'formSubmissionStatus', formSubmissionStatus );
 		return {
 			formSubmissionStatus,
 			formIsSubmitting: 'pending' === formSubmissionStatus,

--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
@@ -12,6 +12,7 @@ import { find, isEmpty } from 'lodash';
  */
 import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
 import { getSiteSlug } from 'state/sites/selectors';
+import getJetpackCredentials from 'state/selectors/get-jetpack-credentials';
 import getJetpackCredentialsUpdateStatus from 'state/selectors/get-jetpack-credentials-update-status';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
@@ -154,12 +155,16 @@ function withServerCredentialsForm( WrappedComponent ) {
 
 	const mapStateToProps = ( state, { siteId } ) => {
 		// I should pass the state of the form update to the child component
-		const x = getJetpackCredentialsUpdateStatus( state, siteId );
+		const formSubmissionStatus = getJetpackCredentialsUpdateStatus( state, siteId );
 
 		// eslint-disable-next-line no-console
-		console.log( 'getJetpackCredentialsUpdateStatus', x );
+		console.log( getJetpackCredentials( state, siteId, 'main' ) );
+
+		// eslint-disable-next-line no-console
+		console.log( 'formSubmissionStatus', formSubmissionStatus );
 		return {
-			formIsSubmitting: 'pending' === x,
+			formSubmissionStatus,
+			formIsSubmitting: 'pending' === formSubmissionStatus,
 			siteSlug: getSiteSlug( state, siteId ),
 			rewindState: getRewindState( state, siteId ),
 		};

--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
@@ -1,0 +1,166 @@
+/**
+ * External dependendies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { translate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { find, isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
+import { getSiteSlug } from 'state/sites/selectors';
+import getJetpackCredentialsUpdateStatus from 'state/selectors/get-jetpack-credentials-update-status';
+import getRewindState from 'state/selectors/get-rewind-state';
+import QueryRewindState from 'components/data/query-rewind-state';
+
+// This is an experiment. I'm 100% sure this is not the right place to put a HOC.
+// I don't like its name either. The idea is to put all the logic here so we can
+// then have the UI we want without having to rewrite this.
+function withServerCredentialsForm( WrappedComponent ) {
+	const ServerCredentialsFormClass = class ServerCredentialsForm extends Component {
+		static propTypes = {
+			role: PropTypes.string.isRequired,
+			siteId: PropTypes.number,
+			siteUrl: PropTypes.string,
+			requirePath: PropTypes.bool,
+			formIsSubmitting: PropTypes.bool,
+		};
+
+		static defaultProps = {
+			requirePath: false,
+		};
+
+		state = {
+			form: {
+				protocol: 'ssh',
+				host: '',
+				port: 22,
+				user: '',
+				pass: '',
+				path: '',
+				kpri: '',
+			},
+			formErrors: {
+				host: false,
+				port: false,
+				user: false,
+				pass: false,
+				path: false,
+			},
+			showAdvancedSettings: false,
+		};
+
+		handleFieldChange = ( { target: { name, value } } ) => {
+			const changedProtocol = 'protocol' === name;
+			const defaultPort = 'ftp' === value ? 21 : 22;
+
+			const form = Object.assign(
+				this.state.form,
+				{ [ name ]: value },
+				changedProtocol && { port: defaultPort }
+			);
+
+			this.setState( {
+				form,
+				formErrors: { ...this.state.formErrors, [ name ]: false },
+			} );
+		};
+
+		handleSubmit = () => {
+			const { requirePath, role, siteId, siteUrl } = this.props;
+
+			const payload = {
+				role,
+				site_url: siteUrl,
+				...this.state.form,
+			};
+
+			let userError = '';
+
+			if ( ! payload.user ) {
+				userError = translate( 'Please enter your server username.' );
+			} else if ( 'root' === payload.user ) {
+				userError = translate(
+					"We can't accept credentials for the root user. " +
+						'Please provide or create credentials for another user with access to your server.'
+				);
+			}
+
+			const errors = Object.assign(
+				! payload.host && { host: translate( 'Please enter a valid server address.' ) },
+				! payload.port && { port: translate( 'Please enter a valid server port.' ) },
+				isNaN( payload.port ) && { port: translate( 'Port number must be numeric.' ) },
+				userError && { user: userError },
+				! payload.pass &&
+					! payload.kpri && { pass: translate( 'Please enter your server password.' ) },
+				! payload.path && requirePath && { path: translate( 'Please enter a server path.' ) }
+			);
+
+			return isEmpty( errors )
+				? this.props.updateCredentials( siteId, payload )
+				: this.setState( { formErrors: errors } );
+		};
+
+		handleDelete = () => this.props.deleteCredentials( this.props.siteId, this.props.role );
+
+		toggleAdvancedSettings = () =>
+			this.setState( { showAdvancedSettings: ! this.state.showAdvancedSettings } );
+
+		UNSAFE_componentWillReceiveProps( nextProps ) {
+			const { rewindState, role, siteSlug } = nextProps;
+			const credentials = find( rewindState.credentials, { role: role } );
+
+			const nextForm = Object.assign( {}, this.state.form );
+
+			// Populate the fields with data from state if credentials are already saved
+			nextForm.protocol = credentials ? credentials.type : nextForm.protocol;
+			nextForm.host = isEmpty( nextForm.host ) && credentials ? credentials.host : nextForm.host;
+			nextForm.port = isEmpty( nextForm.port ) && credentials ? credentials.port : nextForm.port;
+			nextForm.user = isEmpty( nextForm.user ) && credentials ? credentials.user : nextForm.user;
+			nextForm.path = isEmpty( nextForm.path ) && credentials ? credentials.path : nextForm.path;
+
+			// Populate the host field with the site slug if needed
+			nextForm.host =
+				isEmpty( nextForm.host ) && siteSlug ? siteSlug.split( '::' )[ 0 ] : nextForm.host;
+
+			this.setState( { form: nextForm } );
+		}
+
+		render() {
+			const { form, formErrors, showAdvancedSettings } = this.state;
+			const { formIsSubmitting, requirePath, siteId, ...otherProps } = this.props;
+			return (
+				<>
+					<QueryRewindState siteId={ siteId } />
+					<WrappedComponent
+						form={ form }
+						formErrors={ formErrors }
+						formIsSubmitting={ formIsSubmitting }
+						requirePath={ requirePath }
+						handleFieldChange={ this.handleFieldChange }
+						handleSubmit={ this.handleSubmit }
+						handleDelete={ this.handleDelete }
+						showAdvancedSettings={ showAdvancedSettings }
+						toggleAdvancedSettings={ this.toggleAdvancedSettings }
+						{ ...otherProps }
+					/>
+				</>
+			);
+		}
+	};
+
+	const mapStateToProps = ( state, { siteId } ) => ( {
+		formIsSubmitting: 'pending' === getJetpackCredentialsUpdateStatus( state, siteId ),
+		siteSlug: getSiteSlug( state, siteId ),
+		rewindState: getRewindState( state, siteId ),
+	} );
+
+	return connect( mapStateToProps, { deleteCredentials, updateCredentials } )(
+		ServerCredentialsFormClass
+	);
+}
+
+export default withServerCredentialsForm;

--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/index.jsx
@@ -152,11 +152,18 @@ function withServerCredentialsForm( WrappedComponent ) {
 		}
 	};
 
-	const mapStateToProps = ( state, { siteId } ) => ( {
-		formIsSubmitting: 'pending' === getJetpackCredentialsUpdateStatus( state, siteId ),
-		siteSlug: getSiteSlug( state, siteId ),
-		rewindState: getRewindState( state, siteId ),
-	} );
+	const mapStateToProps = ( state, { siteId } ) => {
+		// I should pass the state of the form update to the child component
+		const x = getJetpackCredentialsUpdateStatus( state, siteId );
+
+		// eslint-disable-next-line no-console
+		console.log( 'getJetpackCredentialsUpdateStatus', x );
+		return {
+			formIsSubmitting: 'pending' === x,
+			siteSlug: getSiteSlug( state, siteId ),
+			rewindState: getRewindState( state, siteId ),
+		};
+	};
 
 	return connect( mapStateToProps, { deleteCredentials, updateCredentials } )(
 		ServerCredentialsFormClass

--- a/client/landing/jetpack-cloud/components/with-server-credentials-form/test/index.js
+++ b/client/landing/jetpack-cloud/components/with-server-credentials-form/test/index.js
@@ -1,0 +1,218 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import { render, fireEvent } from '@testing-library/react';
+import * as actions from 'state/jetpack/credentials/actions';
+
+/**
+ * Internal dependencies
+ */
+import withServerCredentialsForm from 'landing/jetpack-cloud/components/with-server-credentials-form';
+
+/**
+ * Mocks
+ */
+jest.doMock( 'components/data/query-rewind-state', () => {
+	const QueryRewindState = () => <div />;
+	return QueryRewindState;
+} );
+
+const mockCredentials = {
+	credentials: [
+		{
+			role: 'main',
+			user: 'someUser',
+			host: 'someHost',
+			port: 33,
+			path: 'somePath',
+		},
+	],
+};
+
+jest.mock( 'state/selectors/get-rewind-state', () => ( {
+	__esModule: true,
+	default: () => mockCredentials,
+} ) );
+
+jest.mock( 'state/sites/selectors', () => ( {
+	getSiteSlug: () => 'site-slug',
+} ) );
+
+jest.mock( 'state/selectors/get-jetpack-credentials-update-status', () => () => 'unsubmitted' );
+
+/**
+ * Helper functions
+ */
+
+function renderInput( name, onChange, values, type = 'text' ) {
+	return (
+		<input
+			type={ type }
+			name={ name }
+			value={ values[ name ] }
+			data-testid={ name }
+			onChange={ onChange }
+		/>
+	);
+}
+
+function setup( { role = 'main', siteId = 9999, siteUrl = 'siteUrl' } = {} ) {
+	// Mutate action creators to make assertions on them
+	actions.updateCredentials = jest.fn( () => ( {
+		type: 'update-credentials',
+	} ) );
+	actions.deleteCredentials = jest.fn( () => ( {
+		type: 'delete-credentials',
+	} ) );
+
+	// We create a simple form to test the utilities and data provided by
+	// the withServerCredentials HOC.
+	const WrappedForm = ( {
+		form,
+		formErrors,
+		handleFieldChange,
+		handleDelete,
+		handleSubmit,
+		toggleAdvancedSettings,
+		showAdvancedSettings,
+	} ) => {
+		return (
+			<form>
+				{ renderInput( 'user', handleFieldChange, form ) }
+				{ renderInput( 'pass', handleFieldChange, form, 'password' ) }
+				{ renderInput( 'host', handleFieldChange, form ) }
+
+				<div data-testid="error-messages">
+					{ Object.values( formErrors )
+						.filter( v => v )
+						.join( ' ' ) }
+				</div>
+
+				<div data-testid="form-content">
+					{ Object.values( form )
+						.filter( v => v )
+						.join( ' ' ) }
+				</div>
+
+				<div data-testid="advanced-section">{ showAdvancedSettings && 'Hidden content!' }</div>
+
+				<button type="button" onClick={ toggleAdvancedSettings }>
+					Advanced Section
+				</button>
+
+				<button type="button" onClick={ handleDelete }>
+					Delete
+				</button>
+
+				<button type="button" onClick={ handleSubmit }>
+					Submit
+				</button>
+			</form>
+		);
+	};
+
+	const FormComponent = withServerCredentialsForm( WrappedForm );
+
+	// We use this function to rerender the component so we can make assertions when
+	// props changes.
+	const store = createStore( () => {}, {} );
+	const FormComponentWithStore = ( otherProps = {} ) => (
+		<Provider store={ store }>
+			<FormComponent role={ role } siteId={ siteId } siteUrl={ siteUrl } { ...otherProps } />
+		</Provider>
+	);
+	const utils = render( FormComponentWithStore() );
+
+	return { utils, FormComponentWithStore };
+}
+
+describe( 'useWithServerCredentials HOC', () => {
+	it( 'should not update credentials (should display error messages)', async () => {
+		const { utils } = setup();
+		const submitButton = utils.getByText( 'Submit' );
+		const errorMessagesContainer = utils.getByTestId( 'error-messages' );
+		fireEvent.click( submitButton );
+		expect( errorMessagesContainer.innerHTML ).toContain( 'Please enter your server username.' );
+		expect( errorMessagesContainer.innerHTML ).toContain( 'Please enter your server password.' );
+		expect( errorMessagesContainer.innerHTML ).toContain( 'Please enter a valid server address.' );
+		expect( actions.updateCredentials ).not.toBeCalled();
+	} );
+
+	it( 'should update credentials (should not display error messages)', async () => {
+		const { utils } = setup();
+		const submitButton = utils.getByText( 'Submit' );
+		const errorMessagesContainer = utils.getByTestId( 'error-messages' );
+		[ 'user', 'pass', 'host' ].forEach( inputName => {
+			const input = utils.getByTestId( inputName );
+			fireEvent.change( input, { target: { value: inputName } } );
+			expect( input.value ).toBe( inputName );
+		} );
+		fireEvent.click( submitButton );
+		expect( errorMessagesContainer.innerHTML ).toBe( '' );
+		expect( actions.updateCredentials ).toHaveBeenCalledTimes( 1 );
+		expect( actions.updateCredentials ).toBeCalledWith(
+			9999,
+			expect.objectContaining( {
+				role: 'main',
+				site_url: 'siteUrl',
+				user: 'user',
+				pass: 'pass',
+				host: 'host',
+				kpri: '',
+				path: '',
+				port: 22,
+				protocol: 'ssh',
+			} )
+		);
+	} );
+
+	it( 'should delete credentials', async () => {
+		const { utils } = setup();
+		const deleteButton = utils.getByText( 'Delete' );
+		fireEvent.click( deleteButton );
+		expect( actions.deleteCredentials ).toHaveBeenCalledTimes( 1 );
+		expect( actions.deleteCredentials ).toBeCalledWith( 9999, 'main' );
+	} );
+
+	it( 'should toggle the advanced section', async () => {
+		const { utils } = setup();
+		const advancedSection = utils.getByTestId( 'advanced-section' );
+		expect( advancedSection.innerHTML ).toContain( '' );
+
+		const toggleButton = utils.getByText( 'Advanced Section' );
+		fireEvent.click( toggleButton );
+		expect( advancedSection.innerHTML ).toContain( 'Hidden content!' );
+	} );
+
+	it( 'should use rewindState to prefill the form', async () => {
+		const { utils, FormComponentWithStore } = setup();
+		const submitButton = utils.getByText( 'Submit' );
+		const errorMessagesContainer = utils.getByTestId( 'error-messages' );
+		const formDataContainer = utils.getByTestId( 'form-content' );
+
+		// Simulate updating props with a rewindState
+		utils.rerender(
+			FormComponentWithStore( {
+				rewindState: mockCredentials,
+			} )
+		);
+		fireEvent.click( submitButton );
+		expect( errorMessagesContainer.innerHTML ).not.toContain(
+			'Please enter your server username.'
+		);
+		expect( errorMessagesContainer.innerHTML ).not.toContain(
+			'Please enter a valid server address.'
+		);
+		expect( formDataContainer.innerHTML ).toContain( 'someUser' );
+		expect( formDataContainer.innerHTML ).toContain( 'someHost' );
+		expect( formDataContainer.innerHTML ).toContain( 33 );
+		expect( formDataContainer.innerHTML ).toContain( 'somePath' );
+	} );
+} );

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -72,12 +72,7 @@ class ScanPage extends Component {
 
 	renderThreats() {
 		const { threats, site } = this.props;
-		return (
-			<>
-				<SecurityIcon icon="error" />
-				<ScanThreats className="scan__threats" threats={ threats } site={ site } />
-			</>
-		);
+		return <ScanThreats className="scan__threats" threats={ threats } site={ site } />;
 	}
 
 	renderScanError() {

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -19,7 +19,6 @@ import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
-import FixAllThreatsDialog from '../../components/fix-all-threats-dialog';
 
 /**
  * Style dependencies
@@ -27,10 +26,6 @@ import FixAllThreatsDialog from '../../components/fix-all-threats-dialog';
 import './style.scss';
 
 class ScanPage extends Component {
-	state = {
-		showFixAllThreatsDialog: false,
-	};
-
 	renderScanOkay() {
 		const { siteSlug, moment, lastScanTimestamp } = this.props;
 

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -19,6 +19,7 @@ import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
+import FixAllThreatsDialog from '../../components/fix-all-threats-dialog';
 
 /**
  * Style dependencies
@@ -26,6 +27,10 @@ import { withLocalizedMoment } from 'components/localized-moment';
 import './style.scss';
 
 class ScanPage extends Component {
+	state = {
+		showFixAllThreatsDialog: false,
+	};
+
 	renderScanOkay() {
 		const { siteSlug, moment, lastScanTimestamp } = this.props;
 

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -20,6 +20,9 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
 
+/**
+ * Style dependencies
+ */
 import './style.scss';
 
 class ScanPage extends Component {

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -53,6 +53,41 @@
 	color: var( --color-primary-40 );
 }
 
+.scan__threats {
+	margin: 40px 0;
+}
+
+.scan__threats-buttons {
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 16px;
+
+	@include breakpoint( '>800px' ) {
+		justify-content: flex-end;
+	}
+}
+
+.scan__fix-all-threats-button {
+	flex: 1 1 75%;
+	padding: 10px 30px;
+	background: var( --color-primary-40 );
+	color: #fff;
+	border-color: var( --color-primary-40 );
+
+	@include breakpoint( '>800px' ) {
+		flex: 0 0 170px;
+	}
+}
+
+.scan__options-button {
+	flex: 0 0 50px;
+	padding: 10px 0;
+	margin-left: 16px;
+	color: var( --color-primary-40 );
+	background: #fff;
+	border-color: var( --color-primary-40 );
+}
+
 .scan__button {
 	margin: 30px 0;
 	width: 100%;

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -53,41 +53,6 @@
 	color: var( --color-primary-40 );
 }
 
-.scan__threats {
-	margin: 40px 0;
-}
-
-.scan__threats-buttons {
-	display: flex;
-	justify-content: space-between;
-	margin-bottom: 16px;
-
-	@include breakpoint( '>800px' ) {
-		justify-content: flex-end;
-	}
-}
-
-.scan__fix-all-threats-button {
-	flex: 1 1 75%;
-	padding: 10px 30px;
-	background: var( --color-primary-40 );
-	color: #fff;
-	border-color: var( --color-primary-40 );
-
-	@include breakpoint( '>800px' ) {
-		flex: 0 0 170px;
-	}
-}
-
-.scan__options-button {
-	flex: 0 0 50px;
-	padding: 10px 0;
-	margin-left: 16px;
-	color: var( --color-primary-40 );
-	background: #fff;
-	border-color: var( --color-primary-40 );
-}
-
 .scan__button {
 	margin: 30px 0;
 	width: 100%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- The goal of this is to create the Threat Card used on the main screen when threats are found.

#### Important note

We are not checking if the provided credentials are valid. We move the user to next step in the progress regardless of the result. This is for testing purposes only.

#### Testing instructions

- Navigate to http://jetpack.cloud.localhost:3000/scan/<yourSiteSlug>?scan-state=threats
- Click the "Open Fix All Threats Dialog" button

See 1151678672052943-as-1165787355206381.

#### Expected result
##### We need credentials

<img width="832" alt="image" src="https://user-images.githubusercontent.com/3418513/76857090-81e34f00-6833-11ea-8a61-a643d71f5e27.png">

##### If credentials were already supplied

<img width="827" alt="image" src="https://user-images.githubusercontent.com/3418513/76857102-87409980-6833-11ea-9d92-04c20662f0af.png">

##### Fixing all threats (notice that the buttons are disabled)
![Kapture 2020-03-25 at 10 38 51](https://user-images.githubusercontent.com/3418513/77542454-f5fda280-6e84-11ea-9b84-abb77dc4fb93.gif)
