### PR TITLE
Gutenboarding: Show user-picked domain when user picks one

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -27,7 +27,6 @@ import {
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
 
 import wp from '../../../../lib/wp';
-import { DomainSuggestion } from '@automattic/data-stores/dist/types/domain-suggestions';
 
 const wpcom = wp.undocumented();
 
@@ -70,8 +69,6 @@ const Header: FunctionComponent = () => {
 
 	const newSite = useSelect( select => select( SITE_STORE ).getNewSite() );
 
-	const [ hasUserPickedDomain, setHasUserPickedDomain ] = useState( false );
-
 	const { domain, siteTitle, siteWasCreatedForDomainPurchase } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
@@ -82,11 +79,6 @@ const Header: FunctionComponent = () => {
 		resetOnboardStore,
 		setSiteWasCreatedForDomainPurchase,
 	} = useDispatch( ONBOARD_STORE );
-
-	function handleDomainSelect( item: DomainSuggestion ) {
-		setHasUserPickedDomain( true );
-		setDomain( item );
-	}
 
 	const allSuggestions = useDomainSuggestions( siteTitle );
 	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
@@ -118,10 +110,8 @@ const Header: FunctionComponent = () => {
 	const currentDomain = domain ?? freeDomainSuggestion;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	const domainElement = hasUserPickedDomain ? (
-		<span className="gutenboarding__header-domain-picker-button-domain">
-			{ currentDomain?.domain_name }
-		</span>
+	const domainElement = domain ? (
+		domain?.domain_name
 	) : (
 		<span
 			className={ classnames( 'gutenboarding__header-domain-picker-button-domain', {
@@ -220,7 +210,7 @@ const Header: FunctionComponent = () => {
 							className="gutenboarding__header-domain-picker-button"
 							disabled={ ! currentDomain }
 							currentDomain={ currentDomain }
-							onDomainSelect={ handleDomainSelect }
+							onDomainSelect={ setDomain }
 							onDomainPurchase={ () =>
 								currentUser
 									? handleCreateSiteForDomains( currentUser.username )

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -111,7 +111,7 @@ const Header: FunctionComponent = () => {
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	const domainElement = domain ? (
-		domain?.domain_name
+		domain.domain_name
 	) : (
 		<span
 			className={ classnames( 'gutenboarding__header-domain-picker-button-domain', {

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -27,6 +27,8 @@ import {
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
 
 import wp from '../../../../lib/wp';
+import { DomainSuggestion } from '@automattic/data-stores/dist/types/domain-suggestions';
+
 const wpcom = wp.undocumented();
 
 interface Cart {
@@ -68,6 +70,8 @@ const Header: FunctionComponent = () => {
 
 	const newSite = useSelect( select => select( SITE_STORE ).getNewSite() );
 
+	const [ hasUserPickedDomain, setHasUserPickedDomain ] = useState( false );
+
 	const { domain, siteTitle, siteWasCreatedForDomainPurchase } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
@@ -78,6 +82,11 @@ const Header: FunctionComponent = () => {
 		resetOnboardStore,
 		setSiteWasCreatedForDomainPurchase,
 	} = useDispatch( ONBOARD_STORE );
+
+	function handleDomainSelect( item: DomainSuggestion ) {
+		setHasUserPickedDomain( true );
+		setDomain( item );
+	}
 
 	const allSuggestions = useDomainSuggestions( siteTitle );
 	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
@@ -109,7 +118,11 @@ const Header: FunctionComponent = () => {
 	const currentDomain = domain ?? freeDomainSuggestion;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
-	const domainElement = (
+	const domainElement = hasUserPickedDomain ? (
+		<span className="gutenboarding__header-domain-picker-button-domain">
+			{ currentDomain?.domain_name }
+		</span>
+	) : (
 		<span
 			className={ classnames( 'gutenboarding__header-domain-picker-button-domain', {
 				placeholder: ! recommendedDomainSuggestion,
@@ -207,7 +220,7 @@ const Header: FunctionComponent = () => {
 							className="gutenboarding__header-domain-picker-button"
 							disabled={ ! currentDomain }
 							currentDomain={ currentDomain }
-							onDomainSelect={ setDomain }
+							onDomainSelect={ handleDomainSelect }
 							onDomainPurchase={ () =>
 								currentUser
 									? handleCreateSiteForDomains( currentUser.username )

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -107,8 +107,6 @@ const Header: FunctionComponent = () => {
 		setShowSignupDialog( false );
 	}, [ pathname, setShowSignupDialog ] );
 
-	const currentDomain = domain ?? freeDomainSuggestion;
-
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	const domainElement = domain ? (
 		domain.domain_name
@@ -123,6 +121,8 @@ const Header: FunctionComponent = () => {
 				: 'example.wordpress.com' }
 		</span>
 	);
+
+	const currentDomain = domain ?? freeDomainSuggestion;
 
 	const handleCreateSite = useCallback(
 		( username: string, bearerToken?: string ) => {

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -14,7 +14,6 @@ import { SITE_STORE } from '../site';
 
 type CreateSiteParams = import('@automattic/data-stores').Site.CreateSiteParams;
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
-type Font = import('../../constants').Font;
 type FontPair = import('../../constants').FontPair;
 type State = import('.').State;
 type Template = VerticalsTemplates.Template;


### PR DESCRIPTION
_1-minute review_

#### Changes proposed in this Pull Request

When the user picks a domain in the domain picker, it should appear on the button instead of keeping the suggestion stuck.

#### Testing instructions

1. Pick a domain. You should see it on the button.
2. Refresh the page. Your choice should persist and the button should reflect that.

Fixes https://github.com/Automattic/wp-calypso/issues/40747
