### PR TITLE
State: Remove JITM data layer from UI actions

### DIFF
--- a/client/state/ui/actions/set-sites.js
+++ b/client/state/ui/actions/set-sites.js
@@ -3,8 +3,6 @@
  */
 import { SELECTED_SITE_SET } from 'state/action-types';
 
-import 'state/data-layer/wpcom/sites/jitm';
-
 /**
  * Returns an action object to be used in signalling that a site has been set
  * as selected.


### PR DESCRIPTION
This PR removes the JITM data layer from UI actions, as it seems to not be necessary there. 

Introduced in #27115, and I couldn't find out why, cc @dmsnell

#### Changes proposed in this Pull Request

* State: Remove JITM data layer from UI actions

#### Testing instructions

* Verify JITMs still work well for a Jetpack site.
