### PR TITLE
[e2e] Disable import in Sign up flow

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1483,7 +1483,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Import a site while signing up @parallel', function() {
+	describe.skip( 'Import a site while signing up @parallel', function() {
 		// Currently must use a Wix or GoDaddy site to be importable through this flow.
 		const siteURL = 'https://hi6822.wixsite.com/eat-here-its-good';
 		const userName = dataHelper.getNewBlogName();


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Test `Import a site while signing up` is [failing](https://circleci.com/gh/Automattic/wp-calypso/650585) against master branch. It is because on Plans page there is no 'Free' option anymore. 

I'm still not sure should we change the test flow. For now, I decided to disable this test.
More info here - pau2Xa-Vs-p2

#### Testing instructions

Make sure that tests are ✅ 
