### PR TITLE
composite-checkout: Only display message property of caught payment Errors (1)

### DIFF
--- a/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
+++ b/packages/composite-checkout/src/lib/payment-methods/apple-pay.js
@@ -45,8 +45,8 @@ export function createApplePayMethod( {
 				};
 				debug( 'stripe transaction complete', stripeResponse );
 			} catch ( error ) {
-				debug( 'stripe transaction had an error', error );
-				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
+				debug( 'stripe transaction had an error', error.message );
+				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error.message };
 			}
 			debug( 'stripe transaction is successful' );
 			return { type: 'STRIPE_TRANSACTION_END', payload: stripeResponse };
@@ -365,7 +365,7 @@ async function submitStripePayment( {
 		setFormReady();
 		debug( 'showing error for submit', error );
 		onEvent( { type: 'APPLE_PAY_TRANSACTION_ERROR', payload: error } );
-		showErrorMessage( error );
+		showErrorMessage( error.message );
 		return;
 	}
 }

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -62,8 +62,8 @@ export function createExistingCardMethod( {
 				};
 				debug( 'existing card transaction complete', response );
 			} catch ( error ) {
-				debug( 'existing card transaction had an error', error );
-				return { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: error };
+				debug( 'existing card transaction had an error', error.message );
+				return { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: error.message };
 			}
 			if ( response?.message?.payment_intent_client_secret ) {
 				debug( 'existing card transaction requires auth' );
@@ -269,7 +269,7 @@ function ExistingCardPayButton( { disabled, id, stripeConfiguration } ) {
 					isSubscribed && setTransactionComplete( authenticationResponse );
 				} )
 				.catch( ( error ) => {
-					debug( 'showing error for auth', error );
+					debug( 'showing error for auth', error.message );
 					showErrorMessage(
 						localize( 'Authorization failed for that card. Please try a different payment method.' )
 					);
@@ -362,8 +362,8 @@ async function submitExistingCardPayment( {
 	} catch ( error ) {
 		resetTransaction();
 		setFormReady();
-		onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: String( error ) } );
-		showErrorMessage( error );
+		onEvent( { type: 'EXISTING_CARD_TRANSACTION_ERROR', payload: String( error.message ) } );
+		showErrorMessage( error.message );
 		return;
 	}
 }

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -32,8 +32,8 @@ export function createFreePaymentMethod( { registerStore, submitTransaction } ) 
 				};
 				debug( 'free transaction complete', response );
 			} catch ( error ) {
-				debug( 'free transaction had an error', error );
-				return { type: 'FREE_PURCHASE_TRANSACTION_ERROR', payload: error };
+				debug( 'free transaction had an error', error.message );
+				return { type: 'FREE_PURCHASE_TRANSACTION_ERROR', payload: error.message };
 			}
 			debug( 'free transaction requires is successful' );
 			return { type: 'FREE_PURCHASE_TRANSACTION_END', payload: response };

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -32,8 +32,8 @@ export function createFullCreditsMethod( { registerStore, submitTransaction } ) 
 				};
 				debug( 'full credits transaction complete', response );
 			} catch ( error ) {
-				debug( 'full credits transaction had an error', error );
-				return { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: error };
+				debug( 'full credits transaction had an error', error.message );
+				return { type: 'FULL_CREDITS_TRANSACTION_ERROR', payload: error.message };
 			}
 			debug( 'full credits transaction requires is successful' );
 			return { type: 'FULL_CREDITS_TRANSACTION_END', payload: response };

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -45,7 +45,7 @@ export function createPayPalMethod( { registerStore } ) {
 					debug( 'received successful paypal endpoint response', paypalResponse );
 					return { type: 'PAYPAL_TRANSACTION_END', payload: paypalResponse };
 				} catch ( error ) {
-					return { type: 'PAYPAL_TRANSACTION_ERROR', payload: error };
+					return { type: 'PAYPAL_TRANSACTION_ERROR', payload: error.message };
 				}
 			},
 		},

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -81,8 +81,8 @@ export function createStripePaymentMethodStore( {
 				};
 				debug( 'stripe transaction complete', stripeResponse );
 			} catch ( error ) {
-				debug( 'stripe transaction had an error', error );
-				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error };
+				debug( 'stripe transaction had an error', error.message );
+				return { type: 'STRIPE_TRANSACTION_ERROR', payload: error.message };
 			}
 			if ( stripeResponse?.message?.payment_intent_client_secret ) {
 				debug( 'stripe transaction requires auth' );
@@ -532,7 +532,7 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 					isSubscribed && setStripeComplete( authenticationResponse );
 				} )
 				.catch( ( error ) => {
-					debug( 'showing error for auth', error );
+					debug( 'showing error for auth', error.message );
 					showErrorMessage(
 						localize( 'Authorization failed for that card. Please try a different payment method.' )
 					);
@@ -652,8 +652,8 @@ async function submitStripePayment( {
 		resetTransaction();
 		setFormReady();
 		onEvent( { type: 'STRIPE_TRANSACTION_ERROR', payload: error } );
-		debug( 'showing error for submit', error );
-		showErrorMessage( error );
+		debug( 'showing error for submit', error.message );
+		showErrorMessage( error.message );
 		return;
 	}
 }


### PR DESCRIPTION
When catching `Error` objects and then displaying them to the user, we currently just use the raw `Error`, which causes its `toString` method to be called, merging the `name` property with the `message` property.

However, this is not really what we want the user to see, as typically the `name` property is the name of the `Error` object "class". Instead they should just see the `message`.

This PR changes the behavior so that we always pass the `message` property on to be displayed.

#### Screenshots

**Before**

![Screen Shot 2020-04-15 at 4 53 53 PM](https://user-images.githubusercontent.com/2036909/79388266-090f0a00-7f3b-11ea-9976-178febe7d3e6.png)

**After**

![Screen Shot 2020-04-15 at 4 52 54 PM](https://user-images.githubusercontent.com/2036909/79388282-0dd3be00-7f3b-11ea-8648-eaccf1d56922.png)


#### Testing instructions

This changes each of the error handlers in all the payment methods, so to be thorough, there's quite a lot of things to try. We'll start with the most basic and the most common instance, however.

- Sandbox the store so you can load the stripe fields.
- Visit composite checkout and choose the credit card payment method. Enter the card number `4000000000009995` which will cause a failure error.
- Press the "Pay" button to submit the payment. Verify that you see the error message "The transaction was declined. Please try another card." rather than "PaymentFailureError: ...".

Other payment methods affected by this but which are harder to test are below, but they're unlikely to be an issue. I will explain how they can be tested, but they may not need to be. This is because every change uses an object defined by the `catch()` statement, every object is guaranteed to be a copy of `Error` and therefore will have the `message` property.

- Existing cards (tricky since you can't authenticate and save a test card that fails).
- Apple Pay (tricky because you'd need to be able to cause Apple Pay to fail).
- Free purchases.
- Full credits.
- PayPal.

Apart from PayPal, all of these use the `/me/transactions` endpoint, so it's possible to test all of them by modifying that endpoint on your sandbox and causing it to return a failure. The response should look something like this (note that despite the failure it's returned with a 200 response code due to the http envelope):

```json
{"code":400,"headers":[{"name":"Content-Type","value":"application\/json"}],"body":{"error":"payment-failure","message":"The transaction was declined. Please try another card."}}
```

The PayPal endpoint uses the `/me/paypal-express-url` endpoint, but can be modified in a similar manner.