### PR TITLE
Update font weights across Calypso from 300 to 400

### DIFF
--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -6,7 +6,6 @@
 	.disconnect-jetpack__header {
 		color: var( --color-neutral-70 );
 		font-size: 24px;
-		font-weight: 300;
 		height: 2em;
 		line-height: 32px;
 		margin-top: 0.5em;

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -16,7 +16,6 @@
 .jetpack-new-site__header-title {
 	margin-bottom: 0.35em;
 	font-size: 34px;
-	font-weight: 300;
 	color: var( --color-neutral-70 );
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -269,7 +269,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__install-step-title {
 	font-size: 21px;
-	font-weight: 300;
 }
 
 .jetpack-connect__install-step-text {
@@ -474,7 +473,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 .jetpack-connect__sso-log-in-as {
 	font-family: $sans;
 	font-size: 21px;
-	font-weight: 300;
 	text-align: center;
 }
 

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -26,7 +26,7 @@
 
 	.themes__auto-loading-homepage-modal-title {
 		display: block;
-		font-weight: 300;
+		font-weight: 400;
 		line-height: 1.5em;
 		margin-bottom: 0;
 		text-align: center;

--- a/client/my-sites/themes/thanks-modal.scss
+++ b/client/my-sites/themes/thanks-modal.scss
@@ -35,7 +35,7 @@
 
 	h1 {
 		display: block;
-		font-weight: 300;
+		font-weight: 400;
 		line-height: 1.5em;
 		margin-bottom: 0;
 		text-align: center;

--- a/client/my-sites/themes/themes-site-selector-modal.scss
+++ b/client/my-sites/themes/themes-site-selector-modal.scss
@@ -13,6 +13,7 @@
 
 		h1 {
 			text-align: center;
+			font-weight: 400;
 			margin-bottom: 0;
 		}
 

--- a/client/my-sites/themes/themes-site-selector-modal.scss
+++ b/client/my-sites/themes/themes-site-selector-modal.scss
@@ -13,7 +13,6 @@
 
 		h1 {
 			text-align: center;
-			font-weight: 300;
 			margin-bottom: 0;
 		}
 

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -28,7 +28,6 @@
 	color: var( --color-primary-5 );
 	text-align: center;
 	font-size: 13px;
-	font-weight: 300;
 	margin: 24px 16px -8px;
 	transition: all 300ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );
 	transition-delay: 200ms;

--- a/client/signup/steps/creds-complete/style.scss
+++ b/client/signup/steps/creds-complete/style.scss
@@ -9,7 +9,6 @@
 .creds-complete__title {
 	display: inline-block;
 	font-size: rem( 25px );
-	font-weight: 300;
 	letter-spacing: rem( 1.5px );
 	color: var( --color-text );
 }
@@ -23,6 +22,5 @@
 .creds-complete__description {
 	color: var( --color-text-subtle );
 	font-size: rem( 14px );
-	font-weight: 100;
 	line-height: rem( 25px );
 }

--- a/client/signup/steps/creds-confirm/style.scss
+++ b/client/signup/steps/creds-confirm/style.scss
@@ -9,7 +9,6 @@
 .creds-confirm__title {
 	display: inline-block;
 	font-size: rem( 25px );
-	font-weight: 300;
 	letter-spacing: rem( 1.5px );
 	color: var( --color-text );
 }

--- a/client/signup/steps/import-url-onboarding/style.scss
+++ b/client/signup/steps/import-url-onboarding/style.scss
@@ -58,7 +58,6 @@
 
 .import-url-onboarding__service-title {
 	font-size: 21px;
-	font-weight: 300;
 	color: var( --color-text-subtle );
 	clear: none;
 }

--- a/client/signup/steps/rewind-migrate/style.scss
+++ b/client/signup/steps/rewind-migrate/style.scss
@@ -36,7 +36,6 @@
 .rewind-switch__heading {
 	display: inline-block;
 	font-size: rem( 25px );
-	font-weight: 300;
 	letter-spacing: rem( 1.5px );
 	color: var( --color-neutral-70 );
 }
@@ -45,7 +44,6 @@
 	max-width: 600px;
 	color: var( --color-text );
 	font-size: rem( 13.5px );
-	font-weight: 100;
 	line-height: rem( 25px );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Swap out `font-weight:300` for `font-weight:400`. See #39596
* I couldn't find several of these, but I'm OK with shipping this update as the changes are minimal.

| Before | After |
| ------- | ------|
| <img width="481" alt="Screen Shot 2020-04-01 at 11 10 18 AM" src="https://user-images.githubusercontent.com/2124984/78154228-00cab100-740a-11ea-9373-27575b96ad74.png"> | <img width="512" alt="Screen Shot 2020-04-01 at 11 09 39 AM" src="https://user-images.githubusercontent.com/2124984/78154230-01634780-740a-11ea-8190-a7f87db08775.png"> |
| <img width="330" alt="Screen Shot 2020-04-01 at 11 09 22 AM" src="https://user-images.githubusercontent.com/2124984/78154170-f0b2d180-7409-11ea-858f-99713a726a95.png"> | <img width="323" alt="Screen Shot 2020-04-01 at 11 11 12 AM" src="https://user-images.githubusercontent.com/2124984/78154166-f01a3b00-7409-11ea-80a2-05405634228d.png"> |
| <img width="390" alt="Screen Shot 2020-04-01 at 11 18 06 AM" src="https://user-images.githubusercontent.com/2124984/78154752-9ebe7b80-740a-11ea-90d4-c8397df7b533.png"> | <img width="383" alt="Screen Shot 2020-04-01 at 11 18 22 AM" src="https://user-images.githubusercontent.com/2124984/78154777-a5e58980-740a-11ea-82b3-1a14e53c19c5.png"> |
| <img width="833" alt="Screen Shot 2020-04-01 at 2 29 28 PM" src="https://user-images.githubusercontent.com/2124984/78173177-4e084c00-7425-11ea-8123-52d89494e1bb.png"> | <img width="782" alt="Screen Shot 2020-04-01 at 2 29 45 PM" src="https://user-images.githubusercontent.com/2124984/78173202-5496c380-7425-11ea-9142-66ef698072f6.png"> |

#### Testing instructions

Switch to this PR and look at the following scenarios:

* Go to `/themes` and change your theme on a new site. It should be one of the recommended themes. You'll get a modal asking if you really want to change your theme, which should be font weight 400, except for 
* Change your theme. You'll see a thank-you modal with a heading that should be font weight 400
* Go to `/themes/twentytwenty` and activate a theme without selecting a site. The modal's "Activate on" heading should be font-weight 400
* Go to Switch Sites -> Add New Site (at the bottom); the heading on that page should be font weight 400