### PR TITLE
New Checkout: remove body overflow style after modal closes.

### DIFF
--- a/packages/composite-checkout/src/components/checkout-modal.js
+++ b/packages/composite-checkout/src/components/checkout-modal.js
@@ -152,12 +152,15 @@ function preventClose( event ) {
 
 function useModalScreen( isVisible, closeModal ) {
 	useEffect( () => {
-		document.body.style.cssText = isVisible ? 'overflow: hidden' : 'overflow: scroll';
+		document.body.style.cssText = isVisible ? 'overflow: hidden' : '';
 		const keyPressHandler = makeHandleKeyPress( closeModal );
 		if ( isVisible ) {
 			document.addEventListener( 'keydown', keyPressHandler, false );
 		}
-		return () => document.removeEventListener( 'keydown', keyPressHandler, false );
+		return () => {
+			document.body.style.cssText = '';
+			document.removeEventListener( 'keydown', keyPressHandler, false );
+		};
 	}, [ isVisible, closeModal ] );
 }
 


### PR DESCRIPTION
When a user removes an item from the cart in the new Checkout, we display a modal with a body style of `overflow: hidden` but don't remove it, breaking scroll on subsequent pages. This removes the style after the modal is closed.

Fixes: #40293 

**To test:**
- add a plan to your cart
- visit the new checkout (using `?flags=composite-checkout-force`)
- from the third step, empty the cart, click "continue", and leave checkout
- verify that you can scroll the subsequent page