### PR TITLE
Upsell Nudge: Swap plan colors for accent color, swap info icon for star icon

### DIFF
--- a/client/blocks/upgrade-nudge/style.scss
+++ b/client/blocks/upgrade-nudge/style.scss
@@ -1,5 +1,5 @@
 .card.upgrade-nudge {
-	border-left: 3px solid var( --color-plan-premium );
+	border-left: 3px solid var( --studio-blue-50 );
 	display: flex;
 	margin: 16px 0;
 	padding: 12px 16px;
@@ -31,7 +31,7 @@
 }
 
 .upgrade-nudge__icon {
-	background: var( --color-plan-premium );
+	background: var( --studio-blue-50 );
 	border-radius: 50%;
 	margin-right: 16px;
 	color: var( --color-text-inverted );
@@ -46,7 +46,7 @@
 	display: inline-flex;
 
 	.upgrade-nudge__icon {
-		background: var( --color-success );
+		background: var( --studio-blue-50 );
 	}
 
 	&.is-full-width {

--- a/client/blocks/upgrade-nudge/style.scss
+++ b/client/blocks/upgrade-nudge/style.scss
@@ -1,5 +1,5 @@
 .card.upgrade-nudge {
-	border-left: 3px solid var( --studio-blue-50 );
+	border-left: 3px solid var( --color-accent );
 	display: flex;
 	margin: 16px 0;
 	padding: 12px 16px;
@@ -31,7 +31,7 @@
 }
 
 .upgrade-nudge__icon {
-	background: var( --studio-blue-50 );
+	background: var( --color-accent );
 	border-radius: 50%;
 	margin-right: 16px;
 	color: var( --color-text-inverted );
@@ -46,7 +46,7 @@
 	display: inline-flex;
 
 	.upgrade-nudge__icon {
-		background: var( --studio-blue-50 );
+		background: var( --color-accent );
 	}
 
 	&.is-full-width {

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -26,7 +26,7 @@ import { addQueryArgs } from 'lib/url';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
-import { Button, Card, ProductIcon } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 import DismissibleCard from 'blocks/dismissible-card';
 import PlanPrice from 'my-sites/plan-price';
 import TrackComponentView from 'lib/analytics/track-component-view';
@@ -137,15 +137,7 @@ export class Banner extends Component {
 	};
 
 	getIcon() {
-		const { icon, jetpack, showIcon, plan } = this.props;
-
-		if ( plan && ! icon ) {
-			return (
-				<div className="banner__icon-plan">
-					<ProductIcon slug={ plan } />
-				</div>
-			);
-		}
+		const { icon, jetpack, showIcon } = this.props;
 
 		if ( ! showIcon ) {
 			return;
@@ -162,10 +154,10 @@ export class Banner extends Component {
 		return (
 			<div className="banner__icons">
 				<div className="banner__icon">
-					<Gridicon icon={ icon || 'info-outline' } size={ 18 } />
+					<Gridicon icon={ icon || 'star' } size={ 18 } />
 				</div>
 				<div className="banner__icon-circle">
-					<Gridicon icon={ icon || 'info-outline' } size={ 18 } />
+					<Gridicon icon={ icon || 'star' } size={ 18 } />
 				</div>
 			</div>
 		);

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -202,11 +202,6 @@
 	text-align: left;
 	width: 100%;
 
-	.button.is-primary {
-		background-color: var( --color-accent );
-		border-color: var( --color-accent );
-	}
-
 	.banner__prices {
 		display: flex;
 		justify-content: flex-start;

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -20,29 +20,7 @@
 		cursor: pointer;
 	}
 
-	@include banner-color( var( --color-primary-40 ) );
-
-	&.is-wpcom-plan {
-		&.is-upgrade-blogger {
-			@include banner-color( var( --color-plan-blogger ) );
-		}
-
-		&.is-upgrade-personal {
-			@include banner-color( var( --color-plan-personal ) );
-		}
-
-		&.is-upgrade-premium {
-			@include banner-color( var( --color-plan-premium ) );
-		}
-
-		&.is-upgrade-business {
-			@include banner-color( var( --color-plan-business ) );
-		}
-
-		&.is-upgrade-ecommerce {
-			@include banner-color( var( --color-plan-ecommerce ) );
-		}
-	}
+	@include banner-color( var( --studio-blue-50 ) );
 
 	&.is-jetpack-plan {
 		&.is-upgrade-personal {
@@ -223,6 +201,11 @@
 	margin: 8px 0 0;
 	text-align: left;
 	width: 100%;
+
+	.button.is-primary {
+		background-color: var( --studio-blue-50 );
+		border-color: var( --studio-blue-60 );
+	}
 
 	.banner__prices {
 		display: flex;

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -20,7 +20,7 @@
 		cursor: pointer;
 	}
 
-	@include banner-color( var( --studio-blue-50 ) );
+	@include banner-color( var( --color-accent ) );
 
 	&.is-jetpack-plan {
 		&.is-upgrade-personal {
@@ -203,8 +203,8 @@
 	width: 100%;
 
 	.button.is-primary {
-		background-color: var( --studio-blue-50 );
-		border-color: var( --studio-blue-60 );
+		background-color: var( --color-accent );
+		border-color: var( --color-accent );
 	}
 
 	.banner__prices {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Globally update upsell nudges (no matter their underlying component) to use a static color and icon for consistency.

* Swap out individual plan colors for the primary accent color across all color schemes
* Swap out plan icons for the star icon, and make star the default icon
* Update `UpsellNudge` to reflect these changes as well.

**Before** (a sampling, not every instance)

<img width="735" alt="Screen Shot 2020-03-24 at 9 34 35 AM" src="https://user-images.githubusercontent.com/2124984/77431200-c1211b00-6db2-11ea-978f-1b593d19c244.png">
<img width="1070" alt="Screen Shot 2020-03-24 at 9 33 56 AM" src="https://user-images.githubusercontent.com/2124984/77431202-c1211b00-6db2-11ea-82fe-7cc664c8e355.png">
<img width="1075" alt="Screen Shot 2020-03-24 at 9 33 41 AM" src="https://user-images.githubusercontent.com/2124984/77431203-c1b9b180-6db2-11ea-91e8-8479bdcd9b1d.png">
<img width="1096" alt="Screen Shot 2020-03-24 at 9 33 32 AM" src="https://user-images.githubusercontent.com/2124984/77431205-c1b9b180-6db2-11ea-8318-cb58a21f44ab.png">
<img width="1073" alt="Screen Shot 2020-03-24 at 9 33 20 AM" src="https://user-images.githubusercontent.com/2124984/77431207-c1b9b180-6db2-11ea-8778-c227a6d8ad90.png">
<img width="1117" alt="Screen Shot 2020-03-24 at 10 01 25 AM" src="https://user-images.githubusercontent.com/2124984/77434909-eebc9300-6db7-11ea-9041-d6083e3f4559.png">

**After**

<img width="721" alt="Screen Shot 2020-03-24 at 10 01 44 AM" src="https://user-images.githubusercontent.com/2124984/77434895-eb290c00-6db7-11ea-81eb-783483662524.png">
<img width="1099" alt="Screen Shot 2020-03-24 at 10 01 35 AM" src="https://user-images.githubusercontent.com/2124984/77434897-ebc1a280-6db7-11ea-87bb-f1acf834405d.png">
<img width="1107" alt="Screen Shot 2020-03-24 at 10 01 06 AM" src="https://user-images.githubusercontent.com/2124984/77434898-ebc1a280-6db7-11ea-9db3-9c16905f0fd8.png">
<img width="1108" alt="Screen Shot 2020-03-24 at 10 00 58 AM" src="https://user-images.githubusercontent.com/2124984/77434899-ebc1a280-6db7-11ea-9d20-eb42f8762a56.png">
<img width="1080" alt="Screen Shot 2020-03-24 at 10 00 40 AM" src="https://user-images.githubusercontent.com/2124984/77434901-ec5a3900-6db7-11ea-875b-4cab949b512d.png">

#### Testing instructions

* Switch to this PR 
* Using a Free site, navigate around Calypso and look at upsell nudges. There are lots, so here are some of the best performing nudges to test:
- Media library: Upload video
- Media library: Upload audio
- Stats: Insights tab, halfway down the page
- Old editor (non Gutenberg): Add a Simple Payments button
- Podcasting settings
- Domains page: Banner to personal nudge
* I know of more upsells on the Activity, Plugins, Marketing, Hosting Config, and Theme Showcase pages; I'm sure there are even more.
* Look for visual issues and bugs and report them here.