### PR TITLE
Gutenboarding: localize domain suggestion price format

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -93,13 +93,13 @@ const SearchIcon = () => (
 );
 
 const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, currentDomain } ) => {
-	const { __ } = useI18n();
+	const { __, i18nLocale } = useI18n();
 	const label = __( 'Search for a domain' );
 
 	const { domainSearch } = useSelect( select => select( STORE_KEY ).getState() );
 	const { setDomainSearch } = useDispatch( STORE_KEY );
 
-	const allSuggestions = useDomainSuggestions();
+	const allSuggestions = useDomainSuggestions( { locale: i18nLocale } );
 	const freeSuggestions = getFreeDomainSuggestions( allSuggestions );
 	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
 		0,

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -64,7 +64,7 @@ interface Cart {
 }
 
 const Header: FunctionComponent = () => {
-	const { __ } = useI18n();
+	const { __, i18nLocale } = useI18n();
 
 	const currentStep = useCurrentStep();
 
@@ -78,7 +78,7 @@ const Header: FunctionComponent = () => {
 
 	const { createSite, setDomain, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
-	const allSuggestions = useDomainSuggestions( siteTitle );
+	const allSuggestions = useDomainSuggestions( { searchOverride: siteTitle, locale: i18nLocale } );
 	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
 		0,
 		PAID_DOMAINS_TO_SHOW

--- a/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
+++ b/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
@@ -11,7 +11,7 @@ import { DOMAIN_SUGGESTIONS_STORE } from '../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { selectorDebounce } from '../constants';
 
-export function useDomainSuggestions( searchOverride = '' ) {
+export function useDomainSuggestions( { searchOverride = '', locale = 'en' } ) {
 	const { siteTitle, siteVertical, domainSearch } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
@@ -30,6 +30,7 @@ export function useDomainSuggestions( searchOverride = '' ) {
 				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
 				include_wordpressdotcom: true,
 				include_dotblogsubdomain: false,
+				locale,
 				...{ vertical: siteVertical?.id },
 			} );
 		},

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -16,6 +16,11 @@ export interface DomainSuggestionQuery {
 	include_wordpressdotcom: boolean;
 
 	/**
+	 * Localizes domain results, e.g., price format
+	 */
+	locale?: string;
+
+	/**
 	 * True to only provide a wordpress.com subdomain
 	 *
 	 * @example


### PR DESCRIPTION
## Changes proposed in this Pull Request

Long and pointless battles have been waged over whose system of decimal separators and other currency punctuation marks make more sense. 

Who can forget the wake of destruction left by the epic combat between `1.000,00` and `1,000.00`?

Rather than continue this senseless conflict, we have capitulated.

In this PR, we pass `i18nLocale` in an object to `useDomainSuggestions()` so the domains suggestions endpoint can return the correct pricing format, e.g., `0.00` for 'en' and `0,00` for 'es/fr' and so on.

## Testing instructions

Go here:

http://calypso.localhost:3000/new/style/

See this:

<img width="616" alt="Screen Shot 2020-04-09 at 10 53 45 am" src="https://user-images.githubusercontent.com/6458278/78847206-79a4bb00-7a51-11ea-9ce7-c57beb174ff9.png">

Now go here:

http://calypso.localhost:3000/new/style/fr

See that:

<img width="585" alt="Screen Shot 2020-04-09 at 10 53 54 am" src="https://user-images.githubusercontent.com/6458278/78847212-7d384200-7a51-11ea-81dd-bbb9187bb437.png">


Fixes #40733
