### PR TITLE
Plugins: Let Upsell Appear for Personal & Premium Sites

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -34,7 +34,7 @@ import PluginAutomatedTransfer from 'my-sites/plugins/plugin-automated-transfer'
 import { getExtensionSettingsPath } from 'my-sites/plugins/utils';
 import { userCan } from 'lib/site/utils';
 import UpsellNudge from 'blocks/upsell-nudge';
-import { TYPE_BUSINESS } from 'lib/plans/constants';
+import { FEATURE_UPLOAD_PLUGINS, TYPE_BUSINESS } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import { isBusiness, isEcommerce, isEnterprise } from 'lib/products-values';
 import { addSiteFragment } from 'lib/route';
@@ -617,6 +617,7 @@ export class PluginMeta extends Component {
 				<UpsellNudge
 					event="calypso_plugin_detail_page_upgrade_nudge"
 					href={ bannerURL }
+					feature={ FEATURE_UPLOAD_PLUGINS }
 					plan={ plan }
 					title={ title }
 					showIcon={ true }

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -37,7 +37,7 @@ import isVipSite from 'state/selectors/is-vip-site';
 import NoPermissionsError from 'my-sites/plugins/no-permissions-error';
 import { Button } from '@automattic/components';
 import { isBusiness, isEcommerce, isEnterprise, isPremium } from 'lib/products-values';
-import { TYPE_BUSINESS } from 'lib/plans/constants';
+import { FEATURE_UPLOAD_PLUGINS, TYPE_BUSINESS } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import UpsellNudge from 'blocks/upsell-nudge';
 import { isEnabled } from 'config';
@@ -526,6 +526,7 @@ export class PluginsBrowser extends Component {
 				event="calypso_plugins_browser_upgrade_nudge"
 				showIcon={ true }
 				href={ bannerURL }
+				feature={ FEATURE_UPLOAD_PLUGINS }
 				plan={ plan }
 				title={ title }
 			/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures the Plugins upsell appears for Personal & Premium plan sites

#### Testing instructions

There's two places to verify where the nudge appears. Firstly, on the Plugin search page.

<img width="1112" alt="Screenshot 2020-04-14 at 10 33 31" src="https://user-images.githubusercontent.com/43215253/79209815-cca8b480-7e3b-11ea-852f-c7575ff226cc.png">

And then on an individual plugin page.

<img width="853" alt="Screenshot 2020-04-14 at 10 33 28" src="https://user-images.githubusercontent.com/43215253/79209830-d500ef80-7e3b-11ea-8d20-f40a44378c51.png">

But also verify that the nudge still doesn't appear for the Business or eCommerce Plan. :) 

cc @sixhours 

Fixes #41046
