### PR TITLE
Old Checkout: Add GSTIN field for local payments in India

### DIFF
--- a/client/lib/checkout/constants.js
+++ b/client/lib/checkout/constants.js
@@ -27,6 +27,7 @@ export const PAYMENT_PROCESSOR_COUNTRIES_FIELDS = {
 		fields: [
 			'name',
 			'pan',
+			'gstin',
 			'street-number',
 			'address-1',
 			'address-2',

--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -127,6 +127,12 @@ export function countrySpecificFieldRules( country ) {
 					description: i18n.translate( 'PAN - Permanent account number' ),
 					rules: [ 'validIndiaPan' ],
 				},
+				gstin: {
+					description: i18n.translate( 'GSTIN - GST identification number', {
+						comment: 'GSTIN: India specific tax id number',
+					} ),
+					rules: [ 'validIndiaGstin' ],
+				},
 				'postal-code': {
 					description: i18n.translate( 'Postal Code' ),
 					rules: [ 'required' ],

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -270,7 +270,7 @@ validators.validIndiaPan = {
 	},
 	error: function( description ) {
 		return i18n.translate( '%(description)s is invalid', {
-			args: { description: capitalize( description ) },
+			args: { description },
 		} );
 	},
 };
@@ -283,6 +283,22 @@ validators.validIndonesiaNik = {
 	error: function( description ) {
 		return i18n.translate( '%(description)s is invalid', {
 			args: { description: capitalize( description ) },
+		} );
+	},
+};
+
+validators.validIndiaGstin = {
+	isValid( value ) {
+		const gstinRegex = /^([0-2][0-9]|[3][0-7])[A-Z]{3}[ABCFGHLJPTK][A-Z]\d{4}[A-Z][A-Z0-9][Z][A-Z0-9]$/i;
+
+		if ( ! value ) {
+			return true;
+		}
+		return gstinRegex.test( value );
+	},
+	error: function( description ) {
+		return i18n.translate( '%(description)s is invalid', {
+			args: { description },
 		} );
 	},
 };

--- a/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
@@ -145,6 +145,13 @@ export class CountrySpecificPaymentFields extends Component {
 					} ),
 				} ) }
 
+				{ this.createField( 'gstin', Input, {
+					placeholder: ' ',
+					label: translate( 'GSTIN (optional)', {
+						comment: 'India PAN number ',
+					} ),
+				} ) }
+
 				{ this.createField( 'phone-number', FormPhoneMediaInput, {
 					onChange: this.handlePhoneFieldChange,
 					countriesList,

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -467,18 +467,28 @@
 	// -----------------------------------
 	.redirect-payment-box,
 	.wechat-payment-box {
-		.checkout__payment-box-section {
-			.checkout__checkout-field {
-				padding: 0 15px 15px;
-			}
+		 .checkout__payment-box-section {
+			 .checkout__checkout-field {
+				 padding: 0 15px 15px;
+			 }
 
-			.checkout__country-payment-fields {
-				.checkout__checkout-field {
-					padding-left: 0;
-					flex-basis: calc( 100% - 30px );
-				}
-			}
-		}
+			 .checkout__country-payment-fields {
+				 .checkout__checkout-field {
+					 padding-left: 0;
+					 flex-basis: calc( 100% - 30px );
+				 }
+				 .checkout__checkout-field.pan, .checkout__checkout-field.gstin {
+					 flex-basis: calc( 50% - 30px );
+					 .form-label {
+						 max-height: 21px;
+					 }
+				 }
+
+				 .checkout__pan-number-popover svg {
+					 max-height: 16px;
+				 }
+			 }
+		 }
 	}
 
 	// Credits Payment Box


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Businesses in India need to include their GSTIN number for tax purposes when paying locally.

This adds an additional optional field next to the PAN number when paying with Netbanking, with simple regex-based validation (no checksum check)

This will only be merged after the payment gateway adds support for the API param, but can already be tested for frontend only validation.

#### Testing instructions
**Setup to show the netbaking payment method**
- The account you're using must have INR set as its currency (a8c/sandbox only).
- You need to use an Indian IP address, or change the geolocation on top of `\Store_Shopping_Cart::get_allowed_payment_methods` to `IN`.
- You can use AAAPL1234C as your PAN

**Validation tests**
- Test an empty GSTIN - no issue
- Test an invalid GSTIN - a validation error should be shown on submit
- Test a valid (format) GSTIN like 23AAAPL1234C1Z1 - no validation error for the GSTIN
