### PR TITLE
Add more unit tests for composite checkout in calypso

### DIFF
--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -417,6 +417,18 @@ describe( 'CompositeCheckout', () => {
 	} );
 
 	it( 'does not redirect if the cart is empty when it loads but the url has a plan alias', async () => {
+		const cartChanges = { products: [] };
+		const additionalProps = { product: 'personal' };
+		await act( async () => {
+			render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adds the aliased plan to the cart when the url has a plan alias', async () => {
 		let renderResult;
 		const cartChanges = { products: [] };
 		const additionalProps = { product: 'personal' };
@@ -426,7 +438,6 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		expect( page.redirect ).not.toHaveBeenCalled();
 		const { getAllByLabelText } = renderResult;
 		getAllByLabelText( 'WordPress.com Personal' ).map( element =>
 			expect( element ).toHaveTextContent( 'R$144' )

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -443,4 +443,35 @@ describe( 'CompositeCheckout', () => {
 			expect( element ).toHaveTextContent( 'R$144' )
 		);
 	} );
+
+	it( 'does not redirect if the cart is empty when it loads but the url has a domain map', async () => {
+		const cartChanges = { products: [] };
+		const additionalProps = { product: 'domain-mapping:bar.com' };
+		await act( async () => {
+			render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adds the domain mapping product to the cart when the url has a domain map', async () => {
+		let renderResult;
+		const cartChanges = { products: [ planWithoutDomain ] };
+		const additionalProps = { product: 'domain-mapping:bar.com' };
+		await act( async () => {
+			renderResult = render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		const { getAllByLabelText } = renderResult;
+		getAllByLabelText( 'WordPress.com Personal' ).map( element =>
+			expect( element ).toHaveTextContent( 'R$144' )
+		);
+		getAllByLabelText( 'Domain Mapping: bar.com' ).map( element =>
+			expect( element ).toHaveTextContent( 'R$0' )
+		);
+	} );
 } );

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -475,6 +475,25 @@ describe( 'CompositeCheckout', () => {
 		);
 	} );
 
+	it( 'adds the coupon to the cart when the url has a coupon code', async () => {
+		let renderResult;
+		const cartChanges = { products: [ planWithoutDomain ] };
+		const additionalProps = { couponCode: 'MYCOUPONCODE' };
+		await act( async () => {
+			renderResult = render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		const { getAllByLabelText } = renderResult;
+		getAllByLabelText( 'WordPress.com Personal' ).map( element =>
+			expect( element ).toHaveTextContent( 'R$144' )
+		);
+		getAllByLabelText( 'Coupon: MYCOUPONCODE' ).map( element =>
+			expect( element ).toHaveTextContent( '-$0' )
+		);
+	} );
+
 	it( 'displays loading while old cart store is loading', async () => {
 		let renderResult;
 		const additionalProps = {

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -474,4 +474,40 @@ describe( 'CompositeCheckout', () => {
 			expect( element ).toHaveTextContent( 'R$0' )
 		);
 	} );
+
+	it( 'displays loading while old cart store is loading', async () => {
+		let renderResult;
+		const additionalProps = {
+			cart: { hasLoadedFromServer: false, hasPendingServerUpdates: false },
+		};
+		await act( async () => {
+			renderResult = render( <MyCheckout additionalProps={ additionalProps } />, container );
+		} );
+		const { getByText } = renderResult;
+		expect( getByText( 'Loading checkout' ) ).toBeInTheDocument();
+	} );
+
+	it( 'displays loading while old cart store has pending updates', async () => {
+		let renderResult;
+		const additionalProps = { cart: { hasLoadedFromServer: true, hasPendingServerUpdates: true } };
+		await act( async () => {
+			renderResult = render( <MyCheckout additionalProps={ additionalProps } />, container );
+		} );
+		const { getByText } = renderResult;
+		expect( getByText( 'Loading checkout' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not display loading when old cart store has pending updates and then they complete', async () => {
+		let renderResult;
+		let additionalProps = { cart: { hasLoadedFromServer: true, hasPendingServerUpdates: true } };
+		await act( async () => {
+			renderResult = render( <MyCheckout additionalProps={ additionalProps } />, container );
+		} );
+		const { queryByText, rerender } = renderResult;
+		additionalProps = { cart: { hasLoadedFromServer: true, hasPendingServerUpdates: false } };
+		await act( async () => {
+			rerender( <MyCheckout additionalProps={ additionalProps } />, container );
+		} );
+		expect( queryByText( 'Loading checkout' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -138,7 +138,7 @@ describe( 'CompositeCheckout', () => {
 						getCart={ mockGetCartEndpointWith( { ...initialCart, ...( cartChanges ?? {} ) } ) }
 						getStoredCards={ async () => [] }
 						allowedPaymentMethods={ [ 'paypal' ] }
-						onlyLoadPaymentMethods={ [ 'paypal', 'full-credits' ] }
+						onlyLoadPaymentMethods={ [ 'paypal', 'full-credits', 'free-purchase' ] }
 						overrideCountryList={ countryList }
 					/>
 				</ReduxProvider>
@@ -216,5 +216,49 @@ describe( 'CompositeCheckout', () => {
 		} );
 		const { getByText } = renderResult;
 		expect( getByText( 'Paypal' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render the free payment method option when the purchase is not free', async () => {
+		let renderResult;
+		await act( async () => {
+			renderResult = render( <MyCheckout />, container );
+		} );
+		const { queryByText } = renderResult;
+		expect( queryByText( 'Free Purchase' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not render the paypal payment method option when the purchase is free', async () => {
+		let renderResult;
+		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
+		await act( async () => {
+			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
+		} );
+		const { queryByText } = renderResult;
+		expect( queryByText( 'Paypal' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not render the full credits payment method option when full credits are available but the purchase is free', async () => {
+		let renderResult;
+		const cartChanges = {
+			total_cost_integer: 0,
+			total_cost_display: '0',
+			credits_integer: 15600,
+			credits_display: 'R$156',
+		};
+		await act( async () => {
+			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
+		} );
+		const { queryByText } = renderResult;
+		expect( queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the free payment method option when the purchase is free', async () => {
+		let renderResult;
+		const cartChanges = { total_cost_integer: 0, total_cost_display: '0' };
+		await act( async () => {
+			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
+		} );
+		const { getByText } = renderResult;
+		expect( getByText( 'Free Purchase' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/checkout/checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/test/composite-checkout.js
@@ -245,6 +245,26 @@ describe( 'CompositeCheckout', () => {
 		expect( queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'does not render the full credits payment method option when partial credits are available', async () => {
+		let renderResult;
+		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
+		await act( async () => {
+			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
+		} );
+		const { queryByText } = renderResult;
+		expect( queryByText( /WordPress.com Credits:/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the paypal payment method option when partial credits are available', async () => {
+		let renderResult;
+		const cartChanges = { credits_integer: 15400, credits_display: 'R$154' };
+		await act( async () => {
+			renderResult = render( <MyCheckout cartChanges={ cartChanges } />, container );
+		} );
+		const { getByText } = renderResult;
+		expect( getByText( 'Paypal' ) ).toBeInTheDocument();
+	} );
+
 	it( 'renders the full credits payment method option when full credits are available', async () => {
 		let renderResult;
 		const cartChanges = { credits_integer: 15600, credits_display: 'R$156' };

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import '@automattic/calypso-polyfills';
 
 /**
@@ -5,15 +8,16 @@ import '@automattic/calypso-polyfills';
  */
 import { RequestCart } from '../types';
 
-/**
- * A fake WPCOM shopping cart endpoint.
- */
-export async function mockSetCartEndpoint( {
-	products: requestProducts,
-	currency: requestCurrency,
-	coupon: requestCoupon,
-	locale: requestLocale,
-}: RequestCart ): Promise< object > {
+export async function mockSetCartEndpoint(
+	_: string,
+	requestCart: RequestCart
+): Promise< object > {
+	const {
+		products: requestProducts,
+		currency: requestCurrency,
+		coupon: requestCoupon,
+		locale: requestLocale,
+	}: RequestCart = requestCart;
 	const products = requestProducts.map( convertRequestProductToResponseProduct( requestCurrency ) );
 
 	const taxInteger = products.reduce( ( accum, current ) => {

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
@@ -48,6 +48,7 @@ export async function mockSetCartEndpoint(
 		coupon: requestCoupon,
 		is_coupon_applied: true,
 		coupon_discounts_integer: [],
+		tax: {},
 	};
 }
 

--- a/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
+++ b/packages/composite-checkout-wpcom/src/mock/cart-endpoint.ts
@@ -67,7 +67,21 @@ function convertRequestProductToResponseProduct( currency ) {
 					item_subtotal_integer: 14400,
 					item_subtotal_display: 'R$144',
 					item_tax: 0,
-					meta: '',
+					meta: product.meta,
+					volume: 1,
+					extra: {},
+				};
+			case 5:
+				return {
+					product_id: 5,
+					product_name: 'Domain Mapping',
+					product_slug: 'domain_map',
+					currency: currency,
+					is_domain_registration: false,
+					item_subtotal_integer: 0,
+					item_subtotal_display: 'R$0',
+					item_tax: 0,
+					meta: product.meta,
 					volume: 1,
 					extra: {},
 				};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds some additional unit tests for the checkout form in calypso, including:

- the display of payment methods normally vs. with free purchase vs. with full credit vs. partial credit.
- the display of the contact form normally vs. with domain vs. with specific country.
- the empty cart redirect normally vs. with urls that add products.
- adding products via urls that add plans or domain mapping or coupon codes.
- race conditions with regular cart.

#### Testing instructions

`npm install && npm run test-client client/my-sites/checkout/checkout/test/composite-checkout`