### PR TITLE
Jetpack Cloud: Add/connect threat dialog to threat cards

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -9,19 +9,12 @@ import { numberFormat, translate } from 'i18n-calypso';
  */
 import ThreatDialog from 'landing/jetpack-cloud/components/threat-dialog';
 import ThreatItem from 'landing/jetpack-cloud/components/threat-item';
+import { Threat, ThreatAction } from 'landing/jetpack-cloud/components/threat-item/types';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-type ThreatAction = 'fix' | 'ignore';
-
-type Threat = {
-	id: number;
-	title: string;
-	details: string;
-};
 
 interface Props {
 	site: {
@@ -47,7 +40,9 @@ const ScanThreats = ( { site, threats }: Props ) => {
 	};
 
 	const confirmAction = () => {
-		window.alert( `Fixing site: ${ site.name }` );
+		window.alert(
+			`We are going to ${ actionToPerform } threat ${ selectedThreat?.id } on site ${ site.name }`
+		);
 		closeDialog();
 	};
 
@@ -78,7 +73,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 					}
 				) }
 			</p>
-			<div className="scan-threats scan__threats">
+			<div className="scan-threats__threats">
 				{ threats.map( threat => (
 					<ThreatItem
 						key={ threat.id }

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { numberFormat, translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ThreatDialog from 'landing/jetpack-cloud/components/threat-dialog';
+import ThreatItem from 'landing/jetpack-cloud/components/threat-item';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	site: object;
+	threats: Array< object >;
+}
+
+const ScanThreats = ( { site, threats }: Props ) => {
+	const [ showThreatDialog, setShowThreatDialog ] = React.useState( false );
+	const [ actionToPerform, setActionToPerform ] = React.useState( '' );
+
+	const openDialog = ( action: string ) => {
+		setActionToPerform( action );
+		setShowThreatDialog( true );
+	};
+
+	const closeDialog = () => {
+		setShowThreatDialog( false );
+	};
+
+	const confirmAction = () => {
+		window.alert( `Fixing site: ${ site.name }` );
+		closeDialog();
+	};
+
+	return (
+		<>
+			<h1 className="scan-threats scan__header">{ translate( 'Your site may be at risk' ) }</h1>
+			<p>
+				{ translate(
+					'The scan found {{strong}}%(threatCount)s{{/strong}} potential threat with {{strong}}%(siteName)s{{/strong}}.',
+					'The scan found {{strong}}%(threatCount)s{{/strong}} potential threats with {{strong}}%(siteName)s{{/strong}}.',
+					{
+						args: {
+							siteName: site.name,
+							threatCount: numberFormat( threats.length, 0 ),
+						},
+						components: { strong: <strong /> },
+						comment:
+							'%(threatCount)s represents the number of threats currently identified on the site, and $(siteName)s is the name of the site.',
+						count: threats.length,
+					}
+				) }
+				<br />
+				{ translate(
+					'Please review them below and take action. We are {{a}}here to help{{/a}} if you need us.',
+					{
+						components: { a: <a href="https://jetpack.com/contact-support/" /> },
+						comment: 'The {{a}} tag is a link that goes to a contact support page.',
+					}
+				) }
+			</p>
+			<div className="scan-threats scan__threats">
+				{ threats.map( threat => (
+					<ThreatItem
+						key={ threat.id }
+						threat={ threat }
+						onFixThreat={ () => openDialog( 'fix' ) }
+						onIgnoreThreat={ () => openDialog( 'ignore' ) }
+					/>
+				) ) }
+			</div>
+			<ThreatDialog
+				showDialog={ showThreatDialog }
+				onCloseDialog={ closeDialog }
+				onConfirmation={ confirmAction }
+				siteName={ site.name }
+				threatTitle={ threats[ 0 ].title }
+				threatDescription={ threats[ 0 ].details }
+				action={ actionToPerform }
+			/>
+		</>
+	);
+};
+
+export default ScanThreats;

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -15,21 +15,34 @@ import ThreatItem from 'landing/jetpack-cloud/components/threat-item';
  */
 import './style.scss';
 
+type ThreatAction = 'fix' | 'ignore';
+
+type Threat = {
+	id: number;
+	title: string;
+	details: string;
+};
+
 interface Props {
-	site: object;
-	threats: Array< object >;
+	site: {
+		name: string;
+	};
+	threats: Array< Threat >;
 }
 
 const ScanThreats = ( { site, threats }: Props ) => {
+	const [ selectedThreat, setSelectedThreat ] = React.useState< Threat | undefined >();
 	const [ showThreatDialog, setShowThreatDialog ] = React.useState( false );
-	const [ actionToPerform, setActionToPerform ] = React.useState( '' );
+	const [ actionToPerform, setActionToPerform ] = React.useState< ThreatAction >( 'fix' );
 
-	const openDialog = ( action: string ) => {
+	const openDialog = ( action: ThreatAction, threat: Threat ) => {
+		setSelectedThreat( threat );
 		setActionToPerform( action );
 		setShowThreatDialog( true );
 	};
 
 	const closeDialog = () => {
+		setSelectedThreat( undefined );
 		setShowThreatDialog( false );
 	};
 
@@ -70,20 +83,22 @@ const ScanThreats = ( { site, threats }: Props ) => {
 					<ThreatItem
 						key={ threat.id }
 						threat={ threat }
-						onFixThreat={ () => openDialog( 'fix' ) }
-						onIgnoreThreat={ () => openDialog( 'ignore' ) }
+						onFixThreat={ () => openDialog( 'fix', threat ) }
+						onIgnoreThreat={ () => openDialog( 'ignore', threat ) }
 					/>
 				) ) }
 			</div>
-			<ThreatDialog
-				showDialog={ showThreatDialog }
-				onCloseDialog={ closeDialog }
-				onConfirmation={ confirmAction }
-				siteName={ site.name }
-				threatTitle={ threats[ 0 ].title }
-				threatDescription={ threats[ 0 ].details }
-				action={ actionToPerform }
-			/>
+			{ selectedThreat && (
+				<ThreatDialog
+					showDialog={ showThreatDialog }
+					onCloseDialog={ closeDialog }
+					onConfirmation={ confirmAction }
+					siteName={ site.name }
+					threatTitle={ selectedThreat.title }
+					threatDescription={ selectedThreat.details }
+					action={ actionToPerform }
+				/>
+			) }
 		</>
 	);
 };

--- a/client/landing/jetpack-cloud/components/scan-threats/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-threats/style.scss
@@ -1,0 +1,5 @@
+.scan-threats {
+	&__threats {
+		margin: 40px 0;
+	}
+}

--- a/client/landing/jetpack-cloud/components/threat-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-dialog/index.tsx
@@ -17,7 +17,6 @@ import Gridicon from 'components/gridicon';
 import './style.scss';
 
 interface Props {
-	threatId: number;
 	threatTitle: string;
 	threatDescription: string | ReactNode;
 	action: 'fix' | 'ignore';

--- a/client/landing/jetpack-cloud/components/threat-item/index.jsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.jsx
@@ -21,12 +21,8 @@ import './style.scss';
 class ThreatItem extends Component {
 	static propTypes = {
 		threat: PropTypes.object,
-	};
-
-	handleFixThreat = () => {
-		const { threat } = this.props;
-		// eslint-disable-next-line no-undef
-		alert( `Fixing threat ${ threat.id }` );
+		onFixThreat: PropTypes.func,
+		onIgnoreThreat: PropTypes.func,
 	};
 
 	/**
@@ -39,9 +35,9 @@ class ThreatItem extends Component {
 	renderFixThreatButton( className ) {
 		return (
 			<Button
-				className={ classnames( 'threat-item__fix-cta', className ) }
+				className={ classnames( 'threat-item__fix-button', className ) }
 				compact
-				onClick={ this.handleFixThreat }
+				onClick={ this.props.onFixThreat }
 			>
 				{ translate( 'Fix threat' ) }
 			</Button>
@@ -49,7 +45,7 @@ class ThreatItem extends Component {
 	}
 
 	render() {
-		const { threat } = this.props;
+		const { threat, onIgnoreThreat } = this.props;
 		const fixThreatCTA = this.renderFixThreatButton( 'is-summary' );
 
 		return (
@@ -67,9 +63,14 @@ class ThreatItem extends Component {
 					details={ threat.description.details }
 					fix={ threat.description.fix }
 					problem={ threat.description.problem }
-				>
+				/>
+
+				<div className="threat-item__buttons">
 					{ this.renderFixThreatButton( 'is-details' ) }
-				</ThreatDescription>
+					<Button className="threat-item__ignore-button" compact onClick={ onIgnoreThreat }>
+						{ translate( 'Ignore threat' ) }
+					</Button>
+				</div>
 			</LogItem>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { translate } from 'i18n-calypso';
 import classnames from 'classnames';
 import { Button } from '@automattic/components';
@@ -12,19 +11,20 @@ import { Button } from '@automattic/components';
  */
 import LogItem from '../log-item';
 import ThreatDescription from '../threat-description';
+import { Threat } from 'landing/jetpack-cloud/components/threat-item/types';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-class ThreatItem extends Component {
-	static propTypes = {
-		threat: PropTypes.object,
-		onFixThreat: PropTypes.func,
-		onIgnoreThreat: PropTypes.func,
-	};
+interface Props {
+	threat: Threat;
+	onFixThreat: Function;
+	onIgnoreThreat: Function;
+}
 
+class ThreatItem extends Component< Props > {
 	/**
 	 * Render a CTA button. Currently, this button is rendered three
 	 * times: in the details section, and in the `summary` and `extendSummary`

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -25,6 +25,10 @@
 			display: none;
 		}
 	}
+
+	.foldable-card__action.foldable-card__expand {
+		border: none;
+	}
 }
 
 .button.threat-item__fix-cta.is-compact {

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -2,12 +2,22 @@
 	// Override the error color to a slightly different red.
 	--color-error-20: var( --color-threat-found );
 
-	&__fix-cta {
-		width: 170px;
-		padding: 10px 30px;
+	&__buttons {
+		display: flex;
+		justify-content: space-evenly;
+
+		@include breakpoint( '>800px' ) {
+			justify-content: flex-end;
+			padding-right: 48px;
+		}
 	}
 
-	&__fix-cta.is-summary {
+	&__fix-button {
+		color: var( --color-primary-50 );
+		border-color: var( --color-primary-50 );
+	}
+
+	&__fix-button.is-summary {
 		display: none;
 
 		@include breakpoint( '>800px' ) {
@@ -16,7 +26,7 @@
 		}
 	}
 
-	&__fix-cta.is-details {
+	&__fix-button.is-details {
 		display: inline-block;
 		width: 100%;
 		margin-left: 0;
@@ -26,15 +36,23 @@
 		}
 	}
 
+	&__ignore-button {
+		color: var( --color-threat-ignored );
+		border-color: var( --color-threat-ignored );
+	}
+
 	.foldable-card__action.foldable-card__expand {
 		border: none;
 	}
 }
 
-.button.threat-item__fix-cta.is-compact {
-	color: var( --color-primary-50 );
-	border-color: var( --color-primary-50 );
-	border-width: 1px;
-	border-style: solid;
-	border-radius: 3px;
+.button.is-compact {
+	&.threat-item__fix-button,
+	&.threat-item__ignore-button {
+		width: 170px;
+		padding: 10px 30px;
+		border-width: 1px;
+		border-style: solid;
+		border-radius: 3px;
+	}
 }

--- a/client/landing/jetpack-cloud/components/threat-item/types.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/types.tsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { ReactNode } from 'react';
+
+export type ThreatAction = 'fix' | 'ignore';
+
+export type Threat = {
+	id: number;
+	title: string;
+	details: string;
+	action: null | 'fixed' | 'ignored';
+	detectionDate: string;
+	actionDate: string;
+	description: {
+		title: string;
+		problem: string | ReactNode;
+		fix: string | ReactNode;
+		details: string | ReactNode;
+	};
+};

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -4,62 +4,25 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Button, ProgressBar } from '@automattic/components';
-import { numberFormat, translate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
-import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
-import { withLocalizedMoment } from 'components/localized-moment';
+import Main from 'components/main';
 import SecurityIcon from 'landing/jetpack-cloud/components/security-icon';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsFooter from 'landing/jetpack-cloud/components/stats-footer';
-import ThreatItem from '../../components/threat-item';
+import ScanThreats from 'landing/jetpack-cloud/components/scan-threats';
 import { isEnabled } from 'config';
-import ThreatDialog from '../../components/threat-dialog';
 import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 import './style.scss';
-
-// This is here for testing purposes only. Once the ThreatItem component
-// is merged into master, we would be able to connect this two pieces of
-// UI.
-const ComponentToTestDialogs = ( { siteName, threat } ) => {
-	const [ showThreatDialog, setShowThreatDialog ] = React.useState( false );
-	const [ actionToPerform, setActionToPerform ] = React.useState();
-
-	const openDialog = action => {
-		setActionToPerform( action );
-		setShowThreatDialog( true );
-	};
-
-	const closeDialog = () => {
-		setShowThreatDialog( false );
-	};
-
-	const confirmAction = () => {
-		window.alert( `Fixing site: ${ siteName }` );
-		closeDialog();
-	};
-
-	return (
-		<>
-			<Button onClick={ () => openDialog( 'fix' ) }>Open Fix Dialog</Button>
-			<Button onClick={ () => openDialog( 'ignore' ) }>Open Ignore Dialog</Button>
-			<ThreatDialog
-				showDialog={ showThreatDialog }
-				onCloseDialog={ closeDialog }
-				onConfirmation={ confirmAction }
-				siteName={ siteName }
-				threatTitle={ threat.title }
-				threatDescription={ threat.details }
-				action={ actionToPerform }
-			/>
-		</>
-	);
-};
 
 class ScanPage extends Component {
 	renderScanOkay() {
@@ -108,49 +71,7 @@ class ScanPage extends Component {
 
 	renderThreats() {
 		const { threats, site } = this.props;
-
-		return (
-			<>
-				<SecurityIcon icon="error" />
-				<h1 className="scan__header">{ translate( 'Your site may be at risk' ) }</h1>
-				<p>
-					{ translate(
-						'The scan found {{strong}}%(threatCount)s{{/strong}} potential threat with {{strong}}%(siteName)s{{/strong}}.',
-						'The scan found {{strong}}%(threatCount)s{{/strong}} potential threats with {{strong}}%(siteName)s{{/strong}}.',
-						{
-							args: {
-								siteName: site.name,
-								threatCount: numberFormat( threats.length ),
-							},
-							components: { strong: <strong /> },
-							comment:
-								'%(threatCount)s represents the number of threats currently identified on the site, and $(siteName)s is the name of the site.',
-							count: threats.length,
-						}
-					) }
-					<br />
-					{ translate(
-						'Please review them below and take action. We are {{a}}here to help{{/a}} if you need us.',
-						{
-							components: { a: <a href="https://jetpack.com/contact-support/" /> },
-							comment: 'The {{a}} tag is a link that goes to a contact support page.',
-						}
-					) }
-				</p>
-				<div className="scan__threats">
-					{ threats.map( threat => (
-						<ThreatItem
-							key={ threat.id }
-							threat={ threat }
-							// eslint-disable-next-line no-console
-							onFixThreat={ () => console.log( 'Fixing threat' ) }
-							// eslint-disable-next-line no-console
-							onIgnoreThreat={ () => console.log( 'Ignoring threat' ) }
-						/>
-					) ) }
-				</div>
-			</>
-		);
+		return <ScanThreats threats={ threats } site={ site } />;
 	}
 
 	renderScanError() {
@@ -193,16 +114,11 @@ class ScanPage extends Component {
 	}
 
 	render() {
-		const { threats, site } = this.props;
-
 		return (
 			<Main className="scan__main">
 				<DocumentHead title="Scanner" />
 				<SidebarNavigation />
-				<div className="scan__content">
-					{ this.renderScanState() }
-					<ComponentToTestDialogs threat={ threats[ 0 ] } siteName={ site.name } />
-				</div>
+				<div className="scan__content">{ this.renderScanState() }</div>
 				<StatsFooter
 					header="Scan Summary"
 					stats={ [

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -139,7 +139,14 @@ class ScanPage extends Component {
 				</p>
 				<div className="scan__threats">
 					{ threats.map( threat => (
-						<ThreatItem key={ threat.id } threat={ threat } />
+						<ThreatItem
+							key={ threat.id }
+							threat={ threat }
+							// eslint-disable-next-line no-console
+							onFixThreat={ () => console.log( 'Fixing threat' ) }
+							// eslint-disable-next-line no-console
+							onIgnoreThreat={ () => console.log( 'Ignoring threat' ) }
+						/>
 					) ) }
 				</div>
 			</>

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -71,7 +71,7 @@ class ScanPage extends Component {
 
 	renderThreats() {
 		const { threats, site } = this.props;
-		return <ScanThreats threats={ threats } site={ site } />;
+		return <ScanThreats className="scan__threats" threats={ threats } site={ site } />;
 	}
 
 	renderScanError() {

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -10,9 +10,7 @@ import { translate } from 'i18n-calypso';
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
-import Main from 'components/main';
 import SecurityIcon from 'landing/jetpack-cloud/components/security-icon';
-import SidebarNavigation from 'my-sites/sidebar-navigation';
 import StatsFooter from 'landing/jetpack-cloud/components/stats-footer';
 import ScanThreats from 'landing/jetpack-cloud/components/scan-threats';
 import { isEnabled } from 'config';

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -15,14 +15,13 @@
 	}
 
 	.progress-bar {
-			margin-bottom: 24px;
+		margin-bottom: 24px;
 	}
 
 	.progress-bar__progress {
-		background-color:  var( --color-primary );
+		background-color: var( --color-primary );
 		box-shadow: 0 2px 6px rgba( var( --color-primary-rgb ), 0.25 );
 	}
-
 }
 
 .scan__header {
@@ -38,10 +37,6 @@
 
 .scan__header--okay {
 	color: var( --color-primary-40 );
-}
-
-.scan__threats {
-	margin: 40px 0;
 }
 
 .scan__button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Currently, the only way to display the ThreatDialog component is by clicking one of the dummy buttons we have in the Scan main screen. Therefore, the goal is to make the Fix/Ignore threat buttons of a ThreatItem component display a ThreatDialog component.

#### Testing instructions

- Navigate to http://jetpack.cloud.localhost:3000/scan/<yourSiteSlug>?scan=threats
- Click the "Fix threat" button
- You should see the "Fix threat" dialog

See 1151678672052943-as-1167257479032409.

#### Expected result
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/3418513/77025675-7e091700-6970-11ea-8708-bb5f784b8a2f.png">
<img width="722" alt="image" src="https://user-images.githubusercontent.com/3418513/77025692-85c8bb80-6970-11ea-94b9-b8e9a596b6fd.png">

#### Current result
![Kapture 2020-03-19 at 11 51 50](https://user-images.githubusercontent.com/3418513/77080548-2d2d0900-69d8-11ea-891a-59c04efe6b75.gif)
![Kapture 2020-03-19 at 15 07 07](https://user-images.githubusercontent.com/3418513/77099821-5e670280-69f3-11ea-90b4-fdf561c320b0.gif)

