### PR TITLE
Update/jetpack cloud mobile view

### DIFF
--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -25,6 +25,13 @@
 
 		svg {
 			fill: var( --color-black );
+			// Ensures the logo is centered by balancing out the avatar item on the right:
+			// ( 15px padding left + 24px avatar + 15px padding right ) / 2 = 27px
+			transform: translateX( 27px );
+
+			@include breakpoint( '>660px' ) {
+				transform: none;
+			}
 		}
 	}
 }

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -4,12 +4,16 @@
 }
 
 .is-jetpack-cloud-masterbar .masterbar__item-home {
-	width: $sidebar-width-max;
+	width: 100%;
 	padding: 0;
 	border-right: 1px solid var( --color-masterbar-border );
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint( '>660px' ) {
 		width: $sidebar-width-min;
+	}
+
+	@include breakpoint( '>960px' ) {
+		width: $sidebar-width-max;
 	}
 
 	.masterbar__item-content {

--- a/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
 
@@ -16,6 +17,7 @@ class BackupDetailPage extends Component {
 
 		return (
 			<Main>
+				<DocumentHead title="Backup Details" />
 				<div>Welcome to the backup detail page</div>
 				<div>Site ID: { siteId }</div>
 				<div>Backup ID: { backupId }</div>

--- a/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
@@ -8,17 +8,18 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
+import Main from 'components/main';
 
 class BackupDetailPage extends Component {
 	render() {
 		const { siteId, backupId } = this.props;
 
 		return (
-			<div>
+			<Main>
 				<div>Welcome to the backup detail page</div>
 				<div>Site ID: { siteId }</div>
 				<div>Backup ID: { backupId }</div>
-			</div>
+			</Main>
 		);
 	}
 }

--- a/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 class BackupDetailPage extends Component {
 	render() {
@@ -18,6 +19,7 @@ class BackupDetailPage extends Component {
 		return (
 			<Main>
 				<DocumentHead title="Backup Details" />
+				<SidebarNavigation />
 				<div>Welcome to the backup detail page</div>
 				<div>Site ID: { siteId }</div>
 				<div>Backup ID: { backupId }</div>

--- a/client/landing/jetpack-cloud/sections/backups/download/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/download/index.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import { BackupProgress } from './types';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { rewindBackup } from 'state/activity-log/actions';
@@ -75,6 +76,7 @@ const BackupDownloadPage = ( { rewindId }: Props ) => {
 
 	return (
 		<Main>
+			<DocumentHead title="Download" />
 			{ siteId && <QueryRewindBackupStatus downloadId={ downloadId } siteId={ siteId } /> }
 			{ render() }
 		</Main>

--- a/client/landing/jetpack-cloud/sections/backups/download/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/download/index.tsx
@@ -17,6 +17,7 @@ import InProgress from './in-progress';
 import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status';
 import Ready from './ready';
 import Error from './error';
+import Main from 'components/main';
 
 interface Props {
 	rewindId: string;
@@ -73,10 +74,10 @@ const BackupDownloadPage = ( { rewindId }: Props ) => {
 	};
 
 	return (
-		<div>
+		<Main>
 			{ siteId && <QueryRewindBackupStatus downloadId={ downloadId } siteId={ siteId } /> }
 			{ render() }
-		</div>
+		</Main>
 	);
 };
 

--- a/client/landing/jetpack-cloud/sections/backups/download/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/download/index.tsx
@@ -19,6 +19,7 @@ import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status'
 import Ready from './ready';
 import Error from './error';
 import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 interface Props {
 	rewindId: string;
@@ -77,6 +78,7 @@ const BackupDownloadPage = ( { rewindId }: Props ) => {
 	return (
 		<Main>
 			<DocumentHead title="Download" />
+			<SidebarNavigation />
 			{ siteId && <QueryRewindBackupStatus downloadId={ downloadId } siteId={ siteId } /> }
 			{ render() }
 		</Main>

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -20,6 +20,7 @@ import getRewindState from 'state/selectors/get-rewind-state';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
 import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySitePurchases from 'components/data/query-site-purchases';
+import Main from 'components/main';
 
 class BackupsPage extends Component {
 	constructor( props ) {
@@ -47,7 +48,7 @@ class BackupsPage extends Component {
 		const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
 
 		return (
-			<div>
+			<Main>
 				<QueryRewindState siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
 				<DatePicker
@@ -71,7 +72,7 @@ class BackupsPage extends Component {
 						moment,
 					} }
 				/>
-			</div>
+			</Main>
 		);
 	}
 }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -7,6 +7,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import { emptyFilter } from 'state/activity-log/reducer';
 import { getBackupAttemptsForDate, getDailyBackupDeltas, getEventsInDailyBackup } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -49,6 +50,7 @@ class BackupsPage extends Component {
 
 		return (
 			<Main>
+				<DocumentHead title="Backups" />
 				<QueryRewindState siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
 				<DatePicker

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -22,6 +22,7 @@ import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
 import QueryRewindState from 'components/data/query-rewind-state';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 class BackupsPage extends Component {
 	constructor( props ) {
@@ -51,6 +52,7 @@ class BackupsPage extends Component {
 		return (
 			<Main>
 				<DocumentHead title="Backups" />
+				<SidebarNavigation />
 				<QueryRewindState siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
 				<DatePicker

--- a/client/landing/jetpack-cloud/sections/backups/restore/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/restore/index.tsx
@@ -16,6 +16,7 @@ import getRewindState from 'state/selectors/get-rewind-state';
 import InProgress from './in-progress';
 import QueryRewindRestoreStatus from 'components/data/query-rewind-restore-status';
 import Queued from './queued';
+import Main from 'components/main';
 
 enum RestoreState {
 	RestoreConfirm,
@@ -95,10 +96,10 @@ const BackupRestorePage = ( { restoreId }: Props ) => {
 	};
 
 	return (
-		<div>
+		<Main>
 			{ siteId && <QueryRewindRestoreStatus siteId={ siteId } /> }
 			{ render() }
-		</div>
+		</Main>
 	);
 };
 

--- a/client/landing/jetpack-cloud/sections/backups/restore/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/restore/index.tsx
@@ -18,6 +18,7 @@ import InProgress from './in-progress';
 import QueryRewindRestoreStatus from 'components/data/query-rewind-restore-status';
 import Queued from './queued';
 import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 enum RestoreState {
 	RestoreConfirm,
@@ -99,6 +100,7 @@ const BackupRestorePage = ( { restoreId }: Props ) => {
 	return (
 		<Main>
 			<DocumentHead title="Restore" />
+			<SidebarNavigation />
 			{ siteId && <QueryRewindRestoreStatus siteId={ siteId } /> }
 			{ render() }
 		</Main>

--- a/client/landing/jetpack-cloud/sections/backups/restore/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/restore/index.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { rewindRestore } from 'state/activity-log/actions';
 import Confirm from './confirm';
@@ -97,6 +98,7 @@ const BackupRestorePage = ( { restoreId }: Props ) => {
 
 	return (
 		<Main>
+			<DocumentHead title="Restore" />
 			{ siteId && <QueryRewindRestoreStatus siteId={ siteId } /> }
 			{ render() }
 		</Main>

--- a/client/landing/jetpack-cloud/sections/dashboard/main.jsx
+++ b/client/landing/jetpack-cloud/sections/dashboard/main.jsx
@@ -8,10 +8,11 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { getCurrentUserName } from 'state/current-user/selectors';
+import Main from 'components/main';
 
 class DashboardPage extends Component {
 	render() {
-		return <div>Welcome to the dashboard, { this.props.currentUserName }!</div>;
+		return <Main>Welcome to the dashboard, { this.props.currentUserName }!</Main>;
 	}
 }
 

--- a/client/landing/jetpack-cloud/sections/dashboard/main.jsx
+++ b/client/landing/jetpack-cloud/sections/dashboard/main.jsx
@@ -7,12 +7,18 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import { getCurrentUserName } from 'state/current-user/selectors';
 import Main from 'components/main';
 
 class DashboardPage extends Component {
 	render() {
-		return <Main>Welcome to the dashboard, { this.props.currentUserName }!</Main>;
+		return (
+			<Main>
+				<DocumentHead title="Welcome to Jetpack Cloud" />
+				Welcome to the dashboard, { this.props.currentUserName }!
+			</Main>
+		);
 	}
 }
 

--- a/client/landing/jetpack-cloud/sections/dashboard/main.jsx
+++ b/client/landing/jetpack-cloud/sections/dashboard/main.jsx
@@ -10,12 +10,14 @@ import { connect } from 'react-redux';
 import DocumentHead from 'components/data/document-head';
 import { getCurrentUserName } from 'state/current-user/selectors';
 import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 class DashboardPage extends Component {
 	render() {
 		return (
 			<Main>
 				<DocumentHead title="Welcome to Jetpack Cloud" />
+				<SidebarNavigation />
 				Welcome to the dashboard, { this.props.currentUserName }!
 			</Main>
 		);

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -8,6 +8,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import ScanHistoryItem from '../../../components/scan-history-item';
 import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -130,6 +131,7 @@ class ScanHistoryPage extends Component {
 		const logEntries = this.filteredEntries();
 		return (
 			<Main className="history">
+				<DocumentHead title={ translate( 'History' ) } />
 				<h1 className="history__header">{ translate( 'History' ) }</h1>
 				<p>
 					{ translate(

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -11,6 +11,7 @@ import { translate } from 'i18n-calypso';
 import ScanHistoryItem from '../../../components/scan-history-item';
 import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import Main from 'components/main';
 
 /**
  * Style dependencies
@@ -128,7 +129,7 @@ class ScanHistoryPage extends Component {
 	render() {
 		const logEntries = this.filteredEntries();
 		return (
-			<section className="history">
+			<Main className="history">
 				<h1 className="history__header">{ translate( 'History' ) }</h1>
 				<p>
 					{ translate(
@@ -145,7 +146,7 @@ class ScanHistoryPage extends Component {
 						<ScanHistoryItem entry={ entry } key={ entry.id } />
 					) ) }
 				</div>
-			</section>
+			</Main>
 		);
 	}
 }

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -13,6 +13,7 @@ import ScanHistoryItem from '../../../components/scan-history-item';
 import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 /**
  * Style dependencies
@@ -132,6 +133,7 @@ class ScanHistoryPage extends Component {
 		return (
 			<Main className="history">
 				<DocumentHead title={ translate( 'History' ) } />
+				<SidebarNavigation />
 				<h1 className="history__header">{ translate( 'History' ) }</h1>
 				<p>
 					{ translate(

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -1,13 +1,14 @@
 .history {
-	padding: 0 10px;
 
 	&__header {
 		font-size: 28px;
 		line-height: 1;
 		margin: 30px 0;
+		padding: 0 16px;
 
 		@include breakpoint( '>660px' ) {
 			font-size: 48px;
+			padding: 0;
 		}
 	}
 

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -9,6 +9,7 @@ import { numberFormat, translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import { withLocalizedMoment } from 'components/localized-moment';
 import SecurityIcon from 'landing/jetpack-cloud/components/security-icon';
@@ -183,6 +184,7 @@ class ScanPage extends Component {
 
 		return (
 			<Main className="scan__main">
+				<DocumentHead title="Scanner" />
 				<div className="scan__content">
 					{ this.renderScanState() }
 					<ComponentToTestDialogs threat={ threats[ 0 ] } siteName={ site.name } />

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -16,6 +16,7 @@ import StatsFooter from 'landing/jetpack-cloud/components/stats-footer';
 import ThreatItem from '../../components/threat-item';
 import { isEnabled } from 'config';
 import ThreatDialog from '../../components/threat-dialog';
+import Main from 'components/main';
 
 import './style.scss';
 
@@ -181,7 +182,7 @@ class ScanPage extends Component {
 		const { threats, site } = this.props;
 
 		return (
-			<div className="scan__main">
+			<Main className="scan__main">
 				<div className="scan__content">
 					{ this.renderScanState() }
 					<ComponentToTestDialogs threat={ threats[ 0 ] } siteName={ site.name } />
@@ -196,7 +197,7 @@ class ScanPage extends Component {
 					noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backups has you covered."
 					noticeLink="https://jetpack/upgrade/backups"
 				/>
-			</div>
+			</Main>
 		);
 	}
 }

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -18,6 +18,7 @@ import ThreatItem from '../../components/threat-item';
 import { isEnabled } from 'config';
 import ThreatDialog from '../../components/threat-dialog';
 import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 import './style.scss';
 
@@ -185,6 +186,7 @@ class ScanPage extends Component {
 		return (
 			<Main className="scan__main">
 				<DocumentHead title="Scanner" />
+				<SidebarNavigation />
 				<div className="scan__content">
 					{ this.renderScanState() }
 					<ComponentToTestDialogs threat={ threats[ 0 ] } siteName={ site.name } />

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -1,23 +1,7 @@
-.scan__main {
-	box-sizing: border-box;
-	display: flex;
-	flex-direction: column;
-	min-height: calc( 100vh - 47px ); // Padding of .layout__content.
-	padding: 40px 16px 0;
-
-	@include breakpoint ( '>660px' ) {
-		min-height: calc( 100vh - 95px ); // 71px top + 24px bottom padding. 
-		padding: 0;
-	}
-
-	@include breakpoint ( '>960px' ) {
-		min-height: calc( 100vh - 111px ); // 79px top + 32px bottom padding.
-	}
-}
-
 .scan__content {
 	flex: 1 0 auto;
 	max-width: 680px;
+	padding: 0 16px;
 
 	.security-icon {
 		display: block;
@@ -26,6 +10,7 @@
 
 		@include breakpoint( '>660px' ) {
 			margin: 0;
+			padding: 0;
 		}
 	}
 

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -14,6 +14,7 @@ import { Card } from '@automattic/components';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
 import Gridicon from 'components/gridicon';
+import Main from 'components/main';
 
 /**
  * Style dependencies
@@ -27,7 +28,7 @@ class SettingsPage extends Component {
 		const isConnected = 'active' === rewind.state;
 
 		return (
-			<div className="settings">
+			<Main className="settings">
 				<QueryRewindState siteId={ siteId } />
 				<div className="settings__page-title">{ translate( 'Server connection details' ) }</div>
 				{ isConnected && (
@@ -64,7 +65,7 @@ class SettingsPage extends Component {
 						showNotices: false,
 					} }
 				/>
-			</div>
+			</Main>
 		);
 	}
 }

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -16,6 +16,7 @@ import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
 import Gridicon from 'components/gridicon';
 import Main from 'components/main';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 
 /**
  * Style dependencies
@@ -31,6 +32,7 @@ class SettingsPage extends Component {
 		return (
 			<Main className="settings">
 				<DocumentHead title={ translate( 'Settings' ) } />
+				<SidebarNavigation />
 				<QueryRewindState siteId={ siteId } />
 				<div className="settings__page-title">{ translate( 'Server connection details' ) }</div>
 				{ isConnected && (

--- a/client/landing/jetpack-cloud/sections/settings/main.jsx
+++ b/client/landing/jetpack-cloud/sections/settings/main.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DocumentHead from 'components/data/document-head';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import RewindCredentialsForm from 'components/rewind-credentials-form';
 import { Card } from '@automattic/components';
@@ -29,6 +30,7 @@ class SettingsPage extends Component {
 
 		return (
 			<Main className="settings">
+				<DocumentHead title={ translate( 'Settings' ) } />
 				<QueryRewindState siteId={ siteId } />
 				<div className="settings__page-title">{ translate( 'Server connection details' ) }</div>
 				{ isConnected && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the pages across jetpack cloud to be more like calypso. 
This PR adds a document title, Main component and SidebarNavigation for each Page in Jetpack Cloud. 

Some things are not yet translated. I think that could betackeld in a different PR. 

It solves the current non mobile navgation in the same way as calypso. 

Before:
<img width="450" alt="Screen Shot 2020-03-19 at 11 51 00 AM" src="https://user-images.githubusercontent.com/115071/77059879-f5be5c80-69d7-11ea-9e03-701d16cd5c46.png">

After:
<img width="626" alt="Screen Shot 2020-03-19 at 11 47 20 AM" src="https://user-images.githubusercontent.com/115071/77059803-d1fb1680-69d7-11ea-8b6f-88cc4729144f.png">


#### Testing instructions
* Load up Jetpack Cloud. 
* Does it work as expected. 
