### PR TITLE
Add Jetpack Cloud ApplySiteOffset Context Provider

### DIFF
--- a/client/landing/jetpack-cloud/components/site-offset/README.md
+++ b/client/landing/jetpack-cloud/components/site-offset/README.md
@@ -1,6 +1,6 @@
 # loaded applySiteOffset
 
-This module provides support for using applySiteOffset inside React components with including the necessary selectors and query components.
+This module provides support for using applySiteOffset inside React components without including the necessary selectors and query components.
 
 # `withApplySiteOffset`
 

--- a/client/landing/jetpack-cloud/components/site-offset/README.md
+++ b/client/landing/jetpack-cloud/components/site-offset/README.md
@@ -1,0 +1,75 @@
+# loaded applySiteOffset
+
+This module provides support for using applySiteOffset inside React components with including the necessary selectors and query components.
+
+# `withApplySiteOffset`
+
+Is a higher-order component (HOC) that provides one prop to the wrapped child:
+
+- `applySiteOffset` is a function that takes any possible moment input and returns either a moment object with the site offset applied or null if enough information has not yet been loaded to apply a site's offset
+
+## Usage
+
+```jsx
+import React from 'react';
+import { withApplySiteOffset } from 'landing/jetpack-cloud/components/site-offset';
+
+class Label extends React.Component {
+	render() {
+		const { moment, date } = this.props;
+		const displayDate = applySiteOffset( date )?.format( 'LLLL' );
+		return <span>{ displayDate ? displayDate : 'Loading...' }</span>;
+	}
+}
+
+export default withApplySiteOffset( Label );
+```
+
+The exported component will format the `date` string prop using the current siteOffset.
+The component is reactive, i.e., when the site offset information is loaded all wrapped components will be
+automatically re-rendered.
+
+# `useApplySiteOffset`
+
+Is a React hook that can be used inside stateless functional components. The function returns
+the same `applySiteOffset` function. Its meaning is the same as
+in `withApplySiteOffset`. It's just a different implementation of the same concept.
+
+## Usage
+
+```jsx
+import React from 'react';
+import { useApplySiteOffset } from 'components/localized-moment';
+
+export default function Label( { date } ) {
+	const applySiteOffset = useApplySiteOffset();
+	const displayDate = applySiteOffset( date )?.format( 'LLLL' );
+	return <span>{ displayDate ? displayDate : 'Loading...' }</span>;
+}
+```
+
+Once again, the exported `Label` component will format the `date` string prop and automatically
+rerender on locale change.
+
+# `SiteOffsetProvider`
+
+All usages of `withApplySiteOffset` and `useApplySiteOffset` should be inside a React tree
+that has `SiteOffsetProvider` mounted on top. The provider provides a context with the current locale
+and all the subcomponents that consume the context will react to changes.
+
+The `SiteOffsetProvider` component takes one prop: `site`. It is a string that is either the current site ID or slug. This means that this Provider will need to be used lower in the React Component Tree than normal.
+
+## Usage
+
+```jsx
+import React from 'react';
+import ReactDom from 'react-dom';
+import { SiteOffsetProvider } from 'landing/jetpack-cloud/components/site-offset/context';
+
+ReactDom.render(
+	<SiteOffsetProvider siteId={ siteId }>
+		<Label date="2019-02-26T16:20:00" />
+	</SiteOffsetProvider>,
+	document.getElementById( 'root' )
+);
+```

--- a/client/landing/jetpack-cloud/components/site-offset/context.tsx
+++ b/client/landing/jetpack-cloud/components/site-offset/context.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ *
+ */
+
+import React, { FunctionComponent, useCallback } from 'react';
+import { MomentInput, Moment } from 'moment';
+import { useSelector } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import getSiteId from 'state/selectors/get-site-id';
+import { applySiteOffset } from 'lib/site/timezone';
+import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
+import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
+import QuerySiteSettings from 'components/data/query-site-settings'; // Required to get site time offset
+
+type contextType = ( input: MomentInput ) => Moment | null;
+
+const SiteOffsetContext = React.createContext< contextType >( () => null );
+
+interface Props {
+	site: string;
+}
+
+const SiteOffsetProvider: FunctionComponent< Props > = ( { children, site } ) => {
+	// hackery here to get around
+	const siteId = useSelector( state => getSiteId( state, site ) ) as number | null;
+
+	const gmtOffset = useSelector( state => ( siteId ? getSiteGmtOffset( state, siteId ) : null ) );
+	const timezone = useSelector( state =>
+		siteId ? getSiteTimezoneValue( state, siteId ) : null
+	);
+
+	const value = useCallback(
+		( input: MomentInput ) =>
+			gmtOffset || timezone ? applySiteOffset( input, { gmtOffset, timezone } ) : null,
+		[ gmtOffset, timezone ]
+	);
+
+	return (
+		<>
+			<QuerySiteSettings siteId={ siteId } />
+			<SiteOffsetContext.Provider value={ value }>{ children }</SiteOffsetContext.Provider>
+		</>
+	);
+};
+
+export { SiteOffsetContext, SiteOffsetProvider };

--- a/client/landing/jetpack-cloud/components/site-offset/index.tsx
+++ b/client/landing/jetpack-cloud/components/site-offset/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ *
+ */
+import React from 'react';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { SiteOffsetContext } from './context';
+
+export const withApplySiteOffset = createHigherOrderComponent( Wrapped => {
+	return function WithApplySiteOffset( props ) {
+		return (
+			<SiteOffsetContext.Consumer>
+				{ applySiteOffset => <Wrapped { ...props } applySiteOffset={ applySiteOffset } /> }
+			</SiteOffsetContext.Consumer>
+		);
+	};
+}, 'WithApplySiteOffset' );
+
+export const useApplySiteOffset = () => {
+	return React.useContext( SiteOffsetContext );
+};

--- a/client/landing/jetpack-cloud/components/site-offset/index.tsx
+++ b/client/landing/jetpack-cloud/components/site-offset/index.tsx
@@ -10,11 +10,11 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  */
 import { SiteOffsetContext } from './context';
 
-export const withApplySiteOffset = createHigherOrderComponent( Wrapped => {
+export const withApplySiteOffset = createHigherOrderComponent( WrappedComponent => {
 	return function WithApplySiteOffset( props ) {
 		return (
 			<SiteOffsetContext.Consumer>
-				{ applySiteOffset => <Wrapped { ...props } applySiteOffset={ applySiteOffset } /> }
+				{ applySiteOffset => <WrappedComponent { ...props } applySiteOffset={ applySiteOffset } /> }
 			</SiteOffsetContext.Consumer>
 		);
 	};

--- a/client/landing/jetpack-cloud/sections/backups/controller.js
+++ b/client/landing/jetpack-cloud/sections/backups/controller.js
@@ -6,9 +6,17 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { SiteOffsetProvider } from 'landing/jetpack-cloud/components/site-offset/context';
 import BackupDetailPage from './detail';
-import BackupsPage from './main';
 import BackupRewindFlow, { RewindFlowPurpose } from './rewind-flow';
+import BackupsPage from './main';
+
+export function wrapInSiteOffsetProvider( context, next ) {
+	context.primary = (
+		<SiteOffsetProvider site={ context.params.site }>{ context.primary }</SiteOffsetProvider>
+	);
+	next();
+}
 
 /* handles /backups/:site, see `backupMainPath` */
 export function backups( context, next ) {

--- a/client/landing/jetpack-cloud/sections/backups/index.js
+++ b/client/landing/jetpack-cloud/sections/backups/index.js
@@ -15,6 +15,7 @@ import {
 	backupDetail,
 	backupDownload,
 	backupRestore,
+	wrapInSiteOffsetProvider,
 } from 'landing/jetpack-cloud/sections/backups/controller';
 import { backupMainPath, backupRestorePath, backupDownloadPath, backupDetailPath } from './paths';
 
@@ -26,6 +27,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			backupDetail,
+			wrapInSiteOffsetProvider,
 			makeLayout,
 			clientRender
 		);
@@ -35,6 +37,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			backupDownload,
+			wrapInSiteOffsetProvider,
 			makeLayout,
 			clientRender
 		);
@@ -46,12 +49,21 @@ export default function() {
 				siteSelection,
 				navigation,
 				backupRestore,
+				wrapInSiteOffsetProvider,
 				makeLayout,
 				clientRender
 			);
 		}
 		/* handles /backups/:site, see `backupMainPath` */
-		page( backupMainPath( ':site' ), siteSelection, navigation, backups, makeLayout, clientRender );
+		page(
+			backupMainPath( ':site' ),
+			siteSelection,
+			navigation,
+			backups,
+			wrapInSiteOffsetProvider,
+			makeLayout,
+			clientRender
+		);
 		/* handles /backups, see `backupMainPath` */
 		page( backupMainPath(), siteSelection, sites, makeLayout, clientRender );
 	}

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
@@ -19,6 +19,7 @@ import DocumentHead from 'components/data/document-head';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Spinner from 'components/spinner';
+import { useLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -32,12 +33,15 @@ interface Props {
 
 const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) => {
 	const applySiteOffset = useApplySiteOffset();
+	const moment = useLocalizedMoment();
 	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( state => ( siteId !== null ? getSiteSlug( state, siteId ) : '' ) );
 
-	const backupDisplayDate = applySiteOffset( parseFloat( rewindId ) * 1000 )?.format( 'LLL' );
+	const backupDisplayDate = applySiteOffset( moment( parseFloat( rewindId ) * 1000 ) )?.format(
+		'LLL'
+	);
 
 	const render = () => {
 		if ( siteId && rewindId && backupDisplayDate ) {

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
@@ -8,20 +8,17 @@ import { useSelector } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { applySiteOffset } from 'lib/site/timezone';
 import { Card } from '@automattic/components';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
-import { isRequestingSiteSettings } from 'state/site-settings/selectors';
 import { RewindFlowPurpose } from './types';
+import { useApplySiteOffset } from 'landing/jetpack-cloud/components/site-offset';
 import BackupDownloadFlow from './download';
 import BackupRestoreFlow from './restore';
 import DocumentHead from 'components/data/document-head';
-import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
-import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import Main from 'components/main';
-import QuerySiteSettings from 'components/data/query-site-settings'; // Required to get site time offset
 import SidebarNavigation from 'my-sites/sidebar-navigation';
+import Spinner from 'components/spinner';
 
 /**
  * Style dependencies
@@ -34,27 +31,16 @@ interface Props {
 }
 
 const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) => {
+	const applySiteOffset = useApplySiteOffset();
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
 
-	const timezone = useSelector( state =>
-		siteId !== null ? getSiteTimezoneValue( state, siteId ) : null
-	);
-	const gmtOffset = useSelector( state =>
-		siteId !== null ? getSiteGmtOffset( state, siteId ) : null
-	);
-	const isSiteSettingLoading = useSelector( state =>
-		siteId !== null ? isRequestingSiteSettings( state, siteId ) : true
-	);
+	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( state => ( siteId !== null ? getSiteSlug( state, siteId ) : '' ) );
 
-	const backupDisplayDate = applySiteOffset( parseFloat( rewindId ) * 1000, {
-		timezone,
-		gmtOffset,
-	} ).format( 'LLL' );
+	const backupDisplayDate = applySiteOffset( parseFloat( rewindId ) * 1000 )?.format( 'LLL' );
 
 	const render = () => {
-		if ( siteId && rewindId ) {
+		if ( siteId && rewindId && backupDisplayDate ) {
 			return purpose === RewindFlowPurpose.RESTORE ? (
 				<BackupRestoreFlow
 					backupDisplayDate={ backupDisplayDate }
@@ -71,20 +57,19 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				/>
 			);
 		}
-		// TODO: good errors/placeholder here
-		return <div />;
+		// TODO: improve this placeholder
+		return <Spinner />;
 	};
 
 	return (
 		<Main className="rewind-flow">
-			<QuerySiteSettings siteId={ siteId } />
 			<DocumentHead
 				title={
 					purpose === RewindFlowPurpose.RESTORE ? translate( 'Restore' ) : translate( 'Download' )
 				}
 			/>
 			<SidebarNavigation />
-			{ ! isSiteSettingLoading && <Card>{ render() }</Card> }
+			<Card>{ render() }</Card>
 		</Main>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We need site offsets a lot in various places since we are splitting up backup/activity log functions across many different components
* Adds a Context Provider to easily access an `applySiteOffset` function that has already had the correct information loaded

#### Testing instructions

1. On a test site that has a different timezone than your own
2. Navigate to the start of the download or restore flow on the branch
3. Navigate to `cloud.jetpack.com` with the same path as from step 2
4. Verify both display the dates the same in the same timezone