### PR TITLE
Make node-sass dependency explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,6 +260,7 @@
 		"moment-timezone-data-webpack-plugin": "1.1.0",
 		"ncp": "2.0.0",
 		"nock": "11.7.2",
+		"node-sass": "4.13.0",
 		"node-sass-package-importer": "5.3.2",
 		"npm-merge-driver": "2.3.5",
 		"npm-package-json-lint": "4.6.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes the version of node-sass.

We are already depending on node-sass in https://github.com/Automattic/wp-calypso/blob/master/package.json#L47, but we don't have an explicit dependency. This works today because `packages/calypso-build` depends on node-sass and we rely on npm hoisting that dependency to the root.

Making this dependency explicit will give us a cleaner transition to `yarn`.

#### Testing instructions

* Checkout master and install deps
* Verify the version of node-sass (`cat node_modules/node-sass/package.json | grep version`). Note the version has not changed.
* Checkout this branch and install deps
* Note `package-lock.json` has not changed (there are no new deps)
* Verify the version of node-sass again (`cat node_modules/node-sass/package.json | grep version`). Note it is the same.
