### PR TITLE
E2E: Add back "can update homepage" step to signup tests

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -419,6 +419,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async closeEditor() {
+		if ( driverManager.currentScreenSize() === 'mobile' ) {
+			return await this.driver.navigate().back();
+		}
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css(

--- a/test/e2e/lib/pages/checklist-page.js
+++ b/test/e2e/lib/pages/checklist-page.js
@@ -15,7 +15,10 @@ export default class ChecklistPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
 		super( driver, By.css( '.customer-home__layout .checklist' ), url );
 		this.headerSelector = By.css( '.customer-home__layout .checklist-site-setup__heading' );
-		this.updateHomeSelector = By.css(
+		this.updateHomepageTaskSelector = By.css(
+			'.customer-home__layout .checklist__task:nth-child(2) button.checklist__task-title-button'
+		);
+		this.updateHomepageButtonSelector = By.css(
 			'.customer-home__layout button[data-e2e-action="update-homepage"]'
 		);
 	}
@@ -36,6 +39,7 @@ export default class ChecklistPage extends AsyncBaseContainer {
 	}
 
 	async updateHomepage() {
-		await driverHelper.clickWhenClickable( this.driver, this.updateHomeSelector );
+		await driverHelper.clickWhenClickable( this.driver, this.updateHomepageTaskSelector );
+		return await driverHelper.clickWhenClickable( this.driver, this.updateHomepageButtonSelector );
 	}
 }

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -280,10 +280,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			} );
 
 			step( 'Can see the Jetpack blocks', async function() {
-				// Jetpack blocks are broken in IE11. See https://github.com/Automattic/jetpack/issues/14273
-				if ( dataHelper.getTargetType() === 'IE11' ) {
-					return this.skip();
-				}
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.openBlockInserterAndSearch( 'Jetpack' );
 				assert.strictEqual(

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -55,6 +55,7 @@ import SignUpStep from '../lib/flows/sign-up-step';
 import * as sharedSteps from '../lib/shared-steps/wp-signup-spec';
 import AccountSettingsPage from '../lib/pages/account/account-settings-page';
 import ChecklistPage from '../lib/pages/checklist-page';
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -461,6 +462,28 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		sharedSteps.canSeeTheOnboardingChecklist();
+
+		step( 'Can update the homepage', async function() {
+			const checklistPage = await ChecklistPage.Expect( this.driver );
+			await checklistPage.updateHomepage();
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.initEditor();
+
+			const errorShown = await gEditorComponent.errorDisplayed();
+			assert.strictEqual(
+				errorShown,
+				false,
+				'There is a block editor error when editing the homepage'
+			);
+
+			const hasInvalidBlocks = await gEditorComponent.hasInvalidBlocks();
+			assert.strictEqual(
+				hasInvalidBlocks,
+				false,
+				'There are invalid blocks when editing the homepage'
+			);
+			return await gEditorComponent.closeEditor();
+		} );
 
 		step( 'Can delete the plan', async function() {
 			return await new DeletePlanFlow( driver ).deletePlan( 'premium' );
@@ -1070,6 +1093,28 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		);
 
 		sharedSteps.canSeeTheOnboardingChecklist();
+
+		step( 'Can update the homepage', async function() {
+			const checklistPage = await ChecklistPage.Expect( this.driver );
+			await checklistPage.updateHomepage();
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await gEditorComponent.initEditor();
+
+			const errorShown = await gEditorComponent.errorDisplayed();
+			assert.strictEqual(
+				errorShown,
+				false,
+				'There is a block editor error when editing the homepage'
+			);
+
+			const hasInvalidBlocks = await gEditorComponent.hasInvalidBlocks();
+			assert.strictEqual(
+				hasInvalidBlocks,
+				false,
+				'There are invalid blocks when editing the homepage'
+			);
+			return await gEditorComponent.closeEditor();
+		} );
 
 		after( 'Can delete our newly created account', async function() {
 			return await new DeleteAccountFlow( driver ).deleteAccount( blogName );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Brings back the "can update homepage" step to the signup E2E tests (removed in #40391) with a few amendments:
- D40692-code added a new task to the top of the checklist, so the "Update your homepage" task is no longer open by default. The signup tests open now that task before trying to update the homepage from "My Home".
- Block editor is closed after performing the checks to ensure that next steps ("can delete the plan"/"can delete our newly created account") don't fail because the masterbar is not present. This needed to initialize the editor in order to dismiss the welcome guide modal and make the close button clickable. Note that the close button is not displayed on mobile, so on such devices we just navigate back.
- Invalid blocks are checked in IE11 now that Jetpack blocks are working again (https://github.com/Automattic/jetpack/issues/14273).

#### Testing instructions

Make sure E2E build passes.

Fixes https://github.com/Automattic/wp-calypso/issues/40291
