### PR TITLE
WooCommerce: Update font weights to avoid using font-weight 300

### DIFF
--- a/client/extensions/woocommerce/app/store-stats/referrers/chart/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/referrers/chart/style.scss
@@ -7,6 +7,6 @@
 		margin-right: 6px;
 	}
 	.chart__title-referrer {
-		font-weight: 300;
+		font-weight: 400;
 	}
 }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/style.scss
@@ -38,7 +38,7 @@
 			.store-stats-orders-chart__value.value {
 				display: inline-block;
 				font-size: 20px;
-				font-weight: 300;
+				font-weight: 400;
 				margin-top: 4px;
 			}
 

--- a/client/extensions/woocommerce/components/delta/style.scss
+++ b/client/extensions/woocommerce/components/delta/style.scss
@@ -65,7 +65,7 @@
 			color: var( --color-neutral-light );
 			display: inline-block;
 			font-size: 13px;
-			font-weight: 300;
+			font-weight: 400;
 			line-height: 13px;
 			text-align: left;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* See #39596 -- auditing and replacing uses of font-weight: 300 with 400 for better readability throughout Calypso

**Before**

<img width="1084" alt="Screen Shot 2020-04-06 at 2 11 01 PM" src="https://user-images.githubusercontent.com/2124984/78590847-7ff82480-7810-11ea-9329-efcb9189ebec.png">

**After**

<img width="1093" alt="Screen Shot 2020-04-06 at 2 08 44 PM" src="https://user-images.githubusercontent.com/2124984/78590644-2263d800-7810-11ea-9b3b-38eea4a037d8.png">

#### Testing instructions

* Switch to this PR
* Open a site that has WooCommerce installed
* Go to the Store tab and note percentages in stats. They should be using 400-weight font rather than 300 now.
