### PR TITLE
registrant-extra-info: Pass consistent error and optional change handler props (3)

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -35,6 +35,8 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	static propTypes = {
 		contactDetails: PropTypes.object.isRequired,
 		ccTldDetails: PropTypes.object.isRequired,
+		onContactDetailsChange: PropTypes.func,
+		contactDetailsValidationErrors: PropTypes.object,
 		userWpcomLang: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
@@ -107,11 +109,14 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 			defaultValues.lang = 'FR';
 		}
 
-		this.props.updateContactDetailsCache( {
+		const payload = {
 			extra: {
 				ca: pick( defaultValues, neededRequiredDetails ),
 			},
-		} );
+		};
+
+		this.props.updateContactDetailsCache( payload );
+		this.props.onContactDetailsChange?.( payload );
 	}
 
 	validateContactDetails = contactDetails => {
@@ -143,6 +148,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		}
 
 		this.props.updateContactDetailsCache( { ...newContactDetails } );
+		this.props.onContactDetailsChange?.( { ...newContactDetails } );
 	};
 
 	needsOrganization() {
@@ -154,7 +160,9 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	}
 
 	getOrganizationErrorMessage() {
-		let message = ( this.state.errorMessages.organization || [] ).join( '\n' );
+		let message = this.props?.contactDetailsValidationErrors?.organization
+			? this.props.contactDetailsValidationErrors.organization
+			: ( this.state.errorMessages.organization || [] ).join( '\n' );
 		if ( this.needsOrganization() && isEmpty( this.props.contactDetails.organization ) ) {
 			message = this.props.translate(
 				'An organization name is required for Canadian corporations'

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -39,6 +39,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		contactDetailsValidationErrors: PropTypes.object,
 		userWpcomLang: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
+        updateContactDetailsCache: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -39,7 +39,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		contactDetailsValidationErrors: PropTypes.object,
 		userWpcomLang: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
-        updateContactDetailsCache: PropTypes.func.isRequired,
+		updateContactDetailsCache: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {
@@ -161,9 +161,9 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	}
 
 	getOrganizationErrorMessage() {
-		let message = this.props?.contactDetailsValidationErrors?.organization
-			? this.props.contactDetailsValidationErrors.organization
-			: ( this.state.errorMessages.organization || [] ).join( '\n' );
+		let message =
+			this.props.contactDetailsValidationErrors?.organization ||
+			( this.state.errorMessages.organization || [] ).join( '\n' );
 		if ( this.needsOrganization() && isEmpty( this.props.contactDetails.organization ) ) {
 			message = this.props.translate(
 				'An organization name is required for Canadian corporations'

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -91,7 +91,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		};
 
 		this.props.updateContactDetailsCache( payload );
-		this.props?.onContactDetailsChange( payload );
+		this.props?.onContactDetailsChange?.( payload );
 	}
 
 	updateContactDetails( field, value ) {
@@ -99,7 +99,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		debug( 'Setting ' + field + ' to ' + value );
 		const payload = set( {}, field, sanitizedValue );
 		this.props.updateContactDetailsCache( payload );
-		this.props.onContactDetailsChange( payload );
+		this.props.onContactDetailsChange?.( payload );
 	}
 
 	handleChangeContactEvent = event => {

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -58,6 +58,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 	static propTypes = {
 		contactDetails: PropTypes.object,
 		ccTldDetails: PropTypes.object,
+		onContactDetailsChange: PropTypes.func,
 		contactDetailsValidationErrors: PropTypes.object,
 		isVisible: PropTypes.bool,
 		onSubmit: PropTypes.func,
@@ -83,17 +84,22 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		//    fields so we can keep them together in one place
 		defaultRegistrantType = this.props.contactDetails.organization ? 'organization' : 'individual';
 
-		this.props.updateContactDetailsCache( {
+		const payload = {
 			extra: {
 				fr: { registrantType: defaultRegistrantType },
 			},
-		} );
+		};
+
+		this.props.updateContactDetailsCache( payload );
+		this.props?.onContactDetailsChange( payload );
 	}
 
 	updateContactDetails( field, value ) {
 		const sanitizedValue = this.sanitizeField( field, value );
 		debug( 'Setting ' + field + ' to ' + value );
-		this.props.updateContactDetailsCache( set( {}, field, sanitizedValue ) );
+		const payload = set( {}, field, sanitizedValue );
+		this.props.updateContactDetailsCache( payload );
+		this.props.onContactDetailsChange( payload );
 	}
 
 	handleChangeContactEvent = event => {

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -91,7 +91,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		};
 
 		this.props.updateContactDetailsCache( payload );
-		this.props?.onContactDetailsChange?.( payload );
+		this.props.onContactDetailsChange?.( payload );
 	}
 
 	updateContactDetails( field, value ) {

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -57,13 +57,13 @@ function renderValidationError( message ) {
 class RegistrantExtraInfoFrForm extends React.PureComponent {
 	static propTypes = {
 		contactDetails: PropTypes.object,
-		ccTldDetails: PropTypes.object,
+		ccTldDetails: PropTypes.object.isRequired,
 		onContactDetailsChange: PropTypes.func,
 		contactDetailsValidationErrors: PropTypes.object,
 		isVisible: PropTypes.bool,
 		onSubmit: PropTypes.func,
-		translate: PropTypes.func,
-		updateContactDetailsCache: PropTypes.func,
+		translate: PropTypes.func.isRequired,
+		updateContactDetailsCache: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/components/domains/registrant-extra-info/test/uk-form.js
+++ b/client/components/domains/registrant-extra-info/test/uk-form.js
@@ -24,7 +24,7 @@ describe( 'uk-form', () => {
 			const testProps = {
 				...mockProps,
 				ccTldDetails: { registrantType: 'LLP' },
-				validationErrors: {
+				contactDetailsValidationErrors: {
 					extra: {
 						uk: {
 							registrationNumber: [ { errorMessage: 'Test error message.' } ],
@@ -42,7 +42,7 @@ describe( 'uk-form', () => {
 			const testProps = {
 				...mockProps,
 				ccTldDetails: { registrantType: 'LLP' },
-				validationErrors: {
+				contactDetailsValidationErrors: {
 					extra: {
 						uk: {
 							registrationNumber: [
@@ -64,7 +64,7 @@ describe( 'uk-form', () => {
 			const testProps = {
 				...mockProps,
 				ccTldDetails: { registrantType: 'LLP' },
-				validationErrors: {
+				contactDetailsValidationErrors: {
 					extra: {
 						uk: {
 							registrationNumber: [ 'dotukRegistrationNumberFormat' ],
@@ -86,7 +86,7 @@ describe( 'uk-form', () => {
 			const testProps = {
 				...mockProps,
 				ccTldDetails: { registrantType: 'IND' },
-				validationErrors: {
+				contactDetailsValidationErrors: {
 					extra: {
 						uk: {
 							registrationNumber: [ 'dotukRegistrationNumberFormat' ],

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -33,7 +33,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		onContactDetailsChange: PropTypes.func,
 		contactDetailsValidationErrors: PropTypes.object,
 		translate: PropTypes.func.isRequired,
-        updateContactDetailsCache: PropTypes.func.isRequired,
+		updateContactDetailsCache: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {
@@ -189,7 +189,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 	};
 
 	render() {
-		const { translate, contactDetailsValidationErrors } = this.props;
+		const { translate } = this.props;
 		const { registrantType } = {
 			...defaultValues,
 			...this.props.ccTldDetails,
@@ -199,11 +199,9 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 			this.isTradingNameRequired( registrantType ) && 'tradingName',
 			this.isRegistrationNumberRequired( registrantType ) && 'registrationNumber',
 		] );
-		const relevantErrors = pick(
-			get( contactDetailsValidationErrors, 'extra.uk', {} ),
-			relevantExtraFields
+		const isValid = Object.keys( this.props.contactDetailsValidationErrors?.extra?.uk ?? {} ).every(
+			errorKey => ! relevantExtraFields.includes( errorKey )
 		);
-		const isValid = isEmpty( relevantErrors );
 
 		return (
 			<form className="registrant-extra-info__form">

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -84,7 +84,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		};
 
 		this.props.updateContactDetailsCache( payload );
-		this.props?.onContactDetailsChange( payload );
+		this.props.onContactDetailsChange?.( payload );
 	}
 
 	handleChangeEvent = event => {
@@ -94,7 +94,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 			},
 		};
 		this.props.updateContactDetailsCache( payload );
-		this.props.onContactDetailsChange( payload );
+		this.props.onContactDetailsChange?.( payload );
 	};
 
 	isTradingNameRequired( registrantType ) {

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -33,6 +33,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		onContactDetailsChange: PropTypes.func,
 		contactDetailsValidationErrors: PropTypes.object,
 		translate: PropTypes.func.isRequired,
+        updateContactDetailsCache: PropTypes.func.isRequired,
 	};
 
 	constructor( props ) {

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -30,6 +30,8 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 	static propTypes = {
 		contactDetails: PropTypes.object.isRequired,
 		ccTldDetails: PropTypes.object.isRequired,
+		onContactDetailsChange: PropTypes.func,
+		contactDetailsValidationErrors: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -75,19 +77,24 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 			return;
 		}
 
-		this.props.updateContactDetailsCache( {
+		const payload = {
 			extra: {
 				uk: pick( defaultValues, neededRequiredDetails ),
 			},
-		} );
+		};
+
+		this.props.updateContactDetailsCache( payload );
+		this.props?.onContactDetailsChange( payload );
 	}
 
 	handleChangeEvent = event => {
-		this.props.updateContactDetailsCache( {
+		const payload = {
 			extra: {
 				uk: { [ camelCase( event.target.id ) ]: event.target.value },
 			},
-		} );
+		};
+		this.props.updateContactDetailsCache( payload );
+		this.props.onContactDetailsChange( payload );
 	};
 
 	isTradingNameRequired( registrantType ) {
@@ -105,7 +112,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		const { ccTldDetails, translate } = this.props;
 		const tradingName = get( ccTldDetails, 'tradingName', '' );
 		const tradingNameErrors = get(
-			this.props.validationErrors,
+			this.props.contactDetailsValidationErrors,
 			[ 'extra', 'uk', 'tradingName' ],
 			[]
 		);
@@ -137,7 +144,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		const { ccTldDetails, translate } = this.props;
 		const registrationNumber = get( ccTldDetails, 'registrationNumber', '' );
 		const registrationNumberErrors = get(
-			this.props.validationErrors,
+			this.props.contactDetailsValidationErrors,
 			[ 'extra', 'uk', 'registrationNumber' ],
 			[]
 		);
@@ -181,7 +188,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 	};
 
 	render() {
-		const { translate, validationErrors } = this.props;
+		const { translate, contactDetailsValidationErrors } = this.props;
 		const { registrantType } = {
 			...defaultValues,
 			...this.props.ccTldDetails,
@@ -191,7 +198,10 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 			this.isTradingNameRequired( registrantType ) && 'tradingName',
 			this.isRegistrationNumberRequired( registrantType ) && 'registrationNumber',
 		] );
-		const relevantErrors = pick( get( validationErrors, 'extra.uk', {} ), relevantExtraFields );
+		const relevantErrors = pick(
+			get( contactDetailsValidationErrors, 'extra.uk', {} ),
+			relevantExtraFields
+		);
 		const isValid = isEmpty( relevantErrors );
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Part 2 of #39837. Composite checkout uses calypso's domain contact forms as managed components, so it needs to be able to pass errors and a custom change event handler. This PR adds these to the extra contact field components for specific TLDs - ca, fr, uk. (The readme indicates this is the intended behavior anyway, but afaict it was not consistently implemented.)
* All TLD specific forms now take a `contactDetailsValidationErrors` prop. This changes the name of the `validationErrors` prop taken by the UK form, which was only explicitly passed in tests.

#### Testing instructions

This patch should have no observable effects yet. Test that this is the case by trying to get through the contact details pages in _regular_ checkout, paying attention to the following cases:

1. Have a .ca, .uk, or .fr domain in your cart. Verify that the extra fields are shown and that there are no JS errors thrown by the contact form components.
2. Try to enter bad data in the extra fields and verify that validation errors are shown.
