### PR TITLE
Media Library: show 200 GB storage limit for Business and eCommerce sites

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -14,7 +14,7 @@ import { getMediaStorage } from 'state/sites/media-storage/selectors';
 import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import canCurrentUser from 'state/selectors/can-current-user';
-import { planHasFeature } from 'lib/plans';
+import { planHasFeature, isBusinessPlan, isEcommercePlan } from 'lib/plans';
 import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
 import PlanStorageBar from './bar';
 
@@ -52,6 +52,9 @@ export class PlanStorage extends Component {
 			return null;
 		}
 
+		const planHasTopStorageSpace =
+			isBusinessPlan( sitePlanSlug ) || isEcommercePlan( sitePlanSlug );
+
 		return (
 			<div className={ classNames( className, 'plan-storage' ) }>
 				<QueryMediaStorage siteId={ siteId } />
@@ -59,7 +62,7 @@ export class PlanStorage extends Component {
 					siteSlug={ siteSlug }
 					sitePlanSlug={ sitePlanSlug }
 					mediaStorage={ this.props.mediaStorage }
-					displayUpgradeLink={ canUserUpgrade }
+					displayUpgradeLink={ canUserUpgrade && ! planHasTopStorageSpace }
 				>
 					{ this.props.children }
 				</PlanStorageBar>

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import { getMediaStorage } from 'state/sites/media-storage/selectors';
 import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { planHasFeature } from 'lib/plans';
 import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
@@ -37,12 +38,13 @@ export class PlanStorage extends Component {
 			canViewBar,
 			className,
 			jetpackSite,
+			atomicSite,
 			siteId,
 			sitePlanSlug,
 			siteSlug,
 		} = this.props;
 
-		if ( jetpackSite || ! canViewBar || ! sitePlanSlug ) {
+		if ( ( jetpackSite && ! atomicSite ) || ! canViewBar || ! sitePlanSlug ) {
 			return null;
 		}
 
@@ -71,6 +73,7 @@ export default connect( ( state, ownProps ) => {
 	return {
 		mediaStorage: getMediaStorage( state, siteId ),
 		jetpackSite: isJetpackSite( state, siteId ),
+		atomicSite: isAtomicSite( state, siteId ),
 		sitePlanSlug: getSitePlanSlug( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 		canUserUpgrade: canCurrentUser( state, siteId, 'manage_options' ),

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -79,22 +79,18 @@ describe( 'PlanStorageBar basic tests', () => {
 
 		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_FREE } /> );
 		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
-	} );
-
-	test( 'should not render when storage is unlimited', () => {
-		let bar;
 
 		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
 
 		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_BUSINESS_2_YEARS } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
 
 		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_ECOMMERCE } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
 
 		bar = shallow( <PlanStorageBar { ...props } sitePlanSlug={ PLAN_ECOMMERCE_2_YEARS } /> );
-		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
+		assert.lengthOf( bar.find( '.plan-storage__bar' ), 1 );
 	} );
 
 	test( 'should not render when storage has valid max_storage_bytes', () => {

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -121,4 +121,14 @@ describe( 'PlanStorageBar basic tests', () => {
 		bar = shallow( <PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: -1 } } /> );
 		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
 	} );
+
+	test( 'should include upgrade links when displayUpgradeLink is true', () => {
+		const bar = shallow( <PlanStorageBar { ...props } displayUpgradeLink={ true } /> );
+		assert.lengthOf( bar.find( '.plan-storage__storage-link' ), 1 );
+	} );
+
+	test( 'should not include upgrade links when displayUpgradeLink is false', () => {
+		const bar = shallow( <PlanStorageBar { ...props } displayUpgradeLink={ false } /> );
+		assert.lengthOf( bar.find( '.plan-storage__storage-link' ), 0 );
+	} );
 } );

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -122,12 +122,12 @@ describe( 'PlanStorageBar basic tests', () => {
 		assert.lengthOf( bar.find( '.plan-storage__bar' ), 0 );
 	} );
 
-	test( 'should include upgrade links when displayUpgradeLink is true', () => {
+	test( 'should include upgrade link when displayUpgradeLink is true', () => {
 		const bar = shallow( <PlanStorageBar { ...props } displayUpgradeLink={ true } /> );
 		assert.lengthOf( bar.find( '.plan-storage__storage-link' ), 1 );
 	} );
 
-	test( 'should not include upgrade links when displayUpgradeLink is false', () => {
+	test( 'should not include upgrade link when displayUpgradeLink is false', () => {
 		const bar = shallow( <PlanStorageBar { ...props } displayUpgradeLink={ false } /> );
 		assert.lengthOf( bar.find( '.plan-storage__storage-link' ), 0 );
 	} );

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -67,26 +67,36 @@ describe( 'PlanStorage basic tests', () => {
 
 		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_FREE } /> );
 		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
-	} );
-
-	test( 'should not render when storage is unlimited', () => {
-		let storage;
 
 		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_BUSINESS } /> );
-		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
 
 		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_BUSINESS_2_YEARS } /> );
-		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
 
 		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_ECOMMERCE } /> );
-		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
 
 		storage = shallow( <PlanStorage { ...props } sitePlanSlug={ PLAN_ECOMMERCE_2_YEARS } /> );
-		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
+	} );
+
+	test( 'should render for atomic sites', () => {
+		const storage = shallow(
+			<PlanStorage
+				{ ...props }
+				sitePlanSlug={ PLAN_BUSINESS }
+				jetpackSite={ true }
+				atomicSite={ true }
+			/>
+		);
+		assert.lengthOf( storage.find( '.plan-storage' ), 1 );
 	} );
 
 	test( 'should not render for jetpack sites', () => {
-		const storage = shallow( <PlanStorage { ...props } jetpackSite={ true } /> );
+		const storage = shallow(
+			<PlanStorage { ...props } jetpackSite={ true } atomicSite={ false } />
+		);
 		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
 	} );
 

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -64,6 +64,7 @@ export const FEATURE_UNLIMITED_PREMIUM_THEMES = 'premium-themes';
 export const FEATURE_3GB_STORAGE = '3gb-storage';
 export const FEATURE_6GB_STORAGE = '6gb-storage';
 export const FEATURE_13GB_STORAGE = '13gb-storage';
+export const FEATURE_200GB_STORAGE = '200gb-storage';
 export const FEATURE_UNLIMITED_STORAGE = 'unlimited-storage';
 export const FEATURE_COMMUNITY_SUPPORT = 'community-support';
 export const FEATURE_EMAIL_SUPPORT = 'email-support';

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -587,6 +587,18 @@ export const FEATURES_LIST = {
 			i18n.translate( 'Upload more images, videos, audio, and documents to your website.' ),
 	},
 
+	[ constants.FEATURE_200GB_STORAGE ]: {
+		getSlug: () => constants.FEATURE_200GB_STORAGE,
+		getTitle: () =>
+			i18n.translate( '{{strong}}200 GB{{/strong}} Storage Space', {
+				components: {
+					strong: <strong />,
+				},
+			} ),
+		getDescription: () =>
+			i18n.translate( 'Upload more images, videos, audio, and documents to your website.' ),
+	},
+
 	[ constants.FEATURE_COMMUNITY_SUPPORT ]: {
 		getSlug: () => constants.FEATURE_COMMUNITY_SUPPORT,
 		getTitle: () => i18n.translate( 'Community support' ),

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -180,7 +180,7 @@ const getPlanEcommerceDetails = () => ( {
 			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,
-			constants.FEATURE_UNLIMITED_STORAGE,
+			constants.FEATURE_200GB_STORAGE,
 			constants.FEATURE_NO_ADS,
 			constants.FEATURE_GOOGLE_ANALYTICS,
 			isEnabled( 'republicize' ) && constants.FEATURE_REPUBLICIZE,
@@ -199,7 +199,7 @@ const getPlanEcommerceDetails = () => ( {
 			constants.FEATURE_PREMIUM_CUSTOMIZABE_THEMES,
 		] ),
 	getPromotedFeatures: () => [
-		constants.FEATURE_UNLIMITED_STORAGE,
+		constants.FEATURE_200GB_STORAGE,
 		constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		constants.FEATURE_CUSTOM_DOMAIN,
 		constants.FEATURE_NO_ADS,
@@ -352,7 +352,7 @@ const getPlanBusinessDetails = () => ( {
 			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_ALL_DAYS,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,
-			constants.FEATURE_UNLIMITED_STORAGE,
+			constants.FEATURE_200GB_STORAGE,
 			constants.FEATURE_NO_ADS,
 			constants.FEATURE_GOOGLE_ANALYTICS,
 			isEnabled( 'republicize' ) && constants.FEATURE_REPUBLICIZE,
@@ -366,7 +366,7 @@ const getPlanBusinessDetails = () => ( {
 			constants.FEATURE_NO_BRANDING,
 		] ),
 	getPromotedFeatures: () => [
-		constants.FEATURE_UNLIMITED_STORAGE,
+		constants.FEATURE_200GB_STORAGE,
 		constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		constants.FEATURE_CUSTOM_DOMAIN,
 		constants.FEATURE_NO_ADS,
@@ -386,7 +386,7 @@ const getPlanBusinessDetails = () => ( {
 	],
 	getPortfolioSignupFeatures: () => [
 		constants.FEATURE_UPLOAD_THEMES_PLUGINS,
-		constants.FEATURE_UNLIMITED_STORAGE_SIGNUP,
+		constants.FEATURE_200GB_STORAGE,
 		constants.FEATURE_ALL_PREMIUM_FEATURES,
 	],
 	// Features not displayed but used for checking plan abilities


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, Business and eCommerce plans do not show users how much of their allotted quota they have used in the media library.

This change will now show that info by updating the features in those plans to use a new `FEATURE_200GB_STORAGE` constant, instead of `FEATURE_UNLIMITED_STORAGE`, which no longer makes sense since they don't have unlimited storage.

This should work for both Simple and Atomic sites.

[Previously we had just updated the copy](https://github.com/Automattic/wp-calypso/commit/9083014a8c07b16449f1b961d28c25b2f74ae020) that's displayed for the unlimited space feature to show 200GB. This change makes the storage space feature for Business and eCommerce more inline with the other plans.

Relies on API endpoint update here: D40523-code

More info: pau2Xa-Xd-p2

Fixes #35965

**TODO:**
* ~~Fix tests.~~
* ~~Make sure the "upgrade" link still shows only when intended.~~

-------------

#### Testing instructions

Apply this wpcom patch on the back end: D40523-code

Boot up this branch locally.

Sandbox `public-api.wordpress.com`.

You'll need a few test sites.

* Business (Simple site).
* eCommerce (Simple site).
* Business or eCommerce (Atomic site).
* Non-Business-or-eCommerce (Premium, Personal, or Free).
* Jetpack site.

Business (Simple site)
* Visit the media library (http://calypso.localhost:3000/media/YOUR_DOMAIN).
* You should see "X% of 200 GB used", **without** an "Upgrade" link.
<img width="1067" alt="Screen Shot 2020-03-19 at 1 27 42 PM" src="https://user-images.githubusercontent.com/690843/77112068-96ffdf80-69e5-11ea-91a2-bf314a0926b3.png">

eCommerce (Simple site)
* Visit the media library (http://calypso.localhost:3000/media/YOUR_DOMAIN).
* You should see "X% of 200 GB used", **without** an "Upgrade" link.
<img width="1067" alt="Screen Shot 2020-03-19 at 1 27 42 PM" src="https://user-images.githubusercontent.com/690843/77112068-96ffdf80-69e5-11ea-91a2-bf314a0926b3.png">

Business or eCommerce (Atomic site)
* Visit the media library (http://calypso.localhost:3000/media/YOUR_DOMAIN).
* You should see "X% of 200 GB used", **without** an "Upgrade" link.
<img width="1067" alt="Screen Shot 2020-03-19 at 1 27 42 PM" src="https://user-images.githubusercontent.com/690843/77112068-96ffdf80-69e5-11ea-91a2-bf314a0926b3.png">

Non-Business-or-eCommerce (Premium, Personal, or Free)
* Visit the media library (http://calypso.localhost:3000/media/YOUR_DOMAIN).
* You should see "X% of 6 GB used" **with** an "Upgrade" link (6 GB for Personal, or the [correct storage space limit](https://wordpress.com/pricing/) for the plan you're testing).
<img width="1149" alt="Screen Shot 2020-03-18 at 4 02 04 PM" src="https://user-images.githubusercontent.com/690843/77015796-226c6880-6933-11ea-8f1c-1ca730c67e5b.png">

Jetpack site
* Visit the media library (http://calypso.localhost:3000/media/YOUR_DOMAIN).
* You **should not** see the storage space messaging.
<img width="1379" alt="Screen Shot 2020-03-18 at 4 06 16 PM" src="https://user-images.githubusercontent.com/690843/77015818-31ebb180-6933-11ea-8d75-26f872cc014c.png">