### PR TITLE
Update DailyBackupStatus to use the backup from date selected + timezone

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -104,7 +104,7 @@ class DailyBackupStatus extends Component {
 				<div className="daily-backup-status__label">
 					<p>
 						{ translate(
-							'A backup for your site was attempted on %(displayDate) at %(displayTime) and was not able to be completed.',
+							'A backup for your site was attempted on %(displayDate)s at %(displayTime)s and was not able to be completed.',
 							{ args: { displayDate, displayTime } }
 						) }
 					</p>

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -11,6 +11,12 @@ import page from 'page';
 import { withLocalizedMoment } from 'components/localized-moment';
 import Gridicon from 'components/gridicon';
 import Button from 'components/forms/form-button';
+import {
+	isSuccessfulBackup,
+	getRestorePath,
+	getDownloadPath,
+} from 'landing/jetpack-cloud/sections/backups/utils';
+import { applySiteOffset } from 'lib/site/timezone';
 
 /**
  * Style dependencies
@@ -18,30 +24,51 @@ import Button from 'components/forms/form-button';
 import './style.scss';
 
 class DailyBackupStatus extends Component {
-	// TODO: now that we are reusing URLs we should have a dedicated paths file
-	createRestoreUrl = restoreId => `/backups/${ this.props.siteSlug }/restore/${ restoreId }`;
-	createDownloadUrl = downloadId => `/backups/${ this.props.siteSlug }/download/${ downloadId }`;
-
 	triggerRestore = () => {
-		const restoreId = this.props.backupAttempts.complete[ 0 ].rewindId;
-		page.redirect( this.createRestoreUrl( restoreId ) );
+		page.redirect( getRestorePath( this.props.siteSlug, this.props.backup.rewindId ) );
 	};
 
 	triggerDownload = () => {
-		const downloadId = this.props.backupAttempts.complete[ 0 ].rewindId;
-		page.redirect( this.createDownloadUrl( downloadId ) );
+		page.redirect( getDownloadPath( this.props.siteSlug, this.props.backup.rewindId ) );
 	};
 
-	renderGoodBackup() {
-		const { allowRestore, backupAttempts, moment, translate } = this.props;
+	goToDetailsPage() {
+		//page.redirect( '/backups/' + this.props.siteSlug + '/detail/' + this.props.backup.rewindId );
+	}
 
-		const displayDate = moment( backupAttempts.complete[ 0 ].activityDate ).format(
-			'MMMM Do YYYY, h:mm:ss a'
-		);
+	getDisplayDate = date => {
+		const { translate, moment, timezone, gmtOffset } = this.props;
+
+		//Apply the time offset
+		const backupDate = applySiteOffset( moment( date ), { timezone, gmtOffset } );
+		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
+
+		const isToday = today.isSame( backupDate, 'day' );
+		const yearToday = today.format( 'YYYY' );
+		const yearDate = backupDate.format( 'YYYY' );
+
+		const dateFormat = yearToday === yearDate ? 'MMM D' : 'MMM D, YYYY';
+
+		let displayableDate;
+
+		if ( isToday ) {
+			displayableDate =
+				translate( 'Latest' ) + ': ' + translate( 'Today' ) + ' ' + backupDate.format( 'LT' );
+		} else {
+			displayableDate = backupDate.format( dateFormat + ' LT' );
+		}
+
+		return displayableDate;
+	};
+
+	renderGoodBackup( backup ) {
+		const { allowRestore, translate } = this.props;
+
+		const displayDate = this.getDisplayDate( backup.activityTs );
 
 		return (
 			<Fragment>
-				<Gridicon icon="cloud-upload" />
+				<Gridicon className="daily-backup-status__status-icon" icon="cloud-upload" />
 				<div className="daily-backup-status__label">
 					{ translate( 'Latest backup completed:' ) }
 				</div>
@@ -60,34 +87,84 @@ class DailyBackupStatus extends Component {
 		);
 	}
 
-	renderFailedBackup() {
-		const { backupAttempts, translate } = this.props;
+	renderFailedBackup( backup ) {
+		const { translate, timezone, gmtOffset } = this.props;
 
-		const hasBackupError = backupAttempts.error.length;
-		const errorMessage =
-			hasBackupError && backupAttempts.error[ 0 ].activityDescription[ 0 ].children[ 0 ].text;
+		const backupTitleDate = this.getDisplayDate( backup.activityTs );
+		const backupDate = applySiteOffset( backup.activityTs, { timezone, gmtOffset } );
+
+		const displayDate = backupDate.format( 'L' );
+		const displayTime = backupDate.format( 'LT' );
 
 		return (
 			<Fragment>
 				<Gridicon icon="cross-circle" className="daily-backup-status__gridicon-error-state" />
-
-				<div className="daily-backup-status__date">{ translate( 'Backup error' ) }</div>
+				<div className="daily-backup-status__date">{ translate( 'Backup attempt failed' ) }</div>
+				<div className="daily-backup-status__date">{ backupTitleDate }</div>
 				<div className="daily-backup-status__label">
-					{ hasBackupError ? errorMessage : translate( 'This day has no backups.' ) }
+					<p>
+						{ translate(
+							'A backup for your site was attempted on %(displayDate) at %(displayTime) and was not able to be completed.',
+							{ args: { displayDate, displayTime } }
+						) }
+					</p>
+					<p>
+						{ /* todo: Add the link of the guide: "backups help guide" */ }
+						{ translate(
+							'Check out the backups help guide or contact our support team to resolve the issue. View to get the issue resolved'
+						) }
+					</p>
+					<Button className="daily-backup-status__download-button">
+						{ translate( 'Contact support' ) }
+					</Button>
 				</div>
 			</Fragment>
 		);
 	}
 
-	render() {
-		const { backupAttempts } = this.props;
-		const dateHasGoodBackup = backupAttempts.complete.length;
+	renderNoBackups() {
+		const { translate } = this.props;
 
 		return (
-			<div className="daily-backup-status">
-				{ dateHasGoodBackup ? this.renderGoodBackup() : this.renderFailedBackup() }
-			</div>
+			<Fragment>
+				<Gridicon icon="sync" />
+
+				<div className="daily-backup-status__date">Next backup at...</div>
+				{ /* translate( 'This day has no backups.' ) */ }
+				<Button className="daily-backup-status__download-button" disabled={ true }>
+					{ translate( 'Download backup' ) }
+				</Button>
+				<Button className="daily-backup-status__restore-button" disabled={ true }>
+					{ translate( 'Restore to this point' ) }
+				</Button>
+
+				<div>
+					<strong>{ translate( 'Get Real-Time Backups' ) }</strong>
+				</div>
+				<div>
+					{ /* todo: add a link to the page for the upgrade: "Upgrade to real-time backups" */ }
+					{ translate(
+						'Upgrade to real-time backups to have your work saved, in real-time as you make changes.'
+					) }
+				</div>
+			</Fragment>
 		);
+	}
+
+	renderBackupStatus( backup ) {
+		if ( ! backup ) {
+			return this.renderNoBackups();
+		} else if ( isSuccessfulBackup( backup ) ) {
+			return this.renderGoodBackup( backup );
+		}
+
+		return this.renderFailedBackup( backup );
+	}
+
+	render() {
+		const backup = this.props.backup;
+
+		return <div className="daily-backup-status">{ this.renderBackupStatus( backup ) }</div>;
 	}
 }
 

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -116,7 +116,6 @@ class DatePicker extends Component {
 				<Button compact borderless onClick={ this.goToNextDay }>
 					<Gridicon icon="chevron-right" className={ ! this.canGoToNextDay() && 'disabled' } />
 				</Button>
-				<div>Date selected: { this.getDisplayDate( selectedDate ) }</div>
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -284,10 +284,10 @@ class BackupsPage extends Component {
  * Create an indexed log of backups based on the date of the backup and in the site time zone
  *
  * @param {Array} logs The activity logs retrieved from the store
- * @param {string} siteTimezone The site time zone
- * @param {number} siteGmtOffset The site offset from the GMT
+ * @param {string} timezone The site time zone
+ * @param {number} gmtOffset The site offset from the GMT
  */
-const createIndexedLog = ( logs, siteTimezone, siteGmtOffset ) => {
+const createIndexedLog = ( logs, timezone, gmtOffset ) => {
 	const indexedLog = {};
 	let oldestDateAvailable = new Date();
 
@@ -295,8 +295,8 @@ const createIndexedLog = ( logs, siteTimezone, siteGmtOffset ) => {
 		logs.data.forEach( log => {
 			//Move the backup date to the site timezone
 			const backupDate = applySiteOffset( momentDate( log.activityTs ), {
-				siteTimezone,
-				siteGmtOffset,
+				timezone,
+				gmtOffset,
 			} );
 
 			//Get the index for this backup, index format: YYYYMMDD

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -148,6 +148,8 @@ class BackupsPage extends Component {
 			siteSlug,
 			isLoadingBackups,
 			oldestDateAvailable,
+			siteTimezone,
+			siteGmtOffset,
 		} = this.props;
 		const { selectedDate } = this.state;
 		const selectedDateString = this.TO_REMOVE_getSelectedDateString();
@@ -178,9 +180,10 @@ class BackupsPage extends Component {
 					<>
 						<DailyBackupStatus
 							allowRestore={ allowRestore }
-							date={ selectedDateString }
-							backupAttempts={ backupAttempts }
 							siteSlug={ siteSlug }
+							backup={ this.state.backupsOnSelectedDate.lastBackup }
+							timezone={ siteTimezone }
+							gmtOffset={ siteGmtOffset }
 						/>
                         { doesRewindNeedCredentials && (
                             <MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -159,7 +159,8 @@ class BackupsPage extends Component {
 			siteTimezone,
 			siteGmtOffset,
 		} = this.props;
-		const { selectedDate } = this.state;
+		const { selectedDate, backupsOnSelectedDate } = this.state;
+
 		const selectedDateString = this.TO_REMOVE_getSelectedDateString();
 
 		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
@@ -189,7 +190,7 @@ class BackupsPage extends Component {
 						<DailyBackupStatus
 							allowRestore={ allowRestore }
 							siteSlug={ siteSlug }
-							backup={ this.state.backupsOnSelectedDate.lastBackup }
+							backup={ backupsOnSelectedDate.lastBackup }
 							timezone={ siteTimezone }
 							gmtOffset={ siteGmtOffset }
 						/>
@@ -344,12 +345,13 @@ const mapStateToProps = state => {
 	}
 
 	const filter = getActivityLogFilter( state, siteId );
-	const logs = siteId && requestActivityLogs( siteId, filter );
+	const logs = requestActivityLogs( siteId, filter );
 	const siteGmtOffset = getSiteGmtOffset( state, siteId );
 	const siteTimezone = getSiteTimezoneValue( state, siteId );
 	const rewind = getRewindState( state, siteId );
 	const restoreStatus = rewind.rewind && rewind.rewind.status;
 	const doesRewindNeedCredentials = getDoesRewindNeedCredentials( state, siteId );
+	const hasRealtimeBackups = siteSupportsRealtimeBackup( state, siteId );
 	const allowRestore =
 		'active' === rewind.state && ! ( 'queued' === restoreStatus || 'running' === restoreStatus );
 
@@ -361,7 +363,7 @@ const mapStateToProps = state => {
 		allowRestore,
 		doesRewindNeedCredentials,
 		filter,
-		hasRealtimeBackups: siteSupportsRealtimeBackup( state, siteId ),
+		hasRealtimeBackups,
 		logs: logs?.data ?? [],
 		rewind,
 		siteId,

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -92,6 +92,7 @@ class BackupsPage extends Component {
 			siteId,
 			siteSlug,
 			isLoadingBackups,
+			oldestDateAvailable,
 		} = this.props;
 		const { selectedDate } = this.state;
 		const selectedDateString = this.TO_REMOVE_getSelectedDateString();
@@ -113,6 +114,7 @@ class BackupsPage extends Component {
 					onDateChange={ this.onDateChange }
 					selectedDate={ selectedDate }
 					siteId={ siteId }
+					oldestDateAvailable={ oldestDateAvailable }
 				/>
 
 				<div>{ isLoadingBackups && 'Loading backups...' }</div>

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -111,9 +111,9 @@ class BackupsPage extends Component {
 					backupsOnSelectedDate.activities.push( log );
 				}
 			} );
-
-			this.setState( { backupsOnSelectedDate } );
 		}
+
+		this.setState( { backupsOnSelectedDate } );
 	};
 
 	isEmptyFilter = filter => {

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -57,26 +57,28 @@ const backupStatusNames = [
 ];
 
 class BackupsPage extends Component {
-	state = {
-		selectedDate: new Date(),
-		backupsOnSelectedDate: {
-			lastBackup: null, // Last activity backup on the date
-			activities: [], // Rest of the activities (including other backups)
-		},
-	};
+	state = this.getDefaultState();
+
+	getDefaultState() {
+		return {
+			selectedDate: new Date(),
+			backupsOnSelectedDate: {
+				lastBackup: null,
+				activities: [],
+				nextBackupAt: null,
+			},
+		};
+	}
 
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.siteId !== this.props.siteId ) {
-			//If we switch the site, reset the current state
+			//If we switch the site, reset the current state to default
 			this.resetState();
 		}
 	}
 
 	resetState() {
-		this.setState( {
-			selectedDate: new Date(),
-			backupsOnSelectedDate: [],
-		} );
+		this.setState( this.getDefaultState() );
 	}
 
 	onDateChange = date => {

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -75,6 +75,14 @@ class BackupsPage extends Component {
 			//If we switch the site, reset the current state to default
 			this.resetState();
 		}
+		if ( prevProps.isLoadingBackups && ! this.props.isLoadingBackups ) {
+			const today = applySiteOffset( momentDate(), {
+				timezone: this.props.siteTimezone,
+				gmtOffset: this.props.gmtOffset,
+			} );
+
+			this.setBackupLogsFor( today );
+		}
 	}
 
 	resetState() {
@@ -185,9 +193,9 @@ class BackupsPage extends Component {
 							timezone={ siteTimezone }
 							gmtOffset={ siteGmtOffset }
 						/>
-                        { doesRewindNeedCredentials && (
-                            <MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
-                        ) }
+						{ doesRewindNeedCredentials && (
+							<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
+						) }
 						<BackupDelta
 							{ ...{
 								deltas,

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -91,6 +91,7 @@ class BackupsPage extends Component {
 			moment,
 			siteId,
 			siteSlug,
+			isLoadingBackups,
 		} = this.props;
 		const { selectedDate } = this.state;
 		const selectedDateString = this.TO_REMOVE_getSelectedDateString();
@@ -113,27 +114,34 @@ class BackupsPage extends Component {
 					selectedDate={ selectedDate }
 					siteId={ siteId }
 				/>
-				<DailyBackupStatus
-					allowRestore={ allowRestore }
-					date={ selectedDateString }
-					backupAttempts={ backupAttempts }
-					siteSlug={ siteSlug }
-				/>
-				{ doesRewindNeedCredentials && (
-					<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
+
+				<div>{ isLoadingBackups && 'Loading backups...' }</div>
+
+				{ ! isLoadingBackups && (
+					<>
+						<DailyBackupStatus
+							allowRestore={ allowRestore }
+							date={ selectedDateString }
+							backupAttempts={ backupAttempts }
+							siteSlug={ siteSlug }
+						/>
+                        { doesRewindNeedCredentials && (
+                            <MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
+                        ) }
+						<BackupDelta
+							{ ...{
+								deltas,
+								backupAttempts,
+								hasRealtimeBackups,
+								realtimeEvents,
+								allowRestore,
+								moment,
+								siteSlug,
+								metaDiff,
+							} }
+						/>
+					</>
 				) }
-				<BackupDelta
-					{ ...{
-						deltas,
-						backupAttempts,
-						hasRealtimeBackups,
-						realtimeEvents,
-						allowRestore,
-						moment,
-						siteSlug,
-						metaDiff,
-					} }
-				/>
 			</Main>
 		);
 	}
@@ -279,6 +287,8 @@ const mapStateToProps = state => {
 
 	const { indexedLog, oldestDateAvailable } = createIndexedLog( logs, siteTimezone, siteGmtOffset );
 
+	const isLoadingBackups = ! ( logs.state === 'success' );
+
 	return {
 		allowRestore,
 		doesRewindNeedCredentials,
@@ -292,6 +302,7 @@ const mapStateToProps = state => {
 		siteGmtOffset,
 		indexedLog,
 		oldestDateAvailable,
+		isLoadingBackups,
 	};
 };
 

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -123,3 +123,37 @@ export const getDailyBackupDeltas = ( logs, date ) => {
 		),
 	};
 };
+
+/**
+ * Check if the activity is the type of backup
+ *
+ * @param activity {object} Activity to check
+ */
+export const isActivityBackup = activity => {
+	return (
+		'rewind__backup_complete_full' === activity.activityName ||
+		'rewind__backup_complete_initial' === activity.activityName ||
+		'rewind__backup_error' === activity.activityName
+	);
+};
+
+/**
+ * Check if the backup is completed
+ *
+ * @param backup {object} Backup to check
+ */
+export const isSuccessfulBackup = backup => {
+	return (
+		'rewind__backup_complete_full' === backup.activityName ||
+		'rewind__backup_complete_initial' === backup.activityName
+	);
+};
+
+// TODO: now that we are reusing URLs we should have a dedicated paths file
+export const getRestorePath = ( siteSlug, rewindId ) => {
+	return `/backups/${ siteSlug }/restore/${ rewindId }`;
+};
+
+export const getDownloadPath = ( siteSlug, rewindId ) => {
+	return `/backups/${ siteSlug }/download/${ rewindId }`;
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adapt the DailyBackupStatus to use the backup for the selected date passed from BackupsPage. We apply the time zone of the site to the backup date and also the right format according to design.

![](https://cldup.com/Mrwti_2G0f.gif)

**Note:** No styles applied.

#### Testing instructions
(see the animation attached)

1. Check if the display backup date-time is the expected on the site time zone
2. Set another time zone for your site and check again (1) if the backup date-time matches with the selected time zone.

Bonus:

1. If you don't have backup performed from today, check the expected copy
2. If you have a day with a failed backup, check the expected copy 
