### PR TITLE
Add gridicons to node modules to transpile

### DIFF
--- a/packages/calypso-build/webpack/util.js
+++ b/packages/calypso-build/webpack/util.js
@@ -81,6 +81,7 @@ const nodeModulesToTranspile = [
 	'debug/',
 	'escape-string-regexp/',
 	'filesize/',
+	'gridicons/',
 	'prismjs/',
 	'punycode/',
 	'react-spring/',


### PR DESCRIPTION
The `gridicons` package contains some ES2015+ code that Calypso imports directly, in its `Gridicon` component. As such, the `gridicons` package needs to be transpiled, in order to avoid ES2015+ code making its way into the fallback build.

It's not entirely clear to me why this hasn't caused issues in production yet, but my guess is that Terser is "accidentally" transpiling the ES2015+ code when minifying it. In any case, we shouldn't leave it to chance, hence this PR.

#### Changes proposed in this Pull Request

* Add `gridicons` to transpilation whitelist

#### Testing instructions

Ensure that the build continues to work normally. If possible, test in IE11 or another older browser to ensure that nothing got broken.
