### PR TITLE
composite-checkout: Record products from cart after first load

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -845,6 +845,13 @@ function getCheckoutEventHandler( reduxDispatch ) {
 				);
 			}
 
+			case 'CART_INIT_COMPLETE':
+				return reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_composite_cart_loaded', {
+						products: action.payload.products.map( product => product.product_slug ).join( ',' ),
+					} )
+				);
+
 			case 'CART_ERROR':
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_cart_error', {

--- a/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
+++ b/packages/composite-checkout-wpcom/src/hooks/use-shopping-cart.ts
@@ -557,9 +557,14 @@ function useInitializeCartFromServer(
 			} )
 			.then( response => {
 				debug( 'initialized cart is', response );
+				const initialResponseCart = processRawResponse( response );
 				hookDispatch( {
 					type: 'RECEIVE_INITIAL_RESPONSE_CART',
-					initialResponseCart: processRawResponse( response ),
+					initialResponseCart,
+				} );
+				onEvent?.( {
+					type: 'CART_INIT_COMPLETE',
+					payload: initialResponseCart,
 				} );
 			} )
 			.catch( error => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a new analytics event, `calypso_checkout_composite_cart_loaded`, which is triggered when checkout first downloads the cart from the shopping cart endpoint. It includes a list of the products from that cart as a comma-separated string of product slugs.

#### Testing instructions

- Run `localStorage.setItem( 'debug', 'calypso:analytics*' );` in your console and refresh the page.
- Complete a purchase using composite checkout. 
- Verify that you see the above properties in the debug log for that event.