### PR TITLE
composite-checkout: Prevent loading cart if CartStore is loading

### DIFF
--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -136,6 +136,8 @@ export default function CompositeCheckout( {
 	);
 	const previousRoute = useSelector( state => getPreviousPath( state ) );
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
+	const isLoadingCartSynchronizer =
+		cart && ( ! cart.hasLoadedFromServer || cart.hasPendingServerUpdates );
 
 	const getThankYouUrl = useCallback( () => {
 		const transactionResult = select( 'wpcom' ).getTransactionResult();
@@ -262,7 +264,7 @@ export default function CompositeCheckout( {
 		responseCart,
 	} = useShoppingCart(
 		siteSlug,
-		canInitializeCart,
+		canInitializeCart && ! isLoadingCartSynchronizer,
 		productForCart,
 		couponCodeFromUrl,
 		setCart || wpcomSetCart,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Composite checkout uses its own function to fetch data from the shopping cart endpoint, but in order for certain features to work (eg: thank-you page generation), it also currently has access to the cart object from the `CartStore`. A common behavior is for a page in Calypso to emit an event to request changes to the cart, and then redirect to checkout. The `CartStore` then asynchronously applies these changes. This can result in a race condition wherein a product added to the cart has not yet reached the cart on the server by the time that composite checkout fetches the cart.

In theory this shouldn't be a problem because when the `CartStore` finishes updating, it will re-render all of checkout, but composite checkout will not re-fetch the cart when it is re-rendered, meaning it will display the incorrect data.

In this PR, we prevent fetching the cart in composite checkout if the `CartStore` has unfinished changes which should hopefully give the server time to be updated before composite checkout gets its version of the data.

#### Testing instructions

- Start calypso using the `composite-checkout-testing` flag or be sure your user is in the composite checkout abtest `composite` group.
- Try adding items to the cart using various buttons around Calypso, especially buttons that do not cause the URL to contain a product. That is, when you click to add something to your cart and you end up at `/checkout/example.com`, it means that there is a potential race condition, rather than when you visit a URL like `/checkout/example.com/business` or `/checkout/renew/dotcom_domain:example.com/12345/example.com`. Verify that you always see the cart when the page loads and you are never redirected to `/plans`.