### PR TITLE
E2E: Temporary remove block editor test from IE11 canary suite

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -244,7 +244,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Basic Public Post @canary @ie11canary @parallel', function() {
+	describe( 'Basic Public Post @canary @parallel', function() {
 		describe( 'Publish a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1095,6 +1095,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can update the homepage', async function() {
+			// Skipping if IE11 due to JS errors caused by missing DOMRect polyfill.
+			// See https://github.com/Automattic/wp-calypso/issues/40502
+			if ( dataHelper.getTargetType() === 'IE11' ) {
+				return this.skip();
+			}
 			const checklistPage = await ChecklistPage.Expect( this.driver );
 			await checklistPage.updateHomepage();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );


### PR DESCRIPTION
Temporary removes the block editor E2E tests from the IE11 canary suite while working on adding the DOMRect polyfill (https://github.com/Automattic/wp-calypso/issues/40502).
