### PR TITLE
WP for Teams: add selector

### DIFF
--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -118,6 +118,7 @@ exports[`Plans should render plans 1`] = `
           "is_multi_network": false,
           "is_multi_site": false,
           "is_redirect": false,
+          "is_wpforteams_site": false,
           "jetpack_version": "5.4",
           "main_network_site": "http://an.example.site",
           "max_upload_size": false,

--- a/client/jetpack-connect/test/lib/plans.js
+++ b/client/jetpack-connect/test/lib/plans.js
@@ -137,6 +137,7 @@ export const SELECTED_SITE = deepFreeze( {
 		podcasting_archive: null,
 		is_domain_only: false,
 		is_automated_transfer: false,
+		is_wpforteams_site: false,
 		jetpack_version: '5.4',
 		main_network_site: `http://${ SITE_SLUG }`,
 		active_modules: [

--- a/client/state/selectors/is-site-wpforteams.js
+++ b/client/state/selectors/is-site-wpforteams.js
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+/**
+ * Returns true if site is a WP for Teams site, false if not and null if unknown
+ *
+ * @param  {object}   state  Global state tree
+ * @param  {number}   siteId Site ID
+ * @returns {?boolean}        Whether site is a WP for Teams site
+ */
+export default function isSiteWPforteams( state, siteId ) {
+	return get( state, [ 'sites', 'items', siteId, 'options', 'is_wpforteams_site' ], null );
+}

--- a/client/state/selectors/test/is-site-wpforteams.js
+++ b/client/state/selectors/test/is-site-wpforteams.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import isSiteWPforteams from 'state/selectors/is-site-wpforteams';
+
+describe( 'isSiteWPforteams()', () => {
+	test( 'should return null if the specified site was not found in the state', () => {
+		const state = {
+			sites: {
+				items: {},
+			},
+		};
+
+		expect( isSiteWPforteams( state, 12345 ) ).to.be.null;
+	} );
+
+	test( 'should return false if site is not a WP for Teams one', () => {
+		const state = {
+			sites: {
+				items: {
+					12345: {
+						options: {
+							is_wpforteams_site: false,
+						},
+					},
+				},
+			},
+		};
+
+		expect( isSiteWPforteams( state, 12345 ) ).to.be.false;
+	} );
+
+	test( 'should return true if site is a WP for Teams one', () => {
+		const state = {
+			sites: {
+				items: {
+					12345: {
+						options: {
+							is_wpforteams_site: true,
+						},
+					},
+				},
+			},
+		};
+
+		expect( isSiteWPforteams( state, 12345 ) ).to.be.true;
+	} );
+} );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -43,6 +43,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'is_redirect',
 	'is_wpcom_atomic',
 	'is_wpcom_store',
+	'is_wpforteams_site',
 	'woocommerce_is_active',
 	'jetpack_frame_nonce',
 	'jetpack_version',


### PR DESCRIPTION
In this PR, we add a selector `isSiteWPforteams` to distinguish between a standard WP.com site and a WP for Teams one.

## Testing

Tests should pass. Code review.