### PR TITLE
Sharing: update text for Facebook sharing message

### DIFF
--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -19,8 +19,8 @@ class SharingServiceDescription extends Component {
 			facebook: function() {
 				if ( this.props.numberOfConnections > 0 ) {
 					return this.props.translate(
-						'Sharing posts to your news feed.',
-						'Sharing posts to your news feeds.',
+						'Sharing posts to your Facebook page.',
+						'Sharing posts to your Facebook pages.',
 						{
 							count: this.props.numberOfConnections,
 							comment: 'Description for Facebook Publicize when one or more accounts are connected',
@@ -28,7 +28,7 @@ class SharingServiceDescription extends Component {
 					);
 				}
 
-				return this.props.translate( 'Share posts to your news feed.', {
+				return this.props.translate( 'Share posts to your Facebook page.', {
 					comment: 'Description for Facebook Publicize when no accounts are connected',
 				} );
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change text from "news feed" to "Facebook page".

Fixes #40709
