### PR TITLE
Home: Add dismissal support to celebratory notices

### DIFF
--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -28,6 +28,7 @@ class DismissibleCard extends Component {
 	static propTypes = {
 		className: PropTypes.string,
 		dismissCard: PropTypes.func,
+		highlight: PropTypes.oneOf( [ 'error', 'info', 'success', 'warning' ] ),
 		isDismissed: PropTypes.bool,
 		temporary: PropTypes.bool,
 		onClick: PropTypes.func,
@@ -39,14 +40,21 @@ class DismissibleCard extends Component {
 	};
 
 	render() {
-		const { className, isDismissed, onClick, dismissCard, hasReceivedPreferences } = this.props;
+		const {
+			className,
+			highlight,
+			isDismissed,
+			onClick,
+			dismissCard,
+			hasReceivedPreferences,
+		} = this.props;
 
 		if ( isDismissed || ! hasReceivedPreferences ) {
 			return null;
 		}
 
 		return (
-			<Card className={ className }>
+			<Card className={ className } highlight={ highlight }>
 				<QueryPreferences />
 				<Gridicon
 					icon="cross"

--- a/client/my-sites/customer-home/notices/celebrate-notice/index.jsx
+++ b/client/my-sites/customer-home/notices/celebrate-notice/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Card } from '@automattic/components';
 import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
@@ -9,6 +8,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import DismissibleCard from 'blocks/dismissible-card';
 import CardHeading from 'components/card-heading';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
@@ -30,6 +30,7 @@ const CelebrateNotice = ( {
 	checklistMode,
 	currentTheme,
 	currentThemeId,
+	dismissalPreferenceName,
 	displayChecklist,
 	message,
 	siteId,
@@ -78,7 +79,11 @@ const CelebrateNotice = ( {
 	};
 
 	return (
-		<Card className="celebrate-notice" highlight="info">
+		<DismissibleCard
+			className="celebrate-notice"
+			highlight="info"
+			preferenceName={ `${ dismissalPreferenceName }-${ siteId }` } // Makes cards dismissable per site.
+		>
 			{ siteId && 'theme' === checklistMode && <QueryActiveTheme siteId={ siteId } /> }
 			{ currentThemeId && <QueryCanonicalTheme themeId={ currentThemeId } siteId={ siteId } /> }
 			<img
@@ -91,7 +96,7 @@ const CelebrateNotice = ( {
 				<CardHeading>{ message }</CardHeading>
 				<p className="celebrate-notice__secondary-text">{ getSecondaryText() }</p>
 			</div>
-		</Card>
+		</DismissibleCard>
 	);
 };
 

--- a/client/my-sites/customer-home/notices/site-created-card/index.jsx
+++ b/client/my-sites/customer-home/notices/site-created-card/index.jsx
@@ -20,9 +20,10 @@ const SiteCreatedCard = ( { checklistMode, displayChecklist, siteHasPaidPlan } )
 
 	return (
 		<CelebrateNotice
-			message={ message }
 			checklistMode={ checklistMode }
+			dismissalPreferenceName="home-notice-site-created"
 			displayChecklist={ displayChecklist }
+			message={ message }
 		/>
 	);
 };

--- a/client/my-sites/customer-home/notices/site-launched-card/index.jsx
+++ b/client/my-sites/customer-home/notices/site-launched-card/index.jsx
@@ -13,9 +13,10 @@ const SiteLaunchedCard = ( { checklistMode, displayChecklist } ) => {
 	const translate = useTranslate();
 	return (
 		<CelebrateNotice
-			message={ translate( 'You launched your site!' ) }
 			checklistMode={ checklistMode }
+			dismissalPreferenceName="home-notice-site-launched"
 			displayChecklist={ displayChecklist }
+			message={ translate( 'You launched your site!' ) }
 		/>
 	);
 };

--- a/client/my-sites/customer-home/notices/site-migrated-card/index.jsx
+++ b/client/my-sites/customer-home/notices/site-migrated-card/index.jsx
@@ -13,9 +13,10 @@ const SiteMigratedCard = ( { checklistMode, displayChecklist } ) => {
 	const translate = useTranslate();
 	return (
 		<CelebrateNotice
-			message={ translate( 'Your site has been imported!' ) }
 			checklistMode={ checklistMode }
+			dismissalPreferenceName="home-notice-site-migrated"
 			displayChecklist={ displayChecklist }
+			message={ translate( 'Your site has been imported!' ) }
 		/>
 	);
 };

--- a/client/my-sites/customer-home/notices/site-setup-complete-card/index.jsx
+++ b/client/my-sites/customer-home/notices/site-setup-complete-card/index.jsx
@@ -13,8 +13,9 @@ const SiteSetupCompleteCard = ( { displayChecklist } ) => {
 	const translate = useTranslate();
 	return (
 		<CelebrateNotice
-			message={ translate( "You've completed each item in your checklist." ) }
+			dismissalPreferenceName="home-notice-site-setup-complete"
 			displayChecklist={ displayChecklist }
+			message={ translate( "You've completed each item in your checklist." ) }
 		/>
 	);
 };


### PR DESCRIPTION
Follows up https://github.com/Automattic/wp-calypso/pull/40299.

#### Changes proposed in this Pull Request

Adds the ability to dismiss the celebratory notices displayed on My Home.

<img width="974" alt="Screen Shot 2020-03-23 at 13 30 08" src="https://user-images.githubusercontent.com/1233880/77317369-5cf74c00-6d0b-11ea-91c0-e6fc7043f177.png">


#### Testing instructions

* Repeat testing instructions from https://github.com/Automattic/wp-calypso/pull/40299.
* Make sure all congratulatory notices can be dismissed.
* Reload the page and make sure the notices don't show up again.
* Make sure the notices are dismissed per site: 
  * Switch to a different site.
  * Make sure the notices show up (unless they have been dismissed for that site).
