### PR TITLE
Revert "Gutenboarding: hide verticals support in previews behind a flag"

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/preview.tsx
@@ -11,7 +11,6 @@ import { useSelect } from '@wordpress/data';
 import { STORE_KEY } from '../../stores/onboard';
 import * as T from './types';
 import { useLangRouteParam } from '../../path';
-import { isEnabled } from 'config';
 
 type Design = import('../../stores/onboard/types').Design;
 type Font = import('../../constants').Font;
@@ -40,19 +39,15 @@ const Preview: React.FunctionComponent< Props > = ( { viewport } ) => {
 				const templateUrl = `https://public-api.wordpress.com/rest/v1/template/demo/${ encodeURIComponent(
 					selectedDesign.theme
 				) }/${ encodeURIComponent( selectedDesign.template ) }/`;
-				let url = addQueryArgs( templateUrl, {
+				const url = addQueryArgs( templateUrl, {
 					language: language,
+					vertical: siteVertical?.label,
 					site_title: siteTitle,
 					...( selectedFonts && {
 						font_headings: selectedFonts.headings,
 						font_base: selectedFonts.base,
 					} ),
 				} );
-				if ( isEnabled( 'gutenboarding/style-preview-verticals' ) ) {
-					url = addQueryArgs( url, {
-						vertical: siteVertical?.label,
-					} );
-				}
 				let resp;
 
 				try {

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -47,7 +47,6 @@
 		"gutenboarding": true,
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview": true,
-		"gutenboarding/style-preview-verticals": false,
 		"happychat": true,
 		"help": true,
 		"help/courses": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#40812