### PR TITLE
[Gutenberg 7.7.1]: E2E test fixes

### DIFF
--- a/test/e2e/lib/components/page-preview-external-component.js
+++ b/test/e2e/lib/components/page-preview-external-component.js
@@ -52,5 +52,10 @@ export default class PagePreviewExternalComponent extends AsyncBaseContainer {
 	static async switchToWindow( driver ) {
 		const handles = await driver.getAllWindowHandles();
 		await driver.switchTo().window( handles[ 1 ] );
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			previewWindowMainSelector,
+			explicitWaitMS
+		);
 	}
 }

--- a/test/e2e/lib/components/page-preview-external-component.js
+++ b/test/e2e/lib/components/page-preview-external-component.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import AsyncBaseContainer from '../async-base-container';
+import ViewPagePage from '../../lib/pages/view-page-page.js';
+import * as driverHelper from '../driver-helper.js';
+
+const explicitWaitMS = config.get( 'explicitWaitMS' );
+const previewWindowMainSelector = By.css( '#main' );
+
+export default class PagePreviewExternalComponent extends AsyncBaseContainer {
+	constructor( driver ) {
+		PagePreviewExternalComponent.switchToWindow( driver );
+		super( driver, previewWindowMainSelector );
+	}
+
+	async _postInit() {
+		return await this.driver.switchTo().defaultContent();
+	}
+
+	async pageTitle() {
+		this.viewPagePage = await ViewPagePage.Expect( this.driver );
+		return await this.viewPagePage.pageTitle();
+	}
+
+	async pageContent() {
+		this.viewPagePage = await ViewPagePage.Expect( this.driver );
+		return await this.viewPagePage.pageContent();
+	}
+
+	async imageDisplayed( fileDetails ) {
+		this.viewPagePage = await ViewPagePage.Expect( this.driver );
+		return await this.viewPagePage.imageDisplayed( fileDetails );
+	}
+
+	async close() {
+		this.driver.close();
+		const handles = await this.driver.getAllWindowHandles();
+		this.driver.switchTo().window( handles[ 0 ] );
+	}
+
+	async isDisplayed() {
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			previewWindowMainSelector,
+			explicitWaitMS
+		);
+	}
+
+	static async switchToWindow( driver ) {
+		const handles = await driver.getAllWindowHandles();
+		await driver.switchTo().window( handles[ 1 ] );
+	}
+}

--- a/test/e2e/lib/components/post-preview-external-component.js
+++ b/test/e2e/lib/components/post-preview-external-component.js
@@ -8,31 +8,41 @@ import config from 'config';
  * Internal dependencies
  */
 import AsyncBaseContainer from '../async-base-container';
-import ViewPagePage from '../../lib/pages/view-page-page.js';
+import ViewPostPage from '../../lib/pages/view-post-page.js';
 import * as driverHelper from '../driver-helper.js';
 
 const explicitWaitMS = config.get( 'explicitWaitMS' );
 const previewWindowMainSelector = By.css( '#main' );
 
-export default class PagePreviewExternalComponent extends AsyncBaseContainer {
+export default class PostPreviewExternalComponent extends AsyncBaseContainer {
 	constructor( driver ) {
-		PagePreviewExternalComponent.switchToWindow( driver );
+		PostPreviewExternalComponent.switchToWindow( driver );
 		super( driver, previewWindowMainSelector );
 	}
 
-	async pageTitle() {
-		this.viewPagePage = await ViewPagePage.Expect( this.driver );
-		return await this.viewPagePage.pageTitle();
+	async postTitle() {
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.postTitle();
 	}
 
-	async pageContent() {
-		this.viewPagePage = await ViewPagePage.Expect( this.driver );
-		return await this.viewPagePage.pageContent();
+	async postContent() {
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.postContent();
+	}
+
+	async categoryDisplayed() {
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.categoryDisplayed();
+	}
+
+	async tagDisplayed() {
+		const viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await viewPostPage.tagDisplayed();
 	}
 
 	async imageDisplayed( fileDetails ) {
-		this.viewPagePage = await ViewPagePage.Expect( this.driver );
-		return await this.viewPagePage.imageDisplayed( fileDetails );
+		this.viewPostPage = await ViewPostPage.Expect( this.driver );
+		return await this.viewPostPage.imageDisplayed( fileDetails );
 	}
 
 	async close() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -349,7 +349,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		}
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.editor-post-preview__dropdown' ),
+			// @TODO: Update to new `.editor-post-preview__dropdown` format once we support it again
+			// https://github.com/Automattic/wp-calypso/issues/40401
+			By.css( '.editor-post-preview' ),
 			this.explicitWaitMS
 		);
 		const editorPostPreviewSelector = By.css( '.editor-post-preview__button-external' );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -401,10 +401,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async closeScheduledPanel() {
-		await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.editor-post-publish-panel__header-publish-button + .components-button.has-icon' )
+		const publishCloseButtonSelector = By.css(
+			'.editor-post-publish-panel__header > .components-button'
 		);
+		return await driverHelper.clickWhenClickable( this.driver, publishCloseButtonSelector );
 	}
 
 	async submitForReview() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -347,16 +347,20 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				this.explicitWaitMS
 			);
 		}
-		await driverHelper.clickWhenClickable(
+
+		return await driverHelper.clickWhenClickable(
 			this.driver,
 			// @TODO: Update to new `.editor-post-preview__dropdown` format once we support it again
 			// https://github.com/Automattic/wp-calypso/issues/40401
 			By.css( '.editor-post-preview' ),
 			this.explicitWaitMS
 		);
-		const editorPostPreviewSelector = By.css( '.editor-post-preview__button-external' );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, editorPostPreviewSelector );
-		return await driverHelper.clickWhenClickable( this.driver, editorPostPreviewSelector );
+		// @TODO: Enable again once we support dropdown preview again
+		// https://github.com/Automattic/wp-calypso/issues/40401
+		//
+		// const editorPostPreviewSelector = By.css( '.editor-post-preview__button-external' );
+		// await driverHelper.waitTillPresentAndDisplayed( this.driver, editorPostPreviewSelector );
+		// return await driverHelper.clickWhenClickable( this.driver, editorPostPreviewSelector );
 	}
 
 	async revertToDraft() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -110,10 +110,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async enterText( text ) {
 		const appenderSelector = By.css( '.block-editor-default-block-appender' );
-		const textSelector = By.css( 'p.block-editor-rich-text__editable:first-of-type' );
+		const paragraphSelector = By.css( 'p.block-editor-rich-text__editable:first-of-type' );
 		await driverHelper.clickWhenClickable( this.driver, appenderSelector );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, textSelector );
-		return await this.driver.findElement( textSelector ).sendKeys( text );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, paragraphSelector );
+		return await this.driver.findElement( paragraphSelector ).sendKeys( text );
 	}
 
 	async getContent() {
@@ -121,9 +121,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async replaceTextOnLastParagraph( text ) {
-		const paragraph = By.css( '.wp-block-paragraph' );
-		await driverHelper.clearTextArea( this.driver, paragraph );
-		return await this.driver.findElement( paragraph ).sendKeys( text );
+		const paragraphSelector = By.css( 'p.block-editor-rich-text__editable:first-of-type' );
+		await driverHelper.clearTextArea( this.driver, paragraphSelector );
+		return await this.driver.findElement( paragraphSelector ).sendKeys( text );
 	}
 
 	async insertShortcode( shortcode ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -433,10 +433,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 					By.css( 'button.template-selector-item__label[value="blank"]' )
 				);
 			} else {
-				await driverHelper.clickWhenClickable(
-					this.driver,
+				const useBlankButton = await this.driver.findElement(
 					By.css( '.page-template-modal__buttons .components-button.is-primary' )
 				);
+				await this.driver.executeScript( 'arguments[0].click()', useBlankButton );
 			}
 		}
 	}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -110,7 +110,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async enterText( text ) {
 		const appenderSelector = By.css( '.block-editor-default-block-appender' );
-		const textSelector = By.css( '.wp-block-paragraph' );
+		const textSelector = By.css( 'p.block-editor-rich-text__editable:first-of-type' );
 		await driverHelper.clickWhenClickable( this.driver, appenderSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, textSelector );
 		return await this.driver.findElement( textSelector ).sendKeys( text );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -336,6 +336,13 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async launchPreview() {
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.components-button.editor-post-preview' ),
+				this.explicitWaitMS
+			);
+		}
 		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( '.editor-post-preview__dropdown' ),

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -49,6 +49,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await this.driver.sleep( 2000 );
 	}
 
+	async _postInit() {
+		await this.driver.sleep( 2000 );
+	}
+
 	async initEditor( { dismissPageTemplateSelector = false } = {} ) {
 		if ( dismissPageTemplateSelector ) {
 			await this.dismissPageTemplateSelector();

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -336,11 +336,14 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async launchPreview() {
-		return await driverHelper.clickWhenClickable(
+		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.editor-post-preview' ),
+			By.css( '.editor-post-preview__dropdown' ),
 			this.explicitWaitMS
 		);
+		const editorPostPreviewSelector = By.css( '.editor-post-preview__button-external' );
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, editorPostPreviewSelector );
+		return await driverHelper.clickWhenClickable( this.driver, editorPostPreviewSelector );
 	}
 
 	async revertToDraft() {
@@ -398,7 +401,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async closeScheduledPanel() {
-		await driverHelper.clickWhenClickable( this.driver, By.css( '.dashicons-no-alt' ) );
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.editor-post-publish-panel__header-publish-button + .components-button.has-icon' )
+		);
 	}
 
 	async submitForReview() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -378,8 +378,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async viewPublishedPostOrPage() {
-		const viewPostSelector = By.css( '.components-snackbar__content a' );
-		await driverHelper.clickWhenClickable( this.driver, viewPostSelector );
+		const viewPostLink = await this.driver.findElement(
+			By.css( '.components-snackbar__content a' )
+		);
+		await this.driver.executeScript( 'arguments[0].click()', viewPostLink );
 	}
 
 	async schedulePost( publishDate ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -339,28 +339,14 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, By.css( '.components-snackbar' ) );
 	}
 
+	// @TODO: Update to new `.editor-post-preview__dropdown` format once we support it again
+	// https://github.com/Automattic/wp-calypso/issues/40401
 	async launchPreview() {
-		if ( driverManager.currentScreenSize() === 'mobile' ) {
-			return await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( '.components-button.editor-post-preview' ),
-				this.explicitWaitMS
-			);
-		}
-
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			// @TODO: Update to new `.editor-post-preview__dropdown` format once we support it again
-			// https://github.com/Automattic/wp-calypso/issues/40401
-			By.css( '.editor-post-preview' ),
+			By.css( '.components-button.editor-post-preview' ),
 			this.explicitWaitMS
 		);
-		// @TODO: Enable again once we support dropdown preview again
-		// https://github.com/Automattic/wp-calypso/issues/40401
-		//
-		// const editorPostPreviewSelector = By.css( '.editor-post-preview__button-external' );
-		// await driverHelper.waitTillPresentAndDisplayed( this.driver, editorPostPreviewSelector );
-		// return await driverHelper.clickWhenClickable( this.driver, editorPostPreviewSelector );
 	}
 
 	async revertToDraft() {

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -602,7 +602,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Use the Calypso Media Modal: @parallel', function() {
+	/* Temporarily disabling this test until we smooth out the integration of Gutenberg 7.7.1 See: #40078 */
+
+	describe.skip( 'Use the Calypso Media Modal: @parallel', function() {
 		let fileDetails;
 
 		// Create image file for upload

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -15,7 +15,6 @@ import NotFoundPage from '../lib/pages/not-found-page.js';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
-import PagePreviewExternalComponent from '../lib/components/page-preview-external-component';
 import PagePreviewComponent from '../lib/components/page-preview-component';
 import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
 
@@ -96,13 +95,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page title in preview', async function() {
-			if ( driverManager.currentScreenSize() === 'mobile' ) {
-				this.pagePreviewComponent = await PagePreviewComponent.Expect( driver );
-				await this.pagePreviewComponent.displayed();
-			} else {
-				this.pagePreviewComponent = new PagePreviewExternalComponent( driver );
-			}
-			const actualPageTitle = await this.pagePreviewComponent.pageTitle();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			await pagePreviewComponent.displayed();
+			const actualPageTitle = await pagePreviewComponent.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
 				pageTitle.toUpperCase(),
@@ -111,7 +106,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page content in preview', async function() {
-			const content = await this.pagePreviewComponent.pageContent();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const content = await pagePreviewComponent.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
 				true,
@@ -124,7 +120,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see the image uploaded in the preview', async function() {
-			const imageDisplayed = await this.pagePreviewComponent.imageDisplayed( fileDetails );
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
 			return assert.strictEqual(
 				imageDisplayed,
 				true,
@@ -133,7 +130,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can close page preview', async function() {
-			await this.pagePreviewComponent.close();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			await pagePreviewComponent.close();
 		} );
 
 		step( 'Can publish and preview published content', async function() {

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -95,7 +95,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page title in preview', async function() {
-			this.pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
+			this.pagePreviewComponent = new PagePreviewExternalComponent( driver );
 			await this.pagePreviewComponent.isDisplayed();
 			const actualPageTitle = await this.pagePreviewComponent.pageTitle();
 			assert.strictEqual(

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -16,6 +16,7 @@ import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 import PagePreviewExternalComponent from '../lib/components/page-preview-external-component';
+import PagePreviewComponent from '../lib/components/page-preview-component';
 import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
 
 import * as driverManager from '../lib/driver-manager.js';
@@ -95,8 +96,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page title in preview', async function() {
-			this.pagePreviewComponent = new PagePreviewExternalComponent( driver );
-			await this.pagePreviewComponent.isDisplayed();
+			if ( driverManager.currentScreenSize() === 'mobile' ) {
+				this.pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+				await this.pagePreviewComponent.displayed();
+			} else {
+				this.pagePreviewComponent = new PagePreviewExternalComponent( driver );
+			}
 			const actualPageTitle = await this.pagePreviewComponent.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -95,9 +95,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page title in preview', async function() {
-			const pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
-			await pagePreviewComponent.isDisplayed();
-			const actualPageTitle = await pagePreviewComponent.pageTitle();
+			this.pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
+			await this.pagePreviewComponent.isDisplayed();
+			const actualPageTitle = await this.pagePreviewComponent.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
 				pageTitle.toUpperCase(),
@@ -106,8 +106,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page content in preview', async function() {
-			const pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
-			const content = await pagePreviewComponent.pageContent();
+			const content = await this.pagePreviewComponent.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
 				true,
@@ -120,8 +119,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see the image uploaded in the preview', async function() {
-			const pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
-			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
+			const imageDisplayed = await this.pagePreviewComponent.imageDisplayed( fileDetails );
 			return assert.strictEqual(
 				imageDisplayed,
 				true,
@@ -130,8 +128,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can close page preview', async function() {
-			const pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
-			await pagePreviewComponent.close();
+			await this.pagePreviewComponent.close();
 		} );
 
 		step( 'Can publish and preview published content', async function() {

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -15,7 +15,7 @@ import NotFoundPage from '../lib/pages/not-found-page.js';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
-import PagePreviewComponent from '../lib/components/page-preview-component';
+import PagePreviewExternalComponent from '../lib/components/page-preview-external-component';
 import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
 
 import * as driverManager from '../lib/driver-manager.js';
@@ -95,8 +95,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page title in preview', async function() {
-			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
-			await pagePreviewComponent.displayed();
+			const pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
+			await pagePreviewComponent.isDisplayed();
 			const actualPageTitle = await pagePreviewComponent.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
@@ -106,7 +106,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page content in preview', async function() {
-			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
 			const content = await pagePreviewComponent.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
@@ -120,7 +120,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see the image uploaded in the preview', async function() {
-			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
 			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
 			return assert.strictEqual(
 				imageDisplayed,
@@ -130,7 +130,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can close page preview', async function() {
-			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const pagePreviewComponent = await PagePreviewExternalComponent.Expect( driver );
 			await pagePreviewComponent.close();
 		} );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -19,6 +19,7 @@ import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import SidebarComponent from '../lib/components/sidebar-component.js';
 import NoticesComponent from '../lib/components/notices-component.js';
 import NavBarComponent from '../lib/components/nav-bar-component.js';
+import PostPreviewComponent from '../lib/components/post-preview-component';
 import PostPreviewExternalComponent from '../lib/components/post-preview-external-component';
 import RevisionsModalComponent from '../lib/components/revisions-modal-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
@@ -129,7 +130,13 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct post title in preview', async function() {
-			this.postPreviewComponent = new PostPreviewExternalComponent( driver );
+			if ( driverManager.currentScreenSize() === 'mobile' ) {
+				this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
+				await this.postPreviewComponent.displayed();
+			} else {
+				this.postPreviewComponent = new PostPreviewExternalComponent( driver );
+			}
+
 			const postTitle = await this.postPreviewComponent.postTitle();
 			assert.strictEqual(
 				postTitle.toLowerCase(),

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -19,7 +19,7 @@ import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import SidebarComponent from '../lib/components/sidebar-component.js';
 import NoticesComponent from '../lib/components/notices-component.js';
 import NavBarComponent from '../lib/components/nav-bar-component.js';
-import PostPreviewComponent from '../lib/components/post-preview-component';
+import PostPreviewExternalComponent from '../lib/components/post-preview-external-component';
 import RevisionsModalComponent from '../lib/components/revisions-modal-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
@@ -129,7 +129,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct post title in preview', async function() {
-			this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
+			this.postPreviewComponent = await PostPreviewExternalComponent.Expect( driver );
 			const postTitle = await this.postPreviewComponent.postTitle();
 			assert.strictEqual(
 				postTitle.toLowerCase(),

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -129,7 +129,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct post title in preview', async function() {
-			this.postPreviewComponent = await PostPreviewExternalComponent.Expect( driver );
+			this.postPreviewComponent = new PostPreviewExternalComponent( driver );
 			const postTitle = await this.postPreviewComponent.postTitle();
 			assert.strictEqual(
 				postTitle.toLowerCase(),

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -250,7 +250,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Basic Public Post @canary @ie11canary @parallel', function() {
+	// @TODO: add `@ie11canary` back here once FSE plugin works with IE11 again.
+	describe( 'Basic Public Post @canary @parallel', function() {
 		describe( 'Publish a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -20,7 +20,6 @@ import SidebarComponent from '../lib/components/sidebar-component.js';
 import NoticesComponent from '../lib/components/notices-component.js';
 import NavBarComponent from '../lib/components/nav-bar-component.js';
 import PostPreviewComponent from '../lib/components/post-preview-component';
-import PostPreviewExternalComponent from '../lib/components/post-preview-external-component';
 import RevisionsModalComponent from '../lib/components/revisions-modal-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
@@ -130,12 +129,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct post title in preview', async function() {
-			if ( driverManager.currentScreenSize() === 'mobile' ) {
-				this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
-				await this.postPreviewComponent.displayed();
-			} else {
-				this.postPreviewComponent = new PostPreviewExternalComponent( driver );
-			}
+			this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
 
 			const postTitle = await this.postPreviewComponent.postTitle();
 			assert.strictEqual(


### PR DESCRIPTION
## Changes proposed in this Pull Request

Thanks for dropping by for what is tipped to be the most exciting PR of 2020^.

If things have gone to plan, we've fixed all the [E2E fails](https://github.com/Automattic/wp-calypso/pull/39292) introduced by [Gutenberg 7.7.1](https://github.com/Automattic/wp-calypso/issues/40078).

You won't be able disguise your awe as you scroll down the page and bask in the radiant glory of green checks in the merge checklist. 

Here, take some more! ✅✅✅✅✅✅✅✅

How does that feel?

_^ according to an exclusive poll of this PR's assignee list_

## Testing instructions

The **Needs e2e Testing Gutenberg** tests should all bear a ✅ 

## ⚠️ Please don't merge until 7.7.1 is in master

🙏 Thank you for your understanding. 


