### PR TITLE
WP Migration: Add missing Tracks events for migration

### DIFF
--- a/client/my-sites/importer/file-importer.jsx
+++ b/client/my-sites/importer/file-importer.jsx
@@ -67,13 +67,15 @@ class FileImporter extends React.PureComponent {
 		} ),
 	};
 
-	handleClick = () => {
+	handleClick = shouldStartImport => {
 		const {
 			importerStatus: { type },
 			site: { ID: siteId },
 		} = this.props;
 
-		startImport( siteId, type );
+		if ( shouldStartImport ) {
+			startImport( siteId, type );
+		}
 
 		this.props.recordTracksEvent( 'calypso_importer_main_start_clicked', {
 			blog_id: siteId,
@@ -99,7 +101,7 @@ class FileImporter extends React.PureComponent {
 		} );
 		const cardProps = {
 			displayAsLink: true,
-			onClick: this.handleClick,
+			onClick: this.handleClick.bind( this, true ),
 			tagName: 'button',
 		};
 
@@ -110,7 +112,7 @@ class FileImporter extends React.PureComponent {
 			 * This is used for the new Migration logic for the moment.
 			 */
 			cardProps.href = overrideDestination.replace( '%SITE_SLUG%', site.slug );
-			cardProps.onClick = null;
+			cardProps.onClick = this.handleClick.bind( this, false );
 		}
 
 		return (

--- a/client/my-sites/migrate/migrate-button.jsx
+++ b/client/my-sites/migrate/migrate-button.jsx
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
 import accept from 'lib/accept';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class MigrateButton extends Component {
 	state = {
@@ -16,6 +18,7 @@ class MigrateButton extends Component {
 
 	confirmCallback = accepted => {
 		if ( accepted ) {
+			this.props.recordTracksEvent( 'calypso_site_migration_start_confirm_clicked' );
 			this.setState( { busy: true }, this.props.onClick );
 		} else {
 			return;
@@ -42,6 +45,8 @@ class MigrateButton extends Component {
 			</>
 		);
 
+		this.props.recordTracksEvent( 'calypso_site_migration_start_clicked' );
+
 		accept( message, this.confirmCallback, translate( 'Import and overwrite' ) );
 	};
 
@@ -54,4 +59,4 @@ class MigrateButton extends Component {
 	}
 }
 
-export default localize( MigrateButton );
+export default connect( null, { recordTracksEvent } )( localize( MigrateButton ) );

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -32,6 +32,7 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import { urlToSlug } from 'lib/url';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import wpcom from 'lib/wp';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -242,6 +243,8 @@ class SectionMigrate extends Component {
 		}
 
 		this.setMigrationState( { migrationStatus: 'backing-up', startTime: null } );
+
+		this.props.recordTracksEvent( 'calypso_site_migration_start_migration' );
 
 		wpcom
 			.undocumented()
@@ -701,5 +704,11 @@ export default connect(
 			targetSiteSlug: getSelectedSiteSlug( state ),
 		};
 	},
-	{ navigateToSelectedSourceSite, receiveSite, updateSiteMigrationMeta, requestSite }
+	{
+		navigateToSelectedSourceSite,
+		receiveSite,
+		updateSiteMigrationMeta,
+		requestSite,
+		recordTracksEvent,
+	}
 )( localize( SectionMigrate ) );

--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -104,6 +104,10 @@ class StepImportOrMigrate extends Component {
 		}
 	};
 
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_importer_wordpress_type_viewed' );
+	}
+
 	render() {
 		const {
 			targetSite,

--- a/client/my-sites/migrate/step-source-select.jsx
+++ b/client/my-sites/migrate/step-source-select.jsx
@@ -113,6 +113,10 @@ class StepSourceSelect extends Component {
 		} );
 	};
 
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_importer_wordpress_source_select_viewed' );
+	}
+
 	render() {
 		const { targetSite, targetSiteSlug, translate } = this.props;
 		const backHref = `/import/${ targetSiteSlug }`;

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -21,6 +21,7 @@ import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getPlan } from 'lib/plans';
 import { getPlanRawPrice } from 'state/plans/selectors';
 import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -34,6 +35,10 @@ class StepUpgrade extends Component {
 		startMigration: PropTypes.func.isRequired,
 		targetSite: PropTypes.object.isRequired,
 	};
+
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_site_migration_business_viewed' );
+	}
 
 	render() {
 		const {
@@ -134,13 +139,16 @@ class StepUpgrade extends Component {
 	}
 }
 
-export default connect( state => {
-	const plan = getPlan( PLAN_BUSINESS );
-	const planId = plan.getProductId();
+export default connect(
+	state => {
+		const plan = getPlan( PLAN_BUSINESS );
+		const planId = plan.getProductId();
 
-	return {
-		billingTimeFrame: plan.getBillingTimeFrame(),
-		currency: getCurrentUserCurrencyCode( state ),
-		planPrice: getPlanRawPrice( state, planId, true ),
-	};
-} )( localize( StepUpgrade ) );
+		return {
+			billingTimeFrame: plan.getBillingTimeFrame(),
+			currency: getCurrentUserCurrencyCode( state ),
+			planPrice: getPlanRawPrice( state, planId, true ),
+		};
+	},
+	{ recordTracksEvent }
+)( localize( StepUpgrade ) );


### PR DESCRIPTION
This PR adds Tracks events for the following:

- When WordPress is clicked in the list of importers

<img width="755" alt="ScreenCapture at Thu Mar 19 15:01:36 EDT 2020" src="https://user-images.githubusercontent.com/2098816/77128683-5b860500-6a27-11ea-9ea9-3c92309f7f11.png">

----

- When "What WordPress site..." screen is viewed

<img width="743" alt="ScreenCapture at Thu Mar 19 15:02:15 EDT 2020" src="https://user-images.githubusercontent.com/2098816/77128690-65a80380-6a27-11ea-8416-094a5141a4fd.png">


----

- When type of WordPress import selection screen is viewed

<img width="742" alt="ScreenCapture at Thu Mar 19 15:18:44 EDT 2020" src="https://user-images.githubusercontent.com/2098816/77128698-6c367b00-6a27-11ea-94d9-51c36dd0d7b5.png">


----

- When Business Plan screen is shown
- When "Upgrade and import" is clicked

<img width="741" alt="ScreenCapture at Thu Mar 19 15:06:25 EDT 2020" src="https://user-images.githubusercontent.com/2098816/77128702-70fb2f00-6a27-11ea-800e-be1b496938bb.png">


----
 
- When "Import and overwrite is clicked"

<img width="574" alt="ScreenCapture at Thu Mar 19 15:06:36 EDT 2020" src="https://user-images.githubusercontent.com/2098816/77128709-75bfe300-6a27-11ea-9e8e-97835d8326cd.png">


----

- When migration is started

<img width="501" alt="ScreenCapture at Thu Mar 19 15:07:48 EDT 2020" src="https://user-images.githubusercontent.com/2098816/77128712-7bb5c400-6a27-11ea-9979-1eb9df258322.png">


