### PR TITLE
Plan step: Update "WordPress powers .." percentage to 35%

### DIFF
--- a/client/my-sites/plan-testimonials/index.jsx
+++ b/client/my-sites/plan-testimonials/index.jsx
@@ -18,7 +18,7 @@ export class PlanTestimonials extends Component {
 				</div>
 				<div className="plan-testimonials__content-right-container">
 					<div className="plan-testimonials__content-right">
-						Did you know that WordPress powers 36% of the entire internet? WordPress.com is the best
+						Did you know that WordPress powers 35% of the entire internet? WordPress.com is the best
 						WordPress solution out there, as trusted by:
 					</div>
 					<div className="plan-testimonials__content-testimonial-image"></div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We're updating the WordPress powers % value to 35% in D41195-code. This PR implements the same change in the plans step

<img width="1021" alt="Screenshot 2020-04-01 at 1 19 46 PM" src="https://user-images.githubusercontent.com/1269602/78112237-93278080-741b-11ea-8d1c-a441e7142328.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow and assign yourself to the variant of `planStepCopyUpdates` test.
* Verify that the % value is 35%

