### PR TITLE
WP for Teams: fix signup styling

### DIFF
--- a/client/signup/steps/wp-for-teams-site/style.scss
+++ b/client/signup/steps/wp-for-teams-site/style.scss
@@ -17,6 +17,6 @@
 	}
 }
 
-.wp-for-teams-site__validation-site-title {
+.wp-for-teams-site__validation-site-title.validation-fieldset {
 	margin-bottom: 20px;
 }


### PR DESCRIPTION
In this PR, we fix the first signup step of the `start/wp-for-teams` signup flow. There was a tiny issue with margins as css specificity was not enough when css resources were minified and compiled.

![image](https://user-images.githubusercontent.com/4988512/78794574-3c3e2000-79b4-11ea-8c99-70a56beb5e87.png)


## Testing

First, add `signup/wpforteams` under the `features` prop in `config/production` file. Then, run Calypso with `CALYPSO_ENV=production npm start` so that it runs as on production. Open a new incognito window and navigate to `start/wp-for-teams`. There should be a proper margin on the site creation step now.