### PR TITLE
My Home: Add Recoleta font

### DIFF
--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -22,11 +22,8 @@
 	font-display: swap;
 	font-family: 'Recoleta';
 	font-weight: 400;
-	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot' );
-	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot?#iefix' ) format( 'embedded-opentype' ),
-	url( 'https://s1.wp.com/i/fonts/recoleta/400.woff2' ) format( 'woff2' ),
-	url( 'https://s1.wp.com/i/fonts/recoleta/400.woff' ) format( 'woff' ),
-	url( 'https://s1.wp.com/i/fonts/recoleta/400.ttf' ) format( 'truetype' );
+	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.woff2' ) format( 'woff2' ),
+	url( 'https://s1.wp.com/i/fonts/recoleta/400.woff' ) format( 'woff' );
 }
 
 .customer-home__heading {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -18,6 +18,17 @@
 		grid-column: $col-start / span $span;
 }
 
+@font-face {
+	font-display: swap;
+	font-family: 'Recoleta';
+	font-weight: 400;
+	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot' );
+	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.eot?#iefix' ) format( 'embedded-opentype' ),
+	url( 'https://s1.wp.com/i/fonts/recoleta/400.woff2' ) format( 'woff2' ),
+	url( 'https://s1.wp.com/i/fonts/recoleta/400.woff' ) format( 'woff' ),
+	url( 'https://s1.wp.com/i/fonts/recoleta/400.ttf' ) format( 'truetype' );
+}
+
 .customer-home__heading {
 	display: flex;
 
@@ -27,6 +38,10 @@
 
 	.formatted-header {
 		margin-right: 12px;
+	}
+
+	.formatted-header__title {
+		font-family: 'Recoleta', $serif;
 	}
 
 	.formatted-header__subtitle {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Loads the Recoleta font when visiting the "My Home" section and uses it on the header.

<img width="408" alt="Screen Shot 2020-04-13 at 15 21 51" src="https://user-images.githubusercontent.com/1233880/79123462-84858580-7d9a-11ea-8fd0-6410ba9d7df3.png">

It fallbacks to the default Calypso serif font ([Noto serif](https://github.com/Automattic/wp-calypso/blob/d5304d75958d699394b47648d325eec3c2b72064/client/assets/stylesheets/shared/_typography.scss#L8)) on unsupported languages.

<img width="366" alt="Screen Shot 2020-04-13 at 15 32 29" src="https://user-images.githubusercontent.com/1233880/79124427-949e6480-7d9c-11ea-95ec-0cde3745f60f.png">
<img width="510" alt="Screen Shot 2020-04-13 at 15 35 19" src="https://user-images.githubusercontent.com/1233880/79124436-9700be80-7d9c-11ea-92b9-ec7510d1bb95.png">

Note that we use a `font-display: swap` option in order to render all texts at the same time (this seems to be the [preferred method in other areas](https://github.com/Automattic/wp-calypso/search?q=font-display%3A+swap&unscoped_q=font-display%3A+swap)):

![Apr-13-2020 13-56-41](https://user-images.githubusercontent.com/1233880/79124628-0676ae00-7d9d-11ea-863a-16911dd40fa6.gif)

This introduces the first precedent of a header using a different font family than the rest of the Calypso pages, so I wonder if we should be consistent and use the font across all pages headers.

#### Testing instructions

- Go to "My Home" and make sure the header is displayed with the Recoleta font.
- Switch to an unsupported language such as Korean or Russian and make sure the font fallbacks to the Calypso serif font.

Fixes #41036
