### PR TITLE
Update Gutenboarding signup styling (error messages and positioning)

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/header.tsx
+++ b/client/landing/gutenboarding/components/signup-form/header.tsx
@@ -7,7 +7,6 @@ import { useI18n } from '@automattic/react-i18n';
 
 interface SignupFormHeaderProps {
 	onRequestClose: () => void;
-	loginUrl: string;
 }
 
 interface CloseButtonProps {
@@ -25,14 +24,13 @@ const CustomCloseButton = ( { onClose }: CloseButtonProps ) => {
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
 			>
-				<path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" stroke-width="1.5" />
+				<path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" strokeWidth="1.5" />
 			</svg>
 		</Button>
 	);
 };
 
-const SignupFormHeader = ( { onRequestClose, loginUrl }: SignupFormHeaderProps ) => {
-	const { __: NO__ } = useI18n();
+const SignupFormHeader = ( { onRequestClose }: SignupFormHeaderProps ) => {
 	return (
 		<div className="signup-form__header">
 			<div className="signup-form__header-section">
@@ -42,12 +40,6 @@ const SignupFormHeader = ( { onRequestClose, loginUrl }: SignupFormHeaderProps )
 			</div>
 
 			<div className="signup-form__header-section">
-				<div className="signup-form__header-section-item">
-					<Button className="signup-form__link" isLink href={ loginUrl }>
-						{ NO__( 'Log in' ) }
-					</Button>
-				</div>
-
 				<div className="signup-form__header-section-item signup-form__header-close-button">
 					<CustomCloseButton onClose={ onRequestClose } />
 				</div>

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { useState, useEffect } from 'react';
-import { ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
+import { Button, ExternalLink, TextControl, Modal, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
@@ -106,6 +106,9 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const loginRedirectUrl = `${ window.location.origin }/gutenboarding${ makePath(
 		Step.CreateSite
 	) }?new`;
+	const loginUrl = `/log-in/gutenboarding${ langFragment }?redirect_to=${ encodeURIComponent(
+		loginRedirectUrl
+	) }`;
 
 	return (
 		<Modal
@@ -118,12 +121,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 			// set to false so that 1password's autofill doesn't automatically close the modal
 			shouldCloseOnClickOutside={ false }
 		>
-			<SignupFormHeader
-				onRequestClose={ closeModal }
-				loginUrl={ `/log-in/gutenboarding${ langFragment }?redirect_to=${ encodeURIComponent(
-					loginRedirectUrl
-				) }` }
-			/>
+			<SignupFormHeader onRequestClose={ closeModal } />
 
 			<div className="signup-form__body">
 				<h1 className="signup-form__title">{ NO__( 'Save your progress' ) }</h1>
@@ -160,11 +158,18 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 						) }
 
 						<div className="signup-form__footer">
-							<p className="signup-form__link signup-form__terms-of-service-link">{ tos }</p>
+							<p className="signup-form__login-link">
+								<span>{ NO__( 'Already have an account?' ) }</span>{ ' ' }
+								<Button className="signup-form__link" isLink href={ loginUrl }>
+									{ NO__( 'Log in' ) }
+								</Button>
+							</p>
 
 							<ModalSubmitButton disabled={ isFetchingNewUser } isBusy={ isFetchingNewUser }>
 								{ NO__( 'Create account' ) }
 							</ModalSubmitButton>
+
+							<p className="signup-form__link signup-form__terms-of-service-link">{ tos }</p>
 						</div>
 					</fieldset>
 				</form>

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -46,16 +46,16 @@
 		@include break-mobile {
 			padding: 0 20px 20px;
 			position: absolute;
-			top: 50%;
+			top: 25%;
 			left: 50%;
 			width: 100%;
-			max-width: 500px;
-			transform: translate( -50%, -50% );
+			max-width: 540px;
+			transform: translateX( -50% );
 		}
 	}
 
 	.signup-form__legend p {
-		@include onboarding-medium-text;
+		@include onboarding-large-text;
 		margin: 15px 0 30px;
 		color: var( --studio-gray-40 );
 	}
@@ -74,16 +74,29 @@
 	}
 
 	.signup-form__error-notice {
+		@include onboarding-medium-text;
 		margin: 0;
+		border: none;
+		background: none;
+		color: var( --studio-red-60 );
 
 		@include break-mobile {
-			margin: 0 30px;
+			margin: 0 16px;
+		}
+
+		.components-notice__content {
+			margin: 0;
 		}
 	}
 
-	.signup-form__login-links {
-		margin-top: 20px;
-		text-align: center;
+	.signup-form__login-link {
+		@include onboarding-medium-text;
+		margin: 24px 0;
+		color: var( --studio-gray-60 );
+
+		.signup-form__link {
+			@include onboarding-medium-text;
+		}
 	}
 
 	.signup-form__link,
@@ -95,7 +108,7 @@
 		@include onboarding-x-small-text;
 		text-align: center;
 		color: var( --studio-gray-40 );
-		margin: 30px 0 20px;
+		margin: 20px 0;
 	}
 
 	.signup-form__footer {

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -21,7 +21,7 @@
 
 @mixin onboarding-large-text {
 	font-size: 16px;
-	line-height: 20px;
+	line-height: 24px;
 }
 
 @mixin onboarding-medium-text {
@@ -35,8 +35,8 @@
 }
 
 @mixin onboarding-x-small-text {
-	font-size: 10px;
-	line-height: 12px;
+	font-size: 11px;
+	line-height: 13px;
 }
 
 @mixin onboarding-heading-padding {


### PR DESCRIPTION
This PR implements feedback on previous PRs regarding [error messages styling](https://github.com/Automattic/wp-calypso/pull/40558#issuecomment-606508009) and the position of [the signup form's title moving](https://github.com/Automattic/wp-calypso/pull/40599#issuecomment-606935988) when an error message is added to the DOM.

#### Changes proposed in this Pull Request

* No longer centre the signup form vertically, instead set it to an approximate height so that when error messages are added to the DOM, the title, etc, remain in place
* Style the error messages as centred red text, instead of the default Gutenberg Notice styling
* Move Log in link to the body of the form as in the Figma.
* Move TOS line below the create account button

(Note the Create account button is not hidden when the error message is about an existing login — I ran out of time for this today, so will leave that to another PR)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![signup-styling-round-two-small](https://user-images.githubusercontent.com/14988353/78231101-0addd400-751e-11ea-925a-65b35a2d087a.gif)

* Go to `/gutenboarding` and go to complete signup
* In the email address field, enter an email address you know already exists (and any password), and check that the error message displays correctly
* Try the same, but with a fresh email address and a short password (less than 3 characters) and ensure it looks correct

* Make sure that the position of the top of the form looks okay across a variety of screen sizes since it is no longer vertically centred but an approximation.

Fixes #
