### PR TITLE
My Home: Display upsells according to the Home API.

### DIFF
--- a/client/my-sites/customer-home/locations/upsells/index.jsx
+++ b/client/my-sites/customer-home/locations/upsells/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import moment from 'moment';
 import React from 'react';
 import { connect } from 'react-redux';
 
@@ -10,41 +9,45 @@ import { connect } from 'react-redux';
  */
 import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { getSiteOption } from 'state/sites/selectors';
 import StatsBanners from 'my-sites/stats/stats-banners';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
-const Upsells = ( {
-	isChecklistComplete,
-	isEstablishedSite,
-	siteId,
-	siteIsUnlaunched,
-	siteSlug,
-} ) => {
+const cardComponents = {
+	'home-banner-legacy-stats-banners': StatsBanners,
+};
+
+const Upsells = ( { cards, primary, siteId, slug } ) => {
+	const componentProps = {
+		primary,
+		siteId,
+		slug,
+	};
 	return (
 		<>
-			{ // Only show upgrade nudges to sites > 2 days old
-			isEstablishedSite && (
-				<StatsBanners
-					siteId={ siteId }
-					slug={ siteSlug }
-					primaryButton={ isChecklistComplete && ! siteIsUnlaunched }
-				/>
-			) }
+			{ cards &&
+				cards.map(
+					( card, index ) =>
+						cardComponents[ card ] &&
+						React.createElement(
+							cardComponents[ card ],
+							card === 'home-banner-legacy-stats-banners'
+								? { key: index, ...componentProps }
+								: { key: index }
+						)
+				) }
 		</>
 	);
 };
 
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
-	const createdAt = getSiteOption( state, siteId, 'created_at' );
+	const isChecklistComplete = isSiteChecklistComplete( state, siteId );
+	const siteIsUnlaunched = isUnlaunchedSite( state, siteId );
 
 	return {
-		isChecklistComplete: isSiteChecklistComplete( state, siteId ),
-		isEstablishedSite: moment().isAfter( moment( createdAt ).add( 2, 'days' ) ),
+		primaryButton: isChecklistComplete && ! siteIsUnlaunched,
 		siteId,
-		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
-		siteSlug: getSelectedSiteSlug( state ),
+		slug: getSelectedSiteSlug( state ),
 	};
 };
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -85,7 +85,7 @@ const Home = ( {
 				) }
 			</div>
 			<Notices checklistMode={ checklistMode } />
-			<Upsells />
+			{ layout && <Upsells cards={ layout.upsells } /> }
 			{ hasChecklistData && layout ? (
 				<div className="customer-home__layout">
 					<div className="customer-home__layout-col customer-home__layout-col-left">


### PR DESCRIPTION
This PR uses the results from the Home layout API to determine cards to display in the `upsells` location. Because the only card at the moment is a legacy stats component requiring a bunch of props, I'm not even convinced this PR is worth the effort – others can decide 🙃

<img width="1269" alt="Screen Shot 2020-03-31 at 5 37 20 PM" src="https://user-images.githubusercontent.com/349751/78087584-5eadb900-7376-11ea-991e-e137c6fc21ce.png">


**Testing Instructions**
* On this branch, go to a business site older than two days (that has not already dismissed the banner).
* Verify the banner displays.