### PR TITLE
Show the destination in the domains navigation item for name servers and DNS

### DIFF
--- a/client/lib/site/utils.js
+++ b/client/lib/site/utils.js
@@ -144,3 +144,17 @@ export function hasCustomDomain( site ) {
 export function isModuleActive( site, moduleId ) {
 	return site.options.active_modules && site.options.active_modules.indexOf( moduleId ) > -1;
 }
+
+/**
+ * Returns the WordPress.com URL of a site (simple or Atomic)
+ *
+ * @param {object} site Site object
+ * @returns {?string} WordPress.com URL
+ */
+export function getUnmappedUrl( site ) {
+	if ( ! site || ! site.options ) {
+		return null;
+	}
+
+	return site.options.main_network_site || site.options.unmapped_url;
+}

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -107,7 +107,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		let description;
 
 		if ( hasWpcomNameservers && pointsToWpcom && isPrimary ) {
-			description = translate( 'Destination: Primary domain for %(wpcomUrl)s', {
+			description = translate( 'Destination: primary domain for %(wpcomUrl)s', {
 				args: {
 					wpcomUrl,
 				},

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -102,17 +102,17 @@ class DomainManagementNavigationEnhanced extends React.Component {
 		}
 
 		const { wpcom_url: wpcomUrl } = selectedSite;
-		const { hasWpcomNameservers, pointsToWpcom, isPrimary } = domain;
+		const { pointsToWpcom, isPrimary } = domain;
 
 		let description;
 
-		if ( hasWpcomNameservers && pointsToWpcom && isPrimary ) {
+		if ( pointsToWpcom && isPrimary ) {
 			description = translate( 'Destination: primary domain for %(wpcomUrl)s', {
 				args: {
 					wpcomUrl,
 				},
 			} );
-		} else if ( hasWpcomNameservers && pointsToWpcom && ! isPrimary ) {
+		} else if ( pointsToWpcom && ! isPrimary ) {
 			description = translate( 'Destination: %(wpcomUrl)s', {
 				args: {
 					wpcomUrl,

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -28,6 +28,7 @@ import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
 import { isCancelable } from 'lib/purchases';
 import { cancelPurchase } from 'me/purchases/paths';
 import RemovePurchase from 'me/purchases/remove-purchase';
+import { withoutHttp } from 'lib/url';
 
 import './style.scss';
 
@@ -101,13 +102,32 @@ class DomainManagementNavigationEnhanced extends React.Component {
 			return null;
 		}
 
-		// NOTE: remember to add translate to the description string once you start working on it
+		const { name, URL } = selectedSite;
+
+		const { pointsToWpcom } = domain;
+
+		let destination;
+
+		if ( pointsToWpcom ) {
+			destination = name || withoutHttp( URL );
+		} else {
+			destination = translate( 'external', {
+				comment: 'Displayed when the domain is not pointed to WordPress.com',
+			} );
+		}
+
+		const description = translate( 'Destination: %(destination)s', {
+			args: {
+				destination,
+			},
+		} );
+
 		return (
 			<DomainManagementNavigationItem
 				path={ domainManagementNameServers( selectedSite.slug, domain.name ) }
 				materialIcon="language"
 				text={ translate( 'Change your name servers & DNS records' ) }
-				description={ 'Destination: somewhere' }
+				description={ description }
 			/>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -28,7 +28,6 @@ import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
 import { isCancelable } from 'lib/purchases';
 import { cancelPurchase } from 'me/purchases/paths';
 import RemovePurchase from 'me/purchases/remove-purchase';
-import { withoutHttp } from 'lib/url';
 
 import './style.scss';
 
@@ -102,25 +101,26 @@ class DomainManagementNavigationEnhanced extends React.Component {
 			return null;
 		}
 
-		const { name, URL } = selectedSite;
+		const { wpcom_url: wpcomUrl } = selectedSite;
+		const { hasWpcomNameservers, pointsToWpcom, isPrimary } = domain;
 
-		const { pointsToWpcom } = domain;
+		let description;
 
-		let destination;
-
-		if ( pointsToWpcom ) {
-			destination = name || withoutHttp( URL );
-		} else {
-			destination = translate( 'external', {
-				comment: 'Displayed when the domain is not pointed to WordPress.com',
+		if ( hasWpcomNameservers && pointsToWpcom && isPrimary ) {
+			description = translate( 'Destination: Primary domain for %(wpcomUrl)s', {
+				args: {
+					wpcomUrl,
+				},
 			} );
+		} else if ( hasWpcomNameservers && pointsToWpcom && ! isPrimary ) {
+			description = translate( 'Destination: %(wpcomUrl)s', {
+				args: {
+					wpcomUrl,
+				},
+			} );
+		} else {
+			description = translate( 'Destination: external to WordPress.com' );
 		}
-
-		const description = translate( 'Destination: %(destination)s', {
-			args: {
-				destination,
-			},
-		} );
 
 		return (
 			<DomainManagementNavigationItem

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -27,6 +27,8 @@ import { type as domainTypes, transferStatus } from 'lib/domains/constants';
 import { recordTracksEvent, recordGoogleEvent } from 'state/analytics/actions';
 import { isCancelable } from 'lib/purchases';
 import { cancelPurchase } from 'me/purchases/paths';
+import { getUnmappedUrl } from 'lib/site/utils';
+import { withoutHttp } from 'lib/url';
 import RemovePurchase from 'me/purchases/remove-purchase';
 
 import './style.scss';
@@ -101,7 +103,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 			return null;
 		}
 
-		const { wpcom_url: wpcomUrl } = selectedSite;
+		const wpcomUrl = withoutHttp( getUnmappedUrl( selectedSite ) );
 		const { pointsToWpcom, isPrimary } = domain;
 
 		let description;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show the destination of a domain - does it point to WordPress.com site or is external.

It looks like this:

<img width="743" alt="Screenshot 2020-04-13 at 22 27 21" src="https://user-images.githubusercontent.com/1355045/79153796-1c08c980-7dd7-11ea-85b7-b5a954a5eb74.png">
<img width="740" alt="Screenshot 2020-04-13 at 22 27 52" src="https://user-images.githubusercontent.com/1355045/79153799-1c08c980-7dd7-11ea-9586-038f514d6d6a.png">
<img width="737" alt="Screenshot 2020-04-13 at 22 26 05" src="https://user-images.githubusercontent.com/1355045/79153794-1ad79c80-7dd7-11ea-9d4a-d7d8162244d3.png">


#### Testing instructions

* Open the new domain section and check the "Change your name servers and DNS records" menu for domains with/without our name servers
