### PR TITLE
Tracking: enrich recorded event with selected_block

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -4,6 +4,11 @@
 import { isObjectLike, isUndefined, omit } from 'lodash';
 import debug from 'debug';
 
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+
 const tracksDebug = debug( 'wpcom-block-editor:analytics:tracks' );
 
 // In case Tracks hasn't loaded.
@@ -25,6 +30,12 @@ export default ( eventName, eventProperties ) => {
 		site_type: window._currentSiteType,
 		user_locale: window._currentUserLocale,
 	};
+
+	// Custom Properties: Populate with selected_block if it's the case.
+	const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
+	if ( selectedBlock ) {
+		customProperties.selected_block = selectedBlock.name;
+	}
 
 	eventProperties = eventProperties || {};
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -16,10 +16,15 @@ if ( typeof window !== 'undefined' ) {
 // This means we don't have any extra props like user
 
 export default ( eventName, eventProperties ) => {
-	// Required by Tracks when added manually
-	const blog_id = window._currentSiteId;
-	const site_type = window._currentSiteType;
-	const user_locale = window._currentUserLocale;
+	/*
+	 * Custom Properties.
+	 * Required by Tracks when added manually.
+	 */
+	const customProperties = {
+		blog_id: window._currentSiteId,
+		site_type: window._currentSiteType,
+		user_locale: window._currentUserLocale,
+	};
 
 	eventProperties = eventProperties || {};
 
@@ -50,7 +55,7 @@ export default ( eventName, eventProperties ) => {
 	eventProperties = omit( eventProperties, isUndefined );
 
 	// Populate custom properties.
-	eventProperties = { ...eventProperties, blog_id, site_type, user_locale };
+	eventProperties = { ...eventProperties, ...customProperties };
 
 	tracksDebug( 'Recording event "%s" with actual props %o', eventName, eventProperties );
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -1,13 +1,9 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
 import { isObjectLike, isUndefined, omit } from 'lodash';
 import debug from 'debug';
-
-/**
- * WordPress dependencies
- */
-import { select } from '@wordpress/data';
 
 const tracksDebug = debug( 'wpcom-block-editor:analytics:tracks' );
 
@@ -30,12 +26,6 @@ export default ( eventName, eventProperties ) => {
 		site_type: window._currentSiteType,
 		user_locale: window._currentUserLocale,
 	};
-
-	// Custom Properties: Populate with selected_block if it's the case.
-	const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
-	if ( selectedBlock ) {
-		customProperties.selected_block = selectedBlock.name;
-	}
 
 	eventProperties = eventProperties || {};
 
@@ -68,7 +58,7 @@ export default ( eventName, eventProperties ) => {
 	// Populate custom properties.
 	eventProperties = { ...eventProperties, ...customProperties };
 
-	tracksDebug( 'Recording event "%s" with actual props %o', eventName, eventProperties );
+	tracksDebug( 'Recording event %o with actual props %o', eventName, eventProperties );
 
 	window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-picker-search-term-handler.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-picker-search-term-handler.js
@@ -7,6 +7,11 @@ import { debounce } from 'lodash';
 import debug from 'debug';
 
 /**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import tracksRecordEvent from './track-record-event';
@@ -17,6 +22,7 @@ let lastSearchTerm;
 const trackSearchTerm = ( event, target ) => {
 	const key = event.key || event.keyCode;
 	const search_term = ( target.value || '' ).trim().toLowerCase();
+
 	if ( lastSearchTerm === search_term && 'Enter' !== key ) {
 		return tracksDebug( 'Same term: %o, type %o key. Skip.', search_term, key );
 	}
@@ -26,7 +32,20 @@ const trackSearchTerm = ( event, target ) => {
 		return;
 	}
 
-	tracksRecordEvent( 'wpcom_block_picker_search_term', { search_term } );
+	const eventProperties = {
+		search_term,
+	};
+
+	/*
+	 * Populate event properties with `selected_block`
+	 * if there is a selected block in the editor.
+	 */
+	const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
+	if ( selectedBlock ) {
+		eventProperties.selected_block = selectedBlock.name;
+	}
+
+	tracksRecordEvent( 'wpcom_block_picker_search_term', { ...eventProperties } );
 
 	// Create a separate event for search with no results to make it easier to filter by them
 	const hasResults = document.querySelectorAll( '.block-editor-inserter__no-results' ).length === 0;
@@ -34,7 +53,7 @@ const trackSearchTerm = ( event, target ) => {
 		return;
 	}
 
-	tracksRecordEvent( 'wpcom_block_picker_no_results', { search_term } );
+	tracksRecordEvent( 'wpcom_block_picker_no_results', { ...eventProperties } );
 };
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR populates the recorded event with the `selected_block` property, which contains the block name if there is a selected block in the editor.

#### Testing instructions

1) Update your testing site with these changes (SB)
2) In your testing site, open the client dev console and setup the debug

```
> localStorage.setItem( 'debug', 'wpcom-block-editor*' )
```

A hard refresh is needed.

3) Open the Blocks List Inserter
4) Start to type until getting the no-results message
5) Look at the debug logs.
6) Inspect the `wpcom_block_picker_no_results` event:

![image](https://user-images.githubusercontent.com/77539/78982219-0dc95d80-7af8-11ea-8742-2ca4d70362c3.png)

2') Repeat the same steps but before `(3)` selects a block
7) Confirm that there is a `selected_block` property among the other event properties.

<img width="793" alt="Screen Shot 2020-04-10 at 6 54 20 AM" src="https://user-images.githubusercontent.com/77539/78982264-26397800-7af8-11ea-87ee-d289210363aa.png">

8) Confirm that the `selected_block` property only appears when the user searches the block using the inserter menu.

Fixes https://github.com/Automattic/wp-calypso/issues/41010
