### PR TITLE
i18n: Disable locale script when use-translation-chunks feature is enabled

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -59,6 +59,7 @@ class Document extends React.Component {
 			isWCComConnect,
 			addEvergreenCheck,
 			requestFrom,
+			useTranslationChunks,
 		} = this.props;
 
 		const installedChunks = entrypoint.js
@@ -200,7 +201,7 @@ class Document extends React.Component {
 						/>
 					) }
 
-					{ i18nLocaleScript && <script src={ i18nLocaleScript } /> }
+					{ i18nLocaleScript && ! useTranslationChunks && <script src={ i18nLocaleScript } /> }
 					{ /*
 					 * inline manifest in production, but reference by url for development.
 					 * this lets us have the performance benefit in prod, without breaking HMR in dev

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -299,6 +299,7 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 	const reduxStore = createReduxStore( initialServerState );
 	setStore( reduxStore );
 
+	const flags = ( request.query.flags || '' ).split( ',' );
 	const context = Object.assign( {}, request.context, {
 		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
 		compileDebug: process.env.NODE_ENV === 'development',
@@ -320,6 +321,8 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 		bodyClasses,
 		addEvergreenCheck: target === 'evergreen' && calypsoEnv !== 'development',
 		target: target || 'fallback',
+		useTranslationChunks:
+			config.isEnabled( 'use-translation-chunks' ) || flags.includes( 'use-translation-chunks' ),
 	} );
 
 	context.app = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a #39873 follow-up PR that will prevent the i18n locale script from being loaded on the page when `use-translation-chunks` feature is enabled via either the config or flags url query parameter.

#### Testing instructions

1. Boot Calypso with `use-translation-chunks` feature enabled
2. Confirm that `https://widgets.wp.com/languages/calypso/{langSlug}-v1.1.js` script is not loaded on the page.