### PR TITLE
Block Editor: Fix trailing comma

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -57,7 +57,7 @@ class WPCOM_Block_Editor_NUX {
 		wp_localize_script(
 			'wpcom-block-editor-nux-script',
 			'wpcomBlockEditorNuxAssetsUrl',
-			plugins_url( 'dist/', __FILE__ ),
+			plugins_url( 'dist/', __FILE__ )
 		);
 
 		$style_path = 'dist/wpcom-block-editor-nux' . ( is_rtl() ? '.rtl' : '' ) . '.css';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up/hotfix to #40828 :man_facepalming: 

Noticed when trying to commit the corresponding diff (D41466-code). :roll_eyes: 

Weird that our commit hooks didn't catch this :confused:  

Already fixed on WP.com (as part of D41466-code).

#### Testing instructions

N/A