### PR TITLE
Gutenboarding: Remove experimental login link from signup form

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -18,7 +18,6 @@ import { SITE_STORE } from '../../stores/site';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
 import SignupForm from '../../components/signup-form';
-import LoginForm from '../../components/login-form';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 
 import wp from '../../../../lib/wp';
@@ -87,7 +86,6 @@ const Header: FunctionComponent = () => {
 	}, [ siteTitle, setDomain ] );
 
 	const [ showSignupDialog, setShowSignupDialog ] = useState( false );
-	const [ showLoginDialog, setShowLoginDialog ] = useState( false );
 
 	const {
 		location: { pathname },
@@ -98,8 +96,7 @@ const Header: FunctionComponent = () => {
 		// this header isn't unmounted on route changes so we need to
 		// explicitly hide the dialog.
 		setShowSignupDialog( false );
-		setShowLoginDialog( false );
-	}, [ pathname, setShowSignupDialog, setShowLoginDialog ] );
+	}, [ pathname, setShowSignupDialog ] );
 
 	const currentDomain = domain ?? freeDomainSuggestion;
 
@@ -136,17 +133,10 @@ const Header: FunctionComponent = () => {
 
 	const handleSignup = () => {
 		setShowSignupDialog( true );
-		setShowLoginDialog( false );
-	};
-
-	const handleLogin = () => {
-		setShowSignupDialog( false );
-		setShowLoginDialog( true );
 	};
 
 	const closeAuthDialog = () => {
 		setShowSignupDialog( false );
-		setShowLoginDialog( false );
 	};
 
 	const handleSignupForDomains = () => {
@@ -243,16 +233,7 @@ const Header: FunctionComponent = () => {
 					) }
 				</div>
 			</section>
-			{ showSignupDialog && (
-				<SignupForm onRequestClose={ closeAuthDialog } onOpenLogin={ handleLogin } />
-			) }
-			{ showLoginDialog && (
-				<LoginForm
-					onRequestClose={ closeAuthDialog }
-					onOpenSignup={ handleSignup }
-					onLogin={ handleCreateSite }
-				/>
-			) }
+			{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -28,10 +28,9 @@ declare module '@wordpress/element' {
 
 interface Props {
 	onRequestClose: () => void;
-	onOpenLogin: () => void;
 }
 
-const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
+const SignupForm = ( { onRequestClose }: Props ) => {
 	const { __: NO__, _x: NO_x } = useI18n();
 	const [ emailVal, setEmailVal ] = useState( '' );
 	const { createAccount, clearErrors } = useDispatch( USER_STORE );
@@ -70,11 +69,6 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 		if ( success ) {
 			closeModal();
 		}
-	};
-
-	const openLogin = ( e: React.MouseEvent< HTMLElement > ) => {
-		onOpenLogin();
-		e.preventDefault();
 	};
 
 	const tos = __experimentalCreateInterpolateElement(
@@ -145,12 +139,6 @@ const SignupForm = ( { onRequestClose, onOpenLogin }: Props ) => {
 			<div className="signup-form__login-links">
 				<Button isLink href={ '/log-in?redirect_to=' + encodeURIComponent( loginRedirectUrl ) }>
 					{ NO__( 'Log in to create a site for your existing account.' ) }
-				</Button>
-			</div>
-			<div className="signup-form__login-links">
-				<Button isLink={ true } onClick={ openLogin }>
-					{ /* Removing before shipping, no need to translate */ }
-					(experimental login)
 				</Button>
 			</div>
 		</Modal>

--- a/client/landing/gutenboarding/devtools.ts
+++ b/client/landing/gutenboarding/devtools.ts
@@ -22,36 +22,8 @@ export const setupWpDataDebug = () => {
 					client_secret: config( 'wpcom_signup_key' ),
 				};
 
-				const { Auth, Site } = require( '@automattic/data-stores' );
-				const AUTH_STORE = Auth.register( clientCreds );
+				const { Site } = require( '@automattic/data-stores' );
 				Site.register( clientCreds );
-
-				window.wp.auth = {};
-				let previousState = window.wp.data.select( AUTH_STORE ).getLoginFlowState();
-				let previousErrors = window.wp.data.select( AUTH_STORE ).getErrors();
-				window.wp.data.subscribe( () => {
-					const newState = window.wp?.data.select( AUTH_STORE ).getLoginFlowState();
-					const newErrors = window.wp?.data.select( AUTH_STORE ).getErrors();
-					if (
-						previousState !== newState ||
-						JSON.stringify( previousErrors ) !== JSON.stringify( newErrors )
-					) {
-						console.log( 'New loginFlowState =', newState );
-						if ( newErrors.length ) {
-							console.log( 'Errors =', JSON.stringify( newErrors, null, 2 ) );
-						} else {
-							console.log( 'No Errors!' );
-						}
-						previousState = newState;
-						previousErrors = newErrors;
-					}
-				} );
-				for ( const [ actionName, actionFn ] of Object.entries(
-					window.wp.data.dispatch( AUTH_STORE )
-				) ) {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					window.wp.auth[ actionName ] = ( ...args: any[] ) => ( actionFn as any )( ...args );
-				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For now we're going to rely on the frankenflow login UI. That means we no longer need the login UI that's embedded in gutenboarding (for now). The

* Remove the "(experimental login)" link from the signup form
* Remove code that links in the login UI so it's no longer included in the bundle
* Remove auth store from devtools so it's no longer included in the dev bundle

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/gutenboarding`
* Choose site vertical and title
* Open domain picker and choose a premium domain
* Click "Create your site and register your new domain"
* See that "(experimental login)" link is gone
* Close modal and complete gutenboarding flow
* In the "save your progress" modal at the end see that the "(experimental login)" link is gone
