### PR TITLE
Jetpack: update links on single products

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -12,6 +12,8 @@ import { recordTracksEvent } from 'state/analytics/actions';
 /**
  * Internal dependencies
  */
+import { addQueryArgs } from 'lib/route';
+import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
 import ProductCard from 'components/product-card';
 import ProductCardAction from 'components/product-card/action';
@@ -502,6 +504,7 @@ export class ProductSelector extends Component {
 			fetchingSitePurchases,
 			intervalType,
 			products,
+			selectedSiteSlug,
 			storeProducts,
 			translate,
 		} = this.props;
@@ -526,6 +529,10 @@ export class ProductSelector extends Component {
 			const selectedSlug = this.state[ stateKey ];
 			const productObject = storeProducts[ selectedSlug ];
 
+			const linkUrl = selectedSiteSlug
+				? addQueryArgs( { site: selectedSiteSlug }, product.link.url )
+				: product.link.url;
+
 			let purchase, isCurrent;
 			if ( this.currentPlanIncludesProduct( product ) ) {
 				purchase = this.getPurchaseByCurrentPlan();
@@ -548,7 +555,25 @@ export class ProductSelector extends Component {
 				<ProductCard
 					key={ product.id }
 					title={ this.getProductDisplayName( product ) }
-					description={ this.getDescriptionByProduct( product ) }
+					description={
+						<Fragment>
+							{ this.getDescriptionByProduct( product ) }
+							{ product.link && ' ' }
+							{ product.link && (
+								<ExternalLinkWithTracking
+									href={ linkUrl }
+									tracksEventName="calypso_plan_link_click"
+									tracksEventProps={ {
+										link_location: product.link.props.location,
+										link_slug: product.link.props.slug,
+									} }
+									icon
+								>
+									{ product.link.label }
+								</ExternalLinkWithTracking>
+							) }
+						</Fragment>
+					}
 					purchase={ purchase }
 					subtitle={ this.getSubtitleByProduct( product ) }
 				>

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -53,6 +53,8 @@ export const JETPACK_SEARCH_TIER_UP_TO_1M_RECORDS = 'up_to_1m_records';
 export const JETPACK_SEARCH_TIER_MORE_THAN_1M_RECORDS = 'more_than_1m_records';
 
 export const JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/backup/';
+export const JETPACK_SEARCH_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/search/';
+export const JETPACK_SCAN_PRODUCT_LANDING_PAGE_URL = 'https://jetpack.com/upgrade/scan/';
 
 export const JETPACK_PRODUCT_PRICE_MATRIX = {
 	[ PRODUCT_JETPACK_BACKUP_DAILY ]: {
@@ -189,8 +191,16 @@ export const getJetpackProducts = () => {
 			description: translate(
 				'Always-on backups ensure you never lose your site. Choose from real-time or daily backups.'
 			),
-			id: PRODUCT_JETPACK_BACKUP,
 			hasPromo: true,
+			id: PRODUCT_JETPACK_BACKUP,
+			link: {
+				label: translate( 'Which backup option is best for me?' ),
+				props: {
+					location: 'product_jetpack_backup_description',
+					slug: 'which-one-do-i-need',
+				},
+				url: JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL,
+			},
 			options: {
 				yearly: JETPACK_BACKUP_PRODUCTS_YEARLY,
 				monthly: JETPACK_BACKUP_PRODUCTS_MONTHLY,
@@ -206,11 +216,19 @@ export const getJetpackProducts = () => {
 		output.push( {
 			title: translate( 'Jetpack Search' ),
 			description: getJetpackProductsDescriptions()[ PRODUCT_JETPACK_SEARCH ],
-			id: PRODUCT_JETPACK_SEARCH,
 			// There is only one option per billing interval, but this
 			// component still needs the full display with radio buttons.
 			forceRadios: true,
 			hasPromo: false,
+			id: PRODUCT_JETPACK_SEARCH,
+			link: {
+				label: translate( 'Learn more' ),
+				props: {
+					location: 'product_jetpack_search_description',
+					slug: 'learn-more-search',
+				},
+				url: JETPACK_SEARCH_PRODUCT_LANDING_PAGE_URL,
+			},
 			options: {
 				yearly: [ PRODUCT_JETPACK_SEARCH ],
 				monthly: [ PRODUCT_JETPACK_SEARCH_MONTHLY ],
@@ -270,11 +288,19 @@ export const getJetpackProducts = () => {
 		output.push( {
 			title: translate( 'Jetpack Scan' ),
 			description: getJetpackProductsDescriptions()[ PRODUCT_JETPACK_SCAN ],
-			id: PRODUCT_JETPACK_SCAN,
 			// There is only one option per billing interval, but this
 			// component still needs the full display with radio buttons.
 			forceRadios: true,
 			hasPromo: false,
+			id: PRODUCT_JETPACK_SCAN,
+			link: {
+				label: translate( 'Learn more' ),
+				props: {
+					location: 'product_jetpack_scan_description',
+					slug: 'learn-more-scan',
+				},
+				url: JETPACK_SCAN_PRODUCT_LANDING_PAGE_URL,
+			},
 			options: {
 				yearly: [ PRODUCT_JETPACK_SCAN ],
 				monthly: [ PRODUCT_JETPACK_SCAN_MONTHLY ],

--- a/client/lib/products-values/constants.js
+++ b/client/lib/products-values/constants.js
@@ -305,7 +305,7 @@ export const getJetpackProducts = () => {
 				yearly: [ PRODUCT_JETPACK_SCAN ],
 				monthly: [ PRODUCT_JETPACK_SCAN_MONTHLY ],
 			},
-			optionShortNames: getJetpackProductsShortNames()[ PRODUCT_JETPACK_SCAN ],
+			optionShortNames: getJetpackProductsShortNames(),
 			optionDisplayNames: getJetpackProductsDisplayNames(),
 			optionDescriptions: getJetpackProductsDescriptions(),
 			optionsLabel: translate( 'Select a product option:' ),

--- a/client/my-sites/plans-features-main/products-header.jsx
+++ b/client/my-sites/plans-features-main/products-header.jsx
@@ -4,75 +4,29 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { isEmpty, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { addQueryArgs } from 'lib/route';
-import ExternalLinkWithTracking from 'components/external-link/with-tracking';
 import FormattedHeader from 'components/formatted-header';
-import { getSiteSlug } from 'state/sites/selectors';
-import { getSitePurchases, isFetchingSitePurchases } from 'state/purchases/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackBackup } from 'lib/products-values';
-import { JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL } from 'lib/products-values/constants';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 
 class PlansFeaturesMainProductsHeader extends Component {
 	static propTypes = {
 		// Connected props
-		isFetching: PropTypes.bool,
-		purchases: PropTypes.array,
 		siteId: PropTypes.number,
-		siteSlug: PropTypes.string,
 
 		// From localize() HoC
 		translate: PropTypes.func.isRequired,
 	};
 
-	siteHasJetpackBackup() {
-		const { purchases } = this.props;
-
-		if ( isEmpty( purchases ) ) {
-			return false;
-		}
-
-		// Search through purchased products for Jetpack Backup.
-		return some( purchases, purchase => purchase.active && isJetpackBackup( purchase ) );
-	}
-
 	getSubHeader() {
-		const { isFetching, siteSlug, translate } = this.props;
-		const baseCopy = translate( "Just looking for backups? We've got you covered." );
-
-		// Don't render a link if a user already has a Jetpack Backup product or a plan with a backup feature.
-		if ( isFetching || this.siteHasJetpackBackup() ) {
-			return baseCopy;
-		}
-
-		// If we have a site in this context, add it to the landing page URL.
-		const linkUrl = siteSlug
-			? addQueryArgs( { site: siteSlug }, JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL )
-			: JETPACK_BACKUP_PRODUCT_LANDING_PAGE_URL;
+		const { translate } = this.props;
 
 		return (
-			<Fragment>
-				{ baseCopy }
-				<br />
-				<ExternalLinkWithTracking
-					href={ linkUrl }
-					tracksEventName="calypso_plan_link_click"
-					tracksEventProps={ {
-						link_location: 'product_jetpack_backup_description',
-						link_slug: 'which-one-do-i-need',
-					} }
-					icon
-				>
-					{ translate( 'Which backup option is best for me?' ) }
-				</ExternalLinkWithTracking>
-			</Fragment>
+			<Fragment>{ translate( "Looking for specific features? We've got you covered." ) }</Fragment>
 		);
 	}
 
@@ -97,9 +51,6 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
-		isFetching: isFetchingSitePurchases( state ),
-		purchases: getSitePurchases( state, siteId ),
 		siteId,
-		siteSlug: getSiteSlug( state, siteId ),
 	};
 } )( localize( PlansFeaturesMainProductsHeader ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates copy.
* Removes “Which backup option is best for me?” link from the products header.
* Updates products constants to add link properties.
* Adds links to single product cards.
* Complementary to https://github.com/Automattic/jetpack/pull/15237

#### Testing instructions

* Fire up this PR
* Go to `http://calypso.localhost:3000/plans/SITE_URL`.
* Ensure: 
  * All single product cards look good.
  * Both have links that redirect to their respective LPs.
  * Tracking works.

#### Before
![image](https://user-images.githubusercontent.com/390760/78175454-cfc29e80-7452-11ea-8e8f-7490ab40c55a.png)

#### After

![image](https://user-images.githubusercontent.com/390760/78175465-d6511600-7452-11ea-8d80-1cc4c8e843c9.png)


Fixes #15183 along with https://github.com/Automattic/jetpack/pull/15237
