### PR TITLE
composite-checkout: Make unique Tracks events for stripe/contact field validation errors

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -85,15 +85,6 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					} )
 				);
 
-			case 'a8c_checkout_contact_field_invalid_error':
-				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_contact_field_invalid_error', {
-						error_type: action.payload.type,
-						error_field: action.payload.field,
-						error_message: action.payload.message,
-					} )
-				);
-
 			case 'a8c_checkout_add_coupon':
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_coupon_add_submit', {

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -76,9 +76,18 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 					} )
 				);
 
-			case 'a8c_checkout_error':
+			case 'a8c_checkout_stripe_field_invalid_error':
 				return reduxDispatch(
-					recordTracksEvent( 'calypso_checkout_composite_error', {
+					recordTracksEvent( 'calypso_checkout_composite_stripe_field_invalid_error', {
+						error_type: action.payload.type,
+						error_field: action.payload.field,
+						error_message: action.payload.message,
+					} )
+				);
+
+			case 'a8c_checkout_contact_field_invalid_error':
+				return reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_composite_contact_field_invalid_error', {
 						error_type: action.payload.type,
 						error_field: action.payload.field,
 						error_message: action.payload.message,

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
@@ -35,11 +35,18 @@ type WpcomStoreAction =
 			payload: PossiblyCompleteDomainContactDetails;
 	  };
 
+type ReactStandardAction = { type: string; payload?: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
+type WordPressDataStore = {
+	getState: () => object;
+	subscribe: ( listener: Function ) => void;
+	dispatch: ( action: object ) => void;
+};
+
 export function useWpcomStore(
-	registerStore,
-	onEvent,
+	registerStore: ( key: string, storeOptions: object ) => WordPressDataStore,
+	onEvent: ( action: ReactStandardAction ) => void,
 	managedContactDetails: ManagedContactDetails,
-	updateContactDetailsCache: ( DomainContactDetails ) => void
+	updateContactDetailsCache: ( _: DomainContactDetails ) => void
 ) {
 	// Only register once
 	const registerIsComplete = useRef< boolean >( false );

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
@@ -146,20 +146,6 @@ export function useWpcomStore(
 				return { type: 'TOUCH_CONTACT_DETAILS' };
 			},
 
-			// TODO: type this; need to use error messages from contact form
-			setContactField( key, field ) {
-				if ( ! field.isValid ) {
-					onEvent( {
-						type: 'a8c_checkout_contact_field_invalid_error',
-						payload: {
-							type: 'Field error',
-							field: key,
-						},
-					} );
-				}
-				return { type: 'CONTACT_SET_FIELD', payload: { key, field } };
-			},
-
 			updateVatId( payload: string ): WpcomStoreAction {
 				return { type: 'UPDATE_VAT_ID', payload: payload };
 			},

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
@@ -150,7 +150,7 @@ export function useWpcomStore(
 			setContactField( key, field ) {
 				if ( ! field.isValid ) {
 					onEvent( {
-						type: 'a8c_checkout_error',
+						type: 'a8c_checkout_contact_field_invalid_error',
 						payload: {
 							type: 'Field error',
 							field: key,

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -280,7 +280,7 @@ function StripeCreditCardFields() {
 
 		if ( input.error && input.error.message ) {
 			onEvent( {
-				type: 'a8c_checkout_error',
+				type: 'a8c_checkout_stripe_field_invalid_error',
 				payload: {
 					type: 'Stripe field error',
 					field: input.elementType,


### PR DESCRIPTION
The internal `a8c_checkout_error` event (resulting in the `calypso_checkout_composite_error` Tracks event) is used for two different events: a stripe field validation error and a contact field validation error (the latter of which is actually never called). In addition, the event's name is not very descriptive, making it hard to triage these errors in Tracks.

This change modifies the events to be unique and descriptive instead, replacing `calypso_checkout_composite_error` with `calypso_checkout_composite_stripe_field_invalid_error` and and removing the unused instance.

#### Testing instructions

- Sandbox the store so that you can load the credit card form.
- Load calypso and run `localStorage.setItem('debug', 'calypso:analytics')` in your browser console. Then reload the page.
- Visit composite checkout, enter an invalid credit card number into the credit card field.
- Press "Continue".
- Verify that you see `calypso_checkout_composite_stripe_field_invalid_error` triggered in your console.