### PR TITLE
Remove prepare script form babel-plugin-i18n-calypso

### DIFF
--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -23,7 +23,6 @@
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"clean": "npx rimraf dist",
-		"prepublish": "npm run clean",
-		"prepare": "transpile"
+		"prepublish": "npm run clean"
 	}
 }

--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -20,9 +20,5 @@
 	},
 	"keywords": [],
 	"author": "Automattic Inc.",
-	"license": "GPL-2.0-or-later",
-	"scripts": {
-		"clean": "npx rimraf dist",
-		"prepublish": "npm run clean"
-	}
+	"license": "GPL-2.0-or-later"
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the `prepare` script from babel-plugin-i18n-calypso as it's obsolete and causes publishing with lerna to fail.

#### Testing instructions

N/A