### PR TITLE
Gutenboarding: update design selector style

### DIFF
--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -40,10 +40,10 @@
 }
 
 @mixin onboarding-heading-padding {
-	margin: $gutenboarding-page-content-padding-mobile 0 $gutenboarding-page-content-padding-mobile + 4px 0;
+	margin: $gutenboarding-heading-padding-top-mobile 0 $gutenboarding-heading-padding-bottom-mobile;
 
 	@include break-mobile {
-		margin: $gutenboarding-page-content-padding-desktop 0 $gutenboarding-page-content-padding-desktop + 8px 0;
+		margin: $gutenboarding-heading-padding-top-desktop 0 $gutenboarding-heading-padding-bottom-desktop;
 	}
 }
 

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -40,10 +40,10 @@
 }
 
 @mixin onboarding-heading-padding {
-	margin: $gutenboarding-heading-padding-top-mobile 0 $gutenboarding-heading-padding-bottom-mobile;
+	margin: $gutenboarding-heading-padding-mobile;
 
 	@include break-mobile {
-		margin: $gutenboarding-heading-padding-top-desktop 0 $gutenboarding-heading-padding-bottom-desktop;
+		margin: $gutenboarding-heading-padding-desktop;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useI18n } from '@automattic/react-i18n';
 import { useHistory } from 'react-router-dom';
-import { Spring, animated } from 'react-spring/renderprops';
 
 /**
  * Internal dependencies
@@ -21,12 +20,6 @@ import { SubTitle, Title } from '../../components/titles';
 import './style.scss';
 
 type Design = import('../../stores/onboard/types').Design;
-
-// Values for springs:
-const ZOOM_OFF = { transform: 'scale(1)' };
-const ZOOM_ON = { transform: 'scale(1.015)' };
-const SHADOW_OFF = { boxShadow: '0 0px 0px rgba(0,0,0,.12)' };
-const SHADOW_ON = { boxShadow: '0 2px 12px rgba(0,0,0,.12)' };
 
 const DesignSelector: React.FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
@@ -51,10 +44,6 @@ const DesignSelector: React.FunctionComponent = () => {
 		return mshotsUrl + encodeURIComponent( previewUrl );
 	};
 
-	// Track hover/focus
-	const [ hoverDesign, setHoverDesign ] = React.useState< string >();
-	const [ focusDesign, setFocusDesign ] = React.useState< string >();
-
 	return (
 		<div className="design-selector">
 			<div className="design-selector__header">
@@ -77,56 +66,29 @@ const DesignSelector: React.FunctionComponent = () => {
 			</div>
 			<div className="design-selector__design-grid">
 				<div className="design-selector__grid">
-					{ designs.featured.map( design => {
-						const isFocused = hoverDesign === design.slug || focusDesign === design.slug;
-						return (
-							<Spring
-								native
-								key={ design.slug }
-								from={ ZOOM_OFF }
-								to={ isFocused ? ZOOM_ON : ZOOM_OFF }
-							>
-								{ ( props: React.CSSProperties ) => (
-									<animated.button
-										style={ props }
-										onMouseEnter={ () => setHoverDesign( design.slug ) }
-										onMouseLeave={ () =>
-											setHoverDesign( s => ( s === design.slug ? undefined : s ) )
-										}
-										onFocus={ () => setFocusDesign( design.slug ) }
-										onBlur={ () => setFocusDesign( s => ( s === design.slug ? undefined : s ) ) }
-										className="design-selector__design-option"
-										onClick={ () => {
-											setSelectedDesign( design );
+					{ designs.featured.map( design => (
+						<button
+							key={ design.slug }
+							className="design-selector__design-option"
+							onClick={ () => {
+								setSelectedDesign( design );
 
-											// Update fonts to the design defaults
-											setFonts( design.fonts );
+								// Update fonts to the design defaults
+								setFonts( design.fonts );
 
-											if ( isEnabled( 'gutenboarding/style-preview' ) ) {
-												push( makePath( Step.Style ) );
-											}
-										} }
-									>
-										<Spring
-											native
-											key={ design.slug }
-											from={ SHADOW_OFF }
-											to={ isFocused ? SHADOW_ON : SHADOW_OFF }
-										>
-											{ ( props2: React.CSSProperties ) => (
-												<animated.span style={ props2 } className="design-selector__image-frame">
-													<img alt={ design.title } src={ getDesignUrl( design ) } />
-												</animated.span>
-											) }
-										</Spring>
-										<span className="design-selector__option-overlay">
-											<span className="design-selector__option-name">{ design.title }</span>
-										</span>
-									</animated.button>
-								) }
-							</Spring>
-						);
-					} ) }
+								if ( isEnabled( 'gutenboarding/style-preview' ) ) {
+									push( makePath( Step.Style ) );
+								}
+							} }
+						>
+							<span className="design-selector__image-frame">
+								<img alt={ design.title } src={ getDesignUrl( design ) } />
+							</span>
+							<span className="design-selector__option-overlay">
+								<span className="design-selector__option-name">{ design.title }</span>
+							</span>
+						</button>
+					) ) }
 				</div>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -39,6 +39,17 @@
 		}
 	}
 
+	.design-selector__design-option {
+		cursor: pointer;
+
+		&:hover,
+		&:focus {
+			.design-selector__image-frame {
+				border-color: var( --highlightColor );
+			}
+		}
+	}
+
 	.design-selector__image-frame {
 		display: block;
 		width: 100%;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -26,20 +26,16 @@
 	.design-selector__grid {
 		display: grid;
 		grid-template-columns: 1fr 1fr;
-		column-gap: 4em;
-		row-gap: 5em;
+		column-gap: 64px;
+		row-gap: 64px;
 		margin-top: 30px;
 
 		@include break-large {
 			grid-template-columns: 1fr 1fr 1fr;
-			column-gap: 3em;
-			row-gap: 4em;
 		}
 
 		@include onboarding-break-gigantic {
 			grid-template-columns: 1fr 1fr 1fr 1fr;
-			column-gap: 2em;
-			row-gap: 3em;
 		}
 	}
 

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -1,4 +1,6 @@
 // Reusable style variables
 $gutenboarding-header-height: 64px;
-$gutenboarding-page-content-padding-desktop: 60px;
-$gutenboarding-page-content-padding-mobile: 44px;
+$gutenboarding-heading-padding-top-desktop: 64px;
+$gutenboarding-heading-padding-bottom-desktop: 80px;
+$gutenboarding-heading-padding-top-mobile: 44px;
+$gutenboarding-heading-padding-bottom-mobile: 50px;

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -1,6 +1,4 @@
 // Reusable style variables
 $gutenboarding-header-height: 64px;
-$gutenboarding-heading-padding-top-desktop: 64px;
-$gutenboarding-heading-padding-bottom-desktop: 80px;
-$gutenboarding-heading-padding-top-mobile: 44px;
-$gutenboarding-heading-padding-bottom-mobile: 50px;
+$gutenboarding-heading-padding-desktop: 64px 0 80px;
+$gutenboarding-heading-padding-mobile: 44px 0 50px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update design picker grid gaps to a fixed value (64px)
* Update heading padding variables (on desktop: 64px top and 80px bottom
* Design frame hover. To align with gutenberg, we should move away from drop shadow, and frame size increase animation to a fixed size, and border color change

#### Testing instructions

* go to /gutenboarding
* test the above style changes on design selection step
