### PR TITLE
Split several modules from `lib/analytics`

### DIFF
--- a/client/lib/analytics/README.md
+++ b/client/lib/analytics/README.md
@@ -35,12 +35,12 @@ When you add a new item to the queue, it is held in `localStorage` under the key
 ### Example of adding an item to the Queue
 
 ```
-import { add } from 'lib/analytics/queue';
+import { addToQueue } from 'lib/analytics/queue';
 
-add( moduleName, trigger, arg1, arg2, ... );
+addToQueue( moduleName, trigger, arg1, arg2, ... );
 ```
 
 - `moduleName` This is the name of the module where the queued method exists, e.g. `signup`.
   Available modules are configured in the `modules` constant in `queue.js`.
-- `trigger` This can be any function in the `analytics` object; e.g., `recordSignupComplete`.
+- `trigger` This can be any exported function in the chosen module.
 - `arg1, arg2, ...` Optional. These are the arguments ultimately passed to the `trigger` function.

--- a/client/lib/analytics/README.md
+++ b/client/lib/analytics/README.md
@@ -34,7 +34,13 @@ When you add a new item to the queue, it is held in `localStorage` under the key
 
 ### Example of adding an item to the Queue
 
-`analytics.queue.add( trigger, arg1, arg2, ... );`
+```
+import { add } from 'lib/analytics/queue';
 
+add( moduleName, trigger, arg1, arg2, ... );
+```
+
+- `moduleName` This is the name of the module where the queued method exists, e.g. `signup`.
+  Available modules are configured in the `modules` constant in `queue.js`.
 - `trigger` This can be any function in the `analytics` object; e.g., `recordSignupComplete`.
 - `arg1, arg2, ...` Optional. These are the arguments ultimately passed to the `trigger` function.

--- a/client/lib/analytics/cart.js
+++ b/client/lib/analytics/cart.js
@@ -8,6 +8,7 @@ import { differenceWith, get, isEqual, each, omit } from 'lodash';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { recordAddToCart } from 'lib/analytics/record-add-to-cart';
 import { getAllCartItems } from 'lib/cart-values/cart-items';
 
 export function recordEvents( previousCart, nextCart ) {
@@ -24,7 +25,7 @@ function removeNestedProperties( cartItem ) {
 
 function recordAddEvent( cartItem ) {
 	analytics.tracks.recordEvent( 'calypso_cart_product_add', removeNestedProperties( cartItem ) );
-	analytics.recordAddToCart( { cartItem } );
+	recordAddToCart( { cartItem } );
 }
 
 function recordRemoveEvent( cartItem ) {

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -13,7 +13,7 @@ import { retarget as retargetAdTrackers, recordAliasInFloodlight } from 'lib/ana
 import { updateQueryParamsTracking } from 'lib/analytics/sem';
 import { trackAffiliateReferral } from './refer';
 import { gaRecordPageView } from './ga';
-import { process as processQueue } from './queue';
+import { processQueue } from './queue';
 import {
 	recordTracksEvent,
 	analyticsEvents,

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -7,17 +7,12 @@ import debug from 'debug';
  * Internal dependencies
  */
 import emitter from 'lib/mixins/emitter';
-import { costToUSD, urlParseAmpCompatible, saveCouponQueryArgument } from 'lib/analytics/utils';
+import { urlParseAmpCompatible, saveCouponQueryArgument } from 'lib/analytics/utils';
 
-import {
-	retarget as retargetAdTrackers,
-	recordAliasInFloodlight,
-	recordAddToCart,
-	recordOrder,
-} from 'lib/analytics/ad-tracking';
+import { retarget as retargetAdTrackers, recordAliasInFloodlight } from 'lib/analytics/ad-tracking';
 import { updateQueryParamsTracking } from 'lib/analytics/sem';
 import { trackAffiliateReferral } from './refer';
-import { gaRecordEvent, gaRecordPageView } from './ga';
+import { gaRecordPageView } from './ga';
 import { process as processQueue } from './queue';
 import {
 	recordTracksEvent,
@@ -72,30 +67,6 @@ const analytics = {
 				processQueue();
 			}, 0 );
 		},
-	},
-
-	recordAddToCart: function ( { cartItem } ) {
-		// TODO: move Tracks event here?
-		// Google Analytics
-		const usdValue = costToUSD( cartItem.cost, cartItem.currency );
-		gaRecordEvent( 'Checkout', 'calypso_cart_product_add', '', usdValue ? usdValue : undefined );
-		// Marketing
-		recordAddToCart( cartItem );
-	},
-
-	recordPurchase: function ( { cart, orderId } ) {
-		if ( cart.total_cost >= 0.01 ) {
-			// Google Analytics
-			const usdValue = costToUSD( cart.total_cost, cart.currency );
-			gaRecordEvent(
-				'Purchase',
-				'calypso_checkout_payment_success',
-				'',
-				usdValue ? usdValue : undefined
-			);
-			// Marketing
-			recordOrder( cart, orderId );
-		}
 	},
 
 	tracks: {

--- a/client/lib/analytics/queue.js
+++ b/client/lib/analytics/queue.js
@@ -50,7 +50,15 @@ function runTrigger( moduleName, trigger, ...args ) {
 	return; // Not possible.
 }
 
-export function add( moduleName, trigger, ...args ) {
+/**
+ * Add an item to the analytics queue.
+ *
+ * @param {*} moduleName the name of the module where the queued method exists, e.g. `signup`.
+ * See the `modules` constant at the top of this file (`lib/analytics/queue.js`).
+ * @param {*} trigger the exported function in the chosen module to be run, e.g. `recordSignupStart` in `signup`.
+ * @param  {...any} args the arguments to be passed to the chosen function. Optional.
+ */
+export function addToQueue( moduleName, trigger, ...args ) {
 	if ( ! window.localStorage ) {
 		// If unable to queue, trigger it now.
 		return runTrigger( moduleName, trigger, ...args );
@@ -66,7 +74,10 @@ export function add( moduleName, trigger, ...args ) {
 	window.localStorage.setItem( lsKey(), JSON.stringify( items ) );
 }
 
-export function process() {
+/**
+ * Process the existing analytics queue, by running any pending triggers and clearing it.
+ */
+export function processQueue() {
 	if ( ! window.localStorage ) {
 		return; // Not possible.
 	}

--- a/client/lib/analytics/queue.js
+++ b/client/lib/analytics/queue.js
@@ -53,9 +53,9 @@ function runTrigger( moduleName, trigger, ...args ) {
 /**
  * Add an item to the analytics queue.
  *
- * @param {*} moduleName the name of the module where the queued method exists, e.g. `signup`.
+ * @param {string} moduleName the name of the module where the queued method exists, e.g. `signup`.
  * See the `modules` constant at the top of this file (`lib/analytics/queue.js`).
- * @param {*} trigger the exported function in the chosen module to be run, e.g. `recordSignupStart` in `signup`.
+ * @param {string} trigger the exported function in the chosen module to be run, e.g. `recordSignupStart` in `signup`.
  * @param  {...any} args the arguments to be passed to the chosen function. Optional.
  */
 export function addToQueue( moduleName, trigger, ...args ) {

--- a/client/lib/analytics/queue.js
+++ b/client/lib/analytics/queue.js
@@ -1,0 +1,85 @@
+// This is a `localStorage` queue for delayed event triggers.
+
+/**
+ * External dependencies
+ */
+import debug from 'debug';
+
+/**
+ * Module variables
+ */
+const queueDebug = debug( 'calypso:analytics:queue' );
+
+// The supported modules for which queue triggers can be set up.
+// We use a layer of indirection to avoid loading the modules until they're needed.
+const modules = {
+	signup: () => import( 'lib/analytics/signup' ),
+};
+
+const lsKey = () => 'analyticsQueue';
+
+function clear() {
+	if ( ! window.localStorage ) {
+		return; // Not possible.
+	}
+
+	window.localStorage.removeItem( lsKey() );
+}
+
+function get() {
+	if ( ! window.localStorage ) {
+		return []; // Not possible.
+	}
+
+	let items = window.localStorage.getItem( lsKey() );
+
+	items = items ? JSON.parse( items ) : [];
+	items = Array.isArray( items ) ? items : [];
+
+	return items;
+}
+
+function runTrigger( moduleName, trigger, ...args ) {
+	if ( 'string' === typeof trigger && 'function' === typeof modules[ moduleName ] ) {
+		modules[ moduleName ]().then( ( mod ) => {
+			if ( 'function' === typeof mod[ trigger ] ) {
+				mod[ trigger ].apply( null, args || undefined );
+			}
+		} );
+	}
+	return; // Not possible.
+}
+
+export function add( moduleName, trigger, ...args ) {
+	if ( ! window.localStorage ) {
+		// If unable to queue, trigger it now.
+		return runTrigger( moduleName, trigger, ...args );
+	}
+
+	let items = get();
+	const newItem = { moduleName, trigger, args };
+
+	items.push( newItem );
+	items = items.slice( -100 ); // Upper limit.
+
+	queueDebug( 'Adding new item to queue.', newItem );
+	window.localStorage.setItem( lsKey(), JSON.stringify( items ) );
+}
+
+export function process() {
+	if ( ! window.localStorage ) {
+		return; // Not possible.
+	}
+
+	const items = get();
+	clear();
+
+	queueDebug( 'Processing items in queue.', items );
+
+	items.forEach( ( item ) => {
+		if ( 'object' === typeof item && 'string' === typeof item.trigger ) {
+			queueDebug( 'Processing item in queue.', item );
+			runTrigger( item.moduleName, item.trigger, ...item.args );
+		}
+	} );
+}

--- a/client/lib/analytics/queue.js
+++ b/client/lib/analytics/queue.js
@@ -13,7 +13,7 @@ const queueDebug = debug( 'calypso:analytics:queue' );
 // The supported modules for which queue triggers can be set up.
 // We use a layer of indirection to avoid loading the modules until they're needed.
 const modules = {
-	signup: () => import( 'lib/analytics/signup' ),
+	signup: () => import( /* webpackChunkName: "lib-analytics-signup" */ 'lib/analytics/signup' ),
 };
 
 const lsKey = () => 'analyticsQueue';

--- a/client/lib/analytics/record-add-to-cart.js
+++ b/client/lib/analytics/record-add-to-cart.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { costToUSD } from 'lib/analytics/utils';
+
+import { recordAddToCart as trackAddToCart } from 'lib/analytics/ad-tracking';
+import { gaRecordEvent } from './ga';
+
+export function recordAddToCart( { cartItem } ) {
+	// TODO: move Tracks event here?
+	// Google Analytics
+	const usdValue = costToUSD( cartItem.cost, cartItem.currency );
+	gaRecordEvent( 'Checkout', 'calypso_cart_product_add', '', usdValue ? usdValue : undefined );
+	// Marketing
+	trackAddToCart( cartItem );
+}

--- a/client/lib/analytics/record-purchase.js
+++ b/client/lib/analytics/record-purchase.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { costToUSD } from 'lib/analytics/utils';
+
+import { recordOrder } from 'lib/analytics/ad-tracking';
+import { gaRecordEvent } from './ga';
+
+export function recordPurchase( { cart, orderId } ) {
+	if ( cart.total_cost >= 0.01 ) {
+		// Google Analytics
+		const usdValue = costToUSD( cart.total_cost, cart.currency );
+		gaRecordEvent(
+			'Purchase',
+			'calypso_checkout_payment_success',
+			'',
+			usdValue ? usdValue : undefined
+		);
+		// Marketing
+		recordOrder( cart, orderId );
+	}
+}

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -8,7 +8,7 @@ import debug from 'debug';
  */
 import analytics from 'lib/analytics';
 import { gaRecordEvent } from 'lib/analytics/ga';
-import { add as addToQueue } from 'lib/analytics/queue';
+import { addToQueue } from 'lib/analytics/queue';
 import {
 	adTrackSignupStart,
 	adTrackSignupComplete,

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -8,6 +8,7 @@ import debug from 'debug';
  */
 import analytics from 'lib/analytics';
 import { gaRecordEvent } from 'lib/analytics/ga';
+import { add as addToQueue } from 'lib/analytics/queue';
 import {
 	adTrackSignupStart,
 	adTrackSignupComplete,
@@ -33,7 +34,8 @@ export function recordSignupComplete(
 
 	if ( ! now ) {
 		// Delay using the analytics localStorage queue.
-		return analytics.queue.add(
+		return addToQueue(
+			'signup',
 			'recordSignupComplete',
 			{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite },
 			true

--- a/client/lib/analytics/store-transactions.js
+++ b/client/lib/analytics/store-transactions.js
@@ -9,6 +9,7 @@ import { omit } from 'lodash';
  */
 import analytics from 'lib/analytics';
 import { gaRecordEvent } from 'lib/analytics/ga';
+import { recordPurchase } from 'lib/analytics/record-purchase';
 import { hasFreeTrial, getDomainRegistrations } from 'lib/cart-values/cart-items';
 import { getTld } from 'lib/domains';
 import {
@@ -96,7 +97,7 @@ export function recordTransactionAnalytics( cart, step, paymentMethod ) {
 				// Makes sure free trials are not recorded as purchases in ad trackers since they are products with
 				// zero-value cost and would thus lead to a wrong computation of conversions
 				if ( ! hasFreeTrial( cart ) ) {
-					analytics.recordPurchase( { cart, orderId: step.data.receipt_id } );
+					recordPurchase( { cart, orderId: step.data.receipt_id } );
 				}
 
 				analytics.tracks.recordEvent( 'calypso_checkout_payment_success', {

--- a/client/lib/analytics/test/cart.js
+++ b/client/lib/analytics/test/cart.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { recordAddToCart } from 'lib/analytics/record-add-to-cart';
 import { getAllCartItems } from 'lib/cart-values/cart-items';
 import { recordEvents } from 'lib/analytics/cart';
 
@@ -11,8 +12,11 @@ jest.mock( 'lib/analytics', () => ( {
 		tracks: {
 			recordEvent: jest.fn(),
 		},
-		recordAddToCart: jest.fn(),
 	},
+} ) );
+jest.mock( 'lib/analytics/record-add-to-cart', () => ( {
+	__esModule: true,
+	recordAddToCart: jest.fn(),
 } ) );
 jest.mock( 'lib/cart-values/cart-items', () => ( { getAllCartItems: jest.fn() } ) );
 
@@ -58,7 +62,7 @@ describe( 'recordEvents', () => {
 		recordEvents( previousCart, nextCart );
 
 		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
-		expect( analytics.recordAddToCart ).not.toHaveBeenCalled();
+		expect( recordAddToCart ).not.toHaveBeenCalled();
 	} );
 
 	it( 'records an add event when an item is added', () => {
@@ -71,8 +75,8 @@ describe( 'recordEvents', () => {
 			'calypso_cart_product_add',
 			domainRegNoExtra
 		);
-		expect( analytics.recordAddToCart ).toHaveBeenCalledTimes( 1 );
-		expect( analytics.recordAddToCart ).toHaveBeenCalledWith( { cartItem: domainReg } );
+		expect( recordAddToCart ).toHaveBeenCalledTimes( 1 );
+		expect( recordAddToCart ).toHaveBeenCalledWith( { cartItem: domainReg } );
 	} );
 
 	it( 'records a remove event when an item is removed', () => {
@@ -85,7 +89,7 @@ describe( 'recordEvents', () => {
 			'calypso_cart_product_remove',
 			domainRegNoExtra
 		);
-		expect( analytics.recordAddToCart ).not.toHaveBeenCalled();
+		expect( recordAddToCart ).not.toHaveBeenCalled();
 	} );
 
 	it( 'records an add and a remove event when items are added and removed', () => {
@@ -102,8 +106,8 @@ describe( 'recordEvents', () => {
 			'calypso_cart_product_add',
 			privateRegNoExtra
 		);
-		expect( analytics.recordAddToCart ).toHaveBeenCalledTimes( 1 );
-		expect( analytics.recordAddToCart ).toHaveBeenCalledWith( { cartItem: privateReg } );
+		expect( recordAddToCart ).toHaveBeenCalledTimes( 1 );
+		expect( recordAddToCart ).toHaveBeenCalledWith( { cartItem: privateReg } );
 	} );
 } );
 

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -9,7 +9,7 @@ import { defaultRegistry } from '@automattic/composite-checkout';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import { recordPurchase } from 'lib/analytics/record-purchase';
 
 const { select } = defaultRegistry;
 const debug = debugFactory( 'calypso:composite-checkout:record-analytics' );
@@ -36,7 +36,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 				const transactionResult = select( 'wpcom' ).getTransactionResult();
-				analytics.recordPurchase( {
+				recordPurchase( {
 					cart: {
 						total_cost,
 						currency: action.payload.total.amount.currency,


### PR DESCRIPTION
This is one of several PRs that will make `lib/analytics` more modular, breaking up its monolithic default export. This will eventually result in being able to contain larger parts of analytics to just the sections they're needed in, instead of loading everything upfront regardless of the current route.

The PR moves `queue` to its own module under `lib/analytics`, and updates all code accordingly. It also removes references to `signup` in the library's index file, thus ensuring that the already-split `signup` module isn't pulled in by the index.

Beyond this, it moves `recordPurchase` and `recordAddToCart` to their own modules as well.

#### Changes proposed in this Pull Request

* Move `queue` to its own module under `lib/analytics`, removing it from the monolithic default export for `lib/analytics`.
* Ensure `queue` doesn't need access to the default `analytics` export. This involved creating a whitelist of modules that can be loaded, and adding an extra parameter to queue calls to specify the module.
* Handle queue processing asynchronously, to allow for dynamic module loading.
* Modify queue-using code and documentation accordingly.
* Remove signup-related code from the monolithic default export for `lib/analytics`.
* Move `recordPurchase` and `recordAddToCart` to their own modules as well.

#### Testing instructions

The main task is to verify that the `queue` functionality continues to work correctly, enqueueing calls and dispatching them at the right time.

@jaswrks: since you originally added the queue functionality, could you verify that it still works correctly after my changes? I ran some signup tests and it appeared to work fine, but I don't know too much about this 🙂 