### PR TITLE
Full Site Editing: Add missing wp_set_script_translations call

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/index.php
@@ -73,6 +73,8 @@ function blog_posts_block_args( $args, $name ) {
 	$args['script']        = 'blog-posts-block-view';
 	$args['style']         = 'blog-posts-block-view';
 
+	wp_set_script_translations( 'blog-posts-block-editor', 'full-site-editing' );
+
 	return $args;
 }
 add_filter( 'newspack_blocks_block_args', __NAMESPACE__ . '\blog_posts_block_args', 10, 2 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This allows the translations to actually be loaded for the Blog Posts block.

#### Testing instructions

* Activate the Full Site Editing plugin on a self-hosted site.
* Change your UI language to something else than English (a popular one, like German, for example).
* Make sure to download the latest language packs (you can verify this in languages/plugins/full-site-editing-*)
* Create a new post in Gutenberg and add a Blog Posts block and observe translated text.

See D39116-code for this, it's already live on WordPress.com.
