### PR TITLE
Jetpack Cloud: Disabled is-site previewable

### DIFF
--- a/client/sections-filter.js
+++ b/client/sections-filter.js
@@ -4,11 +4,15 @@
 import config from 'config';
 
 export default function isSectionEnabled( section ) {
+	return isSectionNameEnabled( section.name );
+}
+
+export function isSectionNameEnabled( sectionName ) {
 	const activeSections = config( 'sections' );
 	const byDefaultEnableSection = config( 'enable_all_sections' );
 
-	if ( activeSections && typeof activeSections[ section.name ] !== 'undefined' ) {
-		return activeSections[ section.name ];
+	if ( activeSections && typeof activeSections[ sectionName ] !== 'undefined' ) {
+		return activeSections[ sectionName ];
 	}
 	return byDefaultEnableSection;
 }

--- a/client/state/sites/selectors/is-site-previewable.js
+++ b/client/state/sites/selectors/is-site-previewable.js
@@ -4,6 +4,7 @@
 import { isHttps } from 'lib/url';
 import getRawSite from 'state/selectors/get-raw-site';
 import getSiteOption from './get-site-option';
+import { isSectionNameEnabled } from 'sections-filter';
 
 /**
  * Returns true if the site can be previewed, false if the site cannot be
@@ -21,6 +22,10 @@ export default function isSitePreviewable( state, siteId ) {
 	}
 
 	if ( site.is_vip ) {
+		return false;
+	}
+
+	if ( ! isSectionNameEnabled( 'preview' ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  This PR disables the view site page in for the Jetpack Cloud unless the preview section is enabled. 

#### Testing instructions

* Load up calypso `npm start` notice that view page for .com sites takes you to 
`/view/siteSlug`

* Load up Jetpack Cloud notice that view Site takes you to the site url. 

Fixes the broken flow that leads to a 404 page now. 

