### PR TITLE
Gutenboarding: Style font selection step for mobile

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -84,6 +84,23 @@ const StylePreview: React.FunctionComponent = () => {
 			<div className="style-preview__content">
 				<FontSelect />
 				<Preview viewport={ selectedViewport } />
+				<div className="style-preview__actions-mobile">
+					{ hasSelectedDesign && (
+						<Button
+							className="style-preview__actions-mobile-continue-button"
+							isPrimary
+							isLarge
+							onClick={ () =>
+								currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
+							}
+						>
+							{ __( 'Continue' ) }
+						</Button>
+					) }
+					<Link isLink to={ makePath( Step.DesignSelection ) }>
+						{ __( 'Choose another design' ) }
+					</Link>
+				</div>
 			</div>
 			{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -1,3 +1,4 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../mixins.scss';
 @import '../../variables.scss';
 
@@ -13,13 +14,46 @@
 	@include onboarding-heading-padding;
 }
 
-.style-preview__viewport-select {
-	display: block;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate( -50%, -50% );
+.style-preview__actions-mobile {
+	clear: both;
+	padding-top: 32px;
+
+	a.is-link {
+		@include onboarding-medium-text;
+		display: block;
+		text-align: center;
+		margin: 1em 0;
+		color: var( --studio-gray-40 );
+	}
+
+	&-continue-button.is-primary.is-large {
+		display: block;
+		width: 100%;
+		padding: 0 40px;
+	}
+
+	@include break-small {
+		display: none;
+	}
 }
+
+.style-preview__viewport-select {
+	@include break-small {
+		display: block;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate( -50%, -50% );
+	}
+}
+
+.style-preview__actions {
+	display: none;
+	@include break-small {
+		display: block;
+	}
+}
+
 
 .style-preview__actions {
 	position: absolute;
@@ -27,14 +61,38 @@
 	right: 0;
 	transform: translateY( -50% );
 
+	@include break-small {
+		display: flex;
+		flex-flow: column;
+	}
+
 	a.is-link {
 		@include onboarding-medium-text;
-		margin: 0 1em;
+		margin: 1em 0 0;
 		color: var( --studio-gray-40 );
+		order: 2;
+
+		@include break-xlarge {
+			margin: 0 1em;
+			order: 1;
+		}
 	}
 
 	&-continue-button.is-primary.is-large {
 		padding: 0 40px;
+		display: block;
+		width: 100%;
+		order: 1;
+
+		@include break-xlarge {
+			display: initial;
+			width: auto;
+			order: 2;
+		}
+	}
+
+	@include break-xlarge {
+		display: block;
 	}
 }
 
@@ -45,6 +103,13 @@
 		column-gap: 1em;
 		align-items: center;
 		@include onboarding-heading-padding;
+
+		@include break-small {
+			grid-template-columns: auto auto 180px;
+		}
+		@include break-xlarge {
+			grid-template-columns: auto auto auto;
+		}
 	}
 
 	.style-preview__titles {
@@ -75,20 +140,37 @@
 
 .style-preview__font-options {
 	float: left;
-	width: 163px;
+	width: 100%;
+
+	@include break-small {
+		width: 163px;
+	}
 }
 
 @supports (display: grid) {
 	.style-preview__content {
-		display: grid;
-		grid-template-areas: 'fonts preview';
-		grid-template-columns: 163px auto;
-		column-gap: 100px;
-		flex: 1;
+		display: block;
+		width: 100%;
+
+		@include break-small {
+			display: grid;
+			grid-template-areas: 'fonts preview';
+			column-gap: 50px;
+			flex: 1;
+			grid-template-columns: 163px auto;
+		}
+
+		@include break-medium {
+			column-gap: 100px;
+		}
 	}
 
 	.style-preview__font-options {
-		width: auto;
+		width: 100%;
+
+		@include break-small {
+			width: auto;
+		}
 	}
 }
 
@@ -102,7 +184,11 @@
 	vertical-align: top;
 
 	+ .style-preview__font-option {
-		margin-top: 1em;
+		margin-top: 8px;
+
+		@include break-small {
+			margin-top: 1em;
+		}
 	}
 
 	.style-preview__font-option-contents {
@@ -141,6 +227,11 @@
 .style-preview__preview {
 	float: left;
 	height: 100%;
+	display: none;
+
+	@include break-small {
+		display: block;
+	}
 }
 
 .style-preview__preview {
@@ -229,8 +320,12 @@ $gutenboarding-style-preview-bar-height: 30px;
 }
 
 .style-preview__viewport-select {
-	display: flex;
-	justify-content: center;
+	display: none;
+
+	@include break-large {
+		display: flex;
+		justify-content: center;
+	}
 }
 
 .style-preview__viewport-select-button {

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -4,6 +4,10 @@
 	margin: 0 20px;
 
 	@include break-small {
+		margin: 0 44px;
+	}
+
+	@include break-medium {
 		margin: 0 88px;
 	}
 }


### PR DESCRIPTION
***WIP: Note this is a work in progress, and needs lots of tidying up and dealing with intricacies of the design!***

Attempting to style this step for mobile brings up lots of questions about how the design should be decomposed from the desktop layout through to mobile, across smaller screen sizes (a variety of tablet sizes, small laptop sizes, and people just not having their window maximised, like me 😄)

Here's a short GIF of where this PR currently sits:

![style-step-mobile-small](https://user-images.githubusercontent.com/14988353/78865655-54c83c00-7a81-11ea-8b38-7e6714d8fad6.gif)

This raises some questions:

* [x] At intermediate screen sizes, what do we do with the viewport selector? (Currently this PR hides it)?
* [x] At intermediate screen sizes, what do we do about the buttons at the top right (`Continue` and `Choose another design`)? This PR currently stacks them vertically, but it feels a bit awkward.

#### Changes proposed in this Pull Request

* Add additional small breakpoint for the onboarding block to use `44px` horizontal margin at smaller screen sizes — gives a bit more wriggle room between mobile and small tablet sizes.
* Add an additional set of action buttons for mobile only on the style step (this is a bit hacky, but I couldn't think of a better way to do it.
* Reduce column gap between font selection and preview to 50px on narrower viewports.
* Attempt to gracefully resize other elements at intermediate breakpoints.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` fill out the intent gathering step, and select a design.
* Play with the sizing of the window at the font selection step, experiment across browsers and devices.

#### Before merging in this change ensure the following:

Note, as it stands, this PR probably breaks IE11 styling again, so make sure:

* [x] The mobile styling preserves the IE11 styling for this step looks correct as in #40881 (compare against master by testing this against `wpcalypso`) 

Fixes #40900
