### PR TITLE
Jetpack Cloud: Apply styles to date-picker component

### DIFF
--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -87,6 +87,14 @@ class DatePicker extends Component {
 		page.redirect( `/activity/${ this.props.siteSlug }` );
 	};
 
+	onSpace = ( evt, fn ) => {
+		if ( evt.key === ' ' ) {
+			return fn;
+		}
+
+		return () => {};
+	};
+
 	render() {
 		const { selectedDate, siteId, moment } = this.props;
 
@@ -99,20 +107,27 @@ class DatePicker extends Component {
 		return (
 			<div className="date-picker">
 				<div className="date-picker__select-date">
-					<div>
-						<Button
-							compact
-							borderless
-							className="date-picker__button--previous"
-							onClick={ this.goToPreviousDay }
-						>
+					<div
+						className="date-picker__select-date--previous"
+						role="button"
+						tabIndex={ 0 }
+						onClick={ this.goToPreviousDay }
+						onKeyDown={ this.onSpace( this.goToPreviousDay ) }
+					>
+						<Button compact borderless className="date-picker__button--previous">
 							<Gridicon
 								icon="chevron-left"
 								className={ ! this.canGoToPreviousDay() && 'disabled' }
 							/>
 						</Button>
 
-						<div className="date-picker__display-date">{ previousDisplayDate }</div>
+						<span
+							className={ classNames( 'date-picker__display-date', {
+								disabled: ! this.canGoToPreviousDay(),
+							} ) }
+						>
+							{ previousDisplayDate }
+						</span>
 					</div>
 
 					<DateRangeSelector
@@ -121,21 +136,22 @@ class DatePicker extends Component {
 						customLabel={ <Gridicon icon="calendar" /> }
 					/>
 
-					<div>
-						<div
+					<div
+						className="date-picker__select-date--next"
+						role="button"
+						tabIndex={ 0 }
+						onClick={ this.goToNextDay }
+						onKeyDown={ this.onSpace( this.goToNextDay ) }
+					>
+						<span
 							className={ classNames( 'date-picker__display-date', {
 								disabled: ! this.canGoToNextDay(),
 							} ) }
 						>
 							{ nextDisplayDate }
-						</div>
+						</span>
 
-						<Button
-							compact
-							borderless
-							className="date-picker__button--next"
-							onClick={ this.goToNextDay }
-						>
+						<Button compact borderless className="date-picker__button--next">
 							<Gridicon icon="chevron-right" className={ ! this.canGoToNextDay() && 'disabled' } />
 						</Button>
 					</div>

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -82,6 +83,10 @@ class DatePicker extends Component {
 		return ! moment( selectedDate ).isSame( moment(), 'day' );
 	};
 
+	goToActivityLog = () => {
+		page.redirect( `/activity/${ this.props.siteSlug }` );
+	};
+
 	render() {
 		const { selectedDate, siteId, moment } = this.props;
 
@@ -93,29 +98,54 @@ class DatePicker extends Component {
 
 		return (
 			<div className="date-picker">
-				<Button compact borderless onClick={ this.goToPreviousDay }>
-					<Gridicon icon="chevron-left" className={ ! this.canGoToPreviousDay() && 'disabled' } />
-				</Button>
+				<div className="date-picker__select-date">
+					<div>
+						<Button
+							compact
+							borderless
+							className="date-picker__button--previous"
+							onClick={ this.goToPreviousDay }
+						>
+							<Gridicon
+								icon="chevron-left"
+								className={ ! this.canGoToPreviousDay() && 'disabled' }
+							/>
+						</Button>
 
-				<div className="date-picker__display-date">{ previousDisplayDate }</div>
+						<div className="date-picker__display-date">{ previousDisplayDate }</div>
+					</div>
 
-				<DateRangeSelector
-					siteId={ siteId }
-					enabled={ true }
-					customLabel={ <Gridicon icon="calendar" /> }
-				/>
+					<DateRangeSelector
+						siteId={ siteId }
+						enabled={ true }
+						customLabel={ <Gridicon icon="calendar" /> }
+					/>
 
-				<div
-					className={ classNames( 'date-picker__display-date', {
-						disabled: ! this.canGoToNextDay(),
-					} ) }
-				>
-					{ nextDisplayDate }
+					<div>
+						<div
+							className={ classNames( 'date-picker__display-date', {
+								disabled: ! this.canGoToNextDay(),
+							} ) }
+						>
+							{ nextDisplayDate }
+						</div>
+
+						<Button
+							compact
+							borderless
+							className="date-picker__button--next"
+							onClick={ this.goToNextDay }
+						>
+							<Gridicon icon="chevron-right" className={ ! this.canGoToNextDay() && 'disabled' } />
+						</Button>
+					</div>
 				</div>
 
-				<Button compact borderless onClick={ this.goToNextDay }>
-					<Gridicon icon="chevron-right" className={ ! this.canGoToNextDay() && 'disabled' } />
-				</Button>
+				<Gridicon
+					icon="search"
+					className="date-picker__search-icon"
+					onClick={ this.goToActivityLog }
+				/>
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -6,7 +6,36 @@
 .date-picker__select-date {
 	flex-grow: 1;
 	display: flex;
-	justify-content: space-evenly;
+	justify-content: center;
+}
+
+.date-picker__select-date--previous {
+	width: 45%;
+	padding-left: 0.5rem;
+	text-align: left;
+	cursor: pointer;
+}
+
+.date-picker__select-date--next {
+	width: 45%;
+	padding-right: 0.5rem;
+	text-align: right;
+	cursor: pointer;
+}
+
+.date-picker__button--previous {
+	margin-left: initial;
+	margin-right: 8px;
+}
+
+.date-picker__button--next {
+	margin-left: 8px;
+	margin-right: initial;
+}
+
+.date-picker__select-date .date-range {
+	text-align: center;
+	width: 10%;
 }
 
 .button.is-primary.date-picker__button--previous:focus,
@@ -14,16 +43,7 @@
 	box-shadow: none;
 }
 
-.date-picker__button--previous {
-	margin-right: 0.5rem;
-}
-
-.date-picker__button--next {
-	margin-left: 0.5rem;
-}
-
 .date-picker .button,
-.date-picker__display-date,
 .date-picker .date-range {
 	display: inline-block;
 	float: none;
@@ -34,6 +54,8 @@
 }
 
 .date-picker__search-icon {
+	align-self: center;
+	margin-left: 0.5rem;
 	margin-right: 1rem;
 }
 

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -9,6 +9,11 @@
 	justify-content: space-evenly;
 }
 
+.button.is-primary.date-picker__button--previous:focus,
+.button.is-primary.date-picker__button--next:focus {
+	box-shadow: none;
+}
+
 .date-picker__button--previous {
 	margin-right: 0.5rem;
 }

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -1,3 +1,22 @@
+.date-picker {
+	display: flex;
+	max-width: 30rem;
+}
+
+.date-picker__select-date {
+	flex-grow: 1;
+	display: flex;
+	justify-content: space-evenly;
+}
+
+.date-picker__button--previous {
+	margin-right: 0.5rem;
+}
+
+.date-picker__button--next {
+	margin-left: 0.5rem;
+}
+
 .date-picker .button,
 .date-picker__display-date,
 .date-picker .date-range {
@@ -7,4 +26,12 @@
 
 .date-picker .button .gridicon.disabled {
 	fill: #dcdcde;
+}
+
+.date-picker__search-icon {
+	margin-right: 1rem;
+}
+
+.date-picker__search-icon.gridicon {
+	fill: green;
 }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -178,6 +178,7 @@ class BackupsPage extends Component {
 					selectedDate={ this.getSelectedDate() }
 					siteId={ siteId }
 					oldestDateAvailable={ oldestDateAvailable }
+					siteSlug={ siteSlug }
 				/>
 
 				<div>{ isLoadingBackups && 'Loading backups...' }</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a search icon that redirects the user to the Activity Log
  * Pass the `siteSlug` prop into the DatePicker component so we can redirect
* Apply styles to the date picker, including the search icon

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load in mobile and desktop format, ensuring styles look correct
* Click search icon to ensure user is redirected to Activity Log URL (page not yet implemented)
