### PR TITLE
Coming Soon: use A/B test for gating

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,4 +115,12 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	ATPrivacy: {
+		datestamp: '20200331',
+		variations: {
+			variant: 0,
+			control: 100,
+		},
+		defaultVariation: 'control',
+	},
 };

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -10,13 +10,12 @@ import { parse as parseURL } from 'url';
  */
 
 // Libraries
-import config from 'config';
 import wpcom from 'lib/wp';
 import guessTimezone from 'lib/i18n-utils/guess-timezone';
 
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
-import { getSavedVariations } from 'lib/abtest';
+import { abtest, getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import { recordRegistration, recordSocialRegistration } from 'lib/analytics/signup';
 import {
@@ -186,7 +185,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		validate: false,
 	};
 
-	if ( config.isEnabled( 'coming-soon' ) ) {
+	if ( 'variant' === abtest( 'ATPrivacy' ) ) {
 		newSiteParams.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
 	}
 
@@ -512,7 +511,7 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 		validate: false,
 	};
 
-	if ( config.isEnabled( 'coming-soon' ) ) {
+	if ( 'variant' === abtest( 'ATPrivacy' ) ) {
 		data.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
 	}
 

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -11,7 +11,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import { abtest } from 'lib/abtest';
 import notices from 'notices';
 import EmptyContent from 'components/empty-content';
 import CreditsPaymentBox from './credits-payment-box';
@@ -218,7 +218,7 @@ export class SecurePaymentForm extends Component {
 			return;
 		}
 
-		if ( ! config.isEnabled( 'coming-soon' ) ) {
+		if ( 'variant' === abtest( 'ATPrivacy' ) ) {
 			// Until Atomic sites support being private / unlaunched, set them to public on upgrade
 			debug( 'Setting site to public because it is an Atomic plan' );
 			const response = await this.props.saveSiteSettings( selectedSiteId, {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -14,7 +14,6 @@ import formatCurrency, { getCurrencyObject } from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import FoldableCard from 'components/foldable-card';
 import InlineSupportLink from 'components/inline-support-link';
 import Notice from 'components/notice';
@@ -624,7 +623,7 @@ export class PlanFeatures extends Component {
 				// Let signup do its thing
 				return;
 			}
-			if ( config.isEnabled( 'coming-soon' ) ) {
+			if ( 'variant' === abtest( 'ATPrivacy' ) ) {
 				// When coming soon feature is enabled, we don't want to show any warnings
 				page( checkoutUrlWithArgs );
 				return;

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -18,6 +18,7 @@ import NoticeAction from 'components/notice/notice-action';
 import LanguagePicker from 'components/language-picker';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import config from 'config';
+import { abtest } from 'lib/abtest';
 import { languages } from 'languages';
 import FormInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -698,7 +699,7 @@ const connectComponent = connect(
 		return {
 			withComingSoonOption: ownProps.hasOwnProperty( 'withComingSoonOption' )
 				? ownProps.withComingSoonOption
-				: config.isEnabled( 'coming-soon' ),
+				: 'variant' === abtest( 'ATPrivacy' ),
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsJetpack,

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import { abtest } from 'lib/abtest';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { isEcommercePlan } from 'lib/plans';
 
@@ -17,7 +17,7 @@ import { isEcommercePlan } from 'lib/plans';
  * @returns `true` for private by default & `false` for not
  */
 export default function shouldNewSiteBePrivateByDefault( state: object ): boolean {
-	if ( config.isEnabled( 'coming-soon' ) ) {
+	if ( 'variant' === abtest( 'ATPrivacy' ) ) {
 		// When coming-soon feature flag is enabled, we want all new sites to be private
 		return true;
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -37,7 +37,6 @@
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,
-		"coming-soon": true,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -22,7 +22,6 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
-		"coming-soon": true,
 		"desktop-promo": true,
 		"dev/test-helper": true,
 		"dev/preferences-helper": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -22,6 +22,7 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
+		"coming-soon": true,
 		"desktop-promo": true,
 		"dev/test-helper": true,
 		"dev/preferences-helper": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,6 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
-		"coming-soon": true,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": false,


### PR DESCRIPTION
**Description**

Current way of having this feature enabled only in certain environments is making it harder to test as certain links will always redirect to root WordPress.com site. This PR makes it easy to enable and disable the feature by using A/B test picker.

**Test plan**

1. Assign yourself to variant of ATPrivacy
1. Create a new simple site
1. Go to plugin installation screen and check eligibility warnings
1. Go to settings, confirm there were no errors
1. Go atomic, confirm it worked, 
1. Repeat steps 3 and 4
1. Assign yourself to control
1. Repeat steps 2-6
