### PR TITLE
[Private media] Request media files using query string

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2492,11 +2492,9 @@ Undocumented.prototype.getAtomicSiteMediaViaProxy = function(
 	{ query = '', maxSize },
 	fn
 ) {
+	const safeQuery = query.replace( /^\?/, '' );
 	const params = {
-		path: `/sites/${ siteIdOrSlug }/atomic-auth-proxy/file?path=${ mediaPath }&${ query.replace(
-			/^\?/,
-			''
-		) }`,
+		path: `/sites/${ siteIdOrSlug }/atomic-auth-proxy/file?path=${ mediaPath }&${ safeQuery }`,
 		apiNamespace: 'wpcom/v2',
 	};
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2493,7 +2493,10 @@ Undocumented.prototype.getAtomicSiteMediaViaProxy = function(
 	fn
 ) {
 	const params = {
-		path: `/sites/${ siteIdOrSlug }/atomic-auth-proxy/file${ mediaPath }${ query }`,
+		path: `/sites/${ siteIdOrSlug }/atomic-auth-proxy/file?path=${ mediaPath }&${ query.replace(
+			/^\?/,
+			''
+		) }`,
 		apiNamespace: 'wpcom/v2',
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Requesting media files using path, such as `/sites/<ID>/atomic-auth-proxy/file/image.jpg` is problematic from http caching point of view (see D41345-code for details). This PR replaces the path with query argument.

#### Testing instructions

Go to media library on private atomic site and confirm your images are loaded correctly. Don't test on calypso.live