### PR TITLE
Gutenboarding: Preview sizing

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -133,21 +133,23 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 
 	return (
 		<div className={ `style-preview__preview is-viewport-${ viewport }` }>
-			{ viewport === 'desktop' && (
-				<div role="presentation" className="style-preview__preview-bar">
-					<div role="presentation" className="style-preview__preview-bar-dot" />
-					<div role="presentation" className="style-preview__preview-bar-dot" />
-					<div role="presentation" className="style-preview__preview-bar-dot" />
-				</div>
-			) }
-			<iframe
-				ref={ iframe }
-				className={ classNames( {
-					'style-preview__iframe': true,
-					hideScroll: viewport !== 'desktop',
-				} ) }
-				title="preview"
-			/>
+			<div className="style-preview__preview-wrapper">
+				{ viewport === 'desktop' && (
+					<div role="presentation" className="style-preview__preview-bar">
+						<div role="presentation" className="style-preview__preview-bar-dot" />
+						<div role="presentation" className="style-preview__preview-bar-dot" />
+						<div role="presentation" className="style-preview__preview-bar-dot" />
+					</div>
+				) }
+				<iframe
+					ref={ iframe }
+					className={ classNames( {
+						'style-preview__iframe': true,
+						hideScroll: viewport !== 'desktop',
+					} ) }
+					title="preview"
+				/>
+			</div>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -4,7 +4,6 @@
 import * as React from 'react';
 import { addQueryArgs } from '@wordpress/url';
 import { useSelect } from '@wordpress/data';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -141,14 +140,7 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 						<div role="presentation" className="style-preview__preview-bar-dot" />
 					</div>
 				) }
-				<iframe
-					ref={ iframe }
-					className={ classNames( {
-						'style-preview__iframe': true,
-						hideScroll: viewport !== 'desktop',
-					} ) }
-					title="preview"
-				/>
+				<iframe ref={ iframe } className="style-preview__iframe" title="preview" />
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -89,6 +89,7 @@
 }
 
 .style-preview__preview {
+	grid-area: preview;
 	width: 100%;
 	margin: 0 auto;
 
@@ -102,7 +103,6 @@
 }
 
 .style-preview__preview-wrapper {
-	grid-area: preview;
 	background: var( --studio-white );
 	box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.25 );
 	border-radius: 4px;

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -1,6 +1,12 @@
 @import '../../mixins.scss';
 @import '../../variables.scss';
 
+.style-preview {
+	height: calc( 100vh - #{$gutenboarding-header-height + 20px} );
+	display: flex;
+	flex-direction: column;
+}
+
 .style-preview__header {
 	display: grid;
 	grid-template-areas: 'title viewport-select actions';
@@ -14,6 +20,7 @@
 	grid-template-areas: 'fonts preview';
 	grid-template-columns: 163px auto;
 	column-gap: 100px;
+	flex: 1;
 }
 
 .style-preview__titles {
@@ -81,20 +88,37 @@
 }
 
 .style-preview__preview {
-	grid-area: preview;
+	width: 100%;
 	margin: 0 auto;
+
+	// &.is-viewport-desktop {
+	// 	max-width: 1024px;
+	// }
+
+	&.is-viewport-tablet {
+		max-width: 1024px;
+	}
+
+	&.is-viewport-mobile {
+		max-width: 351px;
+	}
+}
+
+.style-preview__preview-wrapper {
+	grid-area: preview;
 	background: var( --studio-white );
 	box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.25 );
 	border-radius: 4px;
 	overflow: hidden;
-	width: 100%;
 	position: relative;
-	height: 700px;
 
-	&.is-viewport-mobile,
-	&.is-viewport-tablet {
-		width: 375px;
-		height: 812px;
+	width: 100%;
+	margin: 0 auto;
+	height: 100%;
+
+	.is-viewport-mobile &,
+	.is-viewport-tablet & {
+		height: 0;
 		box-sizing: border-box;
 		border: 13px solid var( --studio-white );
 
@@ -103,14 +127,12 @@
 		border-radius: 31px;
 	}
 
-	&.is-viewport-tablet {
-		width: 1024px;
-		height: 768px;
+	.is-viewport-tablet & {
+		padding-top: 768 / 1024 * 100%;
 	}
 
-	&.is-viewport-mobile {
-		width: 351px;
-		height: 690px;
+	.is-viewport-mobile & {
+		padding-top: 691 / 351 * 100%;
 	}
 }
 
@@ -118,6 +140,8 @@ $gutenboarding-style-preview-bar-height: 30px;
 
 // This and the following dot class render the browser chrome
 .style-preview__preview-bar {
+	position: absolute;
+	top: 0;
 	width: 100%;
 	height: $gutenboarding-style-preview-bar-height;
 	background: var( --studio-white );
@@ -165,10 +189,14 @@ $gutenboarding-style-preview-bar-height: 30px;
 		height: 100% / $scale-factor;
 	}
 
+	position: absolute;
+	top: 0;
+
 	transform: scale( $scale-factor );
 	transform-origin: 0 0;
 
 	.is-viewport-desktop & {
+		top: $gutenboarding-style-preview-bar-height;
 		height: calc(
 			#{100% / $scale-factor} - #{$gutenboarding-style-preview-bar-height / $scale-factor}
 		);

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -114,10 +114,12 @@
 	}
 }
 
+$gutenboarding-style-preview-bar-height: 30px;
+
 // This and the following dot class render the browser chrome
 .style-preview__preview-bar {
 	width: 100%;
-	height: 30px;
+	height: $gutenboarding-style-preview-bar-height;
 	background: var( --studio-white );
 	border-bottom: 1px solid var( --studio-gray-5 );
 	display: flex;
@@ -154,14 +156,21 @@
 		}
 	}
 }
-.block-editor__container iframe.style-preview__iframe {
-	transform: scale( 0.7 );
-	transform-origin: 0 0;
-	width: 143%;
-	height: 143%;
-	position: absolute;
 
-	&.hideScroll {
-		width: 145%;
+.style-preview__iframe {
+	$scale-factor: 0.7;
+	// Extra specificify to override editor ifram styles
+	.style-preview__preview & {
+		width: 100% / $scale-factor;
+		height: 100% / $scale-factor;
+	}
+
+	transform: scale( $scale-factor );
+	transform-origin: 0 0;
+
+	.is-viewport-desktop & {
+		height: calc(
+			#{100% / $scale-factor} - #{$gutenboarding-style-preview-bar-height / $scale-factor}
+		);
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -2,6 +2,7 @@
 @import '../../variables.scss';
 
 .style-preview {
+	// Full height comes from viewport heigh - header - some space for the preview's box-shadow (20px)
 	height: calc( 100vh - #{$gutenboarding-header-height + 20px} );
 	display: flex;
 	flex-direction: column;
@@ -91,10 +92,6 @@
 	width: 100%;
 	margin: 0 auto;
 
-	// &.is-viewport-desktop {
-	// 	max-width: 1024px;
-	// }
-
 	&.is-viewport-tablet {
 		max-width: 1024px;
 	}
@@ -183,7 +180,7 @@ $gutenboarding-style-preview-bar-height: 30px;
 
 .style-preview__iframe {
 	$scale-factor: 0.7;
-	// Extra specificify to override editor ifram styles
+	// Extra specificify to override editor iframe styles
 	.style-preview__preview & {
 		width: 100% / $scale-factor;
 		height: 100% / $scale-factor;


### PR DESCRIPTION
## Changes proposed in this Pull Request

Use CSS to adjust the preview size and constrain it to fit the viewport with some exceptions.

- Desktop fits in reasonably sized viewports
- Tablet and mobile views adjust to an aspect ratio relative to the width, with a max width as shown in the preview. This noticeably improves the tablet on most viewports.

Tablet and mobile only adjust their width, height will still cause overflow on some screens.

Big props to @alshakero who drove a lot of the direction of this change.

Progress on #40568
Alternative to #40729

## Screens

| Before | After | 
| --- | --- |
| ![Screen Shot 2020-04-03 at 17 36 43](https://user-images.githubusercontent.com/841763/78379599-ea238600-75d2-11ea-9fa5-10364cdc6d28.png) | ![Screen Shot 2020-04-03 at 17 37 42](https://user-images.githubusercontent.com/841763/78379602-ebed4980-75d2-11ea-93be-2df29a5c8248.png) | 
| ![Screen Shot 2020-04-03 at 17 38 34](https://user-images.githubusercontent.com/841763/78379898-5ef6c000-75d3-11ea-989e-1552ed504a75.png) | ![Screen Shot 2020-04-03 at 17 38 27](https://user-images.githubusercontent.com/841763/78379905-61f1b080-75d3-11ea-8a29-ebcff04d4adc.png) | 
| ![Screen Shot 2020-04-03 at 17 40 10](https://user-images.githubusercontent.com/841763/78379930-6cac4580-75d3-11ea-9214-dc33279982b0.png) | ![Screen Shot 2020-04-03 at 17 39 59](https://user-images.githubusercontent.com/841763/78379941-6fa73600-75d3-11ea-80a2-ded00b1814e5.png) | 
| ![Screen Shot 2020-04-03 at 17 38 45](https://user-images.githubusercontent.com/841763/78379966-77ff7100-75d3-11ea-8b45-9d0ec18553ee.png) | ![Screen Shot 2020-04-03 at 17 38 57](https://user-images.githubusercontent.com/841763/78379973-7afa6180-75d3-11ea-8412-239d62498ed2.png) | 


## Testing instructions

* [`/gutenboarding`](https://calypso.live/gutenboarding?branch=gutenboarding/aspects)
* Select different viewports and play with your viewport size.