### PR TITLE
Encode no-ads product slug for renewal links

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -125,7 +125,11 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 		notices.error( 'Could not find product slug for renewal.' );
 		throw new Error( 'Could not find product slug for renewal.' );
 	}
-	const productList = meta ? `${ product_slug }:${ meta }` : product_slug;
+	// There is a product with this weird slug, but left to itself the slug will
+	// cause a routing error since it contains a slash, so we encode it here and
+	// then decode it in the checkout code before adding to the cart.
+	const productSlug = product_slug === 'no-adverts/no-adverts.php' ? 'no-ads' : product_slug;
+	const productList = meta ? `${ productSlug }:${ meta }` : productSlug;
 	const renewalUrl = `/checkout/${ productList }/renew/${ purchaseId }/${ siteSlug ||
 		purchaseDomain ||
 		'' }`;


### PR DESCRIPTION
In #40270, I modified all renewal links to use a URL rather than adding
a product to the cart directly; this puts the responsibility of adding
the product in the hands on checkout itself.

Unfortunately, there's a product with a slug of
`no-adverts/no-adverts.php`, which, if put in the URL, causes a calypso
routing error and the user will see a blank page.

The cart code is already set up to handle this thanks to a condition
added in #15043, so we just need to make sure to encode the product slug
`no-adverts/no-adverts.php` as `no-ads`. This PR makes that change.

Props to @sandymcfadden for noticing this regression!

#### Testing instructions

- Use the admin to add a "No Ads" upgrade to a site.
- Visit http://calypso.localhost:3000/me/purchases
- Click "No Ads" and then click "Renew now".
- Verify that you are redirected to checkout and the "No Ads" upgrade is in your cart.