### PR TITLE
Tracking: Register blocks search results from Autocompleter

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
+
 /**
  * Internal dependencies
  */

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -7,6 +7,7 @@ import debugFactory from 'debug';
  */
 import wpcomBlockPickerSearchTerm from './wpcom-block-picker-search-term-handler';
 import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
+import wpcomAutocompleteBlockSearchTerm from './wpcom-autocomplete-block-search-term';
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
@@ -17,7 +18,11 @@ const debug = debugFactory( 'wpcom-block-editor:tracking' );
  *
  * @type {Array}
  */
-const EVENTS_MAPPING = [ wpcomBlockEditorCloseClick(), wpcomBlockPickerSearchTerm() ];
+const EVENTS_MAPPING = [
+	wpcomBlockEditorCloseClick(),
+	wpcomBlockPickerSearchTerm(),
+	wpcomAutocompleteBlockSearchTerm(),
+];
 
 /**
  * Checks the event for a selector which matches

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -25,10 +25,14 @@ const EVENTS_MAPPING = [ wpcomBlockEditorCloseClick(), wpcomBlockPickerSearchTer
  * bubbling.
  *
  * @param  {DOMEvent} event          the DOM event
- * @param  {string} targetSelector the CSS selector for the target element
+ * @param  {string|Function} targetSelector the CSS selector for the target element
  * @returns {Node}                the target element if found
  */
 const getMatchingEventTarget = ( event, targetSelector ) => {
+	if ( typeof targetSelector === 'function' ) {
+		return targetSelector( event );
+	}
+
 	return event.target.matches( targetSelector )
 		? event.target
 		: event.target.closest( targetSelector );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -8,7 +8,7 @@ import debugFactory from 'debug';
  */
 import wpcomBlockPickerSearchTerm from './wpcom-block-picker-search-term-handler';
 import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
-import wpcomAutocompleteBlockSearchTerm from './wpcom-autocomplete-block-search-term';
+import wpcomInserterInlineSearchTerm from './wpcom-inserter-inline-search-term';
 
 // Debugger.
 const debug = debugFactory( 'wpcom-block-editor:tracking' );
@@ -22,7 +22,7 @@ const debug = debugFactory( 'wpcom-block-editor:tracking' );
 const EVENTS_MAPPING = [
 	wpcomBlockEditorCloseClick(),
 	wpcomBlockPickerSearchTerm(),
-	wpcomAutocompleteBlockSearchTerm(),
+	wpcomInserterInlineSearchTerm(),
 ];
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -16,19 +16,19 @@ import { select } from '@wordpress/data';
 import tracksRecordEvent from './track-record-event';
 
 const trackAutocompleteTerm = () => {
-	const content = get( select( 'core/block-editor' ).getSelectedBlock(), [
+	const search_term = get( select( 'core/block-editor' ).getSelectedBlock(), [
 		'attributes',
-		'content',
+		'search_term',
 	] );
 
-	if ( ! content ) {
+	if ( ! search_term ) {
 		return;
 	}
 
-	const context = 'autocompleter_block';
+	const context = 'autocomplete_block';
 
 	tracksRecordEvent( 'wpcom_block_picker_search_term', {
-		search_term: content,
+		search_term,
 		context,
 	} );
 
@@ -39,7 +39,7 @@ const trackAutocompleteTerm = () => {
 	}
 
 	tracksRecordEvent( 'wpcom_block_picker_no_results', {
-		search_term: content,
+		search_term,
 		context,
 	} );
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -21,7 +21,7 @@ const trackAutocompleteBlockTerm = () => {
 		'content',
 	] );
 
-	if ( ! search_term ) {
+	if ( search_term.length < 3 ) {
 		return;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -15,7 +15,7 @@ import { select } from '@wordpress/data';
  */
 import tracksRecordEvent from './track-record-event';
 
-const trackAutocompleteTerm = () => {
+const trackAutocompleteBlockTerm = () => {
 	const search_term = get( select( 'core/block-editor' ).getSelectedBlock(), [
 		'attributes',
 		'content',
@@ -32,7 +32,7 @@ const trackAutocompleteTerm = () => {
 		context,
 	} );
 
-	// Determine if there are results inspecting the DOM Tree.
+	// Check if there are results, inspecting the DOM Tree.
 	const hasResults = !! document.querySelectorAll( '.components-autocomplete__popover' ).length;
 	if ( hasResults ) {
 		return;
@@ -108,5 +108,5 @@ function selectorHandler() {
 export default () => ( {
 	selector: selectorHandler,
 	type: 'keyup',
-	handler: debounce( trackAutocompleteTerm, 500 ),
+	handler: debounce( trackAutocompleteBlockTerm, 500 ),
 } );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -25,9 +25,11 @@ const trackAutocompleteTerm = () => {
 		return;
 	}
 
+	const context = 'autocompleter_block';
+
 	tracksRecordEvent( 'wpcom_block_picker_search_term', {
 		search_term: content,
-		context: 'autocompleter',
+		context,
 	} );
 
 	// Determine if there are results inspecting the DOM Tree.
@@ -38,7 +40,7 @@ const trackAutocompleteTerm = () => {
 
 	tracksRecordEvent( 'wpcom_block_picker_no_results', {
 		search_term: content,
-		context: 'autocompleter',
+		context,
 	} );
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -1,0 +1,110 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+/**
+ * External dependencies
+ */
+import { debounce, get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+const trackAutocompleteTerm = () => {
+	const content = get( select( 'core/block-editor' ).getSelectedBlock(), [
+		'attributes',
+		'content',
+	] );
+
+	if ( ! content ) {
+		return;
+	}
+
+	tracksRecordEvent( 'wpcom_block_picker_search_term', {
+		search_term: content,
+		context: 'autocompleter',
+	} );
+
+	// Determine if there are results inspecting the DOM Tree.
+	const hasResults = !! document.querySelectorAll( '.components-autocomplete__popover' ).length;
+	if ( hasResults ) {
+		return;
+	}
+
+	tracksRecordEvent( 'wpcom_block_picker_no_results', {
+		search_term: content,
+		context: 'autocompleter',
+	} );
+};
+
+/**
+ * This function takes over of returning a valid
+ * target element, which will used to bind the handler function
+ * to record the events.
+ * It looks if there is a selected block in the editor,
+ * checks the block type, if it's the active element in the
+ * document, etc.
+ */
+function selectorHandler() {
+	const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
+
+	// Skip If there isn't a selected block.
+	if ( ! selectedBlock ) {
+		return;
+	}
+
+	const { name, attributes } = selectedBlock;
+
+	// Skip if it is not a core/paragraph block.
+	if ( name !== 'core/paragraph' ) {
+		return;
+	}
+
+	/*
+	 * Skip if content doesn't start with the slash `/`.
+	 * Also, check if the block name can only contain
+	 * lowercase alphanumeric characters and dashes,
+	 * and must begin with a letter.
+	 */
+	const { content } = attributes;
+	if ( ! /^\/[a-z][a-z0-9-]+$/.test( content ) ) {
+		return;
+	}
+
+	const blockDOMElement = document.getElementById( `block-${ selectedBlock.clientId }` );
+	// Skip if there is not a Block DOM element.
+	if ( ! blockDOMElement ) {
+		return;
+	}
+
+	// Skip if the block Element is not the active one.
+	if ( blockDOMElement !== document.activeElement ) {
+		return;
+	}
+
+	const blockClassName = blockDOMElement.className;
+
+	// Skip is the block is not selected through class attribute.
+	if ( ! blockClassName || ! /is-selected/.test( blockClassName ) ) {
+		return;
+	}
+
+	return blockDOMElement;
+}
+/**
+ * Return the event definition object to track `wpcom_block_picker_search_term`,
+ * adding the context event property with the `autocompleter` value.
+ * Also, it tracks `wpcom_block_picker_no_results` is the searcher doesn't return any result.
+ *
+ * @returns {{handler: Function, selector: string|Function, type: string}} event object definition.
+ */
+export default () => ( {
+	selector: selectorHandler,
+	type: 'keyup',
+	handler: debounce( trackAutocompleteTerm, 500 ),
+} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -18,7 +18,7 @@ import tracksRecordEvent from './track-record-event';
 const trackAutocompleteTerm = () => {
 	const search_term = get( select( 'core/block-editor' ).getSelectedBlock(), [
 		'attributes',
-		'search_term',
+		'content',
 	] );
 
 	if ( ! search_term ) {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -15,7 +15,16 @@ import { select } from '@wordpress/data';
  */
 import tracksRecordEvent from './track-record-event';
 
+/**
+ * Handler function which takes over tracking blocks-searching events
+ * from the "Autocomplete / Block" component.
+ * It worths mentioning that the running of it
+ * will be conditioned by a valid target,
+ * which is previously handled by the `selectorHandler()` function.
+ * The most important checks are performed there.
+ */
 const trackAutocompleteBlockTerm = () => {
+	// Pick up the search term from the `content` block attributes.
 	const search_term = get( select( 'core/block-editor' ).getSelectedBlock(), [
 		'attributes',
 		'content',
@@ -32,7 +41,13 @@ const trackAutocompleteBlockTerm = () => {
 		context,
 	} );
 
-	// Check if there are results by looking for the popover autocomplete in the DOM which will only be present if there are blocks that match the search term.
+	/*
+	 * Check if there are results by looking for the popover autocomplete in the DOM
+	 * which will only be present
+	 * if there are blocks that match the search term.
+	 * Also, there is only a single popover Slot
+	 * and so only 1 popover can render at a time.
+	 */
 	const hasResults = !! document.querySelectorAll( '.components-autocomplete__popover' ).length;
 	if ( hasResults ) {
 		return;

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -91,7 +91,7 @@ function selectorHandler() {
 
 	const blockClassName = blockDOMElement.className;
 
-	// Skip is the block is not selected through class attribute.
+	// Skip if the block is not marked as "selected" via a class attribute.
 	if ( ! blockClassName || ! /is-selected/.test( blockClassName ) ) {
 		return;
 	}

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -69,8 +69,8 @@ function selectorHandler() {
 
 	/*
 	 * Skip if content doesn't start with the slash `/`.
-	 * Also, check if the block name can only contain
-	 * lowercase alphanumeric characters and dashes,
+	 * Also, check if the block search term is a valid block name
+	 * ie: only lowercase alphanumeric characters and dashes,
 	 * and must begin with a letter.
 	 */
 	const { content } = attributes;

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -107,7 +107,7 @@ function selectorHandler() {
 	const blockClassName = blockDOMElement.className;
 
 	// Skip if the block is not marked as "selected" via a class attribute.
-	if ( ! blockClassName || ! /is-selected/.test( blockClassName ) ) {
+	if ( ! blockClassName || ! blockDOMElement.classList.contains( 'is-selected' ) ) {
 		return;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -32,7 +32,7 @@ const trackAutocompleteBlockTerm = () => {
 		context,
 	} );
 
-	// Check if there are results, inspecting the DOM Tree.
+	// Check if there are results by looking for the popover autocomplete in the DOM which will only be present if there are blocks that match the search term.
 	const hasResults = !! document.querySelectorAll( '.components-autocomplete__popover' ).length;
 	if ( hasResults ) {
 		return;

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -68,7 +68,7 @@ function selectorHandler() {
 	}
 
 	/*
-	 * Skip if content doesn't start with the slash `/`.
+	 * Skip if content doesn't start with the slash `/` (as this is the shortcut used to trigger the block inserter).
 	 * Also, check if the block search term is a valid block name
 	 * ie: only lowercase alphanumeric characters and dashes,
 	 * and must begin with a letter.

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-autocomplete-block-search-term.js
@@ -101,7 +101,7 @@ function selectorHandler() {
 /**
  * Return the event definition object to track `wpcom_block_picker_search_term`,
  * adding the context event property with the `autocompleter` value.
- * Also, it tracks `wpcom_block_picker_no_results` is the searcher doesn't return any result.
+ * It also tracks `wpcom_block_picker_no_results` if the search term doesn't return any results.
  *
  * @returns {{handler: Function, selector: string|Function, type: string}} event object definition.
  */

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-picker-search-term-handler.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-picker-search-term-handler.js
@@ -34,6 +34,7 @@ const trackSearchTerm = ( event, target ) => {
 
 	const eventProperties = {
 		search_term,
+		context: 'inserter_menu',
 	};
 
 	/*

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
@@ -30,7 +30,7 @@ const trackInserterInlineSearchTerm = () => {
 		'content',
 	] );
 
-	if ( search_term.length < 3 ) {
+	if ( search_term.length < 4 ) {
 		return;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
@@ -25,12 +25,13 @@ import tracksRecordEvent from './track-record-event';
  */
 const trackInserterInlineSearchTerm = () => {
 	// Pick up the search term from the `content` block attributes.
-	const search_term = get( select( 'core/block-editor' ).getSelectedBlock(), [
-		'attributes',
-		'content',
-	] );
+	const search_term = get(
+		select( 'core/block-editor' ).getSelectedBlock(),
+		[ 'attributes', 'content' ],
+		''
+	).substr( 1 );
 
-	if ( search_term.length < 4 ) {
+	if ( search_term.length < 3 ) {
 		return;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
@@ -16,11 +16,9 @@ import { select } from '@wordpress/data';
 import tracksRecordEvent from './track-record-event';
 
 /**
- * Handler function which takes over tracking blocks-searching events
- * from the "Autocomplete / Block" component.
- * It worths mentioning that the running of it
- * will be conditioned by a valid target,
- * which is previously handled by the `selectorHandler()` function.
+ * Handles search tracking from "Autocomplete / Block" component.
+ *
+ * Depends on a valid target, which was previously handled by the `selectorHandler()` function.
  * The most important checks are performed there.
  */
 const trackInserterInlineSearchTerm = () => {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-inline-search-term.js
@@ -23,7 +23,7 @@ import tracksRecordEvent from './track-record-event';
  * which is previously handled by the `selectorHandler()` function.
  * The most important checks are performed there.
  */
-const trackAutocompleteBlockTerm = () => {
+const trackInserterInlineSearchTerm = () => {
 	// Pick up the search term from the `content` block attributes.
 	const search_term = get( select( 'core/block-editor' ).getSelectedBlock(), [
 		'attributes',
@@ -34,7 +34,7 @@ const trackAutocompleteBlockTerm = () => {
 		return;
 	}
 
-	const context = 'autocomplete_block';
+	const context = 'inserter_inline';
 
 	tracksRecordEvent( 'wpcom_block_picker_search_term', {
 		search_term,
@@ -115,7 +115,7 @@ function selectorHandler() {
 }
 /**
  * Return the event definition object to track `wpcom_block_picker_search_term`,
- * adding the context event property with the `autocompleter` value.
+ * adding the context event property with the `inserter_inline` value.
  * It also tracks `wpcom_block_picker_no_results` if the search term doesn't return any results.
  *
  * @returns {{handler: Function, selector: string|Function, type: string}} event object definition.
@@ -123,5 +123,5 @@ function selectorHandler() {
 export default () => ( {
 	selector: selectorHandler,
 	type: 'keyup',
-	handler: debounce( trackAutocompleteBlockTerm, 500 ),
+	handler: debounce( trackInserterInlineSearchTerm, 500 ),
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new event tracker in order to record events when the user opens the autocomplete block to add a block into the editor.
It complements the data what currently collected from Inserter Menu.

| Inserter Menu | Inserter Inline |
|---------------|----------------------|
| ![image](https://user-images.githubusercontent.com/77539/79127435-47a89700-7d78-11ea-8720-1b45b553f5e1.png) | ![image](https://user-images.githubusercontent.com/77539/79127467-568f4980-7d78-11ea-83ae-496a4f86dae9.png) |

### Significant changes

#### * getMatchingEventTarget() accepts a targetSelector function

It allows [delegating the task to define if the target is valid](https://github.com/Automattic/wp-calypso/pull/41022/files#diff-104bf6942a8f026eeed7ad1e4f66a261R38-R40) to the tracker module.

#### Getting a valid target through of selectorHandler()

This selector performs verification steps before to return a valid target. The first one if exists a selected block in the editor, getting data from the store.

#### Recoding event using trackAutocompleteBlockTerm()

It records events in a similar way that the block picker does (inserter menu), doing some DOM manipulation.

#### Context

it adds the context event property to differentiate results between `inserter_menu` and the `autocomplete_Block`.

<img width="361" alt="Screen Shot 2020-04-13 at 11 37 45 AM" src="https://user-images.githubusercontent.com/77539/79129658-ff8b7380-7d7b-11ea-96dd-d7dc18dce8f4.png">


#### Testing instructions

1) Update your testing site with these changes (SB)
2) In your testing site, open the client dev console and set up the debug

```
> localStorage.setItem( 'debug', 'wpcom-block-editor*' )
```

A hard refresh is needed.

3) Open the Inserter Menu
4) Start to type until getting the no-results message
5) Look at the debug logs.
6) Inspect the `wpcom_block_picker_no_results` event:
7) Confirm that you get events but with a new `context` property:

<img width="663" alt="Screen Shot 2020-04-14 at 3 13 16 PM" src="https://user-images.githubusercontent.com/77539/79259251-c5e16800-7e62-11ea-93e2-b0c7000b355e.png">

8) Test now typing `/` in paragraph block. 

<img width="555" alt="Screen Shot 2020-04-14 at 3 14 22 PM" src="https://user-images.githubusercontent.com/77539/79259259-cb3eb280-7e62-11ea-93a1-81a7f6a6fd2a.png">


Fixes #
