### PR TITLE
Home: Move upsells location into its own component

### DIFF
--- a/client/my-sites/customer-home/locations/upsells/index.jsx
+++ b/client/my-sites/customer-home/locations/upsells/index.jsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { getSiteOption } from 'state/sites/selectors';
+import StatsBanners from 'my-sites/stats/stats-banners';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const Upsells = ( {
+	isChecklistComplete,
+	isEstablishedSite,
+	siteId,
+	siteIsUnlaunched,
+	siteSlug,
+} ) => {
+	return (
+		<div className="upsells">
+			{ // Only show upgrade nudges to sites > 2 days old
+			isEstablishedSite && (
+				<StatsBanners
+					siteId={ siteId }
+					slug={ siteSlug }
+					primaryButton={ isChecklistComplete && ! siteIsUnlaunched }
+				/>
+			) }
+		</div>
+	);
+};
+
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+	const createdAt = getSiteOption( state, siteId, 'created_at' );
+
+	return {
+		isChecklistComplete: isSiteChecklistComplete( state, siteId ),
+		isEstablishedSite: moment().isAfter( moment( createdAt ).add( 2, 'days' ) ),
+		siteId,
+		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
+		siteSlug: getSelectedSiteSlug( state ),
+	};
+};
+
+export default connect( mapStateToProps )( Upsells );

--- a/client/my-sites/customer-home/locations/upsells/style.scss
+++ b/client/my-sites/customer-home/locations/upsells/style.scss
@@ -1,0 +1,9 @@
+@mixin grid-column( $col-start, $span ) {
+	-ms-grid-column: $col-start * 2 - 1;
+	-ms-grid-column-span: $span + ($span - 1);
+	grid-column: $col-start / span $span;
+}
+
+.upsells {
+	@include grid-column( 1, 12 );
+}

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -7,7 +7,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
-import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -27,7 +26,6 @@ import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete'
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
-import StatsBanners from 'my-sites/stats/stats-banners';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getCurrentUser, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
@@ -41,6 +39,7 @@ import { getHomeLayout } from 'state/selectors/get-home-layout';
 import Primary from 'my-sites/customer-home/locations/primary';
 import Notices from 'my-sites/customer-home/locations/notices';
 import Support from 'my-sites/customer-home/cards/features/support';
+import Upsells from 'my-sites/customer-home/locations/upsells';
 
 /**
  * Style dependencies
@@ -91,16 +90,7 @@ class Home extends Component {
 	}
 
 	render() {
-		const {
-			checklistMode,
-			translate,
-			canUserUseCustomerHome,
-			siteSlug,
-			siteId,
-			isChecklistComplete,
-			siteIsUnlaunched,
-			isEstablishedSite,
-		} = this.props;
+		const { checklistMode, translate, canUserUseCustomerHome, siteId } = this.props;
 
 		if ( ! canUserUseCustomerHome ) {
 			const title = translate( 'This page is not available on this site.' );
@@ -121,16 +111,7 @@ class Home extends Component {
 				<SidebarNavigation />
 				<div className="customer-home__page-heading">{ this.renderCustomerHomeHeader() }</div>
 				<Notices checklistMode={ checklistMode } />
-				{ //Only show upgrade nudges to sites > 2 days old
-				isEstablishedSite && (
-					<div className="customer-home__upsells">
-						<StatsBanners
-							siteId={ siteId }
-							slug={ siteSlug }
-							primaryButton={ isChecklistComplete && ! siteIsUnlaunched ? true : false }
-						/>
-					</div>
-				) }
+				<Upsells />
 				{ this.renderCustomerHome() }
 			</Main>
 		);
@@ -174,7 +155,6 @@ const connectHome = connect(
 		const siteChecklist = getSiteChecklist( state, siteId );
 		const hasChecklistData = null !== siteChecklist && Array.isArray( siteChecklist.tasks );
 		const isChecklistComplete = isSiteChecklistComplete( state, siteId );
-		const createdAt = getSiteOption( state, siteId, 'created_at' );
 		const user = getCurrentUser( state );
 		const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
 
@@ -188,7 +168,6 @@ const connectHome = connect(
 			needsEmailVerification: ! isCurrentUserEmailVerified( state ),
 			isStaticHomePage:
 				! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
-			isEstablishedSite: moment().isAfter( moment( createdAt ).add( 2, 'days' ) ),
 			siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 			user,
 			cards: getHomeLayout( state, siteId ),

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -26,10 +26,6 @@
 		}
 	}
 
-	&__upsells {
-		@include grid-column( 1, 12 );
-	}
-
 	&__main .banner.card {
 		@include grid-column( 1, 12 );
 		@include grid-row( 3, 1 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the upsells location to its own component, in preparation for cards being displayed according to server-side logic. This continues the work in #40368. 

<img width="967" alt="Screen Shot 2020-03-26 at 16 13 38" src="https://user-images.githubusercontent.com/1233880/77664282-5e7c7a80-6f7e-11ea-9f81-5e21c8e813e4.png">


This location only contains one card (the stats banners) which is already in a separated component, so this PR doesn't move any card, just the location.

No visual or behavioural changes should occur.

#### Testing instructions

- Load this branch, and go to `/home/:site` for a business site that was created more than 2 days ago and without a Google My Business connection currently active.
- Verify it visually looks the same in production (load the same route on wordpress.com).
  - Note that the CTA button could use the default styling locally but the primary one in production. This is unrelated to this PR and caused by the `StatsBanner` not being re-rendered when the [state finishes fetching data](https://github.com/Automattic/wp-calypso/blob/3b2819b88b43e14c5617a1adc2d9a02b79d2de55/client/my-sites/customer-home/locations/upsells/index.jsx#L36). You can verify this by running `master` locally.

Local | Production
---|---
<img width="961" alt="Screen Shot 2020-03-26 at 16 20 25" src="https://user-images.githubusercontent.com/1233880/77664159-39880780-6f7e-11ea-9676-d960477c5e8a.png"> | <img width="971" alt="Screen Shot 2020-03-26 at 16 20 31" src="https://user-images.githubusercontent.com/1233880/77664184-40167f00-6f7e-11ea-97d0-068e3c429af2.png">

