### PR TITLE
[WIP] Try combining signup and login forms into the one container modal

### DIFF
--- a/client/landing/gutenboarding/components/auth-form/index.tsx
+++ b/client/landing/gutenboarding/components/auth-form/index.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import React, { useState } from 'react';
+import { Modal } from '@wordpress/components';
+import { __experimentalCreateInterpolateElement } from '@wordpress/element';
+import { useI18n } from '@automattic/react-i18n';
+
+/**
+ * Internal dependencies
+ */
+import SignupForm from '../signup-form';
+import LoginForm from '../login-form';
+import './style.scss';
+
+// TODO: deploy this change to @types/wordpress__element
+declare module '@wordpress/element' {
+	// eslint-disable-next-line no-shadow
+	export function __experimentalCreateInterpolateElement(
+		interpolatedString: string,
+		conversionMap: Record< string, ReactElement >
+	): ReactNode;
+}
+
+interface Props {
+	onRequestClose: () => void;
+	handleCreateSite: () => void;
+}
+
+const AuthForm = ( { onRequestClose, handleCreateSite }: Props ) => {
+	const { __: NO__ } = useI18n();
+	const [ showLogin, setShowLogin ] = useState( false );
+	const [ isLoading ] = useState( false ); // TODO: add loading behaviour
+
+	const handleSignup = () => {
+		setShowLogin( false );
+	};
+
+	const handleLogin = () => {
+		setShowLogin( true );
+	};
+
+	return (
+		<Modal
+			className="auth-form"
+			title={ NO__( 'Sign up to save your changes' ) }
+			onRequestClose={ onRequestClose }
+			focusOnMount={ false }
+			isDismissible={ ! isLoading }
+			// set to false so that 1password's autofill doesn't automatically close the modal
+			shouldCloseOnClickOutside={ false }
+		>
+			{ ! showLogin && (
+				<SignupForm onRequestClose={ onRequestClose } onOpenLogin={ handleLogin } />
+			) }
+			{ showLogin && (
+				<LoginForm
+					onRequestClose={ onRequestClose }
+					onOpenSignup={ handleSignup }
+					onLogin={ handleCreateSite }
+				/>
+			) }
+		</Modal>
+	);
+};
+
+export default AuthForm;

--- a/client/landing/gutenboarding/components/auth-form/style.scss
+++ b/client/landing/gutenboarding/components/auth-form/style.scss
@@ -1,9 +1,16 @@
 @import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
 
-.signup-form {
+.auth-form.components-modal__frame {
 	border: none;
 	border-radius: 3px;
 	min-width: 450px;
+
+	.components-modal__header {
+		.components-modal__header-heading {
+			font-size: 20px;
+			font-weight: normal;
+		}
+	}
 
 	.components-text-control__input {
 		padding: 7px 14px;
@@ -11,17 +18,16 @@
 		line-height: 1.5;
 	}
 
-	.signup-form__terms-of-service-link {
+	.auth-form__terms-of-service-link {
 		text-align: center;
 		color: var( --color-text-subtle );
 		margin: 20px 0 40px;
 	}
 
-	.signup-form__error-notice {
+	.auth-form__error-notice {
 		margin: 0;
 	}
-
-	.signup-form__login-links {
+	.auth-form__signup-links {
 		margin-top: 20px;
 		text-align: center;
 	}

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -17,8 +17,7 @@ import { USER_STORE } from '../../stores/user';
 import { SITE_STORE } from '../../stores/site';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
-import SignupForm from '../../components/signup-form';
-import LoginForm from '../../components/login-form';
+import AuthForm from '../../components/auth-form';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 
 import wp from '../../../../lib/wp';
@@ -80,7 +79,6 @@ const Header: FunctionComponent = () => {
 	}, [ siteTitle, setDomain ] );
 
 	const [ showSignupDialog, setShowSignupDialog ] = useState( false );
-	const [ showLoginDialog, setShowLoginDialog ] = useState( false );
 
 	const {
 		location: { pathname },
@@ -91,8 +89,7 @@ const Header: FunctionComponent = () => {
 		// this header isn't unmounted on route changes so we need to
 		// explicitly hide the dialog.
 		setShowSignupDialog( false );
-		setShowLoginDialog( false );
-	}, [ pathname, setShowSignupDialog, setShowLoginDialog ] );
+	}, [ pathname, setShowSignupDialog ] );
 
 	const currentDomain = domain ?? freeDomainSuggestion;
 
@@ -129,17 +126,10 @@ const Header: FunctionComponent = () => {
 
 	const handleSignup = () => {
 		setShowSignupDialog( true );
-		setShowLoginDialog( false );
-	};
-
-	const handleLogin = () => {
-		setShowSignupDialog( false );
-		setShowLoginDialog( true );
 	};
 
 	const closeAuthDialog = () => {
 		setShowSignupDialog( false );
-		setShowLoginDialog( false );
 	};
 
 	const handleSignupForDomains = () => {
@@ -237,14 +227,7 @@ const Header: FunctionComponent = () => {
 				</div>
 			</section>
 			{ showSignupDialog && (
-				<SignupForm onRequestClose={ closeAuthDialog } onOpenLogin={ handleLogin } />
-			) }
-			{ showLoginDialog && (
-				<LoginForm
-					onRequestClose={ closeAuthDialog }
-					onOpenSignup={ handleSignup }
-					onLogin={ handleCreateSite }
-				/>
+				<AuthForm onRequestClose={ closeAuthDialog } handleCreateSite={ handleCreateSite } />
 			) }
 		</div>
 	);

--- a/client/landing/gutenboarding/components/login-form/index.tsx
+++ b/client/landing/gutenboarding/components/login-form/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useEffect } from 'react';
-import { Button, ExternalLink, Modal, Notice } from '@wordpress/components';
+import { Button, ExternalLink, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
@@ -82,14 +82,7 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 	// todo: may need to be updated as more states are handled
 
 	return (
-		<Modal
-			className="login-form"
-			isDismissible={ true }
-			// set to false so that 1password's autofill doesn't automatically close the modal
-			shouldCloseOnClickOutside={ false }
-			title={ NO__( 'Log in to save your changes' ) }
-			onRequestClose={ closeModal }
-		>
+		<div className="login-form">
 			{ loginFlowState === 'ENTER_USERNAME_OR_EMAIL' && (
 				<EnterUsernameOrEmailForm tos={ tos } errorNotifications={ errorNotifications } />
 			) }
@@ -102,7 +95,7 @@ const LoginForm = ( { onRequestClose, onOpenSignup, onLogin }: Props ) => {
 					{ NO__( 'Create account.' ) }
 				</Button>
 			</div>
-		</Modal>
+		</div>
 	);
 };
 

--- a/client/landing/gutenboarding/components/login-form/style.scss
+++ b/client/landing/gutenboarding/components/login-form/style.scss
@@ -1,16 +1,9 @@
 @import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
 
-.login-form.components-modal__frame {
+.login-form {
 	border: none;
 	border-radius: 3px;
 	min-width: 450px;
-	
-	.components-modal__header {
-		.components-modal__header-heading {
-			font-size: 20px;
-			font-weight: normal;
-		}
-	}
 
 	.components-text-control__input {
 		padding: 7px 14px;

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState, useEffect } from 'react';
-import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
+import { Button, ExternalLink, TextControl, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
@@ -34,17 +34,12 @@ interface Props {
 const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 	const { __: NO__, _x: NO_x } = useI18n();
 	const [ emailVal, setEmailVal ] = useState( '' );
-	const { createAccount, clearErrors } = useDispatch( USER_STORE );
+	const { createAccount } = useDispatch( USER_STORE );
 	const isFetchingNewUser = useSelect( select => select( USER_STORE ).isFetchingNewUser() );
 	const newUserError = useSelect( select => select( USER_STORE ).getNewUserError() );
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ) ).getState();
 	const langParam = useLangRouteParam();
 	const makePath = usePath();
-
-	const closeModal = () => {
-		clearErrors();
-		onRequestClose();
-	};
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_gutenboarding_signup_start', {
@@ -68,7 +63,7 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 		} );
 
 		if ( success ) {
-			closeModal();
+			onRequestClose();
 		}
 	};
 
@@ -106,15 +101,7 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 	) }?new`;
 
 	return (
-		<Modal
-			className="signup-form"
-			title={ NO__( 'Sign up to save your changes' ) }
-			onRequestClose={ closeModal }
-			focusOnMount={ false }
-			isDismissible={ ! isFetchingNewUser }
-			// set to false so that 1password's autofill doesn't automatically close the modal
-			shouldCloseOnClickOutside={ false }
-		>
+		<div className="signup-form">
 			<form onSubmit={ handleSignUp }>
 				<TextControl
 					label={ NO__( 'Your Email Address' ) }
@@ -153,7 +140,7 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 					(experimental login)
 				</Button>
 			</div>
-		</Modal>
+		</div>
 	);
 };
 


### PR DESCRIPTION
Note: this is just a WIP at the moment and has been hacked together quickly. I think I might try moving the signup and login forms within the auth form directory next so that it's clear they exist as part of that parent component.

The objective is to have the signup and login forms exist within the one modal / parent component so that there isn't a flicker between closing one and opening the other, and so that they're treated more as a single unit from the perspective of the rest of Gutenboarding.

#### Changes proposed in this Pull Request

* TBC

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBC

Fixes #
