### PR TITLE
Gutenboarding: fix correct template matching coutoire theme

### DIFF
--- a/client/landing/gutenboarding/available-designs.json
+++ b/client/landing/gutenboarding/available-designs.json
@@ -50,7 +50,7 @@
 			"slug": "bowen",
 			"template": "bowen",
 			"theme": "coutoire",
-			"src": "https://public-api.wordpress.com/rest/v1/template/demo/coutoire/coutoire/",
+			"src": "https://public-api.wordpress.com/rest/v1/template/demo/coutoire/bowen/",
 			"fonts": [ "Playfair Display", "Fira Sans" ],
 			"categories": [ "featured", "blog" ]
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Correct template name in available designs json 

#### Testing instructions

Can't really test this before it's merged, but as you can observe, this works:

https://public-api.wordpress.com/rest/v1/template/demo/coutoire/bowen/

this doesn't:

https://public-api.wordpress.com/rest/v1/template/demo/coutoire/coutoire/
