### PR TITLE
Jetpack Cloud: Update the loading screen

### DIFF
--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -10,3 +10,23 @@
 		height: 100px;
 	}
 }
+
+.wpcom-site__loader {
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate( -50%, -50% );
+	color: var( --color-text-subtle );
+	text-align: center;
+	animation: loading-fade 1.6s ease-in-out infinite;
+
+	.wpcom-site__logo {
+		display: block;
+		margin-bottom: 10px;
+
+		path {
+			fill: var( --color-text-subtle );
+		}
+	}
+
+}

--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -5,32 +5,12 @@
 	left: 50%;
 	transform: translate( -50%, -50% );
 
+	path {
+		fill: var( --color-neutral-10 );
+	}
+
 	@include breakpoint( '>960px' ) {
 		width: 100px;
 		height: 100px;
 	}
-}
-
-.wpcom-site__loader {
-	position: fixed;
-	top: 50%;
-	left: 50%;
-	transform: translate( -50%, -50% );
-	color: var( --color-text-subtle );
-	text-align: center;
-	animation: loading-fade 1.6s ease-in-out infinite;
-
-	.wpcom-site__logo {
-		display: block;
-		margin-bottom: 10px;
-		position: relative;
-		top:0;
-		left:0;
-		transform: none;
-
-		path {
-			fill: var( --color-text-subtle );
-		}
-	}
-
 }

--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -23,6 +23,10 @@
 	.wpcom-site__logo {
 		display: block;
 		margin-bottom: 10px;
+		position: relative;
+		top:0;
+		left:0;
+		transform: none;
 
 		path {
 			fill: var( --color-text-subtle );

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -124,7 +124,7 @@ class Document extends React.Component {
 							} }
 						/>
 					) : (
-						<div className="wpcom-site">
+						<div id="wpcom" className="wpcom-site">
 							<div
 								className={ classNames( 'layout', {
 									[ 'is-group-' + sectionGroup ]: sectionGroup,

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -135,7 +135,7 @@ class Document extends React.Component {
 							>
 								<div className="masterbar" />
 								<div className="layout__content">
-									{ 'jetpack-cloud' === sectionName ? (
+									{ config.isEnabled( 'jetpack-cloud' ) ? (
 										<div className="wpcom-site__loader">
 											<JetpackLogo size={ 72 } className="wpcom-site__logo" />
 											{ translate( 'Loading' ) }

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -5,7 +5,6 @@
 
 import React, { Fragment } from 'react';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -59,7 +58,6 @@ class Document extends React.Component {
 			isWCComConnect,
 			addEvergreenCheck,
 			requestFrom,
-			translate,
 		} = this.props;
 
 		const inlineScript =
@@ -82,6 +80,8 @@ class Document extends React.Component {
 			'woocommerce-onboarding' === requestFrom;
 
 		const theme = config( 'theme' );
+
+		const LoadingLogo = config.isEnabled( 'jetpack-cloud' ) ? JetpackLogo : WordPressLogo;
 
 		return (
 			<html
@@ -124,7 +124,7 @@ class Document extends React.Component {
 							} }
 						/>
 					) : (
-						<div id="wpcom" className="wpcom-site">
+						<div className="wpcom-site">
 							<div
 								className={ classNames( 'layout', {
 									[ 'is-group-' + sectionGroup ]: sectionGroup,
@@ -135,14 +135,7 @@ class Document extends React.Component {
 							>
 								<div className="masterbar" />
 								<div className="layout__content">
-									{ config.isEnabled( 'jetpack-cloud' ) ? (
-										<div className="wpcom-site__loader">
-											<JetpackLogo size={ 72 } className="wpcom-site__logo" />
-											{ translate( 'Loading' ) }
-										</div>
-									) : (
-										<WordPressLogo size={ 72 } className="wpcom-site__logo" />
-									) }
+									<LoadingLogo size={ 72 } className="wpcom-site__logo" />
 									{ hasSecondary && (
 										<Fragment>
 											<div className="layout__secondary" />
@@ -266,4 +259,4 @@ class Document extends React.Component {
 	}
 }
 
-export default localize( Document );
+export default Document;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the loading screen on Jetpack cloud. 

Before:
<img width="1792" alt="Screen Shot 2020-03-18 at 2 08 35 PM" src="https://user-images.githubusercontent.com/115071/76963835-f85e7a80-6921-11ea-93cf-96b6d3bd4c47.png">

After:
<img width="1146" alt="Screen Shot 2020-03-18 at 3 17 57 PM" src="https://user-images.githubusercontent.com/115071/76970409-1cbf5480-692c-11ea-9301-047c80bd1248.png">

#### Testing instructions

* 1. Load up calypso. does it still look the same?
* 2. Load up jetpack cloud. Does the loading screen look like expected. 
