### PR TITLE
Gutenboarding: Update border of designs in design selector grid to be 2px

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -55,7 +55,7 @@
 		width: 100%;
 		height: 0;
 		padding-top: 360px / 480px * 200%;
-		border: 1px solid var( --studio-gray-5 );
+		border: 2px solid var( --studio-gray-5 );
 		position: relative;
 		overflow: hidden;
 


### PR DESCRIPTION
Requested in p1586295444204100-slack-gutenboarding so that the border is more legible, particularly against dark layouts.

#### Changes proposed in this Pull Request

* Update border of designs in the design selector grid in Gutenboarding to be 2px

#### Testing instructions

![image](https://user-images.githubusercontent.com/14988353/78725789-bef2bb00-7973-11ea-9d70-f6e90f017797.png)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/new/ and proceed to the design selector step.
* Check that the grey and blue hover state border of the designs is now 2px

Fixes #
