### PR TITLE
Allow adding domain mapping via url using composite checkout

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -145,11 +145,16 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 		return false;
 	}
 
-	// If the URL is adding a product, only allow wpcom plans
-	const slugFragmentsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
-	if ( productSlug && ! slugFragmentsToAllow.find( fragment => productSlug === fragment ) ) {
+	// If the URL is adding a product, only allow things already supported
+	const slugsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
+	const slugPrefixesToAllow = [ 'domain-mapping:' ];
+	if (
+		productSlug &&
+		! slugsToAllow.find( slug => productSlug === slug ) &&
+		! slugPrefixesToAllow.find( slugPrefix => productSlug.startsWith( slugPrefix ) )
+	) {
 		debug(
-			'shouldShowCompositeCheckout false because product does not match whitelist',
+			'shouldShowCompositeCheckout false because product does not match list of allowed products',
 			productSlug
 		);
 		return false;

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -129,7 +129,6 @@ export default function CompositeCheckout( {
 	couponCode: couponCodeFromUrl,
 } ) {
 	const translate = useTranslate();
-	const planSlug = useSelector( state => getUpgradePlanSlugFromPath( state, siteId, product ) );
 	const isJetpackNotAtomic = useSelector(
 		state => isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId )
 	);
@@ -244,7 +243,7 @@ export default function CompositeCheckout( {
 	const countriesList = useCountryList( overrideCountryList || [] );
 
 	const { productForCart, canInitializeCart } = usePrepareProductForCart(
-		planSlug,
+		siteId,
 		product,
 		isJetpackNotAtomic
 	);
@@ -1479,7 +1478,10 @@ function getProductSlugFromAlias( productAlias ) {
 	return null;
 }
 
-function usePrepareProductForCart( planSlug, productAlias, isJetpackNotAtomic ) {
+function usePrepareProductForCart( siteId, productAlias, isJetpackNotAtomic ) {
+	const planSlug = useSelector( state =>
+		getUpgradePlanSlugFromPath( state, siteId, productAlias )
+	);
 	const plans = useSelector( state => getPlans( state ) );
 	const plan = useSelector( state => getPlanBySlug( state, planSlug ) );
 	const products = useSelector( state => getProductsList( state ) );

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -780,22 +780,26 @@ function createItemToAddToCart( {
 	let cartItem, cartMeta;
 
 	if ( planSlug && plan ) {
+		debug( 'creating plan product' );
 		cartItem = planItem( planSlug );
 		cartItem.product_id = plan.product_id;
 	}
 
 	if ( product.startsWith( 'theme:' ) ) {
+		debug( 'creating theme product' );
 		cartMeta = product.split( ':' )[ 1 ];
 		cartItem = themeItem( cartMeta );
 	}
 
 	if ( product.startsWith( 'domain-mapping:' ) ) {
+		debug( 'creating domain mapping product' );
 		cartMeta = product.split( ':' )[ 1 ];
 		cartItem = domainMapping( { domain: cartMeta } );
 	}
 
 	if ( product.startsWith( 'concierge-session' ) ) {
 		// TODO: prevent adding a conciergeSessionItem if one already exists
+		debug( 'creating concierge product' );
 		cartItem = conciergeSessionItem();
 	}
 
@@ -803,10 +807,12 @@ function createItemToAddToCart( {
 		( product.startsWith( 'jetpack_backup' ) || product.startsWith( 'jetpack_search' ) ) &&
 		isJetpackNotAtomic
 	) {
+		debug( 'creating jetpack product' );
 		cartItem = jetpackProductItem( product );
 	}
 
 	if ( ! cartItem ) {
+		debug( 'no product created' );
 		return null;
 	}
 

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -1469,8 +1469,10 @@ function usePrepareProductForCart( planSlug, product, isJetpackNotAtomic ) {
 	const plans = useSelector( state => getPlans( state ) );
 	const plan = useSelector( state => getPlanBySlug( state, planSlug ) );
 	const reduxDispatch = useDispatch();
-	const [ canInitializeCart, setCanInitializeCart ] = useState( ! planSlug );
-	const [ productForCart, setProductForCart ] = useState();
+	const [ { canInitializeCart, productForCart }, setState ] = useState( {
+		canInitializeCart: ! planSlug && ! product,
+		productForCart: null,
+	} );
 
 	useEffect( () => {
 		if ( ! planSlug ) {
@@ -1483,21 +1485,29 @@ function usePrepareProductForCart( planSlug, product, isJetpackNotAtomic ) {
 		}
 		if ( ! plan ) {
 			debug( 'there is a request to add a plan but no plan was found' );
-			setCanInitializeCart( true );
+			setState( { canInitializeCart: true } );
 			return;
 		}
-		debug( 'preparing plan that was requested in url', { planSlug, plan, isJetpackNotAtomic } );
-		setProductForCart( createItemToAddToCart( { planSlug, plan, isJetpackNotAtomic } ) );
-		setCanInitializeCart( true );
+		const cartProduct = createItemToAddToCart( { planSlug, plan, isJetpackNotAtomic } );
+		debug(
+			'preparing plan that was requested in url',
+			{ planSlug, plan, isJetpackNotAtomic },
+			cartProduct
+		);
+		setState( { productForCart: cartProduct, canInitializeCart: true } );
 	}, [ reduxDispatch, planSlug, plan, plans, isJetpackNotAtomic ] );
 
 	useEffect( () => {
 		if ( ! product ) {
 			return;
 		}
-		debug( 'preparing product that was requested in url', { product, isJetpackNotAtomic } );
-		setProductForCart( createItemToAddToCart( { product, isJetpackNotAtomic } ) );
-		setCanInitializeCart( true );
+		const cartProduct = createItemToAddToCart( { product, isJetpackNotAtomic } );
+		debug(
+			'preparing product that was requested in url',
+			{ product, isJetpackNotAtomic },
+			cartProduct
+		);
+		setState( { productForCart: cartProduct, canInitializeCart: true } );
 	}, [ reduxDispatch, isJetpackNotAtomic, product ] );
 
 	return { productForCart, canInitializeCart };

--- a/client/my-sites/checkout/checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout-thank-you.js
@@ -1,4 +1,10 @@
 /**
+ * This is required to prevent "ReferenceError: window is not defined"
+ *
+ * @jest-environment jsdom
+ */
+
+/**
  * Internal dependencies
  */
 import { getThankYouPageUrl } from '../composite-checkout-thank-you';

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -97,10 +97,32 @@ describe( 'CompositeCheckout', () => {
 
 		const store = applyMiddleware( thunk )( createStore )( () => {
 			return {
-				plans: { items: [] },
+				plans: {
+					items: [
+						{
+							product_id: 1009,
+							product_name: 'Plan',
+							meta: null,
+							prices: {},
+							path_slug: 'personal',
+							product_slug: 'personal-bundle',
+							product_type: 'bundle',
+							currency_code: 'USD',
+						},
+					],
+				},
 				sites: { items: {} },
 				ui: { selectedSiteId: 123 },
-				productsList: { items: [] },
+				productsList: {
+					items: {
+						domain_map: {
+							product_id: 5,
+							product_name: 'Product',
+							product_slug: 'domain_map',
+							prices: {},
+						},
+					},
+				},
 				countries: { payments: countryList, domains: countryList },
 			};
 		} );


### PR DESCRIPTION
This adds support for adding products of the form `domain-mapping:example.com` directly from the URL. Note that `domain-mapping` is not a real product slug, but rather a special alias used by calypso URLs for the product `domain_map` (another already-supported example is the alias `premium` for `value_bundle`).

Regular checkout already supports this feature, and with this change, composite checkout will also support it. So that it gets used, this change also modifies `CheckoutSystemDecider` so that it routes requests like `/checkout/YOURSITEHERE/domain-mapping:example.com` to composite checkout.

#### Testing instructions

- Make sure your cart in calypso is empty.
- Visit http://calypso.localhost:3000/checkout/YOURSITEHERE/premium
- Verify that you are directed to composite checkout and that the plan product has been added to your cart correctly.
- Visit http://calypso.localhost:3000/checkout/YOURSITEHERE/domain-mapping:example.com?flags=composite-checkout-testing (except you can't use `example.com`; use a real domain but it doesn't have to be one that you intend to actually map).
- Verify that you are directed to composite checkout and that the domain mapping product has been added to your cart correctly for the domain you tried to map.
- Click to renew a purchased product (any kind) somewhere in calypso.
- Verify that the URL is of the form `/checkout/PRODUCT_SLUG/renew/PURCHASE_ID/YOURSITEHERE`.
- Verify that you are directed to _regular_ checkout and that the renewal product has been added to your cart correctly.
