### PR TITLE
Gutenboarding: Long domain text should wrap to next line nicely.

### DIFF
--- a/client/assets/stylesheets/shared/mixins/_placeholder.scss
+++ b/client/assets/stylesheets/shared/mixins/_placeholder.scss
@@ -5,8 +5,7 @@
 
 @mixin placeholder( $color-property: --color-neutral-5 ) {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	// this is just a solid color, but gives background-position and background-size capabilities ;)
-	background-image: linear-gradient( var( $color-property ), var( $color-property ) );
+	background: var( $color-property );
 	color: transparent;
 
 	&::after {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -3,6 +3,8 @@
 @import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
 @import '../../mixins';
 
+$domain-picker__suggestion-item-height: 24px;
+
 .domain-picker.components-panel {
 	border: none;
 
@@ -31,7 +33,7 @@
 
 .domain-picker__search {
 	position: relative;
-	margin-bottom: -7px;
+	margin-bottom: -4px; // Reducing the spacing added by .components-panel__row
 
 	input[type='text'].components-text-control__input {
 		padding: 6px 40px 6px 16px;
@@ -108,14 +110,15 @@
 }
 
 .domain-picker__suggestion-none {
+	@include onboarding-medium-text;
+	line-height: 20px; // matching design
 	display: flex;
 	justify-content: space-between;
 	align-items: flex-start;
 	width: 100%;
 	border-radius: 0;
-	padding: 13px 0;
+	padding: 10px 0;
 	margin-bottom: 7px;
-	font-size: 14px;
 	cursor: pointer;
 }
 
@@ -139,7 +142,7 @@
 	input[type='radio'].domain-picker__suggestion-radio-button {
 		width: 16px;
 		height: 16px;
-		margin: 1px 12px 0 0; // 1px cosmetic alignment
+		margin: 3px 12px 0 0; // 3px cosmetic alignment
 		min-width: 16px; // prevents long domain from squishing the radio button
 		padding: 0;
 		vertical-align: middle;
@@ -177,20 +180,24 @@
 .domain-picker__suggestion-item-name {
 	flex-grow: 1;
 	margin-right: 24px;
-	word-break: break-all;
 	letter-spacing: 0.4px;
+	min-height: $domain-picker__suggestion-item-height;
+
+	.domain-picker__domain-name {
+		word-break: break-word; // use hyphens if any to break domain name
+	}
 
 	&.placeholder {
 		@include placeholder();
-		min-width: 30%;
-		background-repeat: no-repeat;
+		max-width: 30%;
+		margin-right: auto; // position the placeholder to the left overriding justify-content: space-between
 	}
 }
 
 .domain-picker__domain-tld {
 	color: var( --studio-blue-40 );
 	// margin for recommended badge. this margin shouldn't
-	// be place on the badge because if the badge falls 
+	// be place on the badge because if the badge falls
 	// on a newline, it will have whitespace on the left.
 	margin-right: 10px;
 }
@@ -225,6 +232,7 @@
 .domain-picker__price {
 	color: var( --studio-gray-40 );
 	white-space: nowrap;
+	min-height: $domain-picker__suggestion-item-height;
 
 	&.placeholder {
 		@include placeholder();

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -185,7 +185,6 @@
 	&.placeholder {
 		@include placeholder();
 		min-width: 30%;
-		background-position: 30px;
 		background-repeat: no-repeat;
 	}
 }

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -137,15 +137,12 @@
 			}
 		}
 	}
-}
-
-.domain-picker__suggestion-item-name {
-	letter-spacing: 0.4px;
 
 	input[type='radio'].domain-picker__suggestion-radio-button {
 		width: 16px;
 		height: 16px;
 		margin: 0 12px 0 0;
+		min-width: 16px; // prevents long domain from squishing the radio button
 		padding: 0;
 		vertical-align: middle;
 		position: relative;
@@ -177,6 +174,13 @@
 			box-shadow: 0 0 0 1px var( --studio-blue-30 );
 		}
 	}
+}
+
+.domain-picker__suggestion-item-name {
+	flex-grow: 1;
+	margin-right: 24px;
+	word-break: break-all;
+	letter-spacing: 0.4px;
 
 	&.placeholder {
 		@include placeholder();
@@ -188,6 +192,10 @@
 
 .domain-picker__domain-tld {
 	color: var( --studio-blue-40 );
+	// margin for recommended badge. this margin shouldn't
+	// be place on the badge because if the badge falls 
+	// on a newline, it will have whitespace on the left.
+	margin-right: 10px;
 }
 
 .domain-picker__has-domain {
@@ -206,7 +214,6 @@
 	height: 20px;
 	align-items: center;
 	font-size: 10px;
-	margin-left: 10px;
 	text-transform: uppercase;
 
 	background-color: var( --studio-blue-50 );

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -110,13 +110,13 @@
 .domain-picker__suggestion-none {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-start;
 	width: 100%;
-	height: 46px;
 	border-radius: 0;
-	padding: 0;
-	margin-bottom: 10px;
+	padding: 13px 0;
+	margin-bottom: 7px;
 	font-size: 14px;
+	cursor: pointer;
 }
 
 .domain-picker__suggestion-item {
@@ -124,8 +124,6 @@
 	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
 	// See https://github.com/WordPress/gutenberg/pull/19535
 	@extend .domain-picker__suggestion-none;
-	cursor: pointer;
-	margin-bottom: 7px;
 
 	&.components-button {
 		&.is-tertiary {
@@ -141,7 +139,7 @@
 	input[type='radio'].domain-picker__suggestion-radio-button {
 		width: 16px;
 		height: 16px;
-		margin: 0 12px 0 0;
+		margin: 1px 12px 0 0; // 1px cosmetic alignment
 		min-width: 16px; // prevents long domain from squishing the radio button
 		padding: 0;
 		vertical-align: middle;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -197,7 +197,7 @@ $domain-picker__suggestion-item-height: 24px;
 .domain-picker__domain-tld {
 	color: var( --studio-blue-40 );
 	// margin for recommended badge. this margin shouldn't
-	// be place on the badge because if the badge falls
+	// be placed on the badge because if the badge falls
 	// on a newline, it will have whitespace on the left.
 	margin-right: 10px;
 }

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
@@ -6,9 +6,8 @@ import React, { FunctionComponent } from 'react';
 const DomainPickerSuggestionItemPlaceholder: FunctionComponent = () => {
 	return (
 		<div className="domain-picker__suggestion-item">
-			<div className="domain-picker__suggestion-item-name placeholder">
-				<input disabled className="domain-picker__suggestion-radio-button" type="radio" />
-			</div>
+			<input disabled className="domain-picker__suggestion-radio-button" type="radio" />
+			<div className="domain-picker__suggestion-item-name placeholder"></div>
 			<div className="domain-picker__price placeholder"></div>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item-placeholder.tsx
@@ -7,7 +7,7 @@ const DomainPickerSuggestionItemPlaceholder: FunctionComponent = () => {
 	return (
 		<div className="domain-picker__suggestion-item">
 			<input disabled className="domain-picker__suggestion-radio-button" type="radio" />
-			<div className="domain-picker__suggestion-item-name placeholder"></div>
+			<div className="domain-picker__suggestion-item-name placeholder" />
 			<div className="domain-picker__price placeholder"></div>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -30,15 +30,15 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 
 	return (
 		<label className="domain-picker__suggestion-item">
+			<input
+				className="domain-picker__suggestion-radio-button"
+				type="radio"
+				name="domain-picker-suggestion-option"
+				onChange={ () => void onSelect( suggestion ) }
+				checked={ isSelected }
+			/>
 			<div className="domain-picker__suggestion-item-name">
-				<input
-					className="domain-picker__suggestion-radio-button"
-					type="radio"
-					name="domain-picker-suggestion-option"
-					onChange={ () => void onSelect( suggestion ) }
-					checked={ isSelected }
-				/>
-				<span>{ domainName }</span>
+				<span className="domain-picker__domain-name">{ domainName }</span>
 				<span className="domain-picker__domain-tld">{ domainTld }</span>
 				{ isRecommended && (
 					<div className="domain-picker__badge is-recommended">{ __( 'Recommended' ) }</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Long domain text should wrap to the next line nicely.
* Radio button and price should vertical align to the top.
* Line height should match design.
* Don't break the TLD names.
* Break domain names using hyphens if any.

Also, some additional findings:
1. Domains API automatically trim long domain names.
2. Long TLD (visually, not based on char count from fixed-width font) are `.photography`, `.management` & `.apartment` on WP's offerings. See https://wordpress.com/support/domains/domain-pricing-and-available-tlds/

#### Testing instructions

1. Open up `/new`.
2. Enter a long domain name in the domain picker.
3. See the suggestions wrap while TLD names don't break.
4. If a domain suggestion contains hyphen it should be used for breaking.

#### Screenshots
![image](https://user-images.githubusercontent.com/1287077/78894474-ada6cd00-7a9f-11ea-8f65-cd23627473cf.png)

<img width="512" alt="wrap-domain-text-v2" src="https://user-images.githubusercontent.com/14192054/79001116-9a0a6d80-7b56-11ea-98f5-7d94ac6d211f.png">

Fixes #40395
