### PR TITLE
[Gutenberg 7.7.1]: Fix editor close button

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
@@ -1,6 +1,6 @@
-.post-type-wp_template_part .edit-post-fullscreen-mode-close__toolbar,
-.post-type-page .edit-post-fullscreen-mode-close__toolbar,
-.post-type-post .edit-post-fullscreen-mode-close__toolbar,
+.post-type-wp_template_part .edit-post-header .edit-post-fullscreen-mode-close,
+.post-type-page .edit-post-header .edit-post-fullscreen-mode-close,
+.post-type-post .edit-post-header .edit-post-fullscreen-mode-close,
 .close-button-override-thin {
 	display: none;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
@@ -1,7 +1,11 @@
 .post-type-wp_template_part .edit-post-header .edit-post-fullscreen-mode-close,
 .post-type-page .edit-post-header .edit-post-fullscreen-mode-close,
 .post-type-post .edit-post-header .edit-post-fullscreen-mode-close,
-.close-button-override-thin {
+.close-button-override-thin,
+// keep legacy selectors for backward compatibility with Gutenberg plugin < v7.7
+.post-type-wp_template_part .edit-post-fullscreen-mode-close__toolbar,
+.post-type-page .edit-post-fullscreen-mode-close__toolbar,
+.post-type-post .edit-post-fullscreen-mode-close__toolbar {
 	display: none;
 }
 
@@ -11,8 +15,7 @@
 	display: flex;
 	align-items: center;
 	padding: 9px 10px;
-	margin-left: -24px;
-	margin-right: 10px;
+	margin-left: -8px;
 	border: none;
 	border-right: 1px solid #e2e4e7;
 
@@ -32,6 +35,10 @@
 		margin-left: -7px;
 	}
 
+	@media ( max-width: 599px ) {
+		margin-left: -2px;
+	}
+
 	@media ( max-width: 400px ) {
 		.close-button-override-wide {
 			display: none;
@@ -45,3 +52,14 @@
 	}
 }
 
+// add an extra class specific for the new Gutenberg plugin version so the main override above stays compatible with < v7.7
+.post-type-wp_template_part .block-editor-editor-skeleton__header .edit-post-fullscreen-mode-close__toolbar__override,
+.post-type-page .block-editor-editor-skeleton__header .edit-post-fullscreen-mode-close__toolbar__override,
+.post-type-post .block-editor-editor-skeleton__header .edit-post-fullscreen-mode-close__toolbar__override {
+	margin-left: -24px;
+	margin-right: 10px;
+
+	@media ( max-width: 599px ) {
+		margin-left: -24px;
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
@@ -11,7 +11,8 @@
 	display: flex;
 	align-items: center;
 	padding: 9px 10px;
-	margin-left: -8px;
+	margin-left: -24px;
+	margin-right: 10px;
 	border: none;
 	border-right: 1px solid #e2e4e7;
 
@@ -29,10 +30,6 @@
 
 	.dashicons-arrow-left-alt2 {
 		margin-left: -7px;
-	}
-
-	@media ( max-width: 599px ) {
-		margin-left: -2px;
 	}
 
 	@media ( max-width: 400px ) {

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -564,7 +564,7 @@ function handleInsertClassicBlockMedia( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function handleCloseEditor( calypsoPort ) {
-	$( '#editor' ).on( 'click', '.edit-post-fullscreen-mode-close__toolbar a', e => {
+	$( '#editor' ).on( 'click', '.edit-post-header .edit-post-fullscreen-mode-close', e => {
 		e.preventDefault();
 
 		const { port2 } = new MessageChannel();

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -564,7 +564,10 @@ function handleInsertClassicBlockMedia( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function handleCloseEditor( calypsoPort ) {
-	$( '#editor' ).on( 'click', '.edit-post-header .edit-post-fullscreen-mode-close', e => {
+	const legacySelector = '.edit-post-fullscreen-mode-close__toolbar a'; // maintain support for Gutenberg plugin < v7.7
+	const selector = '.edit-post-header .edit-post-fullscreen-mode-close';
+
+	$( '#editor' ).on( 'click', `${ legacySelector }, ${ selector }`, e => {
 		e.preventDefault();
 
 		const { port2 } = new MessageChannel();

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-close-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-close-click.js
@@ -9,7 +9,7 @@ import tracksRecordEvent from './track-record-event';
  * @returns {{handler: Function, selector: string, type: string}} event object definition.
  */
 export default () => ( {
-	selector: '.edit-post-fullscreen-mode-close__toolbar',
+	selector: '.edit-post-header .edit-post-fullscreen-mode-close',
 	type: 'click',
 	handler: () => tracksRecordEvent( 'wpcom_block_editor_close_click' ),
 } );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -410,7 +410,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async closeEditor() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.edit-post-fullscreen-mode-close__toolbar, .edit-post-header-toolbar__back' )
+			By.css(
+				'.edit-post-header .edit-post-fullscreen-mode-close, .edit-post-header-toolbar__back'
+			)
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

### Block editor updates:
- update function to close editor and ignore existing URL
- update tracking
- update e2e gutenberg lib

### FSE updates:
- remove W button
- fix back button positioning

#### Testing instructions
Here is a diff for testing the wpcom-block-editor: D40709-code.

Checkout this PR locally and sync **wp-block-editor** widget and **FSE** plugin using FSE Plugin Development instructions in FG.
* On a non-FSE site start editing a page or post.
* Pressing on top-left W button should close the editor.
* On a FSE enabled site, go to `/block-editor/page/[EDGE_STICKERED_SITE].wordpress.com`
* There shouldn't be any W button
* [Backward compatibility] On a site running the previous version of Gutenberg everything should look and work the same as before.

### Follow up:
- fix editor header positioning for smaller screens https://github.com/Automattic/wp-calypso/issues/40335 

Fixes #40315, Fixes #40334  
Part of: #40078 
