### PR TITLE
Page exports

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -34,6 +34,7 @@ import getEditorUrl from 'state/selectors/get-editor-url';
 import SectionHeader from 'components/section-header';
 import { Button } from '@automattic/components';
 import { withLocalizedMoment } from 'components/localized-moment';
+import config from 'config';
 
 function preloadEditor() {
 	preload( 'post-editor' );
@@ -78,6 +79,11 @@ export default class PageList extends Component {
 			status: mapStatus( status ),
 			type: 'page',
 		};
+
+		if ( config.isEnabled( 'page/export' ) ) {
+			// we need the raw content of the pages to be able to export them
+			query.context = 'edit';
+		}
 
 		return (
 			<div>

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -697,7 +697,9 @@ class Page extends Component {
 			__file: 'wp_template',
 			language: 'en',
 			title: page.title,
-			content: page.content,
+			author: page.author,
+			demoURL: page.URL,
+			content: page.rawContent,
 		} );
 		const blob = new window.Blob( [ fileContent ], { type: 'application/json' } );
 		const fileName = ( page.title ? page.title : 'page' ) + '.json';

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -42,6 +42,7 @@ import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { updateSiteFrontPage } from 'state/sites/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import canCurrentUser from 'state/selectors/can-current-user';
+import config from 'config';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
 
@@ -332,7 +333,7 @@ class Page extends Component {
 
 	getExportItem() {
 		const { page } = this.props;
-		if ( ! page.content ) {
+		if ( ! page.content || ! config.isEnabled( 'page/export' ) ) {
 			return null;
 		}
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -329,6 +329,15 @@ class Page extends Component {
 		);
 	}
 
+	getExportItem() {
+		return (
+			<PopoverMenuItem onClick={ this.exportPage } href={ '#' }>
+				<Gridicon icon="cloud-download" size={ 18 } />
+				{ this.props.translate( 'Export page' ) }
+			</PopoverMenuItem>
+		);
+	}
+
 	getCopyLinkItem() {
 		const { page, translate } = this.props;
 		return (
@@ -440,6 +449,7 @@ class Page extends Component {
 		const copyLinkItem = this.getCopyLinkItem();
 		const statsItem = this.getStatsItem();
 		const moreInfoItem = this.popoverMoreInfo();
+		const exportItem = this.getExportItem();
 		const hasMenuItems =
 			viewItem ||
 			publishItem ||
@@ -448,7 +458,8 @@ class Page extends Component {
 			restoreItem ||
 			frontPageItem ||
 			sendToTrashItem ||
-			moreInfoItem;
+			moreInfoItem ||
+			exportItem;
 
 		const ellipsisMenu = hasMenuItems && (
 			<EllipsisMenu
@@ -465,6 +476,7 @@ class Page extends Component {
 				{ restoreItem }
 				{ frontPageItem }
 				{ postsPageItem }
+				{ exportItem }
 				{ sendToTrashItem }
 				{ moreInfoItem }
 			</EllipsisMenu>
@@ -668,6 +680,25 @@ class Page extends Component {
 
 	copyPage = () => {
 		this.props.recordEvent( 'Clicked Copy Page' );
+	};
+
+	exportPage = () => {
+		this.props.recordEvent( 'Clicked Export Page' );
+		const { page } = this.props;
+
+		const fileContent = JSON.stringify( {
+			__file: 'wp_template',
+			language: 'en',
+			title: page.title,
+			content: page.content,
+		} );
+		const blob = new window.Blob( [ fileContent ], { type: 'application/json' } );
+		const link = document.createElement( 'a' );
+		link.href = URL.createObjectURL( blob );
+		link.download = page.title + '.json';
+		document.body.appendChild( link );
+		link.click();
+		document.body.removeChild( link );
 	};
 
 	copyPageLink = () => {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 import pageRouter from 'page';
 import { connect } from 'react-redux';
 import { flow, get, includes, noop, partial } from 'lodash';
+import { saveAs } from 'browser-filesaver';
 
 /**
  * Internal dependencies
@@ -330,8 +331,13 @@ class Page extends Component {
 	}
 
 	getExportItem() {
+		const { page } = this.props;
+		if ( ! page.content ) {
+			return null;
+		}
+
 		return (
-			<PopoverMenuItem onClick={ this.exportPage } href={ '#' }>
+			<PopoverMenuItem onClick={ this.exportPage }>
 				<Gridicon icon="cloud-download" size={ 18 } />
 				{ this.props.translate( 'Export page' ) }
 			</PopoverMenuItem>
@@ -693,12 +699,8 @@ class Page extends Component {
 			content: page.content,
 		} );
 		const blob = new window.Blob( [ fileContent ], { type: 'application/json' } );
-		const link = document.createElement( 'a' );
-		link.href = URL.createObjectURL( blob );
-		link.download = page.title + '.json';
-		document.body.appendChild( link );
-		link.click();
-		document.body.removeChild( link );
+		const fileName = ( page.title ? page.title : 'page' ) + '.json';
+		saveAs( blob, fileName );
 	};
 
 	copyPageLink = () => {

--- a/client/state/posts/utils/normalize-post-for-display.js
+++ b/client/state/posts/utils/normalize-post-for-display.js
@@ -11,6 +11,7 @@ import decodeEntities from 'lib/post-normalizer/rule-decode-entities';
 import detectMedia from 'lib/post-normalizer/rule-content-detect-media';
 import withContentDom from 'lib/post-normalizer/rule-with-content-dom';
 import stripHtml from 'lib/post-normalizer/rule-strip-html';
+import config from 'config';
 
 const normalizeDisplayFlow = flow( [
 	decodeEntities,
@@ -41,6 +42,10 @@ export function normalizePostForDisplay( post ) {
 	if ( ! normalizedPost ) {
 		// `normalizeDisplayFlow` mutates its argument properties -- hence deep clone is needed
 		normalizedPost = normalizeDisplayFlow( cloneDeep( post ) );
+		if ( config.isEnabled( 'page/export' ) ) {
+			// we need the original content from the API to be able to export a page
+			normalizedPost.rawContent = post.content;
+		}
 		normalizePostCache.set( post, normalizedPost );
 	}
 	return normalizedPost;

--- a/config/development.json
+++ b/config/development.json
@@ -123,6 +123,7 @@
 		"nps-survey/dev-trigger": true,
 		"network-connection": true,
 		"oauth": false,
+		"page/export": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -89,6 +89,7 @@
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
+		"page/export": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
This PR adds an option to the page list dropdown that allows you to export the page as a json file, in the same format that core allows to export reusable blocks. 
This will make it much easier for page template creators to save them as files we can use.

![image](https://user-images.githubusercontent.com/1554855/77343741-7c559f80-6d32-11ea-9ea5-753a65d5862a.png)


How to test
======
0. Pick any of your sites, go to your pages list
1.In any of the pages, click on the ellipsis menu and then 'export'
2. You should get a json file with this format:
```
{
			__file: 'wp_template',
			language: 'en',
			title: page.title,
			content: page.content,
		}
``` 