### PR TITLE
Typography: Replace font-weight: 300 with 400

### DIFF
--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -121,7 +121,6 @@ $feature-upsell-break-at: '1040px';
 		color: var( --studio-jetpack-green-30 );
 		font-size: 15px;
 		line-height: 31px;
-		font-weight: 300;
 	}
 
 	&.is-centered {
@@ -161,7 +160,6 @@ $feature-upsell-break-at: '1040px';
 			order: 1;
 			line-height: 1.25;
 			font-size: 26px;
-			font-weight: 300;
 			padding-right: 30px;
 			@include breakpoint( '<1280px' ) {
 				font-size: 22px;

--- a/client/my-sites/guided-transfer/style.scss
+++ b/client/my-sites/guided-transfer/style.scss
@@ -72,7 +72,3 @@
 	color: red;
 	vertical-align: text-bottom;
 }
-
-.guided-transfer__issue-description {
-	font-weight: 300;
-}

--- a/client/my-sites/invites/invite-accept-logged-in/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-in/style.scss
@@ -2,7 +2,6 @@
 	color: var( --color-neutral-60 );
 	font-family: $sans;
 	font-size: 21px;
-	font-weight: 300;
 	line-height: 24px;
 	margin-bottom: 16px;
 	text-align: center;

--- a/client/my-sites/invites/invite-form-header/style.scss
+++ b/client/my-sites/invites/invite-form-header/style.scss
@@ -2,7 +2,6 @@
 	color: var( --color-neutral-60 );
 	font-family: $sans;
 	font-size: 21px;
-	font-weight: 300;
 	line-height: 24px;
 	margin-bottom: 16px;
 }

--- a/client/my-sites/marketing/connections/account-dialog-account.scss
+++ b/client/my-sites/marketing/connections/account-dialog-account.scss
@@ -54,6 +54,5 @@
 }
 
 .account-dialog-account__description {
-	font-weight: 300;
 	font-size: 0.9em;
 }

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -648,7 +648,6 @@
 .sharing-buttons-preview__fake-like {
 	color: var( --color-neutral-40 );
 	font-size: 11px;
-	font-weight: 300;
 }
 
 .sharing-buttons-preview .sortable-list__navigation {

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -45,7 +45,6 @@
 
 .my-plan-card__tagline {
 	font-size: 18px;
-	font-weight: 300;
 	line-height: 21px;
 	margin: 0 0 24px;
 

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -69,7 +69,6 @@
 
 .current-plan__header-text {
 	font-size: 18px;
-	font-weight: 300;
 }
 
 .current-plan__header.is-placeholder {

--- a/client/my-sites/site-settings/delete-site/style.scss
+++ b/client/my-sites/site-settings/delete-site/style.scss
@@ -44,7 +44,6 @@ h1.delete-site__confirm-header {
 	height: auto;
 	margin-bottom: 16px;
 	font-size: 21px;
-	font-weight: 300;
 	line-height: 24px;
 	color: var( --color-neutral-70 );
 }

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -1,3 +1,4 @@
+client/my-sites/stats/post-trends/style.scss
 .post-trends {
 	display: inline-block;
 	user-select: none;
@@ -20,7 +21,6 @@
 .post-trends__value {
 	text-align: center;
 	font-size: 16px;
-	font-weight: 300;
 	color: var( --color-neutral-50 );
 	margin: 20px 0 30px;
 }

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -31,7 +31,6 @@
 .stats-insights__nonperiodic {
 	&.has-no-recent {
 		color: var( --color-neutral-70 );
-		font-weight: 300;
 
 		p {
 			@include breakpoint( '<660px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* See #39596 
* I wasn't able to find a few of these instances: Feature upsell, guided transfer, marketing account dialog, post trends, stats module. Given the relatively benign nature of this PR I don't think that's an issue, though.

**Before**

<img width="395" alt="Screen Shot 2020-03-30 at 12 44 35 PM" src="https://user-images.githubusercontent.com/2124984/77938792-3cd40980-7284-11ea-8c2b-226dda438393.png">

<img width="440" alt="Screen Shot 2020-03-30 at 12 51 08 PM" src="https://user-images.githubusercontent.com/2124984/77939501-49a52d00-7285-11ea-8dd7-361f6aed8ef3.png">

<img width="321" alt="Screen Shot 2020-03-30 at 1 02 56 PM" src="https://user-images.githubusercontent.com/2124984/77940609-f207c100-7286-11ea-8525-34d7775a7cad.png">

<img width="1093" alt="Screen Shot 2020-03-30 at 1 05 43 PM" src="https://user-images.githubusercontent.com/2124984/77940980-74908080-7287-11ea-9703-ca602130237a.png">

<img width="514" alt="Screen Shot 2020-03-30 at 1 14 40 PM" src="https://user-images.githubusercontent.com/2124984/77941715-9cccaf00-7288-11ea-99f0-2979e64a3b19.png">


**After**

<img width="395" alt="Screen Shot 2020-03-30 at 12 40 36 PM" src="https://user-images.githubusercontent.com/2124984/77938805-41002700-7284-11ea-858f-a23bf14050b5.png">

<img width="429" alt="Screen Shot 2020-03-30 at 12 51 24 PM" src="https://user-images.githubusercontent.com/2124984/77939514-4dd14a80-7285-11ea-9b8c-1de63acebdc2.png">

<img width="309" alt="Screen Shot 2020-03-30 at 1 03 08 PM" src="https://user-images.githubusercontent.com/2124984/77940650-0350cd80-7287-11ea-84d2-c2ad51a1c3bc.png">

<img width="1073" alt="Screen Shot 2020-03-30 at 1 05 52 PM" src="https://user-images.githubusercontent.com/2124984/77940959-6fcbcc80-7287-11ea-9f14-327d6005d3a7.png">

<img width="506" alt="Screen Shot 2020-03-30 at 1 16 23 PM" src="https://user-images.githubusercontent.com/2124984/77941762-ac4bf800-7288-11ea-9d18-e3a91d91b4a5.png">


#### Testing instructions

* Switch to this PR
* Invite your account to a site and open the invitation when that account is not logged in; the heading on the invite accept screen should be font-weight 400.
* Do the same as above, but open the invitation on the account when it is already logged in, and check the heading font weight on that screen.
* Go to Marketing -> Sharing and look at the "One person likes this" text underneath the sharing buttons preview.
* Go to Plans -> My Plan and check the font weight on the subheader under the plan name in the first card.
* Go to Settings -> Delete Site and click the Delete button at the bottom. The card that pops up should have a font-weight: 400 header rather than 300.
