### PR TITLE
Restarting Plan step test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -107,7 +107,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	planStepCopyUpdates: {
-		datestamp: '20200312',
+		datestamp: '20200326',
 		variations: {
 			variantCopyUpdates: 50,
 			control: 50,

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -12,9 +12,7 @@ import { isEnabled } from 'config';
 import * as constants from './constants';
 
 const WPComGetBillingTimeframe = annualPriceText =>
-	annualPriceText
-		? `Billed at ${ annualPriceText } per year`
-		: i18n.translate( 'per month, billed annually' );
+	annualPriceText ? `billed annually` : i18n.translate( 'per month, billed annually' );
 const WPComGetBiennialBillingTimeframe = () => i18n.translate( '/month, billed every two years' );
 
 const plansDescriptionHeadingComponent = {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -869,6 +869,8 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 		&.plan-features__header-billing-info-plan-step-test {
 			font-size: 12px;
+			margin-top: -8px;
+			margin-bottom: 8px;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restarting a test with a minor copy modification.

![image](https://user-images.githubusercontent.com/538790/77652418-777d2f80-6f6e-11ea-8b46-8a40f626b388.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Go through the signup flow at /start.
* When in the control group of the `planStepCopyUpdates` test, verify that you see the unchanged plan step UI version
* When in the variant group, verify that you see the updated UI that matches with the screenshot above, particularly the "billed anually" part.
* Verify that the plans page in Calypso /plans, and the plans step shown in launch flow of private sites both do not show the new UI.
