### PR TITLE
Stats: Remove StatsBanners

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -24,13 +24,11 @@ import StatsModule from './stats-module';
 import statsStrings from './stats-strings';
 import titlecase from 'to-title-case';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import StatsBanners from './stats-banners';
 import StickyPanel from 'components/sticky-panel';
 import JetpackBackupCredsBanner from 'blocks/jetpack-backup-creds-banner';
 import JetpackColophon from 'components/jetpack-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
-import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import { recordGoogleEvent, recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
@@ -128,7 +126,7 @@ class StatsSite extends Component {
 	};
 
 	renderStats() {
-		const { date, siteId, slug, isCustomerHomeEnabled, isJetpack } = this.props;
+		const { date, siteId, slug, isJetpack } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -169,9 +167,6 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				<div id="my-stats-content">
-					{ ! isCustomerHomeEnabled && (
-						<StatsBanners siteId={ siteId } slug={ slug } primaryButton={ true } />
-					) }
 					<ChartTabs
 						activeTab={ getActiveTab( this.props.chartTab ) }
 						activeLegend={ this.state.activeLegend }
@@ -328,7 +323,6 @@ export default connect(
 			siteId,
 			slug: getSelectedSiteSlug( state ),
 			planSlug: getSitePlanSlug( state, siteId ),
-			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			showEnableStatsModule,
 			path: getCurrentRouteParameterized( state, siteId ),
 		};

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -15,28 +15,17 @@ import { isEcommercePlan } from 'lib/plans';
 import config from 'config';
 import ECommerceManageNudge from 'blocks/ecommerce-manage-nudge';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
-import { getEligibleGSuiteDomain } from 'lib/gsuite';
 import { getSitePlanSlug } from 'state/sites/selectors';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
-import GSuiteStatsNudge from 'blocks/gsuite-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
-import isGSuiteStatsNudgeVisible from 'state/selectors/is-gsuite-stats-nudge-visible';
 import isUpworkStatsNudgeDismissed from 'state/selectors/is-upwork-stats-nudge-dismissed';
-import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import UpworkStatsNudge from 'blocks/upwork-stats-nudge';
-import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
-import QueryEmailForwards from 'components/data/query-email-forwards';
-import canCurrentUser from 'state/selectors/can-current-user';
 
 class StatsBanners extends Component {
 	static propTypes = {
 		domains: PropTypes.array.isRequired,
-		gsuiteDomainName: PropTypes.string,
-		isCustomerHomeEnabled: PropTypes.bool.isRequired,
-		isAllowedToManageSite: PropTypes.bool.isRequired,
 		isGoogleMyBusinessStatsNudgeVisible: PropTypes.bool.isRequired,
-		isGSuiteStatsNudgeVisible: PropTypes.bool.isRequired,
 		isUpworkStatsNudgeVisible: PropTypes.bool.isRequired,
 		planSlug: PropTypes.string.isRequired,
 		siteId: PropTypes.number.isRequired,
@@ -45,20 +34,16 @@ class StatsBanners extends Component {
 
 	shouldComponentUpdate( nextProps ) {
 		return (
-			this.props.isGSuiteStatsNudgeVisible !== nextProps.isGSuiteStatsNudgeVisible ||
 			this.props.isUpworkStatsNudgeVisible !== nextProps.isUpworkStatsNudgeVisible ||
 			this.props.isGoogleMyBusinessStatsNudgeVisible !==
 				nextProps.isGoogleMyBusinessStatsNudgeVisible ||
-			this.props.domains.length !== nextProps.domains.length ||
-			this.props.gsuiteDomainName !== nextProps.gsuiteDomainName
+			this.props.domains.length !== nextProps.domains.length
 		);
 	}
 
 	renderBanner() {
 		if ( this.showUpworkBanner() ) {
 			return this.renderUpworkBanner();
-		} else if ( this.showGSuiteBanner() ) {
-			return this.renderGSuiteBanner();
 		} else if ( this.showGoogleMyBusinessBanner() ) {
 			return this.renderGoogleMyBusinessBanner();
 		}
@@ -77,19 +62,6 @@ class StatsBanners extends Component {
 		);
 	}
 
-	renderGSuiteBanner() {
-		const { gsuiteDomainName, siteId, slug, primaryButton } = this.props;
-
-		return (
-			<GSuiteStatsNudge
-				siteSlug={ slug }
-				siteId={ siteId }
-				domainSlug={ gsuiteDomainName }
-				primaryButton={ primaryButton }
-			/>
-		);
-	}
-
 	renderUpworkBanner() {
 		const { siteId, slug, primaryButton } = this.props;
 
@@ -102,10 +74,6 @@ class StatsBanners extends Component {
 		);
 	}
 
-	showGSuiteBanner() {
-		return this.props.isGSuiteStatsNudgeVisible;
-	}
-
 	showUpworkBanner() {
 		return (
 			abtest( 'builderReferralStatsNudge' ) === 'builderReferralBanner' &&
@@ -114,14 +82,7 @@ class StatsBanners extends Component {
 	}
 
 	render() {
-		const {
-			gsuiteDomainName,
-			isCustomerHomeEnabled,
-			isAllowedToManageSite,
-			planSlug,
-			siteId,
-			domains,
-		} = this.props;
+		const { planSlug, siteId, domains } = this.props;
 
 		if ( isEmpty( domains ) ) {
 			return null;
@@ -129,16 +90,8 @@ class StatsBanners extends Component {
 
 		return (
 			<Fragment>
-				{ gsuiteDomainName && isAllowedToManageSite && (
-					<QueryEmailForwards domainName={ gsuiteDomainName } />
-				) }
-
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 
-				{ /* Hide `WpcomChecklist` on the Customer Home because the checklist is displayed on the page. */ }
-				{ ! isEcommercePlan( planSlug ) && ! isCustomerHomeEnabled && (
-					<WpcomChecklist viewMode="banner" />
-				) }
 				{ isEcommercePlan( planSlug ) && <ECommerceManageNudge siteId={ siteId } /> }
 
 				{ this.renderBanner() }
@@ -152,14 +105,10 @@ export default connect( ( state, ownProps ) => {
 
 	return {
 		domains,
-		gsuiteDomainName: getEligibleGSuiteDomain( null, domains ),
-		isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, ownProps.siteId ),
-		isAllowedToManageSite: canCurrentUser( state, ownProps.siteId, 'manage_options' ),
 		isGoogleMyBusinessStatsNudgeVisible: isGoogleMyBusinessStatsNudgeVisibleSelector(
 			state,
 			ownProps.siteId
 		),
-		isGSuiteStatsNudgeVisible: isGSuiteStatsNudgeVisible( state, ownProps.siteId, domains ),
 		isUpworkStatsNudgeVisible: ! isUpworkStatsNudgeDismissed( state, ownProps.siteId ),
 		planSlug: getSitePlanSlug( state, ownProps.siteId ),
 	};

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -15,17 +15,28 @@ import { isEcommercePlan } from 'lib/plans';
 import config from 'config';
 import ECommerceManageNudge from 'blocks/ecommerce-manage-nudge';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
+import { getEligibleGSuiteDomain } from 'lib/gsuite';
 import { getSitePlanSlug } from 'state/sites/selectors';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
+import GSuiteStatsNudge from 'blocks/gsuite-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
+import isGSuiteStatsNudgeVisible from 'state/selectors/is-gsuite-stats-nudge-visible';
 import isUpworkStatsNudgeDismissed from 'state/selectors/is-upwork-stats-nudge-dismissed';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import UpworkStatsNudge from 'blocks/upwork-stats-nudge';
+import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
+import QueryEmailForwards from 'components/data/query-email-forwards';
+import canCurrentUser from 'state/selectors/can-current-user';
 
 class StatsBanners extends Component {
 	static propTypes = {
 		domains: PropTypes.array.isRequired,
+		gsuiteDomainName: PropTypes.string,
+		isCustomerHomeEnabled: PropTypes.bool.isRequired,
+		isAllowedToManageSite: PropTypes.bool.isRequired,
 		isGoogleMyBusinessStatsNudgeVisible: PropTypes.bool.isRequired,
+		isGSuiteStatsNudgeVisible: PropTypes.bool.isRequired,
 		isUpworkStatsNudgeVisible: PropTypes.bool.isRequired,
 		planSlug: PropTypes.string.isRequired,
 		siteId: PropTypes.number.isRequired,
@@ -34,16 +45,20 @@ class StatsBanners extends Component {
 
 	shouldComponentUpdate( nextProps ) {
 		return (
+			this.props.isGSuiteStatsNudgeVisible !== nextProps.isGSuiteStatsNudgeVisible ||
 			this.props.isUpworkStatsNudgeVisible !== nextProps.isUpworkStatsNudgeVisible ||
 			this.props.isGoogleMyBusinessStatsNudgeVisible !==
 				nextProps.isGoogleMyBusinessStatsNudgeVisible ||
-			this.props.domains.length !== nextProps.domains.length
+			this.props.domains.length !== nextProps.domains.length ||
+			this.props.gsuiteDomainName !== nextProps.gsuiteDomainName
 		);
 	}
 
 	renderBanner() {
 		if ( this.showUpworkBanner() ) {
 			return this.renderUpworkBanner();
+		} else if ( this.showGSuiteBanner() ) {
+			return this.renderGSuiteBanner();
 		} else if ( this.showGoogleMyBusinessBanner() ) {
 			return this.renderGoogleMyBusinessBanner();
 		}
@@ -62,6 +77,19 @@ class StatsBanners extends Component {
 		);
 	}
 
+	renderGSuiteBanner() {
+		const { gsuiteDomainName, siteId, slug, primaryButton } = this.props;
+
+		return (
+			<GSuiteStatsNudge
+				siteSlug={ slug }
+				siteId={ siteId }
+				domainSlug={ gsuiteDomainName }
+				primaryButton={ primaryButton }
+			/>
+		);
+	}
+
 	renderUpworkBanner() {
 		const { siteId, slug, primaryButton } = this.props;
 
@@ -74,6 +102,10 @@ class StatsBanners extends Component {
 		);
 	}
 
+	showGSuiteBanner() {
+		return this.props.isGSuiteStatsNudgeVisible;
+	}
+
 	showUpworkBanner() {
 		return (
 			abtest( 'builderReferralStatsNudge' ) === 'builderReferralBanner' &&
@@ -82,7 +114,14 @@ class StatsBanners extends Component {
 	}
 
 	render() {
-		const { planSlug, siteId, domains } = this.props;
+		const {
+			gsuiteDomainName,
+			isCustomerHomeEnabled,
+			isAllowedToManageSite,
+			planSlug,
+			siteId,
+			domains,
+		} = this.props;
 
 		if ( isEmpty( domains ) ) {
 			return null;
@@ -90,8 +129,16 @@ class StatsBanners extends Component {
 
 		return (
 			<Fragment>
+				{ gsuiteDomainName && isAllowedToManageSite && (
+					<QueryEmailForwards domainName={ gsuiteDomainName } />
+				) }
+
 				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
 
+				{ /* Hide `WpcomChecklist` on the Customer Home because the checklist is displayed on the page. */ }
+				{ ! isEcommercePlan( planSlug ) && ! isCustomerHomeEnabled && (
+					<WpcomChecklist viewMode="banner" />
+				) }
 				{ isEcommercePlan( planSlug ) && <ECommerceManageNudge siteId={ siteId } /> }
 
 				{ this.renderBanner() }
@@ -105,10 +152,14 @@ export default connect( ( state, ownProps ) => {
 
 	return {
 		domains,
+		gsuiteDomainName: getEligibleGSuiteDomain( null, domains ),
+		isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, ownProps.siteId ),
+		isAllowedToManageSite: canCurrentUser( state, ownProps.siteId, 'manage_options' ),
 		isGoogleMyBusinessStatsNudgeVisible: isGoogleMyBusinessStatsNudgeVisibleSelector(
 			state,
 			ownProps.siteId
 		),
+		isGSuiteStatsNudgeVisible: isGSuiteStatsNudgeVisible( state, ownProps.siteId, domains ),
 		isUpworkStatsNudgeVisible: ! isUpworkStatsNudgeDismissed( state, ownProps.siteId ),
 		planSlug: getSitePlanSlug( state, ownProps.siteId ),
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the GSuite upsell banner and checklist progress banner from Stats. These have moved to Customer Home.
* Wondering if we should just remove `StatsBanners` entirely, since they're only shown when Customer Home is not active?

https://github.com/Automattic/wp-calypso/blob/9820c2fa70292fda1db438deca943ce1b29f0faa/client/my-sites/stats/site.jsx#L172-L174

**Before**

<img width="1095" alt="Screen Shot 2020-03-19 at 1 33 34 PM" src="https://user-images.githubusercontent.com/2124984/77096839-4b016a80-69e6-11ea-9a9e-21c05af426e0.png">

(You shouldn't see this if you have Customer Home enabled on your site, but this will give you an idea of what the banner would look like.)

**After**

<img width="1107" alt="Screen Shot 2020-03-19 at 1 22 02 PM" src="https://user-images.githubusercontent.com/2124984/77095944-00332300-69e5-11ea-86c1-811da7223e87.png">

#### Testing instructions

* Switch to this PR
* Navigate to Stats with a bunch of different types of sites (Free, Personal, Premium, Business, ECommerce, etc.) to ensure you don't see the GSuite upsell or the checklist progress banners.