### PR TITLE
Revert "AB test for updated Premium plan bump offer"

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -123,13 +123,4 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
-	showPremiumPlanBump: {
-		datestamp: '20200402',
-		variations: {
-			variantShowPlanBump: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -33,7 +33,6 @@ export default function CheckoutSystemDecider( {
 	isComingFromSignup,
 	isComingFromGutenboarding,
 	isGutenboardingCreate,
-	isComingFromUpsell,
 	plan,
 	selectedSite,
 	reduxStore,
@@ -80,7 +79,6 @@ export default function CheckoutSystemDecider( {
 					feature={ selectedFeature }
 					plan={ plan }
 					cart={ cart }
-					isComingFromUpsell={ isComingFromUpsell }
 				/>
 			</StripeHookProvider>
 		);
@@ -95,7 +93,6 @@ export default function CheckoutSystemDecider( {
 			isComingFromSignup={ isComingFromSignup }
 			isComingFromGutenboarding={ isComingFromGutenboarding }
 			isGutenboardingCreate={ isGutenboardingCreate }
-			isComingFromUpsell={ isComingFromUpsell }
 			plan={ plan }
 			selectedSite={ selectedSite }
 			reduxStore={ reduxStore }

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -76,7 +76,6 @@ class CheckoutContainer extends React.Component {
 			shouldShowCart = true,
 			clearTransaction,
 			isComingFromGutenboarding,
-			isComingFromUpsell,
 		} = this.props;
 
 		const TransactionData = clearTransaction ? CartData : CheckoutData;
@@ -111,7 +110,7 @@ class CheckoutContainer extends React.Component {
 							reduxStore={ reduxStore }
 							redirectTo={ redirectTo }
 							upgradeIntent={ upgradeIntent }
-							hideNudge={ isComingFromGutenboarding || isComingFromUpsell }
+							hideNudge={ isComingFromGutenboarding }
 						>
 							{ this.props.children }
 						</Checkout>

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -90,7 +90,6 @@ export default function CompositeCheckout( {
 	purchaseId,
 	cart,
 	couponCode: couponCodeFromUrl,
-	isComingFromUpsell,
 } ) {
 	const translate = useTranslate();
 	const isJetpackNotAtomic = useSelector(
@@ -99,7 +98,6 @@ export default function CompositeCheckout( {
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
 	const isLoadingCartSynchronizer =
 		cart && ( ! cart.hasLoadedFromServer || cart.hasPendingServerUpdates );
-	const hideNudge = isComingFromUpsell;
 
 	const getThankYouUrl = useGetThankYouUrl( {
 		siteSlug,
@@ -110,7 +108,6 @@ export default function CompositeCheckout( {
 		isJetpackNotAtomic,
 		product,
 		siteId,
-		hideNudge,
 	} );
 	const reduxDispatch = useDispatch();
 	const recordEvent = useCallback( createAnalyticsEventHandler( reduxDispatch ), [] );

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -493,7 +493,7 @@ describe( 'getThankYouPageUrl', () => {
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
 
-	it( 'redirects to thank you page if concierge and jetpack are not in the cart, personal is in the cart, but hideNudge is true', () => {
+	it( 'redirects to thank you page if concierge and jetpack are not in the cart, personal is in the cart, but the previous route is the nudge', () => {
 		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
 		const cart = {
 			products: [
@@ -507,7 +507,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: '1234abcd',
-			hideNudge: true,
+			previousRoute: '/checkout/foo.bar/offer-plan-upgrade/premium/1234abcd',
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -6,7 +6,6 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { defaultRegistry } from '@automattic/composite-checkout';
 import debugFactory from 'debug';
-import { isEmpty } from 'lodash';
 
 const { select } = defaultRegistry;
 const debug = debugFactory( 'calypso:composite-checkout-thank-you' );
@@ -33,7 +32,7 @@ import { JETPACK_BACKUP_PRODUCTS } from 'lib/products-values/constants';
 import { persistSignupDestination, retrieveSignupDestination } from 'signup/utils';
 import { getSelectedSite } from 'state/ui/selectors';
 import isEligibleForSignupDestination from 'state/selectors/is-eligible-for-signup-destination';
-import { abtest } from 'lib/abtest';
+import getPreviousPath from 'state/selectors/get-previous-path.js';
 
 export function getThankYouPageUrl( {
 	siteSlug,
@@ -48,10 +47,8 @@ export function getThankYouPageUrl( {
 	product,
 	getUrlFromCookie = retrieveSignupDestination,
 	saveUrlToCookie = persistSignupDestination,
+	previousRoute,
 	isEligibleForSignupDestinationResult,
-	hideNudge,
-	didPurchaseFail,
-	isTransactionResultEmpty,
 } ) {
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
 	// (i.e. on WordPress.com), or a Jetpack or WP.com site's block editor (in wp-admin).
@@ -121,9 +118,7 @@ export function getThankYouPageUrl( {
 		pendingOrReceiptId,
 		cart,
 		siteSlug,
-		hideNudge,
-		didPurchaseFail,
-		isTransactionResultEmpty,
+		previousRoute,
 	} );
 	if ( redirectPathForConciergeUpsell ) {
 		return redirectPathForConciergeUpsell;
@@ -184,55 +179,18 @@ function getFallbackDestination( {
 	return '/';
 }
 
-function maybeShowPlanBumpOfferConcierge( {
-	pendingOrReceiptId,
-	cart,
-	siteSlug,
-	didPurchaseFail,
-	isTransactionResultEmpty,
-} ) {
-	if ( hasPersonalPlan( cart ) && ! isTransactionResultEmpty && ! didPurchaseFail ) {
-		if ( 'variantShowPlanBump' === abtest( 'showPremiumPlanBump' ) ) {
-			return `/checkout/${ siteSlug }/offer-plan-upgrade/premium/${ pendingOrReceiptId }`;
-		}
-	}
-
-	return;
-}
-
-function getRedirectUrlForConciergeNudge( {
-	pendingOrReceiptId,
-	cart,
-	siteSlug,
-	hideNudge,
-	didPurchaseFail,
-	isTransactionResultEmpty,
-} ) {
-	if ( hideNudge ) {
-		return;
-	}
-
+function getRedirectUrlForConciergeNudge( { pendingOrReceiptId, cart, siteSlug, previousRoute } ) {
 	// If the user has upgraded a plan from seeing our upsell(we find this by checking the previous route is /offer-plan-upgrade),
 	// then skip this section so that we do not show further upsells.
 	if (
 		config.isEnabled( 'upsell/concierge-session' ) &&
 		! hasConciergeSession( cart ) &&
 		! hasJetpackPlan( cart ) &&
-		( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) )
+		( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
+		! previousRoute?.includes( `/checkout/${ siteSlug }/offer-plan-upgrade` )
 	) {
 		// A user just purchased one of the qualifying plans
 		// Show them the concierge session upsell page
-
-		const upgradePath = maybeShowPlanBumpOfferConcierge( {
-			pendingOrReceiptId,
-			cart,
-			siteSlug,
-			didPurchaseFail,
-			isTransactionResultEmpty,
-		} );
-		if ( upgradePath ) {
-			return upgradePath;
-		}
 
 		// The conciergeUpsellDial test is used when we need to quickly dial back the volume of concierge sessions
 		// being offered and so sold, to be inline with HE availability.
@@ -309,21 +267,19 @@ export function useGetThankYouUrl( {
 	isJetpackNotAtomic,
 	product,
 	siteId,
-	hideNudge,
 } ) {
 	const selectedSiteData = useSelector( state => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
 	const isEligibleForSignupDestinationResult = useSelector( state =>
 		isEligibleForSignupDestination( state, siteId, cart )
 	);
+	const previousRoute = useSelector( state => getPreviousPath( state ) );
 
 	const getThankYouUrl = useCallback( () => {
 		const transactionResult = select( 'wpcom' ).getTransactionResult();
 		debug( 'for getThankYouUrl, transactionResult is', transactionResult );
-		const didPurchaseFail = Object.keys( transactionResult.failed_purchases ?? {} ).length > 0;
 		const receiptId = transactionResult.receipt_id;
 		const orderId = transactionResult.order_id;
-		const isTransactionResultEmpty = isEmpty( transactionResult );
 
 		debug( 'getThankYouUrl called with', {
 			siteSlug,
@@ -336,10 +292,8 @@ export function useGetThankYouUrl( {
 			cart,
 			isJetpackNotAtomic,
 			product,
+			previousRoute,
 			isEligibleForSignupDestinationResult,
-			hideNudge,
-			didPurchaseFail,
-			isTransactionResultEmpty,
 		} );
 		const url = getThankYouPageUrl( {
 			siteSlug,
@@ -352,14 +306,13 @@ export function useGetThankYouUrl( {
 			cart,
 			isJetpackNotAtomic,
 			product,
+			previousRoute,
 			isEligibleForSignupDestinationResult,
-			hideNudge,
-			didPurchaseFail,
-			isTransactionResultEmpty,
 		} );
 		debug( 'getThankYouUrl returned', url );
 		return url;
 	}, [
+		previousRoute,
 		isEligibleForSignupDestinationResult,
 		siteSlug,
 		adminUrl,
@@ -369,7 +322,6 @@ export function useGetThankYouUrl( {
 		feature,
 		purchaseId,
 		cart,
-		hideNudge,
 	] );
 	return getThankYouUrl;
 }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -64,7 +64,6 @@ export function checkout( context, next ) {
 				isComingFromSignup={ !! context.query.signup }
 				isComingFromGutenboarding={ !! context.query.preLaunch }
 				isGutenboardingCreate={ !! context.query.isGutenboardingCreate }
-				isComingFromUpsell={ !! context.query.upgrade }
 				plan={ plan }
 				selectedSite={ selectedSite }
 				reduxStore={ context.store }

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -35,7 +35,6 @@ import { ConciergeQuickstartSession } from './concierge-quickstart-session';
 import { ConciergeSupportSession } from './concierge-support-session';
 import { PlanUpgradeUpsell } from './plan-upgrade-upsell';
 import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-from-path';
-import { addQueryArgs } from 'lib/url';
 
 /**
  * Style dependencies
@@ -167,21 +166,12 @@ export class UpsellNudge extends React.Component {
 		}
 	}
 
-	handleClickDecline = ( shouldHideUpsellNudges = true ) => {
+	handleClickDecline = () => {
 		const { trackUpsellButtonClick, upsellType, handleCheckoutCompleteRedirect } = this.props;
 
 		trackUpsellButtonClick( `calypso_${ upsellType.replace( /-/g, '_' ) }_decline_button_click` );
-		handleCheckoutCompleteRedirect( shouldHideUpsellNudges );
+		handleCheckoutCompleteRedirect();
 	};
-
-	getCheckoutUrl( url ) {
-		return addQueryArgs(
-			{
-				upgrade: 1,
-			},
-			url
-		);
-	}
 
 	handleClickAccept = buttonAction => {
 		const { trackUpsellButtonClick, upsellType, siteSlug, upgradeItem } = this.props;
@@ -191,8 +181,8 @@ export class UpsellNudge extends React.Component {
 		);
 
 		return siteSlug
-			? page( this.getCheckoutUrl( `/checkout/${ upgradeItem }/${ siteSlug }` ) )
-			: page( this.getCheckoutUrl( `/checkout/${ upgradeItem }` ) );
+			? page( `/checkout/${ upgradeItem }/${ siteSlug }` )
+			: page( `/checkout/${ upgradeItem }` );
 	};
 }
 

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/index.jsx
@@ -62,7 +62,7 @@ export class PlanUpgradeUpsell extends PureComponent {
 
 	body() {
 		const { translate, planRawPrice, planDiscountedRawPrice, currencyCode } = this.props;
-		const bundleValue = planRawPrice * 14.33;
+		const bundleValue = planRawPrice * 77;
 		const premiumThemePriceLow = planRawPrice * 0.73;
 		const premiumThemePriceHigh = planRawPrice * 1.045;
 		return (


### PR DESCRIPTION
Reverts Automattic/wp-calypso#40826

As per the discussion in pbxNRc-fI-p2/#comment-207, we would like to revert the premium plan bump test.

**Testing Instructions**
1. Go through the signup flow at wordpress.com/start
2. Add a Personal plan to cart and complete payment in the checkout page.
3. Verify that you are always shown the Quick Start upsell offer. You should not be assigned to the `showPremiumPlanBump ` test since we are removing it. 
    - Verify that clicking "Yes" on the offer takes you to checkout and that you are able to complete purchase
    - Verify that clicking "No" on the offer takes you to Home page.
4. Test the same steps 1-3 in the new checkout flow. For this, you need to proxy via a US IP address and assign yourself to the `composite` variation of `showCompositeCheckout` A/B test.