### PR TITLE
Gutenboarding: [WIP] add username field to editor onboarding

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -6,6 +6,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
+import { dispatch, select } from '@wordpress/data';
+import { render } from '@wordpress/element';
+import { Modal } from '@wordpress/components';
 /* eslint-disable import/no-extraneous-dependencies */
 
 /**
@@ -15,10 +18,16 @@ import './gutenboarding-editor-overrides.scss';
 
 domReady( () => {
 	calypsoifyGutenberg.isGutenboarding && updateEditor();
+	calypsoifyGutenberg.isGutenboardingNewUser && updateWelcomeGuide();
 	// Hook fallback incase setGutenboardingStatus runs after initial dom render.
-	window.wp.hooks.addAction( 'setGutenboardingStatus', 'a8c-gutenboarding', isGutenboarding => {
-		isGutenboarding && updateEditor();
-	} );
+	window.wp.hooks.addAction(
+		'setGutenboardingStatus',
+		'a8c-gutenboarding',
+		( isGutenboarding, isGutenboardingNewUser ) => {
+			isGutenboarding && updateEditor();
+			isGutenboardingNewUser && updateWelcomeGuide();
+		}
+	);
 } );
 
 function updateEditor() {
@@ -53,4 +62,32 @@ function updateSettingsBar() {
 		settingsBar.prepend( launchLink );
 		settingsBar.prepend( saveButton );
 	} );
+}
+
+function updateWelcomeGuide() {
+	const wasGoingToShowWelcomeGuide = select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' );
+
+	if ( wasGoingToShowWelcomeGuide ) {
+		dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
+	}
+
+	const body = document.querySelector( 'body' );
+	const modalContainer = document.createElement( 'div' );
+	body.appendChild( modalContainer );
+
+	const handleClose = () => {
+		if ( wasGoingToShowWelcomeGuide ) {
+			dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
+		}
+	};
+
+	render( <UsernameModal onClose={ handleClose } />, modalContainer );
+}
+
+function UsernameModal( { onClose } ) {
+	return (
+		<Modal onRequestClose={ onClose }>
+			<div>TODO: fill in dialog</div>
+		</Modal>
+	);
 }

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -76,9 +76,13 @@ function updateWelcomeGuide() {
 	body.appendChild( modalContainer );
 
 	const handleClose = () => {
-		if ( wasGoingToShowWelcomeGuide ) {
-			dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
-		}
+		render( null, modalContainer, () => {
+			body.removeChild( modalContainer );
+
+			if ( wasGoingToShowWelcomeGuide ) {
+				dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' );
+			}
+		} );
 	};
 
 	render( <UsernameModal onClose={ handleClose } />, modalContainer );
@@ -86,7 +90,7 @@ function updateWelcomeGuide() {
 
 function UsernameModal( { onClose } ) {
 	return (
-		<Modal onRequestClose={ onClose }>
+		<Modal title="Welcome" onRequestClose={ onClose }>
 			<div>TODO: fill in dialog</div>
 		</Modal>
 	);

--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.js
@@ -704,11 +704,12 @@ function getGutenboardingStatus( calypsoPort ) {
 		[ port2 ]
 	);
 	port1.onmessage = ( { data } ) => {
-		const { isGutenboarding, frankenflowUrl } = data;
+		const { isGutenboarding, isGutenboardingNewUser, frankenflowUrl } = data;
 		calypsoifyGutenberg.isGutenboarding = isGutenboarding;
+		calypsoifyGutenberg.isGutenboardingNewUser = isGutenboardingNewUser;
 		calypsoifyGutenberg.frankenflowUrl = frankenflowUrl;
 		// Hook necessary if message recieved after editor has loaded.
-		window.wp.hooks.doAction( 'setGutenboardingStatus', isGutenboarding );
+		window.wp.hooks.doAction( 'setGutenboardingStatus', isGutenboarding, isGutenboardingNewUser );
 	};
 }
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -298,8 +298,11 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			const urlParams = new URLSearchParams( window.location.search );
 			const isGutenboarding =
 				config.isEnabled( 'gutenboarding' ) && urlParams.has( 'is-gutenboarding' );
+			const isGutenboardingNewUser =
+				config.isEnabled( 'gutenboarding' ) && urlParams.has( 'is-gutenboarding-new-user' );
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
+				isGutenboardingNewUser,
 				frankenflowUrl: `${ window.location.origin }/start/frankenflow?siteSlug=${ this.props.siteId }`,
 			} );
 		}

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -167,7 +167,9 @@ const Header: FunctionComponent = () => {
 				return;
 			}
 			resetOnboardStore();
-			window.location.replace( `/block-editor/page/${ newSite.site_slug }/home?is-gutenboarding` );
+			window.location.replace(
+				`/block-editor/page/${ newSite.site_slug }/home?is-gutenboarding&is-gutenboarding-new-user`
+			);
 		}
 	}, [ domain, siteWasCreatedForDomainPurchase, newSite, resetOnboardStore ] );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Attempt at adding username form to block editor onboarding.
pbAok1-ww-p2#comment-1074

The welcome guide doesn't have any extension points, so this PR plans to show a modal with the username controls first, and then open the welcome guide after it's closed.

It also gives the user something to look at for the last little bit of the page loading.

* Add a `?is-gutenboarding-new-user` param to the calypso block editor
* If flag is present then a dialog is shown before the welcome guide opens (the dialog should have username controls in it)
* When dialog is closed the welcome guide should appear if it was going to before we interrupted it.

TODO:
* The `?is-gutenboarding-new-user` param should only be appended for users who have just used the signup form.
* Add controls to the username dialog.
* Try and match the size/style of the username modal with the welcome guide so it's less jarring when it switches.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `wpcom-block-editor` dev workflow: PCYsg-l4k-p2, or even p1585878454409400-slack-CNMU1UHHB
* Sandbox a site, public-api, and widgets.wp.com
* Edit a post on the sandboxed site using the calypso block editor
* Append the `?is-gutenboarding-new-user` query param and refresh
* Double check that you're using `calypso.localhost:3000` and that `widgets.wp.com` is truely sandboxed.
* I found I needed to build the editor with the `NODE_ENV=production` environment variable, because the editor was loading the minified code.
