### PR TITLE
Gutenboarding: optimize vertical selector for the first run

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -96,7 +96,8 @@ const VerticalSelect: React.FunctionComponent = () => {
 
 		const normalizedInputValue = inputValue.toLowerCase();
 
-		let newSuggestions = verticals.filter( vertical =>
+		// TODO: write a more advanced compare fn https://github.com/Automattic/wp-calypso/pull/40645#discussion_r402156751
+		const newSuggestions = verticals.filter( vertical =>
 			vertical.label.toLowerCase().includes( normalizedInputValue )
 		);
 
@@ -114,17 +115,6 @@ const VerticalSelect: React.FunctionComponent = () => {
 
 		// ...and finally, we prepend firstSuggestion to our suggestions list.
 		newSuggestions.unshift( firstSuggestion );
-
-		// If there is only one suggestion and that suggestion matches the user input value,
-		// do not show any suggestions.
-
-		// TODO: write a more advanced compare fn https://github.com/Automattic/wp-calypso/pull/40645#discussion_r402156751
-		if (
-			newSuggestions.length === 1 &&
-			newSuggestions[ 0 ].label.toLowerCase() === normalizedInputValue
-		) {
-			newSuggestions = [];
-		}
 
 		setSuggestions( newSuggestions );
 	};


### PR DESCRIPTION
#### Changes
The suggestions list will always display at least one item even if it's an exact match of the user query. 
We decided to optimize for the first run, rather than the coming back scenario. See https://github.com/Automattic/wp-calypso/issues/41121#issuecomment-613875006
So we are reverting #40110

#### Testing instructions

* Starting at URL: [/new](https://hash-6f173afe6310cc98f9b899863027513b673ac275.calypso.live/new)
* After typing _baker_ you see 2 results in the Suggestions list: _baker_ and _Bakery_.
* When pressing the final letter y the list should contain 1 item: _Bakery_.

Fixes #41121
