### PR TITLE
Gutenberg 7.9: Fixes

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
@@ -14,7 +14,8 @@
 .post-type-post .edit-post-fullscreen-mode-close__toolbar__override {
 	display: flex;
 	align-items: center;
-	padding: 9px 10px;
+	margin-right: 10px;
+	margin-left: -24px;
 	border: none;
 	border-right: 1px solid #e2e4e7;
 


### PR DESCRIPTION
This PR tracks fixes added for Gutenberg 7.9

## Changes proposed in this Pull Request

### Back button padding issue in dotcom-fse:

_before_
<img width="474" alt="Screen Shot 2020-04-14 at 4 40 14 PM" src="https://user-images.githubusercontent.com/6265975/79284697-45c1ff00-7e70-11ea-9e9b-1c83a7a71201.png">


_after_

<img width="390" alt="Screen Shot 2020-04-14 at 4 38 11 PM" src="https://user-images.githubusercontent.com/6265975/79284713-4c507680-7e70-11ea-9347-524e7c59cfdc.png">


## Testing instructions
* Go through each of the issues above on a Gutenberg edge site and verify they are fixed with this PR.
* e2e edge tests should pass.