### PR TITLE
i18n: Update localizeUrl for the new WordPress.com URL structure

### DIFF
--- a/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-learn-more/test/__snapshots__/index.js.snap
@@ -11,7 +11,7 @@ exports[`GSuiteLearnMore it renders GSuiteLearnMore with no props 1`] = `
      
     <a
       className="gsuite-learn-more__link"
-      href="https://en.support.wordpress.com/adding-g-suite-to-your-site"
+      href="https://wordpress.com/support/adding-g-suite-to-your-site"
       onClick={[Function]}
       rel="noopener noreferrer"
       target="_blank"

--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -247,7 +247,7 @@ describe( 'utils', () => {
 			[
 				'https://wordpress.com/',
 				'https://de.wordpress.com/',
-				'https://wordpress.com/start',
+				'https://wordpress.com/start/',
 				'https://wordpress.com/wp-login.php?action=lostpassword',
 			].forEach( fullUrl => {
 				getLocaleSlug.mockImplementationOnce( () => 'en' );
@@ -334,38 +334,89 @@ describe( 'utils', () => {
 		test( 'blog url', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
-				'https://en.blog.wordpress.com/'
+				'https://wordpress.com/blog/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
 			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
-				'https://en.blog.wordpress.com/'
+				'https://wordpress.com/blog/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
 			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
-				'https://br.blog.wordpress.com/'
+				'https://wordpress.com/br/blog/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
 			expect( localizeUrl( 'https://en.blog.wordpress.com/' ) ).toEqual(
-				'https://en.blog.wordpress.com/'
+				'https://wordpress.com/blog/'
 			);
 		} );
 
 		test( 'support url', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'en' );
 			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
-				'https://en.support.wordpress.com/'
+				'https://wordpress.com/support/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
 			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
-				'https://de.support.wordpress.com/'
+				'https://wordpress.com/de/support/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
 			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
-				'https://br.support.wordpress.com/'
+				'https://wordpress.com/br/support/'
 			);
 			getLocaleSlug.mockImplementationOnce( () => 'pl' );
 			expect( localizeUrl( 'https://en.support.wordpress.com/' ) ).toEqual(
-				'https://en.support.wordpress.com/'
+				'https://wordpress.com/support/'
+			);
+
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/de/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/br/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://en.support.wordpress.com/path/' ) ).toEqual(
+				'https://wordpress.com/support/path/'
+			);
+
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+				'https://wordpress.com/support/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+				'https://wordpress.com/de/support/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+				'https://wordpress.com/br/support/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://wordpress.com/support/' ) ).toEqual(
+				'https://wordpress.com/support/'
+			);
+
+			getLocaleSlug.mockImplementationOnce( () => 'en' );
+			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+				'https://wordpress.com/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+				'https://wordpress.com/de/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pt-br' );
+			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+				'https://wordpress.com/br/support/path/'
+			);
+			getLocaleSlug.mockImplementationOnce( () => 'pl' );
+			expect( localizeUrl( 'https://wordpress.com/support/path/' ) ).toEqual(
+				'https://wordpress.com/support/path/'
 			);
 		} );
 

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -159,23 +159,35 @@ export function addLocaleToPath( path, locale ) {
 const localesWithBlog = [ 'en', 'ja', 'es', 'pt', 'fr', 'pt-br' ];
 const localesWithPrivacyPolicy = [ 'en', 'fr', 'de' ];
 const localesWithCookiePolicy = [ 'en', 'fr', 'de' ];
+const localesToSubdomains = {
+	'pt-br': 'br',
+	br: 'bre',
+	zh: 'zh-cn',
+	'zh-hk': 'zh-tw',
+	'zh-sg': 'zh-cn',
+	kr: 'ko',
+};
 
 const setLocalizedUrlHost = ( hostname, validLocales = [] ) => ( urlParts, localeSlug ) => {
-	const localesToSubdomains = {
-		'pt-br': 'br',
-		br: 'bre',
-		zh: 'zh-cn',
-		'zh-hk': 'zh-tw',
-		'zh-sg': 'zh-cn',
-		kr: 'ko',
-	};
-
 	if ( typeof validLocales === 'string' ) {
 		validLocales = config( validLocales );
 	}
 
-	if ( validLocales.includes( localeSlug ) ) {
+	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
 		urlParts.host = `${ localesToSubdomains[ localeSlug ] || localeSlug }.${ hostname }`;
+	}
+	return urlParts;
+};
+
+const setLocalizedWpComPath = ( prefix, validLocales = [] ) => ( urlParts, localeSlug ) => {
+	urlParts.host = 'wordpress.com';
+	urlParts.pathname = prefix + urlParts.pathname;
+
+	if ( typeof validLocales === 'string' ) {
+		validLocales = config( validLocales );
+	}
+	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
+		urlParts.pathname = ( localesToSubdomains[ localeSlug ] || localeSlug ) + urlParts.pathname;
 	}
 	return urlParts;
 };
@@ -184,24 +196,23 @@ const prefixLocalizedUrlPath = ( validLocales = [] ) => ( urlParts, localeSlug )
 	if ( typeof validLocales === 'string' ) {
 		validLocales = config( validLocales );
 	}
-	if ( validLocales.includes( localeSlug ) ) {
-		urlParts.pathname = localeSlug + urlParts.pathname;
+	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
+		urlParts.pathname = ( localesToSubdomains[ localeSlug ] || localeSlug ) + urlParts.pathname;
 	}
 	return urlParts;
 };
 
 const urlLocalizationMapping = {
-	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', 'magnificent_non_en_locales' ),
+	'wordpress.com/support/': prefixLocalizedUrlPath( 'support_site_locales' ),
+	'wordpress.com/blog/': prefixLocalizedUrlPath( localesWithBlog ),
 	'wordpress.com/tos/': setLocalizedUrlHost( 'wordpress.com', 'magnificent_non_en_locales' ),
 	'jetpack.com': setLocalizedUrlHost( 'jetpack.com', 'jetpack_com_locales' ),
-	'en.support.wordpress.com': setLocalizedUrlHost(
-		'support.wordpress.com',
-		'support_site_locales'
-	),
-	'en.blog.wordpress.com': setLocalizedUrlHost( 'blog.wordpress.com', localesWithBlog ),
+	'en.support.wordpress.com': setLocalizedWpComPath( '/support', 'support_site_locales' ),
+	'en.blog.wordpress.com': setLocalizedWpComPath( '/blog', localesWithBlog ),
 	'en.forums.wordpress.com': setLocalizedUrlHost( 'forums.wordpress.com', 'forum_locales' ),
 	'automattic.com/privacy/': prefixLocalizedUrlPath( localesWithPrivacyPolicy ),
 	'automattic.com/cookies/': prefixLocalizedUrlPath( localesWithCookiePolicy ),
+	'wordpress.com': setLocalizedUrlHost( 'wordpress.com', 'magnificent_non_en_locales' ),
 };
 
 export function localizeUrl( fullUrl, locale ) {
@@ -226,14 +237,17 @@ export function localizeUrl( fullUrl, locale ) {
 			urlParts.host = 'wordpress.com';
 			return getUrlFromParts( urlParts ).href;
 		}
-		return fullUrl;
 	}
 
 	if ( 'en.wordpress.com' === urlParts.host ) {
 		urlParts.host = 'wordpress.com';
 	}
 
-	const lookup = [ urlParts.host, urlParts.host + urlParts.pathname ];
+	const lookup = [
+		urlParts.host,
+		urlParts.host + urlParts.pathname,
+		urlParts.host + urlParts.pathname.substr( 0, 1 + urlParts.pathname.indexOf( '/', 1 ) ),
+	];
 
 	for ( let i = lookup.length - 1; i >= 0; i-- ) {
 		if ( lookup[ i ] in urlLocalizationMapping ) {

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -135,7 +135,7 @@ describe( 'index', () => {
 				links.some(
 					link =>
 						link.href ===
-						'https://en.support.wordpress.com/domains/map-existing-domain/#change-your-domains-name-servers'
+						'https://wordpress.com/support/domains/map-existing-domain/#change-your-domains-name-servers'
 				)
 			).toBeTruthy();
 		} );

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -184,7 +184,7 @@ exports[`GSuitePurchaseCta renders correctly 1`] = `
          
         <a
           className="gsuite-learn-more__link"
-          href="https://en.support.wordpress.com/adding-g-suite-to-your-site"
+          href="https://wordpress.com/support/adding-g-suite-to-your-site"
           onClick={[Function]}
           rel="noopener noreferrer"
           target="_blank"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates for changes in our URL structure:
   * `en.support.wordpress.com` → `wordpress.com/support/`
   * locale `br`(as an example for all of our languages): `en.support.wordpress.com` → `wordpress.com/br/support/`
   * support for new URL rewriting, locale `br`: `wordpress.com/support/` → `wordpress.com/br/support/` (+ other locales)
   * `en.blog.wordpress.com` → `wordpress.com/blog/`
   * locale `br`(as an example for all of our blog languages): `en.blog.wordpress.com` → `wordpress.com/br/blog/`
   * support for new URL rewriting, locale `br`: `wordpress.com/blog/` → `wordpress.com/br/blog/`

Later, we can update the old English URLs to the new ones as well, this PR includes support Should be merged before #40542.

#### Testing instructions

The unit tests can be run with `npm run test-client lib/i18n-utils` and should cover us.