### PR TITLE
Jetpack: update single product cards

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -555,17 +555,19 @@ export class ProductSelector extends Component {
 					{ hasProductPurchase && isCurrent && this.renderManageButton( product, purchase ) }
 					{ ! hasProductPurchase && ! isCurrent && (
 						<Fragment>
-							<ProductCardPromoNudge
-								badgeText={ translate( 'Up to %(discount)s off!', {
-									args: { discount: '70%' },
-								} ) }
-								text={ translate(
-									'Hurry, these are {{strong}}Limited time introductory prices!{{/strong}}',
-									{
-										components: { strong: <strong /> },
-									}
-								) }
-							/>
+							{ product.hasPromo && (
+								<ProductCardPromoNudge
+									badgeText={ translate( 'Up to %(discount)s off!', {
+										args: { discount: '70%' },
+									} ) }
+									text={ translate(
+										'Hurry, these are {{strong}}Limited time introductory prices!{{/strong}}',
+										{
+											components: { strong: <strong /> },
+										}
+									) }
+								/>
+							) }
 
 							<ProductCardOptions
 								optionsLabel={ optionsLabel }

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -190,6 +190,7 @@
 }
 
 .product-card__options-label {
+	margin-top: 16px;
 	font-size: 14px;
 	text-align: center;
 	color: var( --color-text-subtle );
@@ -287,6 +288,10 @@
 	justify-content: center;
 	align-items: center;
 	margin: 24px auto 8px;
+
+	& + .product-card__options-label {
+		margin-top: 8px;
+	}
 }
 
 .product-card__promo-nudge-badge {

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -157,10 +157,11 @@ export const getJetpackProductsTaglines = () => {
 
 export const getJetpackProductsDescriptions = () => {
 	const searchDescription = translate(
-		'Enhanced Search for more relevant results using modern ranking algorithms, ' +
-			'boosting of specific results, advanced filtering and faceting, and more.'
+		'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
 	);
-	const scanDescription = 'Scan your site.';
+	const scanDescription = translate(
+		'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
+	);
 	return {
 		[ PRODUCT_JETPACK_BACKUP_DAILY ]: translate(
 			'Always-on backups ensure you never lose your site. Your changes are saved every day with a 30-day archive.'
@@ -189,6 +190,7 @@ export const getJetpackProducts = () => {
 				'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
 			),
 			id: PRODUCT_JETPACK_BACKUP,
+			hasPromo: true,
 			options: {
 				yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
 				monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
@@ -200,33 +202,17 @@ export const getJetpackProducts = () => {
 			slugs: JETPACK_BACKUP_PRODUCTS,
 		},
 	];
-	isEnabled( 'jetpack/scan-product' ) &&
-		output.push( {
-			title: translate( 'Jetpack Scan' ),
-			// TODO: Add new description copy for Search
-			description: 'Always-on scan ensure you never lose your site.',
-			id: PRODUCT_JETPACK_SCAN,
-			options: {
-				yearly: [ PRODUCT_JETPACK_SCAN ],
-				monthly: [ PRODUCT_JETPACK_SCAN_MONTHLY ],
-			},
-			optionShortNames: getJetpackProductsShortNames(),
-			optionDisplayNames: getJetpackProductsDisplayNames(),
-			optionDescriptions: getJetpackProductsDescriptions(),
-			optionsLabel: translate( 'Select a product option:' ),
-			slugs: JETPACK_SCAN_PRODUCTS,
-		} );
 	isEnabled( 'jetpack/search-product' ) &&
 		output.push( {
 			title: translate( 'Jetpack Search' ),
-			// TODO: Add new description copy for Search
 			description: translate(
-				'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
+				'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
 			),
 			id: PRODUCT_JETPACK_SEARCH,
 			// There is only one option per billing interval, but this
 			// component still needs the full display with radio buttons.
 			forceRadios: true,
+			hasPromo: false,
 			options: {
 				yearly: [ PRODUCT_JETPACK_SEARCH ],
 				monthly: [ PRODUCT_JETPACK_SEARCH_MONTHLY ],
@@ -281,6 +267,23 @@ export const getJetpackProducts = () => {
 				);
 			},
 			slugs: JETPACK_SEARCH_PRODUCTS,
+		} );
+	isEnabled( 'jetpack/scan-product' ) &&
+		output.push( {
+			title: translate( 'Jetpack Scan' ),
+			description:
+				'Automatic scanning and one-click fixes keep your site one step ahead of security threats.',
+			id: PRODUCT_JETPACK_SCAN,
+			hasPromo: false,
+			options: {
+				yearly: [ PRODUCT_JETPACK_SCAN ],
+				monthly: [ PRODUCT_JETPACK_SCAN_MONTHLY ],
+			},
+			optionShortNames: getJetpackProductsShortNames(),
+			optionDisplayNames: getJetpackProductsDisplayNames(),
+			optionDescriptions: getJetpackProductsDescriptions(),
+			optionsLabel: translate( 'Select a product option:' ),
+			slugs: JETPACK_SCAN_PRODUCTS,
 		} );
 
 	return output;

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -205,9 +205,7 @@ export const getJetpackProducts = () => {
 	isEnabled( 'jetpack/search-product' ) &&
 		output.push( {
 			title: translate( 'Jetpack Search' ),
-			description: translate(
-				'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
-			),
+			description: getJetpackProductsDescriptions()[ PRODUCT_JETPACK_SEARCH ],
 			id: PRODUCT_JETPACK_SEARCH,
 			// There is only one option per billing interval, but this
 			// component still needs the full display with radio buttons.
@@ -271,15 +269,17 @@ export const getJetpackProducts = () => {
 	isEnabled( 'jetpack/scan-product' ) &&
 		output.push( {
 			title: translate( 'Jetpack Scan' ),
-			description:
-				'Automatic scanning and one-click fixes keep your site one step ahead of security threats.',
+			description: getJetpackProductsDescriptions()[ PRODUCT_JETPACK_SCAN ],
 			id: PRODUCT_JETPACK_SCAN,
+			// There is only one option per billing interval, but this
+			// component still needs the full display with radio buttons.
+			forceRadios: true,
 			hasPromo: false,
 			options: {
 				yearly: [ PRODUCT_JETPACK_SCAN ],
 				monthly: [ PRODUCT_JETPACK_SCAN_MONTHLY ],
 			},
-			optionShortNames: getJetpackProductsShortNames(),
+			optionShortNames: getJetpackProductsShortNames()[ PRODUCT_JETPACK_SCAN ],
 			optionDisplayNames: getJetpackProductsDisplayNames(),
 			optionDescriptions: getJetpackProductsDescriptions(),
 			optionsLabel: translate( 'Select a product option:' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update copy for single products.
* Hide promo nudge for products without discounted prices.
* Reordered the cards to show Backup, Search, Scan.

#### Testing instructions

* Fire up this PR.
* Go to WordPress.com and open Plans (`/plans/`) with a Jetpack site.
* Ensure all single product cards have:
  * The correct copy on each.
  * That the promo nudge only appears for Search.
  * Visually look good. For this one, bear in mind the product variation design refresh is being worked on https://github.com/Automattic/wp-calypso/pull/40583

#### Before

![image](https://user-images.githubusercontent.com/390760/78059563-f8c72e80-7381-11ea-9b17-cee89bc15b57.png)


#### After

![image](https://user-images.githubusercontent.com/390760/78059533-ec42d600-7381-11ea-97ff-02800d85d84e.png)


Fixes https://github.com/Automattic/wp-calypso/issues/40551
