### PR TITLE
Themes: Provide Link to Previous Theme

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -321,7 +321,7 @@ class ThemeShowcase extends React.Component {
 							href={ `/theme/${ previousTheme }/${ siteSlug }` }
 						>
 							<Gridicon icon="history" />
-							{ translate( 'Previous theme' ) }
+							{ translate( 'Show previous theme' ) }
 						</Button>
 					) }
 					{ ! this.props.loggedOutComponent && ! isQueried && (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -22,6 +22,7 @@ import DocumentHead from 'components/data/document-head';
 import { buildRelativeSearchUrl } from 'lib/build-url';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
+import { getPreference } from 'state/preferences/selectors';
 import ThemePreview from './theme-preview';
 import config from 'config';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -110,6 +111,7 @@ class ThemeShowcase extends React.Component {
 		search: '',
 		emptyContent: null,
 		upsellBanner: false,
+		showPreviousThemeButton: true,
 		showUploadButton: true,
 	};
 
@@ -217,6 +219,12 @@ class ThemeShowcase extends React.Component {
 		}
 	};
 
+	showPreviousThemeButton = () => {
+		const { isLoggedIn, previousTheme } = this.props;
+
+		return isLoggedIn && previousTheme;
+	};
+
 	showUploadButton = () => {
 		const { isMultisite, isLoggedIn } = this.props;
 
@@ -226,6 +234,7 @@ class ThemeShowcase extends React.Component {
 	render() {
 		const {
 			currentThemeId,
+			previousTheme,
 			siteId,
 			options,
 			getScreenshotOption,
@@ -303,6 +312,16 @@ class ThemeShowcase extends React.Component {
 						>
 							<Gridicon icon="cloud-upload" />
 							{ translate( 'Install theme' ) }
+						</Button>
+					) }
+					{ this.showPreviousThemeButton() && (
+						<Button
+							className="themes__previous-theme-button"
+							compact
+							href={ `/theme/${ previousTheme }/${ siteSlug }` }
+						>
+							<Gridicon icon="history" />
+							{ translate( 'Previous theme' ) }
 						</Button>
 					) }
 					{ ! this.props.loggedOutComponent && ! isQueried && (
@@ -449,6 +468,7 @@ const mapStateToProps = ( state, { siteId, filter, tier, vertical } ) => ( {
 	filterToTermTable: getThemeFilterToTermTable( state ),
 	hasShowcaseOpened: hasShowcaseOpenedSelector( state ),
 	themesBookmark: getThemesBookmark( state ),
+	previousTheme: getPreference( state, 'previousTheme-' + siteId ),
 } );
 
 const mapDispatchToProps = {

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -1,8 +1,10 @@
-.themes__upload-button {
+.themes__upload-button,
+.themes__previous-theme-button {
 	float: right;
 
 	&.is-compact {
 		margin-top: 23px;
+		margin-left: 8px;
 		color: var( --color-neutral-70 );
 		.gridicon {
 			padding-right: 4px;

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -6,6 +6,7 @@ import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import { requestSitePosts } from 'state/posts/actions';
 import { getActiveTheme, getLastThemeQuery, prependThemeFilterKeys } from 'state/themes/selectors';
 import { getThemeIdFromStylesheet } from 'state/themes/utils';
+import { savePreference } from 'state/preferences/actions';
 
 import 'state/themes/init';
 
@@ -40,6 +41,8 @@ export function themeActivated( themeStylesheet, siteId, source = 'unknown', pur
 			search_taxonomies,
 		} );
 		dispatch( withAnalytics( trackThemeActivation, action ) );
+
+		dispatch( savePreference( 'previousTheme-' + siteId, previousThemeId ) );
 
 		// Update pages in case the front page was updated on theme switch.
 		dispatch( requestSitePosts( siteId, { type: 'page' } ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a button to the Theme Showcase to the previous theme.

#### Testing instructions

1. Visit the Theme Showcase and verify that no "Previous theme" button appears
2. Activate another theme
3. Return to the theme showcase and verify the "Previous theme" button is present next to "Install theme"
4. Click it, and confirm you're redirected to the theme you just switched from 

<img width="1251" alt="Screenshot 2020-04-05 at 10 45 07" src="https://user-images.githubusercontent.com/43215253/78471623-8dd37a00-772a-11ea-8a5e-421eb91a19f4.png">

Not sure who to ping for this, but cc @sixhours as #40325 touched this last :)

Fixes #23204 (it only shows the previous theme rather than all of them, but I think that fixes the sentiment of the issue in the cleanest and easiest way)
