### PR TITLE
Improve share post e2e test

### DIFF
--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -26,16 +26,22 @@ export default class LoginPage extends AsyncBaseContainer {
 		const passwordSelector = By.css( '#password' );
 		const changeAccountSelector = By.css( '#loginAsAnotherUser' );
 
-		try {
+		const setUsername = async () => {
 			// If there is already a logged in user, we display the Gravatar and 'Continue as [user]' button and hide login form
 			await driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );
 			await driverHelper.waitTillFocused( driver, userNameSelector );
 			await driverHelper.setWhenSettable( driver, userNameSelector, username );
+		};
+
+		try {
+			await setUsername();
 		} catch ( error ) {
 			console.error( error );
-			// In order to display login form, the link to login with another account should be clicked first
+			// If setting the username failed the first time, we might be on the
+			// "existing user" login page. So to display the actual login form,
+			// we click the link to login with another account.
 			await driverHelper.clickWhenClickable( driver, changeAccountSelector );
-			await driverHelper.setWhenSettable( driver, userNameSelector, username );
+			await setUsername();
 		}
 		await this.driver.sleep( 1000 );
 		await driver.findElement( userNameSelector ).sendKeys( Key.ENTER );

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -27,7 +27,6 @@ export default class LoginPage extends AsyncBaseContainer {
 		const changeAccountSelector = By.css( '#loginAsAnotherUser' );
 
 		const setUsername = async () => {
-			// If there is already a logged in user, we display the Gravatar and 'Continue as [user]' button and hide login form
 			await driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );
 			await driverHelper.waitTillFocused( driver, userNameSelector );
 			await driverHelper.setWhenSettable( driver, userNameSelector, username );

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -26,7 +26,6 @@ export default class LoginPage extends AsyncBaseContainer {
 		const passwordSelector = By.css( '#password' );
 		const changeAccountSelector = By.css( '#loginAsAnotherUser' );
 
-		// await driverHelper.waitTillFocused( driver, userNameSelector );
 		try {
 			// If there is already a logged in user, we display the Gravatar and 'Continue as [user]' button and hide login form
 			await driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -38,7 +38,7 @@ export default class LoginPage extends AsyncBaseContainer {
 			console.error( error );
 			// If setting the username failed the first time, we might be on the
 			// "existing user" login page. So to display the actual login form,
-			// we click the link to login with another account.
+			// we click the link to login with another account. Then try again.
 			await driverHelper.clickWhenClickable( driver, changeAccountSelector );
 			await setUsername();
 		}

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -30,8 +30,10 @@ export default class LoginPage extends AsyncBaseContainer {
 		try {
 			// If there is already a logged in user, we display the Gravatar and 'Continue as [user]' button and hide login form
 			await driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );
+			await driverHelper.waitTillFocused( driver, userNameSelector );
 			await driverHelper.setWhenSettable( driver, userNameSelector, username );
-		} catch {
+		} catch ( error ) {
+			console.error( error );
 			// In order to display login form, the link to login with another account should be clicked first
 			await driverHelper.clickWhenClickable( driver, changeAccountSelector );
 			await driverHelper.setWhenSettable( driver, userNameSelector, username );

--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -28,8 +28,11 @@ export default class ReaderPage extends AsyncBaseContainer {
 
 	async shareLatestPost() {
 		const shareButtonSelector = by.css( '.reader-share__button' );
-		const hasSharablePost = await driverHelper.isElementPresent( this.driver, shareButtonSelector );
 
+		// Allow the components to settle and finish loading, one hopes.
+		await this.driver.sleep( 2000 );
+
+		const hasSharablePost = await driverHelper.isElementPresent( this.driver, shareButtonSelector );
 		if ( ! hasSharablePost ) {
 			// no shareable posts on this screen. try moving into a combined card
 			const firstComboCardPostSelector = by.css( '.reader-combined-card__post-title-link' );
@@ -43,7 +46,7 @@ export default class ReaderPage extends AsyncBaseContainer {
 		);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			by.css( '.reader-popover .site__info' )
+			by.css( '.site-selector__sites .site__content' )
 		);
 	}
 

--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -29,7 +29,11 @@ export default class ReaderPage extends AsyncBaseContainer {
 	async shareLatestPost() {
 		const shareButtonSelector = by.css( '.reader-share__button' );
 
-		// Allow the components to settle and finish loading, one hopes.
+		// Allow the components to settle and finish loading, one hopes. There
+		// continues to be errors where the test cannot find the site selector
+		// below after opening the reader share button. The screencasts indicate
+		// that more posts are added to the page after the share modal opens,
+		// causing the share modal to close before it clicks the site button.
 		await this.driver.sleep( 2000 );
 
 		const hasSharablePost = await driverHelper.isElementPresent( this.driver, shareButtonSelector );
@@ -39,15 +43,25 @@ export default class ReaderPage extends AsyncBaseContainer {
 			await driverHelper.clickWhenClickable( this.driver, firstComboCardPostSelector );
 		}
 
-		await driverHelper.clickWhenClickable( this.driver, shareButtonSelector );
-		await driverHelper.waitTillPresentAndDisplayed(
-			this.driver,
-			by.css( '.site-selector__sites' )
-		);
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			by.css( '.site-selector__sites .site__content' )
-		);
+		async function clickAndOpenShareModal() {
+			await driverHelper.clickWhenClickable( this.driver, shareButtonSelector );
+			await driverHelper.waitTillPresentAndDisplayed(
+				this.driver,
+				by.css( '.site-selector__sites' )
+			);
+			return await driverHelper.clickWhenClickable(
+				this.driver,
+				by.css( '.site-selector__sites .site__content' )
+			);
+		}
+
+		// Try a second time if the share menu is closed during the operation
+		// the first time.
+		try {
+			return await clickAndOpenShareModal();
+		} catch {
+			return await clickAndOpenShareModal();
+		}
 	}
 
 	async commentOnLatestPost( comment ) {

--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -57,11 +57,13 @@ export default class ReaderPage extends AsyncBaseContainer {
 
 		// Try a second time if the share menu is closed during the operation
 		// the first time.
+		let result;
 		try {
-			return await clickAndOpenShareModal();
+			result = await clickAndOpenShareModal();
 		} catch {
-			return await clickAndOpenShareModal();
+			result = await clickAndOpenShareModal();
 		}
+		return result;
 	}
 
 	async commentOnLatestPost( comment ) {

--- a/test/e2e/lib/pages/reader-page.js
+++ b/test/e2e/lib/pages/reader-page.js
@@ -43,7 +43,7 @@ export default class ReaderPage extends AsyncBaseContainer {
 			await driverHelper.clickWhenClickable( this.driver, firstComboCardPostSelector );
 		}
 
-		async function clickAndOpenShareModal() {
+		const clickAndOpenShareModal = async () => {
 			await driverHelper.clickWhenClickable( this.driver, shareButtonSelector );
 			await driverHelper.waitTillPresentAndDisplayed(
 				this.driver,
@@ -53,7 +53,7 @@ export default class ReaderPage extends AsyncBaseContainer {
 				this.driver,
 				by.css( '.site-selector__sites .site__content' )
 			);
-		}
+		};
 
 		// Try a second time if the share menu is closed during the operation
 		// the first time.


### PR DESCRIPTION
This test is very flaky. Many folks have tried to improve it over the past several months. I watched a video of it failing ([link to video download](https://61056-102822243-gh.circle-artifacts.com/1/wp-calypso/test/e2e/screenshots/videos/find-a-post-to-share--press-this--2020-04-08T21-54-13.mpg)), and noticed the following behavior:

1. Reader page loads 
2. Test driver clicks share button and share menu opens
3. Content on the page behind the share menu changes (another post shows up in the reader for example)
4. The share menu is quickly closed when the content behind it changes
5. The test runs several seconds longer until it times out and fails.

So my guess is that the data has not finished loading and rendering, which means that the menu is closed as the page finishes rendering _after_ the test opens the menu, but _before_ the test clicks the site button. Since the menu closes then, it times out trying to find the site button.

#### Changes proposed in this Pull Request
1. Wait 2 seconds before trying to open the share menu (so that all content loads)
2. Retry opening the share menu one more time if any errors happen the first time.

#### Testing instructions
* E2e tests should pass.