### PR TITLE
Upgrade Nudge: Add hover effect like Banners for consistency

### DIFF
--- a/client/blocks/upgrade-nudge/style.scss
+++ b/client/blocks/upgrade-nudge/style.scss
@@ -18,6 +18,15 @@
 
 	&.is-card-link {
 		padding-right: 48px;
+		transition: all 100ms ease-in-out;
+
+		&:hover {
+			box-shadow: 0 0 0 1px var( --color-neutral ), 0 2px 4px var( --color-neutral-10 );
+
+			.card__link-indicator {
+				color: var( --color-neutral-dark );
+			}
+		}
 	}
 }
 

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -43,6 +43,10 @@
 	.card__link-indicator {
 		display: none;
 	}
+
+	&:hover {
+		box-shadow: none;
+	}
 }
 
 .upsell-nudge.banner.card .banner__icon-circle,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a border and box shadow hover effect on UpgradeNudges (without calls to action) to match Banners.
* This came up in #40300 and I'm splitting it into a separate PR to keep that one simpler in case we have to revert it.

**Before**

<img width="1103" alt="Screen Shot 2020-03-26 at 10 21 31 AM" src="https://user-images.githubusercontent.com/2124984/77657406-a504b180-6f4b-11ea-82d5-070e7c90629e.png">

**After**

<img width="1084" alt="Screen Shot 2020-03-26 at 11 35 01 AM" src="https://user-images.githubusercontent.com/2124984/77665343-e732f080-6f55-11ea-85f8-d015c41e4622.png">

#### Testing instructions

* Switch to this PR on a Free site
* Navigate to the Marketing screen. Hover over the upsell nudge to see the effect.
* Check other pages to look at examples of the same component: Media -> Audio, Media -> Video, Settings -> Writing -> Podcasting Setup, and probably many more!