### PR TITLE
Add/gutenboarding signup password field

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -34,6 +34,7 @@ interface Props {
 const SignupForm = ( { onRequestClose }: Props ) => {
 	const { __: NO__ } = useI18n();
 	const [ emailVal, setEmailVal ] = useState( '' );
+	const [ passwordVal, setPasswordVal ] = useState( '' );
 	const { createAccount, clearErrors } = useDispatch( USER_STORE );
 	const isFetchingNewUser = useSelect( select => select( USER_STORE ).isFetchingNewUser() );
 	const newUserError = useSelect( select => select( USER_STORE ).getNewUserError() );
@@ -59,7 +60,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 
 		const success = await createAccount( {
 			email: emailVal,
-			is_passwordless: true,
+			password: passwordVal,
 			signup_flow_name: 'gutenboarding',
 			locale: langParam,
 			...( username_hint && {
@@ -87,7 +88,11 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 			case 'email_exists':
 				errorMessage = NO__( 'An account with this email address already exists.' );
 				break;
-
+			case 'password_invalid':
+				errorMessage = NO__(
+					'Your password must be at least six characters long. Strong passwords use upper and lower case letters, numbers, and symbols like ! ” ? $ % ^ & ).'
+				);
+				break;
 			default:
 				errorMessage = NO__(
 					'Sorry, something went wrong when trying to create your account. Please try again.'
@@ -133,6 +138,15 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 							placeholder={ NO__( 'Email address' ) }
 							required
 							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
+						/>
+
+						<TextControl
+							value={ passwordVal }
+							disabled={ isFetchingNewUser }
+							type="password"
+							onChange={ setPasswordVal }
+							placeholder={ NO__( 'Password' ) }
+							required
 						/>
 
 						{ errorMessage && (

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -66,6 +66,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 			...( username_hint && {
 				extra: { username_hint },
 			} ),
+			is_passwordless: false,
 		} );
 
 		if ( success ) {
@@ -89,9 +90,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 				errorMessage = NO__( 'An account with this email address already exists.' );
 				break;
 			case 'password_invalid':
-				errorMessage = NO__(
-					'Your password must be at least six characters long. Strong passwords use upper and lower case letters, numbers, and symbols like ! ” ? $ % ^ & ).'
-				);
+				errorMessage = newUserError.message;
 				break;
 			default:
 				errorMessage = NO__(

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -41,6 +41,7 @@
 	.signup-form__body {
 		position: relative;
 		padding: 44px 20px 0;
+		text-align: center;
 
 		@include break-mobile {
 			padding: 0 20px 20px;
@@ -50,7 +51,6 @@
 			width: 100%;
 			max-width: 500px;
 			transform: translate( -50%, -50% );
-			text-align: center;
 		}
 	}
 

--- a/packages/data-stores/src/user/actions.ts
+++ b/packages/data-stores/src/user/actions.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { stringify } from 'qs';
+
+/**
  * Internal dependencies
  */
 import {
@@ -57,6 +62,7 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 				path: '/users/new',
 				apiVersion: '1.1',
 				method: 'post',
+				query: stringify( { locale: params.locale } ),
 			} );
 
 			yield reloadProxy();

--- a/packages/wpcom-proxy-request/types/index.d.ts
+++ b/packages/wpcom-proxy-request/types/index.d.ts
@@ -12,6 +12,7 @@ export interface WpcomRequestParams {
 	apiVersion?: string;
 	body?: object;
 	token?: string;
+	query?: string;
 	metaAPI?: {
 		accessAllUsersBlogs?: boolean;
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add password field to Gutenboarding signup
* Display password error messages as they're returned from the server
* Add `locale` query param to be sent to the server along with the `users/new` request so that translated error messages are returned

#### Testing instructions

![create-account-french-small](https://user-images.githubusercontent.com/14988353/77990730-d1666680-736d-11ea-96e5-d389bb3832b8.gif)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Sandbox D41123-code (required to allow a passwordful account to be created without providing an explicit username)

* Go to `http://calypso.localhost:3000/gutenboarding` in a logged-out window
* At the "Save your progress" screen enter an email address and a password that is too short (e.g. 3 chars), and make sure the error message makes sense
* The same, but enter a password that is a common swear word. You should get a different error message.
* Repeat the above steps with a language other than English (e.g. `http://calypso.localhost:3000/gutenboarding/fr`) and ensure that the error messages are returned in the correct language (Note that much of the rest of the UI has not been translated — this can be ignored)
* Create the account with a decent password
* After the site is created, go to `/me` and ensure that you got a sensible seeming username (e.g. based on site title + random numbers)
* Log out and log back in again with the password you used to create the account (this ensures that the account was correctly created as a non-passwordless account)

Fixes #
