### PR TITLE
Jetpack Cloud: Fix alignment of main element for backups, restores, downloads

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
@@ -138,3 +138,7 @@ a.rewind-flow-notice__title-warning:visited {
 	font-size: 16px;
 	font-weight: bold;
 }
+
+.theme-jetpack-cloud .main.rewind-flow {
+	margin-left: auto;
+}

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -16,3 +16,7 @@
 .backups__search-description {
     margin-bottom: 2rem;
 }
+
+.backups__page .main {
+	margin-left: auto;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, after switching away to a different section, and back to backups, the page styles will change and the `main` will lose it's `margin-left: auto`, and slide to the left of the page.

This PR fixes the left margin of the `main` element for the backups page, and the restore/download pages. 

#### Testing instructions

* Load up backup section for an active site. Click on scanner, then click back to backups. The alignment of the page should remain the same as it was before navigating away.
* Test the same thing for the restore page, and the download page _initial styles_.

**BAD:**
![Screen Shot 2020-04-07 at 9 15 14 AM](https://user-images.githubusercontent.com/5528445/78673528-437c0580-78b0-11ea-935e-b8a87568b462.png)

**GOOD:**
![Screen Shot 2020-04-07 at 9 15 28 AM](https://user-images.githubusercontent.com/5528445/78673539-470f8c80-78b0-11ea-9a28-649e93a8f3f6.png)
