### PR TITLE
Activity log: force display the upsell nudge for non-Jetpack sites

### DIFF
--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -47,6 +47,7 @@ class UpgradeBanner extends Component {
 					/>
 				) : (
 					<UpsellNudge
+						forceDisplay={ true }
 						callToAction={ translate( 'Learn more' ) }
 						event="activity_log_upgrade_click_wpcom"
 						feature={ FEATURE_JETPACK_ESSENTIAL }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Force display the upsell nudge on Activity log for non-Jetpack sites.
* Complementary to https://github.com/Automattic/wp-calypso/pull/41047

#### Testing instructions

* Fire up this PR.
* Open the Activity log with a non-Jetpack site on a free plan.
* Make sure you can see the upgrade banner.

Fixes issue reported in https://github.com/Automattic/wp-calypso/pull/40721#issuecomment-612926288 cc @sixhours
