### PR TITLE
UpsellNudge: Add some logic to determine when upsells should not show

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -3,21 +3,73 @@
  */
 import React from 'react';
 import classnames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Banner from 'components/banner';
+import { FEATURE_NO_ADS } from 'lib/plans/constants';
+import { addQueryArgs } from 'lib/url';
+import { hasFeature } from 'state/sites/plans/selectors';
+import { isFreePlan } from 'lib/products-values';
+import canCurrentUser from 'state/selectors/can-current-user';
+import isVipSite from 'state/selectors/is-vip-site';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSite } from 'state/sites/selectors';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export const UpsellNudge = ( { className, showIcon = false, ...props } ) => {
+export const UpsellNudge = ( {
+	className,
+	showIcon = false,
+	isVip,
+	canManageSite,
+	site,
+	feature,
+	href,
+	plan,
+	planHasFeature,
+	jetpack,
+	forceDisplay,
+	...props
+} ) => {
 	const classes = classnames( 'upsell-nudge', className );
+
+	const shouldNotDisplay =
+		isVip ||
+		! canManageSite ||
+		! site ||
+		typeof site !== 'object' ||
+		typeof site.jetpack !== 'boolean' ||
+		( feature && planHasFeature ) ||
+		( ! feature && ! isFreePlan( site.plan ) ) ||
+		( feature === FEATURE_NO_ADS && site.options.wordads ) ||
+		( ! jetpack && site.jetpack ) ||
+		( jetpack && ! site.jetpack );
+
+	if ( shouldNotDisplay && ! forceDisplay ) {
+		return null;
+	}
+
+	if ( ! href && site ) {
+		href = addQueryArgs( { feature, plan }, `/plans/${ site.slug }` );
+	}
 
 	return <Banner { ...props } showIcon={ showIcon } className={ classes } />;
 };
 
-export default UpsellNudge;
+export default connect( ( state, ownProps ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		site: getSite( state, siteId ),
+		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
+		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
+		isVip: isVipSite( state, siteId ),
+	};
+} )( localize( UpsellNudge ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This matches functionality found in `UpgradeNudge` that was missed when I committed #40626 
* Originally reported in p9jf6J-2rd-p2
* It would be good to get Marketing's eyes on this to make sure these upsells are showing in the right places/not showing when they shouldn't.

| Visuals | |
| ------- | ------- |
| <img width="736" alt="Screen Shot 2020-03-31 at 4 03 37 PM" src="https://user-images.githubusercontent.com/2124984/78070269-7f234680-7369-11ea-90f1-3ba61c017831.png"> | <img width="776" alt="Screen Shot 2020-03-31 at 4 03 30 PM" src="https://user-images.githubusercontent.com/2124984/78070273-7fbbdd00-7369-11ea-972e-7777ccb70c44.png"> |
| <img width="1081" alt="Screen Shot 2020-03-31 at 3 32 21 PM" src="https://user-images.githubusercontent.com/2124984/78070275-80547380-7369-11ea-8ec0-3cdd02e72c53.png"> | <img width="1088" alt="Screen Shot 2020-03-31 at 4 29 37 PM" src="https://user-images.githubusercontent.com/2124984/78072276-d4ad2280-736c-11ea-9f79-38fb71ac70fc.png"> |
| <img width="1095" alt="Screen Shot 2020-03-31 at 5 07 32 PM" src="https://user-images.githubusercontent.com/2124984/78075273-38861a00-7372-11ea-8913-409f2e57ebd3.png"> | <img width="1073" alt="Screen Shot 2020-03-31 at 5 14 11 PM" src="https://user-images.githubusercontent.com/2124984/78075753-1d67da00-7373-11ea-90ec-399c472ce815.png"> |
| <img width="772" alt="Screen Shot 2020-03-31 at 5 25 40 PM" src="https://user-images.githubusercontent.com/2124984/78076565-ac292680-7374-11ea-9b9a-7992b65c51ae.png"> | <img width="1086" alt="Screen Shot 2020-03-31 at 5 29 52 PM" src="https://user-images.githubusercontent.com/2124984/78076883-4b4e1e00-7375-11ea-8e4a-4f2fe7d8c6d8.png"> |
| <img width="651" alt="Screen Shot 2020-03-31 at 5 59 15 PM" src="https://user-images.githubusercontent.com/2124984/78079057-5d31c000-7379-11ea-968a-1c66aa7b3e11.png"> | |

#### Testing instructions

* Switch to this PR
* Test upsells in the locations in #40626 following testing instructions there, checking them on all plan types: Business, Free, Premium, Personal
* Ads should make sense in context of the site's plan; ie. no ads for Premium should show up on a Business plan.

Fixes #40790 and #40786