### PR TITLE
Hosting Settings: use monospaced font for SFTP credentials

### DIFF
--- a/client/my-sites/hosting/sftp-card/style.scss
+++ b/client/my-sites/hosting/sftp-card/style.scss
@@ -78,6 +78,7 @@
 }
 
 input[type='text'].sftp-card__copy-input {
+	font-family: $monospace;
 	flex: 1 1 0;
 	border: none;
 	min-width: 0;


### PR DESCRIPTION
It can be hard to distinguish the characters (i.e. `Il10O`) in the SFTP credential fields when using a proportional font-family. This updates the fields to use a monospaced font.

Before | After
------------ | -------------
![Screen Shot 2020-03-18 at 11 38 31 AM](https://user-images.githubusercontent.com/942359/76979221-073b3200-690e-11ea-8eda-c7e1961d86eb.png) | ![Screen Shot 2020-03-18 at 11 38 10 AM](https://user-images.githubusercontent.com/942359/76979092-e4108280-690d-11ea-8f30-d18c275fc758.png)

**To test:**
- on an Atomic site, visit Manage > Hosting Configuration
- verify that the field values under SFTP Credentials are monospaced