### PR TITLE
Gutenboarding: Signup/Login design fixes

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -25,8 +25,7 @@ import {
 	getRecommendedDomainSuggestion,
 } from '../../utils/domain-suggestions';
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
-import { useCurrentStep } from '../../path';
-
+import { usePath, getStepFromPathname, useCurrentStep } from '../../path';
 import wp from '../../../../lib/wp';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
@@ -77,6 +76,8 @@ const Header: FunctionComponent = () => {
 		select( ONBOARD_STORE ).getState()
 	);
 
+	const makePath = usePath();
+
 	const {
 		createSite,
 		setDomain,
@@ -102,14 +103,25 @@ const Header: FunctionComponent = () => {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 
 	const {
-		location: { pathname },
+		location: { pathname, search },
+		push,
 	} = useHistory();
+
 	useEffect( () => {
-		// Dialogs usually close naturally when the user clicks the browser's
-		// back/forward buttons because their parent is unmounted. However
-		// this header isn't unmounted on route changes so we need to
-		// explicitly hide the dialog.
-		setShowSignupDialog( false );
+		// This handles opening the signup modal when there is a ?signup query parameter
+		// then removes the parameter.
+		// The use case is a user clicking "Create account" from login
+		// TODO: We can remove this condition when we've converted signup into it's own page
+		if ( ! showSignupDialog && new URLSearchParams( search ).has( 'signup' ) ) {
+			setShowSignupDialog( true );
+			push( makePath( getStepFromPathname( pathname ) ) );
+		} else {
+			// Dialogs usually close naturally when the user clicks the browser's
+			// back/forward buttons because their parent is unmounted. However
+			// this header isn't unmounted on route changes so we need to
+			// explicitly hide the dialog.
+			setShowSignupDialog( false );
+		}
 	}, [ pathname, setShowSignupDialog ] );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -25,7 +25,7 @@ import {
 	getRecommendedDomainSuggestion,
 } from '../../utils/domain-suggestions';
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
-import { usePath, getStepFromPathname, useCurrentStep } from '../../path';
+import { usePath, useCurrentStep, Step } from '../../path';
 import wp from '../../../../lib/wp';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
@@ -114,7 +114,7 @@ const Header: FunctionComponent = () => {
 		// TODO: We can remove this condition when we've converted signup into it's own page
 		if ( ! showSignupDialog && new URLSearchParams( search ).has( 'signup' ) ) {
 			setShowSignupDialog( true );
-			push( makePath( getStepFromPathname( pathname ) ) );
+			push( makePath( Step[ currentStep ] ) );
 		} else {
 			// Dialogs usually close naturally when the user clicks the browser's
 			// back/forward buttons because their parent is unmounted. However

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -7,13 +7,14 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocation } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import { USER_STORE } from '../../stores/user';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import { useLangRouteParam, usePath, Step } from '../../path';
+import { useLangRouteParam, usePath, Step, getStepFromPathname } from '../../path';
 import ModalSubmitButton from '../modal-submit-button';
 import './style.scss';
 import SignupFormHeader from './header';
@@ -103,12 +104,12 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	}
 
 	const langFragment = lang ? `/${ lang }` : '';
-	const loginRedirectUrl = `${ window.location.origin }/gutenboarding${ makePath(
-		Step.CreateSite
-	) }?new`;
-	const loginUrl = `/log-in/gutenboarding${ langFragment }?redirect_to=${ encodeURIComponent(
-		loginRedirectUrl
-	) }`;
+	const currentStepName = getStepFromPathname( useLocation().pathname );
+	const loginRedirectUrl = encodeURIComponent(
+		`${ window.location.origin }/gutenboarding${ makePath( Step.CreateSite ) }?new`
+	);
+	const signupUrl = encodeURIComponent( `/gutenboarding${ makePath( currentStepName ) }?signup` );
+	const loginUrl = `/log-in/gutenboarding${ langFragment }?redirect_to=${ loginRedirectUrl }&signup_url=${ signupUrl }`;
 
 	return (
 		<Modal

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -7,14 +7,13 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@automattic/react-i18n';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useLocation } from 'react-router-dom';
 
 /**
  * Internal dependencies
  */
 import { USER_STORE } from '../../stores/user';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
-import { useLangRouteParam, usePath, Step, getStepFromPathname } from '../../path';
+import { useLangRouteParam, usePath, Step, useCurrentStep } from '../../path';
 import ModalSubmitButton from '../modal-submit-button';
 import './style.scss';
 import SignupFormHeader from './header';
@@ -42,6 +41,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const { siteTitle, siteVertical } = useSelect( select => select( ONBOARD_STORE ) ).getState();
 	const langParam = useLangRouteParam();
 	const makePath = usePath();
+	const currentStep = useCurrentStep();
 
 	const closeModal = () => {
 		clearErrors();
@@ -104,11 +104,12 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	}
 
 	const langFragment = lang ? `/${ lang }` : '';
-	const currentStepName = getStepFromPathname( useLocation().pathname );
 	const loginRedirectUrl = encodeURIComponent(
 		`${ window.location.origin }/gutenboarding${ makePath( Step.CreateSite ) }?new`
 	);
-	const signupUrl = encodeURIComponent( `/gutenboarding${ makePath( currentStepName ) }?signup` );
+	const signupUrl = encodeURIComponent(
+		`/gutenboarding${ makePath( Step[ currentStep ] ) }?signup`
+	);
 	const loginUrl = `/log-in/gutenboarding${ langFragment }?redirect_to=${ loginRedirectUrl }&signup_url=${ signupUrl }`;
 
 	return (

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -53,15 +53,14 @@
 			transform: translateX( -50% );
 		}
 	}
-
 	.signup-form__legend p {
 		@include onboarding-large-text;
-		margin: 15px 0 30px;
+		margin: 0 0 42px;
 		color: var( --studio-gray-40 );
 	}
 
 	.components-text-control__input {
-		padding: 21px 14px;
+		padding: 18px 14px;
 		@include onboarding-medium-text;
 		border-radius: 0;
 		border: 1px solid var( --studio-gray-10 );
@@ -91,11 +90,12 @@
 
 	.signup-form__login-link {
 		@include onboarding-medium-text;
-		margin: 24px 0;
-		color: var( --studio-gray-60 );
+		margin: 27px 0;
+		color: var( --studio-gray-40 );
 
 		.signup-form__link {
 			@include onboarding-medium-text;
+			color: var( --studio-gray-40 );
 		}
 	}
 
@@ -109,6 +109,10 @@
 		text-align: center;
 		color: var( --studio-gray-40 );
 		margin: 20px 0;
+
+		.components-external-link {
+			text-decoration: none;
+		}
 	}
 
 	.signup-form__footer {
@@ -162,5 +166,10 @@
 	.signup-form__header-wp-logo {
 		color: var( --studio-blue-90 );
 		display: flex;
+	}
+
+	// override spacing between input fields
+	.components-base-control .components-base-control__field {
+		margin-bottom: 10px;
 	}
 }

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -59,7 +59,7 @@ window.AppBoot = async () => {
 	initializeAnalytics( undefined, generateGetSuperProps() );
 	// Add accessible-focus listener.
 	accessibleFocus();
-	
+
 	let locale = DEFAULT_LOCALE_SLUG;
 	try {
 		const [ userLocale, localeData ] = await getLocale();

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -72,22 +72,3 @@ export function useCurrentStep() {
 export function useNewQueryParam() {
 	return new URLSearchParams( useLocation().search ).has( 'new' );
 }
-
-/**
- * Checks if locationPathname is a valid step name and returns that step name
- * locationPathname should be location.pathname or the react router equivalent
- *
- * @param {string} locationPathname The pathname
- * @returns {string|undefined} The valid Step value or an empty string
- */
-export function getStepFromPathname( locationPathname = '' ) {
-	const pathValue =
-		locationPathname[ 0 ] === '/' ? locationPathname.split( '/' )[ 1 ] : locationPathname;
-	const stepValues = Object.values( Step );
-
-	for ( const value of stepValues ) {
-		if ( value === pathValue ) {
-			return value;
-		}
-	}
-}

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -72,3 +72,22 @@ export function useCurrentStep() {
 export function useNewQueryParam() {
 	return new URLSearchParams( useLocation().search ).has( 'new' );
 }
+
+/**
+ * Checks if locationPathname is a valid step name and returns that step name
+ * locationPathname should be location.pathname or the react router equivalent
+ *
+ * @param {string} locationPathname The pathname
+ * @returns {string|undefined} The valid Step value or an empty string
+ */
+export function getStepFromPathname( locationPathname = '' ) {
+	const pathValue =
+		locationPathname[ 0 ] === '/' ? locationPathname.split( '/' )[ 1 ] : locationPathname;
+	const stepValues = Object.values( Step );
+
+	for ( const value of stepValues ) {
+		if ( value === pathValue ) {
+			return value;
+		}
+	}
+}

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -42,6 +42,7 @@ const enhanceContextWithLogin = context => {
 			privateSite={ flow === 'private-site' }
 			domain={ ( query && query.domain ) || null }
 			fromSite={ ( query && query.site ) || null }
+			signupUrl={ ( query && query.signup_url ) || null }
 		/>
 	);
 };

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -198,6 +198,7 @@ export class Login extends React.Component {
 			locale,
 			isLoginView,
 			path,
+			signupUrl,
 		} = this.props;
 
 		if ( privateSite && isLoggedIn ) {
@@ -212,6 +213,7 @@ export class Login extends React.Component {
 						privateSite={ privateSite }
 						twoFactorAuthType={ twoFactorAuthType }
 						isGutenboarding={ isGutenboarding }
+						signupUrl={ signupUrl }
 					/>
 				) }
 				{ isLoginView && <TranslatorInvite path={ path } /> }

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -252,7 +252,9 @@ export class LoginLinks extends React.Component {
 			translate,
 			wccomFrom,
 			isGutenboarding,
+			locale,
 		} = this.props;
+
 		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
 		if (
@@ -307,6 +309,7 @@ export class LoginLinks extends React.Component {
 		}
 
 		if ( isGutenboarding ) {
+			const langFragment = locale && locale !== 'en' ? `/${ locale }` : '';
 			signupUrl = this.props.signupUrl || '/gutenboarding' + langFragment;
 		}
 

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -252,11 +252,7 @@ export class LoginLinks extends React.Component {
 			translate,
 			wccomFrom,
 			isGutenboarding,
-			locale,
 		} = this.props;
-
-		const langFragment = locale && locale !== 'en' ? `/${ locale }` : '';
-
 		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
 		if (
@@ -311,7 +307,7 @@ export class LoginLinks extends React.Component {
 		}
 
 		if ( isGutenboarding ) {
-			signupUrl = '/gutenboarding' + langFragment;
+			signupUrl = this.props.signupUrl;
 		}
 
 		return (

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -307,7 +307,7 @@ export class LoginLinks extends React.Component {
 		}
 
 		if ( isGutenboarding ) {
-			signupUrl = this.props.signupUrl;
+			signupUrl = this.props.signupUrl || '/gutenboarding' + langFragment;
 		}
 
 		return (

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -371,6 +371,7 @@ $image-height: 47px;
 		// change border color to remove 3D effect
 		background-color: #007cba;
 		border-color: #007cba;
+		color: #fff;
 		width: auto;
 		min-width: 170px;
 		text-align: center;
@@ -380,6 +381,20 @@ $image-height: 47px;
 		display: block;
 		margin: 0 auto;
 		float: none;
+		font-weight: 500;
+		letter-spacing: 0;
+		transition: background 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.2s ease-in-out;
+		border-radius: 4px;
+		box-shadow: none;
+
+		&:hover,
+		&:active {
+			background: #72aee6;
+			border-color: #72aee6;
+			color: #fff;
+			outline-color: transparent;
+			box-shadow: none;
+		}
 	}
 
 	.two-factor-authentication__verification-code-form > p,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -349,8 +349,13 @@ $image-height: 47px;
 .layout.is-gutenboarding-login {
 	background-color: #fff;
 
+	.layout__primary {
+		padding-top: 10%;
+	}
+
 	.login__form-header {
 		@include onboarding-heading-text-mobile;
+		margin-bottom: 0;
 
 		@include break-mobile {
 			@include onboarding-heading-text;
@@ -366,5 +371,40 @@ $image-height: 47px;
 		// change border color to remove 3D effect
 		background-color: #007cba;
 		border-color: #007cba;
+		width: auto;
+		min-width: 170px;
+		text-align: center;
+		font-size: 14px;
+		line-height: 14px;
+		height: 42px;
+		display: block;
+		margin: 0 auto;
+		float: none;
+	}
+
+	.two-factor-authentication__verification-code-form > p,
+	.login__form .login__form-userdata label,
+	.login__form-terms,
+	.login__social-tos {
+		color: var( --studio-gray-40 );
+	}
+
+	.login__form-terms a,
+	.login__social-tos a {
+		color: var( --studio-gray-80 );
+	}
+
+	.two-factor-authentication__verification-code-form input,
+	.login__form input {
+		padding: 18px 14px;
+		font-size: 14px;
+	}
+
+	.wp-login__main {
+		max-width: 540px;
+	}
+
+	.form-password-input .form-password-input__toggle-visibility {
+		top: 17px;
 	}
 }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -407,4 +407,8 @@ $image-height: 47px;
 	.form-password-input .form-password-input__toggle-visibility {
 		top: 17px;
 	}
+
+	.wp-login__links a:hover, .wp-login__links a:active, .wp-login__links button:hover, .wp-login__links button:active {
+		color: #00a0d2;
+	}
 }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -417,6 +417,11 @@ $image-height: 47px;
 
 	.wp-login__main {
 		max-width: 540px;
+
+		form {
+			max-width: 440px;
+			margin: 0 auto;
+		}
 	}
 
 	.form-password-input .form-password-input__toggle-visibility {


### PR DESCRIPTION
## Changes proposed in this Pull Request

Getting the signup and login forms into reasonable shape according to the tips in https://github.com/Automattic/wp-calypso/issues/40769 (As much as we can):

- tweaking spacing and colours of text and form controls
- ensuring that _"Create account"_ on the the login page triggers the signup modal. 

![login-redirect-signup](https://user-images.githubusercontent.com/6458278/78553761-282bde80-784d-11ea-9005-eff99bd1620d.gif)

We might not get all this stuff 100% before the call to testing. Let's keep what we've missed in mind for the next iteration.

## Testing

1. Power up this branch and head over to `/gutenboarding`
2. Visit the signup form
3. Now visit the login page (username, password and 2fa)
4. It shouldn't look like 70s wallpaper, but sorta like Gutenboarding.
5. Now, click on **Already have an account? Log in** 
6. Then click on **Create a new account**
7. You should return to Gutenboarding and the signup modal will appear on the route from which you came.
8. Try the above using a lang route fragment, e.g., `/gutenboarding/de`
9. The lang fragment should be preserved.



![rocky](https://user-images.githubusercontent.com/6458278/78516591-774a2300-77fd-11ea-8aa8-590dba90892e.gif)


Fixes #40769
