### PR TITLE
Edits to My Plans

### DIFF
--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -23,7 +23,9 @@ export default localize( ( { isBusinessPlan, selectedSite, translate } ) => {
 				title={ translate( 'Advertising removed' ) }
 				description={
 					isBusinessPlan
-						? translate( 'All WordPress.com advertising has been removed from your site.' )
+						? translate(
+								'All WordPress.com advertising has been removed from your site so your brand can stand out without distractions.'
+						  )
 						: translate(
 								'All WordPress.com advertising has been removed from your site. Upgrade to Business ' +
 									'to remove the WordPress.com footer credit.'

--- a/client/blocks/product-purchase-features-list/business-onboarding.jsx
+++ b/client/blocks/product-purchase-features-list/business-onboarding.jsx
@@ -22,15 +22,17 @@ export default localize( ( { isWpcomPlan, translate, link, onClick = noop } ) =>
 			<PurchaseDetail
 				icon={ <img alt="" src={ conciergeImage } /> }
 				title={ translate( 'Quick Start session' ) }
-				description={ translate(
-					'Schedule a one-on-one orientation session to set up your site ' +
-						'and learn more about %(serviceName)s.',
-					{
-						args: {
-							serviceName: isWpcomPlan ? 'WordPress.com' : 'Jetpack',
-						},
-					}
-				) }
+				description={
+					isWpcomPlan
+						? translate(
+								'Schedule a one-on-one session with a WordPress.com expert ' +
+									'to get your site up and running quickly.'
+						  )
+						: translate(
+								'Schedule a one-on-one orientation session to set up your site ' +
+									'and learn more about Jetpack.'
+						  )
+				}
 				buttonText={ translate( 'Schedule a session' ) }
 				href={ link }
 				onClick={ onClick }

--- a/client/blocks/product-purchase-features-list/custom-css.jsx
+++ b/client/blocks/product-purchase-features-list/custom-css.jsx
@@ -38,7 +38,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon={ <img alt="" src={ customizeImage } /> }
 				title={ translate( 'Custom CSS' ) }
 				description={ translate(
-					"Enjoy more control over your site's look and feel by writing your own CSS."
+					'Enjoy more control over your site’s look and feel by writing your own CSS.'
 				) }
 				buttonText={ translate( 'Edit CSS' ) }
 				href={ getEditCSSLink( selectedSite ) }

--- a/client/blocks/product-purchase-features-list/custom-css.jsx
+++ b/client/blocks/product-purchase-features-list/custom-css.jsx
@@ -38,7 +38,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon={ <img alt="" src={ customizeImage } /> }
 				title={ translate( 'Custom CSS' ) }
 				description={ translate(
-					"Make advanced changes to your site's appearance by writing your own CSS."
+					"Enjoy more control over your site's look and feel by writing your own CSS."
 				) }
 				buttonText={ translate( 'Edit CSS' ) }
 				href={ getEditCSSLink( selectedSite ) }

--- a/client/blocks/product-purchase-features-list/customize-theme.jsx
+++ b/client/blocks/product-purchase-features-list/customize-theme.jsx
@@ -36,7 +36,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				title={ translate( 'Advanced customization' ) }
 				description={ translate(
 					"Change your site's appearance in a few clicks, with an expanded " +
-						'selection of fonts and colors, and access to custom CSS.'
+						'selection of fonts and colors.'
 				) }
 				buttonText={ translate( 'Start customizing' ) }
 				href={ getCustomizeLink( selectedSite ) }

--- a/client/blocks/product-purchase-features-list/find-new-theme.jsx
+++ b/client/blocks/product-purchase-features-list/find-new-theme.jsx
@@ -22,7 +22,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon={ <img alt="" src={ premiumThemesImage } /> }
 				title={ translate( 'Try a premium theme' ) }
 				description={ translate(
-					'Access hundreds of beautifully designed premium themes at no extra cost.'
+					'Access a diverse selection of beautifully designed premium themes included with your plan.'
 				) }
 				buttonText={ translate( 'Browse premium themes' ) }
 				href={ '/themes/' + selectedSite.slug }

--- a/client/blocks/product-purchase-features-list/google-my-business.js
+++ b/client/blocks/product-purchase-features-list/google-my-business.js
@@ -22,7 +22,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				icon={ <img alt="" src={ googleMyBusinessImage } /> }
 				title={ translate( 'Google My Business' ) }
 				description={ translate(
-					'See how customers find you on Google -- and whether they visited your site and looked for more info on your business -- by connecting to a Google My Business location.'
+					'Create a Google business listing, connect with customers, and discover how customers find you on Google by connecting to a Google My Business location.'
 				) }
 				buttonText={ translate( 'Connect to Google My Business' ) }
 				href={ '/google-my-business/' + selectedSite.slug }

--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -20,7 +20,7 @@ export default localize( ( { isJetpack, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
-				buttonText={ translate( 'Sell online' ) }
+				buttonText={ translate( 'Collect payments' ) }
 				description={ translate(
 					'Add a payment button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
 				) }

--- a/client/blocks/product-purchase-features-list/site-activity.jsx
+++ b/client/blocks/product-purchase-features-list/site-activity.jsx
@@ -22,7 +22,7 @@ const SiteActivity = ( { siteSlug, translate } ) => (
 			icon={ <img alt="" src={ siteActivity } /> }
 			title={ translate( 'Activity' ) }
 			description={ translate(
-				'View a chronological list of all the changes and updates to your site in an organized, readable way.'
+				'The at-a-glance and activity list makes it easy to track changes and updates to your site.'
 			) }
 			buttonText={ translate( 'View your site activity' ) }
 			href={ `/activity-log/${ siteSlug }` }

--- a/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/test/video-audio-posts.jsx
@@ -71,7 +71,7 @@ describe( 'VideoAudioPosts should use proper description', () => {
 	[ PLAN_PREMIUM, PLAN_PREMIUM_2_YEARS ].forEach( ( plan ) => {
 		test( `for premium plan ${ plan }`, () => {
 			const comp = shallow( <VideoAudioPosts { ...props } plan={ plan } /> );
-			expect( comp.find( 'PurchaseDetail' ).props().description ).toContain( '13GB of media' );
+			expect( comp.find( 'PurchaseDetail' ).props().description ).toContain( '13 GB of media' );
 		} );
 	} );
 

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -32,7 +32,7 @@ function getDescription( plan, translate ) {
 
 	if ( isWpComPremiumPlan( plan ) ) {
 		return translate(
-			'Enrich your posts and pages with video or audio. Upload up to 13GB of media directly to your site.'
+			'Enrich your posts and pages with video or audio. Upload up to 13 GB of media directly to your site.'
 		);
 	}
 

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -32,7 +32,7 @@
 }
 
 .my-plan-card__title {
-	font-size: 24px;
+	font-size: 21px;
 	font-weight: 400;
 	line-height: 29px;
 	margin: 8px 0;
@@ -44,7 +44,8 @@
 }
 
 .my-plan-card__tagline {
-	font-size: 18px;
+	font-size: 14px;
+	font-weight: 400;
 	line-height: 21px;
 	margin: 0 0 24px;
 


### PR DESCRIPTION
This PR is a continuation of https://github.com/Automattic/wp-calypso/pull/40130 (I accidentally closed that PR while trying to accept copy change conflicts from another PR).

This PR makes a variety of copy tweaks to the My Plans page to improve clarity.

#### Changes proposed in this Pull Request
This PR changes the copy in the following cards on the My Plans page:
* Quick Start session
* Google My Business
* Advertising removed
* Advanced customization
* Custom CSS
* Try a premium theme

#### Testing instructions
* Checkout branch (git fetch origin && git checkout -b update/my-plan origin/update/my-plan)
* Run Calypso (yarn start)
* Navigate to http://calypso.localhost:3000/plans/my-plan/SITENAME with a Business plan account and confirm that all cards are properly displayed, and that copy in the updated cards has no typos or grammatical errors.
* Confirm that the appropriate cards, as defined in /client/blocks/product-purchase-features-list/index.jsx, are properly displayed
* Click links in the cards and confirm they go to the appropriate page.

Here's a screenshot of the page:
![screencapture-calypso-localhost-3000-plans-my-plan-donlair-com-2020-05-01-10_29_50](https://user-images.githubusercontent.com/35781181/80812885-e0238180-8b96-11ea-98d5-5977b5697914.png)
