### PR TITLE
[@automattic/effective-module-tree] - Add option to generate a list

### DIFF
--- a/packages/effective-module-tree/CHANGELOG.md
+++ b/packages/effective-module-tree/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## 0.1.0 - 2020-04-14
+### Added
+- Adds a new flag `-o` to specify the type of output: `-o tree` (an ascii tree, the default) or `-o list`
+
+### Fixed
+- Fix a bug where circular dependencies were cached, potentially mis-marking them as 'circular' in other parts of the tree
+
+## 0.0.1 - 2020-03-10
+- Initial release

--- a/packages/effective-module-tree/README.md
+++ b/packages/effective-module-tree/README.md
@@ -34,6 +34,11 @@ Use `effective-module-tree --root <path>` to print the tree in a different proje
 effective-module-tree --root "./src/package.json"
 ```
 
+This tool can generate either an ascii tree, or a list (easier to visualize dependency chains in
+big trees). It can be specified with the flags `-o tree` or `-o list`.
+
+Check out `effective-module-tree --help` for other flags and examples.
+
 ## Troubleshooting
 
 Invoke the command with `DEBUG=effective-module-tree ./effective-module-tree` to get a verbose

--- a/packages/effective-module-tree/cli.js
+++ b/packages/effective-module-tree/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const yargs = require( 'yargs' );
 const path = require( 'path' );
-const { effectiveTree } = require( './index.js' );
+const { getEffectiveTreeAsTree, getEffectiveTreeAsList } = require( './index.js' );
 
 const args = yargs
 	.usage( 'Usage: $0' )
@@ -11,17 +11,23 @@ const args = yargs
 			describe: 'Path of the root package.json. Defaults to ./package.json',
 			default: path.join( process.cwd(), 'package.json' ),
 		},
+		output: {
+			alias: 'o',
+			describe: 'Output to generate',
+			choices: [ 'tree', 'list' ],
+			default: 'tree',
+		},
 	} )
 	.example( '$0', 'generate the tree for the project in the current directory' )
 	.example( '$0 --root "./src"', 'generate the tree for the project inside ./src' )
 	.help( 'h' )
 	.alias( 'h', 'help' ).argv;
 
-effectiveTree( args.root )
-	.then( tree => {
-		// eslint-disable-next-line no-console
-		console.log( tree );
-	} )
-	.catch( err => {
-		throw err;
-	} );
+let tree;
+if ( args.output === 'tree' ) {
+	tree = getEffectiveTreeAsTree( args.root );
+} else {
+	tree = getEffectiveTreeAsList( args.root );
+}
+// eslint-disable-next-line no-console
+console.log( tree );

--- a/packages/effective-module-tree/test/test.js
+++ b/packages/effective-module-tree/test/test.js
@@ -30,7 +30,7 @@ mockFiles( {
 	},
 } );
 
-const { candidates, effectiveTree } = require( '../index' );
+const { candidates, getEffectiveTreeAsTree } = require( '../index' );
 
 describe( 'Candidate generation', () => {
 	it( 'Traverses the path', () => {
@@ -52,104 +52,160 @@ describe( 'Effective tree generation', () => {
 		jest.spyOn( console, 'warn' ).mockImplementation();
 	} );
 
-	it( 'Generates the simplified tree', async () => {
-		const tree = await effectiveTree( '/project/root/package.json' );
-		//prettier-ignore
-		expect( tree ).toEqual([
-			'└─ root@1.0.0',
-			'   ├─ a@1.1.1',
-			'   └─ b@2.2.2',
-			'      └─ c@3.2.1',
-		].join( '\n' ));
-	} );
-
-	it( 'Detects circular dependencies', async () => {
-		mockFiles( {
-			'/project/root/node_modules/c/package.json': {
-				name: 'c',
-				version: '3.2.1',
-				dependencies: {
-					b: '^2.0.0',
-				},
-			},
+	describe( 'as tree', () => {
+		it( 'Generates the simplified tree', () => {
+			const tree = getEffectiveTreeAsTree( '/project/root/package.json' );
+			//prettier-ignore
+			expect(tree).toEqual([
+				'└─ root@1.0.0',
+				'   ├─ a@1.1.1',
+				'   └─ b@2.2.2',
+				'      └─ c@3.2.1',
+			].join('\n'));
 		} );
 
-		jest.resetModules();
-		//eslint-disable-next-line no-shadow
-		const { effectiveTree } = require( '../index' );
-		const tree = await effectiveTree( '/project/root/package.json' );
+		it( 'Detects circular dependencies', () => {
+			mockFiles( {
+				'/project/root/node_modules/c/package.json': {
+					name: 'c',
+					version: '3.2.1',
+					dependencies: {
+						b: '^2.0.0',
+					},
+				},
+			} );
 
-		//prettier-ignore
-		expect(tree).toEqual([
-			'└─ root@1.0.0',
-			'   ├─ a@1.1.1',
-			'   └─ b@2.2.2',
-			'      └─ c@3.2.1',
-			'         └─ b@2.2.2: [Circular]'
-		].join('\n'));
-	} );
+			jest.resetModules();
+			//eslint-disable-next-line no-shadow
+			const { getEffectiveTreeAsTree } = require( '../index' );
+			const tree = getEffectiveTreeAsTree( '/project/root/package.json' );
 
-	it( 'Does not cache circular dependencies', async () => {
-		jest.resetModules();
-		mockFiles( {
-			'/project/root/package.json': {
-				name: 'root',
-				version: '1.0.0',
-				dependencies: {
-					a: '^1.0.0',
-					b: '^2.0.0',
-				},
-			},
-			'/project/root/node_modules/a/package.json': {
-				name: 'a',
-				version: '1.1.1',
-				dependencies: {
-					b: '^2.0.0',
-				},
-			},
-			'/project/root/node_modules/b/package.json': {
-				name: 'b',
-				version: '2.2.2',
-				dependencies: {
-					c: '3.2.1',
-				},
-			},
-			'/project/root/node_modules/c/package.json': {
-				name: 'c',
-				version: '3.2.1',
-				dependencies: {
-					a: '^1.0.0',
-				},
-			},
+			//prettier-ignore
+			expect(tree).toEqual([
+				'└─ root@1.0.0',
+				'   ├─ a@1.1.1',
+				'   └─ b@2.2.2',
+				'      └─ c@3.2.1',
+				'         └─ b@2.2.2: [Circular]'
+			].join('\n'));
 		} );
 
-		//eslint-disable-next-line no-shadow
-		const { effectiveTree } = require( '../index' );
-		const tree = await effectiveTree( '/project/root/package.json' );
+		it( 'Does not cache circular dependencies', async () => {
+			jest.resetModules();
+			mockFiles( {
+				'/project/root/package.json': {
+					name: 'root',
+					version: '1.0.0',
+					dependencies: {
+						a: '^1.0.0',
+						b: '^2.0.0',
+					},
+				},
+				'/project/root/node_modules/a/package.json': {
+					name: 'a',
+					version: '1.1.1',
+					dependencies: {
+						b: '^2.0.0',
+					},
+				},
+				'/project/root/node_modules/b/package.json': {
+					name: 'b',
+					version: '2.2.2',
+					dependencies: {
+						c: '3.2.1',
+					},
+				},
+				'/project/root/node_modules/c/package.json': {
+					name: 'c',
+					version: '3.2.1',
+					dependencies: {
+						a: '^1.0.0',
+					},
+				},
+			} );
 
-		/**
-		 * Note that when we find 'b' in the second chain (root->b->...), it has been processed previously in the first chain
-		 * (root->a->b->...). However, because that first chain ended in a circular dependency, none of the packages in the chain
-		 * was cached.
-		 *
-		 * This is a good thing. Otherwise, when we process 'b' the chain root->b we would pick 'b' from the cache,
-		 * (equal to 'b->c->a[Circular]'), and we would end up with the chain root->b->c->a[Circular], which is not true.
-		 *
-		 * So tldr: branches with [Circular] dependencies are not cached, and this test is asserting that behaviour.
-		 */
+			//eslint-disable-next-line no-shadow
+			const { getEffectiveTreeAsTree } = require( '../index' );
+			const tree = await getEffectiveTreeAsTree( '/project/root/package.json' );
 
-		//prettier-ignore
-		expect(tree).toEqual([
-			'└─ root@1.0.0',
-			'   ├─ a@1.1.1',
-			'   │  └─ b@2.2.2',
-			'   │     └─ c@3.2.1',
-			'   │        └─ a@1.1.1: [Circular]',
-			'   └─ b@2.2.2',
-			'      └─ c@3.2.1',
-			'         └─ a@1.1.1',
-			'            └─ b@2.2.2: [Circular]',
-		].join('\n'));
+			/**
+			 * Note that when we find 'b' in the second chain (root->b->...), it has been processed previously in the first chain
+			 * (root->a->b->...). However, because that first chain ended in a circular dependency, none of the packages in the chain
+			 * was cached.
+			 *
+			 * This is a good thing. Otherwise, when we process 'b' the chain root->b we would pick 'b' from the cache,
+			 * (equal to 'b->c->a[Circular]'), and we would end up with the chain root->b->c->a[Circular], which is not true.
+			 *
+			 * So tldr: branches with [Circular] dependencies are not cached, and this test is asserting that behaviour.
+			 */
+
+			//prettier-ignore
+			expect(tree).toEqual([
+				'└─ root@1.0.0',
+				'   ├─ a@1.1.1',
+				'   │  └─ b@2.2.2',
+				'   │     └─ c@3.2.1',
+				'   │        └─ a@1.1.1: [Circular]',
+				'   └─ b@2.2.2',
+				'      └─ c@3.2.1',
+				'         └─ a@1.1.1',
+				'            └─ b@2.2.2: [Circular]',
+			].join('\n'));
+		} );
+	} );
+
+	describe( 'as list', () => {
+		it( 'Complex tree', async () => {
+			jest.resetModules();
+			mockFiles( {
+				'/project/root/package.json': {
+					name: 'root',
+					version: '1.0.0',
+					dependencies: {
+						a: '^1.0.0',
+						b: '^2.0.0',
+					},
+				},
+				'/project/root/node_modules/a/package.json': {
+					name: 'a',
+					version: '1.1.1',
+					dependencies: {
+						b: '^2.0.0',
+					},
+				},
+				'/project/root/node_modules/b/package.json': {
+					name: 'b',
+					version: '2.2.2',
+					dependencies: {
+						c: '3.2.1',
+					},
+				},
+				'/project/root/node_modules/c/package.json': {
+					name: 'c',
+					version: '3.2.1',
+					dependencies: {
+						a: '^1.0.0',
+					},
+				},
+			} );
+
+			//eslint-disable-next-line no-shadow
+			const { getEffectiveTreeAsList } = require( '../index' );
+			const tree = await getEffectiveTreeAsList( '/project/root/package.json' );
+
+			//prettier-ignore
+			expect(tree).toEqual([
+				'root@1.0.0',
+				'root@1.0.0 a@1.1.1',
+				'root@1.0.0 a@1.1.1 b@2.2.2',
+				'root@1.0.0 a@1.1.1 b@2.2.2 c@3.2.1',
+				'root@1.0.0 a@1.1.1 b@2.2.2 c@3.2.1 a@1.1.1 [Circular]',
+				'root@1.0.0 b@2.2.2',
+				'root@1.0.0 b@2.2.2 c@3.2.1',
+				'root@1.0.0 b@2.2.2 c@3.2.1 a@1.1.1',
+				'root@1.0.0 b@2.2.2 c@3.2.1 a@1.1.1 b@2.2.2 [Circular]',
+			].join('\n'));
+		} );
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a CLI option to generate a list instead of a tree. This will allow easier visualization of dependency chains in big trees.

#### Testing instructions

* Checkout the branch and install deps
* Run `./node_modules/.bin/effective-module-tree  -o list`. It should generate something like
    ```
    wp-calypso-monorepo@0.17.0
    wp-calypso-monorepo@0.17.0 @automattic/babel-plugin-i18n-calypso@1.1.0
    wp-calypso-monorepo@0.17.0 @automattic/babel-plugin-i18n-calypso@1.1.0 gettext-parser@4.0.2
    wp-calypso-monorepo@0.17.0 @automattic/babel-plugin-i18n-calypso@1.1.0 gettext-parser@4.0.2 content-type@1.0.4
    ...
    ```
* Run `./node_modules/.bin/effective-module-tree  -o tree`. It should generate something like
    ```
    └─ wp-calypso-monorepo@0.17.0
       ├─ @automattic/babel-plugin-i18n-calypso@1.1.0
       │  ├─ gettext-parser@4.0.2
       │  │  ├─ content-type@1.0.4
       │  │  ├─ encoding@0.1.12
        ...
    ```

* Run `./node_modules/.bin/effective-module-tree`. It should generate something like
    ```
    └─ wp-calypso-monorepo@0.17.0
       ├─ @automattic/babel-plugin-i18n-calypso@1.1.0
       │  ├─ gettext-parser@4.0.2
       │  │  ├─ content-type@1.0.4
       │  │  ├─ encoding@0.1.12
        ...
    ```
