### PR TITLE
Gutenboarding: Update domain in header to be recommended paid domain

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -28,8 +28,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	className,
 	onDomainSelect,
 	onDomainPurchase,
-	defaultQuery,
-	queryParameters,
 	currentDomain,
 	...buttonProps
 } ) => {
@@ -93,11 +91,9 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 			{ isDomainPopoverVisible && (
 				<Popover onClose={ handleClose } onFocusOutside={ handleClose } focusOnMount={ false }>
 					<DomainPicker
-						defaultQuery={ defaultQuery }
 						onDomainSelect={ handleDomainSelect }
 						onDomainPurchase={ handlePaidDomainSelect }
 						onClose={ handleClose }
-						queryParameters={ queryParameters }
 						currentDomain={ currentDomain }
 					/>
 				</Popover>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -73,7 +73,10 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 	const allSuggestions = useDomainSuggestions();
 	const freeSuggestions = getFreeDomainSuggestions( allSuggestions );
-	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice( 0, 5 );
+	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
+		0,
+		PAID_DOMAINS_TO_SHOW
+	);
 	const recommendedSuggestion = getRecommendedDomainSuggestion( paidSuggestions );
 
 	return (

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -80,7 +80,7 @@ const Header: FunctionComponent = () => {
 		setSiteWasCreatedForDomainPurchase,
 	} = useDispatch( ONBOARD_STORE );
 
-	const allSuggestions = useDomainSuggestions();
+	const allSuggestions = useDomainSuggestions( siteTitle );
 	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
 		0,
 		PAID_DOMAINS_TO_SHOW

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -18,7 +18,6 @@ import { SITE_STORE } from '../../stores/site';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
 import SignupForm from '../../components/signup-form';
-// import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 import { useDomainSuggestions } from '../../hooks/use-domain-suggestions';
 import {
 	getFreeDomainSuggestions,

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -18,7 +18,14 @@ import { SITE_STORE } from '../../stores/site';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
 import SignupForm from '../../components/signup-form';
-import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
+// import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
+import { useDomainSuggestions } from '../../hooks/use-domain-suggestions';
+import {
+	getFreeDomainSuggestions,
+	getPaidDomainSuggestions,
+	getRecommendedDomainSuggestion,
+} from '../../utils/domain-suggestions';
+import { PAID_DOMAINS_TO_SHOW } from '../../constants';
 
 import wp from '../../../../lib/wp';
 const wpcom = wp.undocumented();
@@ -62,7 +69,7 @@ const Header: FunctionComponent = () => {
 
 	const newSite = useSelect( select => select( SITE_STORE ).getNewSite() );
 
-	const { domain, siteTitle, siteVertical, siteWasCreatedForDomainPurchase } = useSelect( select =>
+	const { domain, siteTitle, siteWasCreatedForDomainPurchase } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
 
@@ -73,7 +80,13 @@ const Header: FunctionComponent = () => {
 		setSiteWasCreatedForDomainPurchase,
 	} = useDispatch( ONBOARD_STORE );
 
-	const freeDomainSuggestion = useFreeDomainSuggestion();
+	const allSuggestions = useDomainSuggestions();
+	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
+		0,
+		PAID_DOMAINS_TO_SHOW
+	);
+	const freeDomainSuggestion = getFreeDomainSuggestions( allSuggestions )?.[ 0 ];
+	const recommendedDomainSuggestion = getRecommendedDomainSuggestion( paidSuggestions );
 
 	useEffect( () => {
 		if ( ! siteTitle ) {
@@ -100,11 +113,11 @@ const Header: FunctionComponent = () => {
 	const domainElement = (
 		<span
 			className={ classnames( 'gutenboarding__header-domain-picker-button-domain', {
-				placeholder: ! currentDomain,
+				placeholder: ! recommendedDomainSuggestion,
 			} ) }
 		>
-			{ currentDomain
-				? sprintf( NO__( '%s is available' ), currentDomain.domain_name )
+			{ recommendedDomainSuggestion
+				? sprintf( NO__( '%s is available' ), recommendedDomainSuggestion.domain_name )
 				: 'example.wordpress.com' }
 		</span>
 	);
@@ -193,7 +206,6 @@ const Header: FunctionComponent = () => {
 					{ siteTitle && (
 						<DomainPickerButton
 							className="gutenboarding__header-domain-picker-button"
-							defaultQuery={ siteTitle }
 							disabled={ ! currentDomain }
 							currentDomain={ currentDomain }
 							onDomainSelect={ setDomain }
@@ -202,7 +214,6 @@ const Header: FunctionComponent = () => {
 									? handleCreateSiteForDomains( currentUser.username )
 									: handleSignupForDomains()
 							}
-							queryParameters={ { vertical: siteVertical?.id } }
 						>
 							{ domainElement }
 						</DomainPickerButton>

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -17,6 +17,8 @@ const fontTitles: Partial< Record< Font, string > > = {
 	'Playfair Display': 'Playfair',
 };
 
+export const PAID_DOMAINS_TO_SHOW = 5;
+
 export function getFontTitle( fontFamily: string ): string {
 	return fontTitles[ fontFamily as Font ] ?? fontFamily;
 }

--- a/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
+++ b/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
@@ -11,12 +11,15 @@ import { DOMAIN_SUGGESTIONS_STORE } from '../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { selectorDebounce } from '../constants';
 
-export function useDomainSuggestions() {
+export function useDomainSuggestions( searchOverride = '' ) {
 	const { siteTitle, siteVertical, domainSearch } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
 
-	const [ searchTerm ] = useDebounce( domainSearch.trim() || siteTitle || '', selectorDebounce );
+	const [ searchTerm ] = useDebounce(
+		searchOverride.trim() || domainSearch.trim() || siteTitle || '',
+		selectorDebounce
+	);
 
 	return useSelect(
 		select => {

--- a/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
+++ b/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useDebounce } from 'use-debounce';
+
+/**
+ * Internal dependencies
+ */
+import { DOMAIN_SUGGESTIONS_STORE } from '../stores/domain-suggestions';
+import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
+import { selectorDebounce } from '../constants';
+
+export function useDomainSuggestions() {
+	const { siteTitle, siteVertical, domainSearch } = useSelect( select =>
+		select( ONBOARD_STORE ).getState()
+	);
+
+	const [ searchTerm ] = useDebounce( domainSearch.trim() || siteTitle || '', selectorDebounce );
+
+	return useSelect(
+		select => {
+			if ( ! searchTerm ) {
+				return;
+			}
+			return select( DOMAIN_SUGGESTIONS_STORE ).getDomainSuggestions( searchTerm, {
+				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
+				include_wordpressdotcom: true,
+				include_dotblogsubdomain: false,
+				...{ vertical: siteVertical?.id },
+			} );
+		},
+		[ searchTerm, siteVertical ]
+	);
+}

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -24,6 +24,11 @@ export const setDomain = ( domain: DomainSuggestion | undefined ) => ( {
 	domain,
 } );
 
+export const setDomainSearch = ( domainSearch: string ) => ( {
+	type: 'SET_DOMAIN_SEARCH_TERM' as const,
+	domainSearch,
+} );
+
 export const setSelectedDesign = ( selectedDesign: Design | undefined ) => ( {
 	type: 'SET_SELECTED_DESIGN' as const,
 	selectedDesign,
@@ -119,6 +124,7 @@ export type OnboardAction = ReturnType<
 	| typeof resetOnboardStore
 	| typeof resetSiteVertical
 	| typeof setDomain
+	| typeof setDomainSearch
 	| typeof setFonts
 	| typeof setSelectedDesign
 	| typeof setSiteTitle

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -24,6 +24,19 @@ const domain: Reducer<
 	return state;
 };
 
+const domainSearch: Reducer< string, OnboardAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_DOMAIN_SEARCH_TERM' ) {
+		return action.domainSearch;
+	}
+	if ( action.type === 'SET_SITE_TITLE' ) {
+		return action.siteTitle;
+	}
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
+		return '';
+	}
+	return state;
+};
+
 const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, action ) => {
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
@@ -99,6 +112,7 @@ const selectedFonts: Reducer< FontPair | undefined, OnboardAction > = (
 
 const reducer = combineReducers( {
 	domain,
+	domainSearch,
 	selectedFonts,
 	selectedDesign,
 	siteTitle,

--- a/client/landing/gutenboarding/utils/domain-suggestions.ts
+++ b/client/landing/gutenboarding/utils/domain-suggestions.ts
@@ -1,0 +1,30 @@
+type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
+
+export function getFreeDomainSuggestions( allSuggestions: DomainSuggestion[] | undefined ) {
+	return allSuggestions?.filter( suggestion => suggestion.is_free );
+}
+
+export function getPaidDomainSuggestions( allSuggestions: DomainSuggestion[] | undefined ) {
+	return allSuggestions?.filter( suggestion => ! suggestion.is_free );
+}
+
+// Recommend either an exact match or the highest relevance score
+export function getRecommendedDomainSuggestion( allSuggestions: DomainSuggestion[] | undefined ) {
+	if ( ! ( Array.isArray( allSuggestions ) && allSuggestions.length > 0 ) ) {
+		return;
+	}
+	const recommendedSuggestion = allSuggestions?.reduce( ( result, suggestion ) => {
+		if ( result.match_reasons?.includes( 'exact-match' ) ) {
+			return result;
+		}
+		if ( suggestion.match_reasons?.includes( 'exact-match' ) ) {
+			return suggestion;
+		}
+		if ( suggestion.relevance > result.relevance ) {
+			return suggestion;
+		}
+		return result;
+	} );
+
+	return recommendedSuggestion;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In Gutenboarding, update the domain in the header to be the recommended paid domain, instead of the selected free domain. (This necessarily involved doing a bigger suggestions query than a single result so that we can get a proper suggested domain)
* Add `useDomainSuggestions` hook to group together calls to get domain suggestions from the header and the domain picker so that they're using the same call — this is to prevent any discrepancy between the two as they should both be working with the same set of results.
* That said, allow a `searchOverride` parameter to fix the results of the suggestion to the site title in the header, so that it doesn't constantly keep updating while the user is searching.
* Fix issue where it was possible to search for a domain, select a sub-domain, then close the domain picker and when you open up the domain picker again, you can't see your selected subdomain. This is because the domain picker used local state, so the search query was being cleared when the picker is closed. This change moves the domain search query to the onboard store.
* Replace `createRef` in AcquireIntent with `useRef` (createRef was causing issues when updating the `domainSearch` state by creating a new reference too frequently, which resulted in focus being switched back to the site title field. Using the hook fixes this)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/gutenboarding` and enter a vertical + site title
* The site title in the header should be a paid domain
* Open up the domain picker — it should show the same recommended domain as in the header, and it should show that the subdomain is selected.
* Start searching for a different title.
* Select a sub-domain (this will close the picker)
* Open the domain picker again, and it should still show the same results as before, persisting your search term, and displaying the selected sub-domain

Fixes #40548
