### PR TITLE
Fix an error in WooCommerce Services modal

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/index.js
@@ -97,7 +97,7 @@ const mapStateToProps = ( state, { orderId, siteId } ) => {
 	return {
 		loaded,
 		form: loaded && shippingLabel.form,
-		showPurchaseDialog: shippingLabel.showPurchaseDialog,
+		showPurchaseDialog: shippingLabel && shippingLabel.showPurchaseDialog,
 		isCustomsFormRequired: isCustomsFormRequired( state, orderId, siteId ),
 	};
 };


### PR DESCRIPTION
In the create shipping label modal, after the label has been purchased,
when the modal is closed, an unhandled Javascript error is thrown and breaks the
app.

#### Changes proposed in this Pull Request

Checks presence of an object before accessing one of its properties.

#### Testing instructions

1. Open an order in the store from: http://calypso.localhost:3000/store/orders/your.site.com
2. Purchase a label.
3. When the label is purchased, close the window by clicking out of the modal.
4. Without this patch, an error will be thrown and the app's execution will stop.

