### PR TITLE
AB Test: bump `showCompositeCheckout` test date

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -27,7 +27,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	showCompositeCheckout: {
-		datestamp: '20200221',
+		datestamp: '20200324',
 		variations: {
 			composite: 50,
 			regular: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -27,7 +27,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	showCompositeCheckout: {
-		datestamp: '20200324',
+		datestamp: '20200326',
 		variations: {
 			composite: 50,
 			regular: 50,


### PR DESCRIPTION
Requires:  #40380

This bumps the test date for the `showCompositeCheckout` test, now that domains support has been added to Composite Checkout in #40380.

Fixes: #40222 

**To Test:**
A visual check that the date matches the current date should suffice. The test is already active for non-domain purchases and the gating is being updated in #40380.