### PR TITLE
E2E: Remove "can update homepage" checks during signup

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -55,7 +55,6 @@ import SignUpStep from '../lib/flows/sign-up-step';
 import * as sharedSteps from '../lib/shared-steps/wp-signup-spec';
 import AccountSettingsPage from '../lib/pages/account/account-settings-page';
 import ChecklistPage from '../lib/pages/checklist-page';
-import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -462,27 +461,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
-
-		step( 'Can update the homepage', async function() {
-			this.skip( 'Needs to complete the site title update task first' );
-			const checklistPage = await ChecklistPage.Expect( this.driver );
-			await checklistPage.updateHomepage();
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			assert.strictEqual(
-				errorShown,
-				false,
-				'There is a block editor error when editing the homepage'
-			);
-
-			const hasInvalidBlocks = await gEditorComponent.hasInvalidBlocks();
-			return assert.strictEqual(
-				hasInvalidBlocks,
-				false,
-				'There are invalid blocks when editing the homepage'
-			);
-		} );
 
 		step( 'Can delete the plan', async function() {
 			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
@@ -1092,32 +1070,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		);
 
 		sharedSteps.canSeeTheOnboardingChecklist();
-
-		step( 'Can update the homepage', async function() {
-			this.skip( 'Needs to complete the site title update task first' );
-			const checklistPage = await ChecklistPage.Expect( this.driver );
-			await checklistPage.updateHomepage();
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-
-			const errorShown = await gEditorComponent.errorDisplayed();
-			assert.strictEqual(
-				errorShown,
-				false,
-				'There is a block editor error when editing the homepage'
-			);
-
-			// Jetpack blocks are broken in IE11. See https://github.com/Automattic/jetpack/issues/14273
-			if ( dataHelper.getTargetType() === 'IE11' ) {
-				return this.skip();
-			}
-
-			const hasInvalidBlocks = await gEditorComponent.hasInvalidBlocks();
-			return assert.strictEqual(
-				hasInvalidBlocks,
-				false,
-				'There are invalid blocks when editing the homepage'
-			);
-		} );
 
 		after( 'Can delete our newly created account', async function() {
 			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -464,6 +464,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can update the homepage', async function() {
+			this.skip( 'Needs to complete the site title update task first' );
 			const checklistPage = await ChecklistPage.Expect( this.driver );
 			await checklistPage.updateHomepage();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
@@ -1093,6 +1094,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can update the homepage', async function() {
+			this.skip( 'Needs to complete the site title update task first' );
 			const checklistPage = await ChecklistPage.Expect( this.driver );
 			await checklistPage.updateHomepage();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're adding a new task to the site setup checklist for updating the site title in https://github.com/Automattic/wp-calypso/issues/40291. That will break the current signup E2E tests since they expect the update homepage task to be first.

This PR removes the "can update homepage" steps, so we can land the checklist changes safely. After that, we'll add a "can update site title" step to the E2E signup test, so we can add back the update homepage steps.

#### Testing instructions

Make sure E2E tests are green.

Part of https://github.com/Automattic/wp-calypso/issues/40291.
