### PR TITLE
Import global styles from the sidebar section

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -36,6 +36,10 @@ export const SIDEBAR_SECTION_BACKUP = 'backup';
  * Style dependencies
  */
 import './style.scss';
+// We import these styles from here because this is the only section that gets always
+// loaded when a user visits Jetpack Cloud. We might have to find a better place for
+// this in the future.
+import 'landing/jetpack-cloud/style.scss';
 
 class JetpackCloudSidebar extends Component {
 	static propTypes = {

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -8,11 +8,6 @@ import page from 'page';
  */
 import config from 'config';
 
-/**
- * Style dependencies
- */
-import './style.scss';
-
 export default function() {
 	page( '/', context => {
 		let redirectPath = '/error';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Import "global" Jetpack Cloud styles from the sidebar section.

#### Implementation notes

In stage and production, sections are loaded in the demand, which means that styles might not get loaded if the user doesn't visit the section from where they are being loaded. This doesn't happen in development, because in there we always load all sections.

#### Testing instructions

- 

See 1151678672052943-as-1171201428833121.


