### PR TITLE
Manage Plans: Fix placeholder loading on plans and product purchases

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -442,12 +442,24 @@ class ManagePurchase extends Component {
 		);
 	}
 
+	isDomainsLoading( props ) {
+		const { purchase, hasLoadedDomains } = props;
+		if ( purchase ) {
+			if ( ! isDomainProduct( purchase ) || isDomainTransfer( purchase ) ) {
+				return false;
+			}
+		}
+
+		return ! hasLoadedDomains;
+	}
+
 	renderPurchaseDetail() {
-		if ( isDataLoading( this.props ) || ! this.props.hasLoadedDomains ) {
+		if ( isDataLoading( this.props ) || this.isDomainsLoading( this.props ) ) {
 			return this.renderPlaceholder();
 		}
 
 		const { purchase, siteId, translate } = this.props;
+
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),
 			'is-personal': isPersonal( purchase ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes https://github.com/Automattic/wp-calypso/issues/40267 

This PR takes the loading of domains out of the account if the purchase isn't a domain. 

The reason why the pages shows the placeholder is because the user isn't part of the site any more and the request for domains (`/sites/(siteID)/domains`) returns access denied error. Since the user is not part of that site any more. 

This PR fixes the page by skipping the loading of placeholder if the purchase is not a domain. 
Since in those cases we don't care how the domains endpoint reacts. 

cc: @eltongo 
Since this regression was introduced in https://github.com/Automattic/wp-calypso/commit/5b9461014fe11939933ef247fadc5a58f2b99ad9#diff-e2b8265ef22dd8af459ffe058b1b3b08R455 

Does the solution make sense or is it breaking something else?

#### Testing instructions
* Login as the user effected. Notice that the page 
http://calypso.localhost:3000/me/purchases/ loads as expected. 
Navigate to a purchase page loads as expected. 

test the purchase under other circumstances and notice the placeholder shows up as expected. 