### PR TITLE
Posts: Ensure Scheduled Time is More Useful

### DIFF
--- a/client/blocks/post-time/index.jsx
+++ b/client/blocks/post-time/index.jsx
@@ -30,8 +30,19 @@ function getDisplayedTimeFromPost( moment, post ) {
 	const { status, modified, date } = post;
 	const time = moment( includes( [ 'draft', 'pending' ], status ) ? modified : date );
 
-	// Like "Friday, 21 April 2020 21:30"
-	return time.format( 'LLLL' );
+	switch ( status ) {
+		// Display relative time for published posts: 9 hours ago
+		case 'publish':
+			return time.fromNow();
+
+		// Display the time, day and date for scheduled posts: Wed, 21 Apr 2020 14:00
+		case 'future':
+			return time.format( 'llll' );
+
+		// Display the date and time for other posts: 21 Apr 2020 14:00
+		default:
+			return time.format( 'lll' );
+	}
 }
 
 export function PostTime( { moment, post } ) {

--- a/client/blocks/post-time/index.jsx
+++ b/client/blocks/post-time/index.jsx
@@ -29,13 +29,9 @@ function getDisplayedTimeFromPost( moment, post ) {
 
 	const { status, modified, date } = post;
 	const time = moment( includes( [ 'draft', 'pending' ], status ) ? modified : date );
-	if ( now.diff( time, 'days' ) >= 7 ) {
-		// Like "Mar 15, 2013 6:23 PM" in English locale
-		return time.format( 'lll' );
-	}
 
-	// Like "3 days ago" in English locale
-	return time.fromNow();
+	// Like "Friday, 21 April 2020 21:30"
+	return time.format( 'LLLL' );
 }
 
 export function PostTime( { moment, post } ) {

--- a/client/blocks/post-time/test/index.jsx
+++ b/client/blocks/post-time/test/index.jsx
@@ -47,9 +47,9 @@ describe( 'PostTime', () => {
 		expect( text ).to.equal( moment( post.modified ).format( 'lll' ) );
 	} );
 
-	test( 'should use the actual date if the post status is not pending/draft', () => {
+	test( 'should use the actual date with the day if the post status is scheduled', () => {
 		const post = {
-			status: 'publish',
+			status: 'future',
 			modified: '2016-09-14T15:47:33-04:00',
 			date: '2016-09-13T15:47:33-04:00',
 		};
@@ -57,10 +57,10 @@ describe( 'PostTime', () => {
 		const wrapper = shallow( <PostTime post={ post } moment={ moment } /> );
 
 		const text = wrapper.text();
-		expect( text ).to.equal( moment( post.date ).format( 'lll' ) );
+		expect( text ).to.equal( moment( post.date ).format( 'llll' ) );
 	} );
 
-	test( 'should use a human-readable approximation for recent dates', () => {
+	test( 'should use a human-readable approximation for recent dates on published posts', () => {
 		const post = {
 			status: 'publish',
 			date: moment()
@@ -72,6 +72,19 @@ describe( 'PostTime', () => {
 
 		const text = wrapper.text();
 		expect( text ).to.equal( '2 days ago' );
+	} );
+
+	test( 'should use the actual date for any other status', () => {
+		const post = {
+			status: 'trash',
+			modified: '2016-09-14T15:47:33-04:00',
+			date: '2016-09-13T15:47:33-04:00',
+		};
+
+		const wrapper = shallow( <PostTime post={ post } moment={ moment } /> );
+
+		const text = wrapper.text();
+		expect( text ).to.equal( moment( post.date ).format( 'lll' ) );
 	} );
 
 	test( 'should render placeholder when post is null', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request


Instead of displaying something vague and unhelpful with the time until a scheduled post is released (such as "in a month"), provide the exact day and date. Although the original issue just mentioned the date, as someone who tries to schedule a post for each Monday, I currently have to use WP-Admin to double check that the scheduled timing is correct, so I think showing the day is also an improvement.

#### Testing instructions

Schedule a post for the long future and go to `/posts/scheduled/site`

**Before:**
<img width="610" alt="Screenshot 2020-04-03 at 21 43 31" src="https://user-images.githubusercontent.com/43215253/78403406-34692f00-75f4-11ea-809f-abde562bb686.png">

**After:**
<img width="555" alt="Screenshot 2020-04-04 at 13 58 32" src="https://user-images.githubusercontent.com/43215253/78451250-63c37e80-767c-11ea-81de-1aed1d0cf232.png">

cc @mattsherman 

Fixes #12052
