### PR TITLE
Jetpack Connect: enable redirect to checkout for preselected Jetpack Search product

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -45,6 +45,8 @@ import {
 	PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 	PRODUCT_JETPACK_BACKUP_REALTIME,
 	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
+	PRODUCT_JETPACK_SEARCH,
+	PRODUCT_JETPACK_SEARCH_MONTHLY,
 } from 'lib/products-values/constants';
 
 /**
@@ -56,6 +58,7 @@ const analyticsPageTitleByType = {
 	personal: 'Jetpack Connect Personal',
 	premium: 'Jetpack Connect Premium',
 	pro: 'Jetpack Install Pro',
+	jetpack_search: 'Jetpack Search',
 };
 
 const removeSidebar = context => context.store.dispatch( hideSidebar() );
@@ -68,6 +71,7 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 			pro: PLAN_JETPACK_BUSINESS,
 			realtimebackup: PRODUCT_JETPACK_BACKUP_REALTIME,
 			backup: PRODUCT_JETPACK_BACKUP_DAILY,
+			jetpack_search: PRODUCT_JETPACK_SEARCH,
 		},
 		monthly: {
 			personal: PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -75,6 +79,7 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 			pro: PLAN_JETPACK_BUSINESS_MONTHLY,
 			realtimebackup: PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
 			backup: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
+			jetpack_search: PRODUCT_JETPACK_SEARCH_MONTHLY,
 		},
 	};
 
@@ -130,7 +135,6 @@ export function connect( context, next ) {
 
 	// Not clearing the plan here, because other flows can set the cookie before arriving here.
 	planSlug && storePlan( planSlug );
-
 	analytics.pageView.record( pathname, analyticsPageTitle );
 
 	removeSidebar( context );

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -38,7 +38,7 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { persistSignupDestination } from 'signup/utils';
-import { isJetpackBackupSlug as getIsJetpackBackupSlug } from 'lib/products-values';
+import { isJetpackProductSlug as getJetpackProductSlug } from 'lib/products-values';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
 const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
@@ -78,7 +78,7 @@ class Plans extends Component {
 		if ( this.props.selectedPlan ) {
 			return this.selectPlan( this.props.selectedPlan );
 		}
-		if ( this.props.hasPlan || this.props.notJetpack ) {
+		if ( ( this.props.hasPlan && ! this.props.product_slug ) || this.props.notJetpack ) {
 			return this.redirect( CALYPSO_PLANS_PAGE );
 		}
 		if ( ! this.props.selectedSite && this.props.isSitesInitialized ) {
@@ -157,7 +157,6 @@ class Plans extends Component {
 
 	selectPlan = cartItem => {
 		clearPlan();
-
 		if ( ! cartItem || cartItem.product_slug === PLAN_JETPACK_FREE ) {
 			return this.selectFreeJetpackPlan();
 		}
@@ -175,6 +174,7 @@ class Plans extends Component {
 		addItem( cartItem );
 		this.props.completeFlow();
 		persistSignupDestination( this.getMyPlansDestination() );
+
 		this.redirect( '/checkout/', cartItem.product_slug );
 	};
 
@@ -246,9 +246,9 @@ const connectComponent = connect(
 		const selectedSiteSlug = selectedSite ? selectedSite.slug : '';
 
 		const selectedPlanSlug = retrievePlan();
-		const isJetpackBackupSlug = getIsJetpackBackupSlug( selectedPlanSlug );
+		const isJetpackProductSlug = getJetpackProductSlug( selectedPlanSlug );
 
-		const selectedPlan = isJetpackBackupSlug
+		const selectedPlan = isJetpackProductSlug
 			? getProductBySlug( state, selectedPlanSlug )
 			: getPlanBySlug( state, selectedPlanSlug );
 

--- a/client/state/jetpack-connect/constants.js
+++ b/client/state/jetpack-connect/constants.js
@@ -3,4 +3,4 @@ export const JETPACK_CONNECT_TTL_SECONDS = JETPACK_CONNECT_TTL / 60;
 export const JETPACK_CONNECT_AUTHORIZE_TTL = 60 * 60 * 1000; // 1 hour
 export const AUTH_ATTEMPS_TTL = 60 * 1000; // 1 minute
 
-export const FLOW_TYPES = [ 'install', 'personal', 'premium', 'pro' ];
+export const FLOW_TYPES = [ 'install', 'jetpack_search', 'backup', 'personal', 'premium', 'pro' ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This change facilitates personalized UX flow when purchasing Search via Jetpack Connect e.g from. the LP. 
The sequence is as follows: chose Search on the LP -> connect your site -> checkout focused on Search. It skips the canonical (connection) plans page or redirect to `/plans` in Calypso.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `jetpack.com/upgrade/search`
* after being redirected to JPC, input site url (change WP.com to local build in the url)
* verify redirect to checkout with Search in cart ( annual option).

Try sites with and without paid plans and without Jetpack installed and/or activated. 
Also, verify that the Backup experience is not broken (start from `jetpack.com/upgrade/backup`)

Verify Tracks being recorded: `recordPageView(  "/jetpack/connect/jetpack_search", "Jetpack Connect" ]`
Note: it will work for monthly using the `.../jetpack/connect/jetpack_search/monthly...` route.

Fixes https://github.com/Automattic/wp-calypso/issues/40763
