### PR TITLE
wpcom-block-editor: track block removals recursively

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -21,8 +21,8 @@ const debug = debugFactory( 'wpcom-block-editor:tracking' );
 /**
  * Looks up the block name based on its id.
  *
- * @param {string} blockId Blog identifier.
- * @returns {string|null} Blg name if it exists. Otherwise, `null`.
+ * @param {string} blockId Block identifier.
+ * @returns {string|null} Block name if it exists. Otherwise, `null`.
  */
 const getTypeForBlockId = blockId => {
 	const block = select( 'core/block-editor' ).getBlock( blockId );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -34,13 +34,13 @@ const getTypeForBlockId = blockId => {
  * or tries to lookup the block by id.
  *
  * @param {string|object} block Block object or string identifier.
- * @returns {object|null} block object or null.
+ * @returns {object} block object or an empty object if not found.
  */
 const ensureBlockObject = block => {
 	if ( typeof block === 'object' ) {
 		return block;
 	}
-	return select( 'core/block-editor' ).getBlock( block );
+	return select( 'core/block-editor' ).getBlock( block ) || {};
 };
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -78,6 +78,11 @@ function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parent
  * This is a convenience method that processes the first argument of the action (blocks)
  * and calls your tracking for each of the blocks involved in the action.
  *
+ * This method tracks only blocks explicitly listed as a target of the action.
+ * If you also want to track an event for all child blocks, use `trackBlocksHandler`.
+ *
+ * @see {@link trackBlocksHandler} for a recursive version.
+ *
  * @param {string} eventName event name
  * @returns {Function} track handler
  */
@@ -98,6 +103,18 @@ const trackBlockInsertion = blocks => {
 	trackBlocksHandler( blocks, 'wpcom_block_inserted', ( { name } ) => ( {
 		block_name: name,
 		blocks_replaced: false,
+	} ) );
+};
+
+/**
+ * Track block removal.
+ *
+ * @param {object|Array} blocks block instance object or an array of such objects
+ * @returns {void}
+ */
+const trackBlockRemoval = blocks => {
+	trackBlocksHandler( blocks, 'wpcom_block_deleted', ( { name } ) => ( {
+		block_name: name,
 	} ) );
 };
 
@@ -179,10 +196,10 @@ const REDUX_TRACKING = {
 	'core/block-editor': {
 		moveBlocksUp: getBlocksTracker( 'wpcom_block_moved_up' ),
 		moveBlocksDown: getBlocksTracker( 'wpcom_block_moved_down' ),
-		removeBlocks: getBlocksTracker( 'wpcom_block_deleted' ),
-		removeBlock: getBlocksTracker( 'wpcom_block_deleted' ),
+		removeBlocks: trackBlockRemoval,
+		removeBlock: trackBlockRemoval,
 		moveBlockToPosition: getBlocksTracker( 'wpcom_block_moved_via_dragging' ),
-		deleteBlock: getBlocksTracker( 'wpcom_block_deleted' ),
+		deleteBlock: trackBlockRemoval,
 		insertBlock: trackBlockInsertion,
 		insertBlocks: trackBlockInsertion,
 		replaceBlock: trackBlockReplacement,
@@ -238,7 +255,7 @@ if (
 		},
 	} ) );
 
-	// Registers Plugin.
+	// Registers Plugin.e
 	registerPlugin( 'wpcom-block-editor-tracking', {
 		render: () => {
 			EVENT_TYPES.forEach( eventType =>

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -216,7 +216,6 @@ const REDUX_TRACKING = {
 		removeBlocks: trackBlockRemoval,
 		removeBlock: trackBlockRemoval,
 		moveBlockToPosition: getBlocksTracker( 'wpcom_block_moved_via_dragging' ),
-		deleteBlock: trackBlockRemoval,
 		insertBlock: trackBlockInsertion,
 		insertBlocks: trackBlockInsertion,
 		replaceBlock: trackBlockReplacement,

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -255,7 +255,7 @@ if (
 		},
 	} ) );
 
-	// Registers Plugin.e
+	// Registers Plugin.
 	registerPlugin( 'wpcom-block-editor-tracking', {
 		render: () => {
 			EVENT_TYPES.forEach( eventType =>

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -30,6 +30,20 @@ const getTypeForBlockId = blockId => {
 };
 
 /**
+ * Ensure you are working with block object. This either returns the object
+ * or tries to lookup the block by id.
+ *
+ * @param {string|object} block Block object or string identifier.
+ * @returns {object|null} block object or null.
+ */
+const ensureBlockObject = block => {
+	if ( typeof block === 'object' ) {
+		return block;
+	}
+	return select( 'core/block-editor' ).getBlock( block );
+};
+
+/**
  * This helper function tracks the given blocks recursively
  * in order to track inner blocks.
  *
@@ -55,6 +69,9 @@ function trackBlocksHandler( blocks, eventName, propertiesHandler = noop, parent
 	}
 
 	castBlocks.forEach( block => {
+		// Make this compatible with actions that pass only block id, not objects.
+		block = ensureBlockObject( block );
+
 		const eventProperties = {
 			...propertiesHandler( block, parentBlock ),
 			inner_block: !! parentBlock,


### PR DESCRIPTION
When you remove for example "Columns" block right now, we only fire a single event for removing the Columns block.

#### Changes proposed in this Pull Request

* This PR now fires an event for all inner blocks recursively. If you for example remove Columns, you will get events for:
  - Columns
  - Column (fired for every column present)
  - Possibly other deeper blocks, like Paragraph or Image inside one of the Column blocks
- We already track block insertions this way (recursively) so it makes sense to apply it for removals too to get an accurate view on insertions/removals

#### Testing instructions

* Test in D41587-code, which is generated from this PR and has detailed testing instructions.

Fixes #40498
