### PR TITLE
Jetpack Cloud: display the real number of threats in the sidebar

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -10,8 +10,9 @@ import { memoize } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getSelectedSiteSlug } from 'state/ui/selectors';
 import config from 'config';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import getJetpackScanThreats from 'state/selectors/get-jetpack-scan-threats';
 import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import { itemLinkMatches } from 'my-sites/sidebar/utils';
@@ -203,17 +204,12 @@ class JetpackCloudSidebar extends Component {
 	}
 }
 
-// This has to be replaced for a real selector once we load the
-// threats information into our Redux store.
-const getSiteThreats = () => {
-	return [ {}, {} ];
-};
-
 export default connect(
 	state => {
+		const siteId = getSelectedSiteId( state );
 		const isBackupSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_BACKUP );
 		const isScanSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_SCAN );
-		const threats = getSiteThreats( state );
+		const threats = getJetpackScanThreats( state, siteId );
 
 		return {
 			isBackupSectionOpen,

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -12,7 +12,7 @@ import { memoize } from 'lodash';
  */
 import config from 'config';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import getJetpackScanThreats from 'state/selectors/get-jetpack-scan-threats';
+import getSiteScanThreats from 'state/selectors/get-site-scan-threats';
 import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import { itemLinkMatches } from 'my-sites/sidebar/utils';
@@ -209,7 +209,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		const isBackupSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_BACKUP );
 		const isScanSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_SCAN );
-		const threats = getJetpackScanThreats( state, siteId );
+		const threats = getSiteScanThreats( state, siteId );
 
 		return {
 			isBackupSectionOpen,

--- a/client/state/selectors/get-jetpack-scan-threats.js
+++ b/client/state/selectors/get-jetpack-scan-threats.js
@@ -1,0 +1,21 @@
+/**
+ * External Dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/data-layer/wpcom/sites/scan';
+
+/**
+ * Returns an array found threats in the current scan process of Jetpack Scan.
+ * Returns an empty array if the site is unknown, or there is no information yet.
+ *
+ * @param  {object}   state    Global state tree
+ * @param  {number}   siteId   The ID of the site we're querying
+ * @returns {object[]}         Array of threats found
+ */
+export default function getJetpackScanThreats( state, siteId ) {
+	return get( state, [ 'jetpackScan', 'scan', siteId, 'threats' ], [] );
+}

--- a/client/state/selectors/get-site-scan-threats.js
+++ b/client/state/selectors/get-site-scan-threats.js
@@ -16,6 +16,6 @@ import 'state/data-layer/wpcom/sites/scan';
  * @param  {number}   siteId   The ID of the site we're querying
  * @returns {object[]}         Array of threats found
  */
-export default function getJetpackScanThreats( state, siteId ) {
+export default function getSiteScanThreats( state, siteId ) {
 	return get( state, [ 'jetpackScan', 'scan', siteId, 'threats' ], [] );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Create a Query Component to fetch the Scan History data and load it into the store.

#### Implementation notes

- Make the sidebar display the real number of found threats.

#### Testing instructions

- Go to http://jetpack.cloud.localhost:3000/scan/<SITE_SLUG>?scan-state=threats.
- If <SITE_SLUG> has threats, you should see a badge with the number of them on the sidebar.
- If <SITE_SLUG> doesn't have threats, you should not see the badge.

#### Screenshots

##### Site with two threats
![image](https://user-images.githubusercontent.com/3418513/79276088-c1767880-7e7d-11ea-8d10-e11e5eb58cbf.png)

##### Site without threats
![image](https://user-images.githubusercontent.com/3418513/79276167-e4a12800-7e7d-11ea-8f97-c2d5713c3e5b.png)

See 1151678672052943-as-1171292173815057.


