### PR TITLE
Signup: Take to Home after purchasing upsell item

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -500,6 +500,7 @@ export class Checkout extends React.Component {
 			redirectTo,
 			selectedSite,
 			selectedSiteSlug,
+			isJetpackNotAtomic,
 			transaction: { step: { data: stepResult = null } = {} } = {},
 		} = this.props;
 
@@ -548,7 +549,7 @@ export class Checkout extends React.Component {
 		this.setDestinationIfEcommPlan( pendingOrReceiptId );
 
 		// if it is a Jetpack product, use product info as a parameter
-		if ( product ) {
+		if ( isJetpackNotAtomic && product ) {
 			signupDestination = this.getFallbackDestination( pendingOrReceiptId );
 		} else {
 			signupDestination =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the signup flow, take the user to customer home(checklist) after purchase of an upsell item(Quick Start or Premium plan). Currently, post purchase of an upsell item redirects to a Thank You page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test WPCOM

*  Go through the signup flow and purchase a Personal plan.
* You will now be shown an upsell offer for either a Quick Start session or Premium plan(depends on the abtest you fall under).
* Purchase the upsell item, and verify that you are taken to Home page(/home).

Test Jetpack

* Verify the testing instructions in https://github.com/Automattic/wp-calypso/pull/40863 pass.

Fixes #https://github.com/Automattic/wp-calypso/issues/41122
