### PR TITLE
Site Migration: Update isSiteRecentlyMigrated selector to use API change

### DIFF
--- a/client/state/selectors/is-site-recently-migrated.js
+++ b/client/state/selectors/is-site-recently-migrated.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { get } from 'lodash';
-import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -20,19 +19,6 @@ import getRawSite from 'state/selectors/get-raw-site';
 export default function isSiteRecentlyMigrated( state, siteId ) {
 	const site = getRawSite( state, siteId );
 	const siteMigrationMeta = get( site, 'site_migration', {} );
-	const status = get( siteMigrationMeta, 'status' );
-	const lastModified = get( siteMigrationMeta, 'last_modified' );
 
-	if ( ! status || ! lastModified ) {
-		return false;
-	}
-
-	if ( 'done' === status ) {
-		const lastModMoment = moment( lastModified );
-		if ( moment().diff( lastModMoment, 'days' ) <= 2 ) {
-			return true;
-		}
-	}
-
-	return false;
+	return !! get( siteMigrationMeta, 'recent_migration', false );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the `isSiteRecentlyMigrated` selector for the API change in D40459-code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow test instructions from D40459-code.

