### PR TITLE
[e2e] Update `Simple payments` block name

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -208,7 +208,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 				prefix = 'jetpack-';
 				blockClass = 'contact-form';
 				break;
-			case 'Simple Payments button':
+			case 'Simple Payments':
 				prefix = 'jetpack-';
 				blockClass = 'simple-payments';
 				break;

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -537,7 +537,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		step( 'Can insert the payment button', async function() {
 			const pageTitle = 'Payment Button Page: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			const blockId = await gEditorComponent.addBlock( 'Simple Payments button' );
+			const blockId = await gEditorComponent.addBlock( 'Simple Payments' );
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1015,7 +1015,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		step( 'Can insert the payment button', async function() {
 			const blogPostTitle = 'Payment Button: ' + dataHelper.randomPhrase();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			const blockId = await gEditorComponent.addBlock( 'Simple Payments button' );
+			const blockId = await gEditorComponent.addBlock( 'Simple Payments' );
 
 			const gPaymentComponent = await SimplePaymentsBlockComponent.Expect( driver, blockId );
 			await gPaymentComponent.insertPaymentButtonDetails( paymentButtonDetails );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The name of "Simple Payments block" has changed to "Simple Payments". Update e2e tests so they are aligned with this change and fix [failures](https://circleci.com/gh/Automattic/wp-calypso/648888)

#### Testing instructions
Make sure that tests are ✅ 
