### PR TITLE
Gutenboarding: Persist selected fonts

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { Button } from '@wordpress/components';
 import classnames from 'classnames';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
 
@@ -54,7 +55,9 @@ const FontSelect: React.FunctionComponent = () => {
 				<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
 			</Button>
 			{ fontPairings.filter( fontPairingsFilter ).map( fontPair => {
-				const isSelected = fontPair === selectedFonts;
+				// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
+				// (E.g. if `selectedFonts` is coming from persisted state)
+				const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );
 				const { headings, base } = fontPair;
 
 				return (

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -30,6 +30,7 @@ registerStore< State >( STORE_KEY, {
 		'siteVertical',
 		'pageLayouts',
 		'selectedDesign',
+		'selectedFonts',
 		'siteWasCreatedForDomainPurchase',
 	],
 } );

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -91,6 +91,9 @@ const selectedFonts: Reducer< FontPair | undefined, OnboardAction > = (
 	if ( action.type === 'SET_FONTS' ) {
 		return action.fonts;
 	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return undefined;
+	}
 	return state;
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add `selectedFonts` to persisted state.
- Fix the font selector to use `isShallowEqual` rather than `===` to compare font pairing _objects_ (cough).
- Clear `selectedFonts` state upon `RESET_ONBOARD_STORE`.

#### Testing instructions

To reproduce the issue:

- Go to https://wpcalypso.wordpress.com/gutenboarding/
- In the browser console, type `localStorage.removeItem('WP_ONBOARD')`
- Reload
- Go through the onboarding flow until you're prompted to select a font pairing.
- Select a font pairing :)
- Close the tab. Open a new one, and start at https://wpcalypso.wordpress.com/gutenboarding/style again.
- Go through the onboarding flow again, picking the same design again
- You'll see that your font pairing choice hasn't been persisted.

To reproduce the fix:

- Follow the same steps as above for this branch (locally on http://calypso.localhost:3000/gutenboarding, or on calypso.live).
- This time, your font pairing selection _should_ be remembered.
- Finally, enter `wp.data.dispatch( 'automattic/onboard' ).resetOnboardStore()` in the browser console. Go through the flow again, and verify that the font setting isn't remembered.