### PR TITLE
Adds query param to force a remote installation

### DIFF
--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -3,7 +3,8 @@ export const JPC_PATH_PLANS = '/jetpack/connect/plans';
 export const JPC_PATH_REMOTE_INSTALL = '/jetpack/connect/install';
 export const MINIMUM_JETPACK_VERSION = '3.9.6';
 export const REMOTE_PATH_ACTIVATE = '/wp-admin/plugins.php';
-export const REMOTE_PATH_AUTH = '/wp-admin/admin.php?page=jetpack&connect_url_redirect=true';
+export const REMOTE_PATH_AUTH =
+	'/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&connect_login_redirect=true';
 export const REMOTE_PATH_INSTALL =
 	'/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 export const MOBILE_APP_REDIRECT_URL_WHITELIST = [ /^wordpress:\/\// ];

--- a/client/jetpack-connect/constants.js
+++ b/client/jetpack-connect/constants.js
@@ -4,7 +4,7 @@ export const JPC_PATH_REMOTE_INSTALL = '/jetpack/connect/install';
 export const MINIMUM_JETPACK_VERSION = '3.9.6';
 export const REMOTE_PATH_ACTIVATE = '/wp-admin/plugins.php';
 export const REMOTE_PATH_AUTH =
-	'/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&connect_login_redirect=true';
+	'/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&jetpack_connect_login_redirect=true';
 export const REMOTE_PATH_INSTALL =
 	'/wp-admin/plugin-install.php?tab=plugin-information&plugin=jetpack';
 export const MOBILE_APP_REDIRECT_URL_WHITELIST = [ /^wordpress:\/\// ];

--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -143,6 +143,7 @@ export function connect( context, next ) {
 			path={ path }
 			type={ type }
 			url={ query.url }
+			forceRemoteInstall={ query.forceInstall }
 		/>
 	);
 	next();

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -104,11 +104,12 @@ export class JetpackConnectMain extends Component {
 	}
 
 	componentDidUpdate() {
-		const { isMobileAppFlow, skipRemoteInstall } = this.props;
+		const { isMobileAppFlow, skipRemoteInstall, forceRemoteInstall } = this.props;
 
 		if (
 			this.getStatus() === NOT_CONNECTED_JETPACK &&
 			this.isCurrentUrlFetched() &&
+			! forceRemoteInstall &&
 			! this.state.redirecting
 		) {
 			return this.goToRemoteAuth( this.props.siteHomeUrl );
@@ -126,7 +127,10 @@ export class JetpackConnectMain extends Component {
 			this.checkUrl( this.state.currentUrl );
 		}
 
-		if ( includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], this.getStatus() ) ) {
+		if (
+			includes( [ NOT_JETPACK, NOT_ACTIVE_JETPACK ], this.getStatus() ) ||
+			( this.getStatus() === NOT_CONNECTED_JETPACK && forceRemoteInstall )
+		) {
 			if (
 				config.isEnabled( 'jetpack/connect/remote-install' ) &&
 				! isMobileAppFlow &&

--- a/client/jetpack-connect/test/__snapshots__/main.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/main.js.snap
@@ -22,6 +22,6 @@ Array [
 
 exports[`JetpackConnectMain goToRemoteAuth should fire redirect 1`] = `
 Array [
-  "example.com/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&calypso_env=test",
+  "example.com/wp-admin/admin.php?page=jetpack&connect_url_redirect=true&jetpack_connect_login_redirect=true&calypso_env=test",
 ]
 `;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a query param to force a remote installation of Jetpack when it is not connected.

Linked to https://github.com/Automattic/jetpack/pull/15124.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a Jetpack site that is not connected.
* Navigate to `/jetpack/connect?url=[sitename]&forceInstall=1`

Observe Calypso query site and jump to remote install screen.

Fixes 1164141197617539-as-1164522491999689.