### PR TITLE
Posts: Improve Clarity of Scheduled Time

### DIFF
--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -101,19 +101,22 @@ class PostRelativeTime extends React.PureComponent {
 			const now = moment();
 			const scheduledDate = moment( this.props.post.date );
 			// If the content is scheduled to be release within a year, do not display the year at the end
-			const displayDate = scheduledDate.diff( now, 'years' ) > 0 ? 'll' : 'D MMM';
 			const scheduledTime = scheduledDate.calendar( null, {
-				sameElse: this.props.translate( '%(displayDate)s [at] LT', {
-					args: { displayDate },
-					comment: 
-					'"displayDate" refers to date (eg. 21 April) & LT refers to time (eg. 18:00) - "at" is translated',
+				sameElse: this.props.translate( 'll [at] LT', {
+					comment:
+						'll refers to date (eg. 21 Apr) & LT refers to time (eg. 18:00) - "at" is translated',
 				} ),
 			} );
 
-			statusText = this.props.translate( 'scheduled for %(scheduledTime)s', {
-				comment: '%(scheduledTime)s is when a scheduled post is set to be published',
+			const displayScheduleTime =
+				scheduledDate.diff( now, 'years' ) > 0
+					? scheduledTime
+					: scheduledTime.replace( scheduledDate.format( 'Y' ), '' );
+
+			statusText = this.props.translate( 'scheduled for %(displayScheduleTime)s', {
+				comment: '%(displayScheduleTime)s is when a scheduled post is set to be published',
 				args: {
-					scheduledTime,
+					displayScheduleTime,
 				},
 			} );
 			statusClassName += ' is-scheduled';

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -103,7 +103,13 @@ class PostRelativeTime extends React.PureComponent {
 			const scheduledTime =
 				scheduledDate.diff( now, 'days' ) <= 7
 					? scheduledDate.calendar()
-					: scheduledDate.format( 'LLLL' );
+					: scheduledDate.format( 'LL' ) +
+					  ' ' +
+					  this.props.translate( 'at', {
+							context: 'scheduled for 21 April at 02:00',
+					  } ) +
+					  ' ' +
+					  scheduledDate.format( 'LT' );
 
 			statusText = this.props.translate( 'scheduled for %(scheduledTime)s', {
 				comment: '%(scheduledTime)s is a future human time, for example "in 3 days"',

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -11,6 +11,7 @@ import { includes } from 'lodash';
  */
 import Gridicon from 'components/gridicon';
 import { withLocalizedMoment } from 'components/localized-moment';
+
 /**
  * Style dependencies
  */
@@ -96,9 +97,15 @@ class PostRelativeTime extends React.PureComponent {
 			statusText = this.props.translate( 'pending review' );
 			statusClassName += ' is-pending';
 		} else if ( status === 'future' ) {
-			const scheduledTime = this.props.moment( this.props.post.date ).fromNow();
+			const moment = this.props.moment;
+			const scheduledDate = moment( this.props.post.date );
+			const now = moment();
+			const scheduledTime =
+				scheduledDate.diff( now, 'days' ) <= 7
+					? scheduledDate.calendar()
+					: scheduledDate.format( 'LLLL' );
 
-			statusText = this.props.translate( 'scheduled %(scheduledTime)s', {
+			statusText = this.props.translate( 'scheduled for %(scheduledTime)s', {
 				comment: '%(scheduledTime)s is a future human time, for example "in 3 days"',
 				args: {
 					scheduledTime,

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -105,7 +105,8 @@ class PostRelativeTime extends React.PureComponent {
 			const scheduledTime = scheduledDate.calendar( null, {
 				sameElse: this.props.translate( '%(displayDate)s [at] LT', {
 					args: { displayDate },
-					comment: 'moment.js formatting string: "displayDate" refers to date (eg. 21 April) and LT refers to time (eg. 18:00) - "at" is translated',
+					comment: 
+					'"displayDate" refers to date (eg. 21 April) & LT refers to time (eg. 18:00) - "at" is translated',
 				} ),
 			} );
 

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -112,7 +112,7 @@ class PostRelativeTime extends React.PureComponent {
 					  scheduledDate.format( 'LT' );
 
 			statusText = this.props.translate( 'scheduled for %(scheduledTime)s', {
-				comment: '%(scheduledTime)s is a future human time, for example "in 3 days"',
+				comment: '%(scheduledTime)s is when a scheduled post is set to be published',
 				args: {
 					scheduledTime,
 				},

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -102,9 +102,9 @@ class PostRelativeTime extends React.PureComponent {
 			const now = moment();
 			const scheduledTime = scheduledDate.calendar( null, {
 				sameElse: this.props.translate( 'LL [at] LT', {
-					comment: 'moment.js formatting string'
-				}
-			);
+					comment: 'moment.js formatting string',
+				} ),
+			} );
 
 			statusText = this.props.translate( 'scheduled for %(scheduledTime)s', {
 				comment: '%(scheduledTime)s is when a scheduled post is set to be published',

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -98,11 +98,14 @@ class PostRelativeTime extends React.PureComponent {
 			statusClassName += ' is-pending';
 		} else if ( status === 'future' ) {
 			const moment = this.props.moment;
-			const scheduledDate = moment( this.props.post.date );
 			const now = moment();
+			const scheduledDate = moment( this.props.post.date );
+			// If the content is scheduled to be release within a year, do not display the year at the end
+			const displayDate = scheduledDate.diff( now, 'years' ) > 0 ? 'll' : 'D MMM';
 			const scheduledTime = scheduledDate.calendar( null, {
-				sameElse: this.props.translate( 'LL [at] LT', {
-					comment: 'moment.js formatting string',
+				sameElse: this.props.translate( '%(displayDate)s [at] LT', {
+					args: { displayDate },
+					comment: 'moment.js formatting string: "displayDate" refers to date (eg. 21 April) and LT refers to time (eg. 18:00) - "at" is translated',
 				} ),
 			} );
 

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -100,16 +100,11 @@ class PostRelativeTime extends React.PureComponent {
 			const moment = this.props.moment;
 			const scheduledDate = moment( this.props.post.date );
 			const now = moment();
-			const scheduledTime =
-				scheduledDate.diff( now, 'days' ) <= 7
-					? scheduledDate.calendar()
-					: scheduledDate.format( 'LL' ) +
-					  ' ' +
-					  this.props.translate( 'at', {
-							context: 'scheduled for 21 April at 02:00',
-					  } ) +
-					  ' ' +
-					  scheduledDate.format( 'LT' );
+			const scheduledTime = scheduledDate.calendar( null, {
+				sameElse: this.props.translate( 'LL [at] LT', {
+					comment: 'moment.js formatting string'
+				}
+			);
 
 			statusText = this.props.translate( 'scheduled for %(scheduledTime)s', {
 				comment: '%(scheduledTime)s is when a scheduled post is set to be published',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This ensures that the scheduled time clearly states when the post is due to be released.

#### Testing instructions

A few things to check:
- when the post is due to be released within a week, it shouldn't give the full date, but it should give the time (I would find this very helpful as someone who tries to schedule posts weekly at the same time, so I'm sure many others would too)
- when the post is due to be released after a week, it should give the full date
- "scheduled in" should be replaced with "scheduled for" (the latter gave the impression that was when the "Schedule" button was actually clicked, when that isn't what it conveys)

**Before:**
<img width="1087" alt="Screenshot 2020-04-07 at 11 58 36" src="https://user-images.githubusercontent.com/43215253/78661693-2141b200-78c7-11ea-95c4-d1e8bfe47004.png">

**After:**
<img width="1058" alt="Screenshot 2020-04-07 at 12 08 36" src="https://user-images.githubusercontent.com/43215253/78662560-8ba72200-78c8-11ea-9a94-5d03fea7f47e.png">

Note: I made a few changes so that it displays the date and then "at" (eg. `27 April 2020 at 02:00`) so that it's consistent with the wording for a post due to be published in under 7 days.

Follows up to #40779 and #40584
Fixes #12052
