### PR TITLE
Reindent markdon with spaces as a workaround for remarkjs/remark#198

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/README-DATA.md
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/README-DATA.md
@@ -7,12 +7,12 @@ In this document we'll go through the existing API:
 - [Introduction](#introduction)
 - [Literal Data Points](#literal-data-points)
 - [Option Data Points](#option-data-points)
-	- [Fallback Values](#fallback-values)
-	- [Working with option's properties](#working-with-options-properties)
-	- [Updatable Options](#updatable-options)
-	- [Filters to prepare and sanitize data](#filters-to-prepare-and-sanitize-data)
+  - [Fallback Values](#fallback-values)
+  - [Working with option's properties](#working-with-options-properties)
+  - [Updatable Options](#updatable-options)
+  - [Filters to prepare and sanitize data](#filters-to-prepare-and-sanitize-data)
 - [Theme Data Points](#theme-data-points)
-	- [Fallback Values](#fallback-values-1)
+  - [Fallback Values](#fallback-values-1)
 - [Working with theme's properties](#working-with-themes-properties)
 
 ## Introduction

--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/README.md
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/README.md
@@ -4,18 +4,18 @@ This plugin creates a new sidebar for the block editor through which the users c
 
 - [How to develop and build the plugin](#how-to-develop-and-build-the-plugin)
 - [How it works and how themes can use it](#how-it-works-and-how-themes-can-use-it)
-	- [Fallbacks for browsers without support for CSS custom properties](#fallbacks-for-browsers-without-support-for-css-custom-properties)
-	- [How to add a "Theme Default" option to the font list](#how-to-add-a-theme-default-option-to-the-font-list)
-	- [How to use a fallback stylesheet (experimental)](#how-to-use-a-fallback-stylesheet-experimental)
+    - [Fallbacks for browsers without support for CSS custom properties](#fallbacks-for-browsers-without-support-for-css-custom-properties)
+    - [How to add a "Theme Default" option to the font list](#how-to-add-a-theme-default-option-to-the-font-list)
+    - [How to use a fallback stylesheet (experimental)](#how-to-use-a-fallback-stylesheet-experimental)
 - [Existing hooks](#existing-hooks)
-	- [jetpack_global_styles_data_set_get_data filter](#jetpack_global_styles_data_set_get_data-filter)
-	- [jetpack_global_styles_data_set_save_data filter](#jetpack_global_styles_data_set_save_data-filter)
-	- [jetpack_global_styles_permission_check_additional filter](#jetpack_global_styles_permission_check_additional-filter)
-	- [jetpack_global_styles_settings](#jetpack_global_styles_settings)
+    - [jetpack_global_styles_data_set_get_data filter](#jetpack_global_styles_data_set_get_data-filter)
+    - [jetpack_global_styles_data_set_save_data filter](#jetpack_global_styles_data_set_save_data-filter)
+    - [jetpack_global_styles_permission_check_additional filter](#jetpack_global_styles_permission_check_additional-filter)
+    - [jetpack_global_styles_settings](#jetpack_global_styles_settings)
 - [FAQ](#faq)
-	- [Which fonts are available?](#which-fonts-are-available)
-	- [What will happen when the user changes to another theme that supports GlobalStyles?](#what-will-happen-when-the-user-changes-to-another-theme-that-supports-globalstyles)
-	- [What will happen when the user changes to a theme that doesn't support Global Styles or the plugin is deactivated?](#what-will-happen-when-the-user-changes-to-a-theme-that-doesnt-support-global-styles-or-the-plugin-is-deactivated)
+    - [Which fonts are available?](#which-fonts-are-available)
+    - [What will happen when the user changes to another theme that supports GlobalStyles?](#what-will-happen-when-the-user-changes-to-another-theme-that-supports-globalstyles)
+    - [What will happen when the user changes to a theme that doesn't support Global Styles or the plugin is deactivated?](#what-will-happen-when-the-user-changes-to-a-theme-that-doesnt-support-global-styles-or-the-plugin-is-deactivated)
 
 ## How to develop and build the plugin
 

--- a/client/blocks/product-selector/README.md
+++ b/client/blocks/product-selector/README.md
@@ -12,26 +12,26 @@ import React from 'react';
 import ProductSelector from 'blocks/product-selector';
 
 const products = [
-	{
-		title: 'Jetpack Backup',
-		description: 'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives',
-		id: 'jetpack_backup',
-		options: {
-			yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],
-			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
-		},
-		optionsLabel: 'Backup options',
-	}
+    {
+        title: 'Jetpack Backup',
+        description: 'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives',
+        id: 'jetpack_backup',
+        options: {
+            yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],
+            monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
+        },
+        optionsLabel: 'Backup options',
+    }
 ];
 
 const interval = 'yearly';
 
 export default class extends React.Component {
-	render() {
-		return (
-			<ProductSelector products={ products } intervalType={ interval } />
-		);
-	}
+    render() {
+        return (
+            <ProductSelector products={ products } intervalType={ interval } />
+        );
+    }
 }
 ```
 
@@ -42,80 +42,80 @@ The following props can be passed to the Product Selector block:
 * `basePlansPath`: ( string ) Plans page base path.
 * `intervalType`: ( string ) Billing interval - `monthly`, `yearly` or `2yearly`.
 * `products`: ( array ) Products to render, each with the following structure:
-	* `title`: ( string ) Product title.
-	* `description`: ( string ) Product description.
-	* `id`: ( string ) Product ID.
-	* `forceRadios`: ( bool ) Used to force a full display with radio buttons, even when
-	there is only option per billing interval and the display would otherwise be simplified.
-	* `options`: ( object ) Product options. Each option has the billing interval as a key, and the value is an array with corresponding product slugs. Example:
-		```
-		options: {
-			yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],
-			monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
-		}
-		```
-	* `optionDescriptions`: ( object ) Optional descriptions for the product options.
-	They replace a default `description` in case a given option (represented by the object's key) has been purchased.
-	Each key is a product slug, and the value is the corresponding copy. Example:
-		```
-		optionDescriptions: {
-			jetpack_backup_daily: translate( 'Looking for more? Get unlimited real-time backup archives' ),
-			jetpack_backup_daily_monthly: translate( 'Looking for more? Get unlimited real-time backup archives' ),
-			jetpack_backup_realtime: translate( 'Your changes are saved as you edit and you have unlimited backup archives' ),
-			jetpack_backup_realtime_monthly: translate( 'Your changes are saved as you edit and you have unlimited backup archives' ),
-		}
-		```
-	* `optionDisplayNames`: ( object ) Optional display names of the product options.
-	They replace a default `title` in case a given option (represented by the object's key) has been purchased.
-	Each key is a product slug, and the value is the corresponding title. Example:
-		```
-		optionDisplayNames: {
-			jetpack_backup_daily: translate( 'Jetpack Backup Daily' ),
-			jetpack_backup_daily_monthly: translate( 'Jetpack Backup Daily' ),
-			jetpack_backup_realtime: translate( 'Jetpack Backup Real-Time' ),
-			jetpack_backup_realtime_monthly: translate( 'Jetpack Backup Real-Time' ),
-		}
-		```
-	* `optionShortNames`: ( object ) Optional short names of the product options.
-	They are used in the product card options listing, and they are also used in
-	the action button (when upgrading), unless overridden by `optionActionButtonNames`.
-	Each key is a product slug, and the value is the corresponding title. Example:
-		```
-		optionShortNames: {
-			jetpack_backup_daily: translate( 'Daily Backups' ),
-			jetpack_backup_daily_monthly: translate( 'Daily Backups' ),
-			jetpack_backup_realtime: translate( 'Real-Time Backups' ),
-			jetpack_backup_realtime_monthly: translate( 'Real-Time Backups' ),
-		}
-		```
-	* `optionShortNamesCallback`: ( function ) A callback function which is
-	passed the store product object and returns the short name for the product
-	option. This is an alternative to `optionShortNames` that can be used when
-	the title needs to depend on more than just the product slug.
-	* `optionActionButtonNames`: ( object ) Optional names of the product options
-	to be used in the action button (when upgrading). Only necessary if you want
-	to override the `optionShortNames`/`optionShortNamesCallback` values (which
-	are used for the action button by default).
-	* `optionsLabel`: ( string ) Title of the product options section.
-	* `optionsLabelCallback`: ( function ) A callback function which is passed
-	the store product object and returns the title of the product options
-	section. This is an alternative to `optionsLabel` that can be used when the
-	title needs to be dynamic.
+    * `title`: ( string ) Product title.
+    * `description`: ( string ) Product description.
+    * `id`: ( string ) Product ID.
+    * `forceRadios`: ( bool ) Used to force a full display with radio buttons, even when
+    there is only option per billing interval and the display would otherwise be simplified.
+    * `options`: ( object ) Product options. Each option has the billing interval as a key, and the value is an array with corresponding product slugs. Example:
+        ```
+        options: {
+            yearly: [ 'jetpack_backup_daily', 'jetpack_backup_realtime' ],
+            monthly: [ 'jetpack_backup_daily_monthly', 'jetpack_backup_realtime_monthly' ],
+        }
+        ```
+    * `optionDescriptions`: ( object ) Optional descriptions for the product options.
+    They replace a default `description` in case a given option (represented by the object's key) has been purchased.
+    Each key is a product slug, and the value is the corresponding copy. Example:
+        ```
+        optionDescriptions: {
+        	jetpack_backup_daily: translate( 'Looking for more? Get unlimited real-time backup archives' ),
+        	jetpack_backup_daily_monthly: translate( 'Looking for more? Get unlimited real-time backup archives' ),
+        	jetpack_backup_realtime: translate( 'Your changes are saved as you edit and you have unlimited backup archives' ),
+        	jetpack_backup_realtime_monthly: translate( 'Your changes are saved as you edit and you have unlimited backup archives' ),
+        }
+        ```
+    * `optionDisplayNames`: ( object ) Optional display names of the product options.
+    They replace a default `title` in case a given option (represented by the object's key) has been purchased.
+    Each key is a product slug, and the value is the corresponding title. Example:
+        ```
+        optionDisplayNames: {
+        	jetpack_backup_daily: translate( 'Jetpack Backup Daily' ),
+        	jetpack_backup_daily_monthly: translate( 'Jetpack Backup Daily' ),
+        	jetpack_backup_realtime: translate( 'Jetpack Backup Real-Time' ),
+        	jetpack_backup_realtime_monthly: translate( 'Jetpack Backup Real-Time' ),
+        }
+        ```
+    * `optionShortNames`: ( object ) Optional short names of the product options.
+    They are used in the product card options listing, and they are also used in
+    the action button (when upgrading), unless overridden by `optionActionButtonNames`.
+    Each key is a product slug, and the value is the corresponding title. Example:
+        ```
+        optionShortNames: {
+        	jetpack_backup_daily: translate( 'Daily Backups' ),
+        	jetpack_backup_daily_monthly: translate( 'Daily Backups' ),
+        	jetpack_backup_realtime: translate( 'Real-Time Backups' ),
+        	jetpack_backup_realtime_monthly: translate( 'Real-Time Backups' ),
+        }
+        ```
+    * `optionShortNamesCallback`: ( function ) A callback function which is
+    passed the store product object and returns the short name for the product
+    option. This is an alternative to `optionShortNames` that can be used when
+    the title needs to depend on more than just the product slug.
+    * `optionActionButtonNames`: ( object ) Optional names of the product options
+    to be used in the action button (when upgrading). Only necessary if you want
+    to override the `optionShortNames`/`optionShortNamesCallback` values (which
+    are used for the action button by default).
+    * `optionsLabel`: ( string ) Title of the product options section.
+    * `optionsLabelCallback`: ( function ) A callback function which is passed
+    the store product object and returns the title of the product options
+    section. This is an alternative to `optionsLabel` that can be used when the
+    title needs to be dynamic.
 * `productPriceMatrix`: ( object ) Matrix of product price relationships. Each key is a product slug, and each value is an object with the following structure:
-	* `relatedProduct`: ( string ) Slug of the related product.
-	* `ratio`: ( number ) Ratio between original plan and related plan. Example: for a `yearly` to `monthly` plan, this should be `12`.
+    * `relatedProduct`: ( string ) Slug of the related product.
+    * `ratio`: ( number ) Ratio between original plan and related plan. Example: for a `yearly` to `monthly` plan, this should be `12`.
 
-	Example:
-	```
-	productPriceMatrix: {
-		jetpack_backup_daily: {
-			relatedProduct: jetpack_backup_daily_monthly,
-			ratio: 12,
-		},
-		jetpack_backup_realtime: {
-			relatedProduct: jetpack_backup_realtime_monthly,
-			ratio: 12,
-		},
-	}
-	```
+    Example:
+    ```
+    productPriceMatrix: {
+        jetpack_backup_daily: {
+        	relatedProduct: jetpack_backup_daily_monthly,
+        	ratio: 12,
+        },
+        jetpack_backup_realtime: {
+        	relatedProduct: jetpack_backup_realtime_monthly,
+        	ratio: 12,
+        },
+    }
+    ```
 * `siteId`: ( number ) ID of the site we're retrieving purchases for. Used to fetch information about the associated purchases of the selected products.

--- a/client/components/pie-chart/README.md
+++ b/client/components/pie-chart/README.md
@@ -2,12 +2,12 @@
 
 This component renders a dataset as a pie chart. A separate `PieChartLegend` sub-component will render an accompanying legend.
 
-## Props 
+## Props
 
 * **data** — (required) Array of objects holding the data
-	* **value** - (required) (Number) Value of the datum
-	* **name** - (required) (String) Name to represent the datum
-	* **description** - (optional) (String) A longer description of the datum 
+    * **value** - (required) (Number) Value of the datum
+    * **name** - (required) (String) Name to represent the datum
+    * **description** - (optional) (String) A longer description of the datum
 * **title** — (optional) (String | Function) Title for the chart. If it is a function it will be called with the arguments
 `translate` and `dataTotal`. This is used to create titles that reference the data total
 

--- a/client/components/wpadmin-auto-login/README.md
+++ b/client/components/wpadmin-auto-login/README.md
@@ -9,8 +9,8 @@ We use this component in Automated Transfer.
 ## Requirements
 
 1. Site needs Jetpack:
-	- enabled and working
-	- connected to wpcom
-	- it cannot be debug nor development mode
+    - enabled and working
+    - connected to wpcom
+    - it cannot be debug nor development mode
 2. Jetpack SSO module needs to be enabled
 3. Jetpack needs to have SSO login passthru option enabled ( `add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );` )

--- a/client/lib/data-poller/README.md
+++ b/client/lib/data-poller/README.md
@@ -22,7 +22,7 @@ Add a new poller that fetches updates
 - @param {object} `[options]` - optional set of options passed to the Poller constructor
     - `interval` - time in ms between each call to the fetch method (default: 30000)
     - `leading` - whether or not fetch is called when starting the Poller when the instance is created (default: true)
-		- `pauseWhenHidden` - whether or not to pause this poller when the browser tab is hidden
+    - `pauseWhenHidden` - whether or not to pause this poller when the browser tab is hidden
 
 ### Pollers#remove( poller )
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,11 +57,11 @@ Then, you may ask that person to review your code by mentioning their GitHub use
 Consistent coding style makes the code so much easier to read. Here are ours:
 
 * [All Coding Guidelines](../docs/coding-guidelines.md)
-	- [JavaScript](../docs/coding-guidelines/javascript.md)
-	- [TypeScript](../docs/coding-guidelines/typescript.md)
-	- [CSS/Sass](../docs/coding-guidelines/css.md)
-	- [HTML](../docs/coding-guidelines/html.md)
-	- [React Components](../docs/components.md)
+    - [JavaScript](../docs/coding-guidelines/javascript.md)
+    - [TypeScript](../docs/coding-guidelines/typescript.md)
+    - [CSS/Sass](../docs/coding-guidelines/css.md)
+    - [HTML](../docs/coding-guidelines/html.md)
+    - [React Components](../docs/components.md)
 * [I18n Guidelines](https://github.com/Automattic/i18n-calypso/blob/master/README.md)
 * [A11y Checklist](../docs/accessibility-checklist.md)
 

--- a/docs/guide/tech-behind-calypso.md
+++ b/docs/guide/tech-behind-calypso.md
@@ -74,10 +74,10 @@ Essential Git resources:
 * The [Pro Git](http://git-scm.com/book/en/v2) book is online and free. It's a great resource, both for beginners and for intermediate users (few dare to call themselves advanced).
 * [git ready](http://gitready.com) – byte-sized tips
 * Several shorter articles with tips:
-	- [A few git tips you didn't know about](http://mislav.uniqpath.com/2010/07/git-tips/)
-	- [25 Tips for Intermediate Git Users](https://www.andyjeffries.co.uk/25-tips-for-intermediate-git-users/)
-	- [Stupid Git Tricks](http://webchick.net/stupid-git-tricks)
-	- [9 Awesome Git Tricks](http://www.tychoish.com/posts/9-awesome-git-tricks/)
+    - [A few git tips you didn't know about](http://mislav.uniqpath.com/2010/07/git-tips/)
+    - [25 Tips for Intermediate Git Users](https://www.andyjeffries.co.uk/25-tips-for-intermediate-git-users/)
+    - [Stupid Git Tricks](http://webchick.net/stupid-git-tricks)
+    - [9 Awesome Git Tricks](http://www.tychoish.com/posts/9-awesome-git-tricks/)
 * Some operations are easier using a GUI. [GitX](http://rowanj.github.io/gitx/) is a simple one for OS X. [Fugitive](https://github.com/tpope/vim-fugitive) is a must for `vim`. The GitHub app doesn’t entirely fit our workflow, but you can use it for pulling and committing. One caveat is that you will have to do all rebasing manually.
 
 Key concepts checklist:

--- a/packages/calypso-codemods/README.md
+++ b/packages/calypso-codemods/README.md
@@ -12,7 +12,7 @@ npm install -g calypso-codemods
 ```
 
 Now you can run codemods using the following cli:
-```bash 
+```bash
 calypso-codemods transformation-name[,second-name,third-name] target [additional targets]
 ```
 
@@ -39,59 +39,59 @@ calypso-codemods commonjs-imports,commonjs-exports,named-exports-from-default cl
 ### 5to6-codemod scripts ([docs](https://github.com/5to6/5to6-codemod#transforms))
 
 - commonjs-exports
-	- This codemod converts `module.exports` to `export` and `export default`.
+    - This codemod converts `module.exports` to `export` and `export default`.
 
 - commonjs-imports
-	- This transformation converts occurrences of `require( '...' )` to `import ... from '...'` occurring at the top level scope. It will ignore CommonJS imports inside block statements, like conditionals or function definitions.
+    - This transformation converts occurrences of `require( '...' )` to `import ... from '...'` occurring at the top level scope. It will ignore CommonJS imports inside block statements, like conditionals or function definitions.
 
 - commonjs-imports-hoist
-	- This transformation hoists all occurrences of `require( '...' )` inside if, loop, and function blocks. This can cause breakage! Use with caution.
+    - This transformation hoists all occurrences of `require( '...' )` inside if, loop, and function blocks. This can cause breakage! Use with caution.
 
 - named-exports-from-default
-	- This transformation generates named exports given a `default export { ... }`. This can be useful in transitioning away from namespace imports (`import * as blah from 'blah'`) to named imports (`import named from 'blah'`).
+    - This transformation generates named exports given a `default export { ... }`. This can be useful in transitioning away from namespace imports (`import * as blah from 'blah'`) to named imports (`import named from 'blah'`).
 
 ### React scripts ([docs](https://github.com/reactjs/react-codemod))
 
 - react-create-class
-	- This transformation converts instances of React.createClass to use React.Component instead.
+    - This transformation converts instances of React.createClass to use React.Component instead.
 
 - react-proptypes
-	- This transformation converts instances of React.PropTypes to use prop-types instead.
+    - This transformation converts instances of React.PropTypes to use prop-types instead.
 
 ### Local scripts
 - combine-reducer-with-persistence
-	- This transformation converts combineReducers imports to use combineReducersWithPersistence.
+    - This transformation converts combineReducers imports to use combineReducersWithPersistence.
 
 - combine-state-utils-imports
-	- This transformation combines state/utils imports.
+    - This transformation combines state/utils imports.
 
 - i18n-mixin-to-localize
   - This transformation converts the following:
-		- `this.translate` to `this.props.translate`
-		- `this.moment` to `this.props.moment`
-		- `this.numberFormat` to `this.props.numberFormat`
-	- If any of the above conversions is performed, this transformation will wrap the React.createClass instance with a `localize()` higher-order component.
+        - `this.translate` to `this.props.translate`
+        - `this.moment` to `this.props.moment`
+        - `this.numberFormat` to `this.props.numberFormat`
+    - If any of the above conversions is performed, this transformation will wrap the React.createClass instance with a `localize()` higher-order component.
 
 - merge-lodash-imports
-	- This transformation merges multiple named lodash imports into one
+    - This transformation merges multiple named lodash imports into one
 
 -	modular-lodash-no-more
-	- This transformation converts modular lodash imports to ES2015-style imports
+    - This transformation converts modular lodash imports to ES2015-style imports
 
 - modular-lodash-requires-no-more
-	- This transformation converts modular lodash requires to ES2015-style imports
+    - This transformation converts modular lodash requires to ES2015-style imports
 
 - rename-combine-reducers
-	- This transformation converts combineReducersWithPersistence imports to use combineReducers from 'state/utils'
+    - This transformation converts combineReducersWithPersistence imports to use combineReducers from 'state/utils'
 
 - single-tree-rendering
-	- Instead of rendering two distinct React element trees to the `#primary` and `#secondary` <div>s,
-	use a single `Layout` component tree that includes both, and render it to `#layout`.
+    - Instead of rendering two distinct React element trees to the `#primary` and `#secondary` <div>s,
+    use a single `Layout` component tree that includes both, and render it to `#layout`.
 
 - sort-imports
-	- This transformation adds import comment blocks and sorts them as necessary.
-	- Note: It only needs to be run twice because of a bug where in certain cases an extra newline is added
-	on the first run.  The second run removes the extra newline.
+    - This transformation adds import comment blocks and sorts them as necessary.
+    - Note: It only needs to be run twice because of a bug where in certain cases an extra newline is added
+    on the first run.  The second run removes the extra newline.
 
 ## Contributing codemods
 ### Write the transform
@@ -102,7 +102,7 @@ You can look at the current directory for inspiration.
 calypso-codemods uses jest snapshots to maintain its tests.
 in order to easily add tests for a new transform, follow these steps:
 
-1. add a directory to `tests` with the exact same name as the added transform. 
+1. add a directory to `tests` with the exact same name as the added transform.
 2. add a file named `codemod.spec.js` with this as its contents contents:
 ```javascript
 test_folder(__dirname);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes indentation in Markdown files from tabs to 4 spaces. This is a workaround for remarkjs/remark#198

This PR is part of https://github.com/Automattic/wp-calypso/issues/40796, check that issue for a overview of the project.