### PR TITLE
Gutenboarding: Updated domain picker styling.

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -52,29 +52,6 @@ export interface Props {
 	currentDomain?: DomainSuggestion;
 }
 
-const FreeDomainIcon = () => (
-	<Icon
-		icon={ () => (
-			<svg
-				width="15"
-				height="15"
-				viewBox="0 0 15 15"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<path
-					d="M13.2878 8.60833L8.61291 13.2844C8.4918 13.4057 8.34798 13.5019 8.18968 13.5676C8.03137 13.6332 7.86169 13.667 7.69032 13.667C7.51895 13.667 7.34926 13.6332 7.19096 13.5676C7.03265 13.5019 6.88884 13.4057 6.76773 13.2844L1.16699 7.68876V1.16699H7.68706L13.2878 6.76919C13.5307 7.01358 13.667 7.34417 13.667 7.68876C13.667 8.03335 13.5307 8.36395 13.2878 8.60833V8.60833Z"
-					stroke="#008A20"
-					strokeWidth="1.5"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-				/>
-				<circle cx="4.50033" cy="4.50033" r="0.833333" fill="#008A20" />
-			</svg>
-		) }
-	/>
-);
-
 const SearchIcon = () => (
 	<Icon
 		icon={ () => (
@@ -112,7 +89,10 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 			<PanelBody>
 				<PanelRow className="domain-picker__panel-row">
 					<div className="domain-picker__header">
-						<div className="domain-picker__header-title">{ __( 'Choose a domain' ) }</div>
+						<div className="domain-picker__header-group">
+							<div className="domain-picker__header-title">{ __( 'Choose a domain' ) }</div>
+							<p>{ __( 'Free for the first year with any paid plan' ) }</p>
+						</div>
 						<CloseButton onClose={ () => onClose() } />
 					</div>
 					<div className="domain-picker__search">
@@ -125,13 +105,6 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 							value={ domainSearch }
 						/>
 					</div>
-				</PanelRow>
-
-				<PanelRow className="domain-picker__panel-row">
-					<p className="domain-picker__free-text">
-						<FreeDomainIcon />
-						{ __( 'Free for the first year with any paid plan' ) }
-					</p>
 				</PanelRow>
 
 				<PanelRow className="domain-picker__panel-row">

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -35,8 +35,8 @@
 
 	input[type='text'].components-text-control__input {
 		padding: 6px 40px 6px 16px;
-		height: 36px;
-		background: var( --studio-gray-0 );
+		height: 38px;
+		background: #f0f0f0;
 		border: none;
 
 		&::placeholder {
@@ -64,7 +64,9 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin-bottom: 14px;
+	margin: 0 -36px -36px;
+	padding: 24px 36px;
+	border-top: 1px solid #f0f0f0;
 }
 
 .domain-picker__footer-options.components-button {
@@ -75,6 +77,7 @@
 .domain-picker__footer-button.components-button {
 	@include onboarding-medium-text;
 	padding: 0 24px;
+	height: 38px;
 }
 
 .domain-picker__connect-domain {
@@ -137,6 +140,8 @@
 }
 
 .domain-picker__suggestion-item-name {
+	letter-spacing: 0.4px;
+
 	input[type='radio'].domain-picker__suggestion-radio-button {
 		width: 16px;
 		height: 16px;
@@ -208,7 +213,7 @@
 }
 
 .domain-picker__price {
-	color: var( --studio-gray-20 );
+	color: var( --studio-gray-40 );
 	white-space: nowrap;
 
 	&.placeholder {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -18,40 +18,46 @@
 .domain-picker__header {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
-	margin-bottom: 14px;
+	align-items: flex-start;
+	margin-bottom: 27px;
 }
 
 .domain-picker__header-title {
 	@include onboarding-font-recoleta;
 	font-size: 26px;
 	line-height: 35px;
+	margin-bottom: 3px;
 }
 
 .domain-picker__search {
 	position: relative;
+	margin-bottom: -7px;
 
 	input[type='text'].components-text-control__input {
-		padding: 6px 8px 6px 40px;
+		padding: 6px 40px 6px 16px;
 		height: 36px;
+		background: var( --studio-gray-0 );
+		border: none;
+
+		&::placeholder {
+			color: var( --studio-black );
+		}
+
+		&:focus {
+			box-shadow: 0 0 0 2px var( --studio-blue-30 );
+			background: var( --studio-white );
+		}
 	}
 
 	svg {
 		position: absolute;
 		top: 6px;
-		left: 8px;
+		right: 8px;
 	}
 }
 
 .domain-picker__free-text {
-	color: var( --studio-green-50 );
-	line-height: 20px;
-	text-align: center;
-
-	svg {
-		margin: 8px;
-		vertical-align: middle;
-	}
+	color: var( --studio-green-40 );
 }
 
 .domain-picker__footer {
@@ -84,6 +90,7 @@
 }
 
 .domain-picker__panel-row {
+
 	// Increasing specificity because @wordpress/components stylesheets are loaded after gutenboarding stylesheets.
 	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
 	// See https://github.com/WordPress/gutenberg/pull/19535
@@ -114,6 +121,8 @@
 	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
 	// See https://github.com/WordPress/gutenberg/pull/19535
 	@extend .domain-picker__suggestion-none;
+	cursor: pointer;
+	margin-bottom: 7px;
 
 	&.components-button {
 		&.is-tertiary {
@@ -172,6 +181,7 @@
 
 .domain-picker__has-domain {
 	align-items: center;
+
 	.components-button {
 		color: var( --studio-blue-30 );
 	}
@@ -179,11 +189,14 @@
 
 .domain-picker__badge {
 	display: inline-flex;
-	border-radius: 1000px;
-	padding: 0.3em 1em;
+	border-radius: 2px;
+	padding: 0 10px;
+	line-height: 20px;
+	height: 20px;
 	align-items: center;
-	font-size: 0.75em;
-	margin-left: 1em;
+	font-size: 10px;
+	margin-left: 10px;
+	text-transform: uppercase;
 
 	background-color: var( --studio-blue-50 );
 	color: var( --color-text-inverted );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Domain search input:
  * Should have a gray background.
  * Search icon should be on the right.
  * Placeholder text color should be black
  * When focused, it should have a 2px blue border.
* The text **Free for the first year with any paid plan** should appear under the header title.
* **Recommended** badge should have a 2px border radius.
* **Free** text should have green color, but only on paid domains.
* The rest are whitespace/margin adjustments to closely match the design specs.

Note: Blue-color TLD will be a separate PR.

#### Testing instructions

* Open up `/gutenboarding`.
* Ensure the domain picker now reflects the changes as listed above and matches closely to the current design specs.

#### Screenshots

![image](https://user-images.githubusercontent.com/1287077/78791843-f8aeda80-79e2-11ea-8296-1664bf13fae1.png)

![image](https://user-images.githubusercontent.com/1287077/78791854-fb113480-79e2-11ea-84dd-f0d92a115541.png)

In comparison to the design specs:

![image](https://user-images.githubusercontent.com/1287077/78791865-ffd5e880-79e2-11ea-98dc-0040cb61cd2e.png)


