### PR TITLE
Fix Jetpack Cloud Activity Log Styles

### DIFF
--- a/client/components/pagination/pagination-page.jsx
+++ b/client/components/pagination/pagination-page.jsx
@@ -75,7 +75,12 @@ class PaginationPage extends Component {
 				} );
 				return (
 					<li className={ listClass }>
-						<Button borderless onClick={ this.clickHandler } disabled={ currentPage <= 1 }>
+						<Button
+							className="pagination__list-button"
+							borderless
+							onClick={ this.clickHandler }
+							disabled={ currentPage <= 1 }
+						>
 							<Gridicon icon="arrow-left" size={ 18 } />
 							{ ! compact && ( prevLabel || translate( 'Previous' ) ) }
 						</Button>
@@ -88,7 +93,12 @@ class PaginationPage extends Component {
 				} );
 				return (
 					<li className={ listClass }>
-						<Button borderless onClick={ this.clickHandler } disabled={ currentPage >= totalPages }>
+						<Button
+							className="pagination__list-button"
+							borderless
+							onClick={ this.clickHandler }
+							disabled={ currentPage >= totalPages }
+						>
 							{ ! compact && ( nextLabel || translate( 'Next' ) ) }
 							<Gridicon icon="arrow-right" size={ 18 } />
 						</Button>
@@ -101,7 +111,7 @@ class PaginationPage extends Component {
 				} );
 				return (
 					<li className={ listClass }>
-						<Button borderless onClick={ this.clickHandler }>
+						<Button className="pagination__list-button" borderless onClick={ this.clickHandler }>
 							{ numberFormat( pageNumber ) }
 						</Button>
 					</li>

--- a/client/components/pagination/style.scss
+++ b/client/components/pagination/style.scss
@@ -5,7 +5,7 @@
 	width: 100%;
 
 	&.is-compact .pagination__list-item {
-		.button {
+		.pagination__list-button.button.is-borderless {
 			padding: 5px 8px;
 		}
 
@@ -13,7 +13,7 @@
 			padding: 5px 6px;
 		}
 
-		&.pagination__arrow .button {
+		&.pagination__arrow .pagination__list-button.button.is-borderless {
 			padding: 6px;
 		}
 	}
@@ -31,7 +31,7 @@
 
 // List item styles for all links
 .pagination__list-item {
-	.button,
+	.pagination__list-button.button.is-borderless,
 	&.pagination__ellipsis span {
 		@extend %mobile-link-element;
 		padding: 8px 12px;
@@ -55,12 +55,12 @@
 		}
 	}
 
-	&:first-child .button {
+	&:first-child .pagination__list-button.button.is-borderless {
 		border-top-left-radius: 4px;
 		border-bottom-left-radius: 4px;
 	}
 
-	&:last-child .button {
+	&:last-child .pagination__list-button.button.is-borderless {
 		border-right: solid 1px var( --color-neutral-10 );
 		border-top-right-radius: 4px;
 		border-bottom-right-radius: 4px;
@@ -98,24 +98,25 @@
 }
 
 // // Hover/focus states
-.pagination__list-item .button:not( [disabled] ):hover,
-.pagination__list-item .button:focus {
+.pagination__list-item .pagination__list-button.button.is-borderless:not( [disabled] ):hover,
+.pagination__list-item .pagination__list-button.button.is-borderless:focus {
 	color: var( --color-neutral-70 );
 	outline: none;
 }
 
 // Selected state
-.pagination__list-item.is-selected .button {
+.pagination__list-item.is-selected .pagination__list-button.button.is-borderless {
 	border-color: var( --color-primary );
 	background-color: var( --color-primary );
 	color: var( --color-text-inverted );
 }
 
-.pagination__list-item.is-selected .button:hover {
+.pagination__list-item.is-selected .pagination__list-button.button.is-borderless:hover {
 	color: var( --color-text-inverted );
 }
 
-.pagination__list-item.is-selected + .pagination__list-item .button {
+.pagination__list-item.is-selected + .pagination__list-item
+	.pagination__list-button.button.is-borderless {
 	border-left: 0;
 }
 

--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { isMobile } from '@automattic/viewport';
+
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
@@ -13,6 +13,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { updateFilter } from 'state/activity-log/actions';
 import { withApplySiteOffset } from '../site-offset';
 import { withLocalizedMoment } from 'components/localized-moment';
+import { withMobileBreakpoint } from '@automattic/viewport-react';
 import ActivityCard from 'landing/jetpack-cloud/components/activity-card';
 import Filterbar from 'my-sites/activity/filterbar';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
@@ -100,7 +101,15 @@ class ActivityCardList extends Component {
 	}
 
 	renderData() {
-		const { filter, logs, pageSize, showFilter, showPagination, siteId } = this.props;
+		const {
+			filter,
+			isBreakpointActive: isMobile,
+			logs,
+			pageSize,
+			showFilter,
+			showPagination,
+			siteId,
+		} = this.props;
 		const { page: requestedPage } = filter;
 
 		const actualPage = Math.max(
@@ -122,7 +131,7 @@ class ActivityCardList extends Component {
 				) }
 				{ showPagination && (
 					<Pagination
-						compact={ isMobile() }
+						compact={ isMobile }
 						className="activity-card-list__pagination-top"
 						key="activity-card-list__pagination-top"
 						nextLabel={ 'Older' }
@@ -136,7 +145,7 @@ class ActivityCardList extends Component {
 				{ this.renderLogs( theseLogs ) }
 				{ showPagination && (
 					<Pagination
-						compact={ isMobile() }
+						compact={ isMobile }
 						className="activity-card-list__pagination-bottom"
 						key="activity-card-list__pagination-bottom"
 						nextLabel={ 'Older' }
@@ -190,4 +199,4 @@ const mapDispatchToProps = ( dispatch ) => ( {
 export default connect(
 	mapStateToProps,
 	mapDispatchToProps
-)( withApplySiteOffset( withLocalizedMoment( ActivityCardList ) ) );
+)( withMobileBreakpoint( withApplySiteOffset( withLocalizedMoment( ActivityCardList ) ) ) );

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -1,5 +1,30 @@
-.activity-card-list .filterbar {
-	margin-bottom: 2rem;
+.activity-card-list {
+	.filterbar {
+		margin-bottom: 2rem;
+	}
+
+	.pagination__list-item {
+		.button.pagination__list-button.is-borderless,
+		&.pagination__ellipsis > span {
+			color: var( --color-text );
+			border: none;
+			border-radius: 8px;
+
+			&:disabled {
+				color: var( --studio-gray-10 );
+			}
+		}
+
+		&:not( .is-selected ) .button.pagination__list-button.is-borderless,
+		&.pagination__ellipsis > span {
+			background-color: var( --color-surface-backdrop );
+		}
+
+		&.is-selected .button.pagination__list-button.is-borderless {
+			background-color: var( --color-primary );
+			color: var( --color-text-inverted );
+		}
+	}
 }
 
 .activity-card-list__pagination-bottom {

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
@@ -28,9 +28,15 @@ interface Props {
 	after?: string;
 	before?: string;
 	group?: string;
+	page?: string;
 }
 
-const BackupActivityLogPage: FunctionComponent< Props > = ( { after, before, group } ) => {
+const BackupActivityLogPage: FunctionComponent< Props > = ( {
+	after,
+	before,
+	group,
+	page = 1,
+} ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -48,10 +54,22 @@ const BackupActivityLogPage: FunctionComponent< Props > = ( { after, before, gro
 		if (
 			! isEqual( filter.group, processedGroup ) ||
 			filter.after !== after ||
-			filter.before !== before
+			filter.before !== before ||
+			filter.page !== page
 		)
-			dispatch( setFilter( siteId, { page: 1, after, before, group: processedGroup } ) );
-	}, [ after, before, dispatch, filter.after, filter.before, filter.group, group, siteId ] );
+			dispatch( setFilter( siteId, { page: page, after, before, group: processedGroup } ) );
+	}, [
+		after,
+		before,
+		dispatch,
+		filter.after,
+		filter.before,
+		filter.group,
+		filter.page,
+		group,
+		page,
+		siteId,
+	] );
 
 	// when the filter changes, re-request the logs
 	useEffect( () => {

--- a/client/landing/jetpack-cloud/sections/backups/controller.js
+++ b/client/landing/jetpack-cloud/sections/backups/controller.js
@@ -27,13 +27,14 @@ export function backups( context, next ) {
 	next();
 }
 
-/* handles /backups/activity/:site, see `backupsActivityPath` */
+/* handles /backups/activity/:site, see `backupActivityPath` */
 export function backupActivity( context, next ) {
 	context.primary = (
 		<BackupActivityLogPage
 			after={ context.query.after }
 			before={ context.query.before }
 			group={ context.query.group }
+			page={ context.query.page }
 		/>
 	);
 	next();

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -38,7 +38,7 @@
 		}
 	}
 
-	.filterbar__selection.button {
+	.filterbar__selection.button.is-borderless {
 		margin: 8px;
 		padding: 8px;
 		border: 1px solid var( --color-neutral-20 );
@@ -119,7 +119,7 @@
 
 .filterbar__activity-types-selection-granular {
 	label {
-		font-weight: normal;
+		font-weight: 400;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the `Pagination` component with more specific button styles ( so they don't get overridden by the Jetpack Cloud overall buttons styles )
*  Add rules to Jetpack Cloud `ActivityCardList` to match pagination with design.
* Add a little tweak to `Filterbar` to make the button styles more specific

![Untitled 9](https://user-images.githubusercontent.com/2810519/79900987-f3c72f00-83c3-11ea-89d4-80f80751c7f1.png)


#### Testing instructions

1. Navigate to `/backups/activity`
2. Verify pagination matches design and works
  * Arrows are correct color, disabled are the end of range
  * Selected page is correct color 