### PR TITLE
Profile: Remove ListEnd

### DIFF
--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -20,7 +20,6 @@ import ProfileLinksAddOther from 'me/profile-links-add-other';
 import { deleteUserProfileLink, resetUserProfileLinkErrors } from 'state/profile-links/actions';
 import getProfileLinks from 'state/selectors/get-profile-links';
 import getProfileLinksErrorType from 'state/selectors/get-profile-links-error-type';
-import ListEnd from 'components/list-end';
 
 /**
  * Style dependencies
@@ -185,7 +184,6 @@ class ProfileLinks extends React.Component {
 					/>
 				</SectionHeader>
 				<Card>{ this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }</Card>
-				<ListEnd />
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes ListEnd from profile, since it doesn't use an Infinite List component. This appears to be the only page that uses ListEnd without a list.

**Before**

<img width="765" alt="Screen Shot 2020-04-07 at 9 29 46 AM" src="https://user-images.githubusercontent.com/2124984/78675394-006f6180-78b3-11ea-9355-42265c1663b5.png">

**After**

<img width="806" alt="Screen Shot 2020-04-07 at 9 31 46 AM" src="https://user-images.githubusercontent.com/2124984/78675529-30b70000-78b3-11ea-9686-5a03d5480d8a.png">

(My links don't seem to load locally, but they're fine on WP.com...)

#### Testing instructions

* Switch to this PR
* Navigate to `/me`
* Note the lack of a WP logo at the end of this page

Fixes #40686
