### PR TITLE
Site Migration: lock sidebar for active migrations

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -25,6 +25,7 @@ import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
 import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-progress';
+import isSiteMigrationActiveRoute from 'state/selectors/is-site-migration-active-route';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -233,6 +234,10 @@ export default connect(
 		const currentSelectedSiteId = getSelectedSiteId( state );
 		const siteId = currentSelectedSiteId || getPrimarySiteId( state );
 
+		const isMigrationInProgress =
+			!! isSiteMigrationInProgress( state, currentSelectedSiteId ) ||
+			isSiteMigrationActiveRoute( state );
+
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
@@ -241,7 +246,7 @@ export default connect(
 			hasMoreThanOneSite: getCurrentUserSiteCount( state ) > 1,
 			user: getCurrentUser( state ),
 			isSupportSession: isSupportSession( state ),
-			isMigrationInProgress: !! isSiteMigrationInProgress( state, currentSelectedSiteId ),
+			isMigrationInProgress,
 			migrationStatus: getSiteMigrationStatus( state, currentSelectedSiteId ),
 			currentSelectedSiteId,
 		};

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -235,7 +235,7 @@ export default connect(
 		const siteId = currentSelectedSiteId || getPrimarySiteId( state );
 
 		const isMigrationInProgress =
-			!! isSiteMigrationInProgress( state, currentSelectedSiteId ) ||
+			isSiteMigrationInProgress( state, currentSelectedSiteId ) ||
 			isSiteMigrationActiveRoute( state );
 
 		return {

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -269,7 +269,7 @@ export default connect(
 		const messagePath = `calypso:${ sectionName }:sidebar_notice`;
 
 		const isMigrationInProgress =
-			!! isSiteMigrationInProgress( state, siteId ) || isSiteMigrationActiveRoute( state );
+			isSiteMigrationInProgress( state, siteId ) || isSiteMigrationActiveRoute( state );
 
 		return {
 			isDomainOnly: isDomainOnlySite( state, siteId ),

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -33,6 +33,7 @@ import formatCurrency from '@automattic/format-currency/src';
 import { getPreference } from 'state/preferences/selectors';
 import { savePreference } from 'state/preferences/actions';
 import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-progress';
+import isSiteMigrationActiveRoute from 'state/selectors/is-site-migration-active-route';
 import { getSectionName } from 'state/ui/selectors';
 import { getTopJITM } from 'state/jitm/selectors';
 import AsyncLoad from 'components/async-load';
@@ -267,6 +268,9 @@ export default connect(
 		const sectionName = getSectionName( state );
 		const messagePath = `calypso:${ sectionName }:sidebar_notice`;
 
+		const isMigrationInProgress =
+			!! isSiteMigrationInProgress( state, siteId ) || isSiteMigrationActiveRoute( state );
+
 		return {
 			isDomainOnly: isDomainOnlySite( state, siteId ),
 			isEligibleForFreeToPaidUpsell: isEligibleForFreeToPaidUpsell( state, siteId ),
@@ -278,7 +282,7 @@ export default connect(
 			isPlanOwner: isCurrentUserCurrentPlanOwner( state, siteId ),
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			domainUpsellNudgeDismissedDate: getPreference( state, DOMAIN_UPSELL_NUDGE_DISMISS_KEY ),
-			isMigrationInProgress: !! isSiteMigrationInProgress( state, siteId ),
+			isMigrationInProgress,
 			hasJITM: getTopJITM( state, messagePath ),
 			messagePath,
 		};

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -779,7 +779,7 @@ function mapStateToProps( state ) {
 	const isManageSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_MANAGE );
 
 	const isMigrationInProgress =
-		!! isSiteMigrationInProgress( state, selectedSiteId ) || isSiteMigrationActiveRoute( state );
+		isSiteMigrationInProgress( state, selectedSiteId ) || isSiteMigrationActiveRoute( state );
 
 	return {
 		canUserEditThemeOptions: canCurrentUser( state, siteId, 'edit_theme_options' ),

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -37,6 +37,7 @@ import hasJetpackSites from 'state/selectors/has-jetpack-sites';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isSiteMigrationInProgress from 'state/selectors/is-site-migration-in-progress';
+import isSiteMigrationActiveRoute from 'state/selectors/is-site-migration-active-route';
 import {
 	getCustomizerUrl,
 	getSite,
@@ -777,6 +778,9 @@ function mapStateToProps( state ) {
 	const isToolsSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_TOOLS );
 	const isManageSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_MANAGE );
 
+	const isMigrationInProgress =
+		!! isSiteMigrationInProgress( state, selectedSiteId ) || isSiteMigrationActiveRoute( state );
+
 	return {
 		canUserEditThemeOptions: canCurrentUser( state, siteId, 'edit_theme_options' ),
 		canUserListUsers: canCurrentUser( state, siteId, 'list_users' ),
@@ -800,7 +804,7 @@ function mapStateToProps( state ) {
 		isToolsSectionOpen,
 		isManageSectionOpen,
 		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
-		isMigrationInProgress: !! isSiteMigrationInProgress( state, selectedSiteId ),
+		isMigrationInProgress,
 		isVip: isVipSite( state, selectedSiteId ),
 		showCustomizerLink: ! (
 			isSiteUsingFullSiteEditing( state, selectedSiteId ) ||

--- a/client/state/selectors/is-site-migration-active-route.js
+++ b/client/state/selectors/is-site-migration-active-route.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+
+import getCurrentRoute from 'state/selectors/get-current-route';
+
+/**
+ * Returns true if the current route is the status page of an active migration.
+ *
+ * @param {object} state Global state tree
+ * @returns {boolean} True if route is an active migration route
+ */
+export default function isSiteMigrationActiveRoute( state ) {
+	const route = getCurrentRoute( state );
+
+	if ( ! route ) {
+		return false;
+	}
+
+	return route.match( /\/migrate\/from\/[^/]+\/to\// );
+}

--- a/client/state/selectors/is-site-migration-active-route.js
+++ b/client/state/selectors/is-site-migration-active-route.js
@@ -17,5 +17,5 @@ export default function isSiteMigrationActiveRoute( state ) {
 		return false;
 	}
 
-	return route.match( /\/migrate\/from\/[^/]+\/to\// );
+	return route.match( /\/migrate\/(upgrade\/)?from\/[^/]+\/to\// );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new selector for active migration routes.
* Checks that selector for the Sidebar, Sidebar notice, and "Write" button in masterbar and hides them.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Calypso.live link or test on local Calypso.
* Create a new WordPress.com Simple site with a free plan.
* Start migration.
* Verify the sidebar flicker is eliminated after checkout.

