### PR TITLE
Gutenboarding: fix signup form spacing on Safari

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -53,10 +53,13 @@
 			transform: translateX( -50% );
 		}
 	}
-	.signup-form__legend p {
-		@include onboarding-large-text;
-		margin: 0 0 42px;
-		color: var( --studio-gray-40 );
+	.signup-form__legend {
+		padding-bottom: 42px;
+
+		& > p {
+			@include onboarding-large-text;
+			color: var( --studio-gray-40 );
+		}
 	}
 
 	.components-text-control__input {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix the bottom spacing issue of signup form on Safari browser
<img width="400" alt="Screenshot 2020-04-08 at 14 12 40" src="https://user-images.githubusercontent.com/14192054/78778343-caf67100-79a3-11ea-8f7a-d0f786a2d8cd.png">

Fixes #40865

