### PR TITLE
Highlight selected fonts button even when focused and hovered

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -47,8 +47,10 @@
 	}
 
 	&.is-selected {
-		box-shadow: inset 0 0 0 1px var( --highlightColor );
-		color: var( --highlightColor );
+		// override default focus and hover styles for selected-fonts buttons
+		// `!important` is used because there are default `focus` and `hover` styles with high specificities.
+		color: var( --highlightColor ) !important;
+		box-shadow: inset 0 0 0 1px var( --highlightColor ) !important;
 	}
 
 	&:hover {


### PR DESCRIPTION
2 mins review.

#### Changes proposed in this Pull Request

It highlights selected fonts buttons property. Before, when you selected fonts, the button remained black until you blur (focus out of it). This PR highlights the selected fonts button in blue even in focus and hover states. 
