### PR TITLE
[E2E tests] Actually select first image in MediaPage.selectFirstImage()

### DIFF
--- a/client/my-sites/media-library/list-item-image.jsx
+++ b/client/my-sites/media-library/list-item-image.jsx
@@ -95,7 +95,7 @@ export default class MediaLibraryListItemImage extends React.Component {
 				onLoad={ this.setUnknownImageDimensions }
 				alt={ this.props.media.alt || this.props.media.title }
 				style={ this.getImageStyle() }
-				className="media-library__list-item-centered"
+				className="media-library__list-item-centered is-image"
 				draggable="false"
 			/>
 		);

--- a/test/e2e/lib/pages/media-page.js
+++ b/test/e2e/lib/pages/media-page.js
@@ -24,7 +24,10 @@ export default class MediaPage extends AsyncBaseContainer {
 			this.driver,
 			By.css( '.media-library__list-item:not(.is-placeholder)' )
 		);
-		await driverHelper.clickWhenClickable( this.driver, By.css( '.media-library__list-item' ) );
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.media-library__list-item.is-image' )
+		);
 		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
 			By.css( '.media-library__list-item.is-selected' )

--- a/test/e2e/lib/pages/media-page.js
+++ b/test/e2e/lib/pages/media-page.js
@@ -26,7 +26,7 @@ export default class MediaPage extends AsyncBaseContainer {
 		);
 		await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.media-library__list-item.is-image' )
+			By.css( '.media-library__list-item .is-image' )
 		);
 		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Media tests tend to fail randomly, e.g. one of them expects to see the edit button after clicking on random image. The problem is that `selectFirstImage()` helper function selects completely random media file, including mp3 files some of the time. We don't display edit button on mp3 preview, so the entire test fails.

#### Testing instructions

Confirm the code makes sense and tests pass.
