### PR TITLE
Update/earn copy tweaks

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -56,6 +56,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	siteId,
 	selectedSiteSlug,
 	isFreePlan,
+	sitePlan,
 	isJetpack,
 	isAtomicSite,
 	hasSimplePayments,
@@ -97,10 +98,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					action: { url: supportLink, onClick: () => trackCtaButton( 'simple-payments' ) },
 			  }
 			: {
-					text: translate( 'Upgrade to Premium' ),
+					text: translate( 'Unlock this feature' ),
 					action: () => {
-						trackUpgrade( 'premium', 'simple-payments' );
-						page( `/checkout/${ selectedSiteSlug }/premium/` );
+						trackUpgrade( 'plans', 'simple-payments' );
+						page( `/plans/${ selectedSiteSlug }` );
 					},
 			  };
 		const learnMoreLink = hasSimplePayments
@@ -108,14 +109,18 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			: { url: supportLink, onClick: () => trackLearnLink( 'simple-payments' ) };
 		return {
 			title: translate( 'Collect one-time payments' ),
-			body: translate(
-				'Add a payment button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations. {{em}}Available to any site with a Premium plan{{/em}}.',
-				{
-					components: {
-						em: <em />,
-					},
-				}
-			),
+			body: hasSimplePayments
+				? translate(
+						'Accept PayPal payments for physical products, digital goods, services, or donations.'
+				  )
+				: translate(
+						'Accept PayPal payments for physical products, digital goods, services, or donations. {{em}}Available only with a Premium, Business, or eCommerce plan{{/em}}.',
+						{
+							components: {
+								em: <em />,
+							},
+						}
+				  ),
 			image: {
 				path: simplePaymentsImage,
 			},
@@ -134,7 +139,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	const getRecurringPaymentsCard = () => {
 		const cta = isFreePlan
 			? {
-					text: translate( 'Upgrade' ),
+					text: translate( 'Unlock this feature' ),
 					action: () => {
 						trackUpgrade( 'any-paid-plan', 'recurring-payments' );
 						page( `/plans/${ selectedSiteSlug }` );
@@ -154,13 +159,17 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			? translate(
 					"Manage your subscribers, or your current subscription options and review the total revenue that you've made from recurring payments."
 			  )
-			: translate(
-					'Charge for services, collect membership dues, or take recurring donations. Automate recurring payments, and use your site to earn reliable revenue. {{em}}Available to any site with a paid plan{{/em}}.',
+			: isFreePlan
+			? translate(
+					'Charge for and automate recurring service payments, membership dues, or donations. {{em}}Available with a subscription to any paid plan{{/em}}.',
 					{
 						components: {
 							em: <em />,
 						},
 					}
+			  )
+			: translate(
+					'Charge for and automate recurring service payments, membership dues, or donations.'
 			  );
 		const learnMoreLink = isFreePlan
 			? {
@@ -259,10 +268,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 						},
 				  }
 				: {
-						text: translate( 'Upgrade to Premium' ),
+						text: translate( 'Unlock this feature' ),
 						action: () => {
-							trackUpgrade( 'premium', 'ads' );
-							page( `/checkout/${ selectedSiteSlug }/premium/` );
+							trackUpgrade( 'plans', 'ads' );
+							page( `/plans/${ selectedSiteSlug }` );
 						},
 				  };
 		const title = hasSetupAds ? translate( 'View ad dashboard' ) : translate( 'Earn ad revenue' );
@@ -270,14 +279,19 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			? translate(
 					"Check out your ad earnings history, including total earnings, total paid to date, and the amount that you've still yet to be paid."
 			  )
+			: hasWordAds
+			? translate(
+					'Make money each time someone visits your site by displaying advertisements on all your posts and pages.'
+			  )
 			: translate(
-					'Publish as you normally would, display advertisements on all your posts and pages, and make money each time someone visits your site. {{em}}Available to sites with a Premium plan{{/em}}.',
+					'Make money each time someone visits your site by displaying advertisements on all your posts and pages. {{em}}Available only with a Premium, Business, or eCommerce plan{{/em}}.',
 					{
 						components: {
 							em: <em />,
 						},
 					}
 			  );
+
 		const learnMoreLink = ! ( hasWordAds || hasSetupAds )
 			? { url: 'https://wordads.co/', onClick: () => trackLearnLink( 'ads' ) }
 			: null;
@@ -300,7 +314,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			image: {
 				path: earnSectionImage,
 			},
-			body: translate( 'There is a range of ways to earn money through your WordPress site.' ),
+			body: translate( 'Turn your website into a reliable source of income.' ),
 		},
 		promos: compact( [
 			getSimplePaymentsCard(),

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -56,7 +56,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	siteId,
 	selectedSiteSlug,
 	isFreePlan,
-	sitePlan,
 	isJetpack,
 	isAtomicSite,
 	hasSimplePayments,
@@ -159,18 +158,15 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			? translate(
 					"Manage your subscribers, or your current subscription options and review the total revenue that you've made from recurring payments."
 			  )
-			: isFreePlan
-			? translate(
+			: translate(
 					'Charge for and automate recurring service payments, membership dues, or donations. {{em}}Available with a subscription to any paid plan{{/em}}.',
 					{
 						components: {
 							em: <em />,
 						},
 					}
-			  )
-			: translate(
-					'Charge for and automate recurring service payments, membership dues, or donations.'
 			  );
+
 		const learnMoreLink = isFreePlan
 			? {
 					url: 'https://wordpress.com/support/recurring-payments/',
@@ -278,10 +274,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const body = hasSetupAds
 			? translate(
 					"Check out your ad earnings history, including total earnings, total paid to date, and the amount that you've still yet to be paid."
-			  )
-			: hasWordAds
-			? translate(
-					'Make money each time someone visits your site by displaying advertisements on all your posts and pages.'
 			  )
 			: translate(
 					'Make money each time someone visits your site by displaying advertisements on all your posts and pages. {{em}}Available only with a Premium, Business, or eCommerce plan{{/em}}.',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Updating the copy in the cards on the Earn page.

#### Testing instructions

<!--
* Navigate to the earn page, /earn/[siteurl], and check the copy.
* Test the copy and destination URL for the CTAs using a variety of plan tiers.
* Free plans should be prompted to upgrade for access to everything except the referral program.
* Personal plans should have access to recurring payments and the referral program.
* Premium and above should have access to everything.
-->
