### PR TITLE
[Private sites] Do not send wpcom_coming_soon value to the API for users in control group

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -738,9 +738,12 @@ const getFormSettings = settings => {
 
 		lang_id: settings.lang_id,
 		blog_public: settings.blog_public,
-		wpcom_coming_soon: settings.wpcom_coming_soon,
 		timezone_string: settings.timezone_string,
 	};
+
+	if ( 'variant' === abtest( 'ATPrivacy' ) ) {
+		formSettings.wpcom_coming_soon = settings.wpcom_coming_soon;
+	}
 
 	// handling `gmt_offset` and `timezone_string` values
 	const gmt_offset = settings.gmt_offset;

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -11,6 +11,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import { protectForm } from 'lib/protect-form';
 import trackForm from 'lib/track-form';
 import {
@@ -160,6 +161,9 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			}
 
 			const siteFields = pick( fields, settingsFields.site );
+			if ( 'variant' !== abtest( 'ATPrivacy' ) ) {
+				delete siteFields.wpcom_coming_soon;
+			}
 			this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion: '1.4' } );
 		};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Private atomic sites feature should be disabled for users in `control` group of `ATPrivacy` test. This means their sites should not have the `wpcom_coming_soon` option. Unfortunately, it's getting stored if they save their settings while still using a simple site. This PR ensures that `wpcom_coming_soon` never gets sent if user does not belong to a proper test group.

#### Testing instructions

1. Apply this PR
1. Create a simple site and launch it
1. While in `control` group of ATPrivacy, go to settings/general and save the form. Inspect POST request and confirm that `wpcom_coming_soon` was sent through
1. While in `test` group of ATPrivacy, go to settings/general and save the form. Inspect POST request and confirm that `wpcom_coming_soon` was **not** sent through

