### PR TITLE
Create the backup state (last backup and activities) for the selected date

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -284,10 +284,10 @@ class BackupsPage extends Component {
  * Create an indexed log of backups based on the date of the backup and in the site time zone
  *
  * @param {Array} logs The activity logs retrieved from the store
- * @param {string} siteTimezone The site time zone
- * @param {number} siteGmtOffset The site offset from the GMT
+ * @param {string} timezone The site time zone
+ * @param {number} gmtOffset The site offset from the GMT
  */
-const createIndexedLog = ( logs, siteTimezone, siteGmtOffset ) => {
+const createIndexedLog = ( logs, timezone, gmtOffset ) => {
 	const indexedLog = {};
 	let oldestDateAvailable = new Date();
 
@@ -295,8 +295,8 @@ const createIndexedLog = ( logs, siteTimezone, siteGmtOffset ) => {
 		logs.data.forEach( log => {
 			//Move the backup date to the site timezone
 			const backupDate = applySiteOffset( momentDate( log.activityTs ), {
-				siteTimezone,
-				siteGmtOffset,
+				timezone,
+				gmtOffset,
 			} );
 
 			//Get the index for this backup, index format: YYYYMMDD

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -111,9 +111,9 @@ class BackupsPage extends Component {
 					backupsOnSelectedDate.activities.push( log );
 				}
 			} );
-
-			this.setState( { backupsOnSelectedDate } );
 		}
+
+		this.setState( { backupsOnSelectedDate } );
 	};
 
 	isEmptyFilter = filter => {

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -57,26 +57,28 @@ const backupStatusNames = [
 ];
 
 class BackupsPage extends Component {
-	state = {
-		selectedDate: new Date(),
-		backupsOnSelectedDate: {
-			lastBackup: null, // Last activity backup on the date
-			activities: [], // Rest of the activities (including other backups)
-		},
-	};
+	state = this.getDefaultState();
+
+	getDefaultState() {
+		return {
+			selectedDate: new Date(),
+			backupsOnSelectedDate: {
+				lastBackup: null,
+				activities: [],
+				nextBackupAt: null,
+			},
+		};
+	}
 
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.siteId !== this.props.siteId ) {
-			//If we switch the site, reset the current state
+			//If we switch the site, reset the current state to default
 			this.resetState();
 		}
 	}
 
 	resetState() {
-		this.setState( {
-			selectedDate: new Date(),
-			backupsOnSelectedDate: [],
-		} );
+		this.setState( this.getDefaultState() );
 	}
 
 	onDateChange = date => {


### PR DESCRIPTION
**Based on this PR:** https://github.com/Automattic/wp-calypso/pull/40403

#### Changes proposed in this Pull Request

Create a centralized function where we control the backup state for the selected date. The backup state for the selected date is component with:

- `lastBackup`: We store the last backup from the selected date. It could be null.
- `activities`:  Contain all the activities on the selected date, including other backups like an initial backup, a full backup or an error backup. It could be empty.

In this PR only was developed the state and how it is modified when we select a date. For now, it doesn't take any further action.

#### Testing instructions

- Check on the React Developer Tools of your browser on the component BackupsPage if the state `backupsOnSelectedDate` is filled with the correct data:

  -  `lastBackup` null or with the last backup on the date
  - `activities` empty or with all of the activities on the date, including other backups if any

#### Next related PRs and based on this branch:
- https://github.com/Automattic/wp-calypso/pull/40496 ( Adapt the DailyBackupStatus component )