### PR TITLE
My Home: Ensure the primary location always has content.

### DIFF
--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -17,14 +17,20 @@ const cardComponents = {
 };
 
 const Primary = ( { checklistMode, cards } ) => {
+	// Always ensure we have primary content.
+	if ( cards && cards.length < 1 ) {
+		cards = [ 'home-primary-quick-links' ];
+	}
 	return (
 		<div className="primary">
 			{ cards &&
-				cards.map( ( card, index ) =>
-					React.createElement( cardComponents[ card ], {
-						key: index,
-						checklistMode: card === 'home-primary-checklist-site-setup' ? checklistMode : null,
-					} )
+				cards.map(
+					( card, index ) =>
+						cardComponents[ card ] &&
+						React.createElement( cardComponents[ card ], {
+							key: index,
+							checklistMode: card === 'home-primary-checklist-site-setup' ? checklistMode : null,
+						} )
 				) }
 		</div>
 	);


### PR DESCRIPTION
To guard against any situation that might leave us with an empty `primary` location array in the Home API response, let's add a fallback to the Quick Links component. This PR also adds a check against invalid card names that could cause fatals.

#### Testing instructions
* Sandbox the API and force it to return an empty primary location array.
* Go to `/home/:site` on this branch.
* Verify the call to the `layout` API endpoint returned your expected empty `primary` array, and that the Quick Links are displayed on the Home page.