### PR TITLE
Upsell Nudges: Replace site settings Banners with UpsellNudge

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -38,7 +38,7 @@ export const UpsellNudge = ( {
 	forceHref,
 	href,
 	icon,
-	isJetpack,
+	jetpack,
 	isVip,
 	list,
 	onClick,
@@ -66,8 +66,8 @@ export const UpsellNudge = ( {
 		( feature && planHasFeature ) ||
 		( ! feature && ! isFreePlan( site.plan ) ) ||
 		( feature === FEATURE_NO_ADS && site.options.wordads ) ||
-		( ! isJetpack && site.jetpack ) ||
-		( isJetpack && ! site.jetpack );
+		( ! jetpack && site.jetpack ) ||
+		( jetpack && ! site.jetpack );
 
 	if ( shouldNotDisplay && ! forceDisplay ) {
 		return null;
@@ -90,7 +90,7 @@ export const UpsellNudge = ( {
 			forceHref={ forceHref }
 			href={ href }
 			icon={ icon }
-			jetpack={ isJetpack }
+			jetpack={ jetpack }
 			list={ list }
 			onClick={ onClick }
 			onDismissClick={ onDismissClick }
@@ -114,7 +114,7 @@ export default connect( ( state, ownProps ) => {
 		site: getSite( state, siteId ),
 		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
-		isJetpack: isJetpackSite( state, siteId ),
+		jetpack: isJetpackSite( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 	};
 } )( localize( UpsellNudge ) );

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -22,20 +22,6 @@
 
 	@include banner-color( var( --color-accent ) );
 
-	&.is-jetpack-plan {
-		&.is-upgrade-personal {
-			@include banner-color( var( --color-jetpack-plan-personal ) );
-		}
-
-		&.is-upgrade-premium {
-			@include banner-color( var( --color-jetpack-plan-premium ) );
-		}
-
-		&.is-upgrade-business {
-			@include banner-color( var( --color-jetpack-plan-professional ) );
-		}
-	}
-
 	&.is-jetpack {
 		@include banner-color( var( --color-jetpack ) );
 	}

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -38,6 +38,7 @@ export const Sharing = ( {
 	showConnections,
 	showTraffic,
 	siteId,
+	isJetpack,
 	isVip,
 	siteSlug,
 	translate,
@@ -105,7 +106,7 @@ export const Sharing = ( {
 					</NavTabs>
 				</SectionNav>
 			) }
-			{ ! isVip && (
+			{ ! isVip && ! isJetpack && (
 				<UpsellNudge
 					event="sharing_no_ads"
 					feature={ FEATURE_NO_ADS }
@@ -146,5 +147,6 @@ export default connect( ( state ) => {
 		isVip: isVipSite( state, siteId ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
+		isJetpack: isJetpack,
 	};
 } )( localize( Sharing ) );

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -141,7 +141,6 @@ export class GoogleAnalyticsForm extends Component {
 							type: TYPE_PREMIUM,
 							...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
 						} ) }
-						jetpack={ siteIsJetpack }
 						showIcon={ true }
 						title={ nudgeTitle }
 					/>

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -12,7 +12,7 @@ import wrapSettingsForm from './wrap-settings-form';
 import { Card } from '@automattic/components';
 import ExternalLink from 'components/external-link';
 import SupportInfo from 'components/support-info';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import { getPlugins } from 'state/plugins/installed/selectors';
 import FormLabel from 'components/forms/form-label';
@@ -131,7 +131,7 @@ export class GoogleAnalyticsForm extends Component {
 				/>
 
 				{ showUpgradeNudge && site && site.plan ? (
-					<Banner
+					<UpsellNudge
 						description={ translate(
 							"Add your unique tracking ID to monitor your site's performance in Google Analytics."
 						) }
@@ -141,6 +141,8 @@ export class GoogleAnalyticsForm extends Component {
 							type: TYPE_PREMIUM,
 							...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
 						} ) }
+						jetpack={ siteIsJetpack }
+						showIcon={ true }
 						title={ nudgeTitle }
 					/>
 				) : (

--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { Card, CompactCard } from '@automattic/components';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import ExternalLink from 'components/external-link';
@@ -48,7 +48,7 @@ class JetpackAds extends Component {
 		const { translate } = this.props;
 
 		return (
-			<Banner
+			<UpsellNudge
 				description={ translate(
 					'Add advertising to your site through our WordAds program and earn money from impressions.'
 				) }
@@ -56,6 +56,8 @@ class JetpackAds extends Component {
 				feature={ FEATURE_WORDADS_INSTANT }
 				plan={ PLAN_JETPACK_PREMIUM }
 				title={ translate( 'Enable WordAds by upgrading to Jetpack Premium' ) }
+				showIcon={ true }
+				jetpack={ true }
 			/>
 		);
 	}

--- a/client/my-sites/site-settings/jetpack-ads.jsx
+++ b/client/my-sites/site-settings/jetpack-ads.jsx
@@ -57,7 +57,6 @@ class JetpackAds extends Component {
 				plan={ PLAN_JETPACK_PREMIUM }
 				title={ translate( 'Enable WordAds by upgrading to Jetpack Premium' ) }
 				showIcon={ true }
-				jetpack={ true }
 			/>
 		);
 	}

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { Card } from '@automattic/components';
 import filesize from 'filesize';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
@@ -128,13 +128,15 @@ class MediaSettingsPerformance extends Component {
 
 		return (
 			! isVideoPressAvailable && (
-				<Banner
+				<UpsellNudge
 					description={ translate(
 						'Get high-speed, high-resolution video hosting without ads or watermarks.'
 					) }
 					event={ 'jetpack_video_settings' }
 					feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PRO }
 					plan={ PLAN_JETPACK_PREMIUM }
+					showIcon={ true }
+					jetpack={ true }
 					title={ translate(
 						'Host video right on your site! Upgrade to Jetpack Premium to get started'
 					) }

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -136,7 +136,6 @@ class MediaSettingsPerformance extends Component {
 					feature={ FEATURE_VIDEO_UPLOADS_JETPACK_PRO }
 					plan={ PLAN_JETPACK_PREMIUM }
 					showIcon={ true }
-					jetpack={ true }
 					title={ translate(
 						'Host video right on your site! Upgrade to Jetpack Premium to get started'
 					) }

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -12,7 +12,7 @@ import { overSome } from 'lodash';
  * Internal dependencies
  */
 import { CompactCard } from '@automattic/components';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import QuerySitePurchases from 'components/data/query-site-purchases';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
@@ -150,7 +150,7 @@ class Search extends Component {
 	renderUpgradeNotice() {
 		return (
 			<Fragment>
-				<Banner
+				<UpsellNudge
 					description={
 						this.props.siteIsJetpack
 							? this.props.translate(
@@ -163,6 +163,8 @@ class Search extends Component {
 					event={ 'calypso_jetpack_search_settings_upgrade_nudge' }
 					feature={ FEATURE_SEARCH }
 					plan={ this.props.siteIsJetpack ? PRODUCT_JETPACK_SEARCH : PLAN_BUSINESS }
+					jetpack={ this.props.siteIsJetpack ? true : false }
+					showIcon={ true }
 					title={
 						this.props.siteIsJetpack
 							? this.props.translate(
@@ -202,7 +204,7 @@ class Search extends Component {
 				{ this.props.siteId && <QuerySitePurchases siteId={ this.props.siteId } /> }
 				<SettingsSectionHeader title={ this.props.translate( 'Jetpack Search' ) } />
 				{ this.props.isLoading ? (
-					<Banner title="Loading..." plan={ PRODUCT_JETPACK_SEARCH } />
+					<UpsellNudge title="Loading..." plan={ PRODUCT_JETPACK_SEARCH } />
 				) : (
 					<Fragment>
 						{ ! this.props.fields.jetpack_search_supported && ! this.props.isSearchEligible

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -163,7 +163,6 @@ class Search extends Component {
 					event={ 'calypso_jetpack_search_settings_upgrade_nudge' }
 					feature={ FEATURE_SEARCH }
 					plan={ this.props.siteIsJetpack ? PRODUCT_JETPACK_SEARCH : PLAN_BUSINESS }
-					jetpack={ this.props.siteIsJetpack }
 					showIcon={ true }
 					title={
 						this.props.siteIsJetpack

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -163,7 +163,7 @@ class Search extends Component {
 					event={ 'calypso_jetpack_search_settings_upgrade_nudge' }
 					feature={ FEATURE_SEARCH }
 					plan={ this.props.siteIsJetpack ? PRODUCT_JETPACK_SEARCH : PLAN_BUSINESS }
-					jetpack={ this.props.siteIsJetpack ? true : false }
+					jetpack={ this.props.siteIsJetpack }
 					showIcon={ true }
 					title={
 						this.props.siteIsJetpack

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -377,7 +377,6 @@ export class SeoForm extends React.Component {
 								...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
 							} ) }
 							showIcon={ true }
-							jetpack={ siteIsJetpack }
 							title={ nudgeTitle }
 						/>
 					) }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -377,7 +377,7 @@ export class SeoForm extends React.Component {
 								...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
 							} ) }
 							showIcon={ true }
-							jetpack={ siteIsJetpack ? true : false }
+							jetpack={ siteIsJetpack }
 							title={ nudgeTitle }
 						/>
 					) }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -20,7 +20,7 @@ import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { getSeoTitleFormatsForSite, isJetpackSite, isRequestingSite } from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,
@@ -366,7 +366,7 @@ export class SeoForm extends React.Component {
 				{ ! this.props.hasSeoPreviewFeature &&
 					! this.props.hasAdvancedSEOFeature &&
 					selectedSite.plan && (
-						<Banner
+						<UpsellNudge
 							description={ translate(
 								'Get tools to optimize your site for improved performance in search engine results.'
 							) }
@@ -376,6 +376,8 @@ export class SeoForm extends React.Component {
 								type: siteIsJetpack ? TYPE_PREMIUM : TYPE_BUSINESS,
 								...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
 							} ) }
+							showIcon={ true }
+							jetpack={ siteIsJetpack ? true : false }
 							title={ nudgeTitle }
 						/>
 					) }

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -4,7 +4,7 @@ jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
 
-jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
 jest.mock( 'components/notice', () => 'Notice' );
 jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
 
@@ -65,7 +65,7 @@ describe( 'SeoForm basic tests', () => {
 		expect( comp.find( 'Notice' ) ).toHaveLength( 0 );
 	} );
 
-	test( 'should render optimize SEO banner when has no SEO features', () => {
+	test( 'should render optimize SEO nudge when has no SEO features', () => {
 		const comp = shallow(
 			<SeoForm
 				{ ...props }
@@ -74,27 +74,29 @@ describe( 'SeoForm basic tests', () => {
 				selectedSite={ { plan: { product_slug: 'free' } } }
 			/>
 		);
-		expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
-		expect( comp.find( 'Banner' ).props().event ).toContain( 'calypso_seo_settings_upgrade_nudge' );
+		expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 1 );
+		expect( comp.find( 'UpsellNudge' ).props().event ).toContain(
+			'calypso_seo_settings_upgrade_nudge'
+		);
 	} );
 
 	test( 'should not render Jetpack unsupported notice when has any SEO features', () => {
 		const comp = shallow( <SeoForm { ...props } hasSeoPreviewFeature={ true } /> );
-		expect( comp.find( 'Banner' ) ).toHaveLength( 0 );
+		expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 0 );
 
 		comp.setProps( {
 			...props,
 			hasSeoPreviewFeature: false,
 			hasAdvancedSEOFeature: true,
 		} );
-		expect( comp.find( 'Banner' ) ).toHaveLength( 0 );
+		expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 0 );
 
 		comp.setProps( {
 			...props,
 			hasSeoPreviewFeature: true,
 			hasAdvancedSEOFeature: true,
 		} );
-		expect( comp.find( 'Banner' ) ).toHaveLength( 0 );
+		expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should not render Jetpack unsupported notice when has no site', () => {
@@ -106,7 +108,7 @@ describe( 'SeoForm basic tests', () => {
 				hasAdvancedSEOFeature={ false }
 			/>
 		);
-		expect( comp.find( 'Banner' ) ).toHaveLength( 0 );
+		expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render SEO editor when has advanced seo and there is no conflicted SEO plugin', () => {
@@ -163,14 +165,14 @@ describe( 'SeoForm basic tests', () => {
 	} );
 } );
 
-describe( 'Upsell Banner should get appropriate plan constant', () => {
+describe( 'UpsellNudge should get appropriate plan constant', () => {
 	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( ( product_slug ) => {
 		test( `Business 1 year for (${ product_slug })`, () => {
 			const comp = shallow(
 				<SeoForm { ...props } siteIsJetpack={ false } selectedSite={ { plan: { product_slug } } } />
 			);
-			expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
-			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS );
+			expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 1 );
+			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_BUSINESS );
 		} );
 	} );
 
@@ -184,8 +186,8 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 						selectedSite={ { plan: { product_slug } } }
 					/>
 				);
-				expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
-				expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS_2_YEARS );
+				expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 1 );
+				expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_BUSINESS_2_YEARS );
 			} );
 		}
 	);
@@ -200,8 +202,8 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 						selectedSite={ { plan: { product_slug } } }
 					/>
 				);
-				expect( comp.find( 'Banner' ) ).toHaveLength( 1 );
-				expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_JETPACK_PREMIUM );
+				expect( comp.find( 'UpsellNudge' ) ).toHaveLength( 1 );
+				expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_JETPACK_PREMIUM );
 			} );
 		}
 	);

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -11,7 +11,7 @@ import { includes, isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import FoldableCard from 'components/foldable-card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
@@ -54,12 +54,14 @@ const SpamFilteringSettings = ( {
 
 	if ( ! inTransition && ! hasAkismetFeature && ! isValidKey ) {
 		return (
-			<Banner
+			<UpsellNudge
 				description={ translate( 'Automatically remove spam from comments and contact forms.' ) }
 				event={ 'calypso_akismet_settings_upgrade_nudge' }
 				feature={ FEATURE_SPAM_AKISMET_PLUS }
 				plan={ PLAN_JETPACK_PERSONAL }
 				title={ translate( 'Defend your site against spam! Upgrade to Jetpack Personal.' ) }
+				showIcon={ true }
+				jetpack={ true }
 			/>
 		);
 	}

--- a/client/my-sites/site-settings/spam-filtering-settings.jsx
+++ b/client/my-sites/site-settings/spam-filtering-settings.jsx
@@ -61,7 +61,6 @@ const SpamFilteringSettings = ( {
 				plan={ PLAN_JETPACK_PERSONAL }
 				title={ translate( 'Defend your site against spam! Upgrade to Jetpack Personal.' ) }
 				showIcon={ true }
-				jetpack={ true }
 			/>
 		);
 	}

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -7,7 +7,7 @@ jest.mock( 'lib/abtest', () => ( {
 } ) );
 
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'components/banner', () => 'UpsellNudge' );
+jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
 jest.mock( 'components/notice', () => 'Notice' );
 jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
 

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -7,7 +7,7 @@ jest.mock( 'lib/abtest', () => ( {
 } ) );
 
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'components/banner', () => 'UpsellNudge' );
 jest.mock( 'components/notice', () => 'Notice' );
 jest.mock( 'components/notice/notice-action', () => 'NoticeAction' );
 
@@ -54,11 +54,11 @@ describe( 'GoogleAnalyticsForm basic tests', () => {
 	} );
 	test( 'should not show upgrade nudge if disabled', () => {
 		const comp = shallow( <GoogleAnalyticsForm { ...props } showUpgradeNudge={ false } /> );
-		expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 0 );
+		expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 0 );
 	} );
 } );
 
-describe( 'Upsell Banner should get appropriate plan constant', () => {
+describe( 'UpsellNudge should get appropriate plan constant', () => {
 	const myProps = {
 		...props,
 		showUpgradeNudge: true,
@@ -73,8 +73,8 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 					site={ { plan: { product_slug } } }
 				/>
 			);
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
+			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
+			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
 				PLAN_PREMIUM
 			);
 		} );
@@ -89,8 +89,8 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 					site={ { plan: { product_slug } } }
 				/>
 			);
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
+			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
+			expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
 				PLAN_PREMIUM_2_YEARS
 			);
 		} );
@@ -106,8 +106,8 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 						site={ { plan: { product_slug } } }
 					/>
 				);
-				expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
-				expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
+				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
+				expect( comp.find( 'UpsellNudge[event="google_analytics_settings"]' ).props().plan ).toBe(
 					PLAN_JETPACK_PREMIUM
 				);
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR migrates instances of `Banner` to `UpsellNudge` for consistency, while keeping all Tracks events (impression and click) the same. See #38778
* Also fixes a bug where the JP icon and colors weren't showing up for Jetpack ads.

| Before | After |
| ------- | ------ |
| <img width="1107" alt="Screen Shot 2020-04-09 at 2 41 09 PM" src="https://user-images.githubusercontent.com/2124984/78929874-22aede00-7a71-11ea-96fc-519c49c0cba0.png"> | <img width="1110" alt="Screen Shot 2020-04-09 at 2 41 02 PM" src="https://user-images.githubusercontent.com/2124984/78929888-28a4bf00-7a71-11ea-9272-5c4ada4c1fdf.png"> |
| <img width="768" alt="Screen Shot 2020-04-09 at 2 46 42 PM" src="https://user-images.githubusercontent.com/2124984/78929913-31959080-7a71-11ea-8942-ba3218e0d8f9.png"> | <img width="763" alt="Screen Shot 2020-04-09 at 2 46 30 PM" src="https://user-images.githubusercontent.com/2124984/78929931-38240800-7a71-11ea-9f05-4dca2ebc7ad3.png"> |
| Jetpack <img width="797" alt="Screen Shot 2020-04-09 at 2 56 24 PM" src="https://user-images.githubusercontent.com/2124984/78930580-5cccaf80-7a72-11ea-901d-7cd479d0999b.png"> | Jetpack <img width="766" alt="Screen Shot 2020-04-09 at 2 56 43 PM" src="https://user-images.githubusercontent.com/2124984/78930607-62c29080-7a72-11ea-9e69-68db6a6996ef.png"> |
| WordPress.com
<img width="761" alt="Screen Shot 2020-04-09 at 2 52 31 PM" src="https://user-images.githubusercontent.com/2124984/78930484-373fa600-7a72-11ea-9f93-9984516c1238.png"> | (No visual change) |
| <img width="758" alt="Screen Shot 2020-04-09 at 3 07 15 PM" src="https://user-images.githubusercontent.com/2124984/78931395-e761de80-7a73-11ea-9329-1a5f14e1d607.png"> | <img width="755" alt="Screen Shot 2020-04-09 at 3 07 21 PM" src="https://user-images.githubusercontent.com/2124984/78931416-ed57bf80-7a73-11ea-8df1-daddaef30b9b.png"> |
| WordPress.com 
<img width="1058" alt="Screen Shot 2020-04-10 at 11 10 52 AM" src="https://user-images.githubusercontent.com/2124984/79001241-1e8bca80-7b1c-11ea-8f44-1bc8c352a367.png"> | No visual change |
| Jetpack <img width="1064" alt="Screen Shot 2020-04-10 at 11 11 23 AM" src="https://user-images.githubusercontent.com/2124984/79001264-277c9c00-7b1c-11ea-8593-bb7ec9ed65d5.png"> | Jetpack <img width="1062" alt="Screen Shot 2020-04-10 at 11 11 29 AM" src="https://user-images.githubusercontent.com/2124984/79001290-32cfc780-7b1c-11ea-9d6b-2c647b4c72a0.png"> |
| Jetpack <img width="1068" alt="Screen Shot 2020-04-17 at 1 59 43 PM" src="https://user-images.githubusercontent.com/2124984/79600117-a5a8e780-80b4-11ea-960d-18c5a0f4dba3.png"> | <img width="1081" alt="Screen Shot 2020-04-17 at 2 00 53 PM" src="https://user-images.githubusercontent.com/2124984/79600238-d12bd200-80b4-11ea-9f3f-c4177e7a94b3.png"> |
| WordPress.com <img width="1070" alt="Screen Shot 2020-04-17 at 2 01 02 PM" src="https://user-images.githubusercontent.com/2124984/79600155-b22d4000-80b4-11ea-93a5-381e2ff27493.png"> | No visual change |




#### Testing instructions

Switch to this PR and test the following upsells:

* Go to Marketing -> Traffic on a Jetpack site with the Free plan; note the WordAds upgrade nudge. Double-check Tracks event and its props to make sure there are no changes.
* Go to Settings -> Performance and scroll down to Media on a Jetpack site with the Free plan; note the upgrade nudge, and double-check Tracks events/props.
* Go to Settings -> Performance and look at the Jetpack Search section on a Jetpack site with the free plan. Note the upgrade nudge, double-check Tracks events.
* Go to Settings -> Performance and look at the Jetpack Search section on a WordPress.com site with the free plan. Double-check Tracks events.
* Go to Settings -> Security and scroll down to the Anti-spam heading on a Jetpack site with a free plan. Note the upsell nudge for Akismet and check Tracks events/props.
* Go to Marketing -> Traffic on a Free site and check the upsell under Search engine optimization
* Go to Marketing -> Traffic on a Jetpack site with a free plan and check the upsell under Search engine optimization
* Go to Marketing -> Traffic on a Jetpack site with a free plan and check the upsell under Google Analytics
* Go to Marketing -> Traffic on a WordPress.com site with a free plan and check the upsell under Google Analytics