### PR TITLE
[Jetpack] Don't show an error after successfully toggling photon features

### DIFF
--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -42,7 +42,7 @@ const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {
 			if ( action.moduleSlug === 'photon' || action.moduleSlug === 'photon-cdn' ) {
 				// We can't know if the other module is still active, so we don't change
 				// Site Accelerator task completion state.
-				return;
+				return state;
 			}
 
 			if ( moduleTaskMap.hasOwnProperty( action.moduleSlug ) ) {

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -12,7 +12,7 @@ import { items as itemSchemas } from './schema';
 
 const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 	...state,
-	tasks: state.tasks.map( task =>
+	tasks: state.tasks?.map( task =>
 		task.id === taskId ? { ...task, isCompleted: completed } : task
 	),
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Photon feature toggles are always showing an error when used, even though they actually issued a working API request:

![Broken](https://user-images.githubusercontent.com/205419/77646987-eace7380-6f65-11ea-8190-68c6bc19a0f0.gif)

This PR fixes that so that you can use them again:

![Working](https://user-images.githubusercontent.com/205419/77646992-ec983700-6f65-11ea-9e63-315362a52e7b.gif)

#### Testing instructions

1. Get a Business plan site, install a plugin
1. Go to settings > performance and confirm photon toggles are functional