### PR TITLE
composite-checkout: Disable plan length picker and delete button when form not ready

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/item-variation-picker.tsx
+++ b/packages/composite-checkout-wpcom/src/components/item-variation-picker.tsx
@@ -27,6 +27,7 @@ export type ItemVariationPickerProps = {
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[];
 	getItemVariants: ( WPCOMProductSlug ) => WPCOMProductVariant[];
 	onChangeItemVariant: ( WPCOMCartItem, WPCOMProductSlug, number ) => void;
+	isDisabled: boolean;
 };
 
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( {
@@ -34,6 +35,7 @@ export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > 
 	variantSelectOverride,
 	getItemVariants,
 	onChangeItemVariant,
+	isDisabled,
 } ) => {
 	const variants = getItemVariants( selectedItem.wpcom_meta.product_slug );
 
@@ -44,7 +46,7 @@ export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > 
 	return (
 		<TermOptions>
 			{ variants.map(
-				renderProductVariant( selectedItem, onChangeItemVariant, variantSelectOverride )
+				renderProductVariant( selectedItem, onChangeItemVariant, variantSelectOverride, isDisabled )
 			) }
 		</TermOptions>
 	);
@@ -53,7 +55,8 @@ export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > 
 function renderProductVariant(
 	selectedItem: WPCOMCartItem,
 	onChangeItemVariant: ( string, WPCOMProductSlug, number ) => void,
-	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[]
+	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[],
+	isDisabled: boolean
 ): ( _0: WPCOMProductVariant, _1: number ) => JSX.Element {
 	return (
 		{ variantLabel, variantDetails, productSlug, productId }: WPCOMProductVariant,
@@ -79,7 +82,7 @@ function renderProductVariant(
 					id={ key }
 					value={ productSlug }
 					checked={ isChecked }
-					isDisabled={ false }
+					isDisabled={ isDisabled }
 					onChange={ () => {
 						onChangeItemVariant( selectedItem.wpcom_meta.uuid, productSlug, productId );
 					} }

--- a/packages/composite-checkout-wpcom/src/components/item-variation-picker.tsx
+++ b/packages/composite-checkout-wpcom/src/components/item-variation-picker.tsx
@@ -84,7 +84,8 @@ function renderProductVariant(
 					checked={ isChecked }
 					isDisabled={ isDisabled }
 					onChange={ () => {
-						onChangeItemVariant( selectedItem.wpcom_meta.uuid, productSlug, productId );
+						! isDisabled &&
+							onChangeItemVariant( selectedItem.wpcom_meta.uuid, productSlug, productId );
 					} }
 					ariaLabel={ translate( 'Select a different term length' ) as string }
 					label={

--- a/packages/composite-checkout-wpcom/src/components/radio-button.js
+++ b/packages/composite-checkout-wpcom/src/components/radio-button.js
@@ -19,7 +19,7 @@ export default function RadioButton( {
 	const [ isFocused, changeFocus ] = useState( false );
 
 	return (
-		<RadioButtonWrapper isFocused={ isFocused } checked={ checked }>
+		<RadioButtonWrapper isDisabled={ isDisabled } isFocused={ isFocused } checked={ checked }>
 			<Radio
 				type="radio"
 				name={ name }
@@ -99,6 +99,8 @@ const RadioButtonWrapper = styled.div`
 	:hover svg {
 		filter: grayscale( 0 );
 	}
+
+	${handleWrapperDisabled};
 `;
 
 const Radio = styled.input`
@@ -133,7 +135,7 @@ const Label = styled.label`
 		transform: translateY( -50% );
 		left: 16px;
 		position: absolute;
-		background: ${getRadioBackgroundColor};
+		background: ${props => props.theme.colors.surface};
 		box-sizing: border-box;
 		z-index: 2;
 	}
@@ -152,6 +154,8 @@ const Label = styled.label`
 		box-sizing: border-box;
 		z-index: 3;
 	}
+
+	${handleLabelDisabled};
 `;
 
 const RadioButtonChildren = styled.div`
@@ -164,10 +168,6 @@ function getBorderColor( { checked, theme } ) {
 
 function getRadioColor( { checked, theme } ) {
 	return checked ? theme.colors.highlight : theme.colors.surface;
-}
-
-function getRadioBackgroundColor( { isDisabled, theme } ) {
-	return isDisabled ? 'lightgray' : theme.colors.surface;
 }
 
 function getBorderWidth( { checked } ) {
@@ -183,4 +183,45 @@ function getOutline( { isFocused, theme } ) {
 		return theme.colors.outline + ' solid 2px';
 	}
 	return '0';
+}
+
+function handleWrapperDisabled( { isDisabled } ) {
+	if ( ! isDisabled ) {
+		return null;
+	}
+
+	return `
+		:before,
+		:hover:before {
+			border: 1px solid lightgray;
+		}
+	`;
+}
+
+function handleLabelDisabled( { isDisabled } ) {
+	if ( ! isDisabled ) {
+		return null;
+	}
+
+	return `
+		color: lightgray;
+		font-style: italic;
+		
+		:hover {
+			cursor: default;
+		}
+		
+		:before {
+			border: 1px solid lightgray;
+			background: lightgray;
+		}
+		
+		:after {
+			background: white;
+		}
+		
+		span {
+			color: lightgray;
+		}
+	`;
 }

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -68,6 +68,7 @@ function WPLineItem( {
 				<React.Fragment>
 					<DeleteButton
 						buttonState="borderless"
+						disabled={ isDisabled }
 						onClick={ () => {
 							setIsModalVisible( true );
 							onEvent( {

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -54,6 +54,7 @@ function WPLineItem( {
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const modalCopy = returnModalCopy( item.type, translate, hasDomainsInCart );
 	const onEvent = useEvents();
+	const isDisabled = formStatus !== 'ready';
 
 	const shouldShowVariantSelector = item.wpcom_meta && item.wpcom_meta.extra?.context === 'signup';
 
@@ -107,6 +108,7 @@ function WPLineItem( {
 					variantSelectOverride={ variantSelectOverride }
 					getItemVariants={ getItemVariants }
 					onChangeItemVariant={ onChangePlanLength }
+					isDisabled={ isDisabled }
 				/>
 			) }
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This disables the plan length picker and the item delete buttons in the review step of composite checkout when the form is not in a "ready" state (when it is loading, submitting, or validating).

#### Testing instructions

- Enter composite checkout from signup (otherwise the plan length picker will not display).
- Click through to the last step.
- Click to submit the form (it's ok if the submission fails). Verify that the plan length picker is disabled while the form is submitting.