### PR TITLE
Gutenboarding: Visual fixes for #40569

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -42,7 +42,6 @@
 .domain-picker__connect-button {
 	&.components-button.is-link {
 		color: var( --color-neutral-40 );
-		text-decoration: underline;
 	}
 }
 

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -3,7 +3,7 @@
  */
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
-import { Button, Icon } from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import React, { FunctionComponent, useEffect, useCallback, useState } from 'react';
 import classnames from 'classnames';
@@ -62,14 +62,10 @@ const Header: FunctionComponent = () => {
 
 	const newSite = useSelect( select => select( SITE_STORE ).getNewSite() );
 
-	const {
-		domain,
-		selectedDesign,
-		siteTitle,
-		siteVertical,
-		siteWasCreatedForDomainPurchase,
-	} = useSelect( select => select( ONBOARD_STORE ).getState() );
-	const hasSelectedDesign = !! selectedDesign;
+	const { domain, siteTitle, siteVertical, siteWasCreatedForDomainPurchase } = useSelect( select =>
+		select( ONBOARD_STORE ).getState()
+	);
+
 	const {
 		createSite,
 		setDomain,
@@ -123,10 +119,6 @@ const Header: FunctionComponent = () => {
 	const handleCreateSiteForDomains: typeof handleCreateSite = ( ...args ) => {
 		setSiteWasCreatedForDomainPurchase( true );
 		handleCreateSite( ...args );
-	};
-
-	const handleSignup = () => {
-		setShowSignupDialog( true );
 	};
 
 	const closeAuthDialog = () => {
@@ -217,26 +209,9 @@ const Header: FunctionComponent = () => {
 					) }
 				</div>
 			</section>
-			<section className="gutenboarding__header-section">
-				<div className="gutenboarding__header-section-item">
-					{ hasSelectedDesign && (
-						<Button
-							className="gutenboarding__header-next-button"
-							isPrimary
-							isLarge
-							onClick={ () =>
-								currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
-							}
-						>
-							{ NO__( 'Create my site' ) }
-						</Button>
-					) }
-				</div>
-			</section>
 			{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }
 		</div>
 	);
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 export default Header;

--- a/client/landing/gutenboarding/components/titles.scss
+++ b/client/landing/gutenboarding/components/titles.scss
@@ -1,8 +1,7 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../mixins';
 
-.gutenboarding-title,
-.gutenboarding-subtitle {
+.gutenboarding-title {
 	color: var( --mainColor );
 }
 .gutenboarding-title {
@@ -11,7 +10,7 @@
 }
 
 .gutenboarding-subtitle {
-	font-size: 16px;
+	font-size: 14px;
 	font-family: $default-font;
 	line-height: 19px;
 	letter-spacing: 0.2px;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -18,7 +18,6 @@
 
 	.design-selector__start-over-button {
 		&.is-link {
-			text-decoration: underline;
 			color: var( --color-text-subtle );
 		}
 	}

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React, { useCallback, useState } from 'react';
 import { useI18n } from '@automattic/react-i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -14,13 +16,45 @@ import ViewportSelect from './viewport-select';
 import FontSelect from './font-select';
 import { Title, SubTitle } from '../../components/titles';
 import * as T from './types';
+import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { USER_STORE } from '../../stores/user';
+import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
+import SignupForm from '../../components/signup-form';
 
 import './style.scss';
 
 const StylePreview: React.FunctionComponent = () => {
+	const { selectedDesign } = useSelect( select => select( ONBOARD_STORE ).getState() );
+
+	const [ showSignupDialog, setShowSignupDialog ] = useState( false );
+
+	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
+
+	const hasSelectedDesign = !! selectedDesign;
+
 	const { __: NO__ } = useI18n();
 	const makePath = usePath();
 	const [ selectedViewport, setSelectedViewport ] = React.useState< T.Viewport >( 'desktop' );
+
+	const { createSite } = useDispatch( ONBOARD_STORE );
+
+	const freeDomainSuggestion = useFreeDomainSuggestion();
+
+	const handleSignup = () => {
+		setShowSignupDialog( true );
+	};
+
+	const closeAuthDialog = () => {
+		setShowSignupDialog( false );
+	};
+
+	const handleCreateSite = useCallback(
+		( username: string, bearerToken?: string ) => {
+			createSite( username, freeDomainSuggestion, bearerToken );
+		},
+		[ createSite, freeDomainSuggestion ]
+	);
+
 	return (
 		<div className="style-preview">
 			<div className="style-preview__header">
@@ -33,12 +67,25 @@ const StylePreview: React.FunctionComponent = () => {
 					<Link isLink to={ makePath( Step.DesignSelection ) }>
 						{ NO__( 'Choose another design' ) }
 					</Link>
+					{ hasSelectedDesign && (
+						<Button
+							className="style-preview__actions-continue-button"
+							isPrimary
+							isLarge
+							onClick={ () =>
+								currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
+							}
+						>
+							{ NO__( 'Continue' ) }
+						</Button>
+					) }
 				</div>
 			</div>
 			<div className="style-preview__content">
 				<FontSelect />
 				<Preview viewport={ selectedViewport } />
 			</div>
+			{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -1,8 +1,11 @@
+@import '../../mixins.scss';
+
 .style-preview__header {
 	display: grid;
 	grid-template-areas: 'title viewport-select actions';
 	column-gap: 1em;
 	margin-top: 53px;
+	align-items: center;
 }
 
 .style-preview__content {
@@ -23,6 +26,17 @@
 
 .style-preview__actions {
 	grid-area: actions;
+	justify-self: end;
+
+	a.is-link {
+		@include onboarding-medium-text;
+		margin: 0 1em;
+		color: var( --studio-gray-40 );
+	}
+
+	&-continue-button.is-primary.is-large {
+		padding: 0 40px;
+	}
 }
 
 .style-preview__font-options {
@@ -53,8 +67,8 @@
 	&.is-selected {
 		// override default focus and hover styles for selected-fonts buttons
 		// `!important` is used because there are default `focus` and `hover` styles with high specificities.
-		color: var( --highlightColor ) !important;
-		box-shadow: inset 0 0 0 1px var( --highlightColor ) !important;
+		color: var( --studio-blue-40 ) !important;
+		box-shadow: inset 0 0 0 1px var( --studio-blue-40 ) !important;
 	}
 
 	&:hover {
@@ -125,6 +139,8 @@
 	justify-content: center;
 
 	.components-button {
+		padding: 4px;
+
 		height: auto;
 
 		svg {
@@ -132,6 +148,7 @@
 		}
 
 		color: var( --studio-gray-10 );
+
 		&.is-selected {
 			color: var( --studio-black );
 		}

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -41,10 +41,6 @@ $admin-sidebar-width-collapsed: 0;
 	}
 }
 
-.components-button.is-link {
-	text-decoration: none;
-}
-
 input:disabled {
 	background: var( --color-neutral-0 );
 	border-color: var( --color-neutral-0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes most points of #40569.

#### Testing

1. [x] The device buttons are spaced a bit too far apart. The buttons should be `56px` high. Desktop should be `56px` wide, `48px` tablet , and `40px` mobile.
2. [ ] The _Choose another design_ button should be styled according to designs (`font-size; 14px`, and `text-decoration: underline`).
3. [x] The _Choose another design_ button should be aligned right to the container and centered vertically with the text.
4. [x] The font buttons should be `blue 40` when selected.
5. [x] Button, _Create my site_, in top right shouldn't be there. Instead, see the screenshot below.


![image](https://user-images.githubusercontent.com/2896062/77914100-af99b080-7295-11ea-9356-ab8cd9fa36ac.png)

