### PR TITLE
Jetpack Connect: redirect to url input form for LP links

### DIFF
--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -23,6 +23,12 @@ export default function() {
 	const user = userFactory();
 	const isLoggedOut = ! user.get();
 	const locale = getLanguageRouteParam( 'locale' );
+	let refParams = '';
+
+	if ( typeof window !== 'undefined' && window.location ) {
+		const urlParams = new URL( window.location.href ).searchParams;
+		refParams = urlParams ? Object.fromEntries( urlParams ) : {};
+	}
 
 	page(
 		'/jetpack/connect/:type(personal|premium|pro|backup|realtimebackup|jetpack_search)/:interval(yearly|monthly)?',
@@ -88,6 +94,10 @@ export default function() {
 		makeLayout,
 		clientRender
 	);
+
+	if ( refParams.ref === 'jetpack-lp' ) {
+		page.redirect( `/jetpack/connect` );
+	}
 
 	page(
 		`/jetpack/connect/store/:interval(yearly|monthly)?/${ locale }`,


### PR DESCRIPTION
Currently, `wordpress.com/jetpack` Get Started link redirects to the plans landing plans page,
where Search pricing is unspecified due to no site info. Here, we redirect users directly to the url input form.

#### Changes proposed in this Pull Request

This is a UX enhancement. We add a redirect for ref parameter coming from the landing page.

#### Testing instructions


* go to the above link (or use `/jetpack/connect/store?ref=jetpack-lp`) and verify the redirect to the form at `/jetpack/connect`.

We will adjust the verbiage on the plans page accordingly, as this change touches specific reference only.

Partially handles https://github.com/Automattic/wp-calypso/issues/41025
