### PR TITLE
Composite checkout: Do not validate contact details if the endpoint call fails

### DIFF
--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -54,7 +54,9 @@ export default function createContactValidationCallback( {
 					);
 				}
 				applyDomainContactValidationResults( { ...( data ? data.messages : {} ) } );
-				resolve( ! ( data && data.success && areRequiredFieldsNotEmpty( decoratedContactDetails ) ) );
+				resolve(
+					! ( data && data.success && areRequiredFieldsNotEmpty( decoratedContactDetails ) )
+				);
 			} );
 		} );
 	};

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -53,7 +53,7 @@ export default function createContactValidationCallback( {
 						)
 					);
 				}
-				applyDomainContactValidationResults( { ...( data ? data.messages : {} ) } );
+				applyDomainContactValidationResults( data?.messages ?? {} );
 				resolve(
 					! ( data && data.success && areRequiredFieldsNotEmpty( decoratedContactDetails ) )
 				);

--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -45,18 +45,16 @@ export default function createContactValidationCallback( {
 							'There was an error validating your contact information. Please contact support.'
 						)
 					);
-					resolve( false );
-					return;
 				}
-				if ( data.messages ) {
+				if ( data && data.messages ) {
 					showErrorMessage(
 						translate(
 							'We could not validate your contact information. Please review and update all the highlighted fields.'
 						)
 					);
 				}
-				applyDomainContactValidationResults( { ...data.messages } );
-				resolve( ! ( data.success && areRequiredFieldsNotEmpty( decoratedContactDetails ) ) );
+				applyDomainContactValidationResults( { ...( data ? data.messages : {} ) } );
+				resolve( ! ( data && data.success && areRequiredFieldsNotEmpty( decoratedContactDetails ) ) );
 			} );
 		} );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust the logic in the contact validation callback in composite checkout to ensure that if the request to the endpoint fails, we do not allow checkout to proceed. (I'm not totally sure why the current logic doesn't block this.)

#### Testing instructions

The best way I can think of to test this is locally. To see the bug using the following steps it may be necessary to apply D41243-code to your sandbox, since that diff introduces max version numbers to the validation endpoint. (The max version number is what exposed the bug, but it would occur with any HTTP failure code.)

1. Run calypso with `ENABLE_FEATURES=composite-checkout-force npm start`
2. Do not apply the PR -- first let's see the buggy behavior.
3. To break validation on purpose make the following edit in [client/lib/wpcom-undocumented/lib/undocumented](https://github.com/Automattic/wp-calypso/blob/master/client/lib/wpcom-undocumented/lib/undocumented.js#L675): Inside the definition of `Undocumented.prototype.validateDomainContactInformation`, insert the following additional argument before `data`: `{ apiVersion: '1.3' }`
4. Open your network tab and filter for calls to `domain-contact-information/validate`.
5. Enter composite checkout with a domain in your cart and proceed to the contact details step.
6. Leave the first name field blank and click Continue.
7. You should see a 404 error on the endpoint call and the "There was an error validating your contact information." notice, but proceed to the next checkout step anyway. (This is the bug.)
8. Now check out this branch and repeat steps 3-6.
9. You should see the same 404 error and "There was an error validating your contact information." notice, but this time should not proceed to the next checkout step.
