### PR TITLE
Add Google Analytics Enhanced Ecommerce purchase tracking

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -11,6 +11,7 @@ import config from 'config';
 // Enable/disable ad-tracking
 // These should not be put in the json config as they must not differ across environments
 export const isGoogleAnalyticsEnabled = true;
+export const isGoogleAnalyticsEnhancedEcommerceEnabled = true;
 export const isFloodlightEnabled = true;
 export const isFacebookEnabled = true;
 export const isBingEnabled = true;

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -89,3 +89,6 @@ export const TRACKING_IDS = {
 // This name is something we created to store a session id for DCM Floodlight session tracking
 export const DCM_FLOODLIGHT_SESSION_COOKIE_NAME = 'dcmsid';
 export const DCM_FLOODLIGHT_SESSION_LENGTH_IN_SECONDS = 1800;
+
+export const GA_PRODUCT_BRAND_WPCOM = 'WordPress.com';
+export const GA_PRODUCT_BRAND_JETPACK = 'Jetpack';

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -26,6 +26,8 @@ import {
 	YAHOO_GEMINI_CONVERSION_PIXEL_URL,
 	PANDORA_CONVERSION_PIXEL_URL,
 	ICON_MEDIA_ORDER_PIXEL_URL,
+	GA_PRODUCT_BRAND_WPCOM,
+	GA_PRODUCT_BRAND_JETPACK,
 } from './constants';
 import { loadTrackingScripts } from './load-tracking-scripts';
 import { recordParamsInFloodlightGtag } from './floodlight';
@@ -450,11 +452,11 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
 		products = wpcomJetpackCartInfo.wpcomProducts;
-		brand = 'WordPress.com';
+		brand = GA_PRODUCT_BRAND_WPCOM;
 		totalCost = wpcomJetpackCartInfo.wpcomCost;
 	} else if ( wpcomJetpackCartInfo.containsJetpackProducts ) {
 		products = wpcomJetpackCartInfo.jetpackProducts;
-		brand = 'Jetpack';
+		brand = GA_PRODUCT_BRAND_JETPACK;
 		totalCost = wpcomJetpackCartInfo.jetpackCost;
 	} else {
 		debug( 'recordOrderInGAEnhancedEcommerce: [Skipping] No products' );
@@ -467,7 +469,7 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 			id: product.product_id,
 			name: product.product_name_en,
 			quantity: product.volume,
-			price: product.item_total,
+			price: product.cost,
 			brand,
 		} );
 	} );
@@ -480,6 +482,7 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 			value: totalCost,
 			currency: cart.currency ?? 'USD',
 			tax: cart.total_tax ?? undefined,
+			coupon: cart.coupon_code ?? '',
 			items,
 		},
 	];

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -74,6 +74,7 @@ export async function recordOrder( cart, orderId ) {
 	recordOrderInBing( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInQuantcast( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInCriteo( cart, orderId );
+	// recordOrderInGAEnhancedEcommerce( cart, orderId );
 
 	// Fire a single tracking event without any details about what was purchased
 
@@ -431,6 +432,33 @@ function recordOrderInGoogleAds( cart, orderId ) {
 		window.gtag( ...params );
 	}
 }
+
+// function recordOrderInGAEnhancedEcommerce( cart, orderId ) {
+// 	if ( ! isAdTrackingAllowed() ) {
+// 		debug( 'recordOrderInGAEnhancedEcommerce: skipping as ad tracking is disallowed' );
+// 		return;
+// 	}
+
+// 	if ( 'function' !== typeof ga ) {
+// 		debug( 'recordOrderInGAEnhancedEcommerce: ga() is not defined' );
+// 		return;
+// 	}
+
+// 	// Load the enhanced ecommerce plugin
+// 	// ga( 'require', 'ec' );
+
+// 	// TODO: verify tax and coupon aren't passed through from the new composite checkout
+// 	const params = {
+// 		id: orderId,
+// 		affiliation: 'travistesting123',
+// 		revenue: cart.total_cost,
+// 		tax: cart.total_tax ?? undefined,
+// 		shipping: undefined,
+// 		coupon: cart.coupon ?? undefined,
+// 	};
+
+// 	// ga( 'ec:setAction', 'purchase', params );
+// }
 
 /**
  * Records an order in Criteo

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -479,7 +479,7 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId ) {
 	// TODO: tax and coupon aren't passed through from the new composite checkout
 	const params = {
 		id: orderId,
-		affiliation: 'travistesting123',
+		affiliation: undefined,
 		revenue: cart.total_cost,
 		tax: cart.total_tax ?? undefined,
 		shipping: undefined,

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -482,18 +482,12 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 			value: totalCost,
 			currency: cart.currency ?? 'USD',
 			tax: cart.total_tax ?? undefined,
-			coupon: cart.coupon_code ?? '',
+			coupon: cart.coupon_code ?? undefined,
 			items,
 		},
 	];
 
 	window.gtag( ...params );
-
-	// TODO:
-	// - should we only send value in usd?
-	// - product.cost instead of product.item_total?
-	// - are there constnats for brand?
-	// - do we differentiate by brand in GA in that way?
 
 	debug( 'recordOrderInGAEnhancedEcommerce: Record WPCom Purchase', params );
 }

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -469,7 +469,7 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 			id: product.product_id.toString(),
 			name: product.product_name_en.toString(),
 			quantity: parseInt( product.volume ),
-			price: costToUSD( product.cost, cart.currency ).toString(),
+			price: ( costToUSD( product.cost, cart.currency ) ?? '' ).toString(),
 			brand,
 		} );
 	} );
@@ -481,8 +481,8 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 			transaction_id: orderId.toString(),
 			value: parseFloat( totalCostUSD ),
 			currency: 'USD',
-			tax: parseFloat( cart.total_tax ) ?? 0,
-			coupon: cart.coupon_code.toString() ?? '',
+			tax: parseFloat( cart.total_tax ?? 0 ),
+			coupon: cart.coupon_code?.toString() ?? '',
 			affiliation: brand,
 			items,
 		},

--- a/client/lib/analytics/ad-tracking/record-order.js
+++ b/client/lib/analytics/ad-tracking/record-order.js
@@ -448,16 +448,16 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 		return;
 	}
 
-	let products, brand, totalCost;
+	let products, brand, totalCostUSD;
 
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
 		products = wpcomJetpackCartInfo.wpcomProducts;
 		brand = GA_PRODUCT_BRAND_WPCOM;
-		totalCost = wpcomJetpackCartInfo.wpcomCost;
+		totalCostUSD = wpcomJetpackCartInfo.wpcomCostUSD;
 	} else if ( wpcomJetpackCartInfo.containsJetpackProducts ) {
 		products = wpcomJetpackCartInfo.jetpackProducts;
 		brand = GA_PRODUCT_BRAND_JETPACK;
-		totalCost = wpcomJetpackCartInfo.jetpackCost;
+		totalCostUSD = wpcomJetpackCartInfo.jetpackCostUSD;
 	} else {
 		debug( 'recordOrderInGAEnhancedEcommerce: [Skipping] No products' );
 		return;
@@ -466,10 +466,10 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 	const items = [];
 	products.map( product => {
 		items.push( {
-			id: product.product_id,
-			name: product.product_name_en,
-			quantity: product.volume,
-			price: product.cost,
+			id: product.product_id.toString(),
+			name: product.product_name_en.toString(),
+			quantity: parseInt( product.volume ),
+			price: costToUSD( product.cost, cart.currency ).toString(),
 			brand,
 		} );
 	} );
@@ -478,11 +478,12 @@ function recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo )
 		'event',
 		'purchase',
 		{
-			transaction_id: orderId,
-			value: totalCost,
-			currency: cart.currency ?? 'USD',
-			tax: cart.total_tax ?? undefined,
-			coupon: cart.coupon_code ?? undefined,
+			transaction_id: orderId.toString(),
+			value: parseFloat( totalCostUSD ),
+			currency: 'USD',
+			tax: parseFloat( cart.total_tax ) ?? 0,
+			coupon: cart.coupon_code.toString() ?? '',
+			affiliation: brand,
 			items,
 		},
 	];

--- a/client/my-sites/checkout/checkout/composite-checkout.js
+++ b/client/my-sites/checkout/checkout/composite-checkout.js
@@ -856,6 +856,8 @@ function getCheckoutEventHandler( reduxDispatch ) {
 						currency: action.payload.total.amount.currency,
 						is_signup: action.payload.responseCart.is_signup,
 						products: action.payload.responseCart.products,
+						coupon_code: action.payload.couponItem?.wpcom_meta.couponCode ?? '',
+						total_tax: action.payload.responseCart.total_tax,
 					},
 					orderId: transactionResult.receipt_id,
 				} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add Google Analytics Enhanced Ecommerce tracking for Calypso purchases.

```
// TODO:
// - should we only send value in usd?
// - product.cost instead of product.item_total?
// - are there existing constants for brand?
// - do we differentiate by brand in GA in that way?
```

#### Testing instructions

* Install the [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en) in Chrome.
* Setup your browser to show debug info and send tracking info. In the console, run the folllowing (might require a refresh after):
```
localStorage.setItem( 'debug', 'calypso:analytics*' );

document.cookie = 'flags=a8c-analytics.on,gdpr-banner,google-analytics,ad-tracking; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );

document.cookie = 'sensitive_pixel_option=yes; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
```
* Make a purchase in Calypso.
* In the console watch for the purchase to get tracked. Look for the output `Processing GTAG command: ["event", "purchase",...`
<img width="692" alt="Screen Shot 2020-04-02 at 7 28 38 PM" src="https://user-images.githubusercontent.com/690843/78318379-71acbe80-7519-11ea-960f-29de1dcb89a1.png">

* ~~In [Google Analytics](https://analytics.google.com/) (Calypso Local Test > All Web Site Data), check for the purchase under Conversions > Ecoommerce.~~ **I think this can actually take many hours to show up**.

* Test purchasing a wpcom plan and also a Jetpack plan. Make sure the `brand` value in the `items` property matches the brand ("WordPrerrss.com" or "Jetpack").
* Test both the regular and composite checkouts. There's an ab test for that.
<img width="646" alt="Screen Shot 2020-04-02 at 7 27 20 PM" src="https://user-images.githubusercontent.com/690843/78318503-b9cbe100-7519-11ea-8393-5d458789562f.png">

