### PR TITLE
Makes site name controlled by config

### DIFF
--- a/client/state/document-head/selectors.js
+++ b/client/state/document-head/selectors.js
@@ -10,6 +10,7 @@ import createSelector from 'lib/create-selector';
 import { decodeEntities } from 'lib/formatting';
 import { getSelectedSiteId, isSiteSection } from 'state/ui/selectors';
 import getSiteTitle from 'state/sites/selectors/get-site-title';
+import config from 'config';
 
 const UNREAD_COUNT_CAP = 40;
 
@@ -76,7 +77,7 @@ export const getDocumentHeadFormattedTitle = createSelector(
 			title = decodeEntities( title ) + ' — ';
 		}
 
-		return title + 'WordPress.com';
+		return title + config( 'site_name' );
 	},
 	state => [ state.documentHead, state.ui.section, state.ui.selectedSiteId ]
 );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -138,5 +138,6 @@
 		"jetpack-cloud-settings": false
 	},
 	"site_filter": [],
-	"theme": "default"
+	"theme": "default",
+	"site_name": "WordPress.com"
 }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -10,6 +10,7 @@
 	"rtl": false,
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"site_name": "Jetpack.com",
 	"features": {
 		"current-site/domain-warning": false,
 		"current-site/notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -8,6 +8,7 @@
 	"rtl": false,
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"site_name": "Jetpack.com",
 	"features": {
 		"current-site/domain-warning": false,
 		"current-site/notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -8,6 +8,7 @@
 	"rtl": false,
 	"login_url": "https://wordpress.com/wp-login.php",
 	"logout_url": "https://wordpress.com/wp-login.php?action=logout&redirect_to=https%3A%2F%2F|subdomain|wordpress.com",
+	"site_name": "Jetpack.com",
 	"features": {
 		"current-site/domain-warning": false,
 		"current-site/notice": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates site name to be controlled by config, to allow Jetpack Cloud to display Jetpack.com.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build a Calypso env (`yarn start`).
* Load `calypso.localhost:3000` and view site title.
* Build a Jetpack Cloud env (`CALYPSO_ENV=jetpack-cloud-development yarn start`).
* Load `http://jetpack.cloud.localhost:3000` and view site title.

Site title should be `WordPress.com` on all environments except Cloud, which has `Jetpack.com`.

<img width="499" alt="Screen Shot 2020-04-10 at 12 10 32 PM" src="https://user-images.githubusercontent.com/1760168/79005505-fe143e00-7b24-11ea-9522-d8b69bfbeed1.png">

Fixes 1156570014567299-as-1164112743175977.
