### PR TITLE
Apply on the ActivityCard component the correct site time zone

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -11,6 +11,7 @@ import Button from 'components/forms/form-button';
 import { Card } from '@automattic/components';
 import ActivityActor from 'my-sites/activity/activity-log-item/activity-actor';
 import ActivityDescription from 'my-sites/activity/activity-log-item/activity-description';
+import { applySiteOffset } from 'lib/site/timezone';
 
 /**
  * Style dependencies
@@ -19,13 +20,18 @@ import './style.scss';
 
 class ActivityCard extends Component {
 	render() {
-		const { activity, moment, allowRestore } = this.props;
+		const { activity, allowRestore, timezone, gmtOffset } = this.props;
+
+		const backupTimeDisplay = applySiteOffset( activity.activityTs, {
+			timezone,
+			gmtOffset,
+		} ).format( 'H:mm' );
 
 		return (
 			<div className="activity-card">
 				<div className="activity-card__time">
 					<Gridicon icon="cloud-upload" />
-					{ moment( activity.activityDate ).format( 'LT' ) }
+					{ backupTimeDisplay }
 				</div>
 				<Card>
 					<ActivityActor

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -25,7 +25,7 @@ class ActivityCard extends Component {
 		const backupTimeDisplay = applySiteOffset( activity.activityTs, {
 			timezone,
 			gmtOffset,
-		} ).format( 'H:mm' );
+		} ).format( 'LT' );
 
 		return (
 			<div className="activity-card">

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -23,16 +23,19 @@ import mediaImage from 'assets/images/illustrations/media.svg';
 
 class BackupDelta extends Component {
 	renderRealtime() {
-		const { allowRestore, moment, translate } = this.props;
+		const { allowRestore, timezone, gmtOffset, moment, translate } = this.props;
 
 		const realtimeEvents = this.props.realtimeEvents.filter( event => event.activityIsRewindable );
 
 		const cards = realtimeEvents.map( activity => (
 			<ActivityCard
+				key={ activity.activityId }
 				{ ...{
 					moment,
 					activity,
 					allowRestore,
+					timezone,
+					gmtOffset,
 				} }
 			/>
 		) );

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -80,11 +80,11 @@ class BackupsPage extends Component {
 	};
 
 	getSelectedDate() {
-		const { siteTimezone, siteGmtOffset, moment } = this.props;
+		const { timezone, gmtOffset, moment } = this.props;
 
 		const today = applySiteOffset( moment(), {
-			timezone: siteTimezone,
-			gmtOffset: siteGmtOffset,
+			timezone: timezone,
+			gmtOffset: gmtOffset,
 		} );
 
 		return this.state.selectedDate || today;
@@ -152,8 +152,8 @@ class BackupsPage extends Component {
 			siteSlug,
 			isLoadingBackups,
 			oldestDateAvailable,
-			siteTimezone,
-			siteGmtOffset,
+			timezone,
+			gmtOffset,
 		} = this.props;
 
 		const backupsOnSelectedDate = this.getBackupLogsFor( this.getSelectedDate() );
@@ -188,8 +188,8 @@ class BackupsPage extends Component {
 							allowRestore={ allowRestore }
 							siteSlug={ siteSlug }
 							backup={ backupsOnSelectedDate.lastBackup }
-							timezone={ siteTimezone }
-							gmtOffset={ siteGmtOffset }
+							timezone={ timezone }
+							gmtOffset={ gmtOffset }
 						/>
 						{ doesRewindNeedCredentials && (
 							<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
@@ -340,8 +340,8 @@ const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const filter = getActivityLogFilter( state, siteId );
 	const logs = requestActivityLogs( siteId, filter );
-	const siteGmtOffset = getSiteGmtOffset( state, siteId );
-	const siteTimezone = getSiteTimezoneValue( state, siteId );
+	const gmtOffset = getSiteGmtOffset( state, siteId );
+	const timezone = getSiteTimezoneValue( state, siteId );
 	const rewind = getRewindState( state, siteId );
 	const restoreStatus = rewind.rewind && rewind.rewind.status;
 	const doesRewindNeedCredentials = getDoesRewindNeedCredentials( state, siteId );
@@ -349,7 +349,7 @@ const mapStateToProps = state => {
 	const allowRestore =
 		'active' === rewind.state && ! ( 'queued' === restoreStatus || 'running' === restoreStatus );
 
-	const { indexedLog, oldestDateAvailable } = createIndexedLog( logs, siteTimezone, siteGmtOffset );
+	const { indexedLog, oldestDateAvailable } = createIndexedLog( logs, timezone, gmtOffset );
 
 	const isLoadingBackups = ! ( logs.state === 'success' );
 
@@ -362,8 +362,8 @@ const mapStateToProps = state => {
 		rewind,
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
-		siteTimezone,
-		siteGmtOffset,
+		timezone,
+		gmtOffset,
 		indexedLog,
 		oldestDateAvailable,
 		isLoadingBackups,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

pass the props `ActivityCard` component will need to apply the correct site time zone. We pass the site TZ and the GMT offset to `ActivityCard` to apply it to the activity time.

Also, we refactor the props `siteTimezone` and `siteGmtOffset` on `BackupsPage` component to  `timezone` and `gmtOffset`to facilitate the use of the destructuring assignments.

#### Testing instructions

- Apply the changes
- Find a date with a backup with real-time changes (to see the Activity Card component in action)
- Check that nothing has changed vs master
