### PR TITLE
Update BackupDelta to use the backup of the selected date and show the activity log

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -103,25 +103,36 @@ export const getMetaDiffForDailyBackup = ( logs, date ) => {
 	];
 };
 
-export const getDailyBackupDeltas = ( logs, date ) => {
-	const changes = getEventsInDailyBackup( logs, date );
-
-	return {
-		mediaCreated: changes.filter( event => 'attachment__uploaded' === event.activityName ),
-		mediaDeleted: changes.filter( event => 'attachment__deleted' === event.activityName ),
-		posts: changes.filter(
-			event => 'post__published' === event.activityName || 'post__trashed' === event.activityName
+export const getCategorizedActivities = activities => {
+	const deltas = {
+		mediaCreated: activities.filter( activity => 'attachment__uploaded' === activity.activityName ),
+		mediaDeleted: activities.filter( activity => 'attachment__deleted' === activity.activityName ),
+		posts: activities.filter(
+			activity =>
+				'post__published' === activity.activityName || 'post__trashed' === activity.activityName
 		),
-		postsCreated: changes.filter( event => 'post__published' === event.activityName ),
-		postsDeleted: changes.filter( event => 'post__trashed' === event.activityName ),
-		plugins: changes.filter(
-			event =>
-				'plugin__installed' === event.activityName || 'plugin__deleted' === event.activityName
+		postsCreated: activities.filter( activity => 'post__published' === activity.activityName ),
+		postsDeleted: activities.filter( activity => 'post__trashed' === activity.activityName ),
+		plugins: activities.filter(
+			activity =>
+				'plugin__installed' === activity.activityName || 'plugin__deleted' === activity.activityName
 		),
-		themes: changes.filter(
-			event => 'theme__installed' === event.activityName || 'theme__deleted' === event.activityName
+		themes: activities.filter(
+			activity =>
+				'theme__installed' === activity.activityName || 'theme__deleted' === activity.activityName
 		),
 	};
+
+	deltas.totalChanges =
+		deltas.mediaCreated.length +
+		deltas.mediaDeleted.length +
+		deltas.posts.length +
+		deltas.postsCreated.length +
+		deltas.postsDeleted.length +
+		deltas.plugins.length +
+		deltas.themes.length;
+
+	return deltas;
 };
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**[ HUGE ]**
_Styles not yet applied_

Update BackupDelta to use the backup of the selected date, simplify the code and doing some clean up of the component.

- Broken down the backup details snapshot view into several renders
- Removed the Activity Log view from this component and move that render responsibility to the BackupsPage component.
- Removed unused props and functions
- Added `getCategorizedActivities` function to utils to get the activities categorized based on the activities passed to it

![](https://cldup.com/L8UoX0QJCH.gif)

#### Testing instructions

- Apply the changes
- Go through your backups and you should see the Backup details of the date and if you have a Real-time subscription, you should see the rewindable activities of that date.
- See the expected copies for the backup status.

