### PR TITLE
Fix error when we switch the section, remove backupOnSelectedDate state

### DIFF
--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -22,9 +22,9 @@ import './style.scss';
 class DatePicker extends Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
-		selectedDate: PropTypes.instanceOf( Date ).isRequired,
+		selectedDate: PropTypes.object.isRequired,
 		onDateChange: PropTypes.func.isRequired,
-		oldestDateAvailable: PropTypes.instanceOf( Date ),
+		oldestDateAvailable: PropTypes.object.isRequired,
 	};
 
 	getDisplayDate = ( date, showTodayYesterday = true ) => {
@@ -56,7 +56,7 @@ class DatePicker extends Component {
 
 		const newSelectedDate = moment( selectedDate ).subtract( 1, 'days' );
 
-		onDateChange( newSelectedDate.toDate() );
+		onDateChange( newSelectedDate );
 	};
 
 	goToNextDay = () => {
@@ -67,7 +67,7 @@ class DatePicker extends Component {
 
 		const newSelectedDate = moment( selectedDate ).add( 1, 'days' );
 
-		onDateChange( newSelectedDate.toDate() );
+		onDateChange( newSelectedDate );
 	};
 
 	canGoToPreviousDay = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When we switch the section and return again to BackupsPage, the backup on the selected date (today) is not in the correct state. To fix it we:

- Removed the backupOnSelectedDate state. It wasn't necessary, we can get it from the props through a method.
- Applied the time zone to some of the dates that should have it applied.
- Ensure that we always work with Moment to preserve the time zone.

#### Testing instructions

- Apply the changes
- If you have a backup from today (you should see it), switch to another section (like Scan) and switch again to the Backup section, you should see the backup of today again.
- Check if everything works as before (navigating through the dates)

