### PR TITLE
Don't import all of `hash.js`

### DIFF
--- a/packages/calypso-analytics/src/utils/hash-pii.ts
+++ b/packages/calypso-analytics/src/utils/hash-pii.ts
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { sha256 } from 'hash.js';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import sha256 from 'hash.js/lib/hash/sha/256';
 
 /**
  * Hashes users' Personally Identifiable Information using SHA256


### PR DESCRIPTION
The `hash.js` library doesn't handle tree-shaking properly, so we can't import functions from its index file, or we end up importing the whole library. Instead, we must import from individual modules inside it.

Forcibly ignoring this import isn't ideal, but there doesn't appear to be a great way of handling this without modifying `hash.js` (which seems abandoned).

This PR should save ~2.9KB (compressed) on the critical path.

#### Changes proposed in this Pull Request

* Import `sha256` directly from its module, rather than from the package index

#### Testing instructions

No testing should be necessary, as long as everything builds correctly.
