### PR TITLE
Purchases: updates purchase cards for Jetpack single products

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -24,7 +24,10 @@ import {
 	isTheme,
 	isConciergeSession,
 } from 'lib/products-values';
-import { getJetpackProductsDisplayNames } from 'lib/products-values/constants';
+import {
+	getJetpackProductsDescriptions,
+	getJetpackProductsDisplayNames,
+} from 'lib/products-values/constants';
 
 const debug = debugFactory( 'calypso:purchases' );
 
@@ -73,6 +76,14 @@ function getName( purchase ) {
 	}
 
 	return purchase.productName;
+}
+
+function getDescription( purchase ) {
+	const jetpackProductsDescriptions = getJetpackProductsDescriptions();
+	if ( jetpackProductsDescriptions[ purchase.productSlug ] ) {
+		return jetpackProductsDescriptions[ purchase.productSlug ];
+	}
+	return getName( purchase );
 }
 
 function getDisplayName( purchase ) {
@@ -515,6 +526,7 @@ export {
 	getDomainRegistrationAgreementUrl,
 	getIncludedDomain,
 	getName,
+	getDescription,
 	getDisplayName,
 	getPartnerName,
 	getPurchasesBySite,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -83,7 +83,7 @@ function getDescription( purchase ) {
 	if ( jetpackProductsDescriptions[ purchase.productSlug ] ) {
 		return jetpackProductsDescriptions[ purchase.productSlug ];
 	}
-	return getName( purchase );
+	return null;
 }
 
 function getDisplayName( purchase ) {

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -19,6 +19,7 @@ import {
 	isDomainRegistration,
 	isDomainTransfer,
 	isJetpackPlan,
+	isJetpackProduct,
 	isPlan,
 	isTheme,
 	isConciergeSession,
@@ -477,6 +478,10 @@ function purchaseType( purchase ) {
 
 	if ( isDomainRegistration( purchase ) ) {
 		return purchase.productName;
+	}
+
+	if ( isJetpackProduct( purchase ) ) {
+		return i18n.translate( 'Site Solution' );
 	}
 
 	if ( purchase.meta ) {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -344,7 +344,7 @@ class ManagePurchase extends Component {
 
 	renderPlanIcon() {
 		const { purchase } = this.props;
-		if ( isPlan( purchase ) || isJetpackBackup( purchase ) ) {
+		if ( isPlan( purchase ) || isJetpackProduct( purchase ) ) {
 			return (
 				<div className="manage-purchase__plan-icon">
 					<ProductIcon slug={ purchase.productSlug } />

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -21,6 +21,7 @@ import config from 'config';
 import {
 	cardProcessorSupportsUpdates,
 	getDomainRegistrationAgreementUrl,
+	getDescription,
 	getDisplayName,
 	getPartnerName,
 	getRenewalPrice,
@@ -54,7 +55,6 @@ import {
 	isDomainMapping,
 	isDomainTransfer,
 	isTheme,
-	isJetpackBackup,
 	isJetpackProduct,
 	isConciergeSession,
 } from 'lib/products-values';
@@ -396,6 +396,8 @@ class ManagePurchase extends Component {
 				'Transfers an existing domain from another provider to WordPress.com, ' +
 					'helping you manage your site and domain in one place.'
 			);
+		} else if ( isJetpackProduct( purchase ) ) {
+			description = getDescription( purchase );
 		}
 
 		const registrationAgreementUrl = getDomainRegistrationAgreementUrl( purchase );

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -29,7 +29,7 @@ import {
 	isGoogleApps,
 	isPlan,
 	isTheme,
-	isJetpackBackup,
+	isJetpackProduct,
 	isConciergeSession,
 } from 'lib/products-values';
 import Notice from 'components/notice';
@@ -158,7 +158,7 @@ class PurchaseItem extends Component {
 			return null;
 		}
 
-		if ( isPlan( purchase ) || isJetpackBackup( purchase ) ) {
+		if ( isPlan( purchase ) || isJetpackProduct( purchase ) ) {
 			return (
 				<div className="purchase-item__plan-icon">
 					<ProductIcon


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For Jetpack single products this PR adds:

* Product icons.
* Product type “Site Solution”. cc @robertbpugh for direction on this.
* Product descriptions.

Still missing:

* Product subscription interval (annual/monthly).
* Current tier for Jetpack Search.

Pinging @jsnmoon to see if this is easily doable. See [initial mock in this PR](https://github.com/Automattic/wp-calypso/issues/40550#issuecomment-605955702).

#### Testing instructions

* Fire up this PR.
* Point your browser to `/me/purchases`:
  * Ensure subscriptions for Jetpack single products are displaying the information mentioned above.
  * Ensure that other products look good.
* Click on a subscription for a Jetpack single product (backup, search, scan):
  * Ensure the expanded card for Jetpack single products is displaying the information mentioned above.
  * Ensure this change doesn't break other plans/products.

Fixes https://github.com/Automattic/wp-calypso/issues/40550


#### Before, item card

![image](https://user-images.githubusercontent.com/390760/78396370-2d87ef80-75e7-11ea-9515-e1743d81e928.png)


#### After, item card

![image](https://user-images.githubusercontent.com/390760/78396391-34166700-75e7-11ea-8b0d-6e1d92932dec.png)


#### Before, expanded view

![image](https://user-images.githubusercontent.com/390760/78396412-3d073880-75e7-11ea-9ecd-df487d5c1022.png)


#### After, expanded view

![image](https://user-images.githubusercontent.com/390760/78396447-4c868180-75e7-11ea-90da-05318e8fbabc.png)
