### PR TITLE
ESLint: Restrict `import`s and `require`s from `lib/wp`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,31 @@
 const { merge } = require( 'lodash' );
 const reactVersion = require( './client/package.json' ).dependencies.react;
 
+const restrictedModulePaths = [
+	// Error if any module depends on the data-observe mixin, which is deprecated.
+	'lib/mixins/data-observe',
+	// Prevent naked import of gridicons module. Use 'components/gridicon' instead.
+	{
+		name: 'gridicons',
+		message: "Please use 'components/gridicon' instead.",
+	},
+	// Use fetch instead of superagent.
+	{
+		name: 'superagent',
+		message: 'Please use native `fetch` instead.',
+	},
+];
+
+const restrictedImportPaths = [
+	...restrictedModulePaths,
+	// Prevent importing Redux's combineReducers.
+	{
+		name: 'redux',
+		importNames: [ 'combineReducers' ],
+		message: "`combineReducers` should be imported from 'state/utils', not 'redux'.",
+	},
+];
+
 module.exports = {
 	root: true,
 	extends: [
@@ -110,45 +135,13 @@ module.exports = {
 		'no-restricted-imports': [
 			2,
 			{
-				paths: [
-					// Error if any module depends on the data-observe mixin, which is deprecated.
-					'lib/mixins/data-observe',
-					// Prevent naked import of gridicons module. Use 'components/gridicon' instead.
-					{
-						name: 'gridicons',
-						message: "Please use 'components/gridicon' instead.",
-					},
-					// Prevent importing Redux's combineReducers.
-					{
-						name: 'redux',
-						importNames: [ 'combineReducers' ],
-						message: "`combineReducers` should be imported from 'state/utils', not 'redux'.",
-					},
-					// Use fetch instead of superagent.
-					{
-						name: 'superagent',
-						message: 'Please use native `fetch` instead.',
-					},
-				],
+				paths: restrictedImportPaths,
 			},
 		],
 		'no-restricted-modules': [
 			2,
 			{
-				paths: [
-					// Error if any module depends on the data-observe mixin, which is deprecated.
-					'lib/mixins/data-observe',
-					// Prevent naked import of gridicons module. Use 'components/gridicon' instead.
-					{
-						name: 'gridicons',
-						message: "Please use 'components/gridicon' instead.",
-					},
-					// Use fetch instead of superagent.
-					{
-						name: 'superagent',
-						message: 'Please use native `fetch` instead.',
-					},
-				],
+				paths: restrictedModulePaths,
 			},
 		],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,12 @@ const restrictedModulePaths = [
 		name: 'superagent',
 		message: 'Please use native `fetch` instead.',
 	},
+	// Use fetch or wpcom-proxy-request instead of `lib/wp`.
+	{
+		name: 'lib/wp',
+		message:
+			'Please use native `fetch` for unauthenticated requests, or `wpcom-proxy-request` for authenticated requests.',
+	},
 ];
 
 const restrictedImportPaths = [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -132,18 +132,8 @@ module.exports = {
 		// i18n-calypso translate triggers false failures
 		'jsx-a11y/anchor-has-content': 'off',
 
-		'no-restricted-imports': [
-			2,
-			{
-				paths: restrictedImportPaths,
-			},
-		],
-		'no-restricted-modules': [
-			2,
-			{
-				paths: restrictedModulePaths,
-			},
-		],
+		'no-restricted-imports': [ 2, { paths: restrictedImportPaths } ],
+		'no-restricted-modules': [ 2, { paths: restrictedModulePaths } ],
 
 		// Allows Chai `expect` expressions. Now that we're on jest, hopefully we can remove this one.
 		'no-unused-expressions': 'off',


### PR DESCRIPTION
As mentioned in #40369: 

> Let's make an `eslint` rule against importing `wpcom` (maybe Calypso-wide; I guess we can consider this legacy and recommend against it)

#### Changes proposed in this Pull Request

* De-duplicate `no-restricted-imports` and `no-restricted-modules`.
* Restrict `import`s and `require`s from `lib/wp`.

#### Testing instructions

* Verify that ESLint now complains about `import`s and `require`s from 'lib/wp`.
* Verify that ESLint still complains about other restricted imports and modules.


#### Questions

- Is the message wording okay?
- Do we need to add other variations? E.g. `lib/wp/undocumented`?