### PR TITLE
Gutenboarding: hide verticals support in previews behind a flag

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -11,6 +11,7 @@ import { useSelect } from '@wordpress/data';
 import { STORE_KEY } from '../../stores/onboard';
 import * as T from './types';
 import { useLangRouteParam } from '../../path';
+import { isEnabled } from 'config';
 
 type Design = import('../../stores/onboard/types').Design;
 type Font = import('../../constants').Font;
@@ -39,15 +40,19 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 				const templateUrl = `https://public-api.wordpress.com/rest/v1/template/demo/${ encodeURIComponent(
 					selectedDesign.theme
 				) }/${ encodeURIComponent( selectedDesign.template ) }/`;
-				const url = addQueryArgs( templateUrl, {
+				let url = addQueryArgs( templateUrl, {
 					language: language,
-					vertical: siteVertical?.label,
 					site_title: siteTitle,
 					...( selectedFonts && {
 						font_headings: selectedFonts.headings,
 						font_base: selectedFonts.base,
 					} ),
 				} );
+				if ( isEnabled( 'gutenboarding/style-preview-verticals' ) ) {
+					url = addQueryArgs( url, {
+						vertical: siteVertical?.label,
+					} );
+				}
 				let resp;
 
 				try {

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -47,6 +47,7 @@
 		"gutenboarding": true,
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview": true,
+		"gutenboarding/style-preview-verticals": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
_2 mins review._ 

This is to fix the Bowen theme preview. 

#### Changes proposed in this Pull Request

This PR hides sending verticals in the preview page behind a flag (`gutenboarding/style-preview-verticals`). 

#### Testing instructions

Go to `gutenboarding/style` after you select Bowen theme. You should see it fully-rendered.

Fixes p1586180166028500-slack-gutenboarding