### PR TITLE
Gutenboarding: Intent gather visual fixes

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/question/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/question/style.scss
@@ -69,7 +69,7 @@
 			min-height: 1em;
 			min-width: 60px;
 			transition: color 0.5s ease-in-out 1s, border-color 0.5s ease-in-out 1s;
-			line-height: 1.1; // default is normal (20%)
+			line-height: 1.1; // default is `normal` (20%)
 
 			&:hover {
 				border-color: var( --highlightColor );

--- a/client/landing/gutenboarding/onboarding-block/question/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/question/style.scss
@@ -69,6 +69,7 @@
 			min-height: 1em;
 			min-width: 60px;
 			transition: color 0.5s ease-in-out 1s, border-color 0.5s ease-in-out 1s;
+			line-height: 1.1; // default is normal (20%)
 
 			&:hover {
 				border-color: var( --highlightColor );

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -46,6 +46,7 @@ $onboarding-block-css-transition-duration: 750ms;
 .components-button.is-primary.onboarding-block__question-skip:not( :disabled ):not( [aria-disabled='true'] ) {
 	background: var( --mainColor );
 	border-color: var( --mainColor );
+	border-radius: 4px;
 	box-shadow: none;
 	color: var( --contrastColor );
 	font-size: 14px;

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -48,8 +48,8 @@ $onboarding-block-css-transition-duration: 750ms;
 	border-color: var( --mainColor );
 	box-shadow: none;
 	color: var( --contrastColor );
-	font-size: 16px;
-	line-height: 16px;
+	font-size: 14px;
+	font-weight: 500;
 	padding: 20px 32px;
 	// @TODO: work out hover-state animations
 	transition:

--- a/client/landing/gutenboarding/onboarding-block/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/vertical-select/style.scss
@@ -35,7 +35,7 @@
 				font-size: 12px;
 				font-weight: bold;
 				border-color: transparent;
-				color: var( --studio-gray-20 );
+				color: var( --studio-gray-30 );
 
 				.suggestions__label.is-emphasized {
 					color: var( --studio-gray-80 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of addressing #40321

- [Spacing on bottom border on input fields](https://d.pr/i/iYa8lQ) (when filled out) should be `12px` from the letter to the top of the border. It's currently around 27px.
- Button font-size should be `14px` not 16px. And font-weight 500
- Button border-radius should be `4px` not 3px
- `suggestions__label` should be `var(--studio-gray-30)` and not gray-20

**before**

<img width="769" alt="Screenshot 2020-03-24 at 12 26 15 PM" src="https://user-images.githubusercontent.com/1705499/77415158-b83c4380-6dca-11ea-98dc-1a8ebe91330e.png">

**after**

<img width="776" alt="Screenshot 2020-03-24 at 12 25 45 PM" src="https://user-images.githubusercontent.com/1705499/77415174-bd00f780-6dca-11ea-9dd9-5ee82a2f727a.png">

#### Testing instructions

http://calypso.localhost:3000/gutenboarding?fresh