### PR TITLE
Redirect to My Home after completing signup

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -56,11 +56,11 @@ function getRedirectDestination( dependencies ) {
 }
 
 function getSignupDestination( dependencies ) {
-	return `/checklist/${ dependencies.siteSlug }`;
+	return `/home/${ dependencies.siteSlug }`;
 }
 
 function getLaunchDestination( dependencies ) {
-	return `/checklist/${ dependencies.siteSlug }?d=launched`;
+	return `/home/${ dependencies.siteSlug }?d=launched`;
 }
 
 function getThankYouNoSiteDestination() {
@@ -68,7 +68,7 @@ function getThankYouNoSiteDestination() {
 }
 
 function getChecklistThemeDestination( dependencies ) {
-	return `/checklist/${ dependencies.siteSlug }?d=theme`;
+	return `/home/${ dependencies.siteSlug }?d=theme`;
 }
 
 function getEditorDestination( dependencies ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of https://github.com/Automattic/wp-calypso/issues/40646

The current signup flows still use the old `/checklist` route as destination path which ends up [redirecting to `/home`](https://github.com/Automattic/wp-calypso/blob/a4616438bcb848e97b784fa6d55ba4e9c5cb3d21/client/my-sites/checklist/controller.jsx#L29-L32) since all sites created during signup are currently eligible for My Home (it is now enabled for all WP.com sites).

This PR updates the destination URL of the signup flows to `/home` so there is less code pointing to the legacy checklist section (which we aim to remove completely once we finish deleting existing code using it).

#### Testing instructions

- Create a site using any of the signup flows modified by this PR:
  - `/start/business`
  - `/start/premium`
  - `/start/personal`
  - `/start/free`
  - `/start/onboarding-with-preview`
  - `/start/onboarding`
  - `/start/desktop`
  - `/start/ecommerce`
  - `/start/ecommerce-onboarding`
  - `/start/ecommerce-design-first`
  - `/start/launch-site`
  - `/start/frankenflow`
  - `/start/with-theme`
  - `/start/design-first`
- Make sure the destination path is `/home/:site` and there is no redirect from `/checklist/:site`.
