### PR TITLE
Gutenboarding: intent capture for mobile

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -60,7 +60,6 @@ const AcquireIntent: FunctionComponent = () => {
 							isPrimary
 							to={ siteVertical && makePath( Step.DesignSelection ) }
 						>
-							{ /* @TODO: add transitions and correct action */ }
 							{ siteTitle ? __( 'Choose a design' ) : __( 'Donʼt know yet' ) }
 						</Link>
 					</div>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -41,14 +41,14 @@ const AcquireIntent: FunctionComponent = () => {
 		>
 			{ displayVerticalSelect && <VerticalSelect onNext={ () => setIsSiteTitleActive( true ) } /> }
 			{ /* We are rendering everything to keep the content vertically centered on desktop while preventing jumping */ }
-			{ isSiteTitleActive && (
-				<Arrow
-					className="acquire-intent__mobile-back-arrow"
-					onClick={ () => setIsSiteTitleActive( false ) }
-				/>
-			) }
 			{ displaySiteTitle && (
 				<>
+					{ isMobile && (
+						<Arrow
+							className="acquire-intent__mobile-back-arrow"
+							onClick={ () => setIsSiteTitleActive( false ) }
+						/>
+					) }
 					<SiteTitle isVisible={ !! ( siteVertical || siteTitle ) } />
 					<div
 						className={ classnames( 'acquire-intent__footer', {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -4,6 +4,7 @@
 import React, { FunctionComponent } from 'react';
 import classnames from 'classnames';
 import { useSelect } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
@@ -14,6 +15,11 @@ import { Step, usePath } from '../../path';
 import Link from '../../components/link';
 import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
+import Arrow from './arrow';
+
+/**
+ * Style dependencies
+ */
 import './style.scss';
 
 const AcquireIntent: FunctionComponent = () => {
@@ -21,15 +27,27 @@ const AcquireIntent: FunctionComponent = () => {
 	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 	const makePath = usePath();
 
+	const [ isSiteTitleActive, setSiteTitleActive ] = React.useState( false );
+	const isMobile = useViewportMatch( 'small', '<' );
+
+	const displaySiteTitle = isSiteTitleActive || ! isMobile;
+	const displayVerticalSelect = ! isSiteTitleActive || ! isMobile;
+
 	return (
 		<div className="gutenboarding-page acquire-intent">
 			<div className="acquire-intent__questions">
-				<VerticalSelect />
+				{ displayVerticalSelect && <VerticalSelect onNext={ () => setSiteTitleActive( true ) } /> }
 				{ /* We are rendering everything to keep the content vertically centered on desktop while preventing jumping */ }
-				<SiteTitle isVisible={ !! ( siteVertical || siteTitle ) } />
+				{ isSiteTitleActive && (
+					<Arrow
+						className="acquire-intent__mobile-back-arrow"
+						onClick={ () => setSiteTitleActive( false ) }
+					/>
+				) }
+				<SiteTitle isVisible={ !! ( siteVertical || siteTitle ) && displaySiteTitle } />
 				<div
 					className={ classnames( 'acquire-intent__footer', {
-						'acquire-intent__footer--hidden': ! siteVertical,
+						'acquire-intent__footer--hidden': ! siteVertical || ! displaySiteTitle,
 					} ) }
 				>
 					<Link

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -27,39 +27,45 @@ const AcquireIntent: FunctionComponent = () => {
 	const { siteVertical, siteTitle } = useSelect( select => select( STORE_KEY ).getState() );
 	const makePath = usePath();
 
-	const [ isSiteTitleActive, setSiteTitleActive ] = React.useState( false );
+	const [ isSiteTitleActive, setIsSiteTitleActive ] = React.useState( false );
 	const isMobile = useViewportMatch( 'small', '<' );
 
 	const displaySiteTitle = isSiteTitleActive || ! isMobile;
 	const displayVerticalSelect = ! isSiteTitleActive || ! isMobile;
 
 	return (
-		<div className="gutenboarding-page acquire-intent">
-			<div className="acquire-intent__questions">
-				{ displayVerticalSelect && <VerticalSelect onNext={ () => setSiteTitleActive( true ) } /> }
-				{ /* We are rendering everything to keep the content vertically centered on desktop while preventing jumping */ }
-				{ isSiteTitleActive && (
-					<Arrow
-						className="acquire-intent__mobile-back-arrow"
-						onClick={ () => setSiteTitleActive( false ) }
-					/>
-				) }
-				<SiteTitle isVisible={ !! ( siteVertical || siteTitle ) && displaySiteTitle } />
-				<div
-					className={ classnames( 'acquire-intent__footer', {
-						'acquire-intent__footer--hidden': ! siteVertical || ! displaySiteTitle,
-					} ) }
-				>
-					<Link
-						className="acquire-intent__question-skip"
-						isPrimary
-						to={ siteVertical && makePath( Step.DesignSelection ) }
+		<div
+			className={ classnames( 'gutenboarding-page acquire-intent', {
+				'acquire-intent--mobile-vertical-step': ! isSiteTitleActive,
+			} ) }
+		>
+			{ displayVerticalSelect && <VerticalSelect onNext={ () => setIsSiteTitleActive( true ) } /> }
+			{ /* We are rendering everything to keep the content vertically centered on desktop while preventing jumping */ }
+			{ isSiteTitleActive && (
+				<Arrow
+					className="acquire-intent__mobile-back-arrow"
+					onClick={ () => setIsSiteTitleActive( false ) }
+				/>
+			) }
+			{ displaySiteTitle && (
+				<>
+					<SiteTitle isVisible={ !! ( siteVertical || siteTitle ) } />
+					<div
+						className={ classnames( 'acquire-intent__footer', {
+							'acquire-intent__footer--hidden': ! siteVertical,
+						} ) }
 					>
-						{ /* @TODO: add transitions and correct action */ }
-						{ siteTitle ? __( 'Choose a design' ) : __( 'Donʼt know yet' ) }
-					</Link>
-				</div>
-			</div>
+						<Link
+							className="acquire-intent__question-skip"
+							isPrimary
+							to={ siteVertical && makePath( Step.DesignSelection ) }
+						>
+							{ /* @TODO: add transitions and correct action */ }
+							{ siteTitle ? __( 'Choose a design' ) : __( 'Donʼt know yet' ) }
+						</Link>
+					</div>
+				</>
+			) }
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -37,7 +37,6 @@ const AcquireIntent: FunctionComponent = () => {
 		<div
 			className={ classnames( 'gutenboarding-page acquire-intent', {
 				'acquire-intent--mobile-vertical-step': ! isSiteTitleActive && isMobile,
-				'acquire-intent--mobile-site-title-step': isSiteTitleActive && isMobile,
 			} ) }
 		>
 			{ displayVerticalSelect && <VerticalSelect onNext={ () => setIsSiteTitleActive( true ) } /> }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -36,7 +36,8 @@ const AcquireIntent: FunctionComponent = () => {
 	return (
 		<div
 			className={ classnames( 'gutenboarding-page acquire-intent', {
-				'acquire-intent--mobile-vertical-step': ! isSiteTitleActive,
+				'acquire-intent--mobile-vertical-step': ! isSiteTitleActive && isMobile,
+				'acquire-intent--mobile-site-title-step': isSiteTitleActive && isMobile,
 			} ) }
 		>
 			{ displayVerticalSelect && <VerticalSelect onNext={ () => setIsSiteTitleActive( true ) } /> }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -45,27 +45,29 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible } ) => {
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	React.useEffect( () => {
-		if ( siteVertical?.label ) {
+		if ( siteVertical?.label && isVisible ) {
 			inputRef.current.focus();
 		}
-	}, [ siteVertical, inputRef ] );
+	}, [ siteVertical, isVisible, inputRef ] );
 
 	// translators: Form input for a site's title where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = __( 'Itʼs called <Input />' );
 	const madlib = createInterpolateElement( madlibTemplate, {
 		Input: (
-			<span
-				contentEditable
-				tabIndex={ 0 }
-				role="textbox"
-				aria-multiline="true"
-				spellCheck={ false }
-				ref={ inputRef }
-				/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
-				className="madlib__input"
-				onKeyDown={ handleKeyDown }
-				onKeyUp={ handleKeyUp }
-			/>
+			<span className="site-title__input-wrapper">
+				<span
+					contentEditable
+					tabIndex={ 0 }
+					role="textbox"
+					aria-multiline="true"
+					spellCheck={ false }
+					ref={ inputRef }
+					/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
+					className="madlib__input"
+					onKeyDown={ handleKeyDown }
+					onKeyUp={ handleKeyUp }
+				/>
+			</span>
 		),
 	} );
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -50,6 +50,15 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible } ) => {
 		}
 	}, [ siteVertical, isVisible, inputRef ] );
 
+	// fix to adjust container height when iOS virtual keyboard pops up
+	const [ isFocused, setIsFocused ] = React.useState( false );
+	React.useEffect( () => {
+		document.documentElement.style.setProperty(
+			'--siteTitleActualHeight',
+			`${ window.innerHeight }px`
+		);
+	}, [ isFocused ] );
+
 	// translators: Form input for a site's title where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = __( 'Itʼs called <Input />' );
 	const madlib = createInterpolateElement( madlibTemplate, {
@@ -66,6 +75,8 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible } ) => {
 					className="madlib__input"
 					onKeyDown={ handleKeyDown }
 					onKeyUp={ handleKeyUp }
+					onFocus={ () => setIsFocused( true ) }
+					onBlur={ () => setIsFocused( false ) }
 				/>
 			</span>
 		),

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -50,17 +50,6 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible } ) => {
 		}
 	}, [ siteVertical, isVisible, inputRef ] );
 
-	// fix to adjust container height when iOS virtual keyboard pops up
-	const [ isFocused, setIsFocused ] = React.useState( false );
-	React.useEffect( () => {
-		setTimeout( () => {
-			document.documentElement.style.setProperty(
-				'--siteTitleActualHeight',
-				`${ window.innerHeight }px`
-			);
-		}, 200 );
-	}, [ isFocused, siteTitle ] );
-
 	// translators: Form input for a site's title where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = __( 'Itʼs called <Input />' );
 	const madlib = createInterpolateElement( madlibTemplate, {
@@ -77,8 +66,6 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible } ) => {
 					className="madlib__input"
 					onKeyDown={ handleKeyDown }
 					onKeyUp={ handleKeyUp }
-					onFocus={ () => setIsFocused( true ) }
-					onBlur={ () => setIsFocused( false ) }
 				/>
 			</span>
 		),

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -53,11 +53,13 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible } ) => {
 	// fix to adjust container height when iOS virtual keyboard pops up
 	const [ isFocused, setIsFocused ] = React.useState( false );
 	React.useEffect( () => {
-		document.documentElement.style.setProperty(
-			'--siteTitleActualHeight',
-			`${ window.innerHeight }px`
-		);
-	}, [ isFocused ] );
+		setTimeout( () => {
+			document.documentElement.style.setProperty(
+				'--siteTitleActualHeight',
+				`${ window.innerHeight }px`
+			);
+		}, 200 );
+	}, [ isFocused, siteTitle ] );
 
 	// translators: Form input for a site's title where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = __( 'Itʼs called <Input />' );

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -10,14 +10,14 @@ $acquire-intent-transition-algorithm: ease-in-out;
 	background-color: var( --contrastColor );
 	color: var( --mainColor );
 	tab-size: 4;
-	width: 100%;
 	min-height: calc( 100vh - #{$gutenboarding-header-height} );
 	display: flex;
 	flex: 1;
     flex-direction: column;
     justify-content: space-between;
 	height: 100%;
-	padding: 20px 0;
+	margin: 0 -20px;
+	padding: 20px;
 	transition: color $acquire-intent-transition-duration
 			$acquire-intent-transition-algorithm,
 		background-color $acquire-intent-transition-duration
@@ -28,14 +28,16 @@ $acquire-intent-transition-algorithm: ease-in-out;
 	}
 
 	@include break-small {
-		padding: 0 calc( 120px - 44px ); // calc difference between design and block margins
+		margin: 0 -44px; // override block margins
+		padding: 0 120px;
 		font-size: 64px;
 		line-height: 80px;
 		justify-content: center;
 	}
 
-	@include break-large {
-		padding: 12px calc( 170px - 88px ) 0; // calc difference between design and block margins
+	@include break-medium {
+		margin: 0 -88px; // override block margins
+		padding: 12px 170px 0;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -7,12 +7,12 @@
 	background-color: var( --contrastColor );
 	color: var( --mainColor );
 	tab-size: 4;
-	min-height: calc( 100vh - #{$gutenboarding-header-height} );
+	position: fixed;
+	min-height: calc( 100% - #{$gutenboarding-header-height} );
+	width: 100%;
 	display: flex;
-	flex: 1;
     flex-direction: column;
     justify-content: space-between;
-	height: 100%;
 	margin: 0 -20px;
 	padding: 20px;
 	transition: color $acquire-intent-transition-duration

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -10,27 +10,32 @@ $acquire-intent-transition-algorithm: ease-in-out;
 	background-color: var( --contrastColor );
 	color: var( --mainColor );
 	tab-size: 4;
-	position: absolute;
-	left: 0;
-	top: 0;
 	width: 100%;
 	min-height: calc( 100vh - #{$gutenboarding-header-height} );
-	padding: 20px;
+	display: flex;
+	flex: 1;
+    flex-direction: column;
+    justify-content: space-between;
+	height: 100%;
+	padding: 20px 0;
 	transition: color $acquire-intent-transition-duration
 			$acquire-intent-transition-algorithm,
 		background-color $acquire-intent-transition-duration
 			$acquire-intent-transition-algorithm;
 
+	&--mobile-vertical-step {
+		justify-content: center;
+	}
+
 	@include break-small {
-		display: flex;
-		align-items: center;
-		padding: 0 120px;
+		padding: 0 calc( 120px - 44px ); // calc difference between design and block margins
 		font-size: 64px;
 		line-height: 80px;
+		justify-content: center;
 	}
 
 	@include break-large {
-		padding: 12px 170px 0;
+		padding: 12px calc( 170px - 88px ) 0; // calc difference between design and block margins
 	}
 }
 
@@ -43,6 +48,11 @@ $acquire-intent-transition-algorithm: ease-in-out;
 		visibility: hidden;
 	}
 
+	align-self: flex-end;
+
+	@include break-small {
+		align-self: flex-start;
+	}
 }
 
 .acquire-intent__mobile-back-arrow {
@@ -116,16 +126,6 @@ $acquire-intent-transition-algorithm: ease-in-out;
 		color: var( --contrastColor );
 		outline-color: transparent;
 		box-shadow: none;
-	}
-}
-
-.acquire-intent__question-skip {
-	position: fixed;
-    bottom: 20px;
-	right: 20px;
-
-	@include break-small {
-		position: static;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -2,9 +2,6 @@
 @import '../../mixins';
 @import '../../variables.scss';
 
-$acquire-intent-transition-duration: 200ms;
-$acquire-intent-transition-algorithm: ease-in-out;
-
 .acquire-intent {
 	@include onboarding-heading-text-mobile;
 	background-color: var( --contrastColor );

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -6,10 +6,9 @@ $acquire-intent-transition-duration: 200ms;
 $acquire-intent-transition-algorithm: ease-in-out;
 
 .acquire-intent {
-	@include onboarding-font-recoleta;
+	@include onboarding-heading-text-mobile;
 	background-color: var( --contrastColor );
 	color: var( --mainColor );
-	font-size: 64px;
 	tab-size: 4;
 	position: absolute;
 	left: 0;
@@ -26,6 +25,8 @@ $acquire-intent-transition-algorithm: ease-in-out;
 		display: flex;
 		align-items: center;
 		padding: 0 120px;
+		font-size: 64px;
+		line-height: 80px;
 	}
 
 	@include break-large {
@@ -41,6 +42,11 @@ $acquire-intent-transition-algorithm: ease-in-out;
 		opacity: 0;
 		visibility: hidden;
 	}
+
+}
+
+.acquire-intent__mobile-back-arrow {
+	transform: rotate( 180deg );
 }
 
 .madlib__input {
@@ -49,6 +55,7 @@ $acquire-intent-transition-algorithm: ease-in-out;
 	border: none;
 	font-size: inherit;
 	line-height: 1em;
+	word-break: break-word;
 	height: 1.01em;
 	padding: 0;
 
@@ -66,12 +73,16 @@ $acquire-intent-transition-algorithm: ease-in-out;
 }
 
 .madlib__input:empty {
-	width: 400px;
+	width: 100%;
 	display: inline-block;
 	border-bottom: 2px solid transparent;
 	position: relative;
 	z-index: 2;
 	vertical-align: middle;
+
+	@include break-small {
+		width: 400px;
+	}
 }
 
 /* hide the placeholder when input is not empty */
@@ -108,11 +119,29 @@ $acquire-intent-transition-algorithm: ease-in-out;
 	}
 }
 
+.acquire-intent__question-skip {
+	position: fixed;
+    bottom: 20px;
+	right: 20px;
+
+	@include break-small {
+		position: static;
+	}
+}
+
 .site-title {
 	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 
 	&--hidden {
 		visibility: hidden;
 		opacity: 0;
+	}
+}
+
+.site-title__input-wrapper {
+	display: block;
+
+	@include break-small {
+		display: inline;
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -11,8 +11,8 @@
 	min-height: calc( 100% - #{$gutenboarding-header-height} );
 	width: 100%;
 	display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+	flex-direction: column;
+	justify-content: space-between;
 	margin: 0 -20px;
 	padding: 20px;
 	transition: color $acquire-intent-transition-duration

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -24,6 +24,10 @@
 		justify-content: center;
 	}
 
+	&--mobile-site-title-step {
+		min-height: calc( var( --siteTitleActualHeight ) - #{$gutenboarding-header-height} );
+	}
+
 	@include break-small {
 		margin: 0 -44px; // override block margins
 		padding: 0 120px;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -24,10 +24,6 @@
 		justify-content: center;
 	}
 
-	&--mobile-site-title-step {
-		min-height: calc( var( --siteTitleActualHeight ) - #{$gutenboarding-header-height} );
-	}
-
 	@include break-small {
 		margin: 0 -44px; // override block margins
 		padding: 0 120px;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -125,13 +125,6 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 
 		setSuggestions( newSuggestions );
 	};
-	const handleInputKeyUpEvent = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
-		const input = e.currentTarget.innerText.trim();
-		if ( ! input.length ) {
-			resetSiteVertical();
-		}
-		updateSuggestions( input );
-	};
 
 	const handleSelect = ( vertical: SiteVertical ) => {
 		setSiteVertical( vertical );
@@ -146,6 +139,24 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 			const vertical = suggestions[ 0 ] ?? { label: lastQuery, id: '', slug: '' };
 			handleSelect( vertical );
 		}
+	};
+
+	const handleArrowClick = () => {
+		handleBlur();
+		onNext();
+	};
+
+	const handleSuggestAction = ( vertical: SiteVertical ) => {
+		handleSelect( vertical );
+		onNext();
+	};
+
+	const handleInputKeyUpEvent = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
+		const input = e.currentTarget.innerText.trim();
+		if ( ! input.length ) {
+			resetSiteVertical();
+		}
+		updateSuggestions( input );
 	};
 
 	const handleInputKeyDownEvent = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
@@ -163,11 +174,6 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 			e.preventDefault();
 			handleBlur();
 		}
-	};
-
-	const handleArrowClick = () => {
-		handleBlur();
-		onNext();
 	};
 
 	React.useEffect( () => {
@@ -215,7 +221,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 								ref={ suggestionRef }
 								query={ inputText }
 								suggestions={ suggestions }
-								suggest={ handleSelect }
+								suggest={ handleSuggestAction }
 								title={ __( 'Suggestions' ) }
 							/>
 						) }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { remove } from 'lodash';
+import classnames from 'classnames';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { ENTER, TAB } from '@wordpress/keycodes';
@@ -204,9 +205,10 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 							onBlur={ handleBlur }
 						/>
 						<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>
+						{ showArrow && (
+							<Arrow className="vertical-select__arrow" onClick={ handleArrowClick } />
+						) }
 					</span>
-					{ /* us visibility to keep the layout fixed with and without the arrow */ }
-					{ showArrow && <Arrow className="vertical-select__arrow" onClick={ handleArrowClick } /> }
 					<div className="vertical-select__suggestions">
 						{ !! verticals.length && (
 							<Suggestions
@@ -223,7 +225,15 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		}
 	);
 
-	return <form className="vertical-select">{ madlib }</form>;
+	return (
+		<form
+			className={ classnames( 'vertical-select', {
+				'vertical-select--with-suggestions': !! suggestions.length && isMobile,
+			} ) }
+		>
+			{ madlib }
+		</form>
+	);
 };
 
 export default VerticalSelect;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -54,7 +54,7 @@
 	left: -16px;
 	margin-top: 20px;
 	min-height: 100px;
-    max-height: calc( 100% - 50px );
+	max-height: calc( 100% - 50px );
 	overflow: auto;
 
 	@include break-small {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -1,7 +1,19 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../../variables.scss';
 
 // Restyle `<Suggestion />` component
 .vertical-select {
+	transition: flex-grow $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+	display: flex;
+	flex-direction: column;
+	&--with-suggestions {
+		flex-grow: 1;
+	}
+
+	@include break-small {
+		display: block;
+	}
+
 	.suggestions__category-heading {
 		display: none;
 	}
@@ -28,7 +40,8 @@
 .vertical-select__suggestions-wrapper {
 	position: relative;
 	display: block;
-	padding-right: 15px; // prevent arrow overflow on mobile
+	padding-right: 20px; // prevent arrow overflow on mobile
+	flex: 1;
 
 	@include break-small {
 		display: inline;
@@ -37,12 +50,21 @@
 }
 
 .vertical-select__suggestions {
-	width: 250px;
-	max-height: 400px;
-	overflow: auto;
 	position: absolute;
 	left: -16px;
 	margin-top: 20px;
+	min-height: 100px;
+    max-height: calc( 100% - 50px );
+	overflow: auto;
+
+	@include break-small {
+		width: 250px;
+		max-height: 400px;
+	}
+}
+
+.vertical-select__input-wrapper {
+	position: relative;
 }
 
 .vertical-select__placeholder {
@@ -57,7 +79,7 @@
 
 .vertical-select__arrow {
 	position: absolute;
-	bottom: 12px;
+	bottom: 8px;
 	margin-left: 15px;
 
 	@include break-small {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -5,40 +5,62 @@
 	.suggestions__category-heading {
 		display: none;
 	}
+	.suggestions__title {
+		line-height: normal;
+		padding: 10px 16px;
+	}
 	.suggestions__item {
 		border: none;
 		background-color: var( --studio-white );
 
 		&.has-highlight {
-			box-shadow: inset 0 0 0 1px var( --studio-blue-30 );
+			box-shadow: none;
 			background-color: var( --studio-white );
-			border-radius: 2px;
+
+			@include break-small {
+				box-shadow: inset 0 0 0 1px var( --studio-blue-30 );
+				border-radius: 2px;
+			}
 		}
 	}
 }
 
 .vertical-select__suggestions-wrapper {
 	position: relative;
+	display: block;
+	padding-right: 15px; // prevent arrow overflow on mobile
+
+	@include break-small {
+		display: inline;
+		padding-right: 0;
+	}
 }
 
 .vertical-select__suggestions {
-	position: absolute;
-	left: 0;
 	width: 250px;
 	max-height: 400px;
 	overflow: auto;
+	position: absolute;
+	left: -16px;
+	margin-top: 20px;
 }
 
 .vertical-select__placeholder {
 	color: var( --studio-gray-5 );
 	position: absolute;
 	left: 0;
-	width: 400px;
+
+	@include break-small {
+		width: 400px;
+	}
 }
 
 .vertical-select__arrow {
-	//TODO: find a way to prevent overflow on mobile (only 20px horizontal padding)
 	position: absolute;
-	bottom: 25px;
+	bottom: 12px;
 	margin-left: 15px;
+
+	@include break-small {
+		bottom: 25px;
+	}
 }

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -2,3 +2,5 @@
 $gutenboarding-header-height: 64px;
 $gutenboarding-heading-padding-desktop: 64px 0 80px;
 $gutenboarding-heading-padding-mobile: 44px 0 50px;
+$acquire-intent-transition-duration: 200ms;
+$acquire-intent-transition-algorithm: ease-in-out;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display Vertical Select or Site Title on mobile as different steps.
* Vertical suggestions list is covering full height of the screen on mobile.
* Vertical input is transitioned vertically from center to top of the screen when suggestions are displayed.
* Add back arrow on mobile on Site Title step.
* Display _Choose a design_ / _Don't know yet_ button and only on Site Title step.

#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-intent-capture-mobile) on mobile.
* No matter what data is stored in the app, only [Vertical Select step](https://user-images.githubusercontent.com/87168/78777078-94b7f200-79a1-11ea-92a1-c78f1a06465b.png) should be displayed.
* After selecting a vertical, pressing the arrow next to it should hide Vertical Select step and display [Site Title step](https://user-images.githubusercontent.com/87168/78777187-bf09af80-79a1-11ea-9e0a-b6e2ed73e64a.png).
* Pressing back arrow (top-left) should return the user to Vertical Select step.
* Skip/Next button should be visible only on Site Title step.

Fixes #40897
