### PR TITLE
Jetpack Cloud: Update styling and functionality of the BackupDelta component

### DIFF
--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -16,6 +16,11 @@ import ActivityCard from '../../components/activity-card';
  */
 import './style.scss';
 
+/**
+ * Image dependencies
+ */
+import mediaImage from 'assets/images/illustrations/media.svg';
+
 class BackupDelta extends Component {
 	renderRealtime() {
 		const { allowRestore, moment, translate } = this.props;
@@ -40,32 +45,149 @@ class BackupDelta extends Component {
 		);
 	}
 
-	renderDaily() {
-		const { backupAttempts, deltas, siteSlug, translate } = this.props;
-		const mainBackup = backupAttempts.complete && backupAttempts.complete[ 0 ];
-		const meta = mainBackup && mainBackup.activityDescription[ 2 ].children[ 0 ];
+	renderMetaDiff() {
+		const { metaDiff, translate } = this.props;
+		const metas = [];
 
-		const media = deltas.mediaCreated.map( item => (
-			<div key={ item.activityId }>
+		if ( metaDiff.plugins > 0 ) {
+			metas.push(
+				translate( '+%(numPlugins)d Plugin', '+%(numPlugins)d Plugins', {
+					count: metaDiff.plugins,
+					args: {
+						numPlugins: metaDiff.plugins,
+					},
+				} )
+			);
+		} else if ( metaDiff.plugins < 0 ) {
+			metas.push(
+				translate( '%(numPlugins)d Plugin', '%(numPlugins)d Plugins', {
+					count: metaDiff.plugins,
+					args: {
+						numPlugins: metaDiff.plugins,
+					},
+				} )
+			);
+		}
+
+		if ( metaDiff.themes > 0 ) {
+			metas.push(
+				translate( '+%(numThemes)d Theme', '+%(numThemes)d Themes', {
+					count: metaDiff.themes,
+					args: {
+						numThemes: metaDiff.themes,
+					},
+				} )
+			);
+		} else if ( metaDiff.themes < 0 ) {
+			metas.push(
+				translate( '%(numThemes)d Theme', '%(numThemes)d Themes', {
+					count: metaDiff.themes,
+					args: {
+						numThemes: metaDiff.themes,
+					},
+				} )
+			);
+		}
+
+		if ( metaDiff.uploads > 0 ) {
+			metas.push(
+				translate( '+%(numUploads)d Upload', '+%(numUploads)d Uploads', {
+					count: metaDiff.uploads,
+					args: {
+						numUploads: metaDiff.uploads,
+					},
+				} )
+			);
+		} else if ( metaDiff.uploads < 0 ) {
+			metas.push(
+				translate( '%(numUploads)d Upload', '%(numUploads)d Uploads', {
+					count: metaDiff.uploads,
+					args: {
+						numUploads: metaDiff.uploads,
+					},
+				} )
+			);
+		}
+
+		if ( metaDiff.posts > 0 ) {
+			metas.push(
+				translate( '+%(numPosts)d Post', '+%(numPosts)d Posts', {
+					count: metaDiff.posts,
+					args: {
+						numPosts: metaDiff.posts,
+					},
+				} )
+			);
+		} else if ( metaDiff.posts < 0 ) {
+			metas.push(
+				translate( '%(numPosts)d Post', '%(numPosts)d Posts', {
+					count: metaDiff.posts,
+					args: {
+						numPosts: metaDiff.posts,
+					},
+				} )
+			);
+		}
+
+		return <div className="backup-delta__metas">{ metas.join( ', ' ) }</div>;
+	}
+
+	renderDaily() {
+		const { backupAttempts, deltas, metaDiff, siteSlug, translate } = this.props;
+		const mainBackup = backupAttempts.complete && backupAttempts.complete[ 0 ];
+
+		const mediaCreated = deltas.mediaCreated.map( item => (
+			<div key={ item.activityId } className="backup-delta__media-image">
 				<img alt="" src={ item.activityMedia.thumbnail_url } />
-				<div>{ item.activityMedia.name }</div>
+				<div className="backup-delta__media-title">
+					<Gridicon icon="add" />
+					{ translate( 'Added' ) }
+				</div>
 			</div>
 		) );
+
+		const mediaCount = deltas.mediaCreated.length - deltas.mediaDeleted.length;
+		const mediaOperator = mediaCount >= 0 ? '+' : '-';
+		const mediaCountDisplay = `${ mediaOperator }${ mediaCount }`;
+
+		const deletedElement = [
+			<div className="backup-delta__media-image">
+				<img alt="" src={ mediaImage } />
+				<div className="backup-delta__deleted-count-bubble">-{ deltas.mediaDeleted.length }</div>
+				<div className="backup-delta__media-title">
+					<Gridicon icon="cross-circle" />
+					{ translate( 'Removed' ) }
+				</div>
+			</div>,
+		];
+
+		const mediaItems =
+			deltas.mediaDeleted.length > 0
+				? mediaCreated.slice( 0, 2 ).concat( deletedElement )
+				: mediaCreated.slice( 0, 3 );
+
+		const postsCount = deltas.postsCreated.length - deltas.postsDeleted.length;
+		const postsOperator = postsCount >= 0 ? '+' : '-';
+		const postCountDisplay = `${ postsOperator }${ postsCount }`;
 
 		const posts = deltas.posts.map( item => {
 			if ( 'post__published' === item.activityName ) {
 				return (
-					<div key={ item.activityId }>
-						<Gridicon icon="pencil" />
-						{ item.activityDescription[ 0 ].children[ 0 ] }
+					<div key={ item.activityId } className="backup-delta__post-block">
+						<Gridicon className="backup-delta__post-icon" icon="pencil" />
+						<a className="backup-delta__post-link" href={ item.activityDescription[ 0 ].url }>
+							{ item.activityDescription[ 0 ].children[ 0 ] }
+						</a>
 					</div>
 				);
 			}
 			if ( 'post__trashed' === item.activityName ) {
 				return (
-					<div key={ item.activityId }>
-						<Gridicon icon="cross" />
-						{ item.activityDescription[ 0 ].children[ 0 ].text }
+					<div key={ item.activityId } className="backup-delta__post-block">
+						<Gridicon className="backup-delta__post-icon" icon="cross" />
+						<a className="backup-delta__post-link" href={ null }>
+							{ item.activityDescription[ 0 ].children[ 0 ].text }
+						</a>
 					</div>
 				);
 			}
@@ -75,28 +197,31 @@ class BackupDelta extends Component {
 
 		return (
 			<div className="backup-delta__daily">
-				{ hasChanges && <div>{ translate( 'Backup details' ) }</div> }
+				<div className="backup-delta__changes-header">
+					{ translate( 'Changes in this backup' ) }
+				</div>
 				{ !! deltas.mediaCreated.length && (
 					<Fragment>
-						<div>{ translate( 'Media' ) }</div>
-						<div>{ media }</div>
+						<div className="backup-delta__section-header">{ translate( 'Media' ) }</div>
+						<div className="backup-delta__section-media">
+							{ mediaItems }
+							<div>
+								<div className="backup-delta__count-bubble">{ mediaCountDisplay }</div>
+							</div>
+						</div>
 					</Fragment>
 				) }
 				{ !! deltas.posts.length && (
 					<Fragment>
-						<div>{ translate( 'Posts' ) }</div>
-						<div>{ posts }</div>
+						<div className="backup-delta__section-header">{ translate( 'Posts' ) }</div>
+						<div className="backup-delta__section-posts">{ posts }</div>
+						<div className="backup-delta__count-bubble">{ postCountDisplay }</div>
 					</Fragment>
 				) }
-				{ hasChanges && <div>{ meta }</div> }
-				{ mainBackup && (
-					<Button
-						className="backup-delta__view-all-button"
-						href={ `/backups/${ siteSlug }/detail/${ mainBackup.rewindId }` }
-					>
-						{ translate( 'View all backup details' ) }
-					</Button>
-				) }
+				{ this.renderMetaDiff() }
+				<Button isPrimary={ false } className="backup-delta__view-all-button">
+					{ translate( 'View all backup details' ) }
+				</Button>
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -76,8 +76,8 @@ class BackupDelta extends Component {
 					src={ item.activityMedia.available ? item.activityMedia.thumbnail_url : mediaImage }
 				/>
 				<div className="backup-delta__media-title">
-					<Gridicon icon="add" />
-					{ translate( 'Added' ) }
+					<Gridicon icon="plus" />
+					<div className="backup-delta__media-title-text">{ translate( 'Added' ) }</div>
 				</div>
 			</div>
 		) );
@@ -91,8 +91,8 @@ class BackupDelta extends Component {
 				<img alt="" src={ mediaImage } />
 				<div className="backup-delta__deleted-count-bubble">-{ deltas.mediaDeleted.length }</div>
 				<div className="backup-delta__media-title">
-					<Gridicon icon="cross-circle" />
-					{ translate( 'Removed' ) }
+					<Gridicon icon="cross-small" />
+					<div className="backup-delta__media-title-text">{ translate( 'Removed' ) }</div>
 				</div>
 			</div>,
 		];
@@ -158,7 +158,9 @@ class BackupDelta extends Component {
 			return (
 				<div key={ item.activityId } className={ className }>
 					{ icon }
-					{ item.activityDescription[ 0 ].children[ 0 ] }
+					<div className="backup-delta__extension-block-text">
+						{ item.activityDescription[ 0 ].children[ 0 ] }
+					</div>
 				</div>
 			);
 		} );

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -50,88 +50,17 @@ class BackupDelta extends Component {
 	}
 
 	renderMetaDiff() {
-		const { metaDiff, translate } = this.props;
+		const { metaDiff } = this.props;
 		const metas = [];
 
-		if ( metaDiff.plugins > 0 ) {
-			metas.push(
-				translate( '+%(numPlugins)d Plugin', '+%(numPlugins)d Plugins', {
-					count: metaDiff.plugins,
-					args: {
-						numPlugins: metaDiff.plugins,
-					},
-				} )
-			);
-		} else if ( metaDiff.plugins < 0 ) {
-			metas.push(
-				translate( '%(numPlugins)d Plugin', '%(numPlugins)d Plugins', {
-					count: metaDiff.plugins,
-					args: {
-						numPlugins: metaDiff.plugins,
-					},
-				} )
-			);
-		}
-
-		if ( metaDiff.themes > 0 ) {
-			metas.push(
-				translate( '+%(numThemes)d Theme', '+%(numThemes)d Themes', {
-					count: metaDiff.themes,
-					args: {
-						numThemes: metaDiff.themes,
-					},
-				} )
-			);
-		} else if ( metaDiff.themes < 0 ) {
-			metas.push(
-				translate( '%(numThemes)d Theme', '%(numThemes)d Themes', {
-					count: metaDiff.themes,
-					args: {
-						numThemes: metaDiff.themes,
-					},
-				} )
-			);
-		}
-
-		if ( metaDiff.uploads > 0 ) {
-			metas.push(
-				translate( '+%(numUploads)d Upload', '+%(numUploads)d Uploads', {
-					count: metaDiff.uploads,
-					args: {
-						numUploads: metaDiff.uploads,
-					},
-				} )
-			);
-		} else if ( metaDiff.uploads < 0 ) {
-			metas.push(
-				translate( '%(numUploads)d Upload', '%(numUploads)d Uploads', {
-					count: metaDiff.uploads,
-					args: {
-						numUploads: metaDiff.uploads,
-					},
-				} )
-			);
-		}
-
-		if ( metaDiff.posts > 0 ) {
-			metas.push(
-				translate( '+%(numPosts)d Post', '+%(numPosts)d Posts', {
-					count: metaDiff.posts,
-					args: {
-						numPosts: metaDiff.posts,
-					},
-				} )
-			);
-		} else if ( metaDiff.posts < 0 ) {
-			metas.push(
-				translate( '%(numPosts)d Post', '%(numPosts)d Posts', {
-					count: metaDiff.posts,
-					args: {
-						numPosts: metaDiff.posts,
-					},
-				} )
-			);
-		}
+		metaDiff.forEach( meta => {
+			if ( meta.num > 0 || meta.num < 0 ) {
+				const operator = meta.num < 0 ? '-' : '+';
+				const plural = meta.num > 1 || meta.num < -1 ? 's' : '';
+				// TBD: How do we deal with translating these strings?
+				metas.push( `${ operator }${ meta.num } ${ meta.type }${ plural }` );
+			}
+		} );
 
 		return <div className="backup-delta__metas">{ metas.join( ', ' ) }</div>;
 	}

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -40,7 +40,11 @@ class BackupDelta extends Component {
 		return (
 			<div className="backup-delta__realtime">
 				<div>{ translate( 'More backups from today' ) }</div>
-				{ cards.length ? cards : <div>{ translate( 'you have no more backups for this day' ) }</div> }
+				{ cards.length ? (
+					cards
+				) : (
+					<div>{ translate( 'you have no more backups for this day' ) }</div>
+				) }
 			</div>
 		);
 	}
@@ -133,7 +137,7 @@ class BackupDelta extends Component {
 	}
 
 	renderDaily() {
-		const { backupAttempts, deltas, metaDiff, siteSlug, translate } = this.props;
+		const { backupAttempts, deltas, siteSlug, translate } = this.props;
 		const mainBackup = backupAttempts.complete && backupAttempts.complete[ 0 ];
 
 		const mediaCreated = deltas.mediaCreated.map( item => (
@@ -185,15 +189,13 @@ class BackupDelta extends Component {
 				return (
 					<div key={ item.activityId } className="backup-delta__post-block">
 						<Gridicon className="backup-delta__post-icon" icon="cross" />
-						<a className="backup-delta__post-link" href={ null }>
+						<div className="backup-delta__post-link">
 							{ item.activityDescription[ 0 ].children[ 0 ].text }
-						</a>
+						</div>
 					</div>
 				);
 			}
 		} );
-
-		const hasChanges = !! ( deltas.posts.length || deltas.mediaCreated.length );
 
 		return (
 			<div className="backup-delta__daily">
@@ -219,9 +221,15 @@ class BackupDelta extends Component {
 					</Fragment>
 				) }
 				{ this.renderMetaDiff() }
-				<Button isPrimary={ false } className="backup-delta__view-all-button">
-					{ translate( 'View all backup details' ) }
-				</Button>
+				{ mainBackup && (
+					<Button
+						isPrimary={ false }
+						className="backup-delta__view-all-button"
+						href={ `/backups/${ siteSlug }/detail/${ mainBackup.rewindId }` }
+					>
+						{ translate( 'View all backup details' ) }
+					</Button>
+				) }
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -3,7 +3,6 @@
 }
 
 .backup-delta__view-all-button {
-    display: block;
     float: none;
 }
 
@@ -40,7 +39,7 @@
 .backup-delta__media-title {
     position: relative;
     top: -1.5rem;
-    background-color: rgba(0,0,0,.5);
+    background-color: rgba( 0, 0, 0, 0.5 );
     color: #fff;
     font-size: 0.8rem;
 }
@@ -52,7 +51,7 @@
 
 .backup-delta__count-bubble {
     display: inline-block;
-    background: #DCDCDE;
+    background: #dcdcde;
     color: #000;
     border-radius: 1rem;
     padding: 0.2rem 0.5rem;
@@ -60,10 +59,10 @@
 
 .backup-delta__deleted-count-bubble {
     position: absolute;
-    right: .5rem;
+    right: 0.5rem;
     top: 2rem;
     display: inline-block;
-    background: #D63638;
+    background: #d63638;
     color: #fff;
     border-radius: 1rem;
     padding: 0.2rem 0.5rem;
@@ -71,13 +70,15 @@
 
 .gridicon.backup-delta__post-icon {
     width: 1rem;
-    fill: #787C82;
+    fill: #787c82;
 }
 
 .backup-delta__post-link {
+    display: inline-block;
     position: relative;
     top: -0.4rem;
     left: 0.5rem;
+    color: #349e0b;
 }
 
 .backup-delta__post-block {
@@ -88,8 +89,9 @@
     margin: 1rem 0;
 }
 
-@media (max-width: 660px) {
+@media ( max-width: 660px ) {
     .backup-delta__view-all-button {
-        width: 100%;
+        display: block;
+        text-align: center;
     }
 }

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -1,3 +1,7 @@
+.backup-delta {
+    margin: 0 1rem;
+}
+
 .backup-delta__view-all-button {
     display: block;
     float: none;
@@ -10,4 +14,82 @@
 .backup-delta__realtime .button.is-borderless.is-primary {
     float: none;
     display: inline-block;
+}
+
+.backup-delta__changes-header {
+    margin-top: 2rem;
+    font-weight: 700;
+}
+
+.backup-delta__section-header {
+    margin: 0.5rem 0;
+
+}
+
+.backup-delta__section-posts {
+    margin-bottom: 1rem;
+
+}
+
+.backup-delta__media-image {
+    display: inline-block;
+    margin-right: 1rem;
+    position: relative;
+}
+
+.backup-delta__media-title {
+    position: relative;
+    top: -1.5rem;
+    background-color: rgba(0,0,0,.5);
+    color: #fff;
+    font-size: 0.8rem;
+}
+
+.backup-delta__media-title .gridicon {
+    width: 1rem;
+    margin: 0 0.3rem;
+}
+
+.backup-delta__count-bubble {
+    display: inline-block;
+    background: #DCDCDE;
+    color: #000;
+    border-radius: 1rem;
+    padding: 0.2rem 0.5rem;
+}
+
+.backup-delta__deleted-count-bubble {
+    position: absolute;
+    right: .5rem;
+    top: 2rem;
+    display: inline-block;
+    background: #D63638;
+    color: #fff;
+    border-radius: 1rem;
+    padding: 0.2rem 0.5rem;
+}
+
+.gridicon.backup-delta__post-icon {
+    width: 1rem;
+    fill: #787C82;
+}
+
+.backup-delta__post-link {
+    position: relative;
+    top: -0.4rem;
+    left: 0.5rem;
+}
+
+.backup-delta__post-block {
+    margin-bottom: -0.5rem;
+}
+
+.backup-delta__metas {
+    margin: 1rem 0;
+}
+
+@media (max-width: 660px) {
+    .backup-delta__view-all-button {
+        width: 100%;
+    }
 }

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -36,17 +36,31 @@
     position: relative;
 }
 
+.backup-delta__media-image img {
+    object-fit: cover;
+    width: 6rem;
+    height: 6rem;
+}
+
 .backup-delta__media-title {
     position: relative;
-    top: -1.5rem;
+    top: -1.9rem;
     background-color: rgba( 0, 0, 0, 0.5 );
     color: #fff;
     font-size: 0.8rem;
+    padding-top: 0.3rem;
 }
 
 .backup-delta__media-title .gridicon {
-    width: 1rem;
+    width: 0.7rem;
+    height: 1rem;
     margin: 0 0.3rem;
+}
+
+.backup-delta__media-title-text {
+    position: relative;
+    top: -0.18rem;
+    display: inline-block;
 }
 
 .backup-delta__count-bubble {
@@ -75,11 +89,13 @@
 
 .gridicon.backup-delta__theme-icon-installed {
     width: 1rem;
+    height: 1rem;
     fill: #349e0b;
 }
 
 .gridicon.backup-delta__theme-icon-removed {
     width: 1rem;
+    height: 1rem;
     fill: #d63638;
 }
 
@@ -105,6 +121,13 @@
 
 .backup-delta__metas {
     margin: 1rem 0;
+}
+
+.backup-delta__extension-block-text {
+    display: inline-block;
+    position: relative;
+    left: 0.2rem;
+    top: -0.1rem;
 }
 
 @media ( max-width: 660px ) {

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -73,6 +73,24 @@
     fill: #787c82;
 }
 
+.gridicon.backup-delta__theme-icon-installed {
+    width: 1rem;
+    fill: #349e0b;
+}
+
+.gridicon.backup-delta__theme-icon-removed {
+    width: 1rem;
+    fill: #d63638;
+}
+
+.backup-delta__extension-block-installed {
+    color: #349e0b;
+}
+
+.backup-delta__extension-block-removed {
+    color: #d63638;
+}
+
 .backup-delta__post-link {
     display: inline-block;
     position: relative;

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -11,6 +11,13 @@ import { isMobile } from '@automattic/viewport';
 import DocumentHead from 'components/data/document-head';
 import { updateFilter } from 'state/activity-log/actions';
 import { getBackupAttemptsForDate, getDailyBackupDeltas, getEventsInDailyBackup } from './utils';
+import { emptyFilter } from 'state/activity-log/reducer';
+import {
+	getBackupAttemptsForDate,
+	getDailyBackupDeltas,
+	getEventsInDailyBackup,
+	getMetaDiffForDailyBackup,
+} from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
@@ -40,7 +47,7 @@ class BackupsPage extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			selectedDateString: props.moment().toISOString( true ),
+			selectedDateString: props.moment( '2020-02-27' ).toISOString( true ),
 		};
 	}
 
@@ -66,6 +73,7 @@ class BackupsPage extends Component {
 		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );
 		const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
+		const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
 
 		return (
 			<Main>
@@ -93,6 +101,7 @@ class BackupsPage extends Component {
 						allowRestore,
 						moment,
 						siteSlug,
+						metaDiff,
 					} }
 				/>
 			</Main>

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -45,7 +45,7 @@ class BackupsPage extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			selectedDateString: props.moment( '2020-02-27' ).toISOString( true ),
+			selectedDateString: props.moment().toISOString( true ),
 		};
 	}
 

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -10,8 +10,6 @@ import { isMobile } from '@automattic/viewport';
  */
 import DocumentHead from 'components/data/document-head';
 import { updateFilter } from 'state/activity-log/actions';
-import { getBackupAttemptsForDate, getDailyBackupDeltas, getEventsInDailyBackup } from './utils';
-import { emptyFilter } from 'state/activity-log/reducer';
 import {
 	getBackupAttemptsForDate,
 	getDailyBackupDeltas,

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -114,5 +114,7 @@ export const getDailyBackupDeltas = ( logs, date ) => {
 		),
 		postsCreated: changes.filter( event => 'post__published' === event.activityName ),
 		postsDeleted: changes.filter( event => 'post__trashed' === event.activityName ),
+		plugins: changes.filter( event => 'plugin__installed' === event.activityName ),
+		themes: changes.filter( event => 'theme__installed' === event.activityName ),
 	};
 };

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -90,16 +90,17 @@ export const getMetaDiffForDailyBackup = ( logs, date ) => {
 	const thisMeta = metaStringToObject(
 		thisBackup.complete[ 0 ].activityDescription[ 2 ].children[ 0 ]
 	);
+
 	const lastMeta = metaStringToObject(
 		lastBackup.complete[ 0 ].activityDescription[ 2 ].children[ 0 ]
 	);
 
-	return {
-		plugins: thisMeta.plugins.val - lastMeta.plugins.val,
-		themes: thisMeta.themes.val - lastMeta.themes.val,
-		uploads: thisMeta.uploads.val - lastMeta.uploads.val,
-		posts: thisMeta.posts.val - lastMeta.posts.val,
-	};
+	return [
+		{ type: 'Plugin', num: thisMeta.plugins.val - lastMeta.plugins.val },
+		{ type: 'Theme', num: thisMeta.themes.val - lastMeta.themes.val },
+		{ type: 'Upload', num: thisMeta.uploads.val - lastMeta.uploads.val },
+		{ type: 'Post', num: thisMeta.posts.val - lastMeta.posts.val },
+	];
 };
 
 export const getDailyBackupDeltas = ( logs, date ) => {

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -114,7 +114,12 @@ export const getDailyBackupDeltas = ( logs, date ) => {
 		),
 		postsCreated: changes.filter( event => 'post__published' === event.activityName ),
 		postsDeleted: changes.filter( event => 'post__trashed' === event.activityName ),
-		plugins: changes.filter( event => 'plugin__installed' === event.activityName ),
-		themes: changes.filter( event => 'theme__installed' === event.activityName ),
+		plugins: changes.filter(
+			event =>
+				'plugin__installed' === event.activityName || 'plugin__deleted' === event.activityName
+		),
+		themes: changes.filter(
+			event => 'theme__installed' === event.activityName || 'theme__deleted' === event.activityName
+		),
 	};
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Brings the BackupDelta component into functional spec
* Brings the BackupDelta component into rough design spec (will improve CSS methodologies later if needed)

#### Testing instructions

Note: These changes are only for  **daily** backup views.

Load up the backups page for a date/site which has various types of changes, including post creation/deletion, media upload/deletion, plugin installation/removal, theme installation/removal.

**Some general things to look at:**

* The entire BackupDelta section should only appear for days that have a change of some sort.
* Media changes should look sensible and reflect what happened on the site, including an accurate count in the "bubble" below the media.
* Edited/deleted posts should appear in the list
* Themes/plugins that were installed/deleted should appear in the list, and look sensible.
* The metadata at the very bottom of the component should appear accurate, showing number diffs from the last backup to this one.
* Significant design departures from the below image should be noted :-)

![Screen Shot 2020-03-24 at 12 05 19 PM](https://user-images.githubusercontent.com/5528445/77448854-aa38f380-6dc7-11ea-81c5-ff3857c32f23.png)

Notes (will add more as I think of them):
* The uploads count in the metadata at the end "looks" incorrect, but this is actually counting the files created in the wp-content/uploads directory, so it includes the resized images. We might want to call this "media files" or something less confusion than "uploads", which a user is likely to associate with images they uploaded, rather than files generated on the server.