### PR TITLE
Hide WPCOM Gutenberg NUX if SPT is open

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
@@ -13,6 +13,7 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { PageTemplatesPlugin } from './page-template-modal';
 import SidebarTemplatesPlugin from './page-template-modal/components/sidebar-modal-opener';
 import { initializeWithIdentity } from './page-template-modal/utils/tracking';
+import './store';
 /* eslint-enable import/no-extraneous-dependencies */
 
 // Load config passed from backend.
@@ -43,6 +44,7 @@ const templatesPluginSharedProps = {
 
 // Open plugin only if we are creating new page.
 if ( screenAction === 'add' ) {
+	dispatch( 'automattic/spt' ).setIsOpen( true );
 	registerPlugin( 'page-templates', {
 		render: () => (
 			<PageTemplatesPlugin { ...templatesPluginSharedProps } shouldPrefetchAssets={ false } />

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
@@ -44,7 +44,7 @@ const templatesPluginSharedProps = {
 
 // Open plugin only if we are creating new page.
 if ( screenAction === 'add' ) {
-	dispatch( 'automattic/spt' ).setIsOpen( true );
+	dispatch( 'automattic/starter-page-layouts' ).setIsOpen( true );
 	registerPlugin( 'page-templates', {
 		render: () => (
 			<PageTemplatesPlugin { ...templatesPluginSharedProps } shouldPrefetchAssets={ false } />

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -127,10 +127,10 @@ const SidebarTemplatesPlugin = compose(
 	withSelect( select => ( {
 		lastTemplateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
 			._starter_page_template,
-		isOpen: select( 'automattic/spt' ).isOpen(),
+		isOpen: select( 'automattic/starter-page-layouts' ).isOpen(),
 	} ) ),
 	withDispatch( dispatch => ( {
-		setIsOpen: dispatch( 'automattic/spt' ).setIsOpen,
+		setIsOpen: dispatch( 'automattic/starter-page-layouts' ).setIsOpen,
 	} ) )
 )( SidebarModalOpener );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 import { Button, Modal } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -17,12 +17,11 @@ import replacePlaceholders from '../utils/replace-placeholders';
 /* eslint-enable import/no-extraneous-dependencies */
 class SidebarModalOpener extends Component {
 	state = {
-		isTemplateModalOpen: false,
 		isWarningOpen: false,
 	};
 
 	toggleTemplateModal = () => {
-		this.setState( { isTemplateModalOpen: ! this.state.isTemplateModalOpen } );
+		this.props.setIsOpen( ! this.props.isOpen );
 	};
 
 	toggleWarningModal = () => {
@@ -61,6 +60,7 @@ class SidebarModalOpener extends Component {
 			siteInformation,
 			hidePageTitle,
 			isFrontPage,
+			isOpen,
 		} = this.props;
 
 		return (
@@ -82,7 +82,7 @@ class SidebarModalOpener extends Component {
 					{ __( 'Change Layout' ) }
 				</Button>
 
-				{ this.state.isTemplateModalOpen && (
+				{ isOpen && (
 					<PageTemplatesPlugin
 						shouldPrefetchAssets={ false }
 						templates={ templates }
@@ -127,6 +127,10 @@ const SidebarTemplatesPlugin = compose(
 	withSelect( select => ( {
 		lastTemplateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
 			._starter_page_template,
+		isOpen: select( 'automattic/spt' ).isOpen(),
+	} ) ),
+	withDispatch( dispatch => ( {
+		setIsOpen: dispatch( 'automattic/spt' ).setIsOpen,
 	} ) )
 )( SidebarModalOpener );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -506,7 +506,7 @@ export const PageTemplatesPlugin = compose(
 	withSelect( select => {
 		const getMeta = () => select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const { _starter_page_template } = getMeta();
-		const isOpen = select( 'automattic/spt' ).isOpen();
+		const isOpen = select( 'automattic/starter-page-layouts' ).isOpen();
 		return {
 			isOpen,
 			getMeta,
@@ -520,7 +520,7 @@ export const PageTemplatesPlugin = compose(
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const editorDispatcher = dispatch( 'core/editor' );
-		const { setIsOpen } = dispatch( 'automattic/spt' );
+		const { setIsOpen } = dispatch( 'automattic/starter-page-layouts' );
 		return {
 			setIsOpen,
 			saveTemplateChoice: slug => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -46,7 +46,6 @@ class PageTemplateModal extends Component {
 		isLoading: false,
 		previewedTemplate: null,
 		error: null,
-		isOpen: false,
 	};
 
 	// Extract titles for faster lookup.
@@ -133,7 +132,6 @@ class PageTemplateModal extends Component {
 		if ( ! state.previewedTemplate && ! isEmpty( props.templates ) ) {
 			// Show the modal, and select the first template automatically.
 			return {
-				isOpen: true,
 				previewedTemplate: PageTemplateModal.getDefaultSelectedTemplate( props ),
 			};
 		}
@@ -141,15 +139,15 @@ class PageTemplateModal extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.state.isOpen ) {
+		if ( this.props.isOpen ) {
 			this.trackCurrentView();
 		}
 	}
 
-	componentDidUpdate( prevProps, prevState ) {
+	componentDidUpdate( prevProps ) {
 		// Only track when the modal is first displayed
 		// and if it didn't already happen during componentDidMount.
-		if ( ! prevState.isOpen && this.state.isOpen ) {
+		if ( ! prevProps.isOpen && this.props.isOpen ) {
 			this.trackCurrentView();
 		}
 
@@ -200,7 +198,7 @@ class PageTemplateModal extends Component {
 		// and reset the template if so.
 		if ( 'blank' === slug ) {
 			this.props.insertTemplate( '', [] );
-			this.setState( { isOpen: false } );
+			this.props.setIsOpen( false );
 			return;
 		}
 
@@ -215,7 +213,7 @@ class PageTemplateModal extends Component {
 		// Skip inserting if this is not a blank template
 		// and there's nothing to insert.
 		if ( ! blocks || ! blocks.length ) {
-			this.setState( { isOpen: false } );
+			this.props.setIsOpen( false );
 			return;
 		}
 
@@ -228,14 +226,15 @@ class PageTemplateModal extends Component {
 		// Make sure all blocks use local assets before inserting.
 		this.maybePrefetchAssets( blocks )
 			.then( blocksWithAssets => {
+				this.setState( { isLoading: false } );
 				// Don't insert anything if the user clicked Cancel/Close
 				// before we loaded everything.
-				if ( ! this.state.isOpen ) {
+				if ( ! this.props.isOpen ) {
 					return;
 				}
 
 				this.props.insertTemplate( title, blocksWithAssets );
-				this.setState( { isOpen: false } );
+				this.props.setIsOpen( false );
 			} )
 			.catch( error => {
 				this.setState( {
@@ -358,8 +357,8 @@ class PageTemplateModal extends Component {
 	};
 
 	render() {
-		const { previewedTemplate, isOpen, isLoading } = this.state;
-		const { isPromptedFromSidebar, hidePageTitle } = this.props;
+		const { previewedTemplate, isLoading } = this.state;
+		const { isPromptedFromSidebar, hidePageTitle, isOpen } = this.props;
 
 		if ( ! isOpen ) {
 			return null;
@@ -507,7 +506,9 @@ export const PageTemplatesPlugin = compose(
 	withSelect( select => {
 		const getMeta = () => select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 		const { _starter_page_template } = getMeta();
+		const isOpen = select( 'automattic/spt' ).isOpen();
 		return {
+			isOpen,
 			getMeta,
 			_starter_page_template,
 			postContentBlock: select( 'core/editor' )
@@ -519,7 +520,9 @@ export const PageTemplatesPlugin = compose(
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const editorDispatcher = dispatch( 'core/editor' );
+		const { setIsOpen } = dispatch( 'automattic/spt' );
 		return {
+			setIsOpen,
 			saveTemplateChoice: slug => {
 				// Save selected template slug in meta.
 				const currentMeta = ownProps.getMeta();

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/store.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/store.js
@@ -1,0 +1,25 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/**
+ * External dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+const reducer = ( state = { isOpen: false }, { type, ...action } ) =>
+	'SET_IS_OPEN' === type ? { ...state, isOpen: action.isOpen } : state;
+
+const actions = {
+	setIsOpen: isOpen => ( {
+		type: 'SET_IS_OPEN',
+		isOpen,
+	} ),
+};
+
+const selectors = {
+	isOpen: state => state.isOpen,
+};
+
+registerStore( 'automattic/spt', {
+	reducer,
+	actions,
+	selectors,
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/store.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/store.js
@@ -18,7 +18,7 @@ const selectors = {
 	isOpen: state => state.isOpen,
 };
 
-registerStore( 'automattic/spt', {
+registerStore( 'automattic/starter-page-layouts', {
 	reducer,
 	actions,
 	selectors,

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -22,7 +22,11 @@ import {
 } from './images';
 
 function WpcomNux() {
-	const isWpcomNuxEnabled = useSelect( select => select( 'automattic/nux' ).isWpcomNuxEnabled() );
+	const { isWpcomNuxEnabled, isSPTOpen } = useSelect( select => ( {
+		isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
+		isSPTOpen: select( 'automattic/spt' ).isOpen(),
+	} ) );
+
 	const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );
 
 	// On mount check if the WPCOM NUX status exists in state, otherwise fetch it from the API.
@@ -37,7 +41,7 @@ function WpcomNux() {
 		fetchWpcomNuxStatus();
 	}, [ isWpcomNuxEnabled, setWpcomNuxStatus ] );
 
-	if ( ! isWpcomNuxEnabled ) {
+	if ( ! isWpcomNuxEnabled || isSPTOpen ) {
 		return null;
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -24,7 +24,7 @@ import {
 function WpcomNux() {
 	const { isWpcomNuxEnabled, isSPTOpen } = useSelect( select => ( {
 		isWpcomNuxEnabled: select( 'automattic/nux' ).isWpcomNuxEnabled(),
-		isSPTOpen: select( 'automattic/spt' ).isOpen(),
+		isSPTOpen: select( 'automattic/starter-page-layouts' ).isOpen(),
 	} ) );
 
 	const { setWpcomNuxStatus } = useDispatch( 'automattic/nux' );


### PR DESCRIPTION
### Changes proposed in this Pull Request
1. Refactor the `isOpen` part of the SPT modal into a wp data-store for SPT.
2. Use that value to hide the wpcom NUX.

### Testing instructions
1. Sandbox a test site and the public API.
2. Test that existing SPT behavior works in the following cases (please try to break it or get into a state that breaks it)
   a. Creating a new page
   b. Changing the layout of an existing page
   c. Creating a new page and then changing the layout of that new page.
   d. Doing the above steps in different orders and multiple times in a row, sometimes canceling the action.
3. Next, enable the wpcom NUX on the site by selecting "welcome guide" from the "more" menu
4. Before you do anything with the modal, go back to the pages list and create a new page.
5. Before this change, the modal should have appeared on top of SPT at this point. Verify that you do not see the modal and that you do see SPT.
6. After selecting a layout, the modal should then appear on the new page.
7. Verify that dismissing the modal and all that works as expected.

Fixes #40265