### PR TITLE
Gutenboarding: Add login link to use existing `/log-in` for the time being

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -6,7 +6,6 @@ import { useI18n } from '@automattic/react-i18n';
 import { Button, Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import React, { FunctionComponent, useEffect, useCallback, useState } from 'react';
-import { useDebounce } from 'use-debounce';
 import classnames from 'classnames';
 import { useHistory } from 'react-router-dom';
 
@@ -16,12 +15,11 @@ import { useHistory } from 'react-router-dom';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { USER_STORE } from '../../stores/user';
 import { SITE_STORE } from '../../stores/site';
-import { DOMAIN_SUGGESTIONS_STORE } from '../../stores/domain-suggestions';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
-import { selectorDebounce } from '../../constants';
 import SignupForm from '../../components/signup-form';
 import LoginForm from '../../components/login-form';
+import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 
 import wp from '../../../../lib/wp';
 const wpcom = wp.undocumented();
@@ -73,21 +71,7 @@ const Header: FunctionComponent = () => {
 	const hasSelectedDesign = !! selectedDesign;
 	const { createSite, setDomain, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
-	const [ domainSearch ] = useDebounce( siteTitle, selectorDebounce );
-	const freeDomainSuggestion = useSelect(
-		select => {
-			if ( ! domainSearch ) {
-				return;
-			}
-			return select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainSearch, {
-				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
-				include_wordpressdotcom: true,
-				quantity: 1,
-				...{ vertical: siteVertical?.id },
-			} )?.[ 0 ];
-		},
-		[ domainSearch, siteVertical ]
-	);
+	const freeDomainSuggestion = useFreeDomainSuggestion();
 
 	useEffect( () => {
 		if ( ! siteTitle ) {

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -96,6 +96,8 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 		}
 	}
 
+	const loginRedirectUrl = `${ originUrl() }/gutenboarding${ makePath( Step.CreateSite ) }?new`;
+
 	return (
 		<Modal
 			className="signup-form"
@@ -134,12 +136,7 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 				</div>
 			</form>
 			<div className="signup-form__login-links">
-				<Button
-					isLink
-					href={ `/log-in?redirect_to=${ originUrl() }/gutenboarding${ makePath(
-						Step.DoCreateSite
-					) }` }
-				>
+				<Button isLink href={ '/log-in?redirect_to=' + encodeURIComponent( loginRedirectUrl ) }>
 					{ NO__( 'Log in to create a site for your existing account.' ) }
 				</Button>
 			</div>

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -13,9 +13,9 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
  */
 import { USER_STORE } from '../../stores/user';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import { useLangRouteParam } from '../../path';
-import './style.scss';
+import { useLangRouteParam, usePath, Step } from '../../path';
 import ModalSubmitButton from '../modal-submit-button';
+import './style.scss';
 
 type NewUserErrorResponse = import('@automattic/data-stores').User.NewUserErrorResponse;
 
@@ -41,6 +41,7 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 	const newUserError = useSelect( select => select( USER_STORE ).getNewUserError() );
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ) ).getState();
 	const langParam = useLangRouteParam();
+	const makePath = usePath();
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_gutenboarding_signup_start', {
@@ -135,12 +136,32 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 				</div>
 			</form>
 			<div className="signup-form__login-links">
-				<Button isLink={ true } onClick={ openLogin }>
+				<Button
+					isLink
+					href={ `/log-in?redirect_to=${ originUrl() }/gutenboarding${ makePath(
+						Step.CreateSite
+					) }` }
+				>
 					{ NO__( 'Log in to create a site for your existing account.' ) }
+				</Button>
+			</div>
+			<div className="signup-form__login-links">
+				<Button isLink={ true } onClick={ openLogin }>
+					{ /* Removing before shipping, no need to translate */ }
+					(experimental login)
 				</Button>
 			</div>
 		</Modal>
 	);
 };
+
+function originUrl() {
+	return (
+		window.location.protocol +
+		'//' +
+		window.location.hostname +
+		( window.location.port ? ':' + window.location.port : '' )
+	);
+}
 
 export default SignupForm;

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -137,7 +137,7 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 				<Button
 					isLink
 					href={ `/log-in?redirect_to=${ originUrl() }/gutenboarding${ makePath(
-						Step.CreateSite
+						Step.DoCreateSite
 					) }` }
 				>
 					{ NO__( 'Log in to create a site for your existing account.' ) }

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -17,8 +17,6 @@ import { useLangRouteParam, usePath, Step } from '../../path';
 import ModalSubmitButton from '../modal-submit-button';
 import './style.scss';
 
-type NewUserErrorResponse = import('@automattic/data-stores').User.NewUserErrorResponse;
-
 // TODO: deploy this change to @types/wordpress__element
 declare module '@wordpress/element' {
 	// eslint-disable-next-line no-shadow

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -96,7 +96,9 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 		}
 	}
 
-	const loginRedirectUrl = `${ originUrl() }/gutenboarding${ makePath( Step.CreateSite ) }?new`;
+	const loginRedirectUrl = `${ window.location.origin }/gutenboarding${ makePath(
+		Step.CreateSite
+	) }?new`;
 
 	return (
 		<Modal
@@ -149,14 +151,5 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 		</Modal>
 	);
 };
-
-function originUrl() {
-	return (
-		window.location.protocol +
-		'//' +
-		window.location.hostname +
-		( window.location.port ? ':' + window.location.port : '' )
-	);
-}
 
 export default SignupForm;

--- a/client/landing/gutenboarding/hooks/use-free-domain-suggestion.ts
+++ b/client/landing/gutenboarding/hooks/use-free-domain-suggestion.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useDebounce } from 'use-debounce';
+
+/**
+ * Internal dependencies
+ */
+import { DOMAIN_SUGGESTIONS_STORE } from '../stores/domain-suggestions';
+import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
+import { selectorDebounce } from '../constants';
+
+export function useFreeDomainSuggestion() {
+	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
+
+	const [ domainSearch ] = useDebounce( siteTitle, selectorDebounce );
+
+	return useSelect(
+		select => {
+			if ( ! domainSearch ) {
+				return;
+			}
+			return select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( domainSearch, {
+				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
+				include_wordpressdotcom: true,
+				quantity: 1,
+				...{ vertical: siteVertical?.id },
+			} )?.[ 0 ];
+		},
+		[ domainSearch, siteVertical ]
+	);
+}

--- a/client/landing/gutenboarding/onboarding-block/create-site/create-and-redirect.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/create-and-redirect.tsx
@@ -16,7 +16,7 @@ import { Step, usePath } from '../../path';
 type Status = 'INIT' | 'SUCCESS' | 'ERROR' | 'MISSING_SITE_DATA';
 
 const CreateAndRedirect = () => {
-	const { siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
+	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const [ status, setStatus ] = useState< Status >( siteVertical ? 'INIT' : 'MISSING_SITE_DATA' );
 
 	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
@@ -26,12 +26,13 @@ const CreateAndRedirect = () => {
 	const freeDomainSuggestion = useFreeDomainSuggestion();
 
 	useEffect( () => {
-		if ( currentUser && freeDomainSuggestion ) {
+		// If there's no site title don't wait for a free domain suggestion, there won't be one
+		if ( currentUser && ( ! siteTitle || freeDomainSuggestion ) ) {
 			createSite( currentUser.username, freeDomainSuggestion ).then( success => {
 				setStatus( success ? 'SUCCESS' : 'ERROR' );
 			} );
 		}
-	}, [ createSite, currentUser, freeDomainSuggestion, setStatus ] );
+	}, [ createSite, currentUser, freeDomainSuggestion, siteTitle, setStatus ] );
 
 	switch ( status ) {
 		case 'INIT':

--- a/client/landing/gutenboarding/onboarding-block/create-site/create-and-redirect.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/create-and-redirect.tsx
@@ -10,6 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { STORE_KEY } from '../../stores/onboard';
 import { USER_STORE } from '../../stores/user';
+import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 
 interface Props {
 	to: string;
@@ -20,13 +21,15 @@ const CreateAndRedirect = ( { to }: Props ) => {
 	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
 	const { createSite } = useDispatch( STORE_KEY );
 
+	const freeDomainSuggestion = useFreeDomainSuggestion();
+
 	useEffect( () => {
-		if ( currentUser ) {
-			createSite( currentUser.username, undefined ).then( () => {
+		if ( currentUser && freeDomainSuggestion ) {
+			createSite( currentUser.username, freeDomainSuggestion ).then( () => {
 				setRedirect( true );
 			} );
 		}
-	}, [ createSite, currentUser, setRedirect ] );
+	}, [ createSite, currentUser, freeDomainSuggestion, setRedirect ] );
 
 	return redirect ? <Redirect to={ to } /> : null;
 };

--- a/client/landing/gutenboarding/onboarding-block/create-site/create-and-redirect.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/create-and-redirect.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -13,11 +13,8 @@ import { USER_STORE } from '../../stores/user';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 import { Step, usePath } from '../../path';
 
-type Status = 'INIT' | 'SUCCESS' | 'ERROR' | 'MISSING_SITE_DATA';
-
 const CreateAndRedirect = () => {
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
-	const [ status, setStatus ] = useState< Status >( siteVertical ? 'INIT' : 'MISSING_SITE_DATA' );
 
 	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
 	const makePath = usePath();
@@ -28,23 +25,15 @@ const CreateAndRedirect = () => {
 	useEffect( () => {
 		// If there's no site title don't wait for a free domain suggestion, there won't be one
 		if ( currentUser && ( ! siteTitle || freeDomainSuggestion ) ) {
-			createSite( currentUser.username, freeDomainSuggestion ).then( success => {
-				setStatus( success ? 'SUCCESS' : 'ERROR' );
-			} );
+			createSite( currentUser.username, freeDomainSuggestion );
 		}
-	}, [ createSite, currentUser, freeDomainSuggestion, siteTitle, setStatus ] );
+	}, [ createSite, currentUser, freeDomainSuggestion, siteTitle ] );
 
-	switch ( status ) {
-		case 'INIT':
-			return null;
-
-		case 'SUCCESS':
-			return <Redirect to={ makePath( Step.CreateSite ) } />;
-
-		case 'ERROR':
-		case 'MISSING_SITE_DATA':
-			return <Redirect to={ makePath( Step.IntentGathering ) } />;
+	if ( ! siteVertical ) {
+		return <Redirect to={ makePath( Step.IntentGathering ) } />;
 	}
+
+	return null;
 };
 
 export default CreateAndRedirect;

--- a/client/landing/gutenboarding/onboarding-block/create-site/create-and-redirect.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/create-and-redirect.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+import { Redirect } from 'react-router-dom';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '../../stores/onboard';
+import { USER_STORE } from '../../stores/user';
+
+interface Props {
+	to: string;
+}
+
+const CreateAndRedirect = ( { to }: Props ) => {
+	const [ redirect, setRedirect ] = useState( false );
+	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
+	const { createSite } = useDispatch( STORE_KEY );
+
+	useEffect( () => {
+		if ( currentUser ) {
+			createSite( currentUser.username, undefined ).then( () => {
+				setRedirect( true );
+			} );
+		}
+	}, [ createSite, currentUser, setRedirect ] );
+
+	return redirect ? <Redirect to={ to } /> : null;
+};
+
+export default CreateAndRedirect;

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -3,21 +3,21 @@
  */
 import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
-import { useLocation } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import AnimatedPlaceholder from '../animated-placeholder';
 import CreateAndRedirect from './create-and-redirect';
+import { useNewQueryParam } from '../../path';
 import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const CreateSite: FunctionComponent< {} > = () => {
 	const { __: NO__ } = useI18n();
-	const query = new URLSearchParams( useLocation().search );
+	const shouldTriggerCreate = useNewQueryParam();
 
-	const createAndRedirect = query.has( 'new' ) ? <CreateAndRedirect /> : null;
+	const createAndRedirect = shouldTriggerCreate ? <CreateAndRedirect /> : null;
 
 	return (
 		<div className="create-site__background">

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -55,3 +55,4 @@ const CreateSite: FunctionComponent< {} > = () => {
 };
 
 export default CreateSite;
+export { default as CreateAndRedirect } from './create-and-redirect';

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -3,18 +3,25 @@
  */
 import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
+import { useLocation } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import AnimatedPlaceholder from '../animated-placeholder';
+import CreateAndRedirect from './create-and-redirect';
 import './style.scss';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const CreateSite: FunctionComponent< {} > = () => {
 	const { __: NO__ } = useI18n();
+	const query = new URLSearchParams( useLocation().search );
+
+	const createAndRedirect = query.has( 'new' ) ? <CreateAndRedirect /> : null;
+
 	return (
 		<div className="create-site__background">
+			{ createAndRedirect }
 			<div className="create-site__layout">
 				<div className="create-site__header">
 					<div className="create-site__toolbar">
@@ -55,4 +62,3 @@ const CreateSite: FunctionComponent< {} > = () => {
 };
 
 export default CreateSite;
-export { default as CreateAndRedirect } from './create-and-redirect';

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -14,7 +14,7 @@ import { SITE_STORE } from '../stores/site';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
 import { Attributes } from './types';
-import { Step, usePath } from '../path';
+import { Step, usePath, useNewQueryParam } from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';
 import { isEnabled } from '../../../config';
@@ -24,12 +24,15 @@ import './style.scss';
 const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => {
 	const { siteVertical, selectedDesign } = useSelect( select => select( STORE_KEY ).getState() );
 	const isCreatingSite = useSelect( select => select( SITE_STORE ).isFetchingSite() );
+	const replaceHistory = useNewQueryParam();
 
 	const makePath = usePath();
 
 	return (
 		<div className="onboarding-block" data-vertical={ siteVertical?.label }>
-			{ isCreatingSite && <Redirect push to={ makePath( Step.CreateSite ) } /> }
+			{ isCreatingSite && (
+				<Redirect push={ replaceHistory ? undefined : true } to={ makePath( Step.CreateSite ) } />
+			) }
 			<Switch>
 				<Route exact path={ makePath( Step.IntentGathering ) }>
 					<AcquireIntent />

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -56,7 +56,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 				</Route>
 
 				<Route path={ makePath( Step.DoCreateSite ) }>
-					<CreateAndRedirect to={ makePath( Step.CreateSite ) } />
+					<CreateAndRedirect />
 					<CreateSite />
 				</Route>
 

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -12,7 +12,7 @@ import { Redirect, Switch, Route } from 'react-router-dom';
 import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
 import DesignSelector from './design-selector';
-import CreateSite, { CreateAndRedirect } from './create-site';
+import CreateSite from './create-site';
 import { Attributes } from './types';
 import { Step, usePath } from '../path';
 import AcquireIntent from './acquire-intent';
@@ -53,11 +53,6 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 					) : (
 						<Redirect to={ makePath( Step.DesignSelection ) } />
 					) }
-				</Route>
-
-				<Route path={ makePath( Step.DoCreateSite ) }>
-					<CreateAndRedirect />
-					<CreateSite />
 				</Route>
 
 				<Route path={ makePath( Step.CreateSite ) }>

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -12,7 +12,7 @@ import { Redirect, Switch, Route } from 'react-router-dom';
 import { STORE_KEY } from '../stores/onboard';
 import { SITE_STORE } from '../stores/site';
 import DesignSelector from './design-selector';
-import CreateSite from './create-site';
+import CreateSite, { CreateAndRedirect } from './create-site';
 import { Attributes } from './types';
 import { Step, usePath } from '../path';
 import AcquireIntent from './acquire-intent';
@@ -53,6 +53,11 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 					) : (
 						<Redirect to={ makePath( Step.DesignSelection ) } />
 					) }
+				</Route>
+
+				<Route path={ makePath( Step.DoCreateSite ) }>
+					<CreateAndRedirect to={ makePath( Step.CreateSite ) } />
+					<CreateSite />
 				</Route>
 
 				<Route path={ makePath( Step.CreateSite ) }>

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { generatePath, useRouteMatch } from 'react-router-dom';
+import { generatePath, useLocation, useRouteMatch } from 'react-router-dom';
 import { getLanguageRouteParam } from '../../lib/i18n-utils';
 import { ValuesType } from 'utility-types';
 
@@ -52,4 +52,11 @@ export function usePath() {
 export function useLangRouteParam() {
 	const match = useRouteMatch< { lang?: string } >( path );
 	return match?.params.lang;
+}
+
+// Returns true if the url has a `?new`, which is used by the
+// CreateSite step to decide whether a site creation needs to
+// be triggered.
+export function useNewQueryParam() {
+	return new URLSearchParams( useLocation().search ).has( 'new' );
 }

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -14,6 +14,7 @@ export const Step = {
 	Style: 'style',
 	Signup: 'signup',
 	Login: 'login',
+	DoCreateSite: 'do-create-site',
 	CreateSite: 'create-site',
 } as const;
 

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -14,7 +14,6 @@ export const Step = {
 	Style: 'style',
 	Signup: 'signup',
 	Login: 'login',
-	DoCreateSite: 'do-create-site',
 	CreateSite: 'create-site',
 } as const;
 

--- a/client/landing/gutenboarding/stores/domain-suggestions/index.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/index.ts
@@ -1,0 +1,6 @@
+/**
+ * External dependencies
+ */
+import { DomainSuggestions } from '@automattic/data-stores';
+
+export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -60,7 +60,7 @@ export function* createSite(
 	const currentDomain = domain ?? freeDomainSuggestion;
 	const siteUrl = currentDomain?.domain_name || siteTitle || username;
 
-	yield dispatch( SITE_STORE, 'createSite', {
+	const success = yield dispatch( SITE_STORE, 'createSite', {
 		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
 		blog_title: siteTitle,
 		options: {
@@ -74,6 +74,8 @@ export function* createSite(
 		},
 		...( bearerToken && { authToken: bearerToken } ),
 	} );
+
+	return success;
 }
 
 export type OnboardAction = ReturnType<

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -10,7 +10,6 @@ import { dispatch, select } from '@wordpress/data-controls';
 import { Design, SiteVertical } from './types';
 import { STORE_KEY as ONBOARD_STORE } from './constants';
 import { SITE_STORE } from '../site';
-import { DOMAIN_SUGGESTIONS_STORE } from '../domain-suggestions';
 
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 type Template = VerticalsTemplates.Template;
@@ -50,7 +49,7 @@ export const resetOnboardStore = () => ( {
 
 export function* createSite(
 	username: string,
-	freeDomainSuggestion: DomainSuggestion | undefined,
+	freeDomainSuggestion?: DomainSuggestion,
 	bearerToken?: string
 ) {
 	const { domain, selectedDesign, siteTitle, siteVertical } = yield select(
@@ -58,18 +57,7 @@ export function* createSite(
 		'getState'
 	);
 
-	let currentDomain = domain ?? freeDomainSuggestion;
-	if ( ! currentDomain && siteTitle ) {
-		const suggestion = yield select( DOMAIN_SUGGESTIONS_STORE, 'getDomainSuggestions', siteTitle, {
-			// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
-			include_wordpressdotcom: true,
-			quantity: 1,
-			...{ vertical: siteVertical?.id },
-		} );
-
-		currentDomain = suggestion?.[ 0 ];
-	}
-
+	const currentDomain = domain ?? freeDomainSuggestion;
 	const siteUrl = currentDomain?.domain_name || siteTitle || username;
 
 	yield dispatch( SITE_STORE, 'createSite', {

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -49,9 +49,11 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				token: authToken,
 			} );
 
-			return receiveNewSite( newSite );
+			yield receiveNewSite( newSite );
+			return true;
 		} catch ( err ) {
-			return receiveNewSiteFailed( err );
+			yield receiveNewSiteFailed( err );
+			return false;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a link to use the existing `/log-in` page for gutenboarding. This allows a way for existing users to log in (regardless of what log in methods they use) while we flesh out an embedded login UI.

Video: https://d.pr/v/8EFkfL

* Add "(experimental login)" link to open existing gutenboarding-based login UI
* Change login link to go to `/log-in`, with a redirect url to return back to gutenboarding when done
* Add `?new` query param to `/create-site` route that creates a site when you land on it
* Redirecting from `/create-site?new` to `/create-site` **replaces** it in the history; if the user clicks the back button we don't create another site
* Refactor site creation code into `createSite()` action and `useFreeDomainSuggestion()` hook so it can be shared
* Tidy unused type definition

Known "issue":
* In gutenboarding if you don't choose a domain name you get a domain name with a randomly generated numeric suffix. However if you use the frankenflow login then the randomly generated suffix will be different from the one you saw in the onboarding UI. This is because when we go to `/create-site?new` we re-search for a domain name. We could store the search result in the store so that the user gets the exact same domain, but I don't know if it's worth the work tbh.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/gutenboarding`
* Go through flow, logging in with an existing user instead of signing up
* After logging in the new site should:
  * Have the correct domain (except for the known issue above)
  * Have the correct site title
  * Have the correct theme etc.
* Experimental login UI still works

