### PR TITLE
Site Editor: changed to pre_option hook

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
@@ -27,8 +27,7 @@ function initialize_site_editor() {
 	}
 
 	// Force enable required Gutenberg experiments if they are not already active.
-	add_filter( 'option_gutenberg-experiments', __NAMESPACE__ . '\enable_site_editor_experiment' );
-
+	add_filter( 'pre_option_gutenberg-experiments', __NAMESPACE__ . '\enable_site_editor_experiment' );
 	// Add top level Site Editor menu item.
 	add_action( 'admin_menu', __NAMESPACE__ . '\add_site_editor_menu_item' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* New sites created result in a blank screen for the Site Editor as noted in #40497 .  This is due to the option not being initialized.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new WP.com test site.
* Add `gutenberg-edge` (we need v7.8.0) and `core-site-editor-enabled` stickers to it.
* Sync FSE plugin from this PR.
* Navigate to test site's wp-admin or Calypso.
* Verify the Site Editor loads properly.

Fixes #40497
