### PR TITLE
Add/jetpack cloud backuppage indexed backup logs with timezone

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -92,6 +92,7 @@ class BackupsPage extends Component {
 			siteId,
 			siteSlug,
 			isLoadingBackups,
+			oldestDateAvailable,
 		} = this.props;
 		const { selectedDate } = this.state;
 		const selectedDateString = this.TO_REMOVE_getSelectedDateString();
@@ -113,6 +114,7 @@ class BackupsPage extends Component {
 					onDateChange={ this.onDateChange }
 					selectedDate={ selectedDate }
 					siteId={ siteId }
+					oldestDateAvailable={ oldestDateAvailable }
 				/>
 
 				<div>{ isLoadingBackups && 'Loading backups...' }</div>

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -91,6 +91,7 @@ class BackupsPage extends Component {
 			moment,
 			siteId,
 			siteSlug,
+			isLoadingBackups,
 		} = this.props;
 		const { selectedDate } = this.state;
 		const selectedDateString = this.TO_REMOVE_getSelectedDateString();
@@ -113,27 +114,34 @@ class BackupsPage extends Component {
 					selectedDate={ selectedDate }
 					siteId={ siteId }
 				/>
-				<DailyBackupStatus
-					allowRestore={ allowRestore }
-					date={ selectedDateString }
-					backupAttempts={ backupAttempts }
-					siteSlug={ siteSlug }
-				/>
-				{ doesRewindNeedCredentials && (
-					<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
+
+				<div>{ isLoadingBackups && 'Loading backups...' }</div>
+
+				{ ! isLoadingBackups && (
+					<>
+						<DailyBackupStatus
+							allowRestore={ allowRestore }
+							date={ selectedDateString }
+							backupAttempts={ backupAttempts }
+							siteSlug={ siteSlug }
+						/>
+                        { doesRewindNeedCredentials && (
+                            <MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
+                        ) }
+						<BackupDelta
+							{ ...{
+								deltas,
+								backupAttempts,
+								hasRealtimeBackups,
+								realtimeEvents,
+								allowRestore,
+								moment,
+								siteSlug,
+								metaDiff,
+							} }
+						/>
+					</>
 				) }
-				<BackupDelta
-					{ ...{
-						deltas,
-						backupAttempts,
-						hasRealtimeBackups,
-						realtimeEvents,
-						allowRestore,
-						moment,
-						siteSlug,
-						metaDiff,
-					} }
-				/>
 			</Main>
 		);
 	}
@@ -279,6 +287,8 @@ const mapStateToProps = state => {
 
 	const { indexedLog, oldestDateAvailable } = createIndexedLog( logs, siteTimezone, siteGmtOffset );
 
+	const isLoadingBackups = ! ( logs.state === 'success' );
+
 	return {
 		allowRestore,
 		doesRewindNeedCredentials,
@@ -292,6 +302,7 @@ const mapStateToProps = state => {
 		siteGmtOffset,
 		indexedLog,
 		oldestDateAvailable,
+		isLoadingBackups,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Create an indexed backup base on the backup date (in the correct time zone), so we can easily manage the backups included on each date without calculating it part of the code where we need it. 

At the same time, when we are creating the indexed backup list, we can determine the oldest date of the backup to pass it to DatePicker and limit the browsing to the left on the dates.


#### Testing instructions

- Check the code to see how indexed backups are created
- It works as before

#### Next related PRs and based on this branch:
- https://github.com/Automattic/wp-calypso/pull/40469
- https://github.com/Automattic/wp-calypso/pull/40496
