### PR TITLE
Gutenboarding: Drop onDomainPurchase and friends

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -26,7 +26,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	children,
 	className,
 	onDomainSelect,
-	onDomainPurchase,
 	currentDomain,
 	...buttonProps
 } ) => {
@@ -40,15 +39,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 			return;
 		}
 		setDomainPopoverVisibility( false );
-	};
-
-	const handleDomainSelect = ( selectedDomain: DomainSuggestion ) => {
-		onDomainSelect( selectedDomain );
-	};
-
-	const handlePaidDomainSelect = ( selectedDomain: DomainSuggestion ) => {
-		onDomainSelect( selectedDomain );
-		onDomainPurchase( selectedDomain );
 	};
 
 	return (
@@ -82,8 +72,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 						<DomainPicker
 							currentDomain={ currentDomain }
 							onClose={ handleClose }
-							onDomainPurchase={ handlePaidDomainSelect }
-							onDomainSelect={ handleDomainSelect }
+							onDomainSelect={ onDomainSelect }
 						/>
 					</Popover>
 				</div>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -40,13 +40,6 @@ export interface Props {
 	onDomainSelect: ( domainSuggestion: DomainSuggestion ) => void;
 
 	/**
-	 * Callback that will be invoked when a paid domain is selected.
-	 *
-	 * @param domainSuggestion The selected domain.
-	 */
-	onDomainPurchase: ( domainSuggestion: DomainSuggestion ) => void;
-
-	/**
 	 * Callback that will be invoked when a close button is clicked
 	 */
 	onClose: () => void;

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -72,18 +72,11 @@ const Header: FunctionComponent = () => {
 
 	const newSite = useSelect( select => select( SITE_STORE ).getNewSite() );
 
-	const { domain, siteTitle, siteWasCreatedForDomainPurchase } = useSelect( select =>
-		select( ONBOARD_STORE ).getState()
-	);
+	const { domain, siteTitle } = useSelect( select => select( ONBOARD_STORE ).getState() );
 
 	const makePath = usePath();
 
-	const {
-		createSite,
-		setDomain,
-		resetOnboardStore,
-		setSiteWasCreatedForDomainPurchase,
-	} = useDispatch( ONBOARD_STORE );
+	const { createSite, setDomain, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	const allSuggestions = useDomainSuggestions( siteTitle );
 	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
@@ -152,16 +145,6 @@ const Header: FunctionComponent = () => {
 		setShowSignupDialog( false );
 	};
 
-	const setFreeDomain = ( selectedDomain: DomainSuggestion ) => {
-		setDomain( selectedDomain );
-		setSiteWasCreatedForDomainPurchase( false );
-	};
-
-	const setPaidDomain = ( selectedDomain: DomainSuggestion ) => {
-		setDomain( selectedDomain );
-		setSiteWasCreatedForDomainPurchase( true );
-	};
-
 	useEffect( () => {
 		if ( newUser && newUser.bearerToken && newUser.username ) {
 			handleCreateSite( newUser.username, newUser.bearerToken );
@@ -171,7 +154,7 @@ const Header: FunctionComponent = () => {
 	useEffect( () => {
 		// isRedirecting check this is needed to make sure we don't overwrite the first window.location.replace() call
 		if ( newSite && ! isRedirecting ) {
-			if ( siteWasCreatedForDomainPurchase ) {
+			if ( ! domain?.is_free ) {
 				// I'd rather not make my own product, but this works.
 				// lib/cart-items helpers did not perform well.
 				const domainProduct = {
@@ -200,7 +183,7 @@ const Header: FunctionComponent = () => {
 			resetOnboardStore();
 			window.location.replace( `/block-editor/page/${ newSite.site_slug }/home?is-gutenboarding` );
 		}
-	}, [ domain, siteWasCreatedForDomainPurchase, newSite, resetOnboardStore, isRedirecting ] );
+	}, [ domain, newSite, resetOnboardStore, isRedirecting ] );
 
 	return (
 		<div
@@ -229,8 +212,7 @@ const Header: FunctionComponent = () => {
 							className="gutenboarding__header-domain-picker-button"
 							disabled={ ! currentDomain }
 							currentDomain={ currentDomain }
-							onDomainSelect={ setFreeDomain }
-							onDomainPurchase={ setPaidDomain }
+							onDomainSelect={ setDomain }
 						>
 							{ domainElement }
 						</DomainPickerButton>

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -67,13 +67,6 @@ export const resetOnboardStore = () => ( {
 	type: 'RESET_ONBOARD_STORE' as const,
 } );
 
-export const setSiteWasCreatedForDomainPurchase = (
-	siteWasCreatedForDomainPurchase: boolean
-) => ( {
-	type: 'SET_SITE_WAS_CREATED_FOR_DOMAIN_PURCHASE' as const,
-	siteWasCreatedForDomainPurchase,
-} );
-
 export function* createSite(
 	username: string,
 	freeDomainSuggestion?: DomainSuggestion,
@@ -128,6 +121,5 @@ export type OnboardAction = ReturnType<
 	| typeof setSelectedDesign
 	| typeof setSiteTitle
 	| typeof setSiteVertical
-	| typeof setSiteWasCreatedForDomainPurchase
 	| typeof togglePageLayout
 >;

--- a/client/landing/gutenboarding/stores/onboard/index.ts
+++ b/client/landing/gutenboarding/stores/onboard/index.ts
@@ -31,7 +31,6 @@ registerStore< State >( STORE_KEY, {
 		'pageLayouts',
 		'selectedDesign',
 		'selectedFonts',
-		'siteWasCreatedForDomainPurchase',
 	],
 } );
 

--- a/client/landing/gutenboarding/stores/onboard/reducer.ts
+++ b/client/landing/gutenboarding/stores/onboard/reducer.ts
@@ -81,22 +81,6 @@ const pageLayouts: Reducer< string[], OnboardAction > = ( state = [], action ) =
 	return state;
 };
 
-const siteWasCreatedForDomainPurchase: Reducer< boolean, OnboardAction > = (
-	state = false,
-	action
-) => {
-	switch ( action.type ) {
-		case 'SET_SITE_WAS_CREATED_FOR_DOMAIN_PURCHASE':
-			return action.siteWasCreatedForDomainPurchase;
-
-		case 'RESET_ONBOARD_STORE':
-			return false;
-
-		default:
-			return state;
-	}
-};
-
 const selectedFonts: Reducer< FontPair | undefined, OnboardAction > = (
 	state = undefined,
 	action
@@ -118,7 +102,6 @@ const reducer = combineReducers( {
 	siteTitle,
 	siteVertical,
 	pageLayouts,
-	siteWasCreatedForDomainPurchase,
 } );
 
 export type State = ReturnType< typeof reducer >;


### PR DESCRIPTION
**Merge only after #40742!**

#### Changes proposed in this Pull Request

Follow-up to #40742.
Removes the `onDomainPurchase` prop from the domain picker, and some related helpers.

This is meant to reconcile #40742 with #40813.

cc @razvanpapadopol 

#### Testing instructions

- http://calypso.localhost:3000/gutenboarding
- Verify that the domain picker works as before.
- Test the entire flow up until site creation, with both a paid and a free domain.