### PR TITLE
[Private sites] Hide VideoPress switch on private atomic sites

### DIFF
--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -71,7 +71,6 @@ class SiteSettingsPerformance extends Component {
 
 						{ siteIsAtomicPrivate ? (
 							<EligibilityWarnings
-								// className="site-settings__card"
 								isEligible={ true }
 								backUrl={ `/settings/performance/${ siteSlug }` }
 								eligibilityData={ {

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -13,6 +13,7 @@ import { flowRight, partialRight, pick } from 'lodash';
 import AmpJetpack from 'my-sites/site-settings/amp/jetpack';
 import AmpWpcom from 'my-sites/site-settings/amp/wpcom';
 import DocumentHead from 'components/data/document-head';
+import EligibilityWarnings from 'blocks/eligibility-warnings';
 import JetpackDevModeNotice from 'my-sites/site-settings/jetpack-dev-mode-notice';
 import Main from 'components/main';
 import MediaSettingsPerformance from 'my-sites/site-settings/media-settings-performance';
@@ -24,8 +25,11 @@ import FormattedHeader from 'components/formatted-header';
 import SiteSettingsNavigation from 'my-sites/site-settings/navigation';
 import SpeedUpYourSite from 'my-sites/site-settings/speed-up-site-settings';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isPrivateSite from 'state/selectors/is-private-site';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
+import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 
 class SiteSettingsPerformance extends Component {
 	render() {
@@ -38,6 +42,9 @@ class SiteSettingsPerformance extends Component {
 			site,
 			siteId,
 			siteIsJetpack,
+			siteIsAtomicPrivate,
+			siteIsUnlaunched,
+			siteSlug,
 			submitForm,
 			translate,
 			trackEvent,
@@ -62,23 +69,36 @@ class SiteSettingsPerformance extends Component {
 
 						<SettingsSectionHeader title={ translate( 'Performance & speed' ) } />
 
-						<SpeedUpYourSite
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							submitForm={ submitForm }
-							updateFields={ updateFields }
-						/>
+						{ siteIsAtomicPrivate ? (
+							<EligibilityWarnings
+								// className="site-settings__card"
+								isEligible={ true }
+								backUrl={ `/settings/performance/${ siteSlug }` }
+								eligibilityData={ {
+									eligibilityHolds: [ siteIsUnlaunched ? 'SITE_UNLAUNCHED' : 'SITE_NOT_PUBLIC' ],
+								} }
+							/>
+						) : (
+							<>
+								<SpeedUpYourSite
+									isSavingSettings={ isSavingSettings }
+									isRequestingSettings={ isRequestingSettings }
+									submitForm={ submitForm }
+									updateFields={ updateFields }
+								/>
 
-						<SettingsSectionHeader title={ translate( 'Media' ) } />
+								<SettingsSectionHeader title={ translate( 'Media' ) } />
 
-						<MediaSettingsPerformance
-							siteId={ siteId }
-							handleAutosavingToggle={ handleAutosavingToggle }
-							onChangeField={ onChangeField }
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-							fields={ fields }
-						/>
+								<MediaSettingsPerformance
+									siteId={ siteId }
+									handleAutosavingToggle={ handleAutosavingToggle }
+									onChangeField={ onChangeField }
+									isSavingSettings={ isSavingSettings }
+									isRequestingSettings={ isRequestingSettings }
+									fields={ fields }
+								/>
+							</>
+						) }
 					</Fragment>
 				) }
 
@@ -110,10 +130,15 @@ const connectComponent = connect( state => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const siteIsJetpack = isJetpackSite( state, siteId );
+	const siteIsAtomicPrivate =
+		isSiteAutomatedTransfer( state, siteId ) && isPrivateSite( state, siteId );
 
 	return {
 		site,
 		siteIsJetpack,
+		siteIsAtomicPrivate,
+		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
+		siteSlug: getSiteSlug( state, siteId ),
 	};
 } );
 

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -11,17 +11,13 @@ import { connect } from 'react-redux';
  */
 import { Card } from '@automattic/components';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import EligibilityWarnings from 'blocks/eligibility-warnings';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import isPrivateSite from 'state/selectors/is-private-site';
+import { isJetpackSite } from 'state/sites/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import SupportInfo from 'components/support-info';
 
@@ -36,8 +32,6 @@ class SpeedUpSiteSettings extends Component {
 		photonModuleUnavailable: PropTypes.bool,
 		selectedSiteId: PropTypes.number,
 		siteAcceleratorStatus: PropTypes.bool,
-		siteIsAtomicPrivate: PropTypes.bool,
-		siteSlug: PropTypes.string,
 	};
 
 	handleCdnChange = () => {
@@ -60,26 +54,11 @@ class SpeedUpSiteSettings extends Component {
 			photonModuleUnavailable,
 			selectedSiteId,
 			siteAcceleratorStatus,
-			siteSlug,
-			siteIsAtomicPrivate,
 			siteIsJetpack,
-			siteIsUnlaunched,
 			translate,
 		} = this.props;
-		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
-		if ( siteIsAtomicPrivate ) {
-			return (
-				<EligibilityWarnings
-					className="site-settings__card"
-					isEligible={ true }
-					backUrl={ `/settings/performance/${ siteSlug }` }
-					eligibilityData={ {
-						eligibilityHolds: [ siteIsUnlaunched ? 'SITE_UNLAUNCHED' : 'SITE_NOT_PUBLIC' ],
-					} }
-				/>
-			);
-		}
+		const isRequestingOrSaving = isRequestingSettings || isSavingSettings;
 
 		return (
 			<div className="site-settings__module-settings site-settings__speed-up-site-settings">
@@ -157,8 +136,6 @@ export default connect( state => {
 		selectedSiteId,
 		'photon'
 	);
-	const siteIsAtomicPrivate =
-		isSiteAutomatedTransfer( state, selectedSiteId ) && isPrivateSite( state, selectedSiteId );
 	const photonModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon' );
 	const assetCdnModuleActive = isJetpackModuleActive( state, selectedSiteId, 'photon-cdn' );
 
@@ -169,9 +146,6 @@ export default connect( state => {
 		photonModuleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
 		selectedSiteId,
 		siteAcceleratorStatus,
-		siteIsAtomicPrivate,
 		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
-		siteIsUnlaunched: isUnlaunchedSite( state, selectedSiteId ),
-		siteSlug: getSiteSlug( state, selectedSiteId ),
 	};
 } )( localize( SpeedUpSiteSettings ) );

--- a/client/state/selectors/is-jetpack-module-active.js
+++ b/client/state/selectors/is-jetpack-module-active.js
@@ -16,9 +16,9 @@ import isPrivateSite from 'state/selectors/is-private-site';
  * @returns {?boolean}            Whether the module is active
  */
 export default function isJetpackModuleActive( state, siteId, moduleSlug ) {
-	if ( moduleSlug === 'photon' || moduleSlug === 'photon-cdn' ) {
-		// When site is atomic and private, we filter out photon from active modules list.
-		// This isn't actually changing any stored preferences, which means photon is going to
+	if ( moduleSlug === 'photon' || moduleSlug === 'photon-cdn' || moduleSlug === 'videopress' ) {
+		// When site is atomic and private, we filter out certain modules from active modules list.
+		// This isn't actually changing any stored preferences, which means they are going to
 		// keep working once privacy is disabled.
 		const siteIsAtomicPrivate =
 			isSiteAutomatedTransfer( state, siteId ) && isPrivateSite( state, siteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

VideoPress files are public so it makes sense to make VideoPress unavailable when the site is Private:

**Before**:
<img width="745" alt="Zrzut ekranu 2020-03-26 o 12 50 57" src="https://user-images.githubusercontent.com/205419/77644368-2ca8eb00-6f61-11ea-8bf3-424db149f0c0.png">

**After**:

<img width="764" alt="Zrzut ekranu 2020-03-26 o 12 51 19" src="https://user-images.githubusercontent.com/205419/77644364-2b77be00-6f61-11ea-85d0-20abf3803aa8.png">

#### Testing instructions

1. Test locally, this won't work on calypso.live.
1. Create a new site and go atomic - it's going to be private by default.
1. Don't launch it.
1. Go to `/settings/performance/` and confirm it looks like on the *first* screen above.
1. Click the "Continue" button, confirm the photon and videopress are now available. 
1. Make the site private again.
1. Go to `/settings/performance/` and confirm it looks like on the *second* screen above.
1. Try with Jetpack and Simple sites. Confirm the eligibility gate is never displayed for these.
1. Follow the test plan on #39527 and confirm it keeps working
1. Create a new site, go Plugins -> Upload, confirm the eligibility gate behaves as expected

