### PR TITLE
Revert "E2E: Temporary remove block editor test from IE11 canary suite"

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -15,7 +15,12 @@ import { ShortcodeBlockComponent } from './blocks/shortcode-block-component';
 import { ImageBlockComponent } from './blocks/image-block-component';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
-	constructor( driver, url, editorType = 'iframe' ) {
+	/**
+	 * @param {*} driver the selenium driver
+	 * @param {*} url url to visit, or null to stay on the same page
+	 * @param { 'iframe' | 'wp-admin' | 'preferIFrame' } editorType editor type the test expect to be on the page
+	 */
+	constructor( driver, url, editorType = 'preferIFrame' ) {
 		super( driver, By.css( '.edit-post-header' ), url );
 		this.editorType = editorType;
 
@@ -37,15 +42,21 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async _preInit() {
-		if ( this.editorType !== 'iframe' ) {
+		if ( this.editorType !== 'iframe' && this.editorType !== 'preferIFrame' ) {
 			return;
 		}
 		await this.driver.switchTo().defaultContent();
-		await this.driver.wait(
-			until.ableToSwitchToFrame( this.editoriFrameSelector ),
-			this.explicitWaitMS,
-			'Could not locate the editor iFrame.'
-		);
+		try {
+			await this.driver.wait(
+				until.ableToSwitchToFrame( this.editoriFrameSelector ),
+				this.explicitWaitMS,
+				'Could not locate the editor iFrame.'
+			);
+		} catch ( error ) {
+			if ( this.editorType === 'preferIFrame' ) {
+				return;
+			}
+		}
 		await this.driver.sleep( 2000 );
 	}
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -244,7 +244,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Basic Public Post @canary @parallel', function() {
+	describe( 'Basic Public Post @canary @ie11canary @parallel', function() {
 		describe( 'Publish a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1095,11 +1095,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can update the homepage', async function() {
-			// Skipping if IE11 due to JS errors caused by missing DOMRect polyfill.
-			// See https://github.com/Automattic/wp-calypso/issues/40502
-			if ( dataHelper.getTargetType() === 'IE11' ) {
-				return this.skip();
-			}
 			const checklistPage = await ChecklistPage.Expect( this.driver );
 			await checklistPage.updateHomepage();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#40510.

This should be obsolete per D40956-code.

**Testing Instructions**

Verify that the IE11 Canary goes green on this PR.

Resolves #40502