### PR TITLE
Remove redirect to en.wordpress.com to prevent an infinite redirect loop

### DIFF
--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -723,7 +723,7 @@ module.exports = function() {
 		// redirect logged-out tag pages to en.wordpress.com
 		app.get( '/tag/:tag_slug', function( req, res, next ) {
 			if ( ! req.context.isLoggedIn ) {
-				res.redirect( 'https://en.wordpress.com/tag/' + encodeURIComponent( req.params.tag_slug ) );
+				res.redirect( 'https://wordpress.com/tag/' + encodeURIComponent( req.params.tag_slug ) );
 			} else {
 				next();
 			}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -720,15 +720,6 @@ module.exports = function() {
 			}
 		} );
 
-		// redirect logged-out tag pages to en.wordpress.com
-		app.get( '/tag/:tag_slug', function( req, res, next ) {
-			if ( ! req.context.isLoggedIn ) {
-				res.redirect( 'https://wordpress.com/tag/' + encodeURIComponent( req.params.tag_slug ) );
-			} else {
-				next();
-			}
-		} );
-
 		// redirect logged-out searches to en.search.wordpress.com
 		app.get( '/read/search', function( req, res, next ) {
 			if ( ! req.context.isLoggedIn ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In D33549-code, we are redirecting all en.wordpress.com URLs to wordpress.com, as part of a larger effort described in pau2Xa-fv-p2.
* Without the change in this PR, visiting https://wordpress.com/tag/a8cgm will redirect to https://en.wordpress.com/tag/a8cgm (from [this line](https://github.com/Automattic/wp-calypso/blob/a1465c083a1d20f9f7c563ed71f306367d39bd98/client/server/pages/index.js#L726)), then again redirect from en.wordpress.com to wordpress.com from the changes in the D33549-code, and an infinite redirect loop gets established. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify code looks okay. 
