### PR TITLE
UpgradeNudge: Swap UpgradeNudge for UpsellNudge

### DIFF
--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -142,7 +142,7 @@
 	}
 }
 
-.is-compact .banner__content {
+.banner.is-compact .banner__content {
 	padding: 5px;
 }
 
@@ -191,7 +191,7 @@
 	}
 }
 
-.is-compact .banner__title {
+.banner.is-compact .banner__title {
 	font-size: 12px;
 }
 
@@ -250,7 +250,7 @@
 	}
 }
 
-.is-compact .dismissible-card__close-icon {
+.banner.is-compact .dismissible-card__close-icon {
 	width: 16px;
 	height: 16px;
 	top: 50%;

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -40,7 +40,7 @@ import {
 } from 'state/simple-payments/product-list/actions';
 import { FEATURE_SIMPLE_PAYMENTS } from 'lib/plans/constants';
 import { hasFeature, getSitePlanSlug } from 'state/sites/plans/selectors';
-import UpgradeNudge from 'blocks/upgrade-nudge';
+import UpsellNudge from 'blocks/upsell-nudge';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import {
 	bumpStat,
@@ -473,14 +473,17 @@ class SimplePaymentsDialog extends Component {
 							: false
 					}
 					action={
-						<UpgradeNudge
+						<UpsellNudge
 							className="editor-simple-payments-modal__nudge-nudge"
 							title={ translate( 'Upgrade your plan to our Premium or Business plan!' ) }
-							message={ translate(
+							description={ translate(
 								'Get simple payments, advanced social media tools, your own domain, and more.'
 							) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							event="editor_simple_payments_modal_nudge"
+							tracksImpressionName="calypso_upgrade_nudge_impression"
+							tracksClickName="calypso_upgrade_nudge_cta_click"
+							showIcon={ true }
 						/>
 					}
 					secondaryAction={

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -74,7 +74,7 @@
 		margin-bottom: 16px;
 	}
 
-	.upgrade-nudge.card.editor-simple-payments-modal__nudge-nudge {
+	.upsell-nudge.card.editor-simple-payments-modal__nudge-nudge {
 		flex-shrink: 0;
 		text-align: left;
 	}

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -22,7 +22,7 @@ import { requestSubscribers, requestSubscriptionStop } from 'state/memberships/s
 import { decodeEntities } from 'lib/formatting';
 import Gravatar from 'components/gravatar';
 import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
-import UpgradeNudge from 'blocks/upgrade-nudge';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { FEATURE_MEMBERSHIPS, PLAN_PERSONAL, PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
@@ -533,12 +533,16 @@ class MembershipsSection extends Component {
 	render() {
 		if ( ! this.props.paidPlan ) {
 			return this.renderOnboarding(
-				<UpgradeNudge
+				<UpsellNudge
 					plan={ this.props.isJetpack ? PLAN_JETPACK_PERSONAL : PLAN_PERSONAL }
 					shouldDisplay={ () => true }
 					feature={ FEATURE_MEMBERSHIPS }
 					title={ this.props.translate( 'Upgrade to the Personal plan' ) }
-					message={ this.props.translate( 'Upgrade to start earning recurring revenue.' ) }
+					description={ this.props.translate( 'Upgrade to start earning recurring revenue.' ) }
+					showIcon={ true }
+					event="calypso_memberships_upsell_nudge"
+					tracksImpressionName="calypso_upgrade_nudge_impression"
+					tracksClickName="calypso_upgrade_nudge_cta_click"
 				/>
 			);
 		}

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -23,7 +23,7 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import FormattedHeader from 'components/formatted-header';
-import UpgradeNudge from 'blocks/upgrade-nudge';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { FEATURE_NO_ADS } from 'lib/plans/constants';
 
 /**
@@ -106,11 +106,14 @@ export const Sharing = ( {
 				</SectionNav>
 			) }
 			{ ! isVip && (
-				<UpgradeNudge
+				<UpsellNudge
 					event="sharing_no_ads"
 					feature={ FEATURE_NO_ADS }
-					message={ translate( 'Prevent ads from showing on your site.' ) }
+					description={ translate( 'Prevent ads from showing on your site.' ) }
 					title={ translate( 'No Ads with WordPress.com Premium' ) }
+					tracksImpressionName="calypso_upgrade_nudge_impression"
+					tracksClickName="calypso_upgrade_nudge_cta_click"
+					showIcon={ true }
 				/>
 			) }
 			{ contentComponent }

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { FEATURE_VIDEO_UPLOADS, FEATURE_AUDIO_UPLOADS } from 'lib/plans/constants';
-import UpgradeNudge from 'blocks/upgrade-nudge';
+import UpsellNudge from 'blocks/upsell-nudge';
 import ListPlanPromo from './list-plan-promo';
 
 function getTitle( filter, translate ) {
@@ -37,12 +37,15 @@ function getSubtitle( filter, translate ) {
 export const MediaLibraryUpgradeNudge = ( { translate, filter, site } ) => (
 	<div className="media-library__videopress-nudge-container">
 		<ListPlanPromo site={ site } filter={ filter }>
-			<UpgradeNudge
+			<UpsellNudge
 				className="media-library__videopress-nudge-regular"
 				title={ getTitle( filter, translate ) }
-				message={ getSubtitle( filter, translate ) }
+				description={ getSubtitle( filter, translate ) }
 				feature={ 'audio' === filter ? FEATURE_AUDIO_UPLOADS : FEATURE_VIDEO_UPLOADS }
 				event="calypso_media_uploads_upgrade_nudge"
+				tracksImpressionName="calypso_upgrade_nudge_impression"
+				tracksClickName="calypso_upgrade_nudge_cta_click"
+				showIcon={ true }
 			/>
 		</ListPlanPromo>
 	</div>

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -272,7 +272,7 @@
 	}
 }
 
-.empty-content .media-library__videopress-nudge-regular.card.upgrade-nudge {
+.empty-content .media-library__videopress-nudge-regular.card.upsell-nudge {
 	margin-left: auto;
 	margin-right: auto;
 	text-align: left;

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -39,7 +39,7 @@ import { Button } from '@automattic/components';
 import { isBusiness, isEcommerce, isEnterprise, isPremium } from 'lib/products-values';
 import { TYPE_BUSINESS } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { isEnabled } from 'config';
 import wpcomFeaturesAsPlugins from './wpcom-features-as-plugins';
 import QuerySiteRecommendedPlugins from 'components/data/query-site-recommended-plugins';
@@ -522,8 +522,9 @@ export class PluginsBrowser extends Component {
 		const title = translate( 'Upgrade to the Business plan to install plugins.' );
 
 		return (
-			<Banner
+			<UpsellNudge
 				event="calypso_plugins_browser_upgrade_nudge"
+				showIcon={ true }
 				href={ bannerURL }
 				plan={ plan }
 				title={ title }

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -14,7 +14,7 @@ jest.mock( 'lib/plugins/wporg-data/list-store', () => ( {
 } ) );
 jest.mock( 'lib/plugins/wporg-data/actions', () => ( {} ) );
 jest.mock( 'components/main', () => 'MainComponent' );
-jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
 jest.mock( 'components/notice', () => 'Notice' );
 jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
 
@@ -54,7 +54,7 @@ describe( 'PluginsBrowser basic tests', () => {
 		const comp = shallow( <PluginsBrowser { ...props } /> );
 		expect( comp.find( 'MainComponent' ).length ).toBe( 1 );
 	} );
-	test( 'should show upgrade nudge when appropriate', () => {
+	test( 'should show upsell nudge when appropriate', () => {
 		const comp = shallow(
 			<PluginsBrowser
 				{ ...props }
@@ -66,7 +66,7 @@ describe( 'PluginsBrowser basic tests', () => {
 		);
 		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 1 );
 	} );
-	test( 'should not show upgrade nudge if no site is selected', () => {
+	test( 'should not show upsell nudge if no site is selected', () => {
 		const comp = shallow(
 			<PluginsBrowser
 				{ ...props }
@@ -76,9 +76,11 @@ describe( 'PluginsBrowser basic tests', () => {
 				hasBusinessPlan={ false }
 			/>
 		);
-		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 0 );
+		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
+			0
+		);
 	} );
-	test( 'should not show upgrade nudge if no sitePlan', () => {
+	test( 'should not show upsell nudge if no sitePlan', () => {
 		const comp = shallow(
 			<PluginsBrowser
 				{ ...props }
@@ -88,9 +90,11 @@ describe( 'PluginsBrowser basic tests', () => {
 				hasBusinessPlan={ false }
 			/>
 		);
-		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 0 );
+		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
+			0
+		);
 	} );
-	test( 'should not show upgrade nudge if jetpack site', () => {
+	test( 'should not show upsell nudge if jetpack site', () => {
 		const comp = shallow(
 			<PluginsBrowser
 				{ ...props }
@@ -100,9 +104,11 @@ describe( 'PluginsBrowser basic tests', () => {
 				hasBusinessPlan={ false }
 			/>
 		);
-		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 0 );
+		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
+			0
+		);
 	} );
-	test( 'should not show upgrade nudge has business plan', () => {
+	test( 'should not show upsell nudge has business plan', () => {
 		const comp = shallow(
 			<PluginsBrowser
 				{ ...props }
@@ -112,11 +118,13 @@ describe( 'PluginsBrowser basic tests', () => {
 				hasBusinessPlan={ true }
 			/>
 		);
-		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 0 );
+		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
+			0
+		);
 	} );
 } );
 
-describe( 'Upsell Banner should get appropriate plan constant', () => {
+describe( 'Upsell Nudge should get appropriate plan constant', () => {
 	const myProps = {
 		...props,
 		showUpgradeNudge: true,
@@ -127,11 +135,11 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( product_slug => {
 		test( `Business 1 year for (${ product_slug })`, () => {
 			const comp = shallow( <PluginsBrowser { ...myProps } sitePlan={ { product_slug } } /> );
-			expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
-				1
-			);
 			expect(
-				comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
+				comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+			).toBe( 1 );
+			expect(
+				comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
 			).toBe( PLAN_BUSINESS );
 		} );
 	} );
@@ -139,11 +147,11 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 	[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach( product_slug => {
 		test( `Business 2 year for (${ product_slug })`, () => {
 			const comp = shallow( <PluginsBrowser { ...myProps } sitePlan={ { product_slug } } /> );
-			expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
-				1
-			);
 			expect(
-				comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
+				comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length
+			).toBe( 1 );
+			expect(
+				comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).props().plan
 			).toBe( PLAN_BUSINESS_2_YEARS );
 		} );
 	} );

--- a/client/my-sites/plugins/plugins-browser/test/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/test/index.jsx
@@ -64,7 +64,9 @@ describe( 'PluginsBrowser basic tests', () => {
 				hasBusinessPlan={ false }
 			/>
 		);
-		expect( comp.find( 'Banner[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe( 1 );
+		expect( comp.find( 'UpsellNudge[event="calypso_plugins_browser_upgrade_nudge"]' ).length ).toBe(
+			1
+		);
 	} );
 	test( 'should not show upsell nudge if no site is selected', () => {
 		const comp = shallow(

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -32,7 +32,7 @@ import PostTypeListEmptyContent from './empty-content';
 import PostTypeListMaxPagesNotice from './max-pages-notice';
 import SectionHeader from 'components/section-header';
 import { Button } from '@automattic/components';
-import UpgradeNudge from 'blocks/upgrade-nudge';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { FEATURE_NO_ADS } from 'lib/plans/constants';
 
 /**
@@ -287,11 +287,14 @@ class PostTypeList extends Component {
 				) }
 				{ posts.slice( 0, 10 ).map( this.renderPost ) }
 				{ showUpgradeNudge && (
-					<UpgradeNudge
+					<UpsellNudge
 						title={ translate( 'No Ads with WordPress.com Premium' ) }
-						message={ translate( 'Prevent ads from showing on your site.' ) }
+						description={ translate( 'Prevent ads from showing on your site.' ) }
 						feature={ FEATURE_NO_ADS }
 						event="published_posts_no_ads"
+						tracksImpressionName="calypso_upgrade_nudge_impression"
+						tracksClickName="calypso_upgrade_nudge_cta_click"
+						showIcon={ true }
 					/>
 				) }
 				{ posts.slice( 10 ).map( this.renderPost ) }

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -36,6 +36,11 @@ import UpsellNudge from 'blocks/upsell-nudge';
 import { FEATURE_NO_ADS } from 'lib/plans/constants';
 
 /**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
  * Constants
  */
 // The maximum number of pages of results that can be displayed in "All My

--- a/client/my-sites/post-type-list/style.scss
+++ b/client/my-sites/post-type-list/style.scss
@@ -1,0 +1,3 @@
+.post-type-list .upsell-nudge {
+	margin-top: 16px;
+}

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -34,7 +34,7 @@ import PodcastingPublishNotice from './publish-notice';
 import PodcastingSupportLink from './support-link';
 import podcastingTopics from './topics';
 import TermTreeSelector from 'blocks/term-tree-selector';
-import UpgradeNudge from 'blocks/upgrade-nudge';
+import UpsellNudge from 'blocks/upsell-nudge';
 
 /**
  * Selectors, actions, and query components
@@ -234,12 +234,17 @@ class PodcastingDetails extends Component {
 						</h1>
 					</HeaderCake>
 					{ ! error && plansDataLoaded && (
-						<UpgradeNudge
+						<UpsellNudge
 							plan={ PLAN_PERSONAL }
 							title={ translate( 'Upload Audio with WordPress.com Personal' ) }
-							message={ translate( 'Embed podcast episodes directly from your media library.' ) }
+							description={ translate(
+								'Embed podcast episodes directly from your media library.'
+							) }
 							feature={ FEATURE_AUDIO_UPLOADS }
 							event="podcasting_details_upload_audio"
+							tracksImpressionName="calypso_upgrade_nudge_impression"
+							tracksClickName="calypso_upgrade_nudge_cta_click"
+							showIcon={ true }
 						/>
 					) }
 					{ ! error && (

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -22,7 +22,7 @@ import { Card } from '@automattic/components';
 import StatsModulePlaceholder from './placeholder';
 import SectionHeader from 'components/section-header';
 import QuerySiteStats from 'components/data/query-site-stats';
-import UpgradeNudge from 'blocks/upgrade-nudge';
+import UpsellNudge from 'blocks/upsell-nudge';
 import AllTimeNav from './all-time-nav';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -194,12 +194,17 @@ class StatsModule extends Component {
 						<StatsModuleExpand href={ summaryLink } />
 					) }
 					{ summary && 'countryviews' === path && (
-						<UpgradeNudge
+						<UpsellNudge
 							title={ translate( 'Add Google Analytics' ) }
-							message={ translate( 'Upgrade to a Premium Plan for Google Analytics integration.' ) }
+							description={ translate(
+								'Upgrade to a Premium Plan for Google Analytics integration.'
+							) }
 							event="googleAnalytics-stats-countries"
 							feature={ FEATURE_GOOGLE_ANALYTICS }
 							plan={ PLAN_PREMIUM }
+							tracksImpressionName="calypso_upgrade_nudge_impression"
+							tracksClickName="calypso_upgrade_nudge_cta_click"
+							showIcon={ true }
 						/>
 					) }
 				</Card>

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -1,5 +1,5 @@
 .stats-module {
-	.upgrade-nudge.card {
+	.upsell-nudge.card {
 		margin: 16px;
 	}
 }
@@ -256,7 +256,7 @@ ul.module-header-actions {
 	}
 }
 
-.module-content .upgrade-nudge.card {
+.module-content .upsell-nudge.card {
 	margin: 16px;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Standardizing upsell nudges from the component end, this replaces all instances of `UpgradeNudge` with `UpsellNudge`
* The nudges should be visually the same, and tracks events should remain the same

| Visuals | |
| ------- | ------- |
| <img width="736" alt="Screen Shot 2020-03-31 at 4 03 37 PM" src="https://user-images.githubusercontent.com/2124984/78070269-7f234680-7369-11ea-90f1-3ba61c017831.png"> | <img width="776" alt="Screen Shot 2020-03-31 at 4 03 30 PM" src="https://user-images.githubusercontent.com/2124984/78070273-7fbbdd00-7369-11ea-972e-7777ccb70c44.png"> |
| <img width="1081" alt="Screen Shot 2020-03-31 at 3 32 21 PM" src="https://user-images.githubusercontent.com/2124984/78070275-80547380-7369-11ea-8ec0-3cdd02e72c53.png"> | <img width="1088" alt="Screen Shot 2020-03-31 at 4 29 37 PM" src="https://user-images.githubusercontent.com/2124984/78072276-d4ad2280-736c-11ea-9f79-38fb71ac70fc.png"> |
| <img width="1095" alt="Screen Shot 2020-03-31 at 5 07 32 PM" src="https://user-images.githubusercontent.com/2124984/78075273-38861a00-7372-11ea-8913-409f2e57ebd3.png"> | <img width="1073" alt="Screen Shot 2020-03-31 at 5 14 11 PM" src="https://user-images.githubusercontent.com/2124984/78075753-1d67da00-7373-11ea-90ec-399c472ce815.png"> |
| <img width="772" alt="Screen Shot 2020-03-31 at 5 25 40 PM" src="https://user-images.githubusercontent.com/2124984/78076565-ac292680-7374-11ea-9b9a-7992b65c51ae.png"> | <img width="1086" alt="Screen Shot 2020-03-31 at 5 29 52 PM" src="https://user-images.githubusercontent.com/2124984/78076883-4b4e1e00-7375-11ea-8e4a-4f2fe7d8c6d8.png"> |
| <img width="651" alt="Screen Shot 2020-03-31 at 5 59 15 PM" src="https://user-images.githubusercontent.com/2124984/78079057-5d31c000-7379-11ea-968a-1c66aa7b3e11.png"> | |


#### Testing instructions

Check upgrades in the following sections on a FREE site:

* Media -> Audio tab
* Media -> Video tab
* Plugins
* `/earn/payments/{site}` - with this one, I had to add a `cta_name` Tracks property which was `null` in the original instance -- I don't think this should cause problems as long as the Tracks funnels aren't counting on that value to be `null`.
* Marketing
* Posts -> End of the posts list on a site with more than ten published posts
* Settings -> Writing -> Scroll down to podcasting, click Set Up
* Stats -> Click on Countries box -> look for Google Analytics upsell
* Add a Simple Payments button on a free site that's using the Classic editor

Double-check tracks events between the two versions; they should be the same, with all the same properties

There should be no visual bugs or regressions.