### PR TITLE
Gutenboarding: Login page styled like gutenboarding

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -389,6 +389,7 @@ class Login extends Component {
 		const {
 			domain,
 			isJetpack,
+			isGutenboarding,
 			privateSite,
 			twoFactorAuthType,
 			twoFactorEnabled,
@@ -397,6 +398,7 @@ class Login extends Component {
 			socialService,
 			socialServiceResponse,
 			disableAutoFocus,
+			locale,
 		} = this.props;
 
 		if ( twoFactorEnabled && twoFactorAuthType === 'webauthn' && this.state.isBrowserSupported ) {
@@ -457,6 +459,8 @@ class Login extends Component {
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
 				isJetpack={ isJetpack }
+				isGutenboarding={ isGutenboarding }
+				locale={ locale }
 			/>
 		);
 	}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -57,6 +57,7 @@ class Login extends Component {
 		disableAutoFocus: PropTypes.bool,
 		isLinking: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
+		isGutenboarding: PropTypes.bool.isRequired,
 		isJetpackWooCommerceFlow: PropTypes.bool.isRequired,
 		isManualRenewalImmediateLoginAttempt: PropTypes.bool,
 		linkingSocialService: PropTypes.string,
@@ -79,7 +80,11 @@ class Login extends Component {
 		continueAsAnotherUser: false,
 	};
 
-	static defaultProps = { isJetpack: false, isJetpackWooCommerceFlow: false };
+	static defaultProps = {
+		isJetpack: false,
+		isGutenboarding: false,
+		isJetpackWooCommerceFlow: false,
+	};
 
 	componentDidMount() {
 		if ( ! this.props.twoFactorEnabled && this.props.twoFactorAuthType ) {
@@ -197,6 +202,7 @@ class Login extends Component {
 	renderHeader() {
 		const {
 			isJetpack,
+			isGutenboarding,
 			isJetpackWooCommerceFlow,
 			wccomFrom,
 			isManualRenewalImmediateLoginAttempt,
@@ -336,6 +342,24 @@ class Login extends Component {
 		} else if ( fromSite ) {
 			// if redirected from Calypso URL with a site slug, offer a link to that site's frontend
 			postHeader = <VisitSite siteSlug={ fromSite } />;
+		}
+
+		if ( isGutenboarding ) {
+			preHeader = (
+				<div class="login__form-gutenboarding-wordpress-logo">
+					<svg
+						aria-hidden="true"
+						role="img"
+						focusable="false"
+						xmlns="http://www.w3.org/2000/svg"
+						width="24"
+						height="24"
+						viewBox="0 0 20 20"
+					>
+						<path d="M20 10c0-5.51-4.49-10-10-10C4.48 0 0 4.49 0 10c0 5.52 4.48 10 10 10 5.51 0 10-4.48 10-10zM7.78 15.37L4.37 6.22c.55-.02 1.17-.08 1.17-.08.5-.06.44-1.13-.06-1.11 0 0-1.45.11-2.37.11-.18 0-.37 0-.58-.01C4.12 2.69 6.87 1.11 10 1.11c2.33 0 4.45.87 6.05 2.34-.68-.11-1.65.39-1.65 1.58 0 .74.45 1.36.9 2.1.35.61.55 1.36.55 2.46 0 1.49-1.4 5-1.4 5l-3.03-8.37c.54-.02.82-.17.82-.17.5-.05.44-1.25-.06-1.22 0 0-1.44.12-2.38.12-.87 0-2.33-.12-2.33-.12-.5-.03-.56 1.2-.06 1.22l.92.08 1.26 3.41zM17.41 10c.24-.64.74-1.87.43-4.25.7 1.29 1.05 2.71 1.05 4.25 0 3.29-1.73 6.24-4.4 7.78.97-2.59 1.94-5.2 2.92-7.78zM6.1 18.09C3.12 16.65 1.11 13.53 1.11 10c0-1.3.23-2.48.72-3.59C3.25 10.3 4.67 14.2 6.1 18.09zm4.03-6.63l2.58 6.98c-.86.29-1.76.45-2.71.45-.79 0-1.57-.11-2.29-.33.81-2.38 1.62-4.74 2.42-7.1z"></path>
+					</svg>
+				</div>
+			);
 		}
 
 		return (

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -78,6 +78,8 @@ export class LoginForm extends Component {
 		translate: PropTypes.func.isRequired,
 		userEmail: PropTypes.string,
 		isJetpack: PropTypes.bool,
+		isGutenboarding: PropTypes.bool,
+		locale: PropTypes.string,
 	};
 
 	state = {
@@ -420,13 +422,17 @@ export class LoginForm extends Component {
 			requestError,
 			socialAccountIsLinking: linkingSocialUser,
 			isJetpackWooCommerceFlow,
+			isGutenboarding,
 			wccomFrom,
 			currentRoute,
 			currentQuery,
 			pathname,
+			locale,
 		} = this.props;
 		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
+
+		const langFragment = locale && locale !== 'en' ? `/${ locale }` : '';
 
 		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
@@ -464,6 +470,10 @@ export class LoginForm extends Component {
 			};
 
 			signupUrl = `/start/${ oauth2Flow }?${ stringify( oauth2Params ) }`;
+		}
+
+		if ( isGutenboarding ) {
+			signupUrl = window.location.origin + '/gutenboarding' + langFragment;
 		}
 
 		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,3 +1,6 @@
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 .layout:not( .is-jetpack-woocommerce-flow ):not( .is-wccom-oauth-flow ) {
 	.login.is-jetpack {
 		.button.is-primary {
@@ -237,12 +240,8 @@
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	border-bottom: 1px solid transparent;
-}
 
-// Manual breakpoint in order to match the Gutenboarding breakpoint perfectly
-@media ( min-width: 600px ) {
-	.login__form-gutenboarding-wordpress-logo {
+	@include break-mobile {
 		padding: 8px 24px;
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -226,3 +226,23 @@
 		margin-top: 20px;
 	}
 }
+
+.login__form-gutenboarding-wordpress-logo {
+	height: 64px;
+	position: absolute;
+	left: 0;
+	top: 0;
+	padding: 0 16px;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	border-bottom: 1px solid transparent;
+}
+
+// Manual breakpoint in order to match the Gutenboarding breakpoint perfectly
+@media ( min-width: 600px ) {
+	.login__form-gutenboarding-wordpress-logo {
+		padding: 8px 24px;
+	}
+}

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -52,6 +52,8 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		} );
 	}, [] );
 
+	const lang = useLangRouteParam();
+
 	const handleSignUp = async ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 
@@ -96,6 +98,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		}
 	}
 
+	const langFragment = lang ? `/${ lang }` : '';
 	const loginRedirectUrl = `${ window.location.origin }/gutenboarding${ makePath(
 		Step.CreateSite
 	) }?new`;
@@ -113,7 +116,9 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		>
 			<SignupFormHeader
 				onRequestClose={ closeModal }
-				loginUrl={ '/log-in?redirect_to=' + encodeURIComponent( loginRedirectUrl ) }
+				loginUrl={ `/log-in/gutenboarding${ langFragment }?redirect_to=${ encodeURIComponent(
+					loginRedirectUrl
+				) }` }
 			/>
 
 			<div className="signup-form__body">

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -41,6 +41,7 @@ const hasSidebar = section => {
 const LayoutLoggedOut = ( {
 	currentRoute,
 	isJetpackLogin,
+	isGutenboardingLogin,
 	isPopup,
 	isJetpackWooCommerceFlow,
 	wccomFrom,
@@ -63,6 +64,7 @@ const LayoutLoggedOut = ( {
 		'has-no-sidebar': ! hasSidebar( section ),
 		'has-no-masterbar': masterbarIsHidden,
 		'is-jetpack-login': isJetpackLogin,
+		'is-gutenboarding-login': isGutenboardingLogin,
 		'is-popup': isPopup,
 		'is-jetpack-woocommerce-flow':
 			config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow,
@@ -137,6 +139,7 @@ export default connect( state => {
 	const section = getSection( state );
 	const currentRoute = getCurrentRoute( state );
 	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
+	const isGutenboardingLogin = startsWith( currentRoute, '/log-in/gutenboarding' );
 	const noMasterbarForRoute = startsWith( currentRoute, '/log-in/jetpack' );
 	const isPopup = '1' === get( getCurrentQueryArguments( state ), 'is_popup' );
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
@@ -147,6 +150,7 @@ export default connect( state => {
 	return {
 		currentRoute,
 		isJetpackLogin,
+		isGutenboardingLogin,
 		isPopup,
 		isJetpackWooCommerceFlow,
 		wccomFrom,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -140,7 +140,7 @@ export default connect( state => {
 	const currentRoute = getCurrentRoute( state );
 	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
 	const isGutenboardingLogin = startsWith( currentRoute, '/log-in/gutenboarding' );
-	const noMasterbarForRoute = startsWith( currentRoute, '/log-in/jetpack' );
+	const noMasterbarForRoute = isJetpackLogin || isGutenboardingLogin;
 	const isPopup = '1' === get( getCurrentQueryArguments( state ), 'is_popup' );
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
 	const isJetpackWooCommerceFlow =

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -8,6 +8,7 @@ import config, { isEnabled } from 'config';
 
 export function login( {
 	isJetpack,
+	isGutenboarding,
 	isWoo,
 	isNative,
 	locale,
@@ -36,6 +37,8 @@ export function login( {
 			url += '/social-connect';
 		} else if ( isJetpack ) {
 			url += '/jetpack';
+		} else if ( isGutenboarding ) {
+			url += '/gutenboarding';
 		} else if ( useMagicLink ) {
 			url += '/link';
 		}

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -74,6 +74,11 @@ describe( 'index', () => {
 			expect( url ).toEqual( '/log-in/jetpack' );
 		} );
 
+		test( 'should return the login url for Gutenboarding specific login', () => {
+			const url = login( { isNative: true, isGutenboarding: true } );
+			expect( url ).toEqual( '/log-in/gutenboarding' );
+		} );
+
 		test( 'should return the login url with WooCommerce from handler', () => {
 			const url = login( { isNative: true, isJetpack: true, isWoo: true } );
 

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -19,7 +19,7 @@ import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selecto
 
 const enhanceContextWithLogin = context => {
 	const {
-		params: { flow, isJetpack, socialService, twoFactorAuthType },
+		params: { flow, isJetpack, isGutenboarding, socialService, twoFactorAuthType },
 		path,
 		query,
 	} = context;
@@ -33,6 +33,7 @@ const enhanceContextWithLogin = context => {
 	context.primary = (
 		<WPLogin
 			isJetpack={ isJetpack === 'jetpack' }
+			isGutenboarding={ isGutenboarding === 'gutenboarding' }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -71,6 +71,7 @@ export default router => {
 				`/log-in/:socialService(google|apple)/callback/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+				`/log-in/:isGutenboarding(gutenboarding)/${ lang }`,
 				`/log-in/${ lang }`,
 			],
 			redirectJetpack,

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -15,7 +15,6 @@ import { startCase } from 'lodash';
 import AutomatticLogo from 'components/automattic-logo';
 import DocumentHead from 'components/data/document-head';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
-import getCurrentRoute from 'state/selectors/get-current-route';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import TranslatorInvite from 'components/translator-invite';
@@ -45,6 +44,7 @@ export class Login extends React.Component {
 		isLoggedIn: PropTypes.bool.isRequired,
 		isLoginView: PropTypes.bool,
 		isJetpack: PropTypes.bool.isRequired,
+		isGutenboarding: PropTypes.bool.isRequired,
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
 		path: PropTypes.string.isRequired,
@@ -57,7 +57,7 @@ export class Login extends React.Component {
 		twoFactorAuthType: PropTypes.string,
 	};
 
-	static defaultProps = { isJetpack: false, isLoginView: true };
+	static defaultProps = { isJetpack: false, isGutenboarding: false, isLoginView: true };
 
 	componentDidMount() {
 		this.recordPageView( this.props );
@@ -107,10 +107,10 @@ export class Login extends React.Component {
 	}
 
 	renderFooter() {
-		const { currentRoute, translate } = this.props;
+		const { isJetpack, isGutenboarding, translate } = this.props;
 		const isOauthLogin = !! this.props.oauth2Client;
 
-		if ( currentRoute === '/log-in/jetpack' ) {
+		if ( isJetpack || isGutenboarding ) {
 			return null;
 		}
 
@@ -187,6 +187,7 @@ export class Login extends React.Component {
 			domain,
 			isLoggedIn,
 			isJetpack,
+			isGutenboarding,
 			oauth2Client,
 			privateSite,
 			socialConnect,
@@ -210,6 +211,7 @@ export class Login extends React.Component {
 						locale={ locale }
 						privateSite={ privateSite }
 						twoFactorAuthType={ twoFactorAuthType }
+						isGutenboarding={ isGutenboarding }
 					/>
 				) }
 				{ isLoginView && <TranslatorInvite path={ path } /> }
@@ -258,7 +260,6 @@ export class Login extends React.Component {
 
 export default connect(
 	( state, props ) => ( {
-		currentRoute: getCurrentRoute( state ),
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
 		locale: getCurrentLocaleSlug( state ),
 		oauth2Client: getCurrentOAuth2Client( state ),

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -232,6 +232,7 @@ export class Login extends React.Component {
 				domain={ domain }
 				fromSite={ fromSite }
 				footer={ footer }
+				locale={ locale }
 			/>
 		);
 	}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -225,6 +225,7 @@ export class Login extends React.Component {
 				privateSite={ privateSite }
 				clientId={ clientId }
 				isJetpack={ isJetpack }
+				isGutenboarding={ isGutenboarding }
 				oauth2Client={ oauth2Client }
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -27,7 +27,6 @@ import { login } from 'lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
-import { localizeUrl } from 'lib/i18n-utils';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
@@ -234,7 +233,10 @@ export class LoginLinks extends React.Component {
 			translate,
 			wccomFrom,
 			isGutenboarding,
+			locale,
 		} = this.props;
+
+		const langFragment = locale && locale !== 'en' ? `/${ locale }` : '';
 
 		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
@@ -290,7 +292,7 @@ export class LoginLinks extends React.Component {
 		}
 
 		if ( isGutenboarding ) {
-			signupUrl = localizeUrl( window.location.origin + '/gutenboarding' );
+			signupUrl = window.location.origin + '/gutenboarding' + langFragment;
 		}
 
 		return (

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -27,6 +27,7 @@ import { login } from 'lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
+import { localizeUrl } from 'lib/i18n-utils';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
@@ -39,6 +40,7 @@ export class LoginLinks extends React.Component {
 		resetMagicLoginRequestForm: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 		twoFactorAuthType: PropTypes.string,
+		isGutenboarding: PropTypes.bool.isRequired,
 	};
 
 	recordBackToWpcomLinkClick = () => {
@@ -224,7 +226,15 @@ export class LoginLinks extends React.Component {
 
 	renderSignUpLink() {
 		// Taken from client/layout/masterbar/logged-out.jsx
-		const { currentQuery, currentRoute, oauth2Client, pathname, translate, wccomFrom } = this.props;
+		const {
+			currentQuery,
+			currentRoute,
+			oauth2Client,
+			pathname,
+			translate,
+			wccomFrom,
+			isGutenboarding,
+		} = this.props;
 
 		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
@@ -279,6 +289,10 @@ export class LoginLinks extends React.Component {
 			signupUrl = `${ signupUrl }/wpcc?${ stringify( oauth2Params ) }`;
 		}
 
+		if ( isGutenboarding ) {
+			signupUrl = localizeUrl( window.location.origin + '/gutenboarding' );
+		}
+
 		return (
 			<a
 				href={ signupUrl }
@@ -299,7 +313,9 @@ export class LoginLinks extends React.Component {
 				{ this.renderHelpLink() }
 				{ this.renderMagicLoginLink() }
 				{ this.renderResetPasswordLink() }
-				{ ! isCrowdsignalOAuth2Client( this.props.oauth2Client ) && this.renderBackLink() }
+				{ ! isCrowdsignalOAuth2Client( this.props.oauth2Client ) &&
+					! this.props.isGutenboarding &&
+					this.renderBackLink() }
 			</div>
 		);
 	}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -1,6 +1,17 @@
 @import 'jetpack-connect/colors.scss';
 @import 'woocommerce/components/text-control/style.scss';
 
+@font-face {
+	font-display: swap;
+	font-family: 'Recoleta';
+	font-weight: 400;
+	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot' );
+	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot?#iefix' ) format( 'embedded-opentype' ),
+		url( 'https://s1.wp.com/i/fonts/recoleta/400.woff2' ) format( 'woff2' ),
+		url( 'https://s1.wp.com/i/fonts/recoleta/400.woff' ) format( 'woff' ),
+		url( 'https://s1.wp.com/i/fonts/recoleta/400.ttf' ) format( 'truetype' );
+}
+
 $image-height: 47px;
 
 .layout.is-section-login {
@@ -329,5 +340,17 @@ $image-height: 47px;
 				border: 0;
 			}
 		}
+	}
+}
+
+.layout.is-gutenboarding-login {
+	background-color: #fff;
+
+	.login__form-header {
+		font-family: Recoleta;
+	}
+
+	.wp-login__container .card {
+		box-shadow: none;
 	}
 }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -1,5 +1,8 @@
 @import 'jetpack-connect/colors.scss';
 @import 'woocommerce/components/text-control/style.scss';
+@import 'landing/gutenboarding/mixins.scss';
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
 
 @font-face {
 	font-display: swap;
@@ -347,7 +350,11 @@ $image-height: 47px;
 	background-color: #fff;
 
 	.login__form-header {
-		font-family: Recoleta;
+		@include onboarding-heading-text-mobile;
+
+		@include break-mobile {
+			@include onboarding-heading-text;
+		}
 	}
 
 	.wp-login__container .card {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -353,4 +353,11 @@ $image-height: 47px;
 	.wp-login__container .card {
 		box-shadow: none;
 	}
+
+	.login .button.is-primary {
+		// Match primary button color in Gutenboarding and
+		// change border color to remove 3D effect
+		background-color: #007cba;
+		border-color: #007cba;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Theming the login page so it looks more like Gutenboarding. This isn't a full re-theme, but just doing a few low-hanging fruit.

<img width="856" alt="Screenshot 2020-03-31 at 5 11 39 PM" src="https://user-images.githubusercontent.com/1500769/77986145-e2fe3d00-7372-11ea-808d-5c2335119bff.png">


* Add `/log-in/gutenboarding` route that's styled more like the Gutenboarding flow
* Log in link in Gutenboarding points to this newly themed login variation
* Change heading font to Recoleta
* Add WordPress logo to top left
* Change primary button to the same blue as Gutenboarding
* Hid the "Powered by Jetpack footer"
* The "Create Account" button points at `/gutenboarding`
* Hid the "Back to WordPress.com" button, they'll need to use the browser back button or the "Create Account" button (which unfortunately doesn't have enough context to take them back to exactly the right spot)

Technical note: theming works in a similar way to `/log-in/jetpack`

**Will be done in another PR**
- second-factor screens
- magic link login

**Won't be done in another PR**
- Forgotten password flow. The Jetpack themed login page doesn't attempt to theme it, and I don't think we should either.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To run locally you'll need to restart your dev server because this adds a new server-side route.

- Test locally or go to calypso.live/?branch=add/gutenboarding-styling-to-login
- Go to `/gutenboarding`
- Create a site or pick a premium domain
- Click **Log In** link on signup form
- Should be taken to log in form that resembles Gutenboarding themeing
- After logging in you should be returned to Gutenboarding and your site created

- Try the other buttons
- Locale should be preserved between page transitions (e.g. start from `/gutenboarding/ja` and the `ja` fragment should stay in the url)
