### PR TITLE
Gutenboarding: Fix gutenboarding theme'd login page for local development

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -346,7 +346,7 @@ class Login extends Component {
 
 		if ( isGutenboarding ) {
 			preHeader = (
-				<div class="login__form-gutenboarding-wordpress-logo">
+				<div className="login__form-gutenboarding-wordpress-logo">
 					<svg
 						aria-hidden="true"
 						role="img"

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -473,7 +473,7 @@ export class LoginForm extends Component {
 		}
 
 		if ( isGutenboarding ) {
-			signupUrl = window.location.origin + '/gutenboarding' + langFragment;
+			signupUrl = '/gutenboarding' + langFragment;
 		}
 
 		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -292,7 +292,7 @@ export class LoginLinks extends React.Component {
 		}
 
 		if ( isGutenboarding ) {
-			signupUrl = window.location.origin + '/gutenboarding' + langFragment;
+			signupUrl = '/gutenboarding' + langFragment;
 		}
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I broke the gutenboarding theme'd login page (at `/log-in/gutenboarding`) when doing local development. Seems like it's only broken when the route _doesn't_ include a locale parameter.

A couple of components on the login page are server-side rendered, but I added a reference to `window`.

* Removes reference to `window` in `<LoginForm>` so it can still be SSR'd
* Removes reference to `window` in `<LoginLinks>` so it can still be SSR'd
* Fixed React warning about `class` vs. `className` while I was on that page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* `calypso.localhost:3000/log-in/gutenboarding` should load now
* `calypso.localhost:3000/log-in/gutenboarding/ja` still works

