### PR TITLE
Fix BPB sync script compatibility

### DIFF
--- a/apps/full-site-editing/bin/sync-blog-posts-block.sh
+++ b/apps/full-site-editing/bin/sync-blog-posts-block.sh
@@ -108,9 +108,6 @@ fi
 
 echo Syncing files to FSE…
 
-full_path=$(pwd)/$TARGET
-echo "Target: $full_path"
-
 # Remove the target dir so that we start on a clean slate.
 rm -rf "$TARGET"
 

--- a/apps/full-site-editing/bin/sync-blog-posts-block.sh
+++ b/apps/full-site-editing/bin/sync-blog-posts-block.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# sed -i behaves differently between macos and linux platforms.
+# See https://stackoverflow.com/a/51060063
+# To use this, do `sed "${sedi[@]}" -e $sed_expression`
+sedi=(-i)
+case "$(uname)" in
+	# For macOS, use two parameters
+	Darwin*) sedi=(-i "")
+esac
+
 # try whether user passed --release
 if [ -n "$npm_config_release" ]
 then
@@ -99,6 +108,9 @@ fi
 
 echo Syncing files to FSE…
 
+full_path=$(pwd)/$TARGET
+echo "Target: $full_path"
+
 # Remove the target dir so that we start on a clean slate.
 rm -rf "$TARGET"
 
@@ -115,14 +127,14 @@ cp -R $CODE/src/shared $TARGET/
 cp -R $CODE/src/components $TARGET/
 
 # Replace text domain
-find $TARGET/blocks/ -name \*.js -exec sed -i '' "s/, 'newspack-blocks' )/, 'full-site-editing' )/g" "{}" \;
-sed -i '' "s/'newspack-blocks',/'full-site-editing',/g" $TARGET/class-newspack-blocks.php
+find $TARGET/blocks/ -name \*.js -exec sed "${sedi[@]}" "s/, 'newspack-blocks' )/, 'full-site-editing' )/g" "{}" \;
+sed "${sedi[@]}" "s/'newspack-blocks',/'full-site-editing',/g" $TARGET/class-newspack-blocks.php
 
 if [ "$MODE" = "npm" ] ; then
 	# Finds and prints the version of newspack from package.json
 	NEW_VERSION=`sed -En 's|.*"newspack-blocks": "github:Automattic/newspack-blocks#?(.*)".*|\1|p' package.json`
 	# Replaces the line containing the version definition with the new version.
-	sed -i '' -e "s|define( 'NEWSPACK_BLOCKS__VERSION', '\(.*\)' );|define( 'NEWSPACK_BLOCKS__VERSION', '$NEW_VERSION' );|" $ENTRY
+	sed "${sedi[@]}" -e "s|define( 'NEWSPACK_BLOCKS__VERSION', '\(.*\)' );|define( 'NEWSPACK_BLOCKS__VERSION', '$NEW_VERSION' );|" $ENTRY
 	echo "Updated Newspack version '$NEW_VERSION'";
 fi
 


### PR DESCRIPTION
On macos, `sed -i` requires a backup file parameter: `sed -i ""`. However, on linux platforms, `sed -i ""` fails (the syntax for specifying that parameter is different). On linux, it needs to be `sed -i`. Since the script failed on Linux, the `npm ci` command which happens in the docker build fails, since docker is using a linux image under the hood. This was not detected because this script was not being automatically run during `npm ci` until #39196. Everyone who ran it locally must have been using macOS.

See p1585149819004800-slack

### Changes proposed in this Pull Request
Adds a compatibility check for the sed command so that the script works on both platforms. (see https://stackoverflow.com/a/51060063)

### Testing instructions
1. Delete the `apps/full-site-editing/full-site-editing-plugin/blog-posts-block/newspack-homepage-articles` directory.
2. Run `npm ci` with macOS and make sure that the directory above is recreated.
3. Run the above command on a linux platform and ensure that it works. If you don't have linux, run `npm run build-docker`. After a couple minutes, that script runs `npm ci` inside the docker image. Search the output for `Updated Newspack version 'v1.2.0'` and you should find it. Previously, an error would be shown in this section of the output. Now, you'll see no errors there.
