### PR TITLE
My Home: Use the layout API results to render notice cards.

### DIFF
--- a/client/my-sites/customer-home/locations/notices/index.jsx
+++ b/client/my-sites/customer-home/locations/notices/index.jsx
@@ -1,117 +1,37 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
-import { connect } from 'react-redux';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import getSiteChecklist from 'state/selectors/get-site-checklist';
-import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
-import isSiteRecentlyMigrated from 'state/selectors/is-site-recently-migrated';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { isNewSite } from 'state/sites/selectors';
-import { getSelectedSiteId } from 'state/ui/selectors';
 import CelebrateSiteCreation from 'my-sites/customer-home/cards/notices/celebrate-site-creation';
 import CelebrateSiteLaunch from 'my-sites/customer-home/cards/notices/celebrate-site-launch';
 import CelebrateSiteMigration from 'my-sites/customer-home/cards/notices/celebrate-site-migration';
 import CelebrateSiteSetupComplete from 'my-sites/customer-home/cards/notices/celebrate-site-setup-complete';
 
-const Notices = ( {
-	checklistMode,
-	displayChecklist,
-	isAtomic,
-	isChecklistComplete,
-	isNewlyCreatedSite,
-	isRecentlyMigratedSite,
-	siteIsUnlaunched,
-} ) => {
-	const [ showSiteSetupComplete, setShowSiteSetupComplete ] = useState( null );
-
-	/**
-	 * Updates showSiteSetupComplete to one of the values below:
-	 * - `true`: if checklist has been completed on current session (prevents displaying the notice on page load).
-	 * - `false`: if checklist is complete on page load.
-	 * - `undefined`: if checklist has not been completed yet.
-	 */
-	const maybeShowSiteSetupComplete = () => {
-		if ( null === isChecklistComplete || false === showSiteSetupComplete ) {
-			return;
-		}
-
-		if ( null === showSiteSetupComplete ) {
-			setShowSiteSetupComplete( isChecklistComplete ? false : undefined );
-			return;
-		}
-
-		if ( isChecklistComplete ) {
-			setShowSiteSetupComplete( true );
-		}
-	};
-
-	useEffect( () => {
-		maybeShowSiteSetupComplete();
-	}, [ isChecklistComplete, showSiteSetupComplete ] );
-
-	// Show a thank-you message 30 mins post site creation/purchase
-	if (
-		isNewlyCreatedSite &&
-		! isRecentlyMigratedSite &&
-		displayChecklist &&
-		'launched' !== checklistMode
-	) {
-		if ( siteIsUnlaunched || isAtomic ) {
-			//Only show pre-launch, or for Atomic sites
-			return (
-				<CelebrateSiteCreation
-					displayChecklist={ displayChecklist }
-					checklistMode={ checklistMode }
-				/>
-			);
-		}
-	}
-
-	if ( isRecentlyMigratedSite ) {
-		return (
-			<CelebrateSiteMigration
-				displayChecklist={ displayChecklist }
-				checklistMode={ checklistMode }
-			/>
-		);
-	}
-
-	if ( ! siteIsUnlaunched && 'launched' === checklistMode ) {
-		return (
-			<CelebrateSiteLaunch displayChecklist={ displayChecklist } checklistMode={ checklistMode } />
-		);
-	}
-
-	if ( showSiteSetupComplete && ! isRecentlyMigratedSite ) {
-		return <CelebrateSiteSetupComplete displayChecklist={ displayChecklist } />;
-	}
-
-	return null;
+const cardComponents = {
+	'home-notice-celebrate-site-creation': CelebrateSiteCreation,
+	'home-notice-celebrate-site-launch': CelebrateSiteLaunch,
+	'home-notice-celebrate-site-migration': CelebrateSiteMigration,
+	'home-notice-celebrate-site-setup-complete': CelebrateSiteSetupComplete,
 };
 
-const mapStateToProps = state => {
-	const siteId = getSelectedSiteId( state );
-
-	const siteChecklist = getSiteChecklist( state, siteId );
-	const hasChecklistData = null !== siteChecklist && Array.isArray( siteChecklist.tasks );
-	const isChecklistComplete = isSiteChecklistComplete( state, siteId );
-
-	return {
-		displayChecklist:
-			isEligibleForDotcomChecklist( state, siteId ) && hasChecklistData && ! isChecklistComplete,
-		isAtomic: isAtomicSite( state, siteId ),
-		isChecklistComplete,
-		isNewlyCreatedSite: isNewSite( state, siteId ),
-		isRecentlyMigratedSite: isSiteRecentlyMigrated( state, siteId ),
-		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
-	};
+const Notices = ( { checklistMode, cards } ) => {
+	return (
+		<>
+			{ cards &&
+				cards.map(
+					( card, index ) =>
+						cardComponents[ card ] &&
+						React.createElement( cardComponents[ card ], {
+							key: index,
+							checklistMode,
+						} )
+				) }
+		</>
+	);
 };
 
-export default connect( mapStateToProps )( Notices );
+export default Notices;

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -89,17 +89,21 @@ const Home = ( {
 					</div>
 				) }
 			</div>
-			{ layout && <Notices cards={ layout.notices } checklistMode={ checklistMode } /> }
-			{ layout && <Upsells cards={ layout.upsells } /> }
-			{ hasChecklistData && layout ? (
-				<div className="customer-home__layout">
-					<div className="customer-home__layout-col customer-home__layout-col-left">
-						<Primary cards={ layout.primary } checklistMode={ checklistMode } />
-					</div>
-					<div className="customer-home__layout-col customer-home__layout-col-right">
-						<Secondary cards={ layout.secondary } />
-					</div>
-				</div>
+			{ layout ? (
+				<>
+					<Notices cards={ layout.notices } checklistMode={ checklistMode } />
+					<Upsells cards={ layout.upsells } />
+					{ hasChecklistData && (
+						<div className="customer-home__layout">
+							<div className="customer-home__layout-col customer-home__layout-col-left">
+								<Primary cards={ layout.primary } checklistMode={ checklistMode } />
+							</div>
+							<div className="customer-home__layout-col customer-home__layout-col-right">
+								<Secondary cards={ layout.secondary } />
+							</div>
+						</div>
+					) }
+				</>
 			) : (
 				<div className="customer-home__loading-placeholder"></div>
 			) }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -89,7 +89,7 @@ const Home = ( {
 					</div>
 				) }
 			</div>
-			<Notices checklistMode={ checklistMode } />
+			{ layout && <Notices cards={ layout.notices } checklistMode={ checklistMode } /> }
 			{ layout && <Upsells cards={ layout.upsells } /> }
 			{ hasChecklistData && layout ? (
 				<div className="customer-home__layout">


### PR DESCRIPTION
In #40172 we wired in the Home layout API; this PR uses those results to determine which cards to render in the `notices` location. No visual or functional changes should happen between this PR and production.

**Testing Instructions**
* On this branch, create a brand-new site and verify the "Your site has been created!" notice is displayed (once you've landed on `/home/:site`).
* Launch the site, and verify the "You launched your site!" notice is displayed.
* Complete the checklist, and verify the "You've completed each item in your checklist" notice is displayed.
* Go to Tools > Import, select "WordPress", and proceed to import everything from a Jetpack site (create a new Jurassic Ninja site if needed; you'll also need to upgrade the destination site's plan).
* Verify the "Your site has been imported!" notice is displayed.
