### PR TITLE
G Suite: Allow purchases for .in domains

### DIFF
--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import formatCurrency from '@automattic/format-currency';
-import { endsWith, get, includes, isNumber, isString, some, sortBy } from 'lodash';
+import { endsWith, get, isNumber, isString, sortBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,22 +28,17 @@ function applyPrecision( cost, precision ) {
 }
 
 /**
- * Can a domain add G Suite
+ * Determines whether G Suite is allowed for the specified domain.
  *
- * @param {string} domainName - domainname
- * @returns {boolean} -Can a domain add G Suite
+ * @param {string} domainName - domain name
+ * @returns {boolean} - true if G Suite is allowed, false otherwise
  */
 function canDomainAddGSuite( domainName ) {
-	const GOOGLE_APPS_INVALID_SUFFIXES = [ '.in', '.wpcomstaging.com' ];
-	const GOOGLE_APPS_BANNED_PHRASES = [ 'google' ];
-	const includesBannedPhrase = some( GOOGLE_APPS_BANNED_PHRASES, bannedPhrase =>
-		includes( domainName, bannedPhrase )
-	);
-	const hasInvalidSuffix = some( GOOGLE_APPS_INVALID_SUFFIXES, invalidSuffix =>
-		endsWith( domainName, invalidSuffix )
-	);
+	if ( endsWith( domainName, '.wpcomstaging.com' ) ) {
+		return false;
+	}
 
-	return ! ( hasInvalidSuffix || includesBannedPhrase || isGSuiteRestricted() );
+	return ! isGSuiteRestricted();
 }
 
 /**

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -29,12 +29,8 @@ describe( 'index', () => {
 			expect( canDomainAddGSuite( 'foobar.blog' ) ).toEqual( true );
 		} );
 
-		test( 'returns false when domain has invalid TLD', () => {
-			expect( canDomainAddGSuite( 'foobar.in' ) ).toEqual( false );
-		} );
-
-		test( 'returns false when domain has banned phrase', () => {
-			expect( canDomainAddGSuite( 'foobargoogle.blog' ) ).toEqual( false );
+		test( 'returns false when domain is invalid', () => {
+			expect( canDomainAddGSuite( 'foobar.wpcomstaging.com' ) ).toEqual( false );
 		} );
 	} );
 
@@ -80,7 +76,7 @@ describe( 'index', () => {
 		} );
 
 		test( 'Returns empty string if selected domain is invalid and domains are empty', () => {
-			expect( getEligibleGSuiteDomain( 'domain-with-google-banned-term.blog', [] ) ).toEqual( '' );
+			expect( getEligibleGSuiteDomain( 'invalid-domain.wpcomstaging.com', [] ) ).toEqual( '' );
 		} );
 
 		test( 'Returns selected domain if selected domain is valid and domains are empty', () => {
@@ -89,7 +85,7 @@ describe( 'index', () => {
 
 		const domains = [
 			{
-				name: 'domain-with-google-banned-term.blog',
+				name: 'invalid-domain.wpcomstaging.com',
 				type: 'REGISTERED',
 			},
 			{
@@ -152,7 +148,7 @@ describe( 'index', () => {
 		test( 'returns empty array if domain is invalid', () => {
 			expect(
 				getGSuiteSupportedDomains( [
-					{ name: 'foogoogle.blog', type: 'REGISTERED', googleAppsSubscription: {} },
+					{ name: 'foo.wpcomstaging.com', type: 'REGISTERED', googleAppsSubscription: {} },
 				] )
 			).toEqual( [] );
 		} );
@@ -212,7 +208,7 @@ describe( 'index', () => {
 		test( 'returns false if passed an array with invalid domains', () => {
 			expect(
 				hasGSuiteSupportedDomain( [
-					{ name: 'foogoogle.blog', type: 'REGISTERED', googleAppsSubscription: {} },
+					{ name: 'foo.wpcomstaging.com', type: 'REGISTERED', googleAppsSubscription: {} },
 				] )
 			).toEqual( false );
 		} );


### PR DESCRIPTION
This pull request enables G Suite for `.in` domains. G Suite should indeed be available to Indian users as well as for any domain except subdomains.

#### Testing instructions

1. Start your server, or open a [live branch](https://calypso.live/?branch=update/allow-in-domains-for-gsuite)
2. Open the [`Domain Search` page](http://calypso.localhost:3000/domains/add)
3. Purchase a `.in` domain
4. Navigate to the [`Email` page](http://calypso.localhost:3000/email)
5. Assert that you can purchase G Suite for this domain

#### Additional notes

The code changed in this pull request actually duplicates part of the logic that is already available server-side. We should really remove it at some point as this is just a recipe for problems such as this one.