### PR TITLE
Assert the post/editor is opened in an iframe on evergreen browsers

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -40,7 +40,7 @@ before( async function() {
 describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Public Pages: @parallel', function() {
+	describe( 'Public Pages: @parallel @ie11canary', function() {
 		let fileDetails;
 		const pageTitle = dataHelper.randomPhrase();
 		const pageQuote =
@@ -58,6 +58,16 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 				this.loginFlow = new LoginFlow( driver );
 			}
 			return await this.loginFlow.loginAndStartNewPage( null, true );
+		} );
+
+		step( 'Post editor loads in iframe', async function() {
+			if ( config.get( 'browser' ) === 'ie' ) {
+				// We don't mind if IE opens the post editor in wp-admin, just
+				// as long as a Gutenberg editor has opened.
+				return;
+			}
+
+			await GutenbergEditorComponent.Expect( driver, 'iframe' );
 		} );
 
 		step( 'Can enter page title, content and image', async function() {

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -61,7 +61,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Post editor loads in iframe', async function() {
-			if ( config.get( 'browser' ) === 'ie' ) {
+			if ( global.browserName === 'Internet Explorer' ) {
 				// We don't mind if IE opens the post editor in wp-admin, just
 				// as long as a Gutenberg editor has opened.
 				return;

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -40,7 +40,7 @@ before( async function() {
 describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Public Pages: @parallel @ie11canary', function() {
+	describe( 'Public Pages: @parallel', function() {
 		let fileDetails;
 		const pageTitle = dataHelper.randomPhrase();
 		const pageQuote =

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -49,7 +49,7 @@ before( async function() {
 describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
+	describe( 'Public Posts: Preview and Publish a Public Post @parallel @ie11canary', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =
@@ -66,6 +66,16 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			return await this.loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Post editor loads in iframe', async function() {
+			if ( config.get( 'browser' ) === 'ie' ) {
+				// We don't mind if IE opens the post editor in wp-admin, just
+				// as long as a Gutenberg editor has opened.
+				return;
+			}
+
+			await GutenbergEditorComponent.Expect( driver, 'iframe' );
 		} );
 
 		step( 'Can enter post title, content and image', async function() {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -49,7 +49,7 @@ before( async function() {
 describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
-	describe( 'Public Posts: Preview and Publish a Public Post @parallel @ie11canary', function() {
+	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {
 		let fileDetails;
 		const blogPostTitle = dataHelper.randomPhrase();
 		const blogPostQuote =

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -69,7 +69,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Post editor loads in iframe', async function() {
-			if ( config.get( 'browser' ) === 'ie' ) {
+			if ( global.browserName === 'Internet Explorer' ) {
 				// We don't mind if IE opens the post editor in wp-admin, just
 				// as long as a Gutenberg editor has opened.
 				return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Asserts the post/editor is opened in an iframe on evergreen browsers.

Since #40517 the `GutenbergEditorComponent` page object works with either wp-admin or iframe. That's because IE sometimes opens the editor in wp-admin when we don't expect, and we're not worried about IE doing that so don't want to fail the test. From the user's point of view they're able to complete the steps under test regardless of which editor opens.

However we do still want evergreen browsers to open the iframe editor. So this makes sure we're still testing that.

However this meant we weren't testing for the fact that modern browsers _should_ open in an iframe, and we'd care about that changing.

This PR adds an assertion to a non-ie11canary test that the editor opens in an iframe.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* CI checks are green

I did attempt to temporarily add the test to the IE canaries to check the logic of the `if ( global.browserName === 'Internet Explorer' )` code, but unfortunately it looks like that test was already failing in IE.