### PR TITLE
Jetpack Cloud: update pricing and tier information UI

### DIFF
--- a/client/components/product-card/options.jsx
+++ b/client/components/product-card/options.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { isEmpty } from 'lodash';
@@ -27,36 +27,38 @@ const ProductCardOptions = ( {
 	const hideRadios = options.length === 1 && ! forceRadiosEvenIfOnlyOneOption;
 
 	return (
-		<div className="product-card__options">
+		<Fragment>
 			{ ! hideRadios && optionsLabel && (
 				<h4 className="product-card__options-label">{ optionsLabel }</h4>
 			) }
-			{ options.map( option => (
-				<FormLabel
-					key={ `product-option-${ option.slug }` }
-					className={ classnames( 'product-card__option', {
-						'is-selected': option.slug === selectedSlug,
-					} ) }
-				>
-					{ ! hideRadios && (
-						<FormRadio
-							className="product-card__radio"
-							checked={ option.slug === selectedSlug }
-							onChange={ () => handleSelect( option.slug ) }
-						/>
-					) }
-					<div className="product-card__option-description">
-						{ ! hideRadios && <div className="product-card__option-name">{ option.title }</div> }
-						<ProductCardPriceGroup
-							billingTimeFrame={ option.billingTimeFrame }
-							currencyCode={ option.currencyCode }
-							discountedPrice={ option.discountedPrice }
-							fullPrice={ option.fullPrice }
-						/>
-					</div>
-				</FormLabel>
-			) ) }
-		</div>
+			<div className="product-card__options">
+				{ options.map( option => (
+					<FormLabel
+						key={ `product-option-${ option.slug }` }
+						className={ classnames( 'product-card__option', {
+							'is-selected': option.slug === selectedSlug,
+						} ) }
+					>
+						{ ! hideRadios && (
+							<FormRadio
+								className="product-card__radio"
+								checked={ option.slug === selectedSlug }
+								onChange={ () => handleSelect( option.slug ) }
+							/>
+						) }
+						<div className="product-card__option-description">
+							{ ! hideRadios && <div className="product-card__option-name">{ option.title }</div> }
+							<ProductCardPriceGroup
+								billingTimeFrame={ option.billingTimeFrame }
+								currencyCode={ option.currencyCode }
+								discountedPrice={ option.discountedPrice }
+								fullPrice={ option.fullPrice }
+							/>
+						</div>
+					</FormLabel>
+				) ) }
+			</div>
+		</Fragment>
 	);
 };
 

--- a/client/components/product-card/options.jsx
+++ b/client/components/product-card/options.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import { isEmpty } from 'lodash';
 
 /**
@@ -31,9 +32,15 @@ const ProductCardOptions = ( {
 				<h4 className="product-card__options-label">{ optionsLabel }</h4>
 			) }
 			{ options.map( option => (
-				<FormLabel key={ `product-option-${ option.slug }` } className="product-card__option">
+				<FormLabel
+					key={ `product-option-${ option.slug }` }
+					className={ classnames( 'product-card__option', {
+						'is-selected': option.slug === selectedSlug,
+					} ) }
+				>
 					{ ! hideRadios && (
 						<FormRadio
+							className="product-card__radio"
 							checked={ option.slug === selectedSlug }
 							onChange={ () => handleSelect( option.slug ) }
 						/>

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -4,7 +4,6 @@
 	@include breakpoint( '>480px' ) {
 		min-width: 460px;
 	}
-
 }
 // Header
 .product-card__header {
@@ -59,7 +58,6 @@
 	.gridicons-checkmark {
 		fill: var( --color-jetpack );
 	}
-
 }
 
 .product-card__secondary {
@@ -218,12 +216,18 @@
 	margin: 24px 0;
 
 	@include breakpoint( '>960px' ) {
-		align-items: flex-start;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		min-width: 180px;
+		padding: 16px;
 		margin-bottom: 8px;
+		border: 1px solid var( --color-neutral-20 );
+		border-radius: 4px;
 
-		& + & {
-			padding-left: 20px;
-			border-left: 1px solid var( --color-border-subtle );
+		&.is-selected {
+			background: var( --color-neutral-0 );
+			border: 1px solid var( --color-primary );
 		}
 	}
 }
@@ -235,8 +239,15 @@
 	margin-left: 8px;
 
 	@include breakpoint( '>960px' ) {
-		margin-left: 4px;
 		flex-flow: column nowrap;
+		align-items: center;
+		margin-left: 0;
+	}
+}
+
+.product-card__radio.form-radio {
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 10px;
 	}
 }
 

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -188,13 +188,13 @@
 
 // Product options
 .product-card__options {
-	padding: 10px 0 0;
+	display: flex;
+	flex-flow: column nowrap;
+	justify-content: space-around; // IE11 fallback.
+	justify-content: space-evenly;
 
-	@include breakpoint( '>960px' ) {
-		display: flex;
+	@include breakpoint( '>480px' ) {
 		flex-flow: row wrap;
-		justify-content: space-around; // IE11 fallback.
-		justify-content: space-evenly;
 	}
 }
 
@@ -211,37 +211,50 @@
 // We need a higher specificity here to override .form-label styles
 .product-card__option.form-label {
 	display: flex;
-	flex-flow: row nowrap;
+	flex: 1;
+	flex-direction: row;
 	align-items: center;
-	margin: 24px 0;
+	margin: 16px 0 8px;
+	padding: 16px;
+	border: 1px solid var( --color-neutral-20 );
+	border-radius: 4px;
+	cursor: pointer;
 
-	@include breakpoint( '>960px' ) {
-		display: flex;
+	@include breakpoint( '>480px' ) {
 		flex-direction: column;
-		align-items: center;
-		min-width: 180px;
-		padding: 16px;
-		margin-bottom: 8px;
-		border: 1px solid var( --color-neutral-20 );
-		border-radius: 4px;
+	}
 
-		&.is-selected {
-			background: var( --color-neutral-0 );
-			border: 1px solid var( --color-primary );
+	&.is-selected {
+		// Matches the feature highlight on the plans tables
+		background-color: rgba( var( --color-primary-rgb ), 0.1 );
+		border-color: var( --color-primary );
+	}
+
+	& + .product-card__option.form-label {
+		margin-top: 0;
+
+		@include breakpoint( '>480px' ) {
+			margin-top: 16px;
+			margin-left: 8px;
 		}
 	}
 }
 
 .product-card__option-description {
 	display: flex;
-	flex-flow: row wrap;
-	flex-grow: 1;
+	flex-flow: column nowrap;
+	align-items: flex-start;
 	margin-left: 8px;
+	
+
+	@include breakpoint( '>480px' ) {
+		align-items: center;
+		margin-top: 6px;
+		margin-left: 0;
+	}
 
 	@include breakpoint( '>960px' ) {
-		flex-flow: column nowrap;
-		align-items: center;
-		margin-left: 0;
+		margin-top: 0;
 	}
 }
 
@@ -252,17 +265,12 @@
 }
 
 .product-card__option-name {
-	flex-grow: 1;
-	margin-right: 10px;
-	font-size: 16px;
+	flex: 0 0 100%;
+	margin-bottom: 2px;
+	font-size: 14px;
 	font-weight: 700;
-
-	@include breakpoint( '>960px' ) {
-		margin-bottom: 2px;
-		flex: 0 0 100%;
-		font-size: 14px;
-		line-height: 20px;
-	}
+	line-height: 20px;
+	text-align: center;
 }
 
 // Action

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -245,7 +245,6 @@
 	flex-flow: column nowrap;
 	align-items: flex-start;
 	margin-left: 8px;
-	
 
 	@include breakpoint( '>480px' ) {
 		align-items: center;
@@ -265,7 +264,6 @@
 }
 
 .product-card__option-name {
-	flex: 0 0 100%;
 	margin-bottom: 2px;
 	font-size: 14px;
 	font-weight: 700;

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -121,12 +121,6 @@
 	@include breakpoint( '>960px' ) {
 		font-size: 12px;
 	}
-
-	.is-discounted & {
-		@include breakpoint( '>660px' ) {
-			color: var( --color-success );
-		}
-	}
 }
 
 // Adjust price group styles when part of product card header
@@ -162,16 +156,9 @@
 		}
 	}
 
-	.is-discounted .product-card__billing-timeframe {
-		color: var( --color-success );
-	}
-
-	@include breakpoint( '>960px' ) {
-		.plan-price.is-discounted,
-		.plan-price.is-discounted *,
-		.is-discounted .product-card__billing-timeframe {
-			color: var( --color-text-subtle );
-		}
+	.plan-price.is-discounted,
+	.plan-price.is-discounted .plan-price__currency-symbol {
+		color: var( --color-neutral-70 );
 	}
 }
 

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -156,6 +156,10 @@
 		}
 	}
 
+	.plan-price.is-discounted {
+		margin-right: 4px;
+	}
+
 	.plan-price.is-discounted,
 	.plan-price.is-discounted .plan-price__currency-symbol {
 		color: var( --color-neutral-70 );

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -202,6 +202,7 @@ export const getJetpackProducts = () => {
 			// TODO: Add new description copy for Search
 			description: 'Always-on scan ensure you never lose your site.',
 			id: PRODUCT_JETPACK_SCAN,
+			forceRadios: true,
 			options: {
 				yearly: [ PRODUCT_JETPACK_SCAN ],
 				monthly: [ PRODUCT_JETPACK_SCAN_MONTHLY ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Update pricing and tier information UI according to what was proposed by @keoshi .

#### Testing instructions

- Navigate to http://calypso.localhost:3000
- Go to the Plan -> Plans
- You should see the new buttons in Jetpack Backup/Search/Scan products.

See 1151678672052943-as-1168017254149561.

#### Demo
##### Desktop
![image](https://user-images.githubusercontent.com/3418513/77953402-9b5cb000-72a3-11ea-9a12-8216e0b33419.png)

##### Mobile
![image](https://user-images.githubusercontent.com/3418513/77953369-8da72a80-72a3-11ea-87f3-619365522544.png)



