### PR TITLE
Wrap the payment settings/auto-renew if on mobile

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/helpers.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/helpers.jsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classNames from 'classnames';
+
+function WrapDomainStatusButtons( props ) {
+	const wrapperClassNames = classNames( 'domain-types__wrap-me', props.className );
+	return (
+		<React.Fragment>
+			<div className="domain-types__break" />
+			<div className={ wrapperClassNames }>{ props.children }</div>
+		</React.Fragment>
+	);
+}
+
+export { WrapDomainStatusButtons };

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -32,6 +32,8 @@ import { isRechargeable, isExpired } from 'lib/purchases';
 import ExpiringCreditCard from '../card/notices/expiring-credit-card';
 import ExpiringSoon from '../card/notices/expiring-soon';
 import DomainManagementNavigation from '../navigation';
+import { WrapDomainStatusButtons } from './helpers';
+
 
 class MappedDomainType extends React.Component {
 	resolveStatus() {
@@ -190,7 +192,7 @@ class MappedDomainType extends React.Component {
 			return null;
 		}
 
-		return (
+		const content = (
 			<AutoRenewToggle
 				planName={ selectedSite.plan.product_name_short }
 				siteDomain={ selectedSite.domain }
@@ -199,24 +201,26 @@ class MappedDomainType extends React.Component {
 				withTextStatus={ true }
 			/>
 		);
+
+		return content && <WrapDomainStatusButtons>{ content }</WrapDomainStatusButtons>;
 	}
 
 	renderAutoRenew() {
 		const { isLoadingPurchase, domain } = this.props;
 
 		if ( domain && domain.bundledPlanSubscriptionId ) {
-			return <div />;
+			return null;
 		}
 
 		if ( isLoadingPurchase ) {
 			return (
-				<div className="domain-types__auto-renew-placeholder">
+				<WrapDomainStatusButtons className="domain-types__auto-renew-placeholder">
 					<p />
-				</div>
+				</WrapDomainStatusButtons>
 			);
 		}
 
-		return <div>{ this.renderAutoRenewToggle() }</div>;
+		return this.renderAutoRenewToggle();
 	}
 
 	handlePaymentSettingsClick = () => {
@@ -277,9 +281,8 @@ class MappedDomainType extends React.Component {
 				<Card compact={ true } className="domain-types__expiration-row">
 					<div>{ expiresText }</div>
 					{ this.renderDefaultRenewButton() }
-					<div className="domain-types__break" />
 					{ ! newStatusDesignAutoRenew && domain.subscriptionId && (
-						<div>
+						<WrapDomainStatusButtons>
 							<SubscriptionSettings
 								type={ domain.type }
 								compact={ true }
@@ -287,7 +290,7 @@ class MappedDomainType extends React.Component {
 								siteSlug={ this.props.selectedSite.slug }
 								onClick={ this.handlePaymentSettingsClick }
 							/>
-						</div>
+						</WrapDomainStatusButtons>
 					) }
 					{ newStatusDesignAutoRenew && domain.currentUserCanManage && this.renderAutoRenew() }
 				</Card>

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -277,6 +277,7 @@ class MappedDomainType extends React.Component {
 				<Card compact={ true } className="domain-types__expiration-row">
 					<div>{ expiresText }</div>
 					{ this.renderDefaultRenewButton() }
+					<div className="domain-types__break" />
 					{ ! newStatusDesignAutoRenew && domain.subscriptionId && (
 						<div>
 							<SubscriptionSettings

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -366,6 +366,7 @@ class RegisteredDomainType extends React.Component {
 							  } ) }
 					</div>
 					{ this.renderDefaultRenewButton() }
+					<div className="domain-types__break" />
 					{ ! newStatusDesignAutoRenew && domain.currentUserCanManage && (
 						<div>
 							<SubscriptionSettings

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -37,6 +37,7 @@ import { isExpired, shouldRenderExpiringCreditCard, isRechargeable } from 'lib/p
 import ExpiringCreditCard from '../card/notices/expiring-credit-card';
 import ExpiringSoon from '../card/notices/expiring-soon';
 import DomainManagementNavigation from '../navigation';
+import { WrapDomainStatusButtons } from './helpers';
 
 class RegisteredDomainType extends React.Component {
 	resolveStatus() {
@@ -258,7 +259,7 @@ class RegisteredDomainType extends React.Component {
 			return null;
 		}
 
-		return (
+		const content = (
 			<AutoRenewToggle
 				planName={ selectedSite.plan.product_name_short }
 				siteDomain={ selectedSite.domain }
@@ -267,6 +268,8 @@ class RegisteredDomainType extends React.Component {
 				withTextStatus={ true }
 			/>
 		);
+
+		return content && <WrapDomainStatusButtons>{ content }</WrapDomainStatusButtons>;
 	}
 
 	renderAutoRenew() {
@@ -274,13 +277,13 @@ class RegisteredDomainType extends React.Component {
 
 		if ( isLoadingPurchase ) {
 			return (
-				<div className="domain-types__auto-renew-placeholder">
+				<WrapDomainStatusButtons className="domain-types__auto-renew-placeholder">
 					<p />
-				</div>
+				</WrapDomainStatusButtons>
 			);
 		}
 
-		return <div>{ this.renderAutoRenewToggle() }</div>;
+		return this.renderAutoRenewToggle();
 	}
 
 	planUpsellForNonPrimaryDomain() {
@@ -366,9 +369,8 @@ class RegisteredDomainType extends React.Component {
 							  } ) }
 					</div>
 					{ this.renderDefaultRenewButton() }
-					<div className="domain-types__break" />
 					{ ! newStatusDesignAutoRenew && domain.currentUserCanManage && (
-						<div>
+						<WrapDomainStatusButtons>
 							<SubscriptionSettings
 								type={ domain.type }
 								compact={ true }
@@ -376,7 +378,7 @@ class RegisteredDomainType extends React.Component {
 								siteSlug={ this.props.selectedSite.slug }
 								onClick={ this.handlePaymentSettingsClick }
 							/>
-						</div>
+						</WrapDomainStatusButtons>
 					) }
 					{ newStatusDesignAutoRenew && domain.currentUserCanManage && this.renderAutoRenew() }
 				</Card>

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -155,8 +155,13 @@
 			.domain-types__break {
 				flex-basis: 100%;
 				height: 0;
-				border-top: 1px solid var( --color-neutral-5 );
 				margin: 0;
+			}
+			> div.domain-types__wrap-me {
+				border-top: 1px solid var( --color-neutral-5 );
+				flex-basis: 100%;
+				margin: 0;
+				padding: 16px 24px;
 			}
 		}
 	}

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -155,7 +155,7 @@
 			.domain-types__break {
 				flex-basis: 100%;
 				height: 0;
-				border-top: 1px solid red;
+				border-top: 1px solid var( --color-neutral-5 );
 				margin: 0;
 			}
 		}

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -138,12 +138,26 @@
 
 	.domain-types__expiration-row {
 		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
-		.renew-button {
-			margin-left: 10px;
+		padding: 0;
+		> div {
+			margin: 16px 0 16px 24px;
 		}
 		> div:nth-last-child( 2 ) {
 			margin-right: auto;
+		}
+		> div:last-child {
+			margin-right: 24px;
+		}
+
+		@include breakpoint( '<800px' ) {
+			.domain-types__break {
+				flex-basis: 100%;
+				height: 0;
+				border-top: 1px solid red;
+				margin: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We need to wrap the payment settings button to a new line on small displays.

Here's how it looks:

<img width="597" alt="Screenshot 2020-03-27 at 15 26 23" src="https://user-images.githubusercontent.com/1355045/77760691-710ab880-703f-11ea-8564-a7db7eac4441.png">

<img width="473" alt="Screenshot 2020-03-27 at 15 26 28" src="https://user-images.githubusercontent.com/1355045/77760697-72d47c00-703f-11ea-9e20-453f29e51715.png">

<img width="444" alt="Screenshot 2020-03-27 at 15 26 39" src="https://user-images.githubusercontent.com/1355045/77760701-736d1280-703f-11ea-9b78-7894490871b0.png">

#### Testing instructions

* Test with `domains/new-status-design/auto-renew` flag disabled and enabled - both should work when you go below 800px the button/auto-rene toggle should wrap on a separate line

Fixes #40182 
