### PR TITLE
Gutenboarding: Use new designs, fix previews

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/available-designs.json
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/available-designs.json
@@ -1,28 +1,94 @@
 {
 	"featured": [
 		{
-			"title": "Twenty twenty",
-			"slug": "twentytwenty",
-			"src": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Ftwentytwentydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?h=332&amp;vpw=960&amp;wph=960",
-			"srcset": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Ftwentytwentydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=480&amp;h=332&amp;vpw=960&amp;wph=960 480w, https://s.wordpress.com/mshots/v1/https%3A%2F%2Ftwentytwentydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=240&amp;h=332&amp;vpw=960&amp;wph=960 240w"
+			"title": "Vesta",
+			"slug": "vesta",
+			"template": "mayland2",
+			"theme": "mayland",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/mayland/mayland2/",
+			"fonts": [ "Cabin", "Raleway" ],
+			"categories": [ "featured", "portfolio" ]
 		},
 		{
-			"title": "Mayland",
-			"slug": "mayland",
-			"src": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Fmaylanddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?h=332&amp;vpw=960&amp;wph=960",
-			"srcset": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Fmaylanddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=480&amp;h=332&amp;vpw=960&amp;wph=960 480w, https://s.wordpress.com/mshots/v1/https%3A%2F%2Fmaylanddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=240&amp;h=332&amp;vpw=960&amp;wph=960 240w"
+			"title": "WIP Event Template",
+			"slug": "rivington",
+			"template": "rivington",
+			"theme": "rivington",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/rivington/rivington/",
+			"fonts": [ "Arvo", "Montserrat" ],
+			"categories": [ "event" ]
 		},
 		{
-			"title": "Rockfield",
-			"slug": "rockfield",
-			"src": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Frockfielddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?h=332&amp;vpw=960&amp;wph=960",
-			"srcset": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Frockfielddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=480&amp;h=332&amp;vpw=960&amp;wph=960 480w, https://s.wordpress.com/mshots/v1/https%3A%2F%2Frockfielddemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=240&amp;h=332&amp;vpw=960&amp;wph=960 240w"
+			"title": "Reynolds",
+			"slug": "reynolds",
+			"template": "rockfield2",
+			"theme": "rockfield",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/rockfield/rockfield2/",
+			"fonts": [ "Playfair Display", "Fira Sans" ],
+			"categories": [ "featured", "portfolio" ]
 		},
 		{
-			"title": "Barnsbury",
-			"slug": "barnsbury",
-			"src": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Fbarnsburydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?h=332&amp;vpw=960&amp;wph=960",
-			"srcset": "https://s.wordpress.com/mshots/v1/https%3A%2F%2Fbarnsburydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=480&amp;h=332&amp;vpw=960&amp;wph=960 480w, https://s.wordpress.com/mshots/v1/https%3A%2F%2Fbarnsburydemo.wordpress.com%2F%3Ftheme_preview%3Dtrue?w=240&amp;h=332&amp;vpw=960&amp;wph=960 240w"
+			"title": "Easley",
+			"slug": "easley",
+			"template": "maywood",
+			"theme": "maywood",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/maywood/maywood/",
+			"fonts": [ "Space Mono", "Roboto" ],
+			"categories": [ "featured", "portfolio" ]
+		},
+		{
+			"title": "Camden",
+			"slug": "Camden",
+			"template": "maywood2",
+			"theme": "maywood",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/maywood/maywood2/",
+			"fonts": [ "Space Mono", "Roboto" ],
+			"categories": [ "featured", "portfolio" ]
+		},
+		{
+			"title": "Bowen",
+			"slug": "bowen",
+			"template": "coutoire",
+			"theme": "coutoire",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/coutoire/coutoire/",
+			"fonts": [ "Playfair Display", "Fira Sans" ],
+			"categories": [ "featured", "blog" ]
+		},
+		{
+			"title": "Edison",
+			"slug": "edison",
+			"template": "stratford2",
+			"theme": "stratford",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/stratford/stratford2/",
+			"fonts": [ "Chivo", "Open Sans" ],
+			"categories": [ "featured", "blog" ]
+		},
+		{
+			"title": "Cassel",
+			"slug": "cassel",
+			"template": "mayland",
+			"theme": "mayland",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/mayland/mayland/",
+			"fonts": [ "Playfair Display", "Fira Sans" ],
+			"categories": [ "featured", "blog" ]
+		},
+		{
+			"title": "Overton",
+			"slug": "overton",
+			"template": "alves",
+			"theme": "alves",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/alves/alves/",
+			"fonts": [ "Cabin", "Raleway" ],
+			"categories": [ "featured", "business" ]
+		},
+		{
+			"title": "Doyle",
+			"slug": "doyle",
+			"template": "alves2",
+			"theme": "alves",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/alves/alves2/",
+			"fonts": [ "Playfair Display", "Fira Sans" ],
+			"categories": [ "featured", "business" ]
 		}
 	]
 }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { useDispatch } from '@wordpress/data';
 import React from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
 import { useI18n } from '@automattic/react-i18n';
 import { useHistory } from 'react-router-dom';
 import { Spring, animated } from 'react-spring/renderprops';
@@ -29,12 +30,22 @@ const DesignSelector: React.FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const { push } = useHistory();
 	const makePath = usePath();
+	const { siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { setSelectedDesign, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const handleStartOverButtonClick = () => {
 		resetOnboardStore();
 	};
 
+	const getDesignUrl = ( design: Design ) => {
+		const mshotsUrl = 'https://s.wordpress.com/mshots/v1/';
+		const previewUrl = addQueryArgs( design.src, {
+			vertical: siteVertical?.label,
+			font_headings: design.fonts[ 0 ],
+			font_base: design.fonts[ 1 ],
+		} );
+		return mshotsUrl + encodeURIComponent( previewUrl );
+	};
 	// Track hover/focus
 	const [ hoverDesign, setHoverDesign ] = React.useState< string >();
 	const [ focusDesign, setFocusDesign ] = React.useState< string >();
@@ -95,7 +106,7 @@ const DesignSelector: React.FunctionComponent = () => {
 										>
 											{ ( props2: React.CSSProperties ) => (
 												<animated.span style={ props2 } className="design-selector__image-frame">
-													<img alt={ design.title } src={ design.src } srcSet={ design.srcset } />
+													<img alt={ design.title } src={ getDesignUrl( design ) } />
 												</animated.span>
 											) }
 										</Spring>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -20,6 +20,8 @@ import { SubTitle, Title } from '../../components/titles';
 
 import './style.scss';
 
+type Design = import('../../stores/onboard/types').Design;
+
 // Values for springs:
 const ZOOM_OFF = { transform: 'scale(1)' };
 const ZOOM_ON = { transform: 'scale(1.03)' };

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { addQueryArgs } from '@wordpress/url';
 import { useSelect } from '@wordpress/data';
 import { ValuesType } from 'utility-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ interface Props {
 	viewport: T.Viewport;
 	fonts: ValuesType< typeof import('../../constants').fontPairings >;
 }
+
 const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 	const [ previewHtml, setPreviewHtml ] = React.useState< string >();
 	const [ requestedFonts, setRequestedFonts ] = React.useState< Set< string > >( new Set() );
@@ -37,8 +39,8 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 			const eff = async () => {
 				const [ { fontFamily: fontHeadings }, { fontFamily: fontBase } ] = fonts;
 				const templateUrl = `https://public-api.wordpress.com/rest/v1/template/demo/${ encodeURIComponent(
-					selectedDesign.slug
-				) }/${ encodeURIComponent( selectedDesign.slug ) }/`;
+					selectedDesign.theme
+				) }/${ encodeURIComponent( selectedDesign.template ) }/`;
 				const url = addQueryArgs( templateUrl, {
 					language: language,
 					vertical: siteVertical.label,
@@ -46,6 +48,7 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 					font_base: fontBase,
 				} );
 				let resp;
+
 				try {
 					resp = await window.fetch( url );
 					if ( resp.status < 200 || resp.status >= 300 ) {
@@ -128,7 +131,14 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 					<div role="presentation" className="style-preview__preview-bar-dot" />
 				</div>
 			) }
-			<iframe ref={ iframe } className="style-preview__iframe" title="preview" />
+			<iframe
+				ref={ iframe }
+				className={ classNames( {
+					'style-preview__iframe': true,
+					hideScroll: viewport !== 'desktop',
+				} ) }
+				title="preview"
+			/>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -29,7 +29,7 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 	// Cast reason: Our flow should ensure these are not `undefined`. Cast to defined types.
 	const { selectedDesign, siteVertical, siteTitle } = useSelect( select =>
 		select( STORE_KEY ).getState()
-	) as { selectedDesign: Design; siteVertical: SiteVertical };
+	) as { selectedDesign: Design; siteVertical: SiteVertical; siteTitle: string };
 
 	const iframe = React.useRef< HTMLIFrameElement >( null );
 	const language = useLangRouteParam();

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -27,7 +27,7 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 	const [ requestedFonts, setRequestedFonts ] = React.useState< Set< string > >( new Set() );
 
 	// Cast reason: Our flow should ensure these are not `undefined`. Cast to defined types.
-	const { selectedDesign, siteVertical } = useSelect( select =>
+	const { selectedDesign, siteVertical, siteTitle } = useSelect( select =>
 		select( STORE_KEY ).getState()
 	) as { selectedDesign: Design; siteVertical: SiteVertical };
 
@@ -46,6 +46,7 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 					vertical: siteVertical.label,
 					font_headings: fontHeadings,
 					font_base: fontBase,
+					site_title: siteTitle,
 				} );
 				let resp;
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -68,6 +68,8 @@
 	border-radius: 4px;
 	overflow: hidden;
 	width: 100%;
+	position: relative;
+	height: 700px;
 
 	&.is-viewport-mobile,
 	&.is-viewport-tablet {
@@ -129,8 +131,14 @@
 		}
 	}
 }
+.block-editor__container iframe.style-preview__iframe {
+	transform: scale( 0.7 );
+	transform-origin: 0 0;
+	width: 143%;
+	height: 143%;
+	position: absolute;
 
-.style-preview__iframe {
-	width: 100%;
-	height: 700px;
+	&.hideScroll {
+		width: 145%;
+	}
 }

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -20,5 +20,8 @@ export interface Design {
 	title: string;
 	slug: string;
 	src: string;
-	srcset: string;
+	theme: string;
+	template: string;
+	fonts: Array< string >;
+	categories: Array< string >;
 }


### PR DESCRIPTION
This PR updates the metadata of the designs available for gutenboarding and changes the design picker and the style preview steps to work with that format.

![image](https://user-images.githubusercontent.com/1554855/77671431-e61ab700-6f87-11ea-8939-3c3267a2ff73.png)

![image](https://user-images.githubusercontent.com/1554855/77671550-15312880-6f88-11ea-9325-7f5c929725bf.png)


How to test:
========

0. Go to calypso.localhost:3000/gutenboarding
1. Enter a vertical and a site title
2. In the design selector screen, you should see 10 different designs
3. Once you are in the preview step, the design should be visible
4. Check the mobile & tablet versions: The scroll bars shouldn't be visible there