### PR TITLE
Add Date Separators to ActivityCardList

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -82,7 +82,7 @@ class ActivityCardList extends Component {
 		return logsByDate.map( ( { date, logs: dateLogs } ) => {
 			return (
 				<>
-					<div>{ date && date.format( 'LLL' ) }</div>
+					<div className="activity-card-list__date">{ date && date.format( 'MMM Do' ) }</div>
 					{ dateLogs.map( activity => (
 						<ActivityCard
 							{ ...{

--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -1,24 +1,24 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { isMobile } from '@automattic/viewport';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
-import ActivityCard from 'landing/jetpack-cloud/components/activity-card';
-import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
-import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
-import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
-import getRewindState from 'state/selectors/get-rewind-state';
-import QueryRewindState from 'components/data/query-rewind-state';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { updateFilter } from 'state/activity-log/actions';
 import { withLocalizedMoment } from 'components/localized-moment';
+import ActivityCard from 'landing/jetpack-cloud/components/activity-card';
 import Filterbar from 'my-sites/activity/filterbar';
+import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
+import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
+import getRewindState from 'state/selectors/get-rewind-state';
 import Pagination from 'components/pagination';
+import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
+import QueryRewindState from 'components/data/query-rewind-state';
 
 /**
  * Style dependencies

--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -4,7 +4,7 @@
 import { connect } from 'react-redux';
 import { isMobile } from '@automattic/viewport';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 
 /**
  * Internal dependencies
@@ -28,14 +28,16 @@ import QueryRewindState from 'components/data/query-rewind-state';
 import './style.scss';
 
 class ActivityCardList extends Component {
-	static PropTypes = {
-		showFilter: PropTypes.boolean,
-		showPagination: PropTypes.boolean,
+	static propTypes = {
 		logs: PropTypes.array.isRequired,
 		pageSize: PropTypes.number.isRequired,
+		showDateSeparators: PropTypes.bool,
+		showFilter: PropTypes.bool,
+		showPagination: PropTypes.bool,
 	};
 
 	static defaultProps = {
+		showDateSeparators: true,
 		showFilter: true,
 		showPagination: true,
 	};
@@ -62,27 +64,15 @@ class ActivityCardList extends Component {
 	}
 
 	renderLogs( logs ) {
-		const { allowRestore, moment, siteSlug } = this.props;
+		const { allowRestore, moment, siteSlug, showDateSeparators } = this.props;
 		const logsByDate = this.splitLogsByDate( logs );
 
-		if ( logsByDate.length === 1 ) {
-			return logsByDate[ 0 ].logs.map( activity => (
-				<ActivityCard
-					{ ...{
-						key: activity.activityId,
-						moment,
-						activity,
-						allowRestore,
-						siteSlug,
-					} }
-				/>
-			) );
-		}
-
-		return logsByDate.map( ( { date, logs: dateLogs } ) => {
+		return logsByDate.map( ( { date, logs: dateLogs }, index ) => {
 			return (
-				<>
-					<div className="activity-card-list__date">{ date && date.format( 'MMM Do' ) }</div>
+				<Fragment key={ `activity-card-list__date-group-${ index }` }>
+					{ showDateSeparators && (
+						<div className="activity-card-list__date">{ date && date.format( 'MMM Do' ) }</div>
+					) }
 					{ dateLogs.map( activity => (
 						<ActivityCard
 							{ ...{
@@ -94,7 +84,7 @@ class ActivityCardList extends Component {
 							} }
 						/>
 					) ) }
-				</>
+				</Fragment>
 			);
 		} );
 	}

--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -53,11 +53,13 @@ class ActivityCardList extends Component {
 		let lastDate = null;
 		for ( const log of logs ) {
 			const activityDateMoment = applySiteOffset( moment( log.activityDate ) );
-			if ( lastDate && lastDate.isSame( activityDateMoment, 'day' ) ) {
-				logsByDate[ logsByDate.length - 1 ].logs.push( log );
-			} else {
-				logsByDate.push( { date: activityDateMoment, logs: [ log ] } );
-				lastDate = activityDateMoment;
+			if ( activityDateMoment ) {
+				if ( lastDate && lastDate.isSame( activityDateMoment, 'day' ) ) {
+					logsByDate[ logsByDate.length - 1 ].logs.push( log );
+				} else {
+					logsByDate.push( { date: activityDateMoment, logs: [ log ] } );
+					lastDate = activityDateMoment;
+				}
 			}
 		}
 		return logsByDate;
@@ -89,7 +91,7 @@ class ActivityCardList extends Component {
 		} );
 	}
 
-	render() {
+	renderData() {
 		const { filter, logs, pageSize, showFilter, showPagination, siteId } = this.props;
 		const { page: requestedPage } = filter;
 
@@ -98,11 +100,8 @@ class ActivityCardList extends Component {
 			Math.min( requestedPage, Math.ceil( logs.length / pageSize ) )
 		);
 		const theseLogs = logs.slice( ( actualPage - 1 ) * pageSize, actualPage * pageSize );
-
 		return (
-			<div className="activity-card-list">
-				<QueryRewindCapabilities siteId={ siteId } />
-				<QueryRewindState siteId={ siteId } />
+			<>
 				{ showFilter && (
 					<Filterbar
 						{ ...{
@@ -140,6 +139,18 @@ class ActivityCardList extends Component {
 						total={ logs.length }
 					/>
 				) }
+			</>
+		);
+	}
+
+	render() {
+		const { applySiteOffset, siteId } = this.props;
+
+		return (
+			<div className="activity-card-list">
+				<QueryRewindCapabilities siteId={ siteId } />
+				<QueryRewindState siteId={ siteId } />
+				{ applySiteOffset && this.renderData() }
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -1,5 +1,5 @@
 .activity-card-list .filterbar {
-    margin-bottom: 2rem;
+	margin-bottom: 2rem;
 }
 
 .activity-card-list__pagination-bottom {
@@ -7,12 +7,20 @@
 }
 
 @include breakpoint( '<660px' ) {
-    .activity-card-list .filterbar__wrap.card {
-        background: transparent;
-        box-shadow: none;
-    }
+	.activity-card-list .filterbar__wrap.card {
+		background: transparent;
+		box-shadow: none;
+	}
 
-    .activity-card-list .filterbar__label {
-        margin-left: 0;
-    }
+	.activity-card-list .filterbar__label {
+		margin-left: 0;
+	}
+}
+
+.activity-card-list__date {
+	font-style: normal;
+	font-weight: bold;
+	font-size: 16px;
+	line-height: 23px;
+	border-bottom: 1px solid #000000;
 }

--- a/client/landing/jetpack-cloud/components/site-offset/context.tsx
+++ b/client/landing/jetpack-cloud/components/site-offset/context.tsx
@@ -16,9 +16,10 @@ import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import QuerySiteSettings from 'components/data/query-site-settings'; // Required to get site time offset
 
-type contextType = ( input: MomentInput ) => Moment | null;
+export type contextTypeLoaded = ( input: MomentInput ) => Moment;
+export type contextType = contextTypeLoaded | null;
 
-const SiteOffsetContext = React.createContext< contextType >( () => null );
+const SiteOffsetContext = React.createContext< contextType >( null );
 
 interface Props {
 	site: string;
@@ -34,15 +35,16 @@ const SiteOffsetProvider: FunctionComponent< Props > = ( { children, site } ) =>
 	);
 
 	const value = useCallback(
-		( input: MomentInput ) =>
-			gmtOffset || timezone ? applySiteOffset( input, { gmtOffset, timezone } ) : null,
+		( input: MomentInput ) => applySiteOffset( input, { gmtOffset, timezone } ),
 		[ gmtOffset, timezone ]
 	);
 
 	return (
 		<>
 			<QuerySiteSettings siteId={ siteId } />
-			<SiteOffsetContext.Provider value={ value }>{ children }</SiteOffsetContext.Provider>
+			<SiteOffsetContext.Provider value={ gmtOffset !== null || timezone !== null ? value : null }>
+				{ children }
+			</SiteOffsetContext.Provider>
 		</>
 	);
 };

--- a/client/landing/jetpack-cloud/components/site-offset/index.tsx
+++ b/client/landing/jetpack-cloud/components/site-offset/index.tsx
@@ -8,7 +8,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { SiteOffsetContext } from './context';
+import { SiteOffsetContext, contextTypeLoaded } from './context';
 
 export const withApplySiteOffset = createHigherOrderComponent( WrappedComponent => {
 	return function WithApplySiteOffset( props ) {
@@ -23,3 +23,5 @@ export const withApplySiteOffset = createHigherOrderComponent( WrappedComponent 
 export const useApplySiteOffset = () => {
 	return React.useContext( SiteOffsetContext );
 };
+
+export type applySiteOffsetType = contextTypeLoaded;

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
@@ -19,6 +19,11 @@ import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 interface Props {
 	after?: string;
 	before?: string;

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/style.scss
@@ -1,0 +1,3 @@
+.backup-activity-log .filterbar .filterbar__wrap.card {
+	display: flex;
+}

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
@@ -12,7 +12,10 @@ import { Card } from '@automattic/components';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { RewindFlowPurpose } from './types';
-import { useApplySiteOffset } from 'landing/jetpack-cloud/components/site-offset';
+import {
+	applySiteOffsetType,
+	useApplySiteOffset,
+} from 'landing/jetpack-cloud/components/site-offset';
 import BackupDownloadFlow from './download';
 import BackupRestoreFlow from './restore';
 import DocumentHead from 'components/data/document-head';
@@ -39,11 +42,10 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( state => ( siteId !== null ? getSiteSlug( state, siteId ) : '' ) );
 
-	const backupDisplayDate = applySiteOffset( moment( parseFloat( rewindId ) * 1000 ) )?.format(
-		'LLL'
-	);
-
-	const render = () => {
+	const render = ( loadedApplySiteOffset: applySiteOffsetType ) => {
+		const backupDisplayDate = loadedApplySiteOffset(
+			moment( parseFloat( rewindId ) * 1000 )
+		)?.format( 'LLL' );
 		if ( siteId && rewindId && backupDisplayDate ) {
 			return purpose === RewindFlowPurpose.RESTORE ? (
 				<BackupRestoreFlow
@@ -73,7 +75,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				}
 			/>
 			<SidebarNavigation />
-			<Card>{ render() }</Card>
+			<Card>{ applySiteOffset && render( applySiteOffset ) }</Card>
 		</Main>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add date separators to `ActivityCardList` an optional parameters to control if they are used.

<img width="500" alt="screenshot" src="https://user-images.githubusercontent.com/2810519/79137558-c1845480-7d67-11ea-8752-aafe2e625a7e.png">

#### Testing instructions

1. Navigate to `/backups/activity`
2. Inspect the rendered list vs the network request for activity or another source of the activity log. Make sure the dates separators are being rendered in the correct places.
