### PR TITLE
Redirect to My Home after completing a guided tour

### DIFF
--- a/client/layout/guided-tours/tours/checklist-about-page-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-about-page-tour/index.js
@@ -140,7 +140,7 @@ export const ChecklistAboutPageTour = makeTour(
 								'return to our checklist and see what’s next.'
 						) }
 					</p>
-					<SiteLink isButton href="/checklist/:site">
+					<SiteLink isButton href="/home/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-contact-page-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-contact-page-tour/index.js
@@ -49,7 +49,7 @@ export const ChecklistContactPageTour = makeTour(
 					</p>
 					<ButtonRow>
 						<Next step="featured-images">{ translate( 'All done, continue' ) }</Next>
-						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+						<SiteLink href="/home/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 						<Continue step="featured-images" hidden />
 					</ButtonRow>
 				</Fragment>
@@ -150,7 +150,7 @@ export const ChecklistContactPageTour = makeTour(
 								'to our checklist and see what’s next.'
 						) }
 					</p>
-					<SiteLink isButton href="/checklist/:site">
+					<SiteLink isButton href="/home/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-domain-register-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-domain-register-tour/index.js
@@ -51,7 +51,7 @@ export const ChecklistDomainRegisterTour = makeTour(
 					</p>
 					<ButtonRow>
 						<Continue hidden when={ whenLeavesAddDomainsRoute } step="finish" />
-						<SiteLink isButton={ false } href="/checklist/:site">
+						<SiteLink isButton={ false } href="/home/:site">
 							{ translate( 'Return to the checklist' ) }
 						</SiteLink>
 					</ButtonRow>

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour/index.js
@@ -90,7 +90,7 @@ export const ChecklistPublishPostTour = makeTour(
 					</p>
 					<ButtonRow>
 						<Next step="categories-tags">{ translate( 'All done, continue' ) }</Next>
-						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+						<SiteLink href="/home/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 						<Continue step="categories-tags" hidden />
 					</ButtonRow>
 				</Fragment>
@@ -227,7 +227,7 @@ export const ChecklistPublishPostTour = makeTour(
 								'Let’s move on and see what’s next on our checklist.'
 						) }
 					</p>
-					<SiteLink isButton href="/checklist/:site">
+					<SiteLink isButton href="/home/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-site-icon-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-icon-tour/index.js
@@ -54,7 +54,7 @@ export const ChecklistSiteIconTour = makeTour(
 					</p>
 					<ButtonRow>
 						<Continue target="settings-site-icon-change" step="choose-image" click hidden />
-						<SiteLink isButton={ false } href="/checklist/:site">
+						<SiteLink isButton={ false } href="/home/:site">
 							{ translate( 'Return to the checklist' ) }
 						</SiteLink>
 					</ButtonRow>
@@ -137,7 +137,7 @@ export const ChecklistSiteIconTour = makeTour(
 							'Your Site Icon has been saved. Let’s move on and see what’s next on our checklist.'
 						) }
 					</p>
-					<SiteLink isButton href="/checklist/:site">
+					<SiteLink isButton href="/home/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour/index.js
@@ -45,7 +45,7 @@ export const ChecklistSiteTaglineTour = makeTour(
 					<ButtonRow>
 						<Continue target="settings-site-profile-save" step="finish" click hidden />
 						<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
-						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+						<SiteLink href="/home/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -78,7 +78,7 @@ export const ChecklistSiteTaglineTour = makeTour(
 							'Your tagline has been saved! Let’s move on and see what’s next on our checklist.'
 						) }
 					</p>
-					<SiteLink isButton href="/checklist/:site">
+					<SiteLink isButton href="/home/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -46,7 +46,7 @@ export const ChecklistSiteTitleTour = makeTour(
 					<ButtonRow>
 						<Continue target="settings-site-profile-save" step="finish" click hidden />
 						<Next step="click-save">{ translate( 'All done, continue' ) }</Next>
-						<SiteLink href="/checklist/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
+						<SiteLink href="/home/:site">{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -79,7 +79,7 @@ export const ChecklistSiteTitleTour = makeTour(
 							'Your changes have been saved. Let’s move on and see what’s next on our checklist.'
 						) }
 					</p>
-					<SiteLink isButton href="/checklist/:site">
+					<SiteLink isButton href="/home/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
@@ -49,7 +49,7 @@ export const ChecklistUserAvatarTour = makeTour(
 					</p>
 					<ButtonRow>
 						<Continue target="edit-gravatar" step="image-notice" click hidden />
-						<SiteLink isButton={ false } href="/checklist/:site">
+						<SiteLink isButton={ false } href="/home/:site">
 							{ translate( 'Return to the checklist' ) }
 						</SiteLink>
 					</ButtonRow>
@@ -112,7 +112,7 @@ export const ChecklistUserAvatarTour = makeTour(
 								"Let's move on and see what's next on our checklist."
 						) }
 					</p>
-					<SiteLink isButton href="/checklist/:site">
+					<SiteLink isButton href="/home/:site">
 						{ translate( 'Return to the checklist' ) }
 					</SiteLink>
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-user-email-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-user-email-tour/index.js
@@ -33,7 +33,7 @@ export const ChecklistUserEmailTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton={ true } href="/checklist/:site">
+						<SiteLink isButton={ true } href="/home/:site">
 							{ translate( 'Return to the checklist' ) }
 						</SiteLink>
 					</ButtonRow>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of https://github.com/Automattic/wp-calypso/issues/40646

The current guided tours still use the old `/checklist` route as return path which ends up [redirecting to `/home`](https://github.com/Automattic/wp-calypso/blob/a4616438bcb848e97b784fa6d55ba4e9c5cb3d21/client/my-sites/checklist/controller.jsx#L29-L32) since they all are shown on sites that are eligible for My Home.

This PR updates the return URL of the guided tours to `/home` so there is less code pointing to the legacy checklist section (which we aim to remove completely once we finish deleting existing code using it).

AFAIK, of all the guided tours this PR modifies, only the site title guided tour is currently used, but the URL has been also updated on the unused ones (in case they are used in the future). Alternatively, we could remove all unused guided tours.

#### Testing instructions

- Go to `/start` and create a new site.
- In My Home, start the site title task to launch its guided tour.
- Make sure the guided tour redirects straight back to `/home/:site` and there is no redirection from `/checklist/:site`.
