### PR TITLE
Gutenboarding: Remove click-focus style from viewports

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -183,10 +183,9 @@ $gutenboarding-style-preview-bar-height: 30px;
 }
 
 // Remove focus styling from clicking a button
-// Keep keyboard-focused focus styl
+// Keep keyboard-focused focus style
 html:not( .accessible-focus )
 	.style-preview__viewport-select-button.is-selected:focus:not( :hover ) {
-	// outline: 1px dotted red !important;
 	box-shadow: none;
 }
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -160,22 +160,34 @@ $gutenboarding-style-preview-bar-height: 30px;
 .style-preview__viewport-select {
 	display: flex;
 	justify-content: center;
+}
 
-	.components-button {
+.style-preview__viewport-select-button {
+	color: var( --studio-gray-10 );
+
+	// Need the extra specificity here to override core
+	&.components-button {
+		height: auto;
 		padding: 4px;
 
-		height: auto;
+		color: var( --studio-gray-10 );
 
 		svg {
 			fill: none;
 		}
-
-		color: var( --studio-gray-10 );
-
-		&.is-selected {
-			color: var( --studio-black );
-		}
 	}
+
+	&.is-selected {
+		color: var( --studio-black );
+	}
+}
+
+// Remove focus styling from clicking a button
+// Keep keyboard-focused focus styl
+html:not( .accessible-focus )
+	.style-preview__viewport-select-button.is-selected:focus:not( :hover ) {
+	// outline: 1px dotted red !important;
+	box-shadow: none;
 }
 
 .style-preview__iframe {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/viewport-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/viewport-select.tsx
@@ -3,6 +3,7 @@
  */
 import * as React from 'react';
 import { SVG, Path, Rect, Button } from '@wordpress/components';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -18,10 +19,7 @@ interface Props {
 }
 const ViewportSelect: React.FunctionComponent< Props > = ( { onSelect, selected } ) => (
 	<div className="style-preview__viewport-select">
-		<Button
-			onClick={ () => onSelect( 'desktop' ) }
-			className={ selected === 'desktop' ? 'is-selected' : undefined }
-		>
+		<ViewportButton onClick={ () => onSelect( 'desktop' ) } isSelected={ selected === 'desktop' }>
 			<SVG width="55" height="55" viewBox="0 0 55 55">
 				<Path
 					d="M10.4258 15.75C10.4258 15.0596 10.9854 14.5 11.6758 14.5H43.3239C44.0143 14.5 44.5739 15.0596 44.5739 15.75V38.463H10.4258V15.75Z"
@@ -33,11 +31,8 @@ const ViewportSelect: React.FunctionComponent< Props > = ( { onSelect, selected 
 					fill="currentColor"
 				/>
 			</SVG>
-		</Button>
-		<Button
-			onClick={ () => onSelect( 'tablet' ) }
-			className={ selected === 'tablet' ? 'is-selected' : undefined }
-		>
+		</ViewportButton>
+		<ViewportButton onClick={ () => onSelect( 'tablet' ) } isSelected={ selected === 'tablet' }>
 			<SVG width="48" height="48" viewBox="0 0 48 48">
 				<Rect
 					x="10.75"
@@ -50,11 +45,8 @@ const ViewportSelect: React.FunctionComponent< Props > = ( { onSelect, selected 
 				/>
 				<Rect x="20" y="32" width="8" height="3" fill="currentColor" />
 			</SVG>
-		</Button>
-		<Button
-			onClick={ () => onSelect( 'mobile' ) }
-			className={ selected === 'mobile' ? 'is-selected' : undefined }
-		>
+		</ViewportButton>
+		<ViewportButton onClick={ () => onSelect( 'mobile' ) } isSelected={ selected === 'mobile' }>
 			<SVG width="40" height="40" viewBox="0 0 40 40">
 				<Rect
 					x="12.417"
@@ -67,8 +59,27 @@ const ViewportSelect: React.FunctionComponent< Props > = ( { onSelect, selected 
 				/>
 				<Rect x="18.333" y="26.667" width="5" height="2.5" fill="currentColor" />
 			</SVG>
-		</Button>
+		</ViewportButton>
 	</div>
+);
+
+interface ButtonProps {
+	onClick: () => void;
+	isSelected?: boolean;
+}
+const ViewportButton: React.FunctionComponent< ButtonProps > = ( {
+	children,
+	onClick,
+	isSelected,
+} ) => (
+	<Button
+		className={ classnames( 'style-preview__viewport-select-button', {
+			'is-selected': isSelected,
+		} ) }
+		onClick={ onClick }
+	>
+		{ children }
+	</Button>
 );
 
 export default ViewportSelect;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove click-initiated focus style on buttons.
If buttons are focused by keyboard navigation, maintain focus style.

Part of #40757

##### Before
![Screen Shot 2020-04-06 at 12 31 32](https://user-images.githubusercontent.com/841763/78549437-add66c80-7802-11ea-86d9-ec222a83791d.png)


##### After
![Screen Shot 2020-04-06 at 12 31 46](https://user-images.githubusercontent.com/841763/78549422-a57e3180-7802-11ea-94c9-eb7bc4f0ca56.png)


#### Testing instructions


* [`/gutenboarding`](/https://calypso.live/gutenboarding?branch=gutenboarding/remove-viewport-active-border)
* Proceed to style step
* Click different viewports
* On hover they should have a box
* The last clicked (focused) button should not
* If focused via keyboard navigation, it should have focus styles regardless (has box)
