### PR TITLE
Use Recoleta on all page headings (take 2)

### DIFF
--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -17,3 +17,8 @@
 .main .empty-content {
 	margin-top: 0;
 }
+
+// Use Recoleta on all page headings
+.main .formatted-header__title {
+	font-family: 'Recoleta', $serif;
+}

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -19,6 +19,6 @@
 }
 
 // Use Recoleta on all page headings
-.main .formatted-header__title {
+.main > .formatted-header .formatted-header__title {
 	font-family: 'Recoleta', $serif;
 }

--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -418,7 +418,7 @@ class ActivityLog extends Component {
 			  );
 
 		return (
-			<div>
+			<>
 				{ siteId && 'active' === rewindState.state && (
 					<QueryRewindBackupStatus siteId={ siteId } />
 				) }
@@ -515,7 +515,7 @@ class ActivityLog extends Component {
 						/>
 					</div>
 				) }
-			</div>
+			</>
 		);
 	}
 

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -144,29 +144,27 @@ class Plans extends React.Component {
 						/>
 					) }
 					{ canAccessPlans && (
-						<div id="plans" className="plans plans__has-sidebar">
-							<FormattedHeader
-								className="plans__page-heading"
-								headerText={ translate( 'Plans' ) }
-								align="left"
-							/>
-							<CartData>
-								<PlansNavigation path={ this.props.context.path } />
-							</CartData>
-							<PlansFeaturesMain
-								displayJetpackPlans={ displayJetpackPlans }
-								hideFreePlan={ true }
-								customerType={ this.props.customerType }
-								intervalType={ this.props.intervalType }
-								selectedFeature={ this.props.selectedFeature }
-								selectedPlan={ this.props.selectedPlan }
-								redirectTo={ this.props.redirectTo }
-								withDiscount={ this.props.withDiscount }
-								discountEndDate={ this.props.discountEndDate }
-								site={ selectedSite }
-								plansWithScroll={ false }
-							/>
-						</div>
+						<>
+							<FormattedHeader headerText={ translate( 'Plans' ) } align="left" />
+							<div id="plans" className="plans plans__has-sidebar">
+								<CartData>
+									<PlansNavigation path={ this.props.context.path } />
+								</CartData>
+								<PlansFeaturesMain
+									displayJetpackPlans={ displayJetpackPlans }
+									hideFreePlan={ true }
+									customerType={ this.props.customerType }
+									intervalType={ this.props.intervalType }
+									selectedFeature={ this.props.selectedFeature }
+									selectedPlan={ this.props.selectedPlan }
+									redirectTo={ this.props.redirectTo }
+									withDiscount={ this.props.withDiscount }
+									discountEndDate={ this.props.discountEndDate }
+									site={ selectedSite }
+									plansWithScroll={ false }
+								/>
+							</div>
+						</>
 					) }
 				</Main>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Second attempt to try bringing font consistency across all page headings.

<img width="248" alt="Screen Shot 2020-04-14 at 18 44 17" src="https://user-images.githubusercontent.com/1233880/79251067-f71c6100-7e7f-11ea-9e4d-2d4561088c4d.png">

<img width="240" alt="Screen Shot 2020-04-14 at 18 48 13" src="https://user-images.githubusercontent.com/1233880/79251495-83c71f00-7e80-11ea-8ee6-693dd6727b34.png">

We tried this first in #41102 but decided to revert it since it was updating the font to Recoleta in more places than page headings. On this attempt, we're adding a more targeted update, so only `FormattedHeader` used in page headings are updated, leaving other instances with the current font.

#### Testing instructions

- Navigate through all pages in Calypso and make sure all headings use the Recoleta font.
- Watch out for other `FormattedHeader` instances not used in page headings and make sure they don't use the Recoleta font (i.e. `/start` or `/jetpack/new`).

Fixes #41090
