### PR TITLE
[Private sites] Adjust the condition keeps the e-commerce site private during checkout

### DIFF
--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -218,7 +218,7 @@ export class SecurePaymentForm extends Component {
 			return;
 		}
 
-		if ( 'control' === abtest( 'ATPrivacy' ) ) {
+		if ( 'variant' !== abtest( 'ATPrivacy' ) ) {
 			// Until Atomic sites support being private / unlaunched, set them to public on upgrade
 			debug( 'Setting site to public because it is an Atomic plan' );
 			const response = await this.props.saveSiteSettings( selectedSiteId, {

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -218,7 +218,7 @@ export class SecurePaymentForm extends Component {
 			return;
 		}
 
-		if ( 'variant' === abtest( 'ATPrivacy' ) ) {
+		if ( 'control' === abtest( 'ATPrivacy' ) ) {
 			// Until Atomic sites support being private / unlaunched, set them to public on upgrade
 			debug( 'Setting site to public because it is an Atomic plan' );
 			const response = await this.props.saveSiteSettings( selectedSiteId, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A wrong comparison was introduced in this condition in #40590, this PR restores the correct one.

#### Testing instructions

First, let's test without this PR applied:

1. Assign yourself to `control` of ATPrivacy AB test
1. Using a8c account create a new site and choose e-commerce plan in signup
1. Confirm that after the checkout the site is public as it should be, even though the code branch from this PR did not kick in

Now, with this PR applied:
1. Assign yourself to `variant` of ATPrivacy AB test
1. Using a8c account create a new site and choose e-commerce plan in signup
1. Confirm that the site is still private after the checkout
1. Assign yourself to `control` of ATPrivacy AB test
1. Using a8c account create a new site and choose e-commerce plan in signup
1. Confirm that the site is public after the checkout