### PR TITLE
Gutenboarding: Header adjustments

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -196,8 +196,8 @@ const Header: FunctionComponent = () => {
 			tabIndex={ -1 }
 		>
 			<section className="gutenboarding__header-section">
-				<div className="gutenboarding__header-section-item">
-					<Icon icon="wordpress-alt" size={ 24 } className="gutenboarding__header-wp-icon" />
+				<div className="gutenboarding__header-section-item gutenboarding__header-wp-logo">
+					<Icon icon="wordpress-alt" size={ 24 } />
 				</div>
 				<div className="gutenboarding__header-section-item">{ siteTitleElement }</div>
 				<div className="gutenboarding__header-section-item">

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -26,7 +26,7 @@
 	}
 }
 
-.gutenboarding__header-wp-icon {
+.gutenboarding__header-wp-logo {
 	color: var( --studio-blue-90 );
 }
 
@@ -34,11 +34,14 @@
 	display: flex;
 	align-items: center;
 	font-size: 14px;
-	padding: 10px;
 }
 
 .gutenboarding__header-section-item {
 	margin-left: 10px;
+
+	&.gutenboarding__header-wp-logo {
+		margin-left: 24px - $grid-size; // ( 24 - header padding )
+	}
 }
 
 $padding--gutenboarding__header-domain-picker-button: 0.3em 0.5em;

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -28,6 +28,7 @@
 
 .gutenboarding__header-wp-logo {
 	color: var( --studio-blue-90 );
+	display: flex;
 }
 
 .gutenboarding__header-section {

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -81,4 +81,5 @@ $padding--gutenboarding__header-domain-picker-button: 0.3em 0.5em;
 
 .gutenboarding__site-title {
 	padding: $padding--gutenboarding__header-domain-picker-button;
+	font-weight: 600;
 }

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -1,6 +1,7 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
 @import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
+@import '../../variables.scss';
 
 // Copied from https://github.com/WordPress/gutenberg/blob/8c0c7b7267473b5c197dd3052e9707f75f4e6448/packages/edit-widgets/src/components/header/style.scss
 .gutenboarding__header {
@@ -8,7 +9,7 @@
 	align-items: center;
 	justify-content: space-between;
 	border-bottom: 1px solid $light-gray-500;
-	height: $header-height;
+	height: $gutenboarding-header-height;
 	background: $white;
 	z-index: z-index( '.block-editor-editor-skeleton__header' );
 

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -27,13 +27,16 @@ $admin-sidebar-width-collapsed: 0;
 @import '~@wordpress/block-editor/src/style.scss';
 @import '~@wordpress/format-library/src/style.scss';
 
+// Own/Gutenboarding styles
+@import './variables.scss';
+
 .gutenboarding__content {
 	position: static;
 }
 
 .gutenboarding__content-editor {
 	// overrides .edit-post-visual-editor
-	padding-top: $header-height;
+	padding-top: $gutenboarding-header-height;
 }
 
 .wp-block {

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -1,1 +1,2 @@
+// Reusable style variables
 $gutenboarding-header-height: 64px;

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -1,0 +1,1 @@
+$gutenboarding-header-height: 64px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of addressing #40321

- Header title `.gutenboarding__site-title` should be `font-weight: 600`
- Padding left on WordPress logo to the edge of the screen should be `24px` not `18px`
- Header height should be `64px`

Also aligns the WP logo a little better with the rest:

**before**

<img width="513" alt="Screenshot 2020-03-23 at 12 38 43 PM" src="https://user-images.githubusercontent.com/1705499/77313617-dd6a7c80-6d0c-11ea-9b9e-1aaed6563a69.png">

**after**

<img width="395" alt="Screenshot 2020-03-23 at 12 39 16 PM" src="https://user-images.githubusercontent.com/1705499/77313657-eb200200-6d0c-11ea-922d-d420c9854cac.png">
