### PR TITLE
Tracking: Populate events with user locale

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -19,7 +19,7 @@ export default ( eventName, eventProperties ) => {
 	// Required by Tracks when added manually
 	const blog_id = window._currentSiteId;
 	const site_type = window._currentSiteType;
-	const user_lang_code = window._currentUserLangCode;
+	const user_locale = window._currentUserLocale;
 
 	eventProperties = eventProperties || {};
 
@@ -50,7 +50,7 @@ export default ( eventName, eventProperties ) => {
 	eventProperties = omit( eventProperties, isUndefined );
 
 	// Populate custom properties.
-	eventProperties = { ...eventProperties, blog_id, site_type, user_lang_code };
+	eventProperties = { ...eventProperties, blog_id, site_type, user_locale };
 
 	tracksDebug( 'Recording event "%s" with actual props %o', eventName, eventProperties );
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -19,6 +19,7 @@ export default ( eventName, eventProperties ) => {
 	// Required by Tracks when added manually
 	const blog_id = window._currentSiteId;
 	const site_type = window._currentSiteType;
+	const user_lang_code = window._currentUserLangCode;
 
 	eventProperties = eventProperties || {};
 
@@ -49,7 +50,7 @@ export default ( eventName, eventProperties ) => {
 	eventProperties = omit( eventProperties, isUndefined );
 
 	// Populate custom properties.
-	eventProperties = { ...eventProperties, blog_id, site_type };
+	eventProperties = { ...eventProperties, blog_id, site_type, user_lang_code };
 
 	tracksDebug( 'Recording event "%s" with actual props %o', eventName, eventProperties );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR picks up the user locale property from the window object and populates the event with this value when it's recorded

#### Testing instructions

**Test in a Simple site**

* Apply these changes in your testing site
* Edit a posy
* start to insert a block from blocks list inserter
* generate a no-results event

Confirm that the user locale is propagated in the event object.

<img width="479" alt="Screen Shot 2020-04-09 at 1 25 31 PM" src="https://user-images.githubusercontent.com/77539/78917714-a5ca3700-7a65-11ea-9ff1-71ea9740b0c1.png">
