### PR TITLE
Mobile support for domain picker - fixed footer & scrollable content.

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -34,7 +34,8 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
 
-	const isMobile = useViewportMatch( 'mobile', '<' );
+	// Popover expands at medium viewport width
+	const isMobile = useViewportMatch( 'medium', '<' );
 
 	const handleClose = ( e?: React.FocusEvent ) => {
 		// Don't collide with button toggling

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -64,7 +64,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<div className="domain-picker-button__popover-container">
 					<Popover
 						className="domain-picker-button__popover"
-						focusOnMount={ ! isMobile }
+						focusOnMount={ isMobile ? 'container' : 'firstElement' }
 						noArrow
 						onClose={ handleClose }
 						onFocusOutside={ handleClose }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { createRef, FunctionComponent, useState } from 'react';
 import { Button, Popover, Dashicon } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
 
 /**
@@ -33,6 +34,8 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
 
+	const isMobile = useViewportMatch( 'mobile', '<' );
+
 	const handleClose = ( e?: React.FocusEvent ) => {
 		// Don't collide with button toggling
 		if ( e?.relatedTarget === buttonRef.current ) {
@@ -61,6 +64,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<div className="domain-picker-button__popover-container">
 					<Popover
 						className="domain-picker-button__popover"
+						focusOnMount={ ! isMobile }
 						noArrow
 						onClose={ handleClose }
 						onFocusOutside={ handleClose }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -3,8 +3,12 @@
  */
 import React, { createRef, FunctionComponent, useState } from 'react';
 import { Button, Popover, Dashicon } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import classnames from 'classnames';
+
+// Core package needs to add this to the type definitions.
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -104,8 +104,6 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 					<div className="domain-picker__search">
 						<SearchIcon />
 						<TextControl
-							// eslint-disable-next-line jsx-a11y/no-autofocus
-							autoFocus={ true }
 							hideLabelFromVision
 							label={ label }
 							placeholder={ label }

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -87,7 +87,7 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 	return (
 		<Panel className="domain-picker">
 			<PanelBody>
-				<PanelRow className="domain-picker__panel-row">
+				<PanelRow className="domain-picker__panel-row-main">
 					<div className="domain-picker__header">
 						<div className="domain-picker__header-group">
 							<div className="domain-picker__header-title">{ __( 'Choose a domain' ) }</div>
@@ -113,9 +113,6 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 							value={ domainSearch }
 						/>
 					</div>
-				</PanelRow>
-
-				<PanelRow className="domain-picker__panel-row">
 					<div className="domain-picker__suggestion-item-group">
 						{ ! freeSuggestions && <SuggestionItemPlaceholder /> }
 						{ freeSuggestions &&
@@ -146,8 +143,7 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 							) ) }
 					</div>
 				</PanelRow>
-
-				<PanelRow className="domain-picker__panel-row">
+				<PanelRow className="domain-picker__panel-row-footer">
 					<div className="domain-picker__footer">
 						<div className="domain-picker__footer-options"></div>
 						<Button

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -238,10 +238,6 @@ $domain-picker__suggestion-item-height: 24px;
 		color: var( --color-text-inverted );
 		background-color: var( --color-success );
 	}
-
-	.components-popover.is-expanded & {
-		display: none;
-	}
 }
 
 .domain-picker__price {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -8,13 +8,38 @@ $domain-picker__suggestion-item-height: 24px;
 .domain-picker.components-panel {
 	border: none;
 
-	.components-panel__body.is-opened {
-		padding: 36px;
+	.components-panel__body {
+		display: flex;
+		flex-direction: column;
+		padding: 0;
+		width: 100%;
+		height: 100%;
+	}
+
+	.components-panel__row {
+		flex-direction: column;
+		align-items: stretch;
+		margin: 0;
+
+		label {
+			max-width: 100%;
+		}
 	}
 
 	@include break-small {
 		min-width: 520px;
 	}
+}
+
+.domain-picker__panel-row-main {
+	overflow-y: auto;
+	flex-grow: 1;
+	padding: 36px;
+}
+
+.domain-picker__panel-row-footer {
+	padding: 24px 36px;
+	border-top: 1px solid #f0f0f0;
 }
 
 .domain-picker__header {
@@ -33,7 +58,7 @@ $domain-picker__suggestion-item-height: 24px;
 
 .domain-picker__search {
 	position: relative;
-	margin-bottom: -4px; // Reducing the spacing added by .components-panel__row
+	margin-bottom: 20px;
 
 	input[type='text'].components-text-control__input {
 		padding: 6px 40px 6px 16px;
@@ -66,9 +91,6 @@ $domain-picker__suggestion-item-height: 24px;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin: 0 -36px -36px;
-	padding: 24px 36px;
-	border-top: 1px solid #f0f0f0;
 }
 
 .domain-picker__footer-options.components-button {
@@ -94,19 +116,8 @@ $domain-picker__suggestion-item-height: 24px;
 	}
 }
 
-.domain-picker__panel-row {
-
-	// Increasing specificity because @wordpress/components stylesheets are loaded after gutenboarding stylesheets.
-	// See https://github.com/Automattic/wp-calypso/pull/38554/commits/e1f9673bcfd9eaa6469a0cfecda9b915a520961a
-	// See https://github.com/WordPress/gutenberg/pull/19535
-	&.components-panel__row {
-		flex-direction: column;
-		align-items: stretch;
-
-		label {
-			max-width: 100%;
-		}
-	}
+.domain-picker__suggestion-item-group {
+	flex-grow: 1;
 }
 
 .domain-picker__suggestion-none {
@@ -226,6 +237,10 @@ $domain-picker__suggestion-item-height: 24px;
 	&.is-selected {
 		color: var( --color-text-inverted );
 		background-color: var( --color-success );
+	}
+
+	.components-popover.is-expanded & {
+		display: none;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Sticky footer on mobile view.
* Scrollable picker content on mobile view.
* Do not autofocus search input on mobile view.

#### Testing instructions

* Go to `/new`.
* Click on domain picker (and enter a domain if needed).
* Resize browser width until domain picker goes full screen.
* Resize browser height until scrollbar appears.
* Search input should not be in focused when dropdown picker appears.

#### Screenshots

![image](https://user-images.githubusercontent.com/1287077/79210764-e7008380-7e77-11ea-9bcd-3e6044180852.png)

#### Additional Notes

I'm waiting for these 2 PRs to rollout first then I'll rebase this PR as there may be conflicting changes.
- https://github.com/Automattic/wp-calypso/pull/41007
- https://github.com/Automattic/wp-calypso/pull/40959

Fixes #40949 