### PR TITLE
Devdocs: Update Typography to specify font weights of 400 or greater

### DIFF
--- a/client/devdocs/design/typography.jsx
+++ b/client/devdocs/design/typography.jsx
@@ -24,8 +24,9 @@ export default class Typography extends React.PureComponent {
 					<h2>Interface Typography</h2>
 
 					<p>
-						We use sans-serif system fonts as the default for UI. This includes UI elements like
-						buttons, notices, and navigation. System fonts improve the page-rendering speed.
+						We use sans-serif system fonts with weights of 400 or greater as the default for UI.
+						This includes UI elements like buttons, notices, and navigation. System fonts improve
+						the page-rendering speed.
 					</p>
 					<p>
 						<code>
@@ -68,9 +69,9 @@ export default class Typography extends React.PureComponent {
 
 					<h2>Content Typography</h2>
 					<p>
-						We mostly use <code>Noto Serif</code> in reading and writing contexts, like the Reader
-						and the editor. Use your best judgment when using Noto Serif for a UI element. Does it
-						add valuable context for the person using our products?
+						We mostly use <code>Noto Serif</code> with weights of 400 or greater in reading and
+						writing contexts, like the Reader and the editor. Use your best judgment when using Noto
+						Serif for a UI element. Does it add valuable context for the person using our products?
 					</p>
 
 					<Card className="design__typography-content-example">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This specifies font weights of 400 or greater to ensure we're no longer using too-thin fonts for better readability.
* See #39596 

Visual ref:

<img width="1680" alt="Screen Shot 2020-04-07 at 12 33 42 PM" src="https://user-images.githubusercontent.com/2124984/78695480-29502080-78cc-11ea-8ee7-f69b25aa4d75.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/devdocs/typography` and note the text changes.
