### PR TITLE
Gutenboarding: Add gutenboarding styling to 2fa login screens

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -147,6 +147,7 @@ class Login extends Component {
 				login( {
 					isNative: true,
 					isJetpack: this.props.isJetpack,
+					isGutenboarding: this.props.isGutenboarding,
 					// If no notification is sent, the user is using the authenticator for 2FA by default
 					twoFactorAuthType: defaultAuthType,
 				} )
@@ -420,6 +421,7 @@ class Login extends Component {
 					{ poller }
 					<VerificationCodeForm
 						isJetpack={ isJetpack }
+						isGutenboarding={ isGutenboarding }
 						onSuccess={ this.handleValid2FACode }
 						twoFactorAuthType={ twoFactorAuthType }
 					/>
@@ -431,7 +433,10 @@ class Login extends Component {
 			return (
 				<div>
 					{ poller }
-					<WaitingTwoFactorNotificationApproval isJetpack={ isJetpack } />
+					<WaitingTwoFactorNotificationApproval
+						isJetpack={ isJetpack }
+						isGutenboarding={ isGutenboarding }
+					/>
 				</div>
 			);
 		}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -113,7 +113,7 @@ export class LoginForm extends Component {
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { disableAutoFocus, isJetpack } = this.props;
+		const { disableAutoFocus, isJetpack, isGutenboarding } = this.props;
 
 		if (
 			this.props.socialAccountIsLinking !== nextProps.socialAccountIsLinking &&
@@ -139,7 +139,7 @@ export class LoginForm extends Component {
 				loginFormFlow: true,
 			} );
 
-			page( login( { isNative: true, twoFactorAuthType: 'link', isJetpack } ) );
+			page( login( { isNative: true, twoFactorAuthType: 'link', isJetpack, isGutenboarding } ) );
 		}
 	}
 

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -28,6 +28,7 @@ class TwoFactorActions extends Component {
 		isAuthenticatorSupported: PropTypes.bool.isRequired,
 		isSecurityKeySupported: PropTypes.bool.isRequired,
 		isJetpack: PropTypes.bool,
+		isGutenboarding: PropTypes.bool,
 		isSmsSupported: PropTypes.bool.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		sendSmsCode: PropTypes.func.isRequired,
@@ -40,7 +41,14 @@ class TwoFactorActions extends Component {
 
 		this.props.recordTracksEvent( 'calypso_login_two_factor_switch_to_sms_link_click' );
 
-		page( login( { isNative: true, twoFactorAuthType: 'sms', isJetpack: this.props.isJetpack } ) );
+		page(
+			login( {
+				isNative: true,
+				twoFactorAuthType: 'sms',
+				isJetpack: this.props.isJetpack,
+				isGutenboarding: this.props.isGutenboarding,
+			} )
+		);
 
 		this.props.sendSmsCode();
 	};
@@ -55,6 +63,7 @@ class TwoFactorActions extends Component {
 				isNative: true,
 				twoFactorAuthType: 'authenticator',
 				isJetpack: this.props.isJetpack,
+				isGutenboarding: this.props.isGutenboarding,
 			} )
 		);
 	};

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -35,6 +35,7 @@ class VerificationCodeForm extends Component {
 	static propTypes = {
 		formUpdate: PropTypes.func.isRequired,
 		isJetpack: PropTypes.bool,
+		isGutenboarding: PropTypes.bool,
 		loginUserWithTwoFactorVerificationCode: PropTypes.func.isRequired,
 		onSuccess: PropTypes.func.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
@@ -116,6 +117,7 @@ class VerificationCodeForm extends Component {
 	render() {
 		const {
 			isJetpack,
+			isGutenboarding,
 			translate,
 			twoFactorAuthRequestError: requestError,
 			twoFactorAuthType,
@@ -175,7 +177,11 @@ class VerificationCodeForm extends Component {
 					{ smallPrint }
 				</Card>
 
-				<TwoFactorActions twoFactorAuthType={ twoFactorAuthType } isJetpack={ isJetpack } />
+				<TwoFactorActions
+					twoFactorAuthType={ twoFactorAuthType }
+					isJetpack={ isJetpack }
+					isGutenboarding={ isGutenboarding }
+				/>
 			</form>
 		);
 	}

--- a/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
+++ b/client/blocks/login/two-factor-authentication/waiting-notification-approval.jsx
@@ -17,7 +17,7 @@ import Divider from '../divider';
  */
 import './waiting-notification-approval.scss';
 
-export default function WaitingTwoFactorNotificationApproval( { isJetpack } ) {
+export default function WaitingTwoFactorNotificationApproval( { isJetpack, isGutenboarding } ) {
 	const translate = useTranslate();
 
 	return (
@@ -32,7 +32,11 @@ export default function WaitingTwoFactorNotificationApproval( { isJetpack } ) {
 				<PushNotificationIllustration />
 			</Card>
 			<Divider>{ translate( 'or' ) }</Divider>
-			<TwoFactorActions twoFactorAuthType="push" isJetpack={ isJetpack } />
+			<TwoFactorActions
+				twoFactorAuthType="push"
+				isJetpack={ isJetpack }
+				isGutenboarding={ isGutenboarding }
+			/>
 		</Fragment>
 	);
 }

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -31,6 +31,8 @@ export function login( {
 			url += '/' + socialService + '/callback';
 		} else if ( twoFactorAuthType && isJetpack ) {
 			url += '/jetpack/' + twoFactorAuthType;
+		} else if ( twoFactorAuthType && isGutenboarding ) {
+			url += '/gutenboarding/' + twoFactorAuthType;
 		} else if ( twoFactorAuthType ) {
 			url += '/' + twoFactorAuthType;
 		} else if ( socialConnect ) {

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -72,6 +72,7 @@ export default router => {
 				`/log-in/:isJetpack(jetpack)/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 				`/log-in/:isGutenboarding(gutenboarding)/${ lang }`,
+				`/log-in/:isGutenboarding(gutenboarding)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 				`/log-in/${ lang }`,
 			],
 			redirectJetpack,

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -55,7 +55,13 @@ export class LoginLinks extends React.Component {
 
 		this.props.recordTracksEvent( 'calypso_login_lost_phone_link_click' );
 
-		page( login( { isNative: true, twoFactorAuthType: 'backup' } ) );
+		page(
+			login( {
+				isNative: true,
+				twoFactorAuthType: 'backup',
+				isGutenboarding: this.props.isGutenboarding,
+			} )
+		);
 	};
 
 	handleMagicLoginLinkClick = event => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds gutenboarding theming to the 2fa screens of log in.
Works in a similar way to Jetpack's theming of these screens.

* Add gutenboarding styling to login screens for:
  * SMS
  * 3rd party authenticator app
  * Push (using the WordPress app)
  * Backup codes

Builds on styling already shipped in #40557 

Doesn't including theming of magic link login screens. That'll be in another PR.

Known issue:
- The locale isn't persisted between some of the login screens (e.g. navigating from entering password to entering SMS code), but this is also broken in production #23126. I think we should fix this in another PR.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/log-in/gutenboarding`
* Log in using accounts with various sorts of 2nd factor options
* Test that you can navigate between different auth types while keeping the gutenboarding theming e.g. authenticate with SMS, but say you've lost your phone, but then say you've found your phone again.
* Go to `/gutenboarding` and create a site, and choose to log in with an existing account. Verify that after going to `/log-in/gutenboarding` you are redirected back to gutenboarding.

I've also tried logging in using an account that users `webauthn`, but that option doesn't seem to appear when testing. Maybe it only works on whitelisted domains 🤷‍♂ 
