### PR TITLE
My Home: Use the layout API results to render primary cards.

### DIFF
--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -11,9 +11,9 @@ import ChecklistSiteSetup from 'my-sites/customer-home/cards/primary/checklist-s
 import QuickLinks from 'my-sites/customer-home/cards/primary/quick-links';
 
 const cardComponents = {
-	'feature.go-mobile-phones': GoMobile,
-	'primary.checklist-site-setup': ChecklistSiteSetup,
-	'primary.quick-links': QuickLinks,
+	'home-feature-go-mobile-phones': GoMobile,
+	'home-primary-checklist-site-setup': ChecklistSiteSetup,
+	'home-primary-quick-links': QuickLinks,
 };
 
 const Primary = ( { checklistMode, cards } ) => {

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { isMobile } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -11,34 +9,25 @@ import { isMobile } from '@automattic/viewport';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import ChecklistSiteSetup from 'my-sites/customer-home/cards/primary/checklist-site-setup';
 import QuickLinks from 'my-sites/customer-home/cards/primary/quick-links';
-import getSiteChecklist from 'state/selectors/get-site-checklist';
-import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
-import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
-const Primary = ( { checklistMode, displayChecklist } ) => {
+const cardComponents = {
+	'feature.go-mobile-phones': GoMobile,
+	'primary.checklist-site-setup': ChecklistSiteSetup,
+	'primary.quick-links': QuickLinks,
+};
+
+const Primary = ( { checklistMode, cards } ) => {
 	return (
-		<>
-			{ // "Go Mobile" is displayed on the primary location when viewed in smaller viewports, so folks
-			// can see it on their phone without needing to scroll.
-			isMobile() && <GoMobile /> }
-			{ displayChecklist && <ChecklistSiteSetup checklistMode={ checklistMode } /> }
-			{ ! displayChecklist && <QuickLinks /> }
-		</>
+		<div className="primary">
+			{ cards &&
+				cards.map( ( card, index ) =>
+					React.createElement( cardComponents[ card ], {
+						key: index,
+						checklistMode: card === 'primary.checklist-site-setup' ? checklistMode : null,
+					} )
+				) }
+		</div>
 	);
 };
 
-const mapStateToProps = state => {
-	const siteId = getSelectedSiteId( state );
-
-	const siteChecklist = getSiteChecklist( state, siteId );
-	const hasChecklistData = null !== siteChecklist && Array.isArray( siteChecklist.tasks );
-	const isChecklistComplete = isSiteChecklistComplete( state, siteId );
-
-	return {
-		displayChecklist:
-			isEligibleForDotcomChecklist( state, siteId ) && hasChecklistData && ! isChecklistComplete,
-	};
-};
-
-export default connect( mapStateToProps )( Primary );
+export default Primary;

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -43,6 +43,7 @@ const Home = ( {
 	canUserUseCustomerHome,
 	checklistMode,
 	hasChecklistData,
+	layout,
 	site,
 	siteId,
 	siteIsUnlaunched,
@@ -85,10 +86,10 @@ const Home = ( {
 			</div>
 			<Notices checklistMode={ checklistMode } />
 			<Upsells />
-			{ hasChecklistData ? (
+			{ hasChecklistData && layout ? (
 				<div className="customer-home__layout">
 					<div className="customer-home__layout-col customer-home__layout-col-left">
-						<Primary checklistMode={ checklistMode } />
+						<Primary cards={ layout.primary } checklistMode={ checklistMode } />
 					</div>
 					<div className="customer-home__layout-col customer-home__layout-col-right">
 						<Secondary />
@@ -103,6 +104,7 @@ const Home = ( {
 
 Home.propTypes = {
 	checklistMode: PropTypes.string,
+	layout: PropTypes.object.isRequired,
 	site: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
 	siteSlug: PropTypes.string.isRequired,
@@ -129,7 +131,7 @@ const mapStateToProps = state => {
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 		user,
-		cards: getHomeLayout( state, siteId ),
+		layout: getHomeLayout( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
In #40172 we wired in the Home layout API; this PR uses those results to determine which cards to render in the primary location. No visual or functional changes should happen between this PR and production.

**Testing Instructions**

* Load `https://wordpress.com/home/:site` in production, with a site that has not completed its checklist,
* Load the same site and URL on this branch.
* Verify both look and behave the same.
* Repeat the process with a site that has completed the checklist (and is therefore showing Quick Links).
