### PR TITLE
Support: prefer plain action over thunk and decorate free video support article open

### DIFF
--- a/client/my-sites/customer-home/free-photo-library-card/index.jsx
+++ b/client/my-sites/customer-home/free-photo-library-card/index.jsx
@@ -11,9 +11,9 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import CardHeading from 'components/card-heading';
-import { recordTracksEvent } from 'state/analytics/actions';
 import { openSupportArticleDialog } from 'state/inline-support-article/actions';
 import { localizeUrl } from 'lib/i18n-utils';
+import { withAnalytics, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -27,7 +27,7 @@ import freePhotoLibraryVideoPrompt from 'assets/images/customer-home/free-photo-
 
 const FreePhotoLibraryCard = ( {
 	recordTracksEvent: tracks,
-	openSupportArticleDialog: supportArticleDialog,
+	openSupportArticleDialogAndTrack,
 } ) => {
 	const [ showDialog, setShowDialog ] = useState( false );
 	const translate = useTranslate();
@@ -75,22 +75,23 @@ const FreePhotoLibraryCard = ( {
 							'create stunning designs.'
 					) }
 				</p>
-				<Button
-					onClick={ () => {
-						tracks( 'calypso_customer_home_free_photo_library_video_support_page_view' );
-						supportArticleDialog( {
-							postId: 145498,
-							postUrl: localizeUrl( 'https://support.wordpress.com/free-photo-library/' ),
-						} );
-					} }
-				>
-					{ translate( 'Learn more' ) }
-				</Button>
+				<Button onClick={ openSupportArticleDialogAndTrack }>{ translate( 'Learn more' ) }</Button>
 			</Card>
 		</Fragment>
 	);
 };
 
-export default connect( null, { openSupportArticleDialog, recordTracksEvent } )(
+const openSupportArticleDialogAndTrack = () =>
+	withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_customer_home_free_photo_library_video_support_page_view' )
+		),
+		openSupportArticleDialog( {
+			postId: 145498,
+			postUrl: localizeUrl( 'https://support.wordpress.com/free-photo-library/' ),
+		} )
+	);
+
+export default connect( null, { openSupportArticleDialogAndTrack, recordTracksEvent } )(
 	FreePhotoLibraryCard
 );

--- a/client/state/inline-support-article/actions.js
+++ b/client/state/inline-support-article/actions.js
@@ -6,26 +6,25 @@ import { SUPPORT_ARTICLE_DIALOG_OPEN, SUPPORT_ARTICLE_DIALOG_CLOSE } from 'state
 /**
  * Shows the given support article (by postId) in a dialog.
  *
- * @param  {number} postId 	The id of the support article
- * @param  {string} postUrl	The URL of the support article
+ * @param {object} options - action options
+ * 	{number} postId 	The id of the support article
+ *  {string} postUrl	The URL of the support article
  *
- * @returns {Function}		Action thunk
+ * @returns {object}		Action
  */
 export function openSupportArticleDialog( { postId, postUrl = null } ) {
-	return dispatch => {
-		dispatch( {
-			type: SUPPORT_ARTICLE_DIALOG_OPEN,
-			postId,
-			postUrl,
-		} );
+	return {
+		type: SUPPORT_ARTICLE_DIALOG_OPEN,
+		postId,
+		postUrl,
 	};
 }
 
 /**
  * Closes/hides the support article dialog
  *
- * @returns {Function}		Action thunk
+ * @returns {object}		Action
  */
 export function closeSupportArticleDialog() {
-	return dispatch => dispatch( { type: SUPPORT_ARTICLE_DIALOG_CLOSE } );
+	return { type: SUPPORT_ARTICLE_DIALOG_CLOSE };
 }


### PR DESCRIPTION
Janitorial follow up to @Aurorum's https://github.com/Automattic/wp-calypso/pull/40157

This updates the open support dialog dispatch to a single redux action, instead of two calls for open/tracking metrics. Changes here also remove the unnecessary `SUPPORT_ARTICLE_DIALOG_OPEN` action thunk (function) in favor of returning a plain action.

<img width="1270" alt="Screen Shot 2020-03-18 at 11 43 17 AM" src="https://user-images.githubusercontent.com/1270189/76996998-c2b09600-690f-11ea-9623-df18e2370164.png">

<img width="1174" alt="Screen Shot 2020-03-18 at 11 53 19 AM" src="https://user-images.githubusercontent.com/1270189/76997154-0b684f00-6910-11ea-8145-7f121711a9e9.png">

<img width="1182" alt="Screen Shot 2020-03-18 at 11 53 04 AM" src="https://user-images.githubusercontent.com/1270189/76997170-128f5d00-6910-11ea-8f73-f920c078585a.png">

### Testing Instructions
- In console `localStorage.debug='calypso:analytics*'` to enable analytics logging
- Refresh calypso.localhost:3000 to have settings take effect
- Navigate to My Home
- Click on "Learn More"
- Verify that `calypso_customer_home_free_photo_library_video_support_page_view` is fired
- No regressions in dialog behavior
- Verify that other support page opens work as expected.