### PR TITLE
[Private sites] Add tests for isUnlaunchedSite

### DIFF
--- a/client/state/selectors/test/is-unlaunched-site.js
+++ b/client/state/selectors/test/is-unlaunched-site.js
@@ -1,0 +1,85 @@
+/**
+ * Internal dependencies
+ */
+import isUnlaunchedSite from '../is-unlaunched-site';
+
+describe( 'isUnlaunchedSite()', () => {
+	test( 'should be falsy when there is no such site', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {},
+					},
+				},
+				222
+			)
+		).toBeFalsy();
+	} );
+
+	test( 'should be falsy when site has no launch status', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {
+							222: {},
+						},
+					},
+				},
+				222
+			)
+		).toBeFalsy();
+	} );
+
+	test( 'should return false when site has non "launched" launch status', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {
+							222: {
+								launch_status: 'launched',
+							},
+						},
+					},
+				},
+				222
+			)
+		).toBe( false );
+	} );
+
+	test( 'should return false when site has non gibberish launch status', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {
+							222: {
+								launch_status: 'gibberish',
+							},
+						},
+					},
+				},
+				222
+			)
+		).toBe( false );
+	} );
+
+	test( 'should return true when site has "unlaunched" launch status', () => {
+		expect(
+			isUnlaunchedSite(
+				{
+					sites: {
+						items: {
+							222: {
+								launch_status: 'unlaunched',
+							},
+						},
+					},
+				},
+				222
+			)
+		).toBe( true );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Brings the tests over from https://github.com/Automattic/wp-calypso/pull/37868 by @jblz . They are slightly updated to pass without modifying the actual selector. A follow-up PR should be issued to fix the inconsistencies and ensure the selector always returns either true or false.

#### Testing instructions

Confirm CI tests passed
