### PR TITLE
Gutenboarding: use api-generated previews

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/available-designs.json
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/available-designs.json
@@ -1,28 +1,94 @@
 {
 	"featured": [
 		{
-			"title": "Twenty twenty",
-			"slug": "twentytwenty",
-			"src": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Ftwentytwentydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?h=332&amp;vpw=960&amp;wph=960",
-			"srcset": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Ftwentytwentydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=480&amp;h=332&amp;vpw=960&amp;wph=960 480w, https://s.wordpress.com/mshots/v1/https%3A%2F%2Ftwentytwentydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=240&amp;h=332&amp;vpw=960&amp;wph=960 240w"
+			"title": "Vesta",
+			"slug": "vesta",
+			"template": "mayland2",
+			"theme": "mayland",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/mayland/mayland2/",
+			"fonts": [ "Cabin", "Raleway" ],
+			"categories": [ "featured", "portfolio" ]
 		},
 		{
-			"title": "Mayland",
-			"slug": "mayland",
-			"src": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Fmaylanddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?h=332&amp;vpw=960&amp;wph=960",
-			"srcset": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Fmaylanddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=480&amp;h=332&amp;vpw=960&amp;wph=960 480w, https://s.wordpress.com/mshots/v1/https%3A%2F%2Fmaylanddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=240&amp;h=332&amp;vpw=960&amp;wph=960 240w"
+			"title": "WIP Event Template",
+			"slug": "rivington",
+			"template": "rivington",
+			"theme": "rivington",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/rivington/rivington/",
+			"fonts": [ "Arvo", "Montserrat" ],
+			"categories": [ "event" ]
 		},
 		{
-			"title": "Rockfield",
-			"slug": "rockfield",
-			"src": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Frockfielddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?h=332&amp;vpw=960&amp;wph=960",
-			"srcset": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Frockfielddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=480&amp;h=332&amp;vpw=960&amp;wph=960 480w, https://s.wordpress.com/mshots/v1/https%3A%2F%2Frockfielddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=240&amp;h=332&amp;vpw=960&amp;wph=960 240w"
+			"title": "Reynolds",
+			"slug": "reynolds",
+			"template": "rockfield2",
+			"theme": "rockfield",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/rockfield/rockfield2/",
+			"fonts": [ "Playfair Display", "Fira Sans" ],
+			"categories": [ "featured", "portfolio" ]
 		},
 		{
-			"title": "Barnsbury",
-			"slug": "barnsbury",
-			"src": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Fbarnsburydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?h=332&amp;vpw=960&amp;wph=960",
-			"srcset": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Fbarnsburydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=480&amp;h=332&amp;vpw=960&amp;wph=960 480w, https://s.wordpress.com/mshots/v1/https%3A%2F%2Fbarnsburydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=240&amp;h=332&amp;vpw=960&amp;wph=960 240w"
+			"title": "Easley",
+			"slug": "easley",
+			"template": "maywood",
+			"theme": "maywood",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/maywood/maywood/",
+			"fonts": [ "Space Mono", "Roboto" ],
+			"categories": [ "featured", "portfolio" ]
+		},
+		{
+			"title": "Camden",
+			"slug": "Camden",
+			"template": "maywood2",
+			"theme": "maywood",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/maywood/maywood2/",
+			"fonts": [ "Space Mono", "Roboto" ],
+			"categories": [ "featured", "portfolio" ]
+		},
+		{
+			"title": "Bowen",
+			"slug": "bowen",
+			"template": "coutoire",
+			"theme": "coutoire",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/coutoire/coutoire/",
+			"fonts": [ "Playfair Display", "Fira Sans" ],
+			"categories": [ "featured", "blog" ]
+		},
+		{
+			"title": "Edison",
+			"slug": "edison",
+			"template": "stratford2",
+			"theme": "stratford",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/stratford/stratford2/",
+			"fonts": [ "Chivo", "Open Sans" ],
+			"categories": [ "featured", "blog" ]
+		},
+		{
+			"title": "Cassel",
+			"slug": "cassel",
+			"template": "mayland",
+			"theme": "mayland",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/mayland/mayland/",
+			"fonts": [ "Playfair Display", "Fira Sans" ],
+			"categories": [ "featured", "blog" ]
+		},
+		{
+			"title": "Overton",
+			"slug": "overton",
+			"template": "alves",
+			"theme": "alves",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/alves/alves/",
+			"fonts": [ "Cabin", "Raleway" ],
+			"categories": [ "featured", "business" ]
+		},
+		{
+			"title": "Doyle",
+			"slug": "doyle",
+			"template": "alves2",
+			"theme": "alves",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/alves/alves2/",
+			"fonts": [ "Playfair Display", "Fira Sans" ],
+			"categories": [ "featured", "business" ]
 		}
 	]
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { useDispatch } from '@wordpress/data';
 import React from 'react';
+import { addQueryArgs } from '@wordpress/url';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import { useHistory } from 'react-router-dom';
 import { Spring, animated } from 'react-spring/renderprops';
@@ -11,6 +12,7 @@ import { Spring, animated } from 'react-spring/renderprops';
  * Internal dependencies
  */
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { Design } from '../../stores/onboard/types';
 import designs from './available-designs.json';
 import { usePath, Step } from '../../path';
 import { isEnabled } from '../../../../config';
@@ -29,11 +31,20 @@ const DesignSelector: React.FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const { push } = useHistory();
 	const makePath = usePath();
+	const { siteVertical, siteTitle } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { setSelectedDesign, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const handleStartOverButtonClick = () => {
 		resetOnboardStore();
 	};
+
+	const getDesignUrl = ( design: Design, title: string ) =>
+		addQueryArgs( design.src, {
+			vertical: siteVertical?.label,
+			font_headings: design.fonts[ 0 ],
+			font_base: design.fonts[ 1 ],
+			site_title: title,
+		} );
 
 	// Track hover/focus
 	const [ hoverDesign, setHoverDesign ] = React.useState< string >();
@@ -95,7 +106,14 @@ const DesignSelector: React.FunctionComponent = () => {
 										>
 											{ ( props2: React.CSSProperties ) => (
 												<animated.span style={ props2 } className="design-selector__image-frame">
-													<img alt={ design.title } src={ design.src } srcSet={ design.srcset } />
+													<iframe
+														title={ design.title }
+														className="design-selector__frame"
+														src={ getDesignUrl( design, siteTitle ) }
+														scrolling="no"
+														sandbox=""
+													/>
+													<div className="design-selector__iframe-overlay" />
 												</animated.span>
 											) }
 										</Spring>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -70,62 +70,58 @@ const DesignSelector: React.FunctionComponent = () => {
 					{ NO__( 'Start over' ) }
 				</Link>
 			</div>
-			<div className="design-selector__design-grid">
-				<div className="design-selector__grid">
-					{ designs.featured.map( design => {
-						const isFocused = hoverDesign === design.slug || focusDesign === design.slug;
-						return (
-							<Spring
-								native
-								key={ design.slug }
-								from={ ZOOM_OFF }
-								to={ isFocused ? ZOOM_ON : ZOOM_OFF }
-							>
-								{ ( props: React.CSSProperties ) => (
-									<animated.button
-										style={ props }
-										onMouseEnter={ () => setHoverDesign( design.slug ) }
-										onMouseLeave={ () =>
-											setHoverDesign( s => ( s === design.slug ? undefined : s ) )
+			<div className="design-selector__grid">
+				{ designs.featured.map( design => {
+					const isFocused = hoverDesign === design.slug || focusDesign === design.slug;
+					return (
+						<Spring
+							native
+							key={ design.slug }
+							from={ ZOOM_OFF }
+							to={ isFocused ? ZOOM_ON : ZOOM_OFF }
+						>
+							{ ( props: React.CSSProperties ) => (
+								<animated.button
+									style={ props }
+									onMouseEnter={ () => setHoverDesign( design.slug ) }
+									onMouseLeave={ () =>
+										setHoverDesign( s => ( s === design.slug ? undefined : s ) )
+									}
+									onFocus={ () => setFocusDesign( design.slug ) }
+									onBlur={ () => setFocusDesign( s => ( s === design.slug ? undefined : s ) ) }
+									onClick={ () => {
+										setSelectedDesign( design );
+										if ( isEnabled( 'gutenboarding/style-preview' ) ) {
+											push( makePath( Step.Style ) );
 										}
-										onFocus={ () => setFocusDesign( design.slug ) }
-										onBlur={ () => setFocusDesign( s => ( s === design.slug ? undefined : s ) ) }
-										className="design-selector__design-option"
-										onClick={ () => {
-											setSelectedDesign( design );
-											if ( isEnabled( 'gutenboarding/style-preview' ) ) {
-												push( makePath( Step.Style ) );
-											}
-										} }
+									} }
+								>
+									<Spring
+										native
+										key={ design.slug }
+										from={ SHADOW_OFF }
+										to={ isFocused ? SHADOW_ON : SHADOW_OFF }
 									>
-										<Spring
-											native
-											key={ design.slug }
-											from={ SHADOW_OFF }
-											to={ isFocused ? SHADOW_ON : SHADOW_OFF }
-										>
-											{ ( props2: React.CSSProperties ) => (
-												<animated.span style={ props2 } className="design-selector__image-frame">
-													<iframe
-														title={ design.title }
-														className="design-selector__frame"
-														src={ getDesignUrl( design, siteTitle ) }
-														scrolling="no"
-														sandbox=""
-													/>
-													<div className="design-selector__iframe-overlay" />
-												</animated.span>
-											) }
-										</Spring>
-										<span className="design-selector__option-overlay">
-											<span className="design-selector__option-name">{ design.title }</span>
-										</span>
-									</animated.button>
-								) }
-							</Spring>
-						);
-					} ) }
-				</div>
+										{ ( props2: React.CSSProperties ) => (
+											<animated.span style={ props2 } className="design-selector__image-frame">
+												<iframe
+													title={ design.title }
+													src={ getDesignUrl( design, siteTitle ) }
+													scrolling="no"
+													sandbox=""
+												/>
+												<div className="design-selector__iframe-overlay" />
+											</animated.span>
+										) }
+									</Spring>
+									<span className="design-selector__option-overlay">
+										<span className="design-selector__option-name">{ design.title }</span>
+									</span>
+								</animated.button>
+							) }
+						</Spring>
+					);
+				} ) }
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -40,14 +40,23 @@
 		position: relative;
 		overflow: hidden;
 
-		img {
+		iframe {
 			position: absolute;
 			top: 0;
 			left: 0;
-			right: 0;
 			margin: 0 auto;
+			width: 200%;
+			height: 200%;
+			transform: scale( 0.5 );
+			transform-origin: 0 0;
+		}
+
+		.design-selector__iframe-overlay {
 			width: 100%;
-			height: auto;
+			height: 100%;
+			position: absolute;
+			top: 0;
+			left: 0;
 		}
 	}
 
@@ -57,6 +66,7 @@
 		text-align: center;
 		width: 100%;
 		font-size: 24px;
+		text-transform: capitalize;
 		@include onboarding-font-recoleta;
 	}
 }

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -19,6 +19,10 @@ export interface SiteVertical {
 export interface Design {
 	title: string;
 	slug: string;
+	template: string;
+	theme: string;
 	src: string;
-	srcset: string;
+	srcset?: string;
+	fonts: string[];
+	categories: string[];
 }


### PR DESCRIPTION
This PR changes how we show the site previews on the design picker step to make them API-based. Replaces the static image for an iframe rendering a live preview of the synthetic demo site that comes from applying a theme+page-template+vertical+language+fonts (ok, the language and fonts are not added yet, but they will)

![image](https://user-images.githubusercontent.com/1554855/77357614-baf65480-6d48-11ea-86e6-eda3436842a5.png)

How to test
==========
0. Go to http://calypso.localhost:3000/gutenboarding (or https://hash-92d882a913ea9ef6a3efe6aa5a05697095640de2.calypso.live/gutenboarding ) and enter a site and a vertical (if you enter "football" you should get some vertical content on the next step)
1. You should see a grid with 4 designs, as you can see in the example up there (again, if you picked 'football' as your vertical, the first two designs will have vertical-related content
2. Click on one of the designs and you should be redirected to the last (yet to be implemented) step