### PR TITLE
CartSynchronizer: Do not emit changes until remote request is complete

### DIFF
--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -105,7 +105,6 @@ CartSynchronizer.prototype.update = function( changeFunction ) {
 
 	this._latestValue = changeFunction( this._latestValue );
 	this._performRequest( 'update', this._postToServer.bind( this ) );
-	this.emit( 'change' );
 };
 
 CartSynchronizer.prototype.pause = function() {

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -223,17 +223,19 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 	async removeCoupon() {
 		// Desktop
 		if ( currentScreenSize() !== 'mobile' ) {
-			return await driverHelper.clickWhenClickable(
+			await driverHelper.clickWhenClickable(
 				this.driver,
 				By.css( '.cart-body .cart__remove-link' )
 			);
+			return await driverHelper.waitTillNotPresent( this.driver, By.css( '.cart__remove-link' ) );
 		}
 
 		// Mobile
-		return await driverHelper.clickWhenClickable(
+		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( '.payment-box__content .cart__remove-link' )
 		);
+		return await driverHelper.waitTillNotPresent( this.driver, By.css( '.cart__remove-link' ) );
 	}
 	async removeFromCart() {
 		return await driverHelper.clickWhenClickable(

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -199,7 +199,11 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 			By.css( 'button[data-e2e-type="apply-coupon"]' )
 		);
 		const noticesComponent = await NoticesComponent.Expect( this.driver );
-		return await noticesComponent.dismissNotice();
+		await noticesComponent.dismissNotice();
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.cart__remove-link' )
+		);
 	}
 
 	async enterCouponCode( couponCode ) {

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -27,6 +27,13 @@ export default class PlansPage extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 
+	async openAdvancedPlansSegment() {
+		const selector = by.css(
+			'.plans-features-main ul.segmented-control.is-primary.plan-features__interval-type.is-customer-type-toggle li:nth-child(2)'
+		);
+		return await driverHelper.clickWhenClickable( this.driver, selector );
+	}
+
 	async waitForComparison() {
 		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -96,6 +96,7 @@ describe( `[${ host }] Plans: (${ screenSize })`, function() {
 		step( 'Can Select Plans tab', async function() {
 			const plansPage = await PlansPage.Expect( driver );
 			await plansPage.openPlansTab();
+			await plansPage.openAdvancedPlansSegment();
 			return await plansPage.waitForComparison();
 		} );
 


### PR DESCRIPTION
When something in the UI causes a modification to the cart, the
`CartStore` creates a state transition function to update its state. It
then passes that transition function to the `CartSynchronizer` via its
`update()` method so that the state modification can be persisted to the
`shopping-cart` endpoint. Often the result of that request is not the
same as the modified local cart anyway, so this request is more than
just persistence. The `CartStore` submits this request, and then waits
for the `CartSynchronizer` to emit a change event before emitting its
own change event to its listeners. Typically these listeners are React
components that want to update their state to match the modified cart.

The `CartSynchronizer`'s `update()` method generates the updated local
state based on the transition function and then sends that updated state
as a request to the `shopping-cart` endpoint. When the request comes
back, the `CartSynchronizer` emits a change event.

However, the `CartSynchronizer` also emits a change event just after
it's submitted the endpoint request. This means that listener React
components will update their state based on possibly incorrect data that
will change when the endpoint request finishes. This optimistic update
can cause race conditions if the result of the update causes side
effects like other `shopping-cart` requests or UI actions that cannot
easily be undone when the new cart instance appears.

This change removes that second change event so that the
`CartSynchronizer`, and thus the `CartStore`, only emit a change when
the server has validated the data.

Fixes #40261 

#### Testing instructions

This is a tricky thing to test. Primarily, we just need to verify that shopping cart operations work as expected (adding and removing items from the cart) in the old checkout and other places in calypso (the new checkout uses a different mechanism), and hope that nothing is relying on this optimistic data.