### PR TITLE
Revert "My Home: Use the layout API results to render primary cards."

### DIFF
--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
+import { isMobile } from '@automattic/viewport';
 
 /**
  * Internal dependencies
@@ -9,25 +11,34 @@ import React from 'react';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import ChecklistSiteSetup from 'my-sites/customer-home/cards/primary/checklist-site-setup';
 import QuickLinks from 'my-sites/customer-home/cards/primary/quick-links';
+import getSiteChecklist from 'state/selectors/get-site-checklist';
+import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
+import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
-const cardComponents = {
-	'home-feature-go-mobile-phones': GoMobile,
-	'home-primary-checklist-site-setup': ChecklistSiteSetup,
-	'home-primary-quick-links': QuickLinks,
-};
-
-const Primary = ( { checklistMode, cards } ) => {
+const Primary = ( { checklistMode, displayChecklist } ) => {
 	return (
-		<div className="primary">
-			{ cards &&
-				cards.map( ( card, index ) =>
-					React.createElement( cardComponents[ card ], {
-						key: index,
-						checklistMode: card === 'primary.checklist-site-setup' ? checklistMode : null,
-					} )
-				) }
-		</div>
+		<>
+			{ // "Go Mobile" is displayed on the primary location when viewed in smaller viewports, so folks
+			// can see it on their phone without needing to scroll.
+			isMobile() && <GoMobile /> }
+			{ displayChecklist && <ChecklistSiteSetup checklistMode={ checklistMode } /> }
+			{ ! displayChecklist && <QuickLinks /> }
+		</>
 	);
 };
 
-export default Primary;
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+
+	const siteChecklist = getSiteChecklist( state, siteId );
+	const hasChecklistData = null !== siteChecklist && Array.isArray( siteChecklist.tasks );
+	const isChecklistComplete = isSiteChecklistComplete( state, siteId );
+
+	return {
+		displayChecklist:
+			isEligibleForDotcomChecklist( state, siteId ) && hasChecklistData && ! isChecklistComplete,
+	};
+};
+
+export default connect( mapStateToProps )( Primary );

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -43,7 +43,6 @@ const Home = ( {
 	canUserUseCustomerHome,
 	checklistMode,
 	hasChecklistData,
-	layout,
 	site,
 	siteId,
 	siteIsUnlaunched,
@@ -86,10 +85,10 @@ const Home = ( {
 			</div>
 			<Notices checklistMode={ checklistMode } />
 			<Upsells />
-			{ hasChecklistData && layout ? (
+			{ hasChecklistData ? (
 				<div className="customer-home__layout">
 					<div className="customer-home__layout-col customer-home__layout-col-left">
-						<Primary cards={ layout.primary } checklistMode={ checklistMode } />
+						<Primary checklistMode={ checklistMode } />
 					</div>
 					<div className="customer-home__layout-col customer-home__layout-col-right">
 						<Secondary />
@@ -104,7 +103,6 @@ const Home = ( {
 
 Home.propTypes = {
 	checklistMode: PropTypes.string,
-	layout: PropTypes.object.isRequired,
 	site: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
 	siteSlug: PropTypes.string.isRequired,
@@ -131,7 +129,7 @@ const mapStateToProps = state => {
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 		user,
-		layout: getHomeLayout( state, siteId ),
+		cards: getHomeLayout( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#40537