### PR TITLE
Update font weights from 300 to 400

### DIFF
--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -53,7 +53,6 @@
 
 	.tours__title {
 		font-size: 140%;
-	    font-weight: 300;
 	    display: flex;
 	    align-items: center;
 	    color: var( --color-text-inverted );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -530,7 +530,6 @@ a.masterbar__quick-language-switcher {
 	}
 
 	.masterbar__secure-checkout-text {
-		font-weight: 300;
 		color: var( --color-primary-5 );
 		transform: translateY( 1px );
 	}

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -22,7 +22,6 @@
 	h1 {
 		color: var( --color-neutral-70 );
 		font-size: 24px;
-		font-weight: 300;
 		height: 2em;
 		line-height: 32px;
 		margin-top: 0.5em;

--- a/client/my-sites/activity/activity-log-switch/style.scss
+++ b/client/my-sites/activity/activity-log-switch/style.scss
@@ -36,7 +36,6 @@
 
 .activity-log-switch__header-text {
 	font-size: 18px;
-	font-weight: 300;
 	margin: 24px 64px 32px;
 }
 
@@ -49,7 +48,6 @@
 .activity-log-switch__features-header {
 	color: var( --color-neutral-50 );
 	font-size: 24px;
-	font-weight: 300;
 	line-height: 32px;
 	margin: 48px 48px 24px;
 }

--- a/client/my-sites/exporter/guided-transfer-card/style.scss
+++ b/client/my-sites/exporter/guided-transfer-card/style.scss
@@ -13,7 +13,6 @@
 
 .guided-transfer-card__title {
 	font-size: 21px;
-	font-weight: 300;
 	color: var( --color-neutral-70 );
 	clear: left;
 }
@@ -100,7 +99,6 @@
 
 .guided-transfer-card__in-progress-title {
 	font-size: 24px;
-	font-weight: 300;
 	color: var( --color-neutral-70 );
 }
 

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -1,7 +1,6 @@
 .export-card__title,
 .export-media-card__title {
 	font-size: 21px;
-	font-weight: 300;
 	color: var( --color-neutral-70 );
 	margin-bottom: 16px;
 	clear: left;
@@ -37,7 +36,6 @@
 
 .export-card__advanced-settings-title {
 	font-size: 21px;
-	font-weight: 300;
 	color: var( --color-neutral-70 );
 	margin-bottom: 16px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes font weights across a few sections from `300` to `400` as per #39596 
* I could not find a couple of these "in the wild" -- one related to the Activity screen confirmation dialog, and ones on the Domains Landing Page (couldn't find that), so the examples below are not complete.

**Before**

<img width="799" alt="Screen Shot 2020-03-27 at 4 18 32 PM" src="https://user-images.githubusercontent.com/2124984/77796970-a23ab700-7046-11ea-8d7f-e449300ef2a1.png">
<img width="476" alt="Screen Shot 2020-03-27 at 4 17 06 PM" src="https://user-images.githubusercontent.com/2124984/77796852-6dc6fb00-7046-11ea-8fdf-3c7758c41791.png">
<img width="760" alt="Screen Shot 2020-03-27 at 4 16 35 PM" src="https://user-images.githubusercontent.com/2124984/77796853-6dc6fb00-7046-11ea-87b9-2f7be831bcd5.png">
<img width="1379" alt="Screen Shot 2020-03-27 at 4 17 58 PM" src="https://user-images.githubusercontent.com/2124984/77796901-8afbc980-7046-11ea-9147-2367dc147b83.png">


**After**

<img width="767" alt="Screen Shot 2020-03-27 at 4 01 29 PM" src="https://user-images.githubusercontent.com/2124984/77795818-90581480-7044-11ea-88ae-6d40427ccef0.png">
<img width="1238" alt="Screen Shot 2020-03-27 at 3 45 59 PM" src="https://user-images.githubusercontent.com/2124984/77795820-9221d800-7044-11ea-91ee-4df91a89b5d9.png">
<img width="428" alt="Screen Shot 2020-03-27 at 3 43 09 PM" src="https://user-images.githubusercontent.com/2124984/77795823-92ba6e80-7044-11ea-84a2-33f819ee07d9.png">
<img width="765" alt="Screen Shot 2020-03-27 at 4 14 27 PM" src="https://user-images.githubusercontent.com/2124984/77796668-1de83400-7046-11ea-8d6d-c2211c53b829.png">


#### Testing instructions

* Switch to this PR
* Check font weight on the heading of the final guided tour step; good example in `/settings/general/{site}?tour=checklistSiteTitle`
* Look at `/export` section and note headings are no longer font-weight 300
* Check out with a new plan or product; on the "Secure Checkout" screen, check the "Secure Checkout" text in the masterbar to ensure it does not use font-weight 300.
* Check the Jetpack Activity log screen on a site that does not yet have Activity Log set up. The "What else can it do?" heading should no longer use font-weight 300.
