### PR TITLE
Gutenboarding: prefetch mshots screenshots

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/MShotsImage.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/MShotsImage.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { loadmShotsPreview } from '../../../../lib/mshots';
+
+const cacheMap: Map< string, string > = new Map();
+
+const loadingImageURL = 'https://wordpress.com/mshots/v1/default/';
+
+interface Props extends React.ImgHTMLAttributes< HTMLImageElement > {
+	siteUrl: string;
+}
+
+export const MShotsImage: React.FunctionComponent< Props > = ( { siteUrl, ...rest } ) => {
+	const [ imageUrl, setImageUrl ] = React.useState< string >( loadingImageURL );
+
+	React.useEffect( () => {
+		async function fetchImage() {
+			// fetch the image
+			const loadedImageUrl = await loadmShotsPreview( {
+				url: siteUrl,
+			} );
+
+			// cache the image
+			cacheMap.set( siteUrl, loadedImageUrl );
+
+			setImageUrl( loadedImageUrl );
+		}
+		// check if the image is cached
+		if ( cacheMap.has( siteUrl ) ) {
+			setImageUrl( cacheMap.get( siteUrl ) as string );
+		} else {
+			fetchImage();
+		}
+	}, [ siteUrl ] );
+
+	// eslint-disable-next-line jsx-a11y/alt-text
+	return <img src={ imageUrl } { ...rest } />;
+};

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -6,9 +6,7 @@ import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useI18n } from '@automattic/react-i18n';
 import { useHistory } from 'react-router-dom';
-import { Spring, animated } from 'react-spring/renderprops';
-import classnames from 'classnames';
-import { loadmShotsPreview, prefetchmShotsPreview } from '../../../../lib/mshots';
+import { MShotsImage } from './MShotsImage';
 /**
  * Internal dependencies
  */
@@ -22,22 +20,6 @@ import { SubTitle, Title } from '../../components/titles';
 import './style.scss';
 
 type Design = import('../../stores/onboard/types').Design;
-interface LoadedImages<T> {
-	[ index: string ]: T
-}
-type PreviewImage = {
-	isLoading: boolean;
-	src: string;
-}
-
-// Values for springs:
-const ZOOM_OFF = { transform: 'scale(1)' };
-const ZOOM_ON = { transform: 'scale(1.015)' };
-const SHADOW_OFF = { boxShadow: '0 0px 0px rgba(0,0,0,.12)' };
-const SHADOW_ON = { boxShadow: '0 2px 12px rgba(0,0,0,.12)' };
-
-
-const previewImageData = {};
 
 const makeOptionId = ( { slug }: Design ): string => `design-selector__option-name__${ slug }`;
 
@@ -47,44 +29,37 @@ const DesignSelector: React.FunctionComponent = () => {
 	const makePath = usePath();
 	const { setSelectedDesign, setFonts, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
-	const getDesignUrl = ( design: Design ) => {
+	const getDesignPreview = ( design: Design ) => {
 		// We temporarily show pre-generated screenshots until we can generate tall versions dynamically using mshots.
 		// See `bin/generate-gutenboarding-design-thumbnails.js` for generating screenshots.
 		// https://github.com/Automattic/mShots/issues/16
 		// https://github.com/Automattic/wp-calypso/issues/40564
 		if ( ! isEnabled( 'gutenboarding/mshot-preview' ) ) {
-			return `/calypso/page-templates/design-screenshots/${ design.slug }_${ design.template }_${ design.theme }.jpg`;
+			return (
+				<img
+					src={ `/calypso/page-templates/design-screenshots/${ design.slug }_${ design.template }_${ design.theme }.jpg` }
+					alt={ design.title }
+					key={ design.slug }
+					aria-labelledby={ makeOptionId( design ) }
+				/>
+			);
 		}
 
-		const mshotsUrl = 'https://s.wordpress.com/mshots/v1/';
 		const previewUrl = addQueryArgs( design.src, {
 			font_headings: design.fonts.headings,
 			font_base: design.fonts.base,
 		} );
-		return encodeURIComponent( previewUrl );
+
+		return (
+			<MShotsImage
+				className={ `design-selector__preview-image-${ design.slug }` }
+				alt={ design.title }
+				siteUrl={ encodeURIComponent( previewUrl ) }
+				key={ design.slug }
+				aria-labelledby={ makeOptionId( design ) }
+			/>
+		);
 	};
-
-	// Track hover/focus
-	const [ hoverDesign, setHoverDesign ] = React.useState< string >();
-	const [ focusDesign, setFocusDesign ] = React.useState< string >();
-
-/*	// Track and manage loaded images
-	const [ loadedImages, setIsPreviewImageLoaded ] = React.useState< LoadedImages< PreviewImage > >(
-		designs.featured.reduce( ( result, design ) => ( {
-			...result,
-			[ design.slug ]: { isLoading: false, src: undefined },
-		} ), {} )
-	);
-	const getImagedata = ( imageId: string ) => loadedImages[ imageId ];
-	const setImageData = ( imageId: string, imageBlob: string | undefined, isLoading = false ): void => {
-		setIsPreviewImageLoaded( {
-			...loadedImages,
-			[ imageId ]: {
-				isLoading,
-				src: imageBlob,
-			},
-		} );
-	};*/
 
 	return (
 		<div className="design-selector">
@@ -108,80 +83,27 @@ const DesignSelector: React.FunctionComponent = () => {
 			</div>
 			<div className="design-selector__design-grid">
 				<div className="design-selector__grid">
-					{ designs.featured.map( design => {
-						const isFocused = hoverDesign === design.slug || focusDesign === design.slug;
-						const designUrl = getDesignUrl( design );
-						const imageData = previewImageData[ design.slug ];
+					{ designs.featured.map( design => (
+						<button
+							key={ design.slug }
+							className="design-selector__design-option"
+							onClick={ () => {
+								setSelectedDesign( design );
 
-						if ( ! imageData ) {
-							previewImageData[ design.slug ] = {};
-							loadmShotsPreview( {
-								url: designUrl,
-								maxRetries: 30,
-								retryTimeout: 1000,
-							} ).then(imageBlob => {
-								previewImageData[ design.slug ].src = imageBlob;
-							} ) ;
-						}
+								// Update fonts to the design defaults
+								setFonts( design.fonts );
 
-						return (
-							<Spring
-								native
-								key={ design.slug }
-								from={ ZOOM_OFF }
-								to={ isFocused ? ZOOM_ON : ZOOM_OFF }
-							>
-								{ ( props: React.CSSProperties ) => (
-									<animated.button
-										style={ props }
-										onMouseEnter={ () => setHoverDesign( design.slug ) }
-										onMouseLeave={ () =>
-											setHoverDesign( s => ( s === design.slug ? undefined : s ) )
-										}
-										onFocus={ () => setFocusDesign( design.slug ) }
-										onBlur={ () => setFocusDesign( s => ( s === design.slug ? undefined : s ) ) }
-										className="design-selector__design-option"
-										onClick={ () => {
-											setSelectedDesign( design );
-
-											// Update fonts to the design defaults
-											setFonts( design.fonts );
-
-											if ( isEnabled( 'gutenboarding/style-preview' ) ) {
-												push( makePath( Step.Style ) );
-											}
-										} }
-									>
-										<Spring
-											native
-											key={ design.slug }
-											from={ SHADOW_OFF }
-											to={ isFocused ? SHADOW_ON : SHADOW_OFF }
-										>
-											{ ( props2: React.CSSProperties ) => (
-												<animated.span style={ props2 } className={ classnames( 'design-selector__image-frame', {
-													'is-loaded': imageData && imageData.src,
-												} ) }>
-													{ imageData && imageData.src &&
-														<img
-															className={ `design-selector__preview-image-${ design.slug }` }
-															alt={ design.title }
-															src={ imageData.src }
-															aria-labelledby={ makeOptionId( design ) }
-														/>
-													}
-
-												</animated.span>
-											) }
-										</Spring>
-										<span className="design-selector__option-overlay">
-											<span  id={ makeOptionId( design ) } className="design-selector__option-name">{ design.title }</span>
-										</span>
-									</animated.button>
-								) }
-							</Spring>
-						);
-					} ) }
+								if ( isEnabled( 'gutenboarding/style-preview' ) ) {
+									push( makePath( Step.Style ) );
+								}
+							} }
+						>
+							<span className="design-selector__image-frame">{ getDesignPreview( design ) }</span>
+							<span className="design-selector__option-overlay">
+								<span id={ makeOptionId( design ) } className="design-selector__option-name">{ design.title }</span>
+							</span>
+						</button>
+					) ) }
 				</div>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -50,16 +50,6 @@
 		}
 	}
 
-	.design-selector__design-option {
-		transition: transform 0.3s ease-out;
-		cursor: pointer;
-
-		&:focus,
-		&:hover {
-			transform: scale( 1.015 );
-		}
-	}
-
 	.design-selector__image-frame {
 		display: block;
 		width: 100%;
@@ -68,13 +58,6 @@
 		border: 1px solid var( --studio-gray-5 );
 		position: relative;
 		overflow: hidden;
-		transition: box-shadow 0.3s ease-out;
-		box-shadow: rgba( 0, 0, 0, 0.12 ) 0 0 0;
-
-		&:focus,
-		&:hover {
-			box-shadow: rgba( 0, 0, 0, 0.12 ) 0 2px 12px;
-		}
 
 		img {
 			position: absolute;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -50,6 +50,16 @@
 		}
 	}
 
+	.design-selector__design-option {
+		transition: transform 0.3s ease-out;
+		cursor: pointer;
+
+		&:focus,
+		&:hover {
+			transform: scale( 1.015 );
+		}
+	}
+
 	.design-selector__image-frame {
 		display: block;
 		width: 100%;
@@ -58,6 +68,13 @@
 		border: 1px solid var( --studio-gray-5 );
 		position: relative;
 		overflow: hidden;
+		transition: box-shadow 0.3s ease-out;
+		box-shadow: rgba( 0, 0, 0, 0.12 ) 0 0 0;
+
+		&:focus,
+		&:hover {
+			box-shadow: rgba( 0, 0, 0, 0.12 ) 0 2px 12px;
+		}
 
 		img {
 			position: absolute;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create a React component that extends `HTMLImageElement` and fetches MShot previews asynchronously. 
* Remove Spring animation for Design-grid in favor of two lines of CSS transition. 

![tonys](https://user-images.githubusercontent.com/6458278/78117296-38a91700-7451-11ea-8293-f152a02e95bd.gif)

#### Testing instructions
1. Head to the live [link](https://hash-2a545bfb69c533006e2bec473ba84a7f575c0c8d.calypso.live/gutenboarding/).
2. Fill vertical and site name. Head to the design page.
3. You should briefly see loading images for design previews then theme screenshots should be loaded without further action (refreshing or such). 

Fixes https://github.com/Automattic/wp-calypso/issues/40562
