### PR TITLE
Do not cache circular deps

### DIFF
--- a/packages/effective-module-tree/index.js
+++ b/packages/effective-module-tree/index.js
@@ -38,7 +38,7 @@ const findTree = ( packageJson, packagePath, parents, cache ) => {
 	const name = `${ packageJson.name }@${ packageJson.version }`;
 	if ( parents.includes( name ) ) {
 		debug( `Package ${ name } at ${ packagePath } seems to be a circular dependency!` );
-		return { [ name ]: '[Circular]' };
+		return { tree: { [ name ]: '[Circular]' }, isCacheable: false };
 	}
 
 	// We alredy solved this part of the tree
@@ -47,12 +47,14 @@ const findTree = ( packageJson, packagePath, parents, cache ) => {
 			`Package ${ name } at ${ packagePath } was already resolved, returning info from cache`
 		);
 		return {
-			...cache.get( packagePath ),
+			tree: cache.get( packagePath ),
+			isCacheable: true,
 		};
 	}
 
 	// For each dependency...
 	debug( `Finding dependencies for ${ name } at ${ packagePath }` );
+	let treeIsCacheable = true;
 	const dependencies = Object.keys( packageJson.dependencies || [] ).reduce(
 		( accumulated, dependency ) => {
 			let dependencyPath;
@@ -79,18 +81,26 @@ const findTree = ( packageJson, packagePath, parents, cache ) => {
 				return accumulated;
 			}
 
-			// Continue finding dependencies recursively
+			// Continue finding dependencies recursively.
+			const { tree, isCacheable } = findTree(
+				dependencyJson,
+				dependencyPath,
+				[ ...parents, name ],
+				cache
+			);
+			// Propagate 'cacheability': if the package is not cacheable, none of the parents should be.
+			treeIsCacheable = treeIsCacheable && isCacheable;
 			return {
 				...accumulated,
-				...findTree( dependencyJson, dependencyPath, [ ...parents, name ], cache ),
+				...tree,
 			};
 		},
 		{}
 	);
 
 	const result = { [ name ]: dependencies };
-	cache.set( packagePath, result );
-	return result;
+	if ( treeIsCacheable ) cache.set( packagePath, result );
+	return { tree: result, isCacheable: treeIsCacheable };
 };
 
 /**
@@ -102,8 +112,8 @@ const findTree = ( packageJson, packagePath, parents, cache ) => {
 const effectiveTree = async root => {
 	const packagePath = path.resolve( root );
 	const packageJson = require( path.join( packagePath ) );
-	const packages = findTree( packageJson, path.dirname( packagePath ), [], new Map() );
-	return treeify( packages, {
+	const { tree } = findTree( packageJson, path.dirname( packagePath ), [], new Map() );
+	return treeify( tree, {
 		sortFn: ( a, b ) => a.localeCompare( b ),
 	} );
 };

--- a/packages/effective-module-tree/test/test.js
+++ b/packages/effective-module-tree/test/test.js
@@ -128,8 +128,9 @@ describe( 'Effective tree generation', () => {
 		const tree = await effectiveTree( '/project/root/package.json' );
 
 		/**
-		 * Note that when we find 'a' in the chain root->b->c->a, it has been processed previously in the chain root->a
-		 * However, because the chain root->a ends up in a circular dependency, none of the packages in that chain is cached.
+		 * Note that when we find 'b' in the second chain (root->b->...), it has been processed previously in the first chain
+		 * (root->a->b->...). However, because that first chain ended in a circular dependency, none of the packages in the chain
+		 * was cached.
 		 *
 		 * This is a good thing. Otherwise, when we process 'b' the chain root->b we would pick 'b' from the cache,
 		 * (equal to 'b->c->a[Circular]'), and we would end up with the chain root->b->c->a[Circular], which is not true.

--- a/packages/effective-module-tree/test/test.js
+++ b/packages/effective-module-tree/test/test.js
@@ -1,4 +1,9 @@
-const mockedFiles = {
+const mockFiles = filesToMock => {
+	Object.entries( filesToMock ).forEach( ( [ file, content ] ) => {
+		jest.mock( file, () => content, { virtual: true } );
+	} );
+};
+mockFiles( {
 	'/project/root/package.json': {
 		name: 'root',
 		version: '1.0.0',
@@ -23,10 +28,6 @@ const mockedFiles = {
 		name: 'c',
 		version: '3.2.1',
 	},
-};
-
-Object.entries( mockedFiles ).forEach( ( [ file, content ] ) => {
-	jest.mock( file, () => content, { virtual: true } );
 } );
 
 const { candidates, effectiveTree } = require( '../index' );
@@ -60,6 +61,94 @@ describe( 'Effective tree generation', () => {
 			'   └─ b@2.2.2',
 			'      └─ c@3.2.1',
 		].join( '\n' ));
+	} );
+
+	it( 'Detects circular dependencies', async () => {
+		mockFiles( {
+			'/project/root/node_modules/c/package.json': {
+				name: 'c',
+				version: '3.2.1',
+				dependencies: {
+					b: '^2.0.0',
+				},
+			},
+		} );
+
+		jest.resetModules();
+		//eslint-disable-next-line no-shadow
+		const { effectiveTree } = require( '../index' );
+		const tree = await effectiveTree( '/project/root/package.json' );
+
+		//prettier-ignore
+		expect(tree).toEqual([
+			'└─ root@1.0.0',
+			'   ├─ a@1.1.1',
+			'   └─ b@2.2.2',
+			'      └─ c@3.2.1',
+			'         └─ b@2.2.2: [Circular]'
+		].join('\n'));
+	} );
+
+	it( 'Does not cache circular dependencies', async () => {
+		jest.resetModules();
+		mockFiles( {
+			'/project/root/package.json': {
+				name: 'root',
+				version: '1.0.0',
+				dependencies: {
+					a: '^1.0.0',
+					b: '^2.0.0',
+				},
+			},
+			'/project/root/node_modules/a/package.json': {
+				name: 'a',
+				version: '1.1.1',
+				dependencies: {
+					b: '^2.0.0',
+				},
+			},
+			'/project/root/node_modules/b/package.json': {
+				name: 'b',
+				version: '2.2.2',
+				dependencies: {
+					c: '3.2.1',
+				},
+			},
+			'/project/root/node_modules/c/package.json': {
+				name: 'c',
+				version: '3.2.1',
+				dependencies: {
+					a: '^1.0.0',
+				},
+			},
+		} );
+
+		//eslint-disable-next-line no-shadow
+		const { effectiveTree } = require( '../index' );
+		const tree = await effectiveTree( '/project/root/package.json' );
+
+		/**
+		 * Note that when we find 'a' in the chain root->b->c->a, it has been processed previously in the chain root->a
+		 * However, because the chain root->a ends up in a circular dependency, none of the packages in that chain is cached.
+		 *
+		 * This is a good thing. Otherwise, when we process 'b' the chain root->b we would pick 'b' from the cache,
+		 * (equal to 'b->c->a[Circular]'), and we would end up with the chain root->b->c->a[Circular], which is not true.
+		 *
+		 * So tldr: branches with [Circular] dependencies are not cached, and this test is asserting that behaviour.
+		 */
+
+		//prettier-ignore
+		expect(tree).toEqual([
+			'└─ root@1.0.0',
+			'   ├─ a@1.1.1',
+			'   │  └─ b@2.2.2',
+			'   │     └─ c@3.2.1',
+			'   │        └─ a@1.1.1: [Circular]',
+			'   └─ b@2.2.2',
+			'      └─ c@3.2.1',
+			'         └─ a@1.1.1',
+			'            └─ b@2.2.2: [Circular]',
+		].join('\n'));
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug in `@automattic/effective-module-tree`, where circular dependencies were cached. This is a bug because the fact that a branch contains a circular dependency it doesn't mean that anywhere that branch is reused in other part of the tree will still form a circular dependency.