### PR TITLE
Tracking: avoiding record duplicated no-results events when typing

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-picker-search-term-handler.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-picker-search-term-handler.js
@@ -11,16 +11,16 @@ import debug from 'debug';
  */
 import tracksRecordEvent from './track-record-event';
 
-const tracksDebug = debug( 'wpcom-block-editor:analytics:tracks' );
+const tracksDebug = debug( 'wpcom-block-editor:analytics:tracks:block-search' );
 
-let previewTerm;
+let lastSearchTerm;
 const trackSearchTerm = ( event, target ) => {
 	const key = event.key || event.keyCode;
 	const search_term = ( target.value || '' ).trim().toLowerCase();
-	if ( previewTerm === search_term && 'Enter' !== key ) {
+	if ( lastSearchTerm === search_term && 'Enter' !== key ) {
 		return tracksDebug( 'Same term: %o, type %o key. Skip.', search_term, key );
 	}
-	previewTerm = search_term;
+	lastSearchTerm = search_term;
 
 	if ( search_term.length < 3 ) {
 		return;

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-picker-search-term-handler.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-picker-search-term-handler.js
@@ -4,14 +4,23 @@
  * External dependencies
  */
 import { debounce } from 'lodash';
+import debug from 'debug';
 
 /**
  * Internal dependencies
  */
 import tracksRecordEvent from './track-record-event';
 
+const tracksDebug = debug( 'wpcom-block-editor:analytics:tracks' );
+
+let previewTerm;
 const trackSearchTerm = ( event, target ) => {
+	const key = event.key || event.keyCode;
 	const search_term = ( target.value || '' ).trim().toLowerCase();
+	if ( previewTerm === search_term && 'Enter' !== key ) {
+		return tracksDebug( 'Same term: %o, type %o key. Skip.', search_term, key );
+	}
+	previewTerm = search_term;
 
 	if ( search_term.length < 3 ) {
 		return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR avoids recording the same event simply typing special keys such as arrows keys, F1, F2, ... SHIRT, etc, in the Blocks List inserter with the only exception the `ENTER` key.

#### Testing instructions

1) Update your testing site with these changes (SB)
2) In your testing site, open the client dev console and set up the debug

```
> localStorage.setItem( 'debug', 'wpcom-block-editor*' )
```

A hard refresh is needed.

3) Open the Blocks List Inserter
4) Start to type until getting the no-results message
5) Look at the debug logs.
6) type special keys such as arrows key, `SHIFT`, `OPTION`, etc
7) Confirm that it avoids recording the event:


![image](https://user-images.githubusercontent.com/77539/78985085-44a27200-7afe-11ea-962b-362c3a2d446f.png)

8) Confirm the exception when pressing the `ENTER` key.

<img width="773" alt="Screen Shot 2020-04-10 at 7 39 15 AM" src="https://user-images.githubusercontent.com/77539/78985198-88957700-7afe-11ea-981f-eba7bb7e96ac.png">


https://github.com/Automattic/wp-calypso/issues/40978

D41759-code