### PR TITLE
Composite Checkout: fix inline errors for organizations and EU cities.

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -23,7 +23,7 @@ const EuAddressFieldset = props => {
 			/>
 			<Input
 				label={ translate( 'City' ) }
-				{ ...getFieldProps( 'city', false, { customErrorMessage: contactDetailsErrors?.city } ) }
+				{ ...getFieldProps( 'city', { customErrorMessage: contactDetailsErrors?.city } ) }
 			/>
 		</div>
 	);

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -382,6 +382,7 @@ export class ContactDetailsFormFields extends Component {
 						},
 						{
 							needsChildRef: true,
+							customErrorMessage: this.props.contactDetailsErrors?.organization,
 						}
 					) }
 				</div>


### PR DESCRIPTION
This adds inline errors for the optional "organization" field and European-style "city" field in the full domain contact form.

Fixes #40416 

**To test:**
- add a domain to your cart
- force composite checkout for domains with `?flags=composite-checkout-testing`
- use invalid content (`! == 'a-z A-Z 0-9 . , ( ) @ & ' - [space]'`) for the organization field under "contact details"
- select a European country
- use invalid content (`! == 'a-z A-Z 0-9 . , ( ) @ & ' - [space]'`) for the city field
- try to submit the step and verify that inline validation errors are shown for each field
