### PR TITLE
Gutenboarding: Create site with fonts

### DIFF
--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { ValuesType } from 'utility-types';
+
+/**
  * Debounce our input + HTTP dependent select changes
  *
  * Rapidly changing input generates excessive HTTP requests.
@@ -9,24 +14,27 @@
 export const selectorDebounce = 300;
 
 export const fontPairings = [
-	[
-		{ title: 'Cabin', fontFamily: 'Cabin' },
-		{ title: 'Raleway', fontFamily: 'Raleway' },
-	],
-	[
-		{ title: 'Chivo', fontFamily: 'Chivo' },
-		{ title: 'Open Sans', fontFamily: 'Open Sans' },
-	],
-	[
-		{ title: 'Playfair', fontFamily: 'Playfair Display' },
-		{ title: 'Fira Sans', fontFamily: 'Fira Sans' },
-	],
-	[
-		{ title: 'Arvo', fontFamily: 'Arvo' },
-		{ title: 'Montserrat', fontFamily: 'Montserrat' },
-	],
-	[
-		{ title: 'Space Mono', fontFamily: 'Space Mono' },
-		{ title: 'Roboto', fontFamily: 'Roboto' },
-	],
+	{
+		headings: { title: 'Cabin', fontFamily: 'Cabin' },
+		base: { title: 'Raleway', fontFamily: 'Raleway' },
+	},
+	{
+		headings: { title: 'Chivo', fontFamily: 'Chivo' },
+		base: { title: 'Open Sans', fontFamily: 'Open Sans' },
+	},
+	{
+		headings: { title: 'Playfair', fontFamily: 'Playfair Display' },
+		base: { title: 'Fira Sans', fontFamily: 'Fira Sans' },
+	},
+	{
+		headings: { title: 'Arvo', fontFamily: 'Arvo' },
+		base: { title: 'Montserrat', fontFamily: 'Montserrat' },
+	},
+	{
+		headings: { title: 'Space Mono', fontFamily: 'Space Mono' },
+		base: { title: 'Roboto', fontFamily: 'Roboto' },
+	},
 ] as const;
+
+export type FontPair = ValuesType< typeof fontPairings >;
+export type Fonts = FontPair[ keyof FontPair ][ 'fontFamily' ];

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -37,4 +37,4 @@ export const fontPairings = [
 ] as const;
 
 export type FontPair = ValuesType< typeof fontPairings >;
-export type Fonts = FontPair[ keyof FontPair ][ 'fontFamily' ];
+export type Font = FontPair[ keyof FontPair ][ 'fontFamily' ];

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -21,7 +21,7 @@ import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytic
 import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import './style.scss';
-import { fontPairings } from './constants';
+import { fontPairings, FontPair } from './constants';
 
 registerBlockType( name, settings );
 
@@ -41,18 +41,18 @@ export function Gutenboard() {
 	// TODO: Don't load like this
 	useEffect( () => {
 		fontPairings.forEach( pair =>
-			pair.forEach(
-				( { title, fontFamily }: { title: string; fontFamily: string }, index: number ) => {
-					const isPrimary = index === 0;
-					const l = document.createElement( 'link' );
-					l.href = `https://fonts.googleapis.com/css2?family=${ encodeURI(
-						`${ fontFamily }${ isPrimary ? ':wght@700' : '' }`
-					) }&text=${ encodeURI( title ) }&display=swap`;
-					l.rel = 'stylesheet';
-					l.type = 'text/css';
-					document.head.appendChild( l );
-				}
-			)
+			Object.keys( pair ).forEach( k => {
+				const fontKey = k as keyof FontPair;
+				const { title, fontFamily }: { title: string; fontFamily: string } = pair[ fontKey ];
+				const isBold = fontKey === 'headings';
+				const l = document.createElement( 'link' );
+				l.href = `https://fonts.googleapis.com/css2?family=${ encodeURI(
+					`${ fontFamily }${ isBold ? ':wght@700' : '' }`
+				) }&text=${ encodeURI( title ) }&display=swap`;
+				l.rel = 'stylesheet';
+				l.type = 'text/css';
+				document.head.appendChild( l );
+			} )
 		);
 	}, [] );
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -11,12 +11,20 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { fontPairings } from '../../constants';
 import { STORE_KEY } from '../../stores/onboard';
+import { useI18n } from '@automattic/react-i18n';
 
 const FontSelect: React.FunctionComponent = () => {
+	const { __: NO__ } = useI18n();
 	const { selectedFonts } = useSelect( select => select( STORE_KEY ).getState() );
 	const { setFonts } = useDispatch( STORE_KEY );
 	return (
 		<div className="style-preview__font-options">
+			<Button
+				className={ classnames( 'style-preview__font-option', { 'is-selected': ! selectedFonts } ) }
+				onClick={ () => setFonts( undefined ) }
+			>
+				{ NO__( 'Theme default' ) }
+			</Button>
 			{ fontPairings.map( fontPair => {
 				const isSelected = fontPair === selectedFonts;
 				const {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -3,40 +3,43 @@
  */
 import * as React from 'react';
 import { Button } from '@wordpress/components';
-import { ValuesType } from 'utility-types';
 import classnames from 'classnames';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { fontPairings } from '../../constants';
+import { STORE_KEY } from '../../stores/onboard';
 
-interface Props {
-	onSelect: ( selection: ValuesType< typeof fontPairings > ) => void;
-	selected: ValuesType< typeof fontPairings >;
-}
-const FontSelect: React.FunctionComponent< Props > = ( { onSelect, selected } ) => (
-	<div className="style-preview__font-options">
-		{ fontPairings.map( fonts => {
-			const isSelected = fonts === selected;
-			const [
-				{ title: a, fontFamily: fontFamilyA },
-				{ title: b, fontFamily: fontFamilyB },
-			] = fonts;
+const FontSelect: React.FunctionComponent = () => {
+	const { selectedFonts } = useSelect( select => select( STORE_KEY ).getState() );
+	const { setFonts } = useDispatch( STORE_KEY );
+	return (
+		<div className="style-preview__font-options">
+			{ fontPairings.map( fontPair => {
+				const isSelected = fontPair === selectedFonts;
+				const {
+					headings: { title: fontHeadings, fontFamily: fontFamilyHeadings },
+					base: { title: fontBase, fontFamily: fontFamilyBase },
+				} = fontPair;
 
-			return (
-				<Button
-					className={ classnames( 'style-preview__font-option', { 'is-selected': isSelected } ) }
-					onClick={ () => onSelect( fonts ) }
-					key={ a + b }
-				>
-					<span style={ { fontFamily: fontFamilyA, fontWeight: 700 } }>{ a }</span>
-					&nbsp;/&nbsp;
-					<span style={ { fontFamily: fontFamilyB } }>{ b }</span>
-				</Button>
-			);
-		} ) }
-	</div>
-);
+				return (
+					<Button
+						className={ classnames( 'style-preview__font-option', { 'is-selected': isSelected } ) }
+						onClick={ () => setFonts( fontPair ) }
+						key={ fontHeadings + fontBase }
+					>
+						<span style={ { fontFamily: fontFamilyHeadings, fontWeight: 700 } }>
+							{ fontHeadings }
+						</span>
+						&nbsp;/&nbsp;
+						<span style={ { fontFamily: fontFamilyBase } }>{ fontBase }</span>
+					</Button>
+				);
+			} ) }
+		</div>
+	);
+};
 
 export default FontSelect;

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -3,7 +3,6 @@
  */
 import * as React from 'react';
 import { useI18n } from '@automattic/react-i18n';
-import { ValuesType } from 'utility-types';
 
 /**
  * Internal dependencies
@@ -14,7 +13,6 @@ import { usePath, Step } from '../../path';
 import ViewportSelect from './viewport-select';
 import FontSelect from './font-select';
 import { Title, SubTitle } from '../../components/titles';
-import { fontPairings } from '../../constants';
 import * as T from './types';
 
 import './style.scss';
@@ -23,9 +21,6 @@ const StylePreview: React.FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const makePath = usePath();
 	const [ selectedViewport, setSelectedViewport ] = React.useState< T.Viewport >( 'desktop' );
-	const [ selectedFonts, setSelectedFonts ] = React.useState< ValuesType< typeof fontPairings > >(
-		fontPairings[ 0 ]
-	);
 	return (
 		<div className="style-preview">
 			<div className="style-preview__header">
@@ -41,8 +36,8 @@ const StylePreview: React.FunctionComponent = () => {
 				</div>
 			</div>
 			<div className="style-preview__content">
-				<FontSelect selected={ selectedFonts } onSelect={ setSelectedFonts } />
-				<Preview fonts={ selectedFonts } viewport={ selectedViewport } />
+				<FontSelect />
+				<Preview viewport={ selectedViewport } />
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -93,41 +93,46 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 
 	React.useEffect( () => {
 		const iframeWindow = iframe.current?.contentWindow;
-		if ( selectedFonts && iframeWindow?.document.body ) {
+		if ( iframeWindow?.document.body ) {
 			const iframeDocument = iframeWindow.document;
-			const {
-				headings: { fontFamily: headings },
-				base: { fontFamily: base },
-			} = selectedFonts;
+			if ( selectedFonts ) {
+				const {
+					headings: { fontFamily: headings },
+					base: { fontFamily: base },
+				} = selectedFonts;
 
-			const baseURL = 'https://fonts.googleapis.com/css2';
+				const baseURL = 'https://fonts.googleapis.com/css2';
 
-			// matrix: regular,bold * regular,italic
-			const axis = 'ital,wght@0,400;0,700;1,400;1,700';
-			const query = [];
+				// matrix: regular,bold * regular,italic
+				const axis = 'ital,wght@0,400;0,700;1,400;1,700';
+				const query = [];
 
-			// To replace state
-			const nextFonts = new Set( requestedFonts );
+				// To replace state
+				const nextFonts = new Set( requestedFonts );
 
-			if ( ! requestedFonts.has( headings ) ) {
-				query.push( `family=${ encodeURI( headings ) }:${ axis }` );
-				nextFonts.add( headings );
+				if ( ! requestedFonts.has( headings ) ) {
+					query.push( `family=${ encodeURI( headings ) }:${ axis }` );
+					nextFonts.add( headings );
+				}
+				if ( ! requestedFonts.has( base ) ) {
+					query.push( `family=${ encodeURI( base ) }:${ axis }` );
+					nextFonts.add( base );
+				}
+
+				if ( query.length ) {
+					const l = iframeDocument.createElement( 'link' );
+					l.rel = 'stylesheet';
+					l.type = 'text/css';
+					l.href = `${ baseURL }?${ query.join( '&' ) }&display=swap`;
+					iframeDocument.head.appendChild( l );
+					setRequestedFonts( nextFonts );
+				}
+				iframeDocument.body.style.setProperty( '--font-headings', headings );
+				iframeDocument.body.style.setProperty( '--font-base', headings );
+			} else {
+				iframeDocument.body.style.removeProperty( '--font-headings' );
+				iframeDocument.body.style.removeProperty( '--font-base' );
 			}
-			if ( ! requestedFonts.has( base ) ) {
-				query.push( `family=${ encodeURI( base ) }:${ axis }` );
-				nextFonts.add( base );
-			}
-
-			if ( query.length ) {
-				const l = iframeDocument.createElement( 'link' );
-				l.rel = 'stylesheet';
-				l.type = 'text/css';
-				l.href = `${ baseURL }?${ query.join( '&' ) }&display=swap`;
-				iframeDocument.head.appendChild( l );
-				setRequestedFonts( nextFonts );
-			}
-			iframeDocument.body.style.setProperty( '--font-headings', `${ headings }` );
-			iframeDocument.body.style.setProperty( '--font-base', `${ headings }` );
 		}
 	}, [ previewHtml, requestedFonts, selectedFonts ] );
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -12,9 +12,9 @@ import classNames from 'classnames';
 import { STORE_KEY } from '../../stores/onboard';
 import * as T from './types';
 import { useLangRouteParam } from '../../path';
-import { Fonts } from 'landing/gutenboarding/constants';
 
 type Design = import('../../stores/onboard/types').Design;
+type Font = import('../../constants').Font;
 type SiteVertical = import('../../stores/onboard/types').SiteVertical;
 
 interface Props {
@@ -22,7 +22,7 @@ interface Props {
 }
 const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 	const [ previewHtml, setPreviewHtml ] = React.useState< string >();
-	const [ requestedFonts, setRequestedFonts ] = React.useState< Set< Fonts > >( new Set() );
+	const [ requestedFonts, setRequestedFonts ] = React.useState< Set< Font > >( new Set() );
 
 	const { selectedDesign, selectedFonts, siteVertical, siteTitle } = useSelect( select =>
 		select( STORE_KEY ).getState()
@@ -70,7 +70,7 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 					new Set(
 						[ selectedFonts?.headings.fontFamily, selectedFonts?.base.fontFamily ].filter(
 							Boolean
-						) as Fonts[]
+						) as Font[]
 					)
 				);
 			};

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -12,9 +12,11 @@ import { Design, SiteVertical } from './types';
 import { STORE_KEY as ONBOARD_STORE } from './constants';
 import { SITE_STORE } from '../site';
 
+type State = import('.').State;
 type FontPair = import('../../constants').FontPair;
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 type Template = VerticalsTemplates.Template;
+type CreateSiteParams = import('@automattic/data-stores').Site.CreateSiteParams;
 
 export const setDomain = ( domain: DomainSuggestion | undefined ) => ( {
 	type: 'SET_DOMAIN' as const,
@@ -66,7 +68,7 @@ export function* createSite(
 	freeDomainSuggestion?: DomainSuggestion,
 	bearerToken?: string
 ) {
-	const { domain, selectedDesign, siteTitle, siteVertical } = yield select(
+	const { domain, selectedDesign, selectedFonts, siteTitle, siteVertical }: State = yield select(
 		ONBOARD_STORE,
 		'getState'
 	);
@@ -74,7 +76,7 @@ export function* createSite(
 	const currentDomain = domain ?? freeDomainSuggestion;
 	const siteUrl = currentDomain?.domain_name || siteTitle || username;
 
-	const success = yield dispatch( SITE_STORE, 'createSite', {
+	const params: CreateSiteParams = {
 		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
 		blog_title: siteTitle,
 		options: {
@@ -86,9 +88,16 @@ export function* createSite(
 			site_creation_flow: 'gutenboarding',
 			theme: `pub/${ selectedDesign?.slug || 'twentytwenty' }`,
 			timezone_string: guessTimezone(),
+			template: selectedDesign?.slug || 'twentytwenty',
+			...( selectedFonts && {
+				font_base: selectedFonts.base.fontFamily,
+				font_headings: selectedFonts.headings.fontFamily,
+			} ),
 		},
 		...( bearerToken && { authToken: bearerToken } ),
-	} );
+	};
+
+	const success = yield dispatch( SITE_STORE, 'createSite', params );
 
 	return success;
 }

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -12,6 +12,7 @@ import { Design, SiteVertical } from './types';
 import { STORE_KEY as ONBOARD_STORE } from './constants';
 import { SITE_STORE } from '../site';
 
+type FontPair = import('../../constants').FontPair;
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 type Template = VerticalsTemplates.Template;
 
@@ -42,6 +43,11 @@ export const setSiteTitle = ( siteTitle: string ) => ( {
 export const togglePageLayout = ( pageLayout: Template ) => ( {
 	type: 'TOGGLE_PAGE_LAYOUT' as const,
 	pageLayout,
+} );
+
+export const setFonts = ( fonts: FontPair | undefined ) => ( {
+	type: 'SET_FONTS' as const,
+	fonts,
 } );
 
 export const resetOnboardStore = () => ( {
@@ -88,12 +94,13 @@ export function* createSite(
 }
 
 export type OnboardAction = ReturnType<
-	| typeof setDomain
-	| typeof setSelectedDesign
-	| typeof setSiteVertical
-	| typeof resetSiteVertical
-	| typeof setSiteTitle
-	| typeof togglePageLayout
 	| typeof resetOnboardStore
+	| typeof resetSiteVertical
+	| typeof setDomain
+	| typeof setFonts
+	| typeof setSelectedDesign
+	| typeof setSiteTitle
+	| typeof setSiteVertical
 	| typeof setSiteWasCreatedForDomainPurchase
+	| typeof togglePageLayout
 >;

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -8,12 +8,13 @@ import { plugins, registerStore, use } from '@wordpress/data';
  * Internal dependencies
  */
 import { STORE_KEY } from './constants';
-import reducer, { State } from './reducer';
+import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
 import persistOptions from './persist';
 import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
 
+export type State = import('./reducer').State;
 export { STORE_KEY };
 
 use( plugins.persistence, persistOptions );

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -9,6 +9,7 @@ import { combineReducers } from '@wordpress/data';
  */
 import { SiteVertical, Design } from './types';
 import { OnboardAction } from './actions';
+import { FontPair } from 'landing/gutenboarding/constants';
 
 const domain: Reducer<
 	import('@automattic/data-stores').DomainSuggestions.DomainSuggestion | undefined,
@@ -83,8 +84,19 @@ const siteWasCreatedForDomainPurchase: Reducer< boolean, OnboardAction > = (
 	}
 };
 
+const selectedFonts: Reducer< FontPair | undefined, OnboardAction > = (
+	state = undefined,
+	action
+) => {
+	if ( action.type === 'SET_FONTS' ) {
+		return action.fonts;
+	}
+	return state;
+};
+
 const reducer = combineReducers( {
 	domain,
+	selectedFonts,
 	selectedDesign,
 	siteTitle,
 	siteVertical,

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -42,6 +42,7 @@ export interface CreateSiteParams {
 		site_creation_flow?: string;
 		theme?: string;
 		template?: string;
+		timezone_string?: string;
 		font_headings?: string;
 		font_base?: string;
 	};

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -41,5 +41,8 @@ export interface CreateSiteParams {
 		};
 		site_creation_flow?: string;
 		theme?: string;
+		template?: string;
+		font_headings?: string;
+		font_base?: string;
 	};
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Send `template` (duplicated from design at the moment), `font_headings` and `font_base` in the site creation API request.

Includes #40591
Part of #40513

#### Testing instructions

* [`/gutenboarding`](https://calypso.live/gutenboarding?branch=gutenboarding/include-font-in-api)
* Follow the flow and pick a custom font pair
* Open the network debug tab and ensure that `font_headings` and `font_base` are included in the request.
* Ensure that with no custom font pair, the flow continues to work well and the site creation request works as expected (don't send font_* in request)
