### PR TITLE
Typography: More font weight updates 300 -> 400

### DIFF
--- a/client/extensions/hello-dolly/hello-dolly-page.js
+++ b/client/extensions/hello-dolly/hello-dolly-page.js
@@ -35,7 +35,7 @@ class HelloDollyPage extends Component {
 					</span>
 				</SectionHeader>
 				<Card>
-					<p style={ { fontSize: 18, fontWeight: 300 } }>
+					<p style={ { fontSize: 18 } }>
 						This is not just an extension, it symbolizes the hope and enthusiasm of an entire
 						generation summed up in two words sung most famously by Louis Armstrong.
 					</p>

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -5,7 +5,7 @@
 	.content-card__title {
 		color: var( --color-neutral-70 );
 		font-size: 34px;
-		font-weight: 300;
+		font-weight: 400;
 		margin-bottom: 1em;
 
 		@include breakpoint( '<660px' ) {
@@ -16,7 +16,7 @@
 	.content-card__message {
 		color: var( --color-neutral-50 );
 		font-size: 22px;
-		font-weight: 300;
+		font-weight: 400;
 		margin-bottom: 40px;
 		text-align: left;
 
@@ -32,7 +32,7 @@
 	.content-card__footer {
 		color: var( --color-neutral-50 );
 		font-size: 18px;
-		font-weight: 300;
+		font-weight: 400;
 		margin-bottom: 16px;
 
 		@include breakpoint( '<660px' ) {

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -5,7 +5,6 @@
 	.content-card__title {
 		color: var( --color-neutral-70 );
 		font-size: 34px;
-		font-weight: 400;
 		margin-bottom: 1em;
 
 		@include breakpoint( '<660px' ) {

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -227,7 +227,7 @@ $feature-upsell-break-at: '1040px';
 
 	&-header.is-sub {
 		font-size: 21px;
-		font-weight: 300;
+		font-weight: 400;
 		color: var( --color-neutral-60 );
 		margin-bottom: 20px;
 		@include breakpoint( '<1280px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* A few stragglers came in after deploying the other sets. :) See #39596 
* I could not find one of these; it appears to be associated with a component that's not active at this time.

| Before | After |
| ------ | ------ |
| <img width="760" alt="Screen Shot 2020-04-03 at 3 22 02 PM" src="https://user-images.githubusercontent.com/2124984/78397382-1fbe7400-75bf-11ea-8598-13c407bb7bc8.png"> | <img width="752" alt="Screen Shot 2020-04-03 at 3 21 43 PM" src="https://user-images.githubusercontent.com/2124984/78397390-23ea9180-75bf-11ea-82e8-0100dd4bded9.png"> 
| <img width="768" alt="Screen Shot 2020-04-03 at 3 38 36 PM" src="https://user-images.githubusercontent.com/2124984/78398581-51d0d580-75c1-11ea-95fb-ec201472327e.png"> | <img width="751" alt="Screen Shot 2020-04-03 at 3 38 43 PM" src="https://user-images.githubusercontent.com/2124984/78398571-4d0c2180-75c1-11ea-8163-553eedfdbfd3.png"> |

#### Testing instructions

* Switch to this PR
* Go to `/domain-services/registrant-verification` and note the font weight on the "Uh Oh!" heading. 
* Go to `/hello-dolly` and ensure the "This is not just an extension, it symbolizes the hope and enthusiasm..." line is font-weight 300.