### PR TITLE
Old checkout: fix cart total display when nominal price is high

### DIFF
--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -141,13 +141,13 @@
 
 		.cart__total-label {
 			display: table-cell;
-			width: 100%;
+			width: auto;
 		}
 
 		.cart__total-amount {
 			display: table-cell;
 			text-align: right;
-			width: auto;
+			width: 100%;
 		}
 
 		.cart__total-amount.last-cell {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This makes sure that nominally long prices are not split into two lines in the cart total:

#### Testing instructions
The easiest way to test long numbers would be with an account using the HUF currency.

Here are some before and after screenshots.

**DESKTOP**

**HU/HUF** - before
<img width="285" alt="before-hu-huf" src="https://user-images.githubusercontent.com/844866/76956831-6f454480-691d-11ea-8e1f-41f5e82938fb.png">
**HU/HUF** - after
<img width="286" alt="after-hu-huf" src="https://user-images.githubusercontent.com/844866/76956824-6ce2ea80-691d-11ea-85eb-b6745f20c96f.png">

**ID/IDR** - before
<img width="285" alt="before-id-idr" src="https://user-images.githubusercontent.com/844866/76956883-82f0ab00-691d-11ea-96ff-342512f74723.png">
**ID/IDR** - after
<img width="279" alt="after-id-idr" src="https://user-images.githubusercontent.com/844866/76956887-84ba6e80-691d-11ea-9153-0db6bdec86d9.png">

**DE/EUR** - before
<img width="284" alt="before-de-eur" src="https://user-images.githubusercontent.com/844866/76956915-8e43d680-691d-11ea-89d8-5858864f64fe.png">
**DE/EUR** - after
<img width="275" alt="after-de-eur" src="https://user-images.githubusercontent.com/844866/76956917-90a63080-691d-11ea-8cf0-5873fac16b54.png">

**Mobile** (shown when clicking on the "Show order details" link)

**HU/HUF** - before
<img width="423" alt="Screen Shot 2020-03-18 at 13 41 56" src="https://user-images.githubusercontent.com/844866/76957434-76208700-691e-11ea-947d-753fab2fbe4b.png">
**HU/HUF** - after
<img width="405" alt="Screen Shot 2020-03-18 at 13 42 16" src="https://user-images.githubusercontent.com/844866/76957446-7b7dd180-691e-11ea-8ff9-3379458e0109.png">


**DE/EUR** - before
<img width="403" alt="Screen Shot 2020-03-18 at 13 42 37" src="https://user-images.githubusercontent.com/844866/76957404-69039800-691e-11ea-974f-1730d8fb14da.png">
**DE/EUR** - after
<img width="419" alt="Screen Shot 2020-03-18 at 13 42 56" src="https://user-images.githubusercontent.com/844866/76957420-702aa600-691e-11ea-89e9-2e4a95190960.png">


