### PR TITLE
Purchases: Add icons to purchase pages

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -54,7 +54,6 @@ import {
 	isDomainMapping,
 	isDomainTransfer,
 	isTheme,
-	isJetpackBackup,
 	isJetpackProduct,
 	isConciergeSession,
 } from 'lib/products-values';
@@ -344,7 +343,7 @@ class ManagePurchase extends Component {
 
 	renderPlanIcon() {
 		const { purchase } = this.props;
-		if ( isPlan( purchase ) || isJetpackBackup( purchase ) ) {
+		if ( isPlan( purchase ) || isJetpackProduct( purchase ) ) {
 			return (
 				<div className="manage-purchase__plan-icon">
 					<ProductIcon slug={ purchase.productSlug } />

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -29,7 +29,7 @@ import {
 	isGoogleApps,
 	isPlan,
 	isTheme,
-	isJetpackBackup,
+	isJetpackProduct,
 	isConciergeSession,
 } from 'lib/products-values';
 import Notice from 'components/notice';
@@ -158,7 +158,7 @@ class PurchaseItem extends Component {
 			return null;
 		}
 
-		if ( isPlan( purchase ) || isJetpackBackup( purchase ) ) {
+		if ( isPlan( purchase ) || isJetpackProduct( purchase ) ) {
 			return (
 				<div className="purchase-item__plan-icon">
 					<ProductIcon


### PR DESCRIPTION
#### Changes proposed in this Pull Request
<img width="755" alt="Screen Shot 2020-03-31 at 3 34 18 PM" src="https://user-images.githubusercontent.com/115071/78032402-408b8d00-7365-11ea-948d-2c3fe49c8125.png">

<img width="787" alt="Screen Shot 2020-03-31 at 3 32 06 PM" src="https://user-images.githubusercontent.com/115071/78032420-45e8d780-7365-11ea-887c-cfcc7ece121d.png">
<img width="774" alt="Screen Shot 2020-03-31 at 3 31 53 PM" src="https://user-images.githubusercontent.com/115071/78032427-47b29b00-7365-11ea-8771-9d94d5387ede.png">

<img width="753" alt="Screen Shot 2020-03-31 at 3 34 07 PM" src="https://user-images.githubusercontent.com/115071/78032415-441f1400-7365-11ea-96dc-ce671cad47f3.png">


#### Testing instructions

* Load up Calypso. 
* Buy Scan and Search Products. 
Visit http://calypso.localhost:3000/me/purchases 
navigate to the scan and search purchase. 
Notice the new icons. 




Fixes https://github.com/Automattic/wp-calypso/issues/40550
