### PR TITLE
Jetpack Connect: adapt the post-checkout Thank you modal to specific Products

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -97,7 +97,7 @@ class Plans extends Component {
 		const { canPurchasePlans, selectedSiteSlug } = this.props;
 
 		if ( selectedSiteSlug && canPurchasePlans ) {
-			return this.redirect( CALYPSO_MY_PLAN_PAGE, { 'thank-you': '' } );
+			return this.redirect( CALYPSO_MY_PLAN_PAGE, null, { 'thank-you': '' } );
 		}
 
 		return this.redirect( CALYPSO_REDIRECTION_PAGE );
@@ -176,7 +176,7 @@ class Plans extends Component {
 		this.props.completeFlow();
 		persistSignupDestination( this.getMyPlansDestination() );
 
-		this.redirect( '/checkout/', cartItem.product_slug );
+		this.redirect( '/checkout/', null, cartItem.product_slug );
 	};
 
 	shouldShowPlaceholder() {

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -129,8 +129,12 @@ class Plans extends Component {
 		return addQueryArgs( args, redirectTo );
 	}
 
-	redirect( path, args ) {
+	redirect( path, product, args ) {
 		let redirectTo = path + this.props.selectedSiteSlug;
+
+		if ( product ) {
+			redirectTo += '/' + product;
+		}
 
 		if ( args ) {
 			redirectTo = addQueryArgs( args, redirectTo );
@@ -172,7 +176,7 @@ class Plans extends Component {
 		this.props.completeFlow();
 		persistSignupDestination( this.getMyPlansDestination() );
 
-		this.redirect( '/checkout/' );
+		this.redirect( '/checkout/', cartItem.product_slug );
 	};
 
 	shouldShowPlaceholder() {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -387,7 +387,6 @@ export class Checkout extends React.Component {
 
 		const isCartEmpty = isEmpty( getAllCartItems( cart ) );
 		const isReceiptEmpty = ':receiptId' === pendingOrReceiptId;
-
 		// We will show the Thank You page if there's a site slug and either one of the following is true:
 		// - has a receipt number
 		// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
@@ -477,9 +476,11 @@ export class Checkout extends React.Component {
 		// Especially around the Concierge / Checklist logic.
 
 		let renewalItem,
+			signupDestination,
 			displayModeParam = {};
 		const {
 			cart,
+			product,
 			redirectTo,
 			selectedSite,
 			selectedSiteSlug,
@@ -530,8 +531,13 @@ export class Checkout extends React.Component {
 
 		this.setDestinationIfEcommPlan( pendingOrReceiptId );
 
-		const signupDestination =
-			retrieveSignupDestination() || this.getFallbackDestination( pendingOrReceiptId );
+		// if it is a Jetpack product, use product info as a parameter
+		if ( product ) {
+			signupDestination = this.getFallbackDestination( pendingOrReceiptId );
+		} else {
+			signupDestination =
+				retrieveSignupDestination() || this.getFallbackDestination( pendingOrReceiptId );
+		}
 
 		if ( hasRenewalItem( cart ) ) {
 			renewalItem = getRenewalItems( cart )[ 0 ];
@@ -838,6 +844,7 @@ export class Checkout extends React.Component {
 
 	render() {
 		const { plan, product, purchaseId, selectedFeature, selectedSiteSlug } = this.props;
+
 		let analyticsPath = '';
 		let analyticsProps = {};
 		if ( purchaseId && product ) {

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -30,15 +30,9 @@ export function currentPlan( context, next ) {
 
 	const product = context.query.product;
 	const requestThankYou = context.query.hasOwnProperty( 'thank-you' );
-	const requestProduct = context.query.hasOwnProperty( 'product' );
 
 	context.primary = (
-		<CurrentPlan
-			path={ context.path }
-			product={ product }
-			requestThankYou={ requestThankYou }
-			requestProduct={ requestProduct }
-		/>
+		<CurrentPlan path={ context.path } product={ product } requestThankYou={ requestThankYou } />
 	);
 
 	next();

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -78,17 +78,17 @@ class CurrentPlan extends Component {
 	}
 
 	renderThankYou() {
-		const { currentPlan, product, requestProduct } = this.props;
+		const { currentPlan, product } = this.props;
 
-		if ( requestProduct && startsWith( product, 'jetpack_backup' ) ) {
+		if ( startsWith( product, 'jetpack_backup' ) ) {
 			return <BackupProductThankYou />;
 		}
 
-		if ( requestProduct && startsWith( product, 'jetpack_scan' ) ) {
+		if ( startsWith( product, 'jetpack_scan' ) ) {
 			return <ScanProductThankYou />;
 		}
 
-		if ( requestProduct && startsWith( product, 'jetpack_search' ) ) {
+		if ( startsWith( product, 'jetpack_search' ) ) {
 			return <SearchProductThankYou />;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR applies to all Jetpack Product, thus pinging for reviews out friends from Backups and Scan, thank you!

* display product info in the route at checkout:, e.g. `/checkout/:site/jetpack_scan` 
* correct the Thank You modal type displayed after purchasing products and plans during the Jetpack Connect flow, without which we show the Free plan modal. The change determines the url directly, including product information as opposed to reading it from the cookies, which is tricky due to the many redirects that happen during the Jetpack connection flow. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start at `/jetpack/connect/plans/:site`,
* purchase a product
* verify that the checkout url contains product info
* verify the relevance of the Thank you note


Fixes https://github.com/Automattic/wp-calypso/issues/40753

