### PR TITLE
My Home: Silence required prop warning.

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -113,7 +113,7 @@ const Home = ( {
 
 Home.propTypes = {
 	checklistMode: PropTypes.string,
-	layout: PropTypes.object.isRequired,
+	layout: PropTypes.object,
 	site: PropTypes.object.isRequired,
 	siteId: PropTypes.number.isRequired,
 	siteSlug: PropTypes.string.isRequired,


### PR DESCRIPTION
This PR quiets a warning about `<Home />`'s `layout` prop being required, but can be `null` (while waiting for a response from the layout API call.

<img width="927" alt="Screen Shot 2020-04-03 at 10 50 56 AM" src="https://user-images.githubusercontent.com/349751/78398502-06f69400-75a8-11ea-8fbf-b5d89d029d9f.png">


#### Testing instructions

* Sandbox the API (this is often enough to trigger the warning).
* Load the Home page of any site, notice (or sometimes not) the warning in the console.
* Apply this branch, and reload.
* Ensure the warning is not displayed.