### PR TITLE
Domains: Add polyfill to domains-landing

### DIFF
--- a/client/landing/domains/index.jsx
+++ b/client/landing/domains/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import '@automattic/calypso-polyfills';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import RenderDom from 'react-dom';


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/40328

Introduced by https://github.com/Automattic/wp-calypso/pull/38313

Similar to https://github.com/Automattic/wp-calypso/pull/38551

#### Testing instructions

Go to https://wordpress.com/domain-services/registrant-verification in different browsers - especially Edge 44 on Windows or old(er) versions of Safari. The page should look like this:

<img width="750" alt="Screenshot 2020-03-20 at 14 49 48" src="https://user-images.githubusercontent.com/3392497/77176644-48714480-6abc-11ea-9bcd-21e78b3b8f38.png">

Make sure there are no critical errors in the console.