### PR TITLE
Update docs to use yarn in examples

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1250,6 +1250,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 <span id="facebook/node-haste"></span>
+
 ### https://github.com/facebook/node-haste
 #### server/devdocs/bin/generate-components-usage-counts
 ```text
@@ -1343,6 +1344,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 <span id="prism"></span>
+
 ### https://github.com/PrismJS/prism/
 ```
 MIT LICENSE
@@ -1366,4 +1368,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+```
+
+### https://classic.yarnpkg.com/en/
+#### .yarn/releases
+```text
+BSD 2-Clause License
+
+For Yarn software
+
+Copyright (c) 2016-present, Yarn Contributors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1250,7 +1250,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 <span id="facebook/node-haste"></span>
-
 ### https://github.com/facebook/node-haste
 #### server/devdocs/bin/generate-components-usage-counts
 ```text
@@ -1344,7 +1343,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 <span id="prism"></span>
-
 ### https://github.com/PrismJS/prism/
 ```
 MIT LICENSE
@@ -1368,35 +1366,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-```
-
-### https://classic.yarnpkg.com/en/
-#### .yarn/releases
-```text
-BSD 2-Clause License
-
-For Yarn software
-
-Copyright (c) 2016-present, Yarn Contributors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
- * Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
- * Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ You can read more about Calypso at [developer.wordpress.com/calypso](https://dev
 
 You can try out the user-side of Calypso on [WordPress.com](https://wordpress.com/) (a lot of the logged-in area is Calypso; if in doubt, view source), you can poke around the code here on GitHub, or you can install it and run it locally. The latter is the most fun.
 
-1. Make sure you have [`git`](https://git-scm.com/), [`node`](https://nodejs.org/), and [`npm`](https://www.npmjs.com/get-npm) installed.
-2. Clone this repository locally.
-3. Add `127.0.0.1 calypso.localhost` to your local `hosts` file.
-4. Execute `npm start` from the root directory of the repository.
-5. Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
+1.	Make sure you have [`git`](https://git-scm.com/), [`node`](https://nodejs.org/), and [`yarn`](https://classic.yarnpkg.com/en/docs/install) installed.
+2.	Clone this repository locally.
+3.	Add `127.0.0.1 calypso.localhost` to your local `hosts` file.
+4.	Execute `yarn start` from the root directory of the repository.
+5.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
 
 Need more detailed installation instructions? [We have them](./docs/install.md).
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,6 +1,6 @@
 # Apps
 
-This directory exists to hold a variety of projects that can produce independent, binary-like outputs deployed elsewhere. Typically not published to NPM or build on `npm start`
+This directory exists to hold a variety of projects that can produce independent, binary-like outputs deployed elsewhere. Typically not published to NPM or build on `yarn start`
 
 For packages that we might publish as NPM packages, see [`/packages`](../packages).
 
@@ -10,7 +10,7 @@ If you want to add a new project into this directory, then add a new directory a
 
 ## Building
 
-Apps (unlike packages) are not built on Calypso's `npm install`.
+Apps (unlike packages) are not built on Calypso's `yarn`.
 
 You must manually build apps by running:
 
@@ -19,6 +19,6 @@ npx lerna run build --scope="@automattic/app-name"
 ```
 
 ## Validating package.json
-Running `npm run lint:package-json` will lint all `package.json`'s under `./apps/**` based on [`npmpackagejsonlint.config.js`](../npmpackagejsonlint.config.js).
+Running `yarn run lint:package-json` will lint all `package.json`'s under `./apps/**` based on [`npmpackagejsonlint.config.js`](../npmpackagejsonlint.config.js).
 
 If you need exceptions to linting rules, add them to overrides section in the config file.

--- a/apps/full-site-editing/bin/sync-blog-posts-block.sh
+++ b/apps/full-site-editing/bin/sync-blog-posts-block.sh
@@ -40,15 +40,15 @@ fi
 # print usage is no mode matched
 if [ -z "$MODE" ]
 then
-	echo "Usage: npm run sync:blog-posts-block [arguments]"
-	echo
-	echo Possible arguments:
-	echo --branch=master
-	echo --release=1.0.0-alpha.17
-	echo
-	echo You can find the latest release ID on https://github.com/Automattic/newspack-blocks/releases/latest
-	echo
-	exit 1
+    echo "Usage: yarn run sync:blog-posts-block [arguments]"
+    echo
+    echo Possible arguments:
+    echo --branch=master
+    echo --release=1.0.0-alpha.17
+    echo
+    echo You can find the latest release ID on https://github.com/Automattic/newspack-blocks/releases/latest
+    echo
+    exit 1
 fi
 
 TARGET=./full-site-editing-plugin/blog-posts-block/newspack-homepage-articles
@@ -98,7 +98,7 @@ elif [ "$MODE" = "path" ] ; then
 	CODE="${npm_config_path}"
 elif [ "$MODE" = "npm" ] ; then
 	# Way back to wp-calypso root:
-	CODE="../../node_modules/newspack-blocks" 
+	CODE="../../node_modules/newspack-blocks"
 fi
 
 if [ ! -d "$CODE" ] ; then

--- a/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/README.md
+++ b/apps/full-site-editing/full-site-editing-plugin/blog-posts-block/README.md
@@ -26,7 +26,7 @@ Once your changes land on the Newspack side, coordinate with the team (over issu
 While being in `apps/full-site-editing/` directory, you can run:
 
 ```
-npm run sync:blog-posts-block --release=1.0.0-alpha.17
+yarn run sync:blog-posts-block --release=1.0.0-alpha.17
 ```
 
 This will pull the code from the release and integrate it into this repository. Please review changes, make sure to update `NEWSPACK_BLOCKS__VERSION` in [index.php](./index.php) and commit.
@@ -36,5 +36,5 @@ This will pull the code from the release and integrate it into this repository. 
 Sometimes, probably, you will need to sync the NHA code straight in your local environment. It means you will get working on both projects at the same time. For this situation, you'd like to reference the code source through the `path` bin script argument.
 
 ```js
-npm run sync:blog-posts-block --path=/Absolute/path/of/newspack-blocks/
+yarn run sync:blog-posts-block --path=/Absolute/path/of/newspack-blocks/
 ```

--- a/client/components/community-translator/README.md
+++ b/client/components/community-translator/README.md
@@ -5,4 +5,4 @@ An asynchronously-loaded, React-based community translator.
 
 At present, it's in its most basic form, loaded behind a feature flag awaiting further development.
 
-To enable in development, run `ENABLE_FEATURES=i18n/community-translator npm start`
+To enable in development, run `ENABLE_FEATURES=i18n/community-translator yarn start`

--- a/client/layout/guided-tours/docs/ARCHITECTURE-FUTURE.md
+++ b/client/layout/guided-tours/docs/ARCHITECTURE-FUTURE.md
@@ -14,8 +14,8 @@ In the interest of keeping Calypso's main bundles small and free of pieces that 
 As of August 2017, Guided Tours impacts Calypso's main bundle `build` as follows:
 
 - `layout/guided-tours`, which includes the view layer and its helpers, as well as individual tour configs: 76 KB stat size, 43 KB parsed, 9 KB gzipped
-- `state/ui/action-log`, for which `npm run analyze-bundles` doesn't provided fine-grained data, but whose raw source, excluding `test`, clocks at 2.5 KB or 1 KB gzipped
-- `state/ui/guided-tours`, for which `npm run analyze-bundles` doesn't provided fine-grained data, but whose raw source, excluding `test`, clocks at 15 KB or 4 KB gzipped
+- `state/ui/action-log`, for which `yarn run analyze-bundles` doesn't provided fine-grained data, but whose raw source, excluding `test`, clocks at 2.5 KB or 1 KB gzipped
+- `state/ui/guided-tours`, for which `yarn run analyze-bundles` doesn't provided fine-grained data, but whose raw source, excluding `test`, clocks at 15 KB or 4 KB gzipped
 
 We don't yet support lazy loading of branches of state, and ultimately `state/ui/action-log` has to be gathering information and `state/ui/guided-tours` has to be running selectors to determine if there is a tour to trigger — luckily, it is also the smaller piece.
 

--- a/client/lib/perfmon/README.md
+++ b/client/lib/perfmon/README.md
@@ -13,7 +13,7 @@ How it works right now:
 - Placeholders can also be scrolled into view - it monitors for 'scroll' events with useCapture = true (debounced to 200ms) so that we can re-check if any known placeholders have now appeared.
 - It hooks into the `page()` system in order to clear pending events when the user navigates (or, at least, when that navigation is done via the `page` library rather than replaceState/pushState)
 
-You can enable this in development by running `ENABLE_FEATURES=perfmon npm start`. You may also want to enable the `google-analytics` feature in your config file (or by URL, &flags=google-analytics) if you want to observe the events being sent to Google Analytics.
+You can enable this in development by running `ENABLE_FEATURES=perfmon yarn start`. You may also want to enable the `google-analytics` feature in your config file (or by URL, &flags=google-analytics) if you want to observe the events being sent to Google Analytics.
 
 You can see how many active placeholders (visible and non visible) there detected during each check by running this in your console:
 

--- a/client/server/bundler/README.md
+++ b/client/server/bundler/README.md
@@ -77,7 +77,7 @@ There are two different modes of operation:
 
 1. development - in development mode, the JavaScript are generated on-the-fly and cached in the server’s memory. The server is running an instance of the webpack compiler that is in watch mode so that it responds to changes to the files. If a file changes, the assets are regenerated and a hot update is emitted over a websocket to the client. The hot update is used by the React hot loader to replace the React component on-the-fly while preserving the components state.
 
-2. production - in production mode, the files are written to the public directory by running the `npm run build` command. The command runs `webpack`, generates a `assets.json` file, and then minifies each file. The `assets.json` file is used in the server to map the chunk name to the current asset.
+2. production - in production mode, the files are written to the public directory by running the `yarn run build` command. The command runs `webpack`, generates a `assets.json` file, and then minifies each file. The `assets.json` file is used in the server to map the chunk name to the current asset.
 
 
 ### Caching
@@ -89,7 +89,7 @@ In most of the environments that Calypso is deployed to, the static assets are s
 Webpack stats can be serialized as JSON for the purposes of analyzing the results of a build. This can be used with tools like [Webpack Analyze](https://webpack.github.io/analyse/) or [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/) to visualize the modules and dependencies comprising a build. To generate a JSON file during a build, use the `preanalyze-bundles` NPM script:
 
 ```bash
-NODE_ENV=production npm run preanalyze-bundles
+NODE_ENV=production yarn run preanalyze-bundles
 ```
 
 This will cause a JSON file `stats.json` to be written to the root project directory once the build succeeds.

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -61,8 +61,8 @@ function shouldPersist() {
  * browser state and loading without it
  *
  * Can be overridden on the command-line with two flags:
- *   - ENABLE_FEATURES=force-sympathy npm start (always sympathize)
- *   - ENABLE_FEATURES=no-force-sympathy npm start (always prevent sympathy)
+ *   - ENABLE_FEATURES=force-sympathy yarn start (always sympathize)
+ *   - ENABLE_FEATURES=no-force-sympathy yarn start (always prevent sympathy)
  *
  * If both of these flags are set, then `force-sympathy` takes precedence.
  *

--- a/client/state/nps-survey/test/README.md
+++ b/client/state/nps-survey/test/README.md
@@ -2,5 +2,5 @@ NPS Survey Testing
 ==================
 
 ```
-npm run test-client -- --grep "state nps-survey"
+yarn run test-client -- --grep "state nps-survey"
 ```

--- a/client/state/push-notifications/test/README.md
+++ b/client/state/push-notifications/test/README.md
@@ -1,4 +1,4 @@
 Push Notification Testing
 ===
 
-`npm run test-client -- --grep "state push-notifications"`
+`yarn run test-client -- --grep "state push-notifications"`

--- a/client/state/ui/nps-survey-notice/test/README.md
+++ b/client/state/ui/nps-survey-notice/test/README.md
@@ -2,5 +2,5 @@ NPS Survey Notice Testing
 =========================
 
 ```
-npm run test-client -- --grep "state ui nps-survey-notice"
+yarn run test-client -- --grep "state ui nps-survey-notice"
 ```

--- a/client/state/ui/post-type-list/README.md
+++ b/client/state/ui/post-type-list/README.md
@@ -2,5 +2,5 @@ Post Type List Testing
 =========================
 
 ```
-npm run test-client client/state/ui/post-type-list/test
+yarn run test-client client/state/ui/post-type-list/test
 ```

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -118,7 +118,7 @@ const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
 const fileLoader = FileConfig.loader(
 	// The server bundler express middleware serves assets from a hard-coded publicPath.
-	// This is required so that running calypso via `npm start` doesn't break.
+	// This is required so that running calypso via `yarn start` doesn't break.
 	isDevelopment
 		? {
 				outputPath: 'images',

--- a/config/README.md
+++ b/config/README.md
@@ -31,7 +31,7 @@ The config files contain a features object that can be used to determine whether
 If you want to temporarily enable/disable some feature flags for a given build, you can do so by setting the `ENABLE_FEATURES` and/or `DISABLE_FEATURES` environment variables. Set them to a comma separated list of features you want to enable/disable, respectively:
 
 ```bash
-ENABLE_FEATURES=manage/plugins/compatibility-warning DISABLE_FEATURES=code-splitting,reader npm start
+ENABLE_FEATURES=manage/plugins/compatibility-warning DISABLE_FEATURES=code-splitting,reader yarn start
 ```
 ### Testing Feature Flags via URLs
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you’d like to contribute code, first, you will need to run Calypso locally.
 1.	Make sure you have `git`, `node`, and `npm` installed.
 2.	Clone this repository locally.
 3.	Add `127.0.0.1 calypso.localhost` to your local hosts file.
-4.	Execute `npm start` from the root directory of the repository.
+4.	Execute `yarn start` from the root directory of the repository.
 5.	Open `http://calypso.localhost:3000` in your browser.
 
 For more detailed instructions, see [Installing Calypso](../docs/install.md).
@@ -30,7 +30,7 @@ For more detailed instructions, see [Installing Calypso](../docs/install.md).
 
 ## Development Workflow
 
-Running `npm start` will build all the code and continuously watch the front-end JS and CSS/Sass for changes and rebuild accordingly.
+Running `yarn start` will build all the code and continuously watch the front-end JS and CSS/Sass for changes and rebuild accordingly.
 
 See [Development Workflow](../docs/development-workflow.md) for details on how to run tests, control what debug messages to receive, and where to look for errors and warnings.
 

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -141,7 +141,7 @@ Good:
 }
 ```
 
-The value passed to this mixin is actually a string rather than a pixel value. Accepted values are: `"<X"`, `">X"`, or `"X-Y"` — where `X` and `Y` are valid breakpoints, for example `480px`. If you provide any other value to the mixin it will fail and give you a warning in the output from `npm start`.
+The value passed to this mixin is actually a string rather than a pixel value. Accepted values are: `"<X"`, `">X"`, or `"X-Y"` — where `X` and `Y` are valid breakpoints, for example `480px`. If you provide any other value to the mixin it will fail and give you a warning in the output from `yarn start`.
 
 Adding additional breakpoints should not be undertaken lightly.
 
@@ -204,7 +204,7 @@ Add as much comments as needed to your Sass file, especially around clever code.
 
 ## Right-To-Left (RTL)
 
-We're using [RTLCSS](https://github.com/MohammadYounes/rtlcss) to convert `public/style.css` to rtl. This happens automatically during `npm run build-css`.
+We're using [RTLCSS](https://github.com/MohammadYounes/rtlcss) to convert `public/style.css` to rtl. This happens automatically during `yarn run build-css`.
 
 - If your css code refers to a filename with ‘left’ or ‘right’ in it, for example background: `url(arrow-left.png)`: the RTL version will reference a different file, e.g. `background: url(arrow-right.png)`. Please make sure that file exists.
 - Same goes for ‘ltr’ and ‘rtl’ in it, for example background: url(icons-ltr.png): the RTL version will link to the other direction, e.g `background: url(icons-ltr.png)`. Please make sure that file exists.

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -721,7 +721,7 @@ If ESLint encounters any issues inside any .jsx or .js files you have updated, a
 To lint the entire project, from the root of your working directory run:
 
 ```bash
-npm run lint:js
+yarn run lint:js
 ```
 
 
@@ -734,7 +734,7 @@ If you are using Sublime Text, you can use the `SublimeLinter-eslint` plugin to 
 Before following these instructions, you'll want to globally install ESLint and related dependencies by running the following command in your terminal:
 
 ```bash
-npm install -g eslint babel-eslint eslint-plugin-react eslint-plugin-wpcalypso eslint-config-wpcalypso
+yarn global add eslint babel-eslint eslint-plugin-react eslint-plugin-wpcalypso eslint-config-wpcalypso
 ```
 
 #### Identifying Spaces with Sublime Text

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -1,0 +1,138 @@
+# Dependency management
+
+This project uses [yarn v1](https://classic.yarnpkg.com/lang/en/) to manage its dependencies. It uses `yarn workspaces` functionallity and [lerna](https://github.com/lerna/lerna) to manage the monorepo.
+
+
+## Working with sub-packages
+
+In this context, a 'sub-package' is any package of the monorepo. That includes `./packages/*`, `./client` and `./apps/*`.
+
+With `yarn`, there are two different modes to work with a sub-package:
+
+*Option 1:*
+
+Go to the directory that contains the package and run regular yarn commands. Example:
+
+```
+cd packages/calypso-analytics
+yarn add ...
+```
+
+*Option 2:*
+
+Run `yarn` commands in teh root of the project, but prepend `workspace <packageName>`. Example
+
+```
+yarn workspace @automattic/calypso-analytics add...
+```
+
+Both options are equivalent, is a matter of personal preference. For the rest of this guide, the examples will follow Option 1.
+
+
+
+
+## Common tasks
+
+
+### Add a new dependency
+
+```
+cd <package-dir>
+yarn add <dependency>
+
+# Example:
+# cd packages/calypso-analytics
+# yarn add lodash
+```
+
+You should add dependencies to the root project _only_ when it will be used to test and/or build other packages. To do this, run:
+
+```
+yarn add -w <dependency>
+```
+
+### Delete a dependency
+
+```
+cd <package-dir>
+yarn remove <dependency>
+
+# Example:
+# cd packages/calypso-analytics
+# yarn remove lodash
+```
+
+To delete a dependency of the root project, run:
+
+```
+yarn remove -w lodash
+```
+
+### Update a dependency
+
+Run
+
+```
+yarn upgrade <package>
+
+# Example
+# yarn upgrade sinon
+```
+
+Note that this won't change the required range of `sinon` (i.e. it won't modify `package.json`). Instead, it will try to update `sinon` and any of its dependencies to the highest version that satisfies the specified range.
+For example, if we declare a dependency on `sinon@^7.5.0` it may update sinon to `7.5.1`, but never to `8.0.0`.
+
+
+### Update a dependency to a new range
+
+Run
+
+```
+yarn upgrade <package>@^<semver-range>
+
+# Example
+# yarn upgrade sinon@^9.0.0
+```
+
+As before, it will update `sinon` and all its dependencies. But in this case, it _will_ change the required range (i.e. it will modify `package.json`)
+
+
+### List oudated dependencies
+
+Run
+
+```
+yarn outdated
+```
+
+Note that the output includes which sub-package has the dependency. It is possible that the same dependency is present in many sub-packages (or even in the root project).
+
+
+### List duplicated dependencies
+
+Run
+
+```
+npx yarn-deduplicate --list
+```
+
+It is recommended to run this command after adding a new dependency and fix potential duplications with `npx yarn-deduplicate --package <duplicated-package>`
+
+
+## Differences with `npm`
+
+### Running scripts
+
+When working with `yarn` we don't have to specify `run` in the command line:
+
+```
+# Before:
+npm run build-client
+
+# After:
+yarn build-client
+```
+
+### Other
+
+Check the [official documentation](https://classic.yarnpkg.com/en/docs/migrating-from-npm/#toc-cli-commands-comparison) to see more equivalences between `npm` and `yarn` commands.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -3,7 +3,7 @@ Development Workflow
 
 ## Build
 
-Running `npm start` will build all the code and continuously watch the front-end JS and CSS/Sass for changes and rebuild
+Running `yarn start` will build all the code and continuously watch the front-end JS and CSS/Sass for changes and rebuild
 accordingly.
 
 ### Limited builds
@@ -19,7 +19,7 @@ To find all available sections in the main entry point, you can refer to the [se
 Additionally, in Calypso, we use multiple [Webpack entry points](https://webpack.js.org/concepts/entry-points/) for separating concerns and serving smaller bundles to the user at any given time.
 Building a limited number of entry points speeds up the build process, and to allow that, the `ENTRY_LIMIT` environment variable is available to allow building and running only a specific entry point.
 
-For example: `ENTRY_LIMIT=entry-login,entry-main npm start` would start Calypso and only build the login and the main entry points.
+For example: `ENTRY_LIMIT=entry-login,entry-main yarn start` would start Calypso and only build the login and the main entry points.
 
 To find all available entry points, you can refer to the `entry` option in Calypso's primary `webpack.config.js` file.
 
@@ -28,20 +28,20 @@ To find all available entry points, you can refer to the `entry` option in Calyp
 If you want to run the tests for a specific library in `client/` use:
 
 ```bash
-> npm run test-client client/<subdirectory>/test
+> yarn run test-client client/<subdirectory>/test
 ```
 
 or for running all tests (client, server, test), use:
 
 ```bash
-> npm test
+> yarn test
 ```
 
 The [test/README.md](../test/README.md) file documents how to create new tests, how to watch for file changes, and how to run all or just some tests from the test suite.
 
 ## Errors and Warnings
 
-Errors and warning appear in the normal places – the terminal where you ran `npm start` and the JavaScript console in the browser. If something isn’t going the way you expected it, look at those places first.
+Errors and warning appear in the normal places – the terminal where you ran `yarn start` and the JavaScript console in the browser. If something isn’t going the way you expected it, look at those places first.
 
 ## Debugging
 
@@ -57,21 +57,21 @@ You can also limit the debugging to a particular scope:
 localStorage.setItem( 'debug', 'calypso:*' );
 ```
 
-The `node` server uses the `DEBUG` environment variable instead of `localStorage`. `npm start` will pass along its environment, so you can turn on all debug messages with:
+The `node` server uses the `DEBUG` environment variable instead of `localStorage`. `yarn start` will pass along its environment, so you can turn on all debug messages with:
 
 ```bash
-DEBUG=* npm start
+DEBUG=* yarn start
 ```
 
 or limit it as before with:
 
 ```bash
-DEBUG=calypso:* npm start
+DEBUG=calypso:* yarn start
 ```
 
 ### Debugging node
 
-Since building and starting the express server is done via a npm command, the normal method of passing argument to the node process won't work. However, you can start the debugger via the `NODE_ARGS` environment variable. The value of this variable is passed to the node command when executing `npm start`.  This means you can run the built-in inspector by running `NODE_ARGS="--inspect" npm start`.  Starting the debugger is similar: `NODE_ARGS="--debug=5858" npm start`.  If you would like to debug the build process as well, it might be convenient to have the debugger/inspector break on the first line and wait for you.  In that case, you should also pass in the `--debug-brk` option like so: `NODE_ARGS="--inspect --debug-brk" npm start` (note: `--debug-brk` can also be used with the `--debug` flag).
+Since building and starting the express server is done via a npm command, the normal method of passing argument to the node process won't work. However, you can start the debugger via the `NODE_ARGS` environment variable. The value of this variable is passed to the node command when executing `yarn start`.  This means you can run the built-in inspector by running `NODE_ARGS="--inspect" yarn start`.  Starting the debugger is similar: `NODE_ARGS="--debug=5858" yarn start`.  If you would like to debug the build process as well, it might be convenient to have the debugger/inspector break on the first line and wait for you.  In that case, you should also pass in the `--debug-brk` option like so: `NODE_ARGS="--inspect --debug-brk" yarn start` (note: `--debug-brk` can also be used with the `--debug` flag).
 
 ## Monitoring builds and tests
 
@@ -90,8 +90,8 @@ One such tool is [AnyBar](https://github.com/tonsky/AnyBar) (_macOS only_), a ve
 - Obtain this [handler shell script](https://gist.github.com/mcsf/56911ae03c6d87ec61429cefc7707cb7/)
 - Optionally, place the script somewhere memorable and make it executable: `chmod +x ~/bin/anybar-calypso`
 - From now on, pipe your Calypso commands through it:
-  * `npm start | anybar-calypso`
-  * `npm run test-client:watch client/my-component | anybar-calypso`
+  * `yarn start | anybar-calypso`
+  * `yarn run test-client:watch client/my-component | anybar-calypso`
 - Feel free to tweak the script and share improvements with the Calypso project
 
 ### Other platforms

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -134,7 +134,7 @@ Through the use of the `config` module, we are conditionally loading our section
 
 Restart the server doing:
 
-* `npm start`
+* `yarn start`
 
 We are ready to load [http://calypso.localhost:3000/hello-world](http://calypso.localhost:3000/hello-world)! Your console should respond with `Hello, world?` if everything is working and you should see Calypso's sidebar for "My Sites".
 
@@ -270,6 +270,6 @@ In the `Main` constant we are getting our main jsx file for our section. We then
 
 ### Ok, ready?
 
-Run `npm start` if it wasn't already running, and load [http://calypso.localhost:3000/hello-world](http://calypso.localhost:3000/hello-world) in your browser. You should see "Hello, World!" on the page next to the sidebar. And since we added `siteSelection` in our initial route setup, changing a site in the sidebar should also work for your hello-world section. Happy _calypsoing_!
+Run `yarn start` if it wasn't already running, and load [http://calypso.localhost:3000/hello-world](http://calypso.localhost:3000/hello-world) in your browser. You should see "Hello, World!" on the page next to the sidebar. And since we added `siteSelection` in our initial route setup, changing a site in the sidebar should also work for your hello-world section. Happy _calypsoing_!
 
 Previous: [Values](0-values.md) Next: [The Technology Behind Calypso](tech-behind-calypso.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ You can install Calypso directly on your machine by following the next steps, or
 1.	Check that you have all prerequisites (Git, Node, NPM). See [below](install.md#prerequisites) for more details. Pay close attention to software versions.
 2.	Clone this repository locally.
 3.	Add `127.0.0.1 calypso.localhost` to your local `hosts` file.
-4.	Execute `npm start` from the root directory of the repository.
+4.	Execute `yarn start` from the root directory of the repository.
 5.	Open [`calypso.localhost:3000`](http://calypso.localhost:3000/) in your browser.
 
 ## Prerequisites
@@ -20,17 +20,17 @@ To be able to clone the repository and run the application you need:
 
 ## Installing and Running
 
-Clone this git repository to your machine via the terminal using the `git clone` command and then run `npm start` from the root Calypso directory:
+Clone this git repository to your machine via the terminal using the `git clone` command and then run `yarn start` from the root Calypso directory:
 
 ```bash
 $ git clone https://github.com/Automattic/wp-calypso.git
 $ cd wp-calypso
-$ npm start
+$ yarn start
 ```
 
 _Note - if you are planning on pushing changes back to Calypso, this workflow will ask you for a username and password every time you push a change, which will not work if you have GitHub 2-factor auth enabled.  In this case you should use `git clone git@github.com:Automattic/wp-calypso.git` instead, and follow the instructions [here](https://help.github.com/articles/about-ssh/) to set up authentication._
 
-The `npm start` command will install any `npm` dependencies and start the development server. When changes are made to either the JavaScript files or the Sass stylesheets, the build process will run automatically. The build process compiles both the JavaScript and CSS to make sure that you have the latest versions of both.
+The `yarn start` command will install any `npm` dependencies and start the development server. When changes are made to either the JavaScript files or the Sass stylesheets, the build process will run automatically. The build process compiles both the JavaScript and CSS to make sure that you have the latest versions of both.
 
 To run Calypso locally, you'll need to add `127.0.0.1 calypso.localhost` to [your hosts file](http://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/), and load the app at [http://calypso.localhost:3000](http://calypso.localhost:3000) instead of just `localhost`. This is necessary, because when running locally Calypso is using the remote version of the WordPress.com REST API, which allows only certain origins via our current authentication methods.
 
@@ -44,7 +44,7 @@ Calypso is [broken up into sections](https://github.com/Automattic/wp-calypso/bl
 This can take a long time and slow down incremental builds as your work. To speed things up,
 you can choose to build and run specific sections of Calypso using the `SECTION_LIMIT` environment variable.
 
-For instance, `SECTION_LIMIT=reader,login npm start` would start Calypso and only build the `reader` and `login` sections.
+For instance, `SECTION_LIMIT=reader,login yarn start` would start Calypso and only build the `reader` and `login` sections.
 
 To find all available sections in the main entry point, you can refer to the [sections.js file](https://github.com/Automattic/wp-calypso/blob/master/client/sections.js). Note that the other entry points are likely to register and handle additional sections.
 
@@ -57,7 +57,7 @@ To find all available entry points, you can refer to the `entry` option in Calyp
 
 ### Starting the node debugger
 
-The `npm start` command will pass anything set in the `NODE_ARGS` environment variable as an option to the Node command.  This means that if you want to start up the debugger on a specific port you can run `NODE_ARGS="--debug=5858" npm start`.  Starting the built-in inspector can also be done by running `NODE_ARGS="--inspect" npm start`.  In either case, if you would like to debug the build process as well, it might be convenient to have the inspector break on the first line and wait for you.  In that case, you should also pass in the `--debug-brk` option like so `NODE_ARGS="--inspect --debug-brk" npm start`.
+The `yarn start` command will pass anything set in the `NODE_ARGS` environment variable as an option to the Node command.  This means that if you want to start up the debugger on a specific port you can run `NODE_ARGS="--debug=5858" yarn start`.  Starting the built-in inspector can also be done by running `NODE_ARGS="--inspect" yarn start`.  In either case, if you would like to debug the build process as well, it might be convenient to have the inspector break on the first line and wait for you.  In that case, you should also pass in the `--debug-brk` option like so `NODE_ARGS="--inspect --debug-brk" yarn start`.
 
 ## Using a portable development environment
 

--- a/docs/lockfile.md
+++ b/docs/lockfile.md
@@ -1,26 +1,18 @@
 NPM Lockfile
 ============
 
-We use [`package-lock.json`](https://github.com/Automattic/wp-calypso/blob/master/package-lock.json)
+We use [`yarn.lock`](https://classic.yarnpkg.com/en/docs/yarn-lock/)
 to lock down our dependency versions. This allows us to freeze all dependencies at the
 exact version we have installed in our node_modules.
 
 ## Generating The Lockfile
 
-If you don't edit `package.json` directly, you shouldn't need to do anything. For example, if you run `npm install --save left-pad`,
-the `package-lock.json` file will be updated automatically.
-
-If you edit `package.json` manually, or you want to bump all our transitive dependencies to their most recent version,
-you'll need to run `npm run update-deps` (that will take a while). Internally, the script does the following:
-- Deletes local `node_modules` folders in all packages
-- Deletes your local copy of `package-lock.json`
-- Runs `npm install`
-- Makes sure that all URLs in `resolved` fields are HTTPS. For some reason, NPM sometimes resolves packages from HTTP URLs
+Yarn will automattically generate and update the lock file whenever `yarn`, `yarn install` or `yarn add` is called. If you've manually updated a `package.json` file then Yarn will update the lock file as necessary.
 
 ## Testing
 
-To verify that the new `package-lock.json` works:
+To verify that the new `yarn.lock` works:
 
-- Run `npm run distclean` to delete local `node_modules`
-- Run `npm ci`
+- Run `yarn run distclean` to delete local `node_modules`
+- Run `yarn install --frozen-lockfile`
 - Verify that Calypso works as expected and that tests pass

--- a/docs/merge-checklist.md
+++ b/docs/merge-checklist.md
@@ -3,14 +3,14 @@ Merge Checklist
 
 This document aims to provide a list of things to check and test whenever you are working on a pull request — or when you are reviewing one — for Calypso.
 
-* Run `npm test` from the calypso root to make sure all tests pass.
+* Run `yarn test` from the calypso root to make sure all tests pass.
 * Test with multiple individual sites, and All My Sites. Does everything work as expected? Use the site switcher and directly via URL.
 * Test scenarios where your feature intentionally doesn't work (e.g. not supported on Jetpack)
 * Explicitly test with a Jetpack-powered site. Calypso features should all work with Jetpack sites unless they are strictly WordPress.com-only.
 * Test different user privileges (admin, editor, author). How does your code behave?
 * Your code should work well with an empty initial state. It's easy to overlook that data cached via [state persistence](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#data-persistence--2754-) may not be present when a user logs in for the first time, clears their browser history, or visits with a different browser. Errors can occur if you've introduced code which operates on this data without checking for its existence.
   * Start a new session in private browsing mode, or run `localStorage.clear(); indexedDB.deleteDatabase( 'calypso' );` in your browser's developer tools console, then refresh the page
-  * To disable state persistence, start Calypso with `DISABLE_FEATURES=persist-redux npm start`
+  * To disable state persistence, start Calypso with `DISABLE_FEATURES=persist-redux yarn start`
 * How are you communicating 'loading' and 'empty' states? See how we approach [reactivity](reactivity.md).
 
 It's also important to keep the general WP.com commit checklist at hand (modified for Calypso):

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -8,8 +8,8 @@ These modules live under the `packages` and `apps` directories, one folder per m
 
 Two different directories for modules are:
 
-`/packages` — projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso and build on `npm start`. See "Publishing" below.
-`/apps` — projects that can produce independent, binary-like outputs deployed elsewhere. Typically not published to NPM or build on `npm start`.
+`/packages` — projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso and build on `yarn start`. See "Publishing" below.
+`/apps` — projects that can produce independent, binary-like outputs deployed elsewhere. Typically not published to NPM or build on `yarn start`.
 
 Modules should follow our convention for layout:
 
@@ -69,7 +69,7 @@ The only exception are `devDependencies` which _must be declared in the wp-calyp
 	"files": [ "dist", "src" ],
 	"scripts": {
 		"clean": "npx rimraf dist",
-		"prepublish": "npm run clean",
+		"prepublish": "yarn run clean",
 		"prepare": "transpile"
 	}
 }
@@ -77,26 +77,26 @@ The only exception are `devDependencies` which _must be declared in the wp-calyp
 
 If your package requires compilation, the `package.json` `prepare` script should compile the package. If it contains ES6+ code that needs to be transpiled, use `transpile` (from `@automattic/calypso-build`) which will automatically compile code in `src/` to `dist/cjs` (CommonJS) and `dist/esm` (ECMAScript Modules) by running `babel` over any source files it finds.
 
-Running `npm run lint:package-json` will lint all `package.json`'s under `./packages|apps/**` based on [`npmpackagejsonlint.config.js`](../npmpackagejsonlint.config.js).
+Running `yarn run lint:package-json` will lint all `package.json`'s under `./packages|apps/**` based on [`npmpackagejsonlint.config.js`](../npmpackagejsonlint.config.js).
 
 ## Running Tests
 
 To run all of the package tests:
 
-`npm run test-packages`
+`yarn run test-packages`
 
 To run one package's tests:
 
-`npm run test-packages [ test file pattern ]`
+`yarn run test-packages [ test file pattern ]`
 
 ## Building packages & apps
 
-Packages will have their `prepare` scripts run automatically on `npm install`.
+Packages will have their `prepare` scripts run automatically on `yarn`.
 
 You can build packages also by running:
 
 ```bash
-npm run build-packages
+yarn run build-packages
 ```
 
 Or even specific packages:
@@ -111,7 +111,7 @@ Or specific apps:
 npx lerna run build --scope="@automattic/calypso-build"
 ```
 
-All `prepare` scripts found in all `package.json`s of apps and packages are always run on Calypso's `npm install`. Therefore independent apps in `/apps` directory can use `build` instead of `prepare` so avoid unnecessary builds.
+All `prepare` scripts found in all `package.json`s of apps and packages are always run on Calypso's `yarn`. Therefore independent apps in `/apps` directory can use `build` instead of `prepare` so avoid unnecessary builds.
 
 You can also run other custom `package.json` scripts only for your app or package:
 
@@ -133,7 +133,7 @@ Note that if you're building with Webpack, you may need to turn off [`resolve.sy
 
 ## Publishing
 
-We use [Lerna](https://lernajs.io/) and its `publish` command to publish the monorepo packages to NPM registry. Please do not use regular [`npm publish`](https://docs.npmjs.com/cli/publish) within a package to publish an individual package; `npx` has issues using this flow.
+We use [Lerna](https://lernajs.io/) and its `publish` command to publish the monorepo packages to NPM registry. Please do not use regular [`yarn publish`](https://docs.npmjs.com/cli/publish) within a package to publish an individual package; `npx` has issues using this flow.
 
 ### Make sure changelogs and `package.json` versions are up to date
 
@@ -153,9 +153,9 @@ Build the `dist/` directories (the transpiled package content that will be publi
 git checkout master
 git pull
 git status (should be clean!)
-npm run distclean
-npm ci
-npm run build-packages
+yarn run distclean
+yarn install --frozen-lockfile
+yarn run build-packages
 ```
 
 ### Getting NPM permissions to publish in the `@automattic` scope
@@ -199,7 +199,7 @@ npx lerna publish --dist-tag next from-package
 The published packages will be tagged as `next`, and installed only when the `next` tag is specified explicitly:
 
 ```
-npm install i18n-calypso@next
+yarn install i18n-calypso@next
 ```
 
 #### Running `lerna publish` in non-interactive mode

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -12,8 +12,8 @@ Performance
 If you want to know why a certain module is bundled you can use `whybundled` to find out. See the following for an example on usage:
 
 ```sh
-npm run preanalyze-bundles
-npm run whybundled -- [module]
+yarn run preanalyze-bundles
+yarn run whybundled -- [module]
 
 npn run whybundled -- is-my-json-valid
 ```

--- a/docs/rtl.md
+++ b/docs/rtl.md
@@ -6,6 +6,6 @@ To test the Calypso interface in RTL-mode, you need to set your interface langua
 If you are testing in your local development environment, you will also need to:
 
 - Change `rtl` to `true` in `config/development.json`.
-- Restart your local server (`Ctrl-c`, then `npm start` again).
+- Restart your local server (`Ctrl-c`, then `yarn start` again).
 
 These additional steps are required because we don't have a user on the server-side in your local environment. On WP.com, we know who the user is, so we can programmatically determine if we should be running in RTL mode.

--- a/docs/testing/component-tests.md
+++ b/docs/testing/component-tests.md
@@ -4,7 +4,7 @@ Calypso has a lot of React UI components. (Try for example running `find . -name
 
 ## [Getting started](#getting-started)
 
-To run all current client side tests, run `npm run test-client` from within the Calypso source. You can also run individual tests, see [Testing overview](testing-overview.md#how-to-run-a-smaller-subset-of-test-files) for more details.
+To run all current client side tests, run `yarn run test-client` from within the Calypso source. You can also run individual tests, see [Testing overview](testing-overview.md#how-to-run-a-smaller-subset-of-test-files) for more details.
 
 Going through the current tests is a good way to get ideas for how different kinds of things can be tested.
 

--- a/docs/testing/snapshot-testing.md
+++ b/docs/testing/snapshot-testing.md
@@ -12,7 +12,7 @@ However, if the change was intentional, follow these steps to update the snapsho
 1. Run the following to update the snapshots:
    ```sh
    # --testPathPattern is optional but will be much faster by only running matching tests
-   npm run test-client -- --updateSnapshot --testPathPattern client/components
+   yarn run test-client -- --updateSnapshot --testPathPattern client/components
    ```
 1. Review the diff and ensure the changes are expected and intentional
 1. Commit
@@ -97,13 +97,13 @@ You might be blindsided by CI tests failing when snapshots don't match. You'll n
 `--updateSnapshot`. In Calypso you can do that as follows:
 
 ```sh
-npm run test-client -- --updateSnapshot --testPathPattern path/to/match
+yarn run test-client -- --updateSnapshot --testPathPattern path/to/match
 ```
 
 `--testPathPattern` is not required, but specifying a path will avoid running the whole suite and
 run much faster.
 
-I strongly recommend that you keep `npm run test-client:watch` in the background as you work. Jest
+I strongly recommend that you keep `yarn run test-client:watch` in the background as you work. Jest
 will run only the relevant tests for changed files, and when snapshot tests fail, just hit `u` to
 update a snapshot!
 

--- a/docs/testing/testing-overview.md
+++ b/docs/testing/testing-overview.md
@@ -20,11 +20,11 @@ It supports automatic test discovery. We only need to put a test file into a `te
 Tests can be run in 3 different modes:
 ```bash
 > # run the entire server suite
-> npm run test-server
+> yarn run test-server
 > # run a configuration customized to work with continuous integration 
-> npm run test-server:ci
+> yarn run test-server:ci
 > # run tests in watch mode, by default it executes tests for the modified files only
-> npm run test-client:watch
+> yarn run test-client:watch
 ```
 
 Those tests are executed on every push on continuous integration (we use CircleCi). This is why all individual tests need to be blazing fast. Please note that network connection is disabled for this configuration.
@@ -40,11 +40,11 @@ It supports automatic test discovery. We only need to put a test file into a `te
 Tests can be run in 3 different modes:
 ```bash
 > # run the entire client suite
-> npm run test-client
+> yarn run test-client
 > # run a configuration customized to work with continuous integration
-> npm run test-server:ci
+> yarn run test-server:ci
 > # run tests in watch mode, by default it executes tests for the modified files only
-> npm run test-client:watch
+> yarn run test-client:watch
 ```
 
 They are executed on every push on continuous integration (CircleCI). This is why all individual tests need to be blazing fast. Please note that network connection is disabled for this configuration.
@@ -63,9 +63,9 @@ It supports automatic test discovery. We only need to put a test file into a `in
 Tests can be run in 2 different modes:
 ```bash
 > # run the entire integration suite
-> npm run test-integration
+> yarn run test-integration
 > # run a configuration customized to work with continuous integration
-> npm run test-integration:ci
+> yarn run test-integration:ci
 ```
 
 They run daily on continuous integration (CircleCI), because they can use network connection or memory intensive processing and therefore can have longer runtime.
@@ -86,23 +86,23 @@ End-to-end tests are still using Mocha to run tests.
 
 ##### How to run all tests?
 
-Executing `npm test` from the root folder will run all test suites.
+Executing `yarn test` from the root folder will run all test suites.
 Behind the scenes we maintain 3 test configuration. This is because each of them (`client`, `server`, and `integration`) has their own requirements.
 
 ##### How to run a smaller subset of test files?
 
-We have a npm run script for each tests type: `npm run test-client`, `npm run test-server`, `npm run test-integration`.
+We have a yarn run script for each tests type: `yarn run test-client`, `yarn run test-server`, `yarn run test-integration`.
 You can pass a filename, folder name or matching pattern to these scripts to narrow down number of executed tests.
 
 Example for client:
 
 ```bash
 > # run test suite for a specific test file
-> npm run test-client client/state/selectors/test/get-media.js
+> yarn run test-client client/state/selectors/test/get-media.js
 > # run test suites for all files in a specific folder
-> npm run test-server server/config
+> yarn run test-server server/config
 > # run test suites for all files matching pattern
-> npm run test-client client/*/domains
+> yarn run test-client client/*/domains
 ```
 
 ##### How to run specified suite or test-case

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ## Building
 This section lists known problems you can encounter while building the project.
-If you have a problem when running `npm start` - this is the proper section to look for a solution.
+If you have a problem when running `yarn start` - this is the proper section to look for a solution.
 
 ### EMFILE - too many open files
 
@@ -63,15 +63,15 @@ $ sudo sysctl -p
 Sometimes, usually during the first build, you can see a message similar to `Please try running again as an administrator`. 
 Just run
 ```
-sudo npm start
+sudo yarn start
 ```
 
 ### Other build problems - try to clean the build
 Sometimes, especially while switching branches, previous build leaves some artifacts in your directory.
-This can cause problems with the next build. Simply re-runnning `npm start` doesn't always clean it up.
+This can cause problems with the next build. Simply re-runnning `yarn start` doesn't always clean it up.
 To clean up directory, just run:
 ```
-npm run distclean
+yarn run distclean
 ```
 
 ## Running

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,6 +1,6 @@
 # Packages
 
-This directory exists to hold a variety of projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso and build on `npm start`.
+This directory exists to hold a variety of projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso and build on `yarn start`.
 
 For projects that can produce independent, binary-like outputs deployed elsewhere, see [`/apps`](../apps).
 
@@ -10,7 +10,7 @@ If you want to add a new project or package into this directory, then add a new 
 
 ## Building
 
-Packages are built on Calypso's `npm install` so you don't need to build them manually, unless you are working directly on them.
+Packages are built on Calypso's `yarn` so you don't need to build them manually, unless you are working directly on them.
 
 If you must manually build a single package, run:
 
@@ -19,6 +19,6 @@ npx lerna run prepare --scope="@automattic/package-name"
 ```
 
 ## Validating package.json
-Running `npm run lint:package-json` will lint all `package.json`'s under `./packages/**` based on [`npmpackagejsonlint.config.js`](../npmpackagejsonlint.config.js).
+Running `yarn run lint:package-json` will lint all `package.json`'s under `./packages/**` based on [`npmpackagejsonlint.config.js`](../npmpackagejsonlint.config.js).
 
 If you need exceptions to linting rules, add them to overrides section in the config file.

--- a/packages/calypso-build/README.md
+++ b/packages/calypso-build/README.md
@@ -13,7 +13,7 @@ It is designed in a way that in its simplest form is very easy to invoke, with v
 Add add `@automattic/calypso-build` to your project's `devDependencies` by running
 
 ```
-npm install --save-dev @automattic/calypso-build
+yarn add --dev @automattic/calypso-build
 ```
 
 Then, add a `build` script that invokes the `calypso-build` command:
@@ -106,7 +106,7 @@ module.exports = getWebpackConfig;
 
 ## Advanced Usage: Use own Babel Config
 
-It is also possible to customize how Babel transpiles a project. Simply add a `babel.config.js` to your project's root (i.e. the location you call `npm run build` from), and the build tool will pick it up over its own `babel.config.js` to transpile your project.
+It is also possible to customize how Babel transpiles a project. Simply add a `babel.config.js` to your project's root (i.e. the location you call `yarn run build` from), and the build tool will pick it up over its own `babel.config.js` to transpile your project.
 
 To extend the default behavior provided by `@automattic/calypso-build`, you can use presets found in its `babel/` directory, and add your own presets and/or plugins, e.g.
 

--- a/packages/calypso-codemods/README.md
+++ b/packages/calypso-codemods/README.md
@@ -8,7 +8,7 @@ Code modification scripts, also known as codemods, are transformation scripts th
 
 Install calypso-codemods using `npm` or `yarn`:
 ```
-npm install -g calypso-codemods
+yarn global add calypso-codemods
 ```
 
 Now you can run codemods using the following cli:
@@ -108,6 +108,6 @@ in order to easily add tests for a new transform, follow these steps:
 test_folder(__dirname);
 ```
 3. add any input files to the folder that you wish to be tested
-4. run `npm test` or `yarn test`. if the tests fail, its usually because a snapshot would be modified and behavior has changed. If you've verified that the updated snapshots look correct, then you can update the snapshots with: `yarn test -- -u`.
+4. run `yarn test` or `yarn test`. if the tests fail, its usually because a snapshot would be modified and behavior has changed. If you've verified that the updated snapshots look correct, then you can update the snapshots with: `yarn test -- -u`.
 
 5. make sure to commit any modified snapshots and include it in your pull request

--- a/packages/calypso-color-schemes/README.md
+++ b/packages/calypso-color-schemes/README.md
@@ -7,7 +7,7 @@ This package contains a number of CSS custom properties used in Calypso.
 ## Installation
 
 ```sh
-npm install @automattic/calypso-color-schemes
+yarn add @automattic/calypso-color-schemes
 ```
 
 ## Usage

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -7,7 +7,7 @@ A library of React components designed for use in Automattic products.
 Install the components and the color schemes they depend on.
 
 ```bash
-npm i -S @automattic/components @automattic/calypso-color-schemes
+yarn add @automattic/components @automattic/calypso-color-schemes
 ```
 
 ## Usage
@@ -29,15 +29,15 @@ const CallToAction = () => (
 
 ## Development Workflow
 
-This package is developed as part of the Calypso monorepo. Run `npm install`
+This package is developed as part of the Calypso monorepo. Run `yarn`
 in the root of the repository to get the required `devDependencies`.
 
 ### Tests
 
-```npm run test-packages```
+```yarn run test-packages```
 
-```npm run test-packages:watch```
+```yarn run test-packages:watch```
 
 ### Using [Storybook](https://storybook.js.org/)
 
-```npm run components:storybook:start```
+```yarn run components:storybook:start```

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -8,7 +8,7 @@ A set of React components, custom Hooks, and helper functions that together can 
 
 Once published, you'll be able to install this package using npm with:
 
-`npm install @automattic/composite-checkout`
+`yarn add @automattic/composite-checkout`
 
 ## Description
 
@@ -363,6 +363,6 @@ If you need specific custom data as part of a line item so that it can be used i
 
 ## Development
 
-In the root of the monorepo, run `npm run composite-checkout-demo` which will start a local webserver that will display the component.
+In the root of the monorepo, run `yarn run composite-checkout-demo` which will start a local webserver that will display the component.
 
-To run the tests for this package, run `npm run test-packages composite-checkout`.
+To run the tests for this package, run `yarn run test-packages composite-checkout`.

--- a/packages/eslint-config-wpcalypso/README.md
+++ b/packages/eslint-config-wpcalypso/README.md
@@ -7,13 +7,13 @@ An ESLint configuration following WordPress.com's "Calypso" [JavaScript Coding G
 You should install this configuration and peer dependencies as `devDependencies` in your project:
 
 ```
-npm install --save-dev eslint-config-wpcalypso eslint eslint-plugin-wpcalypso
+yarn add --dev eslint-config-wpcalypso eslint eslint-plugin-wpcalypso
 ```
 
 If you're planning to use the React superset of rules, you should also install `eslint-plugin-react`:
 
 ```
-npm install --save-dev eslint-plugin-react
+yarn add --dev eslint-plugin-react
 ```
 
 Next, simply extend the configuration from your project's `.eslintrc` file:

--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -66,7 +66,7 @@
 
 - Breaking: Required Node version increased from >=0.10.x to >=4.x ([see ESLint 3.0.0 migration guide](http://eslint.org/docs/user-guide/migrating-to-3.0.0))
 - Fix: `jsx-classname-namespace` can accurately validate elements assigned to variables within render ([#21](https://github.com/Automattic/eslint-plugin-wpcalypso/pull/21))
-- Fix: `npm test` is now run synchronously so it exits with a non-zero code on failure
+- Fix: `yarn test` is now run synchronously so it exits with a non-zero code on failure
 - Fix: Replace ES2015 variable (`let`) declarations to accommodate older Node versions
 - Fix: Remove unintended debugging statement from i18n-no-newlines rule
 - Fix: jsx-classname-namespace will now correctly identify index components in Windows environments ([#18](https://github.com/Automattic/eslint-plugin-wpcalypso/pull/18))
@@ -91,7 +91,7 @@
 
 - Fix: jsx-classname-namespace: Skip validation on render call expressions (ReactDOM.render)
 - General: Upgrade ESLint (^1.10.3 to ^2.13.1) and babel-eslint (^5.0.0-beta6 to ^6.1.0)
-- General: Add `npm run lint` npm script, included in `npm test`
+- General: Add `yarn run lint` npm script, included in `yarn test`
 
 #### v1.3.1 (2016-06-17)
 

--- a/packages/eslint-plugin-wpcalypso/README.md
+++ b/packages/eslint-plugin-wpcalypso/README.md
@@ -4,19 +4,11 @@ Custom ESLint rules for the [WordPress.com Calypso project](https://github.com/a
 
 ## Installation
 
-You'll first need to install [ESLint](http://eslint.org):
+Install [ESLint](http://eslint.org) amd `eslint-plugin-wpcalypso`
 
 ```
-$ npm install eslint --save-dev
+$ yarn add --dev eslint eslint-plugin-wpcalypso
 ```
-
-Next, install `eslint-plugin-wpcalypso`:
-
-```
-$ npm install eslint-plugin-wpcalypso --save-dev
-```
-
-**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-wpcalypso` globally.
 
 ## Usage
 

--- a/packages/i18n-calypso-cli/README.md
+++ b/packages/i18n-calypso-cli/README.md
@@ -4,12 +4,12 @@ Scans your JavaScript sources/build files and generates a POT file or a PHP tran
 
 ## Installation
 
-`npm install i18n-calypso-cli`
+`yarn add i18n-calypso-cli`
 
 
 ## Using the CLI
 
-- `npm install -g i18n-calypso-cli`
+- `yarn global add i18n-calypso-cli`
 - `i18n-calypso -i <input_file> -o <output_file> -f <format:POT|PHP>`
 
 

--- a/packages/media-library/README.md
+++ b/packages/media-library/README.md
@@ -5,7 +5,7 @@ A Media Library component for use in Automattic products.
 ## Installation
 
 ```bash
-npm i -S @automattic/media-library
+yarn add @automattic/media-library
 ```
 
 ## Usage
@@ -18,17 +18,17 @@ import {} from '@automattic/media-library';
 
 ### Installation
 
-Run `npm install` in the root of the repository to get the required `devDependencies`.
+Run `yarn` in the root of the repository to get the required `devDependencies`.
 
 ### Testing
 
 Run the following commands in the root of the repositry to run the tests.
 
-```npm run test-packages```
+```yarn run test-packages```
 
-```npm run test-packages:watch```
+```yarn run test-packages:watch```
 
 ### Development
 
-Run `npm run media-library:storybook:start` in the root of the repository to run the [Storybook](https://storybook.js.org/).
+Run `yarn run media-library:storybook:start` in the root of the repository to run the [Storybook](https://storybook.js.org/).
 

--- a/packages/photon/README.md
+++ b/packages/photon/README.md
@@ -13,7 +13,7 @@ as Internet Explorer 11, and old versions of Node.js (5 or older).
 Install via `npm`:
 
 ```bash
-npm install photon
+yarn add photon
 ```
 
 Import the `photon` method into your module.

--- a/packages/wpcom.js/README.md
+++ b/packages/wpcom.js/README.md
@@ -13,7 +13,7 @@ Compatible with Node.js and web browsers.
 Introduce the `wpcom` dependency into your `package.json` ...
 
 ```cli
-npm install --save wpcom
+yarn add wpcom
 ```
 
 ... and then initialize it with your API token ([optional](#authentication)).


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates README and other docs to use `yarn` commands instead of `npm`
* Adds a new doc `docs/dependency-management.md` with the instructions to handle packages and workspaces in the repo.

#### Testing instructions

Nothing
