### PR TITLE
Visual fixes for #40757

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -54,10 +54,6 @@ $acquire-intent-transition-algorithm: ease-in-out;
 	color: var( --mainColor );
 	border-bottom: 2px solid var( --mainColor );
 
-	transition: border-bottom $acquire-intent-transition-duration
-			$acquire-intent-transition-algorithm,
-		color $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
-
 	&:focus {
 		outline: none;
 	}
@@ -66,6 +62,17 @@ $acquire-intent-transition-algorithm: ease-in-out;
 	// .accessible-focus &:focus {
 	// 	outline: 2px solid var( --highlightColor );
 	// }
+}
+
+.madlib__input:empty {
+	width: 200px;
+	display: inline-block;
+	border-bottom: 2px solid transparent;
+}
+
+/* hide the placeholder when input is not empty */
+.madlib__input:not( :empty ) ~ .vertical-select__placeholder {
+	visibility: hidden;
 }
 
 // Themed core button component
@@ -99,15 +106,6 @@ $acquire-intent-transition-algorithm: ease-in-out;
 
 .site-title {
 	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
-
-	&--without-value {
-		.madlib__input {
-			width: 200px;
-			display: inline-block;
-			vertical-align: middle;
-			border: none;
-		}
-	}
 
 	&--hidden {
 		visibility: hidden;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -65,9 +65,11 @@ $acquire-intent-transition-algorithm: ease-in-out;
 }
 
 .madlib__input:empty {
-	width: 200px;
+	width: 400px;
 	display: inline-block;
 	border-bottom: 2px solid transparent;
+	position: relative;
+	z-index: 2;
 }
 
 /* hide the placeholder when input is not empty */

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -70,6 +70,7 @@ $acquire-intent-transition-algorithm: ease-in-out;
 	border-bottom: 2px solid transparent;
 	position: relative;
 	z-index: 2;
+	vertical-align: middle;
 }
 
 /* hide the placeholder when input is not empty */

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -129,6 +129,8 @@ const VerticalSelect: React.FunctionComponent = () => {
 	const handleSelect = ( vertical: SiteVertical ) => {
 		setSiteVertical( vertical );
 		setIsFocused( false ); // prevent executing handleBlur()
+		// empty suggestions cache once a vertical is selceted
+		setSuggestions( [] );
 	};
 
 	const handleBlur = () => {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -7,7 +7,6 @@ import { Suggestions } from '@automattic/components';
 import { useI18n } from '@automattic/react-i18n';
 import { __experimentalCreateInterpolateElement } from '@wordpress/element';
 import { ENTER, TAB } from '@wordpress/keycodes';
-import classnames from 'classnames';
 import { remove } from 'lodash';
 
 /**
@@ -177,9 +176,6 @@ const VerticalSelect: React.FunctionComponent = () => {
 			Input: (
 				<span className="vertical-select__suggestions-wrapper">
 					<span className="vertical-select__input-wrapper">
-						{ isInputEmpty && (
-							<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>
-						) }
 						<span
 							contentEditable
 							tabIndex={ 0 }
@@ -194,6 +190,7 @@ const VerticalSelect: React.FunctionComponent = () => {
 							onFocus={ () => setIsFocused( true ) }
 							onBlur={ handleBlur }
 						/>
+						<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>
 					</span>
 					{ /* us visibility to keep the layout fixed with and without the arrow */ }
 					{ showArrow && <Arrow className="vertical-select__arrow" /> }
@@ -213,15 +210,7 @@ const VerticalSelect: React.FunctionComponent = () => {
 		}
 	);
 
-	return (
-		<form
-			className={ classnames( 'vertical-select', {
-				'vertical-select--without-value': isInputEmpty,
-			} ) }
-		>
-			{ madlib }
-		</form>
-	);
+	return <form className="vertical-select">{ madlib }</form>;
 };
 
 export default VerticalSelect;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -15,21 +15,6 @@
 			border-radius: 2px;
 		}
 	}
-	&--without-value {
-		.vertical-select__input-wrapper {
-			position: relative;
-			width: 400px;
-			display: inline-block;
-			vertical-align: middle;
-			height: 1.05em;
-			line-height: 1em;
-		}
-		.madlib__input {
-			position: absolute;
-			width: 100%;
-			border: none; //not transparent to prevent a flicker of 100% bottom border when this class is removed
-		}
-	}
 }
 
 .vertical-select__suggestions-wrapper {
@@ -48,6 +33,7 @@
 	color: var( --studio-gray-5 );
 	position: absolute;
 	left: 0;
+	width: 400px;
 }
 
 .vertical-select__arrow {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -104,7 +104,7 @@
 
 .style-preview__preview-wrapper {
 	background: var( --studio-white );
-	box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.25 );
+	box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.1 );
 	border-radius: 4px;
 	overflow: hidden;
 	position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR takes React out of the empty-input state management and uses CSS `:empty` pseudo-selector instead. This results in instantaneous (read: glitch-free) changes to the UI when the state changes from empty <-> not-empty.

#### Checklist

- [ ] Reduce previewer box-shadow to `.1`
- [ ] Intent capture input small glitches (jumping cursor and transitioning underline) mentioned in https://github.com/Automattic/wp-calypso/pull/40743#pullrequestreview-387115515 and detailed in https://github.com/Automattic/wp-calypso/pull/40743#issuecomment-608350809 
- [ ] Vertical suggestions dropdown flicker mentioned in https://github.com/Automattic/wp-calypso/pull/40743#issuecomment-608350809 

#### Testing instructions

Please visit [here](https://hash-9183e9931350194d95486f280bef00a6673e0544.calypso.live/gutenboarding), test against each of the issues mentioned above and check whatever passes. 
