### PR TITLE
Fix: Wait longer for the iFrame to load for IE

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -542,33 +542,40 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	};
 
 	onIframeLoaded = async ( iframeUrl: string ) => {
-		if ( ! this.successfulIframeLoad ) {
-			// Sometimes (like in IE) the WindowActions.Loaded message arrives
-			// after the onLoad event is fired. To deal with this case we'll
-			// poll `this.successfulIframeLoad` for a while before redirecting.
-
-			// Checks to see if the iFrame has loaded every 200ms. If it has
-			// loaded, then resolve the promise.
-			let cancelPolling = false;
-			const pollForLoadedFlag = new Promise( resolve => {
-				const pendingIsLoadedFlag = setInterval( () => {
-					( cancelPolling || this.successfulIframeLoad ) && clearInterval( pendingIsLoadedFlag );
-					this.successfulIframeLoad && resolve( 'iframe-loaded' );
-				}, 200 );
-			} );
-
-			const fiveSeconds = new Promise( resolve => setTimeout( resolve, 5000, 'timeout' ) );
-
-			// Figure out which happens first: 5 seconds have passed, or the
-			// iFrame has loaded successfully. If 5 seconds have passed, then
-			// assume the iFrame will never load and redirect to wp-admin.
-			if ( ( await Promise.race( [ pollForLoadedFlag, fiveSeconds ] ) ) === 'timeout' ) {
-				cancelPolling = true;
-				window.location.replace( iframeUrl );
-				return;
-			}
+		// Shortcut to avoid polling mechanism if not needed.
+		if ( this.successfulIframeLoad ) {
+			this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
+			return;
 		}
-		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
+
+		// Sometimes (like in IE) the WindowActions.Loaded message arrives
+		// after the onLoad event is fired. To deal with this case we'll
+		// poll `this.successfulIframeLoad` for a while before redirecting.
+
+		// Checks to see if the iFrame has loaded every 200ms. If it has
+		// loaded, then resolve the promise.
+		let cancelPolling = false;
+		const pollForLoadedFlag = new Promise( resolve => {
+			const pendingIsLoadedFlag = setInterval( () => {
+				cancelPolling && clearInterval( pendingIsLoadedFlag );
+				this.successfulIframeLoad && resolve( 'iframe-loaded' );
+			}, 200 );
+		} );
+
+		const fiveSeconds = new Promise( resolve => setTimeout( resolve, 5000, 'timeout' ) );
+
+		// Figure out which happens first: 5 seconds have passed, or the
+		// iFrame has loaded successfully. If 5 seconds have passed, then
+		// assume the iFrame will never load and redirect to wp-admin.
+		const finishCondition = await Promise.race( [ pollForLoadedFlag, fiveSeconds ] );
+		cancelPolling = true; // Clears the interval next time it runs.
+
+		if ( finishCondition === 'timeout' ) {
+			// If we timed out, redirect to wp-admin.
+			window.location.replace( iframeUrl );
+		} else if ( finishCondition === 'iframe-loaded' ) {
+			this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
+		}
 	};
 
 	render() {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -543,11 +543,13 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 	onIframeLoaded = async ( iframeUrl: string ) => {
 		if ( ! this.successfulIframeLoad ) {
-			// Sometimes (like in IE) the WindowActions.Loaded message arrives after
-			// the onLoad event is fired. To deal with this case we'll poll
-			// `this.successfulIframeLoad` for a while before redirecting.
+			// Sometimes (like in IE) the WindowActions.Loaded message arrives
+			// after the onLoad event is fired. To deal with this case we'll
+			// poll `this.successfulIframeLoad` for a while before redirecting.
 			let cancelPolling = false;
 
+			// Checks to see if the iFrame has loaded every 200ms. If it has
+			// loaded, then resolve the promise.
 			const pollForLoadedFlag = new Promise( resolve => {
 				const waitForSuccessfulLoad = () => {
 					if ( this.successfulIframeLoad ) {
@@ -563,6 +565,9 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 			const fiveSeconds = new Promise( resolve => setTimeout( resolve, 5000, 'timeout' ) );
 
+			// Figure out which happens first: 5 seconds have passed, or the
+			// iFrame has loaded successfully. If 5 seconds have passed, then
+			// assume the iFrame will never load and redirect to wp-admin.
 			if ( ( await Promise.race( [ pollForLoadedFlag, fiveSeconds ] ) ) === 'timeout' ) {
 				cancelPolling = true;
 				window.location.replace( iframeUrl );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -546,21 +546,15 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			// Sometimes (like in IE) the WindowActions.Loaded message arrives
 			// after the onLoad event is fired. To deal with this case we'll
 			// poll `this.successfulIframeLoad` for a while before redirecting.
-			let cancelPolling = false;
 
 			// Checks to see if the iFrame has loaded every 200ms. If it has
 			// loaded, then resolve the promise.
+			let cancelPolling = false;
 			const pollForLoadedFlag = new Promise( resolve => {
-				const waitForSuccessfulLoad = () => {
-					if ( this.successfulIframeLoad ) {
-						resolve();
-						return;
-					}
-
-					! cancelPolling && setTimeout( waitForSuccessfulLoad, 200 );
-				};
-
-				setTimeout( waitForSuccessfulLoad, 200 );
+				const pendingIsLoadedFlag = setInterval( () => {
+					( cancelPolling || this.successfulIframeLoad ) && clearInterval( pendingIsLoadedFlag );
+					this.successfulIframeLoad && resolve( 'iframe-loaded' );
+				}, 200 );
 			} );
 
 			const fiveSeconds = new Promise( resolve => setTimeout( resolve, 5000, 'timeout' ) );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -541,10 +541,33 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			: `Block Editor > ${ postTypeText } > New`;
 	};
 
-	onIframeLoaded = ( iframeUrl: string ) => {
+	onIframeLoaded = async ( iframeUrl: string ) => {
 		if ( ! this.successfulIframeLoad ) {
-			window.location.replace( iframeUrl );
-			return;
+			// Sometimes (like in IE) the WindowActions.Loaded message arrives after
+			// the onLoad event is fired. To deal with this case we'll poll
+			// `this.successfulIframeLoad` for a while before redirecting.
+			let cancelPolling = false;
+
+			const pollForLoadedFlag = new Promise( resolve => {
+				const waitForSuccessfulLoad = () => {
+					if ( this.successfulIframeLoad ) {
+						resolve();
+						return;
+					}
+
+					! cancelPolling && setTimeout( waitForSuccessfulLoad, 200 );
+				};
+
+				setTimeout( waitForSuccessfulLoad, 200 );
+			} );
+
+			const fiveSeconds = new Promise( resolve => setTimeout( resolve, 5000, 'timeout' ) );
+
+			if ( ( await Promise.race( [ pollForLoadedFlag, fiveSeconds ] ) ) === 'timeout' ) {
+				cancelPolling = true;
+				window.location.replace( iframeUrl );
+				return;
+			}
 		}
 		this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`<CalypsoifyIframe>` waits for the `WindowActions.Loaded` message to be sent by the child window before marking the iframe as loaded. And if this hasn't happened by the time the `<iframe>`'s load event has fired, then that counts as a failure and we abandon the iframe editor approach.

We've found that IE was always falling back to the wp-admin editor, and that's because the `WindowActions.Loaded` message was being sent _after_ the `<iframe>` load event is fired.

This change spends some time polling for the flag set by `WindowActions.Loaded` if it isn't set by the time the `<iframe>` says it's loaded. This seems reasonable to me because it seems like a race condition to me whether the JS that posts the message in the child window will get to it in time.

This PR also re-enables IE e2e tests that had been skipped because the editor was no longer loading in the iframe.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test calypso live branch in IE
* Opening the page or post editor should open in the iframe (url should look like `calypso.live/block-editor/{site-slug}`, not `{site-slug}.wordpress.com/post.php`
