### PR TITLE
Domains: Update messaging and timing for new domains setup period

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
@@ -70,7 +70,7 @@ const DomainRegistrationDetails = ( {
 				icon={ <img alt="" src="/calypso/images/upgrades/wait-time.svg" /> }
 				title={ i18n.translate( 'When will it be ready?', { comment: '"it" refers to a domain' } ) }
 				description={ i18n.translate(
-					'Your domain should start working immediately, but may be unreliable during the first 72 hours.'
+					'Your domain should start working immediately, but may be unreliable during the first 30 minutes.'
 				) }
 				buttonText={ i18n.translate( 'Learn more about your domain' ) }
 				href={ DOMAIN_WAITING }

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -528,7 +528,7 @@ export class DomainWarnings extends React.PureComponent {
 			domain =>
 				domain.registrationDate &&
 				moment( domain.registrationDate )
-					.add( 3, 'days' )
+					.add( 30, 'minutes' )
 					.isAfter( moment() ) &&
 				domain.type === domainTypes.REGISTERED
 		);
@@ -545,7 +545,7 @@ export class DomainWarnings extends React.PureComponent {
 			if ( hasNewPrimaryDomain ) {
 				text = translate(
 					'{{pNode}}We are setting up your new domains for you. ' +
-						'They should start working immediately, but may be unreliable during the first 72 hours.{{/pNode}}' +
+						'They should start working immediately, but may be unreliable during the first 30 minutes.{{/pNode}}' +
 						'{{pNode}}If you are unable to access your site at %(primaryDomain)s, try setting the primary domain to a domain ' +
 						'you know is working. {{domainsLink}}Learn more{{/domainsLink}} about setting the primary domain.{{/pNode}}',
 					{
@@ -559,7 +559,7 @@ export class DomainWarnings extends React.PureComponent {
 			} else {
 				text = translate(
 					'We are setting up your new domains for you. They should start working immediately, ' +
-						'but may be unreliable during the first 72 hours. ' +
+						'but may be unreliable during the first 30 minutes. ' +
 						'{{domainsLink}}Learn more{{/domainsLink}}.',
 					{ components: { domainsLink } }
 				);
@@ -569,7 +569,7 @@ export class DomainWarnings extends React.PureComponent {
 			if ( hasNewPrimaryDomain ) {
 				text = translate(
 					'{{pNode}}We are setting up {{strong}}%(domainName)s{{/strong}} for you. ' +
-						'It should start working immediately, but may be unreliable during the first 72 hours.{{/pNode}}' +
+						'It should start working immediately, but may be unreliable during the first 30 minutes.{{/pNode}}' +
 						'{{pNode}}If you are unable to access your site at {{strong}}%(domainName)s{{/strong}}, ' +
 						'try setting the primary domain to a domain you know is working. ' +
 						'{{domainsLink}}Learn more{{/domainsLink}} about setting the primary domain, or ' +
@@ -587,7 +587,7 @@ export class DomainWarnings extends React.PureComponent {
 			} else {
 				text = translate(
 					'We are setting up {{strong}}%(domainName)s{{/strong}} for you. ' +
-						'It should start working immediately, but may be unreliable during the first 72 hours. ' +
+						'It should start working immediately, but may be unreliable during the first 30 minutes. ' +
 						'{{domainsLink}}Learn more{{/domainsLink}} about your new domain, or ' +
 						'{{tryNowLink}} try it now{{/tryNowLink}}.',
 					{

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -288,8 +288,8 @@ describe( 'index', () => {
 			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
 
 			const domNode = ReactDom.findDOMNode( component ),
-				textContent = domNode.textContent,
-				links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+				textContent = domNode ? domNode.textContent : '',
+				links = domNode ? [].slice.call( domNode.querySelectorAll( 'a' ) ) : [];
 
 			expect( textContent ).not.toContain( 'Please verify ownership of domains' );
 			expect(

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -77,7 +77,7 @@ const DomainOnly = ( { primaryDomain, hasNotice, recordTracks, siteId, slug, tra
 			{ hasNotice && (
 				<div className="domain-only-site__settings-notice">
 					{ translate(
-						'Your domain should start working immediately, but may be unreliable during the first 72 hours.'
+						'Your domain should start working immediately, but may be unreliable during the first 30 minutes.'
 					) }
 				</div>
 			) }

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -220,7 +220,7 @@ export class List extends React.Component {
 			domain.registrationDate &&
 			this.props
 				.moment()
-				.subtract( 1, 'day' )
+				.subtract( 30, 'minutes' )
 				.isBefore( this.props.moment( domain.registrationDate ) )
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates messaging for new domain registrations, to indicate that domains may be unreliable for 30 minutes, instead of the previous 72 hour period.

Sample screenshots:

<img width="1053" alt="Warning in domain management screen" src="https://user-images.githubusercontent.com/13062352/77764647-428bde00-703d-11ea-82a5-1e86f19d12c5.png">

<img width="714" alt="Messaging in post purchase thank you page" src="https://user-images.githubusercontent.com/13062352/77764649-4455a180-703d-11ea-9684-d9902f0f536d.png">


#### Testing instructions

Verify that the correct message (30 minutes) is displayed in the domain settings for each of the scenarios listed below:

- Two or more newly purchased domains
  - Primary domain is a new domain
  - Primary domain is an old domain, or the default free subdomain
- Only one newly purchased domain
  - Primary domain is the new domain
  - Primary domain is an old domain, or the default free subdomain
- Domain only purchase

Also ensure the message won't be displayed for domains purchased more than 30 minutes ago, and that the correct message is displayed in the post checkout page.
