### PR TITLE
Global Styles: fix previews not showing global styles

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/index.js
@@ -28,7 +28,11 @@ import './editor.scss';
 const { PLUGIN_NAME, STORE_NAME, REST_PATH } = JETPACK_GLOBAL_STYLES_EDITOR_CONSTANTS; // eslint-disable-line no-undef
 
 registerStore( STORE_NAME, REST_PATH );
-registerDOMUpdater( [ FONT_BASE, FONT_HEADINGS ], select( STORE_NAME ).getOption );
+registerDOMUpdater(
+	[ FONT_BASE, FONT_HEADINGS ],
+	select( STORE_NAME ).getOption,
+	select( STORE_NAME ).getOptions
+);
 
 registerPlugin( PLUGIN_NAME, {
 	render: compose(

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/index.js
@@ -28,11 +28,7 @@ import './editor.scss';
 const { PLUGIN_NAME, STORE_NAME, REST_PATH } = JETPACK_GLOBAL_STYLES_EDITOR_CONSTANTS; // eslint-disable-line no-undef
 
 registerStore( STORE_NAME, REST_PATH );
-registerDOMUpdater(
-	[ FONT_BASE, FONT_HEADINGS ],
-	select( STORE_NAME ).getOption,
-	select( STORE_NAME ).getOptions
-);
+registerDOMUpdater( [ FONT_BASE, FONT_HEADINGS ], select( STORE_NAME ).getOption );
 
 registerPlugin( PLUGIN_NAME, {
 	render: compose(

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
@@ -3,6 +3,7 @@
  */
 import { subscribe } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
+import { isEmpty } from 'lodash';
 
 /**
  * DOM updater
@@ -14,23 +15,32 @@ export default ( options, getOptionValue ) => {
 	domReady( () => {
 		const current = {};
 		const cssVariables = {};
+		const styleElement = document.createElement( 'style' );
+		document.body.appendChild( styleElement );
+		const styleSheet = styleElement.sheet;
+
 		options.forEach( option => {
 			current[ option ] = null;
 			cssVariables[ option ] = `--${ option.replace( '_', '-' ) }`;
 		} );
 
 		subscribe( () => {
+			let styleProps = '';
 			Object.keys( current ).forEach( key => {
 				const value = getOptionValue( key );
-				if ( current[ key ] !== value ) {
+				if ( ! isEmpty( value ) && current[ key ] !== value ) {
 					current[ key ] = value;
-					// We want to scope this to the root node of the editor.
-					const node = document.getElementsByClassName( 'editor-styles-wrapper' )[ 0 ];
-					if ( node ) {
-						node.style.setProperty( cssVariables[ key ], value );
-					}
+					styleProps += `${ cssVariables[ key ] }:${ value };`;
 				}
 			} );
+			// We want to scope this to the root node of the editor.
+			// We need this to be a stylesheet rather than inline styles so the styles apply to all editor instances incl. previews.
+			if ( ! isEmpty( styleProps ) ) {
+				styleSheet.insertRule(
+					`.editor-styles-wrapper{${ styleProps }}`,
+					styleSheet.cssRules.length
+				);
+			}
 		} );
 	} );
 };

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
@@ -33,9 +33,9 @@ export default ( options, getOptionValue ) => {
 			} );
 			// We need this to be a stylesheet rather than inline styles
 			// so the styles apply to all editor instances incl. previews.
-			if ( ! isEmpty( styleProps ) ) {
-				styleElement.textContent = `.editor-styles-wrapper{${ styleProps }}`;
-			}
+			styleElement.textContent = ! isEmpty( styleProps )
+				? `.editor-styles-wrapper{${ styleProps }}`
+				: '';
 		} );
 	} );
 };

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
@@ -17,8 +17,6 @@ export default ( options, getOptionValue ) => {
 		const cssVariables = {};
 		const styleElement = document.createElement( 'style' );
 		document.body.appendChild( styleElement );
-		const styleSheet = styleElement.sheet;
-
 		options.forEach( option => {
 			current[ option ] = null;
 			cssVariables[ option ] = `--${ option.replace( '_', '-' ) }`;
@@ -28,19 +26,15 @@ export default ( options, getOptionValue ) => {
 			let styleProps = '';
 			Object.keys( current ).forEach( key => {
 				const value = getOptionValue( key );
-				if ( ! isEmpty( value ) && current[ key ] !== value ) {
+				if ( ! isEmpty( value ) ) {
 					current[ key ] = value;
 					styleProps += `${ cssVariables[ key ] }:${ value };`;
 				}
 			} );
-			// We want to scope this to the root node of the editor.
 			// We need this to be a stylesheet rather than inline styles
 			// so the styles apply to all editor instances incl. previews.
 			if ( ! isEmpty( styleProps ) ) {
-				styleSheet.insertRule(
-					`.editor-styles-wrapper{${ styleProps }}`,
-					styleSheet.cssRules.length
-				);
+				styleElement.textContent = `.editor-styles-wrapper{${ styleProps }}`;
 			}
 		} );
 	} );

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
@@ -3,18 +3,20 @@
  */
 import { subscribe } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
-import { isEmpty } from 'lodash';
+import { isEmpty, isEqual } from 'lodash';
 
 /**
  * DOM updater
  *
  * @param {string[]} options A list of option names to keep track of.
  * @param {Function} getOptionValue A function that given an option name as a string, returns the current option value.
+ * @param {Function} getOptions A function that when called returns an object representing the current options.
  */
-export default ( options, getOptionValue ) => {
+export default ( options, getOptionValue, getOptions ) => {
 	domReady( () => {
 		const current = {};
 		const cssVariables = {};
+		let previousOptions = {};
 		const styleElement = document.createElement( 'style' );
 		document.body.appendChild( styleElement );
 		options.forEach( option => {
@@ -24,6 +26,12 @@ export default ( options, getOptionValue ) => {
 
 		subscribe( () => {
 			let styleProps = '';
+			const currentOptions = getOptions();
+			if ( isEmpty( currentOptions ) || isEqual( currentOptions, previousOptions ) ) {
+				return;
+			}
+			previousOptions = { ...currentOptions };
+
 			Object.keys( current ).forEach( key => {
 				const value = getOptionValue( key );
 				if ( ! isEmpty( value ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
@@ -34,7 +34,8 @@ export default ( options, getOptionValue ) => {
 				}
 			} );
 			// We want to scope this to the root node of the editor.
-			// We need this to be a stylesheet rather than inline styles so the styles apply to all editor instances incl. previews.
+			// We need this to be a stylesheet rather than inline styles
+			// so the styles apply to all editor instances incl. previews.
 			if ( ! isEmpty( styleProps ) ) {
 				styleSheet.insertRule(
 					`.editor-styles-wrapper{${ styleProps }}`,

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/store.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/store.js
@@ -43,6 +43,7 @@ const actions = {
  * Selectors under `wp.data.select( STORE_NAME )`:
  *
  * - getOption( String optionName )
+ * - getOptions()
  * - hasLocalChanges()
  *
  * Actions under `wp.data.dispatch( STORE_NAME )`:
@@ -76,14 +77,17 @@ export default ( storeName, optionsPath ) => {
 			getOption( state, key ) {
 				return state ? state[ key ] : undefined;
 			},
+			getOptions( state ) {
+				return state ? state : undefined;
+			},
 			hasLocalChanges( state ) {
 				return !! state && Object.keys( cache ).some( key => cache[ key ] !== state[ key ] );
 			},
 		},
 
 		resolvers: {
+			// eslint-disable-next-line no-unused-vars
 			*getOption( key ) {
-				// eslint-disable-line no-unused-vars
 				if ( alreadyFetchedOptions ) {
 					return; // do nothing
 				}

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/store.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/store.js
@@ -43,7 +43,6 @@ const actions = {
  * Selectors under `wp.data.select( STORE_NAME )`:
  *
  * - getOption( String optionName )
- * - getOptions()
  * - hasLocalChanges()
  *
  * Actions under `wp.data.dispatch( STORE_NAME )`:
@@ -76,9 +75,6 @@ export default ( storeName, optionsPath ) => {
 		selectors: {
 			getOption( state, key ) {
 				return state ? state[ key ] : undefined;
-			},
-			getOptions( state ) {
-				return state;
 			},
 			hasLocalChanges( state ) {
 				return !! state && Object.keys( cache ).some( key => cache[ key ] !== state[ key ] );

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/store.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/store.js
@@ -78,7 +78,7 @@ export default ( storeName, optionsPath ) => {
 				return state ? state[ key ] : undefined;
 			},
 			getOptions( state ) {
-				return state ? state : undefined;
+				return state;
 			},
 			hasLocalChanges( state ) {
 				return !! state && Object.keys( cache ).some( key => cache[ key ] !== state[ key ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, when a user selects a different Global Style, the changes are not immediately reflected in the Block Example and Block Patterns previews.

This is caused by the relevant Global Styles styles being applied inline in the editor. This way they only apply to the main editor instance but not the preview instances. The solution suggested in this PR is to still scope the styles to the same selector but instead of adding them inline adding them to a stylesheet. This way the styles apply to all editor instances including previews.

Fixes https://github.com/Automattic/wp-calypso/issues/40467 and https://github.com/Automattic/wp-calypso/issues/40353

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

(- Select a Varia based theme)
- Create a new post
- Check the visual style of Block Example for Headline and visual style of Block Patterns
- Change to a different Global Style setting
- Check if the visual style of Block Example for Headline and visual style of Block Patterns updated

 **Block Examples - Before** 

![blockexample-before](https://user-images.githubusercontent.com/1562646/77667924-1744b880-6f83-11ea-968b-65bbab9ff95c.gif)

 **Block Examples - After** 

![blockexample-after](https://user-images.githubusercontent.com/1562646/77668137-4fe49200-6f83-11ea-8319-9ada4cad80e0.gif)

 **Block Patterns - Before** 

![blockpatterns-before](https://user-images.githubusercontent.com/1562646/77668394-a651d080-6f83-11ea-9e6f-d5dbc248c4b4.gif)

 **Block Patterns - After** 

![blockpatterns-after](https://user-images.githubusercontent.com/1562646/77668591-e31dc780-6f83-11ea-8094-31d2a354391a.gif)

