### PR TITLE
Allow domains, domain products in the cart for composite checkout

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -162,16 +162,6 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		debug( 'shouldShowCompositeCheckout true because testing config is enabled' );
 		return true;
 	}
-	// Disable for domains in the cart
-	if ( cart.products?.find( product => product.is_domain_registration ) ) {
-		debug( 'shouldShowCompositeCheckout false because cart contains domain registration' );
-		return false;
-	}
-	// Disable for domain mapping
-	if ( cart.products?.find( product => product.product_slug.includes( 'domain' ) ) ) {
-		debug( 'shouldShowCompositeCheckout false because cart contains domain item' );
-		return false;
-	}
 	if ( abtest( 'showCompositeCheckout' ) === 'composite' ) {
 		debug( 'shouldShowCompositeCheckout true because user is in abtest' );
 		return true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a reprise of #40181 which was reverted in #40188

This PR modifies `CheckoutSystemDecider`, which determines which checkout to show (regular or composite checkout) based on various factors, so that it will allow domains and domain related products (domain mapping, domain transfers). Users will still have to pass the `abtest` config or enable the `composite-checkout-testing` flag (which remains enabled on Horizon).

Note that _adding_ domain products via URL (I think this only applies to domain mapping with a path like `/checkout/example.com/domain-mapping:example.com`) is _not_ enabled by this change; such paths will still redirect to regular checkout. That change will need to be done separately because we need to be absolutely sure that we handle all possible product adding paths and we are still verifying that logic.

#### Testing instructions

- Add a domain using a gTLD without special contact fields (eg: .blog) to your cart.
- Visit checkout.
- Verify that you see composite checkout.
- Add a domain using a ccTLD without special contact fields (eg: .tv) to your cart and return to checkout.
- Verify that you still see composite checkout.
- Add a domain using a TLD that has special contact fields (eg: .co.uk) to your cart and return to checkout.
- Verify that you see regular checkout instead.
