### PR TITLE
Composite checkout: Add useDomainNamesInCart hook

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-domains.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-domains.js
@@ -8,6 +8,11 @@ export function useHasDomainsInCart() {
 	return areDomainsInLineItems( items );
 }
 
+export function useDomainNamesInCart() {
+	const [ items ] = useLineItems();
+	return items.filter( isLineItemADomain ).map( item => item.wpcom_meta?.meta );
+}
+
 export function areDomainsInLineItems( items ) {
 	if ( items.find( isLineItemADomain ) ) {
 		return true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In preparation for adding ccTLD forms to composite checkout, we need this hook for getting the domain names in the cart.

#### Testing instructions

This should have no observable effect on checkout.