### PR TITLE
Use Recoleta on all page headings

### DIFF
--- a/client/assets/stylesheets/shared/_typography.scss
+++ b/client/assets/stylesheets/shared/_typography.scss
@@ -21,6 +21,14 @@ $signup-sans: 'Noto Sans', $sans;
 	color: var( --color-text );
 }
 
+@font-face {
+	font-display: swap;
+	font-family: 'Recoleta';
+	font-weight: 400;
+	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.woff2' ) format( 'woff2' ),
+	url( 'https://s1.wp.com/i/fonts/recoleta/400.woff' ) format( 'woff' );
+}
+
 // ======================================================================
 // Rem function
 //

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -29,6 +29,7 @@
 }
 
 .formatted-header__title {
+	font-family: 'Recoleta', $serif;
 	font-size: 20px;
 	margin-top: 24px;
 	padding: 0 10px;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -18,14 +18,6 @@
 		grid-column: $col-start / span $span;
 }
 
-@font-face {
-	font-display: swap;
-	font-family: 'Recoleta';
-	font-weight: 400;
-	src: url( 'https://s1.wp.com/i/fonts/recoleta/400.woff2' ) format( 'woff2' ),
-	url( 'https://s1.wp.com/i/fonts/recoleta/400.woff' ) format( 'woff' );
-}
-
 .customer-home__heading {
 	display: flex;
 
@@ -35,10 +27,6 @@
 
 	.formatted-header {
 		margin-right: 12px;
-	}
-
-	.formatted-header__title {
-		font-family: 'Recoleta', $serif;
 	}
 
 	.formatted-header__subtitle {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to bring font consistency across all page headings, this PR updates to Recoleta the font-family used in the title of the `FormattedHeader` component, so it is not only used in My Home.

<img width="248" alt="Screen Shot 2020-04-14 at 18 44 17" src="https://user-images.githubusercontent.com/1233880/79251067-f71c6100-7e7f-11ea-9e4d-2d4561088c4d.png">

<img width="240" alt="Screen Shot 2020-04-14 at 18 48 13" src="https://user-images.githubusercontent.com/1233880/79251495-83c71f00-7e80-11ea-8ee6-693dd6727b34.png">

#### Testing instructions

- Navigate through all pages in Calypso and make sure all headings use the Recoleta font.
- Watch out for other `FormattedHeader` instances not used in page headings and make sure the Recoleta font looks good on them (I'm happy to audit this tomorrow and update the testing instructions with the exact places).

Fixes #41090
