### PR TITLE
address design feedback on login page

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -58,13 +58,22 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery, onChangeAccount } 
 
 	return (
 		<div className="continue-as-user">
-			<Gravatar user={ currentUser } imgSize={ 400 } size={ 200 } />
+			<a href={ validatedRedirectUrl || '/' } className="continue-as-user__gravatar-link">
+				<Gravatar
+					user={ currentUser }
+					className="continue-as-user__gravatar"
+					imgSize={ 400 }
+					size={ 110 }
+				/>
+				<div>{ userName }</div>
+			</a>
 			<Button primary href={ validatedRedirectUrl || '/' }>
-				{ translate( 'Continue as %(userName)s', { args: { userName } } ) }
+				{ translate( 'Continue' ) }
 			</Button>
 			<p>
-				{ translate( 'Not %(userName)s? Log in with {{link}}another account{{/link}}', {
+				{ translate( 'Not you?{{br/}}Log in with {{link}}another account{{/link}}', {
 					components: {
+						br: <br />,
 						link: (
 							<button
 								type="button"

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -6,6 +6,16 @@
 	flex-direction: column;
 	color: var( --color-text-subtle );
 	font-size: 14px;
+	text-align: center;
+
+	.continue-as-user__gravatar-link {
+		font-weight: 600;
+		color: var( --color-text );
+	}
+
+	.continue-as-user__gravatar {
+		border: 1px solid #a7aaad;
+	}
 
 	& > a.button {
 		margin: 20px 0;


### PR DESCRIPTION
Address the following design feedback from @olaolusoga #40556

- Bump down the gravatar width/height to 110px—it's currently at 200px.
- Add 1px border to gravatar. Border color: #A7AAAD
- Gravatar should be clickable—it isn't at the moment.
- Can we make sure everything is center.
- Remove username from button, and add below gravatar image (see mock)
- Update copy from "Not [username]? Login in with a different account" to "Not you?
- Log in with another account" (see screenshot)

### Before fixes
<img width="903" alt="Screen Shot 2020-04-02 at 11 48 21 AM" src="https://user-images.githubusercontent.com/22446385/78202495-de9f6480-74d7-11ea-9e23-57fa83f5c08e.png">

### After fixes
<img width="905" alt="Screen Shot 2020-04-02 at 11 46 24 AM" src="https://user-images.githubusercontent.com/22446385/78202474-ccbdc180-74d7-11ea-99bc-e76a30a97cc2.png">


### Testing Instructions 

- Stay logged-in
- Open /log-in
- Observe design changes
- Whole avatar should now be clickable


Fixes #40556