### PR TITLE
My Home: Handle new view for WP for Teams sites

### DIFF
--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -30,23 +30,17 @@ import {
 	recordTracksEvent,
 	withAnalytics,
 } from 'state/analytics/actions';
-import ActionBox from './action-box';
-
-/**
- * Image dependencies
- */
-import logoIcon from 'assets/images/customer-home/looka-logo-60.svg';
+import ActionBox from 'my-sites/customer-home/cards/primary/quick-links/action-box';
 
 /**
  * Style dependencies
  */
-import './style.scss';
+import 'my-sites/customer-home/cards/primary/quick-links/style.scss';
 
 export const QuickLinks = ( {
 	customizeUrl,
 	isStaticHomePage,
 	showCustomizer,
-	hasCustomDomain,
 	menusUrl,
 	editHomepageAction,
 	writePostAction,
@@ -54,14 +48,11 @@ export const QuickLinks = ( {
 	manageCommentsAction,
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
-	changeThemeAction,
-	trackDesignLogoAction,
-	addEmailAction,
-	addDomainAction,
 } ) => {
 	const translate = useTranslate();
 
 	const quickLinks = (
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<div className="quick-links__boxes">
 			{ isStaticHomePage ? (
 				<ActionBox
@@ -118,32 +109,6 @@ export const QuickLinks = ( {
 					materialIcon="palette"
 				/>
 			) }
-			<ActionBox
-				onClick={ changeThemeAction }
-				label={ translate( 'Change theme' ) }
-				materialIcon="view_quilt"
-			/>
-			{ hasCustomDomain ? (
-				<ActionBox
-					onClick={ addEmailAction }
-					label={ translate( 'Add email' ) }
-					materialIcon="email"
-				/>
-			) : (
-				<ActionBox
-					onClick={ addDomainAction }
-					label={ translate( 'Add a domain' ) }
-					gridicon="domains"
-				/>
-			) }
-			<ActionBox
-				href="https://wp.me/logo-maker"
-				onClick={ trackDesignLogoAction }
-				target="_blank"
-				label={ translate( 'Create a logo with Looka' ) }
-				external
-				iconSrc={ logoIcon }
-			/>
 		</div>
 	);
 
@@ -226,47 +191,6 @@ const trackCustomizeThemeAction = isStaticHomePage =>
 		bumpStat( 'calypso_customer_home', 'my_site_customize_theme' )
 	);
 
-const changeThemeAction = ( siteSlug, isStaticHomePage ) =>
-	withAnalytics(
-		composeAnalytics(
-			recordTracksEvent( 'calypso_customer_home_my_site_change_theme_click', {
-				is_static_home_page: isStaticHomePage,
-			} ),
-			bumpStat( 'calypso_customer_home', 'my_site_change_theme' )
-		),
-		navigate( `/themes/${ siteSlug }` )
-	);
-
-const trackDesignLogoAction = isStaticHomePage =>
-	composeAnalytics(
-		recordTracksEvent( 'calypso_customer_home_my_site_design_logo_click', {
-			is_static_home_page: isStaticHomePage,
-		} ),
-		bumpStat( 'calypso_customer_home', 'my_site_design_logo' )
-	);
-
-const addEmailAction = ( siteSlug, isStaticHomePage ) =>
-	withAnalytics(
-		composeAnalytics(
-			recordTracksEvent( 'calypso_customer_home_my_site_add_email_click', {
-				is_static_home_page: isStaticHomePage,
-			} ),
-			bumpStat( 'calypso_customer_home', 'my_site_add_email' )
-		),
-		navigate( `/email/${ siteSlug }` )
-	);
-
-const addDomainAction = ( siteSlug, isStaticHomePage ) =>
-	withAnalytics(
-		composeAnalytics(
-			recordTracksEvent( 'calypso_customer_home_my_site_add_domain_click', {
-				is_static_home_page: isStaticHomePage,
-			} ),
-			bumpStat( 'calypso_customer_home', 'my_site_add_domain' )
-		),
-		navigate( `/domains/add/${ siteSlug }` )
-	);
-
 const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const isClassicEditor = getSelectedEditor( state, siteId ) === 'classic';
@@ -297,10 +221,6 @@ const mapDispatchToProps = {
 	manageCommentsAction,
 	trackEditMenusAction,
 	trackCustomizeThemeAction,
-	changeThemeAction,
-	trackDesignLogoAction,
-	addEmailAction,
-	addDomainAction,
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
@@ -313,10 +233,6 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 		manageCommentsAction: () => dispatchProps.manageCommentsAction( siteSlug, isStaticHomePage ),
 		trackEditMenusAction: () => dispatchProps.trackEditMenusAction( isStaticHomePage ),
 		trackCustomizeThemeAction: () => dispatchProps.trackCustomizeThemeAction( isStaticHomePage ),
-		changeThemeAction: () => dispatchProps.changeThemeAction( siteSlug, isStaticHomePage ),
-		trackDesignLogoAction: () => dispatchProps.trackDesignLogoAction( isStaticHomePage ),
-		addEmailAction: () => dispatchProps.addEmailAction( siteSlug, isStaticHomePage ),
-		addDomainAction: () => dispatchProps.addDomainAction( siteSlug, isStaticHomePage ),
 		...ownProps,
 	};
 };

--- a/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
+++ b/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
@@ -6,7 +6,6 @@ import { useTranslate } from 'i18n-calypso';
 import { Button, Card } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
 import { connect } from 'react-redux';
-import { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -20,8 +19,6 @@ import {
 	recordTracksEvent,
 	bumpStat,
 } from 'state/analytics/actions';
-import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Style dependencies
@@ -33,12 +30,8 @@ import './style.scss';
  */
 import freePhotoLibraryVideoPrompt from 'assets/images/customer-home/illustration--free-photo-library.svg';
 
-const FreePhotoLibrary = ( { openSupportArticleDialogAndTrack, isSiteWPForTeamsProp } ) => {
+const FreePhotoLibrary = ( { openSupportArticleDialogAndTrack } ) => {
 	const translate = useTranslate();
-
-	if ( isEnabled( 'signup/wpforteams' ) && isSiteWPForTeamsProp ) {
-		return null;
-	}
 
 	return (
 		<Card className="free-photo-library">
@@ -82,13 +75,4 @@ const openSupportArticleDialogAndTrack = clickSource =>
 		} )
 	);
 
-export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-
-		return {
-			isSiteWPForTeamsProp: isSiteWPForTeams( state, siteId ),
-		};
-	},
-	{ openSupportArticleDialogAndTrack }
-)( FreePhotoLibrary );
+export default connect( null, { openSupportArticleDialogAndTrack } )( FreePhotoLibrary );

--- a/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
+++ b/client/my-sites/customer-home/cards/features/grow-earn/index.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -19,19 +18,14 @@ import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sid
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import { getSiteOption } from 'state/sites/selectors';
-import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export const GrowEarn = ( { siteSlug, expandToolsAndTrack, isSiteWPForTeamsProp } ) => {
+export const GrowEarn = ( { siteSlug, expandToolsAndTrack } ) => {
 	const translate = useTranslate();
-
-	if ( isEnabled( 'signup/wpforteams' ) && isSiteWPForTeamsProp ) {
-		return null;
-	}
 
 	return (
 		<Card className="grow-earn">
@@ -71,7 +65,6 @@ export default connect(
 		return {
 			siteSlug: getSelectedSiteSlug( state ),
 			isStaticHomePage: ! isClassicEditor && pageOnFront,
-			isSiteWPForTeamsProp: isSiteWPForTeams( state, siteId ),
 		};
 	},
 	dispatch => ( {

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -17,7 +17,7 @@ const cardComponents = {
 	'home-primary-checklist-site-setup': ChecklistSiteSetup,
 	'home-primary-quick-links': QuickLinks,
 	'home-education-mastering-gutenberg': MasteringGutenberg,
-	'home-action-wp-for-teams': WpForTeamsQuickLinks,
+	'home-action-wp-for-teams-quick-links': WpForTeamsQuickLinks,
 };
 
 const Primary = ( { checklistMode, cards } ) => {

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -10,12 +10,14 @@ import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import ChecklistSiteSetup from 'my-sites/customer-home/cards/primary/checklist-site-setup';
 import MasteringGutenberg from 'my-sites/customer-home/cards/education/mastering-gutenberg';
 import QuickLinks from 'my-sites/customer-home/cards/primary/quick-links';
+import WpForTeamsQuickLinks from 'my-sites/customer-home/cards/actions/wp-for-teams-quick-links';
 
 const cardComponents = {
 	'home-feature-go-mobile-phones': GoMobile,
 	'home-primary-checklist-site-setup': ChecklistSiteSetup,
 	'home-primary-quick-links': QuickLinks,
 	'home-education-mastering-gutenberg': MasteringGutenberg,
+	'home-action-wp-for-teams': WpForTeamsQuickLinks,
 };
 
 const Primary = ( { checklistMode, cards } ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

D41814-code adds a new view to the Home layout API that is targeted for WP for Teams sites:
- It doesn't return the Grow & Earn or the Free Photo Library cards.
- Returns a new quick links card (`home-action-wp-for-teams-quick-links`) so we can display a different set of quick links without affecting the current quick links card for Simple/Atomic sites.

That way we can rely on the API on what to render and remove all the visibility checks we added in #40723.

#### Testing instructions

- Apply D41814-code and sandbox the API.
- Launch Calypso running this branch.
- Create a WP for Teams site in `/start/wp-for-teams`.
- Go to My Home.
- Make sure the layout renders the following cards:
  - A celebration notice for the site creation.
  - Quick links on the primary location (left).
  - Stats (if the site had any visit), support and go mobile on the secondary location (right).
