### PR TITLE
Migration: Fix progress-item handling for new state

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -525,18 +525,6 @@ class SectionMigrate extends Component {
 		let progressItemText;
 		switch ( progressState ) {
 			case 'backing-up':
-				progressItemText = (
-					<span>
-						{ translate( 'Backup of {{sp}}%(sourceSiteDomain)s{{/sp}} completed', {
-							args: {
-								sourceSiteDomain,
-							},
-							components: {
-								sp: <span className="migrate__domain" />,
-							},
-						} ) }
-					</span>
-				);
 				if ( migrationStatus === 'backing-up' ) {
 					progressItemText = (
 						<span>
@@ -550,7 +538,20 @@ class SectionMigrate extends Component {
 							} ) }
 						</span>
 					);
+					break;
 				}
+				progressItemText = (
+					<span>
+						{ translate( 'Backup of {{sp}}%(sourceSiteDomain)s{{/sp}} completed', {
+							args: {
+								sourceSiteDomain,
+							},
+							components: {
+								sp: <span className="migrate__domain" />,
+							},
+						} ) }
+					</span>
+				);
 				break;
 			case 'restoring':
 				progressItemText = (

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -525,7 +525,7 @@ class SectionMigrate extends Component {
 		let progressItemText;
 		switch ( progressState ) {
 			case 'backing-up':
-				if ( migrationStatus === 'backing-up' ) {
+				if ( 'backing-up' === migrationStatus || 'new' === migrationStatus ) {
 					progressItemText = (
 						<span>
 							{ translate( 'Backing up {{sp}}%(sourceSiteDomain)s{{/sp}}', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prior to this PR, the state would flicker when starting a migration from checkout from "Backed up" to "Backing up", eventually to "Backed up" again. This was because `new` was treated as `restoring` for `renderProgressItem` for the backup progress item.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply PR.
* Do a migration with a simple site.
* Pay attention to the status items immediately when migration starts. They should not flicker from backed up to backing up to backed up.

