### PR TITLE
Gutenboarding: Some more header/style adjustments

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -101,12 +101,6 @@ const Header: FunctionComponent = () => {
 	const currentDomain = domain ?? freeDomainSuggestion;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	const siteTitleElement = (
-		<span className="gutenboarding__site-title">
-			{ siteTitle ? siteTitle : NO__( 'Start your website' ) }
-		</span>
-	);
-
 	const domainElement = (
 		<span
 			className={ classnames( 'gutenboarding__header-domain-picker-button-domain', {
@@ -193,10 +187,16 @@ const Header: FunctionComponent = () => {
 			tabIndex={ -1 }
 		>
 			<section className="gutenboarding__header-section">
-				<div className="gutenboarding__header-section-item gutenboarding__header-wp-logo">
-					<Icon icon="wordpress-alt" size={ 24 } />
+				<div className="gutenboarding__header-section-item">
+					<div className="gutenboarding__header-wp-logo">
+						<Icon icon="wordpress-alt" size={ 24 } />
+					</div>
 				</div>
-				<div className="gutenboarding__header-section-item">{ siteTitleElement }</div>
+				<div className="gutenboarding__header-section-item">
+					<div className="gutenboarding__header-site-title">
+						{ siteTitle ? siteTitle : NO__( 'Start your website' ) }
+					</div>
+				</div>
 				<div className="gutenboarding__header-section-item">
 					{ siteTitle && (
 						<DomainPickerButton

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -37,17 +37,17 @@
 	font-size: 14px;
 }
 
+$margin-left--gutenboarding__header-section-item: 13px; // matches design
 .gutenboarding__header-section-item {
-	margin-left: 10px;
-
-	&.gutenboarding__header-wp-logo {
-		margin-left: 24px - $grid-size; // ( 24 - header padding )
-	}
+	margin-left: $margin-left--gutenboarding__header-section-item;
 }
 
-$padding--gutenboarding__header-domain-picker-button: 0.3em 0.5em;
+.gutenboarding__header-wp-logo {
+	margin-left: 24px - $grid-size - $margin-left--gutenboarding__header-section-item; // we want 24px exact on spec: ( 24 - header padding - own margin )
+}
+
 .gutenboarding__header-domain-picker-button {
-	padding: $padding--gutenboarding__header-domain-picker-button;
+	padding: 0.3em 0.5em;
 	border-radius: $radius-round-rectangle;
 
 	&:focus,
@@ -58,22 +58,6 @@ $padding--gutenboarding__header-domain-picker-button: 0.3em 0.5em;
 
 	&:disabled {
 		opacity: 1;
-		.gutenboarding__site-title {
-			color: black;
-		}
-	}
-
-	.gutenboarding__site-title {
-		padding: 0;
-	}
-
-	> span {
-		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
-	}
-	> .dashicon {
-		align-self: flex-end;
 	}
 }
 
@@ -83,7 +67,6 @@ $padding--gutenboarding__header-domain-picker-button: 0.3em 0.5em;
 	}
 }
 
-.gutenboarding__site-title {
-	padding: $padding--gutenboarding__header-domain-picker-button;
+.gutenboarding__header-site-title {
 	font-weight: 600;
 }

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -3,6 +3,10 @@
 @import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
 @import '../../variables.scss';
 
+$margin-left--gutenboarding__header-section-item: 13px; // matches design
+$padding--gutenboarding__header: $grid-size;
+
+
 // Copied from https://github.com/WordPress/gutenberg/blob/8c0c7b7267473b5c197dd3052e9707f75f4e6448/packages/edit-widgets/src/components/header/style.scss
 .gutenboarding__header {
 	display: flex;
@@ -22,13 +26,8 @@
 	// On mobile the main content area has to scroll, otherwise you can invoke the overscroll bounce on the non-scrolling container.
 	@include break-small {
 		position: fixed;
-		padding: $grid-size;
+		padding: $padding--gutenboarding__header;
 	}
-}
-
-.gutenboarding__header-wp-logo {
-	color: var( --studio-blue-90 );
-	display: flex;
 }
 
 .gutenboarding__header-section {
@@ -37,13 +36,14 @@
 	font-size: 14px;
 }
 
-$margin-left--gutenboarding__header-section-item: 13px; // matches design
 .gutenboarding__header-section-item {
 	margin-left: $margin-left--gutenboarding__header-section-item;
 }
 
 .gutenboarding__header-wp-logo {
-	margin-left: 24px - $grid-size - $margin-left--gutenboarding__header-section-item; // we want 24px exact on spec: ( 24 - header padding - own margin )
+	margin-left: 24px - $padding--gutenboarding__header - $margin-left--gutenboarding__header-section-item; // we want 24px exact on spec: ( 24 - header padding - own margin )
+	color: var( --studio-blue-90 );
+	display: flex;
 }
 
 .gutenboarding__header-domain-picker-button {

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -6,7 +6,6 @@
 $margin-left--gutenboarding__header-section-item: 13px; // matches design
 $padding--gutenboarding__header: $grid-size;
 
-
 // Copied from https://github.com/WordPress/gutenberg/blob/8c0c7b7267473b5c197dd3052e9707f75f4e6448/packages/edit-widgets/src/components/header/style.scss
 .gutenboarding__header {
 	display: flex;

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -16,17 +16,16 @@ $padding--gutenboarding__header: $grid-size;
 	height: $gutenboarding-header-height;
 	background: $white;
 	z-index: z-index( '.block-editor-editor-skeleton__header' );
-
 	left: 0;
 	right: 0;
 	// Stick the toolbar to the top, because the admin bar is not fixed on mobile.
 	top: 0;
 	position: sticky;
+	padding: $padding--gutenboarding__header;
 
 	// On mobile the main content area has to scroll, otherwise you can invoke the overscroll bounce on the non-scrolling container.
 	@include break-small {
 		position: fixed;
-		padding: $padding--gutenboarding__header;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some more header cleanup, also matches the figma a little better.

**before**

<img width="448" alt="Screenshot 2020-03-30 at 11 16 44 AM" src="https://user-images.githubusercontent.com/1705499/77890731-a0f0d080-7278-11ea-8d30-b46ff50fc6cb.png">

**after**

<img width="467" alt="Screenshot 2020-03-30 at 11 15 54 AM" src="https://user-images.githubusercontent.com/1705499/77890720-9d5d4980-7278-11ea-8791-58c8a97aec0b.png">

#### Testing instructions

http://calypso.localhost:3000/gutenboarding