### PR TITLE
Show the domain type in the domain settings header title

### DIFF
--- a/client/lib/domains/index.js
+++ b/client/lib/domains/index.js
@@ -323,7 +323,7 @@ function getDomainTypeText( domain = {} ) {
 			return 'Site Redirect';
 
 		case domainTypes.WPCOM:
-			return 'Wpcom Domain';
+			return 'Default Site Domain';
 
 		case domainTypes.TRANSFER:
 			return 'Transfer';

--- a/client/my-sites/domains/domain-management/edit/index.jsx
+++ b/client/my-sites/domains/domain-management/edit/index.jsx
@@ -9,7 +9,7 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import DomainMainPlaceholder from 'my-sites/domains/domain-management/components/domain/main-placeholder';
-import { getSelectedDomain } from 'lib/domains';
+import { getSelectedDomain, getDomainTypeText } from 'lib/domains';
 import Header from 'my-sites/domains/domain-management/components/header';
 import { localize } from 'i18n-calypso';
 import Main from 'components/main';
@@ -48,7 +48,11 @@ class Edit extends React.Component {
 					onClick={ this.goToDomainManagement }
 					selectedDomainName={ this.props.selectedDomainName }
 				>
-					{ this.props.translate( 'Domain Settings' ) }
+					{ this.props.translate( '%(domainType)s Settings', {
+						args: {
+							domainType: getDomainTypeText( domain ),
+						},
+					} ) }
 				</Header>
 				{ this.renderDetails( domain, Details ) }
 			</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update header title to help people distinguish different domain types

Before:

<img width="749" alt="Screenshot 2020-04-02 at 11 21 10" src="https://user-images.githubusercontent.com/1355045/78226560-8e72d300-74d4-11ea-9e7e-9a33841e7695.png">

After:

<img width="743" alt="Screenshot 2020-04-02 at 11 21 27" src="https://user-images.githubusercontent.com/1355045/78226573-92065a00-74d4-11ea-92a5-3b0d20b51ffd.png">
<img width="738" alt="Screenshot 2020-04-02 at 11 21 35" src="https://user-images.githubusercontent.com/1355045/78226579-93d01d80-74d4-11ea-9b26-da592e4c3b83.png">
<img width="737" alt="Screenshot 2020-04-02 at 11 22 59" src="https://user-images.githubusercontent.com/1355045/78226585-9763a480-74d4-11ea-8c64-da8c3f289b2f.png">
<img width="738" alt="Screenshot 2020-04-02 at 11 23 50" src="https://user-images.githubusercontent.com/1355045/78226595-99c5fe80-74d4-11ea-84b8-54be56a1354e.png">

#### Testing instructions

* Check the domain settings page for registered domain, mapped domain, wpcom domain or incoming transfer

