### PR TITLE
Add the ability limit the browse to previous dates on DatePicker

### DIFF
--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -73,7 +73,11 @@ class DatePicker extends Component {
 	canGoToPreviousDay = () => {
 		const { moment, selectedDate, oldestDateAvailable } = this.props;
 
-		return !! oldestDateAvailable && ! moment( selectedDate ).isSame( oldestDateAvailable, 'day' );
+		if ( false === !! oldestDateAvailable ) {
+			return true;
+		}
+
+		return ! moment( selectedDate ).isSame( oldestDateAvailable, 'day' );
 	};
 
 	canGoToNextDay = () => {

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -73,11 +73,7 @@ class DatePicker extends Component {
 	canGoToPreviousDay = () => {
 		const { moment, selectedDate, oldestDateAvailable } = this.props;
 
-		if ( false === !! oldestDateAvailable ) {
-			return true;
-		}
-
-		return ! moment( selectedDate ).isSame( oldestDateAvailable, 'day' );
+		return ! oldestDateAvailable || ! moment( selectedDate ).isSame( oldestDateAvailable, 'day' );
 	};
 
 	canGoToNextDay = () => {

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -25,6 +25,7 @@ class DatePicker extends Component {
 		selectedDate: PropTypes.instanceOf( Date ).isRequired,
 		onDateChange: PropTypes.func.isRequired,
 		onDateRangeSelection: PropTypes.func.isRequired,
+		oldestDateAvailable: PropTypes.instanceOf( Date ),
 	};
 
 	getDisplayDate = ( date, showTodayYesterday = true ) => {
@@ -34,11 +35,7 @@ class DatePicker extends Component {
 		const yearToday = moment().format( 'YYYY' );
 		const yearDate = moment( date ).format( 'YYYY' );
 
-		let dateFormat = 'MMM D';
-
-		if ( yearToday !== yearDate ) {
-			dateFormat = 'MMM D, YYYY';
-		}
+		const dateFormat = yearToday === yearDate ? 'MMM D' : 'MMM D, YYYY';
 
 		if ( showTodayYesterday ) {
 			switch ( daysDiff ) {
@@ -52,7 +49,10 @@ class DatePicker extends Component {
 		return moment( date ).format( dateFormat );
 	};
 
-	shuttleLeft = () => {
+	goToPreviousDay = () => {
+		if ( ! this.canGoToPreviousDay() ) {
+			return false;
+		}
 		const { moment, onDateChange, selectedDate } = this.props;
 
 		const newSelectedDate = moment( selectedDate ).subtract( 1, 'days' );
@@ -60,11 +60,10 @@ class DatePicker extends Component {
 		onDateChange( newSelectedDate.toDate() );
 	};
 
-	shuttleRight = () => {
-		if ( ! this.canShuttleRight() ) {
+	goToNextDay = () => {
+		if ( ! this.canGoToNextDay() ) {
 			return false;
 		}
-
 		const { moment, onDateChange, selectedDate } = this.props;
 
 		const newSelectedDate = moment( selectedDate ).add( 1, 'days' );
@@ -72,7 +71,13 @@ class DatePicker extends Component {
 		onDateChange( newSelectedDate.toDate() );
 	};
 
-	canShuttleRight = () => {
+	canGoToPreviousDay = () => {
+		const { moment, selectedDate, oldestDateAvailable } = this.props;
+
+		return !! oldestDateAvailable && ! moment( selectedDate ).isSame( oldestDateAvailable, 'day' );
+	};
+
+	canGoToNextDay = () => {
 		const { moment, selectedDate } = this.props;
 
 		return ! moment( selectedDate ).isSame( moment(), 'day' );
@@ -89,8 +94,8 @@ class DatePicker extends Component {
 
 		return (
 			<div className="date-picker">
-				<Button compact borderless onClick={ this.shuttleLeft }>
-					<Gridicon icon="chevron-left" />
+				<Button compact borderless onClick={ this.goToPreviousDay }>
+					<Gridicon icon="chevron-left" className={ ! this.canGoToPreviousDay() && 'disabled' } />
 				</Button>
 
 				<div className="date-picker__display-date">{ previousDisplayDate }</div>
@@ -103,14 +108,14 @@ class DatePicker extends Component {
 
 				<div
 					className={ classNames( 'date-picker__display-date', {
-						disabled: ! this.canShuttleRight(),
+						disabled: ! this.canGoToNextDay(),
 					} ) }
 				>
 					{ nextDisplayDate }
 				</div>
 
-				<Button compact borderless onClick={ this.shuttleRight }>
-					<Gridicon icon="chevron-right" className={ ! this.canShuttleRight() && 'disabled' } />
+				<Button compact borderless onClick={ this.goToNextDay }>
+					<Gridicon icon="chevron-right" className={ ! this.canGoToNextDay() && 'disabled' } />
 				</Button>
 				<div>Date selected: { this.getDisplayDate( selectedDate ) }</div>
 			</div>

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -24,7 +24,6 @@ class DatePicker extends Component {
 		siteId: PropTypes.number.isRequired,
 		selectedDate: PropTypes.instanceOf( Date ).isRequired,
 		onDateChange: PropTypes.func.isRequired,
-		onDateRangeSelection: PropTypes.func.isRequired,
 		oldestDateAvailable: PropTypes.instanceOf( Date ),
 	};
 

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -50,10 +50,6 @@ class BackupsPage extends Component {
 		this.setState( { selectedDate: date } );
 	};
 
-	onDateRangeSelection = () => {
-		//todo: go to the log activity view
-	};
-
 	isEmptyFilter = filter => {
 		if ( ! filter ) {
 			return true;
@@ -91,7 +87,6 @@ class BackupsPage extends Component {
 
 				<DatePicker
 					onDateChange={ this.onDateChange }
-					onDateRangeSelection={ this.onDateRangeSelection }
 					selectedDate={ selectedDate }
 					siteId={ siteId }
 					oldestDateAvailable={ new Date( '2020-03-01' ) } //todo: provide the oldestDateAvailable of backups

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -94,6 +94,7 @@ class BackupsPage extends Component {
 					onDateRangeSelection={ this.onDateRangeSelection }
 					selectedDate={ selectedDate }
 					siteId={ siteId }
+					oldestDateAvailable={ new Date( '2020-03-01' ) } //todo: provide the oldestDateAvailable of backups
 				/>
 				<DailyBackupStatus
 					allowRestore={ allowRestore }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -89,7 +89,6 @@ class BackupsPage extends Component {
 					onDateChange={ this.onDateChange }
 					selectedDate={ selectedDate }
 					siteId={ siteId }
-					oldestDateAvailable={ new Date( '2020-03-01' ) } //todo: provide the oldestDateAvailable of backups
 				/>
 				<DailyBackupStatus
 					allowRestore={ allowRestore }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add the ability to limit the browse to previous dates passing to the DatePicker component the oldest date available.

Other minor improvements.

#### Testing instructions

- Check that everything works as before
- Check that we can't browse more than March 1st (date hardcoded for testing purpose)
