### PR TITLE
Underline start-over button

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -18,6 +18,7 @@
 
 	.design-selector__start-over-button {
 		&.is-link {
+			text-decoration: underline;
 			color: var( --color-text-subtle );
 		}
 	}


### PR DESCRIPTION
_10 seconds review._

Underline start-over button on Gutenboarding styles page.

See point 1 of https://github.com/Automattic/wp-calypso/issues/40394.