### PR TITLE
Fix editor frame classnames for 7.7.1

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
@@ -30,7 +30,7 @@
 		}
 
 		// @TODO Remove the "regions content" class after G2 is available everywhere.
-		.edit-post-visual-editor.editor-styles-wrapper
+		.edit-post-visual-editor.editor-styles-wrapper,
 		.edit-post-editor-regions__content .edit-post-visual-editor {
 			box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
 				0 1px 5px 0 rgba( 0, 0, 0, 0.2 );

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
@@ -23,11 +23,11 @@
 .post-type-page,
 .post-type-wp_template_part {
 	@media ( min-width: 768px ) {
-		.edit-post-editor-regions__content {
+		.block-editor-editor-skeleton__content {
 			background: #eee;
 		}
 
-		.edit-post-editor-regions__content .edit-post-visual-editor {
+		.edit-post-visual-editor.editor-styles-wrapper {
 			box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
 				0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 			flex: none;

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
@@ -23,11 +23,15 @@
 .post-type-page,
 .post-type-wp_template_part {
 	@media ( min-width: 768px ) {
-		.block-editor-editor-skeleton__content {
+		// @TODO Remove the "regions content" class after G2 is available everywhere.
+		.block-editor-editor-skeleton__content,
+		.edit-post-editor-regions__content {
 			background: #eee;
 		}
 
-		.edit-post-visual-editor.editor-styles-wrapper {
+		// @TODO Remove the "regions content" class after G2 is available everywhere.
+		.edit-post-visual-editor.editor-styles-wrapper
+		.edit-post-editor-regions__content .edit-post-visual-editor {
 			box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
 				0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 			flex: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fix dotcom-fse editor classnames for Gutenberg 7.7.1

#### Testing instructions
* On an edge-stickered site, test that the dotcom-fse frame appears on an FSE site. Test that the frame still appears for non-G2 versions like 7.3 as well.

Related to #40078
