### PR TITLE
My Plan: Add support for all Jetpack Products not just Backup

### DIFF
--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -113,12 +113,12 @@ class PurchasesListing extends Component {
 			return getJetpackProductTagline( purchase );
 		}
 
-		const jetpackBackupPurchase = this.getJetpackProductPurchases();
+		const jetpackProductPurchase = this.getJetpackProductPurchases();
 
 		if ( currentPlanSlug ) {
 			const planObject = getPlan( currentPlanSlug );
 			return (
-				planObject.getTagline?.( jetpackBackupPurchase[ 0 ]?.productSlug ) ??
+				planObject.getTagline?.( jetpackProductPurchase[ 0 ]?.productSlug ) ??
 				translate(
 					'Unlock the full potential of your site with all the features included in your plan.'
 				)

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -113,12 +113,12 @@ class PurchasesListing extends Component {
 			return getJetpackProductTagline( purchase );
 		}
 
-		const jetpackProductPurchase = this.getJetpackProductPurchases();
+		const productPurchases = this.getProductPurchases();
 
 		if ( currentPlanSlug ) {
 			const planObject = getPlan( currentPlanSlug );
 			return (
-				planObject.getTagline?.( jetpackProductPurchase[ 0 ]?.productSlug ) ??
+				planObject.getTagline?.( productPurchases[ 0 ]?.productSlug ) ??
 				translate(
 					'Unlock the full potential of your site with all the features included in your plan.'
 				)

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -35,7 +35,6 @@ import {
 import {
 	isFreeJetpackPlan,
 	isFreePlan,
-	isJetpackBackup,
 	isJetpackProduct,
 	getJetpackProductDisplayName,
 	getJetpackProductTagline,
@@ -87,14 +86,7 @@ class PurchasesListing extends Component {
 
 	getProductPurchases() {
 		return (
-			filter( this.props.purchases, purchase => purchase.active && isJetpackProduct( purchase ) ) ??
-			null
-		);
-	}
-
-	getJetpackBackupPurchase() {
-		return (
-			find( this.props.purchases, purchase => purchase.active && isJetpackBackup( purchase ) ) ??
+			find( this.props.purchases, purchase => purchase.active && isJetpackProduct( purchase ) ) ??
 			null
 		);
 	}
@@ -121,7 +113,7 @@ class PurchasesListing extends Component {
 			return getJetpackProductTagline( purchase );
 		}
 
-		const jetpackBackupPurchase = this.getJetpackBackupPurchase();
+		const jetpackBackupPurchase = this.getJetpackProductPurchases();
 
 		if ( currentPlanSlug ) {
 			const planObject = getPlan( currentPlanSlug );
@@ -236,7 +228,7 @@ class PurchasesListing extends Component {
 		const { translate } = this.props;
 
 		// Get all products and filter out falsy items.
-		const productPurchases = this.getProductPurchases().filter( Boolean );
+		const productPurchases = this.getProductPurchases();
 
 		if ( isEmpty( productPurchases ) ) {
 			return null;

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -5,7 +5,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { filter, find, isEmpty } from 'lodash';
+import { filter, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -86,7 +86,7 @@ class PurchasesListing extends Component {
 
 	getProductPurchases() {
 		return (
-			find( this.props.purchases, purchase => purchase.active && isJetpackProduct( purchase ) ) ??
+			filter( this.props.purchases, purchase => purchase.active && isJetpackProduct( purchase ) ) ??
 			null
 		);
 	}
@@ -118,7 +118,7 @@ class PurchasesListing extends Component {
 		if ( currentPlanSlug ) {
 			const planObject = getPlan( currentPlanSlug );
 			return (
-				planObject.getTagline?.( jetpackBackupPurchase?.productSlug ) ??
+				planObject.getTagline?.( jetpackBackupPurchase[ 0 ]?.productSlug ) ??
 				translate(
 					'Unlock the full potential of your site with all the features included in your plan.'
 				)


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Add support for all jetpack product purchases on the My Plans page. 

After:
<img width="1117" alt="Screen Shot 2020-03-26 at 4 06 22 PM" src="https://user-images.githubusercontent.com/115071/77662930-c0d47b80-6f7c-11ea-945b-3f4889ef948f.png">


#### Testing instructions

* Buy a jetpack product other then jetpack Backup. This is currently only possible in calypso dev.
* Notice that the my-plans page looks as expected. 

Fixes #
