### PR TITLE
Fix url for iframed Site Editor close button.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -566,8 +566,9 @@ function handleInsertClassicBlockMedia( calypsoPort ) {
 function handleCloseEditor( calypsoPort ) {
 	const legacySelector = '.edit-post-fullscreen-mode-close__toolbar a'; // maintain support for Gutenberg plugin < v7.7
 	const selector = '.edit-post-header .edit-post-fullscreen-mode-close';
+	const siteEditorSelector = '.edit-site-header .edit-site-fullscreen-mode-close';
 
-	$( '#editor' ).on( 'click', `${ legacySelector }, ${ selector }`, e => {
+	const dispatchAction = e => {
 		e.preventDefault();
 
 		const { port2 } = new MessageChannel();
@@ -580,7 +581,10 @@ function handleCloseEditor( calypsoPort ) {
 			},
 			[ port2 ]
 		);
-	} );
+	};
+
+	$( '#editor' ).on( 'click', `${ legacySelector }, ${ selector }`, dispatchAction );
+	$( '#edit-site-editor' ).on( 'click', `${ siteEditorSelector }`, dispatchAction );
 }
 
 /**

--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -46,15 +46,6 @@ export default function getEditorCloseConfig( state, siteId, postType, fseParent
 		};
 	}
 
-	// If a user comes from Home or from a fresh page load (i.e. Signup),
-	// redirect to Customer Home.
-	if ( ! lastNonEditorRoute || doesRouteMatch( /^\/home\/?/ ) ) {
-		return {
-			url: `/home/${ getSiteSlug( state, siteId ) }`,
-			label: translate( 'Home' ),
-		};
-	}
-
 	// Back to the themes list.
 	if ( doesRouteMatch( /^\/themes\/?/ ) ) {
 		return {
@@ -63,10 +54,13 @@ export default function getEditorCloseConfig( state, siteId, postType, fseParent
 		};
 	}
 
-	// If no postType, assume site editor and land on view.
-	if ( ! postType ) {
+	// If a user comes from Home or from a fresh page load (i.e. Signup),
+	// redirect to Customer Home.
+	// If no postType, assume site editor and land on home.
+	if ( ! lastNonEditorRoute || ! postType || doesRouteMatch( /^\/home\/?/ ) ) {
 		return {
-			url: `/view/${ getSiteSlug( state, siteId ) }`,
+			url: `/home/${ getSiteSlug( state, siteId ) }`,
+			label: translate( 'Home' ),
 		};
 	}
 

--- a/client/state/selectors/get-editor-close-config.js
+++ b/client/state/selectors/get-editor-close-config.js
@@ -63,6 +63,13 @@ export default function getEditorCloseConfig( state, siteId, postType, fseParent
 		};
 	}
 
+	// If no postType, assume site editor and land on view.
+	if ( ! postType ) {
+		return {
+			url: `/view/${ getSiteSlug( state, siteId ) }`,
+		};
+	}
+
 	// Otherwise, just return to post type listings
 	return {
 		url: getPostTypeAllPostsUrl( state, postType ),

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -9,12 +9,14 @@ import { ROUTE_SET } from 'state/action-types';
 
 const postType = 'post';
 const pagePostType = 'page';
+const siteEditorPostType = undefined;
 const templatePostType = 'wp_template_part';
 const siteId = 1;
 const siteSlug = 'fake.url.wordpress.com';
 const siteUrl = `https://${ siteSlug }`;
 const checklistUrl = `/checklist/${ siteSlug }`;
 const customerHomeUrl = `/home/${ siteSlug }`;
+const viewUrl = `/view/${ siteSlug }`;
 const blockEditorAction = { type: ROUTE_SET, path: '/block-editor/page/1' };
 const checklistAction = { type: ROUTE_SET, path: checklistUrl };
 const customerHomeAction = { type: ROUTE_SET, path: customerHomeUrl };
@@ -163,5 +165,49 @@ describe( 'getEditorCloseConfig()', () => {
 		};
 
 		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).toEqual( customerHomeUrl );
+	} );
+
+	test( 'should return URL to view if postType is undefined (site editor) and previous route has no match', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: { URL: siteUrl },
+				},
+			},
+			ui: {
+				route: {
+					path: {
+						previous: '/route-with-no-match',
+					},
+				},
+				selectedSiteId: siteId,
+				actionLog: [],
+			},
+		};
+
+		expect( getEditorCloseConfig( state, siteId, siteEditorPostType ).url ).toEqual( viewUrl );
+	} );
+
+	test( 'should still return to matching route w/ undefined (site editor) postType', () => {
+		const state = {
+			sites: {
+				items: {
+					[ siteId ]: { URL: siteUrl },
+				},
+			},
+			ui: {
+				route: {
+					path: {
+						previous: customerHomeUrl,
+					},
+				},
+				selectedSiteId: siteId,
+				actionLog: [],
+			},
+		};
+
+		expect( getEditorCloseConfig( state, siteId, siteEditorPostType, '' ).url ).toEqual(
+			customerHomeUrl
+		);
 	} );
 } );

--- a/client/state/selectors/test/get-editor-close-config.js
+++ b/client/state/selectors/test/get-editor-close-config.js
@@ -16,7 +16,7 @@ const siteSlug = 'fake.url.wordpress.com';
 const siteUrl = `https://${ siteSlug }`;
 const checklistUrl = `/checklist/${ siteSlug }`;
 const customerHomeUrl = `/home/${ siteSlug }`;
-const viewUrl = `/view/${ siteSlug }`;
+const themesUrl = `/themes/${ siteSlug }`;
 const blockEditorAction = { type: ROUTE_SET, path: '/block-editor/page/1' };
 const checklistAction = { type: ROUTE_SET, path: checklistUrl };
 const customerHomeAction = { type: ROUTE_SET, path: customerHomeUrl };
@@ -167,7 +167,7 @@ describe( 'getEditorCloseConfig()', () => {
 		expect( getEditorCloseConfig( state, siteId, postType, '' ).url ).toEqual( customerHomeUrl );
 	} );
 
-	test( 'should return URL to view if postType is undefined (site editor) and previous route has no match', () => {
+	test( 'should return URL to home if postType is undefined (site editor) and previous route has no match', () => {
 		const state = {
 			sites: {
 				items: {
@@ -185,7 +185,9 @@ describe( 'getEditorCloseConfig()', () => {
 			},
 		};
 
-		expect( getEditorCloseConfig( state, siteId, siteEditorPostType ).url ).toEqual( viewUrl );
+		expect( getEditorCloseConfig( state, siteId, siteEditorPostType ).url ).toEqual(
+			customerHomeUrl
+		);
 	} );
 
 	test( 'should still return to matching route w/ undefined (site editor) postType', () => {
@@ -198,7 +200,7 @@ describe( 'getEditorCloseConfig()', () => {
 			ui: {
 				route: {
 					path: {
-						previous: customerHomeUrl,
+						previous: themesUrl,
 					},
 				},
 				selectedSiteId: siteId,
@@ -207,7 +209,7 @@ describe( 'getEditorCloseConfig()', () => {
 		};
 
 		expect( getEditorCloseConfig( state, siteId, siteEditorPostType, '' ).url ).toEqual(
-			customerHomeUrl
+			themesUrl
 		);
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The site editor close button in the iframe currently leads to wp-admin, lets make this go back to calypso!

With this change, the close button will follow the priority of conditions as found in `get-editor-close-config.js` listed in the changed files here.  That is, if we opened the site editor from being on the checklist, home, or themes page, then we will return to those pages respecively.  If the site editor is opened from none of the above, its default is now `/view/$siteSlug`.

Perhaps there is a better default for the site editor to return to than the "veiw" screen, but the current default before this change would be `/$postType/$siteSlug` which for the site editor would be `/undefined/$siteSlug` since postType DNE in the context of the Site Editor.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this PR on local calypso AND build/sync the wpcom-block-editor from this PR.
* Test a site using the `gutenberg-edge` and `core-site-editor-enabled` stickers.
* Load the site editor, ensure the close button leads you back to the expected screen in calypso.
    * If opened from 'Themes' or 'Home', this should return to 'Themes' or 'Home'
    * If opened from elsewhere, this should return to the calypso 'View' Page.
* Smoke test the page/post editors similarly.

Fixes #
