### PR TITLE
Gutenboarding: Font button style/size

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -30,14 +30,16 @@
 }
 
 .style-preview__font-option {
+	min-height: 3.4em;
+	box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
+	justify-content: center;
+
 	// Extra specificity to override core style
+	// This is effectively a more-specific synonmy of the same selector
 	&.components-button {
 		height: auto;
 		border-radius: 2px;
 	}
-	min-height: 3.4em;
-	box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
-	justify-content: center;
 
 	&.is-selected {
 		box-shadow: inset 0 0 0 1px var( --highlightColor );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -31,7 +31,7 @@
 
 .style-preview__font-option {
 	// Extra specificity to override core style
-	.components-button {
+	&.components-button {
 		height: auto;
 	}
 	min-height: 3.4em;

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -29,14 +29,21 @@
 	align-self: start;
 }
 
-// Extra specificity to override core component border
-.style-preview__font-option.components-button {
-	border: 1px solid var( --studio-gray-10 );
+.style-preview__font-option {
+	// Extra specificity to override core style
+	.components-button {
+		height: auto;
+	}
+	min-height: 3.4em;
+	box-shadow: 0 0 0 1px var( --studio-gray-10 );
 	justify-content: center;
-	height: 3.2em;
+
+	span {
+		align-self: baseline;
+	}
 
 	&.is-selected {
-		border-color: var( --highlightColor );
+		box-shadow: 0 0 0 1px var( --highlightColor );
 		color: var( --highlightColor );
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -39,13 +39,13 @@
 	box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
 	justify-content: center;
 
-	span {
-		align-self: baseline;
-	}
-
 	&.is-selected {
 		box-shadow: inset 0 0 0 1px var( --highlightColor );
 		color: var( --highlightColor );
+	}
+
+	span {
+		align-self: baseline;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -35,7 +35,7 @@
 		height: auto;
 	}
 	min-height: 3.4em;
-	box-shadow: 0 0 0 1px var( --studio-gray-10 );
+	box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
 	justify-content: center;
 
 	span {
@@ -43,7 +43,7 @@
 	}
 
 	&.is-selected {
-		box-shadow: 0 0 0 1px var( --highlightColor );
+		box-shadow: inset 0 0 0 1px var( --highlightColor );
 		color: var( --highlightColor );
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -33,6 +33,7 @@
 	// Extra specificity to override core style
 	&.components-button {
 		height: auto;
+		border-radius: 2px;
 	}
 	min-height: 3.4em;
 	box-shadow: inset 0 0 0 1px var( --studio-gray-10 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This improves the font picker buttons overall to be closer to the designs in their size as well as fixes an issue with the font alignment.

Fixes #40206

#### Screens



##### Current
![Screen Shot 2020-03-19 at 17 07 42](https://user-images.githubusercontent.com/841763/77089697-7005d580-6a06-11ea-9809-8ee6ab4fff76.png)

##### Branch

![Screen Shot 2020-03-19 at 17 21 34](https://user-images.githubusercontent.com/841763/77089705-72682f80-6a06-11ea-837c-f6f6c3ace763.png)

##### 100% / design side-by-side

Design | Branch
--- | ---
![Screen Shot 2020-03-19 at 17 21 53](https://user-images.githubusercontent.com/841763/77089730-7a27d400-6a06-11ea-801e-55647503c6ee.png) | ![Screen Shot 2020-03-19 at 17 21 42](https://user-images.githubusercontent.com/841763/77089733-7ac06a80-6a06-11ea-8a3e-090b437fa29c.png)  


#### Testing instructions

Checkout and run locally. Visit `http://calypso.localhost:3000/gutenboarding` and proceed to this step.