### PR TITLE
Adds tracking to viewing purchase on product overlap notice

### DIFF
--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -97,7 +97,7 @@ class ProductPlanOverlapNotices extends Component {
 	}
 
 	clickPurchaseHandler = purchaseId => {
-		this.props.recordTracksEvent( 'calypso_product_overlap_purchase_view', {
+		this.props.recordTracksEvent( 'calypso_product_overlap_purchase_click', {
 			purchase_id: purchaseId,
 		} );
 	};

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -96,9 +96,9 @@ class ProductPlanOverlapNotices extends Component {
 		return availableProducts[ currentPlanSlug ].product_name;
 	}
 
-	clickPurchaseHandler = purchaseId => {
+	clickPurchaseHandler = productSlug => {
 		this.props.recordTracksEvent( 'calypso_product_overlap_purchase_click', {
-			purchase_id: purchaseId,
+			purchase_slug: productSlug,
 		} );
 	};
 
@@ -114,7 +114,7 @@ class ProductPlanOverlapNotices extends Component {
 			<li key={ productSlug }>
 				<a
 					href={ managePurchase( productPurchase.domain, productPurchase.id ) }
-					onClick={ () => this.clickPurchaseHandler( productPurchase.id ) }
+					onClick={ () => this.clickPurchaseHandler( productSlug ) }
 				>
 					{ this.getProductName( productSlug ) }
 				</a>

--- a/client/blocks/product-plan-overlap-notices/index.jsx
+++ b/client/blocks/product-plan-overlap-notices/index.jsx
@@ -20,6 +20,7 @@ import { getSitePurchases } from 'state/purchases/selectors';
 import { planHasFeature, planHasSuperiorFeature } from 'lib/plans';
 import { managePurchase } from 'me/purchases/paths';
 import { isJetpackProduct } from 'lib/products-values';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 import './style.scss';
 
@@ -95,6 +96,12 @@ class ProductPlanOverlapNotices extends Component {
 		return availableProducts[ currentPlanSlug ].product_name;
 	}
 
+	clickPurchaseHandler = purchaseId => {
+		this.props.recordTracksEvent( 'calypso_product_overlap_purchase_view', {
+			purchase_id: purchaseId,
+		} );
+	};
+
 	getProductItem( productSlug ) {
 		const { purchases } = this.props;
 		const productPurchase = purchases.find( purchase => purchase.productSlug === productSlug );
@@ -105,7 +112,10 @@ class ProductPlanOverlapNotices extends Component {
 
 		return (
 			<li key={ productSlug }>
-				<a href={ managePurchase( productPurchase.domain, productPurchase.id ) }>
+				<a
+					href={ managePurchase( productPurchase.domain, productPurchase.id ) }
+					onClick={ () => this.clickPurchaseHandler( productPurchase.id ) }
+				>
 					{ this.getProductName( productSlug ) }
 				</a>
 			</li>
@@ -165,13 +175,18 @@ class ProductPlanOverlapNotices extends Component {
 	}
 }
 
-export default connect( ( state, { siteId } ) => {
-	const selectedSiteId = siteId || getSelectedSiteId( state );
+export default connect(
+	( state, { siteId } ) => {
+		const selectedSiteId = siteId || getSelectedSiteId( state );
 
-	return {
-		availableProducts: getAvailableProductsList( state ),
-		currentPlanSlug: getSitePlanSlug( state, selectedSiteId ),
-		purchases: getSitePurchases( state, selectedSiteId ),
-		selectedSiteId,
-	};
-} )( localize( ProductPlanOverlapNotices ) );
+		return {
+			availableProducts: getAvailableProductsList( state ),
+			currentPlanSlug: getSitePlanSlug( state, selectedSiteId ),
+			purchases: getSitePurchases( state, selectedSiteId ),
+			selectedSiteId,
+		};
+	},
+	{
+		recordTracksEvent,
+	}
+)( localize( ProductPlanOverlapNotices ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds tracking for managing purchases on product overlap notice.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a connected Jetpack site with a conflicting purchase.
* When the conflict notice appears, click one of the links.
* Observe the tracking event.

Fixes 1151678672052943-as-1169766089949081.