### PR TITLE
Gutenboarding: header side title should not be bold

### DIFF
--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -64,7 +64,3 @@ $padding--gutenboarding__header: $grid-size;
 		@include placeholder();
 	}
 }
-
-.gutenboarding__header-site-title {
-	font-weight: 600;
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<img width="773" alt="Screenshot 2020-04-03 at 10 26 11" src="https://user-images.githubusercontent.com/14192054/78335051-934b8b80-7595-11ea-9320-b17180e06dc8.png">

#### Testing instructions

* Go to /gutenboarding
* Enter site title in intent capture step
* Site title in header (top-left) should not be bold
