### PR TITLE
Gutenboarding: Auto-focus search input when domain picker is open.

### DIFF
--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -5,14 +5,14 @@ import React from 'react';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 
-interface CloseButtonProps {
+interface CloseButtonProps extends Button.ButtonProps {
 	onClose: () => void;
 }
 
-const CloseButton = ( { onClose }: CloseButtonProps ) => {
+const CloseButton = ( { onClose, ...buttonProps }: CloseButtonProps ) => {
 	const { __ } = useI18n();
 	return (
-		<Button onClick={ onClose } label={ __( 'Close dialog' ) }>
+		<Button onClick={ onClose } label={ __( 'Close dialog' ) } { ...buttonProps }>
 			<svg
 				width="12"
 				height="12"

--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -20,7 +20,7 @@ const CloseButton: React.FunctionComponent< CloseButtonProps > = ( { onClose, ..
 				fill="none"
 				xmlns="http://www.w3.org/2000/svg"
 			>
-				<path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" strokeWidth="1.5" />
+				<Path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" strokeWidth="1.5" />
 			</SVG>
 		</Button>
 	);

--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Button } from '@wordpress/components';
+import { SVG, Button } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 
 interface CloseButtonProps extends Button.ButtonProps {
@@ -13,7 +13,7 @@ const CloseButton: React.FunctionComponent< CloseButtonProps > = ( { onClose, ..
 	const { __ } = useI18n();
 	return (
 		<Button onClick={ onClose } label={ __( 'Close dialog' ) } { ...buttonProps }>
-			<svg
+			<SVG
 				width="12"
 				height="12"
 				viewBox="0 0 16 16"
@@ -21,7 +21,7 @@ const CloseButton: React.FunctionComponent< CloseButtonProps > = ( { onClose, ..
 				xmlns="http://www.w3.org/2000/svg"
 			>
 				<path d="M1.40456 1L15 15M1 15L14.5954 1" stroke="#1E1E1E" strokeWidth="1.5" />
-			</svg>
+			</SVG>
 		</Button>
 	);
 };

--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { SVG, Button } from '@wordpress/components';
+import { Button, Path, SVG } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 
 interface CloseButtonProps extends Button.ButtonProps {

--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -9,7 +9,7 @@ interface CloseButtonProps extends Button.ButtonProps {
 	onClose: () => void;
 }
 
-const CloseButton = ( { onClose, ...buttonProps }: CloseButtonProps ) => {
+const CloseButton: React.FunctionComponent< CloseButtonProps > = ( { onClose, ...buttonProps } ) => {
 	const { __ } = useI18n();
 	return (
 		<Button onClick={ onClose } label={ __( 'Close dialog' ) } { ...buttonProps }>

--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -9,7 +9,10 @@ interface CloseButtonProps extends Button.ButtonProps {
 	onClose: () => void;
 }
 
-const CloseButton: React.FunctionComponent< CloseButtonProps > = ( { onClose, ...buttonProps } ) => {
+const CloseButton: React.FunctionComponent< CloseButtonProps > = ( {
+	onClose,
+	...buttonProps
+} ) => {
 	const { __ } = useI18n();
 	return (
 		<Button onClick={ onClose } label={ __( 'Close dialog' ) } { ...buttonProps }>

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -61,9 +61,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<div className="domain-picker-button__popover-container">
 					<Popover
 						className="domain-picker-button__popover"
-						focusOnMount={ false }
 						noArrow
-						onClickOutside={ handleClose } // TODO: investigate why clicking outside is ignored
 						onClose={ handleClose }
 						onFocusOutside={ handleClose }
 						position={ 'bottom center' }

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -93,7 +93,13 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 							<div className="domain-picker__header-title">{ __( 'Choose a domain' ) }</div>
 							<p>{ __( 'Free for the first year with any paid plan' ) }</p>
 						</div>
-						<CloseButton onClose={ () => onClose() } />
+						<CloseButton
+							onClose={ onClose }
+							// removing from tab flow as discussed in p1586489720342200-slack-gutenboarding
+							// @wordpress/popover finds and focuses on the first found focusable element which will be TextControl
+							// footer-button serve the same purpose and also ESC key in closing the popover
+							tabIndex={ -1 }
+						/>
 					</div>
 					<div className="domain-picker__search">
 						<SearchIcon />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Auto-focus search input when domain picker is open.
* Also fixes clicking outside of domain picker not closing the domain picker.

Both fixes are in this PR because they are related to each other. See: https://github.com/Automattic/wp-calypso/issues/40890#issuecomment-611579912

#### Testing instructions

1. Open `/new`.
2. Click on domain picker.
3. The search input should be automatically focused.
4. Clicking outside of the domain picker should close the domain picker.

#### Caveats
Tabbing flow might be weird, because after tabbing out from search input focuses on close button instead of the list of domains. When testing this, I also noticed the list of domain options are not tabbable, a11y is not a priority right now so we'll have another round of PRs for accessibility fixes when its time to look into that.

Fixes #40395 #40890
