### PR TITLE
composite-checkout: Add domain-contact-validation-endpoint types and use them

### DIFF
--- a/client/my-sites/checkout/composite-checkout/contact-validation.js
+++ b/client/my-sites/checkout/composite-checkout/contact-validation.js
@@ -21,8 +21,7 @@ export default function createContactValidationCallback( {
 		paymentMethodId,
 		contactDetails,
 		domainNames,
-		applyDomainContactValidationResults,
-		decoratedContactDetails
+		applyDomainContactValidationResults
 	) {
 		return new Promise( resolve => {
 			const { contact_information, domain_names } = prepareDomainContactValidationRequest(
@@ -65,9 +64,7 @@ export default function createContactValidationCallback( {
 					applyDomainContactValidationResults(
 						formatDomainContactValidationResponse( data ?? {} )
 					);
-					resolve(
-						! ( data && data.success && areRequiredFieldsNotEmpty( decoratedContactDetails ) )
-					);
+					resolve( ! ( data && data.success && areRequiredFieldsNotEmpty( contactDetails ) ) );
 				},
 				{ apiVersion: '1.2' }
 			);

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -27,7 +27,7 @@ import useCouponFieldState from '../hooks/use-coupon-field-state';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
 import WPCheckoutOrderSummary, { WPCheckoutOrderSummaryTitle } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
-import { isCompleteAndValid, prepareDomainContactDetails } from '../types';
+import { isCompleteAndValid } from '../types';
 import { WPOrderReviewTotal, WPOrderReviewSection, LineItemUI } from './wp-order-review-line-items';
 
 const ContactFormTitle = () => {
@@ -112,10 +112,9 @@ export default function WPCheckout( {
 		if ( isDomainFieldsVisible ) {
 			const hasValidationErrors = await domainContactValidationCallback(
 				activePaymentMethod.id,
-				prepareDomainContactDetails( contactInfo ),
+				contactInfo,
 				[ domainName ],
-				applyDomainContactValidationResults,
-				contactInfo
+				applyDomainContactValidationResults
 			);
 			return ! hasValidationErrors;
 		}

--- a/client/my-sites/checkout/composite-checkout/wpcom/index.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/index.js
@@ -17,6 +17,8 @@ import {
 	applyContactDetailsRequiredMask,
 	domainRequiredContactDetails,
 	taxRequiredContactDetails,
+	prepareDomainContactValidationRequest,
+	formatDomainContactValidationResponse,
 	isCompleteAndValid,
 	areRequiredFieldsNotEmpty,
 } from './types';
@@ -37,6 +39,8 @@ export {
 	applyContactDetailsRequiredMask,
 	domainRequiredContactDetails,
 	taxRequiredContactDetails,
+	prepareDomainContactValidationRequest,
+	formatDomainContactValidationResponse,
 	areDomainsInLineItems,
 	isCompleteAndValid,
 	areRequiredFieldsNotEmpty,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types.ts
@@ -52,6 +52,8 @@ import {
 	managedContactDetailsUpdaters,
 	prepareDomainContactDetails,
 	prepareDomainContactDetailsErrors,
+	prepareDomainContactValidationRequest,
+	formatDomainContactValidationResponse,
 	isValid,
 	areRequiredFieldsNotEmpty,
 } from './types/wpcom-store-state';
@@ -99,6 +101,8 @@ export {
 	DomainContactDetailsErrors,
 	prepareDomainContactDetails,
 	prepareDomainContactDetailsErrors,
+	prepareDomainContactValidationRequest,
+	formatDomainContactValidationResponse,
 	isValid,
 	areRequiredFieldsNotEmpty,
 };

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
@@ -1,0 +1,85 @@
+/**
+ * Request parameter expected by the domain contact validation endpoint.
+ *
+ * @see WPCOM_JSON_API_Domains_Validate_Contact_Information_Endpoint
+ */
+export type DomainContactValidationRequest = {
+	domain_names: string[];
+	contact_information: {
+		firstName: string;
+		lastName: string;
+		organization: string;
+		email: string;
+		alternateEmail: string;
+		phone: string;
+		phoneNumberCountry: string;
+		address1: string;
+		address2: string;
+		city: string;
+		state: string;
+		postalCode: string;
+		countryCode: string;
+		fax: string;
+		vatId: string;
+		extra?: DomainContactValidationRequestExtraFields;
+	};
+};
+
+export type DomainContactValidationRequestExtraFields = {
+	ca?: {
+		lang: string;
+		legal_type: string;
+		cira_agreement_accepted: boolean;
+	};
+	uk?: {
+		registrant_type: string;
+		registration_number: string;
+		trading_name: string;
+	};
+	fr?: {
+		registrant_type: string;
+		trademark_number: string;
+		siren_sirat: string;
+	};
+};
+
+/**
+ * Response format of the domain contact validation endpoint.
+ */
+export type DomainContactValidationResponse = {
+	success: boolean;
+	messages: {
+		firstName?: string[];
+		lastName?: string[];
+		organization?: string[];
+		email?: string[];
+		alternateEmail?: string[];
+		phone?: string[];
+		phoneNumberCountry?: string[];
+		address1?: string[];
+		address2?: string[];
+		city?: string[];
+		state?: string[];
+		postalCode?: string[];
+		countryCode?: string[];
+		fax?: string[];
+		vatId?: string[];
+		extra?: {
+			ca?: {
+				lang?: string[];
+				legalType?: string[];
+				ciraAgreementAccepted?: string[];
+			};
+			uk?: {
+				registrantType?: string[];
+				registrationNumber?: string[];
+				tradingName?: string[];
+			};
+			fr?: {
+				registrantType?: string[];
+				trademarkNumber?: string[];
+				sirenSirat?: string[];
+			};
+		};
+	};
+};

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -2,10 +2,15 @@
  * Internal dependencies
  */
 import {
-	DomainContactDetails,
-	PossiblyCompleteDomainContactDetails,
-	DomainContactDetailsErrors,
+    DomainContactDetails,
+    PossiblyCompleteDomainContactDetails,
+    DomainContactDetailsErrors,
 } from './backend/domain-contact-details-components';
+import {
+    DomainContactValidationRequest,
+    DomainContactValidationRequestExtraFields,
+    DomainContactValidationResponse,
+} from './backend/domain-contact-validation-endpoint';
 
 export type ManagedContactDetailsShape< T > = {
 	firstName: T;
@@ -374,6 +379,98 @@ export function prepareDomainContactDetailsErrors(
 		postalCode: details.postalCode.errors[ 0 ],
 		countryCode: details.countryCode.errors[ 0 ],
 		fax: details.fax.errors[ 0 ],
+		extra: prepareTldExtraContactDetailsErrors( details ),
+	};
+}
+
+export function prepareDomainContactValidationRequest(
+	domainNames: string[],
+	details: ManagedContactDetails
+): DomainContactValidationRequest {
+	const extra: DomainContactValidationRequestExtraFields = {};
+
+	if ( details.tldExtraFields?.ca ) {
+		extra.ca = {
+			lang: details.tldExtraFields.ca.lang.value,
+			legal_type: details.tldExtraFields.ca.legalType.value,
+			cira_agreement_accepted: details.tldExtraFields.ca.ciraAgreementAccepted.value === 'true',
+		};
+	}
+	if ( details.tldExtraFields?.uk ) {
+		extra.uk = {
+			registrant_type: details.tldExtraFields.uk.registrantType.value,
+			registration_number: details.tldExtraFields.uk.registrationNumber.value,
+			trading_name: details.tldExtraFields.uk.tradingName.value,
+		};
+	}
+	if ( details.tldExtraFields?.fr ) {
+		extra.fr = {
+			registrant_type: details.tldExtraFields.fr.registrantType.value,
+			trademark_number: details.tldExtraFields.fr.trademarkNumber.value,
+			siren_sirat: details.tldExtraFields.fr.sirenSirat.value,
+		};
+	}
+
+	return {
+		domain_names: domainNames,
+		qualify_properties: true,
+		contact_information: {
+			firstName: details.firstName.value,
+			lastName: details.lastName.value,
+			organization: details.organization.value,
+			email: details.email.value,
+			alternateEmail: details.alternateEmail.value,
+			phone: details.phone.value,
+			phoneNumberCountry: details.phoneNumberCountry.value,
+			address1: details.address1.value,
+			address2: details.address2.value,
+			city: details.city.value,
+			state: details.state.value,
+			postalCode: details.postalCode.value,
+			countryCode: details.countryCode.value,
+			fax: details.fax.value,
+			vatId: details.vatId.value,
+			extra,
+		},
+	};
+}
+
+export function formatDomainContactValidationResponse(
+	response: DomainContactValidationResponse
+): ManagedContactDetailsErrors {
+	return {
+		firstName: response.messages?.firstName,
+		lastName: response.messages?.lastName,
+		organization: response.messages?.organization,
+		email: response.messages?.email,
+		alternateEmail: response.messages?.alternateEmail,
+		phone: response.messages?.phone,
+		phoneNumberCountry: response.messages?.phoneNumberCountry,
+		address1: response.messages?.address1,
+		address2: response.messages?.address2,
+		city: response.messages?.city,
+		state: response.messages?.state,
+		postalCode: response.messages?.postalCode,
+		countryCode: response.messages?.countryCode,
+		fax: response.messages?.fax,
+		vatId: response.messages?.vatId,
+		tldExtraFields: {
+			ca: {
+				lang: response.messages?.extra?.ca?.lang,
+				legalType: response.messages?.extra?.ca?.legalType,
+				ciraAgreementAccepted: response.messages?.extra?.ca?.ciraAgreementAccepted,
+			},
+			uk: {
+				registrantType: response.messages?.extra?.uk?.registrantType,
+				registrationNumber: response.messages?.extra?.uk?.registrationNumber,
+				tradingName: response.messages?.extra?.uk?.tradingName,
+			},
+			fr: {
+				registrantType: response.messages?.extra?.fr?.registrantType,
+				trademarkNumber: response.messages?.extra?.fr?.trademarkNumber,
+				sirenSirat: response.messages?.extra?.fr?.sirenSirat,
+			},
+		},
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -379,7 +379,6 @@ export function prepareDomainContactDetailsErrors(
 		postalCode: details.postalCode.errors[ 0 ],
 		countryCode: details.countryCode.errors[ 0 ],
 		fax: details.fax.errors[ 0 ],
-		extra: prepareTldExtraContactDetailsErrors( details ),
 	};
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -2,14 +2,14 @@
  * Internal dependencies
  */
 import {
-    DomainContactDetails,
-    PossiblyCompleteDomainContactDetails,
-    DomainContactDetailsErrors,
+	DomainContactDetails,
+	PossiblyCompleteDomainContactDetails,
+	DomainContactDetailsErrors,
 } from './backend/domain-contact-details-components';
 import {
-    DomainContactValidationRequest,
-    DomainContactValidationRequestExtraFields,
-    DomainContactValidationResponse,
+	DomainContactValidationRequest,
+	DomainContactValidationRequestExtraFields,
+	DomainContactValidationResponse,
 } from './backend/domain-contact-validation-endpoint';
 
 export type ManagedContactDetailsShape< T > = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR makes the request and response types of the domain contact details validation endpoint explicit, introduces conversion functions to and from the internal type, and uses these in the endpoint wrapper for composite checkout. It also bumps the api version number on the request to trigger the new behavior implemented in D41243-code and #41033.

#### Testing instructions

This patch refactors domain contact validation in composite checkout. To test it, enter checkout with a domain in your cart and jerk test the contact details step. Things to watch for:

- If your data is complete, can you proceed to the next checkout step?
- If your data is incomplete or incorrectly formatted, do you see errors (a notice and field errors) when submitting?
- Look for errors in the JS console
- Keep an eye on the network traffic to the validation endpoint (I do this by filtering on the word "validate"). Check that the request and response data seem reasonable.
