### PR TITLE
localizeUrl: Handle double calls better

### DIFF
--- a/client/lib/i18n-utils/test/utils.js
+++ b/client/lib/i18n-utils/test/utils.js
@@ -280,6 +280,36 @@ describe( 'utils', () => {
 			);
 		} );
 
+		test( 'handles double localizeUrl', () => {
+			getLocaleSlug.mockImplementationOnce( () => 'de' ).mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( localizeUrl( 'https://automattic.com/cookies/' ) ) ).toEqual(
+				'https://automattic.com/de/cookies/'
+			);
+			getLocaleSlug();
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'de' ).mockImplementationOnce( () => 'de' );
+			expect(
+				localizeUrl( localizeUrl( 'https://en.support.wordpress.com/all-about-domains/' ) )
+			).toEqual( 'https://wordpress.com/de/support/all-about-domains/' );
+			getLocaleSlug();
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'de' ).mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( localizeUrl( 'https://wordpress.com/' ) ) ).toEqual(
+				'https://de.wordpress.com/'
+			);
+			getLocaleSlug();
+			getLocaleSlug(); // make sure to consume it.
+
+			getLocaleSlug.mockImplementationOnce( () => 'de' ).mockImplementationOnce( () => 'de' );
+			expect( localizeUrl( localizeUrl( 'https://en.blog.wordpress.com/' ) ) ).toEqual(
+				'https://wordpress.com/blog/'
+			);
+			getLocaleSlug();
+			getLocaleSlug(); // make sure to consume it.
+		} );
+
 		test( 'trailing slash variations', () => {
 			getLocaleSlug.mockImplementationOnce( () => 'de' );
 			expect( localizeUrl( 'https://automattic.com/cookies/' ) ).toEqual(

--- a/client/lib/i18n-utils/utils.js
+++ b/client/lib/i18n-utils/utils.js
@@ -174,7 +174,10 @@ const setLocalizedUrlHost = ( hostname, validLocales = [] ) => ( urlParts, local
 	}
 
 	if ( validLocales.includes( localeSlug ) && localeSlug !== 'en' ) {
-		urlParts.host = `${ localesToSubdomains[ localeSlug ] || localeSlug }.${ hostname }`;
+		// Avoid changing the hostname when the locale is set via the path.
+		if ( urlParts.pathname.substr( 0, localeSlug.length + 2 ) !== '/' + localeSlug + '/' ) {
+			urlParts.host = `${ localesToSubdomains[ localeSlug ] || localeSlug }.${ hostname }`;
+		}
 	}
 	return urlParts;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to #40602 where it shows that some links are double `localizeUrl`ed, resulting in wrong URLs (that still work), for example:
```
localizeUrl( localizeUrl( 'https://en.support.wordpress.com/all-about-domains/' ) )
=>'https://de.wordpress.com/de/support/all-about-domains/'
```

This fixes that double-localizing:
```
localizeUrl( localizeUrl( 'https://en.support.wordpress.com/all-about-domains/' ) )
=>'https://wordpress.com/de/support/all-about-domains/'
```
