### PR TITLE
Gutenboarding: Improve acquire intent UI and experience

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -1,19 +1,19 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
+import classnames from 'classnames';
+import { useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import VerticalSelect from './vertical-select';
-import SiteTitle from './site-title';
 import { Step, usePath } from '../../path';
 import Link from '../../components/link';
-
+import VerticalSelect from './vertical-select';
+import SiteTitle from './site-title';
 import './style.scss';
 
 const AcquireIntent: FunctionComponent = () => {
@@ -25,19 +25,22 @@ const AcquireIntent: FunctionComponent = () => {
 		<div className="acquire-intent">
 			<div className="acquire-intent__questions">
 				<VerticalSelect />
-				{ ( siteVertical || siteTitle ) && <SiteTitle /> }
-				{ siteVertical && (
-					<div className="acquire-intent__footer">
-						<Link
-							className="acquire-intent__question-skip"
-							isPrimary
-							to={ makePath( Step.DesignSelection ) }
-						>
-							{ /* @TODO: add transitions and correct action */ }
-							{ siteTitle ? NO__( 'Choose a design' ) : NO__( 'Donʼt know yet' ) }
-						</Link>
-					</div>
-				) }
+				{ /* We are rendering everything to keep the content vertically centered on desktop while preventing jumping */ }
+				<SiteTitle isVisible={ !! ( siteVertical || siteTitle ) } />
+				<div
+					className={ classnames( 'acquire-intent__footer', {
+						'acquire-intent__footer--hidden': ! siteVertical,
+					} ) }
+				>
+					<Link
+						className="acquire-intent__question-skip"
+						isPrimary
+						to={ siteVertical && makePath( Step.DesignSelection ) }
+					>
+						{ /* @TODO: add transitions and correct action */ }
+						{ siteTitle ? NO__( 'Choose a design' ) : NO__( 'Donʼt know yet' ) }
+					</Link>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useSelect } from '@wordpress/data';
-import React, { FunctionComponent, createRef, useState, useEffect } from 'react';
+import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
@@ -20,25 +20,12 @@ const AcquireIntent: FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 	const makePath = usePath();
-	const siteTitleRef = createRef< HTMLInputElement >();
-
-	const [ siteTitleActive, setSiteTitleActive ] = useState( false );
-
-	useEffect( () => {
-		if ( siteTitleActive ) {
-			siteTitleRef.current?.focus();
-		}
-	}, [ siteTitleActive, siteTitleRef ] );
-
-	const handleVerticalSubmit = () => {
-		setSiteTitleActive( true );
-	};
 
 	return (
 		<div className="acquire-intent">
 			<div className="acquire-intent__questions">
-				<VerticalSelect onSubmit={ handleVerticalSubmit } />
-				{ ( siteVertical || siteTitle ) && <SiteTitle inputRef={ siteTitleRef } /> }
+				<VerticalSelect />
+				{ ( siteVertical || siteTitle ) && <SiteTitle /> }
 				{ siteVertical && (
 					<div className="acquire-intent__footer">
 						<Link

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { __experimentalCreateInterpolateElement } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
+import { __experimentalCreateInterpolateElement } from '@wordpress/element';
+import { ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -13,46 +14,57 @@ import { useI18n } from '@automattic/react-i18n';
 import { STORE_KEY } from '../../stores/onboard';
 import { Step, usePath } from '../../path';
 
-interface Props {
-	inputRef: React.RefObject< HTMLInputElement >;
-}
-const SiteTitle: React.FunctionComponent< Props > = ( { inputRef } ) => {
+const SiteTitle: React.FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
-	const { siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
+	const { siteTitle, siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
 	const history = useHistory();
 	const makePath = usePath();
+	const inputRef = React.useRef< HTMLSpanElement >( document.createElement( 'span' ) );
 
-	const handleChange = ( e: React.ChangeEvent< HTMLInputElement > ) =>
-		setSiteTitle( e.target.value.trim().length ? e.target.value : '' );
+	const handleKeyDown = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
+		if ( e.keyCode === ENTER ) {
+			// As last input on first step, hitting 'Enter' should direct to next step.
+			e.preventDefault();
+			history.push( makePath( Step.DesignSelection ) );
+		}
+	};
 
-	const value = siteTitle.length ? siteTitle : '';
+	const handleKeyUp = ( e: React.KeyboardEvent< HTMLSpanElement > ) =>
+		setSiteTitle( e.currentTarget.innerText.trim().length ? e.currentTarget.innerText : '' );
+
+	React.useEffect( () => {
+		if ( siteTitle ) {
+			inputRef.current.innerText = siteTitle;
+		}
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	React.useEffect( () => {
+		if ( siteVertical?.label ) {
+			inputRef.current.focus();
+		}
+	}, [ siteVertical, inputRef ] );
 
 	// translators: Form input for a site's title where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = NO__( 'Itʼs called <Input />' );
 	const madlib = __experimentalCreateInterpolateElement( madlibTemplate, {
 		Input: (
-			<input
+			<span
+				contentEditable
+				tabIndex={ 0 }
+				role="textbox"
+				aria-multiline="true"
+				spellCheck={ false }
 				ref={ inputRef }
 				/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
 				className="madlib__input"
-				autoComplete="off"
-				style={ {
-					width: `${ value.length * 0.85 }ch`,
-				} }
-				onChange={ handleChange }
-				value={ value }
+				onKeyDown={ handleKeyDown }
+				onKeyUp={ handleKeyUp }
 			/>
 		),
 	} );
 
-	// As last input on first step, hitting 'Enter' should direct to next step.
-	const handleSubmit = ( e: React.FormEvent< HTMLFormElement > ) => {
-		e.preventDefault();
-		history.push( makePath( Step.DesignSelection ) );
-	};
-
-	return <form onSubmit={ handleSubmit }>{ madlib }</form>;
+	return <form>{ madlib }</form>;
 };
 
 export default SiteTitle;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -64,7 +65,11 @@ const SiteTitle: React.FunctionComponent = () => {
 		),
 	} );
 
-	return <form>{ madlib }</form>;
+	return (
+		<form className={ classnames( { 'site-title--without-value': ! siteTitle.length } ) }>
+			{ madlib }
+		</form>
+	);
 };
 
 export default SiteTitle;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -3,11 +3,11 @@
  */
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import classnames from 'classnames';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -15,7 +15,11 @@ import classnames from 'classnames';
 import { STORE_KEY } from '../../stores/onboard';
 import { Step, usePath } from '../../path';
 
-const SiteTitle: React.FunctionComponent = () => {
+interface Props {
+	isVisible: boolean;
+}
+
+const SiteTitle: React.FunctionComponent< Props > = ( { isVisible } ) => {
 	const { __: NO__ } = useI18n();
 	const { siteTitle, siteVertical } = useSelect( select => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
@@ -66,7 +70,12 @@ const SiteTitle: React.FunctionComponent = () => {
 	} );
 
 	return (
-		<form className={ classnames( { 'site-title--without-value': ! siteTitle.length } ) }>
+		<form
+			className={ classnames( 'site-title', {
+				'site-title--without-value': ! siteTitle.length,
+				'site-title--hidden': ! isVisible,
+			} ) }
+		>
 			{ madlib }
 		</form>
 	);

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -2,8 +2,8 @@
 @import '../../mixins';
 @import '../../variables.scss';
 
-$acquire-intent-vertical-transition-duration: 200ms;
-$acquire-intent-vertical-transition-algorithm: ease-in-out;
+$acquire-intent-transition-duration: 200ms;
+$acquire-intent-transition-algorithm: ease-in-out;
 
 .acquire-intent {
 	@include onboarding-font-recoleta;
@@ -17,15 +17,24 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 	width: 100%;
 	min-height: calc( 100vh - #{$gutenboarding-header-height} );
 	padding: 20px;
-	transition: color $acquire-intent-vertical-transition-duration
-			$acquire-intent-vertical-transition-algorithm,
-		background-color $acquire-intent-vertical-transition-duration
-			$acquire-intent-vertical-transition-algorithm;
+	transition: color $acquire-intent-transition-duration
+			$acquire-intent-transition-algorithm,
+		background-color $acquire-intent-transition-duration
+			$acquire-intent-transition-algorithm;
 
 	@include break-small {
 		display: flex;
 		align-items: center;
 		padding: 0 120px;
+	}
+}
+
+.acquire-intent__footer {
+	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+
+	&--hidden {
+		opacity: 0;
+		visibility: hidden;
 	}
 }
 
@@ -41,9 +50,9 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 	color: var( --mainColor );
 	border-bottom: 2px solid var( --mainColor );
 
-	transition: border-bottom $acquire-intent-vertical-transition-duration
-			$acquire-intent-vertical-transition-algorithm,
-		color $acquire-intent-vertical-transition-duration $acquire-intent-vertical-transition-algorithm;
+	transition: border-bottom $acquire-intent-transition-duration
+			$acquire-intent-transition-algorithm,
+		color $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 
 	&:focus {
 		outline: none;
@@ -66,11 +75,11 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 	font-weight: 500;
 	padding: 20px 32px;
 	// @TODO: work out hover-state animations
-	transition: background $acquire-intent-vertical-transition-duration
-			$acquire-intent-vertical-transition-algorithm,
-		border-color $acquire-intent-vertical-transition-duration
-			$acquire-intent-vertical-transition-algorithm,
-		color $acquire-intent-vertical-transition-duration $acquire-intent-vertical-transition-algorithm;
+	transition: background $acquire-intent-transition-duration
+			$acquire-intent-transition-algorithm,
+		border-color $acquire-intent-transition-duration
+			$acquire-intent-transition-algorithm,
+		color $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 
 	&:active,
 	&:hover,
@@ -83,11 +92,20 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 	}
 }
 
-.site-title--without-value {
-	.madlib__input {
-		width: 200px;
-		display: inline-block;
-		vertical-align: middle;
-    	border: none;
+.site-title {
+	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+
+	&--without-value {
+		.madlib__input {
+			width: 200px;
+			display: inline-block;
+			vertical-align: middle;
+			border: none;
+		}
+	}
+
+	&--hidden {
+		visibility: hidden;
+		opacity: 0;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -33,8 +33,8 @@ $acquire-intent-transition-algorithm: ease-in-out;
 	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 
 	&--hidden {
+		// use this to fade-in the footer; since the buttons are disabled we don't need to hide them
 		opacity: 0;
-		visibility: hidden;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -37,10 +37,9 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 	line-height: 1em;
 	height: 1.01em;
 	padding: 0;
-	min-width: 400px;
 
 	color: var( --mainColor );
-	border-bottom: 3px solid var( --mainColor );
+	border-bottom: 2px solid var( --mainColor );
 
 	transition: border-bottom $acquire-intent-vertical-transition-duration
 			$acquire-intent-vertical-transition-algorithm,
@@ -81,5 +80,14 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 		color: var( --contrastColor );
 		outline-color: transparent;
 		box-shadow: none;
+	}
+}
+
+.site-title--without-value {
+	.madlib__input {
+		width: 200px;
+		display: inline-block;
+		vertical-align: middle;
+    	border: none;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -34,7 +34,7 @@ $acquire-intent-vertical-transition-algorithm: ease-in-out;
 	background: transparent;
 	border: none;
 	font-size: inherit;
-	line-height: inherit;
+	line-height: 1em;
 	height: 1.01em;
 	padding: 0;
 	min-width: 400px;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -27,10 +27,7 @@ type Suggestion = SiteVertical & { category?: string };
 
 const VERTICALS_STORE = Verticals.register();
 
-interface Props {
-	onSubmit: () => void;
-}
-const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
+const VerticalSelect: React.FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const inputRef = React.useRef< HTMLSpanElement >( document.createElement( 'span' ) );
 	const [ isFocused, setIsFocused ] = React.useState< boolean >( false );
@@ -112,7 +109,6 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const handleSelect = ( vertical: SiteVertical ) => {
 		setSiteVertical( vertical );
 		setIsFocused( false ); // prevent executing handleBlur()
-		onSubmit();
 	};
 
 	const handleBlur = () => {
@@ -159,18 +155,18 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		Input: (
 			<span className="vertical-select__suggestions-wrapper">
 				<span
+					contentEditable
+					tabIndex={ 0 }
 					role="textbox"
 					aria-multiline="true"
-					tabIndex={ 0 }
-					contentEditable
+					spellCheck={ false }
 					ref={ inputRef }
 					/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
 					className="madlib__input"
-					onBlur={ handleBlur }
-					onFocus={ () => setIsFocused( true ) }
 					onKeyDown={ handleInputKeyDownEvent }
 					onKeyUp={ handleInputKeyUpEvent }
-					spellCheck={ false }
+					onFocus={ () => setIsFocused( true ) }
+					onBlur={ handleBlur }
 				/>
 				{ isInputEmpty && (
 					<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -123,7 +123,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		}
 		if ( e.keyCode === ENTER ) {
 			e.preventDefault();
-			input.length && handleSelect( { label: input } );
+			input.length && ! suggestions.length && handleSelect( { label: input } );
 			return;
 		}
 		if ( e.keyCode === TAB ) {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -115,6 +115,16 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		onSubmit();
 	};
 
+	const handleBlur = () => {
+		const lastQuery = inputText.trim();
+		if ( isFocused && lastQuery.length ) {
+			const vertical = suggestions.find( ( { label } ) =>
+				label.toLowerCase().includes( lastQuery )
+			) ?? { label: lastQuery, id: '', slug: '' };
+			handleSelect( vertical );
+		}
+	};
+
 	const handleInputKeyDownEvent = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
 		const input = e.currentTarget.innerText.trim();
 
@@ -128,23 +138,13 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		}
 		if ( e.keyCode === TAB ) {
 			e.preventDefault();
+			handleBlur();
 		}
-	};
-
-	const handleBlur = () => {
-		// if ( isFocused ) {
-		// 	const vertical = suggestions.find( ( { label } ) =>
-		// 		label.toLowerCase().includes( normalizedInputValue )
-		// 	) ?? { label: inputValue.trim() };
-		// 	handleSelect( vertical );
-		// }
 	};
 
 	React.useEffect( () => {
 		if ( isInputEmpty ) {
-			inputRef?.current?.focus();
-		} else {
-			inputRef.current.innerText = siteVertical?.label || '';
+			inputRef.current.focus();
 		}
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -60,7 +60,9 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const { siteVertical, siteTitle } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { setSiteVertical, resetSiteVertical } = useDispatch( ONBOARD_STORE );
 
-	const isInputEmpty = ! inputRef?.current?.innerText.length;
+	const inputText = inputRef?.current?.innerText || '';
+	const isInputEmpty = ! inputText.length;
+	const showResults = inputText.length > 2;
 
 	const animatedPlaceholder = useTyper(
 		[ NO__( 'football' ), NO__( 'shopping' ), NO__( 'cars' ), NO__( 'design' ), NO__( 'travel' ) ],
@@ -103,9 +105,8 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		const input = e.currentTarget.innerText.trim();
 		if ( ! input.length ) {
 			resetSiteVertical();
-		} else {
-			updateSuggestions( input );
 		}
+		updateSuggestions( input );
 	};
 
 	const handleSelect = ( vertical: SiteVertical ) => {
@@ -120,9 +121,9 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		if ( suggestionRef.current ) {
 			suggestionRef.current.handleKeyEvent( e );
 		}
-		if ( e.keyCode === ENTER && input.length ) {
+		if ( e.keyCode === ENTER ) {
 			e.preventDefault();
-			handleSelect( { label: input } );
+			input.length && handleSelect( { label: input } );
 			return;
 		}
 		if ( e.keyCode === TAB ) {
@@ -188,8 +189,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		),
 	} );
 
-	const showArrow =
-		isFocused && ! siteTitle && ! siteVertical && inputRef?.current?.innerText.length > 2;
+	const showArrow = isFocused && ! siteTitle && ! siteVertical && showResults;
 
 	return (
 		<form

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const { __: NO__ } = useI18n();
-	const inputRef = React.useRef< HTMLElement >( null );
+	const inputRef = React.useRef< HTMLSpanElement >( document.createElement( 'span' ) );
 	const [ isFocused, setIsFocused ] = React.useState< boolean >( false );
 	const [ suggestions, setSuggestions ] = React.useState< Suggestion[] >( [] );
 
@@ -87,7 +87,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 			! newSuggestions.some( suggestion => suggestion.label.toLowerCase() === normalizedInputValue )
 		) {
 			// User-supplied verticals don't have IDs.
-			newSuggestions.unshift( { label: inputValue.trim() } );
+			newSuggestions.unshift( { label: inputValue.trim(), id: '', slug: '' } );
 		}
 
 		// If there is only one suggestion and that suggestion matches the user input value,
@@ -160,6 +160,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 			<span className="vertical-select__suggestions-wrapper">
 				<span
 					role="textbox"
+					aria-multiline="true"
 					tabIndex={ 0 }
 					contentEditable
 					ref={ inputRef }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -116,9 +116,7 @@ const VerticalSelect: React.FunctionComponent = () => {
 	const handleBlur = () => {
 		const lastQuery = inputText.trim();
 		if ( isFocused && lastQuery.length ) {
-			const vertical = suggestions.find( ( { label } ) =>
-				label.toLowerCase().includes( lastQuery )
-			) ?? { label: lastQuery, id: '', slug: '' };
+			const vertical = suggestions[ 0 ] ?? { label: lastQuery, id: '', slug: '' };
 			handleSelect( vertical );
 		}
 	};

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -59,7 +59,7 @@ const VerticalSelect: React.FunctionComponent = () => {
 
 	const inputText = inputRef?.current?.innerText || '';
 	const isInputEmpty = ! inputText.length;
-	const showResults = inputText.length > 2;
+	const showArrow = ! siteTitle && ! siteVertical && inputText.length > 2;
 
 	const animatedPlaceholder = useTyper(
 		[ NO__( 'football' ), NO__( 'shopping' ), NO__( 'cars' ), NO__( 'design' ), NO__( 'travel' ) ],
@@ -154,23 +154,27 @@ const VerticalSelect: React.FunctionComponent = () => {
 	const madlib = __experimentalCreateInterpolateElement( madlibTemplate, {
 		Input: (
 			<span className="vertical-select__suggestions-wrapper">
-				<span
-					contentEditable
-					tabIndex={ 0 }
-					role="textbox"
-					aria-multiline="true"
-					spellCheck={ false }
-					ref={ inputRef }
-					/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
-					className="madlib__input"
-					onKeyDown={ handleInputKeyDownEvent }
-					onKeyUp={ handleInputKeyUpEvent }
-					onFocus={ () => setIsFocused( true ) }
-					onBlur={ handleBlur }
-				/>
-				{ isInputEmpty && (
-					<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>
-				) }
+				<span className="vertical-select__input-wrapper">
+					{ isInputEmpty && (
+						<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>
+					) }
+					<span
+						contentEditable
+						tabIndex={ 0 }
+						role="textbox"
+						aria-multiline="true"
+						spellCheck={ false }
+						ref={ inputRef }
+						/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
+						className="madlib__input"
+						onKeyDown={ handleInputKeyDownEvent }
+						onKeyUp={ handleInputKeyUpEvent }
+						onFocus={ () => setIsFocused( true ) }
+						onBlur={ handleBlur }
+					/>
+				</span>
+				{ /* us visibility to keep the layout fixed with and without the arrow */ }
+				{ showArrow && <Arrow className="vertical-select__arrow" /> }
 				<div className="vertical-select__suggestions">
 					{ isFocused && !! verticals.length && (
 						<Suggestions
@@ -186,8 +190,6 @@ const VerticalSelect: React.FunctionComponent = () => {
 		),
 	} );
 
-	const showArrow = isFocused && ! siteTitle && ! siteVertical && showResults;
-
 	return (
 		<form
 			className={ classnames( 'vertical-select', {
@@ -195,11 +197,6 @@ const VerticalSelect: React.FunctionComponent = () => {
 			} ) }
 		>
 			{ madlib }
-			{ /* us visibility to keep the layout fixed with and without the arrow */ }
-			<Arrow
-				className="vertical-select__arrow"
-				style={ { visibility: showArrow ? 'visible' : 'hidden' } }
-			/>
 		</form>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { Suggestions } from '@automattic/components';
 import { useI18n } from '@automattic/react-i18n';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
-import { ENTER } from '@wordpress/keycodes';
+import { ENTER, TAB } from '@wordpress/keycodes';
 import classnames from 'classnames';
 
 /**
@@ -32,8 +32,9 @@ interface Props {
 }
 const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const { __: NO__ } = useI18n();
-	const inputRef = React.useRef< HTMLInputElement >( null );
+	const inputRef = React.useRef< HTMLElement >( null );
 	const [ isFocused, setIsFocused ] = React.useState< boolean >( false );
+	const [ suggestions, setSuggestions ] = React.useState< Suggestion[] >( [] );
 
 	/**
 	 * Ref to the <Suggestions />, necessary for handling input events
@@ -59,82 +60,96 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const { siteVertical, siteTitle } = useSelect( select => select( ONBOARD_STORE ).getState() );
 	const { setSiteVertical, resetSiteVertical } = useDispatch( ONBOARD_STORE );
 
-	const [ inputValue, setInputValue ] = React.useState( siteVertical?.label ?? '' );
+	const isInputEmpty = ! inputRef?.current?.innerText.length;
 
 	const animatedPlaceholder = useTyper(
 		[ NO__( 'football' ), NO__( 'shopping' ), NO__( 'cars' ), NO__( 'design' ), NO__( 'travel' ) ],
-		inputValue.length === 0
+		isInputEmpty
 	);
 
-	const normalizedInputValue = inputValue.trim().toLowerCase();
-	const hasValue = !! normalizedInputValue.length;
+	const updateSuggestions = ( inputValue: string ) => {
+		if ( inputValue.length < 3 ) {
+			setSuggestions( [] );
+			return;
+		}
 
-	let suggestions: Suggestion[];
+		const normalizedInputValue = inputValue.toLowerCase();
 
-	if ( ! normalizedInputValue ) {
-		suggestions = [];
-		resetSiteVertical();
-	} else {
-		suggestions = verticals.filter( vertical =>
+		let newSuggestions = verticals.filter( vertical =>
 			vertical.label.toLowerCase().includes( normalizedInputValue )
 		);
 
 		// Does the verticals list include an exact match? If it doesn't, we prepend the user-suppied
 		// vertical to the list.
 		if (
-			! suggestions.some( suggestion => suggestion.label.toLowerCase() === normalizedInputValue )
+			! newSuggestions.some( suggestion => suggestion.label.toLowerCase() === normalizedInputValue )
 		) {
 			// User-supplied verticals don't have IDs.
-			suggestions.unshift( { label: inputValue.trim() } );
+			newSuggestions.unshift( { label: inputValue.trim() } );
 		}
 
 		// If there is only one suggestion and that suggestion matches the user input value,
 		// do not show any suggestions.
 		if (
-			suggestions.length === 1 &&
-			suggestions[ 0 ].label.toLowerCase() === normalizedInputValue
+			newSuggestions.length === 1 &&
+			newSuggestions[ 0 ].label.toLowerCase() === normalizedInputValue
 		) {
-			suggestions = [];
+			newSuggestions = [];
 		}
-	}
+
+		setSuggestions( newSuggestions );
+	};
+	const handleInputKeyUpEvent = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
+		const input = e.currentTarget.innerText.trim();
+		if ( ! input.length ) {
+			resetSiteVertical();
+		} else {
+			updateSuggestions( input );
+		}
+	};
 
 	const handleSelect = ( vertical: SiteVertical ) => {
 		setSiteVertical( vertical );
-		setInputValue( vertical.label );
 		setIsFocused( false ); // prevent executing handleBlur()
 		onSubmit();
 	};
 
-	const handleSuggestionChangeEvent = ( e: React.ChangeEvent< HTMLInputElement > ) => {
-		setInputValue( e.target.value );
-	};
+	const handleInputKeyDownEvent = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
+		const input = e.currentTarget.innerText.trim();
 
-	const handleInputKeyDownEvent = ( e: React.KeyboardEvent< HTMLInputElement > ) => {
-		if ( e.keyCode === ENTER ) {
-			e.preventDefault();
-			handleSelect( { label: inputValue } );
-			return;
-		}
 		if ( suggestionRef.current ) {
 			suggestionRef.current.handleKeyEvent( e );
+		}
+		if ( e.keyCode === ENTER && input.length ) {
+			e.preventDefault();
+			handleSelect( { label: input } );
+			return;
+		}
+		if ( e.keyCode === TAB ) {
+			e.preventDefault();
 		}
 	};
 
 	const handleBlur = () => {
-		if ( isFocused ) {
-			const vertical = suggestions.find( ( { label } ) =>
-				label.toLowerCase().includes( normalizedInputValue )
-			) ?? { label: inputValue.trim() };
-
-			handleSelect( vertical );
-		}
+		// if ( isFocused ) {
+		// 	const vertical = suggestions.find( ( { label } ) =>
+		// 		label.toLowerCase().includes( normalizedInputValue )
+		// 	) ?? { label: inputValue.trim() };
+		// 	handleSelect( vertical );
+		// }
 	};
 
 	React.useEffect( () => {
-		if ( ! hasValue ) {
+		if ( isInputEmpty ) {
 			inputRef?.current?.focus();
+		} else {
+			inputRef.current.innerText = siteVertical?.label || '';
 		}
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	React.useEffect( () => {
+		inputRef.current.innerText = siteVertical?.label || '';
+	}, [ siteVertical, inputRef ] );
 
 	// TODO: Write a better translators comment.
 	// translators: Form input for a site's topic where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
@@ -142,26 +157,27 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 	const madlib = __experimentalCreateInterpolateElement( madlibTemplate, {
 		Input: (
 			<span className="vertical-select__suggestions-wrapper">
-				<input
+				<span
+					role="textbox"
+					tabIndex={ 0 }
+					contentEditable
 					ref={ inputRef }
 					/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
 					className="madlib__input"
-					autoComplete="off"
-					style={ {
-						width: `${ inputValue.length * 0.85 }ch`,
-					} }
 					onBlur={ handleBlur }
 					onFocus={ () => setIsFocused( true ) }
-					onChange={ handleSuggestionChangeEvent }
 					onKeyDown={ handleInputKeyDownEvent }
-					placeholder={ animatedPlaceholder }
-					value={ inputValue }
+					onKeyUp={ handleInputKeyUpEvent }
+					spellCheck={ false }
 				/>
+				{ isInputEmpty && (
+					<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>
+				) }
 				<div className="vertical-select__suggestions">
 					{ isFocused && !! verticals.length && (
 						<Suggestions
 							ref={ suggestionRef }
-							query={ inputValue }
+							query={ inputRef?.current?.innerText }
 							suggestions={ suggestions }
 							suggest={ handleSelect }
 							title={ NO__( 'Suggestions' ) }
@@ -172,17 +188,21 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onSubmit } ) => {
 		),
 	} );
 
-	const showArrow = isFocused && ! siteTitle && ! siteVertical && inputValue.length > 2;
+	const showArrow =
+		isFocused && ! siteTitle && ! siteVertical && inputRef?.current?.innerText.length > 2;
 
 	return (
 		<form
 			className={ classnames( 'vertical-select', {
-				'vertical-select--without-value': ! hasValue,
+				'vertical-select--without-value': isInputEmpty,
 			} ) }
 		>
 			{ madlib }
 			{ /* us visibility to keep the layout fixed with and without the arrow */ }
-			<Arrow style={ { visibility: showArrow ? 'visible' : 'hidden' } } />
+			<Arrow
+				className="vertical-select__arrow"
+				style={ { visibility: showArrow ? 'visible' : 'hidden' } }
+			/>
 		</form>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -89,6 +89,8 @@ const VerticalSelect: React.FunctionComponent = () => {
 
 		// If there is only one suggestion and that suggestion matches the user input value,
 		// do not show any suggestions.
+
+		// TODO: write a more advanced compare fn https://github.com/Automattic/wp-calypso/pull/40645#discussion_r402156751
 		if (
 			newSuggestions.length === 1 &&
 			newSuggestions[ 0 ].label.toLowerCase() === normalizedInputValue

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -148,47 +148,51 @@ const VerticalSelect: React.FunctionComponent = () => {
 		inputRef.current.innerText = siteVertical?.label || '';
 	}, [ siteVertical, inputRef ] );
 
-	// TODO: Write a better translators comment.
 	// translators: Form input for a site's topic where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = NO__( 'My site is about <Input />' );
-	const madlib = __experimentalCreateInterpolateElement( madlibTemplate, {
-		Input: (
-			<span className="vertical-select__suggestions-wrapper">
-				<span className="vertical-select__input-wrapper">
-					{ isInputEmpty && (
-						<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>
-					) }
-					<span
-						contentEditable
-						tabIndex={ 0 }
-						role="textbox"
-						aria-multiline="true"
-						spellCheck={ false }
-						ref={ inputRef }
-						/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
-						className="madlib__input"
-						onKeyDown={ handleInputKeyDownEvent }
-						onKeyUp={ handleInputKeyUpEvent }
-						onFocus={ () => setIsFocused( true ) }
-						onBlur={ handleBlur }
-					/>
-				</span>
-				{ /* us visibility to keep the layout fixed with and without the arrow */ }
-				{ showArrow && <Arrow className="vertical-select__arrow" /> }
-				<div className="vertical-select__suggestions">
-					{ isFocused && !! verticals.length && (
-						<Suggestions
-							ref={ suggestionRef }
-							query={ inputRef?.current?.innerText }
-							suggestions={ suggestions }
-							suggest={ handleSelect }
-							title={ NO__( 'Suggestions' ) }
+	// translators: Form input for a site's topic where "<Input />" is replaced with the topic selected by the user.
+	const madlibTemplateWithPeriod = NO__( 'My site is about <Input />.' );
+	const madlib = __experimentalCreateInterpolateElement(
+		siteVertical ? madlibTemplateWithPeriod : madlibTemplate,
+		{
+			Input: (
+				<span className="vertical-select__suggestions-wrapper">
+					<span className="vertical-select__input-wrapper">
+						{ isInputEmpty && (
+							<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>
+						) }
+						<span
+							contentEditable
+							tabIndex={ 0 }
+							role="textbox"
+							aria-multiline="true"
+							spellCheck={ false }
+							ref={ inputRef }
+							/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
+							className="madlib__input"
+							onKeyDown={ handleInputKeyDownEvent }
+							onKeyUp={ handleInputKeyUpEvent }
+							onFocus={ () => setIsFocused( true ) }
+							onBlur={ handleBlur }
 						/>
-					) }
-				</div>
-			</span>
-		),
-	} );
+					</span>
+					{ /* us visibility to keep the layout fixed with and without the arrow */ }
+					{ showArrow && <Arrow className="vertical-select__arrow" /> }
+					<div className="vertical-select__suggestions">
+						{ isFocused && !! verticals.length && (
+							<Suggestions
+								ref={ suggestionRef }
+								query={ inputRef?.current?.innerText }
+								suggestions={ suggestions }
+								suggest={ handleSelect }
+								title={ NO__( 'Suggestions' ) }
+							/>
+						) }
+					</div>
+				</span>
+			),
+		}
+	);
 
 	return (
 		<form

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -16,7 +16,17 @@
 		}
 	}
 	&--without-value {
+		.vertical-select__input-wrapper {
+			position: relative;
+			width: 400px;
+			display: inline-block;
+			vertical-align: middle;
+			height: 1.05em;
+			line-height: 1em;
+		}
 		.madlib__input {
+			position: absolute;
+			width: 100%;
 			border-bottom: 2px solid var( --studio-gray-5 );
 		}
 	}
@@ -36,9 +46,13 @@
 
 .vertical-select__placeholder {
 	color: var( --studio-gray-5 );
+	position: absolute;
+	left: 0;
 }
 
 .vertical-select__arrow {
+	//TODO: find a way to prevent overflow on mobile (only 20px horizontal padding)
+	position: absolute;
+	bottom: 25px;
 	margin-left: 15px;
-	vertical-align: middle;
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -18,10 +18,6 @@
 	&--without-value {
 		.madlib__input {
 			border-bottom: 2px solid var( --studio-gray-5 );
-
-			&::placeholder {
-				color: var( --studio-gray-5 );
-			}
 		}
 	}
 }
@@ -36,4 +32,13 @@
 	width: 250px;
 	max-height: 400px;
 	overflow: auto;
+}
+
+.vertical-select__placeholder {
+	color: var( --studio-gray-5 );
+}
+
+.vertical-select__arrow {
+	margin-left: 15px;
+	vertical-align: middle;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* vertical select input and site title are now inline (using `contenteditable`) so they can be wrapped if longer and on smaller screens like regular texts
* prevent the inputs from going off-screen
* prevent full-width underline for both inputs
* prevent displaying an underline when site title input is empty
* prevent jumping of the inputs when new step (and next button) appears as mentioned in https://github.com/Automattic/wp-calypso/issues/40474#issuecomment-607161116
* the next arrow is always displayed next to the vertical input field
* other small fixes from #40321
* support for further i18n (input can be in the middle of the text)
* added back full stop at the end of vertical input since now the period wraps correctly to the next line: https://cloudup.com/chpR7hnwYht

#### Testing instructions

* Go to [/gutenboarding](https://hash-9a75a48d84da8fc85e6d6a178277a72d3a07b785.calypso.live/gutenboarding)
* Test both inputs and navigation between them and to the next step (tab/ shift+tab), blur, enter.
* Selecting a suggestion from dropdown using keyboard (arrows and Enter) should now work.

Fixes #40321, #40474 
Supersedes #40612 