### PR TITLE
Sidebar: Add Animation to Notification Dot

### DIFF
--- a/client/assets/stylesheets/shared/_animation.scss
+++ b/client/assets/stylesheets/shared/_animation.scss
@@ -23,6 +23,16 @@
 	}
 }
 
+// Simple animations to make elements disappear
+@keyframes disappear {
+	0% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
 // Pulsing background color for loading placeholders
 @keyframes pulse-light {
 	50% {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -147,11 +147,16 @@
 }
 
 .sidebar__menu-notification-dot {
+	animation: fade-in 500ms ease;
 	background-color: var( --color-accent );
 	border: 1px solid var( --color-surface );
 	border-radius: 50px;
 	margin-left: 8px;
 	padding: 4px;
+
+	.sidebar__menu .selected & {
+		animation: disappear 500ms forwards;
+	}
 }
 
 // Expandables: Some sidebar menus act like accordions where


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds an animation to the notification dot in the sidebar, as mentioned by @danhauk in #40233

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Add `showNotificationDot` here: https://github.com/Automattic/wp-calypso/blob/f6785e9c596cd77bcf161b2f4ef170ecdf0568ed/client/my-sites/sidebar/index.jsx#L171-L180

Then verify the animation is the same as the original design.

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/43215253/77172603-2248a600-6ab6-11ea-9c77-fc4a869ac187.gif)

Part of #40233
