### PR TITLE
Reader: Fix settings toggles

### DIFF
--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -161,7 +161,10 @@ class ReaderSiteNotificationSettings extends Component {
 							wrapperClassName="reader-site-notification-settings__popout-form-toggle"
 							id="reader-site-notification-settings__notifications"
 						/>
-						<FormLabel htmlFor="reader-site-notification-settings__notifications">
+						<FormLabel
+							htmlFor="reader-site-notification-settings__notifications"
+							onClick={ this.toggleNewPostNotification }
+						>
 							{ translate( 'Notify me of new posts' ) }
 						</FormLabel>
 						<p className="reader-site-notification-settings__popout-hint">
@@ -182,7 +185,10 @@ class ReaderSiteNotificationSettings extends Component {
 								id={ 'reader-site-notification-settings__email-posts' }
 							/>
 						) }
-						<FormLabel htmlFor="reader-site-notification-settings__email-posts">
+						<FormLabel
+							htmlFor="reader-site-notification-settings__email-posts"
+							onClick={ this.toggleNewPostEmail }
+						>
 							{ translate( 'Email me new posts' ) }
 						</FormLabel>
 						{ isEmailBlocked && (
@@ -228,7 +234,10 @@ class ReaderSiteNotificationSettings extends Component {
 								checked={ sendNewCommentsByEmail }
 								id="reader-site-notification-settings__email-comments"
 							/>
-							<FormLabel htmlFor="reader-site-notification-settings__email-comments">
+							<FormLabel
+								htmlFor="reader-site-notification-settings__email-comments"
+								onClick={ this.toggleNewCommentEmail }
+							>
 								{ translate( 'Email me new comments' ) }
 							</FormLabel>
 						</div>

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -14,6 +14,7 @@ import Gridicon from 'components/gridicon';
 import ReaderPopover from 'reader/components/reader-popover';
 import SegmentedControl from 'components/segmented-control';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
+import FormLabel from 'components/forms/form-label';
 import { getReaderFollows } from 'state/reader/follows/selectors';
 import {
 	subscribeToNewPostEmail,
@@ -158,8 +159,11 @@ class ReaderSiteNotificationSettings extends Component {
 							onChange={ this.toggleNewPostNotification }
 							checked={ sendNewPostsByNotification }
 							wrapperClassName="reader-site-notification-settings__popout-form-toggle"
+							id="reader-site-notification-settings__notifications"
 						/>
-						{ translate( 'Notify me of new posts' ) }
+						<FormLabel htmlFor="reader-site-notification-settings__notifications">
+							{ translate( 'Notify me of new posts' ) }
+						</FormLabel>
 						<p className="reader-site-notification-settings__popout-hint">
 							{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
 						</p>
@@ -175,9 +179,12 @@ class ReaderSiteNotificationSettings extends Component {
 							<CompactFormToggle
 								onChange={ this.toggleNewPostEmail }
 								checked={ sendNewPostsByEmail }
+								id={ 'reader-site-notification-settings__email-posts' }
 							/>
 						) }
-						{ translate( 'Email me new posts' ) }
+						<FormLabel htmlFor="reader-site-notification-settings__email-posts">
+							{ translate( 'Email me new posts' ) }
+						</FormLabel>
 						{ isEmailBlocked && (
 							<p className="reader-site-notification-settings__popout-instructions-hint">
 								{ translate(
@@ -219,8 +226,11 @@ class ReaderSiteNotificationSettings extends Component {
 							<CompactFormToggle
 								onChange={ this.toggleNewCommentEmail }
 								checked={ sendNewCommentsByEmail }
+								id="reader-site-notification-settings__email-comments"
 							/>
-							{ translate( 'Email me new comments' ) }
+							<FormLabel htmlFor="reader-site-notification-settings__email-comments">
+								{ translate( 'Email me new comments' ) }
+							</FormLabel>
 						</div>
 					) }
 				</ReaderPopover>

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -14,7 +14,6 @@ import Gridicon from 'components/gridicon';
 import ReaderPopover from 'reader/components/reader-popover';
 import SegmentedControl from 'components/segmented-control';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
-import FormLabel from 'components/forms/form-label';
 import { getReaderFollows } from 'state/reader/follows/selectors';
 import {
 	subscribeToNewPostEmail,
@@ -160,13 +159,9 @@ class ReaderSiteNotificationSettings extends Component {
 							checked={ sendNewPostsByNotification }
 							wrapperClassName="reader-site-notification-settings__popout-form-toggle"
 							id="reader-site-notification-settings__notifications"
-						/>
-						<FormLabel
-							htmlFor="reader-site-notification-settings__notifications"
-							onClick={ this.toggleNewPostNotification }
 						>
 							{ translate( 'Notify me of new posts' ) }
-						</FormLabel>
+						</CompactFormToggle>
 						<p className="reader-site-notification-settings__popout-hint">
 							{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
 						</p>
@@ -183,25 +178,25 @@ class ReaderSiteNotificationSettings extends Component {
 								onChange={ this.toggleNewPostEmail }
 								checked={ sendNewPostsByEmail }
 								id={ 'reader-site-notification-settings__email-posts' }
-							/>
+							>
+								{ translate( 'Email me new posts' ) }
+							</CompactFormToggle>
 						) }
-						<FormLabel
-							htmlFor="reader-site-notification-settings__email-posts"
-							onClick={ this.toggleNewPostEmail }
-						>
-							{ translate( 'Email me new posts' ) }
-						</FormLabel>
+
 						{ isEmailBlocked && (
-							<p className="reader-site-notification-settings__popout-instructions-hint">
-								{ translate(
-									'You currently have email delivery turned off. Visit your {{a}}Notification Settings{{/a}} to turn it back on.',
-									{
-										components: {
-											a: <a href="/me/notifications/subscriptions" />,
-										},
-									}
-								) }
-							</p>
+							<div>
+								{ translate( 'Email me new posts' ) }
+								<p className="reader-site-notification-settings__popout-instructions-hint">
+									{ translate(
+										'You currently have email delivery turned off. Visit your {{a}}Notification Settings{{/a}} to turn it back on.',
+										{
+											components: {
+												a: <a href="/me/notifications/subscriptions" />,
+											},
+										}
+									) }
+								</p>
+							</div>
 						) }
 					</div>
 
@@ -233,13 +228,9 @@ class ReaderSiteNotificationSettings extends Component {
 								onChange={ this.toggleNewCommentEmail }
 								checked={ sendNewCommentsByEmail }
 								id="reader-site-notification-settings__email-comments"
-							/>
-							<FormLabel
-								htmlFor="reader-site-notification-settings__email-comments"
-								onClick={ this.toggleNewCommentEmail }
 							>
 								{ translate( 'Email me new comments' ) }
-							</FormLabel>
+							</CompactFormToggle>
 						</div>
 					) }
 				</ReaderPopover>

--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -13,7 +13,7 @@ import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 import ReaderPopover from 'reader/components/reader-popover';
 import SegmentedControl from 'components/segmented-control';
-import FormToggle from 'components/forms/form-toggle';
+import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getReaderFollows } from 'state/reader/follows/selectors';
 import {
 	subscribeToNewPostEmail,
@@ -154,13 +154,12 @@ class ReaderSiteNotificationSettings extends Component {
 					className="reader-site-notification-settings__popout"
 				>
 					<div className="reader-site-notification-settings__popout-toggle">
-						{ translate( 'Notify me of new posts' ) }
-						<Gridicon icon="bell" size={ 18 } />
-						<FormToggle
+						<CompactFormToggle
 							onChange={ this.toggleNewPostNotification }
 							checked={ sendNewPostsByNotification }
 							wrapperClassName="reader-site-notification-settings__popout-form-toggle"
 						/>
+						{ translate( 'Notify me of new posts' ) }
 						<p className="reader-site-notification-settings__popout-hint">
 							{ translate( 'Receive web and mobile notifications for new posts from this site.' ) }
 						</p>
@@ -172,10 +171,13 @@ class ReaderSiteNotificationSettings extends Component {
 								: 'reader-site-notification-settings__popout-toggle'
 						}
 					>
-						{ translate( 'Email me new posts' ) }
 						{ ! isEmailBlocked && (
-							<FormToggle onChange={ this.toggleNewPostEmail } checked={ sendNewPostsByEmail } />
+							<CompactFormToggle
+								onChange={ this.toggleNewPostEmail }
+								checked={ sendNewPostsByEmail }
+							/>
 						) }
+						{ translate( 'Email me new posts' ) }
 						{ isEmailBlocked && (
 							<p className="reader-site-notification-settings__popout-instructions-hint">
 								{ translate(
@@ -214,11 +216,11 @@ class ReaderSiteNotificationSettings extends Component {
 					) }
 					{ ! isEmailBlocked && (
 						<div className="reader-site-notification-settings__popout-toggle">
-							{ translate( 'Email me new comments' ) }
-							<FormToggle
+							<CompactFormToggle
 								onChange={ this.toggleNewCommentEmail }
 								checked={ sendNewCommentsByEmail }
 							/>
+							{ translate( 'Email me new comments' ) }
 						</div>
 					) }
 				</ReaderPopover>

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -37,7 +37,14 @@
 	}
 
 	.form-toggle__wrapper {
-		margin-right: 5px;
+		margin-right: 7px;
+	}
+
+	.form-label {
+		display: inline-block;
+		font-weight: 400;
+		position: relative;
+		top: 1px;
 	}
 
 	.reader-site-notification-settings__popout-toggle:nth-child( 2 ),

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -36,11 +36,14 @@
 		background: var( --color-surface );
 	}
 
+	.form-toggle__wrapper {
+		margin-right: 5px;
+	}
+
 	.reader-site-notification-settings__popout-toggle:nth-child( 2 ),
 	.reader-site-notification-settings__popout-toggle:nth-child( 3 ),
 	.reader-site-notification-settings__popout-toggle:nth-child( 4 ) {
 		display: flex;
-		justify-content: space-between;
 	}
 }
 
@@ -55,17 +58,6 @@
 	&:first-child {
 		border-top: 0;
 	}
-
-	.gridicon {
-		fill: var( --color-neutral-light );
-		position: relative;
-			left: 3px;
-			top: 2px;
-	}
-}
-
-.reader-site-notification-settings__popout-form-toggle {
-	margin-left: 45px;
 }
 
 .reader-site-notification-settings__popout-hint,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tidies up the look of the Reader settings by swapping regular form toggles for compact, and moving them to the left of the labels.
* Also removes the notification Gridicon, since it added visual cruft.
* Adds `FormLabel`s around each label with IDs for accessibility. I'm not sure how effective these are, however, as they don't trigger the toggle with a click the way a normal HTML checkbox would. But hopefully this at least helps connect the label text to the toggle itself.

**Before**

<img width="794" alt="Screen Shot 2020-04-07 at 11 10 30 AM" src="https://user-images.githubusercontent.com/2124984/78690521-88f6fd80-78c5-11ea-9d58-b0e1902601e7.png">

**After**

<img width="788" alt="Screen Shot 2020-04-07 at 11 59 37 AM" src="https://user-images.githubusercontent.com/2124984/78692027-4e8e6000-78c7-11ea-8b18-35864dae410f.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/following/manage` and click the Settings menu next to one of your followed blogs.
* Note the changes in the settings screen.

Fixes #40668 