### PR TITLE
Change the auto-renew toggle text during toggling

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -145,6 +145,10 @@ class AutoRenewToggle extends Component {
 	renderTextStatus() {
 		const { translate, isEnabled } = this.props;
 
+		if ( this.isUpdatingAutoRenew() ) {
+			return translate( 'Auto-renew (…)' );
+		}
+
 		return isEnabled ? translate( 'Auto-renew (on)' ) : translate( 'Auto-renew (off)' );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When toggling the auto-renew toggle on the domain status screen there is no way to tell that anything is happening besides the toggle being disabled. This PR changes the text description so that it is clear we're in between states.

It looks like this:

<img width="173" alt="Screenshot 2020-03-27 at 17 32 28" src="https://user-images.githubusercontent.com/1355045/77772569-095d6900-7051-11ea-91ee-0b1b72ab66ff.png">

#### Testing instructions

* Open the new domain status screen with auto-renew toggle enabled (on dev environment) and click on the auto-renew toggle. You should see the ellipsis while the auto-renew status is updating.

