### PR TITLE
Add basic Jetpack Cloud Activity Log route and placeholder page

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -26,7 +26,7 @@ import {
 	expandMySitesSidebarSection as expandSection,
 	toggleMySitesSidebarSection as toggleSection,
 } from 'state/my-sites/sidebar/actions';
-import { backupMainPath } from 'landing/jetpack-cloud/sections/backups/paths';
+import { backupMainPath, backupActivityPath } from 'landing/jetpack-cloud/sections/backups/paths';
 
 // Lowercase because these are used as keys for sidebar state.
 export const SIDEBAR_SECTION_SCAN = 'scan';
@@ -89,16 +89,19 @@ class JetpackCloudSidebar extends Component {
 									} ) }
 									link={ backupMainPath( selectedSiteSlug ) }
 									onNavigate={ this.onNavigate }
-									selected={ itemLinkMatches( backupMainPath(), this.props.path ) }
+									selected={
+										itemLinkMatches( backupMainPath(), this.props.path ) &&
+										! itemLinkMatches( backupActivityPath(), this.props.path )
+									}
 								/>
 								<SidebarItem
 									expandSection={ this.expandBackupSection }
 									label={ translate( 'Activity Log', {
 										comment: 'Jetpack Cloud / Activity Log status sidebar navigation item',
 									} ) }
-									link={ selectedSiteSlug ? `/activity/${ selectedSiteSlug }` : '/activity' }
+									link={ backupActivityPath( selectedSiteSlug ) }
 									onNavigate={ this.onNavigate }
-									selected={ itemLinkMatches( '/activity', this.props.path ) }
+									selected={ itemLinkMatches( backupActivityPath(), this.props.path ) }
 								/>
 							</ul>
 						</ExpandableSidebarMenu>

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+const BackupActivityLogPage: FunctionComponent = () => {
+	return <div>{ 'Welcome to activity log.' }</div>;
+};
+
+export default BackupActivityLogPage;

--- a/client/landing/jetpack-cloud/sections/backups/controller.js
+++ b/client/landing/jetpack-cloud/sections/backups/controller.js
@@ -10,6 +10,7 @@ import { SiteOffsetProvider } from 'landing/jetpack-cloud/components/site-offset
 import BackupDetailPage from './detail';
 import BackupRewindFlow, { RewindFlowPurpose } from './rewind-flow';
 import BackupsPage from './main';
+import BackupActivityLogPage from './backup-activity-log';
 
 export function wrapInSiteOffsetProvider( context, next ) {
 	context.primary = (
@@ -21,6 +22,12 @@ export function wrapInSiteOffsetProvider( context, next ) {
 /* handles /backups/:site, see `backupMainPath` */
 export function backups( context, next ) {
 	context.primary = <BackupsPage />;
+	next();
+}
+
+/* handles /backups/activity/:site, see `backupsActivityPath` */
+export function backupActivity( context, next ) {
+	context.primary = <BackupActivityLogPage />;
 	next();
 }
 

--- a/client/landing/jetpack-cloud/sections/backups/index.js
+++ b/client/landing/jetpack-cloud/sections/backups/index.js
@@ -12,15 +12,35 @@ import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import {
 	backups,
+	backupActivity,
 	backupDetail,
 	backupDownload,
 	backupRestore,
 	wrapInSiteOffsetProvider,
 } from 'landing/jetpack-cloud/sections/backups/controller';
-import { backupMainPath, backupRestorePath, backupDownloadPath, backupDetailPath } from './paths';
+import {
+	backupMainPath,
+	backupActivityPath,
+	backupRestorePath,
+	backupDownloadPath,
+	backupDetailPath,
+} from './paths';
 
 export default function() {
 	if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
+		/* handles /backups/activity, see `backupActivityPath` */
+		page( backupActivityPath(), siteSelection, sites, makeLayout, clientRender );
+
+		/* handles /backups/activity/:site, see `backupActivityPath` */
+		page(
+			backupActivityPath( ':site' ),
+			siteSelection,
+			navigation,
+			backupActivity,
+			makeLayout,
+			clientRender
+		);
+
 		/* handles /backups/:site/detail/:backupId, see `backupDetailPath` */
 		page(
 			backupDetailPath( ':site', ':backupId' ),

--- a/client/landing/jetpack-cloud/sections/backups/index.js
+++ b/client/landing/jetpack-cloud/sections/backups/index.js
@@ -37,6 +37,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			backupActivity,
+			wrapInSiteOffsetProvider,
 			makeLayout,
 			clientRender
 		);

--- a/client/landing/jetpack-cloud/sections/backups/paths.ts
+++ b/client/landing/jetpack-cloud/sections/backups/paths.ts
@@ -1,6 +1,9 @@
 export const backupMainPath = ( siteName?: string | null ) =>
 	siteName ? `/backups/${ siteName }` : '/backups';
 
+export const backupActivityPath = ( siteName?: string | null ) =>
+	siteName ? `/backups/activity/${ siteName }` : '/backups/activity';
+
 const backupSubSectionPath = (
 	siteName: string,
 	subSection: string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add basic route support for `/backups/activity` and placeholder page

#### Testing instructions

1. Navigate to `/backups/activity`
2. Verify site selector appears, you are taken to placeholder page `/backups/activity/:siteSlug`
3. Reload page, verify route with site slug works
4. From a different section ( scan, backup status, etc. ) verify that Backup > Activity Log in the sidebar works as well
