### PR TITLE
Gutenberg E2E: enable section of tests in IE11 canary again

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -244,8 +244,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	// @TODO: add `@ie11canary` back here once FSE plugin works with IE11 again.
-	describe( 'Basic Public Post @canary @parallel', function() {
+	describe( 'Basic Public Post @canary @ie11canary @parallel', function() {
 		describe( 'Publish a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =


### PR DESCRIPTION
These were disabled as part of https://github.com/Automattic/wp-calypso/pull/40239 since FSE plugin running on wpcom (0.25.0) wasn't IE11 compatible. Fix in 0.26.0 was deployed in D40826-code so we can enable these again.

#### Changes proposed in this Pull Request

* Enable section of Gutenberg tests in IE11 canary again

#### Testing instructions

- See CI turn green
<img width="572" alt="image" src="https://user-images.githubusercontent.com/87168/77579137-7c949d00-6ee2-11ea-910c-26beb7735546.png">
