### PR TITLE
[e2e] Close welcome guide

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { By, until } from 'selenium-webdriver';
+import { By, Key, until } from 'selenium-webdriver';
 import { kebabCase } from 'lodash';
 
 /**
@@ -447,13 +447,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async dismissEditorWelcomeModal() {
-		if (
-			await driverHelper.isElementPresent( this.driver, By.css( '.edit-post-welcome-guide' ) )
-		) {
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( '.edit-post-welcome-guide .components-modal__header .components-button' )
-			);
+		const welcomeModal = By.css( '.components-guide__container' );
+		if ( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, welcomeModal ) ) {
+			await this.driver.findElement( By.css( '.components-guide' ) ).sendKeys( Key.ESCAPE );
 		}
 	}
 }

--- a/test/e2e/lib/pages/frontend/comments-area-component.js
+++ b/test/e2e/lib/pages/frontend/comments-area-component.js
@@ -22,6 +22,7 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 		const submitButton = By.css( ".form-submit[style='display: block;'] #comment-submit" );
 		const commentContent = By.xpath( `//div[@class='comment-content']/p[.='${ comment }']` );
 
+		await driverHelper.scrollIntoView( this.driver, commentForm );
 		await driverHelper.clickWhenClickable( this.driver, commentForm );
 		await driverHelper.scrollIntoView( this.driver, commentForm, 'end' );
 		await this.switchToFrameIfJetpack();

--- a/test/e2e/lib/pages/frontend/comments-area-component.js
+++ b/test/e2e/lib/pages/frontend/comments-area-component.js
@@ -22,7 +22,7 @@ export default class CommentsAreaComponent extends AsyncBaseContainer {
 		const submitButton = By.css( ".form-submit[style='display: block;'] #comment-submit" );
 		const commentContent = By.xpath( `//div[@class='comment-content']/p[.='${ comment }']` );
 
-		await driverHelper.scrollIntoView( this.driver, commentForm );
+		await driverHelper.scrollIntoView( this.driver, commentForm, 'end' );
 		await driverHelper.clickWhenClickable( this.driver, commentForm );
 		await driverHelper.scrollIntoView( this.driver, commentForm, 'end' );
 		await this.switchToFrameIfJetpack();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prevent [failures](https://circleci.com/gh/Automattic/wp-calypso/679432#tests/containers/0) that are happening on master lately. 
1. Closing Welcome modal - test was trying to click on _Close_ button which doesn't exist anymore. Instead, pressing Esc button will dismiss modal. 
2. Posting comment and replies - Comment form in some cases was out of the screen, and test was unable to type text in it. Scroll to the text area and make sure it's visible. 


#### Testing instructions

Make sure that tests are 🍏 
