### PR TITLE
Jetpack Cloud: add url query parameter to Backup section with the selected date

### DIFF
--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -31,20 +31,23 @@ class DatePicker extends Component {
 	getDisplayDate = ( date, showTodayYesterday = true ) => {
 		const { today, moment, translate } = this.props;
 
-		const daysDiff = moment( today ).diff( date, 'days' );
+		if ( showTodayYesterday ) {
+			const isToday = today.isSame( date, 'day' );
+			const isYesterday = moment( today )
+				.add( -1, 'day' )
+				.isSame( date, 'day' );
+
+			if ( isToday ) {
+				return translate( 'Today' );
+			}
+			if ( isYesterday ) {
+				return translate( 'Yesterday' );
+			}
+		}
 		const yearToday = moment( today ).format( 'YYYY' );
 		const yearDate = moment( date ).format( 'YYYY' );
 
 		const dateFormat = yearToday === yearDate ? 'MMM D' : 'MMM D, YYYY';
-
-		if ( showTodayYesterday ) {
-			switch ( daysDiff ) {
-				case 0:
-					return translate( 'Today' );
-				case 1:
-					return translate( 'Yesterday' );
-			}
-		}
 
 		return moment( date ).format( dateFormat );
 	};

--- a/client/landing/jetpack-cloud/sections/backups/controller.js
+++ b/client/landing/jetpack-cloud/sections/backups/controller.js
@@ -21,7 +21,9 @@ export function wrapInSiteOffsetProvider( context, next ) {
 
 /* handles /backups/:site, see `backupMainPath` */
 export function backups( context, next ) {
-	context.primary = <BackupsPage />;
+	const { date } = context.query;
+
+	context.primary = <BackupsPage queryDate={ date } />;
 	next();
 }
 

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -61,13 +61,26 @@ class BackupsPage extends Component {
 	state = this.getDefaultState();
 
 	getDefaultState() {
-		const { queryDate, moment } = this.props;
-
-		const selectedDate = ! queryDate ? null : moment( queryDate, INDEX_FORMAT );
-
 		return {
-			selectedDate: selectedDate,
+			selectedDate: null,
 		};
+	}
+
+	componentDidMount() {
+		const { queryDate, moment, timezone, gmtOffset } = this.props;
+
+		if ( queryDate ) {
+			const today = applySiteOffset( moment(), { timezone, gmtOffset } );
+
+			const dateToSelect = moment( queryDate, INDEX_FORMAT );
+
+			// If we don't have dateToSelect or it's greater than today, force null
+			if ( ! dateToSelect.isValid() || dateToSelect > today ) {
+				this.onDateChange( null );
+			} else {
+				this.onDateChange( dateToSelect );
+			}
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -86,11 +99,15 @@ class BackupsPage extends Component {
 
 		this.setState( { selectedDate: date } );
 
-		page(
-			backupMainPath( siteSlug, {
-				date: date.format( INDEX_FORMAT ),
-			} )
-		);
+		if ( date && date.isValid() ) {
+			page(
+				backupMainPath( siteSlug, {
+					date: date.format( INDEX_FORMAT ),
+				} )
+			);
+		} else {
+			page( backupMainPath( siteSlug ) );
+		}
 	};
 
 	getSelectedDate() {

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -4,6 +4,7 @@
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
 import momentDate from 'moment';
+import page from 'page';
 import { localize } from 'i18n-calypso';
 import { includes } from 'lodash';
 
@@ -41,6 +42,7 @@ import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import { applySiteOffset } from 'lib/site/timezone';
 import QuerySiteSettings from 'components/data/query-site-settings'; // Required to get site time offset
 import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
+import { backupMainPath } from './paths';
 
 /**
  * Style dependencies
@@ -59,9 +61,9 @@ class BackupsPage extends Component {
 	state = this.getDefaultState();
 
 	getDefaultState() {
-		const { queryDate } = this.props;
+		const { queryDate, moment } = this.props;
 
-		const selectedDate = ! queryDate ? null : queryDate;
+		const selectedDate = ! queryDate ? null : moment( queryDate, INDEX_FORMAT );
 
 		return {
 			selectedDate: selectedDate,
@@ -80,7 +82,15 @@ class BackupsPage extends Component {
 	}
 
 	onDateChange = date => {
+		const { siteSlug } = this.props;
+
 		this.setState( { selectedDate: date } );
+
+		page(
+			backupMainPath( siteSlug, {
+				date: date.format( INDEX_FORMAT ),
+			} )
+		);
 	};
 
 	getSelectedDate() {
@@ -175,6 +185,7 @@ class BackupsPage extends Component {
 			<Main>
 				<DocumentHead title={ translate( 'Backups' ) } />
 				<SidebarNavigation />
+
 				<QueryRewindState siteId={ siteId } />
 				<QuerySitePurchases siteId={ siteId } />
 				<QuerySiteSettings siteId={ siteId } />

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -59,8 +59,12 @@ class BackupsPage extends Component {
 	state = this.getDefaultState();
 
 	getDefaultState() {
+		const { queryDate } = this.props;
+
+		const selectedDate = ! queryDate ? null : queryDate;
+
 		return {
-			selectedDate: null,
+			selectedDate: selectedDate,
 		};
 	}
 

--- a/client/landing/jetpack-cloud/sections/backups/paths.ts
+++ b/client/landing/jetpack-cloud/sections/backups/paths.ts
@@ -1,5 +1,10 @@
-export const backupMainPath = ( siteName?: string | null ) =>
-	siteName ? `/backups/${ siteName }` : '/backups';
+/**
+ * Internal dependencies
+ */
+import { addQueryArgs } from 'lib/url';
+
+export const backupMainPath = ( siteName?: string | null, query = {} ) =>
+	siteName ? addQueryArgs( query, `/backups/${ siteName }` ) : '/backups';
 
 export const backupActivityPath = ( siteName?: string | null ) =>
 	siteName ? `/backups/activity/${ siteName }` : '/backups/activity';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We need to keep the history when we are browsing through the backup dates, for example, if we have on the Backup Status page and we go to the Download/Restore section of that backup and then we go back, we didn't have the history. We also couldn't copy or share the link if we needed to. With this change, we can go through the dates of the backups and keep the history.

#### Testing instructions

- Apply this change
- The first time, we don't have a selected date, so we see the today backup status
- If we navigate through the dates, we can see in the URL the query parameter `date` with the selected date with this format `YYYYMMDD`
- If we change the parameter for another valid date (with the expected format), the Backup Status page loads the backup of this date.
- If we change the parameter for an invalid date (future date or any character), the Backup Status page loads today's backup status.

**Note:** In this PR the browser back/forward buttons don't work

