### PR TITLE
Support Card: Prevent items from stretching

### DIFF
--- a/client/components/happiness-engineers-tray/style.scss
+++ b/client/components/happiness-engineers-tray/style.scss
@@ -1,5 +1,6 @@
 .happiness-engineers-tray {
 	display: flex;
+	align-items: flex-start;
 	flex-wrap: wrap;
 	height: 42px;
 	justify-content: space-between;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Specify `align-items: flex-start;` so support Gravatars do not stretch to fill the height of the container.

**Before**

<img width="505" alt="Screen Shot 2020-04-07 at 9 05 07 AM" src="https://user-images.githubusercontent.com/2124984/78672935-5e9a4580-78af-11ea-89ad-1d8d7d333600.png">

**After**

<img width="506" alt="Screen Shot 2020-04-07 at 9 04 26 AM" src="https://user-images.githubusercontent.com/2124984/78672952-64902680-78af-11ea-8031-db847578fef5.png">

#### Testing instructions

* Switch to this PR
* On a Business site, go to Hosting Configuration
* The support card Gravatars should appear as circles. Resize the screen to ensure they stay circles at multiple screen sizes.
* These also appear on the support card at `/help`

Fixes #40825
