### PR TITLE
Gutenboarding: Style preview size & chrome

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -19,12 +19,14 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 	const { selectedDesign } = useSelect( select => select( STORE_KEY ).getState() );
 	const [ { title: fontA }, { title: fontB } ] = fonts;
 	return (
-		<div className="style-preview__preview">
-			<div role="presentation" className="style-preview__preview-bar">
-				<div role="presentation" className="style-preview__preview-bar-dot" />
-				<div role="presentation" className="style-preview__preview-bar-dot" />
-				<div role="presentation" className="style-preview__preview-bar-dot" />
-			</div>
+		<div className={ `style-preview__preview is-viewport-${ viewport }` }>
+			{ viewport === 'desktop' && (
+				<div role="presentation" className="style-preview__preview-bar">
+					<div role="presentation" className="style-preview__preview-bar-dot" />
+					<div role="presentation" className="style-preview__preview-bar-dot" />
+					<div role="presentation" className="style-preview__preview-bar-dot" />
+				</div>
+			) }
 			<div style={ { width: '100%', height: '100%', background: 'var(--studio-gray-5)' } }>
 				<p>Preview to be implemented.</p>
 				<p>You picked { selectedDesign?.title ?? 'unknown' } design.</p>

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -26,6 +26,7 @@
 	display: grid;
 	grid-template-columns: 100%;
 	row-gap: 1em;
+	align-self: start;
 }
 
 // Extra specificity to override core component border
@@ -42,17 +43,41 @@
 
 .style-preview__preview {
 	grid-area: preview;
-
-	border: 1px solid var( --studio-gray-5 );
-	box-shadow: 0 4px 14px rgba( 0, 0, 0, 0.25 );
+	margin: 0 auto;
+	background: var( --studio-white );
+	box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.25 );
 	border-radius: 4px;
 	overflow: hidden;
+	width: 100%;
+
+	&.is-viewport-mobile,
+	&.is-viewport-tablet {
+		width: 375px;
+		height: 812px;
+		box-sizing: border-box;
+		border: 13px solid var( --studio-white );
+
+		box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.14 ),
+			inset 0 0 0 1px var( --studio-gray-5 );
+		border-radius: 31px;
+	}
+
+	&.is-viewport-tablet {
+		width: 1024px;
+		height: 768px;
+	}
+
+	&.is-viewport-mobile {
+		width: 351px;
+		height: 690px;
+	}
 }
+
+// This and the following dot class render the browser chrome
 .style-preview__preview-bar {
 	width: 100%;
 	height: 30px;
-
-	background: #fff;
+	background: var( --studio-white );
 	border-bottom: 1px solid var( --studio-gray-5 );
 	display: flex;
 	flex-direction: row;
@@ -80,7 +105,7 @@
 
 		color: var( --studio-gray-10 );
 		&.is-selected {
-			color: #000;
+			color: var( --studio-black );
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Render browser chrome for tablet and mobile viewports
- Size tablet and mobile viewports

The sizes will surely need to be tweaked. Currently, no preview is rendered in the frame, that will be handled by #40227 

There didn't seem to be designs for tablet, so I grabbed a size and added the mobile chrome.

#### Screens
![Screen Shot 2020-03-19 at 16 49 43](https://user-images.githubusercontent.com/841763/77086193-bb69b500-6a01-11ea-95af-6cefd696d70b.png)

**We need to consider how to handle this tablet view** it will force scrolling on many viewports.

![Screen Shot 2020-03-19 at 16 49 54](https://user-images.githubusercontent.com/841763/77086190-ba388800-6a01-11ea-892c-8097c24f93ab.png)

![Screen Shot 2020-03-19 at 16 50 00](https://user-images.githubusercontent.com/841763/77086184-b86ec480-6a01-11ea-83c8-531365c9fbf7.png)


#### Testing instructions

* Boot up this branch locally and navigate to http://calypso.localhost:3000/gutenboarding
* Use the viewport switcher

Fixes #
