### PR TITLE
My Home: Refactor Launch Site card.

### DIFF
--- a/client/my-sites/customer-home/cards/features/launch-site/index.jsx
+++ b/client/my-sites/customer-home/cards/features/launch-site/index.jsx
@@ -30,7 +30,7 @@ export const LaunchSite = ( { isAtomic, isChecklistComplete, launchSite, siteId 
 	return (
 		<Card className="launch-site">
 			<CardHeading>{ translate( 'Site Privacy' ) }</CardHeading>
-			<h6 className="launch-site__card-subheader">{ translate( 'Your site is private' ) }</h6>
+			<h6 className="customer-home__card-subheader launch-site__card-subheader">{ translate( 'Your site is private' ) }</h6>
 			<p>
 				{ translate(
 					'Only you and those you invite can view your site. Launch your site to make it visible to the public.'

--- a/client/my-sites/customer-home/cards/features/launch-site/index.jsx
+++ b/client/my-sites/customer-home/cards/features/launch-site/index.jsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Card, Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import CardHeading from 'components/card-heading';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
+import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export const LaunchSite = ( { isAtomic, isChecklistComplete, launchSite, siteId } ) => {
+	const translate = useTranslate();
+	const isPrimary = ! isAtomic && isChecklistComplete;
+	const onLaunchBannerClick = e => {
+		e.preventDefault();
+		launchSite( siteId );
+	};
+
+	return (
+		<Card className="launch-site">
+			<CardHeading>{ translate( 'Site Privacy' ) }</CardHeading>
+			<h6 className="launch-site__card-subheader">{ translate( 'Your site is private' ) }</h6>
+			<p>
+				{ translate(
+					'Only you and those you invite can view your site. Launch your site to make it visible to the public.'
+				) }
+			</p>
+			<Button primary={ isPrimary } onClick={ onLaunchBannerClick }>
+				{ translate( 'Launch my site' ) }
+			</Button>
+		</Card>
+	);
+};
+
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const isAtomic = isAtomicSite( state, siteId );
+		const isChecklistComplete = isSiteChecklistComplete( state, siteId );
+		return {
+			isAtomic,
+			isChecklistComplete,
+			siteId,
+		};
+	},
+	dispatch => ( {
+		launchSite: siteId => dispatch( launchSiteOrRedirectToLaunchSignupFlow( siteId ) ),
+	} )
+)( LaunchSite );

--- a/client/my-sites/customer-home/cards/features/launch-site/index.jsx
+++ b/client/my-sites/customer-home/cards/features/launch-site/index.jsx
@@ -20,9 +20,8 @@ import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actio
  */
 import './style.scss';
 
-export const LaunchSite = ( { isAtomic, isChecklistComplete, launchSite, siteId } ) => {
+export const LaunchSite = ( { isPrimary, launchSite, siteId } ) => {
 	const translate = useTranslate();
-	const isPrimary = ! isAtomic && isChecklistComplete;
 	const onLaunchBannerClick = () => {
 		launchSite( siteId );
 	};
@@ -48,9 +47,9 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const isAtomic = isAtomicSite( state, siteId );
 		const isChecklistComplete = isSiteChecklistComplete( state, siteId );
+		const isPrimary = ! isAtomic && isChecklistComplete;
 		return {
-			isAtomic,
-			isChecklistComplete,
+			isPrimary,
 			siteId,
 		};
 	},

--- a/client/my-sites/customer-home/cards/features/launch-site/index.jsx
+++ b/client/my-sites/customer-home/cards/features/launch-site/index.jsx
@@ -14,28 +14,28 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export const LaunchSite = ( { isPrimary, launchSite, siteId } ) => {
+export const LaunchSite = ( { isPrimary, launchSiteAndTrack, siteId } ) => {
 	const translate = useTranslate();
-	const onLaunchBannerClick = () => {
-		launchSite( siteId );
-	};
 
 	return (
 		<Card className="launch-site">
 			<CardHeading>{ translate( 'Site Privacy' ) }</CardHeading>
-			<h6 className="customer-home__card-subheader launch-site__card-subheader">{ translate( 'Your site is private' ) }</h6>
+			<h6 className="customer-home__card-subheader launch-site__card-subheader">
+				{ translate( 'Your site is private' ) }
+			</h6>
 			<p>
 				{ translate(
 					'Only you and those you invite can view your site. Launch your site to make it visible to the public.'
 				) }
 			</p>
-			<Button primary={ isPrimary } onClick={ onLaunchBannerClick }>
+			<Button primary={ isPrimary } onClick={ () => launchSiteAndTrack( siteId ) }>
 				{ translate( 'Launch my site' ) }
 			</Button>
 		</Card>
@@ -54,6 +54,21 @@ export default connect(
 		};
 	},
 	dispatch => ( {
+		trackAction: () =>
+			dispatch(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_customer_home_launch_my_site_click' ),
+					bumpStat( 'calypso_customer_home', 'launch_my_site' )
+				)
+			),
 		launchSite: siteId => dispatch( launchSiteOrRedirectToLaunchSignupFlow( siteId ) ),
+	} ),
+	( stateProps, dispatchProps, ownProps ) => ( {
+		...ownProps,
+		...stateProps,
+		launchSiteAndTrack: siteId => {
+			dispatchProps.launchSite( siteId );
+			dispatchProps.trackAction();
+		},
 	} )
 )( LaunchSite );

--- a/client/my-sites/customer-home/cards/features/launch-site/index.jsx
+++ b/client/my-sites/customer-home/cards/features/launch-site/index.jsx
@@ -54,10 +54,12 @@ export default connect(
 		};
 	},
 	dispatch => ( {
-		trackAction: () =>
+		trackAction: siteId =>
 			dispatch(
 				composeAnalytics(
-					recordTracksEvent( 'calypso_customer_home_launch_my_site_click' ),
+					recordTracksEvent( 'calypso_customer_home_launch_my_site_click', {
+						site_id: siteId,
+					} ),
 					bumpStat( 'calypso_customer_home', 'launch_my_site' )
 				)
 			),
@@ -68,7 +70,7 @@ export default connect(
 		...stateProps,
 		launchSiteAndTrack: siteId => {
 			dispatchProps.launchSite( siteId );
-			dispatchProps.trackAction();
+			dispatchProps.trackAction( siteId );
 		},
 	} )
 )( LaunchSite );

--- a/client/my-sites/customer-home/cards/features/launch-site/index.jsx
+++ b/client/my-sites/customer-home/cards/features/launch-site/index.jsx
@@ -23,8 +23,7 @@ import './style.scss';
 export const LaunchSite = ( { isAtomic, isChecklistComplete, launchSite, siteId } ) => {
 	const translate = useTranslate();
 	const isPrimary = ! isAtomic && isChecklistComplete;
-	const onLaunchBannerClick = e => {
-		e.preventDefault();
+	const onLaunchBannerClick = () => {
 		launchSite( siteId );
 	};
 

--- a/client/my-sites/customer-home/cards/features/launch-site/style.scss
+++ b/client/my-sites/customer-home/cards/features/launch-site/style.scss
@@ -1,11 +1,5 @@
 .launch-site {
-	&__card-subheader {
-		color: var( --color-text-subtle );
-		font-size: 0.85rem;
-		margin: -0.5rem 0 1rem;
-	}
-
-	& .button {
+	.button {
 		font-size: 18px;
 		width: 100%;
 		height: 50px;

--- a/client/my-sites/customer-home/cards/features/launch-site/style.scss
+++ b/client/my-sites/customer-home/cards/features/launch-site/style.scss
@@ -1,0 +1,13 @@
+.launch-site {
+	&__card-subheader {
+		color: var( --color-text-subtle );
+		font-size: 0.85rem;
+		margin: -0.5rem 0 1rem;
+	}
+
+	& .button {
+		font-size: 18px;
+		width: 100%;
+		height: 50px;
+	}
+}

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -83,24 +83,22 @@ class Home extends Component {
 		const { translate, site, siteIsUnlaunched, trackAction } = this.props;
 
 		return (
-			<>
-				<div className="customer-home__heading">
-					<FormattedHeader
-						headerText={ translate( 'My Home' ) }
-						subHeaderText={ translate(
-							'Your home base for all the posting, editing, and growing of your site'
-						) }
-						align="left"
-					/>
-					{ ! siteIsUnlaunched && (
-						<div className="customer-home__view-site-button">
-							<Button href={ site.URL } onClick={ () => trackAction( 'my_site', 'view_site' ) }>
-								{ translate( 'View site' ) }
-							</Button>
-						</div>
+			<div className="customer-home__heading">
+				<FormattedHeader
+					headerText={ translate( 'My Home' ) }
+					subHeaderText={ translate(
+						'Your home base for all the posting, editing, and growing of your site'
 					) }
-				</div>
-			</>
+					align="left"
+				/>
+				{ ! siteIsUnlaunched && (
+					<div className="customer-home__view-site-button">
+						<Button href={ site.URL } onClick={ () => trackAction( 'my_site', 'view_site' ) }>
+							{ translate( 'View site' ) }
+						</Button>
+					</div>
+				) }
+			</div>
 		);
 	}
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -33,11 +33,13 @@ import { localizeUrl } from 'lib/i18n-utils';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 import StatsBanners from 'my-sites/stats/stats-banners';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import GrowEarn from 'my-sites/customer-home/cards/features/grow-earn';
+import LaunchSite from 'my-sites/customer-home/cards/features/launch-site';
 import Stats from 'my-sites/customer-home/cards/features/stats';
 import FreePhotoLibrary from 'my-sites/customer-home/cards/education/free-photo-library';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
@@ -75,13 +77,6 @@ class Home extends Component {
 		},
 		trackAction: PropTypes.func.isRequired,
 		isStaticHomePage: PropTypes.bool.isRequired,
-	};
-
-	onLaunchBannerClick = e => {
-		const { siteId } = this.props;
-		e.preventDefault();
-
-		this.props.launchSiteOrRedirectToLaunchSignupFlow( siteId );
 	};
 
 	renderCustomerHomeHeader() {
@@ -157,7 +152,6 @@ class Home extends Component {
 
 	renderCustomerHome = () => {
 		const {
-			isAtomic,
 			isChecklistComplete,
 			needsEmailVerification,
 			translate,
@@ -171,8 +165,6 @@ class Home extends Component {
 			return <div className="customer-home__loading-placeholder"></div>;
 		}
 
-		const isPrimary = ! isAtomic && isChecklistComplete;
-
 		return (
 			<div className="customer-home__layout">
 				<div className="customer-home__layout-col customer-home__layout-col-left">
@@ -180,20 +172,7 @@ class Home extends Component {
 				</div>
 				<div className="customer-home__layout-col customer-home__layout-col-right">
 					{ siteIsUnlaunched && ! needsEmailVerification && (
-						<Card className="customer-home__launch-button">
-							<CardHeading>{ translate( 'Site Privacy' ) }</CardHeading>
-							<h6 className="customer-home__card-subheader">
-								{ translate( 'Your site is private' ) }
-							</h6>
-							<p>
-								{ translate(
-									'Only you and those you invite can view your site. Launch your site to make it visible to the public.'
-								) }
-							</p>
-							<Button primary={ isPrimary } onClick={ this.onLaunchBannerClick }>
-								{ translate( 'Launch my site' ) }
-							</Button>
-						</Card>
+						<LaunchSite />
 					) }
 					{ ! siteIsUnlaunched && <Stats /> }
 					{ <FreePhotoLibrary /> }
@@ -236,7 +215,6 @@ const connectHome = connect(
 		const siteId = getSelectedSiteId( state );
 		const siteChecklist = getSiteChecklist( state, siteId );
 		const hasChecklistData = null !== siteChecklist && Array.isArray( siteChecklist.tasks );
-		const isAtomic = isAtomicSite( state, siteId );
 		const isChecklistComplete = isSiteChecklistComplete( state, siteId );
 		const createdAt = getSiteOption( state, siteId, 'created_at' );
 		const user = getCurrentUser( state );
@@ -249,7 +227,6 @@ const connectHome = connect(
 			canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),
 			hasChecklistData,
 			isChecklistComplete,
-			isAtomic,
 			needsEmailVerification: ! isCurrentUserEmailVerified( state ),
 			isStaticHomePage:
 				! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -30,10 +30,7 @@ import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete'
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { localizeUrl } from 'lib/i18n-utils';
-import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 import StatsBanners from 'my-sites/stats/stats-banners';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
@@ -61,7 +58,6 @@ import happinessIllustration from 'assets/images/customer-home/happiness.png';
 class Home extends Component {
 	static propTypes = {
 		checklistMode: PropTypes.string,
-
 		site: PropTypes.object.isRequired,
 		siteId: PropTypes.number.isRequired,
 		siteSlug: PropTypes.string.isRequired,
@@ -169,9 +165,7 @@ class Home extends Component {
 					<Primary checklistMode={ checklistMode } />
 				</div>
 				<div className="customer-home__layout-col customer-home__layout-col-right">
-					{ siteIsUnlaunched && ! needsEmailVerification && (
-						<LaunchSite />
-					) }
+					{ siteIsUnlaunched && ! needsEmailVerification && <LaunchSite /> }
 					{ ! siteIsUnlaunched && <Stats /> }
 					{ <FreePhotoLibrary /> }
 					{ ! siteIsUnlaunched && isChecklistComplete && <GrowEarn /> }
@@ -244,14 +238,10 @@ const connectHome = connect(
 					bumpStat( 'calypso_customer_home', `${ section }_${ action }` )
 				)
 			),
-		launchSiteOrRedirectToLaunchSignupFlow: siteId =>
-			dispatch( launchSiteOrRedirectToLaunchSignupFlow( siteId ) ),
 	} ),
 	( stateProps, dispatchProps, ownProps ) => ( {
 		...stateProps,
 		...ownProps,
-		launchSiteOrRedirectToLaunchSignupFlow: () =>
-			dispatchProps.launchSiteOrRedirectToLaunchSignupFlow( stateProps.siteId ),
 		trackAction: ( section, action ) =>
 			dispatchProps.trackAction( section, action, stateProps.isStaticHomePage ),
 	} )

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -74,13 +74,6 @@
 			}
 		}
 	}
-	&__launch-button {
-		& .button {
-			font-size: 18px;
-			width: 100%;
-			height: 50px;
-		}
-	}
 
 	&__card-col {
 		display: block;


### PR DESCRIPTION
This PR moves the Launch Site card to its own component, in preparation for cards being displayed according to server-side logic. This continues the work in #40368 . No visual or behavioural changes should occur.

<img width="925" alt="Screen Shot 2020-03-25 at 3 09 28 PM" src="https://user-images.githubusercontent.com/349751/77590347-c1044680-6eaa-11ea-9ab4-ff5f0d149c71.png">

**Testing Instructions**

*  Load this branch, and go to `/home/:site` for a site that has not been launched (or just create a new site).
* Verify it visually looks the same in production (load the same route on `wordpress.com`).
* CLick the Launch Site button, and verify it works as expected.