### PR TITLE
Gutenboarding: adding a popover to explain the launch button

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -6,6 +6,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
+import { Popover } from '@wordpress/components';
 /* eslint-disable import/no-extraneous-dependencies */
 
 /**
@@ -41,16 +42,47 @@ function updateSettingsBar() {
 		saveButton && ( saveButton.innerText = __( 'Save' ) );
 
 		// Wrap 'Launch' button link to frankenflow.
+		const launchLinkContainer = document.createElement( 'div' );
 		const launchLink = document.createElement( 'a' );
+		const launchTipContainer = document.createElement( 'div' );
+		launchLinkContainer.className = 'gutenboarding-editor-overrides__launch-button-container';
 		launchLink.href = calypsoifyGutenberg.frankenflowUrl;
 		launchLink.target = '_top';
 		launchLink.className =
 			'gutenboarding-editor-overrides__launch-button components-button is-primary';
 		const textContent = document.createTextNode( __( 'Launch' ) );
 		launchLink.appendChild( textContent );
+		launchLinkContainer.appendChild( launchLink );
+		launchLinkContainer.appendChild( launchTipContainer );
 
 		// Put 'Launch' and 'Save' back on bar in desired order.
-		settingsBar.prepend( launchLink );
+		settingsBar.prepend( launchLinkContainer );
 		settingsBar.prepend( saveButton );
+
+		// We probably don't need this container, but I've added it in case we need some extra styling
+		const launchTipContentContainer = window.wp.element.createElement(
+			'span',
+			{ className: 'gutenboarding-editor-overrides__launch-button-content' },
+			__(
+				"When you've finished customizing your site's content, launch your site to make it public."
+			)
+		);
+
+		/*
+			TODO:
+				- Work out why the arrow isn't showing: https://developer.wordpress.org/block-editor/components/popover/#noarrow
+				- Define when and how the popover should close. After `n` seconds?
+		*/
+		window.wp.element.render(
+			window.wp.element.createElement(
+				Popover,
+				{
+					className: 'gutenboarding-editor-overrides__launch-button-tip',
+					position: 'bottom left',
+				},
+				launchTipContentContainer
+			),
+			launchTipContainer
+		);
 	} );
 }

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
@@ -1,9 +1,33 @@
 .gutenboarding-editor-overrides {
+
+	.block-editor-editor-skeleton__header {
+		// ensures the header and .gutenboarding-editor-overrides__launch-button-tip appear above the settings sidebar
+		z-index: 100;
+	}
+
     .editor-post-switch-to-draft,
     .editor-post-preview {
         display: none;
     }
-    
+
+	.gutenboarding-editor-overrides__launch-button-container {
+		display: inline-flex;
+	}
+
+	.gutenboarding-editor-overrides__launch-button-tip .components-popover__content {
+		margin-top: 8px;
+		padding: 14px;
+		font-size: 12px;
+		border-color: rgba( 0, 0, 0, 0.15 );
+		box-shadow: 0 0 3px 0 rgba( 0, 0, 0, 0.1 );
+	}
+
+	.arrow_box {
+		position: relative;
+		background: #88b7d5;
+		border: 4px solid #c2e1f5;
+	}
+
     .gutenboarding-editor-overrides__launch-button {
         padding: 0 12px;
         margin: 0 12px 0 3px;


### PR DESCRIPTION
## 🚧 Changes proposed in this Pull Request

In this PR, we're appending a launch button tooltip in Gutenboarding overrides (in Calypso) to indicate to the user that they can launch their site to make it public!

<img width="1151" alt="Screen Shot 2020-04-09 at 8 05 47 pm" src="https://user-images.githubusercontent.com/6458278/78884086-bc8c8000-7a9d-11ea-951e-f40bfaf8717a.png">

### TODO

- [ ] Work out why the arrow isn't showing. See: https://developer.wordpress.org/block-editor/components/popover/#noarrow
- [ ] Define when and how the popover should close. After `n` seconds?
- [ ] ?

## Testing instructions

Build according to the instructions in https://github.com/Automattic/wp-calypso/blob/master/apps/wpcom-block-editor/README.md

Sync files to your sandbox and sandbox `widgets.wp.com`

Reload for glory!

Fixes #40840
