### PR TITLE
Support Article Dialog: Switch Order of Buttons

### DIFF
--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -42,14 +42,14 @@ export class SupportArticleDialog extends Component {
 	getDialogButtons() {
 		const { postUrl, translate } = this.props;
 		return [
+			<Button onClick={ this.props.closeSupportArticleDialog }>
+				{ translate( 'Close', { textOnly: true } ) }
+			</Button>,
 			postUrl && (
 				<Button href={ postUrl } target="_blank" primary>
 					{ translate( 'Visit Article' ) } <Gridicon icon="external" size={ 12 } />
 				</Button>
 			),
-			<Button onClick={ this.props.closeSupportArticleDialog }>
-				{ translate( 'Close', { textOnly: true } ) }
-			</Button>,
 		].filter( Boolean );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'm pretty sure the Support Article Dialog is the only place where the primary button is to the left of the default button. It feels odd, and it's something that will probably be noticeable after #39617 where two different dialogs will be used on Customer Home, but have different positions.

This guide appears to agree with me too: https://murieldesignsystem.blog/components/button
<img width="863" alt="Screenshot 2020-04-07 at 07 43 19" src="https://user-images.githubusercontent.com/43215253/78638653-8afc9480-78a4-11ea-8095-8e6228b104ea.png">


#### Testing instructions

Visit an example of the Support Article Dialog, such as the Free Photo Library card in Customer Home or the links with the Exporter, and verify the buttons are reversed.

**Before:**
<img width="442" alt="Screenshot 2020-04-07 at 07 46 34" src="https://user-images.githubusercontent.com/43215253/78638522-538de800-78a4-11ea-81b6-ef9090d9615f.png">

**After:**
<img width="609" alt="Screenshot 2020-04-07 at 07 46 22" src="https://user-images.githubusercontent.com/43215253/78638545-5983c900-78a4-11ea-8564-c5e29acda3c5.png">

