### PR TITLE
Pages and Posts: search will close when switching sites or when searc…

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -73,7 +73,7 @@ class PagesMain extends React.Component {
 	}
 
 	render() {
-		const { doSearch, siteId, search, status = 'published', translate } = this.props;
+		const { siteId, search, status = 'published', translate } = this.props;
 
 		const filterStrings = {
 			published: translate( 'Published', { context: 'Filter label for pages list' } ),
@@ -98,7 +98,8 @@ class PagesMain extends React.Component {
 					<Search
 						pinned
 						fitsContainer
-						onSearch={ doSearch }
+						isOpen={ this.props.getSearchOpen() }
+						onSearch={ this.props.doSearch }
 						initialValue={ search }
 						placeholder={ this.props.translate( 'Search Pages' ) }
 						analyticsGroup="Pages"

--- a/client/my-sites/post-type-filter/index.jsx
+++ b/client/my-sites/post-type-filter/index.jsx
@@ -204,6 +204,7 @@ export class PostTypeFilter extends Component {
 							pinned
 							fitsContainer
 							initialValue={ query.search }
+							isOpen={ this.props.getSearchOpen() }
 							onSearch={ this.props.doSearch }
 							placeholder={ this.props.translate( 'Search %(postTypes)s…', {
 								args: {


### PR DESCRIPTION
…h is emptied ( linked with urlSearch's state )

#### Changes proposed in this Pull Request

* Link `<Search/>` opened state to `<UrlSearch>` opened state, so when search is blanked (after switching website, etc,...), the search menu closes    

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
On a multi-site environment
* go to `pages`
* start to search
* switch to another website
Before:
 - The search will stay opened and the results would be incoherent
Now:
 - The search closes

Fixes #40586
