### PR TITLE
Jetpack Cloud: Add title to the masterbar.

### DIFF
--- a/client/landing/jetpack-cloud/components/masterbar/index.jsx
+++ b/client/landing/jetpack-cloud/components/masterbar/index.jsx
@@ -13,6 +13,7 @@ import Item from 'layout/masterbar/item';
 import JetpackLogo from 'components/jetpack-logo';
 import Masterbar from 'layout/masterbar/masterbar';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { getDocumentHeadTitle } from 'state/document-head/selectors';
 
 /**
  * Style dependencies
@@ -22,7 +23,7 @@ import './style.scss';
 export default function() {
 	const translate = useTranslate();
 	const user = useSelector( state => getCurrentUser( state ) );
-
+	const headerTitle = useSelector( state => getDocumentHeadTitle( state ) );
 	return (
 		<Masterbar
 			className="is-jetpack-cloud-masterbar" // eslint-disable-line wpcalypso/jsx-classname-namespace
@@ -36,6 +37,7 @@ export default function() {
 			>
 				<JetpackLogo size={ 28 } full />
 			</Item>
+			<Item className="masterbar__item-title">{ headerTitle }</Item>
 			<Item
 				tipTarget="me"
 				url="#" // @todo: add a correct URL

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -4,8 +4,11 @@
 
 	.masterbar__item-title {
 		padding-left: 16px;
+		font-size: 20px;
+		color: var( --color-gray-70 );
 		flex: 1 0 auto;
 		text-transform: none;
+		font-weight: 500;
 	}
 }
 

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -1,13 +1,18 @@
 // Masterbar - home link
 .masterbar.is-jetpack-cloud-masterbar {
 	justify-content: space-between;
+
+	.masterbar__item-title {
+		padding-left: 16px;
+		flex: 1 0 auto;
+		text-transform: none;
+	}
 }
 
 .is-jetpack-cloud-masterbar .masterbar__item-home {
-	width: 100%;
 	padding: 0;
 	border-right: 1px solid var( --color-masterbar-border );
-
+	width: 200px;
 	@include breakpoint( '>660px' ) {
 		width: $sidebar-width-min;
 	}
@@ -25,13 +30,6 @@
 
 		svg {
 			fill: var( --color-black );
-			// Ensures the logo is centered by balancing out the avatar item on the right:
-			// ( 15px padding left + 24px avatar + 15px padding right ) / 2 = 27px
-			transform: translateX( 27px );
-
-			@include breakpoint( '>660px' ) {
-				transform: none;
-			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the masterbar to include the title. 
Before:
<img width="1340" alt="Screen Shot 2020-03-20 at 4 22 59 PM" src="https://user-images.githubusercontent.com/115071/77178288-28934e00-6ac7-11ea-8895-60f65efc5a89.png">


After:
<img width="1380" alt="Screen Shot 2020-03-20 at 4 18 53 PM" src="https://user-images.githubusercontent.com/115071/77178027-cb979800-6ac6-11ea-83d1-334ba0a2e650.png">


#### Testing instructions
Load up jetpack cloud. Dos the styling look of the master as you would expect?
Try different screen widths. 
