### PR TITLE
Decode names in Activity Log updates

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -26,6 +26,7 @@ import { getStatusForPlugin } from 'state/plugins/installed/selectors';
 import { errorNotice, infoNotice, successNotice } from 'state/notices/actions';
 import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { navigate } from 'state/ui/actions';
+import { decodeEntities } from 'lib/formatting';
 
 /**
  * Style dependencies
@@ -238,7 +239,7 @@ class ActivityLogTasklist extends Component {
 
 		showInfoNotice(
 			translate( 'Updating %(item)s on %(siteName)s.', {
-				args: { item: item.name, siteName },
+				args: { item: decodeEntities( item.name ), siteName },
 			} ),
 			{
 				id: `alitemupdate-${ item.slug }`,
@@ -293,7 +294,7 @@ class ActivityLogTasklist extends Component {
 			}
 
 			const noticeArgs = {
-				args: { item: name, siteName },
+				args: { item: decodeEntities( name ), siteName },
 			};
 
 			switch ( updateStatus.status ) {

--- a/client/my-sites/activity/activity-log-tasklist/index.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/index.jsx
@@ -433,9 +433,9 @@ class ActivityLogTasklist extends Component {
  * Normalizes the state result so it's the same than plugins.
  * This normalization allows to reuse methods for plugins, themes, and core.
  *
- * @param {string} state            Current state of update progress.
- * @param {bool}   isUpdateComplete If update actually produced what is expected to be after a successful update.
- *                                  In themes, the 'update' prop of the theme object is nullified when an update is succesful.
+ * @param {string}  state            Current state of update progress.
+ * @param {boolean} isUpdateComplete If update actually produced what is expected to be after a successful update.
+ *                                   In themes, the 'update' prop of the theme object is nullified when an update is succesful.
  *
  * @returns {boolean|object} False is update hasn't started. One of 'inProgress', 'error', 'completed', when
  * the update is running, failed, or was successfully completed, respectively.
@@ -474,6 +474,7 @@ const getStatusForTheme = ( siteId, themeId ) => {
 
 /**
  * Get data about the status of a core update.
+ *
  * @param {number} siteId      Site Id.
  * @param {string} coreVersion Version of core that the WP installation will be updated to.
  * @returns {boolean|object}      False is update hasn't started. One of 'inProgress', 'error', 'completed', when
@@ -498,6 +499,7 @@ const getStatusForCore = ( siteId, coreVersion ) => {
 		state: PropTypes.oneOf( [ 'uninitialized', 'failure', 'success', 'pending' ] ),
 		error: PropTypes.object,
 	} )
+ *
  * @param {Array}  itemList Collection of plugins/themes that will be updated.
  * @param {number} siteId   ID of the site where the plugin/theme is installed.
  * @param {object} state    App state tree.

--- a/client/my-sites/activity/activity-log-tasklist/update.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/update.jsx
@@ -12,6 +12,7 @@ import ActivityIcon from '../activity-log-item/activity-icon';
 import { Card } from '@automattic/components';
 import PopoverMenuItem from 'components/popover/menu-item';
 import SplitButton from 'components/split-button';
+import { decodeEntities } from 'lib/formatting';
 
 class ActivityLogTaskUpdate extends Component {
 	static propTypes = {
@@ -61,11 +62,11 @@ class ActivityLogTaskUpdate extends Component {
 					<div className="activity-log-tasklist__update-text">
 						{ linked ? (
 							<a href={ url } onClick={ this.handleNameClick }>
-								{ name }
+								{ decodeEntities( name ) }
 							</a>
 						) : (
 							// Add button classes so unlinked names look the same.
-							<span className="activity-log-tasklist__unlinked">{ name }</span>
+							<span className="activity-log-tasklist__unlinked">{ decodeEntities( name ) }</span>
 						) }
 						<span className="activity-log-tasklist__update-bullet">&bull;</span>
 						<span className="activity-log-tasklist__update-version">{ version }</span>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Decode plugin/theme name on the Activity Log update cards
* Also decode them on a updating, successful or failure update notification

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Install an **older version** (you can get it on the plugin's advanced view list on dotorg repo) plugin that has a character like `&`. Example: [Coming soon](https://wordpress.org/plugins/coming-soon/advanced/).
- Visit your Activity Log - https://wordpress.com/activity-log using the Calypso live branch below
- Ensure that `&` appears as is. It must not be encoded.

Here are a few screenshots of how they look with the fix:

<img width="787" alt="Screenshot 2020-03-28 at 13 43 34" src="https://user-images.githubusercontent.com/18581859/77818661-331e9a80-70fa-11ea-98e4-c638c6a66e4e.png">
<img width="669" alt="Screenshot 2020-03-28 at 13 43 31" src="https://user-images.githubusercontent.com/18581859/77818663-36198b00-70fa-11ea-8935-0ec316d1dca5.png">
<img width="720" alt="Screenshot 2020-03-28 at 13 43 27" src="https://user-images.githubusercontent.com/18581859/77818665-374ab800-70fa-11ea-9502-ecc2a5c6b2c0.png">


Fixes https://github.com/Automattic/wp-calypso/issues/35667