### PR TITLE
[Private sites] Add support for in-preview authorization

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -96,6 +96,9 @@ export class WebPreviewContent extends Component {
 		debug( 'message from iframe', data );
 
 		switch ( data.type ) {
+			case 'needs-auth':
+				this.redirectToAuth();
+				return;
 			case 'link':
 				page( data.payload.replace( /^https:\/\/wordpress\.com\//i, '/' ) );
 				this.props.onClose();
@@ -119,6 +122,13 @@ export class WebPreviewContent extends Component {
 				return;
 		}
 	};
+
+	redirectToAuth() {
+		const { protocol, host } = parseUrl( this.props.externalUrl );
+		window.location.href =
+			`${ protocol }//${ host }/wp-login.php?redirect_to=` +
+			encodeURIComponent( window.location.href );
+	}
 
 	handleLocationChange = payload => {
 		this.props.onLocationUpdate( payload.pathname );
@@ -241,17 +251,6 @@ export class WebPreviewContent extends Component {
 			// iframe OR redirected to using <a href="" target="_top">.
 			const { protocol, host } = parseUrl( this.props.externalUrl );
 			this.iframe.contentWindow.postMessage( { connected: 'calypso' }, `${ protocol }//${ host }` );
-			window.addEventListener(
-				'message',
-				e => {
-					if ( e.data?.type === 'needs-auth' ) {
-						window.location.href =
-							`${ protocol }//${ host }/wp-login.php?redirect_to=` +
-							encodeURIComponent( window.location.href );
-					}
-				},
-				false
-			);
 		}
 	};
 

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -254,8 +254,13 @@ export class WebPreviewContent extends Component {
 			// "you need to login first" screen. These messages are handled by wpcomsh on the other end,
 			// and they make it possible to redirect to wp-login.php since it cannot be displayed in this
 			// iframe OR redirected to using <a href="" target="_top">.
-			const { protocol, host } = parseUrl( this.props.externalUrl );
-			this.iframe.contentWindow.postMessage( { connected: 'calypso' }, `${ protocol }//${ host }` );
+			if ( this.props.isPrivateAtomic ) {
+				const { protocol, host } = parseUrl( this.props.externalUrl );
+				this.iframe.contentWindow.postMessage(
+					{ connected: 'calypso' },
+					`${ protocol }//${ host }`
+				);
+			}
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a PR complementary to Automattic/wpcomsh#447

Problem: Calypso users may or may not be not authenticated against the remote. If they're not, they won't see the site preview. This PR provides bare minimum "no dead ends" user experience for that case - the user will see a customized error message and a login button as on the screenshot below.

This certainly isn't perfect, but at least makes the preview functional and is a good starting point for future iterations.

<img width="496" alt="Zrzut ekranu 2020-04-9 o 13 27 13" src="https://user-images.githubusercontent.com/205419/78890373-d5793f00-7a65-11ea-8746-9fcd7037f987.png">

#### Testing instructions

Follow the test plan in Automattic/wpcomsh#447