### PR TITLE
Only autofix blocks which have content

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/fix-block-invalidation-errors.js
@@ -11,6 +11,39 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { isEditorReadyWithBlocks } from '../../utils';
 
+/**
+ * Checks if a given block object has content.
+ *
+ * Makes sure that we don't delete content when block auto-fix gives us empty
+ * block content. For example, if a paragraph block structure is invalid, its
+ * content attribute may be an empty string. However, depending on the error,
+ * the block could still be fixed via the code editor. This way, we keep blocks
+ * which do not auto-fix into a somewhat reasonable shape so that they can be
+ * manually fixed.
+ *
+ * Note that we return 'true' if we don't understand how to validate the block.
+ * This way, we continue auto-fixing other blocks if we can.
+ *
+ * @param {object} block The block to check for content.
+ * @returns bool True if the block has content. False otherwise.
+ */
+function blockHasContent( block ) {
+	// There is no content if there is no block.
+	if ( ! block ) {
+		return false;
+	}
+	switch ( block.name ) {
+		case 'core/paragraph':
+			return block.attributes?.content?.length > 0;
+		case 'core/image':
+			return block.attributes?.url?.length > 0;
+		case 'core/quote':
+			return block.attributes?.value?.length > 0;
+		default:
+			return true;
+	}
+}
+
 async function fixInvalidBlocks() {
 	const editorHasBlocks = await isEditorReadyWithBlocks();
 	if ( ! editorHasBlocks ) {
@@ -22,10 +55,10 @@ async function fixInvalidBlocks() {
 		.getBlocks()
 		.filter( block => ! block.isValid )
 		.forEach( ( { clientId, name, attributes, innerBlocks } ) => {
-			dispatch( 'core/editor' ).replaceBlock(
-				clientId,
-				createBlock( name, attributes, innerBlocks )
-			);
+			const replacement = createBlock( name, attributes, innerBlocks );
+			if ( blockHasContent( replacement ) ) {
+				dispatch( 'core/editor' ).replaceBlock( clientId, replacement );
+			}
 		} );
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
In pbAok1-u4-p2, we discussed how certain invalid blocks can make the block auto-fix mechanism replace several blocks with empty content. This PR fixes that by checking for block content in certain commonly used blocks.

Since we don't have a way to check if an arbitrary block has content, we are simply fixing this for some common cases -- particularly the paragraph block, which is the biggest offender.

### Testing instructions
1. Apply D40869-code to your sandbox and then sandbox widgets.wp.com and a test site.
2. Paste the following content into the "code editor" of the test site
```
<!-- wp:paragraph -->
<p>test paragraph 1</p>
<p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
</p>
<p>test paragraph 2</p>
<p>
<!-- /wp:paragraph -->

<!-- wp:image {"sizeSlug":"large"} -->
</p>
<figure class="wp-block-image size-large"><img src="https://www.cbronline.com/wp-content/uploads/2016/06/what-is-URL-770x503.jpg" alt=""/></figure>
<p>
<!-- /wp:image -->

<!-- wp:quote -->
</p>
<blockquote class="wp-block-quote"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>
<p>
<!-- /wp:quote -->

<!-- wp:paragraph -->
</p>
<p>test paragraph final</p>
<!-- /wp:paragraph -->
```

At this point, every block in the editor should be invalid.
3. Save the post and refresh the page. (the refresh should trigger the autofix code)
4. Before this PR, the `test paragraph 2` block would have been replaced with empty content. After this PR, check the following:
  a. `test paragraph 2` block should still display in an invalid state. (the content can be seen in the code editor)
  b. The image and quote blocks should be valid now.
  c. The test paragraph 1 should be valid and fixed.
