### PR TITLE
Gutenboarding: Only use vertical for domain suggestion on non intent gathering steps

### DIFF
--- a/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
+++ b/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
@@ -10,16 +10,23 @@ import { useDebounce } from 'use-debounce';
 import { DOMAIN_SUGGESTIONS_STORE } from '../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { selectorDebounce } from '../constants';
+import { useCurrentStep } from '../path';
 
 export function useDomainSuggestions( searchOverride = '' ) {
 	const { siteTitle, siteVertical, domainSearch } = useSelect( select =>
 		select( ONBOARD_STORE ).getState()
 	);
+	const currentStep = useCurrentStep();
+	const prioritisedSearch = searchOverride.trim() || domainSearch.trim() || siteTitle;
+	let searchVal;
 
-	const [ searchTerm ] = useDebounce(
-		searchOverride.trim() || domainSearch.trim() || siteTitle || siteVertical?.label.trim() || '',
-		selectorDebounce
-	);
+	if ( currentStep !== 'IntentGathering' ) {
+		searchVal = prioritisedSearch || siteVertical?.label.trim() || '';
+	} else {
+		searchVal = prioritisedSearch || '';
+	}
+
+	const [ searchTerm ] = useDebounce( searchVal, selectorDebounce );
 
 	return useSelect(
 		select => {


### PR DESCRIPTION
This is a fix for #41042 — because of the modular nature of the intent gathering step, I couldn't work out a way to infer whether or not the domain suggestions query should use the vertical without making it aware of steps in the flow. This mightn't be the cleanest way to do it, but was simpler than refactoring how the site title is set (an alternative to this PR would be to delay the call to `setSiteTitle` until after someone completes the intent gathering step, but that would also affect the header behaviour).

#### Changes proposed in this Pull Request

* Update the `useDomainSuggestions` hook to be aware of the current step
* Only use vertical fallback for domain suggestions if not on the intent capture step

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Watch the demo in issue #41042 so that you know what to look out for!

* On the Intent Gathering step `/new` select a vertical and slowly start typing a site title
* In the header, you should _not_ see a domain based on the vertical as you start typing
* Skip the step without setting a title
* On the design step, you should see a domain suggestion in the header based on vertical

Also test that selecting a title as normal continues to show the correct domain after completing the intent gathering step.

Fixes #41042
