### PR TITLE
Signup: Change feature in Personal plan column

### DIFF
--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -109,7 +109,7 @@ const getPlanPersonalDetails = () => ( {
 	getSignupFeatures: () => [
 		constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT_SIGNUP,
 		constants.FEATURE_FREE_DOMAIN,
-		constants.FEATURE_ALL_FREE_FEATURES,
+		constants.FEATURE_FREE_THEMES,
 	],
 	getBlogSignupFeatures: () => [
 		constants.FEATURE_FREE_DOMAIN,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes https://github.com/Automattic/wp-calypso/issues/38026

* Change "All free features" to "Dozens of free themes" for the Personal plan

<img width="454" alt="Screenshot 2020-04-07 at 2 14 31 PM" src="https://user-images.githubusercontent.com/1269602/78648850-396efc80-78da-11ea-839a-895d858ab88f.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through signup flow and verify that on the plans step, you can see the dozens of free themes feature for the Personal plan.
* Click the tooltiip for the free themes feature and verify that it renders the right content
* Verify the feature changes for both control and variant of the planStepCopyUpdates test.
* Verify that there is no change to the feature list in Calypso /plans page while logged in.


