### PR TITLE
Migrate package-lock.json to yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 		"@automattic/components": "^1.0.0-alpha.1",
 		"@automattic/composite-checkout": "^1.0.0",
 		"@automattic/data-stores": "^1.0.0-alpha.1",
-		"@automattic/effective-module-tree": "^0.0.1",
+		"@automattic/effective-module-tree": "^0.1.0",
 		"@automattic/format-currency": "^1.0.0-alpha.0",
 		"@automattic/full-site-editing": "^1.0.0",
 		"@automattic/load-script": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,7 +4627,12 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^7.1.0, acorn@^7.1.1:
+acorn@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+
+acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
@@ -8283,21 +8288,21 @@ dom-scroll-into-view@^1.2.1:
   resolved "https://registry.yarnpkg.com/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz#e8f36732dd089b0201a88d7815dc3f88e6d66c7e"
   integrity sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=
 
-dom-serializer@0, dom-serializer@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
-  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
-  dependencies:
-    domelementtype "^2.0.1"
-    entities "^2.0.0"
-
-dom-serializer@~0.1.0, dom-serializer@~0.1.1:
+dom-serializer@0, dom-serializer@~0.1.0, dom-serializer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
   integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
   dependencies:
     domelementtype "^1.3.0"
     entities "^1.1.1"
+
+dom-serializer@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -8516,9 +8521,9 @@ electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.341:
   integrity sha512-zKO/wS+2ChI/jz9WAo647xSW8t2RmgRLFdbUb/77cORkUTargO+SCj4ctTHjBn2VeNFrsLgDT7IuDVrd3F8mLQ==
 
 electron-to-chromium@^1.3.390:
-  version "1.3.406"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.406.tgz#d4b8f8c9f7405dddbbb646d6b15042cd7c1e6e61"
-  integrity sha512-bx8vBZoEbhsMmwEZIj2twzfhFoKKZlSLQiENhqgc5/FdAj4/UHEzAri42OTSFA5+0agLR03ReTvIms2dfZ7/Ew==
+  version "1.3.403"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz#c8bab4e2e72bf78bc28bad1cc355c061f9cc1918"
+  integrity sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw==
 
 element-resize-detector@^1.2.1:
   version "1.2.1"
@@ -15761,9 +15766,11 @@ p-is-promise@^2.0.0:
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
-  integrity sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.2"
@@ -15835,6 +15842,11 @@ p-retry@^3.0.1:
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5940,7 +5940,7 @@ browserslist-useragent@3.0.2:
     semver "^6.3.0"
     useragent "^2.3.0"
 
-browserslist@4.11.1:
+browserslist@4.11.1, browserslist@^4.0.0, browserslist@^4.6.6, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3, browserslist@^4.8.5:
   version "4.11.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.11.1.tgz#92f855ee88d6e050e7e7311d987992014f1a1f1b"
   integrity sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==
@@ -5958,15 +5958,6 @@ browserslist@4.7.0:
     caniuse-lite "^1.0.30000989"
     electron-to-chromium "^1.3.247"
     node-releases "^1.1.29"
-
-browserslist@^4.0.0, browserslist@^4.6.6, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3, browserslist@^4.8.5:
-  version "4.8.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.6.tgz#96406f3f5f0755d272e27a66f4163ca821590a7e"
-  integrity sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
-  dependencies:
-    caniuse-lite "^1.0.30001023"
-    electron-to-chromium "^1.3.341"
-    node-releases "^1.1.47"
 
 bser@2.1.1:
   version "2.1.1"
@@ -6270,15 +6261,10 @@ caniuse-api@3.0.0, caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@1.0.30001041, caniuse-lite@^1.0.30001038:
+caniuse-lite@1.0.30001041, caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001038:
   version "1.0.30001041"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001041.tgz#c2ea138dafc6fe03877921ddcddd4a02a14daf76"
   integrity sha512-fqDtRCApddNrQuBxBS7kEiSGdBsgO4wiVw4G/IClfqzfhW45MbTumfN4cuUJGTM0YGFNn97DCXPJ683PS6zwvA==
-
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001023:
-  version "1.0.30001027"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz#283e2ef17d94889cc216a22c6f85303d78ca852d"
-  integrity sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -8510,7 +8496,7 @@ ejs@^2.6.1, ejs@^2.7.4:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.341:
+electron-to-chromium@^1.3.247:
   version "1.3.355"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.355.tgz#ff805ed8a3d68e550a45955134e4e81adf1122ba"
   integrity sha512-zKO/wS+2ChI/jz9WAo647xSW8t2RmgRLFdbUb/77cORkUTargO+SCj4ctTHjBn2VeNFrsLgDT7IuDVrd3F8mLQ==
@@ -15133,7 +15119,7 @@ node-notifier@^6.0.0:
     shellwords "^0.1.1"
     which "^1.3.1"
 
-node-releases@^1.1.29, node-releases@^1.1.47:
+node-releases@^1.1.29:
   version "1.1.49"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.49.tgz#67ba5a3fac2319262675ef864ed56798bb33b93e"
   integrity sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,6 +11,79 @@
     lodash "^4.17.4"
     recast "^0.12.1"
 
+"@automattic/babel-plugin-i18n-calypso@file:./packages/babel-plugin-i18n-calypso":
+  version "1.1.0"
+  dependencies:
+    gettext-parser "^4.0.0"
+    lodash "^4.17.14"
+
+"@automattic/babel-plugin-transform-wpcalypso-async@file:./packages/babel-plugin-transform-wpcalypso-async":
+  version "1.0.1"
+  dependencies:
+    lodash "^4.17.15"
+
+"@automattic/calypso-analytics@file:packages/calypso-analytics":
+  version "1.0.0-alpha.1"
+  dependencies:
+    "@automattic/load-script" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-calypso-analytics-1.0.0-alpha.1-3ab200c5-1127-4d42-8904-e014dab0404a-1586762929837/node_modules/@automattic/load-script"
+    cookie "0.4.0"
+    debug "^4.1.1"
+    hash.js "^1.1.7"
+    lodash "^4.17.15"
+    tslib "^1.10.0"
+
+"@automattic/calypso-build@file:./packages/calypso-build":
+  version "6.1.0"
+  dependencies:
+    "@automattic/mini-css-extract-plugin-with-rtl" "0.8.0"
+    "@babel/cli" "7.8.4"
+    "@babel/core" "7.8.4"
+    "@babel/plugin-proposal-class-properties" "7.8.3"
+    "@babel/plugin-transform-react-jsx" "7.8.3"
+    "@babel/plugin-transform-runtime" "7.8.3"
+    "@babel/preset-env" "7.8.4"
+    "@babel/preset-react" "7.8.3"
+    "@babel/preset-typescript" "7.8.3"
+    "@types/webpack-env" "1.15.1"
+    "@wordpress/babel-plugin-import-jsx-pragma" "2.5.0"
+    "@wordpress/browserslist-config" "2.6.0"
+    "@wordpress/dependency-extraction-webpack-plugin" "2.2.0"
+    autoprefixer "9.7.3"
+    babel-jest "25.1.0"
+    babel-loader "8.0.6"
+    browserslist "^4.8.2"
+    caniuse-api "3.0.0"
+    css-loader "3.4.2"
+    duplicate-package-checker-webpack-plugin "3.0.0"
+    enzyme-adapter-react-16 "1.15.1"
+    enzyme-to-json "3.4.3"
+    file-loader "4.3.0"
+    jest-config "25.1.0"
+    jest-emotion "^10.0.27"
+    jest-enzyme "7.1.2"
+    node-sass "4.13.0"
+    postcss-custom-properties "9.0.2"
+    postcss-loader "3.0.0"
+    recursive-copy "2.0.10"
+    sass-loader "8.0.0"
+    terser-webpack-plugin "2.3.1"
+    thread-loader "2.1.3"
+    typescript "3.8.3"
+    webpack "4.42.0"
+    webpack-cli "3.3.10"
+    webpack-rtl-plugin "2.0.0"
+
+"@automattic/calypso-color-schemes@file:./packages/calypso-color-schemes", "@automattic/calypso-color-schemes@file:packages/calypso-color-schemes":
+  version "2.1.0"
+
+"@automattic/calypso-polyfills@file:packages/calypso-polyfills":
+  version "1.0.0"
+  dependencies:
+    core-js "3.6.3"
+    isomorphic-fetch "2.2.1"
+    regenerator-runtime "0.13.3"
+    svg4everybody "2.1.9"
+
 "@automattic/color-studio@2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.2.1.tgz#e920af382a4db624ebca1591adace289912bf37b"
@@ -35,6 +108,29 @@
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
+"@automattic/notifications@file:apps/notifications":
+  version "1.0.0"
+  dependencies:
+    "@automattic/calypso-color-schemes" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-notifications-1.0.0-4d85ebb0-88c2-422a-b3bf-48592d5149bd-1586762930275/node_modules/packages/calypso-color-schemes"
+    "@automattic/calypso-polyfills" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-notifications-1.0.0-4d85ebb0-88c2-422a-b3bf-48592d5149bd-1586762930275/node_modules/packages/calypso-polyfills"
+
+"@automattic/o2-blocks@file:apps/o2-blocks":
+  version "1.0.0"
+  dependencies:
+    "@wordpress/block-editor" "3.7.6"
+    "@wordpress/blocks" "6.12.0"
+    "@wordpress/components" "9.2.1"
+    "@wordpress/editor" "9.12.1"
+    "@wordpress/element" "2.11.0"
+    "@wordpress/i18n" "3.9.0"
+    classnames "2.2.6"
+
+"@automattic/react-i18n@file:packages/react-i18n":
+  version "1.0.0-alpha.0"
+  dependencies:
+    "@wordpress/compose" "1.x.x - 3.x.x"
+    tslib "^1.10.0"
+
 "@automattic/react-virtualized@9.21.2":
   version "9.21.2"
   resolved "https://registry.yarnpkg.com/@automattic/react-virtualized/-/react-virtualized-9.21.2.tgz#ea14243e7e7811eaa14daed3f0a6f4579208996f"
@@ -43,6 +139,35 @@
     clsx "^1.0.4"
     loose-envify "^1.4.0"
     react-lifecycles-compat "^3.0.4"
+
+"@automattic/tree-select@file:packages/tree-select":
+  version "1.0.3"
+
+"@automattic/viewport-react@file:packages/viewport-react":
+  version "1.0.0"
+  dependencies:
+    "@automattic/viewport" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-viewport-react-1.0.0-f4b59f2d-f391-489b-bc0e-2af97499e424-1586762930294/node_modules/@automattic/viewport"
+    "@babel/runtime" "^7.8.4"
+    "@wordpress/compose" "^3.7.0"
+
+"@automattic/viewport@file:packages/viewport":
+  version "1.0.0"
+
+"@automattic/webpack-config-flag-plugin@file:packages/webpack-config-flag-plugin":
+  version "1.0.0"
+
+"@automattic/webpack-extensive-lodash-replacement-plugin@file:./packages/webpack-extensive-lodash-replacement-plugin":
+  version "0.0.2"
+  dependencies:
+    semver "^6.1.1"
+
+"@automattic/webpack-inline-constant-exports-plugin@file:./packages/webpack-inline-constant-exports-plugin":
+  version "0.0.1"
+
+"@automattic/wpcom-block-editor@file:apps/wpcom-block-editor":
+  version "1.0.0-alpha.0"
+  dependencies:
+    debug "4.1.1"
 
 "@babel/cli@7.8.4":
   version "7.8.4"
@@ -6188,6 +6313,14 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+"calypso-codemods@file:./packages/calypso-codemods":
+  version "0.1.6"
+  dependencies:
+    "5to6-codemod" "^1.8.0"
+    jscodeshift "^0.7.0"
+    lodash "^4.17.10"
+    react-codemod "^5.0.5"
+
 camel-case@3.0.x, camel-case@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
@@ -8938,6 +9071,11 @@ eslint-config-prettier@^6.10.0:
   dependencies:
     get-stdin "^6.0.0"
 
+"eslint-config-wpcalypso@file:./packages/eslint-config-wpcalypso":
+  version "5.0.0"
+  dependencies:
+    eslint-plugin-react-hooks "^2.0.0"
+
 eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
@@ -9069,6 +9207,9 @@ eslint-plugin-react@7.18.3, eslint-plugin-react@^7.14.3:
     prop-types "^15.7.2"
     resolve "^1.14.2"
     string.prototype.matchall "^4.0.2"
+
+"eslint-plugin-wpcalypso@file:./packages/eslint-plugin-wpcalypso":
+  version "4.1.0"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
@@ -11276,6 +11417,29 @@ husky@3.1.0:
     read-pkg "^5.2.0"
     run-node "^1.0.0"
     slash "^3.0.0"
+
+"i18n-calypso-cli@file:./packages/i18n-calypso-cli":
+  version "1.0.0"
+  dependencies:
+    commander "^4.0.0"
+    debug "^4.0.0"
+    globby "^10.0.0"
+    xgettext-js "^3.0.0"
+
+"i18n-calypso@file:packages/i18n-calypso":
+  version "5.0.0"
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    "@tannin/sprintf" "^1.1.0"
+    "@wordpress/compose" "^3.7.2"
+    debug "^4.0.0"
+    events "^3.0.0"
+    hash.js "^1.1.5"
+    interpolate-components "^1.1.1"
+    lodash "^4.17.11"
+    lru "^3.1.0"
+    tannin "^1.1.1"
+    use-subscription "^1.2.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -16249,6 +16413,14 @@ phone@2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/phone/-/phone-2.4.2.tgz#74d6a54288280470d0cefa31e2f0720b7e59005d"
   integrity sha512-d9oLwWCnInj5wJIZjSyAvyBd4SWM4p3C6VmZVAhAlWG8q0dLANTEfRLMn2ybL/TdXbTuOCY4GJbePf3ujPmVvQ==
+
+"photon@file:packages/photon":
+  version "3.0.0"
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    crc32 "0.2.2"
+    debug "^4.0.0"
+    seed-random "2.2.0"
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
   version "2.2.1"
@@ -22132,6 +22304,163 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
+"wp-calypso@file:client":
+  version "0.17.0"
+  dependencies:
+    "@automattic/calypso-analytics" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/calypso-analytics"
+    "@automattic/calypso-polyfills" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/calypso-polyfills"
+    "@automattic/color-studio" "2.2.1"
+    "@automattic/components" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/components"
+    "@automattic/composite-checkout" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/composite-checkout"
+    "@automattic/data-stores" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/data-stores"
+    "@automattic/format-currency" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/format-currency"
+    "@automattic/load-script" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/load-script"
+    "@automattic/material-design-icons" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/material-design-icons"
+    "@automattic/react-i18n" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/react-i18n"
+    "@automattic/react-virtualized" "9.21.2"
+    "@automattic/tree-select" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/tree-select"
+    "@automattic/viewport" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/viewport"
+    "@automattic/viewport-react" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/viewport-react"
+    "@babel/runtime" "7.8.4"
+    "@emotion/core" "^10.0.27"
+    "@emotion/styled" "10.0.27"
+    "@github/webauthn-json" "0.4.1"
+    "@wordpress/api-fetch" "3.11.0"
+    "@wordpress/base-styles" "1.4.0"
+    "@wordpress/block-editor" "3.7.1"
+    "@wordpress/block-library" "2.14.1"
+    "@wordpress/blocks" "6.12.0"
+    "@wordpress/components" "9.2.1"
+    "@wordpress/compose" "3.11.0"
+    "@wordpress/core-data" "2.12.0"
+    "@wordpress/data" "4.14.0"
+    "@wordpress/data-controls" "1.8.0"
+    "@wordpress/dom" "2.8.0"
+    "@wordpress/edit-post" "3.13.1"
+    "@wordpress/editor" "9.12.1"
+    "@wordpress/element" "2.11.0"
+    "@wordpress/format-library" "1.14.1"
+    "@wordpress/i18n" "3.9.0"
+    "@wordpress/is-shallow-equal" "1.8.0"
+    "@wordpress/keycodes" "2.9.0"
+    "@wordpress/notices" "2.0.0"
+    "@wordpress/nux" "3.12.1"
+    "@wordpress/plugins" "2.12.0"
+    "@wordpress/redux-routine" "3.7.0"
+    "@wordpress/rich-text" "3.12.0"
+    "@wordpress/server-side-render" "1.8.1"
+    "@wordpress/shortcode" "2.6.0"
+    "@wordpress/url" "2.11.0"
+    "@wordpress/viewport" "2.13.0"
+    autosize "4.0.2"
+    body-parser "1.19.0"
+    browser-filesaver "1.1.1"
+    browserslist-useragent "3.0.2"
+    chalk "3.0.0"
+    chrono-node "1.3.5"
+    classnames "2.2.6"
+    clipboard "2.0.4"
+    component-closest "1.0.1"
+    component-file-picker "0.2.1"
+    cookie "0.4.0"
+    cookie-parser "1.4.4"
+    cpf_cnpj "0.2.0"
+    create-react-class "15.6.3"
+    creditcards "3.1.0"
+    d3-array "2.4.0"
+    d3-axis "1.0.12"
+    d3-scale "3.2.1"
+    d3-selection "1.4.1"
+    d3-shape "1.3.7"
+    debug "4.1.1"
+    deep-freeze "0.0.1"
+    diff "4.0.1"
+    doctrine "3.0.0"
+    dom-helpers "5.1.3"
+    dompurify "2.0.7"
+    draft-js "0.11.3"
+    email-validator "2.0.4"
+    emoji-text "0.2.6"
+    events "3.0.0"
+    express "4.17.1"
+    express-useragent "1.0.13"
+    fast-json-stable-stringify "2.0.0"
+    filesize "6.0.1"
+    flag-icon-css "3.4.5"
+    flux "3.1.3"
+    fuse.js "3.4.6"
+    get-video-id "3.1.4"
+    gridicons "3.3.1"
+    hash.js "1.1.7"
+    he "1.2.0"
+    html-to-react "1.4.2"
+    i18n-calypso "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/i18n-calypso"
+    immutability-helper "3.0.1"
+    immutable "3.8.2"
+    inherits "2.0.4"
+    is-my-json-valid "2.20.0"
+    jquery "1.12.3"
+    keymaster "1.6.2"
+    lodash "4.17.15"
+    lodash-es "4.17.15"
+    lru "3.1.0"
+    lunr "2.3.8"
+    marked "0.7.0"
+    moment "2.24.0"
+    moment-timezone "0.5.27"
+    morgan "1.9.1"
+    objectpath "1.2.2"
+    page "1.11.5"
+    path-browserify "1.0.0"
+    percentage-regex "3.0.0"
+    phoenix "1.4.16"
+    phone "2.4.2"
+    photon "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/photon"
+    prismjs "1.17.1"
+    prop-types "15.7.2"
+    qrcode.react "1.0.0"
+    qs "6.9.1"
+    react "16.12.0"
+    react-click-outside "3.0.1"
+    react-day-picker "7.4.0"
+    react-dom "16.12.0"
+    react-element-to-jsx-string "14.1.0"
+    react-lazily-render "1.2.0"
+    react-live "1.12.0"
+    react-modal "3.11.1"
+    react-redux "7.2.0"
+    react-router-dom "5.1.2"
+    react-spring "8.0.27"
+    react-stripe-elements "4.0.2"
+    react-transition-group "4.3.0"
+    reakit "1.0.0-beta.14"
+    redux "4.0.5"
+    redux-form "8.2.6"
+    redux-thunk "2.3.0"
+    refx "3.1.1"
+    resize-observer-polyfill "1.5.1"
+    rtlcss "2.4.0"
+    social-logos "2.1.0"
+    socket.io-client "2.3.0"
+    store "2.0.12"
+    striptags "3.1.1"
+    superagent "3.8.3"
+    textarea-caret "3.1.0"
+    tinymce "4.9.6"
+    to-title-case "1.0.0"
+    tracekit "0.4.5"
+    twemoji "12.1.4"
+    url "0.11.0"
+    use-debounce "3.1.0"
+    use-subscription "1.3.0"
+    utility-types "3.10.0"
+    uuid "7.0.2"
+    valid-url "1.0.9"
+    wpcom "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/wpcom.js"
+    wpcom-proxy-request "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/wpcom-proxy-request"
+    wpcom-xhr-request "1.1.3"
+    yamlparser "0.0.2"
+
 wp-error@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/wp-error/-/wp-error-1.3.0.tgz#720247aa326424991c58775cb2fedc9bfd885420"
@@ -22139,6 +22468,15 @@ wp-error@^1.3.0:
   dependencies:
     builtin-status-codes "^2.0.0"
     uppercamelcase "^1.1.0"
+
+"wpcom-proxy-request@file:packages/wpcom-proxy-request":
+  version "6.0.0"
+  dependencies:
+    "@babel/runtime" "^7.8.4"
+    debug "^4.1.1"
+    progress-event "^1.0.0"
+    uuid "^7.0.1"
+    wp-error "^1.3.0"
 
 wpcom-xhr-request@1.1.3:
   version "1.1.3"
@@ -22149,6 +22487,13 @@ wpcom-xhr-request@1.1.3:
     debug "^3.1.0"
     superagent "^3.8.3"
     wp-error "^1.3.0"
+
+"wpcom@file:packages/wpcom.js":
+  version "6.0.0"
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    debug "^4.1.1"
+    qs "^6.5.2"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,15 +16,6 @@
   resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.2.1.tgz#e920af382a4db624ebca1591adace289912bf37b"
   integrity sha512-doMeOR5ly+qviYgWhWStByZHnnv3AFBC4Tj6aZLTrw8voulIu9AUv3Z9eit8a68uzCI77VkN7fUFadOiYIYBWg==
 
-"@automattic/effective-module-tree@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@automattic/effective-module-tree/-/effective-module-tree-0.0.1.tgz#f642c8034b42f10dedd645a7c78b533a1a965609"
-  integrity sha512-p/3p1vCve2egb1t9z+PUP8QtHimjHcvWFIjH1fDKoDgRvNU8Pdd4iEiOhnb8MjyqLd/O3dzvmK1t76YLxfHHJQ==
-  dependencies:
-    debug "^4.1.1"
-    object-treeify "^1.1.23"
-    yargs "^15.1.0"
-
 "@automattic/mini-css-extract-plugin-with-rtl@0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@automattic/mini-css-extract-plugin-with-rtl/-/mini-css-extract-plugin-with-rtl-0.8.0.tgz#0e0dc9afc43a2d6a82c199aef211565e1211fcac"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,12 +4627,7 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
-  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
-
-acorn@^7.1.1:
+acorn@^7.1.0, acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
@@ -8288,21 +8283,21 @@ dom-scroll-into-view@^1.2.1:
   resolved "https://registry.yarnpkg.com/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz#e8f36732dd089b0201a88d7815dc3f88e6d66c7e"
   integrity sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=
 
-dom-serializer@0, dom-serializer@~0.1.0, dom-serializer@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
-  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
-  dependencies:
-    domelementtype "^1.3.0"
-    entities "^1.1.1"
-
-dom-serializer@^0.2.1:
+dom-serializer@0, dom-serializer@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
   integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
   dependencies:
     domelementtype "^2.0.1"
     entities "^2.0.0"
+
+dom-serializer@~0.1.0, dom-serializer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
+  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
+  dependencies:
+    domelementtype "^1.3.0"
+    entities "^1.1.1"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -15766,11 +15761,9 @@ p-is-promise@^2.0.0:
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
-  dependencies:
-    p-try "^1.0.0"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+  integrity sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.2"
@@ -15842,11 +15835,6 @@ p-retry@^3.0.1:
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
-
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,79 +11,6 @@
     lodash "^4.17.4"
     recast "^0.12.1"
 
-"@automattic/babel-plugin-i18n-calypso@file:./packages/babel-plugin-i18n-calypso":
-  version "1.1.0"
-  dependencies:
-    gettext-parser "^4.0.0"
-    lodash "^4.17.14"
-
-"@automattic/babel-plugin-transform-wpcalypso-async@file:./packages/babel-plugin-transform-wpcalypso-async":
-  version "1.0.1"
-  dependencies:
-    lodash "^4.17.15"
-
-"@automattic/calypso-analytics@file:packages/calypso-analytics":
-  version "1.0.0-alpha.1"
-  dependencies:
-    "@automattic/load-script" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-calypso-analytics-1.0.0-alpha.1-3ab200c5-1127-4d42-8904-e014dab0404a-1586762929837/node_modules/@automattic/load-script"
-    cookie "0.4.0"
-    debug "^4.1.1"
-    hash.js "^1.1.7"
-    lodash "^4.17.15"
-    tslib "^1.10.0"
-
-"@automattic/calypso-build@file:./packages/calypso-build":
-  version "6.1.0"
-  dependencies:
-    "@automattic/mini-css-extract-plugin-with-rtl" "0.8.0"
-    "@babel/cli" "7.8.4"
-    "@babel/core" "7.8.4"
-    "@babel/plugin-proposal-class-properties" "7.8.3"
-    "@babel/plugin-transform-react-jsx" "7.8.3"
-    "@babel/plugin-transform-runtime" "7.8.3"
-    "@babel/preset-env" "7.8.4"
-    "@babel/preset-react" "7.8.3"
-    "@babel/preset-typescript" "7.8.3"
-    "@types/webpack-env" "1.15.1"
-    "@wordpress/babel-plugin-import-jsx-pragma" "2.5.0"
-    "@wordpress/browserslist-config" "2.6.0"
-    "@wordpress/dependency-extraction-webpack-plugin" "2.2.0"
-    autoprefixer "9.7.3"
-    babel-jest "25.1.0"
-    babel-loader "8.0.6"
-    browserslist "^4.8.2"
-    caniuse-api "3.0.0"
-    css-loader "3.4.2"
-    duplicate-package-checker-webpack-plugin "3.0.0"
-    enzyme-adapter-react-16 "1.15.1"
-    enzyme-to-json "3.4.3"
-    file-loader "4.3.0"
-    jest-config "25.1.0"
-    jest-emotion "^10.0.27"
-    jest-enzyme "7.1.2"
-    node-sass "4.13.0"
-    postcss-custom-properties "9.0.2"
-    postcss-loader "3.0.0"
-    recursive-copy "2.0.10"
-    sass-loader "8.0.0"
-    terser-webpack-plugin "2.3.1"
-    thread-loader "2.1.3"
-    typescript "3.8.3"
-    webpack "4.42.0"
-    webpack-cli "3.3.10"
-    webpack-rtl-plugin "2.0.0"
-
-"@automattic/calypso-color-schemes@file:./packages/calypso-color-schemes", "@automattic/calypso-color-schemes@file:packages/calypso-color-schemes":
-  version "2.1.0"
-
-"@automattic/calypso-polyfills@file:packages/calypso-polyfills":
-  version "1.0.0"
-  dependencies:
-    core-js "3.6.3"
-    isomorphic-fetch "2.2.1"
-    regenerator-runtime "0.13.3"
-    svg4everybody "2.1.9"
-
 "@automattic/color-studio@2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.2.1.tgz#e920af382a4db624ebca1591adace289912bf37b"
@@ -108,29 +35,6 @@
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
-"@automattic/notifications@file:apps/notifications":
-  version "1.0.0"
-  dependencies:
-    "@automattic/calypso-color-schemes" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-notifications-1.0.0-4d85ebb0-88c2-422a-b3bf-48592d5149bd-1586762930275/node_modules/packages/calypso-color-schemes"
-    "@automattic/calypso-polyfills" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-notifications-1.0.0-4d85ebb0-88c2-422a-b3bf-48592d5149bd-1586762930275/node_modules/packages/calypso-polyfills"
-
-"@automattic/o2-blocks@file:apps/o2-blocks":
-  version "1.0.0"
-  dependencies:
-    "@wordpress/block-editor" "3.7.6"
-    "@wordpress/blocks" "6.12.0"
-    "@wordpress/components" "9.2.1"
-    "@wordpress/editor" "9.12.1"
-    "@wordpress/element" "2.11.0"
-    "@wordpress/i18n" "3.9.0"
-    classnames "2.2.6"
-
-"@automattic/react-i18n@file:packages/react-i18n":
-  version "1.0.0-alpha.0"
-  dependencies:
-    "@wordpress/compose" "1.x.x - 3.x.x"
-    tslib "^1.10.0"
-
 "@automattic/react-virtualized@9.21.2":
   version "9.21.2"
   resolved "https://registry.yarnpkg.com/@automattic/react-virtualized/-/react-virtualized-9.21.2.tgz#ea14243e7e7811eaa14daed3f0a6f4579208996f"
@@ -139,35 +43,6 @@
     clsx "^1.0.4"
     loose-envify "^1.4.0"
     react-lifecycles-compat "^3.0.4"
-
-"@automattic/tree-select@file:packages/tree-select":
-  version "1.0.3"
-
-"@automattic/viewport-react@file:packages/viewport-react":
-  version "1.0.0"
-  dependencies:
-    "@automattic/viewport" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-viewport-react-1.0.0-f4b59f2d-f391-489b-bc0e-2af97499e424-1586762930294/node_modules/@automattic/viewport"
-    "@babel/runtime" "^7.8.4"
-    "@wordpress/compose" "^3.7.0"
-
-"@automattic/viewport@file:packages/viewport":
-  version "1.0.0"
-
-"@automattic/webpack-config-flag-plugin@file:packages/webpack-config-flag-plugin":
-  version "1.0.0"
-
-"@automattic/webpack-extensive-lodash-replacement-plugin@file:./packages/webpack-extensive-lodash-replacement-plugin":
-  version "0.0.2"
-  dependencies:
-    semver "^6.1.1"
-
-"@automattic/webpack-inline-constant-exports-plugin@file:./packages/webpack-inline-constant-exports-plugin":
-  version "0.0.1"
-
-"@automattic/wpcom-block-editor@file:apps/wpcom-block-editor":
-  version "1.0.0-alpha.0"
-  dependencies:
-    debug "4.1.1"
 
 "@babel/cli@7.8.4":
   version "7.8.4"
@@ -6308,14 +6183,6 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-"calypso-codemods@file:./packages/calypso-codemods":
-  version "0.1.6"
-  dependencies:
-    "5to6-codemod" "^1.8.0"
-    jscodeshift "^0.7.0"
-    lodash "^4.17.10"
-    react-codemod "^5.0.5"
-
 camel-case@3.0.x, camel-case@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
@@ -9066,11 +8933,6 @@ eslint-config-prettier@^6.10.0:
   dependencies:
     get-stdin "^6.0.0"
 
-"eslint-config-wpcalypso@file:./packages/eslint-config-wpcalypso":
-  version "5.0.0"
-  dependencies:
-    eslint-plugin-react-hooks "^2.0.0"
-
 eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
@@ -9202,9 +9064,6 @@ eslint-plugin-react@7.18.3, eslint-plugin-react@^7.14.3:
     prop-types "^15.7.2"
     resolve "^1.14.2"
     string.prototype.matchall "^4.0.2"
-
-"eslint-plugin-wpcalypso@file:./packages/eslint-plugin-wpcalypso":
-  version "4.1.0"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
@@ -11412,29 +11271,6 @@ husky@3.1.0:
     read-pkg "^5.2.0"
     run-node "^1.0.0"
     slash "^3.0.0"
-
-"i18n-calypso-cli@file:./packages/i18n-calypso-cli":
-  version "1.0.0"
-  dependencies:
-    commander "^4.0.0"
-    debug "^4.0.0"
-    globby "^10.0.0"
-    xgettext-js "^3.0.0"
-
-"i18n-calypso@file:packages/i18n-calypso":
-  version "5.0.0"
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@tannin/sprintf" "^1.1.0"
-    "@wordpress/compose" "^3.7.2"
-    debug "^4.0.0"
-    events "^3.0.0"
-    hash.js "^1.1.5"
-    interpolate-components "^1.1.1"
-    lodash "^4.17.11"
-    lru "^3.1.0"
-    tannin "^1.1.1"
-    use-subscription "^1.2.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -15352,29 +15188,6 @@ node-sass@4.13.0:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
-node-sass@^4.13.0:
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
-  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
-  dependencies:
-    async-foreach "^0.1.3"
-    chalk "^1.1.1"
-    cross-spawn "^3.0.0"
-    gaze "^1.0.0"
-    get-stdin "^4.0.1"
-    glob "^7.0.3"
-    in-publish "^2.0.0"
-    lodash "^4.17.15"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    nan "^2.13.2"
-    node-gyp "^3.8.0"
-    npmlog "^4.0.0"
-    request "^2.88.0"
-    sass-graph "^2.2.4"
-    stdout-stream "^1.4.0"
-    "true-case-path" "^1.0.2"
-
 "nopt@2 || 3", nopt@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -16424,14 +16237,6 @@ phone@2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/phone/-/phone-2.4.2.tgz#74d6a54288280470d0cefa31e2f0720b7e59005d"
   integrity sha512-d9oLwWCnInj5wJIZjSyAvyBd4SWM4p3C6VmZVAhAlWG8q0dLANTEfRLMn2ybL/TdXbTuOCY4GJbePf3ujPmVvQ==
-
-"photon@file:packages/photon":
-  version "3.0.0"
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    crc32 "0.2.2"
-    debug "^4.0.0"
-    seed-random "2.2.0"
 
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
   version "2.2.1"
@@ -22315,163 +22120,6 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-"wp-calypso@file:client":
-  version "0.17.0"
-  dependencies:
-    "@automattic/calypso-analytics" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/calypso-analytics"
-    "@automattic/calypso-polyfills" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/calypso-polyfills"
-    "@automattic/color-studio" "2.2.1"
-    "@automattic/components" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/components"
-    "@automattic/composite-checkout" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/composite-checkout"
-    "@automattic/data-stores" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/data-stores"
-    "@automattic/format-currency" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/format-currency"
-    "@automattic/load-script" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/load-script"
-    "@automattic/material-design-icons" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/material-design-icons"
-    "@automattic/react-i18n" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/react-i18n"
-    "@automattic/react-virtualized" "9.21.2"
-    "@automattic/tree-select" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/tree-select"
-    "@automattic/viewport" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/viewport"
-    "@automattic/viewport-react" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/viewport-react"
-    "@babel/runtime" "7.8.4"
-    "@emotion/core" "^10.0.27"
-    "@emotion/styled" "10.0.27"
-    "@github/webauthn-json" "0.4.1"
-    "@wordpress/api-fetch" "3.11.0"
-    "@wordpress/base-styles" "1.4.0"
-    "@wordpress/block-editor" "3.7.1"
-    "@wordpress/block-library" "2.14.1"
-    "@wordpress/blocks" "6.12.0"
-    "@wordpress/components" "9.2.1"
-    "@wordpress/compose" "3.11.0"
-    "@wordpress/core-data" "2.12.0"
-    "@wordpress/data" "4.14.0"
-    "@wordpress/data-controls" "1.8.0"
-    "@wordpress/dom" "2.8.0"
-    "@wordpress/edit-post" "3.13.1"
-    "@wordpress/editor" "9.12.1"
-    "@wordpress/element" "2.11.0"
-    "@wordpress/format-library" "1.14.1"
-    "@wordpress/i18n" "3.9.0"
-    "@wordpress/is-shallow-equal" "1.8.0"
-    "@wordpress/keycodes" "2.9.0"
-    "@wordpress/notices" "2.0.0"
-    "@wordpress/nux" "3.12.1"
-    "@wordpress/plugins" "2.12.0"
-    "@wordpress/redux-routine" "3.7.0"
-    "@wordpress/rich-text" "3.12.0"
-    "@wordpress/server-side-render" "1.8.1"
-    "@wordpress/shortcode" "2.6.0"
-    "@wordpress/url" "2.11.0"
-    "@wordpress/viewport" "2.13.0"
-    autosize "4.0.2"
-    body-parser "1.19.0"
-    browser-filesaver "1.1.1"
-    browserslist-useragent "3.0.2"
-    chalk "3.0.0"
-    chrono-node "1.3.5"
-    classnames "2.2.6"
-    clipboard "2.0.4"
-    component-closest "1.0.1"
-    component-file-picker "0.2.1"
-    cookie "0.4.0"
-    cookie-parser "1.4.4"
-    cpf_cnpj "0.2.0"
-    create-react-class "15.6.3"
-    creditcards "3.1.0"
-    d3-array "2.4.0"
-    d3-axis "1.0.12"
-    d3-scale "3.2.1"
-    d3-selection "1.4.1"
-    d3-shape "1.3.7"
-    debug "4.1.1"
-    deep-freeze "0.0.1"
-    diff "4.0.1"
-    doctrine "3.0.0"
-    dom-helpers "5.1.3"
-    dompurify "2.0.7"
-    draft-js "0.11.3"
-    email-validator "2.0.4"
-    emoji-text "0.2.6"
-    events "3.0.0"
-    express "4.17.1"
-    express-useragent "1.0.13"
-    fast-json-stable-stringify "2.0.0"
-    filesize "6.0.1"
-    flag-icon-css "3.4.5"
-    flux "3.1.3"
-    fuse.js "3.4.6"
-    get-video-id "3.1.4"
-    gridicons "3.3.1"
-    hash.js "1.1.7"
-    he "1.2.0"
-    html-to-react "1.4.2"
-    i18n-calypso "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/i18n-calypso"
-    immutability-helper "3.0.1"
-    immutable "3.8.2"
-    inherits "2.0.4"
-    is-my-json-valid "2.20.0"
-    jquery "1.12.3"
-    keymaster "1.6.2"
-    lodash "4.17.15"
-    lodash-es "4.17.15"
-    lru "3.1.0"
-    lunr "2.3.8"
-    marked "0.7.0"
-    moment "2.24.0"
-    moment-timezone "0.5.27"
-    morgan "1.9.1"
-    objectpath "1.2.2"
-    page "1.11.5"
-    path-browserify "1.0.0"
-    percentage-regex "3.0.0"
-    phoenix "1.4.16"
-    phone "2.4.2"
-    photon "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/photon"
-    prismjs "1.17.1"
-    prop-types "15.7.2"
-    qrcode.react "1.0.0"
-    qs "6.9.1"
-    react "16.12.0"
-    react-click-outside "3.0.1"
-    react-day-picker "7.4.0"
-    react-dom "16.12.0"
-    react-element-to-jsx-string "14.1.0"
-    react-lazily-render "1.2.0"
-    react-live "1.12.0"
-    react-modal "3.11.1"
-    react-redux "7.2.0"
-    react-router-dom "5.1.2"
-    react-spring "8.0.27"
-    react-stripe-elements "4.0.2"
-    react-transition-group "4.3.0"
-    reakit "1.0.0-beta.14"
-    redux "4.0.5"
-    redux-form "8.2.6"
-    redux-thunk "2.3.0"
-    refx "3.1.1"
-    resize-observer-polyfill "1.5.1"
-    rtlcss "2.4.0"
-    social-logos "2.1.0"
-    socket.io-client "2.3.0"
-    store "2.0.12"
-    striptags "3.1.1"
-    superagent "3.8.3"
-    textarea-caret "3.1.0"
-    tinymce "4.9.6"
-    to-title-case "1.0.0"
-    tracekit "0.4.5"
-    twemoji "12.1.4"
-    url "0.11.0"
-    use-debounce "3.1.0"
-    use-subscription "1.3.0"
-    utility-types "3.10.0"
-    uuid "7.0.2"
-    valid-url "1.0.9"
-    wpcom "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/wpcom.js"
-    wpcom-proxy-request "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/wpcom-proxy-request"
-    wpcom-xhr-request "1.1.3"
-    yamlparser "0.0.2"
-
 wp-error@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/wp-error/-/wp-error-1.3.0.tgz#720247aa326424991c58775cb2fedc9bfd885420"
@@ -22479,15 +22127,6 @@ wp-error@^1.3.0:
   dependencies:
     builtin-status-codes "^2.0.0"
     uppercamelcase "^1.1.0"
-
-"wpcom-proxy-request@file:packages/wpcom-proxy-request":
-  version "6.0.0"
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    debug "^4.1.1"
-    progress-event "^1.0.0"
-    uuid "^7.0.1"
-    wp-error "^1.3.0"
 
 wpcom-xhr-request@1.1.3:
   version "1.1.3"
@@ -22498,13 +22137,6 @@ wpcom-xhr-request@1.1.3:
     debug "^3.1.0"
     superagent "^3.8.3"
     wp-error "^1.3.0"
-
-"wpcom@file:packages/wpcom.js":
-  version "6.0.0"
-  dependencies:
-    "@babel/runtime" "^7.8.3"
-    debug "^4.1.1"
-    qs "^6.5.2"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,166 +11,19 @@
     lodash "^4.17.4"
     recast "^0.12.1"
 
-"@automattic/babel-plugin-i18n-calypso@file:./packages/babel-plugin-i18n-calypso":
-  version "1.1.0"
-  dependencies:
-    gettext-parser "^4.0.0"
-    lodash "^4.17.14"
-
-"@automattic/babel-plugin-transform-wpcalypso-async@file:./packages/babel-plugin-transform-wpcalypso-async":
-  version "1.0.1"
-  dependencies:
-    lodash "^4.17.15"
-
-"@automattic/calypso-analytics@file:packages/calypso-analytics":
-  version "1.0.0-alpha.1"
-  dependencies:
-    "@automattic/load-script" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-calypso-analytics-1.0.0-alpha.1-3ab200c5-1127-4d42-8904-e014dab0404a-1586762929837/node_modules/@automattic/load-script"
-    cookie "0.4.0"
-    debug "^4.1.1"
-    hash.js "^1.1.7"
-    lodash "^4.17.15"
-    tslib "^1.10.0"
-
-"@automattic/calypso-build@file:./packages/calypso-build":
-  version "6.1.0"
-  dependencies:
-    "@automattic/mini-css-extract-plugin-with-rtl" "0.8.0"
-    "@babel/cli" "7.8.4"
-    "@babel/core" "7.8.4"
-    "@babel/plugin-proposal-class-properties" "7.8.3"
-    "@babel/plugin-transform-react-jsx" "7.8.3"
-    "@babel/plugin-transform-runtime" "7.8.3"
-    "@babel/preset-env" "7.8.4"
-    "@babel/preset-react" "7.8.3"
-    "@babel/preset-typescript" "7.8.3"
-    "@types/webpack-env" "1.15.1"
-    "@wordpress/babel-plugin-import-jsx-pragma" "2.5.0"
-    "@wordpress/browserslist-config" "2.6.0"
-    "@wordpress/dependency-extraction-webpack-plugin" "2.2.0"
-    autoprefixer "9.7.3"
-    babel-jest "25.1.0"
-    babel-loader "8.0.6"
-    browserslist "^4.8.2"
-    caniuse-api "3.0.0"
-    css-loader "3.4.2"
-    duplicate-package-checker-webpack-plugin "3.0.0"
-    enzyme-adapter-react-16 "1.15.1"
-    enzyme-to-json "3.4.3"
-    file-loader "4.3.0"
-    jest-config "25.1.0"
-    jest-emotion "^10.0.27"
-    jest-enzyme "7.1.2"
-    node-sass "4.13.0"
-    postcss-custom-properties "9.0.2"
-    postcss-loader "3.0.0"
-    recursive-copy "2.0.10"
-    sass-loader "8.0.0"
-    terser-webpack-plugin "2.3.1"
-    thread-loader "2.1.3"
-    typescript "3.8.3"
-    webpack "4.42.0"
-    webpack-cli "3.3.10"
-    webpack-rtl-plugin "2.0.0"
-
-"@automattic/calypso-color-schemes@file:./packages/calypso-color-schemes", "@automattic/calypso-color-schemes@file:packages/calypso-color-schemes":
-  version "2.1.0"
-
-"@automattic/calypso-polyfills@file:packages/calypso-polyfills":
-  version "1.0.0"
-  dependencies:
-    core-js "3.6.3"
-    isomorphic-fetch "2.2.1"
-    regenerator-runtime "0.13.3"
-    svg4everybody "2.1.9"
-
 "@automattic/color-studio@2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.2.1.tgz#e920af382a4db624ebca1591adace289912bf37b"
   integrity sha512-doMeOR5ly+qviYgWhWStByZHnnv3AFBC4Tj6aZLTrw8voulIu9AUv3Z9eit8a68uzCI77VkN7fUFadOiYIYBWg==
 
-"@automattic/components@file:packages/components":
-  version "1.0.0-alpha.1"
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    classnames "^2.2.6"
-    gridicons "^3.3.1"
-    lodash "^4.17.15"
-    prop-types "^15.7.2"
-    react-modal "^3.8.1"
-
-"@automattic/composite-checkout@file:packages/composite-checkout":
-  version "1.0.0"
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@emotion/core" "^10.0.27"
-    "@emotion/styled" "^10.0.27"
-    "@wordpress/i18n" "^3.9.0"
-    debug "^4.1.1"
-    emotion-theming "^10.0.27"
-    prop-types "^15.7.2"
-    react-stripe-elements "4.0.2"
-
-"@automattic/data-stores@file:packages/data-stores":
-  version "1.0.0-alpha.1"
-  dependencies:
-    "@wordpress/data-controls" "^1.4.0"
-    "@wordpress/url" "^2.8.2"
-    fast-json-stable-stringify "^2.1.0"
-    qs "^6.9.1"
-    redux "^4.0.4"
-    tslib "^1.10.0"
-    wpcom-proxy-request "file:../../../Library/Caches/Yarn/v6/npm-@automattic-data-stores-1.0.0-alpha.1-c00c9d9e-8e4b-4878-9076-3e439919c71f-1586762930209/node_modules/@automattic/wpcom-proxy-request"
-
-"@automattic/effective-module-tree@file:packages/effective-module-tree":
+"@automattic/effective-module-tree@^0.0.1":
   version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@automattic/effective-module-tree/-/effective-module-tree-0.0.1.tgz#f642c8034b42f10dedd645a7c78b533a1a965609"
+  integrity sha512-p/3p1vCve2egb1t9z+PUP8QtHimjHcvWFIjH1fDKoDgRvNU8Pdd4iEiOhnb8MjyqLd/O3dzvmK1t76YLxfHHJQ==
   dependencies:
     debug "^4.1.1"
     object-treeify "^1.1.23"
     yargs "^15.1.0"
-
-"@automattic/format-currency@file:packages/format-currency":
-  version "1.0.0-alpha.0"
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    i18n-calypso "file:../../../Library/Caches/Yarn/v6/npm-@automattic-format-currency-1.0.0-alpha.0-bf2e82ee-1e97-4fdc-b9e8-8c6822e99ccb-1586762930225/node_modules/@automattic/i18n-calypso"
-
-"@automattic/full-site-editing@file:apps/full-site-editing":
-  version "1.0.0"
-  dependencies:
-    "@wordpress/api-fetch" "*"
-    "@wordpress/block-editor" "*"
-    "@wordpress/blocks" "*"
-    "@wordpress/components" "*"
-    "@wordpress/compose" "*"
-    "@wordpress/data" "*"
-    "@wordpress/date" "*"
-    "@wordpress/dom-ready" "*"
-    "@wordpress/edit-post" "*"
-    "@wordpress/editor" "*"
-    "@wordpress/element" "*"
-    "@wordpress/hooks" "*"
-    "@wordpress/html-entities" "*"
-    "@wordpress/i18n" "*"
-    "@wordpress/keycodes" "*"
-    "@wordpress/plugins" "*"
-    "@wordpress/url" "*"
-    classnames "2.2.6"
-    lodash "*"
-    moment "*"
-    newspack-blocks "github:Automattic/newspack-blocks#v1.2.1"
-
-"@automattic/load-script@file:packages/load-script":
-  version "1.0.0"
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    debug "^4.0.0"
-
-"@automattic/material-design-icons@file:packages/material-design-icons":
-  version "1.0.0"
-
-"@automattic/media-library@file:packages/media-library":
-  version "1.0.0-alpha.0"
 
 "@automattic/mini-css-extract-plugin-with-rtl@0.8.0":
   version "0.8.0"
@@ -182,29 +35,6 @@
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
-"@automattic/notifications@file:apps/notifications":
-  version "1.0.0"
-  dependencies:
-    "@automattic/calypso-color-schemes" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-notifications-1.0.0-4d85ebb0-88c2-422a-b3bf-48592d5149bd-1586762930275/node_modules/packages/calypso-color-schemes"
-    "@automattic/calypso-polyfills" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-notifications-1.0.0-4d85ebb0-88c2-422a-b3bf-48592d5149bd-1586762930275/node_modules/packages/calypso-polyfills"
-
-"@automattic/o2-blocks@file:apps/o2-blocks":
-  version "1.0.0"
-  dependencies:
-    "@wordpress/block-editor" "3.7.6"
-    "@wordpress/blocks" "6.12.0"
-    "@wordpress/components" "9.2.1"
-    "@wordpress/editor" "9.12.1"
-    "@wordpress/element" "2.11.0"
-    "@wordpress/i18n" "3.9.0"
-    classnames "2.2.6"
-
-"@automattic/react-i18n@file:packages/react-i18n":
-  version "1.0.0-alpha.0"
-  dependencies:
-    "@wordpress/compose" "1.x.x - 3.x.x"
-    tslib "^1.10.0"
-
 "@automattic/react-virtualized@9.21.2":
   version "9.21.2"
   resolved "https://registry.yarnpkg.com/@automattic/react-virtualized/-/react-virtualized-9.21.2.tgz#ea14243e7e7811eaa14daed3f0a6f4579208996f"
@@ -213,35 +43,6 @@
     clsx "^1.0.4"
     loose-envify "^1.4.0"
     react-lifecycles-compat "^3.0.4"
-
-"@automattic/tree-select@file:packages/tree-select":
-  version "1.0.3"
-
-"@automattic/viewport-react@file:packages/viewport-react":
-  version "1.0.0"
-  dependencies:
-    "@automattic/viewport" "file:../../../Library/Caches/Yarn/v6/npm-@automattic-viewport-react-1.0.0-f4b59f2d-f391-489b-bc0e-2af97499e424-1586762930294/node_modules/@automattic/viewport"
-    "@babel/runtime" "^7.8.4"
-    "@wordpress/compose" "^3.7.0"
-
-"@automattic/viewport@file:packages/viewport":
-  version "1.0.0"
-
-"@automattic/webpack-config-flag-plugin@file:packages/webpack-config-flag-plugin":
-  version "1.0.0"
-
-"@automattic/webpack-extensive-lodash-replacement-plugin@file:./packages/webpack-extensive-lodash-replacement-plugin":
-  version "0.0.2"
-  dependencies:
-    semver "^6.1.1"
-
-"@automattic/webpack-inline-constant-exports-plugin@file:./packages/webpack-inline-constant-exports-plugin":
-  version "0.0.1"
-
-"@automattic/wpcom-block-editor@file:apps/wpcom-block-editor":
-  version "1.0.0-alpha.0"
-  dependencies:
-    debug "4.1.1"
 
 "@babel/cli@7.8.4":
   version "7.8.4"
@@ -4826,7 +4627,12 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^7.1.0, acorn@^7.1.1:
+acorn@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
+  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+
+acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
@@ -6139,6 +5945,16 @@ browserslist-useragent@3.0.2:
     semver "^6.3.0"
     useragent "^2.3.0"
 
+browserslist@4.11.1:
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.11.1.tgz#92f855ee88d6e050e7e7311d987992014f1a1f1b"
+  integrity sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==
+  dependencies:
+    caniuse-lite "^1.0.30001038"
+    electron-to-chromium "^1.3.390"
+    node-releases "^1.1.53"
+    pkg-up "^2.0.0"
+
 browserslist@4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.7.0.tgz#9ee89225ffc07db03409f2fee524dc8227458a17"
@@ -6148,7 +5964,7 @@ browserslist@4.7.0:
     electron-to-chromium "^1.3.247"
     node-releases "^1.1.29"
 
-browserslist@4.8.6, browserslist@^4.0.0, browserslist@^4.6.6, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3, browserslist@^4.8.5:
+browserslist@^4.0.0, browserslist@^4.6.6, browserslist@^4.8.0, browserslist@^4.8.2, browserslist@^4.8.3, browserslist@^4.8.5:
   version "4.8.6"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.8.6.tgz#96406f3f5f0755d272e27a66f4163ca821590a7e"
   integrity sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==
@@ -6372,14 +6188,6 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-"calypso-codemods@file:./packages/calypso-codemods":
-  version "0.1.6"
-  dependencies:
-    "5to6-codemod" "^1.8.0"
-    jscodeshift "^0.7.0"
-    lodash "^4.17.10"
-    react-codemod "^5.0.5"
-
 camel-case@3.0.x, camel-case@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
@@ -6467,7 +6275,12 @@ caniuse-api@3.0.0, caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@1.0.30001027, caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001023:
+caniuse-lite@1.0.30001041, caniuse-lite@^1.0.30001038:
+  version "1.0.30001041"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001041.tgz#c2ea138dafc6fe03877921ddcddd4a02a14daf76"
+  integrity sha512-fqDtRCApddNrQuBxBS7kEiSGdBsgO4wiVw4G/IClfqzfhW45MbTumfN4cuUJGTM0YGFNn97DCXPJ683PS6zwvA==
+
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001023:
   version "1.0.30001027"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz#283e2ef17d94889cc216a22c6f85303d78ca852d"
   integrity sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==
@@ -8475,21 +8288,21 @@ dom-scroll-into-view@^1.2.1:
   resolved "https://registry.yarnpkg.com/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz#e8f36732dd089b0201a88d7815dc3f88e6d66c7e"
   integrity sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=
 
-dom-serializer@0, dom-serializer@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
-  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
-  dependencies:
-    domelementtype "^2.0.1"
-    entities "^2.0.0"
-
-dom-serializer@~0.1.0, dom-serializer@~0.1.1:
+dom-serializer@0, dom-serializer@~0.1.0, dom-serializer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
   integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
   dependencies:
     domelementtype "^1.3.0"
     entities "^1.1.1"
+
+dom-serializer@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -8706,6 +8519,11 @@ electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.341:
   version "1.3.355"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.355.tgz#ff805ed8a3d68e550a45955134e4e81adf1122ba"
   integrity sha512-zKO/wS+2ChI/jz9WAo647xSW8t2RmgRLFdbUb/77cORkUTargO+SCj4ctTHjBn2VeNFrsLgDT7IuDVrd3F8mLQ==
+
+electron-to-chromium@^1.3.390:
+  version "1.3.406"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.406.tgz#d4b8f8c9f7405dddbbb646d6b15042cd7c1e6e61"
+  integrity sha512-bx8vBZoEbhsMmwEZIj2twzfhFoKKZlSLQiENhqgc5/FdAj4/UHEzAri42OTSFA5+0agLR03ReTvIms2dfZ7/Ew==
 
 element-resize-detector@^1.2.1:
   version "1.2.1"
@@ -9120,11 +8938,6 @@ eslint-config-prettier@^6.10.0:
   dependencies:
     get-stdin "^6.0.0"
 
-"eslint-config-wpcalypso@file:./packages/eslint-config-wpcalypso":
-  version "5.0.0"
-  dependencies:
-    eslint-plugin-react-hooks "^2.0.0"
-
 eslint-import-resolver-node@^0.3.2:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
@@ -9256,9 +9069,6 @@ eslint-plugin-react@7.18.3, eslint-plugin-react@^7.14.3:
     prop-types "^15.7.2"
     resolve "^1.14.2"
     string.prototype.matchall "^4.0.2"
-
-"eslint-plugin-wpcalypso@file:./packages/eslint-plugin-wpcalypso":
-  version "4.1.0"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
@@ -11466,29 +11276,6 @@ husky@3.1.0:
     read-pkg "^5.2.0"
     run-node "^1.0.0"
     slash "^3.0.0"
-
-"i18n-calypso-cli@file:./packages/i18n-calypso-cli":
-  version "1.0.0"
-  dependencies:
-    commander "^4.0.0"
-    debug "^4.0.0"
-    globby "^10.0.0"
-    xgettext-js "^3.0.0"
-
-"i18n-calypso@file:packages/i18n-calypso":
-  version "5.0.0"
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@tannin/sprintf" "^1.1.0"
-    "@wordpress/compose" "^3.7.2"
-    debug "^4.0.0"
-    events "^3.0.0"
-    hash.js "^1.1.5"
-    interpolate-components "^1.1.1"
-    lodash "^4.17.11"
-    lru "^3.1.0"
-    tannin "^1.1.1"
-    use-subscription "^1.2.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
@@ -15358,6 +15145,11 @@ node-releases@^1.1.29, node-releases@^1.1.47:
   dependencies:
     semver "^6.3.0"
 
+node-releases@^1.1.53:
+  version "1.1.53"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
+  integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
+
 node-sass-magic-importer@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/node-sass-magic-importer/-/node-sass-magic-importer-5.3.2.tgz#2f2248bb2e5cdb275ba34102ebf995edadf99175"
@@ -15382,29 +15174,6 @@ node-sass@4.13.0:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
   integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==
-  dependencies:
-    async-foreach "^0.1.3"
-    chalk "^1.1.1"
-    cross-spawn "^3.0.0"
-    gaze "^1.0.0"
-    get-stdin "^4.0.1"
-    glob "^7.0.3"
-    in-publish "^2.0.0"
-    lodash "^4.17.15"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    nan "^2.13.2"
-    node-gyp "^3.8.0"
-    npmlog "^4.0.0"
-    request "^2.88.0"
-    sass-graph "^2.2.4"
-    stdout-stream "^1.4.0"
-    "true-case-path" "^1.0.2"
-
-node-sass@^4.13.0:
-  version "4.13.1"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
-  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -15997,9 +15766,11 @@ p-is-promise@^2.0.0:
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
-  integrity sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.2"
@@ -16071,6 +15842,11 @@ p-retry@^3.0.1:
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -16474,14 +16250,6 @@ phone@2.4.2:
   resolved "https://registry.yarnpkg.com/phone/-/phone-2.4.2.tgz#74d6a54288280470d0cefa31e2f0720b7e59005d"
   integrity sha512-d9oLwWCnInj5wJIZjSyAvyBd4SWM4p3C6VmZVAhAlWG8q0dLANTEfRLMn2ybL/TdXbTuOCY4GJbePf3ujPmVvQ==
 
-"photon@file:packages/photon":
-  version "3.0.0"
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    crc32 "0.2.2"
-    debug "^4.0.0"
-    seed-random "2.2.0"
-
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
@@ -16547,7 +16315,7 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pkg-up@2.0.0:
+pkg-up@2.0.0, pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
@@ -22364,163 +22132,6 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
-"wp-calypso@file:client":
-  version "0.17.0"
-  dependencies:
-    "@automattic/calypso-analytics" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/calypso-analytics"
-    "@automattic/calypso-polyfills" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/calypso-polyfills"
-    "@automattic/color-studio" "2.2.1"
-    "@automattic/components" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/components"
-    "@automattic/composite-checkout" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/composite-checkout"
-    "@automattic/data-stores" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/data-stores"
-    "@automattic/format-currency" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/format-currency"
-    "@automattic/load-script" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/load-script"
-    "@automattic/material-design-icons" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/material-design-icons"
-    "@automattic/react-i18n" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/react-i18n"
-    "@automattic/react-virtualized" "9.21.2"
-    "@automattic/tree-select" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/tree-select"
-    "@automattic/viewport" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/viewport"
-    "@automattic/viewport-react" "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/viewport-react"
-    "@babel/runtime" "7.8.4"
-    "@emotion/core" "^10.0.27"
-    "@emotion/styled" "10.0.27"
-    "@github/webauthn-json" "0.4.1"
-    "@wordpress/api-fetch" "3.11.0"
-    "@wordpress/base-styles" "1.4.0"
-    "@wordpress/block-editor" "3.7.1"
-    "@wordpress/block-library" "2.14.1"
-    "@wordpress/blocks" "6.12.0"
-    "@wordpress/components" "9.2.1"
-    "@wordpress/compose" "3.11.0"
-    "@wordpress/core-data" "2.12.0"
-    "@wordpress/data" "4.14.0"
-    "@wordpress/data-controls" "1.8.0"
-    "@wordpress/dom" "2.8.0"
-    "@wordpress/edit-post" "3.13.1"
-    "@wordpress/editor" "9.12.1"
-    "@wordpress/element" "2.11.0"
-    "@wordpress/format-library" "1.14.1"
-    "@wordpress/i18n" "3.9.0"
-    "@wordpress/is-shallow-equal" "1.8.0"
-    "@wordpress/keycodes" "2.9.0"
-    "@wordpress/notices" "2.0.0"
-    "@wordpress/nux" "3.12.1"
-    "@wordpress/plugins" "2.12.0"
-    "@wordpress/redux-routine" "3.7.0"
-    "@wordpress/rich-text" "3.12.0"
-    "@wordpress/server-side-render" "1.8.1"
-    "@wordpress/shortcode" "2.6.0"
-    "@wordpress/url" "2.11.0"
-    "@wordpress/viewport" "2.13.0"
-    autosize "4.0.2"
-    body-parser "1.19.0"
-    browser-filesaver "1.1.1"
-    browserslist-useragent "3.0.2"
-    chalk "3.0.0"
-    chrono-node "1.3.5"
-    classnames "2.2.6"
-    clipboard "2.0.4"
-    component-closest "1.0.1"
-    component-file-picker "0.2.1"
-    cookie "0.4.0"
-    cookie-parser "1.4.4"
-    cpf_cnpj "0.2.0"
-    create-react-class "15.6.3"
-    creditcards "3.1.0"
-    d3-array "2.4.0"
-    d3-axis "1.0.12"
-    d3-scale "3.2.1"
-    d3-selection "1.4.1"
-    d3-shape "1.3.7"
-    debug "4.1.1"
-    deep-freeze "0.0.1"
-    diff "4.0.1"
-    doctrine "3.0.0"
-    dom-helpers "5.1.3"
-    dompurify "2.0.7"
-    draft-js "0.11.3"
-    email-validator "2.0.4"
-    emoji-text "0.2.6"
-    events "3.0.0"
-    express "4.17.1"
-    express-useragent "1.0.13"
-    fast-json-stable-stringify "2.0.0"
-    filesize "6.0.1"
-    flag-icon-css "3.4.5"
-    flux "3.1.3"
-    fuse.js "3.4.6"
-    get-video-id "3.1.4"
-    gridicons "3.3.1"
-    hash.js "1.1.7"
-    he "1.2.0"
-    html-to-react "1.4.2"
-    i18n-calypso "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/i18n-calypso"
-    immutability-helper "3.0.1"
-    immutable "3.8.2"
-    inherits "2.0.4"
-    is-my-json-valid "2.20.0"
-    jquery "1.12.3"
-    keymaster "1.6.2"
-    lodash "4.17.15"
-    lodash-es "4.17.15"
-    lru "3.1.0"
-    lunr "2.3.8"
-    marked "0.7.0"
-    moment "2.24.0"
-    moment-timezone "0.5.27"
-    morgan "1.9.1"
-    objectpath "1.2.2"
-    page "1.11.5"
-    path-browserify "1.0.0"
-    percentage-regex "3.0.0"
-    phoenix "1.4.16"
-    phone "2.4.2"
-    photon "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/photon"
-    prismjs "1.17.1"
-    prop-types "15.7.2"
-    qrcode.react "1.0.0"
-    qs "6.9.1"
-    react "16.12.0"
-    react-click-outside "3.0.1"
-    react-day-picker "7.4.0"
-    react-dom "16.12.0"
-    react-element-to-jsx-string "14.1.0"
-    react-lazily-render "1.2.0"
-    react-live "1.12.0"
-    react-modal "3.11.1"
-    react-redux "7.2.0"
-    react-router-dom "5.1.2"
-    react-spring "8.0.27"
-    react-stripe-elements "4.0.2"
-    react-transition-group "4.3.0"
-    reakit "1.0.0-beta.14"
-    redux "4.0.5"
-    redux-form "8.2.6"
-    redux-thunk "2.3.0"
-    refx "3.1.1"
-    resize-observer-polyfill "1.5.1"
-    rtlcss "2.4.0"
-    social-logos "2.1.0"
-    socket.io-client "2.3.0"
-    store "2.0.12"
-    striptags "3.1.1"
-    superagent "3.8.3"
-    textarea-caret "3.1.0"
-    tinymce "4.9.6"
-    to-title-case "1.0.0"
-    tracekit "0.4.5"
-    twemoji "12.1.4"
-    url "0.11.0"
-    use-debounce "3.1.0"
-    use-subscription "1.3.0"
-    utility-types "3.10.0"
-    uuid "7.0.2"
-    valid-url "1.0.9"
-    wpcom "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/wpcom.js"
-    wpcom-proxy-request "file:../../../Library/Caches/Yarn/v6/npm-wp-calypso-0.17.0-8af2d15c-d8eb-447a-b0a3-25bccc13c429-1586762930871/node_modules/packages/wpcom-proxy-request"
-    wpcom-xhr-request "1.1.3"
-    yamlparser "0.0.2"
-
 wp-error@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/wp-error/-/wp-error-1.3.0.tgz#720247aa326424991c58775cb2fedc9bfd885420"
@@ -22528,15 +22139,6 @@ wp-error@^1.3.0:
   dependencies:
     builtin-status-codes "^2.0.0"
     uppercamelcase "^1.1.0"
-
-"wpcom-proxy-request@file:packages/wpcom-proxy-request":
-  version "6.0.0"
-  dependencies:
-    "@babel/runtime" "^7.8.4"
-    debug "^4.1.1"
-    progress-event "^1.0.0"
-    uuid "^7.0.1"
-    wp-error "^1.3.0"
 
 wpcom-xhr-request@1.1.3:
   version "1.1.3"
@@ -22547,13 +22149,6 @@ wpcom-xhr-request@1.1.3:
     debug "^3.1.0"
     superagent "^3.8.3"
     wp-error "^1.3.0"
-
-"wpcom@file:packages/wpcom.js":
-  version "6.0.0"
-  dependencies:
-    "@babel/runtime" "^7.8.3"
-    debug "^4.1.1"
-    qs "^6.5.2"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8338,7 +8338,7 @@ dompurify@2.0.7:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.7.tgz#f8266ad38fe1602fb5b3222f31eedbf5c16c4fd5"
   integrity sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A==
 
-domutils@1.5.1, domutils@^1.5.1:
+domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
   integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
@@ -8346,7 +8346,7 @@ domutils@1.5.1, domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^1.7.0:
+domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
@@ -15747,9 +15747,11 @@ p-is-promise@^2.0.0:
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
-  integrity sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.2"
@@ -15821,6 +15823,11 @@ p-retry@^3.0.1:
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4752,12 +4752,7 @@ acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-acorn@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
-  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
-
-acorn@^7.1.1:
+acorn@^7.1.0, acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
@@ -8421,21 +8416,21 @@ dom-scroll-into-view@^1.2.1:
   resolved "https://registry.yarnpkg.com/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz#e8f36732dd089b0201a88d7815dc3f88e6d66c7e"
   integrity sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=
 
-dom-serializer@0, dom-serializer@~0.1.0, dom-serializer@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
-  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
-  dependencies:
-    domelementtype "^1.3.0"
-    entities "^1.1.1"
-
-dom-serializer@^0.2.1:
+dom-serializer@0, dom-serializer@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
   integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
   dependencies:
     domelementtype "^2.0.1"
     entities "^2.0.0"
+
+dom-serializer@~0.1.0, dom-serializer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
+  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
+  dependencies:
+    domelementtype "^1.3.0"
+    entities "^1.1.1"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -15357,6 +15352,29 @@ node-sass@4.13.0:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
+node-sass@^4.13.0:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
+    node-gyp "^3.8.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
 "nopt@2 || 3", nopt@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -15930,11 +15948,9 @@ p-is-promise@^2.0.0:
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
-  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
-  dependencies:
-    p-try "^1.0.0"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+  integrity sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.2.2"
@@ -16006,11 +16022,6 @@ p-retry@^3.0.1:
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
-
-p-try@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
-  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This is the PR that replaces `package-lock.json` with `yarn.lock`, so it has the potential to change the dependency tree.

### Testing instructions

There is not a lot to review (unless you want to read `yarn.lock` changes), so I'd suggest to rely on comparing the trees to check that nothing has changed.

It is recommended two have two checkouts, one with master and the other with this branch.

In master:
- Checkout master (I used commit 109dd84caf to do this check)
- Install deps with `rm -fr node_modules && npm ci`
- Generate an effective tree in list mode `node_modules/.bin/effective-module-tree -o list > ../npm-tree

In this branch:
- Checkout this branch
- Install deps with `rm -fr node_modules && yarn`
- Generate an effective tree in list mode `node_modules/.bin/effective-module-tree -o list > ../yarn-tree

Once you have both trees:
- Do a diff (`diff npm-tree yarn-tree > tree.diff`)
- Open it in an editor and validate that the changes are limited to the list of differences below

### Notes

It is important to mention that the dependency tree when moving to yarn **will be different**: npm can generate dependency trees that can't be represented in yarn with 100% fidelity. Specifically, in npm a range (eg: `lib@^1.0.0`) can be satisfied with more than one package (eg: some parts of the tree could get `lib@1.0.1` while other parts could get `lib@1.0.2`). This is not possible with yarn: once a range is resolved to whatever version, that version will be used anywhere on the tree where the range was used (eg: `lib@^1.0.0` will always resolve to `lib@1.0.2`)

After analysing both trees, I found many differences but all of them can be explained by the note above. Also, all of them are only present in devDependencies, so that kind of reduces the risk of unexpected changes in production.

Specifically, the differences between both trees are:
- `dom-serializer@0.1.1` vs `dom-serializer@0.2.2`. Reason:
	- In NPM, dependency dependency `domutils@1.5.1 -> dom-serializer@0` is resolved with two different versions: `0.1.1` and `0.2.2`.
	- In YARN, it is always resolved with `0.2.2`

- `acorn@7.1.0` vs `acorn@7.1.1`. Reason:
	- In NPM, package `espree@6.1.2` depends on `acorn@^7.1.0` and gets `acorn@7.1.0`. Package `jsdom@15.2.1` depends on `acorn@^7.1.0` and gets `acorn@7.1.1`
	- In YARN, both packages get `acorn@7.1.1`

- `domutils@1.7.0` vs `domutils@1.5.1`
	- In NPM, dependency `htmlparser2@3.10.1 -> domutils@^1.5.1` is resolved with two different versions: `1.7.0` and `1.5.1`
	- In YARN, it is always resolved with `1.7.0`

- `safe-buffer@5.2.0` vs `safe-buffer@5.1.2`
	- In NPM, depenency `minipass@2.9.0 -> safe-buffer@^5.1.2` is resolved with two different versions: `5.1.2` and `5.2.0`
	- In YARN, it is always resolved with `5.1.2`

- `find-cache-dir@3.2.0` vs `find-cache-dir@3.3.1`
	- In NPM, package `moment-timezone-data-webpack-plugin@1.1.0` depends on `find-cache-dir@^3.0.0` and gets `find-cache-dir@3.2.0`. Package `@storybook/core@5.3.14` depends on `find-cache-dir@^3.0.0` and gets `find-cache-dir@3.3.1`
	- In YARN, both packages get `find-cache-dir@3.3.1`

- `vfile-message@2.0.2`
    - In NPM, `vfile-message@2.0.2` is bring in as a transitive dependency for `@wordpress/server-side-render`, and hoisted to the root. Then `@automattic/media-library` assumes it is there when compiling itself.
    - In YARN, `vfile-message@1.1.1` is the version getting hoisted to the root, so `@automattic/media-library` fails to compile. The solution is to have a explicit dependency on `vfile-message@2.0.2` on the yarn tree.