### PR TITLE
Update Email me a login link URL for Gutenboarding

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -110,7 +110,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 
 	const langFragment = lang ? `/${ lang }` : '';
 	const loginRedirectUrl = encodeURIComponent(
-		`${ window.location.origin }/${ GUTENBOARDING_BASE_NAME }${ makePath( Step.CreateSite ) }?new`
+		`/${ GUTENBOARDING_BASE_NAME }${ makePath( Step[ currentStep ] ) }`
 	);
 	const signupUrl = encodeURIComponent(
 		`/${ GUTENBOARDING_BASE_NAME }${ makePath( Step[ currentStep ] ) }?signup`

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -110,7 +110,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 
 	const langFragment = lang ? `/${ lang }` : '';
 	const loginRedirectUrl = encodeURIComponent(
-		`/${ GUTENBOARDING_BASE_NAME }${ makePath( Step[ currentStep ] ) }`
+		`${ window.location.origin }/${ GUTENBOARDING_BASE_NAME }${ makePath( Step[ currentStep ] ) }`
 	);
 	const signupUrl = encodeURIComponent(
 		`/${ GUTENBOARDING_BASE_NAME }${ makePath( Step[ currentStep ] ) }?signup`

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -212,7 +212,7 @@ export class LoginLinks extends React.Component {
 		if ( this.props.currentRoute === '/log-in/jetpack' ) {
 			loginParameters.twoFactorAuthType = 'jetpack/link';
 		} else if ( this.props.isGutenboarding ) {
-			loginParameters.twoFactorAuthType = 'gutenboarding/link';
+			loginParameters.twoFactorAuthType = `${ GUTENBOARDING_BASE_NAME }/link`;
 		}
 
 		return (
@@ -312,7 +312,7 @@ export class LoginLinks extends React.Component {
 
 		if ( isGutenboarding ) {
 			const langFragment = locale && locale !== 'en' ? `/${ locale }` : '';
-			signupUrl = this.props.signupUrl || '/gutenboarding' + langFragment;
+			signupUrl = this.props.signupUrl || `/${ GUTENBOARDING_BASE_NAME }` + langFragment;
 		}
 
 		return (


### PR DESCRIPTION
The Gutenboarding section was renamed from `gutenboarding` to `new` in https://github.com/Automattic/wp-calypso/pull/40810, and it looks like there were a couple of stray links that needed to be updated.

#### Changes proposed in this Pull Request

In `/log-in`:

* Update the `Email me a login link` to point to `new/link` instead of `gutenboarding/link` (fix 404 error)
* Update the fallback URL of the `Create a new account` button to `new/link`
* Update `loginRedirectUrl` to point to the last step that the user was previously working on, instead of automatically creating a site. This enables a fallback so that if a user uses the "Email me a login link" feature (or they have a passwordless account) and they open the email in a different browser context to the one they signed up with, they'll be redirected back to the beginning of the signup flow (since they'll have no persisted signup state in local storage). This still isn't a _great_ user experience, but it's better than creating an empty site with an unexpected theme as @roo2 [discovered](https://github.com/Automattic/wp-calypso/pull/41064#issuecomment-613223637).

![image](https://user-images.githubusercontent.com/14988353/79177703-d552b800-7e46-11ea-9b43-6efa0fbb7ea7.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/log-in/new` in an incognito window
* Click `Create a new account` and it should redirect you to Gutenboarding at `/new`
* Click `Email me a login link` and it should redirect you to `/log-in/new/link` and you should be able to request a login link

---

Also, test the login flow via Gutenboarding from `/new` where you click the `Log in` button when you get to the signup form

Fixes #
