### PR TITLE
Gutenboarding: Fix style picker font alignment (FF)

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -51,7 +51,7 @@ const FontSelect: React.FunctionComponent = () => {
 				className={ classnames( 'style-preview__font-option', { 'is-selected': ! selectedFonts } ) }
 				onClick={ () => setFonts( undefined ) }
 			>
-				{ defaultFontOption }
+				<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
 			</Button>
 			{ fontPairings.filter( fontPairingsFilter ).map( fontPair => {
 				const isSelected = fontPair === selectedFonts;
@@ -63,11 +63,13 @@ const FontSelect: React.FunctionComponent = () => {
 						onClick={ () => setFonts( fontPair ) }
 						key={ headings + base }
 					>
-						<span style={ { fontFamily: headings, fontWeight: 700 } }>
-							{ getFontTitle( headings ) }
+						<span className="style-preview__font-option-contents">
+							<span style={ { fontFamily: headings, fontWeight: 700 } }>
+								{ getFontTitle( headings ) }
+							</span>
+							&nbsp;/&nbsp;
+							<span style={ { fontFamily: base } }>{ getFontTitle( base ) }</span>
 						</span>
-						&nbsp;/&nbsp;
-						<span style={ { fontFamily: base } }>{ getFontTitle( base ) }</span>
 					</Button>
 				);
 			} ) }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -36,7 +36,11 @@
 .style-preview__font-option {
 	min-height: 3.4em;
 	box-shadow: inset 0 0 0 1px var( --studio-gray-10 );
-	justify-content: center;
+
+	display: flex;
+	flex-direction: column;
+	justify-content: space-around;
+	align-content: center;
 
 	// Extra specificity to override core style
 	// This is effectively a more-specific synonmy of the same selector
@@ -54,10 +58,10 @@
 	&:hover {
 		box-shadow: inset 0 0 0 1px var( --studio-gray-90 );
 	}
+}
 
-	span {
-		align-self: baseline;
-	}
+.style-preview__font-option {
+	display: flex;
 }
 
 .style-preview__preview {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes font alignment in the style picker in Firefox. 

Before / After
![Screen Shot 2020-03-31 at 16 25 52](https://user-images.githubusercontent.com/841763/78037867-636d6f80-736c-11ea-8ea2-ec4173cb4171.png)


#### Testing instructions

* `/gutenboarding`
* Style picker buttons look good in various browsers

Fixes #40559