### PR TITLE
[Private files] Don't use proxy with blobs

### DIFF
--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -674,6 +674,7 @@ describe( 'MediaUtils', () => {
 
 	describe( '#createTransientMedia()', () => {
 		const GUID = 'URL';
+		const originalURL = window.URL;
 
 		beforeEach( () => {
 			window.URL = {
@@ -681,6 +682,10 @@ describe( 'MediaUtils', () => {
 					return GUID;
 				},
 			};
+		} );
+
+		afterEach( () => {
+			window.URL = originalURL;
 		} );
 
 		test( 'should return a transient for a file blob', () => {

--- a/client/lib/media/test/utils.js
+++ b/client/lib/media/test/utils.js
@@ -761,4 +761,82 @@ describe( 'MediaUtils', () => {
 			] );
 		} );
 	} );
+
+	describe( '#mediaURLToProxyConfig()', () => {
+		test( 'should detect media relative to site URL', () => {
+			expect( MediaUtils.mediaURLToProxyConfig( 'https://test.com/media.jpg', 'test.com' ) ).to.eql(
+				{
+					query: '',
+					filePath: '/media.jpg',
+					isRelativeToSiteRoot: true,
+				}
+			);
+		} );
+
+		test( 'should detect query string of given URL', () => {
+			expect(
+				MediaUtils.mediaURLToProxyConfig( 'https://test.com/media.jpg?w=100&h=98', 'test.com' )
+			).to.eql( {
+				query: '?w=100&h=98',
+				filePath: '/media.jpg',
+				isRelativeToSiteRoot: true,
+			} );
+		} );
+
+		test( 'should detect domain mismatch', () => {
+			expect(
+				MediaUtils.mediaURLToProxyConfig( 'https://test.com/media.jpg', 'test2.com' )
+			).to.eql( {
+				query: '',
+				filePath: '/media.jpg',
+				isRelativeToSiteRoot: false,
+			} );
+		} );
+
+		test( 'should recognize photon URLs as ones relative to site URL', () => {
+			expect(
+				MediaUtils.mediaURLToProxyConfig( 'https://i0.wp.com/test.com/media.jpg?w=100', 'test.com' )
+			).to.eql( {
+				query: '?w=100',
+				filePath: '/media.jpg',
+				isRelativeToSiteRoot: true,
+			} );
+		} );
+
+		test( 'should not recognize non-photon wp.com URLs as ones relative to site URL', () => {
+			expect(
+				MediaUtils.mediaURLToProxyConfig(
+					'https://bad.wp.com/test.com/media.jpg?w=100',
+					'test.com'
+				)
+			).to.eql( {
+				query: '?w=100',
+				filePath: '/test.com/media.jpg',
+				isRelativeToSiteRoot: false,
+			} );
+		} );
+
+		test( 'should recognize domain mismatch in photon URL', () => {
+			expect(
+				MediaUtils.mediaURLToProxyConfig(
+					'https://i0.wp.com/test.com/media.jpg?w=100',
+					'test2.com'
+				)
+			).to.eql( {
+				query: '?w=100',
+				filePath: '/media.jpg',
+				isRelativeToSiteRoot: false,
+			} );
+		} );
+
+		test( 'should not consider URLs with non-http protocols as relative to domain root', () => {
+			expect(
+				MediaUtils.mediaURLToProxyConfig( 'blob://test.com/media.jpg?w=100', 'test.com' )
+			).to.eql( {
+				query: '?w=100',
+				filePath: '/media.jpg',
+				isRelativeToSiteRoot: false,
+			} );
+		} );
+	} );
 } );

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -638,15 +638,16 @@ export function mediaURLToProxyConfig( mediaUrl, siteSlug ) {
 
 	if ( [ 'http:', 'https:' ].indexOf( protocol ) === -1 ) {
 		isRelativeToSiteRoot = false;
-	} else if (
-		hostname !== siteSlug &&
-		( hostname.endsWith( 'wp.com' ) || hostname.endsWith( 'wordpress.com' ) )
-	) {
-		const [ first, ...rest ] = filePath.substr( 1 ).split( '/' );
-		filePath = '/' + rest.join( '/' );
+	} else if ( hostname !== siteSlug ) {
+		isRelativeToSiteRoot = false;
+		// CDN URLs like i0.wp.com/mysite.com/media.jpg should also be considered relative to mysite.com
+		if ( /^i[0-2]\.wp\.com$/.test( hostname ) ) {
+			const [ first, ...rest ] = filePath.substr( 1 ).split( '/' );
+			filePath = '/' + rest.join( '/' );
 
-		if ( first !== siteSlug ) {
-			isRelativeToSiteRoot = false;
+			if ( first === siteSlug ) {
+				isRelativeToSiteRoot = true;
+			}
 		}
 	}
 

--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -632,10 +632,13 @@ export function validateMediaItem( site, item ) {
  * @returns {object}	Dictionary
  */
 export function mediaURLToProxyConfig( mediaUrl, siteSlug ) {
-	const { pathname, search: query, hostname } = getUrlParts( mediaUrl );
+	const { pathname, search: query, protocol, hostname } = getUrlParts( mediaUrl );
 	let filePath = pathname;
 	let isRelativeToSiteRoot = true;
-	if (
+
+	if ( [ 'http:', 'https:' ].indexOf( protocol ) === -1 ) {
+		isRelativeToSiteRoot = false;
+	} else if (
 		hostname !== siteSlug &&
 		( hostname.endsWith( 'wp.com' ) || hostname.endsWith( 'wordpress.com' ) )
 	) {

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -67,11 +67,7 @@ export default connect( ( state, { src }: Pick< MediaFileProps, 'src' > ) => {
 	const isAtomic = !! isSiteAutomatedTransfer( state, siteId as number );
 	const isPrivate = !! isPrivateSite( state, siteId );
 	const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-	const useProxy = ( isAtomic &&
-		isPrivate &&
-		filePath &&
-		isRelativeToSiteRoot &&
-		! src?.startsWith( 'blob:' ) ) as boolean;
+	const useProxy = ( isAtomic && isPrivate && filePath && isRelativeToSiteRoot ) as boolean;
 
 	return {
 		query,

--- a/client/my-sites/media-library/media-file.tsx
+++ b/client/my-sites/media-library/media-file.tsx
@@ -67,7 +67,11 @@ export default connect( ( state, { src }: Pick< MediaFileProps, 'src' > ) => {
 	const isAtomic = !! isSiteAutomatedTransfer( state, siteId as number );
 	const isPrivate = !! isPrivateSite( state, siteId );
 	const { filePath, query, isRelativeToSiteRoot } = mediaURLToProxyConfig( src, siteSlug );
-	const useProxy = ( isAtomic && isPrivate && filePath && isRelativeToSiteRoot ) as boolean;
+	const useProxy = ( isAtomic &&
+		isPrivate &&
+		filePath &&
+		isRelativeToSiteRoot &&
+		! src?.startsWith( 'blob:' ) ) as boolean;
 
 	return {
 		query,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While new files are being uploaded, we attempt to display their preview using `blob:<ID>` URL. At the moment this URL is getting passed to `<ProxiedImage />` which isn't meant to handle blobs. This diff makes sure blobs are rendered as regular unproxied images. 

#### Testing instructions

On private atomic site go to /media and upload a large image. Confirm the preview is visible during the upload. Confirm in network tab that browser didn't request an endpoint like `/atomic-auth-proxy/filehttps://wordpress.com/<blob id>`
