### PR TITLE
Show the manage button on thank you pages for Atomic sites

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -29,6 +29,7 @@ import { recordStartTransferClickInThankYou } from 'state/domains/actions';
 import Gridicon from 'components/gridicon';
 import getCheckoutUpgradeIntent from '../../../state/selectors/get-checkout-upgrade-intent';
 import { Button } from '@automattic/components';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 
 export class CheckoutThankYouHeader extends PureComponent {
 	static propTypes = {
@@ -351,13 +352,17 @@ export class CheckoutThankYouHeader extends PureComponent {
 			primaryPurchase,
 			selectedSite,
 			displayMode,
+			isAtomic,
 		} = this.props;
 		const headerButtonClassName = 'button is-primary';
 		const isConciergePurchase = 'concierge' === displayMode;
 
 		if (
 			! isConciergePurchase &&
-			( hasFailedPurchases || ! primaryPurchase || ! selectedSite || selectedSite.jetpack )
+			( hasFailedPurchases ||
+				! primaryPurchase ||
+				! selectedSite ||
+				( selectedSite.jetpack && ! isAtomic ) )
 		) {
 			return null;
 		}
@@ -464,6 +469,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 export default connect(
 	( state, ownProps ) => ( {
 		upgradeIntent: ownProps.upgradeIntent || getCheckoutUpgradeIntent( state ),
+		isAtomic: isAtomicSite( state, ownProps.selectedSite.ID ),
 	} ),
 	{
 		recordStartTransferClickInThankYou,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Manage Domain button was missing from the thank you page after purchase on atomic site. Turned out that we're just skipping any jetpack site so here's a fix for it.

<img width="842" alt="Screenshot 2020-04-03 at 14 57 04" src="https://user-images.githubusercontent.com/1355045/78358179-6ad68800-75bb-11ea-95d7-5c8f5ead312d.png">

#### Testing instructions

* Purchase a domain (or something) for an Atomic site. Without this PR the Manage Domain button would be missing.
