### PR TITLE
Upsell nudge: fix missing Jetpack conditions

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -17,7 +17,7 @@ import { isFreePlan } from 'lib/products-values';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isVipSite from 'state/selectors/is-vip-site';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSite, isJetpackSite } from 'state/sites/selectors';
 
 /**
  * Style dependencies
@@ -27,6 +27,7 @@ import './style.scss';
 export const UpsellNudge = ( {
 	className,
 	showIcon = false,
+	isJetpack,
 	isVip,
 	canManageSite,
 	site,
@@ -34,7 +35,6 @@ export const UpsellNudge = ( {
 	href,
 	plan,
 	planHasFeature,
-	jetpack,
 	forceDisplay,
 	...props
 } ) => {
@@ -49,8 +49,8 @@ export const UpsellNudge = ( {
 		( feature && planHasFeature ) ||
 		( ! feature && ! isFreePlan( site.plan ) ) ||
 		( feature === FEATURE_NO_ADS && site.options.wordads ) ||
-		( ! jetpack && site.jetpack ) ||
-		( jetpack && ! site.jetpack );
+		( ! isJetpack && site.jetpack ) ||
+		( isJetpack && ! site.jetpack );
 
 	if ( shouldNotDisplay && ! forceDisplay ) {
 		return null;
@@ -70,6 +70,7 @@ export default connect( ( state, ownProps ) => {
 		site: getSite( state, siteId ),
 		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
+		isJetpack: isJetpackSite( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 	};
 } )( localize( UpsellNudge ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes Jetpack conditionals on the Upsell Nudge component.

#### Testing instructions

* Fire up this PR
* Ensure the `isJetpack` variable outputs `true` if it's a Jetpack site, `false` otherwise.

Fixes issue reported in https://github.com/Automattic/wp-calypso/pull/40721#issuecomment-612926288 cc @sixhours 
