### PR TITLE
Checkout: Re-use existing signup header for Gutenboarding

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -49,42 +49,7 @@ class CheckoutContainer extends React.Component {
 		}
 	}
 
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	renderCheckoutHeader() {
-		if ( this.props.isComingFromGutenboarding ) {
-			return (
-				<>
-					<Button
-						borderless
-						className="navigation-link back"
-						onClick={ () => window.history.go( this.props.isGutenboardingCreate ? -1 : -2 ) } // going back to signup flow and skipping '/launch' step
-					>
-						<Gridicon icon="arrow-left" size={ 18 } />
-						{ this.props.translate( 'Back' ) }
-					</Button>
-					<div className="checkout__site-created--gutenboarding">
-						<img
-							src="/calypso/images/signup/confetti.svg"
-							aria-hidden="true"
-							className="checkout__site-created-image"
-							alt=""
-						/>
-						<FormattedHeader
-							headerText={ this.props.translate(
-								'Your WordPress.com site is ready! Finish your purchase to get the most out of it.'
-							) }
-						/>
-						<div>
-							{ this.props.translate( '{{em}}%(siteSlug)s{{/em}} is up and running!', {
-								components: { em: <em /> },
-								args: { siteSlug: this.props.selectedSite.slug },
-								comment: '`siteSlug` is the WordPress.com site, e.g., testsite.wordpress.com',
-							} ) }
-						</div>
-					</div>
-				</>
-			);
-		}
 		return this.state.headerText && <FormattedHeader headerText={ this.state.headerText } />;
 	}
 
@@ -92,8 +57,7 @@ class CheckoutContainer extends React.Component {
 
 	shouldDisplaySiteCreatedNotice() {
 		return (
-			this.props.isComingFromSignup &&
-			! this.props.isComingFromGutenboarding &&
+			( this.props.isComingFromSignup || this.props.isComingFromGutenboarding ) &&
 			isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) )
 		);
 	}
@@ -118,6 +82,16 @@ class CheckoutContainer extends React.Component {
 
 		return (
 			<>
+				{ this.props.isComingFromGutenboarding && (
+					<Button
+						borderless
+						className="navigation-link back" // eslint-disable-line wpcalypso/jsx-classname-namespace
+						onClick={ () => window.history.go( this.props.isGutenboardingCreate ? -1 : -2 ) } // going back to signup flow and skipping '/launch' step
+					>
+						<Gridicon icon="arrow-left" size={ 18 } />
+						{ this.props.translate( 'Back' ) }
+					</Button>
+				) }
 				{ this.renderCheckoutHeader() }
 				{ this.shouldDisplaySiteCreatedNotice() && (
 					<TransactionData>

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1,22 +1,22 @@
 @import 'jetpack-connect/colors.scss';
 
-@mixin section-border ( $position ) {
-  &::before {
-  	display: block;
-  	content: '';
-  	position: absolute;
-  	#{ $position }: 0;
-  	left: -8px;
-  	width: calc( 100% + 16px );
-  	height: 1px;
-  	box-sizing: border-box;
-  	background: var( --color-border-subtle );
+@mixin section-border( $position ) {
+	&::before {
+		display: block;
+		content: '';
+		position: absolute;
+		#{ $position }: 0;
+		left: -8px;
+		width: calc( 100% + 16px );
+		height: 1px;
+		box-sizing: border-box;
+		background: var( --color-border-subtle );
 
-  	@include breakpoint( '>660px' ) {
-  		width: calc( 100% + 60px );
-  		left: -30px;
-  	}
-  }
+		@include breakpoint( '>660px' ) {
+			width: calc( 100% + 60px );
+			left: -30px;
+		}
+	}
 }
 
 .checkout {
@@ -465,19 +465,20 @@
 
 	// Redirect Payment Box
 	// -----------------------------------
-	.redirect-payment-box, .wechat-payment-box {
-		 .checkout__payment-box-section {
-			 .checkout__checkout-field {
-				 padding: 0 15px 15px;
-			 }
+	.redirect-payment-box,
+	.wechat-payment-box {
+		.checkout__payment-box-section {
+			.checkout__checkout-field {
+				padding: 0 15px 15px;
+			}
 
-			 .checkout__country-payment-fields {
-				 .checkout__checkout-field {
-					 padding-left: 0;
-					 flex-basis: calc( 100% - 30px );
-				 }
-			 }
-		 }
+			.checkout__country-payment-fields {
+				.checkout__checkout-field {
+					padding-left: 0;
+					flex-basis: calc( 100% - 30px );
+				}
+			}
+		}
 	}
 
 	// Credits Payment Box
@@ -499,7 +500,6 @@
 			}
 
 			.checkout__payment-box-section-content {
-
 				> h6 {
 					color: var( --color-primary );
 					font-size: 18px;
@@ -801,7 +801,6 @@
 		justify-content: left;
 	}
 }
-
 
 .checkout__payment-chat-button.is-borderless {
 	color: var( --color-accent );
@@ -1215,10 +1214,10 @@
 }
 
 .composite-checkout__testing-banner {
-  @media( min-width: 700px ) {
-    margin: auto;
-    max-width: 556px;
-  }
+	@media ( min-width: 700px ) {
+		margin: auto;
+		max-width: 556px;
+	}
 }
 
 .is-section-checkout.is-frankenflow {
@@ -1230,16 +1229,5 @@
 		top: 6px;
 		left: 11px;
 		padding: 0;
-	}
-	.checkout__site-created--gutenboarding {
-		display: flex;
-		flex-direction: column;
-		text-align: center;
-		margin-bottom: 60px;
-
-		.checkout__site-created-image {
-			height: 50px;
-			margin-bottom: 16px;
-		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the checkout screen, drop the specific treatment of the Gutenboarding flow, and rely on the existing logic for the old signup.

This allows both fixing #40827 dropping some duplicated logic, rather than adding more duplicated logic to fix that issue.

Furthermore, the pre-existing signup flow had a somewhat more complex handling of the header (depending on payment state). I think it makes sense to apply the same treatment to the header regardless of whether the user is coming from the 'old' signup flow, or from Gutenboarding.

If there are any styling differences for the checkout header between Gutenboarding and the old signup flow (other than maybe the Back button), I'd argue that we should probably consider them circumstantial -- I don't think there's a strong argument why the copy and design at checkout time should differ with regard to those nuances.

#### Testing instructions

Run through the Gutenboarding with a paid domain selected. Verify that what you at checkout see matches the screenshots below.

##### Screenshots

After:

![checkout-header-with-domain](https://user-images.githubusercontent.com/96308/78677006-7e4d6000-78e7-11ea-86e9-d4436d8297f4.png)

Before (not mentioning the paid domain -- this is #40827):

![image](https://user-images.githubusercontent.com/96308/78677274-d5533500-78e7-11ea-8ad1-d59cc847950f.png)


##### Follow-up

Can we even drop some of our flags? Like `isComingFromGutenboarding` or `isGutenboardingCreate`? 

Fixes #40827.
