### PR TITLE
Gutenboading: remove container max-width

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -84,6 +84,7 @@ export function Gutenboard() {
 						value={ [ onboardingBlock.current ] }
 						settings={ {
 							templateLock: 'all',
+							alignWide: true,
 						} }
 					>
 						<div className="gutenboarding__content edit-post-layout__content">

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -19,7 +19,6 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 	@media ( min-width: 600px ) {
 		display: flex;
 		align-items: center;
-		justify-content: center;
 		position: absolute;
 		left: 0;
 		top: 0;
@@ -27,10 +26,6 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 		min-height: calc( 100vh - #{$gutenboarding-header-height} );
 		padding: 0 120px;
 	}
-}
-
-.acquire-intent__questions {
-	max-width: 1200px;
 }
 
 .madlib__input {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -1,27 +1,32 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins';
+@import '../../variables.scss';
 
 $acquire-intent-vertical-transition-duration: 200ms;
 $acquire-intent-vertical-transition-algorithm: ease-in-out;
 
 .acquire-intent {
 	@include onboarding-font-recoleta;
-	align-items: center;
 	background-color: var( --contrastColor );
 	color: var( --mainColor );
-	display: flex;
 	font-size: 64px;
-	height: 100%;
-	justify-content: center;
-	left: 0%;
-	position: fixed;
 	tab-size: 4;
-	top: 0;
 	transition: color $acquire-intent-vertical-transition-duration
 			$acquire-intent-vertical-transition-algorithm,
 		background-color $acquire-intent-vertical-transition-duration
 			$acquire-intent-vertical-transition-algorithm;
-	width: 100%;
+
+	@media ( min-width: 600px ) {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: absolute;
+		left: 0;
+		top: 0;
+		width: 100%;
+		min-height: calc( 100vh - #{$gutenboarding-header-height} );
+		padding: 0 120px;
+	}
 }
 
 .acquire-intent__questions {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -11,19 +11,20 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 	color: var( --mainColor );
 	font-size: 64px;
 	tab-size: 4;
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	min-height: calc( 100vh - #{$gutenboarding-header-height} );
+	padding: 20px;
 	transition: color $acquire-intent-vertical-transition-duration
 			$acquire-intent-vertical-transition-algorithm,
 		background-color $acquire-intent-vertical-transition-duration
 			$acquire-intent-vertical-transition-algorithm;
 
-	@media ( min-width: 600px ) {
+	@include break-small {
 		display: flex;
 		align-items: center;
-		position: absolute;
-		left: 0;
-		top: 0;
-		width: 100%;
-		min-height: calc( 100vh - #{$gutenboarding-header-height} );
 		padding: 0 120px;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -1,7 +1,9 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+
 .onboarding-block {
 	margin: 0 20px;
 
-	@media ( min-width: 600px ) {
+	@include break-small {
 		margin: 0 88px;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -1,0 +1,7 @@
+.onboarding-block {
+	margin: 0 20px;
+
+	@media ( min-width: 600px ) {
+		margin: 0 88px;
+	}
+}

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -30,9 +30,15 @@ $admin-sidebar-width-collapsed: 0;
 // Own/Gutenboarding styles
 @import './variables.scss';
 
+
 .gutenboarding__content-editor {
 	// overrides .edit-post-visual-editor
-	padding-top: $gutenboarding-header-height;
+	padding-top: 0;
+
+	@include break-small {
+		padding-top: $gutenboarding-header-height;
+
+	}
 }
 
 .components-button.is-link {

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -30,17 +30,9 @@ $admin-sidebar-width-collapsed: 0;
 // Own/Gutenboarding styles
 @import './variables.scss';
 
-.gutenboarding__content {
-	position: static;
-}
-
 .gutenboarding__content-editor {
 	// overrides .edit-post-visual-editor
 	padding-top: $gutenboarding-header-height;
-}
-
-.wp-block {
-	max-width: 1100px; // Overrides default $content-width
 }
 
 .components-button.is-link {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- set margins for desktop (88px) and mobile (20px) as specified in design
- set margins for acquire intent screen as specified (120px)
- left align acquire intent content
- fix acquire intent positioning issues

Screenshots on a 4k screen: [acquire intent](https://cloudup.com/igCTfkhgOzU), [design picker](https://cloudup.com/iLQE-kporYd), [template preview](https://cloudup.com/iWc0Crm5x1i)

#### Testing instructions

* Go to /gutenboarding and checkout the flow
* On larger screens (including 1920px and above), the content should cover the full width of the screen

Fixes #40566 
