### PR TITLE
Gutenboarding: Reset font pairing when selecting new design

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -32,7 +32,7 @@ const DesignSelector: React.FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
 	const { push } = useHistory();
 	const makePath = usePath();
-	const { setSelectedDesign, resetOnboardStore } = useDispatch( ONBOARD_STORE );
+	const { setSelectedDesign, resetFonts, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const handleStartOverButtonClick = () => {
 		resetOnboardStore();
@@ -93,6 +93,11 @@ const DesignSelector: React.FunctionComponent = () => {
 										className="design-selector__design-option"
 										onClick={ () => {
 											setSelectedDesign( design );
+
+											// Our design selector shows each template's default fonts, so the user expects to see those
+											// in the style preview. To match that expectation, we reset any previously user-selected fonts.
+											resetFonts();
+
 											if ( isEnabled( 'gutenboarding/style-preview' ) ) {
 												push( makePath( Step.Style ) );
 											}

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -47,6 +47,10 @@ export const togglePageLayout = ( pageLayout: Template ) => ( {
 	pageLayout,
 } );
 
+export const resetFonts = () => ( {
+	type: 'RESET_FONTS' as const,
+} );
+
 export const setFonts = ( fonts: FontPair | undefined ) => ( {
 	type: 'SET_FONTS' as const,
 	fonts,
@@ -108,6 +112,7 @@ export function* createSite(
 }
 
 export type OnboardAction = ReturnType<
+	| typeof resetFonts
 	| typeof resetOnboardStore
 	| typeof resetSiteVertical
 	| typeof setDomain

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -91,7 +91,7 @@ const selectedFonts: Reducer< FontPair | undefined, OnboardAction > = (
 	if ( action.type === 'SET_FONTS' ) {
 		return action.fonts;
 	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+	if ( action.type === 'RESET_FONTS' || action.type === 'RESET_ONBOARD_STORE' ) {
 		return undefined;
 	}
 	return state;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The [rationale](https://github.com/Automattic/wp-calypso/issues/40649#issuecomment-607177429) for this change is:

> [...] if the previews on the Design step will show the theme default fonts, we should show the font defaults selected on the Fonts step too.

#### Testing instructions

Steps to replicate:
- Choose design
- Change font pairing in font picker to something custom
- Go back to design picker
- Choose another design
- Font pairing has been reset to design's default

Compare that to wpcalypso, where a previously made font selection is carried over when selecting a different design.

Fixes #40649
