### PR TITLE
Remove "Loading backups" and replace it by a pulse loading block

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -217,7 +217,7 @@ class BackupsPage extends Component {
 					siteSlug={ siteSlug }
 				/>
 
-				<div>{ isLoadingBackups && translate( 'Loading backups…' ) }</div>
+				{ isLoadingBackups && <div className="backups__is-loading" /> }
 
 				{ ! isLoadingBackups && (
 					<>

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -24,7 +24,6 @@
 .backups__is-loading {
 	margin: 2rem 1rem;
 	height: 245px;
-	background-color: var( --color-neutral-10 );
-	animation: loading-fade 1.6s ease-in-out infinite;
+	@include placeholder( --color-neutral-10 );
 }
 

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -20,3 +20,11 @@
 .backups__page .main {
 	margin-left: auto;
 }
+
+.backups__is-loading {
+	margin: 2rem 1rem;
+	height: 245px;
+	background-color: var( --color-neutral-10 );
+	animation: loading-fade 1.6s ease-in-out infinite;
+}
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request
**Very small PR**

Remove the "Loading backups..." message from the Backup Status page and replace it by a block with a pulse effect.

#### Testing instructions

- Apply the changes
- Load the Backups section and see a gray block with a pulse effect while the backups are loading.
