### PR TITLE
Enable Search product on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -62,6 +62,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
+		"jetpack/search-product": true,
 		"jitms": true,
 		"legal-updates-banner": false,
 		"login/magic-login": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enables the Jetpack Search product for purchase in the `/plans` page.

#### Testing instructions

* Open up these changes in a live calypso branch.
* Ensure that you can purchase a Jetpack Search product in `/plans`.