### PR TITLE
Gutenboarding: Adapt grid layout in design selection step to floats to support IE 11

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -24,28 +24,58 @@
 	}
 
 	.design-selector__grid {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		column-gap: 64px;
-		row-gap: 64px;
-		margin-top: 30px;
-
-		@include break-large {
-			grid-template-columns: 1fr 1fr 1fr;
-		}
-
-		@include onboarding-break-gigantic {
-			grid-template-columns: 1fr 1fr 1fr 1fr;
-		}
+		float: left;
+		margin: 0 -32px 30px;
+		width: 100%;
 	}
 
 	.design-selector__design-option {
 		cursor: pointer;
+		width: calc( 50% - 64px );
+		margin: 0 32px 48px;
 
 		&:hover,
 		&:focus {
 			.design-selector__image-frame {
 				border-color: var( --highlightColor );
+			}
+		}
+		@include break-large {
+			width: calc( 33.33% - 64px );
+		}
+
+		@include onboarding-break-gigantic {
+			width: calc( 25% - 64px );
+		}
+	}
+
+	@supports (display: grid) {
+		.design-selector__grid {
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			column-gap: 64px;
+			row-gap: 48px;
+			margin: 0 0 30px;
+
+			@include break-large {
+				grid-template-columns: 1fr 1fr 1fr;
+			}
+
+			@include onboarding-break-gigantic {
+				grid-template-columns: 1fr 1fr 1fr 1fr;
+			}
+		}
+
+		.design-selector__design-option {
+			width: auto;
+			margin: 0;
+
+			@include break-large {
+				width: auto;
+			}
+
+			@include onboarding-break-gigantic {
+				width: auto;
 			}
 		}
 	}
@@ -73,7 +103,7 @@
 	.design-selector__option-name {
 		color: var( --studio-gray-40 );
 		display: block;
-		margin-top: 16px;
+		margin: 16px 0;
 		text-align: center;
 		width: 100%;
 		@include onboarding-medium-text;

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -25,7 +25,6 @@
 
 	.design-selector__grid {
 		margin: 0 -32px 30px;
-		width: 100%;
 	}
 
 	.design-selector__design-option {

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -24,13 +24,13 @@
 	}
 
 	.design-selector__grid {
-		float: left;
 		margin: 0 -32px 30px;
 		width: 100%;
 	}
 
 	.design-selector__design-option {
 		cursor: pointer;
+		float: left;
 		width: calc( 50% - 64px );
 		margin: 0 32px 48px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `float` based styles for the design selector for older browsers that don't support grid properly (IE11) (approach based on [this MDN article](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement))
* Use a feature query for grid sizing

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before in IE11:

![image](https://user-images.githubusercontent.com/14988353/78648956-1b1bf780-7900-11ea-82d6-9017bb0aab7b.png)

After:

![image](https://user-images.githubusercontent.com/14988353/78731578-72af7700-7983-11ea-8f63-e21bdf555498.png)

* Go to https://calypso.live/?branch=update/gutenboarding-design-selector-to-support-ie-11 and navigate to `/new` and fill out the intent gathering step so that you get to the design selector at `/new/design`
* Make sure that the layout matches what is currently in wpcalypso / staging in Chrome, FF, Safari.
* Test across a range of window sizes (small should be 2 column, large 3 column, and very wide 4 column)
* Test in IE11 (or Browserstack IE11) and make sure that the layout matches the design (or is a close approximation)

Fixes #
