### PR TITLE
Purchases: Make renew buttons use checkout URL rather than addItems

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -21,7 +21,6 @@ import {
 	isTheme,
 	isConciergeSession,
 } from 'lib/products-values';
-import { addItems } from 'lib/cart/actions';
 import { getJetpackProductsDisplayNames } from 'lib/products-values/constants';
 
 function getIncludedDomain( purchase ) {
@@ -105,7 +104,6 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 	const renewItem = getRenewalItemFromProduct( purchase, {
 		domain: purchase.meta,
 	} );
-	const renewItems = [ renewItem ];
 
 	// Track the renew now submit.
 	analytics.tracks.recordEvent( 'calypso_purchases_renew_now_click', {
@@ -113,9 +111,10 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 		...tracksProps,
 	} );
 
-	addItems( renewItems );
-
-	page( '/checkout/' + siteSlug );
+	const { product_slug, extra, meta } = renewItem;
+	const { purchaseId, purchaseDomain } = extra;
+	const productList = meta ? `${ product_slug }:${ meta }` : product_slug;
+	page( `/checkout/${ productList }/renew/${ purchaseId }/${ purchaseDomain }` );
 }
 
 function hasIncludedDomain( purchase ) {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -113,8 +113,14 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 
 	const { product_slug, extra, meta } = renewItem;
 	const { purchaseId, purchaseDomain } = extra;
+	if ( ! purchaseId ) {
+		throw new Error( 'Could not find purchase id for renewal.' );
+	}
+	if ( ! product_slug ) {
+		throw new Error( 'Could not find product slug for renewal.' );
+	}
 	const productList = meta ? `${ product_slug }:${ meta }` : product_slug;
-	page( `/checkout/${ productList }/renew/${ purchaseId }/${ purchaseDomain }` );
+	page( `/checkout/${ productList }/renew/${ purchaseId }/${ purchaseDomain || siteSlug || '' }` );
 }
 
 function hasIncludedDomain( purchase ) {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -6,6 +6,7 @@ import { find, includes } from 'lodash';
 import moment from 'moment';
 import page from 'page';
 import i18n from 'i18n-calypso';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -23,6 +24,8 @@ import {
 	isConciergeSession,
 } from 'lib/products-values';
 import { getJetpackProductsDisplayNames } from 'lib/products-values/constants';
+
+const debug = debugFactory( 'calypso:purchases' );
 
 function getIncludedDomain( purchase ) {
 	return purchase.includedDomain;
@@ -123,7 +126,12 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 		throw new Error( 'Could not find product slug for renewal.' );
 	}
 	const productList = meta ? `${ product_slug }:${ meta }` : product_slug;
-	page( `/checkout/${ productList }/renew/${ purchaseId }/${ purchaseDomain || siteSlug || '' }` );
+	const renewalUrl = `/checkout/${ productList }/renew/${ purchaseId }/${ purchaseDomain ||
+		siteSlug ||
+		'' }`;
+	debug( 'handling renewal click', purchase, siteSlug, renewItem, renewalUrl );
+
+	page( renewalUrl );
 }
 
 function hasIncludedDomain( purchase ) {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -10,6 +10,7 @@ import i18n from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import notices from 'notices';
 import analytics from 'lib/analytics';
 import { getRenewalItemFromProduct } from 'lib/cart-values/cart-items';
 import {
@@ -114,9 +115,11 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 	const { product_slug, extra, meta } = renewItem;
 	const { purchaseId, purchaseDomain } = extra;
 	if ( ! purchaseId ) {
+		notices.error( 'Could not find purchase id for renewal.' );
 		throw new Error( 'Could not find purchase id for renewal.' );
 	}
 	if ( ! product_slug ) {
+		notices.error( 'Could not find product slug for renewal.' );
 		throw new Error( 'Could not find product slug for renewal.' );
 	}
 	const productList = meta ? `${ product_slug }:${ meta }` : product_slug;

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -126,8 +126,8 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 		throw new Error( 'Could not find product slug for renewal.' );
 	}
 	const productList = meta ? `${ product_slug }:${ meta }` : product_slug;
-	const renewalUrl = `/checkout/${ productList }/renew/${ purchaseId }/${ purchaseDomain ||
-		siteSlug ||
+	const renewalUrl = `/checkout/${ productList }/renew/${ purchaseId }/${ siteSlug ||
+		purchaseDomain ||
 		'' }`;
 	debug( 'handling renewal click', purchase, siteSlug, renewItem, renewalUrl );
 


### PR DESCRIPTION
When pressing the "renew" buttons on products in the purchases section
of Calypso, the intended action is to add the renewal product to the
cart, and then redirect to the checkout pages.

However, these two actions can cause race conditions since the redirect
does not wait for the cart modification to be complete. (Nor can it, in
any easy way, since modifying the cart is an async dispatched action
with no response.)

This commit removes the code that adds the product to the cart and
instead modifies the redirect URL so that it includes the product to be
renewed, thus allowing checkout itself to add the product to the cart
while it loads.

Fixes #40260 

#### Testing instructions

We'll need to test every type of product that can be renewed (at least, those that renew via the `handleRenewNowClick` function) and make sure that after clicking the renew button, the product ends up in the cart correctly.

![Screen Shot 2020-03-18 at 7 16 51 PM](https://user-images.githubusercontent.com/2036909/77016084-0f669200-694d-11ea-9076-a978cebbe4d9.png)


Here's the ones I could find:

- Plan
- Domain registration
- Domain mapping
- Google Apps
- Site Redirect
- No Ads
- Custom Design
- Video Press
- Unlimited Space
- Unlimited Themes
- Space Upgrade
