### PR TITLE
Update/jetpack cloud breaks up into sections

### DIFF
--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -11,65 +11,10 @@ import config from 'config';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { dashboard } from 'landing/jetpack-cloud/sections/dashboard/controller';
-import {
-	backups,
-	backupDetail,
-	backupDownload,
-	backupRestore,
-} from 'landing/jetpack-cloud/sections/backups/controller';
 import { settings } from 'landing/jetpack-cloud/sections/settings/controller';
 
 export default function() {
 	page( '/', siteSelection, navigation, dashboard, makeLayout, clientRender );
-
-	if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
-		page( '/backups', siteSelection, sites, navigation, makeLayout, clientRender );
-		page( '/backups/:site', siteSelection, navigation, backups, makeLayout, clientRender );
-		page(
-			'/backups/:site/detail',
-			siteSelection,
-			navigation,
-			backupDetail,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/backups/:site/detail/:backupId',
-			siteSelection,
-			navigation,
-			backupDetail,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/backups/:site/download/:rewindId',
-			siteSelection,
-			navigation,
-			backupDownload,
-			makeLayout,
-			clientRender
-		);
-
-		if ( config.isEnabled( 'jetpack-cloud/backups-restore' ) ) {
-			page( '/backups/restore', siteSelection, sites, navigation, makeLayout, clientRender );
-			page(
-				'/backups/:site/restore',
-				siteSelection,
-				navigation,
-				backupRestore,
-				makeLayout,
-				clientRender
-			);
-			page(
-				'/backups/:site/restore/:restoreId',
-				siteSelection,
-				navigation,
-				backupRestore,
-				makeLayout,
-				clientRender
-			);
-		}
-	}
 
 	if ( config.isEnabled( 'jetpack-cloud/settings' ) ) {
 		page( '/settings', siteSelection, sites, navigation, makeLayout, clientRender );

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -6,18 +6,10 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import config from 'config';
-
-import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { navigation, siteSelection } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { dashboard } from 'landing/jetpack-cloud/sections/dashboard/controller';
-import { settings } from 'landing/jetpack-cloud/sections/settings/controller';
 
 export default function() {
 	page( '/', siteSelection, navigation, dashboard, makeLayout, clientRender );
-
-	if ( config.isEnabled( 'jetpack-cloud/settings' ) ) {
-		page( '/settings', siteSelection, sites, navigation, makeLayout, clientRender );
-		page( '/settings/:site', siteSelection, navigation, settings, makeLayout, clientRender );
-	}
 }

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -17,7 +17,6 @@ import {
 	backupDownload,
 	backupRestore,
 } from 'landing/jetpack-cloud/sections/backups/controller';
-import { scan, scanHistory } from 'landing/jetpack-cloud/sections/scan/controller';
 import { settings } from 'landing/jetpack-cloud/sections/settings/controller';
 
 export default function() {
@@ -66,22 +65,6 @@ export default function() {
 				siteSelection,
 				navigation,
 				backupRestore,
-				makeLayout,
-				clientRender
-			);
-		}
-	}
-
-	if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
-		page( '/scan', siteSelection, sites, navigation, makeLayout, clientRender );
-		page( '/scan/:site', siteSelection, navigation, scan, makeLayout, clientRender );
-
-		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
-			page(
-				'/scan/history/:site/',
-				siteSelection,
-				navigation,
-				scanHistory,
 				makeLayout,
 				clientRender
 			);

--- a/client/landing/jetpack-cloud/sections/backups/index.js
+++ b/client/landing/jetpack-cloud/sections/backups/index.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller';
+import {
+	backups,
+	backupDetail,
+	backupDownload,
+	backupRestore,
+} from 'landing/jetpack-cloud/sections/backups/controller';
+
+export default function() {
+	if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
+		page( '/backups', siteSelection, sites, navigation, makeLayout, clientRender );
+		page( '/backups/:site', siteSelection, navigation, backups, makeLayout, clientRender );
+		page(
+			'/backups/:site/detail',
+			siteSelection,
+			navigation,
+			backupDetail,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/backups/:site/detail/:backupId',
+			siteSelection,
+			navigation,
+			backupDetail,
+			makeLayout,
+			clientRender
+		);
+		page(
+			'/backups/:site/download/:rewindId',
+			siteSelection,
+			navigation,
+			backupDownload,
+			makeLayout,
+			clientRender
+		);
+
+		if ( config.isEnabled( 'jetpack-cloud/backups-restore' ) ) {
+			page( '/backups/restore', siteSelection, sites, navigation, makeLayout, clientRender );
+			page(
+				'/backups/:site/restore',
+				siteSelection,
+				navigation,
+				backupRestore,
+				makeLayout,
+				clientRender
+			);
+			page(
+				'/backups/:site/restore/:restoreId',
+				siteSelection,
+				navigation,
+				backupRestore,
+				makeLayout,
+				clientRender
+			);
+		}
+	}
+}

--- a/client/landing/jetpack-cloud/sections/scan/index.js
+++ b/client/landing/jetpack-cloud/sections/scan/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller';
+import { scan, scanHistory } from 'landing/jetpack-cloud/sections/scan/controller';
+
+export default function() {
+	if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
+		page( '/scan', siteSelection, sites, navigation, makeLayout, clientRender );
+		page( '/scan/:site', siteSelection, navigation, scan, makeLayout, clientRender );
+
+		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
+			page(
+				'/scan/history/:site/',
+				siteSelection,
+				navigation,
+				scanHistory,
+				makeLayout,
+				clientRender
+			);
+		}
+	}
+}

--- a/client/landing/jetpack-cloud/sections/settings/index.js
+++ b/client/landing/jetpack-cloud/sections/settings/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { makeLayout, render as clientRender } from 'controller';
+import { settings } from 'landing/jetpack-cloud/sections/settings/controller';
+
+export default function() {
+	if ( config.isEnabled( 'jetpack-cloud/settings' ) ) {
+		page( '/settings', siteSelection, sites, navigation, makeLayout, clientRender );
+		page( '/settings/:site', siteSelection, navigation, settings, makeLayout, clientRender );
+	}
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -474,8 +474,16 @@ const sections = [
 	},
 	{
 		name: 'jetpack-cloud',
-		paths: [ '/', '/scan', '/backups', '/settings' ], // TODO: Split this up into its own sections
+		paths: [ '/', '/backups', '/settings' ], // TODO: Split this up into its own sections
 		module: 'landing/jetpack-cloud',
+		secondary: true,
+		group: 'jetpack-cloud',
+		enableLoggedOut: true,
+	},
+	{
+		name: 'scan',
+		paths: [ '/scan' ], // TODO: Split this up into its own sections
+		module: 'landing/jetpack-cloud/sections/scan',
 		secondary: true,
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,

--- a/client/sections.js
+++ b/client/sections.js
@@ -496,6 +496,14 @@ const sections = [
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,
 	},
+	{
+		name: 'jetpack-cloud-settings',
+		paths: [ '/settings' ],
+		module: 'landing/jetpack-cloud/sections/settings',
+		secondary: true,
+		group: 'jetpack-cloud',
+		enableLoggedOut: true,
+	},
 ];
 
 for ( const extension of require( './extensions' ) ) {

--- a/client/sections.js
+++ b/client/sections.js
@@ -489,7 +489,7 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
-		name: 'scan',
+		name: 'backups',
 		paths: [ '/backups' ],
 		module: 'landing/jetpack-cloud/sections/backups',
 		secondary: true,

--- a/client/sections.js
+++ b/client/sections.js
@@ -474,7 +474,7 @@ const sections = [
 	},
 	{
 		name: 'jetpack-cloud',
-		paths: [ '/', '/backups', '/settings' ], // TODO: Split this up into its own sections
+		paths: [ '/', '/settings' ],
 		module: 'landing/jetpack-cloud',
 		secondary: true,
 		group: 'jetpack-cloud',
@@ -482,8 +482,16 @@ const sections = [
 	},
 	{
 		name: 'scan',
-		paths: [ '/scan' ], // TODO: Split this up into its own sections
+		paths: [ '/scan' ],
 		module: 'landing/jetpack-cloud/sections/scan',
+		secondary: true,
+		group: 'jetpack-cloud',
+		enableLoggedOut: true,
+	},
+	{
+		name: 'scan',
+		paths: [ '/backups' ],
+		module: 'landing/jetpack-cloud/sections/backups',
 		secondary: true,
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -133,7 +133,8 @@
 	"sections": {
 		"jetpack-cloud": false,
 		"scan": false,
-		"backups": false
+		"backups": false,
+		"jetpack-cloud-settings": false
 	},
 	"theme": "default"
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -131,7 +131,8 @@
 	"push_notification_vapid_key": "BDQlTOrVTrxRM0i-gCsrxjxOyul281c5WVdfstXaqZqTSpjSI9M-E99CvwwJRWDkZ0goa8VSqUCgwiexxcDuXCs",
 	"enable_all_sections": true,
 	"sections": {
-		"jetpack-cloud": false
+		"jetpack-cloud": false,
+		"scan": false
 	},
 	"theme": "default"
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -132,7 +132,8 @@
 	"enable_all_sections": true,
 	"sections": {
 		"jetpack-cloud": false,
-		"scan": false
+		"scan": false,
+		"backups": false
 	},
 	"theme": "default"
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -22,7 +22,8 @@
 	"enable_all_sections": false,
 	"sections": {
 		"jetpack-cloud": true,
-		"scan": true
+		"scan": true,
+		"backups": true
 	},
 	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -23,7 +23,8 @@
 	"sections": {
 		"jetpack-cloud": true,
 		"scan": true,
-		"backups": true
+		"backups": true,
+		"jetpack-cloud-settings": true
 	},
 	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -21,7 +21,8 @@
 	},
 	"enable_all_sections": false,
 	"sections": {
-		"jetpack-cloud": true
+		"jetpack-cloud": true,
+		"scan": true
 	},
 	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -19,7 +19,8 @@
 	},
 	"enable_all_sections": false,
 	"sections": {
-		"jetpack-cloud": true
+		"jetpack-cloud": true,
+		"scan": true
 	},
 	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -20,7 +20,8 @@
 	"enable_all_sections": false,
 	"sections": {
 		"jetpack-cloud": true,
-		"scan": true
+		"scan": true,
+		"backups": true
 	},
 	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -21,7 +21,8 @@
 	"sections": {
 		"jetpack-cloud": true,
 		"scan": true,
-		"backups": true
+		"backups": true,
+		"jetpack-cloud-settings": true
 	},
 	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -19,7 +19,8 @@
 	},
 	"enable_all_sections": false,
 	"sections": {
-		"jetpack-cloud": true
+		"jetpack-cloud": true,
+		"scan": true
 	},
 	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -20,7 +20,8 @@
 	"enable_all_sections": false,
 	"sections": {
 		"jetpack-cloud": true,
-		"scan": true
+		"scan": true,
+		"backups": true
 	},
 	"theme": "jetpack-cloud"
 }

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -21,7 +21,8 @@
 	"sections": {
 		"jetpack-cloud": true,
 		"scan": true,
-		"backups": true
+		"backups": true,
+		"jetpack-cloud-settings": true
 	},
 	"theme": "jetpack-cloud"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR breaks up jetpack cloud in multiple sections. 
[x] Scan, 
[x] Backups
[x] Settings

#### Testing instructions
Load up jetpack cloud. 
* Does it work as before?
* load up calypso. Make sure that you don't see anything particularly broken such as `/settings`
