### PR TITLE
Remove the selectedDate state from BackupStatus and use the date from

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -59,33 +59,28 @@ const backupStatusNames = [
 
 class BackupsPage extends Component {
 	componentDidMount() {
-		const { queryDate, moment, timezone, gmtOffset } = this.props;
+		const { queryDate, moment } = this.props;
 
 		// On first load, check if we have a selected date from the URL
 		if ( queryDate ) {
-			const today = applySiteOffset( moment(), { timezone, gmtOffset } );
-
-			const dateToSelect = moment( queryDate, INDEX_FORMAT );
-
-			// If we don't have dateToSelect or it's greater than today, force null
-			if ( ! dateToSelect.isValid() || dateToSelect > today ) {
-				this.onDateChange( null );
-			} else {
-				this.onDateChange( dateToSelect );
-			}
+			this.onDateChange( moment( queryDate, INDEX_FORMAT ) );
 		}
 	}
 
 	onDateChange = date => {
-		const { siteSlug } = this.props;
+		const { siteSlug, oldestDateAvailable, moment, timezone, gmtOffset } = this.props;
 
-		if ( date && date.isValid() ) {
+		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
+
+		if ( date && date.isValid() && date <= today && date >= oldestDateAvailable ) {
+			// Valid dates
 			page(
 				backupMainPath( siteSlug, {
 					date: date.format( INDEX_FORMAT ),
 				} )
 			);
 		} else {
+			// No query for invalid dates
 			page( backupMainPath( siteSlug ) );
 		}
 	};

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -58,17 +58,10 @@ const backupStatusNames = [
 ];
 
 class BackupsPage extends Component {
-	state = this.getDefaultState();
-
-	getDefaultState() {
-		return {
-			selectedDate: null,
-		};
-	}
-
 	componentDidMount() {
 		const { queryDate, moment, timezone, gmtOffset } = this.props;
 
+		// On first load, check if we have a selected date from the URL
 		if ( queryDate ) {
 			const today = applySiteOffset( moment(), { timezone, gmtOffset } );
 
@@ -83,21 +76,8 @@ class BackupsPage extends Component {
 		}
 	}
 
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.siteId !== this.props.siteId ) {
-			//If we switch the site, reset the current state to default
-			this.resetState();
-		}
-	}
-
-	resetState() {
-		this.setState( this.getDefaultState() );
-	}
-
 	onDateChange = date => {
 		const { siteSlug } = this.props;
-
-		this.setState( { selectedDate: date } );
 
 		if ( date && date.isValid() ) {
 			page(
@@ -111,14 +91,16 @@ class BackupsPage extends Component {
 	};
 
 	getSelectedDate() {
-		const { timezone, gmtOffset, moment } = this.props;
+		const { timezone, gmtOffset, moment, queryDate } = this.props;
 
 		const today = applySiteOffset( moment(), {
 			timezone: timezone,
 			gmtOffset: gmtOffset,
 		} );
 
-		return this.state.selectedDate || today;
+		const selectedDate = moment( queryDate, INDEX_FORMAT );
+
+		return ( selectedDate.isValid() && selectedDate ) || today;
 	}
 
 	/**
@@ -168,8 +150,8 @@ class BackupsPage extends Component {
 
 	TO_REMOVE_getSelectedDateString = () => {
 		const { moment } = this.props;
-		const { selectedDate } = this.state;
-		return moment.parseZone( selectedDate ).toISOString( true );
+
+		return moment.parseZone( this.getSelectedDate() ).toISOString( true );
 	};
 
 	renderMain() {

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -68,11 +68,11 @@ class BackupsPage extends Component {
 	}
 
 	onDateChange = date => {
-		const { siteSlug, oldestDateAvailable, moment, timezone, gmtOffset } = this.props;
+		const { siteSlug, moment, timezone, gmtOffset } = this.props;
 
 		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
 
-		if ( date && date.isValid() && date <= today && date >= oldestDateAvailable ) {
+		if ( date && date.isValid() && date <= today ) {
 			// Valid dates
 			page(
 				backupMainPath( siteSlug, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the selectedDate state from the BackupStatus component and use the selected date from the URL, if it exists or automatically selects today. Also, the navigation history is tracked and we can browse through the dates using the back/forward buttons

#### Testing instructions

- Apply this change
- The first time, we don't have a selected date, so we see the today backup status
- If we navigate through the dates, we can see in the URL the query parameter date with the selected date with this format YYYYMMDD
- If we change the parameter for another valid date (with the expected format), the Backup Status page loads the backup of this date.
- If we change the parameter for an invalid date (future date, date before the oldest backup, or any text string), the Backup Status page loads today's backup status.
- Navigate through the history using the back/forward buttons of your browser