### PR TITLE
Track where the auto-renew toggle is used from

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -32,6 +32,7 @@ class AutoRenewToggle extends Component {
 		recordTracksEvent: PropTypes.func.isRequired,
 		compact: PropTypes.bool,
 		withTextStatus: PropTypes.bool,
+		toggleSource: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -114,6 +115,7 @@ class AutoRenewToggle extends Component {
 			product_slug: productSlug,
 			is_atomic: isAtomicSite,
 			is_toggling_toward: isTogglingToward,
+			toggle_source: this.props.toggleSource,
 		} );
 	};
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -366,6 +366,7 @@ class PurchaseMeta extends Component {
 								planName={ site.plan.product_name_short }
 								siteDomain={ site.domain }
 								purchase={ purchase }
+								toggleSource="manage-purchase"
 							/>
 						</span>
 					) }

--- a/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/mapped-domain-type.jsx
@@ -197,6 +197,7 @@ class MappedDomainType extends React.Component {
 				purchase={ purchase }
 				compact={ true }
 				withTextStatus={ true }
+				toggleSource="mapped-domain-status"
 			/>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -265,6 +265,7 @@ class RegisteredDomainType extends React.Component {
 				purchase={ purchase }
 				compact={ true }
 				withTextStatus={ true }
+				toggleSource="registered-domain-status"
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We want to check if the auto-renew toggle is used from the new domain status screens or from the purchases page so I had to add a new property to the tracking code

#### Testing instructions

* Enable/disable auto-renew for a domain and verify that it's sending the `toggle_source` property to the tracks event

