### PR TITLE
My Home: Refactor Grow and Earn into its own component.

### DIFF
--- a/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
+++ b/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import CardHeading from 'components/card-heading';
+import VerticalNav from 'components/vertical-nav';
+import VerticalNavItem from 'components/vertical-nav/item';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { SIDEBAR_SECTION_TOOLS } from 'my-sites/sidebar/constants';
+import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import { getSiteOption } from 'state/sites/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export const GrowEarn = ( { siteSlug, expandToolsAndTrack } ) => {
+	const translate = useTranslate();
+
+	return (
+		<Card className="grow-earn">
+			<CardHeading>{ translate( 'Grow & Earn' ) }</CardHeading>
+			<h6 className="grow-earn__card-subheader">
+				{ translate( 'Grow your audience and earn money' ) }
+			</h6>
+			<VerticalNav>
+				<VerticalNavItem
+					path={ `/marketing/connections/${ siteSlug }` }
+					onClick={ () => expandToolsAndTrack( 'earn', 'share_site' ) }
+				>
+					{ translate( 'Share my site' ) }
+				</VerticalNavItem>
+				<VerticalNavItem
+					path={ `/marketing/tools/${ siteSlug }` }
+					onClick={ () => expandToolsAndTrack( 'earn', 'grow_audience' ) }
+				>
+					{ translate( 'Grow my audience' ) }
+				</VerticalNavItem>
+				<VerticalNavItem
+					path={ `/earn/${ siteSlug }` }
+					onClick={ () => expandToolsAndTrack( 'earn', 'money' ) }
+				>
+					{ translate( 'Earn money' ) }
+				</VerticalNavItem>
+			</VerticalNav>
+		</Card>
+	);
+};
+
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
+		const pageOnFront = 'page' === getSiteOption( state, siteId, 'show_on_front' );
+		return {
+			siteSlug: getSelectedSiteSlug( state ),
+			isStaticHomePage: ! isClassicEditor && pageOnFront,
+		};
+	},
+	dispatch => ( {
+		trackAction: ( section, action, isStaticHomePage ) =>
+			dispatch(
+				composeAnalytics(
+					recordTracksEvent( `calypso_customer_home_${ section }_${ action }_click`, {
+						is_static_home_page: isStaticHomePage,
+					} ),
+					bumpStat( 'calypso_customer_home', `${ section }_${ action }` )
+				)
+			),
+		expandToolsSection: () => dispatch( expandSection( SIDEBAR_SECTION_TOOLS ) ),
+	} ),
+	( stateProps, dispatchProps, ownProps ) => ( {
+		...stateProps,
+		...ownProps,
+		expandToolsAndTrack: ( section, action ) => {
+			dispatchProps.expandToolsSection();
+			dispatchProps.trackAction( section, action, stateProps.isStaticHomePage );
+		},
+	} )
+)( GrowEarn );

--- a/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
+++ b/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
@@ -30,7 +30,7 @@ export const GrowEarn = ( { siteSlug, expandToolsAndTrack } ) => {
 	return (
 		<Card className="grow-earn">
 			<CardHeading>{ translate( 'Grow & Earn' ) }</CardHeading>
-			<h6 className="grow-earn__card-subheader">
+			<h6 className="grow-earn__card-subheader customer-home__card-subheader">
 				{ translate( 'Grow your audience and earn money' ) }
 			</h6>
 			<VerticalNav>

--- a/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
+++ b/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
@@ -80,8 +80,8 @@ export default connect(
 		expandToolsSection: () => dispatch( expandSection( SIDEBAR_SECTION_TOOLS ) ),
 	} ),
 	( stateProps, dispatchProps, ownProps ) => ( {
-		...stateProps,
 		...ownProps,
+		...stateProps,
 		expandToolsAndTrack: ( section, action ) => {
 			dispatchProps.expandToolsSection();
 			dispatchProps.trackAction( section, action, stateProps.isStaticHomePage );

--- a/client/my-sites/customer-home/cards/features/grow-earn/style.scss
+++ b/client/my-sites/customer-home/cards/features/grow-earn/style.scss
@@ -1,9 +1,3 @@
 .grow-earn {
     padding-bottom: 12px;
-
-	&__card-subheader {
-		color: var( --color-text-subtle );
-		font-size: 0.85rem;
-		margin: -0.5rem 0 1rem;
-	}
 }

--- a/client/my-sites/customer-home/cards/features/grow-earn/style.scss
+++ b/client/my-sites/customer-home/cards/features/grow-earn/style.scss
@@ -1,0 +1,15 @@
+.grow-earn {
+    padding-bottom: 12px;
+
+	&__card-subheader {
+		color: var( --color-text-subtle );
+		font-size: 0.85rem;
+		margin: -0.5rem 0 1rem;
+	}
+
+	& .button {
+		font-size: 18px;
+		width: 100%;
+		height: 50px;
+	}
+}

--- a/client/my-sites/customer-home/cards/features/grow-earn/style.scss
+++ b/client/my-sites/customer-home/cards/features/grow-earn/style.scss
@@ -6,10 +6,4 @@
 		font-size: 0.85rem;
 		margin: -0.5rem 0 1rem;
 	}
-
-	& .button {
-		font-size: 18px;
-		width: 100%;
-		height: 50px;
-	}
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -21,7 +21,6 @@ import VerticalNavItem from 'components/vertical-nav/item';
 import { preventWidows } from 'lib/formatting';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import FormattedHeader from 'components/formatted-header';
-import { SIDEBAR_SECTION_TOOLS } from 'my-sites/sidebar/constants';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { canCurrentUserUseCustomerHome, getSiteOption } from 'state/sites/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -33,12 +32,12 @@ import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { localizeUrl } from 'lib/i18n-utils';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
-import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import StatsBanners from 'my-sites/stats/stats-banners';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
+import GrowEarn from 'my-sites/customer-home/cards/features/grow-earn';
 import Stats from 'my-sites/customer-home/cards/features/stats';
 import FreePhotoLibrary from 'my-sites/customer-home/cards/education/free-photo-library';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
@@ -74,7 +73,6 @@ class Home extends Component {
 				);
 			}
 		},
-		expandToolsAndTrack: PropTypes.func.isRequired,
 		trackAction: PropTypes.func.isRequired,
 		isStaticHomePage: PropTypes.bool.isRequired,
 	};
@@ -164,9 +162,7 @@ class Home extends Component {
 			needsEmailVerification,
 			translate,
 			checklistMode,
-			siteSlug,
 			trackAction,
-			expandToolsAndTrack,
 			hasChecklistData,
 			siteIsUnlaunched,
 		} = this.props;
@@ -201,34 +197,7 @@ class Home extends Component {
 					) }
 					{ ! siteIsUnlaunched && <Stats /> }
 					{ <FreePhotoLibrary /> }
-					{ ! siteIsUnlaunched && isChecklistComplete && (
-						<Card className="customer-home__grow-earn">
-							<CardHeading>{ translate( 'Grow & Earn' ) }</CardHeading>
-							<h6 className="customer-home__card-subheader">
-								{ translate( 'Grow your audience and earn money' ) }
-							</h6>
-							<VerticalNav className="customer-home__card-links">
-								<VerticalNavItem
-									path={ `/marketing/connections/${ siteSlug }` }
-									onClick={ () => expandToolsAndTrack( 'earn', 'share_site' ) }
-								>
-									{ translate( 'Share my site' ) }
-								</VerticalNavItem>
-								<VerticalNavItem
-									path={ `/marketing/tools/${ siteSlug }` }
-									onClick={ () => expandToolsAndTrack( 'earn', 'grow_audience' ) }
-								>
-									{ translate( 'Grow my audience' ) }
-								</VerticalNavItem>
-								<VerticalNavItem
-									path={ `/earn/${ siteSlug }` }
-									onClick={ () => expandToolsAndTrack( 'earn', 'money' ) }
-								>
-									{ translate( 'Earn money' ) }
-								</VerticalNavItem>
-							</VerticalNav>
-						</Card>
-					) }
+					{ ! siteIsUnlaunched && isChecklistComplete && <GrowEarn /> }
 					<Card>
 						<CardHeading>{ translate( 'Support' ) }</CardHeading>
 						<h6 className="customer-home__card-subheader">
@@ -300,7 +269,6 @@ const connectHome = connect(
 					bumpStat( 'calypso_customer_home', `${ section }_${ action }` )
 				)
 			),
-		expandToolsSection: () => dispatch( expandSection( SIDEBAR_SECTION_TOOLS ) ),
 		launchSiteOrRedirectToLaunchSignupFlow: siteId =>
 			dispatch( launchSiteOrRedirectToLaunchSignupFlow( siteId ) ),
 	} ),
@@ -309,10 +277,6 @@ const connectHome = connect(
 		...ownProps,
 		launchSiteOrRedirectToLaunchSignupFlow: () =>
 			dispatchProps.launchSiteOrRedirectToLaunchSignupFlow( stateProps.siteId ),
-		expandToolsAndTrack: ( section, action ) => {
-			dispatchProps.expandToolsSection();
-			dispatchProps.trackAction( section, action, stateProps.isStaticHomePage );
-		},
 		trackAction: ( section, action ) =>
 			dispatchProps.trackAction( section, action, stateProps.isStaticHomePage ),
 	} )

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -171,9 +171,6 @@
 		font-size: 0.85rem;
 		margin: -0.5rem 0 1rem;
 	}
-	&__grow-earn {
-		padding-bottom: 12px;
-	}
 
 	&__layout {
 		@include grid-row( 4, 1 );


### PR DESCRIPTION
This PR moves the Grow & Earn card to its own component, in preparation for cards being displayed according to server-side logic. This continues the work in #40368 . No visual or behavioural changes should occur.

<img width="928" alt="Screen Shot 2020-03-25 at 4 41 07 PM" src="https://user-images.githubusercontent.com/349751/77595840-88b73500-6eb7-11ea-82fa-b3913538a76f.png">

**Testing Instructions**

*  Load this branch, and go to `/home/:site` for a site that is launched and has a complete checklist.
* Verify it visually looks the same in production (load the same route on `wordpress.com`).
* Check the card links, and verify that stats fire.