### PR TITLE
Only show switch editor button in inline help popover when in block editor or classic editor route.

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -333,6 +333,7 @@ function mapStateToProps( state ) {
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );
 	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
 	const isEligibleForChecklist = isEligibleForDotcomChecklist( state, siteId );
+	const showSwitchEditorButton = currentRoute.match( /^\/(block-editor|post|page)\// );
 
 	return {
 		isOnboardingWelcomeVisible: isEligibleForChecklist && isOnboardingWelcomePromptVisible( state ),
@@ -342,8 +343,8 @@ function mapStateToProps( state ) {
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
 		classicUrl: `/${ classicRoute }`,
 		siteId,
-		showOptOut: isGutenbergOptOutEnabled( state, siteId ),
-		showOptIn: optInEnabled && isCalypsoClassic,
+		showOptOut: showSwitchEditorButton && isGutenbergOptOutEnabled( state, siteId ),
+		showOptIn: showSwitchEditorButton && optInEnabled && isCalypsoClassic,
 		gutenbergUrl,
 		isCheckout: section.name && section.name === 'checkout',
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In inline help popover, currently the "Switch To Block/Classic Editor" button is showing everywhere, this button should only show when user is in the block editor or classic editor page.

#### Testing instructions

Accessing the following urls should show the  "Switch To Block/Classic Editor" button in the inline help popover:
- /block-editor/page/yoursitehere.wordpress.com
- /block-editor/post/yoursitehere.wordpress.com
- /page/yoursitehere.wordpress.com
- /post/yoursitehere.wordpress.com

Accessing other pages should not show this button, including these pages which shows you which WordPress site to switch to:
- /block-editor
- /page
- /post
- ... and all other pages.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/78222631-1dddad80-74f8-11ea-8f5c-25ae51249177.png)

Fixes #40383