### PR TITLE
Jetpack Search: enable and add the Thank you modal

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -38,7 +38,7 @@ import {
 	hasTransferProduct,
 	jetpackProductItem,
 } from 'lib/cart-values/cart-items';
-import { JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
+import { JETPACK_BACKUP_PRODUCTS, JETPACK_SEARCH_PRODUCTS } from 'lib/products-values/constants';
 import PendingPaymentBlocker from './pending-payment-blocker';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -391,7 +391,10 @@ export class Checkout extends React.Component {
 		// - has a receipt number
 		// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
 		if ( selectedSiteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
-			const isJetpackProduct = product && includes( JETPACK_BACKUP_PRODUCTS, product );
+			const isJetpackProduct =
+				product &&
+				( includes( JETPACK_BACKUP_PRODUCTS, product ) ||
+					includes( JETPACK_SEARCH_PRODUCTS, product ) );
 			// If we just purchased a Jetpack product, redirect to the my plans page.
 			if ( isJetpackNotAtomic && isJetpackProduct ) {
 				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&product=${ product }`;

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -28,12 +28,14 @@ export function currentPlan( context, next ) {
 		return null;
 	}
 
+	const product = context.query.product;
 	const requestThankYou = context.query.hasOwnProperty( 'thank-you' );
 	const requestProduct = context.query.hasOwnProperty( 'product' );
 
 	context.primary = (
 		<CurrentPlan
 			path={ context.path }
+			product={ product }
 			requestThankYou={ requestThankYou }
 			requestProduct={ requestProduct }
 		/>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
@@ -19,7 +19,7 @@ const SearchProductThankYou = ( { translate } ) => (
 		<p>
 			{ translate(
 				'Next, we’ll take a look at your new WordPress.com dashboard. ' +
-					'You can manage your Jetpack Search under “Tools > Activity” in the sidebar. ' +
+					'You can manage Jetpack Search under “Tools > Activity” in the sidebar. ' +
 					'There’s also a checklist to help you get the most out of your Jetpack plan.'
 			) }
 		</p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ThankYou from './thank-you';
+
+const SearchProductThankYou = ( { translate } ) => (
+	<ThankYou
+		illustration="/calypso/images/illustrations/security.svg"
+		showContinueButton
+		title={ translate( 'Hello Jetpack Search!' ) }
+	>
+		<p>{ translate( 'We just finished setting up search for you.' ) }</p>
+		<p>
+			{ translate(
+				'Next, we’ll take a look at your new WordPress.com dashboard. ' +
+					'You can manage your Jetpack Search under “Tools > Activity” in the sidebar. ' +
+					'There’s also a checklist to help you get the most out of your Jetpack plan.'
+			) }
+		</p>
+		<p>
+			{ translate(
+				'You can return to your traditional WordPress dashboard anytime by using the link at the bottom of the sidebar.'
+			) }
+		</p>
+	</ThankYou>
+);
+
+export default localize( SearchProductThankYou );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -52,6 +52,8 @@ class CurrentPlan extends Component {
 		path: PropTypes.string.isRequired,
 		domains: PropTypes.array,
 		currentPlan: PropTypes.object,
+		plan: PropTypes.string,
+		product: PropTypes.bool,
 		requestThankYou: PropTypes.bool,
 		shouldShowDomainWarnings: PropTypes.bool,
 		hasDomainsLoaded: PropTypes.bool,
@@ -75,12 +77,12 @@ class CurrentPlan extends Component {
 	}
 
 	renderThankYou() {
-		const { currentPlan, requestProduct } = this.props;
+		const { currentPlan, product, requestProduct } = this.props;
 
 		if ( requestProduct && startsWith( requestProduct, 'jetpack_backup' ) ) {
 			return <BackupProductThankYou />;
 		}
-		if ( requestProduct && startsWith( requestProduct, 'jetpack_search' ) ) {
+		if ( requestProduct && startsWith( product, 'jetpack_search' ) ) {
 			return <SearchProductThankYou />;
 		}
 		if ( ! currentPlan || isFreePlan( currentPlan ) || isFreeJetpackPlan( currentPlan ) ) {

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { Component, Fragment } from 'react';
+import { startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -35,6 +36,7 @@ import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import PaidPlanThankYou from './current-plan-thank-you/paid-plan-thank-you';
 import FreePlanThankYou from './current-plan-thank-you/free-plan-thank-you';
 import BackupProductThankYou from './current-plan-thank-you/backup-thank-you';
+import SearchProductThankYou from './current-plan-thank-you/search-thank-you';
 import { isFreeJetpackPlan, isFreePlan } from 'lib/products-values';
 
 /**
@@ -75,8 +77,11 @@ class CurrentPlan extends Component {
 	renderThankYou() {
 		const { currentPlan, requestProduct } = this.props;
 
-		if ( requestProduct ) {
+		if ( requestProduct && startsWith( requestProduct, 'jetpack_backup' ) ) {
 			return <BackupProductThankYou />;
+		}
+		if ( requestProduct && startsWith( requestProduct, 'jetpack_search' ) ) {
+			return <SearchProductThankYou />;
 		}
 		if ( ! currentPlan || isFreePlan( currentPlan ) || isFreeJetpackPlan( currentPlan ) ) {
 			return <FreePlanThankYou />;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* enabling the Thank you note for the Jetpack Search
* add its content

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/plans` for a JP site on a non-Professional plan
* purchase Jetpack Search, pass the checkout step
* verify that the Thank you modal appears

To do in a sequel: adapt the copy and redirect

