### PR TITLE
Asynchronously load 2FA login code

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { capitalize, get, includes } from 'lodash';
+import { capitalize, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
@@ -39,10 +39,6 @@ import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/wooc
 import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
-import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
-import VerificationCodeForm from './two-factor-authentication/verification-code-form';
-import SecurityKeyForm from './two-factor-authentication/security-key-form';
-import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
 import { isWebAuthnSupported } from 'lib/webauthn';
 
 /**
@@ -402,42 +398,18 @@ class Login extends Component {
 			locale,
 		} = this.props;
 
-		if ( twoFactorEnabled && twoFactorAuthType === 'webauthn' && this.state.isBrowserSupported ) {
+		if ( twoFactorEnabled ) {
 			return (
-				<div>
-					<SecurityKeyForm twoFactorAuthType="webauthn" onSuccess={ this.handleValid2FACode } />
-				</div>
-			);
-		}
-
-		let poller;
-		if ( twoFactorEnabled && twoFactorAuthType && twoFactorNotificationSent === 'push' ) {
-			poller = <PushNotificationApprovalPoller onSuccess={ this.rebootAfterLogin } />;
-		}
-
-		if ( twoFactorEnabled && includes( [ 'authenticator', 'sms', 'backup' ], twoFactorAuthType ) ) {
-			return (
-				<div>
-					{ poller }
-					<VerificationCodeForm
-						isJetpack={ isJetpack }
-						isGutenboarding={ isGutenboarding }
-						onSuccess={ this.handleValid2FACode }
-						twoFactorAuthType={ twoFactorAuthType }
-					/>
-				</div>
-			);
-		}
-
-		if ( twoFactorEnabled && twoFactorAuthType === 'push' ) {
-			return (
-				<div>
-					{ poller }
-					<WaitingTwoFactorNotificationApproval
-						isJetpack={ isJetpack }
-						isGutenboarding={ isGutenboarding }
-					/>
-				</div>
+				<AsyncLoad
+					require="blocks/login/two-factor-authentication/two-factor-content"
+					isBrowserSupported={ this.isBrowserSupported }
+					isJetpack={ isJetpack }
+					isGutenboarding={ isGutenboarding }
+					twoFactorAuthType={ twoFactorAuthType }
+					twoFactorNotificationSent={ twoFactorNotificationSent }
+					handleValid2FACode={ this.handleValid2FACode }
+					rebootAfterLogin={ this.rebootAfterLogin }
+				/>
 			);
 		}
 

--- a/client/blocks/login/two-factor-authentication/two-factor-content.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-content.jsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PushNotificationApprovalPoller from './push-notification-approval-poller';
+import VerificationCodeForm from './verification-code-form';
+import SecurityKeyForm from './security-key-form';
+import WaitingTwoFactorNotificationApproval from './waiting-notification-approval';
+
+export default function TwoFactorContent( {
+	handleValid2FACode,
+	isBrowserSupported,
+	isJetpack,
+	isGutenboarding,
+	twoFactorAuthType,
+	twoFactorNotificationSent,
+	rebootAfterLogin,
+} ) {
+	if ( twoFactorAuthType === 'webauthn' && isBrowserSupported ) {
+		return (
+			<div>
+				<SecurityKeyForm twoFactorAuthType="webauthn" onSuccess={ handleValid2FACode } />
+			</div>
+		);
+	}
+
+	let poller;
+	if ( twoFactorAuthType && twoFactorNotificationSent === 'push' ) {
+		poller = <PushNotificationApprovalPoller onSuccess={ rebootAfterLogin } />;
+	}
+
+	if ( [ 'authenticator', 'sms', 'backup' ].includes( twoFactorAuthType ) ) {
+		return (
+			<div>
+				{ poller }
+				<VerificationCodeForm
+					isJetpack={ isJetpack }
+					isGutenboarding={ isGutenboarding }
+					onSuccess={ handleValid2FACode }
+					twoFactorAuthType={ twoFactorAuthType }
+				/>
+			</div>
+		);
+	}
+
+	if ( twoFactorAuthType === 'push' ) {
+		return (
+			<div>
+				{ poller }
+				<WaitingTwoFactorNotificationApproval
+					isJetpack={ isJetpack }
+					isGutenboarding={ isGutenboarding }
+				/>
+			</div>
+		);
+	}
+}


### PR DESCRIPTION
The login process usually starts with something other than a 2FA form, so it doesn't make sense to load it as part of the initial request to `/log-in`. This PR thus extracts the 2FA functionality into a separate form, which gets asynchronously loaded when needed.

This PR should save ~5.3KB (compressed) on the critical path in `/log-in`.

#### Changes proposed in this Pull Request

* Extract 2FA login functionality, and load it asynchronously

#### Testing instructions

Ensure that login functionality continues to work correctly, particularly 2FA login.
