### PR TITLE
Gutenboarding: tweak account creation UI for mobile

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -90,7 +90,7 @@
 
 	.signup-form__login-link {
 		@include onboarding-medium-text;
-		margin: 27px 0;
+		margin: 4px 0 29px;
 		color: var( --studio-gray-40 );
 
 		.signup-form__link {
@@ -108,7 +108,7 @@
 		@include onboarding-x-small-text;
 		text-align: center;
 		color: var( --studio-gray-40 );
-		margin: 20px 0;
+		margin: 15px 0 20px;
 
 		.components-external-link {
 			text-decoration: none;

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -107,7 +107,7 @@
 	.signup-form__terms-of-service-link {
 		@include onboarding-x-small-text;
 		text-align: center;
-		color: var( --studio-gray-40 );
+		color: var( --studio-gray-30 );
 		margin: 15px 0 20px;
 
 		.components-external-link {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -373,7 +373,7 @@ $image-height: 47px;
 		border-color: #007cba;
 		color: #fff;
 		width: auto;
-		min-width: 170px;
+		min-width: 100%;
 		text-align: center;
 		font-size: 14px;
 		line-height: 14px;
@@ -394,6 +394,10 @@ $image-height: 47px;
 			color: #fff;
 			outline-color: transparent;
 			box-shadow: none;
+		}
+
+		@include break-mobile {
+			min-width: 170px;
 		}
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

A few tweaks to get the signup and login forms looking better in mobile:

- spacing between text in signup
- width of continue button in login for mobile

<img width="362" alt="Screen Shot 2020-04-09 at 9 24 46 am" src="https://user-images.githubusercontent.com/6458278/78842685-06487c80-7a44-11ea-9705-9336fd4c7354.png">


Fixes #40907
