### PR TITLE
Happy Chat: Open support/forum URLs in a new tab

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -48,7 +48,7 @@ import initialReducer from 'state/reducer';
 import { getInitialState, persistOnChange, loadAllState } from 'state/initial-state';
 import detectHistoryNavigation from 'lib/detect-history-navigation';
 import userFactory from 'lib/user';
-import { getUrlParts } from 'lib/url/url-parts';
+import { getUrlParts, isOutsideCalypso } from 'lib/url';
 import { setStore } from 'state/redux-store';
 
 const debug = debugFactory( 'calypso' );
@@ -95,12 +95,7 @@ const setupContextMiddleware = reduxStore => {
 
 		// Some paths live outside of Calypso and should be opened separately
 		// Examples: /support, /forums
-		if (
-			/^\/support($|\/)/i.test( context.pathname ) || // /support or /support/*
-			/^\/([a-z]{2}|[a-z]{2}-[a-z]{2})\/support($|\/)/i.test( context.pathname ) || // /en/support or /pt-br/support/*, etc
-			/^\/forums($|\/)/i.test( context.pathname ) || // /forums or /forums/*
-			/^\/([a-z]{2}|[a-z]{2}-[a-z]{2})\/forums($|\/)/i.test( context.pathname ) // /en/forums or /pt-br/forums/*, etc
-		) {
+		if ( isOutsideCalypso( context.pathname ) ) {
 			window.location.href = context.pathname;
 			return;
 		}

--- a/client/components/happychat/index.jsx
+++ b/client/components/happychat/index.jsx
@@ -11,7 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import { isExternal } from 'lib/url';
+import { isOutsideCalypso } from 'lib/url';
 // actions
 import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connection/actions';
 import {
@@ -163,7 +163,7 @@ const mapState = state => {
 		disabled: ! canUserSendMessages( state ),
 		isChatOpen: isHappychatOpen( state ),
 		isCurrentUser: isMessageFromCurrentUser( currentUser ), // see redux-no-bound-selectors eslint-rule
-		isExternalUrl: isExternal,
+		isExternalUrl: isOutsideCalypso,
 		isMinimizing: isHappychatMinimizing( state ),
 		isServerReachable: isHappychatServerReachable( state ),
 		message: getCurrentMessage( state ),

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -14,7 +14,19 @@ import Gridicon from 'components/gridicon';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import PopoverMenuSeparator from 'components/popover/menu-separator';
-import { isOutsideCalypso } from 'lib/url';
+
+/**
+ * Check if a URL is located outside of Calypso.
+ * Note that the check this function implements is incomplete --
+ * it only returns false for absolute URLs, so it misses
+ * relative URLs, or pure query strings, or hashbangs.
+ *
+ * @param  url URL to check
+ * @returns     true if the given URL is located outside of Calypso
+ */
+function isOutsideCalypso( url ) {
+	return !! url && ( url.startsWith( '//' ) || ! url.startsWith( '/' ) );
+}
 
 class ThemeMoreButton extends Component {
 	state = { showPopover: false };

--- a/client/lib/url/is-outside-calypso.ts
+++ b/client/lib/url/is-outside-calypso.ts
@@ -1,17 +1,26 @@
 /**
  * Internal dependencies
  */
+import { getUrlParts, isExternal } from 'lib/url';
 import { URL as URLString } from 'types';
 
-/**
- * Check if a URL is located outside of Calypso.
- * Note that the check this function implements is incomplete --
- * it only returns false for absolute URLs, so it misses
- * relative URLs, or pure query strings, or hashbangs.
- *
- * @param  url URL to check
- * @returns     true if the given URL is located outside of Calypso
- */
 export default function isOutsideCalypso( url: URLString ): boolean {
-	return !! url && ( url.startsWith( '//' ) || ! url.startsWith( '/' ) );
+	if ( isExternal( url ) ) {
+		return true;
+	}
+
+	const { pathname } = getUrlParts( url );
+
+	// Some paths live outside of Calypso even though they are hosted on the same domain
+	// Examples: /support, /forums
+	if (
+		/^\/support($|\/)/i.test( pathname ) || // /support or /support/*
+		/^\/([a-z]{2}|[a-z]{2}-[a-z]{2})\/support($|\/)/i.test( pathname ) || // /en/support or /pt-br/support/*, etc
+		/^\/forums($|\/)/i.test( pathname ) || // /forums or /forums/*
+		/^\/([a-z]{2}|[a-z]{2}-[a-z]{2})\/forums($|\/)/i.test( pathname ) // /en/forums or /pt-br/forums/*, etc
+	) {
+		return true;
+	}
+
+	return false;
 }

--- a/client/lib/url/test/is-outside-calypso.js
+++ b/client/lib/url/test/is-outside-calypso.js
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import isOutsideCalypso from '../is-outside-calypso';
+
+describe( 'isOutsideCalypso', () => {
+	test( 'should return true for support site without trailing slash', () => {
+		const source = 'https://example.com/support';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for support site with trailing slash', () => {
+		const source = 'http://example.com/support/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for support site page', () => {
+		const source = 'http://example.com/support/test/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for locale specific support site without trailing slash', () => {
+		const source = 'http://example.com/br/support';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for locale specific support site with trailing slash', () => {
+		const source = 'http://example.com/br/support/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for locale specific support site page', () => {
+		const source = 'http://example.com/br/support/test/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for hyphenated locale specific support site without trailing slash', () => {
+		const source = 'http://example.com/pt-br/support';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for hyphenated locale specific support site with trailing slash', () => {
+		const source = 'http://example.com/pt-br/support/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for hyphenated locale specific support site page', () => {
+		const source = 'http://example.com/pt-br/support/test/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for forums site without trailing slash', () => {
+		const source = 'https://example.com/forums';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for forums site with trailing slash', () => {
+		const source = 'http://example.com/forums/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for forums site page', () => {
+		const source = 'http://example.com/forums/test/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for locale specific forums site without trailing slash', () => {
+		const source = 'http://example.com/br/forums';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for locale specific forums site with trailing slash', () => {
+		const source = 'http://example.com/br/forums/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for locale specific forums site page', () => {
+		const source = 'http://example.com/br/forums/test/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for hyphenated locale specific forums site without trailing slash', () => {
+		const source = 'http://example.com/pt-br/forums';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for hyphenated locale specific forums site with trailing slash', () => {
+		const source = 'http://example.com/pt-br/forums/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return true for hyphenated locale specific forums site page', () => {
+		const source = 'http://example.com/pt-br/forums/test/';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( true );
+	} );
+
+	test( 'should return false for support site with invalid locale', () => {
+		const source = 'https://example.com/brr/support';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( false );
+	} );
+
+	test( 'should return false for support site with invalid hyphenated locale', () => {
+		const source = 'https://example.com/pt-brr/support';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( false );
+	} );
+
+	test( 'should return false for support site with invalid hyphenated locale 2', () => {
+		const source = 'https://example.com/ptt-br/support';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( false );
+	} );
+
+	test( 'should return false for support site with invalid double hyphenated locale', () => {
+		const source = 'https://example.com/pt--br/support';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( false );
+	} );
+
+	test( 'should return false for support site with locale and missing slash', () => {
+		const source = 'https://example.com/brsupport';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( false );
+	} );
+
+	test( 'should return false for support site with locale and hyphenated locale', () => {
+		const source = 'https://example.com/br/pt-br/support';
+		const actual = isOutsideCalypso( source );
+		expect( actual ).toBe( false );
+	} );
+} );

--- a/client/me/happychat/main.jsx
+++ b/client/me/happychat/main.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import { isExternal } from 'lib/url';
+import { isOutsideCalypso } from 'lib/url';
 // actions
 import { sendMessage, sendNotTyping, sendTyping } from 'state/happychat/connection/actions';
 import { blur, focus, setCurrentMessage } from 'state/happychat/ui/actions';
@@ -127,7 +127,7 @@ const mapState = state => {
 		currentUserEmail: currentUser.email,
 		disabled: ! canUserSendMessages( state ),
 		isCurrentUser: isMessageFromCurrentUser( currentUser ), // see redux-no-bound-selectors eslint-rule
-		isExternalUrl: isExternal,
+		isExternalUrl: isOutsideCalypso,
 		isServerReachable: isHappychatServerReachable( state ),
 		message: getCurrentMessage( state ),
 		timeline: getHappychatTimeline( state ),


### PR DESCRIPTION
### Changes proposed in this Pull Request

A few days ago @travisw [deployed a change](https://github.com/Automattic/wp-calypso/pull/40461) that fixes a bug due to new support and forums URLs. (See details on #40461 ) This continues that work, so that these links also open in a new tab when clicked from Happy Chat. This way when HEs share support docs, customers won't accidentally leave the chat when they click the link.

This does three things:

1. **Takes the existing `isOutsideCalypso(...)` URL helper and inlines it in the `ThemeMoreButton` which is the only place it was used.** This function has been around [since the initial Calypso commit 4 years ago](https://github.com/Automattic/wp-calypso/blame/3ceb3304a8c8be26c82744780779dc632314fdba/client/lib/url/index.js#L15) and removing it or altering the check seems risky, so inlining feels like the least intrusive and safest step.
2. **Repurposes `isOutsideCalypso(...)` to check for same-domain URLs that should be treated as non-Calypso URLs.** It uses the same Regex checks @travisw had put directly in the boot script. This way we can re-use the logic in various places, for instance the next step...
3. **Uses `isOutsideCalypso(...)` in Happy Chat to know when a link should open in a new tab.** This was the end goal and here it is!

### Testing instructions

#### Make sure `ThemeMoreButton` still works

<img width="337" alt="Screen Shot 2020-03-31 at 5 33 49 PM" src="https://user-images.githubusercontent.com/518059/78081323-e646f800-7375-11ea-8575-faa469dd4f27.png">

Go to http://calypso.localhost:3000/themes — the `ThemeMoreButton` is the three-dot menu button. The links inside this menu could be effected by this PR.

**Test internal URLs:** Click links like "Info" and "Support" which go to internal pages and make sure they work.

**Test external URLs:** I can't find any themes that natively have external URLs in this menu (and I suspect this whole code path is a vestige of previous theme pages). So to just make sure the inlining of `isOutsideCalypso` works, you can [hard-code this line](https://github.com/Automattic/wp-calypso/blob/master/client/components/theme/more-button.jsx#L69) to several external URLs like `http://jetpack.com` and `//happy.tools` and make sure they take you to the correct page.

#### Make sure Happy Chat links open in a new tab

- Sign into Staging Happy Chat: https://hud-staging.happychat.io/
- Start a chat from the Contact Form: http://calypso.localhost:3000/help/contact
- From Happy Chat, send a few internal links — clicking on these in Calypso should take you there without a pageload:
    - http://calypso.localhost:3000/home
    - http://calypso.localhost:3000/me
    - http://calypso.localhost:3000/read
- From Happy Chat, send a few external links — clicking on these should open them in a new tab (there will be no content for some of them because Support pages and Forums don't work locally)
    - http://calypso.localhost:3000/support
   - http://calypso.localhost:3000/pt-br/support
    - http://calypso.localhost:3000/forums
    - http://calypso.localhost:3000/es/forums
    - https://jetpack.com
- Repeat the same process at the other Happy Chat entry point at http://calypso.localhost:3000/me/chat
