### PR TITLE
Exclude Instagram Basic Display from the list of connections

### DIFF
--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -124,6 +124,11 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 			return false;
 		}
 
+		// Omit Instagram Basic Display, which is still in testing
+		if ( 'instagram_basic_display' === service.ID ) {
+			return false;
+		}
+
 		return true;
 	} );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't display the Instagram Basic Display connection, as this isn't supported yet

#### Testing instructions
* Apply the patch D40423 and sandbox the REST API
* Go to http://wordpress.com/marketing/connections/[site]
* Check that you can see the Instagram Basic Display connection
* Go to http://calypso.localhost:3000/marketing/connections/[site]
* Check that you can't see the Instagram Basic Display connection
