### PR TITLE
Updates link and copy in scan page footer

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -127,8 +127,8 @@ class ScanPage extends Component {
 						{ name: 'Plugins', number: 4 },
 						{ name: 'Themes', number: 3 },
 					] }
-					noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backups has you covered."
-					noticeLink="https://jetpack/upgrade/backups"
+					noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backup has you covered."
+					noticeLink="https://jetpack.com/upgrade/backup"
 				/>
 			</Main>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates some minor copy.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up Cloud.
* Navigate to a site with Scan enabled.
* Examine footer and click link in text.

Screenshot:
<img width="663" alt="Screen Shot 2020-04-15 at 3 48 35 PM" src="https://user-images.githubusercontent.com/1760168/79381971-c7796180-7f30-11ea-91bc-597986163c93.png">

Fixes 1151678672052943-as-1171360976928737.