### PR TITLE
Jetpack Cloud: Create ActivityCardList component and integrate into backups

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -1,0 +1,141 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { isMobile } from '@automattic/viewport';
+
+/**
+ * Internal dependencies
+ */
+import ActivityCard from 'landing/jetpack-cloud/components/activity-card';
+import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
+import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
+import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
+import getRewindState from 'state/selectors/get-rewind-state';
+import QueryRewindState from 'components/data/query-rewind-state';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { updateFilter } from 'state/activity-log/actions';
+import { withLocalizedMoment } from 'components/localized-moment';
+import Filterbar from 'my-sites/activity/filterbar';
+import Pagination from 'components/pagination';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ActivityCardList extends Component {
+	static defaultProps = {
+		showFilter: true,
+		showPagination: true,
+	};
+
+	changePage = pageNumber => {
+		this.props.selectPage( this.props.siteId, pageNumber );
+		window.scrollTo( 0, 0 );
+	};
+
+	render() {
+		const {
+			allowRestore,
+			filter,
+			moment,
+			logs,
+			pageSize,
+			showFilter,
+			showPagination,
+			siteId,
+		} = this.props;
+		const { page: requestedPage } = filter;
+
+		const actualPage = Math.max(
+			1,
+			Math.min( requestedPage, Math.ceil( logs.length / pageSize ) )
+		);
+		const theseLogs = logs.slice( ( actualPage - 1 ) * pageSize, actualPage * pageSize );
+
+		const cards = theseLogs.map( activity => (
+			<ActivityCard
+				{ ...{
+					key: activity.activityId,
+					moment,
+					activity,
+					allowRestore,
+				} }
+			/>
+		) );
+
+		return (
+			<div className="activity-card-list">
+				<QueryRewindCapabilities siteId={ siteId } />
+				<QueryRewindState siteId={ siteId } />
+				{ showFilter && (
+					<Filterbar
+						{ ...{
+							siteId,
+							filter,
+							isLoading: false,
+							isVisible: true,
+						} }
+					/>
+				) }
+				{ showPagination && (
+					<Pagination
+						compact={ isMobile() }
+						className="activity-card-list__pagination"
+						key="activity-card-list__pagination-top"
+						nextLabel={ 'Older' }
+						page={ actualPage }
+						pageClick={ this.changePage }
+						perPage={ pageSize }
+						prevLabel={ 'Newer' }
+						total={ logs.length }
+					/>
+				) }
+				{ cards }
+				{ showPagination && (
+					<Pagination
+						compact={ isMobile() }
+						className="activity-card-list__pagination"
+						key="activity-card-list__pagination-bottom"
+						nextLabel={ 'Older' }
+						page={ actualPage }
+						pageClick={ this.changePage }
+						perPage={ pageSize }
+						prevLabel={ 'Newer' }
+						total={ logs.length }
+					/>
+				) }
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = state => {
+	const siteId = getSelectedSiteId( state );
+	const filter = getActivityLogFilter( state, siteId );
+	const rewind = getRewindState( state, siteId );
+	const siteCapabilities = getRewindCapabilities( state, siteId );
+	const restoreStatus = rewind.rewind && rewind.rewind.status;
+	const allowRestore =
+		'active' === rewind.state &&
+		! ( 'queued' === restoreStatus || 'running' === restoreStatus ) &&
+		siteCapabilities.includes( 'restore' );
+
+	return {
+		siteId,
+		filter,
+		rewind,
+		allowRestore,
+	};
+};
+
+const mapDispatchToProps = dispatch => ( {
+	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) ),
+} );
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( withLocalizedMoment( ActivityCardList ) );

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -1,0 +1,14 @@
+.activity-card-list .filterbar {
+    margin-bottom: 2rem;
+}
+
+@include breakpoint( '<660px' ) {
+    .activity-card-list .filterbar__wrap.card {
+        background: transparent;
+        box-shadow: none;
+    }
+
+    .activity-card-list .filterbar__label {
+        margin-left: 0;
+    }
+}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { isMobile } from '@automattic/viewport';
 import React, { Component } from 'react';
 import momentDate from 'moment';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -31,9 +31,7 @@ import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
-import Filterbar from 'my-sites/activity/filterbar';
-import ActivityCard from '../../components/activity-card';
-import Pagination from 'components/pagination';
+import ActivityCardList from 'landing/jetpack-cloud/components/activity-card-list';
 import MissingCredentialsWarning from '../../components/missing-credentials';
 import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials.js';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
@@ -47,7 +45,6 @@ import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
  */
 import './style.scss';
 
-const PAGE_SIZE = 10;
 const INDEX_FORMAT = 'YYYYMMDD';
 
 const backupStatusNames = [
@@ -154,6 +151,7 @@ class BackupsPage extends Component {
 			isLoadingBackups,
 			oldestDateAvailable,
 			timezone,
+			translate,
 			gmtOffset,
 		} = this.props;
 
@@ -168,7 +166,7 @@ class BackupsPage extends Component {
 
 		return (
 			<Main>
-				<DocumentHead title="Backups" />
+				<DocumentHead title={ translate( 'Backups' ) } />
 				<SidebarNavigation />
 				<QueryRewindState siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
@@ -183,7 +181,7 @@ class BackupsPage extends Component {
 					siteSlug={ siteSlug }
 				/>
 
-				<div>{ isLoadingBackups && 'Loading backups...' }</div>
+				<div>{ isLoadingBackups && translate( 'Loading backups…' ) }</div>
 
 				{ ! isLoadingBackups && (
 					<>
@@ -215,70 +213,23 @@ class BackupsPage extends Component {
 		);
 	}
 
-	changePage = pageNumber => {
-		this.props.selectPage( this.props.siteId, pageNumber );
-		window.scrollTo( 0, 0 );
-	};
+	renderBackupSearch() {
+		const { logs, translate } = this.props;
 
-	renderActivityLog() {
-		const { allowRestore, filter, logs, moment, siteId } = this.props;
-		const { page: requestedPage } = filter;
-
-		const actualPage = Math.max(
-			1,
-			Math.min( requestedPage, Math.ceil( logs.length / PAGE_SIZE ) )
-		);
-		const theseLogs = logs.slice( ( actualPage - 1 ) * PAGE_SIZE, actualPage * PAGE_SIZE );
-
-		const cards = theseLogs.map( activity => (
-			<ActivityCard
-				{ ...{
-					key: activity.activityId,
-					moment,
-					activity,
-					allowRestore,
-				} }
-			/>
-		) );
+		// Filter out anything that is not restorable
+		const restorablePoints = logs.filter( event => !! event.activityIsRewindable );
 
 		return (
-			<div>
-				<div>Find a backup or restore point</div>
-				<div>
-					This is the complete event history for your site. Filter by date range and/ or activity
-					type.
+			<div className="backups__search">
+				<div className="backups__search-header">
+					{ translate( 'Find a backup or restore point' ) }
 				</div>
-				<Filterbar
-					{ ...{
-						siteId,
-						filter,
-						isLoading: false,
-						isVisible: true,
-					} }
-				/>
-				<Pagination
-					compact={ isMobile() }
-					className="backups__pagination"
-					key="backups__pagination-top"
-					nextLabel={ 'Older' }
-					page={ actualPage }
-					pageClick={ this.changePage }
-					perPage={ PAGE_SIZE }
-					prevLabel={ 'Newer' }
-					total={ logs.length }
-				/>
-				{ cards }
-				<Pagination
-					compact={ isMobile() }
-					className="backups__pagination"
-					key="backups__pagination-bottom"
-					nextLabel={ 'Older' }
-					page={ actualPage }
-					pageClick={ this.changePage }
-					perPage={ PAGE_SIZE }
-					prevLabel={ 'Newer' }
-					total={ logs.length }
-				/>
+				<div className="backups__search-description">
+					{ translate(
+						'This is the complete event history for your site. Filter by date range and/ or activity type.'
+					) }
+				</div>
+				<ActivityCardList logs={ restorablePoints } pageSize={ 10 } />
 			</div>
 		);
 	}
@@ -288,7 +239,7 @@ class BackupsPage extends Component {
 
 		return (
 			<div className="backups__page">
-				{ ! this.isEmptyFilter( filter ) ? this.renderActivityLog() : this.renderMain() }
+				{ ! this.isEmptyFilter( filter ) ? this.renderBackupSearch() : this.renderMain() }
 			</div>
 		);
 	}
@@ -378,4 +329,7 @@ const mapDispatchToProps = dispatch => ( {
 	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) ),
 } );
 
-export default connect( mapStateToProps, mapDispatchToProps )( withLocalizedMoment( BackupsPage ) );
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( withLocalizedMoment( BackupsPage ) ) );

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -1,3 +1,18 @@
 .backups__page .filterbar .filterbar__wrap.card {
-    display: inline-block;
+    display: flex;
+}
+
+.backups__search {
+    padding: 0 1rem;
+}
+
+.backups__search-header {
+    font-size: 1.3rem;
+    font-weight: 500;
+    margin-top: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+.backups__search-description {
+    margin-bottom: 2rem;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR creates a new component to replace the Activity List on the main backups page. The new component is easily reusable and will be integrated into several other places that this list is utilized.
* Also ... translate a few strings that were not done earlier

#### Testing instructions

* Load up the main backups page, and click the calendar icon at the top to select a date range. Once you select a range, the view should switch to a list of activity cards.
* Play with the filterbar. Does everything work as expected? Great!
