### PR TITLE
New Checkout: don't show remove button for domain redemption cart items.

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -356,6 +356,11 @@ function returnModalCopy( product, translate, hasDomainsInCart ) {
 }
 
 function canItemBeDeleted( item ) {
-	const itemTypesThatCannotBeDeleted = [ 'tax', 'credits', 'wordpress-com-credits' ];
+	const itemTypesThatCannotBeDeleted = [
+		'domain_redemption',
+		'tax',
+		'credits',
+		'wordpress-com-credits',
+	];
 	return ! itemTypesThatCannotBeDeleted.includes( item.type );
 }


### PR DESCRIPTION
This adds the `domain_redemption` item type (the domain redemption one-time fee) to the list of items that shouldn't show a delete icon in the new Checkout.

Fixes #40292 

**To test:**
- on an account with a domain that is both expired and in redemption
- visit Manage Purchases and click "renew" for the domain
- if you're redirected to the plans page (unrelated bug) click the cart item in the top right and visit checkout
- use the `?flags=composite-checkout-force` flag to force new checkout
- verify that the domain redemption fee doesn't have a trash can icon beside it