### PR TITLE
composite-checkout: Use default registry for Stripe payment method

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -25,6 +25,7 @@ import {
 	CheckoutProvider,
 	createPayPalMethod,
 	createStripeMethod,
+	createStripePaymentMethodStore,
 	createFullCreditsMethod,
 	createFreePaymentMethod,
 	createApplePayMethod,
@@ -351,44 +352,42 @@ export default function CompositeCheckout( {
 		};
 	}
 
-	const shouldLoadStripeMethod = onlyLoadPaymentMethods
+	// If this PM is allowed by props, allowed by the cart, stripe is not loading, and there is no stripe error, then create the PM.
+	const isStripeMethodAllowed = onlyLoadPaymentMethods
 		? onlyLoadPaymentMethods.includes( 'card' )
-		: true;
-	const stripeMethod = useMemo( () => {
-		if (
-			isStripeLoading ||
-			stripeLoadingError ||
-			! stripe ||
-			! stripeConfiguration ||
-			! shouldLoadStripeMethod
-		) {
-			return null;
-		}
-		return createStripeMethod( {
-			getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
-			getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
-			getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
-			registerStore,
-			stripe,
-			stripeConfiguration,
-			submitTransaction: submitData => {
-				const pending = sendStripeTransaction(
-					{
-						...submitData,
-						siteId: select( 'wpcom' )?.getSiteId?.(),
-						domainDetails: getDomainDetails( select ),
-					},
-					wpcomTransaction
-				);
-				// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
-				pending.then( result => {
-					debug( 'saving transaction response', result );
-					dispatch( 'wpcom' ).setTransactionResponse( result );
-				} );
-				return pending;
-			},
-		} );
-	}, [ shouldLoadStripeMethod, stripe, stripeConfiguration, isStripeLoading, stripeLoadingError ] );
+		: isPaymentMethodEnabled( 'card', allowedPaymentMethods || serverAllowedPaymentMethods );
+	const shouldLoadStripeMethod = isStripeMethodAllowed && ! isStripeLoading && ! stripeLoadingError;
+	const stripePaymentMethodStore = useMemo(
+		() =>
+			createStripePaymentMethodStore( {
+				getCountry: () => select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value,
+				getPostalCode: () => select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value,
+				getSubdivisionCode: () => select( 'wpcom' )?.getContactInfo?.()?.state?.value,
+				getSiteId: () => select( 'wpcom' )?.getSiteId?.(),
+				getDomainDetails: () => getDomainDetails( select ),
+				submitTransaction: submitData => {
+					const pending = sendStripeTransaction( submitData, wpcomTransaction );
+					// save result so we can get receipt_id and failed_purchases in getThankYouPageUrl
+					pending.then( result => {
+						debug( 'saving transaction response', result );
+						dispatch( 'wpcom' ).setTransactionResponse( result );
+					} );
+					return pending;
+				},
+			} ),
+		[]
+	);
+	const stripeMethod = useMemo(
+		() =>
+			shouldLoadStripeMethod
+				? createStripeMethod( {
+						store: stripePaymentMethodStore,
+						stripe,
+						stripeConfiguration,
+				  } )
+				: null,
+		[ shouldLoadStripeMethod, stripePaymentMethodStore, stripe, stripeConfiguration ]
+	);
 	if ( stripeMethod ) {
 		stripeMethod.id = 'card';
 	}

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -16,6 +16,7 @@ import {
 	createApplePayMethod,
 	createPayPalMethod,
 	createStripeMethod,
+	createStripePaymentMethodStore,
 	defaultRegistry,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummaryStep,
@@ -305,20 +306,29 @@ function MyCheckout() {
 		setTimeout( () => setIsLoading( false ), 1500 );
 	}, [ isStripeLoading, stripeLoadingError, stripe, stripeConfiguration, isApplePayLoading ] );
 
+	const stripeStore = useMemo(
+		() =>
+			createStripePaymentMethodStore( {
+				getCountry: () => select( 'demo' ).getCountry(),
+				getPostalCode: () => 90210,
+				getSubdivisionCode: () => 'CA',
+				getSiteId: () => 12345,
+				getDomainDetails: {},
+				submitTransaction: sendStripeTransaction,
+			} ),
+		[]
+	);
+
 	const stripeMethod = useMemo( () => {
 		if ( isStripeLoading || stripeLoadingError || ! stripe || ! stripeConfiguration ) {
 			return null;
 		}
 		return createStripeMethod( {
-			getCountry: () => select( 'demo' ).getCountry(),
-			getPostalCode: () => 90210,
-			getSubdivisionCode: () => 'CA',
-			registerStore,
+			store: stripeStore,
 			stripe,
 			stripeConfiguration,
-			submitTransaction: sendStripeTransaction,
 		} );
-	}, [ stripe, stripeConfiguration, isStripeLoading, stripeLoadingError ] );
+	}, [ stripeStore, stripe, stripeConfiguration, isStripeLoading, stripeLoadingError ] );
 
 	const applePayMethod = useMemo( () => {
 		if (

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -18,31 +18,24 @@ import GridRow from '../../components/grid-row';
 import Button from '../../components/button';
 import PaymentLogo from './payment-logo';
 import { createStripePaymentMethod, showStripeModalAuth } from '../stripe';
-import {
-	useSelect,
-	useDispatch,
-	useMessages,
-	useLineItems,
-	renderDisplayValueMarkdown,
-	useEvents,
-} from '../../public-api';
+import { useMessages, useLineItems, renderDisplayValueMarkdown, useEvents } from '../../public-api';
 import { sprintf, useLocalize } from '../localize';
 import { SummaryLine, SummaryDetails } from '../styled-components/summary-details';
 import Spinner from '../../components/spinner';
 import { useFormStatus } from '../form-status';
+import { registerStore, useSelect, useDispatch } from '../../lib/registry';
 
 const debug = debugFactory( 'composite-checkout:stripe-payment-method' );
 
-export function createStripeMethod( {
+export function createStripePaymentMethodStore( {
 	getCountry,
 	getPostalCode,
 	getSubdivisionCode,
-	registerStore,
-	stripe,
-	stripeConfiguration,
+	getSiteId,
+	getDomainDetails,
 	submitTransaction,
 } ) {
-	debug( 'creating a new stripe payment method' );
+	debug( 'creating a new stripe payment method store' );
 	const actions = {
 		changeBrand( payload ) {
 			return { type: 'BRAND_SET', payload };
@@ -218,11 +211,19 @@ export function createStripeMethod( {
 				return createStripePaymentMethodToken( action.payload );
 			},
 			STRIPE_TRANSACTION_BEGIN( action ) {
-				return submitTransaction( action.payload );
+				return submitTransaction( {
+					...action.payload,
+					siteId: getSiteId(),
+					domainDetails: getDomainDetails(),
+				} );
 			},
 		},
 	} );
 
+	return { ...store, actions, selectors };
+}
+
+export function createStripeMethod( { store, stripe, stripeConfiguration } ) {
 	return {
 		id: 'stripe-card',
 		label: <CreditCardLabel />,
@@ -233,18 +234,18 @@ export function createStripeMethod( {
 		inactiveContent: <StripeSummary />,
 		getAriaLabel: localize => localize( 'Credit Card' ),
 		isCompleteCallback: () => {
-			const cardholderName = selectors.getCardholderName( store.getState() );
-			const errors = selectors.getCardDataErrors( store.getState() );
-			const incompleteFieldKeys = selectors.getIncompleteFieldKeys( store.getState() );
+			const cardholderName = store.selectors.getCardholderName( store.getState() );
+			const errors = store.selectors.getCardDataErrors( store.getState() );
+			const incompleteFieldKeys = store.selectors.getIncompleteFieldKeys( store.getState() );
 			const areThereErrors = Object.keys( errors ).some( errorKey => errors[ errorKey ] );
 			if ( ! cardholderName?.value.length ) {
 				// Touch the field so it displays a validation error
-				store.dispatch( actions.changeCardholderName( '' ) );
+				store.dispatch( store.actions.changeCardholderName( '' ) );
 			}
 			if ( incompleteFieldKeys.length > 0 ) {
 				// Show "this field is required" for each incomplete field
 				incompleteFieldKeys.map( key =>
-					store.dispatch( actions.setCardDataError( key, 'This field is required' ) )
+					store.dispatch( store.actions.setCardDataError( key, 'This field is required' ) )
 				); // TODO: localize this message
 			}
 			if ( areThereErrors || ! cardholderName?.value.length || incompleteFieldKeys.length > 0 ) {

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -31,7 +31,10 @@ import {
 } from './lib/registry';
 import { createFullCreditsMethod } from './lib/payment-methods/full-credits';
 import { createFreePaymentMethod } from './lib/payment-methods/free-purchase';
-import { createStripeMethod } from './lib/payment-methods/stripe-credit-card-fields';
+import {
+	createStripeMethod,
+	createStripePaymentMethodStore,
+} from './lib/payment-methods/stripe-credit-card-fields';
 import { createApplePayMethod } from './lib/payment-methods/apple-pay';
 import { createPayPalMethod } from './lib/payment-methods/paypal';
 import { createExistingCardMethod } from './lib/payment-methods/existing-credit-card';
@@ -66,6 +69,7 @@ export {
 	createPayPalMethod,
 	createRegistry,
 	createStripeMethod,
+	createStripePaymentMethodStore,
 	defaultRegistry,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummaryStep,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This refactor helps make it less risky to create payment methods within a component.

Creating payment method objects requires passing in a bunch of callbacks which themselves have many dependencies. If the dependencies are dynamic, the payment methods must be created inside a component. However, since the payment methods each include their own internal data store, if they are recreated it can result in unexpected behavior. We can use memoization to only create each payment method once, but this may cause stale data issues because the dependencies might change. Trying to keep the dependencies (which may have their own dependencies) static can be an extremely hard challenge.

This PR helps to address this issue by splitting payment methods into two parts (in this PR, just the Stripe one to begin with): the data store, and the components. The data store has no dependencies so it will never be recreated.

#### Testing instructions

- Sandbox the store.
- Add a product to your cart and visit composite checkout.
- Make sure the credit card payment method appears as expected.
- Complete the form using a test card like `4242 4242 4242 4242` and press the "pay" button.
- Make sure the purchase completes successfully.