### PR TITLE
Inline Help: Lower Position on Mobile

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -131,6 +131,7 @@ $z-layers: (
 		'.accessible-focus .select-dropdown.is-open .select-dropdown__container': 170,
 		'.sites-dropdown.is-open .sites-dropdown__wrapper' : 170,
 		'.editor-publish-date.is-open .editor-publish-date__wrapper': 170,
+		'.inline-help__mobile-overlay': 175,
 		'.floating-help': 176,
 		'.directly-rtm.is-minimized': 176,
 		'.editor-confirmation-sidebar__overlay': 176,

--- a/client/blocks/inline-help/index.jsx
+++ b/client/blocks/inline-help/index.jsx
@@ -16,7 +16,8 @@ import Gridicon from 'components/gridicon';
 import config from 'config';
 import { recordTracksEvent } from 'state/analytics/actions';
 import getGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
-import { Button } from '@automattic/components';
+import { Button, RootChild } from '@automattic/components';
+import { isWithinBreakpoint } from '@automattic/viewport';
 import HappychatButton from 'components/happychat/button';
 import isHappychatOpen from 'state/happychat/selectors/is-happychat-open';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
@@ -186,6 +187,11 @@ class InlineHelp extends Component {
 						setStoredTask={ this.setStoredTask }
 						showNotification={ showChecklistNotification }
 					/>
+				) }
+				{ isWithinBreakpoint( '<660px' ) && isPopoverVisible && (
+					<RootChild>
+						<div className="inline-help__mobile-overlay"></div>
+					</RootChild>
 				) }
 				{ showDialog && (
 					<InlineHelpDialog

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -107,24 +107,8 @@
 
 .inline-help__popover.popover {
 	@include breakpoint( '<660px' ) {
-		top: 0 !important;
-		right: 0 !important;
-		bottom: 0 !important;
-		left: 0 !important;
-		position: fixed;
-		background: rgba( var( --color-neutral-0-rgb ), 0.8 );
-
-		.popover__arrow {
-			display: none;
-		}
-
-		.popover__inner {
-			top: auto !important;
-			right: auto !important;
-			bottom: auto !important;
-			left: auto !important;
-			margin: 16px;
-		}
+		margin-top: -5px;
+		width: calc( 100% - 28px );
 	}
 
 	p {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -105,6 +105,16 @@
 	}
 }
 
+.inline-help__mobile-overlay {
+	background: rgba( var( --color-neutral-0-rgb ), 0.8 );
+	bottom: 0;
+	height: 100%;
+	position: fixed;
+	right: 0;
+	left: 0;
+	z-index: z-index( 'root', '.inline-help__mobile-overlay' );
+}
+
 .inline-help__popover.popover {
 	@include breakpoint( '<660px' ) {
 		margin-top: -5px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the position of Inline Help to the one suggested by @dwolfe:

> Could we just position this window as we do on desktop, just above the help button with a caret pointing to the button? That would be an ergonomic improvement, and also create a stronger association with its trigger.

#### Testing instructions

Verify that Inline Help still loads correctly in a similar fashion to how it does on desktop devices.

**Before:**
<img width="367" alt="Screenshot 2020-03-24 at 08 32 09" src="https://user-images.githubusercontent.com/43215253/77404778-2290bc00-6daa-11ea-93c1-d5ced04e8128.png">

**After:**
<img width="371" alt="Screenshot 2020-03-24 at 08 31 48" src="https://user-images.githubusercontent.com/43215253/77404802-2ae8f700-6daa-11ea-9b59-239aa0b599cf.png">

cc @sixhours, @spen  

Fixes #38092
