### PR TITLE
New Checkout: split purchase details into second column

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -431,13 +431,13 @@ describe( 'CompositeCheckout', () => {
 		expect( getByText( 'ZIP code' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the checkout greeting header', async () => {
+	it( 'renders the checkout summary', async () => {
 		let renderResult;
 		await act( async () => {
 			renderResult = render( <MyCheckout />, container );
 		} );
 		const { getByText } = renderResult;
-		expect( getByText( 'You are all set to check out' ) ).toBeInTheDocument();
+		expect( getByText( 'Purchase Details' ) ).toBeInTheDocument();
 		expect( page.redirect ).not.toHaveBeenCalled();
 	} );
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -12,6 +12,7 @@ import { useLineItems, useFormStatus } from '@automattic/composite-checkout';
 import joinClasses from './join-classes';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
+import { isLineItemADomain } from '../hooks/has-domains';
 
 export default function WPCheckoutOrderReview( {
 	className,
@@ -23,13 +24,19 @@ export default function WPCheckoutOrderReview( {
 	variantSelectOverride,
 	getItemVariants,
 	onChangePlanLength,
+	siteUrl,
 } ) {
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const isPurchaseFree = total.amount.value === 0;
 
+	const firstDomainItem = items.find( isLineItemADomain );
+	const domainUrl = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
+
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
+			{ domainUrl && <DomainURL>{ domainUrl }</DomainURL> }
+
 			<WPOrderReviewSection>
 				<WPOrderReviewLineItems
 					items={ items }
@@ -62,6 +69,11 @@ WPCheckoutOrderReview.propTypes = {
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
 };
+
+const DomainURL = styled.div`
+	margin-top: -12px;
+	word-break: break-word;
+`;
 
 const CouponField = styled( Coupon )`
 	margin: 24px 30px 24px 0;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -68,6 +68,7 @@ WPCheckoutOrderReview.propTypes = {
 	removeCoupon: PropTypes.func.isRequired,
 	getItemVariants: PropTypes.func,
 	onChangePlanLength: PropTypes.func,
+	siteUrl: PropTypes.string,
 };
 
 const DomainURL = styled.div`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -37,7 +37,7 @@ export default function WPCheckoutOrderReview( {
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
-			{ domainUrl && <DomainURL>{ translate( 'Site' ) + ': ' + domainUrl }</DomainURL> }
+			{ domainUrl && <DomainURL>{ translate( 'Site: %s', { args: domainUrl } ) }</DomainURL> }
 
 			<WPOrderReviewSection>
 				<WPOrderReviewLineItems

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -5,6 +5,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { useLineItems, useFormStatus } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -26,6 +27,7 @@ export default function WPCheckoutOrderReview( {
 	onChangePlanLength,
 	siteUrl,
 } ) {
+	const translate = useTranslate();
 	const [ items, total ] = useLineItems();
 	const { formStatus } = useFormStatus();
 	const isPurchaseFree = total.amount.value === 0;
@@ -35,7 +37,7 @@ export default function WPCheckoutOrderReview( {
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>
-			{ domainUrl && <DomainURL>{ domainUrl }</DomainURL> }
+			{ domainUrl && <DomainURL>{ translate( 'Site' ) + ': ' + domainUrl }</DomainURL> }
 
 			<WPOrderReviewSection>
 				<WPOrderReviewLineItems
@@ -72,12 +74,14 @@ WPCheckoutOrderReview.propTypes = {
 };
 
 const DomainURL = styled.div`
-	margin-top: -12px;
+	color: ${( props ) => props.theme.colors.textColorLight};
+	font-size: 14px;
+	margin-top: -10px;
 	word-break: break-word;
 `;
 
 const CouponField = styled( Coupon )`
-	margin: 24px 30px 24px 0;
-	padding-bottom: 24px;
+	margin: 20px 30px 20px 0;
+	padding-bottom: 20px;
 	border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -3,12 +3,16 @@
  */
 import React from 'react';
 import styled from '@emotion/styled';
-import { useTax, useTotal, renderDisplayValueMarkdown } from '@automattic/composite-checkout';
+import {
+	useFirstLineItemOfType,
+	useTotal,
+	renderDisplayValueMarkdown,
+} from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 export default function WPCheckoutOrderSummary() {
 	const translate = useTranslate();
-	const tax = useTax();
+	const tax = useFirstLineItemOfType( 'tax' );
 	const total = useTotal();
 
 	return (
@@ -19,7 +23,7 @@ export default function WPCheckoutOrderSummary() {
 			<CheckoutSummaryAmountWrapper>
 				{ tax && (
 					<CheckoutSummaryLineItem>
-						<CheckoutSummaryLabel>{ translate( 'Taxes' ) }</CheckoutSummaryLabel>
+						<CheckoutSummaryLabel>{ translate( 'Tax' ) }</CheckoutSummaryLabel>
 						<CheckoutSummaryAmount>
 							{ renderDisplayValueMarkdown( tax.amount.displayValue ) }
 						</CheckoutSummaryAmount>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -17,9 +17,7 @@ export default function WPCheckoutOrderSummary() {
 
 	return (
 		<CheckoutSummaryWrapper className="components__checkout-order-summary">
-			<CheckoutSummaryTitle>
-				<span>{ translate( 'Purchase Details' ) }</span>
-			</CheckoutSummaryTitle>
+			<CheckoutSummaryTitle>{ translate( 'Purchase Details' ) }</CheckoutSummaryTitle>
 			<CheckoutSummaryAmountWrapper>
 				{ tax && (
 					<CheckoutSummaryLineItem>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import {
-	useFirstLineItemOfType,
+	useLineItemsOfType,
 	useTotal,
 	renderDisplayValueMarkdown,
 } from '@automattic/composite-checkout';
@@ -12,21 +12,21 @@ import { useTranslate } from 'i18n-calypso';
 
 export default function WPCheckoutOrderSummary() {
 	const translate = useTranslate();
-	const tax = useFirstLineItemOfType( 'tax' );
+	const taxes = useLineItemsOfType( 'tax' );
 	const total = useTotal();
 
 	return (
 		<CheckoutSummaryWrapper className="components__checkout-order-summary">
 			<CheckoutSummaryTitle>{ translate( 'Purchase Details' ) }</CheckoutSummaryTitle>
 			<CheckoutSummaryAmountWrapper>
-				{ tax && (
-					<CheckoutSummaryLineItem>
-						<CheckoutSummaryLabel>{ translate( 'Tax' ) }</CheckoutSummaryLabel>
+				{ taxes.map( tax => (
+					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + tax.id }>
+						<CheckoutSummaryLabel>{ tax.label }</CheckoutSummaryLabel>
 						<CheckoutSummaryAmount>
 							{ renderDisplayValueMarkdown( tax.amount.displayValue ) }
 						</CheckoutSummaryAmount>
 					</CheckoutSummaryLineItem>
-				) }
+				) ) }
 				<CheckoutSummaryTotal>
 					<CheckoutSummaryLabel>{ translate( 'Total' ) }</CheckoutSummaryLabel>
 					<CheckoutSummaryAmount>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -13,7 +13,9 @@ export default function WPCheckoutOrderSummary() {
 
 	return (
 		<CheckoutSummaryWrapper className="components__checkout-order-summary">
-			<WPCheckoutOrderSummaryTitle />
+			<CheckoutSummaryTitle>
+				<span>{ translate( 'Purchase Details' ) }</span>
+			</CheckoutSummaryTitle>
 			<CheckoutSummaryAmountWrapper>
 				{ tax && (
 					<CheckoutSummaryLineItem>
@@ -34,15 +36,6 @@ export default function WPCheckoutOrderSummary() {
 	);
 }
 
-function WPCheckoutOrderSummaryTitle() {
-	const translate = useTranslate();
-	return (
-		<CheckoutSummaryTitle>
-			<span>{ translate( 'Purchase Details' ) }</span>
-		</CheckoutSummaryTitle>
-	);
-}
-
 const CheckoutSummaryWrapper = styled.div`
 	background: ${props => props.theme.colors.surface};
 	border: 1px solid ${props => props.theme.colors.borderColorLight};
@@ -54,9 +47,10 @@ const CheckoutSummaryWrapper = styled.div`
 	}
 `;
 
-const CheckoutSummaryTitle = styled.span`
-	display: flex;
-	justify-content: space-between;
+const CheckoutSummaryTitle = styled.h2`
+	color: ${props => props.theme.colors.textColor};
+	font-weight: ${props => props.theme.weights.bold};
+	padding: 16px;
 `;
 
 const CheckoutSummaryAmountWrapper = styled.div`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -19,7 +19,7 @@ export default function WPCheckoutOrderSummary() {
 		<>
 			<CheckoutSummaryTitle>{ translate( 'Purchase Details' ) }</CheckoutSummaryTitle>
 			<CheckoutSummaryAmountWrapper>
-				{ taxes.map( tax => (
+				{ taxes.map( ( tax ) => (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + tax.id }>
 						<span>{ tax.label }</span>
 						<span>{ renderDisplayValueMarkdown( tax.amount.displayValue ) }</span>
@@ -35,13 +35,13 @@ export default function WPCheckoutOrderSummary() {
 }
 
 const CheckoutSummaryTitle = styled.h2`
-	color: ${props => props.theme.colors.textColor};
-	font-weight: ${props => props.theme.weights.bold};
+	color: ${( props ) => props.theme.colors.textColor};
+	font-weight: ${( props ) => props.theme.weights.bold};
 	padding: 16px;
 `;
 
 const CheckoutSummaryAmountWrapper = styled.div`
-	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
+	border-top: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 	padding: 16px;
 `;
 
@@ -52,5 +52,5 @@ const CheckoutSummaryLineItem = styled.div`
 `;
 
 const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
-	font-weight: ${props => props.theme.weights.bold};
+	font-weight: ${( props ) => props.theme.weights.bold};
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -3,34 +3,73 @@
  */
 import React from 'react';
 import styled from '@emotion/styled';
-import { useTotal, renderDisplayValueMarkdown } from '@automattic/composite-checkout';
+import { useTax, useTotal, renderDisplayValueMarkdown } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
 export default function WPCheckoutOrderSummary() {
+	const translate = useTranslate();
+	const tax = useTax();
+	const total = useTotal();
+
 	return (
-		<React.Fragment>
+		<CheckoutSummaryWrapper className="components__checkout-order-summary">
 			<WPCheckoutOrderSummaryTitle />
-		</React.Fragment>
+			<CheckoutSummaryAmountWrapper>
+				{ tax && (
+					<>
+						<CheckoutSummaryLabel>{ translate( 'Taxes' ) }</CheckoutSummaryLabel>
+						<CheckoutSummaryAmount>
+							{ renderDisplayValueMarkdown( tax.amount.displayValue ) }
+						</CheckoutSummaryAmount>
+					</>
+				) }
+				<CheckoutSummaryTotal>
+					<CheckoutSummaryLabel>{ translate( 'Total' ) }</CheckoutSummaryLabel>
+					<CheckoutSummaryAmount>
+						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
+					</CheckoutSummaryAmount>
+				</CheckoutSummaryTotal>
+			</CheckoutSummaryAmountWrapper>
+		</CheckoutSummaryWrapper>
 	);
 }
 
 function WPCheckoutOrderSummaryTitle() {
 	const translate = useTranslate();
-	const total = useTotal();
 	return (
 		<CheckoutSummaryTitle>
 			<span>{ translate( 'Purchase Details' ) }</span>
-			<CheckoutSummaryTotal>
-				{ renderDisplayValueMarkdown( total.amount.displayValue ) }
-			</CheckoutSummaryTotal>
 		</CheckoutSummaryTitle>
 	);
 }
+
+const CheckoutSummaryWrapper = styled.div`
+	background: ${props => props.theme.colors.surface};
+	border: 1px solid ${props => props.theme.colors.borderColorLight};
+
+	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
+		float: right;
+		margin-left: 16px;
+		width: 326px;
+	}
+`;
 
 const CheckoutSummaryTitle = styled.span`
 	display: flex;
 	justify-content: space-between;
 `;
+
+const CheckoutSummaryAmountWrapper = styled.div`
+	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	padding: 16px;
+`;
+
+const CheckoutSummaryLabel = styled.span``;
+
+const CheckoutSummaryAmount = styled.span``;
 
 const CheckoutSummaryTotal = styled.span`
 	font-weight: ${( props ) => props.theme.weights.bold};

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -16,38 +16,23 @@ export default function WPCheckoutOrderSummary() {
 	const total = useTotal();
 
 	return (
-		<CheckoutSummaryWrapper className="components__checkout-order-summary">
+		<>
 			<CheckoutSummaryTitle>{ translate( 'Purchase Details' ) }</CheckoutSummaryTitle>
 			<CheckoutSummaryAmountWrapper>
 				{ taxes.map( tax => (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + tax.id }>
-						<CheckoutSummaryLabel>{ tax.label }</CheckoutSummaryLabel>
-						<CheckoutSummaryAmount>
-							{ renderDisplayValueMarkdown( tax.amount.displayValue ) }
-						</CheckoutSummaryAmount>
+						<span>{ tax.label }</span>
+						<span>{ renderDisplayValueMarkdown( tax.amount.displayValue ) }</span>
 					</CheckoutSummaryLineItem>
 				) ) }
 				<CheckoutSummaryTotal>
-					<CheckoutSummaryLabel>{ translate( 'Total' ) }</CheckoutSummaryLabel>
-					<CheckoutSummaryAmount>
-						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
-					</CheckoutSummaryAmount>
+					<span>{ translate( 'Total' ) }</span>
+					<span>{ renderDisplayValueMarkdown( total.amount.displayValue ) }</span>
 				</CheckoutSummaryTotal>
 			</CheckoutSummaryAmountWrapper>
-		</CheckoutSummaryWrapper>
+		</>
 	);
 }
-
-const CheckoutSummaryWrapper = styled.div`
-	background: ${props => props.theme.colors.surface};
-	border: 1px solid ${props => props.theme.colors.borderColorLight};
-
-	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
-		float: right;
-		margin-left: 16px;
-		width: 326px;
-	}
-`;
 
 const CheckoutSummaryTitle = styled.h2`
 	color: ${props => props.theme.colors.textColor};
@@ -59,10 +44,6 @@ const CheckoutSummaryAmountWrapper = styled.div`
 	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
 	padding: 16px;
 `;
-
-const CheckoutSummaryLabel = styled.span``;
-
-const CheckoutSummaryAmount = styled.span``;
 
 const CheckoutSummaryLineItem = styled.div`
 	display: flex;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -3,29 +3,23 @@
  */
 import React from 'react';
 import styled from '@emotion/styled';
-import { useLineItems, useTotal, renderDisplayValueMarkdown } from '@automattic/composite-checkout';
+import { useTotal, renderDisplayValueMarkdown } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
-/**
- * Internal dependencies
- */
-import { isLineItemADomain } from '../hooks/has-domains';
-
-export default function WPCheckoutOrderSummary( { siteUrl } ) {
-	const [ items ] = useLineItems();
-
-	const firstDomainItem = items.find( isLineItemADomain );
-	const domainUrl = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
-
-	return <React.Fragment>{ domainUrl && <DomainURL>{ domainUrl }</DomainURL> }</React.Fragment>;
+export default function WPCheckoutOrderSummary() {
+	return (
+		<React.Fragment>
+			<WPCheckoutOrderSummaryTitle />
+		</React.Fragment>
+	);
 }
 
-export function WPCheckoutOrderSummaryTitle() {
+function WPCheckoutOrderSummaryTitle() {
 	const translate = useTranslate();
 	const total = useTotal();
 	return (
 		<CheckoutSummaryTitle>
-			<span>{ translate( 'You are all set to check out' ) }</span>
+			<span>{ translate( 'Purchase Details' ) }</span>
 			<CheckoutSummaryTotal>
 				{ renderDisplayValueMarkdown( total.amount.displayValue ) }
 			</CheckoutSummaryTotal>
@@ -40,9 +34,4 @@ const CheckoutSummaryTitle = styled.span`
 
 const CheckoutSummaryTotal = styled.span`
 	font-weight: ${( props ) => props.theme.weights.bold};
-`;
-
-const DomainURL = styled.div`
-	margin-top: -12px;
-	word-break: break-word;
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -16,12 +16,12 @@ export default function WPCheckoutOrderSummary() {
 			<WPCheckoutOrderSummaryTitle />
 			<CheckoutSummaryAmountWrapper>
 				{ tax && (
-					<>
+					<CheckoutSummaryLineItem>
 						<CheckoutSummaryLabel>{ translate( 'Taxes' ) }</CheckoutSummaryLabel>
 						<CheckoutSummaryAmount>
 							{ renderDisplayValueMarkdown( tax.amount.displayValue ) }
 						</CheckoutSummaryAmount>
-					</>
+					</CheckoutSummaryLineItem>
 				) }
 				<CheckoutSummaryTotal>
 					<CheckoutSummaryLabel>{ translate( 'Total' ) }</CheckoutSummaryLabel>
@@ -61,9 +61,6 @@ const CheckoutSummaryTitle = styled.span`
 
 const CheckoutSummaryAmountWrapper = styled.div`
 	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-between;
 	padding: 16px;
 `;
 
@@ -71,6 +68,12 @@ const CheckoutSummaryLabel = styled.span``;
 
 const CheckoutSummaryAmount = styled.span``;
 
-const CheckoutSummaryTotal = styled.span`
-	font-weight: ${( props ) => props.theme.weights.bold};
+const CheckoutSummaryLineItem = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+`;
+
+const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
+	font-weight: ${props => props.theme.weights.bold};
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -4,9 +4,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import {
+	CheckoutCheckIcon,
+	renderDisplayValueMarkdown,
 	useLineItemsOfType,
 	useTotal,
-	renderDisplayValueMarkdown,
 } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
@@ -18,6 +19,29 @@ export default function WPCheckoutOrderSummary() {
 	return (
 		<>
 			<CheckoutSummaryTitle>{ translate( 'Purchase Details' ) }</CheckoutSummaryTitle>
+			<CheckoutSummaryFeatures>
+				<CheckoutSummaryFeaturesTitle>
+					{ translate( 'Included with your purchase' ) }
+				</CheckoutSummaryFeaturesTitle>
+				<CheckoutSummaryFeaturesList>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon />
+						{ translate( 'Live chat and email support' ) }
+					</CheckoutSummaryFeaturesListItem>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon />
+						{ translate( 'Free custom domain for a year' ) }
+					</CheckoutSummaryFeaturesListItem>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon />
+						{ translate( 'Dozens of free themes' ) }
+					</CheckoutSummaryFeaturesListItem>
+					<CheckoutSummaryFeaturesListItem>
+						<WPCheckoutCheckIcon />
+						{ translate( 'Money back guarantee' ) }
+					</CheckoutSummaryFeaturesListItem>
+				</CheckoutSummaryFeaturesList>
+			</CheckoutSummaryFeatures>
 			<CheckoutSummaryAmountWrapper>
 				{ taxes.map( ( tax ) => (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + tax.id }>
@@ -36,13 +60,44 @@ export default function WPCheckoutOrderSummary() {
 
 const CheckoutSummaryTitle = styled.h2`
 	color: ${( props ) => props.theme.colors.textColor};
+	display: none;
 	font-weight: ${( props ) => props.theme.weights.bold};
-	padding: 16px;
+	padding: 20px 20px 0;
+
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+		display: none;
+	}
+`;
+
+const CheckoutSummaryFeatures = styled.div`
+	padding: 20px;
+`;
+
+const CheckoutSummaryFeaturesTitle = styled.h3`
+	font-size: 16px;
+	font-weight: ${( props ) => props.theme.weights.normal};
+	margin-bottom: 4px;
+`;
+
+const CheckoutSummaryFeaturesList = styled.ul`
+	margin: 0;
+	list-style: none;
+	font-size: 14px;
+`;
+
+const WPCheckoutCheckIcon = styled( CheckoutCheckIcon )`
+	fill: ${( props ) => props.theme.colors.success};
+	margin-right: 4px;
+	vertical-align: bottom;
+`;
+
+const CheckoutSummaryFeaturesListItem = styled.li`
+	margin-bottom: 4px;
 `;
 
 const CheckoutSummaryAmountWrapper = styled.div`
 	border-top: 1px solid ${( props ) => props.theme.colors.borderColorLight};
-	padding: 16px;
+	padding: 20px;
 `;
 
 const CheckoutSummaryLineItem = styled.div`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -130,9 +130,9 @@ export default function WPCheckout( {
 
 	return (
 		<Checkout>
-			<CheckoutSummary>
+			<CheckoutSummaryUI>
 				<WPCheckoutOrderSummary />
-			</CheckoutSummary>
+			</CheckoutSummaryUI>
 			<CheckoutSteps>
 				<CheckoutStep
 					stepId="review-order-step"
@@ -212,6 +212,14 @@ export default function WPCheckout( {
 		</Checkout>
 	);
 }
+
+const CheckoutSummaryUI = styled( CheckoutSummary )`
+	display: none;
+
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+		display: block;
+	}
+`;
 
 function setActiveStepNumber( stepNumber ) {
 	window.location.hash = '#step' + stepNumber;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -6,7 +6,6 @@ import { useTranslate } from 'i18n-calypso';
 import styled from '@emotion/styled';
 import {
 	Checkout,
-	CheckoutStepBody,
 	CheckoutSteps,
 	CheckoutStep,
 	getDefaultPaymentMethodStep,
@@ -25,7 +24,7 @@ import {
 import { areDomainsInLineItems, isLineItemADomain } from '../hooks/has-domains';
 import useCouponFieldState from '../hooks/use-coupon-field-state';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
-import WPCheckoutOrderSummary, { WPCheckoutOrderSummaryTitle } from './wp-checkout-order-summary';
+import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import { isCompleteAndValid } from '../types';
 import { WPOrderReviewTotal, WPOrderReviewSection, LineItemUI } from './wp-order-review-line-items';
@@ -129,94 +128,89 @@ export default function WPCheckout( {
 	};
 
 	return (
-		<Checkout>
-			<CheckoutStepBody
-				activeStepContent={ null }
-				completeStepContent={ <WPCheckoutOrderSummary siteUrl={ siteUrl } /> }
-				titleContent={ <WPCheckoutOrderSummaryTitle /> }
-				errorMessage={ translate( 'There was an error with the summary step.' ) }
-				isStepActive={ false }
-				isStepComplete={ true }
-				stepNumber={ 1 }
-				totalSteps={ 1 }
-				stepId={ 'order-summary' }
-			/>
-			<CheckoutSteps>
-				<CheckoutStep
-					stepId="review-order-step"
-					isCompleteCallback={ () => true }
-					activeStepContent={
-						<WPCheckoutOrderReview
-							removeItem={ removeItem }
-							couponStatus={ couponStatus }
-							couponFieldStateProps={ couponFieldStateProps }
-							removeCoupon={ removeCouponAndResetActiveStep }
-							onChangePlanLength={ changePlanLength }
-							variantRequestStatus={ variantRequestStatus }
-							variantSelectOverride={ variantSelectOverride }
-							getItemVariants={ getItemVariants }
-						/>
-					}
-					titleContent={ <OrderReviewTitle /> }
-					completeStepContent={ <InactiveOrderReview /> }
-					editButtonText={ translate( 'Edit' ) }
-					editButtonAriaLabel={ translate( 'Edit the payment method' ) }
-					nextStepButtonText={ translate( 'Continue' ) }
-					nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
-					validatingButtonText={ translate( 'Please wait…' ) }
-					validatingButtonAriaLabel={ translate( 'Please wait…' ) }
-				/>
-				{ shouldShowContactStep && (
+		<>
+			<WPCheckoutOrderSummary />
+			<Checkout>
+				<CheckoutSteps>
 					<CheckoutStep
-						stepId={ 'contact-form' }
-						isCompleteCallback={ () => {
-							setShouldShowContactDetailsValidationErrors( true );
-							return contactValidationCallback();
-						} }
+						stepId="review-order-step"
+						isCompleteCallback={ () => true }
 						activeStepContent={
-							<WPContactForm
+							<WPCheckoutOrderReview
+								removeItem={ removeItem }
+								couponStatus={ couponStatus }
+								couponFieldStateProps={ couponFieldStateProps }
+								removeCoupon={ removeCouponAndResetActiveStep }
+								onChangePlanLength={ changePlanLength }
+								variantRequestStatus={ variantRequestStatus }
+								variantSelectOverride={ variantSelectOverride }
+								getItemVariants={ getItemVariants }
 								siteUrl={ siteUrl }
-								isComplete={ false }
-								isActive={ true }
-								CountrySelectMenu={ CountrySelectMenu }
-								countriesList={ countriesList }
-								StateSelect={ StateSelect }
-								renderDomainContactFields={ renderDomainContactFields }
-								shouldShowContactDetailsValidationErrors={
-									shouldShowContactDetailsValidationErrors
-								}
 							/>
 						}
-						completeStepContent={ <WPContactForm summary isComplete={ true } isActive={ false } /> }
-						titleContent={ <ContactFormTitle /> }
+						titleContent={ <OrderReviewTitle /> }
+						completeStepContent={ <InactiveOrderReview /> }
 						editButtonText={ translate( 'Edit' ) }
-						editButtonAriaLabel={ translate( 'Edit the contact details' ) }
+						editButtonAriaLabel={ translate( 'Edit the payment method' ) }
 						nextStepButtonText={ translate( 'Continue' ) }
-						nextStepButtonAriaLabel={ translate( 'Continue with the entered contact details' ) }
+						nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
 						validatingButtonText={ translate( 'Please wait…' ) }
 						validatingButtonAriaLabel={ translate( 'Please wait…' ) }
 					/>
-				) }
-				<CheckoutStep
-					stepId="payment-method-step"
-					activeStepContent={
-						<PaymentMethodStep
-							CheckoutTerms={ CheckoutTerms }
-							responseCart={ responseCart }
-							subtotal={ subtotal }
+					{ shouldShowContactStep && (
+						<CheckoutStep
+							stepId={ 'contact-form' }
+							isCompleteCallback={ () => {
+								setShouldShowContactDetailsValidationErrors( true );
+								return contactValidationCallback();
+							} }
+							activeStepContent={
+								<WPContactForm
+									siteUrl={ siteUrl }
+									isComplete={ false }
+									isActive={ true }
+									CountrySelectMenu={ CountrySelectMenu }
+									countriesList={ countriesList }
+									StateSelect={ StateSelect }
+									renderDomainContactFields={ renderDomainContactFields }
+									shouldShowContactDetailsValidationErrors={
+										shouldShowContactDetailsValidationErrors
+									}
+								/>
+							}
+							completeStepContent={
+								<WPContactForm summary isComplete={ true } isActive={ false } />
+							}
+							titleContent={ <ContactFormTitle /> }
+							editButtonText={ translate( 'Edit' ) }
+							editButtonAriaLabel={ translate( 'Edit the contact details' ) }
+							nextStepButtonText={ translate( 'Continue' ) }
+							nextStepButtonAriaLabel={ translate( 'Continue with the entered contact details' ) }
+							validatingButtonText={ translate( 'Please wait…' ) }
+							validatingButtonAriaLabel={ translate( 'Please wait…' ) }
 						/>
-					}
-					completeStepContent={ paymentMethodStep.completeStepContent }
-					titleContent={ paymentMethodStep.titleContent }
-					editButtonText={ translate( 'Edit' ) }
-					editButtonAriaLabel={ translate( 'Edit the payment method' ) }
-					nextStepButtonText={ translate( 'Continue' ) }
-					nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
-					validatingButtonText={ translate( 'Please wait…' ) }
-					validatingButtonAriaLabel={ translate( 'Please wait…' ) }
-				/>
-			</CheckoutSteps>
-		</Checkout>
+					) }
+					<CheckoutStep
+						stepId="payment-method-step"
+						activeStepContent={
+							<PaymentMethodStep
+								CheckoutTerms={ CheckoutTerms }
+								responseCart={ responseCart }
+								subtotal={ subtotal }
+							/>
+						}
+						completeStepContent={ paymentMethodStep.completeStepContent }
+						titleContent={ paymentMethodStep.titleContent }
+						editButtonText={ translate( 'Edit' ) }
+						editButtonAriaLabel={ translate( 'Edit the payment method' ) }
+						nextStepButtonText={ translate( 'Continue' ) }
+						nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
+						validatingButtonText={ translate( 'Please wait…' ) }
+						validatingButtonAriaLabel={ translate( 'Please wait…' ) }
+					/>
+				</CheckoutSteps>
+			</Checkout>
+		</>
 	);
 }
 
@@ -228,7 +222,7 @@ function PaymentMethodStep( { CheckoutTerms, responseCart, subtotal } ) {
 	const [ items, total ] = useLineItems();
 	const taxes = items.filter( ( item ) => item.type === 'tax' );
 	return (
-		<React.Fragment>
+		<>
 			{ paymentMethodStep.activeStepContent }
 
 			<CheckoutTermsUI>
@@ -242,7 +236,7 @@ function PaymentMethodStep( { CheckoutTerms, responseCart, subtotal } ) {
 				) ) }
 				<WPOrderReviewTotal total={ total } />
 			</WPOrderReviewSection>
-		</React.Fragment>
+		</>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -8,6 +8,7 @@ import {
 	Checkout,
 	CheckoutSteps,
 	CheckoutStep,
+	CheckoutSummary,
 	getDefaultPaymentMethodStep,
 	useIsStepActive,
 	useIsStepComplete,
@@ -128,89 +129,87 @@ export default function WPCheckout( {
 	};
 
 	return (
-		<>
-			<WPCheckoutOrderSummary />
-			<Checkout>
-				<CheckoutSteps>
-					<CheckoutStep
-						stepId="review-order-step"
-						isCompleteCallback={ () => true }
-						activeStepContent={
-							<WPCheckoutOrderReview
-								removeItem={ removeItem }
-								couponStatus={ couponStatus }
-								couponFieldStateProps={ couponFieldStateProps }
-								removeCoupon={ removeCouponAndResetActiveStep }
-								onChangePlanLength={ changePlanLength }
-								variantRequestStatus={ variantRequestStatus }
-								variantSelectOverride={ variantSelectOverride }
-								getItemVariants={ getItemVariants }
-								siteUrl={ siteUrl }
-							/>
-						}
-						titleContent={ <OrderReviewTitle /> }
-						completeStepContent={ <InactiveOrderReview /> }
-						editButtonText={ translate( 'Edit' ) }
-						editButtonAriaLabel={ translate( 'Edit the payment method' ) }
-						nextStepButtonText={ translate( 'Continue' ) }
-						nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
-						validatingButtonText={ translate( 'Please wait…' ) }
-						validatingButtonAriaLabel={ translate( 'Please wait…' ) }
-					/>
-					{ shouldShowContactStep && (
-						<CheckoutStep
-							stepId={ 'contact-form' }
-							isCompleteCallback={ () => {
-								setShouldShowContactDetailsValidationErrors( true );
-								return contactValidationCallback();
-							} }
-							activeStepContent={
-								<WPContactForm
-									siteUrl={ siteUrl }
-									isComplete={ false }
-									isActive={ true }
-									CountrySelectMenu={ CountrySelectMenu }
-									countriesList={ countriesList }
-									StateSelect={ StateSelect }
-									renderDomainContactFields={ renderDomainContactFields }
-									shouldShowContactDetailsValidationErrors={
-										shouldShowContactDetailsValidationErrors
-									}
-								/>
-							}
-							completeStepContent={
-								<WPContactForm summary isComplete={ true } isActive={ false } />
-							}
-							titleContent={ <ContactFormTitle /> }
-							editButtonText={ translate( 'Edit' ) }
-							editButtonAriaLabel={ translate( 'Edit the contact details' ) }
-							nextStepButtonText={ translate( 'Continue' ) }
-							nextStepButtonAriaLabel={ translate( 'Continue with the entered contact details' ) }
-							validatingButtonText={ translate( 'Please wait…' ) }
-							validatingButtonAriaLabel={ translate( 'Please wait…' ) }
+		<Checkout>
+			<CheckoutSummary>
+				<WPCheckoutOrderSummary />
+			</CheckoutSummary>
+			<CheckoutSteps>
+				<CheckoutStep
+					stepId="review-order-step"
+					isCompleteCallback={ () => true }
+					activeStepContent={
+						<WPCheckoutOrderReview
+							removeItem={ removeItem }
+							couponStatus={ couponStatus }
+							couponFieldStateProps={ couponFieldStateProps }
+							removeCoupon={ removeCouponAndResetActiveStep }
+							onChangePlanLength={ changePlanLength }
+							variantRequestStatus={ variantRequestStatus }
+							variantSelectOverride={ variantSelectOverride }
+							getItemVariants={ getItemVariants }
+							siteUrl={ siteUrl }
 						/>
-					) }
+					}
+					titleContent={ <OrderReviewTitle /> }
+					completeStepContent={ <InactiveOrderReview /> }
+					editButtonText={ translate( 'Edit' ) }
+					editButtonAriaLabel={ translate( 'Edit the payment method' ) }
+					nextStepButtonText={ translate( 'Continue' ) }
+					nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
+					validatingButtonText={ translate( 'Please wait…' ) }
+					validatingButtonAriaLabel={ translate( 'Please wait…' ) }
+				/>
+				{ shouldShowContactStep && (
 					<CheckoutStep
-						stepId="payment-method-step"
+						stepId={ 'contact-form' }
+						isCompleteCallback={ () => {
+							setShouldShowContactDetailsValidationErrors( true );
+							return contactValidationCallback();
+						} }
 						activeStepContent={
-							<PaymentMethodStep
-								CheckoutTerms={ CheckoutTerms }
-								responseCart={ responseCart }
-								subtotal={ subtotal }
+							<WPContactForm
+								siteUrl={ siteUrl }
+								isComplete={ false }
+								isActive={ true }
+								CountrySelectMenu={ CountrySelectMenu }
+								countriesList={ countriesList }
+								StateSelect={ StateSelect }
+								renderDomainContactFields={ renderDomainContactFields }
+								shouldShowContactDetailsValidationErrors={
+									shouldShowContactDetailsValidationErrors
+								}
 							/>
 						}
-						completeStepContent={ paymentMethodStep.completeStepContent }
-						titleContent={ paymentMethodStep.titleContent }
+						completeStepContent={ <WPContactForm summary isComplete={ true } isActive={ false } /> }
+						titleContent={ <ContactFormTitle /> }
 						editButtonText={ translate( 'Edit' ) }
-						editButtonAriaLabel={ translate( 'Edit the payment method' ) }
+						editButtonAriaLabel={ translate( 'Edit the contact details' ) }
 						nextStepButtonText={ translate( 'Continue' ) }
-						nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
+						nextStepButtonAriaLabel={ translate( 'Continue with the entered contact details' ) }
 						validatingButtonText={ translate( 'Please wait…' ) }
 						validatingButtonAriaLabel={ translate( 'Please wait…' ) }
 					/>
-				</CheckoutSteps>
-			</Checkout>
-		</>
+				) }
+				<CheckoutStep
+					stepId="payment-method-step"
+					activeStepContent={
+						<PaymentMethodStep
+							CheckoutTerms={ CheckoutTerms }
+							responseCart={ responseCart }
+							subtotal={ subtotal }
+						/>
+					}
+					completeStepContent={ paymentMethodStep.completeStepContent }
+					titleContent={ paymentMethodStep.titleContent }
+					editButtonText={ translate( 'Edit' ) }
+					editButtonAriaLabel={ translate( 'Edit the payment method' ) }
+					nextStepButtonText={ translate( 'Continue' ) }
+					nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
+					validatingButtonText={ translate( 'Please wait…' ) }
+					validatingButtonAriaLabel={ translate( 'Please wait…' ) }
+				/>
+			</CheckoutSteps>
+		</Checkout>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -57,7 +57,7 @@ function WPLineItem( {
 				<LineItemPrice lineItem={ item } />
 			</span>
 			{ hasDeleteButton && formStatus === 'ready' && (
-				<React.Fragment>
+				<>
 					<DeleteButton
 						buttonState="borderless"
 						disabled={ isDisabled }
@@ -96,7 +96,7 @@ function WPLineItem( {
 						title={ modalCopy.title }
 						copy={ modalCopy.description }
 					/>
-				</React.Fragment>
+				</>
 			) }
 
 			{ shouldShowVariantSelector && (
@@ -310,8 +310,7 @@ WPOrderReviewLineItems.propTypes = {
 };
 
 const WPOrderReviewList = styled.ul`
-	margin: -10px 0 10px 0;
-	padding: 0;
+	margin: 10px 0;
 `;
 
 const WPOrderReviewListItems = styled.li`
@@ -319,14 +318,6 @@ const WPOrderReviewListItems = styled.li`
 	padding: 0;
 	display: block;
 	list-style: none;
-
-	:first-of-type .checkout-line-item {
-		padding-top: 10px;
-	}
-
-	:first-of-type button {
-		top: -3px;
-	}
 `;
 
 function returnModalCopy( product, translate, hasDomainsInCart ) {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -179,11 +179,10 @@ export const LineItemUI = styled( WPLineItem )`
 	color: ${( { theme, total } ) => ( total ? theme.colors.textColorDark : theme.colors.textColor) };
 	font-size: ${( { total } ) => ( total ? '1.2em' : '1em') };
 	padding: ${( { total, isSummaryVisible, tax, subtotal } ) =>
-		isSummaryVisible || total || subtotal || tax ? '10px 0' : '24px 0'};
+		isSummaryVisible || total || subtotal || tax ? '10px 0' : '20px 0'};
 	border-bottom: ${( { theme, total, isSummaryVisible } ) =>
 		isSummaryVisible || total ? 0 : '1px solid ' + theme.colors.borderColorLight};
 	position: relative;
-	margin-right: ${( { total, tax, subtotal } ) => ( subtotal || total || tax ? '0' : '30px') };
 `;
 
 const LineItemTitleUI = styled.div`
@@ -207,7 +206,7 @@ const DeleteButton = styled( Button )`
 	position: absolute;
 	padding: 10px;
 	right: -50px;
-	top: 10px;
+	top: 8px;
 
 	:hover rect {
 		fill: ${( props ) => props.theme.colors.error};
@@ -275,7 +274,7 @@ export function WPOrderReviewLineItems( {
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
 			{ items.map( ( item ) => (
-				<WPOrderReviewListItems key={ item.id }>
+				<WPOrderReviewListItem key={ item.id }>
 					<LineItemUI
 						isSummaryVisible={ isSummaryVisible }
 						item={ item }
@@ -286,7 +285,7 @@ export function WPOrderReviewLineItems( {
 						getItemVariants={ getItemVariants }
 						onChangePlanLength={ onChangePlanLength }
 					/>
-				</WPOrderReviewListItems>
+				</WPOrderReviewListItem>
 			) ) }
 		</WPOrderReviewList>
 	);
@@ -310,10 +309,12 @@ WPOrderReviewLineItems.propTypes = {
 };
 
 const WPOrderReviewList = styled.ul`
-	margin: 10px 0;
+	border-top: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+	box-sizing: border-box;
+	margin: 20px 30px 20px 0;
 `;
 
-const WPOrderReviewListItems = styled.li`
+const WPOrderReviewListItem = styled.li`
 	margin: 0;
 	padding: 0;
 	display: block;

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -119,12 +119,6 @@ The main wrapper component for the checkout form. It has the following props.
 
 - `className?: string`. The className for the component.
 
-### CheckoutSummary
-
-Renders its `children` prop and acts as a wrapper to flow outside of the [`CheckoutSteps`](#CehckoutSteps) wrapper (floated on desktop, collapsed on mobile). It has the following props.
-
-- `className?: string`. The className for the component.
-
 ### CheckoutProvider
 
 Renders its `children` prop and acts as a React Context provider. All of checkout should be wrapped in this.
@@ -145,6 +139,10 @@ It has the following props.
 - `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder.
 
 The line items are for display purposes only. They should also include subtotals, discounts, and taxes. No math will be performed on the line items. Instead, the amount to be charged will be specified by the required prop `total`, which is another line item.
+
+### CheckoutReviewOrder
+
+Renders a list of the line items and their `displayValue` properties followed by the `total` line item, and whatever `submitButton` is in the current payment method.
 
 ## CheckoutStep
 
@@ -194,9 +192,11 @@ A component that looks like a checkout step. Normally you don't need to use this
 
 A wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [Checkout](#Checkout).
 
-### CheckoutReviewOrder
+### CheckoutSummary
 
-Renders a list of the line items and their `displayValue` properties followed by the `total` line item, and whatever `submitButton` is in the current payment method.
+Renders its `children` prop and acts as a wrapper to flow outside of the [`CheckoutSteps`](#CehckoutSteps) wrapper (floated on desktop, collapsed on mobile). It has the following props.
+
+- `className?: string`. The className for the component.
 
 ### OrderReviewLineItems
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -344,7 +344,7 @@ A React Hook that will return a two element array where the first element is the
 
 ### useLineItemsOfType
 
-A React Hook that will return an array of line items matching a specific 'type' (i.e. 'tax'). Only works within [CheckoutProvider](#CheckoutProvider).
+A React Hook taking one string argument that will return an array of [line items](#line-items) from the cart (derived from the same data returned by [useLineItems](#useLineItems)) whose `type` property matches that string. Only works within [CheckoutProvider](#CheckoutProvider).
 
 ### useMessages
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -12,7 +12,7 @@ Once published, you'll be able to install this package using npm with:
 
 ## Description
 
-This package provides a context provider, `CheckoutProvider`, and a default component, `Checkout`, which creates a checkout form.
+This package provides a context provider, `CheckoutProvider`, a default component, `Checkout`, and the `CheckoutSteps` component which creates a checkout form.
 
 The form has two default steps:
 
@@ -47,10 +47,11 @@ Any component which is a child of `CheckoutProvider` gets access to the followin
  - [useSelect](#useSelect)
  - [useTotal](#useTotal)
 
-The [Checkout](#checkout) component creates the form itself. Within the component you can render any children to create the checkout experience, but a few components are provided to make this easier:
- - [CheckoutSummary](#CheckoutSummary) can be used to render a summary that, by default, floats beside the checkout steps on larger screens and collapses behind a toggle at the top of smaller screens.
- - [CheckoutStepBody](#CheckoutStepBody) can be used to render something that looks like a checkout step. A series of these can be used to create a semantic form.
- - [CheckoutSteps](#CheckoutSteps) with [CheckoutStep](#CheckoutStep) children can be used to create a series of steps that are joined by "Continue" buttons which are hidden and displayed as needed.
+The [Checkout](#checkout) component creates a wrapper for Checkout. Within the component you can render any children to create the checkout experience, but a few components are provided to make this easier:
+ - [CheckoutSummary](#CheckoutSummary) (optional) can be used to render a summary that, by default, floats beside the checkout steps on larger screens and collapses behind a toggle at the top of smaller screens.
+ - [CheckoutSteps](#CheckoutSteps) (required) creates the Checkout form itself. This includes the Checkout submit button and logic to handle step progression.
+ - [CheckoutStep](#CheckoutStep) (optional) children of `CheckoutSteps` can be used to create a series of steps that are joined by "Continue" buttons which are hidden and displayed as needed.
+ - [CheckoutStepBody](#CheckoutStepBody) (optional) can be used to render something that looks like a checkout step. A series of these can be used to create a semantic form.
 
 Each `CheckoutStep` has an `isCompleteCallback` prop, which will be called when the "Continue" button is pressed. It can perform validation on that step's contents to determine if the form should continue to the next step. If the function returns true, the form continues to the next step, otherwise it remains on the same step. If the function returns a `Promise`, then the "Continue" button will change to "Please wait…" until the Promise resolves allowing for async operations. The value resolved by the Promise must be a boolean; true to continue, false to stay on the current step.
 
@@ -115,7 +116,7 @@ While the `Checkout` component takes care of most everything, there are many sit
 
 ### Checkout
 
-The main wrapper component for the checkout form. It has the following props.
+The main wrapper component for Checkout. It has the following props.
 
 - `className?: string`. The className for the component.
 
@@ -190,7 +191,7 @@ A component that looks like a checkout step. Normally you don't need to use this
 
 ## CheckoutSteps
 
-A wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [Checkout](#Checkout).
+Creates the Checkout form and provides a wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [Checkout](#Checkout).
 
 ### CheckoutSummary
 
@@ -340,7 +341,7 @@ A React Hook that will return true if the current step is complete as defined by
 
 ### useLineItems
 
-A React Hook that will return a two element array where the first element is the current array of line items (matching the `items` prop on `Checkout`), and the second element is the current total (matching the `total` prop). Only works within [CheckoutProvider](#CheckoutProvider).
+A React Hook that will return a two element array where the first element is the current array of line items (matching the `items` from the `CheckoutProvider`), and the second element is the current total (matching the `total` from the `CheckoutProvider`). Only works within [CheckoutProvider](#CheckoutProvider).
 
 ### useLineItemsOfType
 

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -25,13 +25,34 @@ It's also possible to build an entirely custom form using the other components e
 
 ## How to use this package
 
-Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form. While you can create these objects manually, the package provides many pre-defined payment method objects that can be created by using the functions [createStripeMethod](#createstripemethod), [createApplePayMethod](#createapplepaymethod), [createPayPalMethod](#createpaypalmethod), [createFullCreditsMethod](#createFullCreditsMethod), and [createExistingCardMethod](#createExistingCardMethod).
+Most components of this package require being inside a [CheckoutProvider](#checkoutprovider). That component requires an array of [Payment Method objects](#payment-methods) which define the available payment methods (stripe credit cards, apple pay, paypal, credits, etc.) that will be displayed in the form. While you can create these objects manually, the package provides many pre-defined payment method objects that can be created by using the following functions:
+ - [createApplePayMethod](#createapplepaymethod)
+ - [createExistingCardMethod](#createExistingCardMethod)
+ - [createFullCreditsMethod](#createFullCreditsMethod)
+ - [createPayPalMethod](#createpaypalmethod)
+ - [createStripeMethod](#createstripemethod)
 
-Any component which is a child of `CheckoutProvider` gets access to the custom hooks [useAllPaymentMethods](#useAllPaymentMethods), [useEvents](#useEvents), [useFormStatus](#useFormStatus), [useMessages](#useMessages), [useDispatch](#useDispatch), [useLineItems](#useLineItems), [usePaymentMethod](#usePaymentMethodId), [usePaymentMethodId](#usePaymentMethodId), [useRegisterStore](#useRegisterStore), [useRegistry](#useRegistry), [useSelect](#useSelect), and [useTotal](#useTotal).
+Any component which is a child of `CheckoutProvider` gets access to the following custom hooks:
+ - [useAllPaymentMethods](#useAllPaymentMethods)
+ - [useEvents](#useEvents)
+ - [useFormStatus](#useFormStatus)
+ - [useMessages](#useMessages)
+ - [useDispatch](#useDispatch)
+ - [useLineItems](#useLineItems)
+ - [useLineItemsOfType](#useLineItemsOfType)
+ - [usePaymentMethod](#usePaymentMethodId)
+ - [usePaymentMethodId](#usePaymentMethodId)
+ - [useRegisterStore](#useRegisterStore)
+ - [useRegistry](#useRegistry)
+ - [useSelect](#useSelect)
+ - [useTotal](#useTotal)
 
-The [Checkout](#checkout) component creates the form itself. Within the component's children, you can render elements to create the checkout experience. Any child is allowed but the [CheckoutStepBody](#CheckoutStepBody) component can be used to render something that looks like a checkout step. A series of these can be used to create a semantic form. If you would like to have a series of steps that are joined by "Continue" buttons which are hidden and displayed as needed, you can instead use the [CheckoutSteps](#CheckoutSteps) component with [CheckoutStep](#CheckoutStep) children that will take care of the logic for you.
+The [Checkout](#checkout) component creates the form itself. Within the component you can render any children to create the checkout experience, but a few components are provided to make this easier:
+ - [CheckoutSummary](#CheckoutSummary) can be used to render a summary that, by default, floats beside the checkout steps on larger screens and collapses behind a toggle at the top of smaller screens.
+ - [CheckoutStepBody](#CheckoutStepBody) can be used to render something that looks like a checkout step. A series of these can be used to create a semantic form.
+ - [CheckoutSteps](#CheckoutSteps) with [CheckoutStep](#CheckoutStep) children can be used to create a series of steps that are joined by "Continue" buttons which are hidden and displayed as needed.
 
-Each `CheckoutStep` has a `isCompleteCallback` prop, which will be called when the "Continue" button is pressed. It can perform validation on that step's contents to determine if the form should continue to the next step. If the function returns true, the form continues to the next step, otherwise it remains on the same step. If the function returns a `Promise`, then the "Continue" button will change to "Please wait…" until the Promise resolves allowing for async operations. The value resolved by the Promise must be a boolean; true to continue, false to stay on the current step.
+Each `CheckoutStep` has an `isCompleteCallback` prop, which will be called when the "Continue" button is pressed. It can perform validation on that step's contents to determine if the form should continue to the next step. If the function returns true, the form continues to the next step, otherwise it remains on the same step. If the function returns a `Promise`, then the "Continue" button will change to "Please wait…" until the Promise resolves allowing for async operations. The value resolved by the Promise must be a boolean; true to continue, false to stay on the current step.
 
 Any component within a `CheckoutStep` gets access to the custom hooks above as well as [useIsStepActive](#useIsStepActive) and [useIsStepComplete](#useIsStepComplete).
 
@@ -95,6 +116,12 @@ While the `Checkout` component takes care of most everything, there are many sit
 ### Checkout
 
 The main wrapper component for the checkout form. It has the following props.
+
+- `className?: string`. The className for the component.
+
+### CheckoutSummary
+
+Renders its `children` prop and acts as a wrapper to flow outside of the [`CheckoutSteps`](#CehckoutSteps) wrapper (floated on desktop, collapsed on mobile). It has the following props.
 
 - `className?: string`. The className for the component.
 
@@ -165,7 +192,7 @@ A component that looks like a checkout step. Normally you don't need to use this
 
 ## CheckoutSteps
 
-A wrapper for [CheckoutStep](#CheckoutStep) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [Checkout](#Checkout).
+A wrapper for [CheckoutStep](#CheckoutStep) and [CheckoutStepBody](#CheckoutStepBody) objects that will connect the steps and provide a way to switch between them. Should be a direct child of [Checkout](#Checkout).
 
 ### CheckoutReviewOrder
 
@@ -314,6 +341,10 @@ A React Hook that will return true if the current step is complete as defined by
 ### useLineItems
 
 A React Hook that will return a two element array where the first element is the current array of line items (matching the `items` prop on `Checkout`), and the second element is the current total (matching the `total` prop). Only works within [CheckoutProvider](#CheckoutProvider).
+
+### useLineItemsOfType
+
+A React Hook that will return an array of line items matching a specific 'type' (i.e. 'tax'). Only works within [CheckoutProvider](#CheckoutProvider).
 
 ### useMessages
 

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -394,18 +394,18 @@ function MyCheckoutBody() {
 
 	return (
 		<Checkout>
-			<CheckoutStepBody
-				activeStepContent={ orderSummaryStep.activeStepContent }
-				completeStepContent={ orderSummaryStep.completeStepContent }
-				titleContent={ orderSummaryStep.titleContent }
-				errorMessage={ 'There was an error with this step.' }
-				isStepActive={ false }
-				isStepComplete={ true }
-				stepNumber={ 1 }
-				totalSteps={ 1 }
-				stepId={ 'order-summary' }
-			/>
 			<CheckoutSteps>
+				<CheckoutStepBody
+					activeStepContent={ orderSummaryStep.activeStepContent }
+					completeStepContent={ orderSummaryStep.completeStepContent }
+					titleContent={ orderSummaryStep.titleContent }
+					errorMessage={ 'There was an error with this step.' }
+					isStepActive={ false }
+					isStepComplete={ true }
+					stepNumber={ 1 }
+					totalSteps={ 1 }
+					stepId={ 'order-summary' }
+				/>
 				<CheckoutStep
 					stepId="review-order-step"
 					isCompleteCallback={ () => true }

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -9,6 +9,7 @@ import styled from '@emotion/styled';
 import ReactDOM from 'react-dom';
 import {
 	Checkout,
+	CheckoutSummary,
 	CheckoutSteps,
 	CheckoutStep,
 	CheckoutStepBody,
@@ -18,6 +19,7 @@ import {
 	createStripeMethod,
 	createStripePaymentMethodStore,
 	defaultRegistry,
+	getDefaultOrderSummary,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
@@ -258,6 +260,7 @@ function ContactForm( { summary } ) {
 	);
 }
 
+const orderSummary = getDefaultOrderSummary();
 const orderSummaryStep = getDefaultOrderSummaryStep();
 const paymentMethodStep = getDefaultPaymentMethodStep();
 const reviewOrderStep = getDefaultOrderReviewStep();
@@ -394,6 +397,12 @@ function MyCheckoutBody() {
 
 	return (
 		<Checkout>
+			<CheckoutSummary
+				titleContent={ orderSummary.titleContent }
+				summaryContent={ orderSummary.summaryContent }
+				stepId={ 'order-summary' }
+				className={ orderSummary.className }
+			/>
 			<CheckoutSteps>
 				<CheckoutStepBody
 					activeStepContent={ orderSummaryStep.activeStepContent }

--- a/packages/composite-checkout/demo/index.js
+++ b/packages/composite-checkout/demo/index.js
@@ -397,12 +397,9 @@ function MyCheckoutBody() {
 
 	return (
 		<Checkout>
-			<CheckoutSummary
-				titleContent={ orderSummary.titleContent }
-				summaryContent={ orderSummary.summaryContent }
-				stepId={ 'order-summary' }
-				className={ orderSummary.className }
-			/>
+			<CheckoutSummary className={ orderSummary.className }>
+				{ orderSummary.summaryContent }
+			</CheckoutSummary>
 			<CheckoutSteps>
 				<CheckoutStepBody
 					activeStepContent={ orderSummaryStep.activeStepContent }

--- a/packages/composite-checkout/src/components/checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/checkout-order-summary.js
@@ -58,7 +58,7 @@ const CheckoutSummaryStepTitle = styled.span`
 `;
 
 const CheckoutSummaryStepTotal = styled.span`
-	font-weight: ${props => props.theme.weights.bold};
+	font-weight: ${( props ) => props.theme.weights.bold};
 `;
 
 export function CheckoutOrderSummary() {
@@ -70,7 +70,7 @@ export function CheckoutOrderSummary() {
 		<>
 			<CheckoutSummaryTitle>{ translate( 'Purchase Details' ) }</CheckoutSummaryTitle>
 			<CheckoutSummaryAmountWrapper>
-				{ taxes.map( tax => (
+				{ taxes.map( ( tax ) => (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + tax.id }>
 						<span>{ tax.label }</span>
 						<span>{ renderDisplayValueMarkdown( tax.amount.displayValue ) }</span>
@@ -86,13 +86,13 @@ export function CheckoutOrderSummary() {
 }
 
 const CheckoutSummaryTitle = styled.div`
-	color: ${props => props.theme.colors.textColor};
-	font-weight: ${props => props.theme.weights.bold};
+	color: ${( props ) => props.theme.colors.textColor};
+	font-weight: ${( props ) => props.theme.weights.bold};
 	padding: 16px;
 `;
 
 const CheckoutSummaryAmountWrapper = styled.div`
-	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
+	border-top: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 	padding: 16px;
 `;
 
@@ -102,5 +102,5 @@ const CheckoutSummaryLineItem = styled.div`
 `;
 
 const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
-	font-weight: ${props => props.theme.weights.bold};
+	font-weight: ${( props ) => props.theme.weights.bold};
 `;

--- a/packages/composite-checkout/src/components/checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/checkout-order-summary.js
@@ -72,17 +72,13 @@ export function CheckoutOrderSummary() {
 			<CheckoutSummaryAmountWrapper>
 				{ taxes.map( tax => (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + tax.id }>
-						<CheckoutSummaryLabel>{ tax.label }</CheckoutSummaryLabel>
-						<CheckoutSummaryAmount>
-							{ renderDisplayValueMarkdown( tax.amount.displayValue ) }
-						</CheckoutSummaryAmount>
+						<span>{ tax.label }</span>
+						<span>{ renderDisplayValueMarkdown( tax.amount.displayValue ) }</span>
 					</CheckoutSummaryLineItem>
 				) ) }
 				<CheckoutSummaryTotal>
-					<CheckoutSummaryLabel>{ translate( 'Total' ) }</CheckoutSummaryLabel>
-					<CheckoutSummaryAmount>
-						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
-					</CheckoutSummaryAmount>
+					<span>{ translate( 'Total' ) }</span>
+					<span>{ renderDisplayValueMarkdown( total.amount.displayValue ) }</span>
 				</CheckoutSummaryTotal>
 			</CheckoutSummaryAmountWrapper>
 		</>
@@ -99,10 +95,6 @@ const CheckoutSummaryAmountWrapper = styled.div`
 	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
 	padding: 16px;
 `;
-
-const CheckoutSummaryLabel = styled.span``;
-
-const CheckoutSummaryAmount = styled.span``;
 
 const CheckoutSummaryLineItem = styled.div`
 	display: flex;

--- a/packages/composite-checkout/src/components/checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/checkout-order-summary.js
@@ -7,8 +7,14 @@ import styled from '@emotion/styled';
 /**
  * Internal dependencies
  */
-import { useLineItems, useTotal, renderDisplayValueMarkdown } from '../public-api';
+import {
+	useLineItems,
+	useLineItemsOfType,
+	useTotal,
+	renderDisplayValueMarkdown,
+} from '../public-api';
 import { useLocalize } from '../lib/localize';
+import { useTranslate } from 'i18n-calypso';
 
 export default function CheckoutOrderSummaryStep() {
 	const [ items ] = useLineItems();
@@ -33,28 +39,76 @@ const ProductListItem = styled.li`
 	list-style-type: none;
 `;
 
-export function CheckoutOrderSummary() {
-	return <CheckoutOrderSummaryTitle />;
-}
-
-export function CheckoutOrderSummaryTitle() {
+export function CheckoutOrderSummaryStepTitle() {
 	const localize = useLocalize();
 	const total = useTotal();
 	return (
-		<CheckoutSummaryTitle>
+		<CheckoutSummaryStepTitle>
 			<span>{ localize( 'You are all set to check out' ) }</span>
-			<CheckoutSummaryTotal>
+			<CheckoutSummaryStepTotal>
 				{ renderDisplayValueMarkdown( total.amount.displayValue ) }
-			</CheckoutSummaryTotal>
-		</CheckoutSummaryTitle>
+			</CheckoutSummaryStepTotal>
+		</CheckoutSummaryStepTitle>
 	);
 }
 
-const CheckoutSummaryTitle = styled.span`
+const CheckoutSummaryStepTitle = styled.span`
 	display: flex;
 	justify-content: space-between;
 `;
 
-const CheckoutSummaryTotal = styled.span`
-	font-weight: ${( props ) => props.theme.weights.bold};
+const CheckoutSummaryStepTotal = styled.span`
+	font-weight: ${props => props.theme.weights.bold};
+`;
+
+export function CheckoutOrderSummary() {
+	const translate = useTranslate();
+	const taxes = useLineItemsOfType( 'tax' );
+	const total = useTotal();
+
+	return (
+		<>
+			<CheckoutSummaryTitle>{ translate( 'Purchase Details' ) }</CheckoutSummaryTitle>
+			<CheckoutSummaryAmountWrapper>
+				{ taxes.map( tax => (
+					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + tax.id }>
+						<CheckoutSummaryLabel>{ tax.label }</CheckoutSummaryLabel>
+						<CheckoutSummaryAmount>
+							{ renderDisplayValueMarkdown( tax.amount.displayValue ) }
+						</CheckoutSummaryAmount>
+					</CheckoutSummaryLineItem>
+				) ) }
+				<CheckoutSummaryTotal>
+					<CheckoutSummaryLabel>{ translate( 'Total' ) }</CheckoutSummaryLabel>
+					<CheckoutSummaryAmount>
+						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
+					</CheckoutSummaryAmount>
+				</CheckoutSummaryTotal>
+			</CheckoutSummaryAmountWrapper>
+		</>
+	);
+}
+
+const CheckoutSummaryTitle = styled.div`
+	color: ${props => props.theme.colors.textColor};
+	font-weight: ${props => props.theme.weights.bold};
+	padding: 16px;
+`;
+
+const CheckoutSummaryAmountWrapper = styled.div`
+	border-top: 1px solid ${props => props.theme.colors.borderColorLight};
+	padding: 16px;
+`;
+
+const CheckoutSummaryLabel = styled.span``;
+
+const CheckoutSummaryAmount = styled.span``;
+
+const CheckoutSummaryLineItem = styled.div`
+	display: flex;
+	justify-content: space-between;
+`;
+
+const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
+	font-weight: ${props => props.theme.weights.bold};
 `;

--- a/packages/composite-checkout/src/components/checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/checkout-order-summary.js
@@ -88,12 +88,12 @@ export function CheckoutOrderSummary() {
 const CheckoutSummaryTitle = styled.div`
 	color: ${( props ) => props.theme.colors.textColor};
 	font-weight: ${( props ) => props.theme.weights.bold};
-	padding: 16px;
+	padding: 24px 20px;
 `;
 
 const CheckoutSummaryAmountWrapper = styled.div`
 	border-top: 1px solid ${( props ) => props.theme.colors.borderColorLight};
-	padding: 16px;
+	padding: 24px 20px;
 `;
 
 const CheckoutSummaryLineItem = styled.div`

--- a/packages/composite-checkout/src/components/checkout-order-summary.js
+++ b/packages/composite-checkout/src/components/checkout-order-summary.js
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import { useLineItems, useTotal, renderDisplayValueMarkdown } from '../public-api';
 import { useLocalize } from '../lib/localize';
 
-export default function CheckoutOrderSummary() {
+export default function CheckoutOrderSummaryStep() {
 	const [ items ] = useLineItems();
 
 	return (
@@ -32,6 +32,10 @@ const ProductListItem = styled.li`
 	padding: 0;
 	list-style-type: none;
 `;
+
+export function CheckoutOrderSummary() {
+	return <CheckoutOrderSummaryTitle />;
+}
 
 export function CheckoutOrderSummaryTitle() {
 	const localize = useLocalize();

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -135,9 +135,9 @@ export function CheckoutSteps( { children, className } ) {
 
 	let stepNumber = 0;
 	let nextStepNumber = 1;
-	const componentChildren = React.Children.toArray( children ).filter( child => child );
-	const nonSteps = componentChildren.filter( child => child.type?.name !== 'CheckoutStep' );
-	const steps = componentChildren.filter( child => child.type?.name === 'CheckoutStep' );
+	const componentChildren = React.Children.toArray( children ).filter( ( child ) => child );
+	const nonSteps = componentChildren.filter( ( child ) => child.type?.name !== 'CheckoutStep' );
+	const steps = componentChildren.filter( ( child ) => child.type?.name === 'CheckoutStep' );
 	const totalSteps = steps.length;
 	const { activeStepNumber, stepCompleteStatus, setTotalSteps } = useContext(
 		CheckoutStepDataContext
@@ -163,7 +163,7 @@ export function CheckoutSteps( { children, className } ) {
 			isLastStepActive={ ! isThereAnotherNumberedStep }
 		>
 			{ nonSteps }
-			{ steps.map( child => {
+			{ steps.map( ( child ) => {
 				stepNumber = nextStepNumber;
 				nextStepNumber = stepNumber === totalSteps ? null : stepNumber + 1;
 				const isStepActive = activeStepNumber === stepNumber;
@@ -390,11 +390,11 @@ const MainContentUI = styled.div`
 	flex-direction: column;
 	width: 100%;
 
-	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
+	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
 		margin: 32px auto;
 	}
 
-	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
 		align-items: flex-start;
 		flex-direction: row;
 		justify-content: center;
@@ -403,19 +403,19 @@ const MainContentUI = styled.div`
 `;
 
 const CheckoutSummaryUI = styled.div`
-	background: ${props => props.theme.colors.surface};
-	border-bottom: 1px solid ${props => props.theme.colors.borderColorLight};
+	background: ${( props ) => props.theme.colors.surface};
+	border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 	box-sizing: border-box;
 	width: 100%;
 
-	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
-		border: 1px solid ${props => props.theme.colors.borderColorLight};
+	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
+		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 		border-bottom: none 0;
 		max-width: 556px;
 	}
 
-	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
-		border: 1px solid ${props => props.theme.colors.borderColorLight};
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 		box-sizing: border-box;
 		margin-left: 16px;
 		margin-right: 0;
@@ -425,17 +425,17 @@ const CheckoutSummaryUI = styled.div`
 `;
 
 const CheckoutStepsWrapperUI = styled.div`
-	background: ${props => props.theme.colors.surface};
+	background: ${( props ) => props.theme.colors.surface};
 	box-sizing: border-box;
-	margin-bottom: ${props => ( props.isLastStepActive ? '100px' : 0 )};
+	margin-bottom: ${( props ) => ( props.isLastStepActive ? '100px' : 0) };
 	width: 100%;
 
-	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
-		border: 1px solid ${props => props.theme.colors.borderColorLight};
+	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
+		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 		max-width: 556px;
 	}
 
-	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
 		width: 556px;
 		order: 1;
 	}

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -59,18 +59,20 @@ export function Checkout( { children, className } ) {
 
 	return (
 		<ContainerUI className={ joinClasses( [ className, 'composite-checkout' ] ) }>
-			<CheckoutStepDataContext.Provider
-				value={ {
-					activeStepNumber: actualActiveStepNumber,
-					stepCompleteStatus,
-					totalSteps,
-					setActiveStepNumber,
-					setStepCompleteStatus,
-					setTotalSteps,
-				} }
-			>
-				{ children || getDefaultCheckoutSteps() }
-			</CheckoutStepDataContext.Provider>
+			<MainContentUI className={ joinClasses( [ className, 'checkout__content' ] ) }>
+				<CheckoutStepDataContext.Provider
+					value={ {
+						activeStepNumber: actualActiveStepNumber,
+						stepCompleteStatus,
+						totalSteps,
+						setActiveStepNumber,
+						setStepCompleteStatus,
+						setTotalSteps,
+					} }
+				>
+					{ children || getDefaultCheckoutSteps() }
+				</CheckoutStepDataContext.Provider>
+			</MainContentUI>
 		</ContainerUI>
 	);
 }
@@ -81,19 +83,19 @@ function DefaultCheckoutSteps() {
 	const reviewOrderStep = getDefaultOrderReviewStep();
 	return (
 		<React.Fragment>
-			<CheckoutStepBody
-				activeStepContent={ orderSummaryStep.activeStepContent }
-				completeStepContent={ orderSummaryStep.completeStepContent }
-				titleContent={ orderSummaryStep.titleContent }
-				errorMessage={ 'There was an error with this step.' }
-				isStepActive={ false }
-				isStepComplete={ true }
-				stepNumber={ 1 }
-				totalSteps={ 1 }
-				stepId={ 'order-summary' }
-				className={ orderSummaryStep.className }
-			/>
 			<CheckoutSteps>
+				<CheckoutStepBody
+					activeStepContent={ orderSummaryStep.activeStepContent }
+					completeStepContent={ orderSummaryStep.completeStepContent }
+					titleContent={ orderSummaryStep.titleContent }
+					errorMessage={ 'There was an error with this step.' }
+					isStepActive={ false }
+					isStepComplete={ true }
+					stepNumber={ 1 }
+					totalSteps={ 1 }
+					stepId={ 'order-summary' }
+					className={ orderSummaryStep.className }
+				/>
 				<CheckoutStep
 					stepId="review-order-step"
 					isCompleteCallback={ () => true }
@@ -120,7 +122,9 @@ export function CheckoutSteps( { children, className } ) {
 
 	let stepNumber = 0;
 	let nextStepNumber = 1;
-	const steps = React.Children.toArray( children ).filter( ( child ) => child );
+	const componentChildren = React.Children.toArray( children ).filter( child => child );
+	const nonSteps = componentChildren.filter( child => child.type?.name !== 'CheckoutStep' );
+	const steps = componentChildren.filter( child => child.type?.name === 'CheckoutStep' );
 	const totalSteps = steps.length;
 	const { activeStepNumber, stepCompleteStatus, setTotalSteps } = useContext(
 		CheckoutStepDataContext
@@ -141,10 +145,11 @@ export function CheckoutSteps( { children, className } ) {
 	);
 
 	return (
-		<MainContentUI
-			className={ joinClasses( [ className, 'checkout__content' ] ) }
+		<CheckoutStepsWrapperUI
+			className={ joinClasses( [ className, 'checkout__steps-wrapper' ] ) }
 			isLastStepActive={ ! isThereAnotherNumberedStep }
 		>
+			{ nonSteps }
 			{ steps.map( child => {
 				stepNumber = nextStepNumber;
 				nextStepNumber = stepNumber === totalSteps ? null : stepNumber + 1;
@@ -172,7 +177,7 @@ export function CheckoutSteps( { children, className } ) {
 					<CheckoutSubmitButton disabled={ isThereAnotherNumberedStep || formStatus !== 'ready' } />
 				</CheckoutErrorBoundary>
 			</SubmitButtonWrapperUI>
-		</MainContentUI>
+		</CheckoutStepsWrapperUI>
 	);
 }
 
@@ -368,7 +373,11 @@ const ContainerUI = styled.div`
 `;
 
 const MainContentUI = styled.div`
-	background: ${( props ) => props.theme.colors.surface};
+	display: flex;
+`;
+
+const CheckoutStepsWrapperUI = styled.div`
+	background: ${props => props.theme.colors.surface};
 	width: 100%;
 	box-sizing: border-box;
 	margin-bottom: ${( props ) => ( props.isLastStepActive ? '100px' : 0) };

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -85,12 +85,9 @@ function DefaultCheckoutSteps() {
 	const reviewOrderStep = getDefaultOrderReviewStep();
 	return (
 		<React.Fragment>
-			<CheckoutSummary
-				titleContent={ orderSummary.titleContent }
-				summaryContent={ orderSummary.summaryContent }
-				stepId={ 'order-summary' }
-				className={ orderSummary.className }
-			/>
+			<CheckoutSummary className={ orderSummary.className }>
+				{ orderSummary.summaryContent }
+			</CheckoutSummary>
 			<CheckoutSteps>
 				<CheckoutStepBody
 					activeStepContent={ orderSummaryStep.activeStepContent }
@@ -397,6 +394,7 @@ const MainContentUI = styled.div`
 	}
 
 	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
+		align-items: flex-start;
 		width: 882px;
 		flex-direction: row;
 	}
@@ -404,6 +402,7 @@ const MainContentUI = styled.div`
 
 const CheckoutSummaryUI = styled.div`
 	background: ${props => props.theme.colors.surface};
+	padding: 16px;
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		border: 1px solid ${props => props.theme.colors.borderColorLight};

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -406,6 +406,7 @@ const CheckoutSummaryUI = styled.div`
 	background: ${( props ) => props.theme.colors.surface};
 	border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 	box-sizing: border-box;
+	margin: 0 auto;
 	width: 100%;
 
 	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
@@ -427,7 +428,7 @@ const CheckoutSummaryUI = styled.div`
 const CheckoutStepsWrapperUI = styled.div`
 	background: ${( props ) => props.theme.colors.surface};
 	box-sizing: border-box;
-	margin-bottom: ${( props ) => ( props.isLastStepActive ? '100px' : 0) };
+	margin: 0 auto ${( props ) => ( props.isLastStepActive ? '100px' : 0) };
 	width: 100%;
 
 	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
@@ -436,8 +437,9 @@ const CheckoutStepsWrapperUI = styled.div`
 	}
 
 	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
-		width: 556px;
+		margin: 0;
 		order: 1;
+		width: 556px;
 	}
 `;
 

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -417,11 +417,10 @@ const CheckoutSummaryUI = styled.div`
 
 	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
 		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
-		box-sizing: border-box;
-		margin-left: 16px;
+		margin-left: 24px;
 		margin-right: 0;
 		order: 2;
-		width: 326px;
+		width: 328px;
 	}
 `;
 

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -392,14 +392,13 @@ const MainContentUI = styled.div`
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		margin: 32px auto;
-		max-width: 556px;
 	}
 
 	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
 		align-items: flex-start;
 		flex-direction: row;
+		justify-content: center;
 		max-width: none;
-		width: 882px;
 	}
 `;
 
@@ -412,6 +411,7 @@ const CheckoutSummaryUI = styled.div`
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		border: 1px solid ${props => props.theme.colors.borderColorLight};
 		border-bottom: none 0;
+		max-width: 556px;
 	}
 
 	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
@@ -432,6 +432,7 @@ const CheckoutStepsWrapperUI = styled.div`
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		border: 1px solid ${props => props.theme.colors.borderColorLight};
+		max-width: 556px;
 	}
 
 	@media ( ${props => props.theme.breakpoints.desktopUp} ) {

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -388,26 +388,29 @@ const ContainerUI = styled.div`
 const MainContentUI = styled.div`
 	display: flex;
 	flex-direction: column;
+	width: 100%;
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		margin: 32px auto;
+		max-width: 556px;
 	}
 
 	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
 		align-items: flex-start;
-		width: 882px;
 		flex-direction: row;
+		max-width: none;
+		width: 882px;
 	}
 `;
 
 const CheckoutSummaryUI = styled.div`
 	background: ${props => props.theme.colors.surface};
+	box-sizing: border-box;
 	padding: 16px;
+	width: 100%;
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		border: 1px solid ${props => props.theme.colors.borderColorLight};
-		box-sizing: border-box;
-		max-width: 556px;
 	}
 
 	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
@@ -428,8 +431,6 @@ const CheckoutStepsWrapperUI = styled.div`
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		border: 1px solid ${props => props.theme.colors.borderColorLight};
-		box-sizing: border-box;
-		max-width: 556px;
 	}
 
 	@media ( ${props => props.theme.breakpoints.desktopUp} ) {

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -405,6 +405,7 @@ const MainContentUI = styled.div`
 
 const CheckoutSummaryUI = styled.div`
 	background: ${props => props.theme.colors.surface};
+	border-bottom: 1px solid ${props => props.theme.colors.borderColorLight};
 	box-sizing: border-box;
 	width: 100%;
 

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -406,11 +406,11 @@ const MainContentUI = styled.div`
 const CheckoutSummaryUI = styled.div`
 	background: ${props => props.theme.colors.surface};
 	box-sizing: border-box;
-	padding: 16px;
 	width: 100%;
 
 	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
 		border: 1px solid ${props => props.theme.colors.borderColorLight};
+		border-bottom: none 0;
 	}
 
 	@media ( ${props => props.theme.breakpoints.desktopUp} ) {

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -20,6 +20,7 @@ import { CheckIcon } from './shared-icons';
 import CheckoutNextStepButton from './checkout-next-step-button';
 import {
 	getDefaultOrderReviewStep,
+	getDefaultOrderSummary,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
 	usePaymentMethod,
@@ -78,11 +79,18 @@ export function Checkout( { children, className } ) {
 }
 
 function DefaultCheckoutSteps() {
+	const orderSummary = getDefaultOrderSummary();
 	const orderSummaryStep = getDefaultOrderSummaryStep();
 	const paymentMethodStep = getDefaultPaymentMethodStep();
 	const reviewOrderStep = getDefaultOrderReviewStep();
 	return (
 		<React.Fragment>
+			<CheckoutSummary
+				titleContent={ orderSummary.titleContent }
+				summaryContent={ orderSummary.summaryContent }
+				stepId={ 'order-summary' }
+				className={ orderSummary.className }
+			/>
 			<CheckoutSteps>
 				<CheckoutStepBody
 					activeStepContent={ orderSummaryStep.activeStepContent }
@@ -93,7 +101,7 @@ function DefaultCheckoutSteps() {
 					isStepComplete={ true }
 					stepNumber={ 1 }
 					totalSteps={ 1 }
-					stepId={ 'order-summary' }
+					stepId={ 'order-summary-step' }
 					className={ orderSummaryStep.className }
 				/>
 				<CheckoutStep
@@ -113,6 +121,14 @@ function DefaultCheckoutSteps() {
 				/>
 			</CheckoutSteps>
 		</React.Fragment>
+	);
+}
+
+export function CheckoutSummary( { children, className } ) {
+	return (
+		<CheckoutSummaryUI className={ joinClasses( [ className, 'checkout__summary-wrapper' ] ) }>
+			{ children }
+		</CheckoutSummaryUI>
 	);
 }
 
@@ -374,19 +390,52 @@ const ContainerUI = styled.div`
 
 const MainContentUI = styled.div`
 	display: flex;
+	flex-direction: column;
+
+	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
+		margin: 32px auto;
+	}
+
+	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
+		width: 882px;
+		flex-direction: row;
+	}
+`;
+
+const CheckoutSummaryUI = styled.div`
+	background: ${props => props.theme.colors.surface};
+
+	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
+		border: 1px solid ${props => props.theme.colors.borderColorLight};
+		box-sizing: border-box;
+		max-width: 556px;
+	}
+
+	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
+		border: 1px solid ${props => props.theme.colors.borderColorLight};
+		box-sizing: border-box;
+		margin-left: 16px;
+		margin-right: 0;
+		order: 2;
+		width: 326px;
+	}
 `;
 
 const CheckoutStepsWrapperUI = styled.div`
 	background: ${props => props.theme.colors.surface};
-	width: 100%;
 	box-sizing: border-box;
-	margin-bottom: ${( props ) => ( props.isLastStepActive ? '100px' : 0) };
+	margin-bottom: ${props => ( props.isLastStepActive ? '100px' : 0 )};
+	width: 100%;
 
-	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
-		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
-		margin: 32px auto;
+	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
+		border: 1px solid ${props => props.theme.colors.borderColorLight};
 		box-sizing: border-box;
 		max-width: 556px;
+	}
+
+	@media ( ${props => props.theme.breakpoints.desktopUp} ) {
+		width: 556px;
+		order: 1;
 	}
 `;
 

--- a/packages/composite-checkout/src/components/default-steps.js
+++ b/packages/composite-checkout/src/components/default-steps.js
@@ -17,7 +17,6 @@ export function getDefaultOrderSummary() {
 	return {
 		id: 'order-summary',
 		className: 'checkout__order-summary',
-		titleContent: <CheckoutOrderSummaryTitle />,
 		summaryContent: <CheckoutOrderSummary />,
 	};
 }

--- a/packages/composite-checkout/src/components/default-steps.js
+++ b/packages/composite-checkout/src/components/default-steps.js
@@ -6,19 +6,31 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import CheckoutOrderSummary, { CheckoutOrderSummaryTitle } from './checkout-order-summary';
+import CheckoutOrderSummaryStep, {
+	CheckoutOrderSummaryTitle,
+	CheckoutOrderSummary,
+} from './checkout-order-summary';
 import CheckoutReviewOrder, { CheckoutReviewOrderTitle } from './checkout-review-order';
 import CheckoutPaymentMethods, { CheckoutPaymentMethodsTitle } from './checkout-payment-methods';
 
-export function getDefaultOrderSummaryStep() {
+export function getDefaultOrderSummary() {
 	return {
 		id: 'order-summary',
+		className: 'checkout__order-summary',
+		titleContent: <CheckoutOrderSummaryTitle />,
+		summaryContent: <CheckoutOrderSummary />,
+	};
+}
+
+export function getDefaultOrderSummaryStep() {
+	return {
+		id: 'order-summary-step',
 		className: 'checkout__order-summary-step',
 		hasStepNumber: false,
 		titleContent: <CheckoutOrderSummaryTitle />,
 		activeStepContent: null,
 		incompleteStepContent: null,
-		completeStepContent: <CheckoutOrderSummary />,
+		completeStepContent: <CheckoutOrderSummaryStep />,
 		isCompleteCallback: () => true,
 	};
 }

--- a/packages/composite-checkout/src/components/default-steps.js
+++ b/packages/composite-checkout/src/components/default-steps.js
@@ -7,7 +7,7 @@ import React from 'react';
  * Internal dependencies
  */
 import CheckoutOrderSummaryStep, {
-	CheckoutOrderSummaryTitle,
+	CheckoutOrderSummaryStepTitle,
 	CheckoutOrderSummary,
 } from './checkout-order-summary';
 import CheckoutReviewOrder, { CheckoutReviewOrderTitle } from './checkout-review-order';
@@ -26,7 +26,7 @@ export function getDefaultOrderSummaryStep() {
 		id: 'order-summary-step',
 		className: 'checkout__order-summary-step',
 		hasStepNumber: false,
-		titleContent: <CheckoutOrderSummaryTitle />,
+		titleContent: <CheckoutOrderSummaryStepTitle />,
 		activeStepContent: null,
 		incompleteStepContent: null,
 		completeStepContent: <CheckoutOrderSummaryStep />,

--- a/packages/composite-checkout/src/components/loading-content.js
+++ b/packages/composite-checkout/src/components/loading-content.js
@@ -37,13 +37,13 @@ export default function LoadingContent() {
 }
 
 const LoadingContentWrapperUI = styled.div`
-	background: ${props => props.theme.colors.surface};
+	background: ${( props ) => props.theme.colors.surface};
 	width: 100%;
 	box-sizing: border-box;
-	margin-bottom: ${props => ( props.isLastStepActive ? '100px' : 0 )};
+	margin-bottom: ${( props ) => ( props.isLastStepActive ? '100px' : 0) };
 
-	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
-		border: 1px solid ${props => props.theme.colors.borderColorLight};
+	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
+		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 		margin: 32px auto;
 		box-sizing: border-box;
 		max-width: 556px;

--- a/packages/composite-checkout/src/components/loading-content.js
+++ b/packages/composite-checkout/src/components/loading-content.js
@@ -14,7 +14,7 @@ export default function LoadingContent() {
 	const localize = useLocalize();
 
 	return (
-		<div>
+		<LoadingContentWrapperUI>
 			<LoadingCard>
 				<LoadingTitle>{ localize( 'Loading checkout' ) }</LoadingTitle>
 				<LoadingCopy />
@@ -32,9 +32,23 @@ export default function LoadingContent() {
 				<LoadingTitle />
 			</LoadingCard>
 			<LoadingFooter />
-		</div>
+		</LoadingContentWrapperUI>
 	);
 }
+
+const LoadingContentWrapperUI = styled.div`
+	background: ${props => props.theme.colors.surface};
+	width: 100%;
+	box-sizing: border-box;
+	margin-bottom: ${props => ( props.isLastStepActive ? '100px' : 0 )};
+
+	@media ( ${props => props.theme.breakpoints.tabletUp} ) {
+		border: 1px solid ${props => props.theme.colors.borderColorLight};
+		margin: 32px auto;
+		box-sizing: border-box;
+		max-width: 556px;
+	}
+`;
 
 const LoadingCard = styled.div`
 	padding: 24px;

--- a/packages/composite-checkout/src/components/shared-icons.js
+++ b/packages/composite-checkout/src/components/shared-icons.js
@@ -3,14 +3,14 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
 
 export function CheckIcon( { className, id } ) {
 	return (
-		<svg
+		<CheckIconUI
 			width="20"
 			height="20"
 			viewBox="0 0 20 20"
-			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			className={ className }
@@ -24,15 +24,12 @@ export function CheckIcon( { className, id } ) {
 				width="16"
 				height="12"
 			>
-				<path
-					d="M7.32916 13.2292L3.85416 9.75417L2.67083 10.9292L7.32916 15.5875L17.3292 5.58751L16.1542 4.41251L7.32916 13.2292Z"
-					fill="white"
-				/>
+				<path d="M7.32916 13.2292L3.85416 9.75417L2.67083 10.9292L7.32916 15.5875L17.3292 5.58751L16.1542 4.41251L7.32916 13.2292Z" />
 			</mask>
 			<g mask={ 'url(#' + id + '-check-icon-mask)' }>
-				<rect width="20" height="20" fill="white" />
+				<rect width="20" height="20" />
 			</g>
-		</svg>
+		</CheckIconUI>
 	);
 }
 
@@ -40,6 +37,10 @@ CheckIcon.propTypes = {
 	className: PropTypes.string,
 	id: PropTypes.string,
 };
+
+const CheckIconUI = styled.svg`
+	fill: #fff;
+`;
 
 export function ErrorIcon( { className } ) {
 	return (

--- a/packages/composite-checkout/src/lib/line-items.js
+++ b/packages/composite-checkout/src/lib/line-items.js
@@ -25,3 +25,8 @@ export function useTotal() {
 	const [ , total ] = useLineItems();
 	return total;
 }
+
+export function useTax() {
+	const [ items ] = useLineItems();
+	return items.find( item => item.type === 'tax' );
+}

--- a/packages/composite-checkout/src/lib/line-items.js
+++ b/packages/composite-checkout/src/lib/line-items.js
@@ -26,10 +26,10 @@ export function useTotal() {
 	return total;
 }
 
-export function useFirstLineItemOfType( itemType = null ) {
+export function useLineItemsOfType( itemType = null ) {
 	if ( ! itemType ) {
-		throw new Error( 'missing itemType for useFirstLineItemOfType' );
+		throw new Error( 'missing itemType for useLineItemsOfType' );
 	}
 	const [ items ] = useLineItems();
-	return items.find( item => item.type === itemType );
+	return items.filter( item => item.type === itemType );
 }

--- a/packages/composite-checkout/src/lib/line-items.js
+++ b/packages/composite-checkout/src/lib/line-items.js
@@ -26,7 +26,10 @@ export function useTotal() {
 	return total;
 }
 
-export function useTax() {
+export function useFirstLineItemOfType( itemType = null ) {
+	if ( ! itemType ) {
+		throw new Error( 'missing itemType for useFirstLineItemOfType' );
+	}
 	const [ items ] = useLineItems();
-	return items.find( item => item.type === 'tax' );
+	return items.find( item => item.type === itemType );
 }

--- a/packages/composite-checkout/src/lib/line-items.js
+++ b/packages/composite-checkout/src/lib/line-items.js
@@ -26,7 +26,7 @@ export function useTotal() {
 	return total;
 }
 
-export function useLineItemsOfType( itemType = null ) {
+export function useLineItemsOfType( itemType ) {
 	if ( ! itemType ) {
 		throw new Error( 'missing itemType for useLineItemsOfType' );
 	}

--- a/packages/composite-checkout/src/lib/line-items.js
+++ b/packages/composite-checkout/src/lib/line-items.js
@@ -31,5 +31,5 @@ export function useLineItemsOfType( itemType = null ) {
 		throw new Error( 'missing itemType for useLineItemsOfType' );
 	}
 	const [ items ] = useLineItems();
-	return items.filter( item => item.type === itemType );
+	return items.filter( ( item ) => item.type === itemType );
 }

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -19,7 +19,7 @@ import {
 import CheckoutModal from './components/checkout-modal';
 import { renderDisplayValueMarkdown } from './lib/render';
 import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
-import { useLineItems, useTotal } from './lib/line-items';
+import { useLineItems, useTotal, useTax } from './lib/line-items';
 import {
 	createRegistry,
 	defaultRegistry,
@@ -89,5 +89,6 @@ export {
 	useRegisterStore,
 	useRegistry,
 	useSelect,
+	useTax,
 	useTotal,
 };

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -19,7 +19,7 @@ import {
 import CheckoutModal from './components/checkout-modal';
 import { renderDisplayValueMarkdown } from './lib/render';
 import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
-import { useLineItems, useTotal, useTax } from './lib/line-items';
+import { useLineItems, useTotal, useFirstLineItemOfType } from './lib/line-items';
 import {
 	createRegistry,
 	defaultRegistry,
@@ -89,6 +89,6 @@ export {
 	useRegisterStore,
 	useRegistry,
 	useSelect,
-	useTax,
+	useFirstLineItemOfType,
 	useTotal,
 };

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -19,7 +19,7 @@ import {
 import CheckoutModal from './components/checkout-modal';
 import { renderDisplayValueMarkdown } from './lib/render';
 import { usePaymentMethod, usePaymentMethodId, useAllPaymentMethods } from './lib/payment-methods';
-import { useLineItems, useTotal, useFirstLineItemOfType } from './lib/line-items';
+import { useLineItems, useTotal, useLineItemsOfType } from './lib/line-items';
 import {
 	createRegistry,
 	defaultRegistry,
@@ -89,6 +89,6 @@ export {
 	useRegisterStore,
 	useRegistry,
 	useSelect,
-	useFirstLineItemOfType,
+	useLineItemsOfType,
 	useTotal,
 };

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -7,6 +7,7 @@ import {
 	Checkout,
 	CheckoutStep,
 	CheckoutStepBody,
+	CheckoutSummary,
 	useIsStepActive,
 	useIsStepComplete,
 } from './components/checkout-steps';
@@ -38,10 +39,12 @@ import {
 import { createApplePayMethod } from './lib/payment-methods/apple-pay';
 import { createPayPalMethod } from './lib/payment-methods/paypal';
 import { createExistingCardMethod } from './lib/payment-methods/existing-credit-card';
-import CheckoutOrderSummary, {
+import CheckoutOrderSummaryStep, {
+	CheckoutOrderSummary,
 	CheckoutOrderSummaryTitle,
 } from './components/checkout-order-summary';
 import {
+	getDefaultOrderSummary,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,
 	getDefaultOrderReviewStep,
@@ -52,6 +55,7 @@ import { useFormStatus } from './lib/form-status';
 export {
 	Checkout,
 	CheckoutModal,
+	CheckoutOrderSummaryStep,
 	CheckoutOrderSummary,
 	CheckoutOrderSummaryTitle,
 	CheckoutPaymentMethods,
@@ -59,6 +63,7 @@ export {
 	CheckoutStep,
 	CheckoutStepBody,
 	CheckoutSteps,
+	CheckoutSummary,
 	OrderReviewLineItems,
 	OrderReviewSection,
 	OrderReviewTotal,
@@ -71,6 +76,7 @@ export {
 	createStripeMethod,
 	createStripePaymentMethodStore,
 	defaultRegistry,
+	getDefaultOrderSummary,
 	getDefaultOrderReviewStep,
 	getDefaultOrderSummaryStep,
 	getDefaultPaymentMethodStep,

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -50,10 +50,12 @@ import {
 	getDefaultOrderReviewStep,
 } from './components/default-steps';
 import { useFormStatus } from './lib/form-status';
+import { CheckIcon as CheckoutCheckIcon } from './components/shared-icons';
 
 // Re-export the public API
 export {
 	Checkout,
+	CheckoutCheckIcon,
 	CheckoutModal,
 	CheckoutOrderSummaryStep,
 	CheckoutOrderSummary,

--- a/packages/composite-checkout/src/public-api.js
+++ b/packages/composite-checkout/src/public-api.js
@@ -41,7 +41,7 @@ import { createPayPalMethod } from './lib/payment-methods/paypal';
 import { createExistingCardMethod } from './lib/payment-methods/existing-credit-card';
 import CheckoutOrderSummaryStep, {
 	CheckoutOrderSummary,
-	CheckoutOrderSummaryTitle,
+	CheckoutOrderSummaryStepTitle,
 } from './components/checkout-order-summary';
 import {
 	getDefaultOrderSummary,
@@ -57,7 +57,7 @@ export {
 	CheckoutModal,
 	CheckoutOrderSummaryStep,
 	CheckoutOrderSummary,
-	CheckoutOrderSummaryTitle,
+	CheckoutOrderSummaryStepTitle,
 	CheckoutPaymentMethods,
 	CheckoutProvider,
 	CheckoutStep,

--- a/packages/composite-checkout/src/theme.js
+++ b/packages/composite-checkout/src/theme.js
@@ -40,6 +40,7 @@ const theme = {
 		placeHolderTextColor: swatches.gray30,
 	},
 	breakpoints: {
+		desktopUp: 'min-width: 960px',
 		tabletUp: 'min-width: 700px',
 		smallPhoneUp: 'min-width: 400px',
 	},


### PR DESCRIPTION
This does a few things with the ultimate goal of splitting out a summary into a separate column on desktop screens.

- adds the floated `CheckoutSummary` component to composite-checkout (package, demo, documentation)
- moves `CheckoutStepBody` component inside `CheckoutSteps`
- uses `CheckoutSummary` in WPcom's implementation of composite-checkout
- moves the current site's address to the review step
- adds a default set of purchase features to the summary (per-product features coming in a future PR)
- hides `CheckoutSummary` on mobile screens (collapse mobile toggle coming in future PR)

Before | After
------------ | -------------
<img width="1164" alt="before-desktop" src="https://user-images.githubusercontent.com/942359/79905306-05b8ca00-83e4-11ea-9c19-7f66901e6e2e.png"> | <img width="1164" alt="after-desktop" src="https://user-images.githubusercontent.com/942359/79905305-05203380-83e4-11ea-8692-4fd43aee5769.png">
<img width="374" alt="before-mobile" src="https://user-images.githubusercontent.com/942359/79905302-05203380-83e4-11ea-9225-1bca7db43ff0.png"> | <img width="372" alt="after-mobile" src="https://user-images.githubusercontent.com/942359/79905300-04879d00-83e4-11ea-936b-54c262a6ae4e.png">

Fixes: #41088

**To test:**
- it might help to step through the PR, commit by commit, but no promises that I didn't change my mind later on in the PR
- run the composite-checkout demo with `yarn run composite-checkout-demo`
- verify that minimal CheckoutSummary is displayed
- verify that the demo otherwise works as expected
- from dev or calypso.live, and a plan and/or domain to your cart and visit Checkout with `?flags=composite-checkout-testing`
- verify that on desktop (`>960px`), the checkout summary is displayed, floated to the right, with a list of default features, and the tax (once calculated) and total
- verify that on screens smaller than desktop, the checkout summary is hidden
- verify that Checkout otherwise works as expected