### PR TITLE
Invalidate emails in site redirection input field

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -116,7 +116,7 @@ function canRedirect( siteId, domainName, onComplete ) {
 		domainName = 'http://' + domainName;
 	}
 
-	if ( domainName.includes(`@`) ) {
+	if ( includes( domainName, '@' ) ) {
 		onComplete( new ValidationError( 'invalid_domain' ) );
 		return;
 	}

--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -116,6 +116,11 @@ function canRedirect( siteId, domainName, onComplete ) {
 		domainName = 'http://' + domainName;
 	}
 
+	if ( domainName.includes(`@`) ) {
+		onComplete( new ValidationError( 'invalid_domain' ) );
+		return;
+	}
+
 	wpcom.undocumented().canRedirect( siteId, domainName, function( serverError, data ) {
 		if ( serverError ) {
 			onComplete( new ValidationError( serverError.error ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Invalidate emails in the site redirection input field

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the Calypso live branch below.
- Visit `/domains/add/site-redirect/{domain}` on that branch. Replace `domain` with one of your site's primary domain
- Enter an email in the site redirection input field. Example: `example@example.com`
- Ensure that you get an error notification that reads `... does not appear to be a valid domain`.

Here is how the error must look:

<img width="1110" alt="Screenshot 2020-03-28 at 12 56 50" src="https://user-images.githubusercontent.com/18581859/77817917-770ea100-70f4-11ea-81c6-6fd9de88b13f.png">


Fixes https://github.com/Automattic/wp-calypso/issues/38548