### PR TITLE
Jetpack Cloud: Scan section fix styles

### DIFF
--- a/client/landing/jetpack-cloud/components/stats-footer/style.scss
+++ b/client/landing/jetpack-cloud/components/stats-footer/style.scss
@@ -2,13 +2,14 @@
 	border-top: 1px solid var( --color-neutral-5 );
 	color: var( --color-neutral-80 );
 	display: flex;
-	padding-top: 10px;
-	margin: 40px 0;
+	margin: 40px 0 20px;
 	flex-shrink: 0;
 	flex-wrap: wrap;
+	padding: 10px 16px 0;
 
 	@include breakpoint( '>660px' ) {
 		margin-bottom: 0;
+		padding: 10px 0 0;
 	}
 }
 
@@ -25,7 +26,7 @@
 	font-size: 20px;
 	margin: 0 24px 20px 0;
 	flex: 1;
-	max-width: 150px;
+	max-width: 110px;
 }
 
 .stats-footer > div:last-child {
@@ -42,7 +43,7 @@
 	padding-left: 40px;
 	flex-basis: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint( '>960px' ) {
 		flex: 1;
 	}
 }

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -131,20 +131,22 @@ class ScanHistoryPage extends Component {
 	render() {
 		const logEntries = this.filteredEntries();
 		return (
-			<Main className="history">
+			<Main wideLayout className="history">
 				<DocumentHead title={ translate( 'History' ) } />
 				<SidebarNavigation />
 				<h1 className="history__header">{ translate( 'History' ) }</h1>
-				<p>
+				<p className="history__description">
 					{ translate(
 						'The scanning history contains a record of all previously active threats on your site.'
 					) }
 				</p>
-				<SimplifiedSegmentedControl
-					className="history__filters"
-					options={ filterOptions }
-					onSelect={ this.handleOnFilterChange }
-				/>
+				<div className="history__filters-wrapper">
+					<SimplifiedSegmentedControl
+						className="history__filters"
+						options={ filterOptions }
+						onSelect={ this.handleOnFilterChange }
+					/>
+				</div>
 				<div className="history__entries">
 					{ logEntries.map( entry => (
 						<ScanHistoryItem entry={ entry } key={ entry.id } />

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -4,15 +4,28 @@
 		font-size: 28px;
 		line-height: 1;
 		margin: 30px 0;
-		padding: 0 16px;
 
 		@include breakpoint( '>660px' ) {
 			font-size: 48px;
-			padding: 0;
 		}
 	}
 
+	&__filters-wrapper {
+		text-align: center;
+	}
+
 	&__filters {
-		margin: 25px 0;
+		margin: 25px;
+		display: inline-flex;
+
+		a:focus {
+			border-color: var( --color-neutral-30 );
+		}
+	}
+
+	&__header,
+	&__description,
+	&__entries {
+		padding: 0 16px;
 	}
 }

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -113,7 +113,7 @@ class ScanPage extends Component {
 
 	render() {
 		return (
-			<Main className="scan__main">
+			<Main wideLayout className="scan__main">
 				<DocumentHead title="Scanner" />
 				<SidebarNavigation />
 				<div className="scan__content">{ this.renderScanState() }</div>

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -69,7 +69,12 @@ class ScanPage extends Component {
 
 	renderThreats() {
 		const { threats, site } = this.props;
-		return <ScanThreats className="scan__threats" threats={ threats } site={ site } />;
+		return (
+			<>
+				<SecurityIcon icon="error" />
+				<ScanThreats className="scan__threats" threats={ threats } site={ site } />
+			</>
+		);
 	}
 
 	renderScanError() {

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -7,8 +7,7 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	min-height: calc( 100vh - 47px ); // Padding of .layout__content.
-
+	min-height: calc( 100vh - 111px ); // Padding of .layout__content: 79px + 32px;
 }
 
 .scan__content {

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -13,7 +13,6 @@
 .scan__content {
 	padding: 40px 16px 0;
 	flex: 1 0 auto;
-	max-width: 680px;
 
 	.security-icon {
 		display: block;

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -1,6 +1,9 @@
 .theme-jetpack-cloud .main {
 	margin-left: 0;
 }
+.theme-jetpack-cloud .main.sites {
+	margin-left: auto;
+}
 
 .scan__main {
 	box-sizing: border-box;

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -1,12 +1,25 @@
+.theme-jetpack-cloud .main {
+	margin-left: 0;
+}
+
+.scan__main {
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	min-height: calc( 100vh - 47px ); // Padding of .layout__content.
+
+}
+
 .scan__content {
+	padding: 40px 16px 0;
 	flex: 1 0 auto;
 	max-width: 680px;
-	padding: 0 16px;
 
 	.security-icon {
 		display: block;
 		margin: 0 auto;
-		width: 70px;
+		width: 56px;
 
 		@include breakpoint( '>660px' ) {
 			margin: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Cleans up some of the Jetpack Cloud Scan section styles. 

Before:
<img width="891" alt="Screen Shot 2020-03-20 at 12 19 49 PM" src="https://user-images.githubusercontent.com/115071/77159247-45b72500-6aa5-11ea-8298-8077a56c4f76.png">


After:
<img width="538" alt="Screen Shot 2020-03-20 at 12 20 15 PM" src="https://user-images.githubusercontent.com/115071/77159200-2fa96480-6aa5-11ea-95a3-af2cff3c1634.png">
<img width="1187" alt="Screen Shot 2020-03-20 at 12 20 07 PM" src="https://user-images.githubusercontent.com/115071/77159205-333ceb80-6aa5-11ea-8bdb-e7daa15b670d.png">


#### Testing instructions
* Load up Jetpack Cloud
* Checkout the Scan section, scanner and history. 
Does it look like as expected. 

Check both Desktop and mobile. 
