### PR TITLE
Replace site creation animation in browser history

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -211,13 +211,15 @@ const Header: FunctionComponent = () => {
 					} );
 
 					resetOnboardStore();
-					window.location.href = `/checkout/${ newSite.site_slug }?redirect_to=%2Fgutenboarding%2Fdesign`;
+					window.location.replace(
+						`/checkout/${ newSite.site_slug }?redirect_to=%2Fgutenboarding%2Fdesign`
+					);
 				};
 				go();
 				return;
 			}
 			resetOnboardStore();
-			window.location.href = `/block-editor/page/${ newSite.site_slug }/home?is-gutenboarding`;
+			window.location.replace( `/block-editor/page/${ newSite.site_slug }/home?is-gutenboarding` );
 		}
 	}, [ domain, isDomainFlow, newSite, resetOnboardStore ] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The "creating site" animation is replaced in browser history by the next step in the flow

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/gutenboarding`
* Create a site and sign up for an account
* Get taken to the block editor
* Click the browser back
* Don't go back to the animation (you actually be taken back to the start of gutenboarding because the data store has been cleared)

We should also test the domain purchase flow too, but it's currently broken on `master`. But the idea is that clicking back from the checkout shouldn't take you to the animation.
