### PR TITLE
Gutenboarding: add transitions on page landing

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -22,7 +22,7 @@ const AcquireIntent: FunctionComponent = () => {
 	const makePath = usePath();
 
 	return (
-		<div className="acquire-intent">
+		<div className="gutenboarding-page acquire-intent">
 			<div className="acquire-intent__questions">
 				<VerticalSelect />
 				{ /* We are rendering everything to keep the content vertically centered on desktop while preventing jumping */ }

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -28,7 +28,7 @@ const CreateSite: FunctionComponent< {} > = () => {
 	];
 
 	return (
-		<div className="create-site__background">
+		<div className="gutenboarding-page create-site__background">
 			{ shouldTriggerCreate && shouldCreateAndRedirect && <CreateAndRedirect /> }
 			<div className="create-site__layout">
 				<div className="create-site__header">

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -47,7 +47,7 @@ const DesignSelector: React.FunctionComponent = () => {
 	};
 
 	return (
-		<div className="design-selector">
+		<div className="gutenboarding-page design-selector">
 			<div className="design-selector__header">
 				<div className="design-selector__heading">
 					<Title>{ __( 'Choose a starting design' ) }</Title>

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -41,7 +41,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 						in={ match !== null }
 						unmountOnExit
 						classNames="gutenboarding-page"
-						timeout={ 500 }
+						timeout={ 240 }
 					>
 						<AcquireIntent />
 					</CSSTransition>
@@ -60,7 +60,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 						in={ match !== null }
 						unmountOnExit
 						classNames="gutenboarding-page"
-						timeout={ 500 }
+						timeout={ 250 }
 					>
 						<DesignSelector />
 					</CSSTransition>
@@ -79,7 +79,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 						in={ match !== null }
 						unmountOnExit
 						classNames="gutenboarding-page"
-						timeout={ 500 }
+						timeout={ 250 }
 					>
 						<StylePreview />
 					</CSSTransition>
@@ -92,7 +92,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 						in={ match !== null }
 						unmountOnExit
 						classNames="gutenboarding-page"
-						timeout={ 500 }
+						timeout={ 250 }
 					>
 						<CreateSite />
 					</CSSTransition>

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -4,7 +4,7 @@
 import { BlockEditProps } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
-import { Redirect, Switch, Route } from 'react-router-dom';
+import { Redirect, Route } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -18,6 +18,7 @@ import { Step, usePath, useNewQueryParam } from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';
 import { isEnabled } from '../../../config';
+import { CSSTransition } from 'react-transition-group';
 
 import './colors.scss';
 import './style.scss';
@@ -34,35 +35,69 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 			{ isCreatingSite && (
 				<Redirect push={ replaceHistory ? undefined : true } to={ makePath( Step.CreateSite ) } />
 			) }
-			<Switch>
-				<Route exact path={ makePath( Step.IntentGathering ) }>
-					<AcquireIntent />
-				</Route>
+			<Route exact path={ makePath( Step.IntentGathering ) }>
+				{ ( { match } ) => (
+					<CSSTransition
+						in={ match !== null }
+						unmountOnExit
+						classNames="gutenboarding-page"
+						timeout={ 500 }
+					>
+						<AcquireIntent />
+					</CSSTransition>
+				) }
+			</Route>
 
+			{ ! siteVertical && (
 				<Route path={ makePath( Step.DesignSelection ) }>
-					{ ! siteVertical ? (
-						<Redirect to={ makePath( Step.IntentGathering ) } />
-					) : (
+					<Redirect to={ makePath( Step.IntentGathering ) } />
+				</Route>
+			) }
+
+			<Route path={ makePath( Step.DesignSelection ) }>
+				{ ( { match } ) => (
+					<CSSTransition
+						in={ match !== null }
+						unmountOnExit
+						classNames="gutenboarding-page"
+						timeout={ 500 }
+					>
 						<DesignSelector />
-					) }
-				</Route>
+					</CSSTransition>
+				) }
+			</Route>
 
+			{ ! selectedDesign && ! isEnabled( 'gutenboarding/style-preview' ) && (
 				<Route path={ makePath( Step.Style ) }>
-					{ // Disable reason: Leave me alone, my nested ternaries are amazing ✨
-					// eslint-disable-next-line no-nested-ternary
-					! selectedDesign ? (
-						<Redirect to={ makePath( Step.DesignSelection ) } />
-					) : isEnabled( 'gutenboarding/style-preview' ) ? (
-						<StylePreview />
-					) : (
-						<Redirect to={ makePath( Step.DesignSelection ) } />
-					) }
+					<Redirect to={ makePath( Step.DesignSelection ) } />
 				</Route>
+			) }
 
-				<Route path={ makePath( Step.CreateSite ) }>
-					<CreateSite />
-				</Route>
-			</Switch>
+			<Route path={ makePath( Step.Style ) }>
+				{ ( { match } ) => (
+					<CSSTransition
+						in={ match !== null }
+						unmountOnExit
+						classNames="gutenboarding-page"
+						timeout={ 500 }
+					>
+						<StylePreview />
+					</CSSTransition>
+				) }
+			</Route>
+
+			<Route path={ makePath( Step.CreateSite ) }>
+				{ ( { match } ) => (
+					<CSSTransition
+						in={ match !== null }
+						unmountOnExit
+						classNames="gutenboarding-page"
+						timeout={ 500 }
+					>
+						<CreateSite />
+					</CSSTransition>
+				) }
+			</Route>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -4,7 +4,7 @@
 import { BlockEditProps } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
-import { Redirect, Route } from 'react-router-dom';
+import { Redirect, Switch, Route } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -18,7 +18,6 @@ import { Step, usePath, useNewQueryParam } from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';
 import { isEnabled } from '../../../config';
-import { CSSTransition } from 'react-transition-group';
 
 import './colors.scss';
 import './style.scss';
@@ -35,69 +34,35 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 			{ isCreatingSite && (
 				<Redirect push={ replaceHistory ? undefined : true } to={ makePath( Step.CreateSite ) } />
 			) }
-			<Route exact path={ makePath( Step.IntentGathering ) }>
-				{ ( { match } ) => (
-					<CSSTransition
-						in={ match !== null }
-						unmountOnExit
-						classNames="gutenboarding-page"
-						timeout={ 240 }
-					>
-						<AcquireIntent />
-					</CSSTransition>
-				) }
-			</Route>
+			<Switch>
+				<Route exact path={ makePath( Step.IntentGathering ) }>
+					<AcquireIntent />
+				</Route>
 
-			{ ! siteVertical && (
 				<Route path={ makePath( Step.DesignSelection ) }>
-					<Redirect to={ makePath( Step.IntentGathering ) } />
-				</Route>
-			) }
-
-			<Route path={ makePath( Step.DesignSelection ) }>
-				{ ( { match } ) => (
-					<CSSTransition
-						in={ match !== null }
-						unmountOnExit
-						classNames="gutenboarding-page"
-						timeout={ 250 }
-					>
+					{ ! siteVertical ? (
+						<Redirect to={ makePath( Step.IntentGathering ) } />
+					) : (
 						<DesignSelector />
-					</CSSTransition>
-				) }
-			</Route>
-
-			{ ! selectedDesign && ! isEnabled( 'gutenboarding/style-preview' ) && (
-				<Route path={ makePath( Step.Style ) }>
-					<Redirect to={ makePath( Step.DesignSelection ) } />
+					) }
 				</Route>
-			) }
 
-			<Route path={ makePath( Step.Style ) }>
-				{ ( { match } ) => (
-					<CSSTransition
-						in={ match !== null }
-						unmountOnExit
-						classNames="gutenboarding-page"
-						timeout={ 250 }
-					>
+				<Route path={ makePath( Step.Style ) }>
+					{ // Disable reason: Leave me alone, my nested ternaries are amazing ✨
+					// eslint-disable-next-line no-nested-ternary
+					! selectedDesign ? (
+						<Redirect to={ makePath( Step.DesignSelection ) } />
+					) : isEnabled( 'gutenboarding/style-preview' ) ? (
 						<StylePreview />
-					</CSSTransition>
-				) }
-			</Route>
+					) : (
+						<Redirect to={ makePath( Step.DesignSelection ) } />
+					) }
+				</Route>
 
-			<Route path={ makePath( Step.CreateSite ) }>
-				{ ( { match } ) => (
-					<CSSTransition
-						in={ match !== null }
-						unmountOnExit
-						classNames="gutenboarding-page"
-						timeout={ 250 }
-					>
-						<CreateSite />
-					</CSSTransition>
-				) }
-			</Route>
+				<Route path={ makePath( Step.CreateSite ) }>
+					<CreateSite />
+				</Route>
+			</Switch>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -56,7 +56,7 @@ const StylePreview: React.FunctionComponent = () => {
 	);
 
 	return (
-		<div className="style-preview">
+		<div className="gutenboarding-page style-preview">
 			<div className="style-preview__header">
 				<div className="style-preview__titles">
 					<Title>{ __( 'Select your fonts' ) }</Title>

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -17,21 +17,31 @@
 }
 
 .gutenboarding-page-enter {
-	animation: gutenboarding-page-appear 0.5s ease-out forwards;
+	animation: gutenboarding-page-appear 240ms ease-out forwards;
+	z-index: 1;
 }
 
 .gutenboarding-page-exit {
-	animation: gutenboarding-page-appear 0.5s ease-out forwards;
-	animation-direction: reverse;
+	animation: gutenboarding-page-disappear 240ms ease-out forwards;
+	z-index: 0;
 }
 
 @keyframes gutenboarding-page-appear {
 	from {
 		opacity: 0;
-		transform: translateY( 20px );
+		transform: translateY( 10px );
 	}
 	to {
 		opacity: 1;
 		transform: translateY( 0 );
+	}
+}
+
+@keyframes gutenboarding-page-disappear {
+	from {
+		opacity: 1;
+	}
+	to {
+		opacity: 0;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -13,9 +13,7 @@
 }
 
 .gutenboarding-page {
-	position: relative;
 	transform-origin: center center;
-	top: 0;
 }
 
 .gutenboarding-page-enter {

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -14,16 +14,7 @@
 
 .gutenboarding-page {
 	transform-origin: center center;
-}
-
-.gutenboarding-page-enter {
-	animation: gutenboarding-page-appear 240ms ease-out forwards;
-	z-index: 1;
-}
-
-.gutenboarding-page-exit {
-	animation: gutenboarding-page-disappear 240ms ease-out forwards;
-	z-index: 0;
+	animation: gutenboarding-page-appear 300ms ease-out forwards;
 }
 
 @keyframes gutenboarding-page-appear {
@@ -34,14 +25,5 @@
 	to {
 		opacity: 1;
 		transform: translateY( 0 );
-	}
-}
-
-@keyframes gutenboarding-page-disappear {
-	from {
-		opacity: 1;
-	}
-	to {
-		opacity: 0;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -11,3 +11,29 @@
 		margin: 0 88px;
 	}
 }
+
+.gutenboarding-page {
+	position: relative;
+	transform-origin: center center;
+	top: 0;
+}
+
+.gutenboarding-page-enter {
+	animation: gutenboarding-page-appear 0.5s ease-in forwards;
+}
+
+.gutenboarding-page-exit {
+	animation: gutenboarding-page-appear 0.5s ease-in forwards;
+	animation-direction: reverse;
+}
+
+@keyframes gutenboarding-page-appear {
+	from {
+		opacity: 0;
+		transform: scale( 1.01 );
+	}
+	to {
+		opacity: 1;
+		transform: scale( 1 );
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -17,21 +17,21 @@
 }
 
 .gutenboarding-page-enter {
-	animation: gutenboarding-page-appear 0.5s ease-in forwards;
+	animation: gutenboarding-page-appear 0.5s ease-out forwards;
 }
 
 .gutenboarding-page-exit {
-	animation: gutenboarding-page-appear 0.5s ease-in forwards;
+	animation: gutenboarding-page-appear 0.5s ease-out forwards;
 	animation-direction: reverse;
 }
 
 @keyframes gutenboarding-page-appear {
 	from {
 		opacity: 0;
-		transform: scale( 1.01 );
+		transform: translateY( 20px );
 	}
 	to {
 		opacity: 1;
-		transform: scale( 1 );
+		transform: translateY( 0 );
 	}
 }

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -56,3 +56,9 @@ input:disabled {
 		color: var( --color-neutral-20 );
 	}
 }
+
+.is-block-content {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+}

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -54,11 +54,3 @@ input:disabled {
 		color: var( --color-neutral-20 );
 	}
 }
-
-.onboarding-block {
-	display: grid;
-}
-
-.onboarding-block > div {
-	grid-area: 1/1;
-}

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -30,14 +30,12 @@ $admin-sidebar-width-collapsed: 0;
 // Own/Gutenboarding styles
 @import './variables.scss';
 
-
 .gutenboarding__content-editor {
 	// overrides .edit-post-visual-editor
 	padding-top: 0;
 
 	@include break-small {
 		padding-top: $gutenboarding-header-height;
-
 	}
 }
 
@@ -57,8 +55,10 @@ input:disabled {
 	}
 }
 
-.is-block-content {
-	display: flex;
-	flex-direction: column;
-	width: 100%;
+.onboarding-block {
+	display: grid;
+}
+
+.onboarding-block > div {
+	grid-area: 1/1;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes navigation between pages smoother and more seamless. 

#### Testing instructions

Just move around the flow from start to finish with the occasional back button to see. 

These transitions are pure CSS, they can be disabled/altered on mobiles using media queries without much effort.

Fixes p1586419553461200-slack-luna.
