### PR TITLE
Customer Home: update card headings size and tags

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -150,15 +150,17 @@ export const QuickLinks = ( {
 	if ( ! isMobile() ) {
 		return (
 			<Card className="quick-links">
-				<CardHeading>{ translate( 'Quick Links' ) }</CardHeading>
+				<CardHeading tagName="h2" size={ 16 }>
+					{ translate( 'Quick links' ) }
+				</CardHeading>
 				{ quickLinks }
 			</Card>
 		);
 	}
 	return (
 		<FoldableCard
-			className="quick-links card-heading-21"
-			header={ translate( 'Quick Links' ) }
+			className="quick-links card-heading-16"
+			header={ translate( 'Quick links' ) }
 			expanded
 		>
 			{ quickLinks }

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -9,6 +9,7 @@
 }
 
 .quick-links.card {
+	padding-top: 16px;
 	padding-bottom: 0;
 
 	.card-heading {
@@ -20,6 +21,7 @@
 	.foldable-card {
 		@include breakpoint( '<480px' ) {
 			&__header {
+				font-weight: 500;
 				min-height: 0;
 				padding: 12px 16px;
 			}

--- a/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
+++ b/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
@@ -44,7 +44,9 @@ const FreePhotoLibrary = ( { openSupportArticleDialogAndTrack } ) => {
 					/>
 				</button>
 			) }
-			<CardHeading>{ translate( 'Over 40,000 Free Photos' ) }</CardHeading>
+			<CardHeading tagName="h2" size={ 16 }>
+				{ translate( 'Over 40,000 free photos' ) }
+			</CardHeading>
 			<p className="free-photo-library__text customer-home__card-subheader">
 				{ translate(
 					'The WordPress.com Free Photo Library integrates ' +

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -44,8 +44,10 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 		<Card className="go-mobile">
 			<div className={ classnames( 'go-mobile__row', { 'has-2-cols': showOnlyOneBadge } ) }>
 				<div className="go-mobile__title">
-					<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
-					<h6 className="go-mobile__subheader">{ translate( 'Make updates on the go' ) }</h6>
+					<CardHeading tagName="h2" size={ 16 }>
+						{ translate( 'Go mobile' ) }
+					</CardHeading>
+					<h6 className="go-mobile__subheader">{ translate( 'Make updates on the go.' ) }</h6>
 				</div>
 				<div className="go-mobile__app-badges">
 					{ showIosBadge && (

--- a/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
+++ b/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
@@ -29,9 +29,11 @@ export const GrowEarn = ( { siteSlug, expandToolsAndTrack } ) => {
 
 	return (
 		<Card className="grow-earn">
-			<CardHeading>{ translate( 'Grow & Earn' ) }</CardHeading>
+			<CardHeading tagName="h2" size={ 16 }>
+				{ translate( 'Grow & earn' ) }
+			</CardHeading>
 			<h6 className="grow-earn__card-subheader customer-home__card-subheader">
-				{ translate( 'Grow your audience and earn money' ) }
+				{ translate( 'Grow your audience and earn money.' ) }
 			</h6>
 			<VerticalNav>
 				<VerticalNavItem

--- a/client/my-sites/customer-home/cards/features/launch-site/index.jsx
+++ b/client/my-sites/customer-home/cards/features/launch-site/index.jsx
@@ -26,9 +26,11 @@ export const LaunchSite = ( { isPrimary, launchSiteAndTrack, siteId } ) => {
 
 	return (
 		<Card className="launch-site">
-			<CardHeading>{ translate( 'Site Privacy' ) }</CardHeading>
+			<CardHeading tagName="h2" size={ 16 }>
+				{ translate( 'Site privacy' ) }
+			</CardHeading>
 			<h6 className="customer-home__card-subheader launch-site__card-subheader">
-				{ translate( 'Your site is private' ) }
+				{ translate( 'Your site is private.' ) }
 			</h6>
 			<p>
 				{ translate(

--- a/client/my-sites/customer-home/cards/features/launch-site/style.scss
+++ b/client/my-sites/customer-home/cards/features/launch-site/style.scss
@@ -1,7 +1,5 @@
 .launch-site {
 	.button {
-		font-size: 18px;
 		width: 100%;
-		height: 50px;
 	}
 }

--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -63,7 +63,7 @@ export const Stats = ( {
 						) }
 					</>
 				) }
-				<CardHeading>
+				<CardHeading tagName="h2" size={ 16 }>
 					{ config.isEnabled( 'home/experimental-layout' )
 						? translate( 'Page views' )
 						: translate( 'Stats at a glance' ) }

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -1,13 +1,12 @@
 .stats__subheader {
 	color: var( --color-text-subtle );
 	font-size: 0.85rem;
-	margin: -0.5rem 0 1rem;
 }
 
 .stats__data {
 	display: flex;
 	justify-content: center;
-	margin-bottom: 1rem;
+	margin: 16px 0;
 
 	@include breakpoint( '1040px-1280px' ) {
 		flex-direction: column;

--- a/client/my-sites/customer-home/cards/features/support/index.jsx
+++ b/client/my-sites/customer-home/cards/features/support/index.jsx
@@ -23,22 +23,18 @@ import { getSelectedEditor } from 'state/selectors/get-selected-editor';
  */
 import './style.scss';
 
-/**
- * Image dependencies
- */
-import happinessIllustration from 'assets/images/customer-home/happiness.png';
-
 const Support = ( { trackContactAction, trackDocsAction } ) => {
 	const translate = useTranslate();
 
 	return (
 		<Card className="support">
-			<CardHeading>{ translate( 'Support' ) }</CardHeading>
+			<CardHeading tagName="h2" size={ 16 }>
+				{ translate( 'Support' ) }
+			</CardHeading>
 			<h6 className="support__header customer-home__card-subheader">
-				{ translate( 'Get all the help you need' ) }
+				{ translate( 'Get all the help you need.' ) }
 			</h6>
 			<div className="support__content">
-				<img src={ happinessIllustration } alt={ translate( 'Support' ) } />
 				<VerticalNav>
 					<VerticalNavItem
 						path={ localizeUrl( 'https://wordpress.com/support' ) }

--- a/client/my-sites/customer-home/cards/features/support/style.scss
+++ b/client/my-sites/customer-home/cards/features/support/style.scss
@@ -1,22 +1,3 @@
-.customer-home__layout .support .support__content {
-	display: flex;
-	justify-content: space-between;
-
-	img {
-		margin: 0 7% 0 0;
-		width: 137px;
-		height: 119px;
-
-		@include breakpoint( '>960px' ) {
-			display: none;
-		}
-	}
-
-	.vertical-nav {
-		width: 60%;
-
-		@include breakpoint( '>960px' ) {
-			width: 100%;
-		}
-	}
+.customer-home__layout .support {
+	padding-bottom: 12px;
 }

--- a/client/my-sites/customer-home/cards/tasks/checklist-site-setup/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/checklist-site-setup/index.jsx
@@ -22,7 +22,9 @@ const ChecklistSiteSetup = ( { checklistMode } ) => {
 	return (
 		<div className="checklist-site-setup">
 			<Card className="checklist-site-setup__heading">
-				<CardHeading>{ translate( 'Site Setup List' ) }</CardHeading>
+				<CardHeading tagName="h2" size={ 16 }>
+					{ translate( 'Site setup list' ) }
+				</CardHeading>
 			</Card>
 			<WpcomChecklist displayMode={ checklistMode } />
 		</div>

--- a/client/my-sites/customer-home/cards/tasks/checklist-site-setup/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/checklist-site-setup/style.scss
@@ -1,6 +1,10 @@
 .checklist-site-setup {
 	.checklist-site-setup__heading {
-		margin-bottom: -16px;
+		margin-bottom: 0;
+
+		.card-heading {
+			margin-bottom: 0;
+		}
 	}
 
 	.checklist__tasks {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -59,7 +59,7 @@
 .customer-home__card-subheader {
 	color: var( --color-text-subtle );
 	font-size: 0.85rem;
-	margin: -0.5rem 0 1rem;
+	margin-bottom: 16px;
 }
 
 .customer-home__layout {
@@ -73,7 +73,9 @@
 }
 .customer-home__layout-col {
 	.card-heading {
-		margin-top: -8px;
+		font-weight: 500;
+		margin-top: 0;
+		margin-bottom: 4px;
 	}
 
 	a:last-child .vertical-nav-item {
@@ -86,10 +88,6 @@
 	}
 }
 .customer-home__layout-col-right {
-	.vertical-nav {
-		margin-top: 0;
-	}
-
 	.vertical-nav-item {
 		border-bottom: 1px solid var( --color-neutral-5 );
 		box-shadow: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the card headings on Customer Home to be a smaller size. They were all fighting with the `My Home` page heading, especially on mobile. This also helps us move towards the explorations in #40734.
* Update the card headings to use a more semantic `<h2>` instead of `<h1>` all over the place.
* General cleanup of some other styles.
* Update headings to use title case and adding periods to subheadings per a recent decision.

@Automattic/dotcom-manage-design can you gut check me on the sizes here?

Before | After
------------ | -------------
<img width="1167" alt="Screen Shot 2020-04-09 at 4 02 48 PM" src="https://user-images.githubusercontent.com/448298/78938966-3bbf8b00-7a81-11ea-924c-40682f1dd84c.png"> | <img width="1166" alt="Screen Shot 2020-04-09 at 4 23 36 PM" src="https://user-images.githubusercontent.com/448298/78938951-319d8c80-7a81-11ea-97c2-8a5fa8ec5273.png">
<img width="375" alt="Screen Shot 2020-04-09 at 4 45 43 PM" src="https://user-images.githubusercontent.com/448298/78939158-9a850480-7a81-11ea-96f5-18371363bc10.png"> | <img width="373" alt="Screen Shot 2020-04-09 at 4 21 56 PM" src="https://user-images.githubusercontent.com/448298/78939059-6d385680-7a81-11ea-8001-41bca5a5ed1e.png">
<img width="375" alt="Screen Shot 2020-04-09 at 4 47 50 PM" src="https://user-images.githubusercontent.com/448298/78939301-e041cd00-7a81-11ea-8fb3-f51f4b05f50d.png"> | <img width="374" alt="Screen Shot 2020-04-09 at 4 22 07 PM" src="https://user-images.githubusercontent.com/448298/78939077-745f6480-7a81-11ea-9317-f67ac24c9520.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch or use the calypso.live link
* Visit My Home to view updated headings
* Test with an established site with no checklist
* Test with a new site with checklist
