### PR TITLE
Editor e2e: reenable tests and replace Jetpack category by Earn

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -278,31 +278,27 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 				);
 			} );
 
-			// Temporarily disabled
-			//
-			// See #40818
-			//
-			// step( 'Can see the Earn blocks', async function() {
-			// 	const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			// 	await gEditorComponent.openBlockInserterAndSearch( 'earn' );
-			// 	assert.strictEqual(
-			// 		await gEditorComponent.isBlockCategoryPresent( 'Jetpack' ),
-			// 		true,
-			// 		'Earn (Jetpack) blocks are not present'
-			// 	);
-			// 	await gEditorComponent.closeBlockInserter();
-			// } );
+			step( 'Can see the Earn blocks', async function() {
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.openBlockInserterAndSearch( 'earn' );
+				assert.strictEqual(
+					await gEditorComponent.isBlockCategoryPresent( 'Earn' ),
+					true,
+					'Earn (Jetpack) blocks are not present'
+				);
+				await gEditorComponent.closeBlockInserter();
+			} );
 
-			// step( 'Can see the Grow blocks', async function() {
-			// 	const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			// 	await gEditorComponent.openBlockInserterAndSearch( 'grow' );
-			// 	assert.strictEqual(
-			// 		await gEditorComponent.isBlockCategoryPresent( 'Grow' ),
-			// 		true,
-			// 		'Grow (Jetpack) blocks are not present'
-			// 	);
-			// 	await gEditorComponent.closeBlockInserter();
-			// } );
+			step( 'Can see the Grow blocks', async function() {
+				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.openBlockInserterAndSearch( 'grow' );
+				assert.strictEqual(
+					await gEditorComponent.isBlockCategoryPresent( 'Grow' ),
+					true,
+					'Grow (Jetpack) blocks are not present'
+				);
+				await gEditorComponent.closeBlockInserter();
+			} );
 
 			step( 'Can publish and view content', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );


### PR DESCRIPTION

#### Changes proposed in this Pull Request

reenable tests and replace Jetpack category by Earn

See #40818 (and follow-up #40819 where the tests were disabled).

#### Testing instructions

* Do e2e tests pass?


