### PR TITLE
Add stand-alone peer referral page for US traffic.

### DIFF
--- a/client/my-sites/earn/index.js
+++ b/client/my-sites/earn/index.js
@@ -24,6 +24,9 @@ export default function() {
 
 	page( '/earn/ads-settings', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/ads-earnings', siteSelection, sites, makeLayout, clientRender );
+
+	page( '/earn/refer-a-friend', siteSelection, sites, makeLayout, clientRender );
+
 	// These are legacy URLs to redirect if they are present anywhere on the web.
 	page( '/ads/earnings/:site_id', earnController.redirectToAdsEarnings, makeLayout, clientRender );
 	page( '/ads/settings/:site_id', earnController.redirectToAdsSettings, makeLayout, clientRender );

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -27,6 +27,7 @@ import Home from './home';
 import AdsWrapper from './ads/wrapper';
 import MembershipsSection from './memberships';
 import MembershipsProductsSection from './memberships/products';
+import ReferAFriendSection from './refer-a-friend';
 import { canAccessAds } from 'lib/ads/utils';
 
 class EarningsMain extends Component {
@@ -84,6 +85,10 @@ class EarningsMain extends Component {
 				return <MembershipsSection section={ this.props.section } query={ this.props.query } />;
 			case 'payments-plans':
 				return <MembershipsProductsSection section={ this.props.section } />;
+
+			case 'refer-a-friend':
+				return <ReferAFriendSection />;
+
 			default:
 				return <Home />;
 		}
@@ -125,6 +130,9 @@ class EarningsMain extends Component {
 			case 'ads-settings':
 				return translate( 'Ads' );
 
+			case 'refer-a-friend':
+				return translate( 'Refer-a-Friend Program' );
+
 			default:
 				return '';
 		}
@@ -146,7 +154,8 @@ class EarningsMain extends Component {
 		const currentPath = this.getCurrentPath();
 
 		return (
-			! section.startsWith( 'payments' ) && (
+			! section.startsWith( 'payments' ) &&
+			! section.startsWith( 'refer-a-friend' ) && (
 				<SectionNav selectedText={ this.getSelectedText() }>
 					<NavTabs>
 						{ this.getFilters().map( filterItem => {
@@ -175,6 +184,7 @@ class EarningsMain extends Component {
 			settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
 			payments: translate( 'Recurring Payments' ),
 			'payments-plans': translate( 'Recurring Payments plans' ),
+			'refer-a-friend': translate( 'Refer-a-Friend Program' ),
 		};
 
 		return (

--- a/client/my-sites/earn/refer-a-friend/index.tsx
+++ b/client/my-sites/earn/refer-a-friend/index.tsx
@@ -131,9 +131,11 @@ const ReferAFriendSection: FunctionComponent< ConnectedProps > = ( {
 	};
 
 	return (
-		<Fragment>
-			<PromoSection { ...promos } />
-		</Fragment>
+		<div className="refer-a-friend__earn-page">
+			<Fragment>
+				<PromoSection { ...promos } />
+			</Fragment>
+		</div>
 	);
 };
 

--- a/client/my-sites/earn/refer-a-friend/index.tsx
+++ b/client/my-sites/earn/refer-a-friend/index.tsx
@@ -71,7 +71,7 @@ const ReferAFriendSection: FunctionComponent< ConnectedProps > = ( {
 		}
 
 		const cta: CtaButton = {
-			text: translate( 'Get Shareable Link' ) as string,
+			text: translate( 'Get shareable link' ) as string,
 			action: () => {
 				trackCtaButton( 'peer-referral-wpcom' );
 				onPeerReferralCtaClick();

--- a/client/my-sites/earn/refer-a-friend/index.tsx
+++ b/client/my-sites/earn/refer-a-friend/index.tsx
@@ -1,0 +1,159 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React, { FunctionComponent, Fragment, useState, useEffect } from 'react';
+import { compact } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import wp from 'lib/wp';
+import { SiteSlug } from 'types';
+import { useTranslate } from 'i18n-calypso';
+import { isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import getSiteBySlug from 'state/sites/selectors/get-site-by-slug';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import ClipboardButtonInput from 'components/clipboard-button-input';
+import { CtaButton } from 'components/promo-section/promo-card/cta';
+
+/**
+ * Image dependencies
+ */
+import earnSectionImage from 'assets/images/earn/earn-section.svg';
+import referralImage from 'assets/images/earn/referral.svg';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface ConnectedProps {
+	siteId: number;
+	selectedSiteSlug: SiteSlug;
+	isJetpack: boolean;
+	isAtomicSite: boolean;
+	trackCtaButton: ( feature: string ) => void;
+}
+
+const wpcom = wp.undocumented();
+
+const ReferAFriendSection: FunctionComponent< ConnectedProps > = ( {
+	isJetpack,
+	isAtomicSite,
+	trackCtaButton,
+} ) => {
+	const translate = useTranslate();
+	const [ peerReferralLink, setPeerReferralLink ] = useState( '' );
+
+	useEffect( () => {
+		if ( peerReferralLink ) return;
+		wpcom.me().getPeerReferralLink( ( error: string, data: string ) => {
+			setPeerReferralLink( ! error && data ? data : '' );
+		} );
+	}, [ peerReferralLink ] );
+
+	const onPeerReferralCtaClick = () => {
+		if ( peerReferralLink ) return;
+		wpcom.me().setPeerReferralLinkEnable( true, ( error: string, data: string ) => {
+			setPeerReferralLink( ! error && data ? data : '' );
+		} );
+	};
+
+	const getPeerReferralsCard = () => {
+		const isJetpackNotAtomic = isJetpack && ! isAtomicSite;
+
+		if ( isJetpackNotAtomic ) {
+			return;
+		}
+
+		const cta: CtaButton = {
+			text: translate( 'Get Shareable Link' ) as string,
+			action: () => {
+				trackCtaButton( 'peer-referral-wpcom' );
+				onPeerReferralCtaClick();
+			},
+		};
+
+		if ( peerReferralLink ) {
+			cta.component = <ClipboardButtonInput value={ peerReferralLink } />;
+		}
+
+		return {
+			title: translate( 'Refer a friend, you’ll both earn credits!' ),
+			body: peerReferralLink
+				? translate(
+						'To earn free credits, share the link below with your friends, family, and website visitors. ' +
+							'By doing so you agree to the WordPress.com Peer Referral Program {{a}}Terms and Conditions.{{/a}}',
+						{
+							components: {
+								a: (
+									<a
+										href="https://wordpress.com/refer-a-friend-program-terms-of-service/"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						}
+				  )
+				: translate(
+						'Copy your tracking link and start sharing it with your friends. It’s that easy!'
+				  ),
+			image: {
+				path: referralImage,
+			},
+			actions: {
+				cta,
+			},
+		};
+	};
+
+	const promos: PromoSectionProps = {
+		header: {
+			title: translate( 'Earn and share rewards when you refer friends.' ),
+			image: {
+				path: earnSectionImage,
+			},
+			body: translate(
+				'Share WordPress.com with friends, family, and website visitors. For every paying customer you send our way, you’ll both earn US$25 in free credits. {{em}}Available with every plan{{/em}}.',
+				{
+					components: {
+						em: <em />,
+					},
+				}
+			),
+		},
+		promos: compact( [ getPeerReferralsCard() ] ),
+	};
+
+	return (
+		<Fragment>
+			<PromoSection { ...promos } />
+		</Fragment>
+	);
+};
+
+export default connect< ConnectedProps, {}, {} >(
+	state => {
+		const selectedSiteSlug = getSelectedSiteSlug( state );
+		const site = getSiteBySlug( state, selectedSiteSlug );
+		return {
+			siteId: site.ID,
+			isJetpack: isJetpackSite( state, site.ID ),
+			isAtomicSite: isSiteAutomatedTransfer( state, site.ID ),
+		};
+	},
+	dispatch => ( {
+		trackCtaButton: ( feature: string ) =>
+			dispatch(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_earn_page_cta_button_click', { feature } ),
+					bumpStat( 'calypso_earn_page', 'cta-button-' + feature )
+				)
+			),
+	} )
+)( ReferAFriendSection );

--- a/client/my-sites/earn/refer-a-friend/style.scss
+++ b/client/my-sites/earn/refer-a-friend/style.scss
@@ -1,0 +1,9 @@
+.promo-section__promos {
+	.promo-card {
+		width: calc( 100% - 1em );
+
+		@include breakpoint( '>1280px' ) {
+			width: calc( 100% - 1em );
+		}
+	}
+}

--- a/client/my-sites/earn/refer-a-friend/style.scss
+++ b/client/my-sites/earn/refer-a-friend/style.scss
@@ -1,4 +1,4 @@
-.earn {
+.refer-a-friend__earn-page {
 	.promo-section__promos {
 		.promo-card {
 			width: calc( 100% - 1em );

--- a/client/my-sites/earn/refer-a-friend/style.scss
+++ b/client/my-sites/earn/refer-a-friend/style.scss
@@ -1,9 +1,11 @@
-.promo-section__promos {
-	.promo-card {
-		width: calc( 100% - 1em );
-
-		@include breakpoint( '>1280px' ) {
+.earn {
+	.promo-section__promos {
+		.promo-card {
 			width: calc( 100% - 1em );
+
+			@include breakpoint( '>1280px' ) {
+				width: calc( 100% - 1em );
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a stand-alone peer referral page with tracking link.

#### Testing instructions

Use calypso.live link below, or locally, open:
http://calypso.localhost:3000/earn/refer-a-friend
- `/earn/refer-a-friend`
- `/earn/refer-a-friend/[site]`

NOTE: This will only be used for US traffic right now.

![Screen Shot 2020-03-19 at 16 54 07](https://user-images.githubusercontent.com/1563559/77114181-7abe6b80-6a02-11ea-9433-26f7f3dd9bc3.png)
![Screen Shot 2020-03-19 at 16 54 23](https://user-images.githubusercontent.com/1563559/77114182-7b570200-6a02-11ea-8314-6ef7206d6d51.png)
