### PR TITLE
composite-checkout: Refactor contact details updater

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -286,7 +286,7 @@ export default function CompositeCheckout( {
 	const renderDomainContactFields = (
 		contactDetails,
 		contactDetailsErrors,
-		updateContactDetails,
+		updateDomainContactFields,
 		shouldShowContactDetailsValidationErrors,
 		isDisabled
 	) => {
@@ -299,7 +299,7 @@ export default function CompositeCheckout( {
 					contactDetailsErrors={
 						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
 					}
-					onContactDetailsChange={ updateContactDetails }
+					onContactDetailsChange={ updateDomainContactFields }
 					shouldForceRenderOnPropChange={ true }
 					getIsFieldDisabled={ getIsFieldDisabled }
 				/>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -86,14 +86,9 @@ export default function WPCheckout( {
 	const shouldShowContactStep = isDomainFieldsVisible || total.amount.value > 0;
 
 	const contactInfo = useSelect( sel => sel( 'wpcom' ).getContactInfo() ) || {};
-	const {
-		setSiteId,
-		touchContactFields,
-		updateContactDetails,
-		updateCountryCode,
-		updatePostalCode,
-		applyDomainContactValidationResults,
-	} = useDispatch( 'wpcom' );
+	const { setSiteId, touchContactFields, applyDomainContactValidationResults } = useDispatch(
+		'wpcom'
+	);
 
 	const [
 		shouldShowContactDetailsValidationErrors,
@@ -187,9 +182,6 @@ export default function WPCheckout( {
 								countriesList={ countriesList }
 								StateSelect={ StateSelect }
 								renderDomainContactFields={ renderDomainContactFields }
-								updateContactDetails={ updateContactDetails }
-								updateCountryCode={ updateCountryCode }
-								updatePostalCode={ updatePostalCode }
 								shouldShowContactDetailsValidationErrors={
 									shouldShowContactDetailsValidationErrors
 								}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -28,9 +28,6 @@ export default function WPContactForm( {
 	CountrySelectMenu,
 	countriesList,
 	renderDomainContactFields,
-	updateContactDetails,
-	updateCountryCode,
-	updatePostalCode,
 	shouldShowContactDetailsValidationErrors,
 } ) {
 	const translate = useTranslate();
@@ -49,19 +46,16 @@ export default function WPContactForm( {
 
 	return (
 		<BillingFormFields>
-			{ renderContactDetails( {
-				translate,
-				isDomainFieldsVisible,
-				contactInfo,
-				renderDomainContactFields,
-				updateContactDetails,
-				updateCountryCode,
-				updatePostalCode,
-				CountrySelectMenu,
-				countriesList,
-				shouldShowContactDetailsValidationErrors,
-				isDisabled,
-			} ) }
+			<RenderContactDetails
+				translate={ translate }
+				isDomainFieldsVisible={ isDomainFieldsVisible }
+				contactInfo={ contactInfo }
+				renderDomainContactFields={ renderDomainContactFields }
+				CountrySelectMenu={ CountrySelectMenu }
+				countriesList={ countriesList }
+				shouldShowContactDetailsValidationErrors={ shouldShowContactDetailsValidationErrors }
+				isDisabled={ isDisabled }
+			/>
 		</BillingFormFields>
 	);
 }
@@ -268,14 +262,11 @@ function getContactDetailsFormat( isDomainFieldsVisible ) {
 	return 'DEFAULT';
 }
 
-function renderContactDetails( {
+function RenderContactDetails( {
 	translate,
 	isDomainFieldsVisible,
 	contactInfo,
 	renderDomainContactFields,
-	updateContactDetails,
-	updateCountryCode,
-	updatePostalCode,
 	CountrySelectMenu,
 	countriesList,
 	shouldShowContactDetailsValidationErrors,
@@ -283,6 +274,9 @@ function renderContactDetails( {
 } ) {
 	const format = getContactDetailsFormat( isDomainFieldsVisible );
 	const requiresVatId = isEligibleForVat( contactInfo.countryCode.value );
+	const domainNames = useDomainNamesInCart();
+	const { updateDomainContactFields, updateCountryCode, updatePostalCode } = useDispatch( 'wpcom' );
+
 	switch ( format ) {
 		case 'DOMAINS':
 			return (
@@ -295,7 +289,7 @@ function renderContactDetails( {
 					{ renderDomainContactFields(
 						prepareDomainContactDetails( contactInfo ),
 						prepareDomainContactDetailsErrors( contactInfo ),
-						updateContactDetails,
+						updateDomainContactFields,
 						shouldShowContactDetailsValidationErrors,
 						isDisabled
 					) }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -15,7 +15,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { useHasDomainsInCart, useDomainNamesInCart } from '../hooks/has-domains';
+import { useHasDomainsInCart } from '../hooks/has-domains';
 import Field from './field';
 import { SummaryLine, SummaryDetails } from './summary-details';
 import { LeftColumn, RightColumn } from './ie-fallback';
@@ -274,7 +274,6 @@ function RenderContactDetails( {
 } ) {
 	const format = getContactDetailsFormat( isDomainFieldsVisible );
 	const requiresVatId = isEligibleForVat( contactInfo.countryCode.value );
-	const domainNames = useDomainNamesInCart();
 	const { updateDomainContactFields, updateCountryCode, updatePostalCode } = useDispatch( 'wpcom' );
 
 	switch ( format ) {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -15,7 +15,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { useHasDomainsInCart } from '../hooks/has-domains';
+import { useHasDomainsInCart, useDomainNamesInCart } from '../hooks/has-domains';
 import Field from './field';
 import { SummaryLine, SummaryDetails } from './summary-details';
 import { LeftColumn, RightColumn } from './ie-fallback';

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/wpcom-store.ts
@@ -21,7 +21,7 @@ type WpcomStoreAction =
 			type: 'APPLY_DOMAIN_CONTACT_VALIDATION_RESULTS';
 			payload: ManagedContactDetailsErrors;
 	  }
-	| { type: 'UPDATE_CONTACT_DETAILS'; payload: DomainContactDetails }
+	| { type: 'UPDATE_DOMAIN_CONTACT_FIELDS'; payload: DomainContactDetails }
 	| { type: 'SET_SITE_ID'; payload: string }
 	| { type: 'TRANSACTION_COMPLETE'; payload: object }
 	| { type: 'UPDATE_VAT_ID'; payload: string }
@@ -60,9 +60,9 @@ export function useWpcomStore(
 		action: WpcomStoreAction
 	): ManagedContactDetails {
 		switch ( action.type ) {
-			case 'UPDATE_CONTACT_DETAILS': {
+			case 'UPDATE_DOMAIN_CONTACT_FIELDS': {
 				updateContactDetailsCache( action.payload );
-				return updaters.updateDomainFields( state, action.payload );
+				return updaters.updateDomainContactFields( state, action.payload );
 			}
 			case 'UPDATE_VAT_ID':
 				return updaters.updateVatId( state, action.payload );
@@ -129,8 +129,8 @@ export function useWpcomStore(
 				return { type: 'TRANSACTION_COMPLETE', payload };
 			},
 
-			updateContactDetails( payload: DomainContactDetails ): WpcomStoreAction {
-				return { type: 'UPDATE_CONTACT_DETAILS', payload };
+			updateDomainContactFields( payload: DomainContactDetails ): WpcomStoreAction {
+				return { type: 'UPDATE_DOMAIN_CONTACT_FIELDS', payload };
 			},
 
 			updatePhone( payload: string ): WpcomStoreAction {

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -290,14 +290,23 @@ function touchField( oldData: ManagedValue ): ManagedValue {
 	return { ...oldData, isTouched: true };
 }
 
-function touchIfDifferent( newValue: string, oldData: ManagedValue ): ManagedValue {
+function touchIfDifferent( newValue: undefined | string, oldData: ManagedValue ): ManagedValue {
+	if ( newValue === undefined ) {
+		return oldData;
+	}
 	return newValue === oldData.value
 		? oldData
 		: { ...oldData, value: newValue, isTouched: true, errors: [] };
 }
 
-function setValueUnlessTouched( newValue: string | null, oldData: ManagedValue ): ManagedValue {
-	return oldData.isTouched ? oldData : { ...oldData, value: newValue || '', errors: [] };
+function setValueUnlessTouched(
+	newValue: undefined | null | string,
+	oldData: ManagedValue
+): ManagedValue {
+	if ( newValue === undefined || newValue === null ) {
+		return oldData;
+	}
+	return oldData.isTouched ? oldData : { ...oldData, value: newValue, errors: [] };
 }
 
 function setErrors( errors: string[] | undefined, oldData: ManagedValue ): ManagedValue {

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -437,166 +437,40 @@ export function formatDomainContactValidationResponse(
 	response: DomainContactValidationResponse
 ): ManagedContactDetailsErrors {
 	return {
-        firstName: response.messages ?.firstName,
-        lastName
-:
-    response.messages ?
-.
-    lastName,
-        organization
-:
-    response.messages ?
-.
-    organization,
-        email
-:
-    response.messages ?
-.
-    email,
-        alternateEmail
-:
-    response.messages ?
-.
-    alternateEmail,
-        phone
-:
-    response.messages ?
-.
-    phone,
-        phoneNumberCountry
-:
-    response.messages ?
-.
-    phoneNumberCountry,
-        address1
-:
-    response.messages ?
-.
-    address1,
-        address2
-:
-    response.messages ?
-.
-    address2,
-        city
-:
-    response.messages ?
-.
-    city,
-        state
-:
-    response.messages ?
-.
-    state,
-        postalCode
-:
-    response.messages ?
-.
-    postalCode,
-        countryCode
-:
-    response.messages ?
-.
-    countryCode,
-        fax
-:
-    response.messages ?
-.
-    fax,
-        vatId
-:
-    response.messages ?
-.
-    vatId,
-        tldExtraFields
-:
-    {
-        ca: {
-            lang: response.messages ?
-        .
-            extra ?
-        .
-            ca ?
-        .
-            lang,
-                legalType
-        :
-            response.messages ?
-        .
-            extra ?
-        .
-            ca ?
-        .
-            legalType,
-                ciraAgreementAccepted
-        :
-            response.messages ?
-        .
-            extra ?
-        .
-            ca ?
-        .
-            ciraAgreementAccepted,
-        }
-    ,
-        uk: {
-            registrantType: response.messages ?
-        .
-            extra ?
-        .
-            uk ?
-        .
-            registrantType,
-                registrationNumber
-        :
-            response.messages ?
-        .
-            extra ?
-        .
-            uk ?
-        .
-            registrationNumber,
-                tradingName
-        :
-            response.messages ?
-        .
-            extra ?
-        .
-            uk ?
-        .
-            tradingName,
-        }
-    ,
-        fr: {
-            registrantType: response.messages ?
-        .
-            extra ?
-        .
-            fr ?
-        .
-            registrantType,
-                trademarkNumber
-        :
-            response.messages ?
-        .
-            extra ?
-        .
-            fr ?
-        .
-            trademarkNumber,
-                sirenSirat
-        :
-            response.messages ?
-        .
-            extra ?
-        .
-            fr ?
-        .
-            sirenSirat,
-        }
-    ,
-    }
-} };
+		firstName: response.messages?.firstName,
+		lastName: response.messages?.lastName,
+		organization: response.messages?.organization,
+		email: response.messages?.email,
+		alternateEmail: response.messages?.alternateEmail,
+		phone: response.messages?.phone,
+		phoneNumberCountry: response.messages?.phoneNumberCountry,
+		address1: response.messages?.address1,
+		address2: response.messages?.address2,
+		city: response.messages?.city,
+		state: response.messages?.state,
+		postalCode: response.messages?.postalCode,
+		countryCode: response.messages?.countryCode,
+		fax: response.messages?.fax,
+		vatId: response.messages?.vatId,
+		tldExtraFields: {
+			ca: {
+				lang: response.messages?.extra?.ca?.lang,
+				legalType: response.messages?.extra?.ca?.legalType,
+				ciraAgreementAccepted: response.messages?.extra?.ca?.ciraAgreementAccepted,
+			},
+			uk: {
+				registrantType: response.messages?.extra?.uk?.registrantType,
+				registrationNumber: response.messages?.extra?.uk?.registrationNumber,
+				tradingName: response.messages?.extra?.uk?.tradingName,
+			},
+			fr: {
+				registrantType: response.messages?.extra?.fr?.registrantType,
+				trademarkNumber: response.messages?.extra?.fr?.trademarkNumber,
+				sirenSirat: response.messages?.extra?.fr?.sirenSirat,
+			},
+		},
+	};
+}
 
 function prepareManagedContactDetailsUpdate(
 	rawFields: DomainContactDetails

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -412,7 +412,6 @@ export function prepareDomainContactValidationRequest(
 
 	return {
 		domain_names: domainNames,
-		qualify_properties: true,
 		contact_information: {
 			firstName: details.firstName.value,
 			lastName: details.lastName.value,
@@ -438,39 +437,218 @@ export function formatDomainContactValidationResponse(
 	response: DomainContactValidationResponse
 ): ManagedContactDetailsErrors {
 	return {
-		firstName: response.messages?.firstName,
-		lastName: response.messages?.lastName,
-		organization: response.messages?.organization,
-		email: response.messages?.email,
-		alternateEmail: response.messages?.alternateEmail,
-		phone: response.messages?.phone,
-		phoneNumberCountry: response.messages?.phoneNumberCountry,
-		address1: response.messages?.address1,
-		address2: response.messages?.address2,
-		city: response.messages?.city,
-		state: response.messages?.state,
-		postalCode: response.messages?.postalCode,
-		countryCode: response.messages?.countryCode,
-		fax: response.messages?.fax,
-		vatId: response.messages?.vatId,
+        firstName: response.messages ?.firstName,
+        lastName
+:
+    response.messages ?
+.
+    lastName,
+        organization
+:
+    response.messages ?
+.
+    organization,
+        email
+:
+    response.messages ?
+.
+    email,
+        alternateEmail
+:
+    response.messages ?
+.
+    alternateEmail,
+        phone
+:
+    response.messages ?
+.
+    phone,
+        phoneNumberCountry
+:
+    response.messages ?
+.
+    phoneNumberCountry,
+        address1
+:
+    response.messages ?
+.
+    address1,
+        address2
+:
+    response.messages ?
+.
+    address2,
+        city
+:
+    response.messages ?
+.
+    city,
+        state
+:
+    response.messages ?
+.
+    state,
+        postalCode
+:
+    response.messages ?
+.
+    postalCode,
+        countryCode
+:
+    response.messages ?
+.
+    countryCode,
+        fax
+:
+    response.messages ?
+.
+    fax,
+        vatId
+:
+    response.messages ?
+.
+    vatId,
+        tldExtraFields
+:
+    {
+        ca: {
+            lang: response.messages ?
+        .
+            extra ?
+        .
+            ca ?
+        .
+            lang,
+                legalType
+        :
+            response.messages ?
+        .
+            extra ?
+        .
+            ca ?
+        .
+            legalType,
+                ciraAgreementAccepted
+        :
+            response.messages ?
+        .
+            extra ?
+        .
+            ca ?
+        .
+            ciraAgreementAccepted,
+        }
+    ,
+        uk: {
+            registrantType: response.messages ?
+        .
+            extra ?
+        .
+            uk ?
+        .
+            registrantType,
+                registrationNumber
+        :
+            response.messages ?
+        .
+            extra ?
+        .
+            uk ?
+        .
+            registrationNumber,
+                tradingName
+        :
+            response.messages ?
+        .
+            extra ?
+        .
+            uk ?
+        .
+            tradingName,
+        }
+    ,
+        fr: {
+            registrantType: response.messages ?
+        .
+            extra ?
+        .
+            fr ?
+        .
+            registrantType,
+                trademarkNumber
+        :
+            response.messages ?
+        .
+            extra ?
+        .
+            fr ?
+        .
+            trademarkNumber,
+                sirenSirat
+        :
+            response.messages ?
+        .
+            extra ?
+        .
+            fr ?
+        .
+            sirenSirat,
+        }
+    ,
+    }
+} };
+
+function prepareManagedContactDetailsUpdate(
+	rawFields: DomainContactDetails
+): ManagedContactDetailsUpdate {
+	return {
+		firstName: rawFields.firstName,
+		lastName: rawFields.lastName,
+		organization: rawFields.organization,
+		email: rawFields.email,
+		alternateEmail: rawFields.alternateEmail,
+		phone: rawFields.phone,
+		phoneNumberCountry: undefined,
+		address1: rawFields.address1,
+		address2: rawFields.address2,
+		city: rawFields.city,
+		state: rawFields.state,
+		postalCode: rawFields.postalCode,
+		countryCode: rawFields.countryCode,
+		fax: rawFields.fax,
+		vatId: rawFields.vatId,
 		tldExtraFields: {
 			ca: {
-				lang: response.messages?.extra?.ca?.lang,
-				legalType: response.messages?.extra?.ca?.legalType,
-				ciraAgreementAccepted: response.messages?.extra?.ca?.ciraAgreementAccepted,
+				lang: rawFields?.extra?.ca?.lang,
+				legalType: rawFields?.extra?.ca?.legalType,
+				ciraAgreementAccepted: rawFields?.extra?.ca?.ciraAgreementAccepted?.toString(),
 			},
 			uk: {
-				registrantType: response.messages?.extra?.uk?.registrantType,
-				registrationNumber: response.messages?.extra?.uk?.registrationNumber,
-				tradingName: response.messages?.extra?.uk?.tradingName,
+				registrantType: rawFields?.extra?.uk?.registrantType,
+				registrationNumber: rawFields?.extra?.uk?.registrationNumber,
+				tradingName: rawFields?.extra?.uk?.tradingName,
 			},
 			fr: {
-				registrantType: response.messages?.extra?.fr?.registrantType,
-				trademarkNumber: response.messages?.extra?.fr?.trademarkNumber,
-				sirenSirat: response.messages?.extra?.fr?.sirenSirat,
+				registrantType: rawFields?.extra?.fr?.registrantType,
+				trademarkNumber: rawFields?.extra?.fr?.trademarkNumber,
+				sirenSirat: rawFields?.extra?.fr?.sirenSirat,
 			},
 		},
 	};
+}
+
+function applyDomainContactDetailsUpdate(
+	oldDetails: ManagedContactDetails,
+	update: ManagedContactDetailsUpdate
+): ManagedContactDetails {
+	return updateManagedContactDetailsShape(
+		( newField: undefined | string, detail: ManagedValue ) => {
+			return touchIfDifferent( newField, detail );
+		},
+		( newField: undefined | string ) => getInitialManagedValue( { value: newField } ),
+		update,
+		oldDetails
+	);
 }
 
 /*
@@ -479,43 +657,27 @@ export function formatDomainContactValidationResponse(
  * assume input came from the user.
  */
 export type ManagedContactDetailsUpdaters = {
-	updateDomainFields: ( ManagedContactDetails, DomainContactDetails ) => ManagedContactDetails;
-	updatePhone: ( ManagedContactDetails, string ) => ManagedContactDetails;
-	updatePhoneNumberCountry: ( ManagedContactDetails, string ) => ManagedContactDetails;
-	updatePostalCode: ( ManagedContactDetails, string ) => ManagedContactDetails;
-	updateCountryCode: ( ManagedContactDetails, string ) => ManagedContactDetails;
-	touchContactFields: ( ManagedContactDetails ) => ManagedContactDetails;
-	updateVatId: ( ManagedContactDetails, string ) => ManagedContactDetails;
-	setErrorMessages: ( ManagedContactDetails, ManagedContactDetailsErrors ) => ManagedContactDetails;
+	updatePhone: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
+	updatePhoneNumberCountry: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
+	updatePostalCode: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
+	updateCountryCode: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
+	updateDomainContactFields: (
+		arg0: ManagedContactDetails,
+		arg1: DomainContactDetails
+	) => ManagedContactDetails;
+	touchContactFields: ( arg0: ManagedContactDetails ) => ManagedContactDetails;
+	updateVatId: ( arg0: ManagedContactDetails, arg1: string ) => ManagedContactDetails;
+	setErrorMessages: (
+		arg0: ManagedContactDetails,
+		arg1: ManagedContactDetailsErrors
+	) => ManagedContactDetails;
 	populateDomainFieldsFromCache: (
-		ManagedContactDetails,
-		PossiblyCompleteDomainContactDetails
+		arg0: ManagedContactDetails,
+		arg1: PossiblyCompleteDomainContactDetails
 	) => ManagedContactDetails;
 };
 
 export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
-	updateDomainFields: (
-		oldDetails: ManagedContactDetails,
-		newDetails: DomainContactDetails
-	): ManagedContactDetails => {
-		return {
-			...oldDetails,
-			firstName: touchIfDifferent( newDetails.firstName, oldDetails.firstName ),
-			lastName: touchIfDifferent( newDetails.lastName, oldDetails.lastName ),
-			organization: touchIfDifferent( newDetails.organization, oldDetails.organization ),
-			email: touchIfDifferent( newDetails.email, oldDetails.email ),
-			alternateEmail: touchIfDifferent( newDetails.alternateEmail, oldDetails.alternateEmail ),
-			phone: touchIfDifferent( newDetails.phone, oldDetails.phone ),
-			address1: touchIfDifferent( newDetails.address1, oldDetails.address1 ),
-			address2: touchIfDifferent( newDetails.address2, oldDetails.address2 ),
-			city: touchIfDifferent( newDetails.city, oldDetails.city ),
-			state: touchIfDifferent( newDetails.state, oldDetails.state ),
-			postalCode: touchIfDifferent( newDetails.postalCode, oldDetails.postalCode ),
-			countryCode: touchIfDifferent( newDetails.countryCode, oldDetails.countryCode ),
-			fax: touchIfDifferent( newDetails.fax, oldDetails.fax ),
-		};
-	},
-
 	updatePhone: ( oldDetails: ManagedContactDetails, newPhone: string ): ManagedContactDetails => {
 		return {
 			...oldDetails,
@@ -551,6 +713,16 @@ export const managedContactDetailsUpdaters: ManagedContactDetailsUpdaters = {
 			...oldDetails,
 			countryCode: touchIfDifferent( newCountryCode, oldDetails.countryCode ),
 		};
+	},
+
+	updateDomainContactFields: (
+		oldDetails: ManagedContactDetails,
+		newField: DomainContactDetails
+	): ManagedContactDetails => {
+		return applyDomainContactDetailsUpdate(
+			oldDetails,
+			prepareManagedContactDetailsUpdate( newField )
+		);
 	},
 
 	touchContactFields: ( oldDetails: ManagedContactDetails ): ManagedContactDetails => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

To do:
- [x] Rebase after #41103, because part of that PR ended up in here and I am too lazy to fix it

This PR does a little cleanup of the ManagedContactDetailsUpdaters and its consumers:
* Replace `updateDomainFields` by `updateDomainContactFields`, which includes the ccTLD data and uses the `updateManagedContactDetailsShape` utility
* Refactor `renderContactDetails` to a component so we can directly use hooks rather than passing in updaters, and remove these from props where we can

#### Testing instructions

This should have no observable effects but touches a core part of the contact details state management. Jerk test the contact form in composite checkout, both with and without a domain, keeping an eye out for fields that behave weirdly, validation that doesn't work as expected, and errors in the console.
