### PR TITLE
My Home: Populate secondary cards with the layout API.

### DIFF
--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { isMobile } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -14,33 +12,27 @@ import GrowEarn from 'my-sites/customer-home/cards/features/grow-earn';
 import LaunchSite from 'my-sites/customer-home/cards/features/launch-site';
 import Stats from 'my-sites/customer-home/cards/features/stats';
 import Support from 'my-sites/customer-home/cards/features/support';
-import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
-import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
-const Secondary = ( { isChecklistComplete, needsEmailVerification, siteIsUnlaunched } ) => {
+const cardComponents = {
+	'home-action-launch-site': LaunchSite,
+	'home-education-free-photo-library': FreePhotoLibrary,
+	'home-feature-go-mobile-desktop': GoMobile,
+	'home-feature-grow-and-earn': GrowEarn,
+	'home-feature-stats': Stats,
+	'home-feature-support': Support,
+};
+
+const Secondary = ( { cards } ) => {
 	return (
 		<>
-			{ siteIsUnlaunched && ! needsEmailVerification && <LaunchSite /> }
-			{ ! siteIsUnlaunched && <Stats /> }
-			{ <FreePhotoLibrary /> }
-			{ ! siteIsUnlaunched && isChecklistComplete && <GrowEarn /> }
-			<Support />
-			{ // "Go Mobile" has the lowest priority placement when viewed in bigger viewports.
-			! isMobile() && <GoMobile /> }
+			{ cards &&
+				cards.map( ( card, index ) =>
+					React.createElement( cardComponents[ card ], {
+						key: index,
+					} )
+				) }
 		</>
 	);
 };
 
-const mapStateToProps = state => {
-	const siteId = getSelectedSiteId( state );
-
-	return {
-		isChecklistComplete: isSiteChecklistComplete( state, siteId ),
-		needsEmailVerification: ! isCurrentUserEmailVerified( state ),
-		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
-	};
-};
-
-export default connect( mapStateToProps )( Secondary );
+export default Secondary;

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -26,10 +26,12 @@ const Secondary = ( { cards } ) => {
 	return (
 		<>
 			{ cards &&
-				cards.map( ( card, index ) =>
-					React.createElement( cardComponents[ card ], {
-						key: index,
-					} )
+				cards.map(
+					( card, index ) =>
+						cardComponents[ card ] &&
+						React.createElement( cardComponents[ card ], {
+							key: index,
+						} )
 				) }
 		</>
 	);

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -92,7 +92,7 @@ const Home = ( {
 						<Primary cards={ layout.primary } checklistMode={ checklistMode } />
 					</div>
 					<div className="customer-home__layout-col customer-home__layout-col-right">
-						<Secondary />
+						<Secondary cards={ layout.secondary } />
 					</div>
 				</div>
 			) : (


### PR DESCRIPTION
**Requires #40537.**

In #40172 we wired in the Home layout API; this PR uses those results to determine which cards to render in the secondary location. No visual or functional changes should happen between this PR and production.

<img width="1083" alt="Screen Shot 2020-03-31 at 2 54 04 PM" src="https://user-images.githubusercontent.com/349751/78078722-9826fa00-735f-11ea-8c0c-692d73daaaa8.png">

**Testing Instructions**

* Load My Home on this branch at `https://calypso.localhost:3000/home/:site`.
* Verify the secondary column loads properly, and doesn't have more than three cards.
* Check other different sites (Atomic, Simple, Business plan) and see if you hit any errors.
