### PR TITLE
Split out `ga` from `lib/analytics`

### DIFF
--- a/client/blocks/term-tree-selector/terms.jsx
+++ b/client/blocks/term-tree-selector/terms.jsx
@@ -22,7 +22,7 @@ import {
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import NoResults from './no-results';
 import Search from './search';
 import { decodeEntities } from 'lib/formatting';
@@ -286,7 +286,7 @@ class TermTreeSelectorList extends Component {
 
 		if ( ! this.hasPerformedSearch ) {
 			this.hasPerformedSearch = true;
-			analytics.ga.recordEvent( this.props.analyticsPrefix, 'Performed Term Search' );
+			gaRecordEvent( this.props.analyticsPrefix, 'Performed Term Search' );
 		}
 
 		this.setState( { searchTerm } );

--- a/client/components/info-popover/README.md
+++ b/client/components/info-popover/README.md
@@ -40,7 +40,9 @@ Also reqires the `gaEventCategory` attribute.
 Turns into this even when opened:
 
 ```js
-analytics.ga.recordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + 'Opened' );
+import { gaRecordEvent } from 'lib/analytics/ga';
+
+gaRecordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + 'Opened' );
 ```
 
 #### `ignoreContext`

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -3,15 +3,15 @@
  */
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'components/gridicon';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'components/gridicon';
 import Popover from 'components/popover';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 /**
  * Style dependencies
@@ -66,7 +66,7 @@ export default class InfoPopover extends Component {
 
 		if ( gaEventCategory && popoverName ) {
 			const dialogState = this.state.showPopover ? ' Opened' : ' Closed';
-			analytics.ga.recordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + dialogState );
+			gaRecordEvent( gaEventCategory, 'InfoPopover: ' + popoverName + dialogState );
 		}
 	};
 

--- a/client/components/search/index.jsx
+++ b/client/components/search/index.jsx
@@ -7,14 +7,14 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { debounce, noop, uniqueId } from 'lodash';
 import i18n from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import Gridicon from 'components/gridicon';
 import Spinner from 'components/spinner';
 import TranslatableString from 'components/translatable/proptype';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 /**
  * Style dependencies
@@ -235,7 +235,7 @@ class Search extends Component {
 			isOpen: true,
 		} );
 
-		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Open Search' );
+		gaRecordEvent( this.props.analyticsGroup, 'Clicked Open Search' );
 	};
 
 	closeSearch = event => {
@@ -259,7 +259,7 @@ class Search extends Component {
 
 		this.props.onSearchClose( event );
 
-		analytics.ga.recordEvent( this.props.analyticsGroup, 'Clicked Close Search' );
+		gaRecordEvent( this.props.analyticsGroup, 'Clicked Close Search' );
 	};
 
 	keyUp = event => {

--- a/client/components/tinymce/plugins/editor-button-analytics/plugin.js
+++ b/client/components/tinymce/plugins/editor-button-analytics/plugin.js
@@ -8,7 +8,7 @@ import debugModule from 'debug';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { bumpStat } from 'lib/analytics/mc';
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 
@@ -20,7 +20,7 @@ function recordTinyMCEButtonClick( buttonName ) {
 	if ( shouldBumpStat ) {
 		bumpStat( 'editor-button', 'calypso_' + buttonName );
 	}
-	analytics.ga.recordEvent( 'Editor', 'Clicked TinyMCE Button', buttonName );
+	gaRecordEvent( 'Editor', 'Clicked TinyMCE Button', buttonName );
 	debug( 'TinyMCE button click', buttonName, 'mc=', shouldBumpStat );
 }
 

--- a/client/lib/analytics/docs/google-analytics.md
+++ b/client/lib/analytics/docs/google-analytics.md
@@ -19,28 +19,32 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 dispatch( recordGoogleEvent( 'Reader', 'Loaded Next Page', 'page', 2 ) );
 ```
 
-### `analytics.ga.recordEvent( category, action [, label, value ] )` (Deprecated)
+### `gaRecordEvent( category, action [, label, value ] )` (Deprecated)
 
 _Note: Unless you have a strong reason to call `analytics.ga` directly, you should use the Analytics Middleware instead._
 
 Record an event:
 
 ```js
-analytics.ga.recordEvent( 'Reader', 'Clicked Like' );
-analytics.ga.recordEvent( 'Reader', 'Loaded Next Page', 'page', 2 );
+import { gaRecordEvent } from 'lib/analytics/ga';
+
+gaRecordEvent( 'Reader', 'Clicked Like' );
+gaRecordEvent( 'Reader', 'Loaded Next Page', 'page', 2 );
 ```
 
 For more information and examples about how and when to provide the optional `optionLabel` and `optionValue` parameters, refer to the [Google Analytics Event Tracking documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/events#overview).
 
 
-### `analytics.ga.recordPageView( url, title )` (Deprecated)
+### `gaRecordPageView( url, title )` (Deprecated)
 
 _Note: Unless you have a strong reason to directly record a page view to Google Analytics, you should use [`PageViewTracker`](./page-views.md) instead._
 
 Record a virtual page view:
 
 ```js
-analytics.ga.recordPageView( '/posts/draft', 'Posts > Drafts' );
+import { gaRecordPageView } from 'lib/analytics/ga';
+
+gaRecordPageView( '/posts/draft', 'Posts > Drafts' );
 ```
 
 ## Naming Conventions

--- a/client/lib/analytics/ga.js
+++ b/client/lib/analytics/ga.js
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import debug from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getGoogleAnalyticsDefaultConfig,
+	setupGoogleAnalyticsGtag,
+	isGoogleAnalyticsAllowed,
+	fireGoogleAnalyticsPageView,
+	fireGoogleAnalyticsEvent,
+	fireGoogleAnalyticsTiming,
+} from 'lib/analytics/ad-tracking';
+
+const gaDebug = debug( 'calypso:analytics:ga' );
+
+let initialized = false;
+
+function initialize() {
+	if ( ! initialized ) {
+		const parameters = {
+			send_page_view: false,
+			...getGoogleAnalyticsDefaultConfig(),
+		};
+
+		gaDebug( 'parameters:', parameters );
+
+		setupGoogleAnalyticsGtag( parameters );
+
+		initialized = true;
+	}
+}
+
+export const gaRecordPageView = makeGoogleAnalyticsTrackingFunction( function recordPageView(
+	urlPath,
+	pageTitle
+) {
+	gaDebug( 'Recording Page View ~ [URL: ' + urlPath + '] [Title: ' + pageTitle + ']' );
+
+	fireGoogleAnalyticsPageView( urlPath, pageTitle );
+} );
+
+/**
+ * Fires a generic Google Analytics event
+ *
+ * {string} category Is the string that will appear as the event category.
+ * {string} action Is the string that will appear as the event action in Google Analytics Event reports.
+ * {string} label Is the string that will appear as the event label.
+ * {string} value Is a non-negative integer that will appear as the event value.
+ */
+export const gaRecordEvent = makeGoogleAnalyticsTrackingFunction( function recordEvent(
+	category,
+	action,
+	label,
+	value
+) {
+	if ( 'undefined' !== typeof value && ! isNaN( Number( String( value ) ) ) ) {
+		value = Math.round( Number( String( value ) ) ); // GA requires an integer value.
+		// https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue
+	}
+
+	let debugText = 'Recording Event ~ [Category: ' + category + '] [Action: ' + action + ']';
+
+	if ( 'undefined' !== typeof label ) {
+		debugText += ' [Option Label: ' + label + ']';
+	}
+
+	if ( 'undefined' !== typeof value ) {
+		debugText += ' [Option Value: ' + value + ']';
+	}
+
+	gaDebug( debugText );
+
+	fireGoogleAnalyticsEvent( category, action, label, value );
+} );
+
+export const gaRecordTiming = makeGoogleAnalyticsTrackingFunction( function recordTiming(
+	urlPath,
+	eventType,
+	duration,
+	triggerName
+) {
+	gaDebug( 'Recording Timing ~ [URL: ' + urlPath + '] [Duration: ' + duration + ']' );
+
+	fireGoogleAnalyticsTiming( eventType, duration, urlPath, triggerName );
+} );
+
+/**
+ * Wrap Google Analytics with debugging, possible analytics supression, and initialization
+ *
+ * This method will display debug output if Google Analytics is suppresed, otherwise it will
+ * initialize and call the Google Analytics function it is passed.
+ *
+ * @see isGoogleAnalyticsAllowed
+ *
+ * @param  {Function} func Google Analytics tracking function
+ * @returns {Function} Wrapped function
+ */
+export function makeGoogleAnalyticsTrackingFunction( func ) {
+	return function( ...args ) {
+		if ( ! isGoogleAnalyticsAllowed() ) {
+			gaDebug( '[Disallowed] analytics %s( %o )', func.name, args );
+			return;
+		}
+
+		initialize();
+
+		func( ...args );
+	};
+}

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -11,22 +11,17 @@ import emitter from 'lib/mixins/emitter';
 import { costToUSD, urlParseAmpCompatible, saveCouponQueryArgument } from 'lib/analytics/utils';
 
 import {
-	getGoogleAnalyticsDefaultConfig,
 	retarget as retargetAdTrackers,
 	recordAliasInFloodlight,
 	recordAddToCart,
 	recordOrder,
-	setupGoogleAnalyticsGtag,
-	isGoogleAnalyticsAllowed,
-	fireGoogleAnalyticsPageView,
-	fireGoogleAnalyticsEvent,
-	fireGoogleAnalyticsTiming,
 } from 'lib/analytics/ad-tracking';
 import { updateQueryParamsTracking } from 'lib/analytics/sem';
 import { statsdTimingUrl, statsdCountingUrl } from 'lib/analytics/statsd';
 import { trackAffiliateReferral } from './refer';
 import { getFeatureSlugFromPageUrl } from './feature-slug';
 import { recordSignupComplete } from './signup';
+import { gaRecordEvent, gaRecordPageView, gaRecordTiming } from './ga';
 import {
 	recordTracksEvent,
 	analyticsEvents,
@@ -44,7 +39,6 @@ import {
  * Module variables
  */
 const identifyUserDebug = debug( 'calypso:analytics:identifyUser' );
-const gaDebug = debug( 'calypso:analytics:ga' );
 const queueDebug = debug( 'calypso:analytics:queue' );
 const statsdDebug = debug( 'calypso:analytics:statsd' );
 
@@ -69,7 +63,7 @@ const analytics = {
 			setTimeout( () => {
 				// Tracks, Google Analytics, Refer platform.
 				recordTracksPageViewWithPageParams( urlPath, params );
-				analytics.ga.recordPageView( urlPath, pageTitle );
+				gaRecordPageView( urlPath, pageTitle );
 				analytics.refer.recordPageView();
 
 				// Retargeting.
@@ -163,12 +157,7 @@ const analytics = {
 		// TODO: move Tracks event here?
 		// Google Analytics
 		const usdValue = costToUSD( cartItem.cost, cartItem.currency );
-		analytics.ga.recordEvent(
-			'Checkout',
-			'calypso_cart_product_add',
-			'',
-			usdValue ? usdValue : undefined
-		);
+		gaRecordEvent( 'Checkout', 'calypso_cart_product_add', '', usdValue ? usdValue : undefined );
 		// Marketing
 		recordAddToCart( cartItem );
 	},
@@ -177,7 +166,7 @@ const analytics = {
 		if ( cart.total_cost >= 0.01 ) {
 			// Google Analytics
 			const usdValue = costToUSD( cart.total_cost, cart.currency );
-			analytics.ga.recordEvent(
+			gaRecordEvent(
 				'Purchase',
 				'calypso_checkout_payment_success',
 				'',
@@ -191,7 +180,7 @@ const analytics = {
 	timing: {
 		record: function( eventType, duration, triggerName ) {
 			const urlPath = getMostRecentUrlPath() || 'unknown';
-			analytics.ga.recordTiming( urlPath, eventType, duration, triggerName );
+			gaRecordTiming( urlPath, eventType, duration, triggerName );
 			analytics.statsd.recordTiming( urlPath, eventType, duration, triggerName );
 		},
 	},
@@ -242,80 +231,6 @@ const analytics = {
 		},
 	},
 
-	// Google Analytics usage and event stat tracking
-	ga: {
-		initialized: false,
-
-		initialize: function() {
-			if ( ! analytics.ga.initialized ) {
-				const parameters = {
-					send_page_view: false,
-					...getGoogleAnalyticsDefaultConfig(),
-				};
-
-				gaDebug( 'parameters:', parameters );
-
-				setupGoogleAnalyticsGtag( parameters );
-
-				analytics.ga.initialized = true;
-			}
-		},
-
-		recordPageView: makeGoogleAnalyticsTrackingFunction( function recordPageView(
-			urlPath,
-			pageTitle
-		) {
-			gaDebug( 'Recording Page View ~ [URL: ' + urlPath + '] [Title: ' + pageTitle + ']' );
-
-			fireGoogleAnalyticsPageView( urlPath, pageTitle );
-		} ),
-
-		/**
-		 * Fires a generic Google Analytics event
-		 *
-		 * {string} category Is the string that will appear as the event category.
-		 * {string} action Is the string that will appear as the event action in Google Analytics Event reports.
-		 * {string} label Is the string that will appear as the event label.
-		 * {string} value Is a non-negative integer that will appear as the event value.
-		 */
-		recordEvent: makeGoogleAnalyticsTrackingFunction( function recordEvent(
-			category,
-			action,
-			label,
-			value
-		) {
-			if ( 'undefined' !== typeof value && ! isNaN( Number( String( value ) ) ) ) {
-				value = Math.round( Number( String( value ) ) ); // GA requires an integer value.
-				// https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue
-			}
-
-			let debugText = 'Recording Event ~ [Category: ' + category + '] [Action: ' + action + ']';
-
-			if ( 'undefined' !== typeof label ) {
-				debugText += ' [Option Label: ' + label + ']';
-			}
-
-			if ( 'undefined' !== typeof value ) {
-				debugText += ' [Option Value: ' + value + ']';
-			}
-
-			gaDebug( debugText );
-
-			fireGoogleAnalyticsEvent( category, action, label, value );
-		} ),
-
-		recordTiming: makeGoogleAnalyticsTrackingFunction( function recordTiming(
-			urlPath,
-			eventType,
-			duration,
-			triggerName
-		) {
-			gaDebug( 'Recording Timing ~ [URL: ' + urlPath + '] [Duration: ' + duration + ']' );
-
-			fireGoogleAnalyticsTiming( eventType, duration, urlPath, triggerName );
-		} ),
-	},
-
 	// Refer platform tracking.
 	refer: {
 		recordPageView: function() {
@@ -360,34 +275,9 @@ const analytics = {
 	},
 };
 
-/**
- * Wrap Google Analytics with debugging, possible analytics supression, and initialization
- *
- * This method will display debug output if Google Analytics is suppresed, otherwise it will
- * initialize and call the Google Analytics function it is passed.
- *
- * @see isGoogleAnalyticsAllowed
- *
- * @param  {Function} func Google Analytics tracking function
- * @returns {Function} Wrapped function
- */
-export function makeGoogleAnalyticsTrackingFunction( func ) {
-	return function( ...args ) {
-		if ( ! isGoogleAnalyticsAllowed() ) {
-			gaDebug( '[Disallowed] analytics %s( %o )', func.name, args );
-			return;
-		}
-
-		analytics.ga.initialize();
-
-		func( ...args );
-	};
-}
-
 emitter( analytics );
 
 export default analytics;
-export const ga = analytics.ga;
 export const queue = analytics.queue;
 export const tracks = analytics.tracks;
 export const pageView = analytics.pageView;

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import {
 	adTrackSignupStart,
 	adTrackSignupComplete,
@@ -12,7 +13,7 @@ export function recordSignupStart( flow, ref ) {
 	// Tracks
 	analytics.tracks.recordEvent( 'calypso_signup_start', { flow, ref } );
 	// Google Analytics
-	analytics.ga.recordEvent( 'Signup', 'calypso_signup_start' );
+	gaRecordEvent( 'Signup', 'calypso_signup_start' );
 	// Marketing
 	adTrackSignupStart( flow );
 }
@@ -45,14 +46,14 @@ export function recordSignupComplete(
 		hasCartItems && 'has_cart_items',
 	].filter( Boolean );
 
-	analytics.ga.recordEvent( 'Signup', 'calypso_signup_complete:' + flags.join( ',' ) );
+	gaRecordEvent( 'Signup', 'calypso_signup_complete:' + flags.join( ',' ) );
 
 	if ( isNew7DUserSite ) {
 		// Tracks
 		analytics.tracks.recordEvent( 'calypso_new_user_site_creation', { flow } );
 
 		// Google Analytics
-		analytics.ga.recordEvent( 'Signup', 'calypso_new_user_site_creation' );
+		gaRecordEvent( 'Signup', 'calypso_new_user_site_creation' );
 	}
 
 	adTrackSignupComplete( { isNewUserSite: isNewUser && isNewSite } );
@@ -70,7 +71,7 @@ export function recordRegistration( flow ) {
 	// Tracks
 	analytics.tracks.recordEvent( 'calypso_user_registration_complete', { flow } );
 	// Google Analytics
-	analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
+	gaRecordEvent( 'Signup', 'calypso_user_registration_complete' );
 	// Marketing
 	adTrackRegistration();
 }
@@ -79,7 +80,7 @@ export function recordPasswordlessRegistration( flow ) {
 	// Tracks
 	analytics.tracks.recordEvent( 'calypso_user_registration_passwordless_complete', { flow } );
 	// Google Analytics
-	analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_passwordless_complete' );
+	gaRecordEvent( 'Signup', 'calypso_user_registration_passwordless_complete' );
 	// Marketing
 	adTrackRegistration();
 }
@@ -88,7 +89,7 @@ export function recordSocialRegistration() {
 	// Tracks
 	analytics.tracks.recordEvent( 'calypso_user_registration_social_complete' );
 	// Google Analytics
-	analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_social_complete' );
+	gaRecordEvent( 'Signup', 'calypso_user_registration_social_complete' );
 	// Marketing
 	adTrackRegistration();
 }

--- a/client/lib/analytics/store-transactions.js
+++ b/client/lib/analytics/store-transactions.js
@@ -8,6 +8,7 @@ import { omit } from 'lodash';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { hasFreeTrial, getDomainRegistrations } from 'lib/cart-values/cart-items';
 import { getTld } from 'lib/domains';
 import {
@@ -46,7 +47,7 @@ function formatError( error ) {
 
 function recordDomainRegistrationAnalytics( { cart, success } ) {
 	for ( const cartItem of getDomainRegistrations( cart ) ) {
-		analytics.ga.recordEvent( 'Checkout', 'calypso_domain_registration', cartItem.meta );
+		gaRecordEvent( 'Checkout', 'calypso_domain_registration', cartItem.meta );
 
 		analytics.tracks.recordEvent( 'calypso_domain_registration', {
 			domain_name: cartItem.meta,

--- a/client/lib/analytics/test/google-analytics.js
+++ b/client/lib/analytics/test/google-analytics.js
@@ -4,7 +4,7 @@
 /**
  * Internal dependencies
  */
-import { makeGoogleAnalyticsTrackingFunction } from '../';
+import { makeGoogleAnalyticsTrackingFunction } from '../ga';
 
 jest.mock( 'config', () => {
 	const isEnabled = feature => {
@@ -39,7 +39,7 @@ jest.mock( '@automattic/calypso-analytics', () => ( {
 
 jest.mock( '@automattic/load-script', () => require( './mocks/lib/load-script' ) );
 
-describe( 'analytics.ga', () => {
+describe( 'analytics/ga', () => {
 	describe( 'makeGoogleAnalyticsTrackingFunction', () => {
 		test( 'calls the wrapped function with passed arguments when enabled', () => {
 			const wrapped = jest.fn();

--- a/client/lib/track-scroll-page/index.js
+++ b/client/lib/track-scroll-page/index.js
@@ -3,9 +3,10 @@
  */
 import analytics from 'lib/analytics';
 import { bumpStat } from 'lib/analytics/mc';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 export default function( path, title, category, page ) {
-	analytics.ga.recordEvent( category, 'Loaded Next Page', 'page', page );
+	gaRecordEvent( category, 'Loaded Next Page', 'page', page );
 	analytics.pageView.record( path, title );
 	bumpStat( 'newdash_pageviews', 'scroll' );
 }

--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import { countBy, map, omit, values, flatten } from 'lodash';
-import Gridicon from 'components/gridicon';
 /* eslint-disable jsx-a11y/anchor-is-valid */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-static-element-interactions */
@@ -14,7 +12,8 @@ import Gridicon from 'components/gridicon';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import Gridicon from 'components/gridicon';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import SiteInfo from 'blocks/site';
 
 class BlogSettingsHeader extends PureComponent {
@@ -35,7 +34,7 @@ class BlogSettingsHeader extends PureComponent {
 		const isExpanded = ! this.state.isExpanded;
 		this.setState( { isExpanded } );
 
-		analytics.ga.recordEvent(
+		gaRecordEvent(
 			'Notification Settings',
 			isExpanded ? 'Expanded Site' : 'Collapsed Site',
 			this.props.site.name

--- a/client/me/security-2fa-backup-codes-prompt/index.jsx
+++ b/client/me/security-2fa-backup-codes-prompt/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -12,7 +11,7 @@ const debug = debugFactory( 'calypso:me:security:2fa-backup-codes-prompt' );
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -84,7 +83,7 @@ class Security2faBackupCodesPrompt extends React.Component {
 	};
 
 	onClickPrintButton = event => {
-		analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Print Backup Codes Again Button' );
+		gaRecordEvent( 'Me', 'Clicked On 2fa Print Backup Codes Again Button' );
 		this.onPrintAgain( event );
 	};
 
@@ -133,7 +132,7 @@ class Security2faBackupCodesPrompt extends React.Component {
 						name="backupCodeEntry"
 						method="backup"
 						onFocus={ function() {
-							analytics.ga.recordEvent(
+							gaRecordEvent(
 								'Me',
 								'Focused On 2fa Backup Codes Confirm Printed Backup Codes Input'
 							);
@@ -151,7 +150,7 @@ class Security2faBackupCodesPrompt extends React.Component {
 					className="security-2fa-backup-codes-prompt__verify"
 					disabled={ this.state.submittingCode }
 					onClick={ function() {
-						analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Backup Codes Verify Button' );
+						gaRecordEvent( 'Me', 'Clicked On 2fa Backup Codes Verify Button' );
 					} }
 				>
 					{ this.state.submittingCode

--- a/client/me/security-2fa-code-prompt/index.jsx
+++ b/client/me/security-2fa-code-prompt/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -12,7 +11,7 @@ const debug = debugFactory( 'calypso:me:security:2fa-code-prompt' );
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -208,7 +207,7 @@ class Security2faCodePrompt extends React.Component {
 						method={ method }
 						name="verificationCode"
 						onFocus={ function() {
-							analytics.ga.recordEvent( 'Me', 'Focused On 2fa Disable Code Verification Input' );
+							gaRecordEvent( 'Me', 'Focused On 2fa Disable Code Verification Input' );
 						} }
 						value={ this.state.verificationCode }
 						onChange={ this.handleChange }
@@ -228,7 +227,7 @@ class Security2faCodePrompt extends React.Component {
 						className="security-2fa-code-prompt__verify-code"
 						disabled={ this.getFormDisabled() }
 						onClick={ function() {
-							analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Code Prompt Verify Button' );
+							gaRecordEvent( 'Me', 'Clicked On 2fa Code Prompt Verify Button' );
 						} }
 					>
 						{ this.getSubmitButtonLabel() }
@@ -240,10 +239,7 @@ class Security2faCodePrompt extends React.Component {
 							disabled={ ! this.state.codeRequestsAllowed }
 							isPrimary={ false }
 							onClick={ function( event ) {
-								analytics.ga.recordEvent(
-									'Me',
-									'Clicked On 2fa Code Prompt Send Code Via SMS Button'
-								);
+								gaRecordEvent( 'Me', 'Clicked On 2fa Code Prompt Send Code Via SMS Button' );
 								this.onRequestCode( event );
 							}.bind( this ) }
 						>
@@ -258,7 +254,7 @@ class Security2faCodePrompt extends React.Component {
 							className="security-2fa-code-prompt__cancel"
 							isPrimary={ false }
 							onClick={ function( event ) {
-								analytics.ga.recordEvent( 'Me', 'Clicked On Disable 2fa Cancel Button' );
+								gaRecordEvent( 'Me', 'Clicked On Disable 2fa Cancel Button' );
 								this.onCancel( event );
 							}.bind( this ) }
 						>

--- a/client/me/security-2fa-enable/index.jsx
+++ b/client/me/security-2fa-enable/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import classNames from 'classnames';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -14,7 +13,7 @@ const debug = debugFactory( 'calypso:me:security:2fa-enable' );
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormLabel from 'components/forms/form-label';
@@ -181,7 +180,7 @@ class Security2faEnable extends React.Component {
 				className="security-2fa-enable__toggle"
 				onClick={ function( event ) {
 					this.toggleMethod( event );
-					analytics.ga.recordEvent(
+					gaRecordEvent(
 						'Me',
 						'Clicked On Barcode Toggle Link',
 						'current-method',
@@ -284,7 +283,7 @@ class Security2faEnable extends React.Component {
 										target="_blank"
 										rel="noopener noreferrer"
 										onClick={ function() {
-											analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Download Authy App Link' );
+											gaRecordEvent( 'Me', 'Clicked On 2fa Download Authy App Link' );
 										} }
 									/>
 								),
@@ -294,10 +293,7 @@ class Security2faEnable extends React.Component {
 										target="_blank"
 										rel="noopener noreferrer"
 										onClick={ function() {
-											analytics.ga.recordEvent(
-												'Me',
-												'Clicked On 2fa Download Google Authenticator Link'
-											);
+											gaRecordEvent( 'Me', 'Clicked On 2fa Download Google Authenticator Link' );
 										} }
 									/>
 								),
@@ -338,7 +334,7 @@ class Security2faEnable extends React.Component {
 					name="verificationCode"
 					method={ this.state.method }
 					onFocus={ function() {
-						analytics.ga.recordEvent( 'Me', 'Focused On 2fa Enable Verification Code Input' );
+						gaRecordEvent( 'Me', 'Focused On 2fa Enable Verification Code Input' );
 					} }
 					value={ this.state.verificationCode }
 					onChange={ this.handleChange }
@@ -367,12 +363,7 @@ class Security2faEnable extends React.Component {
 					className="security-2fa-enable__verify"
 					disabled={ this.getFormDisabled() }
 					onClick={ function() {
-						analytics.ga.recordEvent(
-							'Me',
-							'Clicked On Enable 2fa Button',
-							'method',
-							this.state.method
-						);
+						gaRecordEvent( 'Me', 'Clicked On Enable 2fa Button', 'method', this.state.method );
 					}.bind( this ) }
 				>
 					{ this.state.submittingCode
@@ -388,7 +379,7 @@ class Security2faEnable extends React.Component {
 					className="security-2fa-enable__cancel"
 					isPrimary={ false }
 					onClick={ function( event ) {
-						analytics.ga.recordEvent(
+						gaRecordEvent(
 							'Me',
 							'Clicked On Step 2 Cancel 2fa Button',
 							'method',
@@ -405,7 +396,7 @@ class Security2faEnable extends React.Component {
 						disabled={ ! this.state.smsRequestsAllowed }
 						isPrimary={ false }
 						onClick={ function( event ) {
-							analytics.ga.recordEvent( 'Me', 'Clicked On Resend SMS Button' );
+							gaRecordEvent( 'Me', 'Clicked On Resend SMS Button' );
 							this.onResendCode( event );
 						}.bind( this ) }
 					>
@@ -417,7 +408,7 @@ class Security2faEnable extends React.Component {
 					<FormButton
 						isPrimary={ false }
 						onClick={ function( event ) {
-							analytics.ga.recordEvent( 'Me', 'Clicked On Enable SMS Use SMS Button' );
+							gaRecordEvent( 'Me', 'Clicked On Enable SMS Use SMS Button' );
 							this.onVerifyBySMS( event );
 						}.bind( this ) }
 					>

--- a/client/me/security-2fa-initial-setup/index.jsx
+++ b/client/me/security-2fa-initial-setup/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -12,7 +11,7 @@ const debug = debugFactory( 'calypso:me:security:2fa-initial-setup' );
  * Internal dependencies
  */
 import FormButton from 'components/forms/form-button';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 class Security2faInitialSetup extends React.Component {
 	static displayName = 'Security2faInitialSetup';
@@ -44,7 +43,7 @@ class Security2faInitialSetup extends React.Component {
 
 				<FormButton
 					onClick={ function( event ) {
-						analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Get Started Button' );
+						gaRecordEvent( 'Me', 'Clicked On 2fa Get Started Button' );
 						this.props.onSuccess( event );
 					}.bind( this ) }
 				>

--- a/client/me/security-2fa-sms-settings/index.jsx
+++ b/client/me/security-2fa-sms-settings/index.jsx
@@ -18,7 +18,7 @@ import FormButtonsBar from 'components/forms/form-buttons-bar';
 import Notice from 'components/notice';
 import formBase from 'me/form-base';
 import Security2faProgress from 'me/security-2fa-progress';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import observe from 'lib/mixins/data-observe';
 import { protectForm } from 'lib/protect-form';
 import getCountries from 'state/selectors/get-countries';
@@ -199,12 +199,12 @@ const Security2faSMSSettings = createReactClass( {
 							disabled={ this.state.submittingForm }
 							countrySelectProps={ {
 								onFocus: function() {
-									analytics.ga.recordEvent( 'Me', 'Focused On 2fa SMS Country Select' );
+									gaRecordEvent( 'Me', 'Focused On 2fa SMS Country Select' );
 								},
 							} }
 							phoneInputProps={ {
 								onFocus: function() {
-									analytics.ga.recordEvent( 'Me', 'Focused On 2fa SMS Phone Number' );
+									gaRecordEvent( 'Me', 'Focused On 2fa SMS Phone Number' );
 								},
 							} }
 							initialCountryCode={ this.props.userSettings.getSetting( 'two_step_sms_country' ) }
@@ -221,7 +221,7 @@ const Security2faSMSSettings = createReactClass( {
 						<FormButton
 							disabled={ this.getSubmitDisabled() }
 							onClick={ function( event ) {
-								analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Use App Button' );
+								gaRecordEvent( 'Me', 'Clicked On 2fa Use App Button' );
 								this.onVerifyByApp( event );
 							}.bind( this ) }
 						>
@@ -232,7 +232,7 @@ const Security2faSMSSettings = createReactClass( {
 							disabled={ this.getSubmitDisabled() }
 							isPrimary={ false }
 							onClick={ function( event ) {
-								analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Use SMS Button' );
+								gaRecordEvent( 'Me', 'Clicked On 2fa Use SMS Button' );
 								this.onVerifyBySMS( event );
 							}.bind( this ) }
 						>
@@ -243,7 +243,7 @@ const Security2faSMSSettings = createReactClass( {
 							className="security-2fa-sms-settings__cancel-button"
 							isPrimary={ false }
 							onClick={ function( event ) {
-								analytics.ga.recordEvent( 'Me', 'Clicked On Step 1 2fa Cancel Button' );
+								gaRecordEvent( 'Me', 'Clicked On Step 1 2fa Cancel Button' );
 								this.props.onCancel( event );
 							}.bind( this ) }
 						>

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -3,15 +3,15 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'components/gridicon';
 import { get } from 'lodash';
 import { getCurrencyObject } from '@automattic/format-currency';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'components/gridicon';
 import { withLocalizedMoment } from 'components/localized-moment';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { canRemoveFromCart } from 'lib/cart-values';
 import { getIncludedDomain } from 'lib/cart-values/cart-items';
 import {
@@ -36,7 +36,7 @@ import { calculateMonthlyPriceForPlan, getBillingMonthsForPlan } from 'lib/plans
 export class CartItem extends React.Component {
 	removeFromCart = event => {
 		event.preventDefault();
-		analytics.ga.recordEvent(
+		gaRecordEvent(
 			'Upgrades',
 			'Clicked Remove From Cart Icon',
 			'Product ID',

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -16,7 +16,7 @@ import ClipboardButtonInput from 'components/clipboard-button-input';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import PurchaseButton from 'components/purchase-detail/purchase-button';
 import TipInfo from 'components/purchase-detail/tip-info';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import TermsAndConditions from './terms-and-conditions';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
 import { assignSiteVoucher as assignVoucher } from 'state/sites/vouchers/actions';
@@ -76,10 +76,7 @@ class GoogleVoucherDetails extends Component {
 	}
 
 	onGenerateCode() {
-		analytics.ga.recordEvent(
-			'calypso_plans_google_voucher_generate_click',
-			'Clicked Generate Code Button'
-		);
+		gaRecordEvent( 'calypso_plans_google_voucher_generate_click', 'Clicked Generate Code Button' );
 		this.props.recordTracksEvent( 'calypso_google_adwords_voucher_generate_click' );
 
 		this.changeStep();
@@ -91,10 +88,7 @@ class GoogleVoucherDetails extends Component {
 	}
 
 	onAcceptTermsAndConditions() {
-		analytics.ga.recordEvent(
-			'calypso_plans_google_voucher_toc_accept_click',
-			'Clicked Agree Button'
-		);
+		gaRecordEvent( 'calypso_plans_google_voucher_toc_accept_click', 'Clicked Agree Button' );
 		this.props.recordTracksEvent( 'calypso_google_adwords_voucher_tos_accept_click' );
 
 		this.props.assignVoucher( this.props.selectedSite.ID, GOOGLE_CREDITS );
@@ -102,10 +96,7 @@ class GoogleVoucherDetails extends Component {
 	}
 
 	onSetupGoogleAdWordsLink() {
-		analytics.ga.recordEvent(
-			'calypso_plans_google_voucher_setup_click',
-			'Clicked Setup Google Ads Button'
-		);
+		gaRecordEvent( 'calypso_plans_google_voucher_setup_click', 'Clicked Setup Google Ads Button' );
 		this.props.recordTracksEvent( 'calypso_google_adwords_voucher_setup_click' );
 	}
 

--- a/client/my-sites/checkout/checkout/concierge-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/concierge-refund-policy.jsx
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { REFUNDS } from 'lib/url/support';
 import Gridicon from 'components/gridicon';
 import { hasConciergeSession } from 'lib/cart-values/cart-items';
@@ -17,7 +16,7 @@ class ConciergeRefundPolicy extends React.Component {
 	static displayName = 'RegistrationRefundPolicy';
 
 	recordRefundsSupportClick = () => {
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Refund Support Link' );
+		gaRecordEvent( 'Upgrades', 'Clicked Refund Support Link' );
 	};
 
 	renderPolicy = () => {

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -8,7 +8,7 @@ import { find, defer } from 'lodash';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import CreditCard from 'components/credit-card';
 import NewCardForm from './new-card-form';
 import { newCardPayment, newStripeCardPayment, storedCardPayment } from 'lib/transaction/payments';
@@ -90,7 +90,7 @@ class CreditCardSelector extends React.Component {
 			return;
 		}
 		if ( 'new-card' === section ) {
-			analytics.ga.recordEvent( 'Upgrades', 'Clicked Use a New Credit/Debit Card Link' );
+			gaRecordEvent( 'Upgrades', 'Clicked Use a New Credit/Debit Card Link' );
 		}
 		this.savePayment( section );
 		this.setState( { section: section } );

--- a/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { get, map, reduce } from 'lodash';
@@ -9,7 +8,7 @@ import { get, map, reduce } from 'lodash';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import Gridicon from 'components/gridicon';
 import {
 	getDomainRegistrations,
@@ -20,7 +19,7 @@ import {
 
 class DomainRegistrationAgreement extends React.Component {
 	recordRegistrationAgreementClick = () => {
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Registration Agreement Link' );
+		gaRecordEvent( 'Upgrades', 'Clicked Registration Agreement Link' );
 	};
 
 	renderAgreementLinkForList = ( url, domains ) => {

--- a/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { REFUNDS } from 'lib/url/support';
 import Gridicon from 'components/gridicon';
 import { hasDomainBeingUsedForPlan, hasDomainRegistration } from 'lib/cart-values/cart-items';
@@ -17,7 +16,7 @@ class DomainRegistrationRefundPolicy extends React.Component {
 	static displayName = 'RegistrationRefundPolicy';
 
 	recordRefundsSupportClick = () => {
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Refund Support Link' );
+		gaRecordEvent( 'Upgrades', 'Clicked Refund Support Link' );
 	};
 
 	renderPolicy = () => {

--- a/client/my-sites/checkout/checkout/payment-box.jsx
+++ b/client/my-sites/checkout/checkout/payment-box.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
@@ -17,6 +16,7 @@ import NavTabs from 'components/section-nav/tabs';
 import SectionNav from 'components/section-nav';
 import SectionHeader from 'components/section-header';
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { paymentMethodName, isPaymentMethodEnabled } from 'lib/cart-values';
 import {
 	detectWebPaymentMethod,
@@ -44,7 +44,7 @@ export class PaymentBox extends PureComponent {
 	handlePaymentMethodChange = paymentMethod => {
 		const onSelectPaymentMethod = this.props.onSelectPaymentMethod;
 		return function() {
-			analytics.ga.recordEvent( 'Upgrades', 'Switch Payment Method' );
+			gaRecordEvent( 'Upgrades', 'Switch Payment Method' );
 			analytics.tracks.recordEvent( 'calypso_checkout_switch_to_' + snakeCase( paymentMethod ) );
 			onSelectPaymentMethod( paymentMethod );
 		};

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-
 import { localize } from 'i18n-calypso';
 import { assign, overSome, some } from 'lodash';
 import React from 'react';
-import Gridicon from 'components/gridicon';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'components/gridicon';
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { getLocationOrigin, getTaxPostalCode } from 'lib/cart-values';
 import { hasRenewalItem } from 'lib/cart-values/cart-items';
 import { setTaxPostalCode } from 'lib/cart/actions';
@@ -126,7 +126,7 @@ export class PaypalPaymentBox extends React.Component {
 					info: this.props.translate( 'Redirecting you to PayPal' ),
 					disabled: true,
 				} );
-				analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Paypal Button' );
+				gaRecordEvent( 'Upgrades', 'Clicked Checkout With Paypal Button' );
 				analytics.tracks.recordEvent( 'calypso_checkout_with_paypal' );
 				window.location = paypalExpressURL;
 			}.bind( this )

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -4,11 +4,11 @@
 import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { snakeCase, map, zipObject, isEmpty, mapValues, overSome, some } from 'lodash';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
 import PaymentChatButton from './payment-chat-button';
@@ -19,6 +19,7 @@ import { paymentMethodName, paymentMethodClassName, getLocationOrigin } from 'li
 import { hasRenewalItem, hasRenewableSubscription } from 'lib/cart-values/cart-items';
 import SubscriptionText from './subscription-text';
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import wpcom from 'lib/wp';
 import notices from 'notices';
 import CountrySpecificPaymentFields from './country-specific-payment-fields';
@@ -185,7 +186,7 @@ export class RedirectPaymentBox extends PureComponent {
 						),
 						disabled: true,
 					} );
-					analytics.ga.recordEvent( 'Upgrades', 'Clicked Checkout With Redirect Payment Button' );
+					gaRecordEvent( 'Upgrades', 'Clicked Checkout With Redirect Payment Button' );
 					analytics.tracks.recordEvent(
 						'calypso_checkout_with_redirect_' + snakeCase( this.props.paymentType )
 					);

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -24,7 +24,7 @@ import WechatPaymentBox from './wechat-payment-box';
 import RedirectPaymentBox from './redirect-payment-box';
 import WebPaymentBox from './web-payment-box';
 import { submit } from 'lib/store-transactions';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { setPayment, setTransactionStep } from 'lib/transaction/actions';
 import {
 	fullCreditsPayment,
@@ -155,7 +155,7 @@ export class SecurePaymentForm extends Component {
 	}
 
 	handlePaymentBoxSubmit = event => {
-		analytics.ga.recordEvent( 'Upgrades', 'Submitted Checkout Form' );
+		gaRecordEvent( 'Upgrades', 'Submitted Checkout Form' );
 
 		this.submitTransaction( event );
 	};

--- a/client/my-sites/checkout/checkout/terms-of-service.jsx
+++ b/client/my-sites/checkout/checkout/terms-of-service.jsx
@@ -8,7 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import {
 	MANAGE_PURCHASES_AUTOMATIC_RENEWAL,
 	MANAGE_PURCHASES_FAQ_CANCELLING,
@@ -20,7 +20,7 @@ class TermsOfService extends React.Component {
 	static displayName = 'TermsOfService';
 
 	recordTermsAndConditionsClick = () => {
-		analytics.ga.recordEvent( 'Upgrades', 'Clicked Terms and Conditions Link' );
+		gaRecordEvent( 'Upgrades', 'Clicked Terms and Conditions Link' );
 	};
 
 	renderTerms() {

--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -10,7 +10,7 @@ import { isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormSelect from 'components/forms/form-select';
@@ -18,10 +18,7 @@ import FormSelect from 'components/forms/form-select';
 class CountrySelect extends React.Component {
 	recordCountrySelectClick = () => {
 		if ( this.props.eventFormName ) {
-			analytics.ga.recordEvent(
-				'Upgrades',
-				`Clicked ${ this.props.eventFormName } Country Select`
-			);
+			gaRecordEvent( 'Upgrades', `Clicked ${ this.props.eventFormName } Country Select` );
 		}
 	};
 

--- a/client/my-sites/domains/components/form/input.jsx
+++ b/client/my-sites/domains/components/form/input.jsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import scrollIntoViewport from 'lib/scroll-into-viewport';
 
 export default class Input extends React.Component {
@@ -80,11 +80,7 @@ export default class Input extends React.Component {
 
 	recordFieldClick = () => {
 		if ( this.props.eventFormName ) {
-			analytics.ga.recordEvent(
-				'Upgrades',
-				`Clicked ${ this.props.eventFormName } Field`,
-				this.props.name
-			);
+			gaRecordEvent( 'Upgrades', `Clicked ${ this.props.eventFormName } Field`, this.props.name );
 		}
 	};
 

--- a/client/my-sites/domains/components/form/select.jsx
+++ b/client/my-sites/domains/components/form/select.jsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormSelect from 'components/forms/form-select';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 export default class Select extends PureComponent {
 	static propTypes = {
@@ -33,11 +33,7 @@ export default class Select extends PureComponent {
 
 	recordFieldClick = () => {
 		if ( this.props.eventFormName ) {
-			analytics.ga.recordEvent(
-				'Upgrades',
-				`Clicked ${ this.props.eventFormName } Field`,
-				this.props.name
-			);
+			gaRecordEvent( 'Upgrades', `Clicked ${ this.props.eventFormName } Field`, this.props.name );
 		}
 	};
 

--- a/client/my-sites/jetpack-manage-error-page/index.jsx
+++ b/client/my-sites/jetpack-manage-error-page/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -9,7 +8,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import EmptyContent from 'components/empty-content';
 import FeatureExample from 'components/feature-example';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -20,7 +19,7 @@ class JetpackManageErrorPage extends PureComponent {
 	};
 
 	actionCallbackUpdate = () => {
-		analytics.ga.recordEvent( 'Jetpack', 'Update jetpack', 'Site', this.props.siteId );
+		gaRecordEvent( 'Jetpack', 'Update jetpack', 'Site', this.props.siteId );
 	};
 
 	getSettings() {

--- a/client/my-sites/marketing/buttons/preview-button.jsx
+++ b/client/my-sites/marketing/buttons/preview-button.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -12,6 +11,7 @@ import photon from 'photon';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import SocialLogo from 'components/social-logo';
@@ -67,7 +67,7 @@ class SharingButtonsPreviewButton extends React.Component {
 			enabled: ! this.props.enabled, // during onClick enabled is the old state, so negating gives the new state
 			path: this.props.path,
 		} );
-		analytics.ga.recordEvent( 'Sharing', 'Clicked Share Button', this.props.button.ID );
+		gaRecordEvent( 'Sharing', 'Clicked Share Button', this.props.button.ID );
 		this.props.onClick();
 	};
 

--- a/client/my-sites/marketing/buttons/preview.jsx
+++ b/client/my-sites/marketing/buttons/preview.jsx
@@ -1,23 +1,23 @@
 /**
  * External dependencies
  */
-
 import { filter, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'components/gridicon';
 import ButtonsLabelEditor from './label-editor';
 import ButtonsPreviewButtons from './preview-buttons';
 import ButtonsPreviewAction from './preview-action';
 import ButtonsTray from './tray';
 import { decodeEntities } from 'lib/formatting';
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -58,10 +58,10 @@ class SharingButtonsPreview extends React.Component {
 		if ( isEditingLabel ) {
 			this.hideButtonsTray();
 			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_text_click', { path } );
-			analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Text Link' );
+			gaRecordEvent( 'Sharing', 'Clicked Edit Text Link' );
 		} else {
 			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_text_close_click', { path } );
-			analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Text Done Button' );
+			gaRecordEvent( 'Sharing', 'Clicked Edit Text Done Button' );
 		}
 	};
 
@@ -75,10 +75,10 @@ class SharingButtonsPreview extends React.Component {
 
 		if ( 'hidden' === visibility ) {
 			analytics.tracks.recordEvent( 'calypso_sharing_buttons_more_button_click', { path } );
-			analytics.ga.recordEvent( 'Sharing', 'Clicked More Button Link', visibility );
+			gaRecordEvent( 'Sharing', 'Clicked More Button Link', visibility );
 		} else {
 			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_button_click', { path } );
-			analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Button Link', visibility );
+			gaRecordEvent( 'Sharing', 'Clicked Edit Button Link', visibility );
 		}
 	};
 
@@ -93,7 +93,7 @@ class SharingButtonsPreview extends React.Component {
 		this.setState( { buttonsTrayVisibility: null } );
 
 		analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_buttons_close_click', { path } );
-		analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Buttons Done Button' );
+		gaRecordEvent( 'Sharing', 'Clicked Edit Buttons Done Button' );
 	};
 
 	getButtonsTrayToggleButtonLabel = ( visibility, enabledButtonsExist ) => {

--- a/client/my-sites/marketing/buttons/style.jsx
+++ b/client/my-sites/marketing/buttons/style.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -11,6 +10,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
@@ -36,7 +36,7 @@ class SharingButtonsStyle extends React.Component {
 			value,
 			path,
 		} );
-		analytics.ga.recordEvent( 'Sharing', 'Clicked Button Style Radio Button', value );
+		gaRecordEvent( 'Sharing', 'Clicked Button Style Radio Button', value );
 	};
 
 	getOptions = () => {

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
@@ -267,7 +268,7 @@ export class MediaLibraryContent extends React.Component {
 	}
 
 	recordPlansNavigation( tracksEvent, tracksData ) {
-		analytics.ga.recordEvent( 'Media', 'Clicked Upload Error Action' );
+		gaRecordEvent( 'Media', 'Clicked Upload Error Action' );
 		analytics.tracks.recordEvent( tracksEvent, tracksData );
 	}
 

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -7,11 +7,11 @@ import React, { Component } from 'react';
 import deterministicStringify from 'fast-json-stable-stringify';
 import { omit } from 'lodash';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'components/gridicon';
 import PeopleListItem from 'my-sites/people/people-list-item';
 import { Card, Button } from '@automattic/components';
 import classNames from 'classnames';
@@ -26,7 +26,7 @@ import EmptyContent from 'components/empty-content';
 import FollowersStore from 'lib/followers/store';
 import EmailFollowersStore from 'lib/email-followers/store';
 import accept from 'lib/accept';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import ListEnd from 'components/list-end';
 import { preventWidows } from 'lib/formatting';
 
@@ -68,15 +68,12 @@ const Followers = localize(
 			}
 
 			actions.fetchFollowers( Object.assign( this.props.fetchOptions, { page } ) );
-			analytics.ga.recordEvent( 'People', analyticsAction, 'page', page );
+			gaRecordEvent( 'People', analyticsAction, 'page', page );
 		};
 
 		removeFollower( follower ) {
 			const listType = 'email' === this.props.type ? 'Email Follower' : 'Follower';
-			analytics.ga.recordEvent(
-				'People',
-				'Clicked Remove Follower Button On' + listType + ' list'
-			);
+			gaRecordEvent( 'People', 'Clicked Remove Follower Button On' + listType + ' list' );
 			accept(
 				<div>
 					<p>
@@ -87,7 +84,7 @@ const Followers = localize(
 				</div>,
 				accepted => {
 					if ( accepted ) {
-						analytics.ga.recordEvent(
+						gaRecordEvent(
 							'People',
 							'Clicked Remove Button In Remove ' + listType + ' Confirmation'
 						);
@@ -96,7 +93,7 @@ const Followers = localize(
 							: FollowersActions
 						).removeFollower( this.props.site.ID, follower );
 					} else {
-						analytics.ga.recordEvent(
+						gaRecordEvent(
 							'People',
 							'Clicked Cancel Button In Remove ' + listType + ' Confirmation'
 						);

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -10,7 +10,7 @@ import { includes, some } from 'lodash';
  */
 import { getSiteFragment, sectionify } from 'lib/route';
 import notices from 'notices';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import PlanSetup from './jetpack-plugins-setup';
 import PluginEligibility from './plugin-eligibility';
 import PluginListComponent from './main';
@@ -74,7 +74,7 @@ function renderPluginList( context, basePath ) {
 	} );
 
 	if ( search ) {
-		analytics.ga.recordEvent( 'Plugins', 'Search', 'Search term', search );
+		gaRecordEvent( 'Plugins', 'Search', 'Search term', search );
 	}
 }
 

--- a/client/my-sites/plugins/plugin-information/index.jsx
+++ b/client/my-sites/plugins/plugin-information/index.jsx
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
 import { get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'components/gridicon';
 import { Button, Card } from '@automattic/components';
 import ExternalLink from 'components/external-link';
 import { withLocalizedMoment } from 'components/localized-moment';
@@ -19,6 +19,7 @@ import PluginRatings from 'my-sites/plugins/plugin-ratings/';
 import { getExtensionSettingsPath } from 'my-sites/plugins/utils';
 import versionCompare from 'lib/version-compare';
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 /**
  * Style dependencies
@@ -56,7 +57,7 @@ class PluginInformation extends React.Component {
 		) {
 			return;
 		}
-		const recordEvent = analytics.ga.recordEvent.bind(
+		const recordEvent = gaRecordEvent.bind(
 			analytics,
 			'Plugins',
 			'Clicked Plugin Homepage Link',
@@ -80,7 +81,7 @@ class PluginInformation extends React.Component {
 		if ( ! this.props.plugin.slug ) {
 			return;
 		}
-		const recordEvent = analytics.ga.recordEvent.bind(
+		const recordEvent = gaRecordEvent.bind(
 			analytics,
 			'Plugins',
 			'Clicked wp.org Plugin Link',

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -18,7 +18,7 @@ import ButtonGroup from 'components/button-group';
 import { Button } from '@automattic/components';
 import SelectDropdown from 'components/select-dropdown';
 import BulkSelect from 'components/bulk-select';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 /**
  * Style dependencies
@@ -98,7 +98,7 @@ export class PluginsListHeader extends PureComponent {
 		const { plugins, selected } = this.props;
 		const someSelected = selected.length > 0;
 		this.props.setSelectionState( plugins, ! someSelected );
-		analytics.ga.recordEvent(
+		gaRecordEvent(
 			'Plugins',
 			someSelected ? 'Clicked to Uncheck All Plugins' : 'Clicked to Check All Plugins'
 		);

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -6,14 +6,15 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { get, includes, some } from 'lodash';
-import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'components/gridicon';
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { Button, Card, CompactCard } from '@automattic/components';
 import Count from 'components/count';
 import NoticeAction from 'components/notice/notice-action';
@@ -557,7 +558,7 @@ export class PluginMeta extends Component {
 		event.preventDefault();
 		PluginsActions.updatePlugin( this.props.sites[ 0 ], this.props.sites[ 0 ].plugin );
 
-		analytics.ga.recordEvent(
+		gaRecordEvent(
 			'Plugins',
 			'Clicked Update Selected Site Plugin',
 			'Plugin Name',
@@ -590,7 +591,7 @@ export class PluginMeta extends Component {
 			}
 		} );
 
-		analytics.ga.recordEvent(
+		gaRecordEvent(
 			'Plugins',
 			'Clicked Update All Sites Plugin',
 			'Plugin Name',

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -13,7 +12,7 @@ import createReactClass from 'create-react-class';
  */
 import { ProgressBar } from '@automattic/components';
 import Rating from 'components/rating';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 /**
  * Style dependencies
@@ -58,7 +57,7 @@ const PluginRatings = createReactClass( {
 		const { ratings, slug, numRatings } = this.props;
 		const numberOfRatings = ratings && ratings[ ratingTier ] ? ratings[ ratingTier ] : 0;
 		const onClickPluginRatingsLink = () => {
-			analytics.ga.recordEvent( 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', slug );
+			gaRecordEvent( 'Plugins', 'Clicked Plugin Ratings Link', 'Plugin Name', slug );
 		};
 
 		return (

--- a/client/my-sites/plugins/plugin-remove-button/index.jsx
+++ b/client/my-sites/plugins/plugin-remove-button/index.jsx
@@ -7,12 +7,13 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'components/gridicon';
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import accept from 'lib/accept';
 import PluginsLog from 'lib/plugins/log-store';
 import PluginAction from 'my-sites/plugins/plugin-action/plugin-action';
@@ -57,7 +58,7 @@ class PluginRemoveButton extends React.Component {
 			PluginsActions.removePlugin( this.props.site, this.props.plugin );
 
 			if ( this.props.isEmbed ) {
-				analytics.ga.recordEvent(
+				gaRecordEvent(
 					'Plugins',
 					'Remove plugin with no selected site',
 					'Plugin Name',
@@ -68,7 +69,7 @@ class PluginRemoveButton extends React.Component {
 					plugin: this.props.plugin.slug,
 				} );
 			} else {
-				analytics.ga.recordEvent(
+				gaRecordEvent(
 					'Plugins',
 					'Remove plugin on selected Site',
 					'Plugin Name',
@@ -155,7 +156,7 @@ class PluginRemoveButton extends React.Component {
 	};
 
 	handleHowDoIFixThisButtonClick = () => {
-		analytics.ga.recordEvent( 'Plugins', 'Clicked How do I fix disabled plugin removal.' );
+		gaRecordEvent( 'Plugins', 'Clicked How do I fix disabled plugin removal.' );
 	};
 
 	renderButton = () => {

--- a/client/my-sites/plugins/plugin-sections/index.jsx
+++ b/client/my-sites/plugins/plugin-sections/index.jsx
@@ -1,18 +1,17 @@
 /**
  * External dependencies
  */
-
 import { filter, find } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import titleCase from 'to-title-case';
 import classNames from 'classnames';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import Gridicon from 'components/gridicon';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { Card } from '@automattic/components';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
@@ -35,7 +34,7 @@ class PluginSections extends React.Component {
 	_COLLAPSED_DESCRIPTION_HEIGHT = 140;
 
 	recordEvent = eventAction => {
-		analytics.ga.recordEvent( 'Plugins', eventAction, 'Plugin Name', this.props.plugin.slug );
+		gaRecordEvent( 'Plugins', eventAction, 'Plugin Name', this.props.plugin.slug );
 	};
 
 	componentDidMount() {

--- a/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
+++ b/client/my-sites/plugins/plugin-site-update-indicator/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -10,6 +9,7 @@ import React from 'react';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import Gridicon from 'components/gridicon';
 import PluginsActions from 'lib/plugins/actions';
 
@@ -38,7 +38,7 @@ class PluginSiteUpdateIndicator extends React.Component {
 
 		PluginsActions.updatePlugin( this.props.site, this.props.plugin );
 		PluginsActions.removePluginsNotices( 'completed', 'error' );
-		analytics.ga.recordEvent(
+		gaRecordEvent(
 			'Plugins',
 			'Clicked Update Single Site Plugin',
 			'Plugin Name',

--- a/client/my-sites/post-selector/selector.jsx
+++ b/client/my-sites/post-selector/selector.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -26,7 +25,7 @@ import {
  * Internal dependencies
  */
 import NoResults from './no-results';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import Search from './search';
 import { decodeEntities } from 'lib/formatting';
 import {
@@ -290,7 +289,7 @@ class PostSelectorPosts extends React.Component {
 
 		if ( ! this.hasPerformedSearch ) {
 			this.hasPerformedSearch = true;
-			analytics.ga.recordEvent( this.props.analyticsPrefix, 'Performed Post Search' );
+			gaRecordEvent( this.props.analyticsPrefix, 'Performed Post Search' );
 		}
 
 		this.setState( { searchTerm } );

--- a/client/my-sites/resume-editing/index.jsx
+++ b/client/my-sites/resume-editing/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
@@ -22,7 +21,7 @@ import { isRequestingSitePost } from 'state/posts/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import { decodeEntities } from 'lib/formatting';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { bumpStat } from 'lib/analytics/mc';
 import QueryPosts from 'components/data/query-posts';
 import SiteIcon from 'blocks/site-icon';
@@ -52,7 +51,7 @@ class ResumeEditing extends React.Component {
 	}
 
 	trackAnalytics = () => {
-		analytics.ga.recordEvent( 'Master Bar', 'Resumed Editing' );
+		gaRecordEvent( 'Master Bar', 'Resumed Editing' );
 		bumpStat( 'calypso_edit_via', 'masterbar_resume_editing' );
 	};
 

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import config from 'config';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import QuerySiteStats from 'components/data/query-site-stats';
@@ -72,7 +72,7 @@ class StatsGeochart extends Component {
 	}
 
 	recordEvent = () => {
-		analytics.ga.recordEvent( 'Stats', 'Clicked Country on Map' );
+		gaRecordEvent( 'Stats', 'Clicked Country on Map' );
 	};
 
 	drawRegionsMap = () => {

--- a/client/my-sites/stats/info-panel/index.jsx
+++ b/client/my-sites/stats/info-panel/index.jsx
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import Gridicon from 'components/gridicon';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import titlecase from 'to-title-case';
 
 class StatsInfoPanel extends React.PureComponent {
@@ -21,7 +20,7 @@ class StatsInfoPanel extends React.PureComponent {
 	};
 
 	recordEvent = () => {
-		analytics.ga.recordEvent(
+		gaRecordEvent(
 			'Stats',
 			'Clicked More Panel Information Help Link',
 			titlecase( this.props.module )

--- a/client/my-sites/stats/stats-list/action-follow.jsx
+++ b/client/my-sites/stats/stats-list/action-follow.jsx
@@ -1,13 +1,11 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:stats:action-follow' );
 
 /**
  * Internal dependencies
@@ -15,8 +13,10 @@ const debug = debugFactory( 'calypso:stats:action-follow' );
 /* eslint-disable no-restricted-imports */
 import observe from 'lib/mixins/data-observe';
 /* eslint-enable no-restricted-imports */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import Gridicon from 'components/gridicon';
+
+const debug = debugFactory( 'calypso:stats:action-follow' );
 
 const StatsActionFollow = createReactClass( {
 	displayName: 'StatsActionFollow',
@@ -39,10 +39,7 @@ const StatsActionFollow = createReactClass( {
 			site.unfollow();
 		}
 
-		analytics.ga.recordEvent(
-			'Stats',
-			'Clicked ' + gaEvent + ' in ' + this.props.moduleName + ' List'
-		);
+		gaRecordEvent( 'Stats', 'Clicked ' + gaEvent + ' in ' + this.props.moduleName + ' List' );
 	},
 
 	render: function() {

--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import Gridicon from 'components/gridicon';
+import { gaRecordEvent } from 'lib/analytics/ga';
 
 class StatsActionLink extends PureComponent {
 	static propTypes = {
@@ -21,7 +20,7 @@ class StatsActionLink extends PureComponent {
 
 	onClick = event => {
 		event.stopPropagation();
-		analytics.ga.recordEvent(
+		gaRecordEvent(
 			'Stats',
 			'Clicked on External Link in ' + this.props.moduleName + ' List Action Menu'
 		);

--- a/client/my-sites/stats/stats-list/action-page.jsx
+++ b/client/my-sites/stats/stats-list/action-page.jsx
@@ -1,18 +1,18 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:stats:action-page' );
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import Gridicon from 'components/gridicon';
+
+const debug = debugFactory( 'calypso:stats:action-page' );
 
 class StatsActionPage extends React.Component {
 	static displayName = 'StatsActionPage';
@@ -21,7 +21,7 @@ class StatsActionPage extends React.Component {
 		event.stopPropagation();
 		event.preventDefault();
 		debug( 'handling page click', this.props );
-		analytics.ga.recordEvent(
+		gaRecordEvent(
 			'Stats',
 			'Clicked on Summary Link in ' + this.props.moduleName + ' List Action Menu'
 		);

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -1,20 +1,20 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:stats:action-spam' );
 
 /**
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { Button } from '@automattic/components';
 import Gridicon from 'components/gridicon';
+
+const debug = debugFactory( 'calypso:stats:action-spam' );
 
 class StatsActionSpam extends React.Component {
 	static displayName = 'StatsActionSpam';
@@ -39,7 +39,7 @@ class StatsActionSpam extends React.Component {
 
 		const wpcomSite = wpcom.site( this.props.data.siteID );
 		wpcomSite[ spamType ].call( wpcomSite, this.props.data.domain, function() {} );
-		analytics.ga.recordEvent( 'Stats', gaEvent + ' in ' + this.props.moduleName + ' List' );
+		gaRecordEvent( 'Stats', gaEvent + ' in ' + this.props.moduleName + ' List' );
 	};
 
 	render() {

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -8,12 +8,11 @@ import Gridicon from 'components/gridicon';
 import page from 'page';
 import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
-const debug = debugFactory( 'calypso:stats:list-item' );
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import Emojify from 'components/emojify';
 import { withLocalizedMoment } from 'components/localized-moment';
 import Follow from './action-follow';
@@ -24,6 +23,8 @@ import titlecase from 'to-title-case';
 import { flagUrl } from 'lib/flags';
 import { recordTrack } from 'reader/stats';
 import { decodeEntities } from 'lib/formatting';
+
+const debug = debugFactory( 'calypso:stats:list-item' );
 
 class StatsListItem extends React.Component {
 	static displayName = 'StatsListItem';
@@ -119,7 +120,7 @@ class StatsListItem extends React.Component {
 			}
 
 			if ( gaEvent ) {
-				analytics.ga.recordEvent( 'Stats', gaEvent + ' in List' );
+				gaRecordEvent( 'Stats', gaEvent + ' in List' );
 			}
 		}
 	};

--- a/client/my-sites/stats/stats-module/header.jsx
+++ b/client/my-sites/stats/stats-module/header.jsx
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import Gridicon from 'components/gridicon';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import titlecase from 'to-title-case';
 
 class StatsModuleHeader extends React.Component {
@@ -43,7 +42,7 @@ class StatsModuleHeader extends React.Component {
 		const gaEvent = showInfo ? 'Closed' : 'Opened';
 
 		if ( path ) {
-			analytics.ga.recordEvent( 'Stats', gaEvent + ' More Information Panel', titlecase( path ) );
+			gaRecordEvent( 'Stats', gaEvent + ' More Information Panel', titlecase( path ) );
 		}
 
 		onActionClick( {
@@ -57,7 +56,7 @@ class StatsModuleHeader extends React.Component {
 		const gaEvent = showModule ? 'Collapsed' : 'Expanded';
 
 		if ( path ) {
-			analytics.ga.recordEvent( 'Stats', gaEvent + ' Module', titlecase( path ) );
+			gaRecordEvent( 'Stats', gaEvent + ' Module', titlecase( path ) );
 		}
 
 		onActionClick( {

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import titlecase from 'to-title-case';
 import { mapValues } from 'lodash';
 
 export function trackClick( componentName, eventName, verb = 'click' ) {
 	const stat = `${ componentName } ${ eventName } ${ verb }`;
-	analytics.ga.recordEvent( 'Themes', titlecase( stat ) );
+	gaRecordEvent( 'Themes', titlecase( stat ) );
 }
 
 export function addTracking( options ) {

--- a/client/post-editor/media-modal/detail/detail-fields.jsx
+++ b/client/post-editor/media-modal/detail/detail-fields.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -11,7 +10,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { bumpStat } from 'lib/analytics/mc';
 import { getMimePrefix, url } from 'lib/media/utils';
 import MediaActions from 'lib/media/actions';
@@ -40,22 +39,22 @@ class EditorMediaModalDetailFields extends Component {
 	}
 
 	bumpTitleStat = () => {
-		analytics.ga.recordEvent( 'Media', 'Changed Item Title' );
+		gaRecordEvent( 'Media', 'Changed Item Title' );
 		bumpStat( 'calypso_media_edit_details', 'title' );
 	};
 
 	bumpAltStat = () => {
-		analytics.ga.recordEvent( 'Media', 'Changed Image Alt' );
+		gaRecordEvent( 'Media', 'Changed Image Alt' );
 		bumpStat( 'calypso_media_edit_details', 'alt' );
 	};
 
 	bumpCaptionStat = () => {
-		analytics.ga.recordEvent( 'Media', 'Changed Item Caption' );
+		gaRecordEvent( 'Media', 'Changed Item Caption' );
 		bumpStat( 'calypso_media_edit_details', 'caption' );
 	};
 
 	bumpDescriptionStat = () => {
-		analytics.ga.recordEvent( 'Media', 'Changed Item Description' );
+		gaRecordEvent( 'Media', 'Changed Item Description' );
 		bumpStat( 'calypso_media_edit_details', 'description' );
 	};
 

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
@@ -26,7 +25,7 @@ import {
  * Internal dependencies
  */
 import MediaLibrary from 'my-sites/media-library';
-import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { bumpStat as mcBumpStat } from 'lib/analytics/mc';
 import { recordEditorEvent, recordEditorStat } from 'state/posts/stats';
 import MediaModalGallery from './gallery';
@@ -459,7 +458,7 @@ export class EditorMediaModal extends Component {
 		this.setDetailSelectedIndex( findIndex( items, { ID: item.ID } ) );
 
 		mcBumpStat( 'editor_media_actions', 'edit_button_contextual' );
-		analytics.ga.recordEvent( 'Media', 'Clicked Contextual Edit Button' );
+		gaRecordEvent( 'Media', 'Clicked Contextual Edit Button' );
 
 		this.props.setView( ModalViews.DETAIL );
 	};

--- a/client/reader/controller-helper.js
+++ b/client/reader/controller-helper.js
@@ -8,6 +8,7 @@ import moment from 'moment';
  * Internal Dependencies
  */
 import analytics from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { bumpStat } from 'lib/analytics/mc';
 import { recordTrack } from 'reader/stats';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
@@ -27,7 +28,7 @@ export function getStartDate( context ) {
 }
 
 export function trackScrollPage( path, title, category, readerView, pageNum ) {
-	analytics.ga.recordEvent( category, 'Loaded Next Page', 'page', pageNum );
+	gaRecordEvent( category, 'Loaded Next Page', 'page', pageNum );
 	recordTrack( 'calypso_reader_infinite_scroll_performed', {
 		path: path,
 		page: pageNum,
@@ -42,7 +43,7 @@ export function trackScrollPage( path, title, category, readerView, pageNum ) {
 
 export function trackUpdatesLoaded( key ) {
 	bumpStat( 'reader_views', key + '_load_new' );
-	analytics.ga.recordEvent( 'Reader', 'Clicked Load New Posts', key );
+	gaRecordEvent( 'Reader', 'Clicked Load New Posts', key );
 	recordTrack( 'calypso_reader_load_new_posts', {
 		section: key,
 	} );

--- a/client/state/analytics/middleware.js
+++ b/client/state/analytics/middleware.js
@@ -1,6 +1,5 @@
 /**
  *  External dependencies
- *
  */
 import { has, invoke } from 'lodash';
 
@@ -8,6 +7,7 @@ import { has, invoke } from 'lodash';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { gaRecordEvent, gaRecordPageView } from 'lib/analytics/ga';
 import { bumpStat } from 'lib/analytics/mc';
 import { addHotJarScript } from 'lib/analytics/hotjar';
 import {
@@ -23,15 +23,14 @@ import {
 } from 'state/action-types';
 
 const eventServices = {
-	ga: ( { category, action, label, value } ) =>
-		analytics.ga.recordEvent( category, action, label, value ),
+	ga: ( { category, action, label, value } ) => gaRecordEvent( category, action, label, value ),
 	tracks: ( { name, properties } ) => analytics.tracks.recordEvent( name, properties ),
 	fb: ( { name, properties } ) => trackCustomFacebookConversionEvent( name, properties ),
 	adwords: ( { properties } ) => trackCustomAdWordsRemarketingEvent( properties ),
 };
 
 const pageViewServices = {
-	ga: ( { url, title } ) => analytics.ga.recordPageView( url, title ),
+	ga: ( { url, title } ) => gaRecordPageView( url, title ),
 	default: ( { url, title, ...params } ) => analytics.pageView.record( url, title, params ),
 };
 

--- a/client/state/analytics/test/helpers/analytics-mock.js
+++ b/client/state/analytics/test/helpers/analytics-mock.js
@@ -21,6 +21,8 @@ const adTrackingMocks = [
 
 const mcMocks = [ 'bumpStat', 'bumpStatWithPageView' ];
 
+const gaMocks = [ 'gaRecordEvent', 'gaRecordPageView', 'gaRecordTiming' ];
+
 const mockIt = spy => mock => set( {}, mock, ( ...args ) => spy( mock, ...args ) );
 
 export const moduleMock = moduleMocks => spy =>
@@ -29,5 +31,6 @@ export const moduleMock = moduleMocks => spy =>
 export const analyticsMock = moduleMock( analyticsMocks );
 export const adTrackingMock = moduleMock( adTrackingMocks );
 export const mcMock = moduleMock( mcMocks );
+export const gaMock = moduleMock( gaMocks );
 
 export default analyticsMock;

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -23,6 +23,7 @@ import { analyticsMiddleware } from '../middleware.js';
 import { spy as mockAnalytics } from 'lib/analytics';
 import { spy as mockAdTracking } from 'lib/analytics/ad-tracking';
 import { spy as mockMC } from 'lib/analytics/mc';
+import { spy as mockGA } from 'lib/analytics/ga';
 import { addHotJarScript } from 'lib/analytics/hotjar';
 
 jest.mock( 'lib/analytics', () => {
@@ -51,6 +52,16 @@ jest.mock( 'lib/analytics/mc', () => {
 
 	const mock = mcMock( mcSpy );
 	mock.spy = mcSpy;
+
+	return mock;
+} );
+
+jest.mock( 'lib/analytics/ga', () => {
+	const gaSpy = require( 'sinon' ).spy();
+	const { gaMock } = require( './helpers/analytics-mock' );
+
+	const mock = gaMock( gaSpy );
+	mock.spy = gaSpy;
 
 	return mock;
 } );
@@ -93,8 +104,8 @@ describe( 'middleware', () => {
 		test( 'should call ga.recordEvent', () => {
 			dispatch( recordGoogleEvent( 'category', 'action', 'label', 'value' ) );
 
-			expect( mockAnalytics ).to.have.been.calledWithExactly(
-				'ga.recordEvent',
+			expect( mockGA ).to.have.been.calledWithExactly(
+				'gaRecordEvent',
 				'category',
 				'action',
 				'label',
@@ -105,11 +116,7 @@ describe( 'middleware', () => {
 		test( 'should call ga.recordPageView', () => {
 			dispatch( recordGooglePageView( 'path', 'title' ) );
 
-			expect( mockAnalytics ).to.have.been.calledWithExactly(
-				'ga.recordPageView',
-				'path',
-				'title'
-			);
+			expect( mockGA ).to.have.been.calledWithExactly( 'gaRecordPageView', 'path', 'title' );
 		} );
 
 		test( 'should call trackCustomFacebookConversionEvent', () => {


### PR DESCRIPTION
This is one of several PRs that will make `lib/analytics` more modular, breaking up its monolithic default export. This will eventually result in being able to contain larger parts of analytics to just the sections they're needed in, instead of loading everything upfront regardless of the current route.

The PR moves `ga` to its own module under `lib/analytics` and updates all code accordingly.

Note that I considered lint errors in existing files to be out of scope for this PR, and I let them be. This means that the lint test will fail due to the pre-existing issues.

#### Changes proposed in this Pull Request

* Extract `ga` into its own module
* Update all code accordingly

#### Testing instructions

There are no code changes, so it should be sufficient to ensure that there are no build errors or unit test failures related to e.g. an import not being correctly updated.
