### PR TITLE
Jetpack Cloud: Update support links

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -163,7 +163,7 @@ class JetpackCloudSidebar extends Component {
 							label={ translate( 'Get help', {
 								comment: 'Jetpack Cloud sidebar navigation item',
 							} ) }
-							link="#" // @todo: Add /support route or change link to other destination
+							link="https://jetpack.com/support"
 							materialIcon="help"
 							materialIconStyle="filled"
 							onNavigate={ this.onNavigate }

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -17,6 +17,7 @@ import StatsFooter from 'landing/jetpack-cloud/components/stats-footer';
 import ThreatItem from '../../components/threat-item';
 import { isEnabled } from 'config';
 import ThreatDialog from '../../components/threat-dialog';
+import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 
@@ -158,10 +159,12 @@ class ScanPage extends Component {
 				</p>
 				<Button
 					primary
-					href={ `/contact-us/${ siteSlug }/?scan-state=error` }
+					href={ `https://jetpack.com/contact-support/?scan-state=error&site-slug=${ siteSlug }` }
 					className="scan__button"
 				>
-					{ translate( 'Contact Support' ) }
+					{ translate( 'Contact Support {{externalIcon/}}', {
+						components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
+					} ) }
 				</Button>
 			</>
 		);

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -159,6 +159,8 @@ class ScanPage extends Component {
 				</p>
 				<Button
 					primary
+					target="_blank"
+					rel="noopener noreferrer"
 					href={ `https://jetpack.com/contact-support/?scan-state=error&site-slug=${ siteSlug }` }
 					className="scan__button"
 				>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds links to the jepack.com/support to the jetpack cloud. 

After:
<img width="470" alt="Screen Shot 2020-03-19 at 9 54 35 AM" src="https://user-images.githubusercontent.com/115071/77050141-93f6f600-69c9-11ea-843c-7aeb7d6cd9d2.png">


#### Testing instructions
* Go to http://jetpack.cloud.localhost:3000/scan/{example.com}?scan-state=error
Notice that the links take you to contact support pages as you would expect.

