### PR TITLE
Add animation to Toggle when they're toggling

### DIFF
--- a/client/components/forms/form-toggle/compact.scss
+++ b/client/components/forms/form-toggle/compact.scss
@@ -17,4 +17,18 @@
 			}
 		}
 	}
+	&.is-toggling {
+		+ .form-toggle__label .form-toggle__switch {
+			&::after {
+				left: 8px;
+			}
+		}
+		&:checked {
+			+ .form-toggle__label .form-toggle__switch {
+				&::after {
+					left: 0;
+				}
+			}
+		}
+	}
 }

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -103,10 +103,12 @@
 .form-toggle.is-toggling {
 	+ .form-toggle__label .form-toggle__switch {
 		background: var( --color-primary );
+		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 	&:checked {
 		+ .form-toggle__label .form-toggle__switch {
 			background: var( --color-neutral-10 );
+			animation: loading-fade 1.6s ease-in-out infinite;
 		}
 	}
 }

--- a/client/components/forms/form-toggle/style.scss
+++ b/client/components/forms/form-toggle/style.scss
@@ -97,18 +97,27 @@
 			cursor: default;
 		}
 	}
-}
 
-// Classes for toggle state before action is complete (updating plugin or something)
-.form-toggle.is-toggling {
-	+ .form-toggle__label .form-toggle__switch {
-		background: var( --color-primary );
-		animation: loading-fade 1.6s ease-in-out infinite;
-	}
-	&:checked {
-		+ .form-toggle__label .form-toggle__switch {
-			background: var( --color-neutral-10 );
+	&.is-toggling {
+		+ .form-toggle__label {
+			color: var( --color-neutral );
 			animation: loading-fade 1.6s ease-in-out infinite;
+		}
+		+ .form-toggle__label .form-toggle__switch {
+			background: var( --color-primary );
+			animation: loading-fade 1.6s ease-in-out infinite;
+			&::after {
+				left: 16px;
+			}
+		}
+		&:checked {
+			+ .form-toggle__label .form-toggle__switch {
+				background: var( --color-neutral-10 );
+				animation: loading-fade 1.6s ease-in-out infinite;
+				&::after {
+					left: 0;
+				}
+			}
 		}
 	}
 }

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -135,10 +135,6 @@ class AutoRenewToggle extends Component {
 	};
 
 	getToggleUiStatus() {
-		if ( this.isUpdatingAutoRenew() ) {
-			return this.state.isTogglingToward;
-		}
-
 		return this.props.isEnabled;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a `Toggle` or `CompactToggle` component has the `toggling` prop enabled it doesn't really seem like anything is happening. And if the toggle fires a slow network request it seems like nothing is happening. So I decided it makes sense to add a fading animation to the toggle.

Here's how it looks:

With optimistic toggling and label fading:

![toggle-new](https://user-images.githubusercontent.com/1355045/77966009-e8b04000-72ea-11ea-96ca-ddca9e4ffc2b.gif)

Previous try (just fading animation):
![toggle](https://user-images.githubusercontent.com/1355045/77774519-e41e2a00-7053-11ea-83ba-387480eb9305.gif)

#### Testing instructions

* I guess you can just enable/disable privacy for a domain or just render the `Toggle` component with `toggling={true}`

I'm not sure who should review this since it's a calypso-wide thing