### PR TITLE
Gutenboarding: Highlight domain TLD.

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -184,6 +184,10 @@
 	}
 }
 
+.domain-picker__domain-tld {
+	color: var( --studio-blue-40 );
+}
+
 .domain-picker__has-domain {
 	align-items: center;
 

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -15,6 +15,10 @@ interface Props {
 	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
 }
 
+// foobar.com returns ['foobar.com', 'foobar', '.com'];
+// foobar.wordpress.com returns ['foobar.wordpress.com', 'foobar', '.wordpress.com'];
+const rxDomainParts = /([^.]*)(.*)/;
+
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	suggestion,
 	isRecommended = false,
@@ -22,6 +26,8 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	onSelect,
 } ) => {
 	const { __ } = useI18n();
+
+	const [ , domainName, domainTld ] = suggestion.domain_name.match( rxDomainParts );
 
 	return (
 		<label className="domain-picker__suggestion-item">
@@ -33,7 +39,8 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 					onChange={ () => void onSelect( suggestion ) }
 					checked={ isSelected }
 				/>
-				{ suggestion.domain_name }
+				<span>{ domainName }</span>
+				<span className="domain-picker__domain-tld">{ domainTld }</span>
 				{ isRecommended && (
 					<div className="domain-picker__badge is-recommended">{ __( 'Recommended' ) }</div>
 				) }

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -15,10 +15,6 @@ interface Props {
 	onSelect: ( domainSuggestion: DomainSuggestion ) => void;
 }
 
-// foobar.com returns ['foobar.com', 'foobar', '.com'];
-// foobar.wordpress.com returns ['foobar.wordpress.com', 'foobar', '.wordpress.com'];
-const rxDomainParts = /([^.]*)(.*)/;
-
 const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 	suggestion,
 	isRecommended = false,
@@ -27,7 +23,10 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 } ) => {
 	const { __ } = useI18n();
 
-	const [ , domainName, domainTld ] = suggestion.domain_name.match( rxDomainParts );
+	const domain = suggestion.domain_name;
+	const dotPos = domain.indexOf( '.' );
+	const domainName = domain.slice( 0, dotPos );
+	const domainTld = domain.slice( dotPos );
 
 	return (
 		<label className="domain-picker__suggestion-item">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Highlight domain tld.

Well, not exactly TLD, if it's a subdomain like `.wordpress.com`, the whole domain and tld gets highlighted. So, I don't know how to name the variables, but I tried. :)

#### Testing instructions

* Open the domain picker on `/new`. Domain TLDs should be highlighted.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/78888677-b04ff500-7a94-11ea-89cc-6f77dbbaa36d.png)

