### PR TITLE
Domains: Send correct arguments when searching for subdomains

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -986,7 +986,7 @@ class RegisterDomainStep extends React.Component {
 			quantity: this.getFreeSubdomainSuggestionsQuantity(),
 			include_wordpressdotcom: true,
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
-			only_wordpressdotcom: this.props.includeDotBlogSubdomain,
+			only_wordpressdotcom: true,
 			tld_weight_overrides: null,
 			vendor: 'dot',
 			vertical: this.props.vertical,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the arguments sent to the domain search endpoint when searching for subdomains, so that only free subdomains are suggested.

#### Testing instructions

* Go to calypso.localhost:3000/start
* Enter a search query which contains a blacklisted term
* Ensure you get valid suggestions, and free subdomain suggestions have no price attached

Fixes #40198 
