### PR TITLE
[Private media] Use exponential backoff when API returns error 429

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2530,20 +2530,14 @@ Undocumented.prototype.getAtomicSiteMediaViaProxyRetry = function(
 	let retries = 0;
 	const request = () =>
 		this.getAtomicSiteMediaViaProxy( siteIdOrSlug, mediaPath, options ).catch( error => {
-			// On error 429 retry three times with exponential backoff times
-			if ( error?.statusCode === 429 && retries < 3 ) {
+			// Retry three times with exponential backoff times
+			if ( retries < 3 ) {
 				return new Promise( resolve => {
 					++retries;
 					setTimeout( () => {
 						resolve( request() );
 					}, ( retries * retries * 1000 ) / 2 );
 				} );
-			}
-
-			// On regular errors retry one time (right away)
-			if ( retries === 0 ) {
-				++retries;
-				return request();
 			}
 
 			return Promise.reject( error );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2489,8 +2489,7 @@ Undocumented.prototype.startMigration = function( sourceSiteId, targetSiteId ) {
 Undocumented.prototype.getAtomicSiteMediaViaProxy = function(
 	siteIdOrSlug,
 	mediaPath,
-	{ query = '', maxSize },
-	fn
+	{ query = '', maxSize }
 ) {
 	const safeQuery = query.replace( /^\?/, '' );
 	const params = {
@@ -2498,36 +2497,59 @@ Undocumented.prototype.getAtomicSiteMediaViaProxy = function(
 		apiNamespace: 'wpcom/v2',
 	};
 
-	const fetchMedia = () => this.wpcom.req.get( { ...params, responseType: 'blob' }, fn );
+	return new Promise( ( resolve, _reject ) => {
+		const fetchMedia = () =>
+			this.wpcom.req.get( { ...params, responseType: 'blob' }, ( error, data ) => {
+				if ( error || ! ( data instanceof Blob ) ) {
+					_reject( error );
+				} else {
+					resolve( data );
+				}
+			} );
 
-	if ( ! maxSize ) {
-		return fetchMedia();
-	}
-
-	return this.wpcom.req.get( { ...params, method: 'HEAD' }, ( err, data, headers ) => {
-		if ( headers[ 'Content-Length' ] > maxSize ) {
-			fn( { message: 'exceeded_max_size' }, null );
-			return;
+		if ( ! maxSize ) {
+			return fetchMedia();
 		}
 
-		fetchMedia();
+		return this.wpcom.req.get( { ...params, method: 'HEAD' }, ( err, data, headers ) => {
+			if ( headers[ 'Content-Length' ] > maxSize ) {
+				_reject( { message: 'exceeded_max_size' } );
+				return;
+			}
+
+			fetchMedia();
+		} );
 	} );
 };
 
 Undocumented.prototype.getAtomicSiteMediaViaProxyRetry = function(
 	siteIdOrSlug,
 	mediaPath,
-	options,
-	fn
+	options
 ) {
-	return this.getAtomicSiteMediaViaProxy( siteIdOrSlug, mediaPath, options, ( err, data ) => {
-		if ( data instanceof Blob || ( err && err.message === 'exceeded_max_size' ) ) {
-			fn( err, data );
-			return;
-		}
+	let retries = 0;
+	const request = () =>
+		this.getAtomicSiteMediaViaProxy( siteIdOrSlug, mediaPath, options ).catch( error => {
+			// On error 429 retry three times with exponential backoff times
+			if ( error?.statusCode === 429 && retries < 3 ) {
+				return new Promise( resolve => {
+					++retries;
+					setTimeout( () => {
+						resolve( request() );
+					}, ( retries * retries * 1000 ) / 2 );
+				} );
+			}
 
-		return this.getAtomicSiteMediaViaProxy( siteIdOrSlug, mediaPath, options, fn );
-	} );
+			// On regular errors retry one time (right away)
+			if ( retries === 0 ) {
+				++retries;
+				return request();
+			}
+
+			return Promise.reject( error );
+		} );
+
+	return request();
 };
 
 export default Undocumented;

--- a/client/my-sites/media-library/proxied-image.tsx
+++ b/client/my-sites/media-library/proxied-image.tsx
@@ -73,20 +73,13 @@ const ProxiedImage: React.FC< ProxiedImageProps > = function ProxiedImage( {
 				}
 				wpcom
 					.undocumented()
-					.getAtomicSiteMediaViaProxyRetry(
-						siteSlug,
-						filePath,
-						options,
-						( err: Error, data: Blob | null ) => {
-							if ( data instanceof Blob ) {
-								cacheResponse( requestId, data );
-								setImageObjectUrl( URL.createObjectURL( data ) );
-								debug( 'got image from API', { requestId, imageObjectUrl, data } );
-							} else if ( onError ) {
-								onError( err );
-							}
-						}
-					);
+					.getAtomicSiteMediaViaProxyRetry( siteSlug, filePath, options )
+					.then( ( data: Blob ) => {
+						cacheResponse( requestId, data );
+						setImageObjectUrl( URL.createObjectURL( data ) );
+						debug( 'got image from API', { requestId, imageObjectUrl, data } );
+					} )
+					.catch( onError );
 			}
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is related to Coming Soon/Private atomic sites project (paObgF-Ui-p2). The rationale for this change is described in D41360-code.

This PR is a Calypso counterpart of D41360-code that makes sure we use a customized retry policy for private media files, if the request returned HTTP status 429.

#### Testing instructions

1. Create a new private atomic site (p58i-8OX-p2)
1. Go to /media
1. Confirm the files are being correctly loaded
1. If you see some gray squares instead of actual thumbnails, confirm they're loaded properly after refreshing the page (that's an API issue fixed in another diff)