### PR TITLE
Update BackupDownloadFlow to use date of backup in the correct timezone

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
@@ -9,6 +9,9 @@ import { useSelector } from 'react-redux';
  * Internal dependencies
  */
 import { Card } from '@automattic/components';
+import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
+import { isRequestingSiteSettings } from 'state/site-settings/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { RewindFlowPurpose } from './types';
 import BackupDownloadFlow from './download';
@@ -16,6 +19,8 @@ import BackupRestoreFlow from './restore';
 import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import QuerySiteSettings from 'components/data/query-site-settings'; // Required to get site time offset
+import { applySiteOffset } from 'lib/site/timezone';
 
 /**
  * Style dependencies
@@ -31,12 +36,30 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 
+	const timezone = useSelector( state => getSiteTimezoneValue( state, siteId ) );
+	const gmtOffset = useSelector( state => getSiteGmtOffset( state, siteId ) );
+
+	const isSiteSettingLoading = useSelector( state => isRequestingSiteSettings( state, siteId ) );
+
+	const backupDisplayDate = applySiteOffset( rewindId * 1000, {
+		timezone,
+		gmtOffset,
+	} ).format( 'LLL' );
+
 	const render = () => {
 		if ( siteId && rewindId ) {
 			return purpose === RewindFlowPurpose.RESTORE ? (
-				<BackupRestoreFlow rewindId={ rewindId } siteId={ siteId } />
+				<BackupRestoreFlow
+					rewindId={ rewindId }
+					siteId={ siteId }
+					backupDisplayDate={ backupDisplayDate }
+				/>
 			) : (
-				<BackupDownloadFlow rewindId={ rewindId } siteId={ siteId } />
+				<BackupDownloadFlow
+					rewindId={ rewindId }
+					siteId={ siteId }
+					backupDisplayDate={ backupDisplayDate }
+				/>
 			);
 		}
 		// TODO: good errors/placeholder here
@@ -45,13 +68,14 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 
 	return (
 		<Main className="rewind-flow">
+			<QuerySiteSettings siteId={ siteId } />
 			<DocumentHead
 				title={
 					purpose === RewindFlowPurpose.RESTORE ? translate( 'Restore' ) : translate( 'Download' )
 				}
 			/>
 			<SidebarNavigation />
-			<Card>{ render() }</Card>
+			{ ! isSiteSettingLoading && <Card>{ render() }</Card> }
 		</Main>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the BackupDownloadFlow component to use the date of the backup in the correct time zone. The component should show up when the site settings are loaded because the user could see the date on UTC for a moment before it changes to the correct time zone.

#### Testing instructions

- Apply these changes
- Select a backup and click on Backup backup
- Check if the date/time is correct on the site time zone and you don't see the time in GMT.
