### PR TITLE
My Home: Pass the `is_now_launched` param to the `layout` call.

### DIFF
--- a/client/components/data/query-home-layout/index.js
+++ b/client/components/data/query-home-layout/index.js
@@ -9,11 +9,11 @@ import { useDispatch } from 'react-redux';
  */
 import { requestHomeLayout } from 'state/home/actions';
 
-export default function QueryHomeLayout( { siteId } ) {
+export default function QueryHomeLayout( { siteId, isNowLaunched } ) {
 	const dispatch = useDispatch();
 	React.useEffect( () => {
-		dispatch( requestHomeLayout( siteId ) );
-	}, [ dispatch, siteId ] );
+		dispatch( requestHomeLayout( siteId, isNowLaunched ) );
+	}, [ dispatch, siteId, isNowLaunched ] );
 
 	return null;
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -66,7 +66,12 @@ const Home = ( {
 			<PageViewTracker path={ `/home/:site` } title={ translate( 'My Home' ) } />
 			<DocumentHead title={ translate( 'My Home' ) } />
 			{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
-			{ siteId && <QueryHomeLayout siteId={ siteId } /> }
+			{ siteId && (
+				<QueryHomeLayout
+					siteId={ siteId }
+					isNowLaunched={ checklistMode === 'launched' ? true : false }
+				/>
+			) }
 			<SidebarNavigation />
 			<div className="customer-home__heading">
 				<FormattedHeader

--- a/client/state/data-layer/wpcom/sites/home/layout/index.js
+++ b/client/state/data-layer/wpcom/sites/home/layout/index.js
@@ -8,11 +8,13 @@ import { HOME_LAYOUT_REQUEST } from 'state/action-types';
 import { setHomeLayout } from 'state/home/actions';
 
 const requestLayout = action => {
+	const query = action.isNowLaunched ? { is_now_launched: true } : {};
 	return http(
 		{
 			method: 'GET',
 			path: `/sites/${ action.siteId }/home/layout`,
 			apiNamespace: 'wpcom/v2',
+			query,
 		},
 		action
 	);

--- a/client/state/home/actions.js
+++ b/client/state/home/actions.js
@@ -4,9 +4,10 @@
 import { HOME_LAYOUT_REQUEST, HOME_LAYOUT_SET } from 'state/action-types';
 import 'state/data-layer/wpcom/sites/home/layout';
 
-export const requestHomeLayout = siteId => ( {
+export const requestHomeLayout = ( siteId, isNowLaunched ) => ( {
 	type: HOME_LAYOUT_REQUEST,
 	siteId,
+	isNowLaunched,
 } );
 
 export const setHomeLayout = ( siteId, layout ) => ( {


### PR DESCRIPTION
To allow us to keep logic for the "you launched your site" notice server-side, this PR adds the new `is_now_launched` param to the `layout` API call.

When launching a site, Calypso currently relies on a `?d=launched` query param to trigger display of the "launched" notice. If this param is present, we'll add the `?is_now_launched=true` param to the layout API call, ensuring proper handling server-side in the library (which is added in D41310-code).

#### Testing instructions

* Apply D41310-code and sandbox the API.
* Go to any established site's Home, and make sure it loads content. The API call to `layout` should not show any query params.
* Reload after adding `?d=launched` to the browser URL.
* Verify the "you launched your site!" notice is displayed (it's highest priority notice for established views).