### PR TITLE
Updates plan conflict notice to accommodate more than one conflict

### DIFF
--- a/client/blocks/product-plan-overlap-notices/README.md
+++ b/client/blocks/product-plan-overlap-notices/README.md
@@ -29,3 +29,4 @@ The following props can be passed to the Product Plan Overlap Notices block:
 * `plans`: ( array ) Array of plan slugs that we consider as possibly overlapping with products.
 * `products`: ( array ) Array of product slugs that we consider as possibly overlapping with plans.
 * `siteId`: ( number ) ID of the site we're fetching purchases and plans for. Optional - currently selected site will be used by default.
+* `currentPurchase`: ( object ) Optional: The current purchase. Used for the purchase detail page to hide the notice when not relevant.

--- a/client/blocks/product-plan-overlap-notices/README.md
+++ b/client/blocks/product-plan-overlap-notices/README.md
@@ -3,34 +3,20 @@ Product Plan Overlap Notices
 
 Product Plan Overlap Notices is a React component for rendering a block with notices.
 
-Those notices will appear when there is a feature overlap between the current plan and the current product, when they are within the provided list of products and plans.
+Those notices will appear when there is a feature overlap between the current plan and any products, when they are within the provided list of products and plans.
 
 ## Usage
 
 ```jsx
 import React from 'react';
 import ProductPlanOverlapNotices from 'blocks/product-plan-overlap-notices';
-
-const jetpackPlans = [
-	'jetpack_personal',
-	'jetpack_personal_monthly',
-	'jetpack_premium',
-	'jetpack_premium_monthly',
-	'jetpack_business',
-	'jetpack_business_monthly',
-];
-
-const jetpackProducts = [
-	'jetpack_backup_daily',
-	'jetpack_backup_daily_monthly',
-	'jetpack_backup_realtime',
-	'jetpack_backup_realtime_monthly',
-];
+import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
+import { JETPACK_PLANS } from 'lib/plans/constants';
 
 export default class extends React.Component {
 	render() {
 		return (
-			<ProductPlanOverlapNotices plans={ jetpackPlans } products={ jetpackProducts } />
+			<ProductPlanOverlapNotices plans={ JETPACK_PLANS } products={ JETPACK_PRODUCTS_LIST } />
 		);
 	}
 }

--- a/client/blocks/product-plan-overlap-notices/docs/example.jsx
+++ b/client/blocks/product-plan-overlap-notices/docs/example.jsx
@@ -7,23 +7,9 @@ import React, { Component } from 'react';
  * Internal dependencies
  */
 import SitesDropdown from 'components/sites-dropdown';
+import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
+import { JETPACK_PLANS } from 'lib/plans/constants';
 import ProductPlanOverlapNotices from '../';
-
-const jetpackPlans = [
-	'jetpack_personal',
-	'jetpack_personal_monthly',
-	'jetpack_premium',
-	'jetpack_premium_monthly',
-	'jetpack_business',
-	'jetpack_business_monthly',
-];
-
-const jetpackProducts = [
-	'jetpack_backup_daily',
-	'jetpack_backup_daily_monthly',
-	'jetpack_backup_realtime',
-	'jetpack_backup_realtime_monthly',
-];
 
 class ProductPlanOverlapNoticesExample extends Component {
 	state = {
@@ -39,8 +25,8 @@ class ProductPlanOverlapNoticesExample extends Component {
 
 				{ this.state.siteId ? (
 					<ProductPlanOverlapNotices
-						plans={ jetpackPlans }
-						products={ jetpackProducts }
+						plans={ JETPACK_PLANS }
+						products={ JETPACK_PRODUCTS_LIST }
 						siteId={ this.state.siteId }
 					/>
 				) : (

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -21,6 +21,8 @@ import { getSitePurchases } from 'state/purchases/selectors';
 import { planHasFeature, planHasSuperiorFeature } from 'lib/plans';
 import { managePurchase } from 'me/purchases/paths';
 
+import './style.scss';
+
 class ProductPlanOverlapNotices extends Component {
 	static propTypes = {
 		plans: PropTypes.arrayOf( PropTypes.string ).isRequired,
@@ -132,7 +134,7 @@ class ProductPlanOverlapNotices extends Component {
 								},
 								components: {
 									list: (
-										<ul>
+										<ul className="product-plan-overlap-notices__product-list">
 											{ overlappingProductSlugs.map( productSlug =>
 												this.getProductItem( productSlug )
 											) }

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { includes, some } from 'lodash';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -37,27 +37,26 @@ class ProductPlanOverlapNotices extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	hasOverlap() {
+	getOverlappingProducts() {
 		const { availableProducts, currentPlanSlug, plans, purchases } = this.props;
 
 		if ( ! currentPlanSlug || ! purchases || ! availableProducts ) {
-			return false;
+			return [];
 		}
 
 		// Is the current plan among the plans we're interested in?
 		if ( ! includes( plans, currentPlanSlug ) ) {
-			return false;
+			return [];
 		}
 
 		// Is the current product among the products we're interested in?
 		const currentProductSlugs = this.getCurrentProductSlugs();
 		if ( ! currentProductSlugs.length ) {
-			return false;
+			return [];
 		}
 
 		// Does the current plan include the current product as a feature, or have a superior version of it?
-		return some(
-			currentProductSlugs,
+		return currentProductSlugs.filter(
 			productSlug =>
 				planHasFeature( currentPlanSlug, productSlug ) ||
 				planHasSuperiorFeature( currentPlanSlug, productSlug )
@@ -120,26 +119,25 @@ class ProductPlanOverlapNotices extends Component {
 				<QuerySitePurchases siteId={ selectedSiteId } />
 				<QueryProductsList />
 
-				{ this.hasOverlap() &&
-					this.getCurrentProductSlugs().map( productSlug => (
-						<Notice
-							key={ productSlug }
-							showDismiss={ false }
-							status="is-warning"
-							text={ translate(
-								'Your %(planName)s Plan includes %(featureName)s. ' +
-									'Looks like you also purchased the %(productName)s product. ' +
-									'Consider removing %(productName)s.',
-								{
-									args: {
-										featureName: this.getOverlappingFeatureName( productSlug ),
-										planName: this.getCurrentPlanName(),
-										productName: this.getProductName( productSlug ),
-									},
-								}
-							) }
-						/>
-					) ) }
+				{ this.getOverlappingProducts().map( productSlug => (
+					<Notice
+						key={ productSlug }
+						showDismiss={ false }
+						status="is-warning"
+						text={ translate(
+							'Your %(planName)s Plan includes %(featureName)s. ' +
+								'Looks like you also purchased the %(productName)s product. ' +
+								'Consider removing %(productName)s.',
+							{
+								args: {
+									featureName: this.getOverlappingFeatureName( productSlug ),
+									planName: this.getCurrentPlanName(),
+									productName: this.getProductName( productSlug ),
+								},
+							}
+						) }
+					/>
+				) ) }
 			</Fragment>
 		);
 	}

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -4,7 +4,6 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -47,7 +46,7 @@ class ProductPlanOverlapNotices extends Component {
 		}
 
 		// Is the current plan among the plans we're interested in?
-		if ( ! includes( plans, currentPlanSlug ) ) {
+		if ( ! plans.includes( currentPlanSlug ) ) {
 			return [];
 		}
 
@@ -69,7 +68,7 @@ class ProductPlanOverlapNotices extends Component {
 		const { products, purchases } = this.props;
 
 		const currentProducts = purchases.filter( purchase =>
-			includes( products, purchase.productSlug )
+			products.includes( purchase.productSlug )
 		);
 		return currentProducts.map( product => product.productSlug );
 	}

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -122,7 +122,6 @@ class ProductPlanOverlapNotices extends Component {
 				{ 0 !== overlappingProductSlugs.length && (
 					<Notice
 						showDismiss={ false }
-						status="is-warning"
 						text={ translate(
 							'Your %(planName)s Plan includes:' +
 								'{{list/}}' +

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -70,10 +70,6 @@ class ProductPlanOverlapNotices extends Component {
 		const currentProducts = purchases.filter( purchase =>
 			includes( products, purchase.productSlug )
 		);
-		if ( ! currentProducts.length ) {
-			return null;
-		}
-
 		return currentProducts.map( product => product.productSlug );
 	}
 

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -19,6 +19,7 @@ import { getSitePlanSlug } from 'state/sites/plans/selectors';
 import { getSitePurchases } from 'state/purchases/selectors';
 import { planHasFeature, planHasSuperiorFeature } from 'lib/plans';
 import { managePurchase } from 'me/purchases/paths';
+import { isJetpackProduct } from 'lib/products-values';
 
 import './style.scss';
 
@@ -27,6 +28,7 @@ class ProductPlanOverlapNotices extends Component {
 		plans: PropTypes.arrayOf( PropTypes.string ).isRequired,
 		products: PropTypes.arrayOf( PropTypes.string ).isRequired,
 		siteId: PropTypes.number,
+		currentPurchase: PropTypes.object,
 
 		// Connected props
 		availableProducts: PropTypes.object,
@@ -111,8 +113,22 @@ class ProductPlanOverlapNotices extends Component {
 	}
 
 	render() {
-		const { selectedSiteId, translate } = this.props;
+		const { selectedSiteId, translate, currentPurchase } = this.props;
 		const overlappingProductSlugs = this.getOverlappingProducts();
+		overlappingProductSlugs.sort();
+
+		let showOverlap = false;
+		if ( 0 !== overlappingProductSlugs.length ) {
+			if (
+				currentPurchase &&
+				isJetpackProduct( currentPurchase ) &&
+				! overlappingProductSlugs.includes( currentPurchase.productSlug )
+			) {
+				showOverlap = false;
+			} else {
+				showOverlap = true;
+			}
+		}
 
 		return (
 			<Fragment>
@@ -120,7 +136,7 @@ class ProductPlanOverlapNotices extends Component {
 				<QuerySitePurchases siteId={ selectedSiteId } />
 				<QueryProductsList />
 
-				{ 0 !== overlappingProductSlugs.length && (
+				{ showOverlap && (
 					<Notice
 						showDismiss={ false }
 						text={ translate(

--- a/client/blocks/product-plan-overlap-notices/style.scss
+++ b/client/blocks/product-plan-overlap-notices/style.scss
@@ -1,0 +1,3 @@
+.notice__content .notice__text .product-plan-overlap-notices__product-list {
+	margin-bottom: 0.5em;
+}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -59,7 +59,7 @@ import {
 	isConciergeSession,
 } from 'lib/products-values';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
-import { JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
+import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
 import { JETPACK_PLANS } from 'lib/plans/constants';
 import Main from 'components/main';
 import PlanPrice from 'my-sites/plan-price';
@@ -550,7 +550,7 @@ class ManagePurchase extends Component {
 						require="blocks/product-plan-overlap-notices"
 						placeholder={ null }
 						plans={ JETPACK_PLANS }
-						products={ JETPACK_BACKUP_PRODUCTS }
+						products={ JETPACK_PRODUCTS_LIST }
 						siteId={ siteId }
 					/>
 					{ this.renderPurchaseDetail() }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -552,6 +552,7 @@ class ManagePurchase extends Component {
 						plans={ JETPACK_PLANS }
 						products={ JETPACK_PRODUCTS_LIST }
 						siteId={ siteId }
+						currentPurchase={ purchase }
 					/>
 					{ this.renderPurchaseDetail() }
 					{ site && this.renderNonPrimaryDomainWarningDialog( site, purchase ) }

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -15,7 +15,7 @@ import AsyncLoad from 'components/async-load';
 import { getSite, isRequestingSite } from 'state/sites/selectors';
 import { isJetpackPlan } from 'lib/products-values';
 import { JETPACK_PLANS } from 'lib/plans/constants';
-import { JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
+import { JETPACK_PRODUCTS_LIST } from 'lib/products-values/constants';
 import QuerySites from 'components/data/query-sites';
 import PurchaseItem from '../purchase-item';
 import PurchaseSiteHeader from './header';
@@ -71,7 +71,7 @@ const PurchasesSite = ( {
 				require="blocks/product-plan-overlap-notices"
 				placeholder={ null }
 				plans={ JETPACK_PLANS }
-				products={ JETPACK_BACKUP_PRODUCTS }
+				products={ JETPACK_PRODUCTS_LIST }
 				siteId={ siteId }
 			/>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates `< ProductPlanOverlapNotices />` block to accommodate more than one conflict.
* Changes references to just backups to use all Jetpack products.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a Jetpack site with a plan with two or more conflicting products. For example, Jetpack Professional and Scan and Daily Backups.
* Check notices in plans (`/plans/[site]`).
* Check notices in purchases (`/me/purchases`).
* Check notices in site purchases (`/me/purchases/[site]/[purchase]`).

<img width="1079" alt="Screen Shot 2020-03-27 at 2 20 17 PM" src="https://user-images.githubusercontent.com/1760168/77791502-1ec89800-703d-11ea-84de-e16adff4d622.png">
<img width="772" alt="Screen Shot 2020-03-27 at 2 27 39 PM" src="https://user-images.githubusercontent.com/1760168/77791503-1f612e80-703d-11ea-89f6-97660a5ccc6a.png">
<img width="784" alt="Screen Shot 2020-03-27 at 2 28 37 PM" src="https://user-images.githubusercontent.com/1760168/77791504-1ff9c500-703d-11ea-8a70-9de56bd4392b.png">
<img width="1162" alt="Screen Shot 2020-03-27 at 3 00 07 PM" src="https://user-images.githubusercontent.com/1760168/77791505-1ff9c500-703d-11ea-8333-74e4beb86918.png">


Fixes 1151678672052943-as-1168265713258996.