### PR TITLE
Jetpack Cloud: Show 'No backups exist' for sites that have no backups

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -155,7 +155,37 @@ class DailyBackupStatus extends Component {
 		);
 	}
 
-	renderNoBackup() {
+	renderNoBackupEver() {
+		const { translate } = this.props;
+
+		return (
+			<>
+				<Gridicon icon="cloud-upload" className="daily-backup-status__gridicon-no-backup" />
+				<div className="daily-backup-status__title">{ translate( 'No backup' ) }</div>
+
+				<div className="daily-backup-status__label">
+					<p>{ translate( 'No backups are available yet.' ) }</p>
+					<p>
+						{ translate(
+							'But don’t worry, one should become available in the next 24 hours. Contact support if you still need help.'
+						) }
+					</p>
+				</div>
+
+				<Button
+					className="daily-backup-status__support-button"
+					href="https://jetpack.com/contact-support/"
+					target="_blank"
+					rel="noopener noreferrer"
+					isPrimary={ false }
+				>
+					{ translate( 'Contact support' ) }
+				</Button>
+			</>
+		);
+	}
+
+	renderNoBackupOnDate() {
 		const { translate, selectedDate, onDateChange } = this.props;
 
 		const displayDate = selectedDate.format( 'll' );
@@ -265,22 +295,27 @@ class DailyBackupStatus extends Component {
 	renderBackupStatus( backup ) {
 		const { selectedDate, lastDateAvailable, moment, timezone, gmtOffset } = this.props;
 
+		if ( backup ) {
+			return isSuccessfulBackup( backup )
+				? this.renderGoodBackup( backup )
+				: this.renderFailedBackup( backup );
+		}
+
+		if ( ! lastDateAvailable ) {
+			return this.renderNoBackupEver();
+		}
+
 		const today = applySiteOffset( moment(), {
 			timezone: timezone,
 			gmtOffset: gmtOffset,
 		} );
 
 		const isToday = today.isSame( selectedDate, 'day' );
-
-		if ( ! backup && isToday ) {
+		if ( isToday ) {
 			return this.renderNoBackupToday( lastDateAvailable );
-		} else if ( ! backup ) {
-			return this.renderNoBackup();
-		} else if ( isSuccessfulBackup( backup ) ) {
-			return this.renderGoodBackup( backup );
 		}
 
-		return this.renderFailedBackup( backup );
+		return this.renderNoBackupOnDate();
 	}
 
 	render() {

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -161,15 +161,15 @@ class DailyBackupStatus extends Component {
 		return (
 			<>
 				<Gridicon icon="cloud-upload" className="daily-backup-status__gridicon-no-backup" />
-				<div className="daily-backup-status__title">{ translate( 'No backup' ) }</div>
 
-				<div className="daily-backup-status__label">
-					<p>{ translate( 'No backups are available yet.' ) }</p>
-					<p>
-						{ translate(
-							'But don’t worry, one should become available in the next 24 hours. Contact support if you still need help.'
-						) }
-					</p>
+				<div className="daily-backup-status__date">
+					{ translate( 'No backups are available yet.' ) }
+				</div>
+
+				<div className="daily-backup-status__unavailable">
+					{ translate(
+						'But don’t worry, one should become available in the next 24 hours. Contact support if you still need help.'
+					) }
 				</div>
 
 				<Button

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -28,9 +28,14 @@
 	color: var( --studio-gray-40 );
 }
 
-.daily-backup-status__label {
+.daily-backup-status__label,
+.daily-backup-status__unavailable {
 	color: var( --studio-gray-80 );
 	text-align: left;
+}
+
+.daily-backup-status__unavailable {
+	margin-bottom: 1rem;
 }
 
 .daily-backup-status__date,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently I'm seeing a failure to load the Backups page on Jetpack Cloud when I select a new site that has no backups available. This looks like it's because we're missing a null check on `renderNoBackupToday`, so I switched some logic around to account for this case.

I also inverted the Boolean logic in `renderBackupStatus` a bit, with the intent to keep things readable since I added another condition. (This style is something I borrowed from the Go community; I'm 100% open to adapting it if it's not in tune with _our_ community's coding style.)

I cribbed my verbiage here from the other backup "states," but I feel like it might still be able to be improved.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new WordPress site and connect it to Jetpack.
* Go to Jetpack Cloud and select your new site.
* Ensure that the Backups page loads correctly and shows that no backups are currently available.
* Ensure that for sites with backups available, the Backups page still functions as designed.

<img width="725" alt="No backups are available yet." src="https://user-images.githubusercontent.com/670067/79159161-34f48900-7d9d-11ea-941f-0c6262a540f8.png">
