### PR TITLE
Packages: Add PopupMonitor as package

### DIFF
--- a/packages/popup-monitor/README.md
+++ b/packages/popup-monitor/README.md
@@ -1,0 +1,27 @@
+Popup Monitor
+=============
+
+Popup Monitor is a small utility to facilitate the monitoring of a popup window close action, which is especially useful for temporary popup windows (e.g. an authorization step).
+
+## Usage
+
+A Popup Monitor instance offers an `open` function which accepts an identical set of arguments as the standard `window.open` browser offering. When the window is closed, a `close` event is emitted to the instance with the name of the closed window.
+
+```js
+import PopupMonitor '@automattic/popup-monitor';
+
+const popupMonitor = new PopupMonitor();
+
+popupMonitor.open( 'https://wordpress.com/', 'my-popup' );
+
+popupMonitor.on( 'close', function( name ) {
+	if ( 'my-popup' === name ) {
+		console.log( 'Window closed!' );
+	}
+} );
+```
+
+## Methods
+
+- `open( url, name, features )`: Proxies an identical call to `window.open` and begins to monitor the window open state.
+- `getScreenCenterSpecs( width, height )`: A helper method for generating a feature (specification) string of a specific width and height at the center of the user's screen.

--- a/packages/popup-monitor/package.json
+++ b/packages/popup-monitor/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@automattic/popup-monitor",
+	"version": "1.0.0",
+	"description": "Utility to facilitate the monitoring of a popup window close action.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"sideEffects": false,
+	"keywords": [
+		"wordpress",
+		"popup"
+	],
+	"author": "Automattic Inc.",
+	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/popup-monitor",
+	"license": "GPL-2.0-or-later",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/popup-monitor"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"files": [
+		"dist",
+		"src"
+	],
+	"scripts": {
+		"clean": "npx rimraf dist",
+		"prepublish": "npm run clean",
+		"prepare": "transpile"
+	},
+	"dependencies": {
+		"lodash": "^4.17.15"
+	}
+}

--- a/packages/popup-monitor/package.json
+++ b/packages/popup-monitor/package.json
@@ -29,7 +29,7 @@
 	],
 	"scripts": {
 		"clean": "npx rimraf dist",
-		"prepublish": "npm run clean",
+		"prepublish": "yarn run clean",
 		"prepare": "transpile"
 	},
 	"dependencies": {

--- a/packages/popup-monitor/src/emitter.js
+++ b/packages/popup-monitor/src/emitter.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { assign } from 'lodash';
+import { EventEmitter } from 'events';
+
+export default function( prototype ) {
+	assign( prototype, EventEmitter.prototype );
+	prototype.emitChange = function() {
+		this.emit( 'change' );
+	};
+	prototype.off = prototype.removeListener;
+}

--- a/packages/popup-monitor/src/index.js
+++ b/packages/popup-monitor/src/index.js
@@ -1,0 +1,124 @@
+/**
+ * Internal dependencies
+ */
+import Emitter from './emitter';
+
+/**
+ * PopupMonitor component
+ *
+ * @public
+ */
+function PopupMonitor() {
+	this.intervals = {};
+	this.monitorInterval = null;
+	this.windowInstance = null;
+	this.onMessage = messageEvent => {
+		if ( messageEvent.source === this.windowInstance ) {
+			this.emit( 'message', messageEvent.data );
+		}
+	};
+}
+
+/**
+ * Mixins
+ */
+Emitter( PopupMonitor.prototype );
+
+/**
+ * Opens a new popup and starts monitoring it for changes. This should only be
+ * invoked on a user action to avoid the popup being blocked. Returns the
+ * current instance of PopupMonitor to enable chainability
+ *
+ * @param {string} url The URL to be loaded in the newly opened window
+ * @param {string} name A string name for the new window
+ * @param {string} specs An optional parameter listing the features of the new window as a string
+ * @public
+ */
+PopupMonitor.prototype.open = function( url, name, specs ) {
+	name = name || Date.now();
+
+	this.windowInstance = window.open( url, name, specs );
+	this.startMonitoring( name, this.windowInstance );
+
+	window.addEventListener( 'message', this.onMessage, false );
+
+	return this;
+};
+
+/**
+ * Returns a popup window specification string fragment containing properties
+ * to visually center the popup on the user's current screen.
+ *
+ * @param  {number} width The desired width of the popup
+ * @param  {number} height The desired height of the popup
+ * @returns {string} Popup window specificatino string fragment
+ * @public
+ */
+PopupMonitor.prototype.getScreenCenterSpecs = function( width, height ) {
+	const screenTop = typeof window.screenTop !== 'undefined' ? window.screenTop : window.screenY,
+		screenLeft = typeof window.screenLeft !== 'undefined' ? window.screenLeft : window.screenX;
+
+	return [
+		'width=' + width,
+		'height=' + height,
+		'top=' + ( screenTop + window.innerHeight / 2 - height / 2 ),
+		'left=' + ( screenLeft + window.innerWidth / 2 - width / 2 ),
+	].join();
+};
+
+/**
+ * Returns true if the popup with the specified name is closed, or false
+ * otherwise
+ *
+ * @param {string} name The name of the popup window to check
+ * @public
+ */
+PopupMonitor.prototype.isOpen = function( name ) {
+	let isClosed = false;
+
+	try {
+		isClosed = this.intervals[ name ] && this.intervals[ name ].closed;
+	} catch ( e ) {}
+
+	return ! isClosed;
+};
+
+/**
+ * Detects if any popup windows have closed since the last interval run and
+ * triggers a close event for any closed windows. If no popup windows remain
+ * open, then the interval is stopped.
+ */
+PopupMonitor.prototype.checkStatus = function() {
+	for ( const name in this.intervals ) {
+		if ( this.intervals.hasOwnProperty( name ) && ! this.isOpen( name ) ) {
+			this.emit( 'close', name );
+			delete this.intervals[ name ];
+		}
+	}
+
+	if ( 0 === Object.keys( this.intervals ).length ) {
+		clearInterval( this.monitorInterval );
+		delete this.monitorInterval;
+		window.removeEventListener( 'message', this.onMessage );
+	}
+};
+
+/**
+ * Starts monitoring a popup window instance for changes on a recurring
+ * interval.
+ *
+ * @param {string} name The name of hte popup window to monitor
+ * @param {window} windowInstance The popup window instance
+ */
+PopupMonitor.prototype.startMonitoring = function( name, windowInstance ) {
+	if ( ! this.monitorInterval ) {
+		this.monitorInterval = setInterval( this.checkStatus.bind( this ), 100 );
+	}
+
+	this.intervals[ name ] = windowInstance;
+};
+
+/**
+ * Expose `PopupMonitor`
+ */
+export default PopupMonitor;

--- a/packages/popup-monitor/test/index.js
+++ b/packages/popup-monitor/test/index.js
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import PopupMonitor from '../src';
+
+describe( 'PopupMonitor', () => {
+	let popupMonitor;
+
+	beforeAll( () => {
+		Object.assign( global.window, {
+			screenTop: 0,
+			screenLeft: 0,
+			innerWidth: 1280,
+			innerHeight: 720,
+		} );
+	} );
+
+	beforeEach( () => {
+		popupMonitor = new PopupMonitor();
+	} );
+
+	describe( '#getScreenCenterSpecs()', () => {
+		test( 'should generate a popup specification string given the desired width and height', () => {
+			const specs = popupMonitor.getScreenCenterSpecs( 650, 500 );
+
+			expect( specs ).to.equal( 'width=650,height=500,top=110,left=315' );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the [`PopupMonitor` lib](https://github.com/Automattic/wp-calypso/blob/4a523e7c6551760766e37111e715638a7b2f8712/client/lib/popup-monitor/index.js) into `/packages` to be published on npm and reused in Jetpack.

#### Notes

- This does not affect Calypso yet. I will take care of changing the imports and removing the internal library in a follow up.

- I've took the liberty of copypasting the `emitter.js` file from [this mixin](https://github.com/Automattic/wp-calypso/blob/7af2e4c81d784675ab5d5578e2b363c2e0844833/client/lib/mixins/emitter/index.js).
`PopupMonitor` uses it, as well as _lots_ of other files in Calypso.
I've chosen to copy it because it's such a small utility file, and exporting the original as external package is just overkill imho.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Follow the preparations steps here: https://github.com/Automattic/wp-calypso/pull/40972#issuecomment-615306100
- Follow the testing instructions here: https://github.com/Automattic/jetpack/pull/15482