### PR TITLE
Gutenboarding - prevent navigation within preview iframe

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
@@ -1,4 +1,27 @@
 /**
+ * Changes href attributes' values to "#!" and removes meta-redirect tags.
+ *
+ * @param contentDocument the document you want to process
+ */
+function disarmAnchorsAndMetaRefreshes( contentDocument: HTMLDocument ) {
+	// dis-arm anchors
+	contentDocument.body
+		?.querySelectorAll( 'a[href]:not([href="#!"])' )
+		.forEach( ( anchor: Element ) => {
+			// we don't want to remove href attribute because styling can change without it
+			// using only # will jump to top
+			anchor.setAttribute( 'href', '#!' );
+		} );
+
+	// remove meta redirects
+	contentDocument.head
+		?.querySelectorAll( 'meta[http-equiv="refresh"]' )
+		.forEach( ( element: Element ) => {
+			element.parentNode?.removeChild( element ); // element.remove() doesn't work in IE
+		} );
+}
+
+/**
  * Removes `href` attributes from all anchor elements, prevents submit events from all forms, and removes all meta-redirects
  *
  * @param iframe The iframe you want to disable navigation for.
@@ -7,28 +30,16 @@ export function disableNavigation( iframe: HTMLIFrameElement ) {
 	const { contentDocument, contentWindow } = iframe;
 
 	if ( contentDocument && contentWindow ) {
-		iframe.addEventListener( 'load', () => {
-			// dis-arm anchors
-			contentDocument.body.querySelectorAll( 'a[href]' ).forEach( ( anchor: Element ) => {
-				// we don't want to remove href attribute because styling can change without it
-				// using only # will jump to top
-				anchor.setAttribute( 'href', '#!' );
-			} );
-
-			// disarm forms
-			contentDocument.body.querySelectorAll( 'form' ).forEach( form => {
-				form.addEventListener( 'submit', ( event: Event ) => {
-					event.preventDefault();
-					return false;
-				} );
-			} );
-
-			// remove meta redirects
-			contentDocument.head
-				.querySelectorAll( 'meta[http-equiv="refresh"]' )
-				.forEach( ( element: Element ) => {
-					element.parentNode?.removeChild( element ); // element.remove() doesn't work in IE
-				} );
+		// submit event bubbles up, we only need to catch it on the window level
+		contentWindow.addEventListener( 'submit', ( event: Event ) => {
+			event.preventDefault();
+			return false;
 		} );
+
+		// run right after the HTML is injected
+		disarmAnchorsAndMetaRefreshes( contentDocument );
+
+		// run again after the iframe loads
+		iframe.addEventListener( 'load', () => disarmAnchorsAndMetaRefreshes( contentDocument ) );
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
@@ -32,6 +32,8 @@ export function disableNavigation( iframe: HTMLIFrameElement ) {
 
 	if ( contentDocument && contentWindow ) {
 		// submit event bubbles up, we only need to catch it on the window level
+		// we enforce a none form-action CSP in the iframe, but also need to block the submit event here explicitly
+		// for IE support (IE does not support form-action directive. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action).
 		contentWindow.addEventListener( 'submit', ( event: Event ) => {
 			event.preventDefault();
 			return false;

--- a/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
@@ -3,7 +3,7 @@
  *
  * @param contentDocument the document you want to process
  */
-function disarmAnchorsAndMetaRefreshes( contentDocument: HTMLDocument ) {
+export function disarmAnchorsAndMetaRefreshes( contentDocument: HTMLDocument ) {
 	// dis-arm anchors
 	contentDocument.body
 		?.querySelectorAll( 'a[href]:not([href="#!"])' )
@@ -35,9 +35,6 @@ export function disableNavigation( iframe: HTMLIFrameElement ) {
 			event.preventDefault();
 			return false;
 		} );
-
-		// run right after the HTML is injected
-		disarmAnchorsAndMetaRefreshes( contentDocument );
 
 		// run again after the iframe loads
 		iframe.addEventListener( 'load', () => disarmAnchorsAndMetaRefreshes( contentDocument ) );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
@@ -22,9 +22,10 @@ export function disarmAnchorsAndMetaRefreshes( contentDocument: HTMLDocument ) {
 }
 
 /**
- * Removes `href` attributes from all anchor elements, prevents submit events from all forms, and removes all meta-redirects
+ * Handles all submit events in hte iframe and prevents their default behavior.
+ * Also it handles `load` event for the iframe and calls {@link disarmAnchorsAndMetaRefreshes} on the iframe document when it fires
  *
- * @param iframe The iframe you want to disable navigation for.
+ * @param iframe The iframe you want to process
  */
 export function disableNavigation( iframe: HTMLIFrameElement ) {
 	const { contentDocument, contentWindow } = iframe;

--- a/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/disableNavigation.ts
@@ -1,0 +1,34 @@
+/**
+ * Removes `href` attributes from all anchor elements, prevents submit events from all forms, and removes all meta-redirects
+ *
+ * @param iframe The iframe you want to disable navigation for.
+ */
+export function disableNavigation( iframe: HTMLIFrameElement ) {
+	const { contentDocument, contentWindow } = iframe;
+
+	if ( contentDocument && contentWindow ) {
+		iframe.addEventListener( 'load', () => {
+			// dis-arm anchors
+			contentDocument.body.querySelectorAll( 'a[href]' ).forEach( ( anchor: Element ) => {
+				// we don't want to remove href attribute because styling can change without it
+				// using only # will jump to top
+				anchor.setAttribute( 'href', '#!' );
+			} );
+
+			// disarm forms
+			contentDocument.body.querySelectorAll( 'form' ).forEach( form => {
+				form.addEventListener( 'submit', ( event: Event ) => {
+					event.preventDefault();
+					return false;
+				} );
+			} );
+
+			// remove meta redirects
+			contentDocument.head
+				.querySelectorAll( 'meta[http-equiv="refresh"]' )
+				.forEach( ( element: Element ) => {
+					element.parentNode?.removeChild( element ); // element.remove() doesn't work in IE
+				} );
+		} );
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -67,6 +67,14 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 				// disarm anchors before inserting them into the preview iframe
 				const domParser = new window.DOMParser();
 				const parsedDoc = domParser.parseFromString( html, 'text/html' );
+
+				// Disallow all form submission using a CSP. This fails all submissions silently
+				const CSPTag = document.createElement( 'meta' );
+				CSPTag.setAttribute( 'http-equiv', 'Content-Security-Policy' );
+				CSPTag.setAttribute( 'content', "form-action 'none'" );
+
+				parsedDoc.head.appendChild( CSPTag );
+
 				disarmAnchorsAndMetaRefreshes( parsedDoc );
 
 				setPreviewHtml( parsedDoc.documentElement.innerHTML );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -9,7 +9,7 @@ import { ValuesType } from 'utility-types';
 /**
  * Internal dependencies
  */
-import { disableNavigation } from './disableNavigation';
+import { disableNavigation, disarmAnchorsAndMetaRefreshes } from './disableNavigation';
 import { STORE_KEY } from '../../stores/onboard';
 import * as T from './types';
 import { useLangRouteParam } from '../../path';
@@ -63,7 +63,14 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 					return;
 				}
 				const html = await resp.text();
-				setPreviewHtml( html );
+
+				// disarm anchors before inserting them into the preview iframe
+				const domParser = new window.DOMParser();
+				const parsedDoc = domParser.parseFromString( html, 'text/html' );
+				disarmAnchorsAndMetaRefreshes( parsedDoc );
+
+				setPreviewHtml( parsedDoc.documentElement.innerHTML );
+
 				setRequestedFonts( new Set( [ fontHeadings, fontBase ] ) );
 			};
 			eff();

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -9,6 +9,7 @@ import { ValuesType } from 'utility-types';
 /**
  * Internal dependencies
  */
+import { disableNavigation } from './disableNavigation';
 import { STORE_KEY } from '../../stores/onboard';
 import * as T from './types';
 import { useLangRouteParam } from '../../path';
@@ -72,12 +73,13 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 	);
 
 	React.useEffect( () => {
-		if ( previewHtml ) {
-			const iframeDocument = iframe.current?.contentWindow?.document;
+		if ( previewHtml && iframe.current ) {
+			const iframeDocument = iframe.current.contentWindow?.document;
 			if ( iframeDocument ) {
 				iframeDocument.open();
 				iframeDocument.write( previewHtml );
 				iframeDocument.close();
+				disableNavigation( iframe.current );
 			}
 		}
 	}, [ previewHtml ] );
@@ -114,6 +116,7 @@ const Preview: React.FunctionComponent< Props > = ( { fonts, viewport } ) => {
 				iframeDocument.head.appendChild( l );
 				setRequestedFonts( nextFonts );
 			}
+
 			iframeDocument.body.style.setProperty( '--font-headings', `${ headings }` );
 			iframeDocument.body.style.setProperty( '--font-base', `${ headings }` );
 		}


### PR DESCRIPTION
As stated in #40477 

> In Gutenboarding, iframe shouldn't accept clicks/touch events:


#### This pull request does

1.  Change all `href` attributes' values of all anchor elements within the body to `#!`. The reason for keeping the attribute is to keep the pointer cursor and the CSS that comes with `:link`. 
2. Handle all form submit events and calls `preventDefault` on them. And adds a CSP to the iframe HTML that bans all form submission if the event wasn't caught for any reason. 
3. Remove all meta tags with `http-equiv="refresh"`.

This way, all clicks that show/hide menus, expand cards, all hover effects, parallax, etc, will continue to work. 

#### This pull request doesn't

Handle late mutation to the iframe DOM. If a script adds navigation triggering HTML (anchors or forms) after the `load` event of the iframe, this newly-added HTML won't be disarmed.

We need a `MutationObserver` for this. I didn't implement a MO from the get-go because it ~~needs an IE polyfill~~ (update, not true for IE11) and may over-complicate the PR. If you think we should handle this case, let me know.

#### Interesting lesson

Calling `querySelector` right after calling `document.write` on an empty document will not yield any results. You need to wait for the DOM to be fully loaded to be able to query it. My solution to this is to parse and process the HTML before inserting it into the iframe document. This is the best solution I could come up with to prevent navigation from happening before the `load` event is fired. The iframe can take 5 seconds to load and users might click before then. 

Fixes: #40477