### PR TITLE
Animate Chart: use CSS transform instead of top/height combination for better performance

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -70,7 +70,6 @@ $z-layers: (
 		'.auth__form .form-fieldset input': 1,
 		'.chart__empty': 2,
 		'.chart__bar-marker': 1,
-		'.chart__bar-section.is-ghost::after': 1,
 		'.module-content-table::after': 1,
 		'.stats-popular__empty': 1,
 		'.is-actionable .theme__thumbnail-label': 1,

--- a/client/components/chart/bar.jsx
+++ b/client/components/chart/bar.jsx
@@ -78,19 +78,6 @@ export default class ChartBar extends React.PureComponent {
 
 	setRef = ref => ( this.bar = ref );
 
-	renderSpacer() {
-		const percentage = this.getPercentage();
-		return (
-			<div
-				key="spacer"
-				className={ classNames( 'chart__bar-section', 'is-spacer', {
-					'is-ghost': 0 === percentage && ! this.props.active,
-				} ) }
-				style={ { height: `${ Math.max( 1, Math.floor( 100 - percentage ) ) }%` } }
-			/>
-		);
-	}
-
 	renderNestedBar() {
 		const {
 			data: { nestedValue },
@@ -114,7 +101,7 @@ export default class ChartBar extends React.PureComponent {
 				ref={ this.setRef }
 				key="value"
 				className="chart__bar-section is-bar"
-				style={ { top: `${ Math.max( 1, Math.floor( 100 - percentage ) ) }%` } }
+				style={ { transform: `scaleY( ${ percentage / 100 } )` } }
 			>
 				{ this.renderNestedBar() }
 			</div>
@@ -131,7 +118,6 @@ export default class ChartBar extends React.PureComponent {
 				onMouseLeave={ this.mouseLeave }
 				className={ classNames( 'chart__bar', this.props.className ) }
 			>
-				{ this.renderSpacer() }
 				{ this.renderBar() }
 				<div key="label" className="chart__bar-label">
 					{ this.props.label }

--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -24,8 +24,8 @@ const isTouch = hasTouch();
 
 /**
  * Auxiliary method to calculate the maximum value for the Y axis, based on a dataset.
- * @param {Array} values An array of numeric values.
  *
+ * @param {Array} values An array of numeric values.
  * @returns {number} The maximum value for the Y axis.
  */
 function getYAxisMax( values ) {

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -136,6 +136,7 @@ $y-axis-padding: 0 20px 0 10px;
 
 // Individual bar
 // 1: Needs to be relative so that the contained graphic bar has boundaries
+// 2: Animate the bar on mounting to make it consistent with the transition later when values change
 
 .chart__bar {
 	text-align: center;
@@ -146,6 +147,15 @@ $y-axis-padding: 0 20px 0 10px;
 	flex-grow: 1;
 	-ms-flex-shrink: 1;
 	flex-shrink: 1;
+	transform: scaleY( 0 );
+	transform-origin: 0% 100%;
+	animation: growUpOnMounting 0.2s ease-in forwards;
+
+	@keyframes growUpOnMounting {
+		100% {
+			transform: scaleY( 1 );
+		}
+	}
 
 	&.is-weekend {
 		background-color: rgba( var( --color-neutral-0-rgb ), 0.5 );

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -136,7 +136,7 @@ $y-axis-padding: 0 20px 0 10px;
 
 // Individual bar
 // 1: Needs to be relative so that the contained graphic bar has boundaries
-// 2: Animate the bar on mounting to make it consistent with the transition later when values change
+// 2: Animate the bar on mounting to make it consistent with the transitions later when values change
 
 .chart__bar {
 	text-align: center;
@@ -149,7 +149,7 @@ $y-axis-padding: 0 20px 0 10px;
 	flex-shrink: 1;
 	transform: scaleY( 0 );
 	transform-origin: 0% 100%;
-	animation: growUpOnMounting 0.2s ease-in forwards;
+	animation: growUpOnMounting 0.2s ease-in forwards; // 2
 
 	@keyframes growUpOnMounting {
 		100% {
@@ -174,7 +174,7 @@ $y-axis-padding: 0 20px 0 10px;
 
 // Individual bar wrapper & misc
 // 1: Positions the bar in the space as defined by .bar
-// 2: use `transform` (as opposed to top or height) for better transition performance, see: https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/
+// 2: use `transform` (as opposed to top or height) for better transition performance
 // 3: add a transition to make switching between periods nicer
 // 4: set `transform-origin` to the bottom so scalling takes the bar up ↑
 
@@ -188,7 +188,7 @@ $y-axis-padding: 0 20px 0 10px;
 	height: 100%;
 	transform: scaleY( 0 ); // 2
 	transition: transform 0.3s ease-in-out; // 3
-	transform-origin: 0% 100%; //4 
+	transform-origin: 0% 100%; // 4 
 	z-index: z-index( 'root', '.chart__bar-section' );
 
 	.chart__bar:hover &.is-bar {
@@ -197,27 +197,6 @@ $y-axis-padding: 0 20px 0 10px;
 
 	.chart__bar.is-selected &.is-bar {
 		background-color: var( --color-accent-40 );
-	}
-
-	&.is-ghost::after {
-		content: '';
-		display: block;
-		position: absolute;
-		top: 160px;
-		bottom: 0;
-		left: 0;
-		z-index: z-index( 'root', '.chart__bar-section.is-ghost::after' );
-		width: 100%;
-		height: 40px;
-		background-image: linear-gradient(
-			to bottom,
-			rgba( var( --color-surface-rgb ), 0 ),
-			rgba( var( --color-neutral-0-rgb ), 0.5 )
-		); // TODO: needs to use default color for gradient
-
-		.chart__bar:hover & {
-			display: none;
-		}
 	}
 }
 

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -164,18 +164,21 @@ $y-axis-padding: 0 20px 0 10px;
 
 // Individual bar wrapper & misc
 // 1: Positions the bar in the space as defined by .bar
-// 2: Default value for top so bars grow when they get a new value
-//    (doesn't function correctly for period switching right now, not sure why)
-//    (also doesn't work because updating the DOM is so heavy it stalls all animations)
+// 2: use `transform` (as opposed to top or height) for better transition performance, see: https://www.paulirish.com/2012/why-moving-elements-with-translate-is-better-than-posabs-topleft/
+// 3: add a transition to make switching between periods nicer
+// 4: set `transform-origin` to the bottom so scalling takes the bar up ↑
 
 .chart__bar-section {
 	display: inline-block;
 	background-color: var( --color-primary-40 );
 	position: absolute;
-	top: 0; // 2
 	right: 16%; // 1
 	bottom: 0; // 1
 	left: 16%; // 1
+	height: 100%;
+	transform: scaleY( 0 ); // 2
+	transition: transform 0.3s ease-in-out; // 3
+	transform-origin: 0% 100%; //4 
 	z-index: z-index( 'root', '.chart__bar-section' );
 
 	.chart__bar:hover &.is-bar {
@@ -184,11 +187,6 @@ $y-axis-padding: 0 20px 0 10px;
 
 	.chart__bar.is-selected &.is-bar {
 		background-color: var( --color-accent-40 );
-	}
-
-	&.is-spacer {
-		z-index: z-index( 'root', '.chart__bar-section.is-spacer' );
-		background-color: rgba( var( --color-surface-rgb ), 0 );
 	}
 
 	&.is-ghost::after {

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -104,8 +104,9 @@ class StatModuleChartTabs extends Component {
 		const { isActiveTabLoading } = this.props;
 		const classes = [ 'stats-module', 'is-chart-tabs', { 'is-loading': isActiveTabLoading } ];
 
+		/* pass bars count as `key` to disable transitions between tabs with different column count */
 		return (
-			<Card className={ classNames( ...classes ) }>
+			<Card key={ this.props.chartData.length } className={ classNames( ...classes ) }>
 				<Legend
 					activeCharts={ this.props.activeLegend }
 					activeTab={ this.props.activeTab }


### PR DESCRIPTION
Hi there! This is just micro PR to get me familiar with Calypso and the development process. 

#### Changes proposed in this Pull Request

##### This PR proposes:

##### Logic Changes

1. To use CSS `transform` to adjust the chart bars instead of `top` and `height`. Using `transform` prop usually isolates the element into another rendering layer, allowing it to re-render without reflowing the rest of the DOM => much faster. Although this is up to each browser.

2. This gives the ability to add a transition since transitioning is now efficient enough.

3. Not 100% sure about this one. But since height is 100% now, I don't think a spacer element is needed. Unless it had another purpose. 

4. Make bars start from 0% as opposed to 100%. This solves the ugly intermediate state seen [here](https://d.pr/i/PgXChH).

##### Visual changes:

1. Video before: https://d.pr/v/3bMGUS
2. Video after: https://d.pr/v/TUhfmo

#### Testing instructions

1. Run Calypso.
2. Go to "Stats".
3. Change the periods, refresh the page, play around with it.
4. Open DevTools and enable the mobile view. It should work well there too.


