### PR TITLE
UpsellNudge: Pass props to Banner explicitly

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -67,6 +67,10 @@ export const UpsellNudge = ( {
 			showIcon={ showIcon }
 			disableHref={ disableHref }
 			className={ classes }
+			showIcon={ showIcon }
+			jetpack={ isJetpack }
+			feature={ feature }
+			plan={ plan }
 			href={ href }
 		/>
 	);

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -25,19 +25,35 @@ import { getSite, isJetpackSite } from 'state/sites/selectors';
 import './style.scss';
 
 export const UpsellNudge = ( {
+	callToAction,
+	canManageSite,
 	className,
-	showIcon = false,
+	compact,
+	description,
+	disableHref,
+	dismissPreferenceName,
+	event,
+	feature,
+	forceDisplay,
+	forceHref,
+	href,
+	icon,
 	isJetpack,
 	isVip,
-	canManageSite,
-	site,
-	feature,
-	href,
+	list,
+	onClick,
+	onDismissClick,
 	plan,
 	planHasFeature,
-	disableHref,
-	forceDisplay,
-	...props
+	showIcon = false,
+	site,
+	title,
+	tracksClickName,
+	tracksClickProperties,
+	tracksDismissName,
+	tracksDismissProperties,
+	tracksImpressionName,
+	tracksImpressionProperties,
 } ) => {
 	const classes = classnames( 'upsell-nudge', className );
 
@@ -63,15 +79,30 @@ export const UpsellNudge = ( {
 
 	return (
 		<Banner
-			{ ...props }
-			showIcon={ showIcon }
-			disableHref={ disableHref }
+			callToAction={ callToAction }
 			className={ classes }
-			showIcon={ showIcon }
-			jetpack={ isJetpack }
+			compact={ compact }
+			description={ description }
+			disableHref={ disableHref }
+			dismissPreferenceName={ dismissPreferenceName }
+			event={ event }
 			feature={ feature }
-			plan={ plan }
+			forceHref={ forceHref }
 			href={ href }
+			icon={ icon }
+			jetpack={ isJetpack }
+			list={ list }
+			onClick={ onClick }
+			onDismissClick={ onDismissClick }
+			plan={ plan }
+			showIcon={ showIcon }
+			title={ title }
+			tracksClickName={ tracksClickName }
+			tracksClickProperties={ tracksClickProperties }
+			tracksDismissName={ tracksDismissName }
+			tracksDismissProperties={ tracksDismissProperties }
+			tracksImpressionName={ tracksImpressionName }
+			tracksImpressionProperties={ tracksImpressionProperties }
 		/>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following up on Kerry's work in #41115, this passes through all props from `UpsellNudge` to be used by `Banner`, and removes the use of `...props`.

<img width="1086" alt="Screen Shot 2020-04-15 at 12 52 13 PM" src="https://user-images.githubusercontent.com/2124984/79364965-07801a80-7f18-11ea-9aa1-cf92f89f84ad.png">

#### Testing instructions

Switch to this PR and follow testing instructions for upsells in these PRs:

#40721
#40626

Make sure you test with a Jetpack site as well as a WordPress.com site, and verify that upsells only show when it makes sense (ie. upsell for the Premium plan should not show when on a Premium or Business plan).