### PR TITLE
[Private sites] Use <MediaFile /> to display video thumbnails

### DIFF
--- a/client/my-sites/media-library/list-item-video.jsx
+++ b/client/my-sites/media-library/list-item-video.jsx
@@ -17,6 +17,7 @@ import { MEDIA_IMAGE_THUMBNAIL } from 'lib/media/constants';
  * Style dependencies
  */
 import './list-item-video.scss';
+import MediaImage from './media-image';
 
 export default class extends React.Component {
 	static displayName = 'MediaLibraryListItemVideo';
@@ -51,17 +52,22 @@ export default class extends React.Component {
 					? thumbnail
 					: photon( thumbnail, { width: this.props.maxImageWidth } );
 
-			return (
-				<div
-					className="media-library__list-item-video"
-					style={ { backgroundImage: 'url(' + url + ')' } }
-				>
-					<span className="media-library__list-item-icon media-library__list-item-centered">
-						<Gridicon icon="video-camera" />
-					</span>
-				</div>
-			);
+			return <MediaImage src={ url } component={ ListItemVideo } placeholder={ ListItemVideo } />;
 		}
 		return <ListItemFileDetails { ...this.props } icon="video-camera" />;
 	}
+}
+
+function ListItemVideo( { src } ) {
+	const style = {};
+	if ( src ) {
+		style.backgroundImage = 'url(' + src + ')';
+	}
+	return (
+		<div className="media-library__list-item-video" style={ style }>
+			<span className="media-library__list-item-icon media-library__list-item-centered">
+				<Gridicon icon="video-camera" />
+			</span>
+		</div>
+	);
 }

--- a/client/my-sites/media-library/list-item-video.jsx
+++ b/client/my-sites/media-library/list-item-video.jsx
@@ -17,7 +17,7 @@ import { MEDIA_IMAGE_THUMBNAIL } from 'lib/media/constants';
  * Style dependencies
  */
 import './list-item-video.scss';
-import MediaImage from './media-image';
+import MediaFile from './media-file';
 
 export default class extends React.Component {
 	static displayName = 'MediaLibraryListItemVideo';
@@ -52,7 +52,7 @@ export default class extends React.Component {
 					? thumbnail
 					: photon( thumbnail, { width: this.props.maxImageWidth } );
 
-			return <MediaImage src={ url } component={ ListItemVideo } placeholder={ ListItemVideo } />;
+			return <MediaFile src={ url } component={ ListItemVideo } placeholder={ ListItemVideo } />;
 		}
 		return <ListItemFileDetails { ...this.props } icon="video-camera" />;
 	}

--- a/client/my-sites/media-library/test/list-item-video.jsx
+++ b/client/my-sites/media-library/test/list-item-video.jsx
@@ -5,8 +5,7 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import photon from 'photon';
 import React from 'react';
 
@@ -15,10 +14,35 @@ import React from 'react';
  */
 import fixtures from './fixtures';
 import ListItemVideo from 'my-sites/media-library/list-item-video';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 
 const WIDTH = 450;
 
 const styleUrl = url => `url(${ url })`;
+
+const initialReduxState = {
+	siteSettings: {},
+	sites: {
+		items: [],
+	},
+	media: {
+		queries: {},
+	},
+	currentUser: {
+		capabilities: {},
+	},
+	ui: {
+		editor: {
+			imageEditor: {},
+		},
+	},
+};
+
+function renderWithRedux( ui ) {
+	const store = createStore( state => state, initialReduxState );
+	return render( <Provider store={ store }>{ ui }</Provider> );
+}
 
 describe( 'MediaLibraryListItem video', () => {
 	let wrapper;
@@ -42,22 +66,26 @@ describe( 'MediaLibraryListItem video', () => {
 
 	describe( 'thumbnail display mode', () => {
 		test( 'defaults to photon', () => {
-			wrapper = shallow( getItem() );
+			const { container } = renderWithRedux( getItem() );
 
-			expect( wrapper.props().style.backgroundImage ).to.be.equal( expectedBackground() );
+			expect(
+				container.querySelector( '.media-library__list-item-video' ).style.backgroundImage
+			).toBe( expectedBackground() );
 		} );
 		test( 'returns a photon thumbnail for type MEDIA_IMAGE_RESIZER', () => {
-			wrapper = shallow( getItem( 'MEDIA_IMAGE_RESIZER' ) );
+			const { container } = renderWithRedux( getItem( 'MEDIA_IMAGE_RESIZER' ) );
 
-			expect( wrapper.props().style.backgroundImage ).to.be.equal( expectedBackground() );
+			expect(
+				container.querySelector( '.media-library__list-item-video' ).style.backgroundImage
+			).toBe( expectedBackground() );
 		} );
 
 		test( 'returns existing fmt_hd thumbnail for type MEDIA_IMAGE_THUMBNAIL', () => {
-			wrapper = shallow( getItem( 'MEDIA_IMAGE_THUMBNAIL' ) );
+			const { container } = renderWithRedux( getItem( 'MEDIA_IMAGE_THUMBNAIL' ) );
 
-			expect( wrapper.props().style.backgroundImage ).to.be.equal(
-				styleUrl( fixtures.media[ 1 ].thumbnails.fmt_hd )
-			);
+			expect(
+				container.querySelector( '.media-library__list-item-video' ).style.backgroundImage
+			).toBe( styleUrl( fixtures.media[ 1 ].thumbnails.fmt_hd ) );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes `list-item-video.jsx` use `<MediaImage/>` component to display video thumbnails

#### Testing instructions

I think video thumbnails are only generated when using VideoPress, which means they're also available publicly. Therefore the only way to test this PR is to:

1. Get a public AT site, enable Videopress
1. Upload a video in /media and confirm it got processed using VideoPress
1. Wait until it's encoded (progress visible in preview)
1. Refresh the page
1. Confirm the thumbnail is displayed correctly
1. Make the site private
1. Confirm the thumbnail is still displayed correctly
