### PR TITLE
Gutenboarding: Show domain price from API response in domain picker

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -5,6 +5,7 @@ import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
 import { Button } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
@@ -38,8 +39,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					'is-paid': ! suggestion.is_free,
 				} ) }
 			>
-				{ /* FIXME: What value do we show here for paid domains? */ }
-				{ suggestion.is_free ? NO__( 'Free' ) : NO__( '€4/month' ) }
+				{ suggestion.is_free ? NO__( 'Free' ) : sprintf( NO__( '%s/year' ), suggestion.cost ) }
 			</div>
 		</Button>
 	);

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { controls } from '@wordpress/data-controls';
 import { registerStore } from '@wordpress/data';
 
 /**
@@ -13,6 +12,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import * as selectors from './selectors';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import { controls } from '../wpcom-request-controls';
 
 export * from './types';
 export { State };
@@ -23,7 +23,7 @@ export function register(): typeof STORE_KEY {
 		isRegistered = true;
 		registerStore< State >( STORE_KEY, {
 			actions,
-			controls,
+			controls: controls as any,
 			reducer: reducer as any,
 			resolvers,
 			selectors,

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -1,34 +1,27 @@
 /**
  * External dependencies
  */
-import { addQueryArgs, InputArgsObject } from '@wordpress/url';
-import { apiFetch } from '@wordpress/data-controls';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
  */
 import { receiveDomainSuggestions } from './actions';
+import { wpcomRequest } from '../wpcom-request-controls';
 
 export function* __internalGetDomainSuggestions(
 	// Resolver has the same signature as corresponding selector without the initial state argument
 	queryObject: Parameters< typeof import('./selectors').__internalGetDomainSuggestions >[ 1 ]
 ) {
-	const url = 'https://public-api.wordpress.com/rest/v1.1/domains/suggestions';
-
 	// If normalized search string (`query`) contains no alphanumerics, endpoint 404s
 	if ( ! queryObject.query ) {
 		return receiveDomainSuggestions( queryObject, [] );
 	}
 
-	// `credentials` and `mode` args are needed since we're accessing the WP.com REST API
-	// (rather than the WP Core REST API)
-	const suggestions = yield apiFetch( {
-		credentials: 'same-origin',
-		mode: 'cors',
-		// Cast so we can use our closed interface without an index type.
-		// It's likely the type definitions could be improved upstream to allow this:
-		// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/dd4b4bf26c3bf43ea2df913efe70a427969f3731/types/wordpress__url/index.d.ts#L7-L54
-		url: addQueryArgs( url, ( queryObject as unknown ) as InputArgsObject ),
+	const suggestions = yield wpcomRequest( {
+		apiVersion: '1.1',
+		path: '/domains/suggestions',
+		query: stringify( queryObject ),
 	} );
 
 	return receiveDomainSuggestions( queryObject, suggestions );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Domain picker showing the real price.

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/1500769/78210600-2689b000-7507-11ea-8e7d-5d7a2709590f.png">

* Changed price from per month to per year, because that's what the API returns
* Show price from domain suggestion API in domain picker
* Load domain suggestions using request-proxy, so if the user is logged in the price will be in the user's currency

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/gutenboarding` in incognito
* Search for domains
* Domain picker shows annual cost in a reasonably auto-detected currency
* Visit `/gutenboarding` while logged in
* Search for domains
* Domain picker shows annual cost in the user's currency

