### PR TITLE
i18n: Add support for translation chunks in Gutenboarding

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -51,7 +51,7 @@ export function getLanguageFilePathUrl() {
  * @returns {string} The internal base file path for language files.
  */
 export function getLanguagesInternalBasePath() {
-	if ( ! window.__requireChunkCallback__ ) {
+	if ( ! window || ! window.__requireChunkCallback__ ) {
 		return '/calypso/evergreen/languages';
 	}
 

--- a/client/lib/i18n-utils/test/switch-locale.js
+++ b/client/lib/i18n-utils/test/switch-locale.js
@@ -1,12 +1,18 @@
 /**
  * External dependencies
  */
-import { startsWith } from 'lodash';
+import { set, startsWith } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { getLanguageFilePathUrl, getLanguageFileUrl } from 'lib/i18n-utils/switch-locale';
+import {
+	getLanguageFilePathUrl,
+	getLanguageFileUrl,
+	getLanguageManifestFileUrl,
+	getLanguagesInternalBasePath,
+	getTranslationChunkFileUrl,
+} from 'lib/i18n-utils/switch-locale';
 
 describe( 'getLanguageFileUrl()', () => {
 	test( 'should return a JS url.', () => {
@@ -58,5 +64,84 @@ describe( 'getLanguageFileUrl()', () => {
 		const expected = getLanguageFilePathUrl() + 'zh-v1.1.js';
 
 		expect( getLanguageFileUrl( 'zh', 'js', { zh: 'what-is-this?' } ) ).toEqual( expected );
+	} );
+} );
+
+describe( 'getLanguagesInternalBasePath()', () => {
+	test( 'should return base path for languages.', () => {
+		if ( ! global.window || ! global.__requireChunkCallback__ ) {
+			const expected = '/calypso/evergreen/languages';
+
+			expect( getLanguagesInternalBasePath() ).toEqual( expected );
+		}
+
+		let hasMockedWindow = false;
+		let hasMockedRequireChunkCallback = false;
+
+		if ( ! global.window || ! global.window.__requireChunkCallback__ ) {
+			hasMockedWindow = ! global.window;
+			hasMockedRequireChunkCallback = ! global.window || ! global.window.__requireChunkCallback__;
+
+			const mockFn = jest.fn( () => '/calypso/fallback/' );
+			set( global, [ 'window', '__requireChunkCallback__', 'getPublicPath' ], mockFn );
+
+			const expected = '/calypso/fallback/languages';
+			expect( getLanguagesInternalBasePath() ).toEqual( expected );
+			expect( mockFn ).toHaveBeenCalled();
+		}
+
+		if ( hasMockedRequireChunkCallback ) {
+			global.window.__requireChunkCallback__ = null;
+		}
+
+		if ( hasMockedWindow ) {
+			global.window = null;
+		}
+	} );
+} );
+
+describe( 'getLanguageManifestFileUrl()', () => {
+	test( 'should return language manifest url for a given locale.', () => {
+		const expected = getLanguagesInternalBasePath() + '/ja-language-manifest.json';
+
+		expect( getLanguageManifestFileUrl( 'ja' ) ).toEqual( expected );
+	} );
+
+	test( 'should append a revision cache buster.', () => {
+		const expected = getLanguagesInternalBasePath() + '/zh-language-manifest.json?v=123';
+
+		expect( getLanguageManifestFileUrl( 'zh', { zh: 123 } ) ).toEqual( expected );
+	} );
+
+	test( 'should not append a revision cache buster for an unknown locale.', () => {
+		const expected = getLanguagesInternalBasePath() + '/kr-language-manifest.json';
+
+		expect( getLanguageManifestFileUrl( 'kr', { xd: 222 } ) ).toEqual( expected );
+	} );
+} );
+
+describe( 'getTranslationChunkFileUrl()', () => {
+	test( 'should return language manifest url for a given locale.', () => {
+		const locale = 'ja';
+		const chunkId = 'chunk-abc.min';
+		const expected = `${ getLanguagesInternalBasePath() }/${ locale }-${ chunkId }.json`;
+
+		expect( getTranslationChunkFileUrl( chunkId, locale ) ).toEqual( expected );
+	} );
+
+	test( 'should append a revision cache buster.', () => {
+		const locale = 'zh';
+		const chunkId = 'chunk-abc.min';
+		const expected = `${ getLanguagesInternalBasePath() }/${ locale }-${ chunkId }.json?v=123`;
+
+		expect( getTranslationChunkFileUrl( chunkId, locale, { zh: 123 } ) ).toEqual( expected );
+	} );
+
+	test( 'should not append a revision cache buster for an unknown locale.', () => {
+		const locale = 'kr';
+		const chunkId = 'chunk-abc.min';
+		const expected = `${ getLanguagesInternalBasePath() }/${ locale }-${ chunkId }.json`;
+
+		expect( getTranslationChunkFileUrl( chunkId, locale, { xd: 222 } ) ).toEqual( expected );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds support for translation chunks experimental feature in Gutenboarding landing page.

#### Testing instructions

1. Boot Calypso with `ENABLE_FEATURES=use-translation-chunks npm start` 
2. Go to http://calypso.localhost:3000/new
