### PR TITLE
Upsell Nudge: Only use darker color scheme for sidebar nudges.

### DIFF
--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,13 +1,6 @@
 .upsell-nudge.banner.card {
 	display: flex;
 	align-items: center;
-
-	a,
-	button {
-		border: none;
-		box-shadow: none;
-		color: var( --color-text-inverted );
-	}
 }
 
 .upsell-nudge.banner.card.is-compact {
@@ -18,6 +11,13 @@
 	color: var( --color-text-inverted );
 	margin-top: -1px;
 	margin-bottom: -1px;
+
+	a,
+	button {
+		border: none;
+		box-shadow: none;
+		color: var( --color-text-inverted );
+	}
 
 	.banner__icon-circle,
 	.banner__icon {

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,9 +1,4 @@
 .upsell-nudge.banner.card {
-	border-left-color: var( --color-accent );
-	border-left-width: 6px;
-	background-color: var( --color-neutral-80 );
-	box-shadow: none;
-	color: var( --color-text-inverted );
 	display: flex;
 	align-items: center;
 
@@ -16,7 +11,11 @@
 }
 
 .upsell-nudge.banner.card.is-compact {
+	background-color: var( --color-neutral-80 );
+	border-left-color: var( --color-accent );
+	box-shadow: none;
 	border-left-width: 4px;
+	color: var( --color-text-inverted );
 	margin-top: -1px;
 	margin-bottom: -1px;
 
@@ -26,10 +25,31 @@
 		margin-right: 0.25em;
 	}
 	.dismissible-card__close-icon {
+		fill: var( --color-text-inverted );
 		margin-left: 0.75em;
 	}
 	.banner__content {
+		color: var( --color-text-inverted );
 		padding: 0 0 0 8px;
+	}
+	.banner__description {
+		color: var( --color-neutral-5 );
+	}
+	.banner__info .banner__title {
+		color: var( --color-text-inverted );
+		font-weight: normal;
+	}
+	.card__link-indicator {
+		fill: var( --color-text-inverted );
+	}
+	.banner__icon-circle,
+	.banner__icon {
+		width: auto;
+		height: auto;
+		color: var( --color-text-inverted );
+		border-radius: 0;
+		background: none;
+		padding: 0;
 	}
 
 	&:hover {
@@ -45,33 +65,12 @@
 	}
 }
 
-.upsell-nudge.banner.card .banner__icon-circle,
-.upsell-nudge.banner.card .banner__icon {
-	width: auto;
-	height: auto;
-	color: var( --color-text-inverted );
-	border-radius: 0;
-	background: none;
-	padding: 0;
-}
-
-.upsell-nudge.banner.card .card__link-indicator {
-	fill: var( --color-text-inverted );
-}
-
 .upsell-nudge .banner__content {
 	margin-right: auto;
-	color: var( --color-text-inverted );
 }
 
 .upsell-nudge .banner__info .banner__title {
-	color: var( --color-text-inverted );
-	font-weight: normal;
 	margin-right: 8px;
-}
-
-.upsell-nudge .banner__description {
-	color: var( --color-neutral-5 );
 }
 
 .upsell-nudge .banner__action {
@@ -80,7 +79,6 @@
 }
 
 .upsell-nudge .dismissible-card__close-icon {
-	fill: var( --color-text-inverted );
 	margin-left: 1em;
 	order: 2;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* At some point while I was working on this, I thought UpsellNudge might use the same dark background color scheme as it uses in the sidebar/compact style. That's not the case, so this makes the CSS more specific, so dark colors only apply to the compact/sidebar nudge.

**Before**

<img width="1390" alt="Screen Shot 2020-03-27 at 2 10 53 PM" src="https://user-images.githubusercontent.com/2124984/77786933-179d8c00-7035-11ea-81dd-413cc4ccdb23.png">

**After**

<img width="1384" alt="Screen Shot 2020-03-27 at 3 08 44 PM" src="https://user-images.githubusercontent.com/2124984/77791374-e1640a80-703c-11ea-904b-a1cb87711378.png">

#### Testing instructions

* Switch to this PR
* Navigate to a site with an active JITM (this one appears when you have an account with a CA country code)
* You should see the corrected nudge styles.