### PR TITLE
Tracking: reduxify

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/tip-link.js
+++ b/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/tip-link.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,6 +17,9 @@ export default function ( { section, children, subsection } ) {
 		getCurrentPostId: select( 'core/editor' ).getCurrentPostId,
 		getCurrentPostType: select( 'core/editor' ).getCurrentPostType,
 	} ) );
+
+	// Search dispatchers.
+	const { clickOnContextualTip } = useDispatch( 'automattic/tracking' );
 
 	const postId = getCurrentPostId();
 	const postType = getCurrentPostType();
@@ -52,7 +55,12 @@ export default function ( { section, children, subsection } ) {
 	}
 
 	return (
-		<a href={ href } target="_blank" rel="noreferrer noopener">
+		<a
+			href={ href }
+			target="_blank"
+			rel="noreferrer noopener"
+			onClick={ () => clickOnContextualTip( { context: 'inserter_menu', section, subsection } ) }
+		>
 			{ children }
 		</a>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/tip-link.js
+++ b/apps/full-site-editing/full-site-editing-plugin/block-inserter-modifications/contextual-tips/tip-link.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { select } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,9 +12,14 @@ const isEditorIFramed = inIframe();
 
 export default function ( { section, children, subsection } ) {
 	const { hostname } = window.location;
-	const editorSelector = select( 'core/editor' );
-	const postId = editorSelector.getCurrentPostId();
-	const postType = editorSelector.getCurrentPostType();
+
+	const { getCurrentPostId, getCurrentPostType } = useSelect( ( select ) => ( {
+		getCurrentPostId: select( 'core/editor' ).getCurrentPostId,
+		getCurrentPostType: select( 'core/editor' ).getCurrentPostType,
+	} ) );
+
+	const postId = getCurrentPostId();
+	const postType = getCurrentPostType();
 	const returnLink =
 		isEditorIFramed && ! isSimpleSite
 			? '&' +

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -8,11 +8,13 @@ import {
 	reduce,
 	get,
 	keyBy,
+	map,
 	mapValues,
 	memoize,
 	filter,
 	sortBy,
 	stubTrue,
+	uniq,
 } from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
@@ -82,8 +84,14 @@ class PageTemplateModal extends Component {
 				// 2. There are no blocks at all (likely the "blank" template placeholder)
 				if ( ! templateHasMissingBlocks || ! templateBlocks.length ) {
 					acc[ slug ] = templateBlocks;
+				} else {
+					// Track templates with missing blocks.
+					this.props.registerBrokenTemplates( {
+						slug,
+						context: 'starter-page-templates',
+						blocks: uniq( map( templateBlocks || [], 'name' ) ),
+					} );
 				}
-
 				return acc;
 			},
 			{}
@@ -521,6 +529,7 @@ export const PageTemplatesPlugin = compose(
 	withDispatch( ( dispatch, ownProps ) => {
 		const editorDispatcher = dispatch( 'core/editor' );
 		const { setIsOpen } = dispatch( 'automattic/starter-page-layouts' );
+		const { emitTemplatesWithMissingBlocks } = dispatch( 'automattic/tracking' );
 		return {
 			setIsOpen,
 			saveTemplateChoice: ( slug ) => {
@@ -562,6 +571,7 @@ export const PageTemplatesPlugin = compose(
 					dispatch( 'core/nux' ).disableTips();
 				}
 			},
+			registerBrokenTemplates: emitTemplatesWithMissingBlocks,
 		};
 	} )
 )( PageTemplateModal );

--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -14,6 +14,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import './features/deprecate-coblocks-buttons';
 import './features/fix-block-invalidation-errors';
 import './features/reorder-block-categories';
+import './features/tracking/store';
 import './features/tracking';
 
 import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -192,6 +192,18 @@ const trackErrorNotices = ( content, options ) =>
 	} );
 
 /**
+ * Logs any block search from different context.
+ *
+ * @param {string} context Context where the blocks search happens.
+ */
+const trackSearchBlocks = ( { context } ) => {
+	tracksRecordEvent( 'wpcom_block_picker_search_term', {
+		search_term: select( 'automattic/tracking' ).getSearchTerm( context ),
+		context,
+	} );
+};
+
+/**
  * Tracker can be
  * - string - which means it is an event name and should be tracked as such automatically
  * - function - in case you need to load additional properties from the action.
@@ -222,6 +234,9 @@ const REDUX_TRACKING = {
 	},
 	'core/notices': {
 		createErrorNotice: trackErrorNotices,
+	},
+	'automattic/tracking': {
+		setSearchBlocks: trackSearchBlocks,
 	},
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -203,6 +203,13 @@ const trackSearchBlocks = ( { context } ) => {
 	} );
 };
 
+const trackSearchBlocksNotFound = ( { context } ) => {
+	tracksRecordEvent( 'wpcom_block_picker_no_results', {
+		search_term: select( 'automattic/tracking' ).getSearchTerm( context ),
+		context,
+	} );
+};
+
 /**
  * Tracker can be
  * - string - which means it is an event name and should be tracked as such automatically
@@ -237,6 +244,7 @@ const REDUX_TRACKING = {
 	},
 	'automattic/tracking': {
 		setSearchBlocks: trackSearchBlocks,
+		setSearchBlocksNotFound: trackSearchBlocksNotFound,
 	},
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -210,6 +210,14 @@ const trackSearchBlocksNotFound = ( { context } ) => {
 	} );
 };
 
+const trackTemplatesWithMissingBlocks = ( { slug, context, blocks } ) => {
+	tracksRecordEvent( 'wpcom_tamplates_with_missing_blocks', {
+		slug,
+		context,
+		blocks: blocks && blocks.length ? blocks.join( ', ' ) : null,
+	} );
+};
+
 /**
  * Tracker can be
  * - string - which means it is an event name and should be tracked as such automatically
@@ -245,6 +253,7 @@ const REDUX_TRACKING = {
 	'automattic/tracking': {
 		setSearchBlocks: trackSearchBlocks,
 		setSearchBlocksNotFound: trackSearchBlocksNotFound,
+		emitTemplatesWithMissingBlocks: trackTemplatesWithMissingBlocks,
 	},
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -218,6 +218,15 @@ const trackTemplatesWithMissingBlocks = ( { slug, context, blocks } ) => {
 	} );
 };
 
+const trackClickOnContextualTip = ( { context, section, subsection } ) => {
+	tracksRecordEvent( 'wpcom_block_picker_click_on_tip', {
+		search_term: select( 'automattic/tracking' ).getSearchTerm( context ),
+		context,
+		section,
+		subsection,
+	} );
+};
+
 /**
  * Tracker can be
  * - string - which means it is an event name and should be tracked as such automatically
@@ -254,6 +263,7 @@ const REDUX_TRACKING = {
 		setSearchBlocks: trackSearchBlocks,
 		setSearchBlocksNotFound: trackSearchBlocksNotFound,
 		emitTemplatesWithMissingBlocks: trackTemplatesWithMissingBlocks,
+		clickOnContextualTip: trackClickOnContextualTip,
 	},
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -69,7 +70,9 @@ const actions = {
 /*
  * Tracking selectors.
  */
-const selectors = {};
+const selectors = {
+	getSearchTerm: ( state, context ) => get( state, [ 'searcher', context, 'value' ] ),
+};
 
 registerStore( storeName, {
 	reducer,

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
@@ -16,7 +16,7 @@ const storeName = 'automattic/tracking';
 /*
  * Tracking reducer.
  */
-const reducer = ( state = {}, { type, value, context = 'unknown', notFound } ) => {
+const reducer = ( state = {}, { type, value, context = 'unknown', notFound, slug, blocks } ) => {
 	switch ( type ) {
 		case 'SET_BLOCKS_SEARCH_TERM':
 			return {
@@ -39,6 +39,20 @@ const reducer = ( state = {}, { type, value, context = 'unknown', notFound } ) =
 			return {
 				...state,
 				searcher: { [ context ]: { ...state.searcher[ context ], notFound: true } },
+			};
+
+		case 'SET_TEMPLATES_WITH_MISSING_BLOCKS':
+			return {
+				...state,
+				brokenTemplates: {
+					...state.brokenTemplates,
+					[ slug ]: {
+						slug,
+						context,
+						blocks,
+						cause: 'missing_blocks',
+					},
+				},
 			};
 	}
 
@@ -64,6 +78,23 @@ const actions = {
 	setSearchBlocksNotFound: ( { context } ) => ( {
 		type: 'SET_BLOCKS_SEARCH_BLOCKS_NOT_FOUND',
 		context,
+	} ),
+
+	/**
+	 * Return an function that triggers an action when
+	 * a template has broken blocks.
+	 *
+	 * @param {object} prop         Action properties.
+	 * @param {string} prop.slug    Template name.
+	 * @param {string} prop.context Context where the action is triggered.
+	 * @param {Array}  prop.blocks  Broken blocks array.
+	 * @returns {{blocks: *, name: *, context: *, type: string}} Action handler.
+	 */
+	emitTemplatesWithMissingBlocks: ( { slug, context, blocks } ) => ( {
+		type: 'SET_TEMPLATES_WITH_MISSING_BLOCKS',
+		slug,
+		context,
+		blocks,
 	} ),
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
@@ -1,0 +1,78 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+// Store identifier.
+const storeName = 'automattic/tracking';
+
+/*
+ * Tracking reducer.
+ */
+const reducer = ( state = {}, { type, value, context = 'unknown', notFound } ) => {
+	switch ( type ) {
+		case 'SET_BLOCKS_SEARCH_TERM':
+			return {
+				...state,
+				searcher: {
+					[ context ]: {
+						...( state.searcher ? state.searcher[ context ] : {} ),
+						value,
+					},
+				},
+			};
+
+		case 'SET_BLOCKS_SEARCH_BLOCKS_FOUND':
+			return {
+				...state,
+				searcher: { [ context ]: { ...state.searcher[ context ], notFound } },
+			};
+
+		case 'SET_BLOCKS_SEARCH_BLOCKS_NOT_FOUND':
+			return {
+				...state,
+				searcher: { [ context ]: { ...state.searcher[ context ], notFound: true } },
+			};
+	}
+
+	return state;
+};
+
+/*
+ * Tracking Actions.
+ */
+const actions = {
+	setSearchBlocksTerm: ( { value, context } ) => ( {
+		type: 'SET_BLOCKS_SEARCH_TERM',
+		value,
+		context,
+	} ),
+
+	setSearchBlocks: ( { context, notFound } ) => ( {
+		type: 'SET_BLOCKS_SEARCH_SEARCH_BLOCKS',
+		context,
+		notFound,
+	} ),
+
+	setSearchBlocksNotFound: ( { context } ) => ( {
+		type: 'SET_BLOCKS_SEARCH_BLOCKS_NOT_FOUND',
+		context,
+	} ),
+};
+
+/*
+ * Tracking selectors.
+ */
+const selectors = {};
+
+registerStore( storeName, {
+	reducer,
+	actions,
+	selectors,
+} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
@@ -11,7 +11,7 @@ import { get } from 'lodash';
 import { registerStore } from '@wordpress/data';
 
 // Store identifier.
-const storeName = 'automattic/tracking';
+export const AutomatticTrackingStoreName = 'automattic/tracking';
 
 /*
  * Tracking reducer.
@@ -113,7 +113,7 @@ const selectors = {
 	getSearchTerm: ( state, context ) => get( state, [ 'searcher', context, 'value' ] ),
 };
 
-registerStore( storeName, {
+registerStore( AutomatticTrackingStoreName, {
 	reducer,
 	actions,
 	selectors,

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
@@ -16,7 +16,10 @@ export const AutomatticTrackingStoreName = 'automattic/tracking';
 /*
  * Tracking reducer.
  */
-const reducer = ( state = {}, { type, value, context = 'unknown', notFound, slug, blocks } ) => {
+const reducer = (
+	state = {},
+	{ type, value, context = 'unknown', notFound, slug, blocks, section, subsection }
+) => {
 	switch ( type ) {
 		case 'SET_BLOCKS_SEARCH_TERM':
 			return {
@@ -45,6 +48,19 @@ const reducer = ( state = {}, { type, value, context = 'unknown', notFound, slug
 				searcher: {
 					...state.searcher,
 					[ context ]: { ...state.searcher[ context ], notFound: true },
+				},
+			};
+
+		case 'SET_TIP_CLICK_ON':
+			return {
+				...state,
+				tip: {
+					...state.tip,
+					[ context ]: {
+						...( state.tip ? state.tip[ context ] : {} ),
+						section,
+						subsection,
+					},
 				},
 			};
 
@@ -88,6 +104,13 @@ const actions = {
 		context,
 	} ),
 
+	clickOnContextualTip: ( { context, section, subsection } ) => ( {
+		type: 'SET_TIP_CLICK_ON',
+		context,
+		section,
+		subsection,
+	} ),
+
 	/**
 	 * Return an function that triggers an action when
 	 * a template has broken blocks.
@@ -111,6 +134,7 @@ const actions = {
  */
 const selectors = {
 	getSearchTerm: ( state, context ) => get( state, [ 'searcher', context, 'value' ] ),
+	getContextualTip: ( state, context ) => get( state, [ 'tip', context ] ),
 };
 
 registerStore( AutomatticTrackingStoreName, {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/store.js
@@ -22,6 +22,7 @@ const reducer = ( state = {}, { type, value, context = 'unknown', notFound, slug
 			return {
 				...state,
 				searcher: {
+					...state.searcher,
 					[ context ]: {
 						...( state.searcher ? state.searcher[ context ] : {} ),
 						value,
@@ -32,13 +33,19 @@ const reducer = ( state = {}, { type, value, context = 'unknown', notFound, slug
 		case 'SET_BLOCKS_SEARCH_BLOCKS_FOUND':
 			return {
 				...state,
-				searcher: { [ context ]: { ...state.searcher[ context ], notFound } },
+				searcher: {
+					...state.searcher,
+					[ context ]: { ...state.searcher[ context ], notFound },
+				},
 			};
 
 		case 'SET_BLOCKS_SEARCH_BLOCKS_NOT_FOUND':
 			return {
 				...state,
-				searcher: { [ context ]: { ...state.searcher[ context ], notFound: true } },
+				searcher: {
+					...state.searcher,
+					[ context ]: { ...state.searcher[ context ], notFound: true },
+				},
 			};
 
 		case 'SET_TEMPLATES_WITH_MISSING_BLOCKS':
@@ -54,9 +61,10 @@ const reducer = ( state = {}, { type, value, context = 'unknown', notFound, slug
 					},
 				},
 			};
-	}
 
-	return state;
+		default:
+			return state;
+	}
 };
 
 /*


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is an attempt to add a `tracking` store to the decentralized data registry in favor of consolidating a unique place to record tracking events.

Right now, it tracks events in two ways: using Redux when the event that we want to track is already registered, and another one, a creative way to track those events which are not already registered via an action. For instance, when we want to track "blocks search" from the 'Inserter Menu' or from the 'Inserter Inline'.

Although we still are tied to the lack of these actions emission from the core, we can emit ours and then using the same tracking system to rule all events that we want to track. This is one of the goals of this approach.

* Decentralize the data flow. We will be able to emit these actions from different points of the app.
* Unify recording process from a unique tracking system (tracking.js)
* Scalable. We can start to emit and track our actions in an easier way.

#### Testing instructions

1) Update your testing site with these changes (SB)
2) In your testing site, open the client dev console and set up the debug

```
> localStorage.setItem( 'debug', 'wpcom-block-editor*' )
```

A hard refresh is needed.

3) Open the Inserter Menu
4) Start to type to generate tracking events, paying attention to the console log.

<img width="626" alt="Screen Shot 2020-04-15 at 9 49 05 AM" src="https://user-images.githubusercontent.com/77539/79338911-6fc20280-7efe-11ea-9498-bffeb563227c.png">

Additionally, you can dispatch actions from the console:

**Distpach search term action**
```js
wp.data.dispatch('automattic/tracking').setSearchBlocksTerm( { context: 'test', value: 'testing...' })
```

**Distarch blocks action**
```js
wp.data.dispatch('automattic/tracking').setSearchBlocks( { context: 'test' })
```

![image](https://user-images.githubusercontent.com/77539/79339118-c4fe1400-7efe-11ea-8a70-90516937c81b.png)

**Distarch blocks not found action**

```js
wp.data.dispatch('automattic/tracking').setSearchBlocksNotFound( { context: 'test' })
```
Again, you can confirm the event emission
![image](https://user-images.githubusercontent.com/77539/79339204-e5c66980-7efe-11ea-93b1-49cec75b4e2f.png)


