### PR TITLE
Disable composite checkout for slugs not strictly allowed

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -147,10 +147,7 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 
 	// If the URL is adding a product, only allow wpcom plans
 	const slugFragmentsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
-	if (
-		productSlug &&
-		! slugFragmentsToAllow.find( fragment => productSlug.includes( fragment ) )
-	) {
+	if ( productSlug && ! slugFragmentsToAllow.find( fragment => productSlug === fragment ) ) {
 		debug(
 			'shouldShowCompositeCheckout false because product does not match whitelist',
 			productSlug


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `CheckoutSystemDecider` uses old checkout for most URLs which add a product to the shopping cart, except for the products which have support for adding.

Previously, we made that decision by using `product.includes(allowedProduct)`, but this could create a false positive when `product` contains a dynamic string (eg: a domain name or a theme name) that might include one of the allowed strings.

This PR changes the decision to be `product === allowedProduct` so that the slug must match explicitly.

#### Testing instructions

- Click the buttons on the Plans page to add a plan to your cart. You should see the URL will look something like `/checkout/example.com/personal`.
- Verify that you see composite checkout, and that the item you chose is in the cart.
- Click a button elsewhere in calypso that adds a renewal to your cart.
- Verify that you see regular checkout, and that the item you chose is in the cart.