### PR TITLE
Importer: Utilise Support Article Dialog & Add Missing Links

### DIFF
--- a/client/lib/importer/importer-config.js
+++ b/client/lib/importer/importer-config.js
@@ -8,7 +8,8 @@ import { filter, head, orderBy, values } from 'lodash';
 /**
  * Internal dependencies
  */
-import ExternalLink from 'components/external-link';
+import InlineSupportLink from 'components/inline-support-link';
+import { localizeUrl } from 'lib/i18n-utils';
 
 function getConfig( { siteTitle = '' } = {} ) {
 	const importerConfig = {};
@@ -34,11 +35,18 @@ function getConfig( { siteTitle = '' } = {} ) {
 			'A WordPress export is ' +
 				'an XML file with your page and post content, or a zip archive ' +
 				'containing several XML files. ' +
-				'Need help {{ExternalLink}}exporting your content{{/ExternalLink}}?',
+				'{{supportLink/}}',
 			{
 				components: {
-					ExternalLink: (
-						<ExternalLink href="https://en.support.wordpress.com/coming-from-self-hosted/" />
+					supportLink: (
+						<InlineSupportLink
+							supportPostId={ 67084 }
+							supportLink={ localizeUrl(
+								'https://support.wordpress.com/coming-from-self-hosted/'
+							) }
+							showIcon={ false }
+							text={ translate( 'Need help exporting your content?' ) }
+						/>
 					),
 				},
 			}
@@ -68,14 +76,21 @@ function getConfig( { siteTitle = '' } = {} ) {
 		uploadDescription: translate(
 			'A %(importerName)s export file is an XML file ' +
 				'containing your page and post content. ' +
-				'Need help {{ExternalLink}}exporting your content{{/ExternalLink}}?',
+				'{{supportLink/}}',
 			{
 				args: {
 					importerName: 'Blogger',
 				},
 				components: {
-					ExternalLink: (
-						<ExternalLink href="https://en.support.wordpress.com/import/coming-from-blogger/" />
+					supportLink: (
+						<InlineSupportLink
+							supportPostId={ 66764 }
+							supportLink={ localizeUrl(
+								'https://support.wordpress.com/import/coming-from-blogger/'
+							) }
+							showIcon={ false }
+							text={ translate( 'Need help exporting your content?' ) }
+						/>
 					),
 				},
 			}
@@ -100,7 +115,20 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 			}
 		),
-		uploadDescription: translate( 'Enter the URL of your existing site' ),
+		uploadDescription: translate( 'Enter the URL of your existing site. ' + '{{supportLink/}}', {
+			components: {
+				supportLink: (
+					<InlineSupportLink
+						supportPostId={ 154436 }
+						supportLink={ localizeUrl(
+							'https://support.wordpress.com/import/import-from-godaddy/'
+						) }
+						showIcon={ false }
+						text={ translate( 'Need help?' ) }
+					/>
+				),
+			},
+		} ),
 		weight: 0,
 	};
 
@@ -125,14 +153,21 @@ function getConfig( { siteTitle = '' } = {} ) {
 		uploadDescription: translate(
 			'A %(importerName)s export file is a ZIP ' +
 				'file containing several HTML files with your stories. ' +
-				'Need help {{ExternalLink}}exporting your content{{/ExternalLink}}?',
+				'{{supportLink/}}',
 			{
 				args: {
 					importerName: 'Medium',
 				},
 				components: {
-					ExternalLink: (
-						<ExternalLink href={ 'https://en.support.wordpress.com/import/import-from-medium/' } />
+					supportLink: (
+						<InlineSupportLink
+							supportPostId={ 93180 }
+							supportLink={ localizeUrl(
+								'https://support.wordpress.com/import/import-from-medium/'
+							) }
+							showIcon={ false }
+							text={ translate( 'Need help exporting your content?' ) }
+						/>
 					),
 				},
 			}
@@ -161,15 +196,20 @@ function getConfig( { siteTitle = '' } = {} ) {
 		uploadDescription: translate(
 			'A %(importerName)s export file is an XML file ' +
 				'containing your page and post content. ' +
-				'Need help {{ExternalLink}}exporting your content{{/ExternalLink}}?',
+				'{{supportLink/}}',
 			{
 				args: {
 					importerName: 'Squarespace',
 				},
 				components: {
-					ExternalLink: (
-						<ExternalLink
-							href={ 'https://en.support.wordpress.com/import/import-from-squarespace' }
+					supportLink: (
+						<InlineSupportLink
+							supportPostId={ 87696 }
+							supportLink={ localizeUrl(
+								'https://support.wordpress.com/import/import-from-squarespace/'
+							) }
+							showIcon={ false }
+							text={ translate( 'Need help exporting your content?' ) }
 						/>
 					),
 				},
@@ -195,7 +235,18 @@ function getConfig( { siteTitle = '' } = {} ) {
 				},
 			}
 		),
-		uploadDescription: translate( 'Enter the URL of your existing site' ),
+		uploadDescription: translate( 'Enter the URL of your existing site. ' + '{{supportLink/}}', {
+			components: {
+				supportLink: (
+					<InlineSupportLink
+						supportPostId={ 147777 }
+						supportLink={ localizeUrl( 'https://support.wordpress.com/import/import-from-wix/' ) }
+						showIcon={ false }
+						text={ translate( 'Need help?' ) }
+					/>
+				),
+			},
+		} ),
 		weight: 0,
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the missing support document links for GoDaddy and Wix (the documents already exist), and ensures that all of the importers use the Support Article Dialog to display the documents in-Calypso first.

#### Testing instructions

Check the links for each Importer (they're typically in the description near the Importer's name) and verify that the correct support document is displayed.

<img width="1473" alt="Screenshot 2020-03-22 at 12 31 37" src="https://user-images.githubusercontent.com/43215253/77250028-e5f38200-6c3c-11ea-815d-1fa96c7dbbcf.png">

cc @lancewillett and @jonathansadowski

Fixes #33391
