### PR TITLE
Jetpack Cloud: Add styling and functionality to Realtime Backup view

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -11,6 +13,7 @@ import Button from 'components/forms/form-button';
 import { Card } from '@automattic/components';
 import ActivityActor from 'my-sites/activity/activity-log-item/activity-actor';
 import ActivityDescription from 'my-sites/activity/activity-log-item/activity-description';
+import PopoverMenu from 'components/popover/menu';
 
 /**
  * Style dependencies
@@ -18,14 +21,41 @@ import ActivityDescription from 'my-sites/activity/activity-log-item/activity-de
 import './style.scss';
 
 class ActivityCard extends Component {
+	constructor() {
+		super();
+		this.state = {
+			showPopoverMenu: false,
+		};
+	}
+
+	togglePopoverMenu = () => this.setState( { showPopoverMenu: ! this.state.showPopoverMenu } );
+
+	closePopoverMenu = () => this.setState( { showPopoverMenu: false } );
+
+	// TODO: now that we are reusing URLs we should have a dedicated paths file
+	createRestoreUrl = restoreId => `/backups/${ this.props.siteSlug }/restore/${ restoreId }`;
+	createDownloadUrl = downloadId => `/backups/${ this.props.siteSlug }/download/${ downloadId }`;
+
+	triggerRestore = () => {
+		const restoreId = this.props.activity.rewindId;
+		page.redirect( this.createRestoreUrl( restoreId ) );
+	};
+
+	triggerDownload = () => {
+		const downloadId = this.props.activity.rewindId;
+		page.redirect( this.createDownloadUrl( downloadId ) );
+	};
+
 	render() {
-		const { activity, moment, allowRestore } = this.props;
+		const { activity, moment, allowRestore, translate } = this.props;
 
 		return (
 			<div className="activity-card">
 				<div className="activity-card__time">
-					<Gridicon icon="cloud-upload" />
-					{ moment( activity.activityDate ).format( 'LT' ) }
+					<Gridicon icon="cloud-upload" className="activity-card__time-icon" />
+					<div className="activity-card__time-text">
+						{ moment( activity.activityDate ).format( 'LT' ) }
+					</div>
 				</div>
 				<Card>
 					<ActivityActor
@@ -36,15 +66,45 @@ class ActivityCard extends Component {
 							actorType: activity.actorType,
 						} }
 					/>
-					<ActivityDescription activity={ activity } rewindIsActive={ allowRestore } />
-					<div>{ activity.activityTitle }</div>
-					<div>
-						<Button compact borderless>
-							See content <Gridicon icon="chevron-down" />
+					<div className="activity-card__activity-description">
+						<ActivityDescription activity={ activity } rewindIsActive={ allowRestore } />
+					</div>
+					<div className="activity-card__activity-title">{ activity.activityTitle }</div>
+					<div className="activity-card__activity-actions">
+						<Button compact borderless className="activity-card__detail-button">
+							{ translate( 'See content' ) } <Gridicon icon="chevron-down" />
 						</Button>
-						<Button compact borderless>
-							Actions <Gridicon icon="add" />
+						<Button
+							compact
+							borderless
+							className="activity-card__actions-button"
+							ref="popoverMenuButton"
+							onClick={ this.togglePopoverMenu }
+						>
+							{ translate( 'Actions' ) } <Gridicon icon="add" />
 						</Button>
+
+						<PopoverMenu
+							context={ this.refs && this.refs.popoverMenuButton }
+							isVisible={ this.state.showPopoverMenu }
+							onClose={ this.closePopoverMenu }
+							position="left"
+							className="activity-card__popover"
+						>
+							<Button onClick={ this.triggerRestore } className="activity-card__restore-button">
+								{ translate( 'Restore to this point' ) }
+							</Button>
+							<Button
+								borderless
+								compact
+								isPrimary={ false }
+								onClick={ this.triggerDownload }
+								className="activity-card__download-button"
+							>
+								<Gridicon icon="arrow-down" />
+								{ translate( 'Download backup' ) }
+							</Button>
+						</PopoverMenu>
 					</div>
 				</Card>
 			</div>
@@ -52,4 +112,4 @@ class ActivityCard extends Component {
 	}
 }
 
-export default ActivityCard;
+export default localize( ActivityCard );

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -35,16 +35,13 @@ class ActivityCard extends Component {
 	// TODO: now that we are reusing URLs we should have a dedicated paths file
 	createRestoreUrl = restoreId => `/backups/${ this.props.siteSlug }/restore/${ restoreId }`;
 	createDownloadUrl = downloadId => `/backups/${ this.props.siteSlug }/download/${ downloadId }`;
+	createDetailUrl = backupId => `/backups/${ this.props.siteSlug }/detail/${ backupId }`;
 
-	triggerRestore = () => {
-		const restoreId = this.props.activity.rewindId;
-		page.redirect( this.createRestoreUrl( restoreId ) );
-	};
+	triggerRestore = () => page.redirect( this.createRestoreUrl( this.props.activity.rewindId ) );
 
-	triggerDownload = () => {
-		const downloadId = this.props.activity.rewindId;
-		page.redirect( this.createDownloadUrl( downloadId ) );
-	};
+	triggerDownload = () => page.redirect( this.createDownloadUrl( this.props.activity.rewindId ) );
+
+	triggerDetails = () => page.redirect( this.createDetailUrl( this.props.activity.rewindId ) );
 
 	render() {
 		const { activity, moment, allowRestore, translate } = this.props;
@@ -71,7 +68,12 @@ class ActivityCard extends Component {
 					</div>
 					<div className="activity-card__activity-title">{ activity.activityTitle }</div>
 					<div className="activity-card__activity-actions">
-						<Button compact borderless className="activity-card__detail-button">
+						<Button
+							compact
+							borderless
+							className="activity-card__detail-button"
+							onClick={ this.triggerDetails }
+						>
 							{ translate( 'See content' ) } <Gridicon icon="chevron-down" />
 						</Button>
 						<Button

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -6,3 +6,67 @@
     float: none;
     display: inline-block;
 }
+
+.activity-card__time {
+	margin: 1.5rem 0 0.5rem;
+}
+
+.activity-card__time-icon {
+	width: 1.1rem;
+	height: 1.1rem;
+}
+
+.activity-card__time-text {
+	position: relative;
+	display: inline-block;
+	top: -0.2rem;
+	left: 0.2rem;
+}
+
+.activity-card .activity-log-item__actor-info .activity-log-item__actor-name,
+.activity-card .activity-log-item__actor-info .activity-log-item__actor-role,
+.activity-card__activity-title {
+	font-size: 0.8rem;
+	color: rgb( 100, 105, 112 );
+}
+
+.activity-card__activity-title {
+	font-style: italic;
+}
+
+.activity-card__activity-description {
+	margin: 0.5rem 0;
+}
+
+.activity-card__activity-actions {
+	position: relative;
+	top: 0.5rem;
+	border-top: 1px solid #e4e4e6;
+	padding-top: 0.5rem;
+}
+
+.activity-card__detail-button.button.is-borderless.is-primary {
+	color: #3d444a;
+	font-size: 0.9rem;
+	font-weight: normal;
+}
+
+.backup-delta__realtime .activity-card__actions-button.button.is-borderless.is-primary {
+	float: right;
+	font-size: 0.9rem;
+	font-weight: 400;
+}
+
+.activity-card__restore-button {
+	margin: 0.8rem;
+	margin-bottom: 0;
+}
+
+.activity-card__download-button.is-borderless {
+	margin: 0.8rem;
+	text-align: left;
+	border-radius: 0;
+	border-top: 1px solid #e4e4e6;
+	margin-bottom: 0.5rem;
+	padding-top: 0.8rem;
+}

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -18,24 +18,33 @@ import './style.scss';
 
 class BackupDelta extends Component {
 	renderRealtime() {
-		const { allowRestore, moment, translate } = this.props;
+		const { allowRestore, moment, realtimeEvents, siteSlug, translate } = this.props;
 
-		const realtimeEvents = this.props.realtimeEvents.filter( event => event.activityIsRewindable );
+		//const realtimeEvents = this.props.realtimeEvents.filter( event => event.activityIsRewindable );
 
 		const cards = realtimeEvents.map( activity => (
 			<ActivityCard
 				{ ...{
+					key: activity.activityId,
 					moment,
 					activity,
 					allowRestore,
+					siteSlug,
 				} }
 			/>
 		) );
 
 		return (
 			<div className="backup-delta__realtime">
-				<div>{ translate( 'More backups from today' ) }</div>
-				{ cards.length ? cards : <div>{ translate( 'you have no more backups for this day' ) }</div> }
+				<div className="backup-delta__realtime-header">
+					{ translate( 'More backups from today' ) }
+				</div>
+				<div className="backup-delta__realtime-description">
+					{ translate(
+						'Your site is backed up in real time (as you make changes) as well as in one daily backup.'
+					) }
+				</div>
+				{ !! cards.length && <div className="backup-delta__realtime-cards">{ cards }</div> }
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -20,8 +20,6 @@ class BackupDelta extends Component {
 	renderRealtime() {
 		const { allowRestore, moment, realtimeEvents, siteSlug, translate } = this.props;
 
-		//const realtimeEvents = this.props.realtimeEvents.filter( event => event.activityIsRewindable );
-
 		const cards = realtimeEvents.map( activity => (
 			<ActivityCard
 				{ ...{
@@ -44,7 +42,13 @@ class BackupDelta extends Component {
 						'Your site is backed up in real time (as you make changes) as well as in one daily backup.'
 					) }
 				</div>
-				{ !! cards.length && <div className="backup-delta__realtime-cards">{ cards }</div> }
+				{ cards.length ? (
+					<div className="backup-delta__realtime-cards">{ cards }</div>
+				) : (
+					<div className="backup-delta__realtime-description">
+						{ translate( 'No changes were made on this day.' ) }
+					</div>
+				) }
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -11,3 +11,17 @@
     float: none;
     display: inline-block;
 }
+
+.backup-delta__realtime-cards {
+	margin: 0 1rem;
+}
+
+.backup-delta__realtime-header {
+	margin: 1rem;
+	font-size: 1.3rem;
+	font-weight: 500;
+}
+
+.backup-delta__realtime-description {
+	margin: 1rem;
+}

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -1,3 +1,8 @@
+.daily-backup-status {
+	background: #fff;
+	padding-bottom: 1rem;
+}
+
 .daily-backup-status .gridicon {
 	width: 150px !important;
 	height: 150px !important;

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -1,8 +1,3 @@
-.daily-backup-status {
-	background: #fff;
-	padding-bottom: 1rem;
-}
-
 .daily-backup-status .gridicon {
 	width: 150px !important;
 	height: 150px !important;

--- a/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
@@ -5,6 +5,7 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { isMobile } from '@automattic/viewport';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -41,7 +42,8 @@ class BackupDetailPage extends Component {
 		const backups = logs.filter( event => event.rewindId === backupId );
 		const thisBackup = backups[ 0 ];
 
-		const meta = thisBackup && thisBackup.activityDescription[ 2 ].children[ 0 ];
+		const meta = get( thisBackup, 'activityDescription[2].children[0]', '' );
+
 		const metaList =
 			meta &&
 			meta.split( ', ' ).map( item => {

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -10,7 +10,11 @@ import { isMobile } from '@automattic/viewport';
  */
 import DocumentHead from 'components/data/document-head';
 import { updateFilter } from 'state/activity-log/actions';
-import { getBackupAttemptsForDate, getDailyBackupDeltas, getEventsInDailyBackup } from './utils';
+import {
+	getBackupAttemptsForDate,
+	getDailyBackupDeltas,
+	getEventsInRealtimeBackup,
+} from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
@@ -65,7 +69,7 @@ class BackupsPage extends Component {
 
 		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );
-		const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
+		const realtimeEvents = getEventsInRealtimeBackup( logs, selectedDateString );
 
 		return (
 			<Main>

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -40,6 +40,12 @@ export const getChangesInRange = ( logs, t1, t2 ) => {
 	} );
 };
 
+export const getEventsInRealtimeBackup = ( logs, date ) =>
+	logs.filter(
+		event =>
+			moment( event.activityDate ).format( 'YYYYMMDD' ) === moment( date ).format( 'YYYYMMDD' )
+	);
+
 export const getEventsInDailyBackup = ( logs, date ) => {
 	const d = new Date( date );
 	d.setDate( d.getDate() - 1 );

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -43,7 +43,9 @@ export const getChangesInRange = ( logs, t1, t2 ) => {
 export const getEventsInRealtimeBackup = ( logs, date ) =>
 	logs.filter(
 		event =>
-			moment( event.activityDate ).format( 'YYYYMMDD' ) === moment( date ).format( 'YYYYMMDD' )
+			moment( event.activityDate ).format( 'YYYYMMDD' ) === moment( date ).format( 'YYYYMMDD' ) &&
+			event.activityIsRewindable &&
+			event.activityName !== 'rewind__backup_complete_full'
 	);
 
 export const getEventsInDailyBackup = ( logs, date ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds styles and some functional improvements to the Realtime Backup view (in BackupDelta) as well as the general styling and functionality of the `ActivityCard` component.

#### Testing instructions

* Load up this PR for a site with realtime backups, preferably for a site with plenty of activity. The BackupDelta component should list out restorable events as ActivityCards. You should be able to restore, download, and navigate to the detail page for any activitiy card.