### PR TITLE
Gutenboarding: Change section uri component

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -52,6 +52,7 @@ import SocialLoginForm from './social';
 import { localizeUrl } from 'lib/i18n-utils';
 import TextControl from 'extensions/woocommerce/components/text-control';
 import { sendEmailLogin } from 'state/auth/actions';
+import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
 
 export class LoginForm extends Component {
 	static propTypes = {
@@ -473,7 +474,7 @@ export class LoginForm extends Component {
 		}
 
 		if ( isGutenboarding ) {
-			signupUrl = '/gutenboarding' + langFragment;
+			signupUrl = `/${ GUTENBOARDING_BASE_NAME }` + langFragment;
 		}
 
 		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {

--- a/client/landing/gutenboarding/basename.json
+++ b/client/landing/gutenboarding/basename.json
@@ -1,0 +1,1 @@
+"gutenboarding"

--- a/client/landing/gutenboarding/basename.json
+++ b/client/landing/gutenboarding/basename.json
@@ -1,1 +1,1 @@
-"gutenboarding"
+"new"

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -17,6 +17,7 @@ import { useLangRouteParam, usePath, Step, useCurrentStep } from '../../path';
 import ModalSubmitButton from '../modal-submit-button';
 import './style.scss';
 import SignupFormHeader from './header';
+import GUTENBOARDING_BASE_NAME from '../../basename.json';
 
 // TODO: deploy this change to @types/wordpress__element
 declare module '@wordpress/element' {
@@ -105,12 +106,12 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 
 	const langFragment = lang ? `/${ lang }` : '';
 	const loginRedirectUrl = encodeURIComponent(
-		`${ window.location.origin }/gutenboarding${ makePath( Step.CreateSite ) }?new`
+		`${ window.location.origin }/${ GUTENBOARDING_BASE_NAME }${ makePath( Step.CreateSite ) }?new`
 	);
 	const signupUrl = encodeURIComponent(
-		`/gutenboarding${ makePath( Step[ currentStep ] ) }?signup`
+		`/${ GUTENBOARDING_BASE_NAME }${ makePath( Step[ currentStep ] ) }?signup`
 	);
-	const loginUrl = `/log-in/gutenboarding${ langFragment }?redirect_to=${ loginRedirectUrl }&signup_url=${ signupUrl }`;
+	const loginUrl = `/log-in/${ GUTENBOARDING_BASE_NAME }${ langFragment }?redirect_to=${ loginRedirectUrl }&signup_url=${ signupUrl }`;
 
 	return (
 		<Modal

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -22,6 +22,7 @@ import Header from './components/header';
 import { name, settings } from './onboarding-block';
 import './style.scss';
 import { fontPairings, getFontTitle } from './constants';
+import GUTENARDING_BASE_NAME from './basename.json';
 
 registerBlockType( name, settings );
 
@@ -76,7 +77,7 @@ export function Gutenboard() {
 	} = useHistory();
 
 	useEffect( () => {
-		recordTracksPageViewWithPageParams( `/gutenboarding${ pathname }` );
+		recordTracksPageViewWithPageParams( `/${ GUTENARDING_BASE_NAME }${ pathname }` );
 	}, [ pathname ] );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -48,11 +48,25 @@ interface AppWindow extends Window {
 }
 declare const window: AppWindow;
 
+/**
+ * Handle redirects from development phase
+ * TODO: Remove after a few months. See section definition as well.
+ */
+const DEVELOPMENT_BASENAME = '/gutenboarding';
+
 window.AppBoot = async () => {
 	if ( ! config.isEnabled( 'gutenboarding' ) ) {
 		window.location.href = '/';
 		return;
 	}
+
+	if ( window.location.pathname.startsWith( DEVELOPMENT_BASENAME ) ) {
+		const url = new URL( window.location.href );
+		url.pathname = GUTENBOARDING_BASE_NAME + url.pathname.substring( DEVELOPMENT_BASENAME.length );
+		window.location.replace( url.toString() );
+		return;
+	}
+
 	setupWpDataDebug();
 	// User is left undefined here because the user account will not be created
 	// until after the user has completed the gutenboarding flow.

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -16,6 +16,7 @@ import { initializeAnalytics } from '@automattic/calypso-analytics';
 /**
  * Internal dependencies
  */
+import GUTENBOARDING_BASE_NAME from './basename.json';
 import { Gutenboard } from './gutenboard';
 import { setupWpDataDebug } from './devtools';
 import accessibleFocus from 'lib/accessible-focus';
@@ -74,7 +75,7 @@ window.AppBoot = async () => {
 
 	ReactDom.render(
 		<I18nProvider locale={ locale }>
-			<BrowserRouter basename="gutenboarding">
+			<BrowserRouter basename={ GUTENBOARDING_BASE_NAME }>
 				<Switch>
 					<Route exact path={ path }>
 						<Gutenboard />

--- a/client/landing/gutenboarding/section.ts
+++ b/client/landing/gutenboarding/section.ts
@@ -1,6 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import GUTENBOARDING_BASE_NAME from './basename.json';
+
 export const GUTENBOARDING_SECTION_DEFINITION = {
 	name: 'gutenboarding',
-	paths: [ '/gutenboarding' ],
+	paths: [ `/${ GUTENBOARDING_BASE_NAME }` ],
 	module: 'gutenboarding',
 	secondary: false,
 	group: 'gutenboarding',

--- a/client/landing/gutenboarding/section.ts
+++ b/client/landing/gutenboarding/section.ts
@@ -5,7 +5,10 @@ import GUTENBOARDING_BASE_NAME from './basename.json';
 
 export const GUTENBOARDING_SECTION_DEFINITION = {
 	name: 'gutenboarding',
-	paths: [ `/${ GUTENBOARDING_BASE_NAME }` ],
+	paths: [
+		`/${ GUTENBOARDING_BASE_NAME }`,
+		`/gutenboarding` /* Development path, maintained for redirection */,
+	],
 	module: 'gutenboarding',
 	secondary: false,
 	group: 'gutenboarding',

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -22,6 +22,7 @@ import getCurrentQueryArguments from 'state/selectors/get-current-query-argument
 import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import GdprBanner from 'blocks/gdpr-banner';
+import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
 
 /**
  * Style dependencies
@@ -139,7 +140,7 @@ export default connect( state => {
 	const section = getSection( state );
 	const currentRoute = getCurrentRoute( state );
 	const isJetpackLogin = startsWith( currentRoute, '/log-in/jetpack' );
-	const isGutenboardingLogin = startsWith( currentRoute, '/log-in/gutenboarding' );
+	const isGutenboardingLogin = startsWith( currentRoute, `/log-in/${ GUTENBOARDING_BASE_NAME }` );
 	const noMasterbarForRoute = isJetpackLogin || isGutenboardingLogin;
 	const isPopup = '1' === get( getCurrentQueryArguments( state ), 'is_popup' );
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { addQueryArgs } from 'lib/url';
 import { addLocaleToPath, localizeUrl } from 'lib/i18n-utils';
 import config, { isEnabled } from 'config';
+import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
 
 export function login( {
 	isJetpack,
@@ -32,7 +32,7 @@ export function login( {
 		} else if ( twoFactorAuthType && isJetpack ) {
 			url += '/jetpack/' + twoFactorAuthType;
 		} else if ( twoFactorAuthType && isGutenboarding ) {
-			url += '/gutenboarding/' + twoFactorAuthType;
+			url += `/${ GUTENBOARDING_BASE_NAME }/` + twoFactorAuthType;
 		} else if ( twoFactorAuthType ) {
 			url += '/' + twoFactorAuthType;
 		} else if ( socialConnect ) {
@@ -40,7 +40,7 @@ export function login( {
 		} else if ( isJetpack ) {
 			url += '/jetpack';
 		} else if ( isGutenboarding ) {
-			url += '/gutenboarding';
+			url += `/${ GUTENBOARDING_BASE_NAME }`;
 		} else if ( useMagicLink ) {
 			url += '/link';
 		}

--- a/client/lib/paths/login/test/__snapshots__/index.js.snap
+++ b/client/lib/paths/login/test/__snapshots__/index.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`index #login() should return the login url for Gutenboarding specific login 1`] = `"/log-in/gutenboarding"`;

--- a/client/lib/paths/login/test/__snapshots__/index.js.snap
+++ b/client/lib/paths/login/test/__snapshots__/index.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`index #login() should return the login url for Gutenboarding specific login 1`] = `"/log-in/gutenboarding"`;
+exports[`index #login() should return the login url for Gutenboarding specific login 1`] = `"/log-in/new"`;

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -76,7 +76,7 @@ describe( 'index', () => {
 
 		test( 'should return the login url for Gutenboarding specific login', () => {
 			const url = login( { isNative: true, isGutenboarding: true } );
-			expect( url ).toEqual( '/log-in/gutenboarding' );
+			expect( url ).toMatchSnapshot();
 		} );
 
 		test( 'should return the login url with WooCommerce from handler', () => {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -16,6 +16,7 @@ import MagicLogin from './magic-login';
 import WPLogin from './wp-login';
 import { fetchOAuth2ClientData } from 'state/oauth2-clients/actions';
 import { getCurrentUser, getCurrentUserLocale } from 'state/current-user/selectors';
+import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
 
 const enhanceContextWithLogin = context => {
 	const {
@@ -33,7 +34,7 @@ const enhanceContextWithLogin = context => {
 	context.primary = (
 		<WPLogin
 			isJetpack={ isJetpack === 'jetpack' }
-			isGutenboarding={ isGutenboarding === 'gutenboarding' }
+			isGutenboarding={ isGutenboarding === GUTENBOARDING_BASE_NAME }
 			path={ path }
 			twoFactorAuthType={ twoFactorAuthType }
 			socialService={ socialService }

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -20,6 +20,7 @@ import { setUpLocale, setSection, makeLayoutMiddleware } from 'controller/shared
 import { redirectLoggedIn } from 'controller/web-util';
 import LayoutLoggedOut from 'layout/logged-out';
 import { getLanguageRouteParam } from 'lib/i18n-utils';
+import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
 
 export const LOGIN_SECTION_DEFINITION = {
 	name: 'login',
@@ -57,7 +58,7 @@ export default router => {
 			[
 				`/log-in/link/${ lang }`,
 				`/log-in/jetpack/link/${ lang }`,
-				`/log-in/gutenboarding/link/${ lang }`,
+				`/log-in/${ GUTENBOARDING_BASE_NAME }/link/${ lang }`,
 			],
 			setUpLocale,
 			setSection( LOGIN_SECTION_DEFINITION ),
@@ -75,8 +76,8 @@ export default router => {
 				`/log-in/:socialService(google|apple)/callback/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/${ lang }`,
 				`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
-				`/log-in/:isGutenboarding(gutenboarding)/${ lang }`,
-				`/log-in/:isGutenboarding(gutenboarding)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
+				`/log-in/:isGutenboarding(${ GUTENBOARDING_BASE_NAME })/${ lang }`,
+				`/log-in/:isGutenboarding(${ GUTENBOARDING_BASE_NAME })/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 				`/log-in/${ lang }`,
 			],
 			redirectJetpack,

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -33,6 +33,7 @@ import JetpackHeader from 'components/jetpack-header';
 import RequestLoginEmailForm from './request-login-email-form';
 import GlobalNotices from 'components/global-notices';
 import Gridicon from 'components/gridicon';
+import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
 
 /**
  * Style dependencies
@@ -168,7 +169,9 @@ const mapState = state => ( {
 	query: getCurrentQueryArguments( state ),
 	showCheckYourEmail: getMagicLoginCurrentView( state ) === CHECK_YOUR_EMAIL_PAGE,
 	isJetpackLogin: getCurrentRoute( state ) === '/log-in/jetpack/link',
-	isGutenboardingLogin: getCurrentRoute( state )?.startsWith( '/log-in/gutenboarding/link' ),
+	isGutenboardingLogin: getCurrentRoute( state )?.startsWith(
+		`/log-in/${ GUTENBOARDING_BASE_NAME }/link`
+	),
 } );
 
 const mapDispatch = {

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -27,6 +27,7 @@ import { login } from 'lib/paths';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import { resetMagicLoginRequestForm } from 'state/login/magic-login/actions';
 import { isDomainConnectAuthorizePath } from 'lib/domains/utils';
+import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
 
 export class LoginLinks extends React.Component {
 	static propTypes = {
@@ -83,7 +84,7 @@ export class LoginLinks extends React.Component {
 		if ( this.props.currentRoute === '/log-in/jetpack' ) {
 			loginParameters.twoFactorAuthType = 'jetpack/link';
 		} else if ( this.props.isGutenboarding ) {
-			loginParameters.twoFactorAuthType = 'gutenboarding/link';
+			loginParameters.twoFactorAuthType = `${ GUTENBOARDING_BASE_NAME }/link`;
 		}
 
 		page( login( loginParameters ) );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -55,6 +55,7 @@ import { logSectionResponse } from './analytics';
 import analytics from 'server/lib/analytics';
 import { getLanguage, filterLanguageRevisions } from 'lib/i18n-utils';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
+import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
 import { GUTENBOARDING_SECTION_DEFINITION } from 'landing/gutenboarding/section';
 
 const debug = debugFactory( 'calypso:pages' );
@@ -860,7 +861,11 @@ module.exports = function() {
 	handleSectionPath( LOGIN_SECTION_DEFINITION, '/log-in', 'entry-login' );
 	loginRouter( serverRouter( app, setUpRoute, null ) );
 
-	handleSectionPath( GUTENBOARDING_SECTION_DEFINITION, '/gutenboarding', 'entry-gutenboarding' );
+	handleSectionPath(
+		GUTENBOARDING_SECTION_DEFINITION,
+		`/${ GUTENBOARDING_BASE_NAME }`,
+		'entry-gutenboarding'
+	);
 
 	// This is used to log to tracks Content Security Policy violation reports sent by browsers
 	app.post(

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -867,6 +867,10 @@ module.exports = function() {
 		'entry-gutenboarding'
 	);
 
+	// Handle redirection from development basename
+	// TODO: Remove after a few months
+	handleSectionPath( GUTENBOARDING_SECTION_DEFINITION, `/gutenboarding`, 'entry-gutenboarding' );
+
 	// This is used to log to tracks Content Security Policy violation reports sent by browsers
 	app.post(
 		'/cspreport',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the section base of `/gutenboarding` to be something else!

3fe4f84 makes it so [`/party-time-best-onboard-yay`](https://calypso.live/party-time-best-onboard-yay?branch=gutenboarding/not-gutenboarding) should replace the base name with a single change.

Using a single JSON file should make this easily modifiable across webpack/sections/entrypoints/everywhere without having much impact on the bundle size 🤞

Another alternative may be to add a constant via webpack define plugin.

TODO
- [x] Change the basename to its final form

#### Testing instructions

* [`/new`](https://calypso.live/new?branch=gutenboarding/not-gutenboarding) works!
* [`/log-in/new`](https://calypso.live/new?branch=gutenboarding/not-gutenboarding) works (logged in and logged out)!
* [`/gutenboarding`](https://calypso.live/new?branch=gutenboarding/not-gutenboarding) redirects to `/new` 💡 
* Try login, signup, the entire flow.
