### PR TITLE
[Private sites] Remove redundant dependency on imageObjectUrl

### DIFF
--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -86,7 +86,7 @@ const ProxiedImage: React.FC< Props > = function ProxiedImage( {
 				URL.revokeObjectURL( imageObjectUrl );
 			}
 		};
-	}, [ imageObjectUrl, filePath, requestId, siteSlug ] );
+	}, [ filePath, requestId, siteSlug ] );
 
 	if ( ! imageObjectUrl ) {
 		return placeholder as React.ReactElement;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes effect dependency on `imageObjectUrl`. It's redundant and causes unnecessary reruns of the effect.

#### Testing instructions

Same as in https://github.com/Automattic/wp-calypso/pull/39616