### PR TITLE
Remove url and qs from login (try #2)

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -466,7 +466,7 @@ export class LoginForm extends Component {
 			const oauth2Flow = isCrowdsignalOAuth2Client( oauth2Client ) ? 'crowdsignal' : 'wpcc';
 			const oauth2Params = new globalThis.URLSearchParams( {
 				oauth2_client_id: oauth2Client.id,
-				oauth2_redirect: redirectTo,
+				oauth2_redirect: redirectTo || '',
 			} );
 
 			signupUrl = `/start/${ oauth2Flow }?${ oauth2Params.toString() }`;

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -10,7 +10,6 @@ import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
-import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -465,12 +464,12 @@ export class LoginForm extends Component {
 
 		if ( isOauthLogin && config.isEnabled( 'signup/wpcc' ) ) {
 			const oauth2Flow = isCrowdsignalOAuth2Client( oauth2Client ) ? 'crowdsignal' : 'wpcc';
-			const oauth2Params = {
+			const oauth2Params = new globalThis.URLSearchParams( {
 				oauth2_client_id: oauth2Client.id,
 				oauth2_redirect: redirectTo,
-			};
+			} );
 
-			signupUrl = `/start/${ oauth2Flow }?${ stringify( oauth2Params ) }`;
+			signupUrl = `/start/${ oauth2Flow }?${ oauth2Params.toString() }`;
 		}
 
 		if ( isGutenboarding ) {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -2,10 +2,8 @@
  * External dependencies
  */
 import page from 'page';
-import { parse } from 'qs';
 import React from 'react';
 import { includes } from 'lodash';
-import { parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -14,6 +12,7 @@ import config from 'config';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
 import MagicLogin from './magic-login';
 import WPLogin from './wp-login';
+import { getUrlParts } from 'lib/url';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
 import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
@@ -67,10 +66,9 @@ export async function login( context, next ) {
 			return next( error );
 		}
 
-		const parsedRedirectUrl = parseUrl( redirect_to );
-		const redirectQueryString = parse( parsedRedirectUrl.query );
+		const { searchParams: redirectParams } = getUrlParts( redirect_to );
 
-		if ( client_id !== redirectQueryString.client_id ) {
+		if ( client_id !== redirectParams.get( 'client_id' ) ) {
 			const error = new Error(
 				'The `redirect_to` query parameter is invalid with the given `client_id`.'
 			);

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -7,8 +7,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { get, includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
-import { parse as parseUrl } from 'url';
-import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -18,7 +16,7 @@ import ExternalLink from 'components/external-link';
 import Gridicon from 'components/gridicon';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
-import { addQueryArgs } from 'lib/url';
+import { addQueryArgs, getUrlParts } from 'lib/url';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'state/selectors/get-current-route';
@@ -99,9 +97,9 @@ export class LoginLinks extends React.Component {
 	};
 
 	renderBackLink() {
-		const redirectTo = get( this.props, [ 'query', 'redirect_to' ] );
+		const redirectTo = this.props.query?.redirect_to;
 		if ( redirectTo ) {
-			const { pathname, query: redirectToQuery } = parseUrl( redirectTo, true );
+			const { pathname, searchParams: redirectToQuery } = getUrlParts( redirectTo );
 
 			// If we are in a Domain Connect authorization flow, don't show the back link
 			// since this page was loaded by a redirect from a third party service provider.
@@ -111,13 +109,13 @@ export class LoginLinks extends React.Component {
 
 			// If we seem to be in a Jetpack connection flow, provide some special handling
 			// so users can go back to their site rather than WordPress.com
-			if ( pathname === '/jetpack/connect/authorize' && redirectToQuery.client_id ) {
+			if ( pathname === '/jetpack/connect/authorize' && redirectToQuery.get( 'client_id' ) ) {
 				const returnToSiteUrl = addQueryArgs(
-					{ client_id: redirectToQuery.client_id },
+					{ client_id: redirectToQuery.get( 'client_id' ) },
 					'https://jetpack.wordpress.com/jetpack.returntosite/1/'
 				);
 
-				const { hostname } = parseUrl( redirectToQuery.site_url );
+				const { hostname } = getUrlParts( redirectToQuery.get( 'site_url' ) );
 				const linkText = hostname
 					? this.props.translate( 'Back to %(hostname)s', { args: { hostname } } )
 					: this.props.translate( 'Back' );
@@ -285,12 +283,12 @@ export class LoginLinks extends React.Component {
 		if ( config.isEnabled( 'signup/wpcc' ) && isCrowdsignalOAuth2Client( oauth2Client ) ) {
 			const oauth2Flow = 'crowdsignal';
 			const redirectTo = get( currentQuery, 'redirect_to', '' );
-			const oauth2Params = {
+			const oauth2Params = new URLSearchParams( {
 				oauth2_client_id: oauth2Client.id,
 				oauth2_redirect: redirectTo,
-			};
+			} );
 
-			signupUrl = `${ signupUrl }/${ oauth2Flow }?${ stringify( oauth2Params ) }`;
+			signupUrl = `${ signupUrl }/${ oauth2Flow }?${ oauth2Params.toString() }`;
 		}
 
 		if (
@@ -300,13 +298,13 @@ export class LoginLinks extends React.Component {
 			wccomFrom
 		) {
 			const redirectTo = get( currentQuery, 'redirect_to', '' );
-			const oauth2Params = {
+			const oauth2Params = new URLSearchParams( {
 				oauth2_client_id: oauth2Client.id,
 				'wccom-from': wccomFrom,
 				oauth2_redirect: redirectTo,
-			};
+			} );
 
-			signupUrl = `${ signupUrl }/wpcc?${ stringify( oauth2Params ) }`;
+			signupUrl = `${ signupUrl }/wpcc?${ oauth2Params.toString() }`;
 		}
 
 		if ( isGutenboarding ) {

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { stringify } from 'qs';
-
-/**
  * Internal dependencies
  */
 import config from 'config';
@@ -52,11 +47,11 @@ export const hideMagicLoginRequestNotice = () => {
 };
 
 async function postMagicLoginRequest( url, bodyObj ) {
-	const response = await fetch( url, {
+	const response = await globalThis.fetch( url, {
 		method: 'POST',
 		credentials: 'include',
 		headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-		body: stringify( bodyObj ),
+		body: new globalThis.URLSearchParams( bodyObj ).toString(),
 	} );
 
 	if ( response.ok ) {

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -3,7 +3,7 @@
  */
 import config from 'config';
 import { AUTHENTICATE_URL } from './constants';
-import { HTTPError } from '../utils';
+import { HTTPError, normalizeBody } from '../utils';
 import {
 	LOGIN_REQUEST_SUCCESS,
 	MAGIC_LOGIN_HIDE_REQUEST_FORM,
@@ -51,7 +51,7 @@ async function postMagicLoginRequest( url, bodyObj ) {
 		method: 'POST',
 		credentials: 'include',
 		headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-		body: new globalThis.URLSearchParams( bodyObj ?? {} ).toString(),
+		body: new globalThis.URLSearchParams( normalizeBody( bodyObj ) ).toString(),
 	} );
 
 	if ( response.ok ) {

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -51,7 +51,7 @@ async function postMagicLoginRequest( url, bodyObj ) {
 		method: 'POST',
 		credentials: 'include',
 		headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-		body: new globalThis.URLSearchParams( bodyObj ).toString(),
+		body: new globalThis.URLSearchParams( bodyObj ?? {} ).toString(),
 	} );
 
 	if ( response.ok ) {

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -3,7 +3,7 @@
  */
 import config from 'config';
 import { AUTHENTICATE_URL } from './constants';
-import { HTTPError, normalizeBody } from '../utils';
+import { HTTPError, stringifyBody } from '../utils';
 import {
 	LOGIN_REQUEST_SUCCESS,
 	MAGIC_LOGIN_HIDE_REQUEST_FORM,
@@ -51,7 +51,7 @@ async function postMagicLoginRequest( url, bodyObj ) {
 		method: 'POST',
 		credentials: 'include',
 		headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-		body: new globalThis.URLSearchParams( normalizeBody( bodyObj ) ).toString(),
+		body: stringifyBody( bodyObj ),
 	} );
 
 	if ( response.ok ) {

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -169,7 +169,7 @@ export async function postLoginRequest( action, bodyObj ) {
 			method: 'POST',
 			credentials: 'include',
 			headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: new globalThis.URLSearchParams( bodyObj ).toString(),
+			body: new globalThis.URLSearchParams( bodyObj ?? {} ).toString(),
 		}
 	);
 

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -162,6 +162,12 @@ export const isRegularAccount = authAccountType => authAccountType === 'regular'
  */
 export const isPasswordlessAccount = authAccountType => authAccountType === 'passwordless';
 
+export function normalizeBody( bodyObj ) {
+	return Object.fromEntries(
+		Object.entries( bodyObj ?? {} ).map( ( [ key, val ] ) => [ key, val ?? '' ] )
+	);
+}
+
 export async function postLoginRequest( action, bodyObj ) {
 	const response = await window.fetch(
 		localizeUrl( `https://wordpress.com/wp-login.php?action=${ action }` ),
@@ -169,7 +175,7 @@ export async function postLoginRequest( action, bodyObj ) {
 			method: 'POST',
 			credentials: 'include',
 			headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: new globalThis.URLSearchParams( bodyObj ?? {} ).toString(),
+			body: new globalThis.URLSearchParams( normalizeBody( bodyObj ) ).toString(),
 		}
 	);
 

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { get, omit } from 'lodash';
-import { stringify } from 'qs';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -170,7 +169,7 @@ export async function postLoginRequest( action, bodyObj ) {
 			method: 'POST',
 			credentials: 'include',
 			headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: stringify( bodyObj ),
+			body: new globalThis.URLSearchParams( bodyObj ).toString(),
 		}
 	);
 

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -163,6 +163,7 @@ export const isRegularAccount = authAccountType => authAccountType === 'regular'
 export const isPasswordlessAccount = authAccountType => authAccountType === 'passwordless';
 
 export function normalizeBody( bodyObj ) {
+	// Replace null or undefined values with empty strings.
 	return Object.fromEntries(
 		Object.entries( bodyObj ?? {} ).map( ( [ key, val ] ) => [ key, val ?? '' ] )
 	);

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -162,11 +162,12 @@ export const isRegularAccount = authAccountType => authAccountType === 'regular'
  */
 export const isPasswordlessAccount = authAccountType => authAccountType === 'passwordless';
 
-export function normalizeBody( bodyObj ) {
-	// Replace null or undefined values with empty strings.
-	return Object.fromEntries(
+export function stringifyBody( bodyObj ) {
+	// Clone bodyObj, replacing null or undefined values with empty strings.
+	const body = Object.fromEntries(
 		Object.entries( bodyObj ?? {} ).map( ( [ key, val ] ) => [ key, val ?? '' ] )
 	);
+	return new globalThis.URLSearchParams( body ).toString();
 }
 
 export async function postLoginRequest( action, bodyObj ) {
@@ -176,7 +177,7 @@ export async function postLoginRequest( action, bodyObj ) {
 			method: 'POST',
 			credentials: 'include',
 			headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: new globalThis.URLSearchParams( normalizeBody( bodyObj ) ).toString(),
+			body: stringifyBody( bodyObj ),
 		}
 	);
 


### PR DESCRIPTION
This PR is a second attempt at #38769, which had to be reverted due to bugs. It fixes an issue where parameters with a `null` value would get serialized as `param=null` rather than `param=`.

Node's `url` is deprecated, and `qs` is a largeish 3rd party library.

All of the functionality replaced here is available in `lib/url`, which is built on top of standard APIs that are available in both node and the browser (polyfilled, if needed).

This is one of many PRs working towards dropping 3rd-party libraries for URL and URL parameter handling and replacing them with native functionality.

#### Changes proposed in this Pull Request

* Replace `url` and `qs` usage with `lib/url`.

#### Testing instructions

I'm not very familiar with this part of the login flow (going back to the original site in a Jetpack connection flow), so I'm hoping that the E2E tests and the reviewers will be able to help out with in-depth testing.
