### PR TITLE
[Gutenberg 7.7.1]: remove extra button line height on page starter site

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -262,7 +262,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 	.components-button {
 		height: 33px; // match to Gutenberg toolbar styles
-		line-height: 32px; // match to Gutenberg toolbar styles
 	}
 }
 
@@ -480,7 +479,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		padding-top: 20px;
 	}
 
-	// flex: column; on the parent and flex-basis: 0; on the child in Safari causes a lot of weird overlapping layout 
+	// flex: column; on the parent and flex-basis: 0; on the child in Safari causes a lot of weird overlapping layout
 	// issues in the iframe preview: https://github.com/Automattic/wp-calypso/issues/39874
 	// Using flex-basis: auto; on the child allows the height to be calculated properly
 	.wp-block-columns > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type='core/column'] .block-core-columns {


### PR DESCRIPTION
## ⚠️ Blocked until 7.7.1 is in master

See: https://github.com/Automattic/wp-calypso/issues/40078

## Changes proposed in this Pull Request

Gutenberg has [modified the component button with a smidgen of extra padding](https://github.com/WordPress/gutenberg/pull/19344/files#diff-169503e5275f964f8bd036a7bfcd8f7cR15) (from `padding: 0 8px;` to `padding: 6px 12px;`)

This pushes the text down in the button.

**Current:**
<img width="1261" alt="Screen Shot 2020-03-19 at 3 43 45 pm" src="https://user-images.githubusercontent.com/6458278/77033048-4b0b6580-69fa-11ea-9464-a46b48a8aca6.png">

**On Edge-stickered sites (7.7.1):**
<img width="1103" alt="Screen Shot 2020-03-19 at 3 44 20 pm" src="https://user-images.githubusercontent.com/6458278/77033061-5199dd00-69fa-11ea-844e-0948fd20e738.png">

We now therefore no longer need the extra line height override.

**Result:**

<img width="601" alt="Screen Shot 2020-03-19 at 3 54 58 pm" src="https://user-images.githubusercontent.com/6458278/77033122-7beb9a80-69fa-11ea-990b-8afc6eb45b54.png">


## Testing instructions

You could fire up this PR locally, and sync it using the FG instructions about **FSE Plugin Development**

Test using an Edge-stickered site: `/block-editor/page/[EDGE_STICKERED_SITE].wordpress.com`

Or you could just remove the offending line of CSS in the browser console :)

<img width="655" alt="Screen Shot 2020-03-19 at 4 03 44 pm" src="https://user-images.githubusercontent.com/6458278/77033391-3a0f2400-69fb-11ea-9612-0856fec5bac4.png">


