### PR TITLE
Fix signup form margin in Safari

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -130,11 +130,10 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 				<h1 className="signup-form__title">{ NO__( 'Save your progress' ) }</h1>
 
 				<form onSubmit={ handleSignUp }>
+					<legend className="signup-form__legend">
+						<p>{ NO__( 'Enter an email and password to save your progress and continue' ) }</p>
+					</legend>
 					<fieldset>
-						<legend className="signup-form__legend">
-							<p>{ NO__( 'Enter an email and password to save your progress and continue' ) }</p>
-						</legend>
-
 						<TextControl
 							value={ emailVal }
 							disabled={ isFetchingNewUser }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes signup form margin in Safari. It fixes it by taking the `legend` out of the `fieldset`. 


#### Testing

##### Using Safari

1. Make sure you're not signed in.
2. Navigate up to site-creation.
3. The signup form should have the correct margining as shown in #40865.

Fixes https://github.com/Automattic/wp-calypso/issues/40865
