### PR TITLE
Gutenboarding: remove vertical parameter in thumbnail URL

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useI18n } from '@automattic/react-i18n';
 import { useHistory } from 'react-router-dom';
@@ -32,7 +32,6 @@ const DesignSelector: React.FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const { push } = useHistory();
 	const makePath = usePath();
-	const { siteVertical } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { setSelectedDesign, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const handleStartOverButtonClick = () => {
@@ -42,7 +41,6 @@ const DesignSelector: React.FunctionComponent = () => {
 	const getDesignUrl = ( design: Design ) => {
 		const mshotsUrl = 'https://s.wordpress.com/mshots/v1/';
 		const previewUrl = addQueryArgs( design.src, {
-			vertical: siteVertical?.label,
 			font_headings: design.fonts[ 0 ],
 			font_base: design.fonts[ 1 ],
 		} );


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-calypso/issues/40562

#### Changes proposed in this Pull Request

* Remove vertical info from thumbnail URL to make them more stable, so that we wouldn't see "generating previews" each time different vertical is chosen.

**Less this:**
<img width="1187" alt="Screenshot 2020-03-30 at 11 15 30" src="https://user-images.githubusercontent.com/87168/77894005-59b90e80-727d-11ea-93f3-2594618f3768.png">

**More this, please:**
<img width="1182" alt="Screenshot 2020-03-30 at 11 16 04" src="https://user-images.githubusercontent.com/87168/77894019-5f165900-727d-11ea-8080-b65fc861ae13.png">


We can solve this problem differently a little later once we know we'll have vertical content. See https://github.com/Automattic/wp-calypso/issues/40562 for ideas.

#### Testing instructions

- Observe how designs are always loaded right away no matter if you change to different verticals 
