### PR TITLE
composite-checkout: Swap payment method and review steps

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -336,6 +336,7 @@ export default function CompositeCheckout( {
 					getItemVariants={ getItemVariants }
 					domainContactValidationCallback={ domainContactValidationCallback }
 					responseCart={ responseCart }
+					subtotal={ subtotal }
 					CheckoutTerms={ CheckoutTerms }
 				/>
 			</CheckoutProvider>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -11,11 +11,7 @@ import { useLineItems, useFormStatus } from '@automattic/composite-checkout';
  */
 import joinClasses from './join-classes';
 import Coupon from './coupon';
-import {
-	WPOrderReviewLineItems,
-	WPOrderReviewTotal,
-	WPOrderReviewSection,
-} from './wp-order-review-line-items';
+import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 
 export default function WPCheckoutOrderReview( {
 	className,
@@ -28,7 +24,7 @@ export default function WPCheckoutOrderReview( {
 	getItemVariants,
 	onChangePlanLength,
 } ) {
-	const [ items, total ] = useLineItems();
+	const [ items ] = useLineItems();
 	const { formStatus } = useFormStatus();
 
 	return (
@@ -51,10 +47,6 @@ export default function WPCheckoutOrderReview( {
 				couponStatus={ couponStatus }
 				couponFieldStateProps={ couponFieldStateProps }
 			/>
-
-			<WPOrderReviewSection>
-				<WPOrderReviewTotal total={ total } />
-			</WPOrderReviewSection>
 		</div>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -24,8 +24,9 @@ export default function WPCheckoutOrderReview( {
 	getItemVariants,
 	onChangePlanLength,
 } ) {
-	const [ items ] = useLineItems();
+	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
+	const isPurchaseFree = total.amount.value === 0;
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
@@ -41,12 +42,14 @@ export default function WPCheckoutOrderReview( {
 				/>
 			</WPOrderReviewSection>
 
-			<CouponField
-				id="order-review-coupon"
-				disabled={ formStatus !== 'ready' }
-				couponStatus={ couponStatus }
-				couponFieldStateProps={ couponFieldStateProps }
-			/>
+			{ ! isPurchaseFree && (
+				<CouponField
+					id="order-review-coupon"
+					disabled={ formStatus !== 'ready' }
+					couponStatus={ couponStatus }
+					couponFieldStateProps={ couponFieldStateProps }
+				/>
+			) }
 		</div>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -27,8 +27,6 @@ export default function WPCheckoutOrderReview( {
 	variantSelectOverride,
 	getItemVariants,
 	onChangePlanLength,
-	responseCart,
-	CheckoutTerms,
 } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
@@ -57,10 +55,6 @@ export default function WPCheckoutOrderReview( {
 			<WPOrderReviewSection>
 				<WPOrderReviewTotal total={ total } />
 			</WPOrderReviewSection>
-
-			<CheckoutTermsUI>
-				<CheckoutTerms cart={ responseCart } />
-			</CheckoutTermsUI>
 		</div>
 	);
 }
@@ -72,47 +66,10 @@ WPCheckoutOrderReview.propTypes = {
 	removeCoupon: PropTypes.func.isRequired,
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
-	responseCart: PropTypes.object.isRequired,
-	CheckoutTerms: PropTypes.elementType.isRequired,
 };
 
 const CouponField = styled( Coupon )`
 	margin: 24px 30px 24px 0;
 	padding-bottom: 24px;
 	border-bottom: 1px solid ${props => props.theme.colors.borderColorLight};
-`;
-
-const CheckoutTermsUI = styled.div`
-	& > * {
-		margin: 16px 16px 16px -24px;
-		padding-left: 24px;
-		position: relative;
-	}
-
-	& div:first-of-type {
-		padding-left: 0;
-		margin-left: 0;
-	}
-
-	svg {
-		width: 16px;
-		height: 16px;
-		position: absolute;
-		top: 0;
-		left: 0;
-	}
-
-	p {
-		font-size: 12px;
-		margin: 0;
-		word-break: break-word;
-	}
-
-	a {
-		text-decoration: underline;
-	}
-
-	a:hover {
-		text-decoration: none;
-	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -1,32 +1,18 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
-import {
-	useLineItems,
-	useTotal,
-	renderDisplayValueMarkdown,
-	useEvents,
-	useFormStatus,
-} from '@automattic/composite-checkout';
+import { useLineItems, useTotal, renderDisplayValueMarkdown } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Button from './button';
-import Coupon from './coupon';
 import { isLineItemADomain } from '../hooks/has-domains';
 
-export default function WPCheckoutOrderSummary( { siteUrl, couponStatus, couponFieldStateProps } ) {
-	const translate = useTranslate();
-	const { formStatus } = useFormStatus();
+export default function WPCheckoutOrderSummary( { siteUrl } ) {
 	const [ items ] = useLineItems();
-	const onEvent = useEvents();
-	//TODO: tie the default coupon field visibility based on whether there is a coupon in the cart
-	const [ isCouponFieldVisible, setIsCouponFieldVisible ] = useState( false );
-	const hasCouponBeenApplied = couponStatus === 'applied';
 
 	const firstDomainItem = items.find( isLineItemADomain );
 	const domainUrl = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
@@ -41,27 +27,7 @@ export default function WPCheckoutOrderSummary( { siteUrl, couponStatus, couponF
 						return <ProductListItem key={ product.id }>{ product.label }</ProductListItem>;
 					} ) }
 				</ProductList>
-
-				{ ! hasCouponBeenApplied && ! isCouponFieldVisible && formStatus === 'ready' && (
-					<AddCouponButton
-						buttonState="text-button"
-						onClick={ () => {
-							handleAddCouponButtonClick( setIsCouponFieldVisible, onEvent );
-						} }
-					>
-						{ translate( 'Add a coupon' ) }
-					</AddCouponButton>
-				) }
 			</SummaryContent>
-
-			{ isCouponFieldVisible && (
-				<CouponField
-					id="order-summary-coupon"
-					disabled={ formStatus !== 'ready' }
-					couponStatus={ couponStatus }
-					couponFieldStateProps={ couponFieldStateProps }
-				/>
-			) }
 		</React.Fragment>
 	);
 }
@@ -113,26 +79,6 @@ const ProductListItem = styled.li`
 	padding: 0;
 	list-style-type: none;
 `;
-
-const CouponField = styled( Coupon )`
-	margin-top: 16px;
-`;
-
-const AddCouponButton = styled( Button )`
-	font-size: ${props => props.theme.fontSize.small};
-	margin-top: 8px;
-
-	@media ( ${props => props.theme.breakpoints.smallPhoneUp} ) {
-		margin-top: 0;
-	}
-`;
-
-function handleAddCouponButtonClick( setIsCouponFieldVisible, onEvent ) {
-	setIsCouponFieldVisible( true );
-	onEvent( {
-		type: 'a8c_checkout_add_coupon_button_clicked',
-	} );
-}
 
 function shouldItemBeInSummary( item ) {
 	const itemTypesToIgnore = [ 'tax', 'credits', 'wordpress-com-credits' ];

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -17,19 +17,7 @@ export default function WPCheckoutOrderSummary( { siteUrl } ) {
 	const firstDomainItem = items.find( isLineItemADomain );
 	const domainUrl = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
 
-	return (
-		<React.Fragment>
-			{ domainUrl && <DomainURL>{ domainUrl }</DomainURL> }
-
-			<SummaryContent>
-				<ProductList>
-					{ items.filter( shouldItemBeInSummary ).map( product => {
-						return <ProductListItem key={ product.id }>{ product.label }</ProductListItem>;
-					} ) }
-				</ProductList>
-			</SummaryContent>
-		</React.Fragment>
-	);
+	return <React.Fragment>{ domainUrl && <DomainURL>{ domainUrl }</DomainURL> }</React.Fragment>;
 }
 
 export function WPCheckoutOrderSummaryTitle() {
@@ -58,29 +46,3 @@ const DomainURL = styled.div`
 	margin-top: -12px;
 	word-break: break-word;
 `;
-
-const SummaryContent = styled.div`
-	margin-top: 12px;
-
-	@media ( ${props => props.theme.breakpoints.smallPhoneUp} ) {
-		display: flex;
-		justify-content: space-between;
-		align-items: flex-end;
-	}
-`;
-
-const ProductList = styled.ul`
-	margin: 0;
-	padding: 0;
-`;
-
-const ProductListItem = styled.li`
-	margin: 0;
-	padding: 0;
-	list-style-type: none;
-`;
-
-function shouldItemBeInSummary( item ) {
-	const itemTypesToIgnore = [ 'tax', 'credits', 'wordpress-com-credits' ];
-	return ! itemTypesToIgnore.includes( item.type );
-}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -136,13 +136,7 @@ export default function WPCheckout( {
 		<Checkout>
 			<CheckoutStepBody
 				activeStepContent={ null }
-				completeStepContent={
-					<WPCheckoutOrderSummary
-						siteUrl={ siteUrl }
-						couponStatus={ couponStatus }
-						couponFieldStateProps={ couponFieldStateProps }
-					/>
-				}
+				completeStepContent={ <WPCheckoutOrderSummary siteUrl={ siteUrl } /> }
 				titleContent={ <WPCheckoutOrderSummaryTitle /> }
 				errorMessage={ translate( 'There was an error with the summary step.' ) }
 				isStepActive={ false }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -28,6 +28,7 @@ import WPCheckoutOrderReview from './wp-checkout-order-review';
 import WPCheckoutOrderSummary, { WPCheckoutOrderSummaryTitle } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import { isCompleteAndValid, prepareDomainContactDetails } from '../types';
+import { WPOrderReviewTotal, WPOrderReviewSection } from './wp-order-review-line-items';
 
 const ContactFormTitle = () => {
 	const translate = useTranslate();
@@ -207,13 +208,7 @@ export default function WPCheckout( {
 				<CheckoutStep
 					stepId="payment-method-step"
 					activeStepContent={
-						<React.Fragment>
-							{ paymentMethodStep.activeStepContent }
-
-							<CheckoutTermsUI>
-								<CheckoutTerms cart={ responseCart } />
-							</CheckoutTermsUI>
-						</React.Fragment>
+						<PaymentMethodStep CheckoutTerms={ CheckoutTerms } responseCart={ responseCart } />
 					}
 					completeStepContent={ paymentMethodStep.completeStepContent }
 					titleContent={ paymentMethodStep.titleContent }
@@ -231,6 +226,23 @@ export default function WPCheckout( {
 
 function setActiveStepNumber( stepNumber ) {
 	window.location.hash = '#step' + stepNumber;
+}
+
+function PaymentMethodStep( { CheckoutTerms, responseCart } ) {
+	const total = useTotal();
+	return (
+		<React.Fragment>
+			{ paymentMethodStep.activeStepContent }
+
+			<CheckoutTermsUI>
+				<CheckoutTerms cart={ responseCart } />
+			</CheckoutTermsUI>
+
+			<WPOrderReviewSection>
+				<WPOrderReviewTotal total={ total } />
+			</WPOrderReviewSection>
+		</React.Fragment>
+	);
 }
 
 function InactiveOrderReview() {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -28,7 +28,7 @@ import WPCheckoutOrderReview from './wp-checkout-order-review';
 import WPCheckoutOrderSummary, { WPCheckoutOrderSummaryTitle } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import { isCompleteAndValid, prepareDomainContactDetails } from '../types';
-import { WPOrderReviewTotal, WPOrderReviewSection } from './wp-order-review-line-items';
+import { WPOrderReviewTotal, WPOrderReviewSection, LineItemUI } from './wp-order-review-line-items';
 
 const ContactFormTitle = () => {
 	const translate = useTranslate();
@@ -72,6 +72,7 @@ export default function WPCheckout( {
 	getItemVariants,
 	domainContactValidationCallback,
 	responseCart,
+	subtotal,
 } ) {
 	const translate = useTranslate();
 	const couponFieldStateProps = useCouponFieldState( submitCoupon );
@@ -208,7 +209,11 @@ export default function WPCheckout( {
 				<CheckoutStep
 					stepId="payment-method-step"
 					activeStepContent={
-						<PaymentMethodStep CheckoutTerms={ CheckoutTerms } responseCart={ responseCart } />
+						<PaymentMethodStep
+							CheckoutTerms={ CheckoutTerms }
+							responseCart={ responseCart }
+							subtotal={ subtotal }
+						/>
 					}
 					completeStepContent={ paymentMethodStep.completeStepContent }
 					titleContent={ paymentMethodStep.titleContent }
@@ -228,8 +233,9 @@ function setActiveStepNumber( stepNumber ) {
 	window.location.hash = '#step' + stepNumber;
 }
 
-function PaymentMethodStep( { CheckoutTerms, responseCart } ) {
-	const total = useTotal();
+function PaymentMethodStep( { CheckoutTerms, responseCart, subtotal } ) {
+	const [ items, total ] = useLineItems();
+	const taxes = items.filter( item => item.type === 'tax' );
 	return (
 		<React.Fragment>
 			{ paymentMethodStep.activeStepContent }
@@ -239,6 +245,10 @@ function PaymentMethodStep( { CheckoutTerms, responseCart } ) {
 			</CheckoutTermsUI>
 
 			<WPOrderReviewSection>
+				{ subtotal && <LineItemUI subtotal item={ subtotal } /> }
+				{ taxes.map( tax => (
+					<LineItemUI tax key={ tax.id } item={ tax } />
+				) ) }
 				<WPOrderReviewTotal total={ total } />
 			</WPOrderReviewSection>
 		</React.Fragment>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -152,13 +152,23 @@ export default function WPCheckout( {
 			/>
 			<CheckoutSteps>
 				<CheckoutStep
-					stepId="payment-method-step"
-					isCompleteCallback={ () =>
-						paymentMethodStep.isCompleteCallback( { activePaymentMethod } )
+					stepId="review-order-step"
+					isCompleteCallback={ () => true }
+					activeStepContent={
+						<WPCheckoutOrderReview
+							removeItem={ removeItem }
+							couponStatus={ couponStatus }
+							couponFieldStateProps={ couponFieldStateProps }
+							removeCoupon={ removeCouponAndResetActiveStep }
+							onChangePlanLength={ changePlanLength }
+							variantRequestStatus={ variantRequestStatus }
+							variantSelectOverride={ variantSelectOverride }
+							getItemVariants={ getItemVariants }
+							responseCart={ responseCart }
+							CheckoutTerms={ CheckoutTerms }
+						/>
 					}
-					activeStepContent={ paymentMethodStep.activeStepContent }
-					completeStepContent={ paymentMethodStep.completeStepContent }
-					titleContent={ paymentMethodStep.titleContent }
+					titleContent={ <OrderReviewTitle /> }
 					editButtonText={ translate( 'Edit' ) }
 					editButtonAriaLabel={ translate( 'Edit the payment method' ) }
 					nextStepButtonText={ translate( 'Continue' ) }
@@ -201,23 +211,10 @@ export default function WPCheckout( {
 					/>
 				) }
 				<CheckoutStep
-					stepId="review-order-step"
-					isCompleteCallback={ () => true }
-					activeStepContent={
-						<WPCheckoutOrderReview
-							removeItem={ removeItem }
-							couponStatus={ couponStatus }
-							couponFieldStateProps={ couponFieldStateProps }
-							removeCoupon={ removeCouponAndResetActiveStep }
-							onChangePlanLength={ changePlanLength }
-							variantRequestStatus={ variantRequestStatus }
-							variantSelectOverride={ variantSelectOverride }
-							getItemVariants={ getItemVariants }
-							responseCart={ responseCart }
-							CheckoutTerms={ CheckoutTerms }
-						/>
-					}
-					titleContent={ <OrderReviewTitle /> }
+					stepId="payment-method-step"
+					activeStepContent={ paymentMethodStep.activeStepContent }
+					completeStepContent={ paymentMethodStep.completeStepContent }
+					titleContent={ paymentMethodStep.titleContent }
 					editButtonText={ translate( 'Edit' ) }
 					editButtonAriaLabel={ translate( 'Edit the payment method' ) }
 					nextStepButtonText={ translate( 'Continue' ) }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -162,6 +162,7 @@ export default function WPCheckout( {
 						/>
 					}
 					titleContent={ <OrderReviewTitle /> }
+					completeStepContent={ <InactiveOrderReview /> }
 					editButtonText={ translate( 'Edit' ) }
 					editButtonAriaLabel={ translate( 'Edit the payment method' ) }
 					nextStepButtonText={ translate( 'Continue' ) }
@@ -232,6 +233,24 @@ function setActiveStepNumber( stepNumber ) {
 	window.location.hash = '#step' + stepNumber;
 }
 
+function InactiveOrderReview() {
+	const [ items ] = useLineItems();
+	return (
+		<SummaryContent>
+			<ProductList>
+				{ items.filter( shouldItemBeInSummary ).map( product => {
+					return <ProductListItem key={ product.id }>{ product.label }</ProductListItem>;
+				} ) }
+			</ProductList>
+		</SummaryContent>
+	);
+}
+
+function shouldItemBeInSummary( item ) {
+	const itemTypesToIgnore = [ 'tax', 'credits', 'wordpress-com-credits' ];
+	return ! itemTypesToIgnore.includes( item.type );
+}
+
 const CheckoutTermsUI = styled.div`
 	& > * {
 		margin: 16px 16px 16px -24px;
@@ -265,4 +284,25 @@ const CheckoutTermsUI = styled.div`
 	a:hover {
 		text-decoration: none;
 	}
+`;
+
+const SummaryContent = styled.div`
+	margin-top: 12px;
+
+	@media ( ${props => props.theme.breakpoints.smallPhoneUp} ) {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-end;
+	}
+`;
+
+const ProductList = styled.ul`
+	margin: 0;
+	padding: 0;
+`;
+
+const ProductListItem = styled.li`
+	margin: 0;
+	padding: 0;
+	list-style-type: none;
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -265,7 +265,7 @@ function shouldItemBeInSummary( item ) {
 
 const CheckoutTermsUI = styled.div`
 	& > * {
-		margin: 16px 16px 16px -24px;
+		margin: 16px 0 16px -24px;
 		padding-left: 24px;
 		position: relative;
 	}
@@ -273,6 +273,7 @@ const CheckoutTermsUI = styled.div`
 	& div:first-of-type {
 		padding-left: 0;
 		margin-left: 0;
+		margin-top: 32px;
 	}
 
 	svg {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -3,6 +3,7 @@
  */
 import React, { useEffect, useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
+import styled from '@emotion/styled';
 import {
 	Checkout,
 	CheckoutStepBody,
@@ -164,8 +165,6 @@ export default function WPCheckout( {
 							variantRequestStatus={ variantRequestStatus }
 							variantSelectOverride={ variantSelectOverride }
 							getItemVariants={ getItemVariants }
-							responseCart={ responseCart }
-							CheckoutTerms={ CheckoutTerms }
 						/>
 					}
 					titleContent={ <OrderReviewTitle /> }
@@ -212,7 +211,15 @@ export default function WPCheckout( {
 				) }
 				<CheckoutStep
 					stepId="payment-method-step"
-					activeStepContent={ paymentMethodStep.activeStepContent }
+					activeStepContent={
+						<React.Fragment>
+							{ paymentMethodStep.activeStepContent }
+
+							<CheckoutTermsUI>
+								<CheckoutTerms cart={ responseCart } />
+							</CheckoutTermsUI>
+						</React.Fragment>
+					}
 					completeStepContent={ paymentMethodStep.completeStepContent }
 					titleContent={ paymentMethodStep.titleContent }
 					editButtonText={ translate( 'Edit' ) }
@@ -230,3 +237,38 @@ export default function WPCheckout( {
 function setActiveStepNumber( stepNumber ) {
 	window.location.hash = '#step' + stepNumber;
 }
+
+const CheckoutTermsUI = styled.div`
+	& > * {
+		margin: 16px 16px 16px -24px;
+		padding-left: 24px;
+		position: relative;
+	}
+
+	& div:first-of-type {
+		padding-left: 0;
+		margin-left: 0;
+	}
+
+	svg {
+		width: 16px;
+		height: 16px;
+		position: absolute;
+		top: 0;
+		left: 0;
+	}
+
+	p {
+		font-size: 12px;
+		margin: 0;
+		word-break: break-word;
+	}
+
+	a {
+		text-decoration: underline;
+	}
+
+	a:hover {
+		text-decoration: none;
+	}
+`;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -309,7 +309,7 @@ WPOrderReviewLineItems.propTypes = {
 };
 
 const WPOrderReviewList = styled.ul`
-	margin: -10px 0 0;
+	margin: -10px 0 10px 0;
 	padding: 0;
 `;
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -171,18 +171,19 @@ function LineItemPrice( { lineItem } ) {
 	);
 }
 
-const LineItemUI = styled( WPLineItem )`
+export const LineItemUI = styled( WPLineItem )`
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
 	font-weight: ${( { theme, total } ) => ( total ? theme.weights.bold : theme.weights.normal )};
 	color: ${( { theme, total } ) => ( total ? theme.colors.textColorDark : theme.colors.textColor )};
 	font-size: ${( { total } ) => ( total ? '1.2em' : '1em' )};
-	padding: ${( { total, isSummaryVisible } ) => ( isSummaryVisible || total ? 0 : '24px 0' )};
+	padding: ${( { total, isSummaryVisible, tax, subtotal } ) =>
+		isSummaryVisible || total || subtotal || tax ? '10px 0' : '24px 0'};
 	border-bottom: ${( { theme, total, isSummaryVisible } ) =>
 		isSummaryVisible || total ? 0 : '1px solid ' + theme.colors.borderColorLight};
 	position: relative;
-	margin-right: ${( { total } ) => ( total ? '0' : '30px' )};
+	margin-right: ${( { total, tax, subtotal } ) => ( subtotal || total || tax ? '0' : '30px' )};
 `;
 
 const LineItemTitleUI = styled.div`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -21,20 +21,12 @@ import { useHasDomainsInCart, isLineItemADomain } from '../hooks/has-domains';
 import { ItemVariationPicker } from './item-variation-picker';
 
 export function WPOrderReviewSection( { children, className } ) {
-	return (
-		<OrderReviewSectionArea className={ joinClasses( [ className, 'order-review-section' ] ) }>
-			{ children }
-		</OrderReviewSectionArea>
-	);
+	return <div className={ joinClasses( [ className, 'order-review-section' ] ) }>{ children }</div>;
 }
 
 WPOrderReviewSection.propTypes = {
 	className: PropTypes.string,
 };
-
-const OrderReviewSectionArea = styled.div`
-	margin-bottom: 16px;
-`;
 
 function WPLineItem( {
 	item,
@@ -190,7 +182,7 @@ const LineItemUI = styled( WPLineItem )`
 	border-bottom: ${( { theme, total, isSummaryVisible } ) =>
 		isSummaryVisible || total ? 0 : '1px solid ' + theme.colors.borderColorLight};
 	position: relative;
-	margin-right: 30px;
+	margin-right: ${( { total } ) => ( total ? '0' : '30px' )};
 `;
 
 const LineItemTitleUI = styled.div`

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -63,7 +63,6 @@ Each payment method is an object with the following properties:
 - `submitButton: React.ReactNode`. A component button that is used to submit the payment method. This button should include a click handler that performs the actual payment process. When disabled, it will be provided with the `disabled` prop and must disable the button.
 - `inactiveContent: React.ReactNode`. A component that renders a summary of the selected payment method when the step is inactive.
 - `getAriaLabel: (localize: () => string) => string`. A function to return the name of the Payment Method. It will receive the localize function as an argument.
-- `isCompleteCallback?: () => boolean | Promise<boolean>`. Used to determine if a step is complete for purposes of validation. Default is a function returning true.
 
 Within the components, the Hook `usePaymentMethod()` will return an object of the above form with the key of the currently selected payment method or null if none is selected. To retrieve all the payment methods and their properties, the Hook `useAllPaymentMethods()` will return an array that contains them all.
 
@@ -131,7 +130,7 @@ This component's props are:
 - `titleContent: React.ReactNode`. Displays as the title of the step.
 - `activeStepContent?: React.ReactNode`. Displays as the content of the step when it is active. It is also displayed when the step is inactive but is hidden by CSS.
 - `completeStepContent?: React.ReactNode`. Displays as the content of the step when it is inactive and complete as defined by the `isCompleteCallback`.
-- `isCompleteCallback: () => boolean | Promise<boolean>`. Used to determine if a step is complete for purposes of validation.
+- `isCompleteCallback: () => boolean | Promise<boolean>`. Used to determine if a step is complete for purposes of validation. Note that this is not called for the last step!
 - `editButtonAriaLabel?: string`. Used to fill in the `aria-label` attribute for the "Edit" button if one exists.
 - `nextStepButtonAriaLabel?: string`. Used to fill in the `aria-label` attribute for the "Continue" button if one exists.
 - `editButtonText?: string`. Used in place of "Edit" on the edit step button.

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -26,7 +26,6 @@ import {
 	useDispatch,
 	useMessages,
 	useFormStatus,
-	usePaymentMethod,
 } from '../src/public-api';
 import { StripeHookProvider, useStripe } from '../src/lib/stripe';
 
@@ -391,7 +390,6 @@ function MyCheckout() {
 function MyCheckoutBody() {
 	const country = useSelect( storeSelect => storeSelect( 'demo' )?.getCountry() ?? '' );
 	const { showErrorMessage: showError } = useMessages();
-	const activePaymentMethod = usePaymentMethod();
 
 	return (
 		<Checkout>
@@ -408,13 +406,11 @@ function MyCheckoutBody() {
 			/>
 			<CheckoutSteps>
 				<CheckoutStep
-					stepId="payment-method-step"
-					isCompleteCallback={ () =>
-						paymentMethodStep.isCompleteCallback( { activePaymentMethod } )
-					}
-					activeStepContent={ paymentMethodStep.activeStepContent }
-					completeStepContent={ paymentMethodStep.completeStepContent }
-					titleContent={ paymentMethodStep.titleContent }
+					stepId="review-order-step"
+					isCompleteCallback={ () => true }
+					activeStepContent={ reviewOrderStep.activeStepContent }
+					completeStepContent={ reviewOrderStep.completeStepContent }
+					titleContent={ reviewOrderStep.titleContent }
 				/>
 				<CheckoutStep
 					stepId={ contactFormStep.id }
@@ -435,11 +431,10 @@ function MyCheckoutBody() {
 					titleContent={ contactFormStep.titleContent }
 				/>
 				<CheckoutStep
-					stepId="review-order-step"
-					isCompleteCallback={ () => true }
-					activeStepContent={ reviewOrderStep.activeStepContent }
-					completeStepContent={ reviewOrderStep.completeStepContent }
-					titleContent={ reviewOrderStep.titleContent }
+					stepId="payment-method-step"
+					activeStepContent={ paymentMethodStep.activeStepContent }
+					completeStepContent={ paymentMethodStep.completeStepContent }
+					titleContent={ paymentMethodStep.titleContent }
 				/>
 			</CheckoutSteps>
 		</Checkout>

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -93,7 +93,6 @@ export function Checkout( { children, className } ) {
 }
 
 function DefaultCheckoutSteps() {
-	const activePaymentMethod = usePaymentMethod();
 	const orderSummaryStep = getDefaultOrderSummaryStep();
 	const paymentMethodStep = getDefaultPaymentMethodStep();
 	const reviewOrderStep = getDefaultOrderReviewStep();
@@ -113,22 +112,19 @@ function DefaultCheckoutSteps() {
 			/>
 			<CheckoutSteps>
 				<CheckoutStep
-					stepId="payment-method-step"
-					isCompleteCallback={ () =>
-						paymentMethodStep.isCompleteCallback( { activePaymentMethod } )
-					}
-					activeStepContent={ paymentMethodStep.activeStepContent }
-					completeStepContent={ paymentMethodStep.completeStepContent }
-					titleContent={ paymentMethodStep.titleContent }
-					className={ paymentMethodStep.className }
-				/>
-				<CheckoutStep
 					stepId="review-order-step"
 					isCompleteCallback={ () => true }
 					activeStepContent={ reviewOrderStep.activeStepContent }
 					completeStepContent={ reviewOrderStep.completeStepContent }
 					titleContent={ reviewOrderStep.titleContent }
 					className={ reviewOrderStep.className }
+				/>
+				<CheckoutStep
+					stepId="payment-method-step"
+					activeStepContent={ paymentMethodStep.activeStepContent }
+					completeStepContent={ paymentMethodStep.completeStepContent }
+					titleContent={ paymentMethodStep.titleContent }
+					className={ paymentMethodStep.className }
 				/>
 			</CheckoutSteps>
 		</React.Fragment>

--- a/packages/composite-checkout/src/components/default-steps.js
+++ b/packages/composite-checkout/src/components/default-steps.js
@@ -32,9 +32,6 @@ export function getDefaultPaymentMethodStep() {
 		activeStepContent: <CheckoutPaymentMethods isComplete={ false } />,
 		incompleteStepContent: null,
 		completeStepContent: <CheckoutPaymentMethods summary isComplete={ true } />,
-		isCompleteCallback: ( { activePaymentMethod } ) => {
-			return activePaymentMethod?.isCompleteCallback?.() ?? true;
-		},
 		isEditableCallback: () => true,
 		// These cannot be translated because they are not inside a component and
 		// we don't know if they are being created by the package or the host page.

--- a/packages/composite-checkout/test/checkout.js
+++ b/packages/composite-checkout/test/checkout.js
@@ -189,27 +189,27 @@ describe( 'Checkout', () => {
 				container = renderResult.container;
 			} );
 
-			it( 'makes the payment method step active', () => {
+			it( 'makes the review step active', () => {
 				const activeSteps = container.querySelectorAll( '.checkout-step--is-active' );
 				expect( activeSteps ).toHaveLength( 1 );
-				expect( activeSteps[ 0 ] ).toHaveTextContent( 'Pick a payment method' );
+				expect( activeSteps[ 0 ] ).toHaveTextContent( 'Review your order' );
 			} );
 
-			it( 'makes the payment method step visible', () => {
+			it( 'makes the payment method step invisible', () => {
 				const firstStep = container.querySelector( '.checkout__payment-methods-step' );
 				const firstStepContent = firstStep.querySelector( '.checkout-steps__step-content' );
-				expect( firstStepContent ).toHaveStyle( 'display: block' );
+				expect( firstStepContent ).toHaveStyle( 'display: none' );
 			} );
 
-			it( 'makes the review step invisible', () => {
+			it( 'makes the review step visible', () => {
 				const reviewStep = container.querySelector( '.checkout__review-order-step' );
 				expect( reviewStep ).toHaveTextContent( 'Review your order' );
 				const reviewStepContent = reviewStep.querySelector( '.checkout-steps__step-content' );
-				expect( reviewStepContent ).toHaveStyle( 'display: none' );
+				expect( reviewStepContent ).toHaveStyle( 'display: block' );
 			} );
 		} );
 
-		describe( 'when clicking continue from the payment method step', function() {
+		describe( 'when clicking continue from the first step', function() {
 			let container;
 
 			beforeEach( () => {
@@ -236,13 +236,13 @@ describe( 'Checkout', () => {
 			} );
 
 			it( 'makes the first step invisible', () => {
-				const firstStep = container.querySelector( '.checkout__payment-methods-step' );
+				const firstStep = container.querySelector( '.checkout__review-order-step' );
 				const firstStepContent = firstStep.querySelector( '.checkout-steps__step-content' );
 				expect( firstStepContent ).toHaveStyle( 'display: none' );
 			} );
 
-			it( 'makes the review step visible', () => {
-				const reviewStep = container.querySelector( '.checkout__review-order-step' );
+			it( 'makes the next step visible', () => {
+				const reviewStep = container.querySelector( '.checkout__payment-methods-step' );
 				const reviewStepContent = reviewStep.querySelector( '.checkout-steps__step-content' );
 				expect( reviewStepContent ).toHaveStyle( 'display: block' );
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This re-orders the steps in composite checkout such that instead of the order:

- Payment methods
- Contact
- Review

it becomes the order:

- Review
- Contact
- Payment methods

This has the added advantage that we can remove the slightly awkward `isCompleteCallback` with an argument from the API of payment method objects, which was only being used by the credit card payment method (and is now inline with the submit button).

See p8hgLy-2LL-p2 for the design on which this is based.

#### Screenshots

**Before**

![first-step-payment-methods](https://user-images.githubusercontent.com/2036909/78732530-dcdb0400-7910-11ea-96f8-0bb3c2aa95c5.png)

![last-step-review](https://user-images.githubusercontent.com/2036909/78732535-dfd5f480-7910-11ea-9cf5-72654e237087.png)

**After**

![first-step-review-2-active](https://user-images.githubusercontent.com/2036909/78814519-c084a900-799c-11ea-9452-54a34015770c.png)

![first-step-review-2-inactive](https://user-images.githubusercontent.com/2036909/78814524-c2e70300-799c-11ea-89c5-8ebca984c050.png)

![last-step-payment-methods-4](https://user-images.githubusercontent.com/2036909/79014626-4e959680-7b39-11ea-9044-30e0ed2b5d4f.png)

#### Testing instructions

- Sandbox the store so we can load stripe.
- Visit composite checkout with items in your cart.
- Verify that after the summary (which only looks like a step), the first active step is the review step (it displays a list of the items in the cart with "remove" buttons next to some of them and a total).
- Click "Continue" to move to the next step.
- Verify that the second step is the contact details step (it will ask for just the postal code and country unless you have a domain product in the cart in which case it will display more fields). Note that if your purchase is free (due to credits, a coupon, or a bundled domain) you should not see this step at all.
- Click "Continue" to move to the last step.
- Verify that the last step is the payment method selection step (it should display a list of available payment methods).
- Without filling in the credit card fields, press the submit button.
- Verify that the submission does not occur (there is no global error notice displayed) and that you see validation errors appear below the credit card fields.
- Fill in the credit card fields with test data (eg: card number `4242 4242 4242 4242`) and press the submit button.
- Verify that the submission works and the purchase completes.