### PR TITLE
Fix Global Styles on wpcom

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { subscribe } from '@wordpress/data';
+import { subscribe, select } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { isEmpty, isEqual } from 'lodash';
 
@@ -13,10 +13,6 @@ import { isEmpty, isEqual } from 'lodash';
  */
 export default ( options, getOptionValue ) => {
 	domReady( () => {
-		// Create style node.
-		const styleElement = document.createElement( 'style' );
-		document.body.appendChild( styleElement );
-
 		// Book-keeping.
 		const currentOptions = {};
 		let previousOptions = {};
@@ -25,7 +21,22 @@ export default ( options, getOptionValue ) => {
 			cssVariables[ option ] = `--${ option.replace( '_', '-' ) }`;
 		} );
 
+		let styleElement = null;
 		subscribe( () => {
+			// Do nothing until the editor is ready.
+			const isEditorReady = select( 'core/editor' ).__unstableIsEditorReady;
+			if ( isEditorReady && isEditorReady() === false ) {
+				return;
+			}
+
+			// Create style element if it has not been created yet. Must happen
+			// after the editor is ready or the style element will be appended
+			// before the styles it needs to affect.
+			if ( ! styleElement ) {
+				styleElement = document.createElement( 'style' );
+				document.body.appendChild( styleElement );
+			}
+
 			// Maybe bail-out early.
 			options.forEach( option => {
 				currentOptions[ option ] = getOptionValue( option );

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
@@ -23,7 +23,13 @@ export default ( options, getOptionValue ) => {
 
 		let styleElement = null;
 		subscribe( () => {
-			// Do nothing until the editor is ready.
+			/**
+			 * Do nothing until the editor is ready. This is required when
+			 * working in wpcom iframe environment to avoid running code before
+			 * everything has loaded, which can cause bugs like the following.
+			 *
+			 * @see https://github.com/Automattic/wp-calypso/pull/40690
+			 */
 			const isEditorReady = select( 'core/editor' ).__unstableIsEditorReady;
 			if ( isEditorReady && isEditorReady() === false ) {
 				return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
#40489 broke global styles inside the iFrame (changing a font did not change the font inside the preview). This fixes that.

The root cause is that the `<style />` element we dynamically update for Global Styles was not appended at the end of the other `<style />` elements. I'm not quite sure why, but it seems that this script can begin executing before all the style elements have been loaded. So the fix is to wait some time to add the style element. I chose the `isEditorReady` selector for this, but there could be a better heuristic. At any rate, this fixes the issue for me.

#### Testing instructions
1. Sync to dotcom. Changing the font selection in Global Styles should update the editor.
2. Test the same on a self hosted site
3. Test that changes in #40489 still work correctly