### PR TITLE
composite-checkout: Move DomainContactDetails to separate file and add ccTLD data

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/types.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types.ts
@@ -26,6 +26,11 @@ import {
 	processRawResponse,
 } from './types/backend/shopping-cart-endpoint';
 import {
+	DomainContactDetails,
+	PossiblyCompleteDomainContactDetails,
+	DomainContactDetailsErrors,
+} from './types/backend/domain-contact-details-components';
+import {
 	WPCOMCart,
 	WPCOMCartItem,
 	WPCOMCartCouponItem,
@@ -43,8 +48,6 @@ import {
 	isTouched,
 	ManagedContactDetailsErrors,
 	managedContactDetailsUpdaters,
-	DomainContactDetails,
-	PossiblyCompleteDomainContactDetails,
 	prepareDomainContactDetails,
 	prepareDomainContactDetailsErrors,
 	isValid,
@@ -89,6 +92,7 @@ export {
 	managedContactDetailsUpdaters,
 	DomainContactDetails,
 	PossiblyCompleteDomainContactDetails,
+	DomainContactDetailsErrors,
 	prepareDomainContactDetails,
 	prepareDomainContactDetailsErrors,
 	isValid,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-details-components.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-details-components.ts
@@ -1,0 +1,112 @@
+/*
+ * The data model used in ContactDetailsFormFields and related components.
+ * This belongs in components/domains/contact-details-form-fields, but until
+ * that component is rewritten in TypeScript we'll put it here.
+ *
+ * @see components/domains/contact-details-form-fields
+ * @see components/domains/registrant-extra-info
+ */
+
+export type DomainContactDetails = {
+	firstName?: string;
+	lastName?: string;
+	organization?: string;
+	email?: string;
+	alternateEmail?: string;
+	phone?: string;
+	address1?: string;
+	address2?: string;
+	city?: string;
+	state?: string;
+	postalCode?: string;
+	countryCode?: string;
+	fax?: string;
+	vatId?: string;
+	extra?: DomainContactDetailsExtra;
+};
+
+type DomainContactDetailsExtra = {
+	ca?: CaDomainContactExtraDetails | null;
+	uk?: UkDomainContactExtraDetails | null;
+	fr?: FrDomainContactExtraDetails | null;
+};
+
+export type CaDomainContactExtraDetails = {
+	lang?: string;
+	legalType?: string;
+	ciraAgreementAccepted?: boolean;
+};
+
+export type UkDomainContactExtraDetails = {
+	registrantType?: string;
+	registrationNumber?: string;
+	tradingName?: string;
+};
+
+export type FrDomainContactExtraDetails = {
+	registrantType?: string;
+	registrantVatId?: string;
+	trademarkNumber?: string;
+	sirenSirat?: string;
+};
+
+// This is the data returned by the redux state, where the fields could have a
+// null value.
+export type PossiblyCompleteDomainContactDetails = {
+	firstName: string | null;
+	lastName: string | null;
+	organization: string | null;
+	email: string | null;
+	alternateEmail: string | null;
+	phone: string | null;
+	address1: string | null;
+	address2: string | null;
+	city: string | null;
+	state: string | null;
+	postalCode: string | null;
+	countryCode: string | null;
+	fax: string | null;
+};
+
+export type DomainContactDetailsErrors = {
+	firstName?: string;
+	lastName?: string;
+	organization?: string;
+	email?: string;
+	alternateEmail?: string;
+	phone?: string;
+	address1?: string;
+	address2?: string;
+	city?: string;
+	state?: string;
+	postalCode?: string;
+	countryCode?: string;
+	fax?: string;
+	vatId?: string;
+	extra?: DomainContactDetailsErrorsExtra;
+};
+
+type DomainContactDetailsErrorsExtra = {
+	ca?: CaDomainContactExtraDetailsErrors | null;
+	uk?: UkDomainContactExtraDetailsErrors | null;
+	fr?: FrDomainContactExtraDetailsErrors | null;
+};
+
+export type CaDomainContactExtraDetailsErrors = {
+	lang?: string;
+	legalType?: string;
+	ciraAgreementAccepted?: string;
+};
+
+export type UkDomainContactExtraDetailsErrors = {
+	registrantType?: { errorCode: string; errorMessage: string }[];
+	registrationNumber?: { errorCode: string; errorMessage: string }[];
+	tradingName?: { errorCode: string; errorMessage: string }[];
+};
+
+export type FrDomainContactExtraDetailsErrors = {
+	registrantType?: string;
+	registrantVatId?: string;
+	trademarkNumber?: string;
+	sirenSirat?: string;
+};

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -5,12 +5,12 @@ import {
 	DomainContactDetails,
 	PossiblyCompleteDomainContactDetails,
 	DomainContactDetailsErrors,
-	CaDomainContactExtraDetails,
-	CaDomainContactExtraDetailsErrors,
-	UkDomainContactExtraDetails,
-	UkDomainContactExtraDetailsErrors,
-	FrDomainContactExtraDetails,
-	FrDomainContactExtraDetailsErrors,
+	CaDomainContactExtraDetails, // eslint-disable-line @typescript-eslint/no-unused-vars
+	CaDomainContactExtraDetailsErrors, // eslint-disable-line @typescript-eslint/no-unused-vars
+	UkDomainContactExtraDetails, // eslint-disable-line @typescript-eslint/no-unused-vars
+	UkDomainContactExtraDetailsErrors, // eslint-disable-line @typescript-eslint/no-unused-vars
+	FrDomainContactExtraDetails, // eslint-disable-line @typescript-eslint/no-unused-vars
+	FrDomainContactExtraDetailsErrors, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from './backend/domain-contact-details-components';
 
 /*

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -5,12 +5,6 @@ import {
 	DomainContactDetails,
 	PossiblyCompleteDomainContactDetails,
 	DomainContactDetailsErrors,
-	CaDomainContactExtraDetails, // eslint-disable-line @typescript-eslint/no-unused-vars
-	CaDomainContactExtraDetailsErrors, // eslint-disable-line @typescript-eslint/no-unused-vars
-	UkDomainContactExtraDetails, // eslint-disable-line @typescript-eslint/no-unused-vars
-	UkDomainContactExtraDetailsErrors, // eslint-disable-line @typescript-eslint/no-unused-vars
-	FrDomainContactExtraDetails, // eslint-disable-line @typescript-eslint/no-unused-vars
-	FrDomainContactExtraDetailsErrors, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from './backend/domain-contact-details-components';
 
 /*

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -1,3 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import {
+	DomainContactDetails,
+	PossiblyCompleteDomainContactDetails,
+	DomainContactDetailsErrors,
+	CaDomainContactExtraDetails,
+	CaDomainContactExtraDetailsErrors,
+	UkDomainContactExtraDetails,
+	UkDomainContactExtraDetailsErrors,
+	FrDomainContactExtraDetails,
+	FrDomainContactExtraDetailsErrors,
+} from './backend/domain-contact-details-components';
+
 /*
  * All child components in composite checkout are controlled -- they accept
  * data from their parents and evaluate callbacks when edited, rather than
@@ -133,61 +148,6 @@ function setManagedContactDetailsErrors(
 		vatId: setErrors( errors.vatId, details.vatId ),
 	};
 }
-
-/*
- * The data model used in the ContactDetailsFormFields component.
- * This belongs in components/domains/contact-details-form-fields, but until
- * that component is rewritten in TypeScript we'll put it here.
- */
-export type DomainContactDetails = {
-	firstName: string;
-	lastName: string;
-	organization: string;
-	email: string;
-	alternateEmail: string;
-	phone: string;
-	address1: string;
-	address2: string;
-	city: string;
-	state: string;
-	postalCode: string;
-	countryCode: string;
-	fax: string;
-};
-
-// This is the data returned by the redux state, where the fields could have a
-// null value.
-export type PossiblyCompleteDomainContactDetails = {
-	firstName: string | null;
-	lastName: string | null;
-	organization: string | null;
-	email: string | null;
-	alternateEmail: string | null;
-	phone: string | null;
-	address1: string | null;
-	address2: string | null;
-	city: string | null;
-	state: string | null;
-	postalCode: string | null;
-	countryCode: string | null;
-	fax: string | null;
-};
-
-export type DomainContactDetailsErrors = {
-	firstName?: string;
-	lastName?: string;
-	organization?: string;
-	email?: string;
-	alternateEmail?: string;
-	phone?: string;
-	address1?: string;
-	address2?: string;
-	city?: string;
-	state?: string;
-	postalCode?: string;
-	countryCode?: string;
-	fax?: string;
-};
 
 /*
  * Convert a ManagedContactDetails object (used internally by the


### PR DESCRIPTION
In preparation for adding the extra tld contact fields, we need to separate out three different kinds of contact details objects with slightly different semantics:

1. The data expected by the contact form component in calypso (and the data returned by it)
2. The data expected by the validation endpoint,
3. The data stored by composite-checkout.

In a better world than the one we have now, these could be unified.

This PR deals with case 1 by pulling this data type out of `wpcom-store-state` and adding extra fields related to ccTLDs.

#### Testing instructions

This should have no observable effect on composite checkout -- make sure this is the case by going through checkout looking for errors.
