### PR TITLE
Themes: Hide Upsell Banner for Retired Themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -654,7 +654,8 @@ class ThemeSheet extends React.Component {
 		}
 
 		let pageUpsellBanner, previewUpsellBanner;
-		const hasUpsellBanner = ! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip;
+		const hasUpsellBanner =
+			! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip && ! retired;
 		if ( hasUpsellBanner ) {
 			pageUpsellBanner = (
 				<Banner


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This hides the misleading upsell banner for retired themes

<img width="772" alt="Screenshot 2020-03-28 at 10 41 06" src="https://user-images.githubusercontent.com/43215253/77821261-ac10f880-70e0-11ea-9895-759d306989d7.png">

There is a wider question being addressed in #40310 on whether or not they should be advertised; technically, yes, purchasing a Premium plan would allow retired themes to be accessed in WP-admin. But as @lancewillett puts it:

> We should do everything we can to hide them and discourage their use.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the page of a retired theme (eg. `/theme/ladder`) and verify the upsell banner no longer appears.

<img width="861" alt="Screenshot 2020-03-28 at 10 44 22" src="https://user-images.githubusercontent.com/43215253/77821311-19248e00-70e1-11ea-9a42-11de106c22fd.png">

cc @mendezcode, @sixhours 

Fixes #40475
