### PR TITLE
Gutenboarding: fix domain flow, request all blog access after reloading proxy

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -58,18 +58,25 @@ interface Cart {
 const Header: FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 
-	const [ isDomainFlow, setDomainFlow ] = useState( false );
-
 	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
 	const newUser = useSelect( select => select( USER_STORE ).getNewUser() );
 
 	const newSite = useSelect( select => select( SITE_STORE ).getNewSite() );
 
-	const { domain, selectedDesign, siteTitle, siteVertical } = useSelect( select =>
-		select( ONBOARD_STORE ).getState()
-	);
+	const {
+		domain,
+		selectedDesign,
+		siteTitle,
+		siteVertical,
+		siteWasCreatedForDomainPurchase,
+	} = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const hasSelectedDesign = !! selectedDesign;
-	const { createSite, setDomain, resetOnboardStore } = useDispatch( ONBOARD_STORE );
+	const {
+		createSite,
+		setDomain,
+		resetOnboardStore,
+		setSiteWasCreatedForDomainPurchase,
+	} = useDispatch( ONBOARD_STORE );
 
 	const freeDomainSuggestion = useFreeDomainSuggestion();
 
@@ -123,7 +130,7 @@ const Header: FunctionComponent = () => {
 	);
 
 	const handleCreateSiteForDomains: typeof handleCreateSite = ( ...args ) => {
-		setDomainFlow( true );
+		setSiteWasCreatedForDomainPurchase( true );
 		handleCreateSite( ...args );
 	};
 
@@ -144,7 +151,7 @@ const Header: FunctionComponent = () => {
 
 	const handleSignupForDomains = () => {
 		setShowSignupDialog( true );
-		setDomainFlow( true );
+		setSiteWasCreatedForDomainPurchase( true );
 	};
 
 	useEffect( () => {
@@ -155,7 +162,7 @@ const Header: FunctionComponent = () => {
 
 	useEffect( () => {
 		if ( newSite ) {
-			if ( isDomainFlow ) {
+			if ( siteWasCreatedForDomainPurchase ) {
 				// I'd rather not make my own product, but this works.
 				// lib/cart-items helpers did not perform well.
 				const domainProduct = {
@@ -186,7 +193,7 @@ const Header: FunctionComponent = () => {
 			resetOnboardStore();
 			window.location.replace( `/block-editor/page/${ newSite.site_slug }/home?is-gutenboarding` );
 		}
-	}, [ domain, isDomainFlow, newSite, resetOnboardStore ] );
+	}, [ domain, siteWasCreatedForDomainPurchase, newSite, resetOnboardStore ] );
 
 	return (
 		<div

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -47,6 +47,13 @@ export const resetOnboardStore = () => ( {
 	type: 'RESET_ONBOARD_STORE' as const,
 } );
 
+export const setSiteWasCreatedForDomainPurchase = (
+	siteWasCreatedForDomainPurchase: boolean
+) => ( {
+	type: 'SET_SITE_WAS_CREATED_FOR_DOMAIN_PURCHASE' as const,
+	siteWasCreatedForDomainPurchase,
+} );
+
 export function* createSite(
 	username: string,
 	freeDomainSuggestion?: DomainSuggestion,
@@ -86,4 +93,5 @@ export type OnboardAction = ReturnType<
 	| typeof setSiteTitle
 	| typeof togglePageLayout
 	| typeof resetOnboardStore
+	| typeof setSiteWasCreatedForDomainPurchase
 >;

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -23,7 +23,14 @@ registerStore< State >( STORE_KEY, {
 	controls,
 	reducer: reducer as any,
 	selectors,
-	persist: [ 'domain', 'siteTitle', 'siteVertical', 'pageLayouts', 'selectedDesign' ],
+	persist: [
+		'domain',
+		'siteTitle',
+		'siteVertical',
+		'pageLayouts',
+		'selectedDesign',
+		'siteWasCreatedForDomainPurchase',
+	],
 } );
 
 declare module '@wordpress/data' {

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -67,12 +67,24 @@ const pageLayouts: Reducer< string[], OnboardAction > = ( state = [], action ) =
 	return state;
 };
 
+const siteWasCreatedForDomainPurchase: Reducer< boolean, OnboardAction > = (
+	state = false,
+	action
+) => {
+	if ( action.type === 'SET_SITE_WAS_CREATED_FOR_DOMAIN_PURCHASE' ) {
+		return action.siteWasCreatedForDomainPurchase;
+	}
+
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
 	selectedDesign,
 	siteTitle,
 	siteVertical,
 	pageLayouts,
+	siteWasCreatedForDomainPurchase,
 } );
 
 export type State = ReturnType< typeof reducer >;

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -71,11 +71,16 @@ const siteWasCreatedForDomainPurchase: Reducer< boolean, OnboardAction > = (
 	state = false,
 	action
 ) => {
-	if ( action.type === 'SET_SITE_WAS_CREATED_FOR_DOMAIN_PURCHASE' ) {
-		return action.siteWasCreatedForDomainPurchase;
-	}
+	switch ( action.type ) {
+		case 'SET_SITE_WAS_CREATED_FOR_DOMAIN_PURCHASE':
+			return action.siteWasCreatedForDomainPurchase;
 
-	return state;
+		case 'RESET_ONBOARD_STORE':
+			return false;
+
+		default:
+			return state;
+	}
 };
 
 const reducer = combineReducers( {

--- a/packages/data-stores/src/auth/actions.ts
+++ b/packages/data-stores/src/auth/actions.ts
@@ -16,8 +16,13 @@ import {
 	SendLoginEmailErrorResponse,
 } from './types';
 import { STORE_KEY } from './constants';
-import { wpcomRequest, fetchAndParse } from '../wpcom-request-controls';
-import { reloadProxy, remoteLoginUser } from './controls';
+import {
+	wpcomRequest,
+	fetchAndParse,
+	requestAllBlogsAccess,
+	reloadProxy,
+} from '../wpcom-request-controls';
+import { remoteLoginUser } from './controls';
 import { WpcomClientCredentials } from '../shared-types';
 
 export interface ActionsConfig extends WpcomClientCredentials {
@@ -149,6 +154,8 @@ export function createActions( {
 			if ( loginResponse.ok && loginResponse.body.success ) {
 				if ( loadCookiesAfterLogin ) {
 					yield reloadProxy();
+					// Need to rerequest access after the proxy is reloaded
+					yield requestAllBlogsAccess();
 				}
 				yield remoteLoginUser( loginResponse.body.data.token_links );
 				yield receiveWpLogin( loginResponse.body );

--- a/packages/data-stores/src/auth/controls.ts
+++ b/packages/data-stores/src/auth/controls.ts
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { reloadProxy as triggerReloadProxy } from 'wpcom-proxy-request';
-
-/**
  * Creates a promise that will be rejected after a given timeout
  *
  * @param ms amount of milliseconds till reject the promise
@@ -52,11 +47,6 @@ export const remoteLoginUser = ( loginLinks: string[] ) =>
 		loginLinks,
 	} as const );
 
-export const reloadProxy = () =>
-	( {
-		type: 'RELOAD_PROXY',
-	} as const );
-
 export const controls = {
 	REMOTE_LOGIN_USER: ( { loginLinks }: ReturnType< typeof remoteLoginUser > ) =>
 		Promise.all(
@@ -65,7 +55,4 @@ export const controls = {
 				// make sure we continue even when a remote login fails
 				.map( promise => promise.catch( () => undefined ) )
 		),
-	RELOAD_PROXY: () => {
-		triggerReloadProxy();
-	},
 };

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -7,7 +7,7 @@ import {
 	NewUserErrorResponse,
 	NewUserSuccessResponse,
 } from './types';
-import { wpcomRequest } from '../wpcom-request-controls';
+import { wpcomRequest, requestAllBlogsAccess, reloadProxy } from '../wpcom-request-controls';
 import { WpcomClientCredentials } from '../shared-types';
 
 export function createActions( clientCreds: WpcomClientCredentials ) {
@@ -58,6 +58,12 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				apiVersion: '1.1',
 				method: 'post',
 			} );
+
+			yield reloadProxy();
+
+			// Need to rerequest access after the proxy is reloaded
+			yield requestAllBlogsAccess();
+
 			return receiveNewUser( newUser );
 		} catch ( err ) {
 			yield receiveNewUserFailed( err );

--- a/packages/data-stores/src/user/test/actions.ts
+++ b/packages/data-stores/src/user/test/actions.ts
@@ -58,7 +58,10 @@ describe( 'createAccount', () => {
 			} ),
 		} );
 
-		const finalResult = generator.next( apiResponse );
+		expect( generator.next( apiResponse ).value ).toEqual( { type: 'RELOAD_PROXY' } );
+		expect( generator.next().value ).toEqual( { type: 'REQUEST_ALL_BLOGS_ACCESS' } );
+
+		const finalResult = generator.next();
 
 		expect( finalResult.value ).toEqual( {
 			type: 'RECEIVE_NEW_USER',

--- a/packages/data-stores/src/wpcom-request-controls/index.ts
+++ b/packages/data-stores/src/wpcom-request-controls/index.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import wpcomProxyRequest from 'wpcom-proxy-request';
+import wpcomProxyRequest, {
+	reloadProxy as triggerReloadProxy,
+	requestAllBlogsAccess as triggerRequestAllBlogsAccess,
+} from 'wpcom-proxy-request';
 
 type WpcomProxyRequestOptions = Parameters< typeof wpcomProxyRequest >[ 0 ];
 
@@ -26,6 +29,16 @@ export const fetchAndParse = (
 		options,
 	} as const );
 
+export const reloadProxy = () =>
+	( {
+		type: 'RELOAD_PROXY',
+	} as const );
+
+export const requestAllBlogsAccess = () =>
+	( {
+		type: 'REQUEST_ALL_BLOGS_ACCESS',
+	} as const );
+
 export const controls = {
 	WPCOM_REQUEST: ( { request }: ReturnType< typeof wpcomRequest > ) => wpcomProxyRequest( request ),
 	FETCH_AND_PARSE: async ( { resource, options }: ReturnType< typeof fetchAndParse > ) => {
@@ -36,4 +49,8 @@ export const controls = {
 			body: await response.json(),
 		};
 	},
+	RELOAD_PROXY: () => {
+		triggerReloadProxy();
+	},
+	REQUEST_ALL_BLOGS_ACCESS: () => triggerRequestAllBlogsAccess(),
 } as const;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The domain flow (creating a site by choosing a premium domain from the domain picker) is broken. The site gets created the subsequent calls to the shopping cart API fail.

Changes:

* Reload proxy after signing up with a new account
  We had been getting away using the bearer token returned in the signup response to make API calls, however the calls to the shopping cart API in the domain flow are using cookie authentication, and reloading the proxy gets the required cookies
* Re-request access to all blogs after reloading the proxy
  The token given to the proxy isn't "global", it doesn't have access to all the users sites. This was blocking the domain flow from getting info about the shopping cart for the newly created site
* Move `isDomainFlow` state to store to persist in local storage
  If the user uses frankenflow login during the domain flow then we need to store the fact that the user should be taken to the checkout after log in.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test different flows through gutenboarding
  * Use auto-assigned domain and go through the flow till landing in the block editor
  * Choose a custom domain and go through the flow till landing in the checkout
* Test different authentication methods
  * Sign up for a new account
  * Log in with gutenboarding login controls (the "experimental" link in the signup modal)
  * Log in using frankenflow login (the "non-experimental" link in the signup modal)

