### PR TITLE
Revert "Jetpack Connect: adapt the post-checkout Thank you modal to specific Products"

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -97,7 +97,7 @@ class Plans extends Component {
 		const { canPurchasePlans, selectedSiteSlug } = this.props;
 
 		if ( selectedSiteSlug && canPurchasePlans ) {
-			return this.redirect( CALYPSO_MY_PLAN_PAGE, null, { 'thank-you': '' } );
+			return this.redirect( CALYPSO_MY_PLAN_PAGE, { 'thank-you': '' } );
 		}
 
 		return this.redirect( CALYPSO_REDIRECTION_PAGE );
@@ -129,12 +129,8 @@ class Plans extends Component {
 		return addQueryArgs( args, redirectTo );
 	}
 
-	redirect( path, product, args ) {
+	redirect( path, args ) {
 		let redirectTo = path + this.props.selectedSiteSlug;
-
-		if ( product ) {
-			redirectTo += '/' + product;
-		}
 
 		if ( args ) {
 			redirectTo = addQueryArgs( args, redirectTo );
@@ -176,7 +172,7 @@ class Plans extends Component {
 		this.props.completeFlow();
 		persistSignupDestination( this.getMyPlansDestination() );
 
-		this.redirect( '/checkout/', null, cartItem.product_slug );
+		this.redirect( '/checkout/' );
 	};
 
 	shouldShowPlaceholder() {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -387,6 +387,7 @@ export class Checkout extends React.Component {
 
 		const isCartEmpty = isEmpty( getAllCartItems( cart ) );
 		const isReceiptEmpty = ':receiptId' === pendingOrReceiptId;
+
 		// We will show the Thank You page if there's a site slug and either one of the following is true:
 		// - has a receipt number
 		// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
@@ -476,11 +477,9 @@ export class Checkout extends React.Component {
 		// Especially around the Concierge / Checklist logic.
 
 		let renewalItem,
-			signupDestination,
 			displayModeParam = {};
 		const {
 			cart,
-			product,
 			redirectTo,
 			selectedSite,
 			selectedSiteSlug,
@@ -531,13 +530,8 @@ export class Checkout extends React.Component {
 
 		this.setDestinationIfEcommPlan( pendingOrReceiptId );
 
-		// if it is a Jetpack product, use product info as a parameter
-		if ( product ) {
-			signupDestination = this.getFallbackDestination( pendingOrReceiptId );
-		} else {
-			signupDestination =
-				retrieveSignupDestination() || this.getFallbackDestination( pendingOrReceiptId );
-		}
+		const signupDestination =
+			retrieveSignupDestination() || this.getFallbackDestination( pendingOrReceiptId );
 
 		if ( hasRenewalItem( cart ) ) {
 			renewalItem = getRenewalItems( cart )[ 0 ];
@@ -844,7 +838,6 @@ export class Checkout extends React.Component {
 
 	render() {
 		const { plan, product, purchaseId, selectedFeature, selectedSiteSlug } = this.props;
-
 		let analyticsPath = '';
 		let analyticsProps = {};
 		if ( purchaseId && product ) {

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -30,9 +30,15 @@ export function currentPlan( context, next ) {
 
 	const product = context.query.product;
 	const requestThankYou = context.query.hasOwnProperty( 'thank-you' );
+	const requestProduct = context.query.hasOwnProperty( 'product' );
 
 	context.primary = (
-		<CurrentPlan path={ context.path } product={ product } requestThankYou={ requestThankYou } />
+		<CurrentPlan
+			path={ context.path }
+			product={ product }
+			requestThankYou={ requestThankYou }
+			requestProduct={ requestProduct }
+		/>
 	);
 
 	next();

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -78,17 +78,17 @@ class CurrentPlan extends Component {
 	}
 
 	renderThankYou() {
-		const { currentPlan, product } = this.props;
+		const { currentPlan, product, requestProduct } = this.props;
 
-		if ( startsWith( product, 'jetpack_backup' ) ) {
+		if ( requestProduct && startsWith( product, 'jetpack_backup' ) ) {
 			return <BackupProductThankYou />;
 		}
 
-		if ( startsWith( product, 'jetpack_scan' ) ) {
+		if ( requestProduct && startsWith( product, 'jetpack_scan' ) ) {
 			return <ScanProductThankYou />;
 		}
 
-		if ( startsWith( product, 'jetpack_search' ) ) {
+		if ( requestProduct && startsWith( product, 'jetpack_search' ) ) {
 			return <SearchProductThankYou />;
 		}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#40794

Think it was breaking the connect purchase flow... buttons not working.