### PR TITLE
Gutenboarding: Activate flag to use mshots

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -44,6 +44,7 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"gutenboarding": true,
+		"gutenboarding/mshot-preview": true,
 		"gutenboarding/style-preview": true,
 		"happychat": true,
 		"help": true,


### PR DESCRIPTION
After uploading the new templates, with updated names, the pre-rendered screenshots links are broken, so I'm updating the flags to use mshots until we generate them again

