### PR TITLE
New Checkout: add missing fields to contact information summary

### DIFF
--- a/packages/composite-checkout-wpcom/src/components/summary-details.js
+++ b/packages/composite-checkout-wpcom/src/components/summary-details.js
@@ -17,7 +17,3 @@ export const SummaryLine = styled.li`
 	padding: 0;
 	list-style: none;
 `;
-
-export const SummarySpacerLine = styled( SummaryLine )`
-	margin-bottom: 8px;
-`;

--- a/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
+++ b/packages/composite-checkout-wpcom/src/components/wp-contact-form.js
@@ -17,7 +17,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { useHasDomainsInCart } from '../hooks/has-domains';
 import Field from './field';
-import { SummaryLine, SummaryDetails, SummarySpacerLine } from './summary-details';
+import { SummaryLine, SummaryDetails } from './summary-details';
 import { LeftColumn, RightColumn } from './ie-fallback';
 import { prepareDomainContactDetails, prepareDomainContactDetailsErrors, isValid } from '../types';
 
@@ -209,12 +209,30 @@ function ContactFormSummary( { isDomainFieldsVisible } ) {
 				<SummaryDetails>
 					{ showDomainContactSummary && fullName && <SummaryLine>{ fullName }</SummaryLine> }
 
-					{ showDomainContactSummary && contactInfo.email.value?.length > 0 && (
-						<SummarySpacerLine>{ contactInfo.email.value }</SummarySpacerLine>
+					{ showDomainContactSummary && contactInfo.organization.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.organization.value } </SummaryLine>
 					) }
 
+					{ showDomainContactSummary && contactInfo.email.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.email.value }</SummaryLine>
+					) }
+
+					{ showDomainContactSummary && contactInfo.alternateEmail.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.alternateEmail.value }</SummaryLine>
+					) }
+
+					{ showDomainContactSummary && contactInfo.phone.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.phone.value }</SummaryLine>
+					) }
+				</SummaryDetails>
+
+				<SummaryDetails>
 					{ showDomainContactSummary && contactInfo.address1.value?.length > 0 && (
 						<SummaryLine>{ contactInfo.address1.value } </SummaryLine>
+					) }
+
+					{ showDomainContactSummary && contactInfo.address2.value?.length > 0 && (
+						<SummaryLine>{ contactInfo.address2.value } </SummaryLine>
 					) }
 
 					{ showDomainContactSummary && cityAndState && (


### PR DESCRIPTION
This adds the optional contact form fields for domains (organization, address2, alternate email) and phone number to the contact details summary.

Fixes #40448 

Before | After
------------ | -------------
<img width="570" alt="Screen Shot 2020-03-25 at 5 09 45 PM" src="https://user-images.githubusercontent.com/942359/77585871-9bcc0400-6ebb-11ea-80cf-dadd37558551.png"> | <img width="572" alt="Screen Shot 2020-03-25 at 3 38 50 PM" src="https://user-images.githubusercontent.com/942359/77579016-f0698200-6eaf-11ea-83c7-504b56e27825.png">

**To test:**
- add a domain to your cart
- visit Checkout (with `?flags=composite-checkout-testing`)
- under "Contact information" fill out all of the fields
- submit the step
- verify that all submitted fields are displayed in the step summary