### PR TITLE
Home: Move Quick Links into its own component

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import page from 'page';
 import { flowRight } from 'lodash';
 import moment from 'moment';
 
@@ -17,8 +16,6 @@ import Banner from 'components/banner';
 import { Button, Card } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import EmptyContent from 'components/empty-content';
-import FoldableCard from 'components/foldable-card';
-import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
@@ -27,14 +24,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import FormattedHeader from 'components/formatted-header';
 import { SIDEBAR_SECTION_TOOLS } from 'my-sites/sidebar/constants';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import {
-	canCurrentUserUseCustomerHome,
-	getSiteFrontPage,
-	getCustomizerUrl,
-	getSiteOption,
-	isNewSite,
-} from 'state/sites/selectors';
-import { getDomainsBySiteId } from 'state/sites/domains/selectors';
+import { canCurrentUserUseCustomerHome, getSiteOption, isNewSite } from 'state/sites/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
@@ -42,14 +32,12 @@ import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete'
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
-import { getGSuiteSupportedDomains } from 'lib/gsuite';
 import { localizeUrl } from 'lib/i18n-utils';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import isSiteRecentlyMigrated from 'state/selectors/is-site-recently-migrated';
-import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import StatsBanners from 'my-sites/stats/stats-banners';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getActiveTheme, getCanonicalTheme } from 'state/themes/selectors';
@@ -63,6 +51,7 @@ import StatsCard from './stats-card';
 import FreePhotoLibraryCard from './free-photo-library-card';
 import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import QuickLinks from 'my-sites/customer-home/quick-links';
 
 /**
  * Style dependencies
@@ -72,32 +61,8 @@ import './style.scss';
 /**
  * Image dependencies
  */
-import commentIcon from 'assets/images/customer-home/comment.svg';
-import customDomainIcon from 'assets/images/customer-home/custom-domain.svg';
-import customizeIcon from 'assets/images/customer-home/customize.svg';
 import fireworksIllustration from 'assets/images/illustrations/fireworks.svg';
-import gSuiteIcon from 'assets/images/customer-home/gsuite.svg';
 import happinessIllustration from 'assets/images/customer-home/happiness.png';
-import imagesIcon from 'assets/images/customer-home/images.svg';
-import logoIcon from 'assets/images/customer-home/looka-logo.svg';
-import menuIcon from 'assets/images/customer-home/menus.svg';
-import pageIcon from 'assets/images/customer-home/page.svg';
-import postIcon from 'assets/images/customer-home/post.svg';
-import themeIcon from 'assets/images/customer-home/theme.svg';
-
-const ActionBox = ( { external, href, onClick, target, iconSrc, label } ) => {
-	const buttonAction = { href, onClick, target };
-	return (
-		<div className="customer-home__box-action">
-			<Button { ...buttonAction }>
-				<img src={ iconSrc } alt="" />
-				<span>
-					{ label } { external && <Gridicon icon="external" /> }
-				</span>
-			</Button>
-		</div>
-	);
-};
 
 class Home extends Component {
 	static propTypes = {
@@ -106,8 +71,6 @@ class Home extends Component {
 		site: PropTypes.object.isRequired,
 		siteId: PropTypes.number.isRequired,
 		siteSlug: PropTypes.string.isRequired,
-		customizeUrl: PropTypes.string.isRequired,
-		menusUrl: PropTypes.string.isRequired,
 		canUserUseCustomerHome: PropTypes.bool.isRequired,
 		hasChecklistData: PropTypes.bool.isRequired,
 		isChecklistComplete: function( props, propName, componentName ) {
@@ -121,7 +84,6 @@ class Home extends Component {
 		expandToolsAndTrack: PropTypes.func.isRequired,
 		trackAction: PropTypes.func.isRequired,
 		isStaticHomePage: PropTypes.bool.isRequired,
-		staticHomePageId: PropTypes.number, // this is unused if isStaticHomePage is false. In such case, it's null.
 	};
 
 	state = {
@@ -366,158 +328,6 @@ class Home extends Component {
 		);
 	}
 
-	renderQuickLinks() {
-		const {
-			displayChecklist,
-			translate,
-			customizeUrl,
-			menusUrl,
-			siteSlug,
-			trackAction,
-			isStaticHomePage,
-			staticHomePageId,
-			showCustomizer,
-			hasCustomDomain,
-		} = this.props;
-
-		const editHomePageUrl =
-			isStaticHomePage && `/block-editor/page/${ siteSlug }/${ staticHomePageId }`;
-
-		const quickLinks = (
-			<div className="customer-home__boxes">
-				{ isStaticHomePage ? (
-					<ActionBox
-						onClick={ () => {
-							trackAction( 'my_site', 'edit_homepage' );
-							page( editHomePageUrl );
-						} }
-						label={ translate( 'Edit homepage' ) }
-						iconSrc={ imagesIcon }
-					/>
-				) : (
-					<ActionBox
-						onClick={ () => {
-							trackAction( 'my_site', 'write_post' );
-							page( `/post/${ siteSlug }` );
-						} }
-						label={ translate( 'Write blog post' ) }
-						iconSrc={ postIcon }
-					/>
-				) }
-				{ isStaticHomePage ? (
-					<ActionBox
-						onClick={ () => {
-							trackAction( 'my_site', 'add_page' );
-							page( `/page/${ siteSlug }` );
-						} }
-						label={ translate( 'Add a page' ) }
-						iconSrc={ pageIcon }
-					/>
-				) : (
-					<ActionBox
-						onClick={ () => {
-							trackAction( 'my_site', 'manage_comments' );
-							page( `/comments/${ siteSlug }` );
-						} }
-						label={ translate( 'Manage comments' ) }
-						iconSrc={ commentIcon }
-					/>
-				) }
-				{ isStaticHomePage ? (
-					<ActionBox
-						onClick={ () => {
-							trackAction( 'my_site', 'write_post' );
-							page( `/post/${ siteSlug }` );
-						} }
-						label={ translate( 'Write blog post' ) }
-						iconSrc={ postIcon }
-					/>
-				) : (
-					<ActionBox
-						onClick={ () => {
-							trackAction( 'my_site', 'add_page' );
-							page( `/page/${ siteSlug }` );
-						} }
-						label={ translate( 'Add a page' ) }
-						iconSrc={ pageIcon }
-					/>
-				) }
-				{ showCustomizer && (
-					<ActionBox
-						href={ menusUrl }
-						onClick={ () => trackAction( 'my_site', 'edit_menus' ) }
-						label={ translate( 'Edit menus' ) }
-						iconSrc={ menuIcon }
-					/>
-				) }
-				{ showCustomizer && (
-					<ActionBox
-						href={ customizeUrl }
-						onClick={ () => trackAction( 'my_site', 'customize_theme' ) }
-						label={ translate( 'Customize theme' ) }
-						iconSrc={ customizeIcon }
-					/>
-				) }
-				<ActionBox
-					onClick={ () => {
-						trackAction( 'my_site', 'change_theme' );
-						page( `/themes/${ siteSlug }` );
-					} }
-					label={ translate( 'Change theme' ) }
-					iconSrc={ themeIcon }
-				/>
-				<ActionBox
-					href="https://wp.me/logo-maker"
-					onClick={ () => trackAction( 'my_site', 'design_logo' ) }
-					target="_blank"
-					label={ translate( 'Create a logo with Looka' ) }
-					external
-					iconSrc={ logoIcon }
-				/>
-				{ hasCustomDomain ? (
-					<ActionBox
-						onClick={ () => {
-							trackAction( 'my_site', 'add_email' );
-							page( `/email/${ siteSlug }` );
-						} }
-						label={ translate( 'Add email' ) }
-						iconSrc={ gSuiteIcon }
-					/>
-				) : (
-					<ActionBox
-						onClick={ () => {
-							trackAction( 'my_site', 'add_domain' );
-							page( `/domains/add/${ siteSlug }` );
-						} }
-						label={ translate( 'Add a domain' ) }
-						iconSrc={ customDomainIcon }
-					/>
-				) }
-			</div>
-		);
-		if ( displayChecklist ) {
-			return null;
-		}
-		return (
-			<>
-				{ ! isMobile() ? (
-					<Card className="customer-home__card-boxes">
-						<CardHeading>{ translate( 'Quick Links' ) }</CardHeading>
-						{ quickLinks }
-					</Card>
-				) : (
-					<FoldableCard
-						className="customer-home__card-boxes card-heading-21"
-						header={ translate( 'Quick Links' ) }
-						expanded
-					>
-						{ quickLinks }
-					</FoldableCard>
-				) }
-			</>
-		);
-	}
-
 	renderCustomerHome = () => {
 		const {
 			displayChecklist,
@@ -553,7 +363,7 @@ class Home extends Component {
 							<WpcomChecklist displayMode={ checklistMode } />
 						</>
 					) }
-					{ this.renderQuickLinks() }
+					{ ! displayChecklist && <QuickLinks /> }
 				</div>
 				<div className="customer-home__layout-col customer-home__layout-col-right">
 					{ siteIsUnlaunched && ! needsEmailVerification && (
@@ -640,7 +450,6 @@ const connectHome = connect(
 		const siteId = getSelectedSiteId( state );
 		const siteChecklist = getSiteChecklist( state, siteId );
 		const hasChecklistData = null !== siteChecklist && Array.isArray( siteChecklist.tasks );
-		const domains = getDomainsBySiteId( state, siteId );
 		let themeInfo = {};
 		if ( 'theme' === checklistMode ) {
 			const currentThemeId = getActiveTheme( state, siteId );
@@ -663,8 +472,6 @@ const connectHome = connect(
 			site: getSelectedSite( state ),
 			siteId,
 			siteSlug: getSelectedSiteSlug( state ),
-			customizeUrl: getCustomizerUrl( state, siteId ),
-			menusUrl: getCustomizerUrl( state, siteId, 'menus' ),
 			canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),
 			hasChecklistData,
 			isChecklistComplete,
@@ -677,9 +484,6 @@ const connectHome = connect(
 			isEstablishedSite: moment().isAfter( moment( createdAt ).add( 2, 'days' ) ),
 			isRecentlyMigratedSite: isSiteRecentlyMigrated( state, siteId ),
 			siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
-			staticHomePageId: getSiteFrontPage( state, siteId ),
-			showCustomizer: ! isSiteUsingFullSiteEditing( state, siteId ),
-			hasCustomDomain: getGSuiteSupportedDomains( domains ).length > 0,
 			user,
 			...themeInfo,
 		};

--- a/client/my-sites/customer-home/quick-links/action-box.jsx
+++ b/client/my-sites/customer-home/quick-links/action-box.jsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+import { Button } from '@automattic/components';
+
+const ActionBox = ( { external, href, onClick, target, iconSrc, label } ) => {
+	const buttonAction = { href, onClick, target };
+	return (
+		<div className="quick-links__action-box">
+			<Button { ...buttonAction }>
+				<img src={ iconSrc } alt="" />
+				<span>
+					{ label } { external && <Gridicon icon="external" /> }
+				</span>
+			</Button>
+		</div>
+	);
+};
+
+export default ActionBox;

--- a/client/my-sites/customer-home/quick-links/index.jsx
+++ b/client/my-sites/customer-home/quick-links/index.jsx
@@ -175,6 +175,107 @@ export const QuickLinks = ( {
 	);
 };
 
+const editHomepageAction = ( editHomePageUrl, isStaticHomePage ) =>
+	withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( `calypso_customer_home_my_site_edit_homepage_click`, {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', `my_site_edit_homepage` )
+		),
+		navigate( editHomePageUrl )
+	);
+
+const writePostAction = ( siteSlug, isStaticHomePage ) =>
+	withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( `calypso_customer_home_my_site_write_post_click`, {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', `my_site_write_post` )
+		),
+		navigate( `/post/${ siteSlug }` )
+	);
+
+const addPageAction = ( siteSlug, isStaticHomePage ) =>
+	withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( `calypso_customer_home_my_site_add_page_click`, {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', `my_site_add_page` )
+		),
+		navigate( `/page/${ siteSlug }` )
+	);
+
+const manageCommentsAction = ( siteSlug, isStaticHomePage ) =>
+	withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( `calypso_customer_home_my_site_manage_comments_click`, {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', `my_site_manage_comments` )
+		),
+		navigate( `/comments/${ siteSlug }` )
+	);
+
+const trackEditMenusAction = isStaticHomePage =>
+	composeAnalytics(
+		recordTracksEvent( `calypso_customer_home_my_site_edit_menus_click`, {
+			is_static_home_page: isStaticHomePage,
+		} ),
+		bumpStat( 'calypso_customer_home', `my_site_edit_menus` )
+	);
+
+const trackCustomizeThemeAction = isStaticHomePage =>
+	composeAnalytics(
+		recordTracksEvent( `calypso_customer_home_my_site_customize_theme_click`, {
+			is_static_home_page: isStaticHomePage,
+		} ),
+		bumpStat( 'calypso_customer_home', `my_site_customize_theme` )
+	);
+
+const changeThemeAction = ( siteSlug, isStaticHomePage ) =>
+	withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( `calypso_customer_home_my_site_change_theme_click`, {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', `my_site_change_theme` )
+		),
+		navigate( `/themes/${ siteSlug }` )
+	);
+
+const trackDesignLogoAction = isStaticHomePage =>
+	composeAnalytics(
+		recordTracksEvent( `calypso_customer_home_my_site_design_logo_click`, {
+			is_static_home_page: isStaticHomePage,
+		} ),
+		bumpStat( 'calypso_customer_home', `my_site_design_logo` )
+	);
+
+const addEmailAction = ( siteSlug, isStaticHomePage ) =>
+	withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( `calypso_customer_home_my_site_add_email_click`, {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', `my_site_add_email` )
+		),
+		navigate( `/email/${ siteSlug }` )
+	);
+
+const addDomainAction = ( siteSlug, isStaticHomePage ) =>
+	withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( `calypso_customer_home_my_site_add_domain_click`, {
+				is_static_home_page: isStaticHomePage,
+			} ),
+			bumpStat( 'calypso_customer_home', `my_site_add_domain` )
+		),
+		navigate( `/domains/add/${ siteSlug }` )
+	);
+
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
@@ -198,120 +299,35 @@ const mapStateToProps = state => {
 	};
 };
 
-const mapDispatchToProps = ( dispatch, { isStaticHomePage, editHomePageUrl, siteSlug } ) => {
+const mapDispatchToProps = {
+	editHomepageAction,
+	writePostAction,
+	addPageAction,
+	manageCommentsAction,
+	trackEditMenusAction,
+	trackCustomizeThemeAction,
+	changeThemeAction,
+	trackDesignLogoAction,
+	addEmailAction,
+	addDomainAction,
+};
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const { editHomePageUrl, isStaticHomePage, siteSlug } = stateProps;
 	return {
-		editHomepageAction: () =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( `calypso_customer_home_my_site_edit_homepage_click`, {
-							is_static_home_page: isStaticHomePage,
-						} ),
-						bumpStat( 'calypso_customer_home', `my_site_edit_homepage` )
-					),
-					navigate( editHomePageUrl )
-				)
-			),
-		writePostAction: () =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( `calypso_customer_home_my_site_write_post_click`, {
-							is_static_home_page: isStaticHomePage,
-						} ),
-						bumpStat( 'calypso_customer_home', `my_site_write_post` )
-					),
-					navigate( `/post/${ siteSlug }` )
-				)
-			),
-		addPageAction: () =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( `calypso_customer_home_my_site_add_page_click`, {
-							is_static_home_page: isStaticHomePage,
-						} ),
-						bumpStat( 'calypso_customer_home', `my_site_add_page` )
-					),
-					navigate( `/page/${ siteSlug }` )
-				)
-			),
-		manageCommentsAction: () =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( `calypso_customer_home_my_site_manage_comments_click`, {
-							is_static_home_page: isStaticHomePage,
-						} ),
-						bumpStat( 'calypso_customer_home', `my_site_manage_comments` )
-					),
-					navigate( `/comments/${ siteSlug }` )
-				)
-			),
-		trackEditMenusAction: () =>
-			dispatch(
-				composeAnalytics(
-					recordTracksEvent( `calypso_customer_home_my_site_edit_menus_click`, {
-						is_static_home_page: isStaticHomePage,
-					} ),
-					bumpStat( 'calypso_customer_home', `my_site_edit_menus` )
-				)
-			),
-		trackCustomizeThemeAction: () =>
-			dispatch(
-				composeAnalytics(
-					recordTracksEvent( `calypso_customer_home_my_site_customize_theme_click`, {
-						is_static_home_page: isStaticHomePage,
-					} ),
-					bumpStat( 'calypso_customer_home', `my_site_customize_theme` )
-				)
-			),
-		changeThemeAction: () =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( `calypso_customer_home_my_site_change_theme_click`, {
-							is_static_home_page: isStaticHomePage,
-						} ),
-						bumpStat( 'calypso_customer_home', `my_site_change_theme` )
-					),
-					navigate( `/themes/${ siteSlug }` )
-				)
-			),
-		trackDesignLogoAction: () =>
-			dispatch(
-				composeAnalytics(
-					recordTracksEvent( `calypso_customer_home_my_site_design_logo_click`, {
-						is_static_home_page: isStaticHomePage,
-					} ),
-					bumpStat( 'calypso_customer_home', `my_site_design_logo` )
-				)
-			),
-		addEmailAction: () =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( `calypso_customer_home_my_site_add_email_click`, {
-							is_static_home_page: isStaticHomePage,
-						} ),
-						bumpStat( 'calypso_customer_home', `my_site_add_email` )
-					),
-					navigate( `/email/${ siteSlug }` )
-				)
-			),
-		addDomainAction: () =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( `calypso_customer_home_my_site_add_domain_click`, {
-							is_static_home_page: isStaticHomePage,
-						} ),
-						bumpStat( 'calypso_customer_home', `my_site_add_domain` )
-					),
-					navigate( `/domains/add/${ siteSlug }` )
-				)
-			),
+		...stateProps,
+		editHomepageAction: () => dispatchProps.editHomepageAction( editHomePageUrl, isStaticHomePage ),
+		writePostAction: () => dispatchProps.writePostAction( siteSlug, isStaticHomePage ),
+		addPageAction: () => dispatchProps.addPageAction( siteSlug, isStaticHomePage ),
+		manageCommentsAction: () => dispatchProps.manageCommentsAction( siteSlug, isStaticHomePage ),
+		trackEditMenusAction: () => dispatchProps.trackEditMenusAction( isStaticHomePage ),
+		trackCustomizeThemeAction: () => dispatchProps.trackCustomizeThemeAction( isStaticHomePage ),
+		changeThemeAction: () => dispatchProps.changeThemeAction( siteSlug, isStaticHomePage ),
+		trackDesignLogoAction: () => dispatchProps.trackDesignLogoAction( isStaticHomePage ),
+		addEmailAction: () => dispatchProps.addEmailAction( siteSlug, isStaticHomePage ),
+		addDomainAction: () => dispatchProps.addDomainAction( siteSlug, isStaticHomePage ),
+		...ownProps,
 	};
 };
 
-export default connect( mapStateToProps, mapDispatchToProps )( QuickLinks );
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( QuickLinks );

--- a/client/my-sites/customer-home/quick-links/index.jsx
+++ b/client/my-sites/customer-home/quick-links/index.jsx
@@ -178,10 +178,10 @@ export const QuickLinks = ( {
 const editHomepageAction = ( editHomePageUrl, isStaticHomePage ) =>
 	withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( `calypso_customer_home_my_site_edit_homepage_click`, {
+			recordTracksEvent( 'calypso_customer_home_my_site_edit_homepage_click', {
 				is_static_home_page: isStaticHomePage,
 			} ),
-			bumpStat( 'calypso_customer_home', `my_site_edit_homepage` )
+			bumpStat( 'calypso_customer_home', 'my_site_edit_homepage' )
 		),
 		navigate( editHomePageUrl )
 	);
@@ -189,10 +189,10 @@ const editHomepageAction = ( editHomePageUrl, isStaticHomePage ) =>
 const writePostAction = ( siteSlug, isStaticHomePage ) =>
 	withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( `calypso_customer_home_my_site_write_post_click`, {
+			recordTracksEvent( 'calypso_customer_home_my_site_write_post_click', {
 				is_static_home_page: isStaticHomePage,
 			} ),
-			bumpStat( 'calypso_customer_home', `my_site_write_post` )
+			bumpStat( 'calypso_customer_home', 'my_site_write_post' )
 		),
 		navigate( `/post/${ siteSlug }` )
 	);
@@ -200,10 +200,10 @@ const writePostAction = ( siteSlug, isStaticHomePage ) =>
 const addPageAction = ( siteSlug, isStaticHomePage ) =>
 	withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( `calypso_customer_home_my_site_add_page_click`, {
+			recordTracksEvent( 'calypso_customer_home_my_site_add_page_click', {
 				is_static_home_page: isStaticHomePage,
 			} ),
-			bumpStat( 'calypso_customer_home', `my_site_add_page` )
+			bumpStat( 'calypso_customer_home', 'my_site_add_page' )
 		),
 		navigate( `/page/${ siteSlug }` )
 	);
@@ -211,56 +211,56 @@ const addPageAction = ( siteSlug, isStaticHomePage ) =>
 const manageCommentsAction = ( siteSlug, isStaticHomePage ) =>
 	withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( `calypso_customer_home_my_site_manage_comments_click`, {
+			recordTracksEvent( 'calypso_customer_home_my_site_manage_comments_click', {
 				is_static_home_page: isStaticHomePage,
 			} ),
-			bumpStat( 'calypso_customer_home', `my_site_manage_comments` )
+			bumpStat( 'calypso_customer_home', 'my_site_manage_comments' )
 		),
 		navigate( `/comments/${ siteSlug }` )
 	);
 
 const trackEditMenusAction = isStaticHomePage =>
 	composeAnalytics(
-		recordTracksEvent( `calypso_customer_home_my_site_edit_menus_click`, {
+		recordTracksEvent( 'calypso_customer_home_my_site_edit_menus_click', {
 			is_static_home_page: isStaticHomePage,
 		} ),
-		bumpStat( 'calypso_customer_home', `my_site_edit_menus` )
+		bumpStat( 'calypso_customer_home', 'my_site_edit_menus' )
 	);
 
 const trackCustomizeThemeAction = isStaticHomePage =>
 	composeAnalytics(
-		recordTracksEvent( `calypso_customer_home_my_site_customize_theme_click`, {
+		recordTracksEvent( 'calypso_customer_home_my_site_customize_theme_click', {
 			is_static_home_page: isStaticHomePage,
 		} ),
-		bumpStat( 'calypso_customer_home', `my_site_customize_theme` )
+		bumpStat( 'calypso_customer_home', 'my_site_customize_theme' )
 	);
 
 const changeThemeAction = ( siteSlug, isStaticHomePage ) =>
 	withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( `calypso_customer_home_my_site_change_theme_click`, {
+			recordTracksEvent( 'calypso_customer_home_my_site_change_theme_click', {
 				is_static_home_page: isStaticHomePage,
 			} ),
-			bumpStat( 'calypso_customer_home', `my_site_change_theme` )
+			bumpStat( 'calypso_customer_home', 'my_site_change_theme' )
 		),
 		navigate( `/themes/${ siteSlug }` )
 	);
 
 const trackDesignLogoAction = isStaticHomePage =>
 	composeAnalytics(
-		recordTracksEvent( `calypso_customer_home_my_site_design_logo_click`, {
+		recordTracksEvent( 'calypso_customer_home_my_site_design_logo_click', {
 			is_static_home_page: isStaticHomePage,
 		} ),
-		bumpStat( 'calypso_customer_home', `my_site_design_logo` )
+		bumpStat( 'calypso_customer_home', 'my_site_design_logo' )
 	);
 
 const addEmailAction = ( siteSlug, isStaticHomePage ) =>
 	withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( `calypso_customer_home_my_site_add_email_click`, {
+			recordTracksEvent( 'calypso_customer_home_my_site_add_email_click', {
 				is_static_home_page: isStaticHomePage,
 			} ),
-			bumpStat( 'calypso_customer_home', `my_site_add_email` )
+			bumpStat( 'calypso_customer_home', 'my_site_add_email' )
 		),
 		navigate( `/email/${ siteSlug }` )
 	);
@@ -268,10 +268,10 @@ const addEmailAction = ( siteSlug, isStaticHomePage ) =>
 const addDomainAction = ( siteSlug, isStaticHomePage ) =>
 	withAnalytics(
 		composeAnalytics(
-			recordTracksEvent( `calypso_customer_home_my_site_add_domain_click`, {
+			recordTracksEvent( 'calypso_customer_home_my_site_add_domain_click', {
 				is_static_home_page: isStaticHomePage,
 			} ),
-			bumpStat( 'calypso_customer_home', `my_site_add_domain` )
+			bumpStat( 'calypso_customer_home', 'my_site_add_domain' )
 		),
 		navigate( `/domains/add/${ siteSlug }` )
 	);

--- a/client/my-sites/customer-home/quick-links/style.scss
+++ b/client/my-sites/customer-home/quick-links/style.scss
@@ -1,0 +1,74 @@
+.quick-links__boxes {
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: space-between;
+	align-items: stretch;
+}
+
+.quick-links__card-boxes.foldable-card {
+	&.is-expanded .foldable-card__header {
+		padding-bottom: 0;
+	}
+	.foldable-card {
+		@include breakpoint( '<480px' ) {
+			&__header {
+				min-height: 0;
+				padding: 12px 16px;
+			}
+		}
+
+		&__content {
+			border: 0;
+		}
+	}
+}
+@include breakpoint( '>480px' ) {
+	.quick-links__card-boxes.card.foldable-card {
+		margin-top: 0;
+		padding-bottom: 0;
+
+		.foldable-card__header {
+			padding: 0 24px;
+		}
+
+		.foldable-card__content {
+			padding: 0 24px;
+		}
+	}
+}
+
+.quick-links__action-box {
+	margin-bottom: 16px;
+	width: 100%;
+
+	@include breakpoint( '>480px' ) {
+		width: 48%;
+		margin-bottom: 24px;
+	}
+
+	.button {
+		border-width: 1px;
+		display: flex;
+		height: 100%;
+		min-width: 100%;
+		padding: 16px;
+		text-align: center;
+
+		@include breakpoint( '>480px' ) {
+			display: block;
+			min-height: 85px;
+			padding: 24px;
+		}
+	}
+	.button:hover {
+		box-shadow: 0 2px 3px 0 rgba( 98, 109, 118, 0.15 );
+	}
+
+	span {
+		display: block;
+
+		@include breakpoint( '<480px' ) {
+			margin: auto 14px;
+		}
+	}
+}

--- a/client/my-sites/customer-home/quick-links/style.scss
+++ b/client/my-sites/customer-home/quick-links/style.scss
@@ -5,7 +5,7 @@
 	align-items: stretch;
 }
 
-.quick-links__card-boxes.foldable-card {
+.quick-links.foldable-card {
 	&.is-expanded .foldable-card__header {
 		padding-bottom: 0;
 	}
@@ -23,7 +23,7 @@
 	}
 }
 @include breakpoint( '>480px' ) {
-	.quick-links__card-boxes.card.foldable-card {
+	.quick-links.card.foldable-card {
 		margin-top: 0;
 		padding-bottom: 0;
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -145,81 +145,10 @@
 		}
 	}
 
-	&__box-action {
-		margin-bottom: 16px;
-		width: 100%;
-
-		@include breakpoint( '>480px' ) {
-			width: 48%;
-			margin-bottom: 24px;
-		}
-
-		.button {
-			border-width: 1px;
-			display: flex;
-			height: 100%;
-			min-width: 100%;
-			padding: 16px;
-			text-align: center;
-
-			@include breakpoint( '>480px' ) {
-				display: block;
-				min-height: 85px;
-				padding: 24px;
-			}
-		}
-		.button:hover {
-			box-shadow: 0 2px 3px 0 rgba( 98, 109, 118, 0.15 );
-		}
-
-		span {
-			display: block;
-
-			@include breakpoint( '<480px' ) {
-				margin: auto 14px;
-			}
-		}
-	}
 	&__card-checklist-heading {
 		margin-bottom: -16px;
 	}
-	&__card-boxes.foldable-card {
-		&.is-expanded .foldable-card__header {
-			padding-bottom: 0;
-		}
-		.foldable-card {
-			@include breakpoint( '<480px' ) {
-				&__header {
-					min-height: 0;
-					padding: 12px 16px;
-				}
-			}
 
-			&__content {
-				border: 0;
-			}
-		}
-	}
-	@include breakpoint( '>480px' ) {
-		&__card-boxes.card.foldable-card {
-			margin-top: 0;
-			padding-bottom: 0;
-
-			.foldable-card__header {
-				padding: 0 24px;
-			}
-
-			.foldable-card__content {
-				padding: 0 24px;
-			}
-		}
-	}
-	&__boxes {
-		display: flex;
-		flex-flow: row wrap;
-		justify-content: space-between;
-		align-items: stretch;
-	}
 	&__card-col {
 		display: block;
 


### PR DESCRIPTION
This PR moves QuickLinks in the Home section from main to its own component file.

<img width="1017" alt="Screen Shot 2020-03-18 at 6 40 26 PM" src="https://user-images.githubusercontent.com/1270189/77022919-0e7f3180-6948-11ea-9142-0dbb6eaf6d38.png">

Folks are welcome to hop into this if y'all are interested

I expanded out the `trackAction`, so we can do a proper string search for analytics events. Same thing applies for being verbose for SASS `&__` rules. It makes it much easier to refactor and debug when we can find related code with a simple search. 