### PR TITLE
Support Article Dialog: add support to scroll to anchor and refactor to functional component

### DIFF
--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -2,10 +2,10 @@
  * External Dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-import { flowRight as compose, get, noop } from 'lodash';
-import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
 
 /**
@@ -24,7 +24,7 @@ import getInlineSupportArticlePostId from 'state/selectors/get-inline-support-ar
 import getInlineSupportArticleActionUrl from 'state/selectors/get-inline-support-article-action-url';
 import getInlineSupportArticleActionLabel from 'state/selectors/get-inline-support-article-action-label';
 import getInlineSupportArticleActionIsExternal from 'state/selectors/get-inline-support-article-action-is-external';
-import { closeSupportArticleDialog } from 'state/inline-support-article/actions';
+import { closeSupportArticleDialog as closeDialog } from 'state/inline-support-article/actions';
 
 /**
  * Style Dependencies
@@ -32,86 +32,83 @@ import { closeSupportArticleDialog } from 'state/inline-support-article/actions'
 import './style.scss';
 import './content.scss';
 
-export class SupportArticleDialog extends Component {
-	static propTypes = {
-		actionIsExternal: PropTypes.bool,
-		actionLabel: PropTypes.string,
-		actionUrl: PropTypes.string,
-		closeSupportArticleDialog: PropTypes.func.isRequired,
-		post: PropTypes.object,
-		postId: PropTypes.number,
-		translate: PropTypes.func.isRequired,
-	};
+export const SupportArticleDialog = ( {
+	actionIsExternal,
+	actionLabel,
+	actionUrl,
+	closeSupportArticleDialog,
+	post,
+	postId,
+} ) => {
+	const translate = useTranslate();
+	const isLoading = ! post;
+	const postKey = { blogId: SUPPORT_BLOG_ID, postId };
+	const siteId = post?.site_ID;
 
-	getDialogButtons() {
-		const { actionIsExternal, actionLabel, actionUrl, translate } = this.props;
-		return [
-			<Button onClick={ this.props.closeSupportArticleDialog }>
-				{ translate( 'Close', { textOnly: true } ) }
-			</Button>,
-			actionUrl && (
-				<Button
-					href={ actionUrl }
-					target={ actionIsExternal ? '_blank' : undefined }
-					primary
-					onClick={ () => ( actionIsExternal ? noop() : this.props.closeSupportArticleDialog() ) }
-				>
-					{ actionLabel } { actionIsExternal && <Gridicon icon="external" size={ 12 } /> }
-				</Button>
-			),
-		].filter( Boolean );
-	}
+	return (
+		<Dialog
+			isVisible
+			additionalClassNames="support-article-dialog"
+			buttons={ [
+				<Button onClick={ closeSupportArticleDialog }>
+					{ translate( 'Close', { textOnly: true } ) }
+				</Button>,
+				actionUrl && (
+					<Button
+						href={ actionUrl }
+						target={ actionIsExternal ? '_blank' : undefined }
+						primary
+						onClick={ () => ( actionIsExternal ? noop() : closeSupportArticleDialog() ) }
+					>
+						{ actionLabel } { actionIsExternal && <Gridicon icon="external" size={ 12 } /> }
+					</Button>
+				),
+			].filter( Boolean ) }
+			onCancel={ closeSupportArticleDialog }
+			onClose={ closeSupportArticleDialog }
+		>
+			<Emojify>
+				{ siteId && <QueryReaderSite siteId={ +siteId } /> }
+				{ isLoading && <QueryReaderPost postKey={ postKey } /> }
+				<article className="support-article-dialog__story">
+					<SupportArticleHeader post={ post } isLoading={ isLoading } />
+					{ isLoading ? (
+						<Placeholders />
+					) : (
+						/*eslint-disable react/no-danger */
+						<EmbedContainer>
+							<div
+								className="support-article-dialog__story-content"
+								dangerouslySetInnerHTML={ { __html: post?.content } }
+							/>
+						</EmbedContainer>
+						/*eslint-enable react/no-danger */
+					) }
+				</article>
+			</Emojify>
+		</Dialog>
+	);
+};
 
-	render() {
-		const { post, postId } = this.props;
-		const isLoading = ! post;
-		const postKey = { blogId: SUPPORT_BLOG_ID, postId };
-		const siteId = get( post, 'site_ID' );
+SupportArticleDialog.propTypes = {
+	actionIsExternal: PropTypes.bool,
+	actionLabel: PropTypes.string,
+	actionUrl: PropTypes.string,
+	closeSupportArticleDialog: PropTypes.func.isRequired,
+	post: PropTypes.object,
+	postId: PropTypes.number,
+};
 
-		/*eslint-disable react/no-danger */
-		return (
-			<Dialog
-				isVisible
-				additionalClassNames="support-article-dialog"
-				buttons={ this.getDialogButtons() }
-				onCancel={ this.props.closeSupportArticleDialog }
-				onClose={ this.props.closeSupportArticleDialog }
-			>
-				<Emojify>
-					{ siteId && <QueryReaderSite siteId={ +siteId } /> }
-					{ isLoading && <QueryReaderPost postKey={ postKey } /> }
-					<article className="support-article-dialog__story">
-						<SupportArticleHeader post={ post } isLoading={ isLoading } />
-						{ isLoading ? (
-							<Placeholders />
-						) : (
-							<EmbedContainer>
-								<div
-									className="support-article-dialog__story-content"
-									dangerouslySetInnerHTML={ { __html: get( post, 'content' ) } }
-								/>
-							</EmbedContainer>
-						) }
-					</article>
-				</Emojify>
-			</Dialog>
-		);
-		/*eslint-enable react/no-danger */
-	}
-}
+const mapStateToProps = state => {
+	const postId = getInlineSupportArticlePostId( state );
+	const actionUrl = getInlineSupportArticleActionUrl( state );
+	const actionLabel = getInlineSupportArticleActionLabel( state );
+	const actionIsExternal = getInlineSupportArticleActionIsExternal( state );
+	const post = getPostByKey( state, { blogId: SUPPORT_BLOG_ID, postId } );
 
-export default compose(
-	connect(
-		state => {
-			const postId = getInlineSupportArticlePostId( state );
-			const actionUrl = getInlineSupportArticleActionUrl( state );
-			const actionLabel = getInlineSupportArticleActionLabel( state );
-			const actionIsExternal = getInlineSupportArticleActionIsExternal( state );
-			const post = getPostByKey( state, { blogId: SUPPORT_BLOG_ID, postId } );
+	return { post, postId, actionUrl, actionLabel, actionIsExternal };
+};
 
-			return { post, postId, actionUrl, actionLabel, actionIsExternal };
-		},
-		{ closeSupportArticleDialog }
-	),
-	localize
-)( SupportArticleDialog );
+export default connect( mapStateToProps, { closeSupportArticleDialog: closeDialog } )(
+	SupportArticleDialog
+);

--- a/client/blocks/support-article-dialog/dialog.jsx
+++ b/client/blocks/support-article-dialog/dialog.jsx
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { noop } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
@@ -44,6 +44,19 @@ export const SupportArticleDialog = ( {
 	const isLoading = ! post;
 	const postKey = { blogId: SUPPORT_BLOG_ID, postId };
 	const siteId = post?.site_ID;
+
+	useEffect( () => {
+		//If a url includes an anchor, let's scroll this into view!
+		if ( typeof window !== 'undefined' && actionUrl.indexOf( '#' ) !== -1 && post?.content ) {
+			setTimeout( () => {
+				const anchorId = actionUrl.split( '#' ).pop();
+				const element = document.getElementById( anchorId );
+				if ( element ) {
+					element.scrollIntoView();
+				}
+			}, 0 );
+		}
+	}, [ actionUrl, post ] );
 
 	return (
 		<Dialog


### PR DESCRIPTION
This PR updates the Support Article Dialog to a functional component and also adds support to scroll to an anchor point if specified in the postUrl. 

So for example: 

| Without Anchor | Support Page with Anchor |
| ------------- | ------------- |
| ![Apr-08-2020 14-45-20](https://user-images.githubusercontent.com/1270189/78836766-9b496800-79a7-11ea-82f6-d95917bd2909.gif)  | ![Apr-08-2020 14-42-48](https://user-images.githubusercontent.com/1270189/78836579-3d1c8500-79a7-11ea-9b31-ac971fb4468a.gif) |

### Testing Instructions
- Spin up the branch
- In console ```dispatch( { type: 'SUPPORT_ARTICLE_DIALOG_OPEN', postId: 145498, postUrl: 'https://support.wordpress.com/free-photo-library/' } )``` opens the support dialog to the top of the page content.
- In console ```dispatch( { type: 'SUPPORT_ARTICLE_DIALOG_OPEN', postId: 145498, postUrl: 'https://support.wordpress.com/free-photo-library/#add-images-from-a-post-or-page' } )``` scrolls to the correct anchor point
- In console `dispatch( { type: 'SUPPORT_ARTICLE_DIALOG_OPEN', postId: 147594, postUrl: 'https://wordpress.com/support/wordpress-editor/#blocks' } ) ` scrolls to the correct anchor point
- In console `dispatch( { type: 'SUPPORT_ARTICLE_DIALOG_OPEN', postId: 147594, postUrl: 'https://wordpress.com/support/wordpress-editor/#configuring-a-block' } ) ` scrolls to the correct anchor point
- No regressions with existing inline help (?) or the free photo library card in My Home

