### PR TITLE
Gutenboarding: Rework design picker styling

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -36,8 +36,8 @@ const DesignSelector: React.FunctionComponent = () => {
 	};
 
 	// Track hover/focus
-	const [ hoverDesigns, setHoverDesigns ] = React.useState< Set< string > >( new Set() );
-	const [ focusDesigns, setFocusDesigns ] = React.useState< Set< string > >( new Set() );
+	const [ hoverDesign, setHoverDesign ] = React.useState< string >();
+	const [ focusDesign, setFocusDesign ] = React.useState< string >();
 
 	return (
 		<div className="design-selector">
@@ -62,7 +62,7 @@ const DesignSelector: React.FunctionComponent = () => {
 			<div className="design-selector__design-grid">
 				<div className="design-selector__grid">
 					{ designs.featured.map( design => {
-						const isFocused = hoverDesigns.has( design.slug ) || focusDesigns.has( design.slug );
+						const isFocused = hoverDesign === design.slug || focusDesign === design.slug;
 						return (
 							<Spring
 								native
@@ -73,34 +73,12 @@ const DesignSelector: React.FunctionComponent = () => {
 								{ ( props: React.CSSProperties ) => (
 									<animated.button
 										style={ props }
-										onMouseEnter={ () =>
-											setHoverDesigns( s => {
-												const nextState = new Set( s );
-												nextState.add( design.slug );
-												return nextState;
-											} )
-										}
+										onMouseEnter={ () => setHoverDesign( design.slug ) }
 										onMouseLeave={ () =>
-											setHoverDesigns( s => {
-												const nextState = new Set( s );
-												nextState.delete( design.slug );
-												return nextState;
-											} )
+											setHoverDesign( s => ( s === design.slug ? undefined : s ) )
 										}
-										onFocus={ () =>
-											setFocusDesigns( s => {
-												const nextState = new Set( s );
-												nextState.add( design.slug );
-												return nextState;
-											} )
-										}
-										onBlur={ () =>
-											setFocusDesigns( s => {
-												const nextState = new Set( s );
-												nextState.delete( design.slug );
-												return nextState;
-											} )
-										}
+										onFocus={ () => setFocusDesign( design.slug ) }
+										onBlur={ () => setFocusDesign( s => ( s === design.slug ? undefined : s ) ) }
 										className="design-selector__design-option"
 										onClick={ () => {
 											setSelectedDesign( design );

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
-import React, { FunctionComponent } from 'react';
-import classnames from 'classnames';
+import { useDispatch } from '@wordpress/data';
+import React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { useHistory } from 'react-router-dom';
+import { Spring, animated } from 'react-spring/renderprops';
 
 /**
  * Internal dependencies
@@ -15,19 +15,29 @@ import designs from './available-designs.json';
 import { usePath, Step } from '../../path';
 import { isEnabled } from '../../../../config';
 import Link from '../../components/link';
-import './style.scss';
-import { SubTitle, Title } from 'landing/gutenboarding/components/titles';
+import { SubTitle, Title } from '../../components/titles';
 
-const DesignSelector: FunctionComponent = () => {
+import './style.scss';
+
+// Values for springs:
+const ZOOM_OFF = { transform: 'scale(1)' };
+const ZOOM_ON = { transform: 'scale(1.03)' };
+const SHADOW_OFF = { boxShadow: '0 0 0px rgba(0,0,0,.2)' };
+const SHADOW_ON = { boxShadow: '0 0 15px rgba(0,0,0,.2)' };
+
+const DesignSelector: React.FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const { push } = useHistory();
 	const makePath = usePath();
-	const { selectedDesign } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { setSelectedDesign, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const handleStartOverButtonClick = () => {
 		resetOnboardStore();
 	};
+
+	// Track hover/focus
+	const [ hoverDesigns, setHoverDesigns ] = React.useState< Set< string > >( new Set() );
+	const [ focusDesigns, setFocusDesigns ] = React.useState< Set< string > >( new Set() );
 
 	return (
 		<div className="design-selector">
@@ -51,28 +61,74 @@ const DesignSelector: FunctionComponent = () => {
 			</div>
 			<div className="design-selector__design-grid">
 				<div className="design-selector__grid">
-					{ designs.featured.map( design => (
-						<button
-							key={ design.slug }
-							className={ classnames(
-								'design-selector__design-option',
-								design.slug === selectedDesign?.slug ? 'selected' : null
-							) }
-							onClick={ () => {
-								setSelectedDesign( design );
-								if ( isEnabled( 'gutenboarding/style-preview' ) ) {
-									push( makePath( Step.Style ) );
-								}
-							} }
-						>
-							<div className="design-selector__image-frame">
-								<img alt={ design.title } src={ design.src } srcSet={ design.srcset } />
-							</div>
-							<span className="design-selector__option-overlay">
-								<span className="design-selector__option-name">{ design.title }</span>
-							</span>
-						</button>
-					) ) }
+					{ designs.featured.map( design => {
+						const isFocused = hoverDesigns.has( design.slug ) || focusDesigns.has( design.slug );
+						return (
+							<Spring
+								native
+								key={ design.slug }
+								from={ ZOOM_OFF }
+								to={ isFocused ? ZOOM_ON : ZOOM_OFF }
+							>
+								{ ( props: React.CSSProperties ) => (
+									<animated.button
+										style={ props }
+										onMouseEnter={ () =>
+											setHoverDesigns( s => {
+												const nextState = new Set( s );
+												nextState.add( design.slug );
+												return nextState;
+											} )
+										}
+										onMouseLeave={ () =>
+											setHoverDesigns( s => {
+												const nextState = new Set( s );
+												nextState.delete( design.slug );
+												return nextState;
+											} )
+										}
+										onFocus={ () =>
+											setFocusDesigns( s => {
+												const nextState = new Set( s );
+												nextState.add( design.slug );
+												return nextState;
+											} )
+										}
+										onBlur={ () =>
+											setFocusDesigns( s => {
+												const nextState = new Set( s );
+												nextState.delete( design.slug );
+												return nextState;
+											} )
+										}
+										className="design-selector__design-option"
+										onClick={ () => {
+											setSelectedDesign( design );
+											if ( isEnabled( 'gutenboarding/style-preview' ) ) {
+												push( makePath( Step.Style ) );
+											}
+										} }
+									>
+										<Spring
+											native
+											key={ design.slug }
+											from={ SHADOW_OFF }
+											to={ isFocused ? SHADOW_ON : SHADOW_OFF }
+										>
+											{ ( props2: React.CSSProperties ) => (
+												<animated.span style={ props2 } className="design-selector__image-frame">
+													<img alt={ design.title } src={ design.src } srcSet={ design.srcset } />
+												</animated.span>
+											) }
+										</Spring>
+										<span className="design-selector__option-overlay">
+											<span className="design-selector__option-name">{ design.title }</span>
+										</span>
+									</animated.button>
+								) }
+							</Spring>
+						);
+					} ) }
 				</div>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -23,46 +23,31 @@
 	}
 
 	.design-selector__grid {
-		display: flex;
-		margin-top: 40px;
-		flex-wrap: wrap;
-		justify-content: space-between;
-	}
-
-	.design-selector__design-option {
-		width: 48%;
-		margin-bottom: 24px;
-
-		&.selected .design-selector__image-frame {
-			border: 2px solid var( --studio-green-20 );
-		}
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		column-gap: 4em;
+		row-gap: 5em;
+		margin-top: 30px;
 	}
 
 	.design-selector__image-frame {
 		display: block;
-		height: 406px;
+		width: 100%;
+		height: 0;
+		padding-top: 360px / 480px * 100%;
 		border: 1px solid var( --studio-gray-5 );
 		border-radius: 4px;
+		position: relative;
 		overflow: hidden;
-		margin: 8px;
-		transition: transform 0.2s;
-		box-shadow: rgba( 0, 0, 0, 0.2 ) 0 0 0;
 
-		&:hover {
-			transform: scale( 1.03 );
-			box-shadow: rgba( 0, 0, 0, 0.2 ) 0 0 15px;
-		}
-
-		@include breakpoint( '<1400px' ) {
-			height: 326px;
-		}
-
-		@include breakpoint( '<1280px' ) {
-			height: 243px;
-		}
-
-		@include breakpoint( '<660px' ) {
-			height: 163px;
+		img {
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			margin: 0 auto;
+			width: 100%;
+			height: auto;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use CSS grid for layout.
* Animate with `react-spring`.
* Remove that outline
* Remove selected design styling. When style picker is enabled, we'd proceed to that step.

![demo](https://user-images.githubusercontent.com/841763/77340807-1d8e2700-6d2e-11ea-992b-0b80fcc0aafd.gif)

##### Before

(no focus style)

![before](https://user-images.githubusercontent.com/841763/77341268-c2106900-6d2e-11ea-87cf-205bd6f90c51.gif)


#### Testing instructions

* [`/gutenboarding`](https://calypso.live/gutenboarding?branch=fix/40320-gutenboarding-design-outline)
* Go to the design picker step
* It's beautiful 💅 
* Hover tab works well 

Fixes #40320 
