### PR TITLE
Gutenboarding: site creation progress/loading page

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { FunctionComponent } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { Icon } from '@wordpress/components';
 
@@ -11,13 +11,6 @@ import { Icon } from '@wordpress/components';
 import CreateAndRedirect from './create-and-redirect';
 import { useNewQueryParam } from '../../path';
 import './style.scss';
-/**
- * Internal dependencies
- */
-import { ProgressBar } from '@automattic/components';
-
-const CREATE_SITE_PROGRESS_TOTAL = 100;
-const CREATE_SITE_PROGRESS_INTERVAL = 2000;
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const CreateSite: FunctionComponent< {} > = () => {
@@ -26,37 +19,16 @@ const CreateSite: FunctionComponent< {} > = () => {
 	const [ shouldCreateAndRedirect, setCreateAndRedirect ] = React.useState( false );
 
 	// Some very rudimentary progress illusions
-	const [ currentStepIndex, setCurentStepIndex ] = React.useState( 0 );
+
 	const progressSteps = [
-		{
-			title: NO__( 'Building your site' ),
-		},
-		{
-			title: NO__( 'Getting your domain' ),
-		},
-		{
-			title: NO__( 'Applying design' ),
-		},
+		NO__( 'Building your site' ),
+		NO__( 'Getting your domain' ),
+		NO__( 'Applying design' ),
 	];
-	const progressStepFactor = CREATE_SITE_PROGRESS_TOTAL / progressSteps.length;
-	const progressBarValue = ( currentStepIndex + 1 ) * progressStepFactor;
-
-	useEffect( () => {
-		const isProgressComplete = currentStepIndex >= progressSteps.length - 1;
-		if ( ! isProgressComplete ) {
-			setTimeout( () => {
-				setCurentStepIndex( currentStepIndex + 1 );
-			}, CREATE_SITE_PROGRESS_INTERVAL );
-		}
-
-		if ( shouldTriggerCreate && isProgressComplete ) {
-			setCreateAndRedirect( true );
-		}
-	}, [ currentStepIndex ] );
 
 	return (
 		<div className="create-site__background">
-			{ shouldCreateAndRedirect && <CreateAndRedirect /> }
+			{ shouldTriggerCreate && shouldCreateAndRedirect && <CreateAndRedirect /> }
 			<div className="create-site__layout">
 				<div className="create-site__header">
 					<div className="gutenboarding__header-wp-logo">
@@ -64,14 +36,19 @@ const CreateSite: FunctionComponent< {} > = () => {
 					</div>
 				</div>
 				<div className="create-site__content">
-					<h1 className="create-site__title">{ progressSteps[ currentStepIndex ].title }</h1>
 					<div className="create-site__progress">
-						<ProgressBar value={ progressBarValue } total={ CREATE_SITE_PROGRESS_TOTAL } />
+						<div className="create-site__progress-steps">
+							{ progressSteps.map( step => (
+								<div key={ step } className="create-site__progress-step">
+									{ step }
+								</div>
+							) ) }
+						</div>
 					</div>
-					{ /* TODO: interpolate this test in an i18n method with step count args */ }
-					<p className="create-site__progress-text">
-						{ `Step ${ currentStepIndex + 1 } of ${ progressSteps.length }` }
-					</p>
+					<div
+						className="create-site__progress-bar"
+						onAnimationEnd={ () => setCreateAndRedirect( true ) }
+					/>
 				</div>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -11,49 +11,29 @@ import AnimatedPlaceholder from '../animated-placeholder';
 import CreateAndRedirect from './create-and-redirect';
 import { useNewQueryParam } from '../../path';
 import './style.scss';
+import {Icon} from "@wordpress/components";
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const CreateSite: FunctionComponent< {} > = () => {
 	const { __: NO__ } = useI18n();
 	const shouldTriggerCreate = useNewQueryParam();
 
-	const createAndRedirect = shouldTriggerCreate ? <CreateAndRedirect /> : null;
+	//const createAndRedirect = shouldTriggerCreate ? <CreateAndRedirect /> : null;
 
 	return (
 		<div className="create-site__background">
+{/*
 			{ createAndRedirect }
+*/}
 			<div className="create-site__layout">
 				<div className="create-site__header">
-					<div className="create-site__toolbar">
-						<div className="create-site__placeholder create-site__placeholder-site">
-							Placeholder
-						</div>
-					</div>
-					<div className="create-site__settings">
-						<div className="create-site__placeholder create-site__placeholder-button">
-							Placeholder
-						</div>
-						<div className="create-site__placeholder create-site__placeholder-button">
-							Placeholder
-						</div>
-						<div className="create-site__placeholder create-site__placeholder-button">
-							Placeholder
-						</div>
+					<div className="gutenboarding__header-wp-logo">
+						<Icon icon="wordpress-alt" size={ 24 } />
 					</div>
 				</div>
 				<div className="create-site__content">
-					<div className="create-site__placeholder create-site__placeholder-title">Placeholder</div>
 					<div className="create-site__text">
-						<AnimatedPlaceholder
-							isSlow
-							texts={ [
-								NO__( 'We are creating your site.' ),
-								NO__( 'It will be ready in a moment.' ),
-								NO__( 'Almost there, hang on!' ),
-								NO__( 'Your site is almost ready!' ),
-								NO__( 'We are about to finish!' ),
-							] }
-						/>
+						{ NO__( 'Building your site' ) }
 					</div>
 				</div>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -1,30 +1,47 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import { useI18n } from '@automattic/react-i18n';
+import { Icon } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import AnimatedPlaceholder from '../animated-placeholder';
 import CreateAndRedirect from './create-and-redirect';
 import { useNewQueryParam } from '../../path';
 import './style.scss';
-import {Icon} from "@wordpress/components";
+/**
+ * Internal dependencies
+ */
+import { ProgressBar } from '@automattic/components';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const CreateSite: FunctionComponent< {} > = () => {
 	const { __: NO__ } = useI18n();
 	const shouldTriggerCreate = useNewQueryParam();
+	const progressTotal = 100;
+	const progressStepCount = 3;
+	const [ progressComplete, setProgressComplete ] = React.useState( 0 );
+	const [ shouldCreateAndRedirect, setCreateAndRedirect ] = React.useState( false );
 
-	//const createAndRedirect = shouldTriggerCreate ? <CreateAndRedirect /> : null;
+	useEffect( () => {
+		if ( progressComplete < progressTotal ) {
+			setTimeout( () => {
+				const progressFactor = progressTotal / progressStepCount;
+				setProgressComplete( progressComplete + progressFactor );
+			}, 2000 );
+		}
+
+		if ( progressComplete >= progressTotal ) {
+			setCreateAndRedirect( true );
+		}
+	}, [ progressComplete, shouldTriggerCreate ] );
 
 	return (
 		<div className="create-site__background">
-{/*
-			{ createAndRedirect }
-*/}
+			{ /* TODO: uncomment this after dev work :) */ }
+			{ shouldCreateAndRedirect ? <CreateAndRedirect /> : null }
 			<div className="create-site__layout">
 				<div className="create-site__header">
 					<div className="gutenboarding__header-wp-logo">
@@ -32,9 +49,12 @@ const CreateSite: FunctionComponent< {} > = () => {
 					</div>
 				</div>
 				<div className="create-site__content">
-					<div className="create-site__text">
-						{ NO__( 'Building your site' ) }
+					<h1 className="create-site__title">{ NO__( 'Building your site' ) }</h1>
+					<div className="create-site__progress">
+						<ProgressBar value={ progressComplete } total={ progressTotal } />
 					</div>
+					{ /* TODO: interpolate this test with step count args */ }
+					<p className="create-site__progress-text">{ NO__( 'Step 1 of 3' ) }</p>
 				</div>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -40,7 +40,6 @@ const CreateSite: FunctionComponent< {} > = () => {
 
 	return (
 		<div className="create-site__background">
-			{ /* TODO: uncomment this after dev work :) */ }
 			{ shouldCreateAndRedirect ? <CreateAndRedirect /> : null }
 			<div className="create-site__layout">
 				<div className="create-site__header">

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -17,28 +17,42 @@ import './style.scss';
 import { ProgressBar } from '@automattic/components';
 
 const CREATE_SITE_PROGRESS_TOTAL = 100;
-const CREATE_SITE_PROGRESS_STEP_COUNT = 3;
 const CREATE_SITE_PROGRESS_INTERVAL = 2000;
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const CreateSite: FunctionComponent< {} > = () => {
 	const { __: NO__ } = useI18n();
 	const shouldTriggerCreate = useNewQueryParam();
-	const [ progressComplete, setProgressComplete ] = React.useState( 0 );
 	const [ shouldCreateAndRedirect, setCreateAndRedirect ] = React.useState( false );
 
+	// Some very rudimentary progress illusions
+	const [ currentStepIndex, setCurentStepIndex ] = React.useState( 0 );
+	const progressSteps = [
+		{
+			title: NO__( 'Building your site' ),
+		},
+		{
+			title: NO__( 'Getting your domain' ),
+		},
+		{
+			title: NO__( 'Applying design' ),
+		},
+	];
+	const progressStepFactor = CREATE_SITE_PROGRESS_TOTAL / progressSteps.length;
+	const progressBarValue = ( currentStepIndex + 1 ) * progressStepFactor;
+
 	useEffect( () => {
-		if ( progressComplete < CREATE_SITE_PROGRESS_TOTAL ) {
+		const isProgressComplete = currentStepIndex >= progressSteps.length - 1;
+		if ( ! isProgressComplete ) {
 			setTimeout( () => {
-				const progressFactor = CREATE_SITE_PROGRESS_TOTAL / CREATE_SITE_PROGRESS_STEP_COUNT;
-				setProgressComplete( progressComplete + progressFactor );
+				setCurentStepIndex( currentStepIndex + 1 );
 			}, CREATE_SITE_PROGRESS_INTERVAL );
 		}
 
-		if ( shouldTriggerCreate && progressComplete >= CREATE_SITE_PROGRESS_TOTAL ) {
+		if ( shouldTriggerCreate && isProgressComplete ) {
 			setCreateAndRedirect( true );
 		}
-	}, [ progressComplete ] );
+	}, [ currentStepIndex ] );
 
 	return (
 		<div className="create-site__background">
@@ -50,12 +64,14 @@ const CreateSite: FunctionComponent< {} > = () => {
 					</div>
 				</div>
 				<div className="create-site__content">
-					<h1 className="create-site__title">{ NO__( 'Building your site' ) }</h1>
+					<h1 className="create-site__title">{ progressSteps[ currentStepIndex ].title }</h1>
 					<div className="create-site__progress">
-						<ProgressBar value={ progressComplete } total={ CREATE_SITE_PROGRESS_TOTAL } />
+						<ProgressBar value={ progressBarValue } total={ CREATE_SITE_PROGRESS_TOTAL } />
 					</div>
-					{ /* TODO: interpolate this test with step count args */ }
-					<p className="create-site__progress-text">{ NO__( 'Step 1 of 3' ) }</p>
+					{ /* TODO: interpolate this test in an i18n method with step count args */ }
+					<p className="create-site__progress-text">
+						{ `Step ${ currentStepIndex + 1 } of ${ progressSteps.length }` }
+					</p>
 				</div>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -16,31 +16,33 @@ import './style.scss';
  */
 import { ProgressBar } from '@automattic/components';
 
+const CREATE_SITE_PROGRESS_TOTAL = 100;
+const CREATE_SITE_PROGRESS_STEP_COUNT = 3;
+const CREATE_SITE_PROGRESS_INTERVAL = 2000;
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const CreateSite: FunctionComponent< {} > = () => {
 	const { __: NO__ } = useI18n();
 	const shouldTriggerCreate = useNewQueryParam();
-	const progressTotal = 100;
-	const progressStepCount = 3;
 	const [ progressComplete, setProgressComplete ] = React.useState( 0 );
 	const [ shouldCreateAndRedirect, setCreateAndRedirect ] = React.useState( false );
 
 	useEffect( () => {
-		if ( progressComplete < progressTotal ) {
+		if ( progressComplete < CREATE_SITE_PROGRESS_TOTAL ) {
 			setTimeout( () => {
-				const progressFactor = progressTotal / progressStepCount;
+				const progressFactor = CREATE_SITE_PROGRESS_TOTAL / CREATE_SITE_PROGRESS_STEP_COUNT;
 				setProgressComplete( progressComplete + progressFactor );
-			}, 2000 );
+			}, CREATE_SITE_PROGRESS_INTERVAL );
 		}
 
-		if ( progressComplete >= progressTotal ) {
+		if ( shouldTriggerCreate && progressComplete >= CREATE_SITE_PROGRESS_TOTAL ) {
 			setCreateAndRedirect( true );
 		}
-	}, [ progressComplete, shouldTriggerCreate ] );
+	}, [ progressComplete ] );
 
 	return (
 		<div className="create-site__background">
-			{ shouldCreateAndRedirect ? <CreateAndRedirect /> : null }
+			{ shouldCreateAndRedirect && <CreateAndRedirect /> }
 			<div className="create-site__layout">
 				<div className="create-site__header">
 					<div className="gutenboarding__header-wp-logo">
@@ -50,7 +52,7 @@ const CreateSite: FunctionComponent< {} > = () => {
 				<div className="create-site__content">
 					<h1 className="create-site__title">{ NO__( 'Building your site' ) }</h1>
 					<div className="create-site__progress">
-						<ProgressBar value={ progressComplete } total={ progressTotal } />
+						<ProgressBar value={ progressComplete } total={ CREATE_SITE_PROGRESS_TOTAL } />
 					</div>
 					{ /* TODO: interpolate this test with step count args */ }
 					<p className="create-site__progress-text">{ NO__( 'Step 1 of 3' ) }</p>

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -49,6 +49,11 @@ const CreateSite: FunctionComponent< {} > = () => {
 						className="create-site__progress-bar"
 						onAnimationEnd={ () => setCreateAndRedirect( true ) }
 					/>
+					<div className="create-site__progress-numbered-steps">
+						{ progressSteps.map( ( _, index ) => (
+							<p>{ `Step ${ index + 1 } of ${ progressSteps.length }` }</p>
+						) ) }
+					</div>
 				</div>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -1,7 +1,8 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins';
 
-$progress-step-title-height: 50px;
+$progress-step-title-height: 40px;
+$progress-step-number-step-height: 45px;
 $progress-duration: 5s;
 
 .create-site__background {
@@ -35,9 +36,9 @@ $progress-duration: 5s;
 		}
 
 		.create-site__progress-steps {
-			animation: progress-steps $progress-duration ease-out forwards;
+			animation: create-site__progress-steps $progress-duration ease-out forwards;
 
-			@keyframes progress-steps {
+			@keyframes create-site__progress-steps {
 				@for $i from 0 through 3 {
 					#{$i / 3 * 100%} {
 						transform: translateY( -$progress-step-title-height * ( $i - 1 ) );
@@ -53,9 +54,9 @@ $progress-duration: 5s;
 			transform-origin: 0% 0%;
 			margin-top: 1em;
 
-			animation: progress-move #{$progress-duration + 1} ease-out forwards;
+			animation: create-site__progress-bar-progress-move #{$progress-duration + 1} ease-out forwards;
 
-			@keyframes progress-move {
+			@keyframes create-site__progress-bar-progress-move {
 				@for $i from 1 through 3 {
 					#{$i / 3 * 100%} {
 						transform: scaleX( #{$i / 3} );
@@ -70,6 +71,28 @@ $progress-duration: 5s;
 			vertical-align: middle;
 			margin: 0;
 			height: $progress-step-title-height;
+		}
+
+		.create-site__progress-numbered-steps {
+			height: $progress-step-title-height;
+			overflow: hidden;
+			margin-top: 0.7em;
+
+			> p {
+				height: $progress-step-number-step-height;
+				padding: 1em;
+				text-align: center;
+				color: var( --studio-gray-40 );
+
+				animation: create-site__progress-numbered-step-up $progress-duration steps( 2, end )
+					forwards;
+
+				@keyframes create-site__progress-numbered-step-up {
+					to {
+						transform: translateY( -$progress-step-number-step-height * 2 );
+					}
+				}
+			}
 		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -16,54 +16,33 @@
 		align-items: center;
 		height: 56px;
 		padding: 8px;
-
-		.create-site__toolbar,
-		.create-site__settings {
-			display: inline-flex;
-			align-items: center;
-		}
 	}
 
 	.create-site__content {
-		min-height: 70vh;
-		padding-top: 40px;
+		position: absolute;
+		top: 25%;
+		left: 50%;
+		width: 100%;
+		max-width: 540px;
+		transform: translateX( -50% );
 
-		.create-site__text {
-			@include onboarding-font-recoleta;
-			margin-top: 60px;
+		.create-site__title {
+			@include onboarding-heading-text-mobile;
 			text-align: center;
-			font-size: 32px;
-			color: var( --studio-blue-40 );
-			display: flex;
-			justify-content: center;
-
-			.animated-input-placeholder span {
-				color: var( --studio-blue-40 );
-			}
+			margin-bottom: 20px;
 		}
-	}
+		.create-site__progress-text {
+			text-align: center;
+			margin: 20px 0;
+		}
+		// progress bar overrides
+		.progress-bar {
+			height: 7px;
+		}
 
-	.create-site__placeholder {
-		@include placeholder();
-		height: 16px;
-		border-radius: 8px;
-	}
-
-	.create-site__placeholder-site {
-		margin-left: 18px;
-	}
-
-	.create-site__placeholder-button {
-		width: 40px;
-		margin: 0 8px;
-	}
-
-	.create-site__placeholder-title {
-		height: 40px;
-		min-width: 250px;
-		width: 40%;
-		max-width: 600px;
-		margin: 0 58px;
-		border-radius: 20px;
+		.progress-bar,
+		.progress-bar__progress {
+			border-radius: unset;
+		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -8,7 +8,7 @@
 	right: 0;
 	bottom: 0;
 	z-index: 50;
-	background-color: var( --studio-gray-0 );
+	background-color: $white;
 
 	.create-site__header {
 		display: flex;
@@ -16,7 +16,6 @@
 		align-items: center;
 		height: 56px;
 		padding: 8px;
-		background-color: $white;
 
 		.create-site__toolbar,
 		.create-site__settings {

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -4,6 +4,7 @@
 $progress-step-title-height: 40px;
 $progress-step-number-step-height: 45px;
 $progress-duration: 5s;
+$progress-widget-height: 300px;
 
 .create-site__background {
 	position: fixed;
@@ -24,11 +25,14 @@ $progress-duration: 5s;
 
 	.create-site__content {
 		position: absolute;
-		top: 25%;
+		top: calc( 50% - #{$progress-widget-height / 4} );
 		left: 50%;
 		width: 100%;
 		max-width: 540px;
+		height: $progress-widget-height;
 		transform: translateX( -50% );
+		// for mobiles
+		padding: 1em;
 
 		.create-site__progress {
 			height: $progress-step-title-height;

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -37,6 +37,7 @@ $progress-widget-height: 300px;
 		.create-site__progress {
 			height: $progress-step-title-height;
 			overflow: hidden;
+			margin-bottom: 20px;
 		}
 
 		.create-site__progress-steps {

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -2,7 +2,6 @@
 @import '../../mixins';
 
 $progress-step-title-height: 50px;
-$progress-step-title-margin: 40px;
 $progress-duration: 5s;
 
 .create-site__background {

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -1,6 +1,10 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins';
 
+$progress-step-title-height: 50px;
+$progress-step-title-margin: 40px;
+$progress-duration: 5s;
+
 .create-site__background {
 	position: fixed;
 	top: 0;
@@ -26,23 +30,47 @@
 		max-width: 540px;
 		transform: translateX( -50% );
 
-		.create-site__title {
-			@include onboarding-heading-text-mobile;
-			text-align: center;
-			margin-bottom: 20px;
-		}
-		.create-site__progress-text {
-			text-align: center;
-			margin: 20px 0;
-		}
-		// progress bar overrides
-		.progress-bar {
-			height: 7px;
+		.create-site__progress {
+			height: $progress-step-title-height;
+			overflow: hidden;
 		}
 
-		.progress-bar,
-		.progress-bar__progress {
-			border-radius: unset;
+		.create-site__progress-steps {
+			animation: progress-steps $progress-duration ease-out forwards;
+
+			@keyframes progress-steps {
+				@for $i from 0 through 3 {
+					#{$i / 3 * 100%} {
+						transform: translateY( -$progress-step-title-height * ( $i - 1 ) );
+					}
+				}
+			}
+		}
+
+		.create-site__progress-bar {
+			height: 7px;
+			background: var( --mainColor );
+			transform: scaleX( 0 );
+			transform-origin: 0% 0%;
+			margin-top: 1em;
+
+			animation: progress-move #{$progress-duration + 1} ease-out forwards;
+
+			@keyframes progress-move {
+				@for $i from 1 through 3 {
+					#{$i / 3 * 100%} {
+						transform: scaleX( #{$i / 3} );
+					}
+				}
+			}
+		}
+
+		.create-site__progress-step {
+			@include onboarding-heading-text-mobile;
+			text-align: center;
+			vertical-align: middle;
+			margin: 0;
+			height: $progress-step-title-height;
 		}
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Very, very, very, very, very first iteration of Loady McLoadface

![schwung](https://user-images.githubusercontent.com/6458278/78651664-fb86ce00-7903-11ea-904c-d123e48dd89f.gif)

## Known issues

- There is a flash of blue: the current signup backend before we're shipped off to the plans page.
- Yes, the progress is fake
- Blue or brown for the progress bar color? 💊 

## Testing instructions

This PR doesn't work that well right now, but you can still test by creating a site.

Even better, you can [comment out the line](https://github.com/Automattic/wp-calypso/pull/40831/files#diff-25ff1d094074b9d9d1f5a148c6f7c363R59)

`{ shouldCreateAndRedirect && <CreateAndRedirect /> }`

to work/view the screen.

Fixes #39287
