### PR TITLE
My Home: update styling for Block-Editor card and add analytics

### DIFF
--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -27,3 +27,7 @@ render() {
 - `showText` - *optional* (bool) Whether or not to display the link text. Default `true`.
 - `showIcon` - *optional* (bool) Whether or not to display the "help-outline" Gridicon. Default `true`.
 - `iconSize` - *optional* (number) Gridicon size. Default `14`.
+- `tracksEvent` - *optional* (string) Tracks Analytics Event name
+- `tracksOptions` - *optional* (object) Tracks Analytics options
+- `statsGroup` - *optional* (string) Stat analytics group name
+- `statsName` - *optional* (string)  Stat analytics name

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -33,7 +33,7 @@ class InlineSupportLink extends Component {
 		text: PropTypes.string,
 		showIcon: PropTypes.bool,
 		iconSize: PropTypes.number,
-		trackEvent: PropTypes.string,
+		tracksEvent: PropTypes.string,
 		tracksOptions: PropTypes.object,
 		statsGroup: PropTypes.string,
 		statsName: PropTypes.string,

--- a/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
+++ b/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
@@ -23,11 +23,6 @@ const MasteringGutenberg = () => {
 
 	return (
 		<Card className="mastering-gutenberg">
-			{ ! isMobile() && (
-				<div className="mastering-gutenberg__illustration">
-					<img src="/calypso/images/illustrations/gutenberg-mini.svg" alt="" />
-				</div>
-			) }
 			<div>
 				<CardHeading>{ translate( 'Master the Block Editor' ) }</CardHeading>
 				<p className="mastering-gutenberg__text customer-home__card-subheader">
@@ -53,11 +48,14 @@ const MasteringGutenberg = () => {
 					supportPostId={ 145498 }
 					supportLink={ localizeUrl( 'https://support.wordpress.com/free-photo-library' ) }
 					showIcon={ false }
-					text={ translate(
-						'Add free beautiful copyright-free photos to create stunning designs'
-					) }
+					text={ translate( 'Add beautiful copyright-free photos' ) }
 				/>
 			</div>
+			{ ! isMobile() && (
+				<div className="mastering-gutenberg__illustration">
+					<img src="/calypso/images/illustrations/gutenberg-mini.svg" alt="" />
+				</div>
+			) }
 		</Card>
 	);
 };

--- a/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
+++ b/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
@@ -35,6 +35,7 @@ const MasteringGutenberg = () => {
 					supportLink={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/#blocks' ) }
 					showIcon={ false }
 					text={ translate( 'Customizing posts and pages with blocks' ) }
+					tracksEvent={ 'calypso_customer_home_customizing_with_blocks_support_page_view' }
 				/>
 				<InlineSupportLink
 					supportPostId={ 147594 }
@@ -43,12 +44,7 @@ const MasteringGutenberg = () => {
 					) }
 					showIcon={ false }
 					text={ translate( 'Adjusting settings of blocks' ) }
-				/>
-				<InlineSupportLink
-					supportPostId={ 145498 }
-					supportLink={ localizeUrl( 'https://support.wordpress.com/free-photo-library' ) }
-					showIcon={ false }
-					text={ translate( 'Add beautiful copyright-free photos' ) }
+					tracksEvent={ 'calypso_customer_home_adjust_blocks_support_page_view' }
 				/>
 			</div>
 			{ ! isMobile() && (

--- a/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
+++ b/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
@@ -49,6 +49,14 @@ const MasteringGutenberg = () => {
 					showIcon={ false }
 					text={ translate( 'Adjusting settings of blocks' ) }
 				/>
+				<InlineSupportLink
+					supportPostId={ 145498 }
+					supportLink={ localizeUrl( 'https://support.wordpress.com/free-photo-library' ) }
+					showIcon={ false }
+					text={ translate(
+						'Add free beautiful copyright-free photos to create stunning designs'
+					) }
+				/>
 			</div>
 		</Card>
 	);

--- a/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
+++ b/client/my-sites/customer-home/cards/education/mastering-gutenberg/index.jsx
@@ -35,7 +35,9 @@ const MasteringGutenberg = () => {
 					supportLink={ localizeUrl( 'https://wordpress.com/support/wordpress-editor/#blocks' ) }
 					showIcon={ false }
 					text={ translate( 'Customizing posts and pages with blocks' ) }
-					tracksEvent={ 'calypso_customer_home_customizing_with_blocks_support_page_view' }
+					tracksEvent="calypso_customer_home_customizing_with_blocks_support_page_view"
+					statsGroup="calypso_customer_home"
+					statsName="view_customizing_with_blocks_video"
 				/>
 				<InlineSupportLink
 					supportPostId={ 147594 }
@@ -45,6 +47,8 @@ const MasteringGutenberg = () => {
 					showIcon={ false }
 					text={ translate( 'Adjusting settings of blocks' ) }
 					tracksEvent={ 'calypso_customer_home_adjust_blocks_support_page_view' }
+					statsGroup="calypso_customer_home"
+					statsName="view_adjust_blocks_video"
 				/>
 			</div>
 			{ ! isMobile() && (

--- a/client/my-sites/customer-home/cards/education/mastering-gutenberg/style.scss
+++ b/client/my-sites/customer-home/cards/education/mastering-gutenberg/style.scss
@@ -3,10 +3,17 @@
 
 	.inline-support-link {
 		display: block;
-		margin-bottom: 2px;
+		margin: 0;
+		padding: 12px 0;
+		border-bottom: 1px solid var( --color-neutral-5 );
 	}
+
+	.inline-support-link:last-child {
+		border-bottom: none;
+	}
+
 	.mastering-gutenberg__illustration {
 		margin: auto;
-		margin-right: 16px;
+		margin-left: 16px;
 	}
 }

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -27,6 +27,7 @@ const Primary = ( { checklistMode, cards } ) => {
 	}
 	return (
 		<div className="primary">
+			<MasteringGutenberg />
 			{ cards &&
 				cards.map(
 					( card, index ) =>

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -27,7 +27,6 @@ const Primary = ( { checklistMode, cards } ) => {
 	}
 	return (
 		<div className="primary">
-			<MasteringGutenberg />
 			{ cards &&
 				cards.map(
 					( card, index ) =>


### PR DESCRIPTION
This PR updates:
*  Styling for "Master the Block Editor" to better match existing cards
* Adds some missing analytics events to the card
* Enhances the InlineSupportLink to accept tracks and stats analytics

- [x] Before landing drop the update in primary for `<MasteringGutenberg />`. This was added only for easier testing/reviewing.

| Before  | After |
| ------------- | ------------- |
|  <img width="722" alt="78721460-81644280-791f-11ea-9e82-0d510b209245" src="https://user-images.githubusercontent.com/1270189/79397773-c3027800-7f33-11ea-9ed6-d7bf8ed299d4.png"> | <img width="695" alt="Screen Shot 2020-04-15 at 4 12 41 PM" src="https://user-images.githubusercontent.com/1270189/79397906-29879600-7f34-11ea-896f-96f378763fbf.png"> |

| Open Article  |
| ------------- |
| <img width="1134" alt="Screen Shot 2020-04-15 at 4 02 15 PM" src="https://user-images.githubusercontent.com/1270189/79397800-d7df0b80-7f33-11ea-973a-3b6ba434cc8f.png"> |

### Testing Instructions
* Start the branch
* Visit http://calypso.localhost:3000 (My Home section) 
* In console type `localStorage.debug='calypso:analytics*'`
* Click on customizing post and pages. Verify that the support article opens in the appropriate area to display the right video. 
* Verify that the following analytics events fire
<img width="820" alt="Screen Shot 2020-04-15 at 3 56 52 PM" src="https://user-images.githubusercontent.com/1270189/79398023-79665d00-7f34-11ea-9df7-bbb72663b040.png">
* Click on Adjusting Settings of Blocks. Verify that the support article opens in the appropriate area to display the right video. 
* Verify that the following analytics events fire:
<img width="913" alt="Screen Shot 2020-04-15 at 3 57 10 PM" src="https://user-images.githubusercontent.com/1270189/79398079-94d16800-7f34-11ea-9e5e-03514f97d09a.png">

* Verify no regressions in InlineSupportLink
* For example try clicking on the podcast InlineSupportLink under Settings > Writing
* The Support article should appear as expected
<img width="1291" alt="Screen Shot 2020-04-15 at 4 01 24 PM" src="https://user-images.githubusercontent.com/1270189/79398140-bb8f9e80-7f34-11ea-9852-0df52a780196.png">
* Redux events fired by InlineSupportLink should look like the following:

| Open Article without Analytics  | Open Article With Analytics |
| ------------- | ------------- |
| <img width="472" alt="Screen Shot 2020-04-15 at 4 06 14 PM" src="https://user-images.githubusercontent.com/1270189/79397670-7b7bec00-7f33-11ea-81fe-dbc16d60efff.png"> | <img width="807" alt="Screen Shot 2020-04-15 at 4 06 32 PM" src="https://user-images.githubusercontent.com/1270189/79397694-89317180-7f33-11ea-97b0-0d7378f27cac.png"> |

