### PR TITLE
Fix Gutenberg Error Notice logging

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -188,7 +188,7 @@ const trackGlobalStyles = eventName => options => {
 const trackErrorNotices = ( content, options ) =>
 	tracksRecordEvent( 'wpcom_gutenberg_error_notice', {
 		notice_text: content,
-		notice_options: options,
+		notice_options: JSON.stringify( options ), // Returns undefined if options is undefined.
 	} );
 
 /**

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -185,13 +185,11 @@ const trackGlobalStyles = eventName => options => {
  * @param {string} content The error message. Like "Update failed."
  * @param {object} options Optional. Extra data logged with the error in Gutenberg.
  */
-const trackErrorNotices = ( content, options ) => {
-	const logInfo = {
-		errorText: content,
-		errorOptions: options,
-	};
-	tracksRecordEvent( 'wpcom_gutenberg_error_notice', logInfo );
-};
+const trackErrorNotices = ( content, options ) =>
+	tracksRecordEvent( 'wpcom_gutenberg_error_notice', {
+		error_text: content,
+		error_options: options,
+	} );
 
 /**
  * Tracker can be

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -187,8 +187,8 @@ const trackGlobalStyles = eventName => options => {
  */
 const trackErrorNotices = ( content, options ) =>
 	tracksRecordEvent( 'wpcom_gutenberg_error_notice', {
-		error_text: content,
-		error_options: options,
+		notice_text: content,
+		notice_options: options,
 	} );
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Use underscore for event properties. (oof)

#### Testing instructions
Follow https://github.com/Automattic/wp-calypso/pull/40035. Only difference is to use this diff (D41949-code) for testing instead of the one there. (And to make sure the error properties are the new ones)