### PR TITLE
Marketing Connections: Add an Instagram connection

### DIFF
--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -105,7 +105,7 @@ class SharingServiceDescription extends Component {
 					comment: 'Description for Tumblr Publicize when no accounts are connected',
 				} );
 			},
-			instagram: function() {
+			instagram_basic_display: function() {
 				if ( this.props.numberOfConnections > 0 ) {
 					return this.props.translate( 'Connected to your Instagram account.', {
 						comment: 'Description for Instagram when one or more accounts are connected',
@@ -173,8 +173,12 @@ class SharingServiceDescription extends Component {
 				args: { service: this.props.service.label },
 				context: 'Sharing: Publicize',
 			} );
-		} else if ( 'function' === typeof this.props.descriptions[ this.props.service.ID ] ) {
-			description = this.props.descriptions[ this.props.service.ID ].call( this );
+		} else if (
+			'function' === typeof this.props.descriptions[ this.props.service.ID.replace( /-/g, '_' ) ]
+		) {
+			description = this.props.descriptions[ this.props.service.ID.replace( /-/g, '_' ) ].call(
+				this
+			);
 		}
 
 		/**

--- a/client/my-sites/marketing/connections/service-examples.jsx
+++ b/client/my-sites/marketing/connections/service-examples.jsx
@@ -32,7 +32,7 @@ const SERVICES_WHITELIST = [
 	'facebook',
 	'google_plus',
 	'google_my_business',
-	'instagram',
+	'instagram-basic-display',
 	'linkedin',
 	'tumblr',
 	'twitter',
@@ -158,7 +158,7 @@ class SharingServiceExamples extends Component {
 		];
 	}
 
-	instagram() {
+	instagram_basic_display() {
 		return [
 			{
 				image: {
@@ -319,7 +319,7 @@ class SharingServiceExamples extends Component {
 			return <GooglePlusDeprication />;
 		}
 
-		const examples = this[ this.props.service.ID ]();
+		const examples = this[ this.props.service.ID.replace( /-/g, '_' ) ]();
 
 		return (
 			/**

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -602,11 +602,11 @@ export class SharingService extends Component {
 /**
  * Connect a SharingService component to a Redux store.
  *
- * @param  {component} sharingService     A SharingService component
+ * @param  {Component} sharingService     A SharingService component
  * @param  {Function}  mapStateToProps    Optional. A function to pick props from the state.
  *                                        It should return a plain object, which will be merged into the component's props.
  * @param  {object}    mapDispatchToProps Optional. An object that contains additional action creators. Default: {}
- * @returns {component} A highter-order service component
+ * @returns {Component} A highter-order service component
  */
 export function connectFor( sharingService, mapStateToProps, mapDispatchToProps = {} ) {
 	return connect(

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -460,7 +460,7 @@ export class SharingService extends Component {
 		return (
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<SocialLogo
-				icon={ replace( this.props.service.ID, '_', '-' ) }
+				icon={ replace( this.props.service.ID, /_/g, '-' ) }
 				size={ 48 }
 				className="sharing-service__logo"
 			/>

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -55,8 +55,9 @@ const SharingServicesGroup = ( { isFetching, services, title } ) => {
 			<ul className="sharing-services-group__services">
 				{ services.length
 					? services.map( service => {
-							const Component = Components.hasOwnProperty( service.ID )
-								? Components[ service.ID ]
+							const componentName = service.ID.replace( /-/g, '_' );
+							const Component = Components.hasOwnProperty( componentName )
+								? Components[ componentName ]
 								: Service;
 
 							if ( service.warnings ) {

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -55,10 +55,7 @@ const SharingServicesGroup = ( { isFetching, services, title } ) => {
 			<ul className="sharing-services-group__services">
 				{ services.length
 					? services.map( service => {
-							const componentName = service.ID.replace( /-/g, '_' );
-							const Component = Components.hasOwnProperty( componentName )
-								? Components[ componentName ]
-								: Service;
+							const Component = Components[ service.ID.replace( /-/g, '_' ) ] || Service;
 
 							if ( service.warnings ) {
 								return (

--- a/client/my-sites/marketing/connections/services/index.js
+++ b/client/my-sites/marketing/connections/services/index.js
@@ -1,4 +1,4 @@
-export { default as instagram } from './instagram';
+export { default as instagram_basic_display } from './instagram';
 export { default as google_photos } from './google-photos';
 export { default as google_my_business } from './google-my-business';
 export { default as facebook } from './facebook';
@@ -6,7 +6,7 @@ export { default as mailchimp } from './mailchimp';
 
 const services = new Set( [
 	'facebook',
-	'instagram',
+	'instagram_basic_display',
 	'google_photos',
 	'google_my_business',
 	'mailchimp',

--- a/client/my-sites/marketing/connections/services/instagram.jsx
+++ b/client/my-sites/marketing/connections/services/instagram.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-
+import React from 'react';
 import PropTypes from 'prop-types';
 import { last, isEqual } from 'lodash';
 
@@ -10,6 +10,7 @@ import { last, isEqual } from 'lodash';
  */
 import { deleteStoredKeyringConnection } from 'state/sharing/keyring/actions';
 import { SharingService, connectFor } from 'my-sites/marketing/connections/service';
+import SocialLogo from 'components/social-logo';
 
 export class Instagram extends SharingService {
 	static propTypes = {
@@ -36,6 +37,15 @@ export class Instagram extends SharingService {
 		this.setState( { isDisconnecting: true } );
 		this.props.deleteStoredKeyringConnection( last( this.props.keyringConnections ) );
 	};
+
+	renderLogo = () => (
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		<SocialLogo
+			icon="instagram"
+			size={ 48 }
+			className="sharing-service__logo"
+		/>
+	);
 
 	UNSAFE_componentWillReceiveProps( { availableExternalAccounts } ) {
 		if ( ! isEqual( this.props.availableExternalAccounts, availableExternalAccounts ) ) {

--- a/client/my-sites/marketing/connections/services/instagram.jsx
+++ b/client/my-sites/marketing/connections/services/instagram.jsx
@@ -29,9 +29,6 @@ export class Instagram extends SharingService {
 
 	/**
 	 * Deletes the passed connections.
-	 *
-	 * @param {Array} connections Optional. Connections to be deleted.
-	 *                            Default: All connections for this service.
 	 */
 	removeConnection = () => {
 		this.setState( { isDisconnecting: true } );
@@ -40,11 +37,7 @@ export class Instagram extends SharingService {
 
 	renderLogo = () => (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		<SocialLogo
-			icon="instagram"
-			size={ 48 }
-			className="sharing-service__logo"
-		/>
+		<SocialLogo icon="instagram" size={ 48 } className="sharing-service__logo" />
 	);
 
 	UNSAFE_componentWillReceiveProps( { availableExternalAccounts } ) {

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -39,7 +39,7 @@
 		}
 	}
 
-	&.instagram {
+	&.instagram-basic-display {
 		h2,
 		.sharing-service__logo {
 			color: var( --color-instagram );
@@ -275,7 +275,7 @@
 @include sharing-service( 'google_plus', var( --color-google-plus ));
 @include sharing-service( 'tumblr', var( --color-tumblr ));
 @include sharing-service( 'linkedin', var( --color-linkedin ));
-@include sharing-service( 'instagram', var( --color-instagram ));
+@include sharing-service( 'instagram-basic-display', var( --color-instagram ));
 
 .sharing-service__name {
 	clear: none;
@@ -919,7 +919,7 @@
 @include sharing-button-service( 'twitter', var( --color-twitter ));
 @include sharing-button-service( 'press-this', var( --color-wordpress-com ));
 @include sharing-button-service( 'google-plus-1', var( --color-google-plus ));
-@include sharing-button-service( 'instagram', var( --color-instagram ));
+@include sharing-button-service( 'instagram-basic-display', var( --color-instagram ));
 @include sharing-button-service( 'linkedin', var( --color-linkedin ));
 @include sharing-button-service( 'stumbleupon', var( --color-stumbleupon ));
 @include sharing-button-service( 'tumblr', var( --color-tumblr ));

--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -124,11 +124,6 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 			return false;
 		}
 
-		// Omit Instagram Basic Display, which is still in testing
-		if ( 'instagram-basic-display' === service.ID ) {
-			return false;
-		}
-
 		return true;
 	} );
 }


### PR DESCRIPTION
As part of the Instagram API upgrade that's used by the Instagram widget
and the upcoming Instagram Gallery block, we need to add the service to
the connections list, so that it can be managed from within Calypso.

#### Changes proposed in this Pull Request

This change adds the Instagram service to the `/marketing/connections` section.

<img width="700" alt="Screenshot 2020-04-16 at 00 06 02" src="https://user-images.githubusercontent.com/96462/79397491-1f868700-7f76-11ea-9744-17d18da5e040.png">


#### Testing instructions
* Sandbox the API and apply ~~D41054-code~~ D41937-code if it hasn't been merged. 
* Go to the `marketing/connections` page and test connecting and disconnecting an Instagram account.

