### PR TITLE
Split out `mc` from `lib/analytics`

### DIFF
--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -24,11 +24,6 @@ jest.mock( 'reader/stats', () => ( {
 	recordGaEvent: () => {},
 	recordTrackForPost: () => {},
 } ) );
-jest.mock( 'lib/analytics', () => ( {
-	mc: {
-		bumpStat: () => {},
-	},
-} ) );
 jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'page', () => require( 'sinon' ).spy() );
 const markPostSeen = jest.fn();

--- a/client/blocks/daily-post-button/test/index.jsx
+++ b/client/blocks/daily-post-button/test/index.jsx
@@ -92,7 +92,7 @@ describe( 'DailyPostButton', () => {
 			assert.isTrue( pageSpy.calledWithMatch( /post\/apps.wordpress.com?/ ) );
 		} );
 
-		test( 'shows the site selector if the user has more than one site', done => {
+		test( 'shows the site selector if the user has more than one site', () => {
 			const dailyPostButton = shallow(
 				<DailyPostButton
 					tagName="span"
@@ -104,8 +104,10 @@ describe( 'DailyPostButton', () => {
 					markPostSeen={ markPostSeen }
 				/>
 			);
-			dailyPostButton.instance().renderSitesPopover = done;
-			dailyPostButton.simulate( 'click', { preventDefault: noop } );
+			return new Promise( resolve => {
+				dailyPostButton.instance().renderSitesPopover = resolve;
+				dailyPostButton.simulate( 'click', { preventDefault: noop } );
+			} );
 		} );
 	} );
 

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -25,6 +25,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { hasAnsweredNpsSurvey, isAvailableForConciergeSession } from 'state/nps-survey/selectors';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import RecommendationSelect from './recommendation-select';
 
 /**
@@ -129,7 +130,7 @@ export class NpsSurvey extends PureComponent {
 	};
 
 	UNSAFE_componentWillMount() {
-		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_displayed' );
+		bumpStat( 'calypso_nps_survey', 'survey_displayed' );
 		analytics.tracks.recordEvent( 'calypso_nps_survey_displayed' );
 	}
 

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -30,6 +30,7 @@ import { setReduxStore as setReduxBridgeReduxStore } from 'lib/redux-bridge';
 import { init as pushNotificationsInit } from 'state/push-notifications/actions';
 import { setSupportSessionReduxStore } from 'lib/user/support-user-interop';
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import getSuperProps from 'lib/analytics/super-props';
 import { getSiteFragment, normalize } from 'lib/route';
 import { isLegacyRoute } from 'lib/route/legacy-routes';
@@ -284,7 +285,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 		}
 
 		// Bump general stat tracking overall Newdash usage
-		analytics.mc.bumpStat( { newdash_pageviews: 'route' } );
+		bumpStat( { newdash_pageviews: 'route' } );
 
 		next();
 	} );

--- a/client/components/tinymce/plugins/editor-button-analytics/plugin.js
+++ b/client/components/tinymce/plugins/editor-button-analytics/plugin.js
@@ -9,6 +9,7 @@ import debugModule from 'debug';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 
 const debug = debugModule( 'calypso:posts:stats' );
@@ -17,7 +18,7 @@ const shouldBumpStat = Math.random() <= 0.01 || process.env.NODE_ENV === 'develo
 
 function recordTinyMCEButtonClick( buttonName ) {
 	if ( shouldBumpStat ) {
-		analytics.mc.bumpStat( 'editor-button', 'calypso_' + buttonName );
+		bumpStat( 'editor-button', 'calypso_' + buttonName );
 	}
 	analytics.ga.recordEvent( 'Editor', 'Clicked TinyMCE Button', buttonName );
 	debug( 'TinyMCE button click', buttonName, 'mc=', shouldBumpStat );

--- a/client/components/tinymce/plugins/media/drop-zone.jsx
+++ b/client/components/tinymce/plugins/media/drop-zone.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { isEmpty, noop } from 'lodash';
@@ -10,7 +9,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import getMediaErrors from 'state/selectors/get-media-errors';
 import MediaDropZone from 'my-sites/media-library/drop-zone';
 import MediaActions from 'lib/media/actions';
@@ -116,7 +115,7 @@ class TinyMCEDropZone extends React.Component {
 			onRenderModal( { visible: true } );
 		}
 
-		analytics.mc.bumpStat( 'editor_upload_via', 'editor_drop' );
+		bumpStat( 'editor_upload_via', 'editor_drop' );
 	};
 
 	render() {

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -31,7 +31,7 @@ import { getProductBySlug } from 'state/products-list/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isCurrentPlanPaid, isJetpackSite } from 'state/sites/selectors';
 import { JPC_PATH_PLANS } from './constants';
-import { mc } from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -146,7 +146,7 @@ class Plans extends Component {
 		this.props.recordTracksEvent( 'calypso_jpc_plans_submit_free', {
 			user: this.props.userId,
 		} );
-		mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_free' );
+		bumpStat( 'calypso_jpc_plan_selection', 'jetpack_free' );
 
 		this.redirectToCalypso();
 	}
@@ -166,7 +166,7 @@ class Plans extends Component {
 			user: this.props.userId,
 			product_slug: cartItem.product_slug,
 		} );
-		mc.bumpStat( 'calypso_jpc_plan_selection', cartItem.product_slug );
+		bumpStat( 'calypso_jpc_plan_selection', cartItem.product_slug );
 
 		addItem( cartItem );
 		this.props.completeFlow();

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -18,7 +18,7 @@ import config from 'config';
 import translator, { trackTranslatorStatus } from 'lib/translator-jumpstart';
 import localStorageHelper from 'store';
 import { Button, Dialog } from '@automattic/components';
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import { TranslationScanner } from 'lib/i18n-utils/translation-scanner';
 import getUserSettings from 'state/selectors/get-user-settings';
 import getOriginalUserSetting from 'state/selectors/get-original-user-setting';
@@ -113,7 +113,7 @@ class TranslatorLauncher extends React.Component {
 			}
 
 			if ( this.state.firstActivation ) {
-				analytics.mc.bumpStat( 'calypso_translator_toggle', 'intial_activation' );
+				bumpStat( 'calypso_translator_toggle', 'intial_activation' );
 				this.setState( { firstActivation: false } );
 			}
 		} else if ( this.state.isActive && ! translator.isActivated() ) {
@@ -199,7 +199,7 @@ class TranslatorLauncher extends React.Component {
 	toggle = event => {
 		event.preventDefault();
 		const nextIsActive = translator.toggle();
-		analytics.mc.bumpStat( 'calypso_translator_toggle', nextIsActive ? 'on' : 'off' );
+		bumpStat( 'calypso_translator_toggle', nextIsActive ? 'on' : 'off' );
 		this.setState( { isActive: nextIsActive } );
 	};
 

--- a/client/layout/error.jsx
+++ b/client/layout/error.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import debug from 'debug';
 import { localize } from 'i18n-calypso';
 import { assign, noop } from 'lodash';
@@ -12,7 +11,7 @@ import { stringify } from 'qs';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import EmptyContent from 'components/empty-content';
 import { makeLayout, render as clientRender } from 'controller';
 import { SECTION_SET } from 'state/action-types';
@@ -30,15 +29,15 @@ const LoadingErrorMessage = localize( ( { translate } ) => (
 ) );
 
 export function isRetry() {
-	const parsed = url.parse( location.href, true );
+	const parsed = url.parse( window.location.href, true );
 	return parsed.query.retry === '1';
 }
 
 export function retry( chunkName ) {
 	if ( ! isRetry() ) {
-		const parsed = url.parse( location.href, true );
+		const parsed = url.parse( window.location.href, true );
 
-		analytics.mc.bumpStat( 'calypso_chunk_retry', chunkName );
+		bumpStat( 'calypso_chunk_retry', chunkName );
 
 		// Trigger a full page load which should include script tags for the current chunk
 		window.location.search = stringify( assign( parsed.query, { retry: '1' } ) );
@@ -47,7 +46,7 @@ export function retry( chunkName ) {
 
 export function show( context, chunkName ) {
 	log( 'Chunk %s could not be loaded', chunkName );
-	analytics.mc.bumpStat( 'calypso_chunk_error', chunkName );
+	bumpStat( 'calypso_chunk_error', chunkName );
 	context.store.dispatch( {
 		type: SECTION_SET,
 		section: false,

--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
@@ -33,6 +32,7 @@ import { isSupportSession } from 'state/support/selectors';
 import getSites from 'state/selectors/get-sites';
 import { isBusinessPlan } from 'lib/plans';
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 
 /**
  * Style dependencies
@@ -93,7 +93,7 @@ class NpsSurveyNotice extends Component {
 			this.props.setNpsSurveyDialogShowing( true );
 			this.props.markNpsSurveyShownThisSession();
 
-			analytics.mc.bumpStat( 'calypso_nps_survey', 'notice_displayed' );
+			bumpStat( 'calypso_nps_survey', 'notice_displayed' );
 			analytics.tracks.recordEvent( 'calypso_nps_notice_displayed' );
 		}
 	}

--- a/client/lib/analytics/docs/mc.md
+++ b/client/lib/analytics/docs/mc.md
@@ -5,20 +5,24 @@ Automatticians may refer to internal documentation for more information about MC
 
 ## Usage
 
-### `analytics.mc.bumpStat( group, name )`
+### `bumpStat( group, name )`
 
 Bump a single WP.com stat:
 
 ```js
-analytics.mc.bumpStat( 'newdash_visits', 'sites' );
+import { bumpStat } from 'lib/analytics/mc';
+
+bumpStat( 'newdash_visits', 'sites' );
 ```
 
-### `analytics.mc.bumpStat( obj )`
+### `bumpStat( obj )`
 
 Bump multiple WP.com stats:
 
 ```js
-analytics.mc.bumpStat( {
+import { bumpStat } from 'lib/analytics/mc';
+
+bumpStat( {
 	'stat_name1': 'stat_value1',
 	'statname2': 'stat_value2'
 } );

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -44,38 +44,9 @@ import {
  * Module variables
  */
 const identifyUserDebug = debug( 'calypso:analytics:identifyUser' );
-const mcDebug = debug( 'calypso:analytics:mc' );
 const gaDebug = debug( 'calypso:analytics:ga' );
 const queueDebug = debug( 'calypso:analytics:queue' );
 const statsdDebug = debug( 'calypso:analytics:statsd' );
-
-function buildQuerystring( group, name ) {
-	let uriComponent = '';
-
-	if ( 'object' === typeof group ) {
-		for ( const key in group ) {
-			uriComponent += '&x_' + encodeURIComponent( key ) + '=' + encodeURIComponent( group[ key ] );
-		}
-	} else {
-		uriComponent = '&x_' + encodeURIComponent( group ) + '=' + encodeURIComponent( name );
-	}
-
-	return uriComponent;
-}
-
-function buildQuerystringNoPrefix( group, name ) {
-	let uriComponent = '';
-
-	if ( 'object' === typeof group ) {
-		for ( const key in group ) {
-			uriComponent += '&' + encodeURIComponent( key ) + '=' + encodeURIComponent( group[ key ] );
-		}
-	} else {
-		uriComponent = '&' + encodeURIComponent( group ) + '=' + encodeURIComponent( name );
-	}
-
-	return uriComponent;
-}
 
 const analytics = {
 	initialize: function( currentUser, superProps ) {
@@ -88,45 +59,6 @@ const analytics = {
 				recordAliasInFloodlight();
 			}
 		} );
-	},
-
-	mc: {
-		bumpStat: function( group, name ) {
-			if ( 'object' === typeof group ) {
-				mcDebug( 'Bumping stats %o', group );
-			} else {
-				mcDebug( 'Bumping stat %s:%s', group, name );
-			}
-
-			if ( config( 'mc_analytics_enabled' ) ) {
-				const uriComponent = buildQuerystring( group, name );
-				new window.Image().src =
-					document.location.protocol +
-					'//pixel.wp.com/g.gif?v=wpcom-no-pv' +
-					uriComponent +
-					'&t=' +
-					Math.random();
-			}
-		},
-
-		bumpStatWithPageView: function( group, name ) {
-			// this function is fairly dangerous, as it bumps page views for wpcom and should only be called in very specific cases.
-			if ( 'object' === typeof group ) {
-				mcDebug( 'Bumping page view with props %o', group );
-			} else {
-				mcDebug( 'Bumping page view %s:%s', group, name );
-			}
-
-			if ( config( 'mc_analytics_enabled' ) ) {
-				const uriComponent = buildQuerystringNoPrefix( group, name );
-				new window.Image().src =
-					document.location.protocol +
-					'//pixel.wp.com/g.gif?v=wpcom' +
-					uriComponent +
-					'&t=' +
-					Math.random();
-			}
-		},
 	},
 
 	// pageView is a wrapper for pageview events across Tracks and GA.
@@ -456,7 +388,6 @@ emitter( analytics );
 
 export default analytics;
 export const ga = analytics.ga;
-export const mc = analytics.mc;
 export const queue = analytics.queue;
 export const tracks = analytics.tracks;
 export const pageView = analytics.pageView;

--- a/client/lib/analytics/mc.js
+++ b/client/lib/analytics/mc.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import debug from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+const mcDebug = debug( 'calypso:analytics:mc' );
+
+function buildQuerystring( group, name ) {
+	let uriComponent = '';
+
+	if ( 'object' === typeof group ) {
+		for ( const key in group ) {
+			uriComponent += '&x_' + encodeURIComponent( key ) + '=' + encodeURIComponent( group[ key ] );
+		}
+	} else {
+		uriComponent = '&x_' + encodeURIComponent( group ) + '=' + encodeURIComponent( name );
+	}
+
+	return uriComponent;
+}
+
+function buildQuerystringNoPrefix( group, name ) {
+	let uriComponent = '';
+
+	if ( 'object' === typeof group ) {
+		for ( const key in group ) {
+			uriComponent += '&' + encodeURIComponent( key ) + '=' + encodeURIComponent( group[ key ] );
+		}
+	} else {
+		uriComponent = '&' + encodeURIComponent( group ) + '=' + encodeURIComponent( name );
+	}
+
+	return uriComponent;
+}
+
+export function bumpStat( group, name ) {
+	if ( 'object' === typeof group ) {
+		mcDebug( 'Bumping stats %o', group );
+	} else {
+		mcDebug( 'Bumping stat %s:%s', group, name );
+	}
+
+	if ( config( 'mc_analytics_enabled' ) ) {
+		const uriComponent = buildQuerystring( group, name );
+		new window.Image().src =
+			document.location.protocol +
+			'//pixel.wp.com/g.gif?v=wpcom-no-pv' +
+			uriComponent +
+			'&t=' +
+			Math.random();
+	}
+}
+
+export function bumpStatWithPageView( group, name ) {
+	// this function is fairly dangerous, as it bumps page views for wpcom and should only be called in very specific cases.
+	if ( 'object' === typeof group ) {
+		mcDebug( 'Bumping page view with props %o', group );
+	} else {
+		mcDebug( 'Bumping page view %s:%s', group, name );
+	}
+
+	if ( config( 'mc_analytics_enabled' ) ) {
+		const uriComponent = buildQuerystringNoPrefix( group, name );
+		new window.Image().src =
+			document.location.protocol +
+			'//pixel.wp.com/g.gif?v=wpcom' +
+			uriComponent +
+			'&t=' +
+			Math.random();
+	}
+}

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -11,7 +11,8 @@ import cookie from 'cookie';
 /**
  * Internal dependencies
  */
-import analytics from '../';
+import analytics from 'lib/analytics';
+import { bumpStat, bumpStatWithPageView } from 'lib/analytics/mc';
 import { recordAliasInFloodlight } from 'lib/analytics/ad-tracking';
 
 jest.mock( 'config', () => require( './mocks/config' ) );
@@ -70,14 +71,14 @@ describe( 'Analytics', () => {
 
 	describe( 'mc', () => {
 		test( 'bumpStat with group and stat', () => {
-			analytics.mc.bumpStat( 'go', 'time' );
+			bumpStat( 'go', 'time' );
 			expect( imagesLoaded[ 0 ].query.v ).toEqual( 'wpcom-no-pv' );
 			expect( imagesLoaded[ 0 ].query.x_go ).toEqual( 'time' );
 			expect( imagesLoaded[ 0 ].query.t ).toBeTruthy();
 		} );
 
 		test( 'bumpStat with value object', () => {
-			analytics.mc.bumpStat( {
+			bumpStat( {
 				go: 'time',
 				another: 'one',
 			} );
@@ -88,14 +89,14 @@ describe( 'Analytics', () => {
 		} );
 
 		test( 'bumpStatWithPageView with group and stat', () => {
-			analytics.mc.bumpStatWithPageView( 'go', 'time' );
+			bumpStatWithPageView( 'go', 'time' );
 			expect( imagesLoaded[ 0 ].query.v ).toEqual( 'wpcom' );
 			expect( imagesLoaded[ 0 ].query.go ).toEqual( 'time' );
 			expect( imagesLoaded[ 0 ].query.t ).toBeTruthy();
 		} );
 
 		test( 'bumpStatWithPageView with value object', () => {
-			analytics.mc.bumpStatWithPageView( {
+			bumpStatWithPageView( {
 				go: 'time',
 				another: 'one',
 			} );

--- a/client/lib/browser-storage/index.ts
+++ b/client/lib/browser-storage/index.ts
@@ -16,7 +16,7 @@ import {
 	activate as activateBypass,
 } from './bypass';
 import { StoredItems } from './types';
-import { mc } from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import config from 'config';
 
 const debug = debugFactory( 'calypso:browser-storage' );
@@ -84,7 +84,7 @@ const getDB = once( () => {
 					db.onerror = function( errorEvent: any ) {
 						debug( 'IDB Error', errorEvent );
 						if ( errorEvent.target?.error?.name ) {
-							mc.bumpStat( 'calypso-browser-storage', kebabCase( errorEvent.target.error.name ) );
+							bumpStat( 'calypso-browser-storage', kebabCase( errorEvent.target.error.name ) );
 
 							if ( errorEvent.target.error.name === 'QuotaExceededError' ) {
 								// we've blown through the quota. Turn off IDB for this page load

--- a/client/lib/oauth-store/actions.js
+++ b/client/lib/oauth-store/actions.js
@@ -4,10 +4,11 @@
 import Dispatcher from 'dispatcher';
 import { actions, errors as errorTypes } from './constants';
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 
 async function makeRequest( username, password, authCode = '' ) {
 	try {
-		const response = await fetch( '/oauth', {
+		const response = await globalThis.fetch( '/oauth', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify( {
@@ -58,18 +59,18 @@ function bumpStats( error, data ) {
 
 	if ( errorType === errorTypes.ERROR_REQUIRES_2FA ) {
 		analytics.tracks.recordEvent( 'calypso_oauth_login_needs2fa' );
-		analytics.mc.bumpStat( 'calypso_oauth_login', 'success-needs-2fa' );
+		bumpStat( 'calypso_oauth_login', 'success-needs-2fa' );
 	} else if ( errorType ) {
 		analytics.tracks.recordEvent( 'calypso_oauth_login_fail', {
 			error: error.error,
 		} );
 
-		analytics.mc.bumpStat( {
+		bumpStat( {
 			calypso_oauth_login_error: errorType,
 			calypso_oauth_login: 'error',
 		} );
 	} else {
 		analytics.tracks.recordEvent( 'calypso_oauth_login_success' );
-		analytics.mc.bumpStat( 'calypso_oauth_login', 'success' );
+		bumpStat( 'calypso_oauth_login', 'success' );
 	}
 }

--- a/client/lib/plugins/actions.js
+++ b/client/lib/plugins/actions.js
@@ -8,6 +8,7 @@ import { defer } from 'lodash';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import Dispatcher from 'dispatcher';
 import { userCan } from 'lib/site/utils';
 import wpcom from 'lib/wp';
@@ -84,7 +85,7 @@ const getPluginId = ( site, plugin ) => {
  *
  * @param {object} site - site object
  * @param {string} pluginId - plugin identifier
- * @returns {SitePlugin} SitePlugin instance
+ * @returns {object} SitePlugin instance
  */
 const getPluginHandler = ( site, pluginId ) => {
 	const siteHandler = wpcom.site( site.ID );
@@ -115,14 +116,14 @@ const recordEvent = ( eventType, plugin, site, error ) => {
 			plugin: plugin.slug,
 			error: error.error,
 		} );
-		analytics.mc.bumpStat( eventType, 'failed' );
+		bumpStat( eventType, 'failed' );
 		return;
 	}
 	analytics.tracks.recordEvent( eventType + '_success', {
 		site: site.ID,
 		plugin: plugin.slug,
 	} );
-	analytics.mc.bumpStat( eventType, 'succeeded' );
+	bumpStat( eventType, 'succeeded' );
 };
 
 const PluginsActions = {
@@ -379,7 +380,7 @@ const PluginsActions = {
 				( error && error.error !== 'activation_error' ) ||
 				( ! ( data && data.active ) && ! error )
 			) {
-				analytics.mc.bumpStat( 'calypso_plugin_activated', 'failed' );
+				bumpStat( 'calypso_plugin_activated', 'failed' );
 				analytics.tracks.recordEvent( 'calypso_plugin_activated_error', {
 					error: error && error.error ? error.error : 'Undefined activation error',
 					site: site.ID,
@@ -389,7 +390,7 @@ const PluginsActions = {
 				return;
 			}
 
-			analytics.mc.bumpStat( 'calypso_plugin_activated', 'succeeded' );
+			bumpStat( 'calypso_plugin_activated', 'succeeded' );
 			analytics.tracks.recordEvent( 'calypso_plugin_activated_success', {
 				site: site.ID,
 				plugin: plugin.slug,
@@ -424,7 +425,7 @@ const PluginsActions = {
 			// return the active state even when the error is empty.
 			// Activation error is ok, because it means the plugin is already active
 			if ( error && error.error !== 'deactivation_error' ) {
-				analytics.mc.bumpStat( 'calypso_plugin_deactivated', 'failed' );
+				bumpStat( 'calypso_plugin_deactivated', 'failed' );
 				analytics.tracks.recordEvent( 'calypso_plugin_deactivated_error', {
 					error: error.error ? error.error : 'Undefined deactivation error',
 					site: site.ID,
@@ -433,7 +434,7 @@ const PluginsActions = {
 
 				return;
 			}
-			analytics.mc.bumpStat( 'calypso_plugin_deactivated', 'succeeded' );
+			bumpStat( 'calypso_plugin_deactivated', 'succeeded' );
 			analytics.tracks.recordEvent( 'calypso_plugin_deactivated_success', {
 				site: site.ID,
 				plugin: plugin.slug,

--- a/client/lib/plugins/test/actions.js
+++ b/client/lib/plugins/test/actions.js
@@ -18,7 +18,6 @@ import actions from 'lib/plugins/actions';
 jest.mock( 'lib/analytics', () => ( {} ) );
 jest.mock( 'lib/wp', () => require( './mocks/wpcom' ) );
 jest.mock( 'lib/analytics', () => ( {
-	mc: { bumpStat: () => {} },
 	tracks: { recordEvent: () => {} },
 } ) );
 

--- a/client/lib/track-scroll-page/index.js
+++ b/client/lib/track-scroll-page/index.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 
 export default function( path, title, category, page ) {
 	analytics.ga.recordEvent( category, 'Loaded Next Page', 'page', page );
 	analytics.pageView.record( path, title );
-	analytics.mc.bumpStat( 'newdash_pageviews', 'scroll' );
+	bumpStat( 'newdash_pageviews', 'scroll' );
 }

--- a/client/lib/two-step-authorization/index.js
+++ b/client/lib/two-step-authorization/index.js
@@ -11,6 +11,7 @@ const debug = debugFactory( 'calypso:two-step-authorization' );
  * Internal Dependencies
  */
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import config from 'config';
 import emitter from 'lib/mixins/emitter';
 import userSettings from 'lib/user-settings';
@@ -34,7 +35,7 @@ function TwoStepAuthorization() {
 	this.smsResendThrottled = false;
 
 	this.bumpMCStat = function( eventAction ) {
-		analytics.mc.bumpStat( '2fa', eventAction );
+		bumpStat( '2fa', eventAction );
 		analytics.tracks.recordEvent( 'calypso_login_twostep_authorize', {
 			event_action: eventAction,
 		} );

--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
@@ -11,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import DropZone from 'components/drop-zone';
 import MediaActions from 'lib/media/actions';
 import { userCan } from 'lib/site/utils';
@@ -42,7 +41,7 @@ class MediaLibraryDropZone extends React.Component {
 		this.props.onAddMedia();
 
 		if ( this.props.trackStats ) {
-			analytics.mc.bumpStat( 'editor_upload_via', 'drop' );
+			bumpStat( 'editor_upload_via', 'drop' );
 		}
 	};
 

--- a/client/my-sites/media-library/upload-button.jsx
+++ b/client/my-sites/media-library/upload-button.jsx
@@ -10,7 +10,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import MediaActions from 'lib/media/actions';
 import { getAllowedFileTypesForSite, isSiteAllowedFileTypesToBeTrusted } from 'lib/media/utils';
 import { VideoPressFileTypes } from 'lib/media/constants';
@@ -54,7 +54,7 @@ export default class extends React.Component {
 
 		this.formRef.current.reset();
 		this.props.onAddMedia();
-		analytics.mc.bumpStat( 'editor_upload_via', 'add_button' );
+		bumpStat( 'editor_upload_via', 'add_button' );
 	};
 
 	/**

--- a/client/my-sites/media-library/upload-url.jsx
+++ b/client/my-sites/media-library/upload-url.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import FormTextInput from 'components/forms/form-text-input';
 import { ScreenReaderText } from '@automattic/components';
 import MediaActions from 'lib/media/actions';
@@ -56,7 +56,7 @@ class MediaLibraryUploadUrl extends Component {
 		this.setState( { value: '', isError: false } );
 		this.props.onAddMedia();
 		this.props.onClose();
-		analytics.mc.bumpStat( 'editor_upload_via', 'url' );
+		bumpStat( 'editor_upload_via', 'url' );
 	};
 
 	onChange = event => {

--- a/client/my-sites/resume-editing/index.jsx
+++ b/client/my-sites/resume-editing/index.jsx
@@ -23,6 +23,7 @@ import { getEditorPath } from 'state/ui/editor/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import { decodeEntities } from 'lib/formatting';
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import QueryPosts from 'components/data/query-posts';
 import SiteIcon from 'blocks/site-icon';
 
@@ -52,7 +53,7 @@ class ResumeEditing extends React.Component {
 
 	trackAnalytics = () => {
 		analytics.ga.recordEvent( 'Master Bar', 'Resumed Editing' );
-		analytics.mc.bumpStat( 'calypso_edit_via', 'masterbar_resume_editing' );
+		bumpStat( 'calypso_edit_via', 'masterbar_resume_editing' );
 	};
 
 	render() {

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -15,7 +15,7 @@ import SidebarItem from 'layout/sidebar/item';
 import config from 'config';
 import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import { decodeEntities } from 'lib/formatting';
 import compareProps from 'lib/compare-props';
 import {
@@ -118,7 +118,7 @@ class SiteMenu extends PureComponent {
 
 	onNavigate = postType => () => {
 		if ( ! includes( [ 'post', 'page' ], postType ) ) {
-			analytics.mc.bumpStat( 'calypso_publish_menu_click', postType );
+			bumpStat( 'calypso_publish_menu_click', postType );
 		}
 		this.props.recordTracksEvent( 'calypso_mysites_site_sidebar_item_clicked', {
 			menu_item: postType,

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
  */
 import SidebarItem from 'layout/sidebar/item';
 import config from 'config';
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import compareProps from 'lib/compare-props';
 import { getSiteAdminUrl, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { canCurrentUser as canCurrentUserStateSelector } from 'state/selectors/can-current-user';
@@ -83,7 +83,7 @@ class ToolsMenu extends PureComponent {
 
 	onNavigate = postType => () => {
 		if ( ! includes( [ 'post', 'page' ], postType ) ) {
-			analytics.mc.bumpStat( 'calypso_publish_menu_click', postType );
+			bumpStat( 'calypso_publish_menu_click', postType );
 		}
 		this.props.recordTracksEvent( 'calypso_mysites_tools_sidebar_item_clicked', {
 			menu_item: postType,

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -12,7 +12,7 @@ import moment from 'moment';
  * Internal dependencies
  */
 import { getSiteFragment, getStatsDefaultSitePage } from 'lib/route';
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { getSite, getSiteOption } from 'state/sites/selectors';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
@@ -203,7 +203,7 @@ export default {
 			return next();
 		}
 
-		analytics.mc.bumpStat( 'calypso_stats_overview_period', activeFilter.period );
+		bumpStat( 'calypso_stats_overview_period', activeFilter.period );
 
 		context.primary = <StatsOverview period={ activeFilter.period } path={ context.pathname } />;
 		next();
@@ -258,7 +258,7 @@ export default {
 		// eslint-disable-next-line no-nested-ternary
 		const numPeriodAgo = parsedPeriod ? ( parsedPeriod > 9 ? '10plus' : '-' + parsedPeriod ) : '';
 
-		analytics.mc.bumpStat( 'calypso_stats_site_period', activeFilter.period + numPeriodAgo );
+		bumpStat( 'calypso_stats_site_period', activeFilter.period + numPeriodAgo );
 		recordPlaceholdersTiming();
 
 		const validTabs = [ 'views', 'visitors', 'likes', 'comments' ];
@@ -444,10 +444,7 @@ export default {
 		// eslint-disable-next-line no-nested-ternary
 		const numPeriodAgo = parsedPeriod ? ( parsedPeriod > 9 ? '10plus' : '-' + parsedPeriod ) : '';
 
-		analytics.mc.bumpStat(
-			'calypso_wordads_stats_site_period',
-			activeFilter.period + numPeriodAgo
-		);
+		bumpStat( 'calypso_wordads_stats_site_period', activeFilter.period + numPeriodAgo );
 
 		context.primary = (
 			<WordAds

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import { getMimePrefix, url } from 'lib/media/utils';
 import MediaActions from 'lib/media/actions';
 import ClipboardButtonInput from 'components/clipboard-button-input';
@@ -40,22 +41,22 @@ class EditorMediaModalDetailFields extends Component {
 
 	bumpTitleStat = () => {
 		analytics.ga.recordEvent( 'Media', 'Changed Item Title' );
-		analytics.mc.bumpStat( 'calypso_media_edit_details', 'title' );
+		bumpStat( 'calypso_media_edit_details', 'title' );
 	};
 
 	bumpAltStat = () => {
 		analytics.ga.recordEvent( 'Media', 'Changed Image Alt' );
-		analytics.mc.bumpStat( 'calypso_media_edit_details', 'alt' );
+		bumpStat( 'calypso_media_edit_details', 'alt' );
 	};
 
 	bumpCaptionStat = () => {
 		analytics.ga.recordEvent( 'Media', 'Changed Item Caption' );
-		analytics.mc.bumpStat( 'calypso_media_edit_details', 'caption' );
+		bumpStat( 'calypso_media_edit_details', 'caption' );
 	};
 
 	bumpDescriptionStat = () => {
 		analytics.ga.recordEvent( 'Media', 'Changed Item Description' );
-		analytics.mc.bumpStat( 'calypso_media_edit_details', 'description' );
+		bumpStat( 'calypso_media_edit_details', 'description' );
 	};
 
 	isMimePrefix( prefix ) {

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -27,6 +27,7 @@ import {
  */
 import MediaLibrary from 'my-sites/media-library';
 import analytics from 'lib/analytics';
+import { bumpStat as mcBumpStat } from 'lib/analytics/mc';
 import { recordEditorEvent, recordEditorStat } from 'state/posts/stats';
 import MediaModalGallery from './gallery';
 import MediaActions from 'lib/media/actions';
@@ -267,7 +268,7 @@ export class EditorMediaModal extends Component {
 		}
 
 		MediaActions.delete( site.ID, toDelete );
-		analytics.mc.bumpStat( 'editor_media_actions', 'delete_media' );
+		mcBumpStat( 'editor_media_actions', 'delete_media' );
 		this.props.deleteMedia( site.ID, map( toDelete, 'ID' ) );
 	};
 
@@ -400,7 +401,7 @@ export class EditorMediaModal extends Component {
 
 	onFilterChange = filter => {
 		if ( filter !== this.state.filter ) {
-			analytics.mc.bumpStat( 'editor_media_actions', 'filter_' + ( filter || 'all' ) );
+			mcBumpStat( 'editor_media_actions', 'filter_' + ( filter || 'all' ) );
 		}
 
 		this.setState( { filter } );
@@ -408,7 +409,7 @@ export class EditorMediaModal extends Component {
 
 	onScaleChange = () => {
 		if ( ! this.statsTracking.scale ) {
-			analytics.mc.bumpStat( 'editor_media_actions', 'scale' );
+			mcBumpStat( 'editor_media_actions', 'scale' );
 			this.statsTracking.scale = true;
 		}
 	};
@@ -419,7 +420,7 @@ export class EditorMediaModal extends Component {
 		} );
 
 		if ( ! this.statsTracking.search ) {
-			analytics.mc.bumpStat( 'editor_media_actions', 'search' );
+			mcBumpStat( 'editor_media_actions', 'search' );
 			this.statsTracking.search = true;
 		}
 	};
@@ -457,7 +458,7 @@ export class EditorMediaModal extends Component {
 		// Find and set detail selected index for the edited item
 		this.setDetailSelectedIndex( findIndex( items, { ID: item.ID } ) );
 
-		analytics.mc.bumpStat( 'editor_media_actions', 'edit_button_contextual' );
+		mcBumpStat( 'editor_media_actions', 'edit_button_contextual' );
 		analytics.ga.recordEvent( 'Media', 'Clicked Contextual Edit Button' );
 
 		this.props.setView( ModalViews.DETAIL );

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -20,7 +20,14 @@ import { ModalViews } from 'state/ui/media-modal/constants';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 jest.mock( 'component-closest', () => {} );
-jest.mock( 'event', () => require( 'component-event' ), { virtual: true } );
+jest.mock(
+	'event',
+	() => ( {
+		bind: jest.fn,
+		unbind: jest.fn,
+	} ),
+	{ virtual: true }
+);
 jest.mock( 'post-editor/media-modal/detail', () => ( {
 	default: require( 'components/empty-component' ),
 } ) );
@@ -81,11 +88,10 @@ describe( 'EditorMediaModal', () => {
 		expect( setLibrarySelectedItems ).to.have.been.calledWith( DUMMY_SITE.ID, [] );
 	} );
 
-	test( 'should prompt to delete a single item from the list view', done => {
-		let media = DUMMY_MEDIA.slice( 0, 1 ),
-			tree;
+	test( 'should prompt to delete a single item from the list view', () => {
+		const media = DUMMY_MEDIA.slice( 0, 1 );
 
-		tree = shallow(
+		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
 				mediaLibrarySelectedItems={ media }
@@ -99,13 +105,15 @@ describe( 'EditorMediaModal', () => {
 				'Deleted media will no longer appear anywhere on your website, including all posts, pages, and widgets. ' +
 				'This cannot be undone.'
 		);
-		process.nextTick( function() {
-			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
-			done();
+		return new Promise( resolve => {
+			process.nextTick( function() {
+				expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
+				resolve();
+			} );
 		} );
 	} );
 
-	test( 'should prompt to delete multiple items from the list view', done => {
+	test( 'should prompt to delete multiple items from the list view', () => {
 		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
@@ -120,17 +128,19 @@ describe( 'EditorMediaModal', () => {
 				'Deleted media will no longer appear anywhere on your website, including all posts, pages, and widgets. ' +
 				'This cannot be undone.'
 		);
-		process.nextTick( function() {
-			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA );
-			done();
+
+		return new Promise( resolve => {
+			process.nextTick( function() {
+				expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA );
+				resolve();
+			} );
 		} );
 	} );
 
-	test( 'should prompt to delete a single item from the detail view', done => {
-		let media = DUMMY_MEDIA[ 0 ],
-			tree;
+	test( 'should prompt to delete a single item from the detail view', () => {
+		const media = DUMMY_MEDIA[ 0 ];
 
-		tree = shallow(
+		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
 				mediaLibrarySelectedItems={ [ media ] }
@@ -144,13 +154,15 @@ describe( 'EditorMediaModal', () => {
 				'Deleted media will no longer appear anywhere on your website, including all posts, pages, and widgets. ' +
 				'This cannot be undone.'
 		);
-		process.nextTick( function() {
-			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
-			done();
+		return new Promise( resolve => {
+			process.nextTick( function() {
+				expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, media );
+				resolve();
+			} );
 		} );
 	} );
 
-	test( 'should prompt to delete a single item from the detail view, even when multiple selected', done => {
+	test( 'should prompt to delete a single item from the detail view, even when multiple selected', () => {
 		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
@@ -165,13 +177,16 @@ describe( 'EditorMediaModal', () => {
 				'Deleted media will no longer appear anywhere on your website, including all posts, pages, and widgets. ' +
 				'This cannot be undone.'
 		);
-		process.nextTick( function() {
-			expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA[ 0 ] );
-			done();
+
+		return new Promise( resolve => {
+			process.nextTick( function() {
+				expect( deleteMedia ).to.have.been.calledWith( DUMMY_SITE.ID, DUMMY_MEDIA[ 0 ] );
+				resolve();
+			} );
 		} );
 	} );
 
-	test( 'should return to the list view after deleting the only item in detail view', done => {
+	test( 'should return to the list view after deleting the only item in detail view', () => {
 		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
@@ -183,13 +198,15 @@ describe( 'EditorMediaModal', () => {
 
 		tree.deleteMedia();
 
-		process.nextTick( function() {
-			expect( spy ).to.have.been.calledWith( ModalViews.LIST );
-			done();
+		return new Promise( resolve => {
+			process.nextTick( function() {
+				expect( spy ).to.have.been.calledWith( ModalViews.LIST );
+				resolve();
+			} );
 		} );
 	} );
 
-	test( 'should revert to an earlier media item when the last item is deleted from detail view', done => {
+	test( 'should revert to an earlier media item when the last item is deleted from detail view', () => {
 		const tree = shallow(
 			<EditorMediaModal
 				site={ DUMMY_SITE }
@@ -201,10 +218,12 @@ describe( 'EditorMediaModal', () => {
 		tree.setDetailSelectedIndex( 1 );
 		tree.deleteMedia();
 
-		process.nextTick( function() {
-			expect( spy ).to.not.have.been.called;
-			expect( tree.state.detailSelectedIndex ).to.equal( 0 );
-			done();
+		return new Promise( resolve => {
+			process.nextTick( function() {
+				expect( spy ).to.not.have.been.called;
+				expect( tree.state.detailSelectedIndex ).to.equal( 0 );
+				resolve();
+			} );
 		} );
 	} );
 
@@ -328,7 +347,7 @@ describe( 'EditorMediaModal', () => {
 	} );
 
 	describe( '#confirmSelection()', () => {
-		test( 'should close modal if viewing local media and button is pressed', done => {
+		test( 'should close modal if viewing local media and button is pressed', () => {
 			const tree = shallow(
 				<EditorMediaModal
 					site={ DUMMY_SITE }
@@ -341,18 +360,20 @@ describe( 'EditorMediaModal', () => {
 
 			tree.confirmSelection();
 
-			process.nextTick( () => {
-				expect( onClose ).to.have.been.calledWith( {
-					items: DUMMY_MEDIA,
-					settings: undefined,
-					type: 'media',
-				} );
+			return new Promise( resolve => {
+				process.nextTick( () => {
+					expect( onClose ).to.have.been.calledWith( {
+						items: DUMMY_MEDIA,
+						settings: undefined,
+						type: 'media',
+					} );
 
-				done();
+					resolve();
+				} );
 			} );
 		} );
 
-		test( 'should copy external media after loading WordPress library if 1 or more media are selected and button is pressed', done => {
+		test( 'should copy external media after loading WordPress library if 1 or more media are selected and button is pressed', () => {
 			const tree = shallow(
 				<EditorMediaModal
 					site={ DUMMY_SITE }
@@ -372,13 +393,16 @@ describe( 'EditorMediaModal', () => {
 				Object.assign( {}, DUMMY_MEDIA[ 0 ], { ID: 'media-1', transient: true } ),
 				Object.assign( {}, DUMMY_MEDIA[ 1 ], { ID: 'media-2', transient: true } ),
 			];
-			process.nextTick( () => {
-				expect( onClose ).to.have.been.calledWith( transientItems, 'external' );
-				done();
+
+			return new Promise( resolve => {
+				process.nextTick( () => {
+					expect( onClose ).to.have.been.calledWith( transientItems, 'external' );
+					resolve();
+				} );
 			} );
 		} );
 
-		test( 'should copy external after loading WordPress library if 1 video is selected and button is pressed', done => {
+		test( 'should copy external after loading WordPress library if 1 video is selected and button is pressed', () => {
 			const tree = shallow(
 				<EditorMediaModal
 					site={ DUMMY_SITE }
@@ -397,9 +421,11 @@ describe( 'EditorMediaModal', () => {
 			const transientItems = [
 				Object.assign( {}, DUMMY_VIDEO_MEDIA[ 0 ], { ID: 'media-3', transient: true } ),
 			];
-			process.nextTick( () => {
-				expect( onClose ).to.have.been.calledWith( transientItems, 'external' );
-				done();
+			return new Promise( resolve => {
+				process.nextTick( () => {
+					expect( onClose ).to.have.been.calledWith( transientItems, 'external' );
+					resolve();
+				} );
 			} );
 		} );
 	} );

--- a/client/post-editor/media-modal/test/index.jsx
+++ b/client/post-editor/media-modal/test/index.jsx
@@ -36,11 +36,6 @@ jest.mock( 'lib/accept', () =>
 		.stub()
 		.callsArgWithAsync( 1, true )
 );
-jest.mock( 'lib/analytics', () => ( {
-	mc: {
-		bumpStat: () => {},
-	},
-} ) );
 jest.mock( 'lib/media/actions', () => ( {
 	delete: () => {},
 	setLibrarySelectedItems: () => {},

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -30,7 +30,7 @@ import VerifyEmailDialog from 'components/email-verification/email-verification-
 import * as utils from 'state/posts/utils';
 import EditorPreview from './editor-preview';
 import { recordEditorStat, recordEditorEvent } from 'state/posts/stats';
-import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import {
 	saveConfirmationSidebarPreference,
@@ -159,7 +159,7 @@ export class PostEditor extends React.Component {
 		this.switchEditorHtmlMode = this.switchEditorMode.bind( this, 'html' );
 		this.debouncedCopySelectedText = debounce( this.copySelectedText, 200 );
 		this.useDefaultSidebarFocus();
-		analytics.mc.bumpStat( 'calypso_default_sidebar_mode', this.props.editorSidebarPreference );
+		bumpStat( 'calypso_default_sidebar_mode', this.props.editorSidebarPreference );
 
 		this.setState( {
 			isEditorInitialized: false,
@@ -182,7 +182,7 @@ export class PostEditor extends React.Component {
 
 		// record the initial value of the editor mode preference
 		if ( this.props.editorModePreference ) {
-			analytics.mc.bumpStat( 'calypso_default_editor_mode', this.props.editorModePreference );
+			bumpStat( 'calypso_default_editor_mode', this.props.editorModePreference );
 		}
 	}
 

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -8,15 +8,13 @@ import moment from 'moment';
  * Internal Dependencies
  */
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import { recordTrack } from 'reader/stats';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 
 export function trackPageLoad( path, title, readerView ) {
 	analytics.pageView.record( path, title );
-	analytics.mc.bumpStat(
-		'reader_views',
-		readerView === 'full_post' ? readerView : readerView + '_load'
-	);
+	bumpStat( 'reader_views', readerView === 'full_post' ? readerView : readerView + '_load' );
 }
 
 export function getStartDate( context ) {
@@ -36,14 +34,14 @@ export function trackScrollPage( path, title, category, readerView, pageNum ) {
 		section: readerView,
 	} );
 	analytics.pageView.record( path, title );
-	analytics.mc.bumpStat( {
+	bumpStat( {
 		newdash_pageviews: 'scroll',
 		reader_views: readerView + '_scroll',
 	} );
 }
 
 export function trackUpdatesLoaded( key ) {
-	analytics.mc.bumpStat( 'reader_views', key + '_load_new' );
+	bumpStat( 'reader_views', key + '_load_new' );
 	analytics.ga.recordEvent( 'Reader', 'Clicked Load New Posts', key );
 	recordTrack( 'calypso_reader_load_new_posts', {
 		section: key,

--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -7,13 +7,14 @@ import debugFactory from 'debug';
 /**
  * Internal Dependencies
  */
-import { mc, ga, tracks } from 'lib/analytics';
+import { ga, tracks } from 'lib/analytics';
+import { bumpStat, bumpStatWithPageView } from 'lib/analytics/mc';
 
 const debug = debugFactory( 'calypso:reader:stats' );
 
 export function recordAction( action ) {
 	debug( 'reader action', action );
-	mc.bumpStat( 'reader_actions', action );
+	bumpStat( 'reader_actions', action );
 }
 
 export function recordGaEvent( action, label, value ) {
@@ -22,7 +23,7 @@ export function recordGaEvent( action, label, value ) {
 }
 
 export function recordPermalinkClick( source, post, eventProperties = {} ) {
-	mc.bumpStat( {
+	bumpStat( {
 		reader_actions: 'visited_post_permalink',
 		reader_permalink_source: source,
 	} );
@@ -210,12 +211,12 @@ export function pageViewForPost( blogId, blogUrl, postId, isPrivate ) {
 		params.priv = 1;
 	}
 	debug( 'reader page view for post', params );
-	mc.bumpStatWithPageView( params );
+	bumpStatWithPageView( params );
 }
 
 export function recordFollow( url, railcar, additionalProps = {} ) {
 	const source = additionalProps.source || getLocation( window.location.pathname );
-	mc.bumpStat( 'reader_follows', source );
+	bumpStat( 'reader_follows', source );
 	recordAction( 'followed_blog' );
 	recordGaEvent( 'Clicked Follow Blog', source );
 	recordTrack( 'calypso_reader_site_followed', {
@@ -230,7 +231,7 @@ export function recordFollow( url, railcar, additionalProps = {} ) {
 
 export function recordUnfollow( url, railcar, additionalProps = {} ) {
 	const source = getLocation( window.location.pathname );
-	mc.bumpStat( 'reader_unfollows', source );
+	bumpStat( 'reader_unfollows', source );
 	recordAction( 'unfollowed_blog' );
 	recordGaEvent( 'Clicked Unfollow Blog', source );
 	recordTrack( 'calypso_reader_site_unfollowed', {

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -2,13 +2,13 @@
  *  External dependencies
  *
  */
-
 import { has, invoke } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import { addHotJarScript } from 'lib/analytics/hotjar';
 import {
 	trackCustomAdWordsRemarketingEvent,
@@ -41,7 +41,7 @@ const loadTrackingTool = trackingTool => {
 	}
 };
 
-const statBump = ( { group, name } ) => analytics.mc.bumpStat( group, name );
+const statBump = ( { group, name } ) => bumpStat( group, name );
 
 const dispatcher = action => {
 	const analyticsMeta = action.meta.analytics;

--- a/client/state/analytics/test/helpers/analytics-mock.js
+++ b/client/state/analytics/test/helpers/analytics-mock.js
@@ -7,7 +7,6 @@ import { merge, set } from 'lodash';
 const analyticsMocks = [
 	'ga.recordEvent',
 	'ga.recordPageView',
-	'mc.bumpStat',
 	'pageView.record',
 	'tracks.recordEvent',
 	'tracks.recordPageView',
@@ -20,6 +19,8 @@ const adTrackingMocks = [
 	'trackCustomFacebookConversionEvent',
 ];
 
+const mcMocks = [ 'bumpStat', 'bumpStatWithPageView' ];
+
 const mockIt = spy => mock => set( {}, mock, ( ...args ) => spy( mock, ...args ) );
 
 export const moduleMock = moduleMocks => spy =>
@@ -27,5 +28,6 @@ export const moduleMock = moduleMocks => spy =>
 
 export const analyticsMock = moduleMock( analyticsMocks );
 export const adTrackingMock = moduleMock( adTrackingMocks );
+export const mcMock = moduleMock( mcMocks );
 
 export default analyticsMock;

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -22,6 +22,7 @@ import {
 import { analyticsMiddleware } from '../middleware.js';
 import { spy as mockAnalytics } from 'lib/analytics';
 import { spy as mockAdTracking } from 'lib/analytics/ad-tracking';
+import { spy as mockMC } from 'lib/analytics/mc';
 import { addHotJarScript } from 'lib/analytics/hotjar';
 
 jest.mock( 'lib/analytics', () => {
@@ -44,6 +45,16 @@ jest.mock( 'lib/analytics/ad-tracking', () => {
 	return mock;
 } );
 
+jest.mock( 'lib/analytics/mc', () => {
+	const mcSpy = require( 'sinon' ).spy();
+	const { mcMock } = require( './helpers/analytics-mock' );
+
+	const mock = mcMock( mcSpy );
+	mock.spy = mcSpy;
+
+	return mock;
+} );
+
 jest.mock( 'lib/analytics/hotjar', () => ( {
 	addHotJarScript: require( 'sinon' ).spy(),
 } ) );
@@ -60,7 +71,7 @@ describe( 'middleware', () => {
 		test( 'should call mc.bumpStat', () => {
 			dispatch( bumpStat( 'test', 'value' ) );
 
-			expect( mockAnalytics ).to.have.been.calledWithExactly( 'mc.bumpStat', 'test', 'value' );
+			expect( mockMC ).to.have.been.calledWithExactly( 'bumpStat', 'test', 'value' );
 		} );
 
 		test( 'should call tracks.recordEvent', () => {
@@ -123,7 +134,7 @@ describe( 'middleware', () => {
 		test( 'should call analytics events with wrapped actions', () => {
 			dispatch( withAnalytics( bumpStat( 'name', 'value' ), { type: 'TEST_ACTION' } ) );
 
-			expect( mockAnalytics ).to.have.been.calledWithExactly( 'mc.bumpStat', 'name', 'value' );
+			expect( mockMC ).to.have.been.calledWithExactly( 'bumpStat', 'name', 'value' );
 		} );
 
 		test( 'should call `setOptOut`', () => {

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -16,7 +16,6 @@ import {
 
 jest.mock( 'lib/analytics', () => ( {
 	tracks: { recordEvent: jest.fn() },
-	mc: { bumpStat: jest.fn() },
 } ) );
 
 jest.mock( 'lib/wp' );

--- a/client/state/nps-survey/actions.js
+++ b/client/state/nps-survey/actions.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import wpcom from 'lib/wp';
 
@@ -9,6 +8,7 @@ import wpcom from 'lib/wp';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import {
 	NPS_SURVEY_SET_ELIGIBILITY,
 	NPS_SURVEY_SET_CONCIERGE_SESSION_AVAILABILITY,
@@ -71,7 +71,7 @@ export function submitNpsSurvey( surveyName, score ) {
 		debug( 'Submitting NPS survey...' );
 		dispatch( submitNpsSurveyRequesting( surveyName, score ) );
 
-		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_submitted' );
+		bumpStat( 'calypso_nps_survey', 'survey_submitted' );
 		analytics.tracks.recordEvent( 'calypso_nps_survey_submitted' );
 
 		return wpcom
@@ -93,7 +93,7 @@ export function submitNpsSurveyWithNoScore( surveyName ) {
 		debug( 'Submitting NPS survey with no score...' );
 		dispatch( submitNpsSurveyWithNoScoreRequesting( surveyName ) );
 
-		analytics.mc.bumpStat( 'calypso_nps_survey', 'survey_dismissed' );
+		bumpStat( 'calypso_nps_survey', 'survey_dismissed' );
 		analytics.tracks.recordEvent( 'calypso_nps_survey_dismissed' );
 
 		return wpcom
@@ -115,7 +115,7 @@ export function sendNpsSurveyFeedback( surveyName, feedback ) {
 		debug( 'Sending NPS survey feedback...' );
 		dispatch( sendNpsSurveyFeedbackRequesting( surveyName, feedback ) );
 
-		analytics.mc.bumpStat( 'calypso_nps_survey', 'feedback_submitted' );
+		bumpStat( 'calypso_nps_survey', 'feedback_submitted' );
 		analytics.tracks.recordEvent( 'calypso_nps_survey_feedback_submitted' );
 
 		return wpcom

--- a/client/state/nps-survey/test/actions.js
+++ b/client/state/nps-survey/test/actions.js
@@ -27,7 +27,6 @@ jest.mock( 'lib/wp', () => ( {
 	} ),
 } ) );
 jest.mock( 'lib/analytics', () => ( {
-	mc: { bumpStat: jest.fn() },
 	tracks: { recordEvent: jest.fn() },
 } ) );
 jest.mock( 'lib/analytics/mc', () => ( {

--- a/client/state/nps-survey/test/actions.js
+++ b/client/state/nps-survey/test/actions.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
 import {
 	submitNpsSurvey,
 	submitNpsSurveyWithNoScore,
@@ -29,28 +30,28 @@ jest.mock( 'lib/analytics', () => ( {
 	mc: { bumpStat: jest.fn() },
 	tracks: { recordEvent: jest.fn() },
 } ) );
+jest.mock( 'lib/analytics/mc', () => ( {
+	bumpStat: jest.fn(),
+} ) );
 
 describe( 'actions', () => {
 	const dispatch = jest.fn();
 
 	describe( '#submitNpsSurvey()', () => {
 		beforeEach( () => {
-			analytics.mc.bumpStat.mockClear();
+			bumpStat.mockClear();
 			analytics.tracks.recordEvent.mockClear();
 			dispatch.mockClear();
 		} );
 
 		test( 'should track the successful survey submission', async () => {
-			expect( analytics.mc.bumpStat.mock.calls ).toHaveLength( 0 );
+			expect( bumpStat.mock.calls ).toHaveLength( 0 );
 			expect( analytics.tracks.recordEvent.mock.calls ).toHaveLength( 0 );
 
 			await submitNpsSurvey( 'nps_test', 10 )( dispatch );
 
-			expect( analytics.mc.bumpStat.mock.calls ).toHaveLength( 1 );
-			expect( analytics.mc.bumpStat.mock.calls[ 0 ] ).toEqual( [
-				'calypso_nps_survey',
-				'survey_submitted',
-			] );
+			expect( bumpStat.mock.calls ).toHaveLength( 1 );
+			expect( bumpStat.mock.calls[ 0 ] ).toEqual( [ 'calypso_nps_survey', 'survey_submitted' ] );
 
 			expect( analytics.tracks.recordEvent.mock.calls ).toHaveLength( 1 );
 			expect( analytics.tracks.recordEvent.mock.calls[ 0 ] ).toEqual( [
@@ -61,22 +62,19 @@ describe( 'actions', () => {
 
 	describe( '#submitNpsSurveyWithNoScore', () => {
 		beforeEach( () => {
-			analytics.mc.bumpStat.mockClear();
+			bumpStat.mockClear();
 			analytics.tracks.recordEvent.mockClear();
 			dispatch.mockClear();
 		} );
 
 		test( 'should track the successful survey dismissal', async () => {
-			expect( analytics.mc.bumpStat.mock.calls ).toHaveLength( 0 );
+			expect( bumpStat.mock.calls ).toHaveLength( 0 );
 			expect( analytics.tracks.recordEvent.mock.calls ).toHaveLength( 0 );
 
 			await submitNpsSurveyWithNoScore( 'nps_test' )( dispatch );
 
-			expect( analytics.mc.bumpStat.mock.calls ).toHaveLength( 1 );
-			expect( analytics.mc.bumpStat.mock.calls[ 0 ] ).toEqual( [
-				'calypso_nps_survey',
-				'survey_dismissed',
-			] );
+			expect( bumpStat.mock.calls ).toHaveLength( 1 );
+			expect( bumpStat.mock.calls[ 0 ] ).toEqual( [ 'calypso_nps_survey', 'survey_dismissed' ] );
 
 			expect( analytics.tracks.recordEvent.mock.calls ).toHaveLength( 1 );
 			expect( analytics.tracks.recordEvent.mock.calls[ 0 ] ).toEqual( [
@@ -87,22 +85,19 @@ describe( 'actions', () => {
 
 	describe( '#sendNpsSurveyFeedback', () => {
 		beforeEach( () => {
-			analytics.mc.bumpStat.mockClear();
+			bumpStat.mockClear();
 			analytics.tracks.recordEvent.mockClear();
 			dispatch.mockClear();
 		} );
 
 		test( 'should track the successful feedback submission', async () => {
-			expect( analytics.mc.bumpStat.mock.calls ).toHaveLength( 0 );
+			expect( bumpStat.mock.calls ).toHaveLength( 0 );
 			expect( analytics.tracks.recordEvent.mock.calls ).toHaveLength( 0 );
 
 			await sendNpsSurveyFeedback( 'nps_test', 'dummy feedback data' )( dispatch );
 
-			expect( analytics.mc.bumpStat.mock.calls ).toHaveLength( 1 );
-			expect( analytics.mc.bumpStat.mock.calls[ 0 ] ).toEqual( [
-				'calypso_nps_survey',
-				'feedback_submitted',
-			] );
+			expect( bumpStat.mock.calls ).toHaveLength( 1 );
+			expect( bumpStat.mock.calls[ 0 ] ).toEqual( [ 'calypso_nps_survey', 'feedback_submitted' ] );
 
 			expect( analytics.tracks.recordEvent.mock.calls ).toHaveLength( 1 );
 			expect( analytics.tracks.recordEvent.mock.calls[ 0 ] ).toEqual( [

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -13,12 +13,13 @@ import wpcom from 'lib/wp';
 import { keyForPost, keyToString } from 'reader/post-key';
 import { hasPostBeenSeen } from './selectors';
 import { receiveLikes } from 'state/posts/likes/actions';
+import { bumpStat } from 'lib/analytics/mc';
 
 import 'state/reader/init';
 
 // TODO: make underlying lib/analytics and reader/stats capable of existing in test code without mocks
 // OR switch to analytics middleware
-let analytics = { tracks: { recordEvent: () => {} }, mc: { bumpStat: () => {} } };
+let analytics = { tracks: { recordEvent: () => {} } };
 let pageViewForPost = () => {};
 if ( process.env.NODE_ENV !== 'test' ) {
 	pageViewForPost = require( 'reader/stats' ).pageViewForPost;
@@ -155,10 +156,7 @@ export const markPostSeen = ( post, site ) => ( dispatch, getState ) => {
 		if ( site && site.ID ) {
 			if ( site.is_private || ! isAdmin ) {
 				pageViewForPost( site.ID, site.URL, post.ID, site.is_private );
-				analytics.mc.bumpStat(
-					'reader_pageviews',
-					site.is_private ? 'private_view' : 'public_view'
-				);
+				bumpStat( 'reader_pageviews', site.is_private ? 'private_view' : 'public_view' );
 			}
 		}
 	}

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -3,6 +3,8 @@
  */
 import * as actions from '../actions';
 import { tracks } from 'lib/analytics';
+import { bumpStat } from 'lib/analytics/mc';
+
 import { READER_POSTS_RECEIVE, READER_POST_SEEN } from 'state/reader/action-types';
 import wp from 'lib/wp';
 
@@ -10,7 +12,10 @@ jest.mock( 'reader/stats', () => ( { pageViewForPost: jest.fn() } ) );
 
 jest.mock( 'lib/analytics', () => ( {
 	tracks: { recordEvent: jest.fn() },
-	mc: { bumpStat: jest.fn() },
+} ) );
+
+jest.mock( 'lib/analytics/mc', () => ( {
+	bumpStat: jest.fn(),
 } ) );
 
 jest.mock( 'lib/wp', () => {
@@ -27,7 +32,6 @@ jest.mock( 'lib/wp', () => {
 
 const undocumented = wp.undocumented;
 const { pageViewForPost } = require( 'reader/stats' );
-const { mc } = require( 'lib/analytics' );
 
 describe( 'actions', () => {
 	const dispatchSpy = jest.fn();
@@ -178,7 +182,7 @@ describe( 'actions', () => {
 			dispatch.mockReset();
 			getState.mockReset();
 			pageViewForPost.mockReset();
-			mc.bumpStat.mockReset();
+			bumpStat.mockReset();
 		} );
 
 		test( 'should not dispatch if post is falsey', () => {
@@ -208,7 +212,7 @@ describe( 'actions', () => {
 			} );
 
 			// expect( pageViewForPost.mock.calls.length ).toBe( 1 );
-			// expect( mc.bumpStat.mock.calls.length ).toBe( 1 );
+			expect( bumpStat.mock.calls.length ).toBe( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
This is the first of several PRs that will make `lib/analytics` more modular, breaking up its monolithic default export. This will eventually result in being able to contain larger parts of analytics to just the sections they're needed in, instead of loading everything upfront regardless of the current route.

The PR moves `mc` to its own module under `lib/analytics` and updates all code accordingly.

Note that while I fixed a few easy lint issues, I felt that others were out of scope for this PR, and I let them be. This means that the lint test will fail due to the pre-existing issues.

#### Changes proposed in this Pull Request

* Extract `mc` into its own module
* Update all code accordingly
* Minor lint fixes

#### Testing instructions

There are no code changes, so it should be sufficient to ensure that there are no build errors or unit test failures related to e.g. an import not being correctly updated.
