### PR TITLE
Replace plugin update indicator with plugin settings link

### DIFF
--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -13,6 +13,7 @@ import FoldableCard from 'components/foldable-card';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
+import PluginUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
 import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
 import Site from 'blocks/site';
@@ -73,27 +74,6 @@ class PluginSiteJetpack extends React.Component {
 		);
 	};
 
-	renderSummary = () => {
-		const actionLinks = this.props.site.plugin.action_links;
-		let summary;
-
-		if ( actionLinks ) {
-			if ( actionLinks.Settings ) {
-				summary = actionLinks.Settings;
-			}
-		}
-
-		return (
-			<div>
-				{ summary && (
-					<Button compact href={ summary }>
-						{ this.props.translate( 'Settings' ) }
-					</Button>
-				) }
-			</div>
-		);
-	};
-
 	renderPluginSite = () => {
 		const {
 			activation: canToggleActivation,
@@ -103,14 +83,37 @@ class PluginSiteJetpack extends React.Component {
 
 		const showAutoManagedMessage = this.props.isAutoManaged;
 
+		const actionLinks = this.props.site.plugin.action_links;
+		let settingsLink;
+
+		if ( actionLinks ) {
+			if ( actionLinks.Settings ) {
+				settingsLink = actionLinks.Settings;
+			}
+		}
+
 		return (
 			<FoldableCard
 				compact
 				clickableHeader
 				className="plugin-site-jetpack"
 				header={ <Site site={ this.props.site } indicator={ false } /> }
-				summary={ this.renderSummary() }
-				expandedSummary={ this.renderSummary() }
+				summary={
+					<PluginUpdateIndicator
+						site={ this.props.site }
+						plugin={ this.props.plugin }
+						notices={ this.props.notices }
+						expanded={ false }
+					/>
+				}
+				expandedSummary={
+					<PluginUpdateIndicator
+						site={ this.props.site }
+						plugin={ this.props.plugin }
+						notices={ this.props.notices }
+						expanded={ true }
+					/>
+				}
 			>
 				<div>
 					{ canToggleActivation && (
@@ -125,6 +128,11 @@ class PluginSiteJetpack extends React.Component {
 					) }
 					{ canToggleRemove && (
 						<PluginRemoveButton plugin={ this.props.site.plugin } site={ this.props.site } />
+					) }
+					{ settingsLink && (
+						<Button compact href={ settingsLink }>
+							{ this.props.translate( `Settings` ) }
+						</Button>
 					) }
 					{ showAutoManagedMessage && (
 						<div className="plugin-site-jetpack__automanage-notice">

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -13,10 +13,10 @@ import FoldableCard from 'components/foldable-card';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
-import PluginUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
 import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
 import Site from 'blocks/site';
+import { Button } from '@automattic/components';
 
 /**
  * Style dependencies
@@ -73,6 +73,27 @@ class PluginSiteJetpack extends React.Component {
 		);
 	};
 
+	renderSummary = () => {
+		const actionLinks = this.props.site.plugin.action_links;
+		let summary;
+
+		if ( actionLinks ) {
+			if ( actionLinks.Settings ) {
+				summary = actionLinks.Settings;
+			}
+		}
+
+		return (
+			<div>
+				{ summary && (
+					<Button compact href={ summary }>
+						{ this.props.translate( 'Settings' ) }
+					</Button>
+				) }
+			</div>
+		);
+	};
+
 	renderPluginSite = () => {
 		const {
 			activation: canToggleActivation,
@@ -88,22 +109,8 @@ class PluginSiteJetpack extends React.Component {
 				clickableHeader
 				className="plugin-site-jetpack"
 				header={ <Site site={ this.props.site } indicator={ false } /> }
-				summary={
-					<PluginUpdateIndicator
-						site={ this.props.site }
-						plugin={ this.props.plugin }
-						notices={ this.props.notices }
-						expanded={ false }
-					/>
-				}
-				expandedSummary={
-					<PluginUpdateIndicator
-						site={ this.props.site }
-						plugin={ this.props.plugin }
-						notices={ this.props.notices }
-						expanded={ true }
-					/>
-				}
+				summary={ this.renderSummary() }
+				expandedSummary={ this.renderSummary() }
 			>
 				<div>
 					{ canToggleActivation && (

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -13,6 +13,7 @@ import FoldableCard from 'components/foldable-card';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
+import PluginUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
 import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
 import Site from 'blocks/site';
@@ -73,27 +74,6 @@ class PluginSiteJetpack extends React.Component {
 		);
 	};
 
-	renderSummary = () => {
-		const actionLinks = this.props.site.plugin.action_links;
-		let summary;
-
-		if ( actionLinks ) {
-			if ( actionLinks.Settings ) {
-				summary = actionLinks.Settings;
-			}
-		}
-
-		return (
-			<div>
-				{ summary && (
-					<Button compact href={ summary }>
-						{ this.props.translate( 'Settings' ) }
-					</Button>
-				) }
-			</div>
-		);
-	};
-
 	renderPluginSite = () => {
 		const {
 			activation: canToggleActivation,
@@ -118,8 +98,22 @@ class PluginSiteJetpack extends React.Component {
 				clickableHeader
 				className="plugin-site-jetpack"
 				header={ <Site site={ this.props.site } indicator={ false } /> }
-				summary={ this.renderSummary() }
-				expandedSummary={ this.renderSummary() }
+				summary={
+					<PluginUpdateIndicator
+						site={ this.props.site }
+						plugin={ this.props.plugin }
+						notices={ this.props.notices }
+						expanded={ false }
+					/>
+				}
+				expandedSummary={
+					<PluginUpdateIndicator
+						site={ this.props.site }
+						plugin={ this.props.plugin }
+						notices={ this.props.notices }
+						expanded={ true }
+					/>
+				}
 			>
 				<div>
 					{ canToggleActivation && (

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -13,7 +13,6 @@ import FoldableCard from 'components/foldable-card';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginActivateToggle from 'my-sites/plugins/plugin-activate-toggle';
 import PluginAutoupdateToggle from 'my-sites/plugins/plugin-autoupdate-toggle';
-import PluginUpdateIndicator from 'my-sites/plugins/plugin-site-update-indicator';
 import PluginInstallButton from 'my-sites/plugins/plugin-install-button';
 import PluginRemoveButton from 'my-sites/plugins/plugin-remove-button';
 import Site from 'blocks/site';
@@ -74,6 +73,27 @@ class PluginSiteJetpack extends React.Component {
 		);
 	};
 
+	renderSummary = () => {
+		const actionLinks = this.props.site.plugin.action_links;
+		let summary;
+
+		if ( actionLinks ) {
+			if ( actionLinks.Settings ) {
+				summary = actionLinks.Settings;
+			}
+		}
+
+		return (
+			<div>
+				{ summary && (
+					<Button compact href={ summary }>
+						{ this.props.translate( 'Settings' ) }
+					</Button>
+				) }
+			</div>
+		);
+	};
+
 	renderPluginSite = () => {
 		const {
 			activation: canToggleActivation,
@@ -98,22 +118,8 @@ class PluginSiteJetpack extends React.Component {
 				clickableHeader
 				className="plugin-site-jetpack"
 				header={ <Site site={ this.props.site } indicator={ false } /> }
-				summary={
-					<PluginUpdateIndicator
-						site={ this.props.site }
-						plugin={ this.props.plugin }
-						notices={ this.props.notices }
-						expanded={ false }
-					/>
-				}
-				expandedSummary={
-					<PluginUpdateIndicator
-						site={ this.props.site }
-						plugin={ this.props.plugin }
-						notices={ this.props.notices }
-						expanded={ true }
-					/>
-				}
+				summary={ this.renderSummary() }
+				expandedSummary={ this.renderSummary() }
 			>
 				<div>
 					{ canToggleActivation && (

--- a/client/my-sites/plugins/plugin-site-jetpack/index.jsx
+++ b/client/my-sites/plugins/plugin-site-jetpack/index.jsx
@@ -83,14 +83,7 @@ class PluginSiteJetpack extends React.Component {
 
 		const showAutoManagedMessage = this.props.isAutoManaged;
 
-		const actionLinks = this.props.site.plugin.action_links;
-		let settingsLink;
-
-		if ( actionLinks ) {
-			if ( actionLinks.Settings ) {
-				settingsLink = actionLinks.Settings;
-			}
-		}
+		const settingsLink = this.props?.site?.plugin?.action_links?.Settings ?? null;
 
 		return (
 			<FoldableCard

--- a/client/my-sites/plugins/plugin-site-jetpack/style.scss
+++ b/client/my-sites/plugins/plugin-site-jetpack/style.scss
@@ -38,6 +38,11 @@
 	.plugin-activate-toggle__link {
 		margin-left: 12px;
 	}
+
+	.is-compact {
+		margin-left: 12px;
+		margin-top: 16px;
+	}
 }
 
 .plugin-site-jetpack .plugin-action__disabled-info.info-popover .gridicons-info-outline {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Replace plugin update indicator with plugin settings link on an individual plugin page. (example: https://wordpress.com/plugins/woocommerce)
- The link is shown only if available; in a case where it's not available the button does not display. More on that below. ⬇️

Plugins can define action links as outlined by [this filter](https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)). There are a few plugins that define `Settings` action link in addition to other action links, like `About`, `Contact us` (leading to their own customer support page), etc. In such cases, we are interested only in the one that reads `Settings`. 

This PR attempts to show a button only for that action link, and all other links are ignored.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the Calypso live branch below.
- Once you have opened it, visit https://wordpress.com/plugins/woocommerce (replace `https://wordpress.com` with your live branch domain)
- On your `Installed on` list, see that you have a button called `Settings`. If you do not see it, it is possible that your plugin does not define [that filter](https://codex.wordpress.org/Plugin_API/Filter_Reference/plugin_action_links_(plugin_file_name)).
- Click on it and see that it takes you to that plugin's settings page.

**Before:**

![Screen Shot 2020-03-31 at 18 19 06](https://user-images.githubusercontent.com/18581859/78028227-4ccf1480-737c-11ea-9010-f6e874ae5c71.png)

**After:**

![Screen Shot 2020-03-31 at 18 18 40](https://user-images.githubusercontent.com/18581859/78028242-52c4f580-737c-11ea-8651-c7da86d00b10.png)
![Screen Shot 2020-03-31 at 18 18 23](https://user-images.githubusercontent.com/18581859/78028248-535d8c00-737c-11ea-973d-cc41e8d2d7f4.png)



#### Notes

I am also calling for design review because this new button replaces the existing plugin update indicator. My reasoning is that, we **already have a notice at the top of the plugin page** (images below) that shows whenever an update is available.

<img width="787" alt="Screenshot 2020-03-29 at 19 36 32" src="https://user-images.githubusercontent.com/18581859/77855569-d82a9780-720e-11ea-9fe9-cfa426478afc.png">
<img width="791" alt="Screenshot 2020-03-29 at 19 33 24" src="https://user-images.githubusercontent.com/18581859/77855571-da8cf180-720e-11ea-9e13-b2e001bb1fae.png">

So, using this available space to show a setting link feels to be a better option.

@gwwar @lancewillett could either of you help me identify which team's best-placed to review this? 

Fixes https://github.com/Automattic/wp-calypso/issues/40539