### PR TITLE
Gutenboarding: Updating color of WordPress logo and dropdown arrow fixes

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -55,7 +55,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				ref={ buttonRef }
 			>
 				<span>{ children }</span>
-				<Dashicon icon="arrow-down-alt2" />
+				<Dashicon icon="arrow-down-alt2" size={ 16 } />
 			</Button>
 			{ isDomainPopoverVisible && (
 				<div className="domain-picker-button__popover-container">

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -3,6 +3,7 @@
 .domain-picker-button {
 	.dashicon {
 		margin-left: 0.5em;
+		margin-top: 2px;
 		transition: transform 100ms ease-in-out;
 	}
 	&.is-open .dashicon {

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -39,8 +39,9 @@ $padding--gutenboarding__header: $grid-size;
 }
 
 .gutenboarding__header-wp-logo {
-	margin-left: 24px - $padding--gutenboarding__header - $margin-left--gutenboarding__header-section-item; // we want 24px exact on spec: ( 24 - header padding - own margin )
-	color: var( --studio-blue-90 );
+	margin-left: 24px - $padding--gutenboarding__header -
+		$margin-left--gutenboarding__header-section-item; // we want 24px exact on spec: ( 24 - header padding - own margin )
+	color: var( --studio-black );
 	display: flex;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updated the WordPress logo to be black
* Shrunk the arrow on the domain picker

#### Testing instructions

* Navigate to /new/design