### PR TITLE
G Suite: Fix the checkout display by integrating the number of licenses into the original product cost for comparison against the discount

### DIFF
--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -68,9 +68,10 @@ export class CartItem extends React.Component {
 
 		if ( isGSuiteProductSlug( cartItem.product_slug ) ) {
 			const {
-				cost_before_coupon: costBeforeCoupon,
+				cost_before_coupon: costPerProductBeforeCoupon,
 				is_sale_coupon_applied: isSaleCouponApplied,
 			} = cartItem;
+			const costBeforeCoupon = costPerProductBeforeCoupon * cartItem.volume;
 
 			if ( isSaleCouponApplied ) {
 				const { is_coupon_applied: isCouponApplied } = cart;


### PR DESCRIPTION
### Summary

The original cost displayed in the checkout (i.e. cost before the coupon is applied) is juxtaposed against the actual cost (i.e. cost after the discount is applied, and volume of licences) to highlight the discount.

The volume is not integrated into the original cost, making the checkout display confusing to customers when the number of licences exceed one.

<img width="293" alt="Screenshot 2020-03-25 at 2 13 09 PM" src="https://user-images.githubusercontent.com/277661/77557907-97531b80-6eba-11ea-9294-8d7bfc2d8949.png">


#### Changes proposed in this Pull Request

* The volume of licences is multiplied by the cost before the coupon is applied, to produce a figure that is appropriately comparable to the actual total cost.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Before*

* Add a G Suite product into the cart with multiple licenses
* Observe that the original cost isn't a multiple of the number of licences

*After*

* Checkout this branch i.e. [`fix/gsuite-wrong-display-of-discount-in-checkout-for-multiple-licenses`](fix/gsuite-wrong-display-of-discount-in-checkout-for-multiple-licenses)
* Confirm that the original cost is now a multiple of the number of licences



