### PR TITLE
Add Jetpack Cloud Styled Button Component

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -11,7 +11,7 @@ import { get } from 'lodash';
  */
 import { withLocalizedMoment } from 'components/localized-moment';
 import Gridicon from 'components/gridicon';
-import Button from 'components/forms/form-button';
+import Button from 'landing/jetpack-cloud/components/jetpack-cloud-button';
 import { isSuccessfulBackup } from 'landing/jetpack-cloud/sections/backups/utils';
 import {
 	/*backupDetailPath,*/ backupDownloadPath,
@@ -142,11 +142,9 @@ class DailyBackupStatus extends Component {
 						) }
 					</p>
 					<Button
-						className="daily-backup-status__support-button"
 						href="https://jetpack.com/contact-support/"
 						target="_blank"
 						rel="noopener noreferrer"
-						isPrimary={ false }
 					>
 						{ translate( 'Contact support' ) }
 					</Button>
@@ -197,11 +195,9 @@ class DailyBackupStatus extends Component {
 				</div>
 
 				<Button
-					className="daily-backup-status__support-button"
 					href="https://jetpack.com/contact-support/"
 					target="_blank"
 					rel="noopener noreferrer"
-					isPrimary={ false }
 				>
 					{ translate( 'Contact support' ) }
 				</Button>
@@ -303,23 +299,14 @@ const ActionButtons = ( {
 	const translate = useTranslate();
 
 	return (
-		<>
-			<Button
-				className="daily-backup-status__download-button"
-				onClick={ onDownloadClick }
-				disabled={ disabledDownload }
-				isPrimary={ false }
-			>
+		<div className="daily-backup-status__action-buttons">
+			<Button onClick={ onDownloadClick } disabled={ disabledDownload }>
 				{ translate( 'Download backup' ) }
 			</Button>
-			<Button
-				className="daily-backup-status__restore-button"
-				disabled={ disabledRestore }
-				onClick={ onRestoreClick }
-			>
+			<Button disabled={ disabledRestore } onClick={ onRestoreClick } primary>
 				{ translate( 'Restore to this point' ) }
 			</Button>
-		</>
+		</div>
 	);
 };
 ActionButtons.defaultProps = {

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -123,7 +123,7 @@
 	flex-direction: column;
 
 	& > :not( :first-child ) {
-		margin-left: auto;
+		margin-left: 0;
 		margin-top: 1rem;
 	}
 
@@ -132,7 +132,7 @@
 
 		& > :not( :first-child ) {
 			margin-left: 1rem;
-			margin-top: auto;
+			margin-top: 0;
 		}
 	}
 }

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -53,20 +53,6 @@
 	font-style: italic;
 }
 
-.form-button.daily-backup-status__restore-button,
-.form-button.daily-backup-status__download-button,
-.form-button.daily-backup-status__support-button {
-	float: none;
-	display: block;
-	width: 100%;
-	text-align: center;
-	margin-left: 0;
-}
-
-.form-button.daily-backup-status__download-button {
-	margin: 1rem 0;
-}
-
 .daily-backup-status__meta,
 .daily-backup-status__title {
 	display: none;

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -114,16 +114,25 @@
 		margin-bottom: 1rem;
 		color: var( --studio-gray-40 );
 		font-weight: 400;
-    	font-size: 0.9rem;
+		font-size: 0.9rem;
+	}
+}
+
+.daily-backup-status__action-buttons {
+	display: flex;
+	flex-direction: column;
+
+	& > :not( :first-child ) {
+		margin-left: auto;
+		margin-top: 1rem;
 	}
 
-	.form-button.daily-backup-status__download-button,
-	.form-button.daily-backup-status__restore-button {
-		display: inline-block;
-		width: initial;
-		margin: 0;
-		margin-right: 1rem;
-		padding-left: 2rem;
-		padding-right: 2rem;
+	@include breakpoint( '>660px' ) {
+		flex-direction: row;
+
+		& > :not( :first-child ) {
+			margin-left: 1rem;
+			margin-top: auto;
+		}
 	}
 }

--- a/client/landing/jetpack-cloud/components/jetpack-cloud-button/index.tsx
+++ b/client/landing/jetpack-cloud/components/jetpack-cloud-button/index.tsx
@@ -22,7 +22,7 @@ interface Props {
 	href?: string;
 	busy?: boolean;
 	onClick?: MouseEventHandler< Button >;
-	diasbled?: boolean;
+	disabled?: boolean;
 }
 
 const JetpackCloudButton: FunctionComponent< Props > = props => {

--- a/client/landing/jetpack-cloud/components/jetpack-cloud-button/index.tsx
+++ b/client/landing/jetpack-cloud/components/jetpack-cloud-button/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent, MouseEventHandler } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@automattic/components';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+// copied from packages/components/src/button/index.jsx, stops ts complaining
+interface Props {
+	primary?: boolean;
+	compact?: boolean;
+	target?: string;
+	rel?: string;
+	href?: string;
+	busy?: boolean;
+	onClick?: MouseEventHandler< Button >;
+	diasbled?: boolean;
+}
+
+const JetpackCloudButton: FunctionComponent< Props > = props => {
+	return <Button borderless className="jetpack-cloud-button" { ...props } />;
+};
+
+export default JetpackCloudButton;

--- a/client/landing/jetpack-cloud/components/jetpack-cloud-button/style.scss
+++ b/client/landing/jetpack-cloud/components/jetpack-cloud-button/style.scss
@@ -1,13 +1,12 @@
 .button.jetpack-cloud-button.is-borderless {
-	align-items: center;
+	// align-items: center;
 	border-radius: 3px;
-	display: flex;
+	// display: flex;
 	font-size: 16px;
 	font-style: normal;
 	font-weight: 600;
-	justify-content: center;
 	line-height: 23px;
-	padding: 8px 16px;
+	padding: 0.5rem 2rem;
 	text-align: center;
 	width: 100%;
 	// secondary button border
@@ -24,7 +23,7 @@
 
 	// pressed secondary button
 	&:active {
-		background: var( --color-primary-50 );
+		background: var( --color-primary-5 );
 	}
 
 	// disabled secondary button
@@ -35,21 +34,28 @@
 	}
 
 	&.is-primary {
-		background: var( --studio-jetpack-green-40 );
-		color: var( --studio-white );
+		background: var( --color-primary-40 );
 		border: none;
+		box-shadow: none;
+		color: var( --studio-white );
 
 		&:hover,
 		&:focus {
-			background: var( --studio-jetpack-green-30 );
+			background: var( --color-primary-30 );
+			border: none;
+			box-shadow: none;
 		}
 
 		&:active {
-			background: var( --studio-jetpack-green-50 );
+			background: var( --color-primary-50 );
+			border: none;
+			box-shadow: none;
 		}
 
 		&:disabled {
 			background: var( --studio-gray-10 );
+			border: none;
+			box-shadow: none;
 		}
 	}
 

--- a/client/landing/jetpack-cloud/components/jetpack-cloud-button/style.scss
+++ b/client/landing/jetpack-cloud/components/jetpack-cloud-button/style.scss
@@ -1,0 +1,59 @@
+.button.jetpack-cloud-button.is-borderless {
+	align-items: center;
+	border-radius: 3px;
+	display: flex;
+	font-size: 16px;
+	font-style: normal;
+	font-weight: 600;
+	justify-content: center;
+	line-height: 23px;
+	padding: 8px 16px;
+	text-align: center;
+	width: 100%;
+	// secondary button border
+	border: 1px solid var( --color-primary-40 );
+	// resting secondary button
+	background: var( --studio-white );
+	color: var( --color-primary-60 );
+
+	// hover/focused secondary button
+	&:hover,
+	&:focus {
+		background: var( --color-primary-0 );
+	}
+
+	// pressed secondary button
+	&:active {
+		background: var( --color-primary-50 );
+	}
+
+	// disabled secondary button
+	&:disabled {
+		background: var( --studio-white );
+		color: var( --studio-gray-10 );
+		border: 1px solid var( --studio-gray-10 );
+	}
+
+	&.is-primary {
+		background: var( --studio-jetpack-green-40 );
+		color: var( --studio-white );
+		border: none;
+
+		&:hover,
+		&:focus {
+			background: var( --studio-jetpack-green-30 );
+		}
+
+		&:active {
+			background: var( --studio-jetpack-green-50 );
+		}
+
+		&:disabled {
+			background: var( --studio-gray-10 );
+		}
+	}
+
+	@include breakpoint( '>660px' ) {
+		width: auto;
+	}
+}

--- a/client/landing/jetpack-cloud/components/jetpack-cloud-button/style.scss
+++ b/client/landing/jetpack-cloud/components/jetpack-cloud-button/style.scss
@@ -1,7 +1,5 @@
 .button.jetpack-cloud-button.is-borderless {
-	// align-items: center;
 	border-radius: 3px;
-	// display: flex;
 	font-size: 16px;
 	font-style: normal;
 	font-weight: 600;
@@ -33,12 +31,14 @@
 		border: 1px solid var( --studio-gray-10 );
 	}
 
+	// resting primary button
 	&.is-primary {
 		background: var( --color-primary-40 );
 		border: none;
 		box-shadow: none;
 		color: var( --studio-white );
 
+		// hover/focused primary button
 		&:hover,
 		&:focus {
 			background: var( --color-primary-30 );
@@ -46,12 +46,14 @@
 			box-shadow: none;
 		}
 
+		// pressed secondary button
 		&:active {
 			background: var( --color-primary-50 );
 			border: none;
 			box-shadow: none;
 		}
 
+		// resting primary button
 		&:disabled {
 			background: var( --studio-gray-10 );
 			border: none;

--- a/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/detail/index.jsx
@@ -19,7 +19,7 @@ import { emptyFilter } from 'state/activity-log/reducer';
 import { withLocalizedMoment } from 'components/localized-moment';
 import Gridicon from 'components/gridicon';
 import FoldableCard from 'components/foldable-card';
-import { Button } from '@automattic/components';
+import Button from '../../../components/jetpack-cloud-button';
 import Filterbar from 'my-sites/activity/filterbar';
 import { updateFilter } from 'state/activity-log/actions';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
@@ -78,8 +78,8 @@ class BackupDetailPage extends Component {
 					{ thisBackup && moment( thisBackup.activityDate ).format( 'YYYY-MM-DD' ) }
 				</div>
 				<div>
-					<Button primary={ false }>{ translate( 'Download backup' ) }</Button>
-					<Button primary={ true }>{ translate( 'Restore to this point' ) }</Button>
+					<Button>{ translate( 'Download backup' ) }</Button>
+					<Button primary>{ translate( 'Restore to this point' ) }</Button>
 				</div>
 				<FoldableCard header={ translate( 'Total # of files backed up' ) }>
 					<ul>{ metaList }</ul>

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
@@ -8,9 +8,9 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import { defaultRewindConfig, RewindConfig } from './types';
 import { rewindBackup } from 'state/activity-log/actions';
+import Button from 'landing/jetpack-cloud/components/jetpack-cloud-button';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
 import getBackupDownloadId from 'state/selectors/get-backup-download-id';
 import getBackupDownloadProgress from 'state/selectors/get-backup-download-progress';
@@ -81,7 +81,6 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 				link="https://jetpack.com/support/backup"
 			/>
 			<Button
-				className="rewind-flow__primary-button"
 				primary
 				onClick={ requestDownload }
 				disabled={ Object.values( rewindConfig ).every( setting => ! setting ) }
@@ -146,7 +145,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<Button href={ downloadUrl } primary className="rewind-flow__primary-button">
+			<Button href={ downloadUrl } primary>
 				{ translate( 'Download file' ) }
 			</Button>
 			<CheckYourEmail
@@ -169,7 +168,6 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 				{ translate( 'An error occurred while creating your download' ) }
 			</h3>
 			<Button
-				className="rewind-flow__primary-button"
 				href={ `https://jetpack.com/contact-support/?scan-state=error&site-slug=${ siteSlug }` }
 				primary
 				rel="noopener noreferrer"

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
@@ -145,7 +145,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<Button href={ downloadUrl } primary>
+			<Button href={ downloadUrl } primary disabled={ ! downloadUrl }>
 				{ translate( 'Download file' ) }
 			</Button>
 			<CheckYourEmail

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
@@ -8,9 +8,9 @@ import React, { FunctionComponent, useCallback, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { Button } from '@automattic/components';
 import { defaultRewindConfig, RewindConfig } from './types';
 import { rewindRestore } from 'state/activity-log/actions';
+import Button from 'landing/jetpack-cloud/components/jetpack-cloud-button';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
 import getInProgressRewindPercentComplete from 'state/selectors/get-in-progress-rewind-percent-complete';
 import getInProgressRewindStatus from 'state/selectors/get-in-progress-rewind-status';
@@ -99,7 +99,6 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				type={ RewindFlowNoticeLevel.WARNING }
 			/>
 			<Button
-				className="rewind-flow__primary-button"
 				primary
 				onClick={ onConfirm }
 				disabled={ Object.values( rewindConfig ).every( setting => ! setting ) }
@@ -161,7 +160,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					}
 				) }
 			</p>
-			<Button primary href={ siteUrl } className="rewind-flow__primary-button">
+			<Button primary href={ siteUrl } disabled={ ! siteUrl }>
 				{ translate( 'View your website' ) }
 			</Button>
 		</>
@@ -179,7 +178,6 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				{ translate( 'An error occurred while restoring your site' ) }
 			</h3>
 			<Button
-				className="rewind-flow__primary-button"
 				href={ `https://jetpack.com/contact-support/?scan-state=error&site-slug=${ siteSlug }` }
 				primary
 				rel="noopener noreferrer"

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
@@ -109,17 +109,6 @@ a.rewind-flow-notice__title-warning:visited {
 	}
 }
 
-.rewind-flow__primary-button {
-	margin-bottom: 22.5px;
-	text-align: center;
-	width: 100%;
-
-	@include breakpoint( '>660px' ) {
-		text-align: auto;
-		width: auto;
-	}
-}
-
 .rewind-flow__progress-bar {
 	margin-bottom: 22.5px;
 

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
@@ -1,3 +1,9 @@
+.rewind-flow {
+	.button {
+		margin-bottom: 16px;
+	}
+}
+
 .rewind-flow__header {
 	display: flex;
 	justify-content: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* New component for styled Jetpack Cloud Button
* Use in Download & Restore flows
* Use in Backup Status Page

<img width="300" src="https://user-images.githubusercontent.com/2810519/79160544-d1fbf580-7d8e-11ea-9d7b-c7b2a5d3f024.png" >

<img width="300" src="https://user-images.githubusercontent.com/2810519/79160554-d45e4f80-7d8e-11ea-8b00-70f8d700dc00.png" >

<img width="300" src="https://user-images.githubusercontent.com/2810519/79160556-d4f6e600-7d8e-11ea-8b2f-45e909cc1659.png" >

#### Testing instructions

1. Navigate to `/backups`
2. Verify that the buttons look correct in narrow and wide, disabled and active states
3. Go through the restore and download flows, confirming again that the buttons match the Jetpack Cloud Style Guide
