### PR TITLE
Pass optional query object to validateDomainContactInformation (2)

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -689,7 +689,7 @@ Undocumented.prototype.validateDomainContactInformation = function(
 
 	return this.wpcom.req.post(
 		{ path: '/me/domain-contact-information/validate' },
-        query,
+		query,
 		data,
 		function( error, successData ) {
 			if ( error ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -671,13 +671,13 @@ function mapKeysRecursively( object, fn ) {
  * @param {object} contactInformation - user's contact information
  * @param {string[]} domainNames - list of domain names
  * @param {Function} fn The callback function
- * @param {object} postOptions Additional options for the call to wpcom.req.post
+ * @param {object} query Query object for the call to wpcom.req.post
  */
 Undocumented.prototype.validateDomainContactInformation = function(
 	contactInformation,
 	domainNames,
 	fn,
-	postOptions
+	query
 ) {
 	let data = {
 		contactInformation: contactInformation,
@@ -688,7 +688,8 @@ Undocumented.prototype.validateDomainContactInformation = function(
 	data = mapKeysRecursively( data, snakeCase );
 
 	return this.wpcom.req.post(
-		{ ...postOptions, path: '/me/domain-contact-information/validate' },
+		{ path: '/me/domain-contact-information/validate' },
+        query,
 		data,
 		function( error, successData ) {
 			if ( error ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -671,11 +671,13 @@ function mapKeysRecursively( object, fn ) {
  * @param {object} contactInformation - user's contact information
  * @param {string[]} domainNames - list of domain names
  * @param {Function} fn The callback function
+ * @param {object} postOptions Additional options for the call to wpcom.req.post
  */
 Undocumented.prototype.validateDomainContactInformation = function(
 	contactInformation,
 	domainNames,
-	fn
+	fn,
+	postOptions
 ) {
 	let data = {
 		contactInformation: contactInformation,
@@ -685,20 +687,21 @@ Undocumented.prototype.validateDomainContactInformation = function(
 	debug( '/me/domain-contact-information/validate query' );
 	data = mapKeysRecursively( data, snakeCase );
 
-	return this.wpcom.req.post( { path: '/me/domain-contact-information/validate' }, data, function(
-		error,
-		successData
-	) {
-		if ( error ) {
-			return fn( error );
+	return this.wpcom.req.post(
+		{ ...postOptions, path: '/me/domain-contact-information/validate' },
+		data,
+		function( error, successData ) {
+			if ( error ) {
+				return fn( error );
+			}
+
+			const newData = mapKeysRecursively( successData, function( key ) {
+				return key === '_headers' ? key : camelCase( key );
+			} );
+
+			fn( null, newData );
 		}
-
-		const newData = mapKeysRecursively( successData, function( key ) {
-			return key === '_headers' ? key : camelCase( key );
-		} );
-
-		fn( null, newData );
-	} );
+	);
 };
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Companion to backend change D41243-code, although this patch is independent. Exposes a new optional parameter to the domain contact validation endpoint, allowing callers to pass in a `query` object to be passed on to `wpcom.req.post`. The immediate reason for this is to allow passing an `apiVersion` parameter.

To do:
* [x] Fix order of arguments (callback last)
* [x] ~Update consumers of this code to the new argument order~ (obsolete)

#### Testing instructions

This touches three pages:
* Normal domain contact form: enter checkout with a domain, make sure you can validate your contact info.
* Canadian domain contact form: enter checkout with a .ca domain, make sure you can validate your contact info.
* Domain contact update form: Try to update your contact information on an existing domain, make sure it can validate.

In all three cases I think it is enough to watch the network tab for requests to `me/domain-contact-information/validate` and check that the request and response look ok.
