### PR TITLE
Gutenboarding: update domain picker styling

### DIFF
--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -5,10 +5,6 @@ import React from 'react';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 
-interface SignupFormHeaderProps {
-	onRequestClose: () => void;
-}
-
 interface CloseButtonProps {
 	onClose: () => void;
 }

--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Button } from '@wordpress/components';
+import { useI18n } from '@automattic/react-i18n';
+
+interface SignupFormHeaderProps {
+	onRequestClose: () => void;
+}
+
+interface CloseButtonProps {
+	onClose: () => void;
+}
+
+const CloseButton = ( { onClose }: CloseButtonProps ) => {
+	const { __: NO__ } = useI18n();
+	return (
+		<Button onClick={ onClose } label={ NO__( 'Close dialog' ) }>
+			<svg
+				width="12"
+				height="12"
+				viewBox="0 0 16 16"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" strokeWidth="1.5" />
+			</svg>
+		</Button>
+	);
+};
+
+export default CloseButton;

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -70,7 +70,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 			{ isDomainPopoverVisible && (
 				<div className="domain-picker-button__popover-container">
 					<Popover
-						className="domain-picker-button"
 						onClose={ handleClose }
 						onFocusOutside={ handleClose }
 						onClickOutside={ handleClose }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -70,6 +70,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 			{ isDomainPopoverVisible && (
 				<div className="domain-picker-button__popover-container">
 					<Popover
+						className="domain-picker-button__popover"
 						focusOnMount={ false }
 						noArrow
 						onClickOutside={ handleClose }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -69,7 +69,13 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
 			{ isDomainPopoverVisible && (
-				<Popover onClose={ handleClose } onFocusOutside={ handleClose } focusOnMount={ false }>
+				<Popover
+					className="domain-picker-button__popover"
+					onClose={ handleClose }
+					onFocusOutside={ handleClose }
+					focusOnMount={ false }
+					noArrow
+				>
 					<DomainPicker
 						onDomainSelect={ handleDomainSelect }
 						onDomainPurchase={ handlePaidDomainSelect }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -77,6 +77,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 						onClose={ handleClose }
 						onFocusOutside={ handleClose }
 						position={ 'bottom center' }
+						expandOnMobile={ true }
 					>
 						<DomainPicker
 							currentDomain={ currentDomain }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -70,18 +70,18 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 			{ isDomainPopoverVisible && (
 				<div className="domain-picker-button__popover-container">
 					<Popover
-						onClose={ handleClose }
-						onFocusOutside={ handleClose }
-						onClickOutside={ handleClose }
 						focusOnMount={ false }
 						noArrow
+						onClickOutside={ handleClose }
+						onClose={ handleClose }
+						onFocusOutside={ handleClose }
 						position={ 'bottom center' }
 					>
 						<DomainPicker
-							onDomainSelect={ handleDomainSelect }
-							onDomainPurchase={ handlePaidDomainSelect }
-							onClose={ handleClose }
 							currentDomain={ currentDomain }
+							onClose={ handleClose }
+							onDomainPurchase={ handlePaidDomainSelect }
+							onDomainSelect={ handleDomainSelect }
 						/>
 					</Popover>
 				</div>

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -42,12 +42,12 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 		setDomainPopoverVisibility( false );
 	};
 
-	const handleDomainSelect: typeof onDomainSelect = selectedDomain => {
+	const handleDomainSelect = ( selectedDomain: DomainSuggestion ) => {
 		onDomainSelect( selectedDomain );
 	};
 
 	const handlePaidDomainSelect = ( selectedDomain: DomainSuggestion ) => {
-		setDomainPopoverVisibility( false );
+		onDomainSelect( selectedDomain );
 		onDomainPurchase( selectedDomain );
 	};
 

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -43,7 +43,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	};
 
 	const handleDomainSelect: typeof onDomainSelect = selectedDomain => {
-		setDomainPopoverVisibility( false );
 		onDomainSelect( selectedDomain );
 	};
 
@@ -69,20 +68,24 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<Dashicon icon="arrow-down-alt2" />
 			</Button>
 			{ isDomainPopoverVisible && (
-				<Popover
-					className="domain-picker-button__popover"
-					onClose={ handleClose }
-					onFocusOutside={ handleClose }
-					focusOnMount={ false }
-					noArrow
-				>
-					<DomainPicker
-						onDomainSelect={ handleDomainSelect }
-						onDomainPurchase={ handlePaidDomainSelect }
+				<div className="domain-picker-button__popover-container">
+					<Popover
+						className="domain-picker-button"
 						onClose={ handleClose }
-						currentDomain={ currentDomain }
-					/>
-				</Popover>
+						onFocusOutside={ handleClose }
+						onClickOutside={ handleClose }
+						focusOnMount={ false }
+						noArrow
+						position={ 'bottom center' }
+					>
+						<DomainPicker
+							onDomainSelect={ handleDomainSelect }
+							onDomainPurchase={ handlePaidDomainSelect }
+							onClose={ handleClose }
+							currentDomain={ currentDomain }
+						/>
+					</Popover>
+				</div>
 			) }
 		</>
 	);

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -15,3 +15,9 @@
 		border-radius: 4px;
 	}
 }
+
+.domain-picker-button__popover-container {
+	position: fixed;
+	left: 72px;
+	top: 54px;
+}

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -7,3 +7,11 @@
 		transform: rotate( 180deg );
 	}
 }
+
+.domain-picker-button__popover {
+	.components-popover__content {
+		border: 1px solid var( --studio-gray-5 );
+		box-shadow: 0 4px 10px rgba( 0, 0, 0, 0.12 );
+		border-radius: 4px;
+	}
+}

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -1,3 +1,5 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+
 .domain-picker-button {
 	.dashicon {
 		margin-left: 0.5em;
@@ -17,7 +19,17 @@
 }
 
 .domain-picker-button__popover-container {
-	position: fixed;
-	left: 72px;
-	top: 54px;
+	.components-popover__header {
+		display: none;
+	}
+
+	.components-popover.is-expanded .components-popover__content {
+		height: 100%;
+	}
+
+	@include break-small {
+		position: fixed;
+		left: 72px;
+		top: 54px;
+	}
 }

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -2,11 +2,10 @@
  * External dependencies
  */
 import React, { FunctionComponent } from 'react';
-import { Button, Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
+import { Button, Panel, PanelBody, PanelRow, TextControl, Icon } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { times } from 'lodash';
 import { useI18n } from '@automattic/react-i18n';
-import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -59,6 +58,29 @@ export interface Props {
 	currentDomain?: DomainSuggestion;
 }
 
+const FreeDomainIcon = () => (
+	<Icon
+		icon={ () => (
+			<svg
+				width="15"
+				height="15"
+				viewBox="0 0 15 15"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					d="M13.2878 8.60833L8.61291 13.2844C8.4918 13.4057 8.34798 13.5019 8.18968 13.5676C8.03137 13.6332 7.86169 13.667 7.69032 13.667C7.51895 13.667 7.34926 13.6332 7.19096 13.5676C7.03265 13.5019 6.88884 13.4057 6.76773 13.2844L1.16699 7.68876V1.16699H7.68706L13.2878 6.76919C13.5307 7.01358 13.667 7.34417 13.667 7.68876C13.667 8.03335 13.5307 8.36395 13.2878 8.60833V8.60833Z"
+					stroke="#008A20"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+				<circle cx="4.50033" cy="4.50033" r="0.833333" fill="#008A20" />
+			</svg>
+		) }
+	/>
+);
+
 const DomainPicker: FunctionComponent< Props > = ( {
 	onDomainSelect,
 	onDomainPurchase,
@@ -84,7 +106,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 			<PanelBody>
 				<PanelRow className="domain-picker__panel-row">
 					<div className="domain-picker__header">
-						<div className="domain-picker__header-title">{ NO__( 'Choose a new domain' ) }</div>
+						<div className="domain-picker__header-title">{ NO__( 'Choose a domain' ) }</div>
 						<Button className="domain-picker__close-button" isTertiary onClick={ () => onClose() }>
 							{ NO__( 'Skip for now' ) }
 						</Button>
@@ -101,20 +123,27 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				</PanelRow>
 
 				<PanelRow className="domain-picker__panel-row">
-					<div className="domain-picker__suggestion-header">
-						<div className="domain-picker__suggestion-header-title">
-							{ NO__( 'Professional domain' ) }
-						</div>
-						<div className="domain-picker__suggestion-header-description">
-							{ __experimentalCreateInterpolateElement(
-								NO__( '<Price>Free</Price> for the first year with a paid plan' ),
-								{ Price: <em /> }
-							) }
-						</div>
-					</div>
+					<p className="domain-picker__free-text domain-picker__paragraph">
+						<FreeDomainIcon />
+						{ NO__( 'Free for the first year with any paid plan' ) }
+					</p>
+				</PanelRow>
+
+				<PanelRow className="domain-picker__panel-row">
 					<div className="domain-picker__suggestion-item-group">
+						{ ! freeSuggestions && <SuggestionItemPlaceholder /> }
+						{ freeSuggestions &&
+							( freeSuggestions.length ? (
+								<SuggestionItem
+									suggestion={ freeSuggestions[ 0 ] }
+									isCurrent={ currentDomain?.domain_name === freeSuggestions[ 0 ].domain_name }
+									onClick={ () => onDomainSelect( freeSuggestions[ 0 ] ) }
+								/>
+							) : (
+								<SuggestionNone />
+							) ) }
 						{ ! paidSuggestions &&
-							times( PAID_DOMAINS_TO_SHOW, i => <SuggestionItemPlaceholder key={ i } /> ) }
+							times( PAID_DOMAINS_TO_SHOW - 1, i => <SuggestionItemPlaceholder key={ i } /> ) }
 						{ paidSuggestions &&
 							( paidSuggestions?.length ? (
 								paidSuggestions.map( suggestion => (
@@ -133,21 +162,11 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				</PanelRow>
 
 				<PanelRow className="domain-picker__panel-row">
-					<div className="domain-picker__suggestion-header">
-						<div className="domain-picker__suggestion-header-title">{ NO__( 'Subdomain' ) }</div>
-					</div>
-					<div className="domain-picker__suggestion-item-group">
-						{ ! freeSuggestions && <SuggestionItemPlaceholder /> }
-						{ freeSuggestions &&
-							( freeSuggestions.length ? (
-								<SuggestionItem
-									suggestion={ freeSuggestions[ 0 ] }
-									isCurrent={ currentDomain?.domain_name === freeSuggestions[ 0 ].domain_name }
-									onClick={ () => onDomainSelect( freeSuggestions[ 0 ] ) }
-								/>
-							) : (
-								<SuggestionNone />
-							) ) }
+					<div className="domain-picker__footer">
+						<Button className="domain-picker__footer-options">{ NO__( 'More options' ) }</Button>
+						<Button className="domain-picker__footer-button" isPrimary onClick={ () => onClose() }>
+							{ NO__( 'Confirm' ) }
+						</Button>
 					</div>
 				</PanelRow>
 			</PanelBody>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -149,7 +149,7 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 								<SuggestionItem
 									suggestion={ freeSuggestions[ 0 ] }
 									isCurrent={ currentDomain?.domain_name === freeSuggestions[ 0 ].domain_name }
-									onClick={ () => onDomainSelect( freeSuggestions[ 0 ] ) }
+									onSelect={ onDomainSelect }
 								/>
 							) : (
 								<SuggestionNone />
@@ -163,7 +163,7 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 										suggestion={ suggestion }
 										isRecommended={ suggestion === recommendedSuggestion }
 										isCurrent={ currentDomain?.domain_name === suggestion.domain_name }
-										onClick={ () => onDomainSelect( suggestion ) }
+										onSelect={ onDomainSelect }
 										key={ suggestion.domain_name }
 									/>
 								) )

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -123,9 +123,7 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 						<CloseButton onClose={ () => onClose() } />
 					</div>
 					<div className="domain-picker__search">
-						<div className="domain-picker__search-icon">
-							<SearchIcon />
-						</div>
+						<SearchIcon />
 						<TextControl
 							hideLabelFromVision
 							label={ label }

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -148,7 +148,7 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 							( freeSuggestions.length ? (
 								<SuggestionItem
 									suggestion={ freeSuggestions[ 0 ] }
-									isCurrent={ currentDomain?.domain_name === freeSuggestions[ 0 ].domain_name }
+									isSelected={ currentDomain?.domain_name === freeSuggestions[ 0 ].domain_name }
 									onSelect={ onDomainSelect }
 								/>
 							) : (
@@ -162,7 +162,7 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 									<SuggestionItem
 										suggestion={ suggestion }
 										isRecommended={ suggestion === recommendedSuggestion }
-										isCurrent={ currentDomain?.domain_name === suggestion.domain_name }
+										isSelected={ currentDomain?.domain_name === suggestion.domain_name }
 										onSelect={ onDomainSelect }
 										key={ suggestion.domain_name }
 									/>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -20,6 +20,7 @@ import {
 	getPaidDomainSuggestions,
 	getRecommendedDomainSuggestion,
 } from '../../utils/domain-suggestions';
+import CloseButton from '../close-button';
 import { useDomainSuggestions } from '../../hooks/use-domain-suggestions';
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
 
@@ -81,12 +82,24 @@ const FreeDomainIcon = () => (
 	/>
 );
 
-const DomainPicker: FunctionComponent< Props > = ( {
-	onDomainSelect,
-	onDomainPurchase,
-	onClose,
-	currentDomain,
-} ) => {
+const SearchIcon = () => (
+	<Icon
+		icon={ () => (
+			<svg
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path d="M6 18L10 14.5" stroke="black" strokeWidth="1.5" />
+				<circle cx="13.5" cy="11.5" r="4.75" stroke="black" strokeWidth="1.5" />
+			</svg>
+		) }
+	/>
+);
+
+const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, currentDomain } ) => {
 	const { __: NO__ } = useI18n();
 	const label = NO__( 'Search for a domain' );
 
@@ -107,11 +120,12 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				<PanelRow className="domain-picker__panel-row">
 					<div className="domain-picker__header">
 						<div className="domain-picker__header-title">{ NO__( 'Choose a domain' ) }</div>
-						<Button className="domain-picker__close-button" isTertiary onClick={ () => onClose() }>
-							{ NO__( 'Skip for now' ) }
-						</Button>
+						<CloseButton onClose={ () => onClose() } />
 					</div>
 					<div className="domain-picker__search">
+						<div className="domain-picker__search-icon">
+							<SearchIcon />
+						</div>
 						<TextControl
 							hideLabelFromVision
 							label={ label }
@@ -151,7 +165,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 										suggestion={ suggestion }
 										isRecommended={ suggestion === recommendedSuggestion }
 										isCurrent={ currentDomain?.domain_name === suggestion.domain_name }
-										onClick={ () => onDomainPurchase( suggestion ) }
+										onClick={ () => onDomainSelect( suggestion ) }
 										key={ suggestion.domain_name }
 									/>
 								) )
@@ -163,7 +177,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 				<PanelRow className="domain-picker__panel-row">
 					<div className="domain-picker__footer">
-						<Button className="domain-picker__footer-options">{ NO__( 'More options' ) }</Button>
+						<div className="domain-picker__footer-options"></div>
 						<Button className="domain-picker__footer-button" isPrimary onClick={ () => onClose() }>
 							{ NO__( 'Confirm' ) }
 						</Button>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -135,7 +135,7 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 				</PanelRow>
 
 				<PanelRow className="domain-picker__panel-row">
-					<p className="domain-picker__free-text domain-picker__paragraph">
+					<p className="domain-picker__free-text">
 						<FreeDomainIcon />
 						{ NO__( 'Free for the first year with any paid plan' ) }
 					</p>

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -35,7 +35,6 @@
 		padding: 6px 8px 6px 40px;
 		height: 36px;
 	}
-	@include reset;
 
 	svg {
 		position: absolute;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -75,16 +75,6 @@
 	padding: 0 24px;
 }
 
-.domain-picker__close-button {
-	font-size: 14px;
-	text-transform: lowercase;
-
-	&.components-button.is-tertiary {
-		color: var( --color-neutral-40 );
-		text-decoration: underline;
-	}
-}
-
 .domain-picker__connect-domain {
 	text-align: center;
 	margin-top: 14px;
@@ -130,7 +120,6 @@
 	@extend .domain-picker__suggestion-none;
 
 	&.components-button {
-
 		&.is-tertiary {
 			color: var( --color-text );
 
@@ -143,7 +132,6 @@
 }
 
 .domain-picker__suggestion-item-name {
-
 	input[type='radio'].domain-picker__suggestion-radio-button {
 		width: 16px;
 		height: 16px;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -28,6 +28,22 @@
 	line-height: 35px;
 }
 
+.domain-picker__search {
+	position: relative;
+
+	input[type='text'].components-text-control__input {
+		padding: 6px 8px 6px 40px;
+		height: 36px;
+	}
+	@include reset;
+}
+
+.domain-picker__search-icon {
+	position: absolute;
+	top: 6px;
+	left: 8px;
+}
+
 .domain-picker__paragraph {
 	text-align: center;
 }
@@ -88,6 +104,10 @@
 	&.components-panel__row {
 		flex-direction: column;
 		align-items: stretch;
+
+		label {
+			max-width: 100%;
+		}
 	}
 }
 
@@ -98,15 +118,18 @@
 	width: 100%;
 	height: 46px;
 	border-radius: 0;
-	padding: 0 16px;
+	padding: 0;
+	margin-bottom: 10px;
 	font-size: 14px;
 }
+
 .domain-picker__suggestion-item {
 	// Increasing specificity because @wordpress/components stylesheets are loaded after gutenboarding stylesheets.
 	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
 	// See https://github.com/WordPress/gutenberg/pull/19535
+	@extend .domain-picker__suggestion-none;
+
 	&.components-button {
-		@extend .domain-picker__suggestion-none;
 
 		&.is-tertiary {
 			color: var( --color-text );
@@ -120,6 +143,43 @@
 }
 
 .domain-picker__suggestion-item-name {
+
+	input[type='radio'].domain-picker__suggestion-radio-button {
+		width: 16px;
+		height: 16px;
+		margin: 0 12px 0 0;
+		padding: 0;
+		vertical-align: middle;
+		position: relative;
+
+		&:checked {
+			border-color: var( --studio-blue-30 );
+			background-color: var( --studio-blue-30 );
+
+			&::before {
+				content: '';
+				width: 12px;
+				height: 12px;
+				border: 2px solid white;
+				border-radius: 50%;
+				position: absolute;
+				margin: 0;
+				background: transparent;
+			}
+
+			&:focus {
+				border-color: var( --studio-blue-30 );
+				box-shadow: 0 0 0 1px var( --studio-blue-30 );
+			}
+		}
+
+		&:focus,
+		&:hover {
+			border-color: var( --studio-blue-30 );
+			box-shadow: 0 0 0 1px var( --studio-blue-30 );
+		}
+	}
+
 	&.placeholder {
 		@include placeholder();
 		min-width: 30%;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -36,12 +36,12 @@
 		height: 36px;
 	}
 	@include reset;
-}
 
-.domain-picker__search-icon {
-	position: absolute;
-	top: 6px;
-	left: 8px;
+	svg {
+		position: absolute;
+		top: 6px;
+		left: 8px;
+	}
 }
 
 .domain-picker__paragraph {
@@ -51,11 +51,11 @@
 .domain-picker__free-text {
 	line-height: 20px;
 	color: var( --studio-green-50 );
-}
 
-.domain-picker__free-text svg {
-	margin: 8px;
-	vertical-align: middle;
+	svg {
+		margin: 8px;
+		vertical-align: middle;
+	}
 }
 
 .domain-picker__footer {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -44,13 +44,10 @@
 	}
 }
 
-.domain-picker__paragraph {
-	text-align: center;
-}
-
 .domain-picker__free-text {
-	line-height: 20px;
 	color: var( --studio-green-50 );
+	line-height: 20px;
+	text-align: center;
 
 	svg {
 		margin: 8px;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -3,11 +3,15 @@
 @import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
 @import '../../mixins';
 
-.domain-picker {
-	min-width: 530px;
+.domain-picker.components-panel {
+	border: none;
 
 	.components-panel__body.is-opened {
 		padding: 36px;
+	}
+
+	@include break-small {
+		min-width: 520px;
 	}
 }
 
@@ -21,6 +25,38 @@
 .domain-picker__header-title {
 	@include onboarding-font-recoleta;
 	font-size: 26px;
+	line-height: 35px;
+}
+
+.domain-picker__paragraph {
+	text-align: center;
+}
+
+.domain-picker__free-text {
+	line-height: 20px;
+	color: var( --studio-green-50 );
+}
+
+.domain-picker__free-text svg {
+	margin: 8px;
+	vertical-align: middle;
+}
+
+.domain-picker__footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 14px;
+}
+
+.domain-picker__footer-options.components-button {
+	@include onboarding-medium-text;
+	color: var( --color-neutral-100 );
+}
+
+.domain-picker__footer-button.components-button {
+	@include onboarding-medium-text;
+	padding: 0 24px;
 }
 
 .domain-picker__close-button {
@@ -53,37 +89,6 @@
 		flex-direction: column;
 		align-items: stretch;
 	}
-
-	+ .domain-picker__panel-row {
-		margin-top: 36px;
-	}
-}
-
-.domain-picker__suggestion-header {
-	display: flex;
-	justify-content: space-between;
-	padding-bottom: 12px;
-}
-
-.domain-picker__suggestion-header-title {
-	font-size: 12px;
-	font-weight: 600;
-	letter-spacing: 2px;
-	text-transform: uppercase;
-	color: var( --color-neutral-40 );
-}
-
-.domain-picker__suggestion-header-description {
-	font-size: 12px;
-	color: var( --color-neutral-40 );
-
-	em {
-		font-weight: 600;
-	}
-}
-
-.domain-picker__suggestion-item-group {
-	border: 1px solid var( --color-neutral-5 );
 }
 
 .domain-picker__suggestion-none {
@@ -111,10 +116,6 @@
 				color: var( --color-text );
 			}
 		}
-	}
-
-	+ .domain-picker__suggestion-item {
-		border-top: 1px solid var( --color-neutral-5 );
 	}
 }
 
@@ -153,12 +154,12 @@
 	color: var( --studio-gray-20 );
 	white-space: nowrap;
 
-	&.is-paid {
-		text-decoration: line-through;
-	}
-
 	&.placeholder {
 		@include placeholder();
 		min-width: 64px;
 	}
+}
+
+.domain-picker__price-is-paid {
+	text-decoration: line-through;
 }

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -47,10 +47,8 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					NO__( 'Free' )
 				) : (
 					<>
-						{ ' ' }
 						<span className="domain-picker__free-text"> { NO__( 'Free' ) } </span>
 						<span className="domain-picker__price-is-paid">
-							{ ' ' }
 							{ sprintf( NO__( '%s/year' ), suggestion.cost ) }{ ' ' }
 						</span>
 					</>

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -11,14 +11,14 @@ type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.Doma
 interface Props {
 	suggestion: DomainSuggestion;
 	isRecommended?: boolean;
-	isCurrent?: boolean;
+	isSelected?: boolean;
 	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
 }
 
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	suggestion,
 	isRecommended = false,
-	isCurrent = false,
+	isSelected = false,
 	onSelect,
 } ) => {
 	const { __: NO__ } = useI18n();
@@ -31,7 +31,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					type="radio"
 					name="domain-picker-suggestion-option"
 					onChange={ () => void onSelect( suggestion ) }
-					checked={ isCurrent }
+					checked={ isSelected }
 				/>
 				{ suggestion.domain_name }
 				{ isRecommended && (

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -4,22 +4,22 @@
 import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import classnames from 'classnames';
-import { Button } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
-interface Props extends Button.AnchorProps {
+interface Props {
 	suggestion: DomainSuggestion;
 	isRecommended?: boolean;
 	isCurrent?: boolean;
+	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
 }
 
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	suggestion,
 	isRecommended = false,
 	isCurrent = false,
-	onClick,
+	onSelect,
 } ) => {
 	const { __: NO__ } = useI18n();
 
@@ -30,7 +30,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					className="domain-picker__suggestion-radio-button"
 					type="radio"
 					name="domain-picker-suggestion-option"
-					onClick={ onClick }
+					onChange={ () => void onSelect( suggestion ) }
 					checked={ isCurrent }
 				/>
 				{ suggestion.domain_name }

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -19,19 +19,23 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	suggestion,
 	isRecommended = false,
 	isCurrent = false,
-	...props
+	onClick,
 } ) => {
 	const { __: NO__ } = useI18n();
 
 	return (
-		<Button className="domain-picker__suggestion-item" isTertiary { ...props }>
+		<label className="domain-picker__suggestion-item">
 			<div className="domain-picker__suggestion-item-name">
+				<input
+					className="domain-picker__suggestion-radio-button"
+					type="radio"
+					name="domain-picker-suggestion-option"
+					onClick={ onClick }
+					checked={ isCurrent }
+				/>
 				{ suggestion.domain_name }
 				{ isRecommended && (
 					<div className="domain-picker__badge is-recommended">{ NO__( 'Recommended' ) }</div>
-				) }
-				{ isCurrent && (
-					<div className="domain-picker__badge is-selected">{ NO__( 'Selected' ) }</div>
 				) }
 			</div>
 			<div
@@ -52,7 +56,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					</>
 				) }
 			</div>
-		</Button>
+		</label>
 	);
 };
 

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -39,7 +39,18 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					'is-paid': ! suggestion.is_free,
 				} ) }
 			>
-				{ suggestion.is_free ? NO__( 'Free' ) : sprintf( NO__( '%s/year' ), suggestion.cost ) }
+				{ suggestion.is_free ? (
+					NO__( 'Free' )
+				) : (
+					<>
+						{ ' ' }
+						<span className="domain-picker__free-text"> { NO__( 'Free' ) } </span>
+						<span className="domain-picker__price-is-paid">
+							{ ' ' }
+							{ sprintf( NO__( '%s/year' ), suggestion.cost ) }{ ' ' }
+						</span>
+					</>
+				) }
 			</div>
 		</Button>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Quoting https://github.com/Automattic/wp-calypso/pull/40742#issuecomment-609659426:

> ![image](https://user-images.githubusercontent.com/14988353/78539535-12f78580-7836-11ea-87f8-82fb2cb169e9.png)
> 
> Update from today. I've done the following:
> 
> * [x] Restyled the suggestion items as radio input fields, with checked, focus, and hover states
> * [x] Updated the domain form to use `onDomainSelect` when selecting a paid domain instead of `onDomainPurchase` (this will require the rest of the domain flow to be in place as it means cutting off the current domain flow), but it ensures that selecting a domain works as expected
> * [x] Add a popover container so that the popover can be fixed in position matching the positioning in the Figma — this ensures that the popover doesn't move around as the user selects their domain and the text is updated in the header
> * [x] Added search icon
> * [x] Added close button
>
> There's still a bit to be tidied up — the spacing is approximate in places, so might need to be double-checked / tweaked against the Figma. And the spacing in the loading state needs to be adjusted, as it's current too short. I also haven't addressed any mobile styling.

(Note by @ockham -- I think we can tweak the above in a follow-up.)

#### Testing instructions

- http://calypso.localhost:3000/gutenboarding
- Verify that the domain picker looks as in the above screenshot, and that it still works.
