### PR TITLE
Simplify vertical-selection arrow appearance conditions

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -12,7 +12,6 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import { STORE_KEY } from '../../stores/onboard';
 import { Step, usePath } from '../../path';
-import Arrow from './arrow';
 
 interface Props {
 	inputRef: React.RefObject< HTMLInputElement >;
@@ -53,12 +52,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { inputRef } ) => {
 		history.push( makePath( Step.DesignSelection ) );
 	};
 
-	return (
-		<form onSubmit={ handleSubmit }>
-			{ madlib }
-			{ !! value.length && <Arrow /> }
-		</form>
-	);
+	return <form onSubmit={ handleSubmit }>{ madlib }</form>;
 };
 
 export default SiteTitle;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -55,7 +55,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 			} ) )
 	);
 
-	const { siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
+	const { siteVertical, siteTitle } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { setSiteVertical, resetSiteVertical } = useDispatch( ONBOARD_STORE );
 
 	const [ inputValue, setInputValue ] = React.useState( siteVertical?.label ?? '' );
@@ -171,6 +171,8 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		),
 	} );
 
+	const showArrow = isFocused && ! siteTitle && ! siteVertical;
+
 	return (
 		<form
 			className={ classnames( 'vertical-select', {
@@ -178,7 +180,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 			} ) }
 		>
 			{ madlib }
-			{ hasValue && ( isFocused ? <Arrow /> : '.' ) }
+			{ showArrow ? <Arrow /> : '.' }
 		</form>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes the arrow only appear in the clean-slate state. If you have any input in the vertical or in the site title, a dot will appear instead. 


#### Testing instructions

See the live link below. The arrow should only appear during the first entry of the site vertical.

Fixes part of #40321 
