### PR TITLE
Jetpack Cloud: track events in Scan (analytics)

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -15,6 +15,7 @@ import SecurityIcon from 'landing/jetpack-cloud/components/security-icon';
 import ThreatDialog from 'landing/jetpack-cloud/components/threat-dialog';
 import ThreatItem from 'landing/jetpack-cloud/components/threat-item';
 import { Threat, ThreatAction } from 'landing/jetpack-cloud/components/threat-item/types';
+import { recordTracksEvent } from 'state/analytics/actions';
 import getJetpackCredentials from 'state/selectors/get-jetpack-credentials';
 import { fixThreatAlert, ignoreThreatAlert } from 'state/jetpack/site-alerts/actions';
 import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
@@ -45,20 +46,40 @@ const ScanThreats = ( { site, threats }: Props ) => {
 	const dispatch = useDispatch();
 
 	const openFixAllThreatsDialog = React.useCallback( () => {
+		dispatch(
+			recordTracksEvent( `calypso_scan_all_threats_dialog_open`, {
+				site_id: site.ID,
+			} )
+		);
 		setShowFixAllThreatsDialog( true );
-	}, [] );
+	}, [ dispatch, site ] );
 
-	const openDialog = React.useCallback( ( action: ThreatAction, threat: Threat ) => {
-		setSelectedThreat( threat );
-		setActionToPerform( action );
-		setShowThreatDialog( true );
-	}, [] );
+	const openDialog = React.useCallback(
+		( action: ThreatAction, threat: Threat ) => {
+			dispatch(
+				recordTracksEvent( `calypso_scan_${ action }_threat_dialog_open`, {
+					site_id: site.ID,
+					threat_id: threat.id,
+				} )
+			);
+			setSelectedThreat( threat );
+			setActionToPerform( action );
+			setShowThreatDialog( true );
+		},
+		[ dispatch, site ]
+	);
 
 	const closeDialog = React.useCallback( () => {
 		setShowThreatDialog( false );
 	}, [] );
 
 	const confirmAction = React.useCallback( () => {
+		dispatch(
+			recordTracksEvent( `calypso_scan_threat_${ actionToPerform }`, {
+				site_id: site.ID,
+				threat_id: selectedThreat.id,
+			} )
+		);
 		const actionCreator = actionToPerform === 'fix' ? fixThreatAlert : ignoreThreatAlert;
 		closeDialog();
 		setFixingThreats( ( stateThreats ) => [ ...stateThreats, selectedThreat ] );
@@ -66,6 +87,11 @@ const ScanThreats = ( { site, threats }: Props ) => {
 	}, [ actionToPerform, closeDialog, dispatch, selectedThreat, site ] );
 
 	const confirmFixAllThreats = React.useCallback( () => {
+		dispatch(
+			recordTracksEvent( `calypso_scan_all_threats_fix`, {
+				site_id: site.ID,
+			} )
+		);
 		threats.forEach( ( threat ) => {
 			dispatch( fixThreatAlert( site.ID, threat.id ) );
 		} );

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -96,7 +96,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		dispatch(
 			recordTracksEvent( `calypso_scan_all_threats_fix`, {
 				site_id: site.ID,
-				numberOfThreats: threats.length,
+				threats_number: threats.length,
 			} )
 		);
 		threats.forEach( ( threat ) => {

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -49,11 +49,10 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		dispatch(
 			recordTracksEvent( `calypso_scan_all_threats_dialog_open`, {
 				site_id: site.ID,
-				numberOfThreats: threats.length,
 			} )
 		);
 		setShowFixAllThreatsDialog( true );
-	}, [ dispatch, site, threats ] );
+	}, [ dispatch, site ] );
 
 	const openDialog = React.useCallback(
 		( action: ThreatAction, threat: Threat ) => {
@@ -64,7 +63,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 			dispatch(
 				recordTracksEvent( eventName, {
 					site_id: site.ID,
-					threat_id: threat.id,
+					threat_signature: threat.signature,
 				} )
 			);
 			setSelectedThreat( threat );
@@ -84,7 +83,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		dispatch(
 			recordTracksEvent( eventName, {
 				site_id: site.ID,
-				threat_id: selectedThreat.id,
+				threat_signature: selectedThreat.signature,
 			} )
 		);
 		const actionCreator = actionToPerform === 'fix' ? fixThreatAlert : ignoreThreatAlert;
@@ -97,6 +96,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		dispatch(
 			recordTracksEvent( `calypso_scan_all_threats_fix`, {
 				site_id: site.ID,
+				numberOfThreats: threats.length,
 			} )
 		);
 		threats.forEach( ( threat ) => {

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -49,10 +49,11 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		dispatch(
 			recordTracksEvent( `calypso_scan_all_threats_dialog_open`, {
 				site_id: site.ID,
+				numberOfThreats: threats.length,
 			} )
 		);
 		setShowFixAllThreatsDialog( true );
-	}, [ dispatch, site ] );
+	}, [ dispatch, site, threats ] );
 
 	const openDialog = React.useCallback(
 		( action: ThreatAction, threat: Threat ) => {

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -56,8 +56,12 @@ const ScanThreats = ( { site, threats }: Props ) => {
 
 	const openDialog = React.useCallback(
 		( action: ThreatAction, threat: Threat ) => {
+			const eventName =
+				action === 'fix'
+					? 'calypso_scan_fix_threat_dialog_open'
+					: 'calypso_scan_ignore_threat_dialog_open';
 			dispatch(
-				recordTracksEvent( `calypso_scan_${ action }_threat_dialog_open`, {
+				recordTracksEvent( eventName, {
 					site_id: site.ID,
 					threat_id: threat.id,
 				} )
@@ -74,8 +78,10 @@ const ScanThreats = ( { site, threats }: Props ) => {
 	}, [] );
 
 	const confirmAction = React.useCallback( () => {
+		const eventName =
+			actionToPerform === 'fix' ? 'calypso_scan_threat_fix' : 'calypso_scan_threat_ignore';
 		dispatch(
-			recordTracksEvent( `calypso_scan_threat_${ actionToPerform }`, {
+			recordTracksEvent( eventName, {
 				site_id: site.ID,
 				threat_id: selectedThreat.id,
 			} )

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -24,6 +24,7 @@ import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarRegion from 'layout/sidebar/region';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { isSidebarSectionOpen } from 'state/my-sites/sidebar/selectors';
 import {
 	expandMySitesSidebarSection as expandSection,
@@ -66,9 +67,16 @@ class JetpackCloudSidebar extends Component {
 
 	toggleSection = memoize( ( id ) => () => this.props.toggleSection( id ) );
 
-	onNavigate = () => {
+	scrollToTop() {
 		window.scrollTo( 0, 0 );
-	};
+	}
+
+	onNavigate = memoize( ( menuItem ) => () => {
+		this.props.dispatchRecordTracksEvent( 'calypso_jetpack_cloud_sidebar_menuitem_click', {
+			menu_item: menuItem,
+		} );
+		this.scrollToTop();
+	} );
 
 	render() {
 		const { selectedSiteSlug, translate, threats, siteId, scanProgress } = this.props;
@@ -103,7 +111,7 @@ class JetpackCloudSidebar extends Component {
 										comment: 'Jetpack Cloud / Backup status sidebar navigation item',
 									} ) }
 									link={ backupMainPath( selectedSiteSlug ) }
-									onNavigate={ this.onNavigate }
+									onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Status' ) }
 									selected={
 										itemLinkMatches( backupMainPath(), this.props.path ) &&
 										! itemLinkMatches( backupActivityPath(), this.props.path )
@@ -115,7 +123,7 @@ class JetpackCloudSidebar extends Component {
 										comment: 'Jetpack Cloud / Activity Log status sidebar navigation item',
 									} ) }
 									link={ backupActivityPath( selectedSiteSlug ) }
-									onNavigate={ this.onNavigate }
+									onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Activity Log' ) }
 									selected={ itemLinkMatches( backupActivityPath(), this.props.path ) }
 								/>
 							</ul>
@@ -146,7 +154,7 @@ class JetpackCloudSidebar extends Component {
 											comment: 'Jetpack Cloud / Scanner sidebar navigation item',
 										} ) }
 										link={ selectedSiteSlug ? `/scan/${ selectedSiteSlug }` : '/scan' }
-										onNavigate={ this.onNavigate }
+										onNavigate={ this.onNavigate( 'Jetpack Cloud Scan / Scanner' ) }
 										selected={
 											itemLinkMatches( '/scan', this.props.path ) &&
 											! itemLinkMatches( '/scan/history', this.props.path )
@@ -162,7 +170,7 @@ class JetpackCloudSidebar extends Component {
 										link={
 											selectedSiteSlug ? `/scan/history/${ selectedSiteSlug }` : '/scan/history'
 										}
-										onNavigate={ this.onNavigate }
+										onNavigate={ this.onNavigate( 'Jetpack Cloud Scan / History' ) }
 										selected={ itemLinkMatches( '/scan/history', this.props.path ) }
 									/>
 								</ul>
@@ -175,7 +183,7 @@ class JetpackCloudSidebar extends Component {
 								comment: 'Jetpack Cloud / Backups sidebar navigation item',
 							} ) }
 							link={ selectedSiteSlug ? `/settings/${ selectedSiteSlug }` : '/settings' }
-							onNavigate={ this.onNavigate }
+							onNavigate={ this.onNavigate( 'Jetpack Cloud / Settings' ) }
 							materialIcon="settings"
 							materialIconStyle="filled"
 							selected={ this.isSelected( '/settings' ) }
@@ -191,7 +199,7 @@ class JetpackCloudSidebar extends Component {
 							link="https://jetpack.com/support"
 							materialIcon="help"
 							materialIconStyle="filled"
-							onNavigate={ this.onNavigate }
+							onNavigate={ this.onNavigate( 'Jetpack Cloud / Support' ) }
 							selected={ this.isSelected( '/support' ) }
 						/>
 						<SidebarItem
@@ -234,5 +242,6 @@ export default connect(
 	{
 		expandSection,
 		toggleSection,
+		dispatchRecordTracksEvent: recordTracksEvent,
 	}
 )( localize( JetpackCloudSidebar ) );

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -19,11 +19,6 @@
 		padding: 20px 0;
 	}
 
-	&__fix-button {
-		color: var( --color-primary-50 );
-		border-color: var( --color-primary-50 );
-	}
-
 	&__fix-button.is-summary {
 		display: none;
 

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -13,6 +13,7 @@ import DocumentHead from 'components/data/document-head';
 import QueryJetpackScanHistory from 'components/data/query-jetpack-scan-history';
 import ScanHistoryItem from 'landing/jetpack-cloud/components/scan-history-item';
 import SimplifiedSegmentedControl from 'components/segmented-control/simplified';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -40,11 +41,15 @@ class ScanHistoryPage extends Component {
 	};
 
 	handleOnFilterChange = ( filter ) => {
-		const { siteSlug } = this.props;
+		const { siteSlug, siteId, dispatchRecordTracksEvent } = this.props;
 		let filterValue = filter.value;
 		if ( 'all' === filterValue ) {
 			filterValue = '';
 		}
+		dispatchRecordTracksEvent( 'calypso_scan_history_filter_update', {
+			site_id: siteId,
+			filter: filterValue,
+		} );
 		page.show( `/scan/history/${ siteSlug }/${ filterValue }` );
 	};
 
@@ -93,23 +98,26 @@ class ScanHistoryPage extends Component {
 	}
 }
 
-export default connect( ( state ) => {
-	const siteId = getSelectedSiteId( state );
-	const isRequestingHistory = isRequestingJetpackScanHistory( state, siteId );
+export default connect(
+	( state ) => {
+		const siteId = getSelectedSiteId( state );
+		const isRequestingHistory = isRequestingJetpackScanHistory( state, siteId );
 
-	const logEntries = isRequestingHistory
-		? [
-				{ id: 1, status: 'fixed' },
-				{ id: 2, status: 'ignored' },
-				{ id: 3, status: 'fixed' },
-				{ id: 4, status: 'ignored' },
-		  ]
-		: getSiteScanHistory( state, siteId );
+		const logEntries = isRequestingHistory
+			? [
+					{ id: 1, status: 'fixed' },
+					{ id: 2, status: 'ignored' },
+					{ id: 3, status: 'fixed' },
+					{ id: 4, status: 'ignored' },
+			  ]
+			: getSiteScanHistory( state, siteId );
 
-	return {
-		siteId,
-		siteSlug: getSelectedSiteSlug( state ),
-		isRequestingHistory,
-		logEntries,
-	};
-} )( ScanHistoryPage );
+		return {
+			siteId,
+			siteSlug: getSelectedSiteSlug( state ),
+			isRequestingHistory,
+			logEntries,
+		};
+	},
+	{ dispatchRecordTracksEvent: recordTracksEvent }
+)( ScanHistoryPage );

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -169,15 +169,13 @@ export function recordTracksEvent( eventName: string, eventProperties: any ) {
 
 	if ( process.env.NODE_ENV !== 'production' && typeof console !== 'undefined' ) {
 		if (
-			( ! /^calypso(?:_[a-z]+){2,}$/.test( eventName ) ||
-				! /^jetpack_cloud(?:_[a-z]+){2,}$/.test( eventName ) ) &&
+			! /^calypso(?:_[a-z]+){2,}$/.test( eventName ) &&
 			! includes( EVENT_NAME_EXCEPTIONS, eventName )
 		) {
 			//eslint-disable-next-line no-console
 			console.error(
-				'Tracks: Event `%s` will be ignored because it does not match /^calypso(?:_[a-z]+){2,}$/ ' +
-					'nor /^jetpack_cloud(?:_[a-z]+){2,}$/, and is not a listed exception. ' +
-					'Please use a compliant event name.',
+				'Tracks: Event `%s` will be ignored because it does not match /^calypso(?:_[a-z]+){2,}$/ and is ' +
+					'not a listed exception. Please use a compliant event name.',
 				eventName
 			);
 		}

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -169,13 +169,15 @@ export function recordTracksEvent( eventName: string, eventProperties: any ) {
 
 	if ( process.env.NODE_ENV !== 'production' && typeof console !== 'undefined' ) {
 		if (
-			! /^calypso(?:_[a-z]+){2,}$/.test( eventName ) &&
+			( ! /^calypso(?:_[a-z]+){2,}$/.test( eventName ) ||
+				! /^jetpack_cloud(?:_[a-z]+){2,}$/.test( eventName ) ) &&
 			! includes( EVENT_NAME_EXCEPTIONS, eventName )
 		) {
 			//eslint-disable-next-line no-console
 			console.error(
-				'Tracks: Event `%s` will be ignored because it does not match /^calypso(?:_[a-z]+){2,}$/ and is ' +
-					'not a listed exception. Please use a compliant event name.',
+				'Tracks: Event `%s` will be ignored because it does not match /^calypso(?:_[a-z]+){2,}$/ ' +
+					'nor /^jetpack_cloud(?:_[a-z]+){2,}$/, and is not a listed exception. ' +
+					'Please use a compliant event name.',
 				eventName
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add analytics to Jetpack Scan by tracking main UI events.

#### Implementation notes

- It's open for discussion if we should prefix our events with `calyspso` as the rest of the events of the platform are or if we should create a new prefix for Jetpack Cloud. Depending on that, the name of the events may change accordingly.

#### Testing instructions
I have separated the testing instructions by sections to make them easier to understand. The sections affected by this PR are: sidebar, Scan -> Scanner, and Scan -> History.

##### Sidebar events

- Go to http://jetpack.cloud.localhost:3000
- Select a site
- Click on Backup -> Activity Log menu item
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_jetpack_cloud_sidebar_menuitem_click',
          properties: {
            menu_item: 'Jetpack Cloud Backup / Activity Log'
          }
        }
```
- Click on Backup -> Status menu item
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_jetpack_cloud_sidebar_menuitem_click',
          properties: {
            menu_item: 'Jetpack Cloud Backup / Status'
          }
        }
```
- Click on Scan -> Scanner menu item
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_jetpack_cloud_sidebar_menuitem_click',
          properties: {
            menu_item: 'Jetpack Cloud Scan / Scanner'
          }
        }
```
- Click on Scan -> History menu item
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_jetpack_cloud_sidebar_menuitem_click',
          properties: {
            menu_item: 'Jetpack Cloud Scan / History'
          }
        }
```
- Click on Settings menu item
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_jetpack_cloud_sidebar_menuitem_click',
          properties: {
            menu_item: 'Jetpack Cloud / Settings'
          }
        }
```

##### Scan -> Scanner

- Go to http://jetpack.cloud.localhost:3000
- Select a site
- Click on Scan -> Scanner
- Click on the "Scan now" button
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_scan_run',
          properties: {
            site_id: <YOUR_SITE_ID>
          }
        }
``` 
- Go to http://jetpack.cloud.localhost:3000/scan/<YOUR_SITE_SLUG>?scan-state=error
- Click on the "Contact Support" button
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_scan_error_contact_support',
          properties: {
            site_id: <YOUR_SITE_ID>
          }
        }
``` 
- Go to http://jetpack.cloud.localhost:3000/scan/ephemeral-rcanepag-20200331.atomicsites.blog?scan-state=threats
- Click on the "Fix threat" of any reported threat
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_scan_fix_threat_dialog_open',
          properties: {
            site_id: <YOUR_SITE_ID>
          }
        }
```
- Click on the "Fix threat" to confirm the action
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_scan_threat_fix',
          properties: {
            site_id: <YOUR_SITE_ID>
          }
        }
```
- Repeat the same procedure but this time to ignore a threat
- Verify that two `ANALYTICS_EVENT_RECORD` actions were dispatched with the following payloads
```
        {
          service: 'tracks',
          name: 'calypso_scan_ignore_threat_dialog_open',
          properties: {
            site_id: <YOUR_SITE_ID>
          }
        }
```
```
        {
          service: 'tracks',
          name: 'calypso_scan_threat_ignore',
          properties: {
            site_id: <YOUR_SITE_ID>
          }
        }
```
- Click on the "Fix all" button to open the Fix all threats dialog (you might have to refresh the page)
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_scan_all_threats_dialog_open',
          properties: {
            site_id: <YOUR_SITE_ID>
          }
        }
``` 
- Enter your server credentials
- Click on the "Fix all threats" to confirm the action
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_scan_all_threats_fix',
          properties: {
            site_id: <YOUR_SITE_ID>,
            numberOfThreats: 2
          }
        }
``` 

##### Scan -> History

- Go to http://jetpack.cloud.localhost:3000
- Select a site
- Click on Scan -> History
- Click on the "Fixed" filter button
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_scan_history_filter_update',
          properties: {
            site_id: <YOUR_SITE_ID>,
            filter: 'fixed'
          }
        }
``` 
- Click on the "Ignored" filter button
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_scan_history_filter_update',
          properties: {
            site_id: <YOUR_SITE_ID>,
            filter: 'ignored'
          }
        }
``` 
- Click on the "All" filter button
- Verify that the `ANALYTICS_EVENT_RECORD` action was dispatched with the following payload
```
        {
          service: 'tracks',
          name: 'calypso_scan_history_filter_update',
          properties: {
            site_id: <YOUR_SITE_ID>,
            filter: ''
          }
        }
``` 

See 1151678672052943-as-1165787355206371.