### PR TITLE
My Home: Update the completed description for the site title step.

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -402,6 +402,7 @@ class WpcomChecklistComponent extends PureComponent {
 				{ ...baseProps }
 				bannerImageSrc="/calypso/images/stats/tasks/personalize-your-site.svg"
 				completedButtonText={ translate( 'Edit' ) }
+				completedDescription={ translate( 'You can edit your site title whenever you like.' ) }
 				completedTitle={ translate( 'You updated your site title' ) }
 				description={ translate( 'Give your site a descriptive name to entice visitors.' ) }
 				duration={ translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ) }


### PR DESCRIPTION
With D40692-code, we're bringing back the site title step to My Home (since setting the site title was recently removed from signup). This PR updates the completed text for the step, to be less confusing.

**Before**
<img width="716" alt="Screen Shot 2020-03-23 at 11 26 53 AM" src="https://user-images.githubusercontent.com/349751/77350259-72fc1100-6cf9-11ea-918f-8dc1ee803737.png">

**After**
<img width="723" alt="Screen Shot 2020-03-23 at 11 21 03 AM" src="https://user-images.githubusercontent.com/349751/77350267-75f70180-6cf9-11ea-8be4-23acda102bef.png">


#### Testing instructions

* If it hasn't been deployed yet, sandbox the API and apply D40692-code.
* Create a new Simple site.
* Complete the site title checklist step.
* Go back to My Home, click the "you updated your site title" dropdown, and verify the text is correct.
