### PR TITLE
Update backup status views: no backup, failed backup, scheduled backup

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -55,9 +55,15 @@ class DailyBackupStatus extends Component {
 		let displayableDate;
 
 		if ( isToday && withLatest ) {
-			displayableDate = translate( 'Latest: Today %s', { args: [ displayBackupTime ] } );
+			displayableDate = translate( 'Latest: Today %s', {
+				args: [ displayBackupTime ],
+				comment: '%s is the time of the last backup from today',
+			} );
 		} else if ( isToday ) {
-			displayableDate = translate( 'Today %s', { args: [ displayBackupTime ] } );
+			displayableDate = translate( 'Today %s', {
+				args: [ displayBackupTime ],
+				comment: '%s is the time of the last backup from today',
+			} );
 		} else if ( withLatest ) {
 			displayableDate = translate( 'Latest: %s', {
 				args: [ backupDate.format( dateFormat + ', LT' ) ],
@@ -106,7 +112,9 @@ class DailyBackupStatus extends Component {
 			<>
 				<Gridicon icon="cloud-upload" className="daily-backup-status__gridicon-error-state" />
 				<div className="daily-backup-status__failed-message">
-					{ translate( 'Backup failed' ) }: { backupTitleDate }
+					{ translate( 'Backup failed: %(backupDate)s', {
+						args: { backupDate: backupTitleDate },
+					} ) }
 				</div>
 				<div className="daily-backup-status__label">
 					<p>

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { localize, useTranslate } from 'i18n-calypso';
 import page from 'page';
 import { get } from 'lodash';
@@ -38,7 +38,7 @@ class DailyBackupStatus extends Component {
 		//page.redirect( backupDetailPath( this.props.siteSlug, this.props.backup.rewindId ) );
 	}
 
-	getDisplayDate = date => {
+	getDisplayDate = ( date, withLatest = true ) => {
 		const { translate, moment, timezone, gmtOffset } = this.props;
 
 		//Apply the time offset
@@ -50,11 +50,18 @@ class DailyBackupStatus extends Component {
 		const yearDate = backupDate.format( 'YYYY' );
 
 		const dateFormat = yearToday === yearDate ? 'MMM D' : 'MMM D, YYYY';
+		const displayBackupTime = backupDate.format( 'LT' );
 
 		let displayableDate;
 
-		if ( isToday ) {
-			displayableDate = translate( 'Latest: Today ' ) + backupDate.format( 'LT' );
+		if ( isToday && withLatest ) {
+			displayableDate = translate( 'Latest: Today %s', { args: [ displayBackupTime ] } );
+		} else if ( isToday ) {
+			displayableDate = translate( 'Today %s', { args: [ displayBackupTime ] } );
+		} else if ( withLatest ) {
+			displayableDate = translate( 'Latest: %s', {
+				args: [ backupDate.format( dateFormat + ', LT' ) ],
+			} );
 		} else {
 			displayableDate = backupDate.format( dateFormat + ', LT' );
 		}
@@ -70,7 +77,7 @@ class DailyBackupStatus extends Component {
 		const meta = get( backup, 'activityDescription[2].children[0]', '' );
 
 		return (
-			<Card className="daily-backup-status__success">
+			<>
 				<div className="daily-backup-status__icon-section">
 					<Gridicon className="daily-backup-status__status-icon" icon="cloud-upload" />
 					<div className="daily-backup-status__title">{ translate( 'Latest backup' ) }</div>
@@ -82,36 +89,37 @@ class DailyBackupStatus extends Component {
 					onRestoreClick={ this.triggerRestore }
 					disabledRestore={ ! allowRestore }
 				/>
-			</Card>
+			</>
 		);
 	}
 
 	renderFailedBackup( backup ) {
 		const { translate, timezone, gmtOffset } = this.props;
 
-		const backupTitleDate = this.getDisplayDate( backup.activityTs );
+		const backupTitleDate = this.getDisplayDate( backup.activityTs, false );
 		const backupDate = applySiteOffset( backup.activityTs, { timezone, gmtOffset } );
 
 		const displayDate = backupDate.format( 'L' );
 		const displayTime = backupDate.format( 'LT' );
 
 		return (
-			<Card className="daily-backup-status__failed">
+			<>
 				<Gridicon icon="cloud-upload" className="daily-backup-status__gridicon-error-state" />
 				<div className="daily-backup-status__failed-message">
-					{ translate( 'Backup attempt failed' ) }
+					{ translate( 'Backup failed' ) }: { backupTitleDate }
 				</div>
-				<div className="daily-backup-status__date">{ backupTitleDate }</div>
 				<div className="daily-backup-status__label">
 					<p>
 						{ translate(
-							'A backup for your site was attempted on %(displayDate)s at %(displayTime)s and was not able to be completed.',
+							'A backup for your site was attempted on %(displayDate)s at %(displayTime)s and was not ' +
+								'able to be completed.',
 							{ args: { displayDate, displayTime } }
 						) }
 					</p>
 					<p>
 						{ translate(
-							'Check out the {{a}}backups help guide{{/a}} or contact our support team to resolve the issue. View to get the issue resolved',
+							'Check out the {{a}}backups help guide{{/a}} or contact our support team to resolve the ' +
+								'issue. View to get the issue resolved',
 							{
 								components: {
 									a: (
@@ -135,34 +143,131 @@ class DailyBackupStatus extends Component {
 						{ translate( 'Contact support' ) }
 					</Button>
 				</div>
-			</Card>
+			</>
 		);
 	}
 
-	renderNoBackups() {
-		const { translate } = this.props;
+	renderNoBackup() {
+		const { translate, selectedDate, onDateChange } = this.props;
 
-		// todo: remove the mock dates by the real dates
-		const lastBackupAt = 'Yesterday 16:02';
-		const nextBackupAt = 'Today 16:02';
+		const displayDate = selectedDate.format( 'll' );
+		const nextDate = selectedDate.clone().add( 1, 'days' );
+		const displayNextDate = nextDate.format( 'll' );
 
 		return (
-			<Fragment>
-				<Gridicon icon="sync" />
+			<>
+				<Gridicon icon="cloud-upload" className="daily-backup-status__gridicon-no-backup" />
+				<div className="daily-backup-status__title">{ translate( 'No backup' ) }</div>
 
-				<div className="daily-backup-status__date">
-					{ translate( 'Backup Scheduled' ) }: { nextBackupAt }
+				<div className="daily-backup-status__label">
+					<p>
+						{ translate( 'The backup attempt for %(displayDate)s was delayed.', {
+							args: { displayDate },
+						} ) }
+					</p>
+					<p>
+						{ translate(
+							'But don’t worry, it was likely completed in the early hours the next morning. ' +
+								'Check the following day, {{link}}%(displayNextDate)s{{/link}} or contact support if you still need help.',
+							{
+								args: { displayNextDate },
+								components: {
+									//todo: href need implementation and add the correct query
+									link: (
+										<a
+											href="?date="
+											onClick={ event => {
+												event.preventDefault();
+												onDateChange( nextDate );
+											} }
+										/>
+									),
+								},
+							}
+						) }
+					</p>
 				</div>
-				<div>{ translate( 'Last daily backup' ) + ` ${ lastBackupAt }` }</div>
 
+				<Button
+					className="daily-backup-status__support-button"
+					href="https://jetpack.com/contact-support/"
+					target="_blank"
+					rel="noopener noreferrer"
+					isPrimary={ false }
+				>
+					{ translate( 'Contact support' ) }
+				</Button>
+			</>
+		);
+	}
+
+	renderNoBackupToday( lastBackupDate ) {
+		const { translate, timezone, gmtOffset, moment, onDateChange } = this.props;
+
+		const today = applySiteOffset( moment(), {
+			timezone: timezone,
+			gmtOffset: gmtOffset,
+		} );
+		const yesterday = today.subtract( 1, 'days' );
+
+		const lastBackupDay = lastBackupDate.isSame( yesterday, 'day' )
+			? translate( 'Yesterday ' )
+			: lastBackupDate.format( 'll' );
+
+		const lastBackupTime = lastBackupDate.format( 'LT' );
+
+		// Calculates the remaining hours for the next backup + 3 hours of safety margin
+		const hoursForNextBackup =
+			parseInt( lastBackupDate.format( 'H' ) ) - parseInt( today.format( 'H' ) ) + 3;
+
+		return (
+			<>
+				<Gridicon className="daily-backup-status__gridicon-backup-scheduled" icon="cloud-upload" />
+				<div className="daily-backup-status__static-title">
+					{ translate( 'Backup Scheduled:' ) }
+					<div>
+						{ translate( 'In the next %d hour', 'In the next %d hours', {
+							args: [ hoursForNextBackup ],
+							count: hoursForNextBackup,
+						} ) }
+					</div>
+				</div>
+				<div className="daily-backup-status__no-backup-last-backup">
+					{ translate( 'Last daily backup: {{link}}%(lastBackupDay)s %(lastBackupTime)s{{/link}}', {
+						args: { lastBackupDay, lastBackupTime },
+						components: {
+							//todo: href need implementation and add the correct query
+							link: (
+								<a
+									href="?date="
+									onClick={ event => {
+										event.preventDefault();
+										onDateChange( lastBackupDate );
+									} }
+								/>
+							),
+						},
+					} ) }
+				</div>
 				<ActionButtons disabledDownload={ true } disabledRestore={ true } />
-			</Fragment>
+			</>
 		);
 	}
 
 	renderBackupStatus( backup ) {
-		if ( ! backup ) {
-			return this.renderNoBackups();
+		const { selectedDate, lastDateAvailable, moment, timezone, gmtOffset } = this.props;
+
+		const today = applySiteOffset( moment(), {
+			timezone: timezone,
+			gmtOffset: gmtOffset,
+		} );
+
+		const isToday = today.isSame( selectedDate, 'day' );
+
+		if ( ! backup && isToday ) {
+			return this.renderNoBackupToday( lastDateAvailable );
+		} else if ( ! backup ) {
+			return this.renderNoBackup();
 		} else if ( isSuccessfulBackup( backup ) ) {
 			return this.renderGoodBackup( backup );
 		}
@@ -173,7 +278,11 @@ class DailyBackupStatus extends Component {
 	render() {
 		const backup = this.props.backup;
 
-		return <div className="daily-backup-status">{ this.renderBackupStatus( backup ) }</div>;
+		return (
+			<div className="daily-backup-status">
+				<Card className="daily-backup-status__success">{ this.renderBackupStatus( backup ) }</Card>
+			</div>
+		);
 	}
 }
 

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -16,12 +16,25 @@
 	fill: rgb( 214, 54, 56 );
 }
 
+.daily-backup-status__gridicon-no-backup {
+	width: 3rem;
+	height: 3rem;
+	color: var( --studio-yellow-20 );
+}
+
+.daily-backup-status__gridicon-backup-scheduled {
+	width: 3rem;
+	height: 3rem;
+	color: var( --studio-gray-40 );
+}
+
 .daily-backup-status__label {
 	color: var( --studio-gray-80 );
 	text-align: left;
 }
 
-.daily-backup-status__date {
+.daily-backup-status__date,
+.daily-backup-status__static-title {
 	font-size: 1.4rem;
 	font-weight: 500;
 	margin-bottom: 1rem;
@@ -33,6 +46,11 @@
 	color: rgb( 214, 54, 56 );
 	margin-bottom: 0.5rem;
 	margin-top: -0.5rem;
+}
+
+.daily-backup-status__no-backup-last-backup {
+	margin-top: 1rem;
+	font-style: italic;
 }
 
 .form-button.daily-backup-status__restore-button,

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -197,8 +197,10 @@ class BackupsPage extends Component {
 							siteSlug={ siteSlug }
 							backup={ backupsOnSelectedDate.lastBackup }
 							lastDateAvailable={ lastDateAvailable }
+							selectedDate={ this.getSelectedDate() }
 							timezone={ timezone }
 							gmtOffset={ gmtOffset }
+							onDateChange={ this.onDateChange }
 						/>
 						{ doesRewindNeedCredentials && (
 							<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the backup status views when:
- We don't have a backup on the selected date
- The backup from today is scheduled (it calculates the next expected time plus 3 hours of safety margin)
- Some styles applied.

Backup scheduled:
![image](https://user-images.githubusercontent.com/9832440/78828444-a2d73400-79dc-11ea-9378-07b5a8b46d37.png)

Failed backup (copy updated):
![image](https://user-images.githubusercontent.com/9832440/78828596-d74af000-79dc-11ea-8a9d-505b31f1d6ee.png)

No Backup:
![image](https://user-images.githubusercontent.com/9832440/78829322-0b72e080-79de-11ea-87bb-b7b9d9308c72.png)


#### Testing instructions

- Apply these changes
- Check the copies for the different views: Backup Failed, No Backup, Scheduled Backup
- Check the expected time (the remaining hours) if you have a scheduled backup for today

You need to have a Jetpack site with a backup subscription (or a plan with it). To have a:

- **Failed Backup scenario:** disconnect the site for one, so you'll get a failed backup. Also, you can modify the props of the component, change `rewind__backup_complete_full` by `rewind__backup_error`
![image](https://user-images.githubusercontent.com/9832440/78896321-37d33f00-7a68-11ea-9c68-b8b216de6705.png)


- **No Backup scenario:** cancel your subscription and after that, the system will not trigger any backup. The other case is when your backup is delayed to the next day, but it's out of your hands. Directly you can modify the props of DailyBackupStatus component, add in `new prop`field `backup: null`

![image](https://user-images.githubusercontent.com/9832440/78897188-b11f6180-7a69-11ea-80ca-e79359e2c7a4.png)

- **Scheduled Backup scenario:** If the backup for today already happened, move your time zone until reach the next day. Also, you can manipulate the props as before, select today and set the `backup` props to `null`
