### PR TITLE
Fix ga.recordEvent in Reader

### DIFF
--- a/client/reader/stats.js
+++ b/client/reader/stats.js
@@ -7,7 +7,8 @@ import debugFactory from 'debug';
 /**
  * Internal Dependencies
  */
-import { ga, tracks } from 'lib/analytics';
+import { tracks } from 'lib/analytics';
+import { gaRecordEvent } from 'lib/analytics/ga';
 import { bumpStat, bumpStatWithPageView } from 'lib/analytics/mc';
 
 const debug = debugFactory( 'calypso:reader:stats' );
@@ -19,7 +20,7 @@ export function recordAction( action ) {
 
 export function recordGaEvent( action, label, value ) {
 	debug( 'reader ga event', ...arguments );
-	ga.recordEvent( 'Reader', action, label, value );
+	gaRecordEvent( 'Reader', action, label, value );
 }
 
 export function recordPermalinkClick( source, post, eventProperties = {} ) {

--- a/client/state/analytics/test/helpers/analytics-mock.js
+++ b/client/state/analytics/test/helpers/analytics-mock.js
@@ -5,8 +5,6 @@
 import { merge, set } from 'lodash';
 
 const analyticsMocks = [
-	'ga.recordEvent',
-	'ga.recordPageView',
 	'pageView.record',
 	'tracks.recordEvent',
 	'tracks.recordPageView',

--- a/client/state/analytics/test/middleware.js
+++ b/client/state/analytics/test/middleware.js
@@ -101,7 +101,7 @@ describe( 'middleware', () => {
 			} );
 		} );
 
-		test( 'should call ga.recordEvent', () => {
+		test( 'should call gaRecordEvent', () => {
 			dispatch( recordGoogleEvent( 'category', 'action', 'label', 'value' ) );
 
 			expect( mockGA ).to.have.been.calledWithExactly(


### PR DESCRIPTION
This was a bug introduced in #40655.

#### Changes proposed in this Pull Request

* Fix GA event recording in Reader

#### Testing instructions

Follow the steps in #40759, copied below:

1. Starting at URL: wordpress.com/read
2. Find a post in the reader and click the comment icon

This should not produce a console error, and should allow you to comment.

Fixes #40759.
