### PR TITLE
Manage Plans: Hide billing period changes on disconnected sites

### DIFF
--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -94,15 +94,17 @@ export class PlanBillingPeriod extends Component {
 		}
 
 		return (
-			<FormSettingExplanation>
-				{ translate( 'Billed monthly' ) }
-				{ site ? (
-					<Button onClick={ this.handleMonthlyToYearlyButtonClick } primary compact>
-						{ translate( 'Upgrade to yearly billing' ) }
-					</Button>
-				) : (
-					<span>
-						<br />
+			<React.Fragment>
+				<FormSettingExplanation>
+					{ translate( 'Billed monthly' ) }
+					{ site && (
+						<Button onClick={ this.handleMonthlyToYearlyButtonClick } primary compact>
+							{ translate( 'Upgrade to yearly billing' ) }
+						</Button>
+					) }
+				</FormSettingExplanation>
+				{ ! site && (
+					<FormSettingExplanation>
 						{ translate(
 							'To manage your plan, please {{supportPageLink}}reconnect{{/supportPageLink}} your site.',
 							{
@@ -117,9 +119,9 @@ export class PlanBillingPeriod extends Component {
 								},
 							}
 						) }
-					</span>
+					</FormSettingExplanation>
 				) }
-			</FormSettingExplanation>
+			</React.Fragment>
 		);
 	}
 

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -24,7 +24,7 @@ import { isExpired, isExpiring, isRenewing, showCreditCardExpiringWarning } from
 import { JETPACK_SUPPORT } from 'lib/url/support';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-class PlanBillingPeriod extends Component {
+export class PlanBillingPeriod extends Component {
 	static propTypes = {
 		purchase: PropTypes.object,
 		site: PropTypes.object,

--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -21,11 +21,13 @@ import { getYearlyPlanByMonthly } from 'lib/plans';
 import { planItem } from 'lib/cart-values/cart-items';
 import { addItem } from 'lib/cart/actions';
 import { isExpired, isExpiring, isRenewing, showCreditCardExpiringWarning } from 'lib/purchases';
+import { JETPACK_SUPPORT } from 'lib/url/support';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class PlanBillingPeriod extends Component {
 	static propTypes = {
 		purchase: PropTypes.object,
+		site: PropTypes.object,
 	};
 
 	handleMonthlyToYearlyButtonClick = () => {
@@ -75,7 +77,7 @@ class PlanBillingPeriod extends Component {
 	}
 
 	renderBillingPeriod() {
-		const { purchase, translate } = this.props;
+		const { purchase, site, translate } = this.props;
 		if ( ! purchase ) {
 			return;
 		}
@@ -94,9 +96,29 @@ class PlanBillingPeriod extends Component {
 		return (
 			<FormSettingExplanation>
 				{ translate( 'Billed monthly' ) }
-				<Button onClick={ this.handleMonthlyToYearlyButtonClick } primary compact>
-					{ translate( 'Upgrade to yearly billing' ) }
-				</Button>
+				{ site ? (
+					<Button onClick={ this.handleMonthlyToYearlyButtonClick } primary compact>
+						{ translate( 'Upgrade to yearly billing' ) }
+					</Button>
+				) : (
+					<span>
+						<br />
+						{ translate(
+							'To manage your plan, please {{supportPageLink}}reconnect{{/supportPageLink}} your site.',
+							{
+								components: {
+									supportPageLink: (
+										<a
+											href={
+												JETPACK_SUPPORT + 'reconnecting-reinstalling-jetpack/#reconnecting-jetpack'
+											}
+										/>
+									),
+								},
+							}
+						) }
+					</span>
+				) }
 			</FormSettingExplanation>
 		);
 	}

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -28,7 +28,7 @@ import { getPluginsForSite } from 'state/plugins/premium/selectors';
  */
 import './style.scss';
 
-class PurchasePlanDetails extends Component {
+export class PurchasePlanDetails extends Component {
 	static propTypes = {
 		purchaseId: PropTypes.number,
 		isPlaceholder: PropTypes.bool,

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -16,7 +16,7 @@ import FormLabel from 'components/forms/form-label';
 import QueryPluginKeys from 'components/data/query-plugin-keys';
 import SectionHeader from 'components/section-header';
 import PlanBillingPeriod from './billing-period';
-import { isRequestingSites } from 'state/sites/selectors';
+import { isRequestingSites, getSite } from 'state/sites/selectors';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { isDataLoading } from 'me/purchases/utils';
 import { getName, isExpired, isPartnerPurchase } from 'lib/purchases';
@@ -43,6 +43,7 @@ class PurchasePlanDetails extends Component {
 				key: PropTypes.string,
 			} ).isRequired
 		).isRequired,
+		site: PropTypes.object,
 		siteId: PropTypes.number,
 	};
 
@@ -68,7 +69,7 @@ class PurchasePlanDetails extends Component {
 	}
 
 	render() {
-		const { pluginList, purchase, siteId, translate } = this.props;
+		const { pluginList, purchase, site, siteId, translate } = this.props;
 
 		// Short out as soon as we know it's not a Jetpack plan
 		if ( purchase && ( ! isJetpackPlan( purchase ) || isFreeJetpackPlan( purchase ) ) ) {
@@ -94,7 +95,9 @@ class PurchasePlanDetails extends Component {
 				{ siteId && <QueryPluginKeys siteId={ siteId } /> }
 				<SectionHeader label={ headerText } />
 				<Card>
-					{ ! isPartnerPurchase( purchase ) && <PlanBillingPeriod purchase={ purchase } /> }
+					{ ! isPartnerPurchase( purchase ) && (
+						<PlanBillingPeriod purchase={ purchase } site={ site } />
+					) }
 
 					{ pluginList.map( ( plugin, i ) => {
 						return (
@@ -118,6 +121,7 @@ export default connect( ( state, props ) => {
 	const siteId = purchase ? purchase.siteId : null;
 	return {
 		hasLoadedSites: ! isRequestingSites( state ),
+		site: purchase ? getSite( state, purchase.siteId ) : null,
 		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
 		purchase,
 		pluginList: getPluginsForSite( state, siteId ),

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -74,6 +74,7 @@ describe( 'PlanBillingPeriod', () => {
 				expect(
 					wrapper
 						.find( 'FormSettingExplanation' )
+						.last()
 						.shallow()
 						.text()
 				).toContain( 'To manage your plan, please reconnect your site.' );

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -1,0 +1,190 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import moment from 'moment';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { PlanBillingPeriod } from '../billing-period';
+import page from 'page';
+import { planItem } from 'lib/cart-values/cart-items';
+import { addItem } from 'lib/cart/actions';
+
+const props = {
+	purchase: {
+		// Including only the properties that are used by this component
+		id: 123,
+		siteId: 123,
+		productName: 'Jetpack Personal',
+		productSlug: 'jetpack_premium_monthly',
+		domain: 'site.com',
+		expiryStatus: 'active',
+		payment: {
+			type: 'paypal',
+		},
+	},
+	site: {
+		ID: 123,
+		name: 'Site Name',
+	},
+	recordTracksEvent: jest.fn(),
+	translate,
+	moment,
+};
+
+jest.mock( 'lib/cart-values/cart-items', () => ( {
+	planItem: jest.fn(),
+} ) );
+
+jest.mock( 'lib/cart/actions', () => ( {
+	addItem: jest.fn(),
+} ) );
+
+jest.mock( 'page', () => jest.fn() );
+
+describe( 'PlanBillingPeriod', () => {
+	describe( 'a monthly plan', () => {
+		it( 'should display the current period', () => {
+			const wrapper = shallow( <PlanBillingPeriod { ...props } /> );
+			expect(
+				wrapper
+					.find( 'FormSettingExplanation' )
+					.shallow()
+					.text()
+			).toContain( 'Billed monthly' );
+		} );
+
+		it( 'should upgrade to a yearly plan when the button is clicked', () => {
+			const wrapper = shallow( <PlanBillingPeriod { ...props } /> );
+			wrapper.find( 'Button' ).simulate( 'click' );
+			expect( planItem ).toHaveBeenCalledWith( 'jetpack_premium' );
+			expect( addItem ).toHaveBeenCalled();
+			expect( page ).toHaveBeenCalledWith( '/checkout/site.com' );
+		} );
+
+		describe( 'a disconnected site', () => {
+			test( 'should display a message instead of the upgrade button', () => {
+				const site = null;
+				const wrapper = shallow( <PlanBillingPeriod { ...props } site={ site } /> );
+				expect( wrapper.find( 'Button' ) ).toHaveLength( 0 );
+				expect(
+					wrapper
+						.find( 'FormSettingExplanation' )
+						.shallow()
+						.text()
+				).toContain( 'To manage your plan, please reconnect your site.' );
+			} );
+		} );
+	} );
+
+	describe( 'an annual plan', () => {
+		beforeEach( () => moment.locale( 'en' ) );
+
+		const annualPlanProps = {
+			...props,
+			purchase: {
+				...props.purchase,
+				productSlug: 'jetpack_personal',
+			},
+		};
+
+		it( 'should display the current period', () => {
+			const wrapper = shallow( <PlanBillingPeriod { ...annualPlanProps } /> );
+			expect(
+				wrapper
+					.find( 'FormSettingExplanation' )
+					.shallow()
+					.text()
+			).toEqual( 'Billed yearly' );
+		} );
+
+		describe( 'when credit card is expiring', () => {
+			it( 'should display a warning to the user', () => {
+				const planExpiryDate = moment()
+					.add( 3, 'months' )
+					.format();
+				const cardExpiryDate = moment()
+					.add( 1, 'months' )
+					.format( 'MM/YY' );
+				const purchase = {
+					...annualPlanProps.purchase,
+					expiryDate: planExpiryDate,
+					payment: {
+						type: 'credit_card',
+						creditCard: {
+							expiryDate: cardExpiryDate,
+						},
+					},
+				};
+				const wrapper = shallow(
+					<PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } />
+				);
+				expect(
+					wrapper
+						.find( 'FormSettingExplanation' )
+						.shallow()
+						.text()
+				).toEqual( 'Billed yearly, credit card expiring soon' );
+			} );
+		} );
+		describe( 'when plan is renewing', () => {
+			it( 'should display a warning to the user', () => {
+				const purchase = {
+					...annualPlanProps.purchase,
+					renewDate: moment( '2020-01-01' ).format(),
+				};
+				const wrapper = shallow(
+					<PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } />
+				);
+				expect(
+					wrapper
+						.find( 'FormSettingExplanation' )
+						.shallow()
+						.text()
+				).toEqual( 'Billed yearly, renews on January 1, 2020' );
+			} );
+		} );
+		describe( 'when plan is expiring', () => {
+			it( 'should display a warning to the user', () => {
+				const purchase = {
+					...annualPlanProps.purchase,
+					expiryDate: moment( '2020-01-01' ).format(),
+					expiryStatus: 'expiring',
+				};
+				const wrapper = shallow(
+					<PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } />
+				);
+				expect(
+					wrapper
+						.find( 'FormSettingExplanation' )
+						.shallow()
+						.text()
+				).toEqual( 'Billed yearly, expires on January 1, 2020' );
+			} );
+		} );
+		describe( 'when plan is expired', () => {
+			it( 'should display a warning to the user', () => {
+				const purchase = {
+					...annualPlanProps.purchase,
+					expiryDate: moment()
+						.subtract( 1, 'month' )
+						.format(),
+					expiryStatus: 'expired',
+				};
+				const wrapper = shallow(
+					<PlanBillingPeriod { ...annualPlanProps } purchase={ purchase } />
+				);
+				expect(
+					wrapper
+						.find( 'FormSettingExplanation' )
+						.shallow()
+						.text()
+				).toEqual( 'Billed yearly, expired a month ago' );
+			} );
+		} );
+	} );
+} );

--- a/client/me/purchases/manage-purchase/plan-details/test/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/index.jsx
@@ -51,7 +51,7 @@ describe( 'PurchasePlanDetails', () => {
 		} );
 
 		describe( 'a partner purchase', () => {
-			it( 'should render the PlanBillingPeriod', () => {
+			it( 'should not render the PlanBillingPeriod', () => {
 				const purchase = {
 					...props.purchase,
 					partnerName: 'partner',

--- a/client/me/purchases/manage-purchase/plan-details/test/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/index.jsx
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { PurchasePlanDetails } from '../index';
+import PlanBillingPeriod from '../billing-period';
+
+const props = {
+	purchaseId: 123,
+	isPlaceholder: false,
+	purchase: {
+		// Including only the properties that are used by this component
+		id: 123,
+		siteId: 123,
+		productName: 'Jetpack Personal',
+		productSlug: 'jetpack_premium_monthly',
+		expiryStatus: 'active',
+	},
+	hasLoadedSites: true,
+	hasLoadedUserPurchasesFromServer: true,
+	pluginList: [
+		{
+			slug: 'vaultpress',
+			name: 'vaultpress',
+			key: 'abcdef',
+			status: 'wait',
+			error: null,
+		},
+		{ slug: 'akismet', name: 'akismet', key: 'abcdef', status: 'wait', error: null },
+	],
+	site: {
+		ID: 123,
+		name: 'Site Name',
+	},
+	siteId: 123,
+	translate,
+};
+
+describe( 'PurchasePlanDetails', () => {
+	describe( 'a jetpack plan', () => {
+		it( 'should render the plugin data', () => {
+			const wrapper = shallow( <PurchasePlanDetails { ...props } /> );
+			expect( wrapper.find( '#plugin-vaultpress' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '#plugin-akismet' ) ).toHaveLength( 1 );
+		} );
+
+		describe( 'a partner purchase', () => {
+			it( 'should render the PlanBillingPeriod', () => {
+				const purchase = {
+					...props.purchase,
+					partnerName: 'partner',
+				};
+				const wrapper = shallow( <PurchasePlanDetails { ...props } purchase={ purchase } /> );
+				const planBillingPeriod = wrapper.find( PlanBillingPeriod );
+				expect( planBillingPeriod ).toHaveLength( 0 );
+			} );
+		} );
+
+		describe( 'not a partner purchase', () => {
+			it( 'should render the PlanBillingPeriod', () => {
+				const wrapper = shallow( <PurchasePlanDetails { ...props } /> );
+				const planBillingPeriod = wrapper.find( PlanBillingPeriod );
+				expect( planBillingPeriod ).toHaveLength( 1 );
+				expect( planBillingPeriod.props() ).toMatchObject( {
+					site: props.site,
+					purchase: props.purchase,
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'is loading data', () => {
+		it( 'should render the placeholder', () => {
+			const hasLoadedSites = false;
+			const wrapper = shallow(
+				<PurchasePlanDetails { ...props } hasLoadedSites={ hasLoadedSites } />
+			);
+			expect( wrapper.find( '.is-placeholder' ) ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'not a jetpack plan', () => {
+		it( 'should return null', () => {
+			const purchase = {
+				...props.purchase,
+				productSlug: 'business-bundle',
+			};
+			const wrapper = shallow( <PurchasePlanDetails { ...props } purchase={ purchase } /> );
+			expect( wrapper.isEmptyRender() ).toEqual( true );
+		} );
+	} );
+
+	describe( 'expired plan', () => {
+		it( 'should return null', () => {
+			const purchase = {
+				...props.purchase,
+				expiryStatus: 'expired',
+			};
+			const wrapper = shallow( <PurchasePlanDetails { ...props } purchase={ purchase } /> );
+			expect( wrapper.isEmptyRender() ).toEqual( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
Reported in 3876-gh-jpop-issues

#### Changes proposed in this Pull Request

* When the user has a monthly plan but Jetpack is disconnected, the button to upgrade to a Yearly plan will be hidden and a text asking the user to reconnect will appear

#### Testing instructions

##### Disconnected Site
* Connect a Jetpack site to your account using a monthly plan
* Go to the Site Settings and disconnect the site
* Go to /me/purchases and click on your Jetpack Plan

### Before
* The "Upgrade to yearly billing" button will appear
* Click the button and you will be redirected to the Site Selector, since the Jetpack site was disconnected.
![image](https://user-images.githubusercontent.com/15204776/77805644-0e69ea80-7048-11ea-8c6d-e60012b00a4d.png)

### After
* The legend "Billed monthly" will appear, with no buttons next to it.
* The message "To manage your plan, please reconnect your site." with a link to Jetpack support will be displayed below.
![image](https://user-images.githubusercontent.com/15204776/77805902-c7302980-7048-11ea-9341-49042f28cbce.png)

##### Connected Site
* Connect a Jetpack site to your account using a monthly plan
* Go to /me/purchases and click on your Jetpack Plan
* The "Upgrade to yearly billing" button will appear
* Click the button and you will be redirected to the Checkout screen with an Annual subscription in the order summary.
