### PR TITLE
Jetpack Cloud: Do not use includes in connect

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import React, { Component } from 'react';
 import momentDate from 'moment';
 import { localize } from 'i18n-calypso';
+import { includes } from 'lodash';
 
 /**
  * Internal dependencies
@@ -143,7 +144,7 @@ class BackupsPage extends Component {
 		const {
 			allowRestore,
 			doesRewindNeedCredentials,
-			hasRealtimeBackups,
+			siteCapabilities,
 			logs,
 			moment,
 			siteId,
@@ -156,15 +157,13 @@ class BackupsPage extends Component {
 		} = this.props;
 
 		const backupsOnSelectedDate = this.getBackupLogsFor( this.getSelectedDate() );
-
 		const selectedDateString = this.TO_REMOVE_getSelectedDateString();
-
 		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
-
 		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );
 		const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
 		const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
+		const hasRealtimeBackups = includes( siteCapabilities, 'backup-realtime' );
 
 		return (
 			<Main>
@@ -315,7 +314,7 @@ const mapStateToProps = state => {
 		allowRestore,
 		doesRewindNeedCredentials,
 		filter,
-		hasRealtimeBackups: siteCapabilities.includes( 'backup-realtime' ),
+		siteCapabilities,
 		logs: logs?.data ?? [],
 		rewind,
 		siteId,

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -109,7 +109,7 @@ class BackupsPage extends Component {
 				// Looking for the last backup on the date
 				if (
 					! backupsOnSelectedDate.lastBackup &&
-					backupStatusNames.includes( log.activityName )
+					includes( backupStatusNames, log.activityName )
 				) {
 					backupsOnSelectedDate.lastBackup = log;
 				} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR sends site capabilities into the component from redux, instead of checking for the capability slug in the connect function. The previous method was causing trouble in certain circumstances.
* Also, use lodash `includes` for a bit of added type safety.
* Also, update the other usage of `includes` in main.jsx.

#### Testing instructions

* Load up backups page. There should be no effect and everything should look/work normally, unless the site was broken previously.
