### PR TITLE
SPT: fix IE issue when creating fragment

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-iframe-preview.js
@@ -43,8 +43,8 @@ const copyStylesToIframe = ( srcDocument, targetiFrameDocument ) => {
 
 	// See https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment
 	const targetDOMFragment = {
-		head: new DocumentFragment(), // eslint-disable-line no-undef
-		body: new DocumentFragment(), // eslint-disable-line no-undef
+		head: document.createDocumentFragment(), // eslint-disable-line no-undef
+		body: document.createDocumentFragment(), // eslint-disable-line no-undef
 	};
 
 	each( Object.keys( targetDOMFragment ), domReference => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
It fixes an IE issue when it creates the body and head elements of the iFrame content page. Issue: https://github.com/Automattic/wp-calypso/issues/40433. Props to @sgomes!!!

#### Testing instructions

Test the templates selector using IE11 and confirm that it fixes the bug.

Fixes https://github.com/Automattic/wp-calypso/issues/40433
