### PR TITLE
Remove unused backToChecklist function

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -200,10 +200,6 @@ class WpcomChecklistComponent extends PureComponent {
 		return translate( 'Resend email' );
 	}
 
-	backToChecklist = () => {
-		page( `/checklist/${ this.props.siteSlug }` );
-	};
-
 	render() {
 		const { siteId, taskList, taskStatuses, updateCompletion } = this.props;
 
@@ -772,7 +768,6 @@ class WpcomChecklistComponent extends PureComponent {
 					url: taskUrls[ task.id ],
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
-				backToChecklist={ this.backToChecklist }
 				showSkip={ false }
 				buttonText={ translate( 'Start' ) }
 			/>
@@ -812,7 +807,6 @@ class WpcomChecklistComponent extends PureComponent {
 					url: taskUrls[ task.id ],
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
-				backToChecklist={ this.backToChecklist }
 				showSkip={ false }
 				buttonText={ translate( 'Start' ) }
 			/>
@@ -843,7 +837,6 @@ class WpcomChecklistComponent extends PureComponent {
 					url: taskUrls[ task.id ],
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
-				backToChecklist={ this.backToChecklist }
 				showSkip={ false }
 				buttonText={ translate( 'Update homepage' ) }
 				action="update-homepage"
@@ -881,7 +874,6 @@ class WpcomChecklistComponent extends PureComponent {
 					url: taskUrls[ task.id ],
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
-				backToChecklist={ this.backToChecklist }
 				showSkip={ false }
 				buttonText={ translate( 'Start' ) }
 			/>
@@ -916,7 +908,6 @@ class WpcomChecklistComponent extends PureComponent {
 					url: taskUrls[ task.id ],
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
-				backToChecklist={ this.backToChecklist }
 				showSkip={ false }
 				buttonText={ translate( 'Start' ) }
 			/>
@@ -959,7 +950,6 @@ class WpcomChecklistComponent extends PureComponent {
 				duration={ translate( '%d minute', '%d minutes', { count: 5, args: [ 5 ] } ) }
 				targetUrl={ taskUrls[ task.id ] }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
-				backToChecklist={ this.backToChecklist }
 				showSkip={ false }
 				buttonText={ translate( 'Start' ) }
 			/>
@@ -993,7 +983,6 @@ class WpcomChecklistComponent extends PureComponent {
 				duration={ translate( '%d minute', '%d minutes', { count: 10, args: [ 10 ] } ) }
 				targetUrl={ taskUrls[ task.id ] }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
-				backToChecklist={ this.backToChecklist }
 				showSkip={ false }
 				buttonText={ translate( 'Start' ) }
 			/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Part of https://github.com/Automattic/wp-calypso/issues/40646

While auditing where we are still using the legacy checklist section, I noted the checklist is setting a `/checklist/:site` path in [the `backToCheckList` function](https://github.com/Automattic/wp-calypso/blob/c9a8c341f663cd1bebd0bd3459a1edae734db0f3/client/my-sites/checklist/wpcom-checklist/component.jsx#L190-L192) which is later passed as a prop when rendering the `Task` component ([example](https://github.com/Automattic/wp-calypso/blob/c9a8c341f663cd1bebd0bd3459a1edae734db0f3/client/my-sites/checklist/wpcom-checklist/component.jsx#L762)).

However, seems [the `Task` component](https://github.com/Automattic/wp-calypso/blob/c9a8c341f663cd1bebd0bd3459a1edae734db0f3/client/components/checklist/task.js) does not use that prop at all, so this PR removes the related code in order to decrease the code pointing to the legacy checklist section (which we aim to remove completely once we finish deleting existing code using it).

AFAIK, of all the tasks this PR modifies, only the update homepage task is currently displayed, but the prop has been also removed from the unused ones (in case they are used in the future). Alternatively, we could remove all unused tasks.

#### Testing instructions

- Create a new site.
- Start the update homepage task.
- Make sure you can still go back to My Home by clicking on the top-left WordPress logo.
