### PR TITLE
[Private sites] Copy updates

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -531,9 +531,13 @@ export class SiteSettingsFormGeneral extends Component {
 				<Card className="site-settings__general-settings-launch-site">
 					<div className="site-settings__general-settings-launch-site-text">
 						<p>
-							{ translate(
-								"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
-							) }
+							{ btnText
+								? translate(
+										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
+								  )
+								: translate(
+										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
+								  ) }
 						</p>
 					</div>
 					<div className={ launchSiteClasses }>{ btnComponent }</div>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -44,6 +44,7 @@ import { launchSite } from 'state/sites/launch/actions';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import FormInputCheckbox from 'components/forms/form-checkbox';
+import { hasLocalizedText } from 'blocks/eligibility-warnings/has-localized-text';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentDidMount() {
@@ -532,9 +533,12 @@ export class SiteSettingsFormGeneral extends Component {
 				<Card className="site-settings__general-settings-launch-site">
 					<div className="site-settings__general-settings-launch-site-text">
 						<p>
-							{ isComingSoon
+							{ isComingSoon &&
+							hasLocalizedText(
+								'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
+							)
 								? translate(
-										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
+										'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
 								  )
 								: translate(
 										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -36,6 +36,7 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import guessTimezone from 'lib/i18n-utils/guess-timezone';
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
+import isSiteComingSoon from 'state/selectors/is-site-coming-soon';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
@@ -504,7 +505,7 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	renderLaunchSite() {
-		const { translate, siteDomains, siteSlug, siteId, isPaidPlan } = this.props;
+		const { translate, siteDomains, siteSlug, siteId, isPaidPlan, isComingSoon } = this.props;
 
 		const launchSiteClasses = classNames( 'site-settings__general-settings-launch-site-button', {
 			'site-settings__disable-privacy-settings': ! siteDomains.length,
@@ -531,7 +532,7 @@ export class SiteSettingsFormGeneral extends Component {
 				<Card className="site-settings__general-settings-launch-site">
 					<div className="site-settings__general-settings-launch-site-text">
 						<p>
-							{ btnText
+							{ isComingSoon
 								? translate(
 										"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
 								  )
@@ -707,6 +708,7 @@ const connectComponent = connect(
 				? ownProps.withComingSoonOption
 				: 'variant' === abtest( 'ATPrivacy' ),
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
+			isComingSoon: isSiteComingSoon( state, siteId ),
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsJetpack,
 			siteIsVip: isVipSite( state, siteId ),

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -547,7 +547,8 @@ export class SiteSettingsFormGeneral extends Component {
 				<Card className="site-settings__general-settings-launch-site">
 					<div className="site-settings__general-settings-launch-site-text">
 						<p>
-							{ isComingSoon && hasLocalizedText(
+							{ isComingSoon &&
+							hasLocalizedText(
 								'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
 							)
 								? translate(
@@ -764,7 +765,6 @@ const getFormSettings = settings => {
 		wpcom_coming_soon: settings.wpcom_coming_soon,
 		timezone_string: settings.timezone_string,
 	};
-
 
 	// handling `gmt_offset` and `timezone_string` values
 	const gmt_offset = settings.gmt_offset;

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -32,6 +32,7 @@ import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { isJetpackSite, isCurrentPlanPaid } from 'state/sites/selectors';
+import isSiteComingSoon from 'state/selectors/is-site-coming-soon';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import guessTimezone from 'lib/i18n-utils/guess-timezone';
 import { preventWidows } from 'lib/formatting';
@@ -388,7 +389,13 @@ export class SiteSettingsFormGeneral extends Component {
 							<span>{ translate( 'Coming Soon' ) }</span>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
-							{ translate( "Your site is hidden from visitors until it's ready for viewing." ) }
+							{ hasLocalizedText(
+								'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+							)
+								? translate(
+										'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+								  )
+								: translate( "Your site is hidden from visitors until it's ready for viewing." ) }
 						</FormSettingExplanation>
 					</>
 				) }
@@ -448,7 +455,15 @@ export class SiteSettingsFormGeneral extends Component {
 							<span>{ translate( 'Private' ) }</span>
 						</FormLabel>
 						<FormSettingExplanation isIndented>
-							{ translate( 'Your site is only visible to you and logged-in members you approve.' ) }
+							{ hasLocalizedText(
+								'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+							)
+								? translate(
+										'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+								  )
+								: translate(
+										'Your site is only visible to you and logged-in members you approve.'
+								  ) }
 						</FormSettingExplanation>
 					</>
 				) }
@@ -505,7 +520,7 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	renderLaunchSite() {
-		const { translate, siteDomains, siteSlug, siteId, isPaidPlan } = this.props;
+		const { translate, siteDomains, siteSlug, siteId, isPaidPlan, isComingSoon } = this.props;
 
 		const launchSiteClasses = classNames( 'site-settings__general-settings-launch-site-button', {
 			'site-settings__disable-privacy-settings': ! siteDomains.length,
@@ -710,6 +725,7 @@ const connectComponent = connect(
 				? ownProps.withComingSoonOption
 				: 'variant' === abtest( 'ATPrivacy' ),
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
+			isComingSoon: isSiteComingSoon( state, siteId ),
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsJetpack,
 			siteIsVip: isVipSite( state, siteId ),

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -36,7 +36,6 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import guessTimezone from 'lib/i18n-utils/guess-timezone';
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
-import isSiteComingSoon from 'state/selectors/is-site-coming-soon';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
@@ -506,7 +505,7 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	renderLaunchSite() {
-		const { translate, siteDomains, siteSlug, siteId, isPaidPlan, isComingSoon } = this.props;
+		const { translate, siteDomains, siteSlug, siteId, isPaidPlan } = this.props;
 
 		const launchSiteClasses = classNames( 'site-settings__general-settings-launch-site-button', {
 			'site-settings__disable-privacy-settings': ! siteDomains.length,
@@ -533,8 +532,7 @@ export class SiteSettingsFormGeneral extends Component {
 				<Card className="site-settings__general-settings-launch-site">
 					<div className="site-settings__general-settings-launch-site-text">
 						<p>
-							{ isComingSoon &&
-							hasLocalizedText(
+							{ isComingSoon && hasLocalizedText(
 								'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
 							)
 								? translate(
@@ -712,7 +710,6 @@ const connectComponent = connect(
 				? ownProps.withComingSoonOption
 				: 'variant' === abtest( 'ATPrivacy' ),
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
-			isComingSoon: isSiteComingSoon( state, siteId ),
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			siteIsJetpack,
 			siteIsVip: isVipSite( state, siteId ),
@@ -751,6 +748,7 @@ const getFormSettings = settings => {
 		wpcom_coming_soon: settings.wpcom_coming_soon,
 		timezone_string: settings.timezone_string,
 	};
+
 
 	// handling `gmt_offset` and `timezone_string` values
 	const gmt_offset = settings.gmt_offset;

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -283,6 +283,7 @@ export class SeoForm extends React.Component {
 			isFetchingSite,
 			siteId,
 			siteIsJetpack,
+			siteIsComingSoon,
 			showAdvancedSeo,
 			showWebsiteMeta,
 			selectedSite,
@@ -329,7 +330,7 @@ export class SeoForm extends React.Component {
 						showDismiss={ false }
 						text={ ( function() {
 							if ( isSitePrivate ) {
-								if ( isSiteComingSoon ) {
+								if ( siteIsComingSoon ) {
 									return translate(
 										"SEO settings aren't recognized by search engines while your site is Coming Soon."
 									);
@@ -501,7 +502,7 @@ const mapStateToProps = state => {
 		isSeoToolsActive: isJetpackModuleActive( state, siteId, 'seo-tools' ),
 		isSiteHidden: isHiddenSite( state, siteId ),
 		isSitePrivate: isPrivateSite( state, siteId ),
-		isSiteComingSoon: isSiteComingSoon( state, siteId ),
+		siteIsComingSoon: isSiteComingSoon( state, siteId ),
 		hasAdvancedSEOFeature: hasFeature( state, siteId, FEATURE_ADVANCED_SEO ),
 		hasSeoPreviewFeature: hasFeature( state, siteId, FEATURE_SEO_PREVIEW_TOOLS ),
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR improves the copy related to private sites.

#### Test instructions and details:

**Settings page**

With this PR, it should provide an intuitive copy that distinct between the private and coming soon modes.

<img width="742" alt="Zrzut ekranu 2020-04-9 o 16 04 01" src="https://user-images.githubusercontent.com/205419/78903652-c1403c80-7a7b-11ea-842d-f7e2aaa8cabb.png">

**SEO settings page**

Before this PR, it always displays the Coming Soon copy, even if the site is just private:

<img width="1114" alt="Zrzut ekranu 2020-04-9 o 15 00 16" src="https://user-images.githubusercontent.com/205419/78897707-e1b7c900-7a72-11ea-9759-f63a2023bab2.png">

With this PR it displays appropriate copy:

<img width="1091" alt="Zrzut ekranu 2020-04-9 o 15 00 54" src="https://user-images.githubusercontent.com/205419/78897740-ed0af480-7a72-11ea-8aeb-dea714ee409b.png">

