### PR TITLE
composite-checkout: Display both title and domain for domain products

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -142,7 +142,9 @@ function LineItemTitle( { item, id } ) {
 	return (
 		<LineItemTitleUI>
 			{ isLineItemADomain( item ) && item.sublabel ? (
-				<ProductTitleUI id={ id }>{ item.sublabel }</ProductTitleUI>
+				<ProductTitleUI id={ id }>
+					{ item.label }: { item.sublabel }
+				</ProductTitleUI>
 			) : (
 				<ProductTitleUI id={ id }>{ item.label }</ProductTitleUI>
 			) }

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -141,7 +141,7 @@ function LineItemTitle( { item, id } ) {
 	if ( isLineItemADomain( item ) ) {
 		return <LineItemDomainTitle item={ item } id={ id } />;
 	}
-	if ( item.type === 'domain_map' ) {
+	if ( item.type === 'domain_map' || item.type === 'offsite_redirect' ) {
 		return <LineItemDomainTitle item={ item } id={ id } />;
 	}
 	return (

--- a/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-order-review-line-items.js
@@ -138,17 +138,27 @@ WPLineItem.propTypes = {
 };
 
 function LineItemTitle( { item, id } ) {
+	if ( isLineItemADomain( item ) ) {
+		return <LineItemDomainTitle item={ item } id={ id } />;
+	}
+	if ( item.type === 'domain_map' ) {
+		return <LineItemDomainTitle item={ item } id={ id } />;
+	}
+	return (
+		<LineItemTitleUI>
+			<ProductTitleUI id={ id }>{ item.label }</ProductTitleUI>
+		</LineItemTitleUI>
+	);
+}
+
+function LineItemDomainTitle( { item, id } ) {
 	const translate = useTranslate();
 	return (
 		<LineItemTitleUI>
-			{ isLineItemADomain( item ) && item.sublabel ? (
-				<ProductTitleUI id={ id }>
-					{ item.label }: { item.sublabel }
-				</ProductTitleUI>
-			) : (
-				<ProductTitleUI id={ id }>{ item.label }</ProductTitleUI>
-			) }
-			{ isLineItemADomain( item ) && item.wpcom_meta?.is_bundled && item.amount.value === 0 && (
+			<ProductTitleUI id={ id }>
+				{ item.label }: { item.sublabel }
+			</ProductTitleUI>
+			{ item.wpcom_meta?.is_bundled && item.amount.value === 0 && (
 				<BundledDomainFreeUI>{ translate( 'First year free with your plan' ) }</BundledDomainFreeUI>
 			) }
 		</LineItemTitleUI>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This modifies domain products (registrations, transfers, mapping, and redirects) so that instead of just displaying the product name or just the domain name, we display both.

#### Screenshots

**Before**

![Screen Shot 2020-03-25 at 1 51 16 PM](https://user-images.githubusercontent.com/2036909/77569199-33bbf480-6ea0-11ea-8bd2-7081a79e1498.png)

**After**

![Screen Shot 2020-03-25 at 1 52 03 PM](https://user-images.githubusercontent.com/2036909/77569206-374f7b80-6ea0-11ea-9c69-44bdca2592f0.png)


#### Testing instructions

- Try adding a domain registration, a domain transfer, a domain mapping, and a site redirect to your cart (or test each one individually).
- Visit composite checkout.
- Click through to the review step (step 3).
- Verify that you see both the product name and the domain name.