### PR TITLE
Customer Home: Removed Unused Photo Library Card Styling

### DIFF
--- a/client/my-sites/customer-home/cards/education/free-photo-library/style.scss
+++ b/client/my-sites/customer-home/cards/education/free-photo-library/style.scss
@@ -14,24 +14,3 @@
 	margin-top: 12px;
 	text-align: right;
 }
-
-.free-photo-library__demonstration-video {
-	max-height: 600px;
-	max-width: 800px;
-	width: calc( 90vw - 16px * 2 );
-	position: relative;
-	padding-bottom: calc( 9 / 16 * 100% );
-	height: 0;
-
-	@include breakpoint( '>480px' ) {
-		width: calc( 90vw - 24px * 2 );
-	}
-
-	iframe {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The video was moved into the support document in #40257, so the separate video styles are no longer necessary (or having any effect)

#### Testing instructions

Verify the `free-photo-library__demonstration-video` class isn't present anywhere: https://github.com/Automattic/wp-calypso/search?q=free-photo-library__demonstration-video&unscoped_q=free-photo-library__demonstration-video

cc @kwight, @gwwar 
