### PR TITLE
Domains: Send correct CORRECT arguments when searching for subdomains

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -938,7 +938,7 @@ class RegisterDomainStep extends React.Component {
 			quantity: this.getFreeSubdomainSuggestionsQuantity(),
 			include_wordpressdotcom: true,
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
-			only_wordpressdotcom: true,
+			only_wordpressdotcom: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
 			vendor: 'dot',
 			vertical: this.props.vertical,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reverts the change from https://github.com/Automattic/wp-calypso/pull/40318
Along with D41668-code this should fix the issue mentioned in https://github.com/Automattic/wp-calypso/issues/40164#issuecomment-611714867

#### Testing instructions
Apply D41668-code to your sandbox and test this PR.
Go to https://wordpress.com/start/
Search for some queries.
You should always get WPCOM subdomain results, even with blacklisted terms like `wordpress`. Try, for example, `demo.wordpress`.