### PR TITLE
GSuite: Hide G Suite nudge from My Home

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -145,6 +145,7 @@ class Home extends Component {
 				isEstablishedSite && (
 					<div className="customer-home__upsells">
 						<StatsBanners
+							isGSuiteStatsNudgeVisible={ false }
 							siteId={ siteId }
 							slug={ siteSlug }
 							primaryButton={ isChecklistComplete && ! siteIsUnlaunched ? true : false }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -145,7 +145,6 @@ class Home extends Component {
 				isEstablishedSite && (
 					<div className="customer-home__upsells">
 						<StatsBanners
-							isGSuiteStatsNudgeVisible={ false }
 							siteId={ siteId }
 							slug={ siteSlug }
 							primaryButton={ isChecklistComplete && ! siteIsUnlaunched ? true : false }

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -20,7 +20,6 @@ import { getSitePlanSlug } from 'state/sites/selectors';
 import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
 import GSuiteStatsNudge from 'blocks/gsuite-stats-nudge';
 import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
-import isGSuiteStatsNudgeVisible from 'state/selectors/is-gsuite-stats-nudge-visible';
 import isUpworkStatsNudgeDismissed from 'state/selectors/is-upwork-stats-nudge-dismissed';
 import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import QuerySiteDomains from 'components/data/query-site-domains';
@@ -159,7 +158,7 @@ export default connect( ( state, ownProps ) => {
 			state,
 			ownProps.siteId
 		),
-		isGSuiteStatsNudgeVisible: isGSuiteStatsNudgeVisible( state, ownProps.siteId, domains ),
+		isGSuiteStatsNudgeVisible: false,
 		isUpworkStatsNudgeVisible: ! isUpworkStatsNudgeDismissed( state, ownProps.siteId ),
 		planSlug: getSitePlanSlug( state, ownProps.siteId ),
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the G Suite nudge from My Home page.

#### Testing instructions

Right now this upsell appears in the My Home page:

<img width="1058" alt="Screenshot 2020-03-20 at 8 11 37 PM" src="https://user-images.githubusercontent.com/13062352/77198297-03aed300-6ae7-11ea-8964-a647ba227e9e.png">

Make sure that after the changes, it no longer appears.