### PR TITLE
Revert "Sidebar: Add Notification Dot "

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -20,7 +20,7 @@ export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
 	const showAsExternal = isExternalLink && ! props.forceInternalLink;
 	const classes = classnames( props.className, { selected: props.selected } );
-	const { materialIcon, materialIconStyle, icon, customIcon, showNotificationDot } = props;
+	const { materialIcon, materialIconStyle, icon, customIcon } = props;
 
 	let _preloaded = false;
 
@@ -69,7 +69,6 @@ export default function SidebarItem( props ) {
 				</span>
 				{ showAsExternal && <Gridicon icon="external" size={ 24 } /> }
 				{ props.children }
-				{ showNotificationDot && <div className="sidebar__menu-notification-dot"></div> }
 			</a>
 		</li>
 	);
@@ -87,7 +86,6 @@ SidebarItem.propTypes = {
 	selected: PropTypes.bool,
 	expandSection: PropTypes.func,
 	preloadSectionName: PropTypes.string,
-	showNotificationDot: PropTypes.bool,
 	forceInternalLink: PropTypes.bool,
 	testTarget: PropTypes.string,
 	tipTarget: PropTypes.string,

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -146,14 +146,6 @@
 	}
 }
 
-.sidebar__menu-notification-dot {
-	background-color: var( --color-accent );
-	border: 1px solid var( --color-surface );
-	border-radius: 50px;
-	margin-left: 8px;
-	padding: 4px;
-}
-
 // Expandables: Some sidebar menus act like accordions where
 // you can hide and show the contained list.
 .sidebar__menu.is-togglable {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#40259.

We finally decided to use the existing notifications panel rather than adding a dot to the sidebar, so this work won't be needed. See https://github.com/Automattic/wp-calypso/issues/40233#issuecomment-607102594.