### PR TITLE
WP for Teams signup: make form labels clickable

### DIFF
--- a/client/signup/steps/wp-for-teams-site/index.jsx
+++ b/client/signup/steps/wp-for-teams-site/index.jsx
@@ -256,10 +256,11 @@ class WpForTeamsSite extends React.Component {
 					errorMessages={ this.getErrorMessagesWithLogin( 'siteTitle' ) }
 					className="wp-for-teams-site__validation-site-title"
 				>
-					<FormLabel htmlFor="site-title">
+					<FormLabel htmlFor="site-title-input">
 						{ this.props.translate( "What's the name of your team or project?" ) }
 					</FormLabel>
 					<FormTextInput
+						id="site-title-input"
 						autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						autoCapitalize={ 'off' }
 						className="wp-for-teams-site__site-title"
@@ -276,8 +277,11 @@ class WpForTeamsSite extends React.Component {
 					errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }
 					className="wp-for-teams-site__validation-site"
 				>
-					<FormLabel htmlFor="site">{ this.props.translate( 'Choose a site address' ) }</FormLabel>
+					<FormLabel htmlFor="site-address-input">
+						{ this.props.translate( 'Choose a site address' ) }
+					</FormLabel>
 					<FormTextInput
+						id="site-address-input"
 						autoCapitalize={ 'off' }
 						className="wp-for-teams-site__site-url"
 						disabled={ fieldDisabled }

--- a/client/signup/steps/wp-for-teams-site/style.scss
+++ b/client/signup/steps/wp-for-teams-site/style.scss
@@ -20,3 +20,10 @@
 .wp-for-teams-site__validation-site-title.validation-fieldset {
 	margin-bottom: 20px;
 }
+
+.signup.is-wp-for-teams .form-label {
+	&:hover {
+		cursor: pointer;
+	}
+
+}

--- a/client/signup/steps/wp-for-teams-site/style.scss
+++ b/client/signup/steps/wp-for-teams-site/style.scss
@@ -20,10 +20,3 @@
 .wp-for-teams-site__validation-site-title.validation-fieldset {
 	margin-bottom: 20px;
 }
-
-.signup.is-wp-for-teams .form-label {
-	&:hover {
-		cursor: pointer;
-	}
-
-}


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-for-teams/issues/141.

In this PR, we make the form labels of the WP for Teams signup flow clickable.

## Testing

Navigate to `start/wp-for-teams`. Click on form labels on the first Site step. Cursor should change to a pointer and the input for the label should get focused.