### PR TITLE
Jetpack Search: Include Search in the route of the JPC flow

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -25,7 +25,7 @@ export default function() {
 	const locale = getLanguageRouteParam( 'locale' );
 
 	page(
-		'/jetpack/connect/:type(personal|premium|pro|backup|realtimebackup)/:interval(yearly|monthly)?',
+		'/jetpack/connect/:type(personal|premium|pro|backup|realtimebackup|jetpack_search)/:interval(yearly|monthly)?',
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,
 		controller.connect,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Point the routes:
https://wordpress.com/jetpack/connect/jetpack_search
https://wordpress.com/jetpack/connect/jetpack_search/monthly

to the Jetpack Connect Flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- start Calypso with this change
- visit the above urls and confirm the first screen of JPC
![jpc](https://user-images.githubusercontent.com/13561163/78161373-9f283800-7445-11ea-8240-44606c205683.png)


Note: the change also works for 
https://wordpress.com/jetpack/connect/jetpack_search/yearly

Fixes https://github.com/Automattic/wp-calypso/issues/40627
