### PR TITLE
Remove i18n revision from docker image commit_sha

### DIFF
--- a/bin/build-docker.js
+++ b/bin/build-docker.js
@@ -13,19 +13,8 @@
 const { spawnSync, execSync } = require( 'child_process' );
 
 const sha = String( execSync( 'git rev-parse HEAD' ) ).trim();
-const revisions = JSON.parse(
-	String( execSync( 'curl http://widgets.wp.com/languages/calypso/lang-revisions.json' ) ).trim()
-);
-const wpcomI18nSvnRevision = Math.max( ...Object.values( revisions ) );
 
-const args = [
-	'build',
-	'--build-arg',
-	'commit_sha=' + sha + '_' + wpcomI18nSvnRevision,
-	'-t',
-	'wp-calypso',
-	'.',
-];
+const args = [ 'build', '--build-arg', 'commit_sha=' + sha, '-t', 'wp-calypso', '.' ];
 
 console.log( 'docker ' + args.join( ' ' ) );
 spawnSync( 'docker', args, { stdio: 'inherit' } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR reverts the code that appends i18n revision id to the Docker image commit_sha introduced in https://github.com/Automattic/wp-calypso/pull/39873/files#diff-1fca34fed286ef93626c90367b5fefe9R16-R28.

#### Testing instructions

N/A