### PR TITLE
[Gutenberg 7.7] Fix margin on block inserter button.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
@@ -15,12 +15,6 @@
 	display: flex;
 	align-items: center;
 	padding: 9px 10px;
-	// Close button override doesn't need the extraneous left-padding
-	// provided by .edit-post-header__toolbar from WP. So here we
-	// offset the -24px padding and then restore the 24px padding
-	// for other toolbar buttons that comes after this button.
-	margin-left: -24px;
-	margin-right: 24px;
 	border: none;
 	border-right: 1px solid #e2e4e7;
 
@@ -51,7 +45,28 @@
 		.close-button-override-thin {
 			display: flex;
 		}
+		.close-button-override__label {
+			display: none;
+		}
 	}
+}
+
+// add an extra class specific for the new Gutenberg plugin version so the main override above stays compatible with < v7.7
+.post-type-wp_template_part
+	.block-editor-editor-skeleton__header
+	.edit-post-fullscreen-mode-close__toolbar__override,
+.post-type-page
+	.block-editor-editor-skeleton__header
+	.edit-post-fullscreen-mode-close__toolbar__override,
+.post-type-post
+	.block-editor-editor-skeleton__header
+	.edit-post-fullscreen-mode-close__toolbar__override {
+	// Close button override doesn't need the extraneous left-padding
+	// provided by .edit-post-header__toolbar from WP. So here we
+	// offset the -24px padding and then restore the 24px padding
+	// for other toolbar buttons that comes after this button.
+	margin-left: -24px;
+	margin-right: 24px;
 
 	// Back button is not displayed in mobile & tablet view.
 	@media ( max-width: 782px ) {
@@ -64,15 +79,8 @@
 			display: none;
 		}
 	}
-}
 
-// add an extra class specific for the new Gutenberg plugin version so the main override above stays compatible with < v7.7
-.post-type-wp_template_part .block-editor-editor-skeleton__header .edit-post-fullscreen-mode-close__toolbar__override,
-.post-type-page .block-editor-editor-skeleton__header .edit-post-fullscreen-mode-close__toolbar__override,
-.post-type-post .block-editor-editor-skeleton__header .edit-post-fullscreen-mode-close__toolbar__override {
-	margin-left: -24px;
-	margin-right: 10px;
-
+	// Overrides < v7.7.
 	@media ( max-width: 599px ) {
 		margin-left: -24px;
 	}

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
@@ -53,6 +53,8 @@ body.is-fullscreen-mode {
 // To make the toolbar buttons look more balanced, an left offset of -8px
 // is added to this custom block inserter button (24px - 16px = 8px). This
 // -8px offset also contributes in solving spacing issue in mobile/tablet view.
-.block-editor-inserter__toggle {
+//
+// Specific to Gutenberg >= 7.7.
+.block-editor-editor-skeleton__header .block-editor-inserter__toggle {
 	margin-left: -8px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixed margin-left issue on **Block Insert Button**.
* Fixed missing margin-left on **Close/Back Button** dotcom-fse non-gutenberg edge page editor.

#### Testing instructions

When opening the editor in post or page / fse or non-fse / wp-admin or wp-calypso, the block inserter button should look like this:

![image](https://user-images.githubusercontent.com/1287077/77512618-5bb25480-6eae-11ea-8c76-61556533214f.png)
