### PR TITLE
[Gutenberg 7.7.1]: Fix editor header layout issues on mobile & tablet view.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/block-inserter/post-content-block-appender.js
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/block-inserter/post-content-block-appender.js
@@ -19,8 +19,14 @@ const PostContentBlockAppender = compose(
 		};
 	} )
 )( ( { rootClientId, showInserter } ) => {
+	const inserterToggleProps = { isPrimary: true };
 	return (
-		<Inserter rootClientId={ rootClientId } disabled={ ! showInserter } position="bottom right" />
+		<Inserter
+			rootClientId={ rootClientId }
+			disabled={ ! showInserter }
+			position="bottom right"
+			toggleProps={ inserterToggleProps }
+		/>
 	);
 } );
 

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
@@ -94,3 +94,10 @@
 		margin: 0;
 	}
 }
+
+@media ( max-width: 600px ) {
+	// Table of contents button is not displayed in mobile view.
+	.components-dropdown.table-of-contents {
+		display: none;
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
@@ -15,7 +15,12 @@
 	display: flex;
 	align-items: center;
 	padding: 9px 10px;
-	margin-left: -8px;
+	// Close button override doesn't need the extraneous left-padding
+	// provided by .edit-post-header__toolbar from WP. So here we
+	// offset the -24px padding and then restore the 24px padding
+	// for other toolbar buttons that comes after this button.
+	margin-left: -24px;
+	margin-right: 24px;
 	border: none;
 	border-right: 1px solid #e2e4e7;
 
@@ -46,6 +51,15 @@
 		.close-button-override-thin {
 			display: flex;
 		}
+	}
+
+	// Back button is not displayed in mobile & tablet view.
+	@media ( max-width: 782px ) {
+		display: none;
+	}
+
+	// Hide label to make room for others
+	@media ( max-width: 960px ) {
 		.close-button-override__label {
 			display: none;
 		}

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
@@ -9,8 +9,22 @@
 	}
 }
 
+// For Gutenberg < 7.7
 @media ( min-width: 600px ) {
 	body.is-iframed.is-fullscreen-mode .edit-post-header {
+		top: 0;
+	}
+}
+
+// For Gutenberg >= 7.7
+// 782px is $break-medium in Gutenberg which is
+// the starting breakpoint for tablet view.
+@media ( max-width: 782px ) {
+	// In non-iframed version, top: 46px is provided to accommodate #wpadminbar.
+	// On fullscreen mode, #wpadminbar is visible on tablet & mobile voew because
+	// fullscreen mode actually don't exists on tablet & mobile view.
+	// See: https://github.com/WordPress/gutenberg/pull/13425
+	body.is-iframed.is-fullscreen-mode .block-editor-editor-skeleton {
 		top: 0;
 	}
 }
@@ -30,4 +44,15 @@ body.is-fullscreen-mode {
 
 .components-notice-list {
 	z-index: 29; // Ensure notices are placed behind the editor header (z-index: 30).
+}
+
+// The parent element .edit-post-header__toolbar provides
+// a padding-left of 24px. However, the right side of the header
+// only has a padding-right of 16px.
+//
+// To make the toolbar buttons look more balanced, an left offset of -8px
+// is added to this custom block inserter button (24px - 16px = 8px). This
+// -8px offset also contributes in solving spacing issue in mobile/tablet view.
+.block-editor-inserter__toggle {
+	margin-left: -8px;
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

The following changes were made to fix header layout issues mobile & tablet view on Gutenberg 7.7.

* Fix visible whitespace in mobile & tablet view. https://github.com/WordPress/gutenberg/pull/13425).
* Hide **Back/Close Button** in mobile & tablet view (as how it behaved in previous version).
* Hide **Table of Contents Button** in mobile view (as how it behaved in previous version).
* Ensure our custom **Block Inserter Button** on page editor has a blue background (as seen on newer Gutenberg)

Fixes #40335

## Testing instructions

- Build `@automattic/full-site-editing` and sync to wpcom
- Build `@automattic/wpcom-block-editor` and sync to wpcom

1. Test the editor against the following scenarios:
- **WP-Calypso Page Editor FSE**
   https://wordpress.com/block-editor/page/YOUR_FSE_SITE_HERE.wordpress.com
- **WP-Calypso Page Editor Non-FSE**
   https://wordpress.com/block-editor/page/YOUR_NON_FSE_SITE_HERE.wordpress.com
- **WP-Admin Page Editor FSE**
   https://YOUR_FSE_SITE_HERE.wordpress.com/wp-admin/post-new.php?post_type=page
- **WP-Admin Page Editor Non-FSE**
   https://YOUR_NON_FSE_SITE_HERE.wordpress.com/wp-admin/post-new.php?post_type=page
- **WP-Calypso Post Editor**
   https://wordpress.com/block-editor/post/YOUR_SITE_HERE.wordpress.com
- **WP-Admin Post Editor**
   https://YOUR_SITE_HERE.wordpress.com/wp-admin/post-new.php

2. Spot for any possible regressions by testing the above scenarios **again** on another site running non `gutenberg-edge` version. This is for backwards compatiblity with older Atomic sites.

**Note:**
- You'll need to build and sync over both `full-site-editing-plugin` and `wpcom-block-editor` scopes to your sandbox.

## Known Issues / Remaining Work
- [ ] **Hamburger Button** is overlapping **Block Inserter Button** on WP-Admin version of the editor. Also take note that this issue already exist in live production so we don't necessarily have to fix it in this PR.
- [ ] (Optional) The layout may break on fringe viewport widths. I'm limiting the scope to just some of the standard viewport widths as seen in the screenshot below.

## Screenshots

### WP-Calypso FSE Page Editor

![image](https://user-images.githubusercontent.com/1287077/77427312-20157d00-6e11-11ea-924d-571d489f7859.png)
![image](https://user-images.githubusercontent.com/1287077/77427327-24419a80-6e11-11ea-8fd9-822e877debc2.png)
![image](https://user-images.githubusercontent.com/1287077/77427329-26a3f480-6e11-11ea-9fbd-91d150ab35d1.png)
![image](https://user-images.githubusercontent.com/1287077/77427334-29064e80-6e11-11ea-8d83-ecc7b7a41eae.png)

### WP-Calypso Non-FSE Page Editor (Has Issues)

![image](https://user-images.githubusercontent.com/1287077/77427392-4804e080-6e11-11ea-9596-f478b576374f.png)
![image](https://user-images.githubusercontent.com/1287077/77427390-463b1d00-6e11-11ea-9b29-b77f4bc29d9d.png)
![image](https://user-images.githubusercontent.com/1287077/77427394-49cea400-6e11-11ea-821c-e37afb57b290.png)
![image](https://user-images.githubusercontent.com/1287077/77427517-84384100-6e11-11ea-8dd7-e391c86c63f6.png)

### WP-Admin FSE Page Editor (Has Issues)

![image](https://user-images.githubusercontent.com/1287077/77427478-75518e80-6e11-11ea-821d-7ba39965a19f.png)
![image](https://user-images.githubusercontent.com/1287077/77427481-771b5200-6e11-11ea-83ca-e90f14e1ff49.png)
![image](https://user-images.githubusercontent.com/1287077/77427489-7aaed900-6e11-11ea-8287-2a03185edf4e.png)
![image](https://user-images.githubusercontent.com/1287077/77427485-784c7f00-6e11-11ea-87b5-859140b0196e.png)

## WP-Admin Non-FSE Page Editor (Has Issues)

![image](https://user-images.githubusercontent.com/1287077/77427608-a5992d00-6e11-11ea-9a43-2af773d9b8ae.png)
![image](https://user-images.githubusercontent.com/1287077/77427613-a7fb8700-6e11-11ea-8f41-8c83393b9f04.png)
![image](https://user-images.githubusercontent.com/1287077/77427616-a9c54a80-6e11-11ea-9dfe-a8a8bcd503a8.png)
![image](https://user-images.githubusercontent.com/1287077/77427626-ac27a480-6e11-11ea-9be5-28e04eafe2af.png)

### WP-Calypso Post Editor

![image](https://user-images.githubusercontent.com/1287077/77427702-ca8da000-6e11-11ea-99de-daeec63dc93e.png)
![image](https://user-images.githubusercontent.com/1287077/77427705-cbbecd00-6e11-11ea-9b3b-88dfa791c683.png)
![image](https://user-images.githubusercontent.com/1287077/77427709-cd889080-6e11-11ea-8b7b-c37f6689533a.png)
![image](https://user-images.githubusercontent.com/1287077/77427712-cf525400-6e11-11ea-9de8-923f25b30a92.png)

### WP-Admin Post Editor

![image](https://user-images.githubusercontent.com/1287077/77427788-f01aa980-6e11-11ea-97ab-559e729db24d.png)
![image](https://user-images.githubusercontent.com/1287077/77427792-f1e46d00-6e11-11ea-90c9-b100b6458723.png)
![image](https://user-images.githubusercontent.com/1287077/77427795-f3159a00-6e11-11ea-8974-35080af63e5f.png)
![image](https://user-images.githubusercontent.com/1287077/77427802-f4df5d80-6e11-11ea-8673-b86ee414acdb.png)

