### PR TITLE
Gutenboarding: gutenboarding theming for magic link login

### DIFF
--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -54,7 +54,11 @@ export default router => {
 		);
 
 		router(
-			[ `/log-in/link/${ lang }`, `/log-in/jetpack/link/${ lang }` ],
+			[
+				`/log-in/link/${ lang }`,
+				`/log-in/jetpack/link/${ lang }`,
+				`/log-in/gutenboarding/link/${ lang }`,
+			],
 			setUpLocale,
 			setSection( LOGIN_SECTION_DEFINITION ),
 			redirectLoggedIn,

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -75,11 +75,7 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 				<h1 className="magic-login__form-header">{ translate( 'Check your email!' ) }</h1>
 
 				<Card className="magic-login__form">
-					<img
-						alt=""
-						src={ checkEmailImage }
-						className="magic-login__check-email-image"
-					/>
+					<img alt="" src={ checkEmailImage } className="magic-login__check-email-image" />
 					<p>{ line }</p>
 				</Card>
 
@@ -88,6 +84,7 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 						href={ login( {
 							isNative: true,
 							isJetpack: this.props.isJetpackLogin,
+							isGutenboarding: this.props.isGutenboardingLogin,
 							locale: this.props.locale,
 						} ) }
 						onClick={ this.onClickBackLink }
@@ -104,6 +101,7 @@ class EmailedLoginLinkSuccessfully extends React.Component {
 const mapState = state => ( {
 	locale: getCurrentLocaleSlug( state ),
 	isJetpackLogin: getCurrentRoute( state ) === '/log-in/jetpack/link',
+	isGutenboardingLogin: getCurrentRoute( state )?.startsWith( '/log-in/gutenboarding/link' ),
 } );
 
 const mapDispatch = {

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import page from 'page';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -68,6 +69,7 @@ class MagicLogin extends React.Component {
 		const loginParameters = {
 			isNative: true,
 			isJetpack: this.props.isJetpackLogin,
+			isGutenboarding: this.props.isGutenboardingLogin,
 			locale: this.props.locale,
 		};
 		const emailAddress = get( this.props, [ 'query', 'email_address' ] );
@@ -78,7 +80,13 @@ class MagicLogin extends React.Component {
 	};
 
 	renderLinks() {
-		const { isJetpackLogin, locale, showCheckYourEmail, translate } = this.props;
+		const {
+			isJetpackLogin,
+			isGutenboardingLogin,
+			locale,
+			showCheckYourEmail,
+			translate,
+		} = this.props;
 
 		if ( showCheckYourEmail ) {
 			return null;
@@ -91,6 +99,7 @@ class MagicLogin extends React.Component {
 		const loginParameters = {
 			isNative: true,
 			isJetpack: isJetpackLogin,
+			isGutenboarding: isGutenboardingLogin,
 			locale: locale,
 		};
 
@@ -114,10 +123,33 @@ class MagicLogin extends React.Component {
 		return <LocaleSuggestions locale={ locale } path={ path } />;
 	}
 
+	renderGutenboardingLogo() {
+		return (
+			<div className="magic-login__gutenboarding-wordpress-logo">
+				<svg
+					aria-hidden="true"
+					role="img"
+					focusable="false"
+					xmlns="http://www.w3.org/2000/svg"
+					width="24"
+					height="24"
+					viewBox="0 0 20 20"
+				>
+					<path d="M20 10c0-5.51-4.49-10-10-10C4.48 0 0 4.49 0 10c0 5.52 4.48 10 10 10 5.51 0 10-4.48 10-10zM7.78 15.37L4.37 6.22c.55-.02 1.17-.08 1.17-.08.5-.06.44-1.13-.06-1.11 0 0-1.45.11-2.37.11-.18 0-.37 0-.58-.01C4.12 2.69 6.87 1.11 10 1.11c2.33 0 4.45.87 6.05 2.34-.68-.11-1.65.39-1.65 1.58 0 .74.45 1.36.9 2.1.35.61.55 1.36.55 2.46 0 1.49-1.4 5-1.4 5l-3.03-8.37c.54-.02.82-.17.82-.17.5-.05.44-1.25-.06-1.22 0 0-1.44.12-2.38.12-.87 0-2.33-.12-2.33-.12-.5-.03-.56 1.2-.06 1.22l.92.08 1.26 3.41zM17.41 10c.24-.64.74-1.87.43-4.25.7 1.29 1.05 2.71 1.05 4.25 0 3.29-1.73 6.24-4.4 7.78.97-2.59 1.94-5.2 2.92-7.78zM6.1 18.09C3.12 16.65 1.11 13.53 1.11 10c0-1.3.23-2.48.72-3.59C3.25 10.3 4.67 14.2 6.1 18.09zm4.03-6.63l2.58 6.98c-.86.29-1.76.45-2.71.45-.79 0-1.57-.11-2.29-.33.81-2.38 1.62-4.74 2.42-7.1z"></path>
+				</svg>
+			</div>
+		);
+	}
+
 	render() {
 		return (
-			<Main className="magic-login magic-login__request-link">
-				{ this.props.isJetpackLogin && ( <JetpackHeader/> ) }
+			<Main
+				className={ classNames( 'magic-login', 'magic-login__request-link', {
+					'is-gutenboarding-login': this.props.isGutenboardingLogin,
+				} ) }
+			>
+				{ this.props.isJetpackLogin && <JetpackHeader /> }
+				{ this.props.isGutenboardingLogin && this.renderGutenboardingLogo() }
 
 				{ this.renderLocaleSuggestions() }
 
@@ -136,6 +168,7 @@ const mapState = state => ( {
 	query: getCurrentQueryArguments( state ),
 	showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 	isJetpackLogin: getCurrentRoute( state ) === '/log-in/jetpack/link',
+	isGutenboardingLogin: getCurrentRoute( state )?.startsWith( '/log-in/gutenboarding/link' ),
 } );
 
 const mapDispatch = {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -1,3 +1,7 @@
+@import 'landing/gutenboarding/mixins.scss';
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
 @media ( max-height: 450px ) {
 	.magic-login__handle-link,
 	.magic-login__check-email,
@@ -109,4 +113,41 @@
 	display: block;
 	height: 132px;
 	margin: 0 auto 1.5em;
+}
+
+.magic-login.is-gutenboarding-login {
+	.magic-login__form-header {
+		@include onboarding-heading-text-mobile;
+
+		@include break-mobile {
+			@include onboarding-heading-text;
+		}
+	}
+
+	.card {
+		box-shadow: none;
+	}
+
+	.magic-login__form-action .button.is-primary:not( [disabled] ) {
+		// Match primary button color in Gutenboarding and
+		// change border color to remove 3D effect
+		background-color: #007cba;
+		border-color: #007cba;
+	}
+}
+
+.magic-login__gutenboarding-wordpress-logo {
+	height: 64px;
+	position: absolute;
+	left: 0;
+	top: 0;
+	padding: 0 16px;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+
+	@include break-mobile {
+		padding: 8px 24px;
+	}
 }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -73,12 +73,19 @@ export class LoginLinks extends React.Component {
 		const loginParameters = {
 			isNative: true,
 			locale: this.props.locale,
-			twoFactorAuthType: this.props.currentRoute === '/log-in/jetpack' ? 'jetpack/link' : 'link',
+			twoFactorAuthType: 'link',
 		};
 		const emailAddress = get( this.props, [ 'query', 'email_address' ] );
 		if ( emailAddress ) {
 			loginParameters.emailAddress = emailAddress;
 		}
+
+		if ( this.props.currentRoute === '/log-in/jetpack' ) {
+			loginParameters.twoFactorAuthType = 'jetpack/link';
+		} else if ( this.props.isGutenboarding ) {
+			loginParameters.twoFactorAuthType = 'gutenboarding/link';
+		}
+
 		page( login( loginParameters ) );
 	};
 
@@ -197,8 +204,14 @@ export class LoginLinks extends React.Component {
 		const loginParameters = {
 			isNative: true,
 			locale: this.props.locale,
-			twoFactorAuthType: this.props.currentRoute === '/log-in/jetpack' ? 'jetpack/link' : 'link',
+			twoFactorAuthType: 'link',
 		};
+
+		if ( this.props.currentRoute === '/log-in/jetpack' ) {
+			loginParameters.twoFactorAuthType = 'jetpack/link';
+		} else if ( this.props.isGutenboarding ) {
+			loginParameters.twoFactorAuthType = 'gutenboarding/link';
+		}
 
 		return (
 			<a


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Create `/log-in/gutenboarding/link` route
* Change card borders, heading font, button colours to match gutenboarding
* Fix up back button links
* Add WordPress logo in top-left

Not in this PR:
- 2FA screens, that's #40637 
- The login screens after clicking the link in your inbox is still unstyled. Jetpack hasn't even addressed this, so I don't know if we should attempt that as part of the CfT.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test flow starting from `/log-in/gutenboarding` and click "Email me a login link"
* Test flow starting from `/log-in/gutenboarding` and entering a passwordless username/email into the field
* Test flow starting from `/gutenboarding`, log in with existing account, ask for magic link, click link in your inbox, at the end of the whole flow you should be taken back to gutenboarding and you site should get created.
