### PR TITLE
Gutenboarding: Enable style picker

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import { Button } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 import { ValuesType } from 'utility-types';
 
@@ -39,14 +38,6 @@ const StylePreview: React.FunctionComponent = () => {
 					<Link isLink to={ makePath( Step.DesignSelection ) }>
 						{ NO__( 'Choose another design' ) }
 					</Link>
-					<Button
-						isPrimary
-						onClick={ () => {
-							window.alert( 'Not implemented!' );
-						} }
-					>
-						{ NO__( 'Continue' ) }
-					</Button>
 				</div>
 			</div>
 			<div className="style-preview__content">

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -46,6 +46,7 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"gutenboarding": true,
+		"gutenboarding/style-preview": true,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
This is a quick first pass to enable the style picker. We should remove the style-picker specific feature flag entirely.

Anyone, feel free to rebase this often to keep it up to date. It's a handy way to preview the style pickers via calypso.live.

#### Changes proposed in this Pull Request

* Enable Gutenboarding style picker.

#### Testing instructions

* [`/gutenboarding`](https://calypso.live/gutenboarding?branch=update/enable-gutenboarding-style-picker)
* After picking a design, you'll be presented with the font preview screen on [calypso.live](https://calypso.live/gutenboarding?branch=update/enable-gutenboarding-style-picker).

