### PR TITLE
package.json: Add vendor to distclean

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 		"clean:build": "npx rimraf build client/server/bundler/*.json client/server/devdocs/search-index.js",
 		"clean:packages": "npx lerna run clean --stream",
 		"clean:public": "npx rimraf public",
-		"distclean": "npm run clean && npx rimraf node_modules client/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .tsc-cache",
+		"distclean": "npm run clean && npx rimraf node_modules client/node_modules apps/*/node_modules packages/*/node_modules test/e2e/node_modules .tsc-cache vendor",
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"docker-jetpack-cloud": "docker run -it --env CALYPSO_ENV=jetpack-cloud-production --name wp-calypso --rm -p 80:3000 wp-calypso",
 		"eslint-branch": "node bin/eslint-branch.js",


### PR DESCRIPTION
If you run `composer install` in the Calypso root, it will create a `vendor` directory (akin to `node_modules`). Currently a `npm run distclean` doesn't remove it, thus it doesn't revert this to a clean environment.

With this patch we also remove that directory.