### PR TITLE
Gutenboarding: Layout style step

### DIFF
--- a/client/landing/gutenboarding/components/titles.scss
+++ b/client/landing/gutenboarding/components/titles.scss
@@ -13,4 +13,7 @@
 .gutenboarding-subtitle {
 	font-size: 16px;
 	font-family: $default-font;
+	line-height: 19px;
+	letter-spacing: 0.2px;
+	color: var( --studio-gray-60 );
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -9,7 +9,7 @@
 	.design-selector__header {
 		display: flex;
 		align-items: center;
-		margin: 5% 0%;
+		margin-top: 53px;
 	}
 
 	.design-selector__heading {
@@ -24,6 +24,7 @@
 
 	.design-selector__grid {
 		display: flex;
+		margin-top: 40px;
 		flex-wrap: wrap;
 		justify-content: space-between;
 	}

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -25,12 +25,13 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 				<div role="presentation" className="style-preview__preview-bar-dot" />
 				<div role="presentation" className="style-preview__preview-bar-dot" />
 			</div>
-			<p>Preview to be implemented.</p>
-			<p>You picked { selectedDesign?.title ?? 'unknown' } design.</p>
-			<p>Showing { viewport } display.</p>
-			<p>
-				With { fontA }&nbsp;/&nbsp;{ fontB } display.
-			</p>
+			<div style={ { width: '100%', height: '100%', background: 'var(--studio-gray-5)' } }>
+				<p>Preview to be implemented.</p>
+				<p>You picked { selectedDesign?.title ?? 'unknown' } design.</p>
+				<p>
+					Showing { viewport } display with { fontA }&nbsp;/&nbsp;{ fontB } fonts.
+				</p>
+			</div>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -2,13 +2,15 @@
 	display: grid;
 	grid-template-areas: 'title viewport-select actions';
 	column-gap: 1em;
+	margin-top: 53px;
 }
 
 .style-preview__content {
 	display: grid;
+	margin-top: 55px;
 	grid-template-areas: 'fonts preview';
-	grid-template-columns: 200px auto;
-	column-gap: 80px;
+	grid-template-columns: 163px auto;
+	column-gap: 100px;
 }
 .style-preview__titles {
 	grid-area: title;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Major layout improvements to the style (font) step as well as several visual improvements e.g. subtitle font color:

![Screen Shot 2020-03-19 at 17 49 10](https://user-images.githubusercontent.com/841763/77092779-61b9b880-6a0a-11ea-96e5-aa065c0e673a.png)

The design selection step is also affected:

![Screen Shot 2020-03-19 at 17 48 56](https://user-images.githubusercontent.com/841763/77092771-60888b80-6a0a-11ea-8ea5-df983a0ab9c1.png)

Part of  #40160

#### Testing instructions

Boot calypso in local development and visit http://calypso.localhost:3000/gutenboarding. Run through and check the changes on the design and style steps.