### PR TITLE
Remove unnecessary underline on guided tour links that are buttons.

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -17,6 +17,15 @@
 
 	a {
 		color: var( --color-text-inverted );
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
+	}
+
+	a.button {
+		text-decoration: none;
 	}
 
 	p {

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -17,11 +17,6 @@
 
 	a {
 		color: var( --color-text-inverted );
-		text-decoration: underline;
-
-		&:hover {
-			text-decoration: none;
-		}
 	}
 
 	p {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes underline from button links in guided tours to match other primary button styles.
* Found this as I was working on #40437, and discovered (of course) that it's not as simple as it looked at first. :)
* We have [a lot of guided tours](https://github.com/Automattic/wp-calypso/blob/f2c9d99b07e14ea938829e9b2e5b31b6fb388a90/client/layout/guided-tours/all-tours.js), and it's not always clear where they're triggered, or which ones are still in use (a bunch of those checklist ones can probably be stripped out). I tried as many as I could find.
* I don't think this change will have a negative effect on most existing tours that are still in use, but please speak up if you know of a case where it does.

**Before**

<img width="439" alt="Screen Shot 2020-03-25 at 10 32 35 AM" src="https://user-images.githubusercontent.com/2124984/77549599-6ce76b00-6e86-11ea-8fdb-a6aa81b94caf.png">

**After**

<img width="444" alt="Screen Shot 2020-03-25 at 10 02 29 AM" src="https://user-images.githubusercontent.com/2124984/77549655-7b358700-6e86-11ea-9f8a-d75d4166e254.png">

#### Testing instructions

* Switch to this PR
* Test tours from the list here: https://github.com/Automattic/wp-calypso/blob/f2c9d99b07e14ea938829e9b2e5b31b6fb388a90/client/layout/guided-tours/all-tours.js by adding `/?tour=tourid` from the indexes in that list to the appropriate screen in Calypso
* Make sure there are no visual issues introduced as a result of this change.
