### PR TITLE
[Private sites] Enable the new privacy picker UI when private_sites_enabled flag is detected

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -716,15 +716,12 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 };
 
 const connectComponent = connect(
-	( state, ownProps ) => {
+	state => {
 		const siteId = getSelectedSiteId( state );
 		const siteIsJetpack = isJetpackSite( state, siteId );
 		const selectedSite = getSelectedSite( state );
 
 		return {
-			withComingSoonOption: ownProps.hasOwnProperty( 'withComingSoonOption' )
-				? ownProps.withComingSoonOption
-				: 'variant' === abtest( 'ATPrivacy' ),
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 			isComingSoon: isSiteComingSoon( state, siteId ),
 			needsVerification: ! isCurrentUserEmailVerified( state ),
@@ -765,7 +762,7 @@ const getFormSettings = settings => {
 		timezone_string: settings.timezone_string,
 	};
 
-	if ( 'variant' === abtest( 'ATPrivacy' ) ) {
+	if ( settings.private_sites_enabled || 'variant' === abtest( 'ATPrivacy' ) ) {
 		formSettings.wpcom_coming_soon = settings.wpcom_coming_soon;
 	}
 
@@ -781,5 +778,10 @@ const getFormSettings = settings => {
 
 export default flowRight(
 	connectComponent,
-	wrapSettingsForm( getFormSettings )
+	wrapSettingsForm( getFormSettings ),
+	connect( ( state, ownProps ) => ( {
+		withComingSoonOption: ownProps.hasOwnProperty( 'withComingSoonOption' )
+			? ownProps.withComingSoonOption
+			: ownProps?.settings?.private_sites_enabled || 'variant' === abtest( 'ATPrivacy' ),
+	} ) )
 )( SiteSettingsFormGeneral );

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -161,7 +161,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			}
 
 			const siteFields = pick( fields, settingsFields.site );
-			if ( 'variant' !== abtest( 'ATPrivacy' ) ) {
+			if ( ! this.props.settings.private_sites_enabled && 'variant' !== abtest( 'ATPrivacy' ) ) {
 				delete siteFields.wpcom_coming_soon;
 			}
 			this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion: '1.4' } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR ensures that every user with a privacy-enabled site will see the correct **New privacy picker**. Technically, we add a an interim `private_sites_enabled` flag that makes it possible to decide server-side which users/sites see the old privacy pickers, and which ones see the new one. The flag will be removed after 100% rollout

See D41819-code for rationale.

**Old picker**
<img width="747" alt="Zrzut ekranu 2020-04-14 o 14 27 18" src="https://user-images.githubusercontent.com/205419/79224933-38027e80-7e5c-11ea-86b4-0e513851830e.png">

**New picker**
<img width="743" alt="Zrzut ekranu 2020-04-14 o 14 26 50" src="https://user-images.githubusercontent.com/205419/79224930-36d15180-7e5c-11ea-8bbc-09debbee3c2d.png">


#### Testing instructions

1. Apply D41819-code
1. Assign yourself to `control` group of `ATPrivacy` test
1. Create a new simple site, launch it
1. Go to settings > general, and confirm you see the **Old Picker**
1. Make the site private
1. Go to settings > general, and confirm you see the **Old Picker**
1. Assign yourself to `variant` group of `ATPrivacy` test
1. Go to settings > general, and confirm you see the **New Picker**
1. Assign yourself to `control` group of `ATPrivacy` test
1. Manually add the `wpcom_coming_soon` option to the cloud site
1. Go to settings > general, and confirm you see the **New Picker** even though you're in `control` group
1. Create a new atomic site and repeat