### PR TITLE
Theme Showcase: Remove dark upsell banner styles on theme showcase

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -56,7 +56,7 @@ import {
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
-import { decodeEntities } from 'lib/formatting';
+import { decodeEntities, preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { setThemePreviewOptions } from 'state/themes/actions';
 import ThemeNotFoundError from './theme-not-found-error';
@@ -661,11 +661,13 @@ class ThemeSheet extends React.Component {
 					plan={ PLAN_PREMIUM }
 					className="theme__page-upsell-banner"
 					title={ translate( 'Access this theme for FREE with a Premium or Business plan!' ) }
-					description={ translate(
-						'Instantly unlock all premium themes, more storage space, advanced customization, video support, and more when you upgrade.'
+					description={ preventWidows(
+						translate(
+							'Instantly unlock all premium themes, more storage space, advanced customization, video support, and more when you upgrade.'
+						)
 					) }
 					event="themes_plan_particular_free_with_plan"
-					callToAction={ translate( 'View Plans' ) }
+					callToAction={ preventWidows( translate( 'View Plans' ) ) }
 					forceHref={ true }
 					href={ plansUrl }
 				/>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -667,7 +667,6 @@ class ThemeSheet extends React.Component {
 						)
 					) }
 					event="themes_plan_particular_free_with_plan"
-					callToAction={ preventWidows( translate( 'View Plans' ) ) }
 					forceHref={ true }
 					href={ plansUrl }
 				/>

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -505,12 +505,8 @@
 }
 
 .banner.theme__page-upsell-banner {
-	@include banner-dark();
-
 	width: 50%;
-
 	margin: 0 0 10px;
-	background-color: #34444d;
 
 	@include breakpoint( '<960px' ) {
 		width: 100%;

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -49,7 +49,6 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 					className="themes__showcase-banner"
 					title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
 					event="themes_plans_free_personal"
-					callToAction={ translate( 'View Plans' ) }
 					forceHref={ true }
 				/>
 			);

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -32,7 +32,6 @@
 }
 
 .banner.themes__showcase-banner {
-	@include banner-dark();
 	margin-top: 15px;
 	margin-bottom: 15px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is more a suggestion I'm proposing than a done deal, so please speak up if you don't agree.

* Use a light color scheme to match other upsell nudges in the main content area of Calypso. The audit Jan worked on shows this is the only upsell that uses a dark color scheme.
* Also use a light color scheme on the single theme page upsell, and prevent widows on the button and copy for a cleaner look.

**Before**

<img width="1676" alt="Screen Shot 2020-03-20 at 9 52 40 AM" src="https://user-images.githubusercontent.com/2124984/77170770-e7347b80-6a91-11ea-9e25-d756cc48b709.png">
<img width="1380" alt="Screen Shot 2020-03-20 at 10 03 36 AM" src="https://user-images.githubusercontent.com/2124984/77170911-1e0a9180-6a92-11ea-89d3-c2604cfdc5bf.png">



**After**

<img width="1676" alt="Screen Shot 2020-03-20 at 9 58 04 AM" src="https://user-images.githubusercontent.com/2124984/77170787-eef42000-6a91-11ea-9003-19bae381b289.png">
<img width="1386" alt="Screen Shot 2020-03-20 at 9 48 38 AM" src="https://user-images.githubusercontent.com/2124984/77170795-f1ef1080-6a91-11ea-8b3e-18ab0995cfd6.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/themes` when logged in, with a site on a Free plan
* You'll see an upsell nudge when you click the Advanced Themes button at the bottom
* Click on one of the premium themes in the showcase; you'll see another upsell nudge at the top of the screen.
