### PR TITLE
[WIP] Gutenboarding: restyle SignupForm to match current designs

### DIFF
--- a/client/landing/gutenboarding/components/modal-submit-button/style.scss
+++ b/client/landing/gutenboarding/components/modal-submit-button/style.scss
@@ -1,8 +1,16 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+
 .components-button.modal-submit-button {
-	display: inline-block;
-	min-width: 10em;
+	display: block;
+	width: 100%;
+	min-width: 170px;
 	text-align: center;
 	font-size: 14px;
-	line-height: 17px;
+	line-height: 14px;
 	height: 42px;
+
+	@include break-mobile {
+		display: inline-block;
+		width: auto;
+	}
 }

--- a/client/landing/gutenboarding/components/modal-submit-button/style.scss
+++ b/client/landing/gutenboarding/components/modal-submit-button/style.scss
@@ -1,8 +1,8 @@
-
 .components-button.modal-submit-button {
-    display: block;
-    width: 100%;
-    text-align: center;
-    font-size: 16px;
-    height: 40px;
+	display: inline-block;
+	min-width: 10em;
+	text-align: center;
+	font-size: 14px;
+	line-height: 17px;
+	height: 42px;
 }

--- a/client/landing/gutenboarding/components/signup-form/header.tsx
+++ b/client/landing/gutenboarding/components/signup-form/header.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Button, Icon } from '@wordpress/components';
+import { useI18n } from '@automattic/react-i18n';
+
+interface SignupFormHeaderProps {
+	onRequestClose: () => void;
+	loginUrl: string;
+}
+
+interface CloseButtonProps {
+	onClose: () => void;
+	closeLabel?: string;
+}
+
+const CustomCloseButton = ( { onClose, closeLabel }: CloseButtonProps ) => {
+	const { __: NO__ } = useI18n();
+	const label = closeLabel ? closeLabel : NO__( 'Close dialog' );
+	return (
+		<Button onClick={ onClose } label={ label }>
+			<svg
+				width="16"
+				height="16"
+				viewBox="0 0 16 16"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" stroke-width="1.5" />
+			</svg>
+		</Button>
+	);
+};
+
+const SignupFormHeader = ( { onRequestClose, loginUrl }: SignupFormHeaderProps ) => {
+	const { __: NO__ } = useI18n();
+	return (
+		<div className="signup-form__header">
+			<div className="signup-form__header-section">
+				<div className="signup-form__header-section-item signup-form__header-wp-logo">
+					<Icon icon="wordpress-alt" size={ 24 } />
+				</div>
+			</div>
+
+			<div className="signup-form__header-section">
+				<div className="signup-form__header-section-item">
+					<Button className="signup-form__link" isLink href={ loginUrl }>
+						{ NO__( 'Log in' ) }
+					</Button>
+				</div>
+
+				<div className="signup-form__header-section-item signup-form__header-close-button">
+					<CustomCloseButton onClose={ onRequestClose } />
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default SignupFormHeader;

--- a/client/landing/gutenboarding/components/signup-form/header.tsx
+++ b/client/landing/gutenboarding/components/signup-form/header.tsx
@@ -12,14 +12,12 @@ interface SignupFormHeaderProps {
 
 interface CloseButtonProps {
 	onClose: () => void;
-	closeLabel?: string;
 }
 
-const CustomCloseButton = ( { onClose, closeLabel }: CloseButtonProps ) => {
+const CustomCloseButton = ( { onClose }: CloseButtonProps ) => {
 	const { __: NO__ } = useI18n();
-	const label = closeLabel ? closeLabel : NO__( 'Close dialog' );
 	return (
-		<Button onClick={ onClose } label={ label }>
+		<Button onClick={ onClose } label={ NO__( 'Close dialog' ) }>
 			<svg
 				width="16"
 				height="16"

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import React, { useState, useEffect } from 'react';
-import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
+import { Button, ExternalLink, TextControl, Icon, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { useLangRouteParam, usePath, Step } from '../../path';
 import ModalSubmitButton from '../modal-submit-button';
 import './style.scss';
+import { __ } from '@wordpress/i18n';
 
 // TODO: deploy this change to @types/wordpress__element
 declare module '@wordpress/element' {
@@ -30,8 +32,30 @@ interface Props {
 	onRequestClose: () => void;
 }
 
+interface CloseButtonProps {
+	onClose: () => void;
+	closeLabel?: string;
+}
+
+const CustomCloseButton = ( { onClose, closeLabel }: CloseButtonProps ) => {
+	const label = closeLabel ? closeLabel : __( 'Close dialog' );
+	return (
+		<Button onClick={ onClose } label={ label }>
+			<svg
+				width="16"
+				height="16"
+				viewBox="0 0 16 16"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" stroke-width="1.5" />
+			</svg>
+		</Button>
+	);
+};
+
 const SignupForm = ( { onRequestClose }: Props ) => {
-	const { __: NO__, _x: NO_x } = useI18n();
+	const { __: NO__ } = useI18n();
 	const [ emailVal, setEmailVal ] = useState( '' );
 	const { createAccount, clearErrors } = useDispatch( USER_STORE );
 	const isFetchingNewUser = useSelect( select => select( USER_STORE ).isFetchingNewUser() );
@@ -99,48 +123,77 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		Step.CreateSite
 	) }?new`;
 
+	const modalClasses = classnames( 'signup-form', {
+		'signup-form__fullscreen': true,
+	} );
+
 	return (
 		<Modal
-			className="signup-form"
-			title={ NO__( 'Sign up to save your changes' ) }
+			className={ modalClasses }
+			title={ NO__( 'Save your progress' ) }
 			onRequestClose={ closeModal }
 			focusOnMount={ false }
-			isDismissible={ ! isFetchingNewUser }
+			isDismissible={ false }
+			overlayClassName={ 'signup-form__overlay' }
 			// set to false so that 1password's autofill doesn't automatically close the modal
 			shouldCloseOnClickOutside={ false }
 		>
-			<form onSubmit={ handleSignUp }>
-				<TextControl
-					label={ NO__( 'Your Email Address' ) }
-					value={ emailVal }
-					disabled={ isFetchingNewUser }
-					type="email"
-					onChange={ setEmailVal }
-					placeholder={ NO_x(
-						'E.g., yourname@email.com',
-						"An example of a person's email, use something appropriate for the locale"
-					) }
-					required
-					autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
-				/>
-				{ errorMessage && (
-					<Notice className="signup-form__error-notice" status="error" isDismissible={ false }>
-						{ errorMessage }
-					</Notice>
-				) }
-				<div className="signup-form__footer">
-					<p className="signup-form__terms-of-service-link">{ tos }</p>
-
-					<ModalSubmitButton disabled={ isFetchingNewUser } isBusy={ isFetchingNewUser }>
-						{ NO__( 'Create your account' ) }
-					</ModalSubmitButton>
+			<div className="signup-form__header">
+				<div className="signup-form__header-section">
+					<div className="signup-form__header-section-item signup-form__header-wp-logo">
+						<Icon icon="wordpress-alt" size={ 24 } />
+					</div>
 				</div>
-			</form>
-			<div className="signup-form__login-links">
-				<Button isLink href={ '/log-in?redirect_to=' + encodeURIComponent( loginRedirectUrl ) }>
-					{ NO__( 'Log in to create a site for your existing account.' ) }
-				</Button>
+
+				<div className="signup-form__header-section">
+					<div className="signup-form__header-section-item">
+						<Button
+							className="signup-form__link"
+							isLink
+							href={ '/log-in?redirect_to=' + encodeURIComponent( loginRedirectUrl ) }
+						>
+							{ NO__( 'Log in' ) }
+						</Button>
+					</div>
+
+					<div className="signup-form__header-section-item signup-form__header-close-button">
+						<CustomCloseButton onClose={ onRequestClose } />
+					</div>
+				</div>
 			</div>
+
+			<main className="signup-form__body">
+				<h1 className="signup-form__title">{ NO__( 'Save your progress' ) }</h1>
+
+				<form onSubmit={ handleSignUp }>
+					<fieldset>
+						<legend className="signup-form__legend">
+							{ NO__( 'Enter an email and password to save your progress and continue' ) }
+						</legend>
+						<TextControl
+							value={ emailVal }
+							disabled={ isFetchingNewUser }
+							type="email"
+							onChange={ setEmailVal }
+							placeholder={ NO__( 'Email address' ) }
+							required
+							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
+						/>
+						{ errorMessage && (
+							<Notice className="signup-form__error-notice" status="error" isDismissible={ false }>
+								{ errorMessage }
+							</Notice>
+						) }
+						<div className="signup-form__footer">
+							<p className="signup-form__terms-of-service-link">{ tos }</p>
+
+							<ModalSubmitButton disabled={ isFetchingNewUser } isBusy={ isFetchingNewUser }>
+								{ NO__( 'Create account' ) }
+							</ModalSubmitButton>
+						</div>
+					</fieldset>
+				</form>
+			</main>
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -2,12 +2,11 @@
  * External dependencies
  */
 import React, { useState, useEffect } from 'react';
-import { Button, ExternalLink, TextControl, Icon, Modal, Notice } from '@wordpress/components';
+import { ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -17,7 +16,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { useLangRouteParam, usePath, Step } from '../../path';
 import ModalSubmitButton from '../modal-submit-button';
 import './style.scss';
-import { __ } from '@wordpress/i18n';
+import SignupFormHeader from './header';
 
 // TODO: deploy this change to @types/wordpress__element
 declare module '@wordpress/element' {
@@ -31,28 +30,6 @@ declare module '@wordpress/element' {
 interface Props {
 	onRequestClose: () => void;
 }
-
-interface CloseButtonProps {
-	onClose: () => void;
-	closeLabel?: string;
-}
-
-const CustomCloseButton = ( { onClose, closeLabel }: CloseButtonProps ) => {
-	const label = closeLabel ? closeLabel : __( 'Close dialog' );
-	return (
-		<Button onClick={ onClose } label={ label }>
-			<svg
-				width="16"
-				height="16"
-				viewBox="0 0 16 16"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" stroke-width="1.5" />
-			</svg>
-		</Button>
-	);
-};
 
 const SignupForm = ( { onRequestClose }: Props ) => {
 	const { __: NO__ } = useI18n();
@@ -123,13 +100,9 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 		Step.CreateSite
 	) }?new`;
 
-	const modalClasses = classnames( 'signup-form', {
-		'signup-form__fullscreen': true,
-	} );
-
 	return (
 		<Modal
-			className={ modalClasses }
+			className={ 'signup-form' }
 			title={ NO__( 'Save your progress' ) }
 			onRequestClose={ closeModal }
 			focusOnMount={ false }
@@ -138,29 +111,10 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 			// set to false so that 1password's autofill doesn't automatically close the modal
 			shouldCloseOnClickOutside={ false }
 		>
-			<div className="signup-form__header">
-				<div className="signup-form__header-section">
-					<div className="signup-form__header-section-item signup-form__header-wp-logo">
-						<Icon icon="wordpress-alt" size={ 24 } />
-					</div>
-				</div>
-
-				<div className="signup-form__header-section">
-					<div className="signup-form__header-section-item">
-						<Button
-							className="signup-form__link"
-							isLink
-							href={ '/log-in?redirect_to=' + encodeURIComponent( loginRedirectUrl ) }
-						>
-							{ NO__( 'Log in' ) }
-						</Button>
-					</div>
-
-					<div className="signup-form__header-section-item signup-form__header-close-button">
-						<CustomCloseButton onClose={ onRequestClose } />
-					</div>
-				</div>
-			</div>
+			<SignupFormHeader
+				onRequestClose={ closeModal }
+				loginUrl={ '/log-in?redirect_to=' + encodeURIComponent( loginRedirectUrl ) }
+			/>
 
 			<main className="signup-form__body">
 				<h1 className="signup-form__title">{ NO__( 'Save your progress' ) }</h1>
@@ -168,8 +122,9 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 				<form onSubmit={ handleSignUp }>
 					<fieldset>
 						<legend className="signup-form__legend">
-							{ NO__( 'Enter an email and password to save your progress and continue' ) }
+							<p>{ NO__( 'Enter an email and password to save your progress and continue' ) }</p>
 						</legend>
+
 						<TextControl
 							value={ emailVal }
 							disabled={ isFetchingNewUser }
@@ -179,13 +134,15 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 							required
 							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						/>
+
 						{ errorMessage && (
 							<Notice className="signup-form__error-notice" status="error" isDismissible={ false }>
 								{ errorMessage }
 							</Notice>
 						) }
+
 						<div className="signup-form__footer">
-							<p className="signup-form__terms-of-service-link">{ tos }</p>
+							<p className="signup-form__link signup-form__terms-of-service-link">{ tos }</p>
 
 							<ModalSubmitButton disabled={ isFetchingNewUser } isBusy={ isFetchingNewUser }>
 								{ NO__( 'Create account' ) }

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -116,7 +116,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 				loginUrl={ '/log-in?redirect_to=' + encodeURIComponent( loginRedirectUrl ) }
 			/>
 
-			<main className="signup-form__body">
+			<div className="signup-form__body">
 				<h1 className="signup-form__title">{ NO__( 'Save your progress' ) }</h1>
 
 				<form onSubmit={ handleSignUp }>
@@ -150,7 +150,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 						</div>
 					</fieldset>
 				</form>
-			</main>
+			</div>
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -30,10 +30,12 @@
 	}
 
 	.signup-form__title {
-		@include onboarding-font-recoleta;
-		font-size: 42px;
-		line-height: 57px;
+		@include onboarding-heading-text-mobile;
 		text-align: center;
+
+		@include break-mobile {
+			@include onboarding-heading-text;
+		}
 	}
 
 	.signup-form__body {
@@ -47,26 +49,23 @@
 		text-align: center;
 	}
 
-	.signup-form__legend {
-		font-size: 14px;
-		line-height: 17px;
-		margin: 30px 0;
+	.signup-form__legend p {
+		@include onboarding-medium-text;
+		margin: 15px 0 30px;
 		color: var( --studio-gray-40 );
 	}
 
 	.components-text-control__input {
 		padding: 21px 14px;
-		font-size: 14px;
-		line-height: 17px;
+		@include onboarding-medium-text;
 		border-radius: 0;
 		border: 1px solid var( --studio-gray-10 );
-		max-width: 400px;
-	}
+		width: 100%;
+		max-width: 100%;
 
-	.signup-form__terms-of-service-link {
-		text-align: center;
-		color: var( --color-text-subtle );
-		margin: 20px 0 40px;
+		@include break-mobile {
+			max-width: 400px;
+		}
 	}
 
 	.signup-form__error-notice {
@@ -78,17 +77,21 @@
 		text-align: center;
 	}
 
-	.signup-form__link {
+	.signup-form__link,
+	.signup-form__link a {
 		color: var( --studio-gray-80 );
+	}
+
+	.signup-form__terms-of-service-link {
+		@include onboarding-x-small-text;
+		text-align: center;
+		color: var( --studio-gray-40 );
+		margin: 30px 0 20px;
 	}
 
 	.signup-form__footer {
 		text-align: center;
 	}
-
-	// &.signup-form__fullscreen {
-	// 	overflow: visible;
-	// }
 
 	.signup-form__header {
 		display: flex;
@@ -123,12 +126,14 @@
 			margin-left: 24px - $grid-size; // ( 24 - header padding )
 		}
 
-		&.signup-form__link {
+		&.signup-form__header-close-button {
 			margin-right: 24px - $grid-size; // ( 24 - header padding )
 		}
 
-		&.signup-form__header-close-button {
+		.signup-form__link {
 			margin-right: 24px - $grid-size; // ( 24 - header padding )
+			font-weight: 600;
+			@include onboarding-small-text;
 		}
 	}
 

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -1,20 +1,66 @@
+@import '../../variables.scss';
 @import '~@automattic/calypso-color-schemes/src/calypso-color-schemes';
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../mixins';
+
+.signup-form__overlay.components-modal__screen-overlay {
+	background-color: $white;
+}
 
 .signup-form.components-modal__frame {
 	border: none;
-	border-radius: 3px;
-	min-width: 450px;
+	border-radius: 0;
+	box-shadow: none;
+	top: 0;
+	left: 0;
+	right: auto;
+	bottom: auto;
+	width: 100%;
+	height: 100%;
+	max-width: 100%;
+	max-height: 100%;
+	transform: translate( 0%, 0% );
 
 	.components-modal__header {
-		.components-modal__header-heading {
-			font-size: 20px;
-			font-weight: normal;
-		}
+		display: none;
 	}
+
+	.components-modal__content {
+		padding: 0;
+	}
+
+	.signup-form__title {
+		@include onboarding-font-recoleta;
+		font-size: 42px;
+		line-height: 57px;
+		text-align: center;
+	}
+
+	.signup-form__body {
+		padding: 0 20px 20px;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 100%;
+		max-width: 500px;
+		transform: translate( -50%, -50% );
+		text-align: center;
+	}
+
+	.signup-form__legend {
+		font-size: 14px;
+		line-height: 17px;
+		margin: 30px 0;
+		color: var( --studio-gray-40 );
+	}
+
 	.components-text-control__input {
-		padding: 7px 14px;
-		font-size: 16px;
-		line-height: 1.5;
+		padding: 21px 14px;
+		font-size: 14px;
+		line-height: 17px;
+		border-radius: 0;
+		border: 1px solid var( --studio-gray-10 );
+		max-width: 400px;
 	}
 
 	.signup-form__terms-of-service-link {
@@ -30,5 +76,64 @@
 	.signup-form__login-links {
 		margin-top: 20px;
 		text-align: center;
+	}
+
+	.signup-form__link {
+		color: var( --studio-gray-80 );
+	}
+
+	.signup-form__footer {
+		text-align: center;
+	}
+
+	// &.signup-form__fullscreen {
+	// 	overflow: visible;
+	// }
+
+	.signup-form__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		height: $gutenboarding-header-height;
+		background: $white;
+
+		left: 0;
+		right: 0;
+		// Stick the toolbar to the top, because the admin bar is not fixed on mobile.
+		top: 0;
+		position: sticky;
+
+		// On mobile the main content area has to scroll, otherwise you can invoke the overscroll bounce on the non-scrolling container.
+		@include break-small {
+			position: fixed;
+			padding: $grid-size;
+		}
+	}
+
+	.signup-form__header-section {
+		display: flex;
+		align-items: center;
+		left: 0;
+	}
+
+	.signup-form__header-section-item {
+		margin-left: 10px;
+
+		&.signup-form__header-wp-logo {
+			margin-left: 24px - $grid-size; // ( 24 - header padding )
+		}
+
+		&.signup-form__link {
+			margin-right: 24px - $grid-size; // ( 24 - header padding )
+		}
+
+		&.signup-form__header-close-button {
+			margin-right: 24px - $grid-size; // ( 24 - header padding )
+		}
+	}
+
+	.signup-form__header-wp-logo {
+		color: var( --studio-blue-90 );
+		display: flex;
 	}
 }

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -39,14 +39,19 @@
 	}
 
 	.signup-form__body {
-		padding: 0 20px 20px;
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		width: 100%;
-		max-width: 500px;
-		transform: translate( -50%, -50% );
-		text-align: center;
+		position: relative;
+		padding: 44px 20px 0;
+
+		@include break-mobile {
+			padding: 0 20px 20px;
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			width: 100%;
+			max-width: 500px;
+			transform: translate( -50%, -50% );
+			text-align: center;
+		}
 	}
 
 	.signup-form__legend p {
@@ -70,6 +75,10 @@
 
 	.signup-form__error-notice {
 		margin: 0;
+
+		@include break-mobile {
+			margin: 0 30px;
+		}
 	}
 
 	.signup-form__login-links {

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -3,3 +3,35 @@
 	font-weight: 400;
 	letter-spacing: -0.4px;
 }
+
+@mixin onboarding-heading-text {
+	@include onboarding-font-recoleta;
+	font-size: 42px;
+	line-height: 57px;
+}
+
+@mixin onboarding-heading-text-mobile {
+	@include onboarding-font-recoleta;
+	font-size: 32px;
+	line-height: 40px;
+}
+
+@mixin onboarding-large-text {
+	font-size: 16px;
+	line-height: 19px;
+}
+
+@mixin onboarding-medium-text {
+	font-size: 14px;
+	line-height: 17px;
+}
+
+@mixin onboarding-small-text {
+	font-size: 12px;
+	line-height: 14px;
+}
+
+@mixin onboarding-x-small-text {
+	font-size: 10px;
+	line-height: 12px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restyle signup form in Gutenboarding to match current Figma
* Add additional mixins to cover most of the common text sizes

Note: it is yet to be determined whether or not a password field is required, so I've left it off for the time being and just focused on styling in this PR.

Also note, that due to how the Modal component works, I've had to use `display:none` on the standard header that's included in the modal, and add our own custom header component. This is slightly hacky because there are technically two header components being mounted. My hope is that `display:none` is a suitable workaround to avoid writing our own modal from scratch, since the `wordpress/components` has some nice affordances.

#### Testing instructions

![image](https://user-images.githubusercontent.com/14988353/77886224-352c5900-72b4-11ea-958d-ba86c3ec80ed.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From a logged out session, go to `http://calypso.localhost:3000/gutenboarding and complete the signup process until you get to the `Save your progress` screen.
* Ensure closing the modal works as intended

Fixes #40504 
