### PR TITLE
composite-checkout: support adding renewal products to cart via url

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -66,7 +66,7 @@ export default function CheckoutSystemDecider( {
 		return null; // TODO: replace with loading page
 	}
 
-	if ( shouldShowCompositeCheckout( cart, countryCode, locale, product, isJetpack ) ) {
+	if ( shouldShowCompositeCheckout( cart, countryCode, locale, product, purchaseId, isJetpack ) ) {
 		return (
 			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfigurationWpcom }>
 				<CompositeCheckout
@@ -103,7 +103,14 @@ export default function CheckoutSystemDecider( {
 	);
 }
 
-function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, isJetpack ) {
+function shouldShowCompositeCheckout(
+	cart,
+	countryCode,
+	locale,
+	productSlug,
+	purchaseId,
+	isJetpack
+) {
 	if ( config.isEnabled( 'composite-checkout-force' ) ) {
 		debug( 'shouldShowCompositeCheckout true because force config is enabled' );
 		return true;
@@ -148,12 +155,14 @@ function shouldShowCompositeCheckout( cart, countryCode, locale, productSlug, is
 	}
 
 	// If the URL is adding a product, only allow things already supported
+	const isRenewal = !! purchaseId;
 	const slugsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
 	const slugPrefixesToAllow = [ 'domain-mapping:' ];
 	if (
+		( ! isRenewal,
 		productSlug &&
-		! slugsToAllow.find( slug => productSlug === slug ) &&
-		! slugPrefixesToAllow.find( slugPrefix => productSlug.startsWith( slugPrefix ) )
+			! slugsToAllow.find( slug => productSlug === slug ) &&
+			! slugPrefixesToAllow.find( slugPrefix => productSlug.startsWith( slugPrefix ) ) )
 	) {
 		debug(
 			'shouldShowCompositeCheckout false because product does not match list of allowed products',

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -154,14 +154,17 @@ function shouldShowCompositeCheckout(
 		return false;
 	}
 
-	// If the URL is adding a product, only allow things already supported
+	// If the URL is adding a product, only allow things already supported.
+	// Calypso uses special slugs that aren't real product slugs when adding
+	// products via URL, so we list those slugs here. Renewals use actual slugs,
+	// so they do not need to go through this check.
 	const isRenewal = !! purchaseId;
-	const slugsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
+	const pseudoSlugsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
 	const slugPrefixesToAllow = [ 'domain-mapping:' ];
 	if (
 		! isRenewal &&
 		productSlug &&
-		! slugsToAllow.find( slug => productSlug === slug ) &&
+		! pseudoSlugsToAllow.find( slug => productSlug === slug ) &&
 		! slugPrefixesToAllow.find( slugPrefix => productSlug.startsWith( slugPrefix ) )
 	) {
 		debug(

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -159,10 +159,10 @@ function shouldShowCompositeCheckout(
 	const slugsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
 	const slugPrefixesToAllow = [ 'domain-mapping:' ];
 	if (
-		( ! isRenewal,
+		! isRenewal &&
 		productSlug &&
-			! slugsToAllow.find( slug => productSlug === slug ) &&
-			! slugPrefixesToAllow.find( slugPrefix => productSlug.startsWith( slugPrefix ) ) )
+		! slugsToAllow.find( slug => productSlug === slug ) &&
+		! slugPrefixesToAllow.find( slugPrefix => productSlug.startsWith( slugPrefix ) )
 	) {
 		debug(
 			'shouldShowCompositeCheckout false because product does not match list of allowed products',

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -146,11 +146,12 @@ export default function CompositeCheckout( {
 
 	const countriesList = useCountryList( overrideCountryList || [] );
 
-	const { productForCart, canInitializeCart } = usePrepareProductForCart(
+	const { productForCart, canInitializeCart } = usePrepareProductForCart( {
 		siteId,
 		product,
-		isJetpackNotAtomic
-	);
+		purchaseId,
+		isJetpackNotAtomic,
+	} );
 
 	const {
 		items,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -31,7 +31,7 @@ import {
 	useIsApplePayAvailable,
 	filterAppropriatePaymentMethods,
 } from './payment-method-helpers';
-import usePrepareProductForCart from './use-prepare-product-for-cart';
+import usePrepareProductsForCart from './use-prepare-product-for-cart';
 import notices from 'notices';
 import { isJetpackSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
@@ -146,7 +146,7 @@ export default function CompositeCheckout( {
 
 	const countriesList = useCountryList( overrideCountryList || [] );
 
-	const { productForCart, canInitializeCart } = usePrepareProductForCart( {
+	const { productsForCart, canInitializeCart } = usePrepareProductsForCart( {
 		siteId,
 		product,
 		purchaseId,
@@ -175,7 +175,7 @@ export default function CompositeCheckout( {
 	} = useShoppingCart(
 		siteSlug,
 		canInitializeCart && ! isLoadingCartSynchronizer,
-		productForCart,
+		productsForCart,
 		couponCodeFromUrl,
 		setCart || wpcomSetCart,
 		getCart || wpcomGetCart,

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -162,6 +162,12 @@ describe( 'CompositeCheckout', () => {
 				ui: { selectedSiteId: 123 },
 				productsList: {
 					items: {
+						'personal-bundle': {
+							product_id: 1009,
+							product_name: 'Plan',
+							product_slug: 'personal-bundle',
+							prices: {},
+						},
 						domain_map: {
 							product_id: 5,
 							product_name: 'Product',
@@ -491,6 +497,22 @@ describe( 'CompositeCheckout', () => {
 		);
 		getAllByLabelText( 'Domain Mapping: bar.com' ).map( element =>
 			expect( element ).toHaveTextContent( 'R$0' )
+		);
+	} );
+
+	it( 'adds renewal product to the cart when the url has a renewal', async () => {
+		let renderResult;
+		const cartChanges = { products: [] };
+		const additionalProps = { product: 'personal-bundle', purchaseId: '12345' };
+		await act( async () => {
+			renderResult = render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		const { getAllByLabelText } = renderResult;
+		getAllByLabelText( 'WordPress.com Personal' ).map( element =>
+			expect( element ).toHaveTextContent( 'R$144' )
 		);
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -174,6 +174,12 @@ describe( 'CompositeCheckout', () => {
 							product_slug: 'domain_map',
 							prices: {},
 						},
+						domain_reg: {
+							product_id: 6,
+							product_name: 'Product',
+							product_slug: 'domain_reg',
+							prices: {},
+						},
 					},
 				},
 				countries: { payments: countryList, domains: countryList },
@@ -514,6 +520,52 @@ describe( 'CompositeCheckout', () => {
 		getAllByLabelText( 'WordPress.com Personal' ).map( element =>
 			expect( element ).toHaveTextContent( 'R$144' )
 		);
+	} );
+
+	it( 'adds renewal product to the cart when the url has a renewal with a domain registration', async () => {
+		let renderResult;
+		const cartChanges = { products: [] };
+		const additionalProps = { product: 'domain_reg:foo.cash', purchaseId: '12345' };
+		await act( async () => {
+			renderResult = render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		const { getByLabelText } = renderResult;
+		expect( getByLabelText( 'Domain Registration: foo.cash' ) ).toBeInTheDocument();
+	} );
+
+	it( 'adds renewal product to the cart when the url has a renewal with a domain mapping', async () => {
+		let renderResult;
+		const cartChanges = { products: [] };
+		const additionalProps = { product: 'domain_map:bar.com', purchaseId: '12345' };
+		await act( async () => {
+			renderResult = render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		const { getByLabelText } = renderResult;
+		expect( getByLabelText( 'Domain Mapping: bar.com' ) ).toBeInTheDocument();
+	} );
+
+	it( 'adds renewal products to the cart when the url has multiple renewals', async () => {
+		let renderResult;
+		const cartChanges = { products: [] };
+		const additionalProps = {
+			product: 'domain_map:bar.com,domain_reg:bar.com',
+			purchaseId: '12345,54321',
+		};
+		await act( async () => {
+			renderResult = render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		const { getByLabelText } = renderResult;
+		expect( getByLabelText( 'Domain Mapping: bar.com' ) ).toBeInTheDocument();
+		expect( getByLabelText( 'Domain Registration: bar.com' ) ).toBeInTheDocument();
 	} );
 
 	it( 'adds the coupon to the cart when the url has a coupon code', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -65,7 +65,7 @@ const domainTransferProduct = {
 
 const planWithBundledDomain = {
 	product_name: 'WordPress.com Personal',
-	product_slug: 'personal_bundle',
+	product_slug: 'personal-bundle',
 	currency: 'BRL',
 	extra: {
 		context: 'signup',
@@ -81,7 +81,7 @@ const planWithBundledDomain = {
 
 const planWithoutDomain = {
 	product_name: 'WordPress.com Personal',
-	product_slug: 'personal_bundle',
+	product_slug: 'personal-bundle',
 	currency: 'BRL',
 	extra: {
 		context: 'signup',

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -45,21 +45,8 @@ export default function usePrepareProductForCart( siteId, productAlias, isJetpac
 		productForCart: null,
 	} );
 
-	useEffect( () => {
-		if ( ! isFetchingProducts && Object.keys( products || {} ).length < 1 ) {
-			debug( 'fetching products list' );
-			reduxDispatch( requestProductsList() );
-			return;
-		}
-	}, [ isFetchingProducts, products, reduxDispatch ] );
-
-	useEffect( () => {
-		if ( ! isFetchingPlans && plans?.length < 1 ) {
-			debug( 'fetching plans list' );
-			reduxDispatch( requestPlans() );
-			return;
-		}
-	}, [ isFetchingPlans, plans, reduxDispatch ] );
+	useFetchProductsIfNotLoaded();
+	useFetchPlansIfNotLoaded();
 
 	// Add a plan if one is requested
 	useEffect( () => {
@@ -128,6 +115,32 @@ export default function usePrepareProductForCart( siteId, productAlias, isJetpac
 	] );
 
 	return { productForCart, canInitializeCart };
+}
+
+function useFetchProductsIfNotLoaded() {
+	const reduxDispatch = useDispatch();
+	const isFetchingProducts = useSelector( state => isProductsListFetching( state ) );
+	const products = useSelector( state => getProductsList( state ) );
+	useEffect( () => {
+		if ( ! isFetchingProducts && Object.keys( products || {} ).length < 1 ) {
+			debug( 'fetching products list' );
+			reduxDispatch( requestProductsList() );
+			return;
+		}
+	}, [ isFetchingProducts, products, reduxDispatch ] );
+}
+
+function useFetchPlansIfNotLoaded() {
+	const reduxDispatch = useDispatch();
+	const isFetchingPlans = useSelector( state => isRequestingPlans( state ) );
+	const plans = useSelector( state => getPlans( state ) );
+	useEffect( () => {
+		if ( ! isFetchingPlans && plans?.length < 1 ) {
+			debug( 'fetching plans list' );
+			reduxDispatch( requestPlans() );
+			return;
+		}
+	}, [ isFetchingPlans, plans, reduxDispatch ] );
 }
 
 function getProductSlugFromAlias( productAlias ) {

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -27,7 +27,12 @@ import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-fr
 
 const debug = debugFactory( 'calypso:composite-checkout:use-prepare-product-for-cart' );
 
-export default function usePrepareProductForCart( siteId, productAlias, isJetpackNotAtomic ) {
+export default function usePrepareProductForCart( {
+	siteId,
+	product: productAlias,
+	purchaseId: originalPurchaseId,
+	isJetpackNotAtomic,
+} ) {
 	const planSlug = useSelector( state =>
 		getUpgradePlanSlugFromPath( state, siteId, productAlias )
 	);

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -27,7 +27,7 @@ import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-fr
 
 const debug = debugFactory( 'calypso:composite-checkout:use-prepare-product-for-cart' );
 
-export default function usePrepareProductForCart( {
+export default function usePrepareProductsForCart( {
 	siteId,
 	product: productAlias,
 	purchaseId: originalPurchaseId,
@@ -36,9 +36,9 @@ export default function usePrepareProductForCart( {
 	const planSlug = useSelector( state =>
 		getUpgradePlanSlugFromPath( state, siteId, productAlias )
 	);
-	const [ { canInitializeCart, productForCart }, setState ] = useState( {
+	const [ { canInitializeCart, productsForCart }, setState ] = useState( {
 		canInitializeCart: ! planSlug && ! productAlias,
-		productForCart: null,
+		productsForCart: [],
 	} );
 
 	useFetchProductsIfNotLoaded();
@@ -53,7 +53,7 @@ export default function usePrepareProductForCart( {
 		originalPurchaseId,
 	} );
 
-	return { productForCart, canInitializeCart };
+	return { productsForCart, canInitializeCart };
 }
 
 function useAddPlanFromSlug( { planSlug, setState, isJetpackNotAtomic, originalPurchaseId } ) {
@@ -86,7 +86,7 @@ function useAddPlanFromSlug( { planSlug, setState, isJetpackNotAtomic, originalP
 			{ planSlug, plan, isJetpackNotAtomic },
 			cartProduct
 		);
-		setState( { productForCart: cartProduct, canInitializeCart: true } );
+		setState( { productsForCart: [ cartProduct ], canInitializeCart: true } );
 	}, [ originalPurchaseId, isFetchingPlans, planSlug, plan, isJetpackNotAtomic, setState ] );
 }
 
@@ -134,7 +134,7 @@ function useAddProductFromSlug( {
 			{ productAlias, isJetpackNotAtomic },
 			cartProduct
 		);
-		setState( { productForCart: cartProduct, canInitializeCart: true } );
+		setState( { productsForCart: [ cartProduct ], canInitializeCart: true } );
 	}, [
 		originalPurchaseId,
 		isFetchingPlans,

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -372,8 +372,8 @@ type ReactStandardAction = { type: string; payload?: any }; // eslint-disable-li
  *     If false, the cart will not be initialized until it changes to true. Can
  *     be used along with productToAdd to delay initializing the cart until the
  *     product is ready to be added.
- * @param productToAdd
- *     The product object to add to the cart immediately when the cart is
+ * @param productsToAdd
+ *     The product objects to add to the cart immediately when the cart is
  *     initialized. Has no effect if it changes after initializing.
  * @param couponToAdd
  *     The coupon code to add to the cart immediately when the cart is
@@ -398,7 +398,7 @@ type ReactStandardAction = { type: string; payload?: any }; // eslint-disable-li
 export function useShoppingCart(
 	cartKey: string | null,
 	canInitializeCart: boolean,
-	productToAdd: ResponseCartProduct | null,
+	productsToAdd: ResponseCartProduct[] | null,
 	couponToAdd: string | null,
 	setCart: ( string, RequestCart ) => Promise< ResponseCart >,
 	getCart: ( string ) => Promise< ResponseCart >,
@@ -429,7 +429,7 @@ export function useShoppingCart(
 	useInitializeCartFromServer(
 		cacheStatus,
 		canInitializeCart,
-		productToAdd,
+		productsToAdd,
 		couponToAdd,
 		getServerCart,
 		setServerCart,
@@ -508,7 +508,7 @@ export function useShoppingCart(
 function useInitializeCartFromServer(
 	cacheStatus: CacheStatus,
 	canInitializeCart: boolean,
-	productToAdd: ResponseCartProduct | null,
+	productsToAdd: ResponseCartProduct[] | null,
 	couponToAdd: string | null,
 	getServerCart: () => Promise< ResponseCart >,
 	setServerCart: ( RequestCart ) => Promise< ResponseCart >,
@@ -535,18 +535,21 @@ function useInitializeCartFromServer(
 
 		getServerCart()
 			.then( response => {
-				if ( productToAdd || couponToAdd ) {
+				if ( productsToAdd?.length || couponToAdd ) {
 					debug(
 						'initialized cart is',
 						response,
-						'; proceeding to add either initial product',
-						productToAdd,
-						' or coupon',
+						'; proceeding to add initial products',
+						productsToAdd,
+						' and coupons',
 						couponToAdd
 					);
 					let updatedResponseCart = processRawResponse( response );
-					if ( productToAdd ) {
-						updatedResponseCart = addItemToResponseCart( updatedResponseCart, productToAdd );
+					if ( productsToAdd?.length ) {
+						updatedResponseCart = productsToAdd.reduce(
+							( updatedCart, productToAdd ) => addItemToResponseCart( updatedCart, productToAdd ),
+							updatedResponseCart
+						);
 					}
 					if ( couponToAdd ) {
 						updatedResponseCart = addCouponToResponseCart( updatedResponseCart, couponToAdd );
@@ -582,7 +585,7 @@ function useInitializeCartFromServer(
 		hookDispatch,
 		onEvent,
 		getServerCart,
-		productToAdd,
+		productsToAdd,
 		couponToAdd,
 		setServerCart,
 	] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Renewal URLs contain both product slugs and purchase Ids and must be handled in a particular way; notably, unlike "new product" URLs, they use real product slugs. They were originally added in #15043. This PR adds support for such URLs to composite checkout.

Renewal URLs look something like `checkout/dotblog_domain:example.com,domain_map:example.com/renew/12345,54321/example.com`

#### Testing instructions

- Verify that your cart is empty.
- Use the flag `composite-checkout-testing` to ensure you are in the AB test.
- Click a "renew" link in Calypso for a product and visit checkout.
- Verify that you see composite checkout.
- Verify that the renewed product is in your cart.
- Check out and verify that the product is successfully renewed.
- Repeat the above steps with different types of products (eg: plans, domains, domain mapping, etc.).
- Repeat the above steps but instead of clicking a renew link, manually visit a URL with multiple product slugs separated by commas (eg: `domain_map:example.com,domain_reg:example.com`) and the purchase Ids also separated by commas (eg: `12345,54321`). Verify that all products are added to your cart.