### PR TITLE
Gutenboarding: update domain flow

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -49,7 +49,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 
 	const handlePaidDomainSelect = ( selectedDomain: DomainSuggestion ) => {
 		setDomainPopoverVisibility( false );
-		onDomainSelect( selectedDomain );
 		onDomainPurchase( selectedDomain );
 	};
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -263,7 +263,9 @@ export default connect( state => {
 	const oauth2Client = getCurrentOAuth2Client( state );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
-	const isFrankenflow = startsWith( currentRoute, '/start/frankenflow' );
+	const isFrankenflow =
+		startsWith( currentRoute, '/start/frankenflow' ) ||
+		startsWith( currentRoute, '/start/prelaunch' );
 
 	return {
 		masterbarIsHidden:

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -57,7 +57,7 @@ class CheckoutContainer extends React.Component {
 					<Button
 						borderless
 						className="navigation-link back"
-						onClick={ () => window.history.go( -2 ) } // going back to signup flow and skipping '/launch' step
+						onClick={ () => window.history.go( this.props.isGutenboardingCreate ? -1 : -2 ) } // going back to signup flow and skipping '/launch' step
 					>
 						<Gridicon icon="arrow-left" size={ 18 } />
 						{ this.props.translate( 'Back' ) }

--- a/client/my-sites/checkout/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout/checkout-system-decider.js
@@ -32,6 +32,7 @@ export default function CheckoutSystemDecider( {
 	couponCode,
 	isComingFromSignup,
 	isComingFromGutenboarding,
+	isGutenboardingCreate,
 	plan,
 	selectedSite,
 	reduxStore,
@@ -91,6 +92,7 @@ export default function CheckoutSystemDecider( {
 			couponCode={ couponCode }
 			isComingFromSignup={ isComingFromSignup }
 			isComingFromGutenboarding={ isComingFromGutenboarding }
+			isGutenboardingCreate={ isGutenboardingCreate }
 			plan={ plan }
 			selectedSite={ selectedSite }
 			reduxStore={ reduxStore }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -63,6 +63,7 @@ export function checkout( context, next ) {
 				couponCode={ couponCode }
 				isComingFromSignup={ !! context.query.signup }
 				isComingFromGutenboarding={ !! context.query.preLaunch }
+				isGutenboardingCreate={ !! context.query.isGutenboardingCreate }
 				plan={ plan }
 				selectedSite={ selectedSite }
 				reduxStore={ context.store }

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -17,6 +17,7 @@ export function generateFlows( {
 	getLaunchDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
+	getPreLaunchEditorDestination = noop,
 } = {} ) {
 	const flows = {
 		account: {
@@ -349,6 +350,17 @@ export function generateFlows( {
 			description: 'Frankenflow launch for a site created from Gutenboarding',
 			lastModified: '2020-01-22',
 			pageTitle: translate( 'Launch your site' ),
+			providesDependenciesInQuery: [ 'siteSlug' ],
+		};
+	}
+
+	if ( isEnabled( 'gutenboarding' ) ) {
+		flows.prelaunch = {
+			steps: [ 'plans-with-domain' ],
+			destination: getPreLaunchEditorDestination,
+			description: 'Gutenboarding flow for creating a site with a paid domain',
+			lastModified: '2020-04-06',
+			pageTitle: translate( 'Get a domain for your site' ),
 			providesDependenciesInQuery: [ 'siteSlug' ],
 		};
 	}

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -19,6 +19,7 @@ function getCheckoutUrl( dependencies ) {
 		{
 			signup: 1,
 			...( dependencies.isPreLaunch && { preLaunch: 1 } ),
+			...( dependencies.isGutenboardingCreate && { isGutenboardingCreate: 1 } ),
 		},
 		`/checkout/${ dependencies.siteSlug }`
 	);
@@ -74,6 +75,10 @@ function getEditorDestination( dependencies ) {
 	return `/block-editor/page/${ dependencies.siteSlug }/home`;
 }
 
+function getPreLaunchEditorDestination( dependencies ) {
+	return `/block-editor/page/${ dependencies.siteSlug }/home?is-gutenboarding`;
+}
+
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
@@ -82,6 +87,7 @@ const flows = generateFlows( {
 	getThankYouNoSiteDestination,
 	getChecklistThemeDestination,
 	getEditorDestination,
+	getPreLaunchEditorDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -28,6 +28,7 @@ const stepNameToModuleName = {
 	'plans-personal': 'plans',
 	'plans-premium': 'plans',
 	'plans-site-selected': 'plans',
+	'plans-with-domain': 'plans',
 	'plans-store-nux': 'plans-atomic-store',
 	site: 'site',
 	'rebrand-cities-welcome': 'rebrand-cities-welcome',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -257,6 +257,21 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 		},
 
+		'plans-with-domain': {
+			stepName: 'plans-with-domain',
+			apiRequestFunction: addPlanToCart,
+			fulfilledStepCallback: isPlanFulfilled,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem', 'isPreLaunch', 'isGutenboardingCreate' ],
+			props: {
+				headerText: i18n.translate( 'Getting ready to launch your website' ),
+				subHeaderText: i18n.translate( "Pick a plan that's right for you. Upgrade as you grow." ),
+				fallbackHeaderText: i18n.translate(
+					"Almost there, pick a plan that's right for you. Upgrade as you grow."
+				),
+			},
+		},
+
 		domains: {
 			stepName: 'domains',
 			apiRequestFunction: createSiteWithCart,

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -71,7 +71,11 @@ export class PlansStep extends Component {
 			...additionalStepData,
 		};
 
-		this.props.submitSignupStep( step, { cartItem } );
+		this.props.submitSignupStep( step, {
+			cartItem,
+			// dependencies used only for 'plans-with-domain' step in Gutenboarding pre-launch flow
+			...( flowName === 'prelaunch' && { isPreLaunch: true, isGutenboardingCreate: true } ),
+		} );
 		this.props.goToNextStep();
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* change domain flow to the one described in #40284
* fix redirect to checkout sometimes now working as expected after creating the site

#### Testing instructions

* Go to /gutenboarding 
* Fill in the site name, click on the Domain Picker and select a TLD domain
* Select a design and create a site
* You should see the plans grid on a white background and you could pick one or choose to create a free site.
* Then the /checkout page should also be on a white background and the cart should contain the selected TLD domain and the selected plan. Back button in top-left corner should redirect back to plans selection
* Regression testing for existing signup flows that include /plans and frankenflow launch flow (pressing the _Launch_ button in editor)

Fixes part of #40284
