### PR TITLE
Unify calypso_user_registration_complete event

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -11,9 +11,8 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { getSavedVariations } from 'lib/abtest';
-import analytics from 'lib/analytics';
 import wpcom from 'lib/wp';
-import { recordPasswordlessRegistration } from 'lib/analytics/signup';
+import { recordRegistration } from 'lib/analytics/signup';
 import { recordGoogleRecaptchaAction } from 'lib/analytics/recaptcha';
 import { Button } from '@automattic/components';
 import FormLabel from 'components/forms/form-label';
@@ -141,8 +140,17 @@ class PasswordlessSignupForm extends Component {
 		const userId =
 			( response && response.signup_sandbox_user_id ) || ( response && response.user_id );
 
-		recordPasswordlessRegistration( this.props.flowName );
-		analytics.identifyUser( { ID: userId, username, email: this.state.email } );
+		const userData = {
+			ID: userId,
+			username: username,
+			email: this.state.email,
+		};
+
+		recordRegistration( {
+			userData,
+			flow: this.props.flowName,
+			type: 'passwordless',
+		} );
 
 		this.submitStep( {
 			username,

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -74,6 +74,17 @@ export function recordSignupInvalidStep( flow, step ) {
 	analytics.tracks.recordEvent( 'calypso_signup_goto_invalid_step', { flow, step } );
 }
 
+/**
+ * Records registration event.
+ *
+ * @param {object} param {}
+ * @param {object} param.userData User data
+ * @param {string} param.userData.ID User id
+ * @param {string} param.userData.username Username
+ * @param {string} param.userData.email Email
+ * @param {string} param.flow Registration flow
+ * @param {string} param.type Registration type
+ */
 export function recordRegistration( { userData, flow, type } ) {
 	signupDebug( 'recordRegistration:', { userData, flow, type } );
 

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import debug from 'debug';
+
+/**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
@@ -8,6 +13,8 @@ import {
 	adTrackSignupComplete,
 	adTrackRegistration,
 } from 'lib/analytics/ad-tracking';
+
+const signupDebug = debug( 'calypso:analytics:signup' );
 
 export function recordSignupStart( flow, ref ) {
 	// Tracks
@@ -67,29 +74,15 @@ export function recordSignupInvalidStep( flow, step ) {
 	analytics.tracks.recordEvent( 'calypso_signup_goto_invalid_step', { flow, step } );
 }
 
-export function recordRegistration( flow ) {
+export function recordRegistration( { userData, flow, type } ) {
+	signupDebug( 'recordRegistration:', { userData, flow, type } );
+
+	// Tracks user identification
+	analytics.identifyUser( userData );
 	// Tracks
-	analytics.tracks.recordEvent( 'calypso_user_registration_complete', { flow } );
+	analytics.tracks.recordEvent( 'calypso_user_registration_complete', { flow, type } );
 	// Google Analytics
 	gaRecordEvent( 'Signup', 'calypso_user_registration_complete' );
-	// Marketing
-	adTrackRegistration();
-}
-
-export function recordPasswordlessRegistration( flow ) {
-	// Tracks
-	analytics.tracks.recordEvent( 'calypso_user_registration_passwordless_complete', { flow } );
-	// Google Analytics
-	gaRecordEvent( 'Signup', 'calypso_user_registration_passwordless_complete' );
-	// Marketing
-	adTrackRegistration();
-}
-
-export function recordSocialRegistration() {
-	// Tracks
-	analytics.tracks.recordEvent( 'calypso_user_registration_social_complete' );
-	// Google Analytics
-	gaRecordEvent( 'Signup', 'calypso_user_registration_social_complete' );
 	// Marketing
 	adTrackRegistration();
 }

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -414,13 +414,6 @@ export function createAccount(
 					);
 				}
 
-				// TEMP DEBUG:
-				/*
-				 Google: ok
-				 Normal: ...
-				 Apple: ...
-				 Passwordless: ...
-				 */
 				debug( 'Social Signup: response: ', response );
 				debug( 'Social Signup: userData: ', userData );
 


### PR DESCRIPTION
This is a rewrite based on the updated analytics code of https://github.com/Automattic/wp-calypso/pull/37410. I think I have addressed all the issues reported there in this PR.

The one thing I'm not quite sure how to test is the Apple signup.

## Changes proposed in this Pull Request

* Unify `calypso_user_registration_complete`, `calypso_user_registration_passwordless_complete`, `calypso_user_registration_complete` into one single `calypso_user_registration_complete`.
* Adds a `type` prop in `calypso_user_registration_complete` set to `default`, `social`, `passwordless`.
* Calls Tracks `identifyUser()` before calling Tracks and GA `calypso_user_registration_complete` this way making sure it is de-anonymized promptly.
* `identifyUser()` is called from inside `recordRegistration()` making sure it will be called in the future when new signup methods will be added.
* Fixes missing `identifyUser()` for `social` registration.

## Testing instructions

**Test normal registration**
- Open new incognito tab
- Go to: http://calypso.localhost:3000/start/user?flags=gdpr-banner,google-analytics,ad-tracking
- Enable logs: `localStorage.setItem( 'debug', 'calypso:analytics:*,calypso:signup:*' );`
- Reload page
- Register normally using email:
![image](https://user-images.githubusercontent.com/10284338/77571767-cd49cd00-6ec5-11ea-95b8-e86ec2ddd2b3.png)
- The JS logs should show a:
![image](https://user-images.githubusercontent.com/10284338/77572946-c9b74580-6ec7-11ea-82b5-2e0bedfa9740.png)
make sure all the data look correct.
- In the dev tools Network tab filter by `calypso_user_registration_complete`, you should see the Tracks and Google Analytics events:
![image](https://user-images.githubusercontent.com/10284338/77573456-a04ae980-6ec8-11ea-9534-89892ee68f9a.png)
and
![image](https://user-images.githubusercontent.com/10284338/77573573-c7a1b680-6ec8-11ea-8776-aaf4621c33f7.png)

**Test passwordless registration**
- Open new incognito tab
- Go to: http://calypso.localhost:3000/start/user?flags=gdpr-banner,google-analytics,ad-tracking
- Enable passwordless A/B test: in the A/B test settings select `passwordlessSignup -> passwordless` variation.
- Enable logs: `localStorage.setItem( 'debug', 'calypso:analytics:*,calypso:signup:*' );`
- Reload page
- Signup using just your email:
![image](https://user-images.githubusercontent.com/10284338/77573893-4565c200-6ec9-11ea-9588-e8d1e9e8d866.png)
- Your JS log should include something like:
![image](https://user-images.githubusercontent.com/10284338/77574032-6e865280-6ec9-11ea-9060-f3eeb5cb5876.png)
Make sure the above parameters look ok, particular `type=passwordless` and `userData` includes all the expected data.
- Make sure Tracks and GA event fire as expected:
![image](https://user-images.githubusercontent.com/10284338/77574320-bc02bf80-6ec9-11ea-839a-d5573ceba426.png)
and
![image](https://user-images.githubusercontent.com/10284338/77574413-db015180-6ec9-11ea-88c8-3d3dd50d406c.png)

**Test Google registration**

- Open new incognito tab
- Go to: http://calypso.localhost:3000/start/user?flags=gdpr-banner,google-analytics,ad-tracking
- Enable logs: `localStorage.setItem( 'debug', 'calypso:analytics:*,calypso:signup:*' );`
- Reload page
- Signup using "Continue with Google"
- Make sure all the params passed to `recordRegistration()` look good:
![image](https://user-images.githubusercontent.com/10284338/77574782-74c8fe80-6eca-11ea-9c56-eeecbdd73b41.png)
in particular `type=social`.
- Make sure Tracks and Google Analytics events fire as expected:
![image](https://user-images.githubusercontent.com/10284338/77574944-acd04180-6eca-11ea-95fa-55576426b607.png)

**Test Apple registration**

- Open new incognito tab
- Go to: http://calypso.localhost:3000/start/user?flags=gdpr-banner,google-analytics,ad-tracking
- Enable logs: `localStorage.setItem( 'debug', 'calypso:analytics:*,calypso:signup:*' );`
- Reload page
- Signup using "Continue with Apple"

---

At this point you will get a:
![image](https://user-images.githubusercontent.com/10284338/77575318-4697ee80-6ecb-11ea-9a0a-3a00301801ab.png)

because the redirect url (https://appleid.apple.com/auth/authorize?client_id=com.wordpress.siwa&redirect_uri=https%3A%2F%2Fcalypso.localhost%3A3000%2Fstart%2Fuser&response_type=code%20id_token&state=9672001117&scope=name%20email&response_mode=form_post&frame_id=efbb2ae0-686c-4f5c-8d27-07816a862e08&m=11&v=1.4.2)
has the `redirect_uri` pointing to your local calypso rather than to wordpress.com.

You can test by doctoring the URL and replacing the redirect uri with the wordpress.com one and then inspecting the payload of the response and replaying it on your calypso instance.