### PR TITLE
Add/contextual help for domains

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -998,7 +998,7 @@ const contextLinksForSection = {
 			post_id: 41298,
 			title: translate( 'Connect an Existing Domain' ),
 			description: translate(
-				'There are two ways to use a domain that you bought with another registrar. (A registrar is a company with whom you can buy domains).'
+				'You can connect an existing domain you own that’s registered elsewhere by either mapping or transferring. Domain mapping lets you connect a domain while keeping it registered at the current registrar (where you purchased the domain from). Domain transferring moves the domain to WordPress.com so we become the new registrar.'
 			),
 		},
 		{

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -966,6 +966,16 @@ const contextLinksForSection = {
 			),
 		},
 	],
+	domains: [
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/all-about-domains/' ),
+			post_id: 41171,
+			title: translate( 'All About Domains' ),
+			description: translate(
+				'Set up your domain whether it’s registered with WordPress.com or elsewhere.'
+			),
+		},
+	],
 };
 
 /*

--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -968,11 +968,45 @@ const contextLinksForSection = {
 	],
 	domains: [
 		{
-			link: localizeUrl( 'https://en.support.wordpress.com/all-about-domains/' ),
-			post_id: 41171,
-			title: translate( 'All About Domains' ),
+			link: localizeUrl( 'https://en.support.wordpress.com/add-email/' ),
+			post_id: 34087,
+			title: translate( 'Add Email to your Domain' ),
 			description: translate(
-				'Set up your domain whether it’s registered with WordPress.com or elsewhere.'
+				'Want to use a custom email with your domain, such as info@yourgroovydomain.com? There are multiple ways to add email to your custom domain.'
+			),
+		},
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/domains/custom-dns/' ),
+			post_id: 6595,
+			title: translate( 'Manage Custom DNS' ),
+			description: translate(
+				'Custom DNS records are special settings that change how your domain works. They allow you to connect your domain to third-party services that are not hosted on WordPress.com, such as an email provider.'
+			),
+		},
+		{
+			link: localizeUrl(
+				'https://en.support.wordpress.com/move-domain/transfer-domain-registration/'
+			),
+			post_id: 41298,
+			title: translate( 'Transfer a Domain to Another Registrar' ),
+			description: translate(
+				'This article walks you through transferring your domain registration to another registrar. Your domain will need to be unlocked and privacy removed (if applicable) for the transfer.'
+			),
+		},
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/domain-mapping-vs-domain-transfer/' ),
+			post_id: 41298,
+			title: translate( 'Connect an Existing Domain' ),
+			description: translate(
+				'There are two ways to use a domain that you bought with another registrar. (A registrar is a company with whom you can buy domains).'
+			),
+		},
+		{
+			link: localizeUrl( 'https://en.support.wordpress.com/domains/' ),
+			post_id: 1988,
+			title: translate( 'All about domains' ),
+			description: translate(
+				'A domain name is an address people use to visit your site. It tells the web browser where to look for your site. Just like a street address, a domain is how people visit your website online. And, like having a sign in front of your store, a custom domain name helps give your site a professional look.'
 			),
 		},
 	],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce a new contextual menu for the domains section

It looks like this:

<img width="362" alt="Screenshot 2020-04-08 at 23 09 44" src="https://user-images.githubusercontent.com/1355045/78894920-a28b7700-7a76-11ea-9cd2-51619205af95.png">
<img width="350" alt="Screenshot 2020-04-08 at 23 09 51" src="https://user-images.githubusercontent.com/1355045/78894926-a3bca400-7a76-11ea-8af8-1bedbcd13c3b.png">
<img width="346" alt="Screenshot 2020-04-08 at 23 10 00" src="https://user-images.githubusercontent.com/1355045/78894928-a3bca400-7a76-11ea-8c10-93c338d12bd6.png">
<img width="344" alt="Screenshot 2020-04-08 at 23 10 10" src="https://user-images.githubusercontent.com/1355045/78894930-a4553a80-7a76-11ea-9bc4-7c2eaf59e0ee.png">
<img width="351" alt="Screenshot 2020-04-08 at 23 10 18" src="https://user-images.githubusercontent.com/1355045/78894931-a4553a80-7a76-11ea-8da7-557297085448.png">
<img width="347" alt="Screenshot 2020-04-08 at 23 10 25" src="https://user-images.githubusercontent.com/1355045/78894934-a4edd100-7a76-11ea-908e-9515d0c430f0.png">

discussed in p7zo6Z-jf-p2

#### Testing instructions

* Open /domains/manage or any other path under the domains section and verify that the help menu bottom-right shows contextual links. Verify that the links work