### PR TITLE
My Home: Have notices correctly refer to the quick links or checklist.

### DIFF
--- a/client/my-sites/customer-home/locations/notices/index.jsx
+++ b/client/my-sites/customer-home/locations/notices/index.jsx
@@ -18,7 +18,7 @@ const cardComponents = {
 	'home-notice-celebrate-site-setup-complete': CelebrateSiteSetupComplete,
 };
 
-const Notices = ( { checklistMode, cards } ) => {
+const Notices = ( { checklistMode, displayChecklist, cards } ) => {
 	return (
 		<>
 			{ cards &&
@@ -28,6 +28,7 @@ const Notices = ( { checklistMode, cards } ) => {
 						React.createElement( cardComponents[ card ], {
 							key: index,
 							checklistMode,
+							displayChecklist,
 						} )
 				) }
 		</>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -27,8 +27,6 @@ import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/a
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
-import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
-import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
 import QueryHomeLayout from 'components/data/query-home-layout';
 import { getHomeLayout } from 'state/selectors/get-home-layout';
 import Notices from 'my-sites/customer-home/locations/notices';
@@ -136,7 +134,7 @@ const mapStateToProps = state => {
 	const hasChecklistData = null !== siteChecklist && Array.isArray( siteChecklist.tasks );
 	const user = getCurrentUser( state );
 	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
-	const isChecklistComplete = isSiteChecklistComplete( state, siteId );
+	const layout = getHomeLayout( state, siteId );
 
 	return {
 		site: getSelectedSite( state ),
@@ -146,11 +144,10 @@ const mapStateToProps = state => {
 		hasChecklistData,
 		isStaticHomePage:
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
-		displayChecklist:
-			isEligibleForDotcomChecklist( state, siteId ) && hasChecklistData && ! isChecklistComplete,
+		displayChecklist: layout?.primary?.includes( 'home-primary-checklist-site-setup' ),
 		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 		user,
-		layout: getHomeLayout( state, siteId ),
+		layout,
 	};
 };
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -27,6 +27,8 @@ import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/a
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
+import isSiteChecklistComplete from 'state/selectors/is-site-checklist-complete';
 import QueryHomeLayout from 'components/data/query-home-layout';
 import { getHomeLayout } from 'state/selectors/get-home-layout';
 import Notices from 'my-sites/customer-home/locations/notices';
@@ -43,6 +45,7 @@ const Home = ( {
 	canUserUseCustomerHome,
 	checklistMode,
 	hasChecklistData,
+	displayChecklist,
 	layout,
 	site,
 	siteId,
@@ -91,7 +94,11 @@ const Home = ( {
 			</div>
 			{ layout ? (
 				<>
-					<Notices cards={ layout.notices } checklistMode={ checklistMode } />
+					<Notices
+						cards={ layout.notices }
+						checklistMode={ checklistMode }
+						displayChecklist={ displayChecklist }
+					/>
 					<Upsells cards={ layout.upsells } />
 					{ hasChecklistData && (
 						<div className="customer-home__layout">
@@ -129,6 +136,7 @@ const mapStateToProps = state => {
 	const hasChecklistData = null !== siteChecklist && Array.isArray( siteChecklist.tasks );
 	const user = getCurrentUser( state );
 	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
+	const isChecklistComplete = isSiteChecklistComplete( state, siteId );
 
 	return {
 		site: getSelectedSite( state ),
@@ -138,6 +146,8 @@ const mapStateToProps = state => {
 		hasChecklistData,
 		isStaticHomePage:
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
+		displayChecklist:
+			isEligibleForDotcomChecklist( state, siteId ) && hasChecklistData && ! isChecklistComplete,
 		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 		user,
 		layout: getHomeLayout( state, siteId ),


### PR DESCRIPTION
[Observed](https://github.com/Automattic/wp-calypso/pull/40634#issuecomment-607345928) by @jancavan :

> I also noticed that our success message is incorrect for certain use cases; it keeps mentioning Quick Links even though it hasn't even shown up yet.

The specific Home Notice components only provide the title text to `<CelebrateNotice />` – it in turn uses the value of `displayChecklist` to determine the second line of descriptive text. When we refactored in #40368, we stopped passing down `displayChecklist`; this PR restores it to correct the logic of that second line display.

This will be followed up with more notice refactoring; they really should be 100% responsible for all content passed to `<CelebrateNotice />`, so that we can get rid of this sort of logic, and also remove the troublesome `checklistMode` mechanism.

**Master**
<img width="1069" alt="Screen Shot 2020-04-03 at 11 43 36 AM" src="https://user-images.githubusercontent.com/349751/78395149-d01d7f80-75a1-11ea-9a3c-67dfb83c608a.png">

**This Branch**
<img width="1070" alt="Screen Shot 2020-04-03 at 11 55 31 AM" src="https://user-images.githubusercontent.com/349751/78395329-1f63b000-75a2-11ea-8e29-c2282883c665.png">

**Testing Instructions**
* Create a new site on WordPress.com.
* See that the celebratory notice on Home mentions the Quick Links, hen the checklist is being shown.
* Load the new site's Home on this branch.
* Verify that the message now refers to the setup checklist.