### PR TITLE
Sidebar: Add Notification Dot 

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -20,7 +20,7 @@ export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
 	const showAsExternal = isExternalLink && ! props.forceInternalLink;
 	const classes = classnames( props.className, { selected: props.selected } );
-	const { materialIcon, materialIconStyle, icon, customIcon } = props;
+	const { materialIcon, materialIconStyle, icon, customIcon, showNotificationDot } = props;
 
 	let _preloaded = false;
 
@@ -69,6 +69,7 @@ export default function SidebarItem( props ) {
 				</span>
 				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
 				{ props.children }
+				{ showNotificationDot && <div className="sidebar__menu-notification-dot"></div> }
 			</a>
 		</li>
 	);
@@ -86,6 +87,7 @@ SidebarItem.propTypes = {
 	selected: PropTypes.bool,
 	expandSection: PropTypes.func,
 	preloadSectionName: PropTypes.string,
+	showNotificationDot: PropTypes.bool,
 	forceInternalLink: PropTypes.bool,
 	testTarget: PropTypes.string,
 	tipTarget: PropTypes.string,

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -146,6 +146,14 @@
 	}
 }
 
+.sidebar__menu-notification-dot {
+	background-color: var( --color-accent );
+	border: 1px solid var( --color-surface );
+	border-radius: 50px;
+	margin-left: 8px;
+	padding: 4px;
+}
+
 // Expandables: Some sidebar menus act like accordions where
 // you can hide and show the contained list.
 .sidebar__menu.is-togglable {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the notification dot to the Sidebar. It doesn't display yet (see #40233), but this is how it would look if it did for the Customer Home. 

<img width="1520" alt="Screenshot_2020-03-18_at_19 03 12" src="https://user-images.githubusercontent.com/43215253/76998201-95360d80-694c-11ea-8213-07903990391f.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Add `showNotificationDot` here: https://github.com/Automattic/wp-calypso/blob/f6785e9c596cd77bcf161b2f4ef170ecdf0568ed/client/my-sites/sidebar/index.jsx#L171-L180

Then verify that the dot appears in the Sidebar! 

Part of #40233
