### PR TITLE
Gutenboarding: Use @wordpress/icons in Domain Picker

### DIFF
--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -10,7 +10,7 @@ const CloseButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 	const { __ } = useI18n();
 	return (
 		<Button label={ __( 'Close dialog' ) } { ...buttonProps }>
-			<Icon icon={ close } />
+			<Icon icon={ close } size={ 16 } />
 		</Button>
 	);
 };

--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -2,22 +2,15 @@
  * External dependencies
  */
 import React from 'react';
-import { Button, Path, SVG } from '@wordpress/components';
+import { Button } from '@wordpress/components';
+import { Icon, close } from '@wordpress/icons';
 import { useI18n } from '@automattic/react-i18n';
 
 const CloseButton: React.FunctionComponent< Button.ButtonProps > = ( { ...buttonProps } ) => {
 	const { __ } = useI18n();
 	return (
 		<Button label={ __( 'Close dialog' ) } { ...buttonProps }>
-			<SVG
-				width="12"
-				height="12"
-				viewBox="0 0 16 16"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<Path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" strokeWidth="1.5" />
-			</SVG>
+			<Icon icon={ close } />
 		</Button>
 	);
 };

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import React, { FunctionComponent, useState, useEffect } from 'react';
-import { Button, Panel, PanelBody, PanelRow, TextControl, Icon } from '@wordpress/components';
+import { Button, Panel, PanelBody, PanelRow, TextControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { Icon, search } from '@wordpress/icons';
 import { times } from 'lodash';
 import { useI18n } from '@automattic/react-i18n';
 
@@ -186,7 +187,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 						</div>
 					</div>
 					<div className="domain-picker__search">
-						<SearchIcon />
+						<div className="domain-picker__search-icon">
+							<Icon icon={ search } />
+						</div>
 						<TextControl
 							data-hj-whitelist
 							hideLabelFromVision
@@ -254,22 +257,5 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		</Panel>
 	);
 };
-
-const SearchIcon = () => (
-	<Icon
-		icon={ () => (
-			<svg
-				width="24"
-				height="24"
-				viewBox="0 0 24 24"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<path d="M6 18L10 14.5" stroke="black" strokeWidth="1.5" />
-				<circle cx="13.5" cy="11.5" r="4.75" stroke="black" strokeWidth="1.5" />
-			</svg>
-		) }
-	/>
-);
 
 export default DomainPicker;

--- a/client/package.json
+++ b/client/package.json
@@ -49,6 +49,7 @@
 		"@wordpress/element": "^2.12.0",
 		"@wordpress/format-library": "^1.15.0",
 		"@wordpress/i18n": "^3.10.0",
+		"@wordpress/icons": "^2.0.0",
 		"@wordpress/is-shallow-equal": "^2.0.0",
 		"@wordpress/keycodes": "^2.10.0",
 		"@wordpress/notices": "^2.1.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to https://github.com/Automattic/wp-calypso/pull/40742/files#r404025438.

~Rebase on master once the following have been merged:~ Done :white_check_mark: 
- [x] #40742
- [x] #39644

#### Testing instructions

- http://calypso.localhost:3000/gutenboarding
- In the domain picker, verify that the close and search icons look like before:

![image](https://user-images.githubusercontent.com/96308/82215715-1e030280-9918-11ea-8346-e66bedd8dd7e.png)

