### PR TITLE
Fix switching sites from Jetpack Cloud backups download, restore, or detail

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -511,6 +511,11 @@ const navigateToSite = ( siteId, { allSitesPath, allSitesSingleUser, siteBasePat
 			}
 		}
 
+		// Jetpack Cloud: default to /backups/ when in the details of a particular backup
+		if ( path.match( /^\/backups\/.*\/(download|restore|detail)/ ) ) {
+			path = '/backups';
+		}
+
 		return path;
 	}
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add special handling for the backups download, restore, and detail paths so switching sites sets the path back to `/backups`

#### Testing instructions

1. Navigate to a backup download page( `/backups/:site/download/:rewindId` )
2. Switch to a different site
3. Verify you are taken back to `/backups/:newSite`
4. repeat steps 1-3 for restore and detail
