### PR TITLE
Alters scan history to have filter state in route

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/controller.js
+++ b/client/landing/jetpack-cloud/sections/scan/controller.js
@@ -19,6 +19,7 @@ export function scan( context, next ) {
  */
 
 export function scanHistory( context, next ) {
-	context.primary = <ScanHistoryPage />;
+	const { filter } = context.params;
+	context.primary = <ScanHistoryPage filter={ filter } />;
 	next();
 }

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -11,7 +12,7 @@ import { translate } from 'i18n-calypso';
 import DocumentHead from 'components/data/document-head';
 import ScanHistoryItem from '../../../components/scan-history-item';
 import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 
@@ -108,20 +109,27 @@ const scanEntries = [
 ];
 
 class ScanHistoryPage extends Component {
-	state = {
-		filter: filterOptions[ 0 ],
+	getCurrentFilter = () => {
+		const { filter } = this.props;
+
+		if ( filter ) {
+			return filterOptions.find( ( { value } ) => value === filter ) || filterOptions[ 0 ];
+		}
+		return filterOptions[ 0 ];
 	};
 
 	handleOnFilterChange = filter => {
-		// @todo: should we filter in the front end?
-		this.setState( {
-			filter,
-		} );
+		const { siteSlug } = this.props;
+		let filterValue = filter.value;
+		if ( 'all' === filterValue ) {
+			filterValue = '';
+		}
+		page.show( `/scan/history/${ siteSlug }/${ filterValue }` );
 	};
 
 	filteredEntries() {
 		const { logEntries } = this.props;
-		const { value: filter } = this.state.filter;
+		const { value: filter } = this.getCurrentFilter();
 		if ( filter === 'all' ) {
 			return logEntries;
 		}
@@ -130,6 +138,7 @@ class ScanHistoryPage extends Component {
 
 	render() {
 		const logEntries = this.filteredEntries();
+		const { value: filter } = this.getCurrentFilter();
 		return (
 			<Main wideLayout className="history">
 				<DocumentHead title={ translate( 'History' ) } />
@@ -145,6 +154,7 @@ class ScanHistoryPage extends Component {
 						className="history__filters"
 						options={ filterOptions }
 						onSelect={ this.handleOnFilterChange }
+						initialSelected={ filter }
 					/>
 				</div>
 				<div className="history__entries">
@@ -165,6 +175,7 @@ export default connect( state => {
 
 	return {
 		siteId,
+		siteSlug: getSelectedSiteSlug( state ),
 		logEntries: scanHistoryLogEntries,
 	};
 } )( ScanHistoryPage );

--- a/client/landing/jetpack-cloud/sections/scan/index.js
+++ b/client/landing/jetpack-cloud/sections/scan/index.js
@@ -19,7 +19,7 @@ export default function() {
 
 		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
 			page(
-				'/scan/history/:site/',
+				'/scan/history/:site/:filter?',
 				siteSelection,
 				navigation,
 				scanHistory,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This uses page navigation to set the correct filter instead of relying on the state. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load Jetpack Cloud.
* Navigate to Scan, and select your site.
* Click History.
* Filter scan history events.

Expected result: Changing scan history updates UI and alters current URL. Reloading the page sets the state as expected.

Fixes 1151678672052943-as-1165787355206373.