### PR TITLE
Media: Dispatch deletion and selected items update actions from flux actions

### DIFF
--- a/client/lib/media/actions.js
+++ b/client/lib/media/actions.js
@@ -21,9 +21,11 @@ import {
 	clearMediaErrors,
 	clearMediaItemErrors,
 	createMediaItem,
+	deleteMedia,
 	failMediaItemRequest,
 	failMediaRequest,
 	receiveMedia,
+	setMediaLibrarySelectedItems,
 	successMediaItemRequest,
 	successMediaRequest,
 } from 'state/media/actions';
@@ -319,6 +321,8 @@ MediaActions.delete = function ( siteId, item ) {
 		data: item,
 	} );
 
+	reduxDispatch( deleteMedia( siteId, item.ID ) );
+
 	debug( 'Deleting media from %d by ID %d', siteId, item.ID );
 	wpcom
 		.site( siteId )
@@ -345,6 +349,7 @@ MediaActions.setLibrarySelectedItems = function ( siteId, items ) {
 		siteId: siteId,
 		data: items,
 	} );
+	reduxDispatch( setMediaLibrarySelectedItems( siteId, items ) );
 };
 
 MediaActions.clearValidationErrors = function ( siteId, itemId ) {

--- a/client/lib/media/test/actions.js
+++ b/client/lib/media/test/actions.js
@@ -24,9 +24,6 @@ import {
 import { stubs } from './mocks/lib/wp';
 import { site } from './fixtures/site';
 
-jest.mock( 'lib/media/library-selected-store', () => ( {
-	getAll: () => [ require( './fixtures' ).DUMMY_ITEM ],
-} ) );
 jest.mock( 'lib/media/store', () => ( {
 	dispatchToken: require( 'dispatcher' ).register( () => {} ),
 	get: () => require( './fixtures' ).DUMMY_ITEM,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Media: Dispatch deletion and selected items update actions from flux actions

#### Testing instructions

* Checkout this branch.
* Smoke test media library, especially (de)selecting items in the media library, performing actions with selected items, as well as media item deletion.
* Verify there are no regressions.

Note: #40271 precedes this PR and should be merged first. Feel free to review this one separately, though.

Note: This PR is part of an iteration to remove the media library selected items store, see #40269 for the full effort that removes it completely. Also, see #39379 for the complete media reduxification effort.
