### PR TITLE
Update the jetpack logo in the masterbar for jetpack cloud.

### DIFF
--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -34,7 +34,7 @@ export default function() {
 					comment: 'Jetpack Cloud top navigation bar item',
 				} ) }
 			>
-				<JetpackLogo size={ 28 } full monochrome />
+				<JetpackLogo size={ 28 } full />
 			</Item>
 			<Item
 				tipTarget="me"

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -20,7 +20,7 @@
 		color: var( --color-masterbar-text );
 
 		svg {
-			fill: var( --color-masterbar-text );
+			fill: var( --color-black );
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the logo in the masterbar. 

Before:
<img width="473" alt="Screen Shot 2020-03-18 at 2 47 49 PM" src="https://user-images.githubusercontent.com/115071/76967242-72453280-6927-11ea-97ab-923beec64fa7.png">

After:
<img width="563" alt="Screen Shot 2020-03-18 at 2 48 20 PM" src="https://user-images.githubusercontent.com/115071/76967298-86892f80-6927-11ea-90bb-e94aedef4d79.png">

#### Testing instructions
Load up the jetpack Cloud. 
Notice the  new jetpack logo in the masterbar does it look like expected?
