### PR TITLE
Gutenboarding: Fall back to vertical for domain suggestion

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -25,6 +25,7 @@ import {
 	getRecommendedDomainSuggestion,
 } from '../../utils/domain-suggestions';
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
+import { useCurrentStep } from '../../path';
 
 import wp from '../../../../lib/wp';
 
@@ -63,6 +64,8 @@ interface Cart {
 
 const Header: FunctionComponent = () => {
 	const { __: NO__ } = useI18n();
+
+	const currentStep = useCurrentStep();
 
 	const currentUser = useSelect( select => select( USER_STORE ).getCurrentUser() );
 	const newUser = useSelect( select => select( USER_STORE ).getNewUser() );
@@ -205,7 +208,10 @@ const Header: FunctionComponent = () => {
 					</div>
 				</div>
 				<div className="gutenboarding__header-section-item">
-					{ currentDomain && (
+					{ // We display the DomainPickerButton as soon as we have a domain suggestion,
+					//   unless we're still at the IntentGathering step. In that case, we only
+					//   show it comes from a site title (but hide it if it comes from a vertical).
+					currentDomain && ( siteTitle || currentStep !== 'IntentGathering' ) && (
 						<DomainPickerButton
 							className="gutenboarding__header-domain-picker-button"
 							disabled={ ! currentDomain }

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -205,7 +205,7 @@ const Header: FunctionComponent = () => {
 					</div>
 				</div>
 				<div className="gutenboarding__header-section-item">
-					{ siteTitle && (
+					{ currentDomain && (
 						<DomainPickerButton
 							className="gutenboarding__header-domain-picker-button"
 							disabled={ ! currentDomain }

--- a/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
+++ b/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
@@ -17,7 +17,7 @@ export function useDomainSuggestions( searchOverride = '' ) {
 	);
 
 	const [ searchTerm ] = useDebounce(
-		searchOverride.trim() || domainSearch.trim() || siteTitle || '',
+		searchOverride.trim() || domainSearch.trim() || siteTitle || siteVertical?.label.trim() || '',
 		selectorDebounce
 	);
 

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { findKey } from 'lodash';
 import { generatePath, useLocation, useRouteMatch } from 'react-router-dom';
 import { getLanguageRouteParam } from '../../lib/i18n-utils';
 import { ValuesType } from 'utility-types';
@@ -24,6 +25,7 @@ export const steps = Object.values( Step ).filter( Boolean );
 export const path = `/:step(${ steps.join( '|' ) })?/${ getLanguageRouteParam() }`;
 
 export type StepType = ValuesType< typeof Step >;
+export type StepNameType = keyof typeof Step;
 
 export function usePath() {
 	const langParam = useLangRouteParam();
@@ -52,6 +54,16 @@ export function usePath() {
 export function useLangRouteParam() {
 	const match = useRouteMatch< { lang?: string } >( path );
 	return match?.params.lang;
+}
+
+export function useStepRouteParam() {
+	const match = useRouteMatch< { step?: string } >( path );
+	return match?.params.step as StepType;
+}
+
+export function useCurrentStep() {
+	const stepRouteParam = useStepRouteParam();
+	return findKey( Step, step => step === stepRouteParam ) as StepNameType;
 }
 
 // Returns true if the url has a `?new`, which is used by the


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For the domain suggestion, fall back to the vertical set by the user if no sitle has been entered.

#### Screenshots

##### Before

![image](https://user-images.githubusercontent.com/96308/78385934-fad8f980-75dc-11ea-8e03-7a1f92210841.png)

##### After

![image](https://user-images.githubusercontent.com/96308/78385864-d8df7700-75dc-11ea-97cb-b881b55b9d28.png)

#### Testing instructions

- Go to http://calypso.localhost:3000/gutenboarding
- Enter a vertical and confirm with Enter
- Notice that the domain picker makes a suggestion based on the vertical
- Enter a site title. The domain picker will change to a suggestion based on the site title.

Fixes part of #40748.
