### PR TITLE
Gutenboarding: update plans header for launch flow + mobile

### DIFF
--- a/client/my-sites/plans-features-main/gutenboarding-header/index.jsx
+++ b/client/my-sites/plans-features-main/gutenboarding-header/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -14,27 +15,28 @@ import FormattedHeader from 'components/formatted-header';
  */
 import './style.scss';
 
-const GutenboardingHeader = ( { translate, onFreePlanSelect } ) => {
+const GutenboardingHeader = ( { headerText, subHeaderText, onFreePlanSelect, translate } ) => {
 	return (
 		<div className="gutenboarding-header">
 			<FormattedHeader
-				headerText={ translate( 'Choose a plan' ) }
-				subHeaderText={ translate(
-					'Pick a plan that’s right for you. Switch plans as your needs change. {{br/}} There’s no risk, you can cancel for a full refund within 30 days.',
-					{
-						components: { br: <br /> },
-						comment:
-							'Subheader of the plans page where users land from onboarding after they picked a paid domain',
-					}
-				) }
+				headerText={ headerText }
+				subHeaderText={ subHeaderText }
 				compactOnMobile
 				isSecondary
+				align="left"
 			/>
 			<button className="gutenboarding-header__select-free-plan" onClick={ onFreePlanSelect }>
 				{ translate( 'Start with a free plan' ) }
 			</button>
 		</div>
 	);
+};
+
+GutenboardingHeader.propTypes = {
+	headerText: PropTypes.node,
+	subHeaderText: PropTypes.node,
+	onFreePlanSelect: PropTypes.func,
+	translate: PropTypes.func,
 };
 
 export default localize( GutenboardingHeader );

--- a/client/my-sites/plans-features-main/gutenboarding-header/index.jsx
+++ b/client/my-sites/plans-features-main/gutenboarding-header/index.jsx
@@ -21,7 +21,6 @@ const GutenboardingHeader = ( { headerText, subHeaderText, onFreePlanSelect, tra
 			<FormattedHeader
 				headerText={ headerText }
 				subHeaderText={ subHeaderText }
-				compactOnMobile
 				isSecondary
 				align="left"
 			/>

--- a/client/my-sites/plans-features-main/gutenboarding-header/style.scss
+++ b/client/my-sites/plans-features-main/gutenboarding-header/style.scss
@@ -3,10 +3,6 @@
 	margin: 0 27px 80px;
 	justify-content: space-between;
 
-	& > header {
-		text-align: left;
-	}
-
 	&__select-free-plan {
 		color: var( --color-neutral );
 		text-decoration: underline;

--- a/client/my-sites/plans-features-main/gutenboarding-header/style.scss
+++ b/client/my-sites/plans-features-main/gutenboarding-header/style.scss
@@ -1,11 +1,18 @@
 .gutenboarding-header {
 	display: flex;
-	margin: 0 27px 80px;
+	flex-wrap: wrap;
+	margin: -12px 27px 50px;
 	justify-content: space-between;
 
 	&__select-free-plan {
 		color: var( --color-neutral );
 		text-decoration: underline;
 		cursor: pointer;
+		font-size: 14px !important;
+	}
+
+	@include breakpoint( '>480px' ) {
+		margin-bottom: 80px;
+		margin-top: 0;
 	}
 }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -71,7 +71,6 @@ import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 import PlanTestimonials from '../plan-testimonials';
-import GutenboardingHeader from './gutenboarding-header';
 
 /**
  * Style dependencies
@@ -131,7 +130,7 @@ export class PlansFeaturesMain extends Component {
 			siteId,
 			plansWithScroll,
 			translate,
-			isGutenboarding,
+			customHeader,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -149,9 +148,7 @@ export class PlansFeaturesMain extends Component {
 				) }
 				data-e2e-plans={ displayJetpackPlans ? 'jetpack' : 'wpcom' }
 			>
-				{ isGutenboarding && (
-					<GutenboardingHeader onFreePlanSelect={ this.handleFreePlanButtonClick } />
-				) }
+				{ customHeader }
 				{ this.isJetpackBackupAvailable() && (
 					<FormattedHeader
 						headerText={ translate( 'Plans' ) }
@@ -397,14 +394,14 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	renderFreePlanBanner() {
-		const { hideFreePlan, translate, flowName, isInSignup, isGutenboarding } = this.props;
+		const { hideFreePlan, translate, flowName, isInSignup, customHeader } = this.props;
 		const className = 'is-free-plan';
 		const callToAction =
 			isInSignup && flowName === 'launch-site'
 				? translate( 'Continue with your free site' )
 				: translate( 'Start with a free site' );
 
-		if ( hideFreePlan || isGutenboarding ) {
+		if ( hideFreePlan || !! customHeader ) {
 			return null;
 		}
 
@@ -519,6 +516,7 @@ PlansFeaturesMain.propTypes = {
 	withWPPlanTabs: PropTypes.bool,
 	plansWithScroll: PropTypes.bool,
 	planTypes: PropTypes.array,
+	customHeader: PropTypes.node,
 };
 
 PlansFeaturesMain.defaultProps = {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { noop } from 'lodash';
 import i18n from 'i18n-calypso';
 
@@ -264,7 +265,15 @@ export function generateSteps( {
 			dependencies: [ 'siteSlug' ],
 			providesDependencies: [ 'cartItem', 'isPreLaunch', 'isGutenboardingCreate' ],
 			props: {
-				isGutenboarding: true,
+				headerText: i18n.translate( 'Choose a plan' ),
+				subHeaderText: i18n.translate(
+					'Pick a plan that’s right for you. Switch plans as your needs change. {{br/}} There’s no risk, you can cancel for a full refund within 30 days.',
+					{
+						components: { br: <br /> },
+						comment:
+							'Subheader of the plans page where users land from onboarding after they picked a paid domain',
+					}
+				),
 			},
 		},
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -17,6 +17,7 @@ import { getTld, isSubdomain } from 'lib/domains';
 import { getSiteBySlug } from 'state/sites/selectors';
 import StepWrapper from 'signup/step-wrapper';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
+import GutenboardingHeader from 'my-sites/plans-features-main/gutenboarding-header';
 import QueryPlans from 'components/data/query-plans';
 import { FEATURE_UPLOAD_THEMES_PLUGINS } from '../../../lib/plans/constants';
 import { planHasFeature } from '../../../lib/plans';
@@ -74,7 +75,11 @@ export class PlansStep extends Component {
 		this.props.submitSignupStep( step, {
 			cartItem,
 			// dependencies used only for 'plans-with-domain' step in Gutenboarding pre-launch flow
-			...( this.props.isGutenboarding && { isPreLaunch: true, isGutenboardingCreate: true } ),
+			...( this.isGutenboarding() &&
+				! this.props.isLaunchPage && {
+					isPreLaunch: true,
+					isGutenboardingCreate: true,
+				} ),
 		} );
 		this.props.goToNextStep();
 	};
@@ -102,12 +107,31 @@ export class PlansStep extends Component {
 		this.onSelectPlan( null ); // onUpgradeClick expects a cart item -- null means Free Plan.
 	};
 
+	isGutenboarding = () =>
+		this.props.flowName === 'frankenflow' || this.props.flowName === 'prelaunch'; // signup flows coming from Gutenboarding
+
 	isEligibleForPlanStepTest() {
 		return (
 			! this.props.isLaunchPage &&
-			! this.props.isGutenboarding &&
+			! this.isGutenboarding() &&
 			'variantCopyUpdates' === abtest( 'planStepCopyUpdates' )
 		);
+	}
+
+	getGutenboardingHeader() {
+		if ( this.isGutenboarding() ) {
+			const { headerText, subHeaderText } = this.props;
+
+			return (
+				<GutenboardingHeader
+					headerText={ headerText }
+					subHeaderText={ subHeaderText }
+					onFreePlanSelect={ this.handleFreePlanButtonClick }
+				/>
+			);
+		}
+
+		return null;
 	}
 
 	plansFeaturesList() {
@@ -139,7 +163,7 @@ export class PlansStep extends Component {
 					plansWithScroll={ true }
 					planTypes={ planTypes }
 					flowName={ flowName }
-					isGutenboarding={ this.props.isGutenboarding }
+					customHeader={ this.getGutenboardingHeader() }
 				/>
 			</div>
 		);
@@ -196,7 +220,7 @@ export class PlansStep extends Component {
 				allowBackFirstStep={ !! selectedSite }
 				backUrl={ backUrl }
 				backLabelText={ backLabelText }
-				hideFormattedHeader={ this.props.isGutenboarding }
+				hideFormattedHeader={ this.isGutenboarding() }
 			/>
 		);
 	}
@@ -222,7 +246,7 @@ PlansStep.propTypes = {
 	customerType: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 	planTypes: PropTypes.array,
-	isGutenboarding: PropTypes.bool,
+	flowName: PropTypes.string,
 };
 
 /**

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -359,7 +359,6 @@ body.is-section-signup.is-frankenflow {
 
 	.formatted-header__title {
 		@include onboarding-heading-text;
-		font-size: 32px;
 	}
 
 	.formatted-header__subtitle {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -297,7 +297,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 	}
 }
 
-// Background color override for new flow
+// Background color and plans grid overrides for new flow
 body.is-section-signup.is-frankenflow {
 	background: var( --color-white );
 
@@ -358,7 +358,11 @@ body.is-section-signup.is-frankenflow {
 	}
 
 	.formatted-header__title {
-		@include onboarding-heading-text;
+		@include onboarding-heading-text-mobile;
+
+		@include breakpoint( '>480px' ) {
+			@include onboarding-heading-text;
+		}
 	}
 
 	.formatted-header__subtitle {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update launch flow to re-use the [plans grid header](https://github.com/Automattic/wp-calypso/pull/40860) from Gutenboarding site creation; Fix p58i-8QA-p2#comment-45907
* Increase heading font size to match design.
* Add some mobile tweaks to the plans grid header and align with the rest of Gutenboarding.

#### Testing instructions

* Create a site from Gutenboarding then press the Launch button.
* Everything should stay the same except the header style.

#### Before:
<img width="1349" alt="Screenshot 2020-04-13 at 18 11 44" src="https://user-images.githubusercontent.com/14192054/79132652-64ae8b80-7db3-11ea-8a2c-800530a69d34.png">

#### After:
<img width="1301" alt="Screenshot 2020-04-13 at 18 42 11" src="https://user-images.githubusercontent.com/14192054/79134531-89583280-7db6-11ea-8f96-8b4ecbae029c.png">

#### [Mobile] Before:
<img width="321" alt="Screenshot 2020-04-14 at 08 20 24" src="https://user-images.githubusercontent.com/14192054/79190927-1be7e880-7e2e-11ea-88f5-3a455e76a108.png">

#### [Mobile] After
<img width="321" alt="Screenshot 2020-04-14 at 08 49 38" src="https://user-images.githubusercontent.com/14192054/79190937-21ddc980-7e2e-11ea-96af-401cdcaea4c2.png">