### PR TITLE
Site Migration: Don't update the Site instance in Calypso until the site becomes WordPress.com Business

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -283,6 +283,7 @@ class SectionMigrate extends Component {
 					source_blog_id: sourceSiteId,
 					created: startTime,
 					last_modified: lastModified,
+					is_atomic: isBackendAtomic,
 				} = response;
 
 				if ( sourceSiteId && sourceSiteId !== this.props.sourceSiteId ) {
@@ -317,9 +318,9 @@ class SectionMigrate extends Component {
 					}
 
 					/**
-					 * Request the site information until the site upgrades to Atomic
+					 * Renew the site if the backend upgraded do Atomic, but Calypso still has old data
 					 */
-					if ( ! get( targetSite, 'options.is_wpcom_atomic', false ) ) {
+					if ( isBackendAtomic && ! get( targetSite, 'options.is_wpcom_atomic', false ) ) {
 						this.props.requestSite( targetSiteId );
 					}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes a very obtrusive flickering that happens when starting a migration from a WordPress.com Simple site.
* The issue is that we were updating the site status until it became WordPress.com Business site, but due to the nature of how the API responds, we were causing state issues and the UI flickered between locked and unlocked states until the site was upgraded succesfully.

#### Testing instructions

* Apply D40543-code to your sandbox
* Sandbox the API
* Use the Calypso.live link or test on local Calypso
* Create a new WordPress.com Simple site
* Start migration
* Notice reduced lock/unlock flickering

Known issue: There's still some initial flickering that's happening, but will be investigated in a separate PR. 
