### PR TITLE
Site migration: show proper progress elements when migration has the status "new"

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -341,7 +341,7 @@ class SectionMigrate extends Component {
 	};
 
 	isInProgress = () => {
-		return includes( [ 'backing-up', 'restoring' ], this.state.migrationStatus );
+		return includes( [ 'new', 'backing-up', 'restoring' ], this.state.migrationStatus );
 	};
 
 	isFinished = () => {
@@ -505,6 +505,9 @@ class SectionMigrate extends Component {
 		}
 
 		if ( 'backing-up' === progressState ) {
+			if ( 'new' === migrationStatus ) {
+				return <Spinner />;
+			}
 			return <Gridicon className="migrate__progress-item-icon-success" icon="checkmark-circle" />;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In this PR, we treat the migration status "new" the same as "backing-up" to eliminate a momentary flash of the wrong progress UI at the beginning of a migration to a Simple site, after the user has bought a Business plan.

When we first insert the DB record for a migration, we give it the status "new". Almost immediately afterward, it gets the status "backing-up".

When you migrate to a Simple site without a Business plan, after you've paid for the plan, we redirect from the cart back to the migration section. When it mounts, the migration component sets the local migration status to "backing-up". On redirection, the page makes a request to the `sites` endpoint. Depending on the timing, this can return `site_migration` meta for the current site with the status "new". This status should be rendered the same as "backing-up".

#### Testing instructions

* Use the Calypso.live link or test on local Calypso.
* Create a new WordPress.com Simple site with a free plan.
* Start migration.
* Notice reduced UI flickering:
    * The icon next to the "Backing up" item in the progress list should start as a circle or spinner and stay a spinner while backup is going on. 
    * The progress bar should remain visible throughout, even if no progress is shown in it.

**Note:** You may see a flash of the sidebar during the process – that's a separate issue that should be addressed in a different PR.

![image](https://user-images.githubusercontent.com/1647564/77083736-e0582b00-69f5-11ea-8dab-fb78b5d468e3.png)


Related: https://github.com/Automattic/wp-calypso/pull/40283

