### PR TITLE
Revert "Revert "E2E: Temporary remove block editor test from IE11 canary suite""

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -15,12 +15,7 @@ import { ShortcodeBlockComponent } from './blocks/shortcode-block-component';
 import { ImageBlockComponent } from './blocks/image-block-component';
 
 export default class GutenbergEditorComponent extends AsyncBaseContainer {
-	/**
-	 * @param {*} driver the selenium driver
-	 * @param {*} url url to visit, or null to stay on the same page
-	 * @param { 'iframe' | 'wp-admin' | 'preferIFrame' } editorType editor type the test expect to be on the page
-	 */
-	constructor( driver, url, editorType = 'preferIFrame' ) {
+	constructor( driver, url, editorType = 'iframe' ) {
 		super( driver, By.css( '.edit-post-header' ), url );
 		this.editorType = editorType;
 
@@ -42,21 +37,15 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async _preInit() {
-		if ( this.editorType !== 'iframe' && this.editorType !== 'preferIFrame' ) {
+		if ( this.editorType !== 'iframe' ) {
 			return;
 		}
 		await this.driver.switchTo().defaultContent();
-		try {
-			await this.driver.wait(
-				until.ableToSwitchToFrame( this.editoriFrameSelector ),
-				this.explicitWaitMS,
-				'Could not locate the editor iFrame.'
-			);
-		} catch ( error ) {
-			if ( this.editorType === 'preferIFrame' ) {
-				return;
-			}
-		}
+		await this.driver.wait(
+			until.ableToSwitchToFrame( this.editoriFrameSelector ),
+			this.explicitWaitMS,
+			'Could not locate the editor iFrame.'
+		);
 		await this.driver.sleep( 2000 );
 	}
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -244,7 +244,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Basic Public Post @canary @ie11canary @parallel', function() {
+	describe( 'Basic Public Post @canary @parallel', function() {
 		describe( 'Publish a New Post', function() {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1095,6 +1095,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can update the homepage', async function() {
+			// Skipping if IE11 due to JS errors caused by missing DOMRect polyfill.
+			// See https://github.com/Automattic/wp-calypso/issues/40502
+			if ( dataHelper.getTargetType() === 'IE11' ) {
+				return this.skip();
+			}
 			const checklistPage = await ChecklistPage.Expect( this.driver );
 			await checklistPage.updateHomepage();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#40517 

Reasons given at https://github.com/Automattic/wp-calypso/pull/40517#issuecomment-610341677:

> Still failing across new PRs(e.g. #40807, #40841, #40842), _and_ on the follow-up PR that's supposed to address this (#40832). Going to revert the revert :confused: 
