### PR TITLE
My Home: Add a Quick Start Session card.

### DIFF
--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -10,15 +10,12 @@ import page from 'page';
 import controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { siteSelection, sites } from 'my-sites/controller';
-import reducer from 'state/concierge/reducer';
 
 const redirectToBooking = ( context ) => {
 	page.redirect( `/me/concierge/${ context.params.siteSlug }/book` );
 };
 
-export default async ( _, addReducer ) => {
-	await addReducer( [ 'concierge' ], reducer );
-
+export default async () => {
 	page( '/me/concierge', controller.siteSelector, siteSelection, sites, makeLayout, clientRender );
 
 	// redirect to booking page after site selection

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -27,7 +27,7 @@ import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appo
  */
 import './style.scss';
 
-const QuickStartCard = ( {
+const QuickStart = ( {
 	translate,
 	siteId,
 	siteSlug,
@@ -116,4 +116,4 @@ export default connect(
 				)
 			),
 	} )
-)( localize( QuickStartCard ) );
+)( localize( QuickStart ) );

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { localize } from 'i18n-calypso';
 import { Button, Card } from '@automattic/components';
 import { connect } from 'react-redux';
+import 'moment-timezone';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import { navigate } from 'state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryConciergeInitial from 'components/data/query-concierge-initial';
 import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -28,13 +30,14 @@ import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appo
 import './style.scss';
 
 const QuickStart = ( {
-	translate,
+	bookASession,
+	moment,
+	nextSession,
+	reschedule,
 	siteId,
 	siteSlug,
-	nextSession,
-	bookASession,
+	translate,
 	viewDetails,
-	reschedule,
 } ) => {
 	return nextSession ? (
 		<Card className="quick-start next-session">
@@ -42,11 +45,11 @@ const QuickStart = ( {
 			<CardHeading>{ translate( 'Your scheduled Quick Start support session' ) }</CardHeading>
 			<div className="quick-start__date">
 				{ translate( 'Date' ) }
-				{ nextSession.beginTimestamp }
+				{ moment( nextSession.beginTimestamp ).format( 'llll' ) }
 			</div>
 			<div className="quick-start__time">
 				{ translate( 'Time' ) }
-				{ nextSession.beginTimestamp }
+				{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }
 			</div>
 			<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
 			<a
@@ -118,4 +121,4 @@ export default connect(
 				)
 			),
 	} )
-)( localize( QuickStart ) );
+)( localize( withLocalizedMoment( QuickStart ) ) );

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -49,9 +49,12 @@ const QuickStart = ( {
 				{ nextSession.beginTimestamp }
 			</div>
 			<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
-			<Button onClick={ () => reschedule( siteSlug, nextSession.id ) }>
+			<a
+				href={ `/me/concierge/${ siteSlug }/book` }
+				onClick={ () => reschedule( siteSlug, nextSession.id ) }
+			>
 				{ translate( 'Reschedule' ) }
-			</Button>
+			</a>
 		</Card>
 	) : (
 		<>
@@ -87,8 +90,7 @@ export default connect(
 							siteSlug: siteSlug,
 						} ),
 						bumpStat( 'calypso_customer_home', 'book_quick_start_session' )
-					),
-					navigate( `/me/concierge/${ siteSlug }/book` )
+					)
 				)
 			),
 		viewDetails: siteSlug =>

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { Button, Card } from '@automattic/components';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import HappinessEngineersTray from 'components/happiness-engineers-tray';
+import CardHeading from 'components/card-heading';
+import {
+	withAnalytics,
+	composeAnalytics,
+	recordTracksEvent,
+	bumpStat,
+} from 'state/analytics/actions';
+import { navigate } from 'state/ui/actions';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const QuickStartCard = ( { translate, siteSlug, bookASession } ) => {
+	return (
+		<Card className="quick-start">
+			<HappinessEngineersTray />
+			<CardHeading>{ translate( 'Schedule time with an expert' ) }</CardHeading>
+			<p>
+				{ translate(
+					'Need help with your site? Set up a video call to get hands-on 1-on-1 support.'
+				) }
+			</p>
+			<Button onClick={ () => bookASession( siteSlug ) }>{ translate( 'Book a session' ) }</Button>
+		</Card>
+	);
+};
+
+const bookASession = siteSlug => {
+	return withAnalytics(
+		composeAnalytics(
+			recordTracksEvent( 'calypso_customer_home_book_a_session_click' ),
+			bumpStat( 'calypso_customer_home', 'book_a_session' )
+		),
+		navigate( `/me/concierge/${ siteSlug }/book` )
+	);
+};
+
+export default connect(
+	state => ( {
+		siteSlug: getSelectedSiteSlug( state ),
+	} ),
+	{ bookASession }
+)( localize( QuickStartCard ) );

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -34,17 +34,24 @@ const QuickStartCard = ( {
 	nextSession,
 	bookASession,
 	viewDetails,
+	reschedule,
 } ) => {
 	return nextSession ? (
 		<Card className="quick-start next-session">
 			<HappinessEngineersTray />
 			<CardHeading>{ translate( 'Your scheduled Quick Start support session' ) }</CardHeading>
-			<p>
-				{ translate(
-					'Need help with your site? Set up a video call to get hands-on 1-on-1 support.'
-				) }
-			</p>
+			<div className="quick-start__date">
+				{ translate( 'Date' ) }
+				{ nextSession.beginTimestamp }
+			</div>
+			<div className="quick-start__time">
+				{ translate( 'Time' ) }
+				{ nextSession.beginTimestamp }
+			</div>
 			<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
+			<Button onClick={ () => reschedule( siteSlug, nextSession.id ) }>
+				{ translate( 'Reschedule' ) }
+			</Button>
 		</Card>
 	) : (
 		<>
@@ -96,7 +103,7 @@ export default connect(
 					navigate( `/me/concierge/${ siteSlug }/book` )
 				)
 			),
-		reschedule: siteSlug =>
+		reschedule: ( siteSlug, sessionId ) =>
 			dispatch(
 				withAnalytics(
 					composeAnalytics(
@@ -105,7 +112,7 @@ export default connect(
 						} ),
 						bumpStat( 'calypso_customer_home', 'reschedule_quick_start_session' )
 					),
-					navigate( `/me/concierge/${ siteSlug }/cancel` )
+					navigate( `/me/concierge/${ siteSlug }/${ sessionId }/cancel` )
 				)
 			),
 	} )

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -60,7 +60,6 @@ const QuickStart = ( {
 			<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
 			<Button
 				className={ 'quick-start__reschedule' }
-				href={ `/me/concierge/${ siteSlug }/book` }
 				onClick={ () => reschedule( siteSlug, nextSession.id ) }
 				borderless
 			>

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -45,7 +45,7 @@ const QuickStart = ( {
 			<CardHeading>{ translate( 'Your scheduled Quick Start support session' ) }</CardHeading>
 			<div className="quick-start__date">
 				{ translate( 'Date' ) }
-				{ moment( nextSession.beginTimestamp ).format( 'llll' ) }
+				{ moment( nextSession.beginTimestamp ).format( 'LL' ) }
 			</div>
 			<div className="quick-start__time">
 				{ translate( 'Time' ) }

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -30,6 +30,7 @@ import { withLocalizedMoment } from 'components/localized-moment';
 import './style.scss';
 
 const QuickStart = ( {
+	bookASession,
 	moment,
 	nextSession,
 	reschedule,
@@ -38,44 +39,57 @@ const QuickStart = ( {
 	translate,
 	viewDetails,
 } ) => {
-	if ( ! siteId ) {
-		return null;
-	}
-	{
-		nextSession ? (
-			<Card className="quick-start next-session">
+	return nextSession ? (
+		<Card className="quick-start next-session">
+			<HappinessEngineersTray />
+			<CardHeading>{ translate( 'Your scheduled Quick Start support session' ) }</CardHeading>
+			<table>
+				<thead>
+					<tr>
+						<th>{ translate( 'Date' ) }</th>
+						<th>{ translate( 'Time' ) }</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>{ moment( nextSession.beginTimestamp ).format( 'LL' ) }</td>
+						<td>{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }</td>
+					</tr>
+				</tbody>
+			</table>
+			<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
+			<Button
+				className={ 'quick-start__reschedule' }
+				href={ `/me/concierge/${ siteSlug }/book` }
+				onClick={ () => reschedule( siteSlug, nextSession.id ) }
+				borderless
+			>
+				{ translate( 'Reschedule' ) }
+			</Button>
+			{ /* <a
+				
+				onClick={ () => reschedule( siteSlug, nextSession.id ) }
+			>
+				{ translate( 'Reschedule' ) }
+			</a> */ }
+		</Card>
+	) : (
+		<>
+			{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
+			<Card className="quick-start book-session">
 				<HappinessEngineersTray />
-				<CardHeading>{ translate( 'Your scheduled Quick Start support session' ) }</CardHeading>
-				<table>
-					<thead>
-						<tr>
-							<th>{ translate( 'Date' ) }</th>
-							<th>{ translate( 'Time' ) }</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>{ moment( nextSession.beginTimestamp ).format( 'LL' ) }</td>
-							<td>
-								{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }
-							</td>
-						</tr>
-					</tbody>
-				</table>
-				<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
-				<Button
-					className={ 'quick-start__reschedule' }
-					href={ `/me/concierge/${ siteSlug }/book` }
-					onClick={ () => reschedule( siteSlug, nextSession.id ) }
-					borderless
-				>
-					{ translate( 'Reschedule' ) }
+				<CardHeading>{ translate( 'Schedule time with an expert' ) }</CardHeading>
+				<p>
+					{ translate(
+						'Need help with your site? Set up a video call to get hands-on 1-on-1 support.'
+					) }
+				</p>
+				<Button onClick={ () => bookASession( siteSlug ) }>
+					{ translate( 'Book a session' ) }
 				</Button>
 			</Card>
-		) : (
-			<QueryConciergeInitial siteId={ siteId } />
-		);
-	}
+		</>
+	);
 };
 
 export default connect(
@@ -85,6 +99,18 @@ export default connect(
 		nextSession: getConciergeNextAppointment( state ),
 	} ),
 	( dispatch ) => ( {
+		bookASession: ( siteSlug ) =>
+			dispatch(
+				withAnalytics(
+					composeAnalytics(
+						recordTracksEvent( 'calypso_customer_home_quick_start_book_a_session_click', {
+							siteSlug: siteSlug,
+						} ),
+						bumpStat( 'calypso_customer_home', 'book_quick_start_session' )
+					),
+					navigate( `/me/concierge/${ siteSlug }/book` )
+				)
+			),
 		viewDetails: ( siteSlug ) =>
 			dispatch(
 				withAnalytics(

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -79,13 +79,13 @@ const QuickStart = ( {
 };
 
 export default connect(
-	state => ( {
+	( state ) => ( {
 		siteId: getSelectedSiteId( state ),
 		siteSlug: getSelectedSiteSlug( state ),
 		nextSession: getConciergeNextAppointment( state ),
 	} ),
-	dispatch => ( {
-		bookASession: siteSlug =>
+	( dispatch ) => ( {
+		bookASession: ( siteSlug ) =>
 			dispatch(
 				withAnalytics(
 					composeAnalytics(
@@ -96,7 +96,7 @@ export default connect(
 					)
 				)
 			),
-		viewDetails: siteSlug =>
+		viewDetails: ( siteSlug ) =>
 			dispatch(
 				withAnalytics(
 					composeAnalytics(

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -30,7 +30,6 @@ import { withLocalizedMoment } from 'components/localized-moment';
 import './style.scss';
 
 const QuickStart = ( {
-	bookASession,
 	moment,
 	nextSession,
 	reschedule,
@@ -39,57 +38,44 @@ const QuickStart = ( {
 	translate,
 	viewDetails,
 } ) => {
-	return nextSession ? (
-		<Card className="quick-start next-session">
-			<HappinessEngineersTray />
-			<CardHeading>{ translate( 'Your scheduled Quick Start support session' ) }</CardHeading>
-			<table>
-				<thead>
-					<tr>
-						<th>{ translate( 'Date' ) }</th>
-						<th>{ translate( 'Time' ) }</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>{ moment( nextSession.beginTimestamp ).format( 'LL' ) }</td>
-						<td>{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }</td>
-					</tr>
-				</tbody>
-			</table>
-			<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
-			<Button
-				className={ 'quick-start__reschedule' }
-				href={ `/me/concierge/${ siteSlug }/book` }
-				onClick={ () => reschedule( siteSlug, nextSession.id ) }
-				borderless
-			>
-				{ translate( 'Reschedule' ) }
-			</Button>
-			{ /* <a
-				
-				onClick={ () => reschedule( siteSlug, nextSession.id ) }
-			>
-				{ translate( 'Reschedule' ) }
-			</a> */ }
-		</Card>
-	) : (
-		<>
-			{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
-			<Card className="quick-start book-session">
+	if ( ! siteId ) {
+		return null;
+	}
+	{
+		nextSession ? (
+			<Card className="quick-start next-session">
 				<HappinessEngineersTray />
-				<CardHeading>{ translate( 'Schedule time with an expert' ) }</CardHeading>
-				<p>
-					{ translate(
-						'Need help with your site? Set up a video call to get hands-on 1-on-1 support.'
-					) }
-				</p>
-				<Button onClick={ () => bookASession( siteSlug ) }>
-					{ translate( 'Book a session' ) }
+				<CardHeading>{ translate( 'Your scheduled Quick Start support session' ) }</CardHeading>
+				<table>
+					<thead>
+						<tr>
+							<th>{ translate( 'Date' ) }</th>
+							<th>{ translate( 'Time' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>{ moment( nextSession.beginTimestamp ).format( 'LL' ) }</td>
+							<td>
+								{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
+				<Button
+					className={ 'quick-start__reschedule' }
+					href={ `/me/concierge/${ siteSlug }/book` }
+					onClick={ () => reschedule( siteSlug, nextSession.id ) }
+					borderless
+				>
+					{ translate( 'Reschedule' ) }
 				</Button>
 			</Card>
-		</>
-	);
+		) : (
+			<QueryConciergeInitial siteId={ siteId } />
+		);
+	}
 };
 
 export default connect(
@@ -99,18 +85,6 @@ export default connect(
 		nextSession: getConciergeNextAppointment( state ),
 	} ),
 	( dispatch ) => ( {
-		bookASession: ( siteSlug ) =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( 'calypso_customer_home_quick_start_book_a_session_click', {
-							siteSlug: siteSlug,
-						} ),
-						bumpStat( 'calypso_customer_home', 'book_quick_start_session' )
-					),
-					navigate( `/me/concierge/${ siteSlug }/book` )
-				)
-			),
 		viewDetails: ( siteSlug ) =>
 			dispatch(
 				withAnalytics(

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -93,7 +93,8 @@ export default connect(
 							siteSlug: siteSlug,
 						} ),
 						bumpStat( 'calypso_customer_home', 'book_quick_start_session' )
-					)
+					),
+					navigate( `/me/concierge/${ siteSlug }/book` )
 				)
 			),
 		viewDetails: ( siteSlug ) =>

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -54,14 +54,18 @@ const QuickStart = ( {
 					<tbody>
 						<tr>
 							<td>
-								{ nextSession
-									? moment( nextSession.beginTimestamp ).format( 'LL' )
-									: translate( 'Loading…' ) }
+								{ nextSession ? (
+									moment( nextSession.beginTimestamp ).format( 'LL' )
+								) : (
+									<div className="quick-start__placeholder"></div>
+								) }
 							</td>
 							<td>
-								{ nextSession
-									? moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' )
-									: translate( 'Loading…' ) }
+								{ nextSession ? (
+									moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' )
+								) : (
+									<div className="quick-start__placeholder"></div>
+								) }
 							</td>
 						</tr>
 					</tbody>

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -42,7 +42,7 @@ const QuickStart = ( {
 	return nextSession ? (
 		<Card className="quick-start next-session">
 			<HappinessEngineersTray />
-			<CardHeading>{ translate( 'Your scheduled Quick Start support session' ) }</CardHeading>
+			<CardHeading>{ translate( 'Your scheduled Quick Start support session:' ) }</CardHeading>
 			<table>
 				<thead>
 					<tr>

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -43,21 +43,35 @@ const QuickStart = ( {
 		<Card className="quick-start next-session">
 			<HappinessEngineersTray />
 			<CardHeading>{ translate( 'Your scheduled Quick Start support session' ) }</CardHeading>
-			<div className="quick-start__date">
-				{ translate( 'Date' ) }
-				{ moment( nextSession.beginTimestamp ).format( 'LL' ) }
-			</div>
-			<div className="quick-start__time">
-				{ translate( 'Time' ) }
-				{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }
-			</div>
+			<table>
+				<thead>
+					<tr>
+						<th>{ translate( 'Date' ) }</th>
+						<th>{ translate( 'Time' ) }</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>{ moment( nextSession.beginTimestamp ).format( 'LL' ) }</td>
+						<td>{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }</td>
+					</tr>
+				</tbody>
+			</table>
 			<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
-			<a
+			<Button
+				className={ 'quick-start__reschedule' }
 				href={ `/me/concierge/${ siteSlug }/book` }
+				onClick={ () => reschedule( siteSlug, nextSession.id ) }
+				borderless
+			>
+				{ translate( 'Reschedule' ) }
+			</Button>
+			{ /* <a
+				
 				onClick={ () => reschedule( siteSlug, nextSession.id ) }
 			>
 				{ translate( 'Reschedule' ) }
-			</a>
+			</a> */ }
 		</Card>
 	) : (
 		<>

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -23,6 +23,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryConciergeInitial from 'components/data/query-concierge-initial';
 import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
 import { withLocalizedMoment } from 'components/localized-moment';
+import Spinner from 'components/spinner';
 
 /**
  * Style dependencies
@@ -30,7 +31,6 @@ import { withLocalizedMoment } from 'components/localized-moment';
 import './style.scss';
 
 const QuickStart = ( {
-	bookASession,
 	moment,
 	nextSession,
 	reschedule,
@@ -39,47 +39,43 @@ const QuickStart = ( {
 	translate,
 	viewDetails,
 } ) => {
-	return nextSession ? (
-		<Card className="quick-start next-session">
-			<HappinessEngineersTray />
-			<CardHeading>{ translate( 'Your scheduled Quick Start support session:' ) }</CardHeading>
-			<table>
-				<thead>
-					<tr>
-						<th>{ translate( 'Date' ) }</th>
-						<th>{ translate( 'Time' ) }</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>{ moment( nextSession.beginTimestamp ).format( 'LL' ) }</td>
-						<td>{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }</td>
-					</tr>
-				</tbody>
-			</table>
-			<Button onClick={ () => viewDetails( siteSlug ) }>{ translate( 'View details' ) }</Button>
-			<Button
-				className={ 'quick-start__reschedule' }
-				onClick={ () => reschedule( siteSlug, nextSession.id ) }
-				borderless
-			>
-				{ translate( 'Reschedule' ) }
-			</Button>
-		</Card>
-	) : (
+	return (
 		<>
 			{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
-			<Card className="quick-start book-session">
+			<Card className="quick-start next-session">
 				<HappinessEngineersTray />
-				<CardHeading>{ translate( 'Schedule time with an expert' ) }</CardHeading>
-				<p>
-					{ translate(
-						'Need help with your site? Set up a video call to get hands-on 1-on-1 support.'
-					) }
-				</p>
-				<Button onClick={ () => bookASession( siteSlug ) }>
-					{ translate( 'Book a session' ) }
-				</Button>
+				<CardHeading>{ translate( 'Your scheduled Quick Start support session:' ) }</CardHeading>
+				{ nextSession && (
+					<>
+						<table>
+							<thead>
+								<tr>
+									<th>{ translate( 'Date' ) }</th>
+									<th>{ translate( 'Time' ) }</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>{ moment( nextSession.beginTimestamp ).format( 'LL' ) }</td>
+									<td>
+										{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }
+									</td>
+								</tr>
+							</tbody>
+						</table>
+						<Button onClick={ () => viewDetails( siteSlug ) }>
+							{ translate( 'View details' ) }
+						</Button>
+						<Button
+							className={ 'quick-start__reschedule' }
+							onClick={ () => reschedule( siteSlug, nextSession.id ) }
+							borderless
+						>
+							{ translate( 'Reschedule' ) }
+						</Button>
+					</>
+				) }
+				{ ! nextSession && <Spinner /> }
 			</Card>
 		</>
 	);
@@ -92,18 +88,6 @@ export default connect(
 		nextSession: getConciergeNextAppointment( state ),
 	} ),
 	( dispatch ) => ( {
-		bookASession: ( siteSlug ) =>
-			dispatch(
-				withAnalytics(
-					composeAnalytics(
-						recordTracksEvent( 'calypso_customer_home_quick_start_book_a_session_click', {
-							siteSlug: siteSlug,
-						} ),
-						bumpStat( 'calypso_customer_home', 'book_quick_start_session' )
-					),
-					navigate( `/me/concierge/${ siteSlug }/book` )
-				)
-			),
 		viewDetails: ( siteSlug ) =>
 			dispatch(
 				withAnalytics(

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -66,12 +66,6 @@ const QuickStart = ( {
 			>
 				{ translate( 'Reschedule' ) }
 			</Button>
-			{ /* <a
-				
-				onClick={ () => reschedule( siteSlug, nextSession.id ) }
-			>
-				{ translate( 'Reschedule' ) }
-			</a> */ }
 		</Card>
 	) : (
 		<>

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -67,12 +67,12 @@ const QuickStart = ( {
 					</tbody>
 				</table>
 				<div className="quick-start__buttons">
-					<Button disabled={ ! nextSession } onClick={ () => viewDetails( siteSlug ) }>
+					<Button disabled={ ! nextSession } onClick={ () => viewDetails( siteId, siteSlug ) }>
 						{ translate( 'View details' ) }
 					</Button>
 					<Button
 						className={ 'quick-start__reschedule' }
-						onClick={ () => reschedule( siteSlug, nextSession.id ) }
+						onClick={ () => reschedule( siteId, siteSlug, nextSession.id ) }
 						borderless
 						disabled={ ! nextSession }
 					>
@@ -91,24 +91,24 @@ export default connect(
 		nextSession: getConciergeNextAppointment( state ),
 	} ),
 	( dispatch ) => ( {
-		viewDetails: ( siteSlug ) =>
+		viewDetails: ( siteId, siteSlug ) =>
 			dispatch(
 				withAnalytics(
 					composeAnalytics(
 						recordTracksEvent( 'calypso_customer_home_quick_start_view_details_click', {
-							siteSlug: siteSlug,
+							site_id: siteId,
 						} ),
 						bumpStat( 'calypso_customer_home', 'view_quick_start_session_details' )
 					),
 					navigate( `/me/concierge/${ siteSlug }/book` )
 				)
 			),
-		reschedule: ( siteSlug, sessionId ) =>
+		reschedule: ( siteId, siteSlug, sessionId ) =>
 			dispatch(
 				withAnalytics(
 					composeAnalytics(
 						recordTracksEvent( 'calypso_customer_home_quick_start_reschedule_click', {
-							siteSlug: siteSlug,
+							site_id: siteId,
 						} ),
 						bumpStat( 'calypso_customer_home', 'reschedule_quick_start_session' )
 					),

--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -23,7 +23,6 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryConciergeInitial from 'components/data/query-concierge-initial';
 import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
 import { withLocalizedMoment } from 'components/localized-moment';
-import Spinner from 'components/spinner';
 
 /**
  * Style dependencies
@@ -45,37 +44,41 @@ const QuickStart = ( {
 			<Card className="quick-start next-session">
 				<HappinessEngineersTray />
 				<CardHeading>{ translate( 'Your scheduled Quick Start support session:' ) }</CardHeading>
-				{ nextSession && (
-					<>
-						<table>
-							<thead>
-								<tr>
-									<th>{ translate( 'Date' ) }</th>
-									<th>{ translate( 'Time' ) }</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>{ moment( nextSession.beginTimestamp ).format( 'LL' ) }</td>
-									<td>
-										{ moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' ) }
-									</td>
-								</tr>
-							</tbody>
-						</table>
-						<Button onClick={ () => viewDetails( siteSlug ) }>
-							{ translate( 'View details' ) }
-						</Button>
-						<Button
-							className={ 'quick-start__reschedule' }
-							onClick={ () => reschedule( siteSlug, nextSession.id ) }
-							borderless
-						>
-							{ translate( 'Reschedule' ) }
-						</Button>
-					</>
-				) }
-				{ ! nextSession && <Spinner /> }
+				<table>
+					<thead>
+						<tr>
+							<th>{ translate( 'Date' ) }</th>
+							<th>{ translate( 'Time' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>
+								{ nextSession
+									? moment( nextSession.beginTimestamp ).format( 'LL' )
+									: translate( 'Loading…' ) }
+							</td>
+							<td>
+								{ nextSession
+									? moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' )
+									: translate( 'Loading…' ) }
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<div className="quick-start__buttons">
+					<Button disabled={ ! nextSession } onClick={ () => viewDetails( siteSlug ) }>
+						{ translate( 'View details' ) }
+					</Button>
+					<Button
+						className={ 'quick-start__reschedule' }
+						onClick={ () => reschedule( siteSlug, nextSession.id ) }
+						borderless
+						disabled={ ! nextSession }
+					>
+						{ translate( 'Reschedule' ) }
+					</Button>
+				</div>
 			</Card>
 		</>
 	);

--- a/client/my-sites/customer-home/cards/features/quick-start/style.scss
+++ b/client/my-sites/customer-home/cards/features/quick-start/style.scss
@@ -1,0 +1,3 @@
+.support-card p {
+	margin-bottom: 16px;
+}

--- a/client/my-sites/customer-home/cards/features/quick-start/style.scss
+++ b/client/my-sites/customer-home/cards/features/quick-start/style.scss
@@ -10,8 +10,8 @@
 	font-weight: 400;
 }
 
-.quick-start__reschedule,
-.quick-start__reschedule:visited {
+.quick-start__reschedule.is-borderless,
+.quick-start__reschedule.is-borderless:visited {
 	color: var( --color-link );
 	margin: 7px 14px 9px;
 	padding: 0;

--- a/client/my-sites/customer-home/cards/features/quick-start/style.scss
+++ b/client/my-sites/customer-home/cards/features/quick-start/style.scss
@@ -1,3 +1,3 @@
-.support-card p {
+.quick-start p {
 	margin-bottom: 16px;
 }

--- a/client/my-sites/customer-home/cards/features/quick-start/style.scss
+++ b/client/my-sites/customer-home/cards/features/quick-start/style.scss
@@ -1,3 +1,18 @@
-.quick-start p {
-	margin-bottom: 16px;
+.quick-start p,
+.quick-start .happiness-engineers-tray,
+.quick-start table {
+	margin-bottom: 1.1rem;
+}
+
+.quick-start th {
+	color: var( --color-text-subtle );
+	font-size: 14px;
+	font-weight: 400;
+}
+
+.quick-start__reschedule,
+.quick-start__reschedule:visited {
+	color: var( --color-link );
+	margin: 7px 14px 9px;
+	padding: 0;
 }

--- a/client/my-sites/customer-home/cards/features/quick-start/style.scss
+++ b/client/my-sites/customer-home/cards/features/quick-start/style.scss
@@ -16,3 +16,9 @@
 	margin: 7px 14px 9px;
 	padding: 0;
 }
+
+.quick-start__placeholder {
+	@include placeholder();
+	width: 100px;
+	max-width: 80%;
+}

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -9,20 +9,13 @@ import page from 'page';
  * Internal Dependencies
  */
 import CustomerHome from './main';
-import { isBusinessPlan, isEcommercePlan } from 'lib/plans';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
-import { canCurrentUserUseCustomerHome, getSitePlan } from 'state/sites/selectors';
+import { canCurrentUserUseCustomerHome } from 'state/sites/selectors';
 import isRecentlyMigratedSite from 'state/selectors/is-site-recently-migrated';
-import reducer from 'state/concierge/reducer';
 
 export default async function ( context, next ) {
 	const state = await context.store.getState();
 	const siteId = await getSelectedSiteId( state );
-	const plan = await getSitePlan( state, siteId );
-
-	if ( isBusinessPlan( plan.product_slug ) || isEcommercePlan( plan.product_slug ) ) {
-		await context.store.addReducer( [ 'concierge' ], reducer );
-	}
 
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -9,6 +9,7 @@ import page from 'page';
  * Internal Dependencies
  */
 import CustomerHome from './main';
+import { isBusinessPlan, isEcommercePlan } from 'lib/plans';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import { canCurrentUserUseCustomerHome, getSitePlan } from 'state/sites/selectors';
 import isRecentlyMigratedSite from 'state/selectors/is-site-recently-migrated';
@@ -19,7 +20,7 @@ export default async function ( context, next ) {
 	const siteId = await getSelectedSiteId( state );
 	const plan = await getSitePlan( state, siteId );
 
-	if ( ! plan.is_free && [ 'Business', 'eCommerce' ].includes( plan.product_name_short ) ) {
+	if ( isBusinessPlan( plan.product_slug ) || isEcommercePlan( plan.product_slug ) ) {
 		await context.store.addReducer( [ 'concierge' ], reducer );
 	}
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -10,12 +10,19 @@ import page from 'page';
  */
 import CustomerHome from './main';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
-import { canCurrentUserUseCustomerHome } from 'state/sites/selectors';
+import { canCurrentUserUseCustomerHome, getSitePlan } from 'state/sites/selectors';
 import isRecentlyMigratedSite from 'state/selectors/is-site-recently-migrated';
+import reducer from 'state/concierge/reducer';
 
-export default function ( context, next ) {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
+export default async function ( context, next ) {
+	const state = await context.store.getState();
+	const siteId = await getSelectedSiteId( state );
+	const plan = await getSitePlan( state, siteId );
+
+	if ( ! plan.is_free && [ 'Business', 'eCommerce' ].includes( plan.product_name_short ) ) {
+		await context.store.addReducer( [ 'concierge' ], reducer );
+	}
+
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -10,6 +10,7 @@ import MasteringGutenberg from 'my-sites/customer-home/cards/education/mastering
 import FreePhotoLibrary from 'my-sites/customer-home/cards/education/free-photo-library-compact';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import GrowEarn from 'my-sites/customer-home/cards/features/grow-earn';
+import QuickStartCard from 'my-sites/customer-home/cards/features/quick-start';
 import LaunchSite from 'my-sites/customer-home/cards/features/launch-site';
 import Stats from 'my-sites/customer-home/cards/features/stats';
 import StatsV2 from 'my-sites/customer-home/cards/features/stats-v2';

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -26,6 +26,7 @@ const cardComponents = {
 	'home-feature-go-mobile-desktop': GoMobile,
 	'home-feature-grow-and-earn': GrowEarn,
 	'home-feature-stats': config.isEnabled( 'home/experimental-layout' ) ? StatsV2 : Stats,
+	'home-feature-quick-start': QuickStart,
 	'home-feature-support': Support,
 	'home-section-learn-grow': LearnGrow,
 };

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -10,7 +10,7 @@ import MasteringGutenberg from 'my-sites/customer-home/cards/education/mastering
 import FreePhotoLibrary from 'my-sites/customer-home/cards/education/free-photo-library-compact';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import GrowEarn from 'my-sites/customer-home/cards/features/grow-earn';
-import QuickStartCard from 'my-sites/customer-home/cards/features/quick-start';
+import QuickStart from 'my-sites/customer-home/cards/features/quick-start';
 import LaunchSite from 'my-sites/customer-home/cards/features/launch-site';
 import Stats from 'my-sites/customer-home/cards/features/stats';
 import StatsV2 from 'my-sites/customer-home/cards/features/stats-v2';

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -10,7 +10,6 @@ import MasteringGutenberg from 'my-sites/customer-home/cards/education/mastering
 import FreePhotoLibrary from 'my-sites/customer-home/cards/education/free-photo-library-compact';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import GrowEarn from 'my-sites/customer-home/cards/features/grow-earn';
-import QuickStart from 'my-sites/customer-home/cards/features/quick-start';
 import LaunchSite from 'my-sites/customer-home/cards/features/launch-site';
 import Stats from 'my-sites/customer-home/cards/features/stats';
 import StatsV2 from 'my-sites/customer-home/cards/features/stats-v2';
@@ -26,7 +25,6 @@ const cardComponents = {
 	'home-feature-go-mobile-desktop': GoMobile,
 	'home-feature-grow-and-earn': GrowEarn,
 	'home-feature-stats': config.isEnabled( 'home/experimental-layout' ) ? StatsV2 : Stats,
-	'home-feature-quick-start': QuickStart,
 	'home-feature-support': Support,
 	'home-section-learn-grow': LearnGrow,
 };

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import Support from 'my-sites/customer-home/cards/features/support';
+import QuickStart from 'my-sites/customer-home/cards/features/quick-start';
 import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links-compact';
 import WpForTeamsQuickLinks from 'my-sites/customer-home/cards/actions/wp-for-teams-quick-links-compact';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -19,6 +20,7 @@ const cardComponents = {
 	'home-feature-go-mobile': GoMobile,
 	'home-feature-support': Support,
 	'home-action-quick-links': QuickLinks,
+	'home-feature-quick-start': QuickStart,
 	'home-action-wp-for-teams-quick-links': WpForTeamsQuickLinks,
 };
 

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import Support from 'my-sites/customer-home/cards/features/support';
 import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links-compact';
+import QuickStart from 'my-sites/customer-home/cards/features/quick-start';
 import WpForTeamsQuickLinks from 'my-sites/customer-home/cards/actions/wp-for-teams-quick-links-compact';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getHomeLayout } from 'state/selectors/get-home-layout';
@@ -19,6 +20,7 @@ const cardComponents = {
 	'home-feature-go-mobile': GoMobile,
 	'home-feature-support': Support,
 	'home-action-quick-links': QuickLinks,
+	'home-feature-quick-start': QuickStart,
 	'home-action-wp-for-teams-quick-links': WpForTeamsQuickLinks,
 };
 

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -11,7 +11,6 @@ import { useTranslate } from 'i18n-calypso';
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import Support from 'my-sites/customer-home/cards/features/support';
 import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links-compact';
-import QuickStart from 'my-sites/customer-home/cards/features/quick-start';
 import WpForTeamsQuickLinks from 'my-sites/customer-home/cards/actions/wp-for-teams-quick-links-compact';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getHomeLayout } from 'state/selectors/get-home-layout';
@@ -20,7 +19,6 @@ const cardComponents = {
 	'home-feature-go-mobile': GoMobile,
 	'home-feature-support': Support,
 	'home-action-quick-links': QuickLinks,
-	'home-feature-quick-start': QuickStart,
 	'home-action-wp-for-teams-quick-links': WpForTeamsQuickLinks,
 };
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -94,6 +94,7 @@
 }
 
 .customer-home__main .card-heading {
+	line-height: 1.3;
 	margin-top: -8px;
 }
 

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -23,7 +23,6 @@ import atomicHosting from './hosting/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import checklist from './checklist/reducer';
-import concierge from './concierge/reducer';
 import connectedApplications from './connected-applications/reducer';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
@@ -109,7 +108,6 @@ const reducers = {
 	atomicTransfer,
 	billingTransactions,
 	checklist,
-	concierge,
 	connectedApplications,
 	countries,
 	countryStates,

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -23,6 +23,7 @@ import atomicHosting from './hosting/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import checklist from './checklist/reducer';
+import concierge from './concierge/reducer';
 import connectedApplications from './connected-applications/reducer';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
@@ -108,6 +109,7 @@ const reducers = {
 	atomicTransfer,
 	billingTransactions,
 	checklist,
+	concierge,
 	connectedApplications,
 	countries,
 	countryStates,


### PR DESCRIPTION
This PR adds a Quick Start Sessions card to My Home.

Not Booked | Booked
--- | ---
![image](https://user-images.githubusercontent.com/349751/80265145-65fd7500-864b-11ea-8779-7efcbb0c27e2.png) | ![image](https://user-images.githubusercontent.com/349751/80265182-8b8a7e80-864b-11ea-86f5-fa2327ef6c85.png)

#### Testing instructions

* Go to `/home/:site` for a site with either an eCommerce or Business plan.
* Verify the "Book a session" button goes to `/me/concierge/:site/book`.
* On prod, take a test site with a Business plan and register for a Quick Start session at the above booking URL. (Be sure to comment that we're just testing. 🙃)
* Back on this branch for the Business test site, verify that the card title changes appropriately.
* Verify the "View details" button goes to `/me/concierge/:site/book`.
* Verify the "Reschedule" link goes to `/me/concierge/:site/:sessionId/cancel`.

Fixes #38998
