### PR TITLE
Jetpack Search: adapt post-checkout modals

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
@@ -22,11 +22,6 @@ const SearchProductThankYou = ( { translate } ) => (
 					'that you should try customizing in your traditional WordPress dashboard.'
 			) }
 		</p>
-		<p>
-			{ translate(
-				'You can return to your traditional WordPress dashboard anytime by using the link at the bottom of the sidebar.'
-			) }
-		</p>
 	</ThankYou>
 );
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
@@ -11,20 +11,15 @@ import ThankYou from './thank-you';
 
 const SearchProductThankYou = ( { translate } ) => (
 	<ThankYou
-		illustration="/calypso/images/illustrations/security.svg"
-		showContinueButton
-		title={ translate( 'Hello Jetpack Search!' ) }
+		illustration="/calypso/images/illustrations/thankYou.svg"
+		showSearchRedirects
+		title={ translate( 'Welcome to Jetpack Search!' ) }
 	>
-		<p>{ translate( 'We just finished setting up search for you.' ) }</p>
+		<p>{ translate( 'We are currently indexing your site.' ) }</p>
 		<p>
 			{ translate(
-				'Next, we’ll take a look at your new WordPress.com dashboard. ' +
-<<<<<<< HEAD
-					'You can manage Jetpack Search under “Tools > Activity” in the sidebar. ' +
-=======
-					'You can manage your Jetpack Search under “Tools > Activity” in the sidebar. ' +
->>>>>>> Jetpack Search: add draft of the thank you note
-					'There’s also a checklist to help you get the most out of your Jetpack plan.'
+				'In the meantime, we have added some common filtering widgets to your site ' +
+					'that you should try customizing in your traditional WordPress dashboard.'
 			) }
 		</p>
 		<p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
@@ -19,7 +19,11 @@ const SearchProductThankYou = ( { translate } ) => (
 		<p>
 			{ translate(
 				'Next, we’ll take a look at your new WordPress.com dashboard. ' +
+<<<<<<< HEAD
 					'You can manage Jetpack Search under “Tools > Activity” in the sidebar. ' +
+=======
+					'You can manage your Jetpack Search under “Tools > Activity” in the sidebar. ' +
+>>>>>>> Jetpack Search: add draft of the thank you note
 					'There’s also a checklist to help you get the most out of your Jetpack plan.'
 			) }
 		</p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
@@ -18,7 +18,7 @@ const SearchProductThankYou = ( { translate } ) => (
 		<p>{ translate( 'We are currently indexing your site.' ) }</p>
 		<p>
 			{ translate(
-				'In the meantime, we have configured Jetpack Search on your site —' +
+				'In the meantime, we have configured Jetpack Search on your site — ' +
 					'you should try customizing it in your traditional WordPress dashboard.'
 			) }
 		</p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
@@ -18,8 +18,8 @@ const SearchProductThankYou = ( { translate } ) => (
 		<p>{ translate( 'We are currently indexing your site.' ) }</p>
 		<p>
 			{ translate(
-				'In the meantime, we have added some common filtering widgets to your site ' +
-					'that you should try customizing in your traditional WordPress dashboard.'
+				'In the meantime, we have configured Jetpack Search on your site —' +
+					'you should try customizing in your traditional WordPress dashboard.'
 			) }
 		</p>
 	</ThankYou>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/search-thank-you.js
@@ -19,7 +19,7 @@ const SearchProductThankYou = ( { translate } ) => (
 		<p>
 			{ translate(
 				'In the meantime, we have configured Jetpack Search on your site —' +
-					'you should try customizing in your traditional WordPress dashboard.'
+					'you should try customizing it in your traditional WordPress dashboard.'
 			) }
 		</p>
 	</ThankYou>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -37,6 +37,14 @@
 	}
 }
 
+.current-plan-thank-you__followup {
+	.button.is-compact {
+		padding-left: 30px;
+		padding-right: 30px;
+		margin-right: 30px;
+	}
+}
+
 .current-plan-thank-you__illustration {
 	margin-right: 32px;
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -39,9 +39,10 @@
 
 .current-plan-thank-you__followup {
 	.button.is-compact {
-		padding-left: 30px;
-		padding-right: 30px;
+		padding-left: 20px;
+		padding-right: 20px;
 		margin-right: 30px;
+		margin-top: 20px;
 	}
 }
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -38,10 +38,10 @@
 }
 
 .current-plan-thank-you__followup {
-	.button.is-compact {
+	.button {
 		padding-left: 20px;
 		padding-right: 20px;
-		margin-right: 30px;
+		margin-right: 16px;
 		margin-top: 20px;
 	}
 }

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -33,6 +33,7 @@ export class ThankYouCard extends Component {
 			showCalypsoIntro,
 			showContinueButton,
 			showHideMessage,
+			showSearchRedirects,
 			title,
 			translate,
 		} = this.props;
@@ -80,6 +81,21 @@ export class ThankYouCard extends Component {
 							>
 								{ translate( 'Hide message' ) }
 							</a>
+						</p>
+					) }
+					{ showSearchRedirects && (
+						<p className="current-plan-thank-you__followup">
+							<Button
+								primary
+								compact={ true }
+								href="customize.php?autofocus[section]=jetpack_search"
+							>
+								{ translate( 'Customize Search Now' ) }
+							</Button>
+
+							<Button compact={ true } href={ '/plans/' }>
+								{ translate( "I'll do it later" ) }
+							</Button>
 						</p>
 					) }
 				</div>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -98,7 +98,7 @@ export class ThankYouCard extends Component {
 								{ translate( 'Customize Search now' ) }
 							</Button>
 
-							<Button compact={ true } href={ siteAdminUrl + '/admin.php?page=jetpack#/dashboard' }>
+							<Button compact={ true } href={ siteAdminUrl + 'admin.php?page=jetpack#/dashboard' }>
 								{ translate( 'Go back to my site' ) }
 							</Button>
 						</p>
@@ -109,19 +109,18 @@ export class ThankYouCard extends Component {
 	}
 }
 
-export default connect( state => {
-	const currentUser = getCurrentUser( state );
-	const selectedSiteId = getSelectedSiteId( state );
-	const isSingleSite = !! selectedSiteId || currentUser.site_count === 1;
-	const siteId = selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) ) || null;
-	const siteAdminUrl = getSiteAdminUrl( state, siteId );
-	return (
-		{
-			siteId,
+export default connect(
+	state => {
+		const currentUser = getCurrentUser( state );
+		const selectedSiteId = getSelectedSiteId( state );
+		const isSingleSite = !! selectedSiteId || currentUser.site_count === 1;
+		const siteId = selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) ) || null;
+		const siteAdminUrl = getSiteAdminUrl( state, siteId );
+		return {
 			siteAdminUrl,
 			currentRoute: getCurrentRoute( state ),
 			queryArgs: getCurrentQueryArguments( state ),
-		},
-		{ requestGuidedTour }
-	);
-} )( localize( ThankYouCard ) );
+		};
+	},
+	{ requestGuidedTour }
+)( localize( ThankYouCard ) );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -94,11 +94,11 @@ export class ThankYouCard extends Component {
 					) }
 					{ showSearchRedirects && (
 						<p className="current-plan-thank-you__followup">
-							<Button primary compact={ true } href={ siteAdminUrl + 'customize.php' }>
+							<Button primary href={ siteAdminUrl + 'customize.php' }>
 								{ translate( 'Customize Search now' ) }
 							</Button>
 
-							<Button compact={ true } href={ siteAdminUrl + 'admin.php?page=jetpack#/dashboard' }>
+							<Button href={ siteAdminUrl + 'admin.php?page=jetpack#/dashboard' }>
 								{ translate( 'Go back to my site' ) }
 							</Button>
 						</p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -94,7 +94,10 @@ export class ThankYouCard extends Component {
 					) }
 					{ showSearchRedirects && (
 						<p className="current-plan-thank-you__followup">
-							<Button primary href={ siteAdminUrl + 'customize.php' }>
+							<Button
+								primary
+								href={ siteAdminUrl + 'customize.php?autofocus[section]=jetpack_search' }
+							>
 								{ translate( 'Customize Search now' ) }
 							</Button>
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -90,11 +90,11 @@ export class ThankYouCard extends Component {
 								compact={ true }
 								href="customize.php?autofocus[section]=jetpack_search"
 							>
-								{ translate( 'Customize Search Now' ) }
+								{ translate( 'Customize Search now' ) }
 							</Button>
 
 							<Button compact={ true } href={ '/plans/' }>
-								{ translate( "I'll do it later" ) }
+								{ translate( 'Go back to my site' ) }
 							</Button>
 						</p>
 					) }

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -53,7 +53,7 @@ class CurrentPlan extends Component {
 		domains: PropTypes.array,
 		currentPlan: PropTypes.object,
 		plan: PropTypes.string,
-		product: PropTypes.bool,
+		product: PropTypes.string,
 		requestThankYou: PropTypes.bool,
 		shouldShowDomainWarnings: PropTypes.bool,
 		hasDomainsLoaded: PropTypes.bool,
@@ -79,9 +79,10 @@ class CurrentPlan extends Component {
 	renderThankYou() {
 		const { currentPlan, product, requestProduct } = this.props;
 
-		if ( requestProduct && startsWith( requestProduct, 'jetpack_backup' ) ) {
+		if ( requestProduct && startsWith( product, 'jetpack_backup' ) ) {
 			return <BackupProductThankYou />;
 		}
+
 		if ( requestProduct && startsWith( product, 'jetpack_search' ) ) {
 			return <SearchProductThankYou />;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adapt a copy and redirects within the Thank you modal displayed in the post-checkout step of the Jetpack Search product purchase.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/plans` for a JP connected site on a non-Professional plan
* purchase Jetpack Search, pass the checkout step
* verify that the Thank you modal appears and the copy is correct
* verify the redirects to the customizer and Jetpack dashboard within `WP-Admin`
![thanku](https://user-images.githubusercontent.com/13561163/77708316-079b9300-6fc8-11ea-9cb4-16df30fd53c1.png)


Fixes https://github.com/Automattic/wp-calypso/issues/40434 



Sequel: add tracking
