### PR TITLE
Enable auto-renew toggle in domain settings screen

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -31,6 +31,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/new-status-design/auto-renew": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/production.json
+++ b/config/production.json
@@ -30,6 +30,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/new-status-design/auto-renew": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -33,6 +33,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
 		"domains/new-status-design": true,
+		"domains/new-status-design/auto-renew": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We've been working on the auto-renew toggle for a while now and it is good enough to enable on production now

Here are all PRs related to the auto-renew toggle thus far:
* https://github.com/Automattic/wp-calypso/pull/40012
* https://github.com/Automattic/wp-calypso/pull/40514
* https://github.com/Automattic/wp-calypso/pull/40519
* https://github.com/Automattic/wp-calypso/pull/40522
* https://github.com/Automattic/wp-calypso/pull/40527
* https://github.com/Automattic/wp-calypso/pull/40660

#### Testing instructions

* Verify that on the stage/horizon/production environment there is auto-renew toggle in the domain settings screen
