### PR TITLE
Build: Improved the building of Jetpack Cloud and Calypso in dev mode

### DIFF
--- a/client/server/bundler/sections-loader.js
+++ b/client/server/bundler/sections-loader.js
@@ -53,12 +53,29 @@ function printSectionsAndPaths( sections ) {
 	}
 }
 
+function filterSections( sections ) {
+	const bundleEnv = config( 'env' );
+	if ( 'development' !== bundleEnv ) {
+		return sections;
+	}
+
+	const activeSections = config( 'sections' );
+	const byDefaultEnableSection = config( 'enable_all_sections' );
+
+	return sections.filter( section => {
+		if ( activeSections && typeof activeSections[ section.name ] !== 'undefined' ) {
+			return activeSections[ section.name ];
+		}
+		return byDefaultEnableSection;
+	} );
+}
+
 const loader = function() {
 	const options = getOptions( this ) || {};
 	const { useRequire, onlyIsomorphic } = options;
 	let { include } = options;
 
-	let sections = require( this.resourcePath );
+	let sections = filterSections( require( this.resourcePath ) );
 
 	if ( include ) {
 		if ( ! Array.isArray( include ) ) {

--- a/client/server/bundler/sections-loader.js
+++ b/client/server/bundler/sections-loader.js
@@ -6,7 +6,7 @@ const { getOptions } = require( 'loader-utils' ); // eslint-disable-line import/
 /**
  * Internal dependencies
  */
-const config = require( 'server/config' );
+const config = require( '../config' );
 
 /*
  * This sections-loader has one responsibility: adding import statements for the section modules.

--- a/client/server/bundler/sections-loader.js
+++ b/client/server/bundler/sections-loader.js
@@ -3,6 +3,10 @@
  */
 const { getOptions } = require( 'loader-utils' ); // eslint-disable-line import/no-extraneous-dependencies
 
+/**
+ * Internal dependencies
+ */
+const config = require( 'config' );
 /*
  * This sections-loader has one responsibility: adding import statements for the section modules.
  *

--- a/client/server/bundler/sections-loader.js
+++ b/client/server/bundler/sections-loader.js
@@ -53,7 +53,7 @@ function printSectionsAndPaths( sections ) {
 	}
 }
 
-function filterSections( sections ) {
+function filterSectionsInDevelopment( sections ) {
 	const bundleEnv = config( 'env' );
 	if ( 'development' !== bundleEnv ) {
 		return sections;
@@ -75,7 +75,7 @@ const loader = function() {
 	const { useRequire, onlyIsomorphic } = options;
 	let { include } = options;
 
-	let sections = filterSections( require( this.resourcePath ) );
+	let sections = filterSectionsInDevelopment( require( this.resourcePath ) );
 
 	if ( include ) {
 		if ( ! Array.isArray( include ) ) {

--- a/client/server/bundler/sections-loader.js
+++ b/client/server/bundler/sections-loader.js
@@ -6,7 +6,8 @@ const { getOptions } = require( 'loader-utils' ); // eslint-disable-line import/
 /**
  * Internal dependencies
  */
-const config = require( 'config' );
+const config = require( 'server/config' );
+
 /*
  * This sections-loader has one responsibility: adding import statements for the section modules.
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Since we merged the jetpack cloud to use the calypso entry point in https://github.com/Automattic/wp-calypso/pull/40022 we introduced a the concept of sections. 

We want to build all the section during the production build process since that produces a single docker file. That then gets moved around. For development this is not neccessery. So an easy optimization that we can make is only build the section that we care about. As defined in config files. 

#### Testing instructions

1. Build calypso `npm start` notice that all the section build as expected. (Navigate around calypso.localhost:3000 and notice that nothing is broken. 
2. Build Jetpack Cloud `npm run start-jetpack-cloud` notice that we build all the sections. Navigate around cloud.jetpack.locahost:3000 notice that it still works as expected.
