### PR TITLE
Jetpack Connect: Arrange Solution Cards Side-by-Side

### DIFF
--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -178,17 +178,6 @@
 }
 
 // Product options
-.product-card__options {
-	display: flex;
-	flex-flow: column nowrap;
-	justify-content: space-around; // IE11 fallback.
-	justify-content: space-evenly;
-
-	@include breakpoint( '>480px' ) {
-		flex-flow: row wrap;
-	}
-}
-
 .product-card__options-label {
 	margin-top: 16px;
 	font-size: 14px;
@@ -224,11 +213,6 @@
 
 	& + .product-card__option.form-label {
 		margin-top: 0;
-
-		@include breakpoint( '>480px' ) {
-			margin-top: 16px;
-			margin-left: 8px;
-		}
 	}
 }
 

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -178,6 +178,17 @@
 }
 
 // Product options
+.product-card__options {
+	display: flex;
+	flex-flow: column nowrap;
+	justify-content: space-around; // IE11 fallback.
+	justify-content: space-evenly;
+
+	@include breakpoint( '>480px' ) {
+		flex-flow: row wrap;
+	}
+}
+
 .product-card__options-label {
 	margin-top: 16px;
 	font-size: 14px;
@@ -213,6 +224,11 @@
 
 	& + .product-card__option.form-label {
 		margin-top: 0;
+
+		@include breakpoint( '>480px' ) {
+			margin-top: 16px;
+			margin-left: 8px;
+		}
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1150,6 +1150,7 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 
 // ProductSelector and ProductCard overrides
 .is-section-jetpack-connect .product-selector {
+	max-width: 984px;
 	margin-left: auto;
 	margin-right: auto;
 	padding-left: 16px;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1150,7 +1150,6 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 
 // ProductSelector and ProductCard overrides
 .is-section-jetpack-connect .product-selector {
-	max-width: 520px;
 	margin-left: auto;
 	margin-right: auto;
 	padding-left: 16px;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -15,6 +15,7 @@
 
 			@include breakpoint( '>660px' ) {
 				flex-flow: row;
+				max-width: 1000px;
 			}
 
 			.product-card {

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -13,19 +13,9 @@
 			display: flex;
 			flex-flow: row wrap;
 
-			@include breakpoint( '>660px' ) {
-				flex-flow: row;
-				max-width: 1000px;
-			}
-
 			.product-card {
-				@include breakpoint( '>660px' ) {
-					min-width: 0;
-				}
-
-				@include breakpoint( '>1040px' ) {
-					margin-right: 12px;
-					margin-left: 12px;
+				@include breakpoint( '>480px' ) {
+					flex-basis: calc( 50% - 1em );
 				}
 
 				&:first-child:last-child {

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -13,11 +13,20 @@
 			display: flex;
 			flex-flow: row wrap;
 
+			@include breakpoint( '>660px' ) {
+				flex-flow: row;
+			}
+
 			.product-card {
-				
-				@include breakpoint( '>480px' ) {
-					flex-basis: calc( 50% - 1em );
+				@include breakpoint( '>660px' ) {
+					min-width: 0;
 				}
+
+				@include breakpoint( '>1040px' ) {
+					margin-right: 12px;
+					margin-left: 12px;
+				}
+
 				&:first-child:last-child {
 					@include breakpoint( '>960px' ) {
 						margin-left: auto;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -14,10 +14,10 @@
 			flex-flow: row wrap;
 
 			.product-card {
+
 				@include breakpoint( '>480px' ) {
 					flex-basis: calc( 50% - 1em );
 				}
-
 				&:first-child:last-child {
 					@include breakpoint( '>960px' ) {
 						margin-left: auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This ensures that the Solutions cards during Jetpack Connect break exactly like the Plans ones do.

#### Testing instructions

Follow the Jetpack Connect route to the Plans stage: `/jetpack/connect/plans/monthly/site`

At this point, verify that no issues occur with the columns, no matter how you resize the screen or how many there are. They should stack when the content is too small to fit in columns, but otherwise appear like this.

<img width="689" alt="Screenshot 2020-04-10 at 12 06 32" src="https://user-images.githubusercontent.com/43215253/78986687-bccf5e80-7b23-11ea-84b1-e06ea8d5c6ce.png">

cc @keoshi, @tyxla, @simison 

Fixes #40679
