### PR TITLE
Jetpack Cloud: Add thank you note to JP Scan purchases

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -38,7 +38,11 @@ import {
 	hasTransferProduct,
 	jetpackProductItem,
 } from 'lib/cart-values/cart-items';
-import { JETPACK_BACKUP_PRODUCTS, JETPACK_SEARCH_PRODUCTS } from 'lib/products-values/constants';
+import {
+	JETPACK_BACKUP_PRODUCTS,
+	JETPACK_SCAN_PRODUCTS,
+	JETPACK_SEARCH_PRODUCTS,
+} from 'lib/products-values/constants';
 import PendingPaymentBlocker from './pending-payment-blocker';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -395,7 +399,8 @@ export class Checkout extends React.Component {
 			const isJetpackProduct =
 				product &&
 				( includes( JETPACK_BACKUP_PRODUCTS, product ) ||
-					includes( JETPACK_SEARCH_PRODUCTS, product ) );
+					includes( JETPACK_SEARCH_PRODUCTS, product ) ||
+					includes( JETPACK_SCAN_PRODUCTS, product ) );
 			// If we just purchased a Jetpack product, redirect to the my plans page.
 			if ( isJetpackNotAtomic && isJetpackProduct ) {
 				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&product=${ product }`;

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { flatten, find, get, includes, isEmpty, isEqual, reduce, startsWith } from 'lodash';
+import { flatten, find, get, isEmpty, isEqual, reduce, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -38,11 +38,7 @@ import {
 	hasTransferProduct,
 	jetpackProductItem,
 } from 'lib/cart-values/cart-items';
-import {
-	JETPACK_BACKUP_PRODUCTS,
-	JETPACK_SCAN_PRODUCTS,
-	JETPACK_SEARCH_PRODUCTS,
-} from 'lib/products-values/constants';
+import { isJetpackProductSlug } from 'lib/products-values';
 import PendingPaymentBlocker from './pending-payment-blocker';
 import { clearSitePlans } from 'state/sites/plans/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -396,11 +392,7 @@ export class Checkout extends React.Component {
 		// - has a receipt number
 		// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
 		if ( selectedSiteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
-			const isJetpackProduct =
-				product &&
-				( includes( JETPACK_BACKUP_PRODUCTS, product ) ||
-					includes( JETPACK_SEARCH_PRODUCTS, product ) ||
-					includes( JETPACK_SCAN_PRODUCTS, product ) );
+			const isJetpackProduct = product && isJetpackProductSlug( product );
 			// If we just purchased a Jetpack product, redirect to the my plans page.
 			if ( isJetpackNotAtomic && isJetpackProduct ) {
 				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&product=${ product }`;

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.js
@@ -11,7 +11,7 @@ import ThankYou from './thank-you';
 
 const ScanProductThankYou = ( { translate } ) => (
 	<ThankYou
-		illustration="/calypso/images/illustrations/thankYou.svg"
+		illustration="/calypso/images/illustrations/security.svg"
 		showContinueButton
 		title={ translate( 'Welcome to Jetpack Scan!' ) }
 	>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.js
@@ -12,7 +12,7 @@ import ThankYou from './thank-you';
 const ScanProductThankYou = ( { translate } ) => (
 	<ThankYou
 		illustration="/calypso/images/illustrations/security.svg"
-		showContinueButton
+		showScanCTAs
 		title={ translate( 'Welcome to Jetpack Scan!' ) }
 	>
 		<p>{ translate( 'We just finished setting up automated malware scanning for you.' ) }</p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.js
@@ -15,13 +15,13 @@ const ScanProductThankYou = ( { translate } ) => (
 		showContinueButton
 		title={ translate( 'Welcome to Jetpack Scan!' ) }
 	>
-		<p>{ translate( 'We are currently scanning your site.' ) }</p>
+		<p>{ translate( 'We just finished setting up automated malware scanning for you.' ) }</p>
 		<p>
 			{ translate(
-				'In the meantime, we have configured Jetpack Scan on your site — ' +
-					'you should try customizing it in your traditional WordPress dashboard.'
+				'Please add your server information to set up automated and one-click fixes. '
 			) }
 		</p>
+		<p>{ translate( "There's also a checklist to help you get the most out of Jetpack." ) }</p>
 	</ThankYou>
 );
 export default localize( ScanProductThankYou );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/scan-thank-you.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ThankYou from './thank-you';
+
+const ScanProductThankYou = ( { translate } ) => (
+	<ThankYou
+		illustration="/calypso/images/illustrations/thankYou.svg"
+		showContinueButton
+		title={ translate( 'Welcome to Jetpack Scan!' ) }
+	>
+		<p>{ translate( 'We are currently scanning your site.' ) }</p>
+		<p>
+			{ translate(
+				'In the meantime, we have configured Jetpack Scan on your site — ' +
+					'you should try customizing it in your traditional WordPress dashboard.'
+			) }
+		</p>
+	</ThankYou>
+);
+export default localize( ScanProductThankYou );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -6,6 +6,7 @@
 	@include breakpoint( '>800px' ) {
 		font-size: 16px;
 		padding: 20px 0;
+		width: 720px;
 	}
 
 	&__title {
@@ -47,6 +48,7 @@
 }
 
 .current-plan-thank-you__illustration {
+	max-width: 220px;
 	margin-right: 32px;
 
 	@include breakpoint( '<660px' ) {

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -16,7 +16,7 @@ import getCurrentQueryArguments from 'state/selectors/get-current-query-argument
 import getCurrentRoute from 'state/selectors/get-current-route';
 import { addQueryArgs } from 'lib/url';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteAdminUrl } from 'state/sites/selectors';
+import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import { getCurrentUser } from 'state/current-user/selectors';
 
@@ -38,7 +38,9 @@ export class ThankYouCard extends Component {
 			showContinueButton,
 			showHideMessage,
 			showSearchRedirects,
+			showScanCTAs,
 			siteAdminUrl,
+			selectedSiteSlug,
 			title,
 			translate,
 		} = this.props;
@@ -106,6 +108,16 @@ export class ThankYouCard extends Component {
 							</Button>
 						</p>
 					) }
+					{ showScanCTAs && (
+						<p className="current-plan-thank-you__followup">
+							<Button href={ `/settings/security/${ selectedSiteSlug }#credentials` } primary>
+								{ translate( 'Add server credentials now' ) }
+							</Button>
+							<Button href={ dismissUrl } onClick={ this.startChecklistTour } primary>
+								{ translate( 'See checklist' ) }
+							</Button>
+						</p>
+					) }
 				</div>
 			</div>
 		);
@@ -116,11 +128,13 @@ export default connect(
 	state => {
 		const currentUser = getCurrentUser( state );
 		const selectedSiteId = getSelectedSiteId( state );
+		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
 		const isSingleSite = !! selectedSiteId || currentUser.site_count === 1;
 		const siteId = selectedSiteId || ( isSingleSite && getPrimarySiteId( state ) ) || null;
 		const siteAdminUrl = getSiteAdminUrl( state, siteId );
 		return {
 			siteAdminUrl,
+			selectedSiteSlug,
 			currentRoute: getCurrentRoute( state ),
 			queryArgs: getCurrentQueryArguments( state ),
 		};

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -113,7 +113,7 @@ export class ThankYouCard extends Component {
 							<Button href={ `/settings/security/${ selectedSiteSlug }#credentials` } primary>
 								{ translate( 'Add server credentials now' ) }
 							</Button>
-							<Button href={ dismissUrl } onClick={ this.startChecklistTour } primary>
+							<Button href={ dismissUrl } onClick={ this.startChecklistTour }>
 								{ translate( 'See checklist' ) }
 							</Button>
 						</p>

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -36,6 +36,7 @@ import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import PaidPlanThankYou from './current-plan-thank-you/paid-plan-thank-you';
 import FreePlanThankYou from './current-plan-thank-you/free-plan-thank-you';
 import BackupProductThankYou from './current-plan-thank-you/backup-thank-you';
+import ScanProductThankYou from './current-plan-thank-you/scan-thank-you';
 import SearchProductThankYou from './current-plan-thank-you/search-thank-you';
 import { isFreeJetpackPlan, isFreePlan } from 'lib/products-values';
 
@@ -83,9 +84,14 @@ class CurrentPlan extends Component {
 			return <BackupProductThankYou />;
 		}
 
+		if ( requestProduct && startsWith( product, 'jetpack_scan' ) ) {
+			return <ScanProductThankYou />;
+		}
+
 		if ( requestProduct && startsWith( product, 'jetpack_search' ) ) {
 			return <SearchProductThankYou />;
 		}
+
 		if ( ! currentPlan || isFreePlan( currentPlan ) || isFreeJetpackPlan( currentPlan ) ) {
 			return <FreePlanThankYou />;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- We need to add a "Thank you" note after purchasing Jetpack Scan.

#### Important note

It is still unclear what should the CTA do. Right now, it brings the user to the checklist tour. This seems reasonable since Scan requires the server credentials to work and we could add that requirement to the checklist.

#### Testing instructions

- Navigate to http://calypso.localhost:3000/plans/
- Purchase Jetpack Scan
- You should see the "Thank you" note and the end of the URL should look like `?thank-you=&product=jetpack_scan`

See 1151678672052943-as-1168017254149561.

#### Demo
![Kapture 2020-03-30 at 15 01 54](https://user-images.githubusercontent.com/3418513/77945765-909c1e00-7297-11ea-8088-8c004e1db03a.gif)


