### PR TITLE
AB test for updated Premium plan bump offer

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,4 +123,13 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
+	showPremiumPlanBump: {
+		datestamp: '20200402',
+		variations: {
+			variantShowPlanBump: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -33,6 +33,7 @@ export default function CheckoutSystemDecider( {
 	isComingFromSignup,
 	isComingFromGutenboarding,
 	isGutenboardingCreate,
+	isComingFromUpsell,
 	plan,
 	selectedSite,
 	reduxStore,
@@ -79,6 +80,7 @@ export default function CheckoutSystemDecider( {
 					feature={ selectedFeature }
 					plan={ plan }
 					cart={ cart }
+					isComingFromUpsell={ isComingFromUpsell }
 				/>
 			</StripeHookProvider>
 		);
@@ -93,6 +95,7 @@ export default function CheckoutSystemDecider( {
 			isComingFromSignup={ isComingFromSignup }
 			isComingFromGutenboarding={ isComingFromGutenboarding }
 			isGutenboardingCreate={ isGutenboardingCreate }
+			isComingFromUpsell={ isComingFromUpsell }
 			plan={ plan }
 			selectedSite={ selectedSite }
 			reduxStore={ reduxStore }

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -76,6 +76,7 @@ class CheckoutContainer extends React.Component {
 			shouldShowCart = true,
 			clearTransaction,
 			isComingFromGutenboarding,
+			isComingFromUpsell,
 		} = this.props;
 
 		const TransactionData = clearTransaction ? CartData : CheckoutData;
@@ -110,7 +111,7 @@ class CheckoutContainer extends React.Component {
 							reduxStore={ reduxStore }
 							redirectTo={ redirectTo }
 							upgradeIntent={ upgradeIntent }
-							hideNudge={ isComingFromGutenboarding }
+							hideNudge={ isComingFromGutenboarding || isComingFromUpsell }
 						>
 							{ this.props.children }
 						</Checkout>

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -356,6 +356,10 @@ export class Checkout extends React.Component {
 		return true;
 	}
 
+	emptyOutCart() {
+		replaceCartWithItems( [] );
+	}
+
 	/**
 	 * Purchases are of the format { [siteId]: [ { productId: ... } ] }
 	 * so we need to flatten them to get a list of purchases
@@ -453,9 +457,9 @@ export class Checkout extends React.Component {
 		return;
 	}
 
-	maybeRedirectToConciergeNudge( pendingOrReceiptId, stepResult ) {
+	maybeRedirectToConciergeNudge( pendingOrReceiptId, stepResult, shouldHideUpsellNudges ) {
 		// Using hideNudge prop will disable any redirect to Nudge
-		if ( this.props.hideNudge ) {
+		if ( this.props.hideNudge || shouldHideUpsellNudges ) {
 			return;
 		}
 
@@ -486,7 +490,7 @@ export class Checkout extends React.Component {
 		}
 	}
 
-	getCheckoutCompleteRedirectPath = () => {
+	getCheckoutCompleteRedirectPath = ( shouldHideUpsellNudges = false, shouldEmptyCart = false ) => {
 		// TODO: Cleanup and simplify this function.
 		// I wouldn't be surprised if it doesn't work as intended in some scenarios.
 		// Especially around the Concierge / Checklist logic.
@@ -579,9 +583,12 @@ export class Checkout extends React.Component {
 			return `${ signupDestination }/${ pendingOrReceiptId }`;
 		}
 
+		shouldEmptyCart && this.emptyOutCart();
+
 		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge(
 			pendingOrReceiptId,
-			stepResult
+			stepResult,
+			shouldHideUpsellNudges
 		);
 		if ( redirectPathForConciergeUpsell ) {
 			return redirectPathForConciergeUpsell;
@@ -607,7 +614,7 @@ export class Checkout extends React.Component {
 		window.location.href = redirectUrl;
 	}
 
-	handleCheckoutCompleteRedirect = () => {
+	handleCheckoutCompleteRedirect = ( shouldHideUpsellNudges = false, shouldEmptyCart = false ) => {
 		let product, purchasedProducts, renewalItem;
 
 		const {
@@ -619,7 +626,10 @@ export class Checkout extends React.Component {
 			translate,
 		} = this.props;
 
-		const redirectPath = this.getCheckoutCompleteRedirectPath();
+		const redirectPath = this.getCheckoutCompleteRedirectPath(
+			shouldHideUpsellNudges,
+			shouldEmptyCart
+		);
 		const destinationFromCookie = retrieveSignupDestination();
 
 		this.props.clearPurchases();

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -94,6 +94,7 @@ import {
 } from 'signup/utils';
 import { isExternal } from 'lib/url';
 import { withLocalizedMoment } from 'components/localized-moment';
+import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -441,7 +442,19 @@ export class Checkout extends React.Component {
 		}
 	}
 
-	maybeRedirectToConciergeNudge( pendingOrReceiptId ) {
+	maybeShowPlanBumpOfferConcierge( receiptId, stepResult ) {
+		const { cart, selectedSiteSlug } = this.props;
+
+		if ( hasPersonalPlan( cart ) && stepResult && isEmpty( stepResult.failed_purchases ) ) {
+			if ( 'variantShowPlanBump' === abtest( 'showPremiumPlanBump' ) ) {
+				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
+			}
+		}
+
+		return;
+	}
+
+	maybeRedirectToConciergeNudge( pendingOrReceiptId, stepResult ) {
 		// Using hideNudge prop will disable any redirect to Nudge
 		if ( this.props.hideNudge ) {
 			return;
@@ -460,6 +473,11 @@ export class Checkout extends React.Component {
 		) {
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
+
+			const upgradePath = this.maybeShowPlanBumpOfferConcierge( pendingOrReceiptId, stepResult );
+			if ( upgradePath ) {
+				return upgradePath;
+			}
 
 			// The conciergeUpsellDial test is used when we need to quickly dial back the volume of concierge sessions
 			// being offered and so sold, to be inline with HE availability.
@@ -563,7 +581,10 @@ export class Checkout extends React.Component {
 			return `${ signupDestination }/${ pendingOrReceiptId }`;
 		}
 
-		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge( pendingOrReceiptId );
+		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge(
+			pendingOrReceiptId,
+			stepResult
+		);
 		if ( redirectPathForConciergeUpsell ) {
 			return redirectPathForConciergeUpsell;
 		}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -84,7 +84,6 @@ import { isRequestingPlans } from 'state/plans/selectors';
 import { isApplePayAvailable } from 'lib/web-payment';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import getPreviousPath from 'state/selectors/get-previous-path.js';
 import config from 'config';
 import { loadTrackingTool } from 'state/analytics/actions';
 import {
@@ -460,7 +459,7 @@ export class Checkout extends React.Component {
 			return;
 		}
 
-		const { cart, selectedSiteSlug, previousRoute } = this.props;
+		const { cart, selectedSiteSlug } = this.props;
 
 		// If the user has upgraded a plan from seeing our upsell (we find this by checking the previous route is /offer-plan-upgrade),
 		// then skip this section so that we do not show further upsells.
@@ -468,8 +467,7 @@ export class Checkout extends React.Component {
 			config.isEnabled( 'upsell/concierge-session' ) &&
 			! hasConciergeSession( cart ) &&
 			! hasJetpackPlan( cart ) &&
-			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
-			! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-plan-upgrade` )
+			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) )
 		) {
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
@@ -939,7 +937,6 @@ export default connect(
 			isPlansListFetching: isRequestingPlans( state ),
 			isSitePlansListFetching: isRequestingSitePlans( state, selectedSiteId ),
 			planSlug: getUpgradePlanSlugFromPath( state, selectedSiteId, props.product ),
-			previousRoute: getPreviousPath( state ),
 			isJetpackNotAtomic:
 				isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ),
 		};

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -356,10 +356,6 @@ export class Checkout extends React.Component {
 		return true;
 	}
 
-	emptyOutCart() {
-		replaceCartWithItems( [] );
-	}
-
 	/**
 	 * Purchases are of the format { [siteId]: [ { productId: ... } ] }
 	 * so we need to flatten them to get a list of purchases
@@ -490,7 +486,7 @@ export class Checkout extends React.Component {
 		}
 	}
 
-	getCheckoutCompleteRedirectPath = ( shouldHideUpsellNudges = false, shouldEmptyCart = false ) => {
+	getCheckoutCompleteRedirectPath = ( shouldHideUpsellNudges = false ) => {
 		// TODO: Cleanup and simplify this function.
 		// I wouldn't be surprised if it doesn't work as intended in some scenarios.
 		// Especially around the Concierge / Checklist logic.
@@ -583,8 +579,6 @@ export class Checkout extends React.Component {
 			return `${ signupDestination }/${ pendingOrReceiptId }`;
 		}
 
-		shouldEmptyCart && this.emptyOutCart();
-
 		const redirectPathForConciergeUpsell = this.maybeRedirectToConciergeNudge(
 			pendingOrReceiptId,
 			stepResult,
@@ -614,7 +608,7 @@ export class Checkout extends React.Component {
 		window.location.href = redirectUrl;
 	}
 
-	handleCheckoutCompleteRedirect = ( shouldHideUpsellNudges = false, shouldEmptyCart = false ) => {
+	handleCheckoutCompleteRedirect = ( shouldHideUpsellNudges = false ) => {
 		let product, purchasedProducts, renewalItem;
 
 		const {
@@ -626,10 +620,7 @@ export class Checkout extends React.Component {
 			translate,
 		} = this.props;
 
-		const redirectPath = this.getCheckoutCompleteRedirectPath(
-			shouldHideUpsellNudges,
-			shouldEmptyCart
-		);
+		const redirectPath = this.getCheckoutCompleteRedirectPath( shouldHideUpsellNudges );
 		const destinationFromCookie = retrieveSignupDestination();
 
 		this.props.clearPurchases();

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -88,6 +88,7 @@ export default function CompositeCheckout( {
 	purchaseId,
 	cart,
 	couponCode: couponCodeFromUrl,
+	isComingFromUpsell,
 } ) {
 	const translate = useTranslate();
 	const isJetpackNotAtomic = useSelector(
@@ -96,6 +97,7 @@ export default function CompositeCheckout( {
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const isLoadingCartSynchronizer =
 		cart && ( ! cart.hasLoadedFromServer || cart.hasPendingServerUpdates );
+	const hideNudge = isComingFromUpsell;
 
 	const getThankYouUrl = useGetThankYouUrl( {
 		siteSlug,
@@ -106,6 +108,7 @@ export default function CompositeCheckout( {
 		isJetpackNotAtomic,
 		product,
 		siteId,
+		hideNudge,
 	} );
 	const reduxDispatch = useDispatch();
 	const recordEvent = useCallback( createAnalyticsEventHandler( reduxDispatch ), [] );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -492,4 +492,23 @@ describe( 'getThankYouPageUrl', () => {
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
+
+	it( 'redirects to thank you page if concierge and jetpack are not in the cart, personal is in the cart, but hideNudge is true', () => {
+		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
+		const cart = {
+			products: [
+				{
+					product_slug: 'personal-bundle',
+				},
+			],
+		};
+		const url = getThankYouPageUrl( {
+			...defaultArgs,
+			siteSlug: 'foo.bar',
+			cart,
+			receiptId: '1234abcd',
+			hideNudge: true,
+		} );
+		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
+	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -492,23 +492,4 @@ describe( 'getThankYouPageUrl', () => {
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
-
-	it( 'redirects to thank you page if concierge and jetpack are not in the cart, personal is in the cart, but the previous route is the nudge', () => {
-		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
-		const cart = {
-			products: [
-				{
-					product_slug: 'personal-bundle',
-				},
-			],
-		};
-		const url = getThankYouPageUrl( {
-			...defaultArgs,
-			siteSlug: 'foo.bar',
-			cart,
-			receiptId: '1234abcd',
-			previousRoute: '/checkout/foo.bar/offer-plan-upgrade/premium/1234abcd',
-		} );
-		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
-	} );
 } );

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -6,6 +6,7 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { defaultRegistry } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
+import { isEmpty } from 'lodash';
 
 const { select } = defaultRegistry;
 const debug = debugFactory( 'calypso:composite-checkout-thank-you' );
@@ -50,6 +51,7 @@ export function getThankYouPageUrl( {
 	isEligibleForSignupDestinationResult,
 	hideNudge,
 	didPurchaseFail,
+	isTransactionResultEmpty,
 } ) {
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
 	// (i.e. on WordPress.com), or a Jetpack or WP.com site's block editor (in wp-admin).
@@ -121,6 +123,7 @@ export function getThankYouPageUrl( {
 		siteSlug,
 		hideNudge,
 		didPurchaseFail,
+		isTransactionResultEmpty,
 	} );
 	if ( redirectPathForConciergeUpsell ) {
 		return redirectPathForConciergeUpsell;
@@ -186,8 +189,9 @@ function maybeShowPlanBumpOfferConcierge( {
 	cart,
 	siteSlug,
 	didPurchaseFail,
+	isTransactionResultEmpty,
 } ) {
-	if ( hasPersonalPlan( cart ) && ! didPurchaseFail ) {
+	if ( hasPersonalPlan( cart ) && ! isTransactionResultEmpty && ! didPurchaseFail ) {
 		if ( 'variantShowPlanBump' === abtest( 'showPremiumPlanBump' ) ) {
 			return `/checkout/${ siteSlug }/offer-plan-upgrade/premium/${ pendingOrReceiptId }`;
 		}
@@ -202,6 +206,7 @@ function getRedirectUrlForConciergeNudge( {
 	siteSlug,
 	hideNudge,
 	didPurchaseFail,
+	isTransactionResultEmpty,
 } ) {
 	if ( hideNudge ) {
 		return;
@@ -223,6 +228,7 @@ function getRedirectUrlForConciergeNudge( {
 			cart,
 			siteSlug,
 			didPurchaseFail,
+			isTransactionResultEmpty,
 		} );
 		if ( upgradePath ) {
 			return upgradePath;
@@ -317,6 +323,7 @@ export function useGetThankYouUrl( {
 		const didPurchaseFail = Object.keys( transactionResult.failed_purchases ?? {} ).length > 0;
 		const receiptId = transactionResult.receipt_id;
 		const orderId = transactionResult.order_id;
+		const isTransactionResultEmpty = isEmpty( transactionResult );
 
 		debug( 'getThankYouUrl called with', {
 			siteSlug,
@@ -332,6 +339,7 @@ export function useGetThankYouUrl( {
 			isEligibleForSignupDestinationResult,
 			hideNudge,
 			didPurchaseFail,
+			isTransactionResultEmpty,
 		} );
 		const url = getThankYouPageUrl( {
 			siteSlug,
@@ -347,6 +355,7 @@ export function useGetThankYouUrl( {
 			isEligibleForSignupDestinationResult,
 			hideNudge,
 			didPurchaseFail,
+			isTransactionResultEmpty,
 		} );
 		debug( 'getThankYouUrl returned', url );
 		return url;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -64,6 +64,7 @@ export function checkout( context, next ) {
 				isComingFromSignup={ !! context.query.signup }
 				isComingFromGutenboarding={ !! context.query.preLaunch }
 				isGutenboardingCreate={ !! context.query.isGutenboardingCreate }
+				isComingFromUpsell={ !! context.query.upgrade }
 				plan={ plan }
 				selectedSite={ selectedSite }
 				reduxStore={ context.store }

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -167,11 +167,11 @@ export class UpsellNudge extends React.Component {
 		}
 	}
 
-	handleClickDecline = ( shouldHideUpsellNudges = true, shouldEmptyCart = false ) => {
+	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
 		const { trackUpsellButtonClick, upsellType, handleCheckoutCompleteRedirect } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
-		handleCheckoutCompleteRedirect( shouldHideUpsellNudges, shouldEmptyCart );
+		handleCheckoutCompleteRedirect( shouldHideUpsellNudges );
 	};
 
 	getCheckoutUrl( url ) {

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -167,11 +167,11 @@ export class UpsellNudge extends React.Component {
 		}
 	}
 
-	handleClickDecline = () => {
+	handleClickDecline = ( shouldHideUpsellNudges = true, shouldEmptyCart = false ) => {
 		const { trackUpsellButtonClick, upsellType, handleCheckoutCompleteRedirect } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
-		handleCheckoutCompleteRedirect();
+		handleCheckoutCompleteRedirect( shouldHideUpsellNudges, shouldEmptyCart );
 	};
 
 	getCheckoutUrl( url ) {

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -35,6 +35,7 @@ import { ConciergeQuickstartSession } from './concierge-quickstart-session';
 import { ConciergeSupportSession } from './concierge-support-session';
 import { PlanUpgradeUpsell } from './plan-upgrade-upsell';
 import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-from-path';
+import { addQueryArgs } from 'lib/url';
 
 /**
  * Style dependencies
@@ -173,6 +174,15 @@ export class UpsellNudge extends React.Component {
 		handleCheckoutCompleteRedirect();
 	};
 
+	getCheckoutUrl( url ) {
+		return addQueryArgs(
+			{
+				upgrade: 1,
+			},
+			url
+		);
+	}
+
 	handleClickAccept = buttonAction => {
 		const { trackUpsellButtonClick, upsellType, siteSlug, upgradeItem } = this.props;
 
@@ -181,8 +191,8 @@ export class UpsellNudge extends React.Component {
 		);
 
 		return siteSlug
-			? page( `/checkout/${ upgradeItem }/${ siteSlug }` )
-			: page( `/checkout/${ upgradeItem }` );
+			? page( this.getCheckoutUrl( `/checkout/${ upgradeItem }/${ siteSlug }` ) )
+			: page( this.getCheckoutUrl( `/checkout/${ upgradeItem }` ) );
 	};
 }
 

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -62,7 +62,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 
 	body() {
 		const { translate, planRawPrice, planDiscountedRawPrice, currencyCode } = this.props;
-		const bundleValue = planRawPrice * 77;
+		const bundleValue = planRawPrice * 14.33;
 		const premiumThemePriceLow = planRawPrice * 0.73;
 		const premiumThemePriceHigh = planRawPrice * 1.045;
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Testing the updated Premium bump offer for qualified Personal plan customers. More info here pNEWy-cIg.

#### Testing instructions
* Make sure that the test plan in https://github.com/Automattic/wp-calypso/pull/38286 passes for all cases. 

* Signup for an account and purchase a Personal plan.
* Put yourself in `control` group for `showPremiumPlanBump` test:
  * After completing payment, verify you're shown the Concierge/Quick Start upsell after purchase.
* Put yourself in `variantShowPlanBump` for `showPremiumPlanBump` test:
  * After completing payment, verify that you are shown the Premium plan bump offer.

**Test in the new checkout flow**
* Where relevant, repeat all the cases listed above for the new checkout flow - proxy through a US IP and assign yourself to `composite` variation of `showCompositeCheckout` test.


Fixes 33-gh-engagement-team. Continues https://github.com/Automattic/wp-calypso/pull/40577