### PR TITLE
My Home: Move Support into its own component

### DIFF
--- a/client/my-sites/customer-home/cards/features/support/index.jsx
+++ b/client/my-sites/customer-home/cards/features/support/index.jsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { Card } from '@automattic/components';
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import CardHeading from 'components/card-heading';
+import VerticalNav from 'components/vertical-nav';
+import VerticalNavItem from 'components/vertical-nav/item';
+import { localizeUrl } from 'lib/i18n-utils';
+import { composeAnalytics, recordTracksEvent, bumpStat } from 'state/analytics/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteOption } from 'state/sites/selectors';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
+ * Image dependencies
+ */
+import happinessIllustration from 'assets/images/customer-home/happiness.png';
+
+const Support = ( { trackContactAction, trackDocsAction } ) => {
+	const translate = useTranslate();
+
+	return (
+		<Card className="support">
+			<CardHeading>{ translate( 'Support' ) }</CardHeading>
+			<h6 className="support__header customer-home__card-subheader">
+				{ translate( 'Get all the help you need' ) }
+			</h6>
+			<div className="support__content">
+				<img src={ happinessIllustration } alt={ translate( 'Support' ) } />
+				<VerticalNav className="support__links customer-home__card-links">
+					<VerticalNavItem
+						path={ localizeUrl( 'https://en.support.wordpress.com' ) }
+						external
+						onClick={ trackDocsAction }
+					>
+						{ translate( 'Support articles' ) }
+					</VerticalNavItem>
+					<VerticalNavItem path="/help/contact" external onClick={ trackContactAction }>
+						{ translate( 'Contact us' ) }
+					</VerticalNavItem>
+				</VerticalNav>
+			</div>
+		</Card>
+	);
+};
+
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
+	const isStaticHomePage =
+		! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' );
+
+	return {
+		isStaticHomePage,
+	};
+};
+
+const trackDocsAction = isStaticHomePage =>
+	composeAnalytics(
+		recordTracksEvent( 'calypso_customer_home_support_docs_click', {
+			is_static_home_page: isStaticHomePage,
+		} ),
+		bumpStat( 'calypso_customer_home', 'support_docs' )
+	);
+
+const trackContactAction = isStaticHomePage =>
+	composeAnalytics(
+		recordTracksEvent( 'calypso_customer_home_support_contact_click', {
+			is_static_home_page: isStaticHomePage,
+		} ),
+		bumpStat( 'calypso_customer_home', 'support_contact' )
+	);
+
+const mapDispatchToProps = {
+	trackContactAction,
+	trackDocsAction,
+};
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const { isStaticHomePage } = stateProps;
+	return {
+		...ownProps,
+		...stateProps,
+		trackContactAction: () => dispatchProps.trackContactAction( isStaticHomePage ),
+		trackDocsAction: () => dispatchProps.trackDocsAction( isStaticHomePage ),
+	};
+};
+
+export default connect( mapStateToProps, mapDispatchToProps, mergeProps )( Support );

--- a/client/my-sites/customer-home/cards/features/support/index.jsx
+++ b/client/my-sites/customer-home/cards/features/support/index.jsx
@@ -39,7 +39,7 @@ const Support = ( { trackContactAction, trackDocsAction } ) => {
 			</h6>
 			<div className="support__content">
 				<img src={ happinessIllustration } alt={ translate( 'Support' ) } />
-				<VerticalNav className="support__links customer-home__card-links">
+				<VerticalNav>
 					<VerticalNavItem
 						path={ localizeUrl( 'https://en.support.wordpress.com' ) }
 						external

--- a/client/my-sites/customer-home/cards/features/support/style.scss
+++ b/client/my-sites/customer-home/cards/features/support/style.scss
@@ -1,0 +1,22 @@
+.customer-home__layout .support .support__content {
+	display: flex;
+	justify-content: space-between;
+
+	img {
+		margin: 0 7% 0 0;
+		width: 137px;
+		height: 119px;
+
+		@include breakpoint( '>960px' ) {
+			display: none;
+		}
+	}
+
+	.vertical-nav {
+		width: 60%;
+
+		@include breakpoint( '>960px' ) {
+			width: 100%;
+		}
+	}
+}

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -12,8 +12,7 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { Button, Card } from '@automattic/components';
-import CardHeading from 'components/card-heading';
+import { Button } from '@automattic/components';
 import EmptyContent from 'components/empty-content';
 import Main from 'components/main';
 import { preventWidows } from 'lib/formatting';
@@ -141,7 +140,6 @@ class Home extends Component {
 		const {
 			isChecklistComplete,
 			needsEmailVerification,
-			translate,
 			checklistMode,
 			hasChecklistData,
 			siteIsUnlaunched,

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -16,8 +16,6 @@ import { Button, Card } from '@automattic/components';
 import CardHeading from 'components/card-heading';
 import EmptyContent from 'components/empty-content';
 import Main from 'components/main';
-import VerticalNav from 'components/vertical-nav';
-import VerticalNavItem from 'components/vertical-nav/item';
 import { preventWidows } from 'lib/formatting';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import FormattedHeader from 'components/formatted-header';
@@ -29,7 +27,6 @@ import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
-import { localizeUrl } from 'lib/i18n-utils';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import StatsBanners from 'my-sites/stats/stats-banners';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
@@ -44,16 +41,12 @@ import QueryHomeLayout from 'components/data/query-home-layout';
 import { getHomeLayout } from 'state/selectors/get-home-layout';
 import Primary from 'my-sites/customer-home/locations/primary';
 import Notices from 'my-sites/customer-home/locations/notices';
+import Support from 'my-sites/customer-home/cards/features/support';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-/**
- * Image dependencies
- */
-import happinessIllustration from 'assets/images/customer-home/happiness.png';
 
 class Home extends Component {
 	static propTypes = {
@@ -150,7 +143,6 @@ class Home extends Component {
 			needsEmailVerification,
 			translate,
 			checklistMode,
-			trackAction,
 			hasChecklistData,
 			siteIsUnlaunched,
 		} = this.props;
@@ -169,31 +161,7 @@ class Home extends Component {
 					{ ! siteIsUnlaunched && <Stats /> }
 					{ <FreePhotoLibrary /> }
 					{ ! siteIsUnlaunched && isChecklistComplete && <GrowEarn /> }
-					<Card>
-						<CardHeading>{ translate( 'Support' ) }</CardHeading>
-						<h6 className="customer-home__card-subheader">
-							{ translate( 'Get all the help you need' ) }
-						</h6>
-						<div className="customer-home__card-support">
-							<img src={ happinessIllustration } alt={ translate( 'Support' ) } />
-							<VerticalNav className="customer-home__card-links">
-								<VerticalNavItem
-									path={ localizeUrl( 'https://en.support.wordpress.com' ) }
-									external
-									onClick={ () => trackAction( 'support', 'docs' ) }
-								>
-									{ translate( 'Support articles' ) }
-								</VerticalNavItem>
-								<VerticalNavItem
-									path="/help/contact"
-									external
-									onClick={ () => trackAction( 'support', 'contact' ) }
-								>
-									{ translate( 'Contact us' ) }
-								</VerticalNavItem>
-							</VerticalNav>
-						</div>
-					</Card>
+					<Support />
 					{ // "Go Mobile" has the lowest priority placement when viewed in bigger viewports.
 					! isMobile() && <GoMobile /> }
 				</div>

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -136,28 +136,6 @@
 			@include card-col-right-two-col;
 		}
 	}
-	&__card-support {
-		display: flex;
-		justify-content: space-between;
-
-		img {
-			margin: 0 7% 0 0;
-			width: 137px;
-			height: 119px;
-
-			@include breakpoint( '>960px' ) {
-				display: none;
-			}
-		}
-
-		.vertical-nav {
-			width: 60%;
-
-			@include breakpoint( '>960px' ) {
-				width: 100%;
-			}
-		}
-	}
 
 	&__card-subheader {
 		color: var( --color-text-subtle );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the Support card to its own component, in preparation for cards being displayed according to server-side logic. This continues the work in #40368 . No visual or behavioural changes should occur.

<img width="980" alt="Screen Shot 2020-03-26 at 15 11 50" src="https://user-images.githubusercontent.com/1233880/77656865-c7f78b80-6f74-11ea-8f46-307e7d0421b6.png">

#### Testing instructions

- Load this branch, and go to `/home/:site`.
- Verify it visually looks the same in production (load the same route on wordpress.com).
- Check the card links, and verify that stats fire.
