### PR TITLE
Jetpack Cloud: Add Scan Error Page

### DIFF
--- a/client/landing/jetpack-cloud/components/security-icon/images/error.svg
+++ b/client/landing/jetpack-cloud/components/security-icon/images/error.svg
@@ -1,0 +1,1 @@
+<svg width="151" height="150" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M75.73 0c-41.4 0-75 33.6-75 75s33.6 75 75 75 75-33.6 75-75-33.6-75-75-75z" fill="#D63638"/><path d="M83.23 112.5h-15v-15h15v15zM83.23 82.5h-15v-45h15v45z" fill="#fff"/></svg>

--- a/client/landing/jetpack-cloud/components/security-icon/index.tsx
+++ b/client/landing/jetpack-cloud/components/security-icon/index.tsx
@@ -7,8 +7,9 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import errorIcon from './images/error.svg';
 import okayIcon from './images/security-okay.svg';
-import errorIcon from './images/security-error.svg';
+import scanErrorIcon from './images/security-error.svg';
 
 interface Props {
 	icon: string;
@@ -19,8 +20,13 @@ function SecurityIcon( props: Props ) {
 	const { icon, className } = props;
 
 	let iconPath = okayIcon;
-	if ( 'error' === icon ) {
-		iconPath = errorIcon;
+	switch ( icon ) {
+		case 'error':
+			iconPath = scanErrorIcon;
+			break;
+		case 'scan-error':
+			iconPath = errorIcon;
+			break;
 	}
 
 	return (

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -89,7 +89,25 @@ class ScanPage extends Component {
 	}
 
 	renderScanError() {
-		return <p>There is an error with the scan.</p>;
+		const { siteSlug } = this.props;
+
+		return (
+			<>
+				<SecurityIcon className="scan__icon" icon="scan-error" />
+				<h1 className="scan__header">{ translate( 'Something went wrong' ) }</h1>
+				<p>
+					The scan did not complete successfully. In order to complete the scan you need to contact
+					support.
+				</p>
+				<Button
+					primary
+					href={ `/contact-us/${ siteSlug }/?scan-state=error` }
+					className="scan__button"
+				>
+					{ translate( 'Contact Support' ) }
+				</Button>
+			</>
+		);
 	}
 
 	renderScanState() {

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -23,6 +23,7 @@
 .scan__icon {
 	display: block;
 	margin: 0 auto;
+	width: 70px;
 
 	@include breakpoint( '>660px' ) {
 		margin: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a basic Scan error page. 
See:
<img width="1252" alt="Screen Shot 2020-03-17 at 4 12 35 PM" src="https://user-images.githubusercontent.com/115071/76870770-6cd5e280-686a-11ea-8433-532d557a9c6b.png">


#### Testing instructions
* Load up jetpack cloud with `npm run start-jetpack-cloud`
* Go to http://jetpack.cloud.localhost:3000/scan/{siteSlug}?scan-state=error
* Does the page look lke you would expect. 

This page doesn't take into account the if threats are already found. 
