### PR TITLE
composite-checkout: Treat domain transfers as domains

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -640,9 +640,22 @@ export default function CompositeCheckout( {
 					},
 				} );
 				debug(
-					'Domain contact info validation ' + ( data.messages ? 'errors:' : 'successful' ),
-					data.messages
+					'Domain contact info validation for domains',
+					domainNames,
+					'and contact info',
+					contactDetails,
+					'result:',
+					data
 				);
+				if ( ! data ) {
+					showErrorMessage(
+						translate(
+							'There was an error validating your contact information. Please contact support.'
+						)
+					);
+					resolve( false );
+					return;
+				}
 				if ( data.messages ) {
 					showErrorMessage(
 						translate(

--- a/packages/composite-checkout-wpcom/src/hooks/has-domains.js
+++ b/packages/composite-checkout-wpcom/src/hooks/has-domains.js
@@ -16,5 +16,5 @@ export function areDomainsInLineItems( items ) {
 }
 
 export function isLineItemADomain( item ) {
-	return item.wpcom_meta?.is_domain_registration;
+	return item.wpcom_meta?.is_domain_registration || item.type === 'domain_transfer';
 }

--- a/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
+++ b/packages/composite-checkout-wpcom/src/lib/translate-cart.ts
@@ -160,7 +160,7 @@ function translateWpcomCartItemToCheckoutCartItem(
 		} = serverCartItem;
 
 		// Sublabel is the domain name for registrations
-		const sublabel = is_domain_registration ? meta : undefined;
+		const sublabel = meta;
 
 		// TODO: watch out for this when localizing
 		const value = is_coupon_applied


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This treats Domain Transfers as domains for the purposes of showing the extra contact fields and other behaviors which rely on identifying domains.

#### Testing instructions

- Visit composite checkout with a domain transfer in your cart. (You'll need to add `?flags=composite-checkout-testing` as the query string.)
- You can select any payment method in the first step.
- Verify that the second step displays the full contact details form (name, address, etc.)
- (Bonus) Verify that purchasing the domain transfer is successful. Only do this if you are ok transferring a domain!