### PR TITLE
Gutenboarding: pass theme and vertical slugs to sites/new 

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -52,6 +52,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 			.map( x => ( {
 				label: x.vertical_name,
 				id: x.vertical_id,
+				slug: x.vertical_slug,
 			} ) )
 	);
 

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -82,11 +82,16 @@ export function* createSite(
 		options: {
 			site_vertical: siteVertical?.id,
 			site_vertical_name: siteVertical?.label,
+			// untranslated vertical slug
+			// so we can match directories in
+			// https://github.com/Automattic/wp-calypso/tree/master/static/page-templates/verticals
+			// TODO: determine default vertical should user input match no official vertical
+			site_vertical_slug: siteVertical?.slug || 'football',
 			site_information: {
 				title: siteTitle,
 			},
 			site_creation_flow: 'gutenboarding',
-			theme: `pub/${ selectedDesign?.slug || 'twentytwenty' }`,
+			theme: `pub/${ selectedDesign?.theme || 'twentytwenty' }`,
 			timezone_string: guessTimezone(),
 			template: selectedDesign?.slug || 'twentytwenty',
 			...( selectedFonts && {

--- a/client/landing/gutenboarding/stores/onboard/types.ts
+++ b/client/landing/gutenboarding/stores/onboard/types.ts
@@ -8,6 +8,14 @@ export interface SiteVertical {
 	label: string;
 
 	/**
+	 * Untranslated Vertical Label. Obtained from WP.com.
+	 *
+	 * @example
+	 * Christmas Tree Farm
+	 */
+	slug?: string;
+
+	/**
 	 * Vertical ID. Can be undefined for user-specified verticals that don't exist in WP.com's curated list.
 	 *
 	 * @example

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -36,6 +36,7 @@ export interface CreateSiteParams {
 	options?: {
 		site_vertical?: string;
 		site_vertical_name?: string;
+		site_vertical_slug?: string;
 		site_information?: {
 			title?: string;
 		};

--- a/packages/data-stores/src/verticals/types.ts
+++ b/packages/data-stores/src/verticals/types.ts
@@ -3,7 +3,6 @@
  */
 export interface Vertical {
 	is_user_input_vertical: false;
-
 	vertical_id: string;
 	vertical_slug: string;
 	vertical_name: string;


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR introduced two changes:

1. Sends the correct theme name to the `sites/new` endpoint as defined in [available-designs.json](https://github.com/Automattic/wp-calypso/blob/0413b99/client/landing/gutenboarding/available-designs.json)

So, after creating a site, instead of this:
<img width="961" alt="Screen Shot 2020-04-01 at 10 52 18 am" src="https://user-images.githubusercontent.com/6458278/78085500-e2af8180-7406-11ea-841c-18bd45743f81.png">

We'll see this:
<img width="1271" alt="Screen Shot 2020-04-01 at 10 49 37 am" src="https://user-images.githubusercontent.com/6458278/78085494-e04d2780-7406-11ea-8ed5-51ce3c8a9913.png">


2. Passes `site_vertical_slug` to the `sites/new` endpoint in options. 

`site_vertical_slug` is the untranslated version of the site vertical name. 

We need the site vertical slug because the template mill pulls files from [/static/page-templates/verticals](https://github.com/Automattic/wp-calypso/tree/master/static/page-templates/verticals), in which there are directories labelled in English. 

If we use the vertical name, there is the possibility it might be translated and therefore won't build the correct path. Some context over at D40501-code

(Also removed a teensy bit of whitespace in the Vertical interface. Yay.)

## Testing instructions

Hop over to `/gutenboarding` and create a site!

The site you create should have the correct theme.


