### PR TITLE
Add Easter closure notices for Chat and Quick Start

### DIFF
--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -22,8 +22,8 @@ class PrimaryHeader extends Component {
 			<Fragment>
 				<ClosureNotice
 					displayAt="2020-04-09 00:00Z"
-					closesAt="2020-04-12 00:00Z"
-					reopensAt="2020-04-13 07:00Z"
+					closesAt="2020-04-12 06:00Z"
+					reopensAt="2020-04-13 06:00Z"
 					holidayName={ easterHolidayName }
 				/>
 				<Card>

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -8,9 +8,9 @@ import React, { Component, Fragment } from 'react';
  */
 import { Card } from '@automattic/components';
 import ClosureNotice from '../shared/closure-notice';
-import GMClosureNotice from '../shared/gm-closure-notice';
 import FormattedHeader from 'components/formatted-header';
 import ExternalLink from 'components/external-link';
+import { easterHolidayName } from 'me/help/contact-form-notice/live-chat-closure';
 import { localize } from 'i18n-calypso';
 import { CONCIERGE_SUPPORT } from 'lib/url/support';
 
@@ -18,28 +18,13 @@ class PrimaryHeader extends Component {
 	render() {
 		const { translate } = this.props;
 
-		const xmasHolidayName = translate( 'Christmas', {
-			context: 'Holiday name',
-		} );
-
 		return (
 			<Fragment>
-				<GMClosureNotice
-					displayAt="2019-09-03 00:00Z"
-					closesAt="2019-09-10 00:00Z"
-					reopensAt="2019-09-19 04:00Z"
-				/>
 				<ClosureNotice
-					displayAt="2019-12-17 00:00Z"
-					closesAt="2019-12-24 00:00Z"
-					reopensAt="2019-12-26 07:00Z"
-					holidayName={ xmasHolidayName }
-				/>
-				<ClosureNotice
-					displayAt="2019-12-26 07:00Z"
-					closesAt="2019-12-31 00:00Z"
-					reopensAt="2020-01-02 07:00Z"
-					holidayName={ translate( "New Year's Day" ) }
+					displayAt="2020-04-09 00:00Z"
+					closesAt="2020-04-12 00:00Z"
+					reopensAt="2020-04-13 07:00Z"
+					holidayName={ easterHolidayName }
 				/>
 				<Card>
 					<img

--- a/client/me/help/contact-form-notice/live-chat-closure.jsx
+++ b/client/me/help/contact-form-notice/live-chat-closure.jsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { useTranslate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import 'moment-timezone'; // monkey patches the existing moment.js
 
 /**
@@ -13,7 +13,10 @@ import ContactFormNotice from 'me/help/contact-form-notice/index';
 import { useLocalizedMoment } from 'components/localized-moment';
 
 const DATE_FORMAT = 'LLL';
-const translate = useTranslate();
+
+export const easterHolidayName = translate( 'Easter', {
+	context: 'Holiday name',
+} );
 
 export const xmasHolidayName = translate( 'Christmas', {
 	context: 'Holiday name',

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -18,6 +18,9 @@ import { Card } from '@automattic/components';
 import Notice from 'components/notice';
 import HelpContactForm from 'me/help/help-contact-form';
 import LimitedChatAvailabilityNotice from 'me/help/contact-form-notice/limited-chat-availability';
+import LiveChatClosureNotice, {
+	easterHolidayName,
+} from 'me/help/contact-form-notice/live-chat-closure';
 import HelpContactConfirmation from 'me/help/help-contact-confirmation';
 import HeaderCake from 'components/header-cake';
 import wpcomLib from 'lib/wp';
@@ -553,6 +556,20 @@ class HelpContact extends React.Component {
 						<LimitedChatAvailabilityNotice
 							compact={ compact }
 							showAt="2020-03-27 00:00Z"
+							hideAt="2020-04-12 00:00Z"
+						/>
+
+						<LiveChatClosureNotice
+							compact={ compact }
+							holidayName={ easterHolidayName }
+							displayAt="2020-04-12 00:00Z"
+							closesAt="2020-04-12 06:00Z"
+							reopensAt="2020-04-13 06:00Z"
+						/>
+
+						<LimitedChatAvailabilityNotice
+							compact={ compact }
+							showAt="2020-04-13 06:00Z"
 							hideAt="2021-01-01 00:00Z"
 						/>
 					</>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Shows Easter closure notices in Live Chat and Quick Start.

#### Testing instructions

Go to http://calypso.localhost:3000/help/contact:
- The existing "Limited chat availability" notice should show
- Set your computer's clock to April 12 at 0:00 UTC — the "Live chat will be closed for Easter" notice should show
- Set your computer's clock to April 12 at 6:00 UTC — the "Live chat closed for Easter" notice should show
- Set your computer's clock to April 13 at 6:00 UTC — the "Limited chat availability" notice should be back up

Go to http://calypso.localhost:3000/me/concierge and pick a site:
- The "**Note**: Quick Start sessions will be closed for Easter..." notice should show
- Set your computer's clock to April 12 at 6:00 UTC — the "**Note**: Quick Start sessions are closed for Easter..." notice should show
- Set your computer's clock to April 13 at 6:00 UTC — the notices should be gone

Fixes 783-gh-hg 784-gh-hg
