### PR TITLE
Domain contact validation: nest qualified errors in domain validation endpoint response (2)

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { camelCase, isPlainObject, omit, pick, reject, snakeCase } from 'lodash';
+import { camelCase, isPlainObject, omit, pick, reject, snakeCase, set } from 'lodash';
 import { stringify } from 'qs';
 
 /**
@@ -694,6 +694,14 @@ Undocumented.prototype.validateDomainContactInformation = function(
 		function( error, successData ) {
 			if ( error ) {
 				return fn( error );
+			}
+
+			// Reshape the error messages to a nested object
+			if ( successData.messages ) {
+				successData.messages = Object.keys( successData.messages ).reduce( ( obj, key ) => {
+					set( obj, key, successData.messages[ key ] );
+					return obj;
+				}, {} );
 			}
 
 			const newData = mapKeysRecursively( successData, function( key ) {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -697,7 +697,7 @@ Undocumented.prototype.validateDomainContactInformation = function(
 			}
 
 			// Reshape the error messages to a nested object
-			if ( successData.messages ) {
+			if ( successData.messages && query?.apiVersion === '1.2' ) {
 				successData.messages = Object.keys( successData.messages ).reduce( ( obj, key ) => {
 					set( obj, key, successData.messages[ key ] );
 					return obj;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The domain contact validation endpoint returns a list of errors, but the contact details are an object - it would be nice if it sent an object back. For reasons we can't do that. Instead, D41243-code introduces v1.2 of the domain contact validation endpoint, which qualifies the names of nested properties using dot notation. This patch "rehydrates" these on the frontend to a nested object.

To the best of my understanding this should not have any effect on existing consumers of this endpoint, even though it does not gate on the api version, because the qualified names are new behavior, and even though there are some ad-hoc qualified names returned by the backend already (in the UK validator), they are not actually used in calypso.

#### Testing instructions

It is not necessary to apply D41243-code to test this locally. It's probably better not to.

This patch alters the output of `Undocumented.prototype.validateDomainContactInformation`. It _should_ do this in a way that has no effect on existing flows, but to be sure we should make sure that validation still works as expected.

- Normal domain contact form: enter checkout with a domain, make sure you can validate your contact info.
- Contact form for ccTLDs with special requirements: enter checkout with a .ca, .uk, or .fr domain, make sure you can validate your contact info.
- Domain contact update form: Try to update your contact information on an existing domain, make sure it can validate.