### PR TITLE
Plugins: Fix bad rebase in PlansSetup

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import FeatureExample from 'components/feature-example';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import Spinner from 'components/spinner';
@@ -550,8 +549,7 @@ class PlansSetup extends React.Component {
 					{ translate( "We need to install a few plugins for you. It won't take long!" ) }
 				</p>
 				{ this.renderSuccess() }
-				<FeatureExample>{ this.renderPlugins( true ) }</FeatureExample>) : ( this.renderPlugins(
-				false ) ) }
+				{ this.renderPlugins( false ) }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a defect that was introduced during #39490 (likely due to a bad rebase)

#### Testing instructions

* Checkout this branch.
* Go to `https://wordpress.com/plugins/setup/:site` where `:site` is the slug of a connected Jetpack site.
* Verify you can no longer repro what is being reported in #40194.

Fixes #40194
