### PR TITLE
Update the time format to match the user locale 'LT' and update DatePicker today TZ

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -54,9 +54,9 @@ class DailyBackupStatus extends Component {
 		let displayableDate;
 
 		if ( isToday ) {
-			displayableDate = translate( 'Latest: Today ' ) + backupDate.format( 'H:mm a' );
+			displayableDate = translate( 'Latest: Today ' ) + backupDate.format( 'LT' );
 		} else {
-			displayableDate = backupDate.format( dateFormat + ', H:mm a' );
+			displayableDate = backupDate.format( dateFormat + ', LT' );
 		}
 
 		return displayableDate;
@@ -93,7 +93,7 @@ class DailyBackupStatus extends Component {
 		const backupDate = applySiteOffset( backup.activityTs, { timezone, gmtOffset } );
 
 		const displayDate = backupDate.format( 'L' );
-		const displayTime = backupDate.format( 'H:mm' );
+		const displayTime = backupDate.format( 'LT' );
 
 		return (
 			<Card className="daily-backup-status__failed">

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -29,10 +29,10 @@ class DatePicker extends Component {
 	};
 
 	getDisplayDate = ( date, showTodayYesterday = true ) => {
-		const { moment, translate } = this.props;
+		const { today, moment, translate } = this.props;
 
-		const daysDiff = moment().diff( date, 'days' );
-		const yearToday = moment().format( 'YYYY' );
+		const daysDiff = moment( today ).diff( date, 'days' );
+		const yearToday = moment( today ).format( 'YYYY' );
 		const yearDate = moment( date ).format( 'YYYY' );
 
 		const dateFormat = yearToday === yearDate ? 'MMM D' : 'MMM D, YYYY';
@@ -78,9 +78,9 @@ class DatePicker extends Component {
 	};
 
 	canGoToNextDay = () => {
-		const { moment, selectedDate } = this.props;
+		const { today, moment, selectedDate } = this.props;
 
-		return ! moment( selectedDate ).isSame( moment(), 'day' );
+		return ! moment( selectedDate ).isSame( moment( today ), 'day' );
 	};
 
 	goToActivityLog = () => {

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -160,6 +160,8 @@ class BackupsPage extends Component {
 
 		const selectedDateString = this.TO_REMOVE_getSelectedDateString();
 
+		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
+
 		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );
 		const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
@@ -178,6 +180,7 @@ class BackupsPage extends Component {
 					selectedDate={ this.getSelectedDate() }
 					siteId={ siteId }
 					oldestDateAvailable={ oldestDateAvailable }
+					today={ today }
 					siteSlug={ siteSlug }
 				/>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
**[ Small review ]**

Update the time format on DailyBackupStatus to match the user locale 'LT', and also, update the DatePicker to use today date with the site time zone applied to always work in the same time zone.

Fixed a minor issue (avoid to add am/pm, 'LT' format add it automatically). Before:

![image](https://user-images.githubusercontent.com/9832440/78782635-3afff980-799a-11ea-8ce1-23224f688f6d.png)


After:

![image](https://user-images.githubusercontent.com/9832440/78782577-23c10c00-799a-11ea-807a-57dfe9f05c4c.png)


#### Testing instructions

- Apply the changes
- Check that everything works as before, the backup time shows up in its correct locale format (Except on the Backup Scheduled view, the scheduled and last backup date/time are fake)
