### PR TITLE
Inline Help: remove unfriendly autofocus from search box

### DIFF
--- a/client/blocks/inline-help/inline-help-search-card.jsx
+++ b/client/blocks/inline-help/inline-help-search-card.jsx
@@ -82,7 +82,6 @@ class InlineHelpSearchCard extends Component {
 				onSearch={ this.onSearch }
 				onKeyDown={ this.onKeyDown }
 				placeholder={ this.props.translate( 'Search for help…' ) }
-				autoFocus // eslint-disable-line jsx-a11y/no-autofocus
 				delaySearch={ true }
 			/>
 		);


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/40938

<img width="435" alt="78840319-43aefa80-79af-11ea-905a-c27cb30c1ade" src="https://user-images.githubusercontent.com/1270189/78842461-e1f18f00-79b4-11ea-945a-9d91bb89e449.png">

Most native mobile devices will not let the soft keyboard appear without an explicit user tap. Previously when clicking on inline help, the autofocus would trigger the soft keyboard to appear for a moment before disappearing on Chrome/Pixel4 causing a visually distracting jank.

This PR removes autofocus since mobile users will need to tap on the search bar anyway.

### Testing Instructions
- On a native device, click on inline help at WordPress.com. Verify that the search input flashes, causing the soft keyboard to (maybe visually flash) before disappearing
- Use the calypso.live link https://calypso.live/?branch=fix/inline-help-focus and click on inline help using a native device
- The search bar should no longer autofocus (no jank from the keyboard glitching)
- Tapping on the search input displays the keyboard normally.
