### PR TITLE
composite-checkout: Hide contact validation error message after delay

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -124,6 +124,17 @@ export default function CompositeCheckout( {
 		[ translate ]
 	);
 
+	const showErrorMessageBriefly = useCallback(
+		error => {
+			debug( 'error', error );
+			const message = error && error.toString ? error.toString() : error;
+			notices.error( message || translate( 'An error occurred during your purchase.' ), {
+				duration: 5000,
+			} );
+		},
+		[ translate ]
+	);
+
 	const showInfoMessage = useCallback( message => {
 		debug( 'info', message );
 		notices.info( message );
@@ -259,7 +270,7 @@ export default function CompositeCheckout( {
 	const domainContactValidationCallback = createContactValidationCallback( {
 		validateDomainContact: validateDomainContactDetails || wpcomValidateDomainContactInformation,
 		recordEvent,
-		showErrorMessage,
+		showErrorMessage: showErrorMessageBriefly,
 		translate,
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This causes the error message that is displayed (in composite checkout) when domain contact details validation fails to disappear after 5 seconds.

![disappearing-notice](https://user-images.githubusercontent.com/2036909/78844370-8a165080-79d3-11ea-8d2c-80c09f3c9a17.gif)


Fixes #40220

#### Testing instructions

- Add a domain to your cart in calypso and visit composite checkout.
- Proceed to the contact details step.
- Leave at least some contact fields empty.
- Press "Continue" on the step.
- Verify that you see the "We could not validate your contact information. Please review and update all the highlighted fields." error message appear.
- Verify that the message disappears after 5 seconds.