### PR TITLE
Posts list: Use JS to Sentence case "Add new post" label

### DIFF
--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -199,7 +199,7 @@ class PostTypeList extends Component {
 
 		let addNewLabel = postLabels.add_new_item;
 
-		if ( 'en' === localeSlug ) {
+		if ( 'en' === localeSlug || 'en-gb' === localeSlug ) {
 			// Temporary workaround to Sentence case label from core API for EN lang
 			addNewLabel =
 				postLabels.add_new_item[ 0 ].toUpperCase() +

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -197,10 +197,14 @@ class PostTypeList extends Component {
 			return null;
 		}
 
+		//Temporary workaround to Sentence case label from core API
+		const addNewLabel =
+			postLabels.add_new_item[ 0 ].toUpperCase() + postLabels.add_new_item.slice( 1 ).toLowerCase();
+
 		return (
 			<SectionHeader label={ postLabels.name }>
 				<Button primary compact className="post-type-list__add-post" href={ editorUrl }>
-					{ postLabels.add_new_item }
+					{ addNewLabel }
 				</Button>
 			</SectionHeader>
 		);

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -197,10 +197,14 @@ class PostTypeList extends Component {
 			return null;
 		}
 
+		/*
+		 * Temporary workaround to Sentence case label from core API for EN langs
+		 * @TODO: Remove when https://core.trac.wordpress.org/ticket/49616 is merged
+		 */
+
 		let addNewLabel = postLabels.add_new_item;
 
 		if ( 'en' === localeSlug || 'en-gb' === localeSlug ) {
-			// Temporary workaround to Sentence case label from core API for EN lang
 			addNewLabel =
 				postLabels.add_new_item[ 0 ].toUpperCase() +
 				postLabels.add_new_item.slice( 1 ).toLowerCase();

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { isEqual, range, throttle, difference, isEmpty, get } from 'lodash';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -191,15 +191,20 @@ class PostTypeList extends Component {
 	}
 
 	renderSectionHeader() {
-		const { editorUrl, postLabels } = this.props;
+		const { editorUrl, postLabels, localeSlug } = this.props;
 
 		if ( ! postLabels ) {
 			return null;
 		}
 
-		//Temporary workaround to Sentence case label from core API
-		const addNewLabel =
-			postLabels.add_new_item[ 0 ].toUpperCase() + postLabels.add_new_item.slice( 1 ).toLowerCase();
+		let addNewLabel = postLabels.add_new_item;
+
+		if ( 'en' === localeSlug ) {
+			// Temporary workaround to Sentence case label from core API for EN lang
+			addNewLabel =
+				postLabels.add_new_item[ 0 ].toUpperCase() +
+				postLabels.add_new_item.slice( 1 ).toLowerCase();
+		}
 
 		return (
 			<SectionHeader label={ postLabels.name }>
@@ -314,5 +319,6 @@ export default connect( ( state, ownProps ) => {
 		lastPageToRequest,
 		editorUrl: getEditorUrl( state, siteId, null, ownProps.query.type ),
 		postLabels: get( getPostType( state, siteId, ownProps.query.type ), 'labels' ),
+		localeSlug: getLocaleSlug( state ),
 	};
 } )( localize( PostTypeList ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use JS to change "Add new post" label from Title Case to Sentence case to match changes made throughout Calypso in #40120 and #39692 

**Before**

<img width="1089" alt="Screen Shot 2020-03-18 at 2 36 05 PM" src="https://user-images.githubusercontent.com/2124984/76995306-0f06d080-6926-11ea-9e47-a37fde25e2e0.png">

**After**

<img width="1067" alt="Screen Shot 2020-03-18 at 2 35 43 PM" src="https://user-images.githubusercontent.com/2124984/76995316-129a5780-6926-11ea-8d1d-a71fb0b2099c.png">

#### Testing instructions

* Switch to this PR
* Navigate to /posts
* Note the "Add new post" button text.

Fixes #40027
