### PR TITLE
Allow Jetpack Search products to be added to the shopping cart from the plans page

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -789,7 +789,10 @@ function createItemToAddToCart( { planSlug, plan, isJetpackNotAtomic } ) {
 		cartItem = conciergeSessionItem();
 	}
 
-	if ( planSlug.startsWith( 'jetpack_backup' ) && isJetpackNotAtomic ) {
+	if (
+		( planSlug.startsWith( 'jetpack_backup' ) || planSlug.startsWith( 'jetpack_search' ) ) &&
+		isJetpackNotAtomic
+	) {
 		cartItem = jetpackProductItem( planSlug );
 	}
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -296,7 +296,11 @@ export class Checkout extends React.Component {
 			cartItem = ! hasConciergeSession( cart ) && conciergeSessionItem();
 		}
 
-		if ( startsWith( this.props.product, 'jetpack_backup' ) && isJetpackNotAtomic ) {
+		if (
+			( startsWith( this.props.product, 'jetpack_backup' ) ||
+				startsWith( this.props.product, 'jetpack_search' ) ) &&
+			isJetpackNotAtomic
+		) {
 			cartItem = jetpackProductItem( this.props.product );
 		}
 


### PR DESCRIPTION
It wasn't possible to do that before, since the way the shopping cart code works, Jetpack products need to be hardcoded in.

#### Testing instructions

Connect a Jetpack site to WordPress.com, then go to `plans/[site]` and make sure you can add a Jetpack Search product by clicking "Get Search".