### PR TITLE
Gutenboarding: clear errors when signup form is closed, add tests to user data store

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -34,12 +34,17 @@ interface Props {
 const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 	const { __: NO__, _x: NO_x } = useI18n();
 	const [ emailVal, setEmailVal ] = useState( '' );
-	const { createAccount } = useDispatch( USER_STORE );
+	const { createAccount, clearErrors } = useDispatch( USER_STORE );
 	const isFetchingNewUser = useSelect( select => select( USER_STORE ).isFetchingNewUser() );
 	const newUserError = useSelect( select => select( USER_STORE ).getNewUserError() );
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ) ).getState();
 	const langParam = useLangRouteParam();
 	const makePath = usePath();
+
+	const closeModal = () => {
+		clearErrors();
+		onRequestClose();
+	};
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_gutenboarding_signup_start', {
@@ -63,7 +68,7 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 		} );
 
 		if ( success ) {
-			onRequestClose();
+			closeModal();
 		}
 	};
 
@@ -104,7 +109,7 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 		<Modal
 			className="signup-form"
 			title={ NO__( 'Sign up to save your changes' ) }
-			onRequestClose={ onRequestClose }
+			onRequestClose={ closeModal }
 			focusOnMount={ false }
 			isDismissible={ ! isFetchingNewUser }
 			// set to false so that 1password's autofill doesn't automatically close the modal

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -34,6 +34,10 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		error,
 	} );
 
+	const clearErrors = () => ( {
+		type: 'CLEAR_ERRORS' as const,
+	} );
+
 	function* createAccount( params: CreateAccountParams ) {
 		yield fetchNewUser();
 		try {
@@ -68,6 +72,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		fetchNewUser,
 		receiveNewUser,
 		receiveNewUserFailed,
+		clearErrors,
 		createAccount,
 	};
 }

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -79,10 +79,14 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 
 type ActionCreators = ReturnType< typeof createActions >;
 
-export type Action = ReturnType<
-	| ActionCreators[ 'receiveCurrentUser' ]
-	| ActionCreators[ 'receiveCurrentUserFailed' ]
-	| ActionCreators[ 'fetchNewUser' ]
-	| ActionCreators[ 'receiveNewUser' ]
-	| ActionCreators[ 'receiveNewUserFailed' ]
->;
+export type Action =
+	| ReturnType<
+			| ActionCreators[ 'receiveCurrentUser' ]
+			| ActionCreators[ 'receiveCurrentUserFailed' ]
+			| ActionCreators[ 'fetchNewUser' ]
+			| ActionCreators[ 'receiveNewUser' ]
+			| ActionCreators[ 'receiveNewUserFailed' ]
+			| ActionCreators[ 'clearErrors' ]
+	  >
+	// Type added so we can dispatch actions in tests, but has no runtime cost
+	| { type: 'TEST_ACTION' };

--- a/packages/data-stores/src/user/reducer.ts
+++ b/packages/data-stores/src/user/reducer.ts
@@ -40,6 +40,8 @@ const newUserError: Reducer< NewUserErrorResponse | undefined, Action > = ( stat
 			return undefined;
 		case 'RECEIVE_NEW_USER':
 			return undefined;
+		case 'CLEAR_ERRORS':
+			return undefined;
 		case 'RECEIVE_NEW_USER_FAILED':
 			return {
 				error: action.error.error,

--- a/packages/data-stores/src/user/reducer.ts
+++ b/packages/data-stores/src/user/reducer.ts
@@ -10,7 +10,7 @@ import { combineReducers } from '@wordpress/data';
 import { CurrentUser, NewUser, NewUserErrorResponse } from './types';
 import { Action } from './actions';
 
-const currentUser: Reducer< CurrentUser | null | undefined, Action > = ( state, action ) => {
+export const currentUser: Reducer< CurrentUser | null | undefined, Action > = ( state, action ) => {
 	switch ( action.type ) {
 		case 'RECEIVE_CURRENT_USER':
 			return action.currentUser;
@@ -20,7 +20,7 @@ const currentUser: Reducer< CurrentUser | null | undefined, Action > = ( state, 
 	return state;
 };
 
-const newUserData: Reducer< NewUser | undefined, Action > = ( state, action ) => {
+export const newUserData: Reducer< NewUser | undefined, Action > = ( state, action ) => {
 	if ( action.type === 'RECEIVE_NEW_USER' ) {
 		const { response } = action;
 		return {
@@ -34,7 +34,10 @@ const newUserData: Reducer< NewUser | undefined, Action > = ( state, action ) =>
 	return state;
 };
 
-const newUserError: Reducer< NewUserErrorResponse | undefined, Action > = ( state, action ) => {
+export const newUserError: Reducer< NewUserErrorResponse | undefined, Action > = (
+	state,
+	action
+) => {
 	switch ( action.type ) {
 		case 'FETCH_NEW_USER':
 			return undefined;
@@ -54,7 +57,10 @@ const newUserError: Reducer< NewUserErrorResponse | undefined, Action > = ( stat
 	return state;
 };
 
-const isFetchingNewUser: Reducer< boolean | undefined, Action > = ( state = false, action ) => {
+export const isFetchingNewUser: Reducer< boolean | undefined, Action > = (
+	state = false,
+	action
+) => {
 	switch ( action.type ) {
 		case 'FETCH_NEW_USER':
 			return true;

--- a/packages/data-stores/src/user/test/actions.ts
+++ b/packages/data-stores/src/user/test/actions.ts
@@ -1,0 +1,104 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createActions } from '../actions';
+
+const client_id = 'magic_client_id';
+const client_secret = 'magic_client_secret';
+
+describe( 'createAccount', () => {
+	const { createAccount } = createActions( {
+		client_id,
+		client_secret,
+	} );
+
+	const params = {
+		email: 'test@example.com',
+		extra: {
+			username_hint: 'Test Site Title',
+		},
+	};
+
+	const defaults = {
+		client_id,
+		client_secret,
+		is_passwordless: true,
+		signup_flow_name: 'gutenboarding',
+		locale: 'en',
+	};
+
+	it( 'requests a new passwordless account to be created', () => {
+		const generator = createAccount( params );
+
+		expect( generator.next().value ).toEqual( { type: 'FETCH_NEW_USER' } );
+
+		const apiResponse = {
+			success: true,
+			bearer_token: 'bearer-token',
+			username: 'testusernamer12345',
+			user_id: 12345,
+		};
+
+		expect( generator.next().value ).toEqual( {
+			type: 'WPCOM_REQUEST',
+			request: expect.objectContaining( {
+				body: {
+					...defaults,
+					...params,
+					validate: false,
+				},
+			} ),
+		} );
+
+		const finalResult = generator.next( apiResponse );
+
+		expect( finalResult.value ).toEqual( {
+			type: 'RECEIVE_NEW_USER',
+			response: apiResponse,
+		} );
+		expect( finalResult.done ).toBe( true );
+	} );
+
+	it( 'receives an error object and returns false', () => {
+		const generator = createAccount( params );
+
+		expect( generator.next().value ).toEqual( { type: 'FETCH_NEW_USER' } );
+
+		const apiResponse = {
+			error: 'email_exists',
+			status: 400,
+			statusCode: 400,
+			name: 'EmailExistsError',
+			message: 'Invalid email input',
+		};
+
+		expect( generator.next().value ).toEqual( {
+			type: 'WPCOM_REQUEST',
+			request: expect.objectContaining( {
+				body: {
+					...defaults,
+					...params,
+					validate: false,
+				},
+			} ),
+		} );
+
+		expect( generator.throw( apiResponse ).value ).toEqual( {
+			type: 'RECEIVE_NEW_USER_FAILED',
+			error: apiResponse,
+		} );
+
+		const finalResult = generator.next();
+
+		expect( finalResult.value ).toBe( false );
+		expect( finalResult.done ).toBe( true );
+	} );
+} );

--- a/packages/data-stores/src/user/test/reducer.ts
+++ b/packages/data-stores/src/user/test/reducer.ts
@@ -1,0 +1,159 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { currentUser, newUserData, newUserError, isFetchingNewUser } from '../reducer';
+import { createActions } from '../actions';
+
+const {
+	receiveCurrentUser,
+	receiveCurrentUserFailed,
+	fetchNewUser,
+	receiveNewUser,
+	receiveNewUserFailed,
+	clearErrors,
+} = createActions( {
+	client_id: '',
+	client_secret: '',
+} );
+
+const newUserSuccessResponse = {
+	success: true,
+	bearer_token: 'bearer-token',
+	username: 'testusernamer12345',
+	user_id: 12345,
+	is_signup_sandbox: false,
+};
+
+const newUserSuccessResponseSandboxed = {
+	success: true,
+	bearer_token: 'bearer-token',
+	signup_sandbox_username: 'testusernamer12345',
+	signup_sandbox_user_id: 12345,
+	is_signup_sandbox: true,
+};
+
+const newUserErrorResponse = {
+	error: 'email_exists',
+	status: 400,
+	statusCode: 400,
+	name: 'EmailExistsError',
+	message: 'Invalid email input',
+};
+
+describe( 'currentUser', () => {
+	it( 'defaults to undefined', () => {
+		const state = currentUser( undefined, { type: 'TEST_ACTION' } );
+		expect( state ).toBe( undefined );
+	} );
+
+	it( 'returns a current user object', () => {
+		const testUser = {
+			ID: 1,
+			username: 'testusername',
+			display_name: 'testusername',
+			language: 'en',
+			locale_variant: '',
+		};
+		const state = currentUser( undefined, receiveCurrentUser( testUser ) );
+		expect( state ).toEqual( testUser );
+	} );
+
+	it( 'returns null if receiving the current user failed', () => {
+		const state = currentUser( undefined, receiveCurrentUserFailed() );
+		expect( state ).toBe( null );
+	} );
+} );
+
+describe( 'newUserData', () => {
+	it( 'defaults to undefined', () => {
+		const state = newUserData( undefined, { type: 'TEST_ACTION' } );
+		expect( state ).toBe( undefined );
+	} );
+
+	it( 'sets username, userId, and bearerToken from a standard response', () => {
+		const state = newUserData( undefined, receiveNewUser( newUserSuccessResponse ) );
+		const { username, user_id, bearer_token } = newUserSuccessResponse;
+		expect( state ).toEqual( {
+			username,
+			userId: user_id,
+			bearerToken: bearer_token,
+		} );
+	} );
+
+	it( 'set username, userId, and bearerToken from a sandboxed response', () => {
+		const state = newUserData( undefined, receiveNewUser( newUserSuccessResponseSandboxed ) );
+		const {
+			signup_sandbox_username,
+			signup_sandbox_user_id,
+			bearer_token,
+		} = newUserSuccessResponseSandboxed;
+		expect( state ).toEqual( {
+			username: signup_sandbox_username,
+			userId: signup_sandbox_user_id,
+			bearerToken: bearer_token,
+		} );
+	} );
+} );
+
+describe( 'newUserError', () => {
+	it( 'defaults to undefined', () => {
+		const state = newUserError( undefined, { type: 'TEST_ACTION' } );
+		expect( state ).toBe( undefined );
+	} );
+
+	it( 'stores an error message', () => {
+		const state = newUserError( undefined, receiveNewUserFailed( newUserErrorResponse ) );
+		expect( state ).toEqual( newUserErrorResponse );
+	} );
+
+	it( 'clears existing error messages on clearErrors', () => {
+		const originalState = newUserError( undefined, receiveNewUserFailed( newUserErrorResponse ) );
+		expect( originalState ).toEqual( newUserErrorResponse );
+		const state = newUserError( originalState, clearErrors() );
+		expect( state ).toBe( undefined );
+	} );
+
+	it( 'clears existing error messages on fetching a new user', () => {
+		const originalState = newUserError( undefined, receiveNewUserFailed( newUserErrorResponse ) );
+		expect( originalState ).toEqual( newUserErrorResponse );
+		const state = newUserError( originalState, fetchNewUser() );
+		expect( state ).toBe( undefined );
+	} );
+
+	it( 'clears existing error messages on receiving a new user', () => {
+		const originalState = newUserError( undefined, receiveNewUserFailed( newUserErrorResponse ) );
+		expect( originalState ).toEqual( newUserErrorResponse );
+		const state = newUserError( originalState, receiveNewUser( newUserSuccessResponse ) );
+		expect( state ).toBe( undefined );
+	} );
+} );
+
+describe( 'isFetchingNewUser', () => {
+	it( 'defaults to false', () => {
+		const state = isFetchingNewUser( undefined, { type: 'TEST_ACTION' } );
+		expect( state ).toBe( false );
+	} );
+
+	it( 'returns true on fetching a new user', () => {
+		const state = isFetchingNewUser( undefined, fetchNewUser() );
+		expect( state ).toBe( true );
+	} );
+
+	it( 'returns false on receiving a new user', () => {
+		const state = isFetchingNewUser( true, receiveNewUser( newUserSuccessResponse ) );
+		expect( state ).toBe( false );
+	} );
+
+	it( 'returns false on a failed new user request', () => {
+		const state = isFetchingNewUser( true, receiveNewUserFailed( newUserErrorResponse ) );
+		expect( state ).toBe( false );
+	} );
+} );

--- a/packages/data-stores/src/user/test/resolvers.ts
+++ b/packages/data-stores/src/user/test/resolvers.ts
@@ -1,0 +1,68 @@
+/*
+ * These tests shouldn't require the jsdom environment,
+ * but we're waiting for this PR to merge:
+ * https://github.com/WordPress/gutenberg/pull/20486
+ *
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createResolvers } from '../resolvers';
+
+const { getCurrentUser } = createResolvers( { client_id: '', client_secret: '' } );
+
+describe( 'getCurrentUser', () => {
+	it( 'should return a receiveCurrentUser action object on success', async () => {
+		const apiResponse = {
+			ID: 1,
+			username: 'testusername',
+		};
+
+		const generator = getCurrentUser();
+
+		expect( generator.next().value ).toEqual( {
+			type: 'WPCOM_REQUEST',
+			request: {
+				path: '/me',
+				apiVersion: '1.1',
+			},
+		} );
+
+		const finalResult = generator.next( apiResponse );
+		expect( finalResult.value ).toEqual( {
+			type: 'RECEIVE_CURRENT_USER',
+			currentUser: apiResponse,
+		} );
+
+		expect( finalResult.done ).toBe( true );
+	} );
+
+	it( 'should return a receiveCurrentUserFailed action object on fail', async () => {
+		const apiResponse = {
+			error: 'authorization_required',
+			status: 403,
+			statusCode: 403,
+			name: 'AuthorizationRequiredError',
+			message: 'An active access token must be used to query information about the current user.',
+		};
+
+		const generator = getCurrentUser();
+
+		expect( generator.next().value ).toEqual( {
+			type: 'WPCOM_REQUEST',
+			request: {
+				path: '/me',
+				apiVersion: '1.1',
+			},
+		} );
+
+		const finalResult = generator.throw( apiResponse );
+		expect( finalResult.value ).toEqual( {
+			type: 'RECEIVE_CURRENT_USER_FAILED',
+		} );
+
+		expect( finalResult.done ).toBe( true );
+	} );
+} );

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -33,7 +33,7 @@ export interface NewUserSuccessResponse {
 	username?: string;
 	signup_sandbox_username?: string;
 	user_id?: number;
-	signup_sandbox_user_id?: string;
+	signup_sandbox_user_id?: number;
 }
 
 export interface NewUserErrorResponse {


### PR DESCRIPTION
Previously, in Gutenboarding if you go to create a new user, receive an error message, and then close the modal, when you re-open the modal, the old error message still exists even though the form is empty.

This PR clears the error messages when the form is closed, and adds in tests for the user data store. Here's an example of it working (please ignore the unrelated error in the preview in the `style` step):

![create-user-errors-small](https://user-images.githubusercontent.com/14988353/77509908-bbfec180-6ec1-11ea-913c-9a6a5dc266da.gif)

#### Changes proposed in this Pull Request

* Clear the `newUserError` state when the signup form is closed
* Add test coverage to the user data store to cover the main actions, resolver and reducers.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Run tests

You probably don't need to run these manually since they're already run by CI, however you can run them from the terminal with:

```
npm run test-packages ./packages/data-stores/src/user/test/
```

##### Test signup form clears errors when modal is closed

In a fresh or incognito / private browsing window:

1. Go to `http://calypso.localhost:3000/gutenboarding` and complete the signup flow until you get to the account sign up form.
2. Here, enter an email address for which there is already an account and click "Create you account"
3. You should get an error message "An account with this email address already exists."
4. Close the modal.
5. Click "Create my site" again.
6. The modal should open, the email field should be empty, and no errors should be displayed.
