### PR TITLE
Gutenboarding: Fix Vertical Select to put exact match first

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '@automattic/react-i18n';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { ENTER, TAB } from '@wordpress/keycodes';
 import classnames from 'classnames';
+import { remove } from 'lodash';
 
 /**
  * Internal dependencies
@@ -78,14 +79,20 @@ const VerticalSelect: React.FunctionComponent = () => {
 			vertical.label.toLowerCase().includes( normalizedInputValue )
 		);
 
-		// Does the verticals list include an exact match? If it doesn't, we prepend the user-suppied
-		// vertical to the list.
-		if (
-			! newSuggestions.some( suggestion => suggestion.label.toLowerCase() === normalizedInputValue )
-		) {
-			// User-supplied verticals don't have IDs.
-			newSuggestions.unshift( { label: inputValue.trim(), id: '', slug: '' } );
-		}
+		// Does the verticals list include an exact match?
+		// If yes, we store it in firstSuggestion (for later use), and remove it from newSuggestions...
+		const firstSuggestion = remove(
+			newSuggestions,
+			suggestion => suggestion.label.toLowerCase() === normalizedInputValue
+		)[ 0 ] ?? {
+			// ...otherwise, we set firstSuggestion to the user-supplied vertical...
+			label: inputValue.trim(),
+			id: '', // User-supplied verticals don't have IDs or slugs
+			slug: '',
+		};
+
+		// ...and finally, we prepend firstSuggestion to our suggestions list.
+		newSuggestions.unshift( firstSuggestion );
 
 		// If there is only one suggestion and that suggestion matches the user input value,
 		// do not show any suggestions.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the Vertical Select component, we were previously only prepending a user-supplied vertical to our suggestions list if it wasn't found in the suggestions list. This caused an issue with _known_ verticals (see #40715). This PR fixes that issue by also prepending a _known_ vertical to the suggestions list.

![image](https://user-images.githubusercontent.com/96308/78275822-6d30d780-7512-11ea-96f4-d7eb93340f59.png)

Note that this also makes for a more consistent transition from entering a partial string to a recognized vertical:

Before:

![before](https://user-images.githubusercontent.com/96308/78292695-bc353780-7527-11ea-9836-844b33f47db8.gif)

After:

![after](https://user-images.githubusercontent.com/96308/78292684-b8a1b080-7527-11ea-815b-efc29e9931b9.gif)


#### Testing instructions

See #40715, and verify that it is fixed.

Fixes #40715
