### PR TITLE
Data-stores: Provide domain suggestions vendor

### DIFF
--- a/client/landing/gutenboarding/stores/domain-suggestions/index.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/index.ts
@@ -5,5 +5,5 @@ import { DomainSuggestions } from '@automattic/data-stores';
 import { getSuggestionsVendor } from '../../../../lib/domains/suggestions';
 
 export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( {
-	vendor: getSuggestionsVendor(),
+	vendor: getSuggestionsVendor( true ),
 } );

--- a/client/landing/gutenboarding/stores/domain-suggestions/index.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/index.ts
@@ -2,5 +2,6 @@
  * External dependencies
  */
 import { DomainSuggestions } from '@automattic/data-stores';
+import { getSuggestionsVendor } from '../../../../lib/domains/suggestions';
 
-export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register();
+export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( getSuggestionsVendor() );

--- a/client/landing/gutenboarding/stores/domain-suggestions/index.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/index.ts
@@ -4,4 +4,6 @@
 import { DomainSuggestions } from '@automattic/data-stores';
 import { getSuggestionsVendor } from '../../../../lib/domains/suggestions';
 
-export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( getSuggestionsVendor() );
+export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( {
+	vendor: getSuggestionsVendor(),
+} );

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,3 +1,10 @@
+/**
+ * Get the suggestions vendor
+ *
+ * @param {boolean} [isSignup=false] Whether the query is part of a signup flow.
+ *
+ * @returns {string} Vendor string to pass as part of the query.
+ */
 export const getSuggestionsVendor = ( isSignup = false ) => {
 	if ( isSignup ) {
 		return 'variation4_front';

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,7 +1,3 @@
-/**
- * Internal dependencies
- */
-
 export const getSuggestionsVendor = ( isSignup = false ) => {
 	if ( isSignup ) {
 		return 'variation4_front';

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"lint:package-json": "check-npm-client && npmPkgJsonLint './package.json' './client/package.json' './packages/*/package.json' './apps/*/package.json'",
 		"prestart": "check-npm-client && npx check-node-version --package && yarn run install-if-deps-outdated && node bin/welcome.js",
 		"start": "check-npm-client && yarn run -s build",
-		"poststart": "check-npm-client && run-p -s start-build-if-web start-build-if-desktop # build-packages:watch",
+		"poststart": "check-npm-client && run-p -s start-build-if-web start-build-if-desktop build-packages:watch",
 		"start-fallback": "check-npm-client && DEV_TARGET=fallback yarn run start",
 		"start-jetpack-cloud": "check-npm-client && CALYPSO_ENV=jetpack-cloud-development yarn start",
 		"reformat-files": "check-npm-client && ./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"lint:package-json": "check-npm-client && npmPkgJsonLint './package.json' './client/package.json' './packages/*/package.json' './apps/*/package.json'",
 		"prestart": "check-npm-client && npx check-node-version --package && yarn run install-if-deps-outdated && node bin/welcome.js",
 		"start": "check-npm-client && yarn run -s build",
-		"poststart": "check-npm-client && run-p -s start-build-if-web start-build-if-desktop build-packages:watch",
+		"poststart": "check-npm-client && run-p -s start-build-if-web start-build-if-desktop # build-packages:watch",
 		"start-fallback": "check-npm-client && DEV_TARGET=fallback yarn run start",
 		"start-jetpack-cloud": "check-npm-client && CALYPSO_ENV=jetpack-cloud-development yarn start",
 		"reformat-files": "check-npm-client && ./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -38,6 +38,7 @@
 		"qs": "^6.9.1",
 		"redux": "^4.0.4",
 		"tslib": "^1.10.0",
+		"utility-types": "^3.10.0",
 		"wpcom-proxy-request": "^6.0.0"
 	},
 	"peerDependencies": {

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -18,7 +18,14 @@ export * from './types';
 export { State };
 
 let isRegistered = false;
-export function register( vendor: string ): typeof STORE_KEY {
+interface StoreConfiguration {
+	/**
+	 * The default vendor to pass to domain queries.
+	 * Can be overridden in individual queries.
+	 */
+	vendor: string;
+}
+export function register( { vendor }: StoreConfiguration ): typeof STORE_KEY {
 	if ( ! isRegistered ) {
 		isRegistered = true;
 		registerStore< State >( STORE_KEY, {

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -10,7 +10,7 @@ import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
-import Selectors from './selectors';
+import createSelectors, { Selectors } from './selectors';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
 
@@ -26,7 +26,7 @@ export function register( vendor: string ): typeof STORE_KEY {
 			controls: controls as any,
 			reducer: reducer as any,
 			resolvers,
-			selectors: new Selectors( vendor ) as any,
+			selectors: createSelectors( vendor ),
 		} );
 	}
 	return STORE_KEY;

--- a/packages/data-stores/src/domain-suggestions/index.ts
+++ b/packages/data-stores/src/domain-suggestions/index.ts
@@ -10,7 +10,7 @@ import { STORE_KEY } from './constants';
 import reducer, { State } from './reducer';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
-import * as selectors from './selectors';
+import Selectors from './selectors';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
 import { controls } from '../wpcom-request-controls';
 
@@ -18,7 +18,7 @@ export * from './types';
 export { State };
 
 let isRegistered = false;
-export function register(): typeof STORE_KEY {
+export function register( vendor: string ): typeof STORE_KEY {
 	if ( ! isRegistered ) {
 		isRegistered = true;
 		registerStore< State >( STORE_KEY, {
@@ -26,7 +26,7 @@ export function register(): typeof STORE_KEY {
 			controls: controls as any,
 			reducer: reducer as any,
 			resolvers,
-			selectors,
+			selectors: new Selectors( vendor ) as any,
 		} );
 	}
 	return STORE_KEY;
@@ -34,5 +34,5 @@ export function register(): typeof STORE_KEY {
 
 declare module '@wordpress/data' {
 	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
-	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< Selectors >;
 }

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -11,7 +11,7 @@ import { wpcomRequest } from '../wpcom-request-controls';
 
 export function* __internalGetDomainSuggestions(
 	// Resolver has the same signature as corresponding selector without the initial state argument
-	queryObject: Parameters< typeof import('./selectors').__internalGetDomainSuggestions >[ 1 ]
+	queryObject: Parameters< import('./selectors').default[ '__internalGetDomainSuggestions' ] >[ 1 ]
 ) {
 	// If normalized search string (`query`) contains no alphanumerics, endpoint 404s
 	if ( ! queryObject.query ) {

--- a/packages/data-stores/src/domain-suggestions/resolvers.ts
+++ b/packages/data-stores/src/domain-suggestions/resolvers.ts
@@ -11,7 +11,9 @@ import { wpcomRequest } from '../wpcom-request-controls';
 
 export function* __internalGetDomainSuggestions(
 	// Resolver has the same signature as corresponding selector without the initial state argument
-	queryObject: Parameters< import('./selectors').default[ '__internalGetDomainSuggestions' ] >[ 1 ]
+	queryObject: Parameters<
+		import('./selectors').Selectors[ '__internalGetDomainSuggestions' ]
+	>[ 1 ]
 ) {
 	// If normalized search string (`query`) contains no alphanumerics, endpoint 404s
 	if ( ! queryObject.query ) {

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -11,78 +11,85 @@ import { DomainSuggestionQuery } from './types';
 import { State } from './reducer';
 import { stringifyDomainQueryObject } from './utils';
 
-export const getState = ( state: State ) => state;
-
 type DomainSuggestionSelectorOptions = Partial< Exclude< DomainSuggestionQuery, 'query' > >;
 
-export const getDomainSuggestions = (
-	_state: State,
-	search: string,
-	options: DomainSuggestionSelectorOptions = {}
-) => {
-	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
+export default class Selectors {
+	private vendor: string;
 
-	// We need to go through the `select` store to get the resolver action
-	return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
-};
+	constructor( vendor: string ) {
+		this.vendor = vendor;
+	}
 
-export const isLoadingDomainSuggestions = (
-	_state: State,
-	search: string,
-	options: DomainSuggestionSelectorOptions = {}
-) => {
-	const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
+	getState( state: State ) {
+		return state;
+	}
 
-	return select( 'core/data' ).isResolving( STORE_KEY, '__internalGetDomainSuggestions', [
-		normalizedQuery,
-	] );
-};
+	getDomainSuggestions(
+		_state: State,
+		search: string,
+		options: DomainSuggestionSelectorOptions = {}
+	) {
+		const normalizedQuery = this.normalizeDomainSuggestionQuery( search, options );
 
-/**
- * Do not use this selector. It is for internal use.
- *
- * @private
- *
- * @param state Store state
- * @param queryObject Normalized object representing the query
- * @returns suggestions
- */
-export const __internalGetDomainSuggestions = (
-	state: State,
-	queryObject: DomainSuggestionQuery
-) => {
-	return state.domainSuggestions[ stringifyDomainQueryObject( queryObject ) ];
-};
+		// We need to go through the `select` store to get the resolver action
+		return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
+	}
 
-/**
- * Normalize domain query
- *
- * It's important to have a consistent, reproduceable representation of a domains query so that the result can be
- * stored and retrieved.
- *
- * @see client/state/domains/suggestions/utils.js
- * @see client/components/data/query-domains-suggestions/index.jsx
- *
- * @param search       Domain search string
- * @param queryOptions Optional paramaters for the query
- * @returns Normalized query object
- */
-function normalizeDomainSuggestionQuery(
-	search: string,
-	queryOptions: DomainSuggestionSelectorOptions
-): DomainSuggestionQuery {
-	return {
-		// Defaults
-		include_wordpressdotcom: queryOptions.only_wordpressdotcom || false,
-		include_dotblogsubdomain: false,
-		only_wordpressdotcom: false,
-		quantity: 5,
-		vendor: 'variation2_front',
+	isLoadingDomainSuggestions(
+		_state: State,
+		search: string,
+		options: DomainSuggestionSelectorOptions = {}
+	) {
+		const normalizedQuery = this.normalizeDomainSuggestionQuery( search, options );
 
-		// Merge options
-		...queryOptions,
+		return select( 'core/data' ).isResolving( STORE_KEY, '__internalGetDomainSuggestions', [
+			normalizedQuery,
+		] );
+	}
 
-		// Add the search query
-		query: search.trim().toLocaleLowerCase(),
-	};
+	/**
+	 * Normalize domain query
+	 *
+	 * It's important to have a consistent, reproduceable representation of a domains query so that the result can be
+	 * stored and retrieved.
+	 *
+	 * @see client/state/domains/suggestions/utils.js
+	 * @see client/components/data/query-domains-suggestions/index.jsx
+	 *
+	 * @param search       Domain search string
+	 * @param queryOptions Optional paramaters for the query
+	 * @returns Normalized query object
+	 */
+	normalizeDomainSuggestionQuery(
+		search: string,
+		queryOptions: DomainSuggestionSelectorOptions
+	): DomainSuggestionQuery {
+		return {
+			// Defaults
+			include_wordpressdotcom: queryOptions.only_wordpressdotcom || false,
+			include_dotblogsubdomain: false,
+			only_wordpressdotcom: false,
+			quantity: 5,
+			vendor: this.vendor,
+
+			// Merge options
+			...queryOptions,
+
+			// Add the search query
+			query: search.trim().toLocaleLowerCase(),
+		};
+	}
+
+	/**
+	 * Do not use this selector. It is for internal use.
+	 *
+	 * @private
+	 *
+	 * @param state Store state
+	 * @param queryObject Normalized object representing the query
+	 * @returns suggestions
+	 */
+	__internalGetDomainSuggestions( state: State, queryObject: DomainSuggestionQuery ) {
+		return state.domainSuggestions[ stringifyDomainQueryObject( queryObject ) ];
+	}
 }

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -13,34 +13,28 @@ import { stringifyDomainQueryObject } from './utils';
 
 type DomainSuggestionSelectorOptions = Partial< Exclude< DomainSuggestionQuery, 'query' > >;
 
-export default class Selectors {
-	private vendor: string;
-
-	constructor( vendor: string ) {
-		this.vendor = vendor;
-	}
-
-	getState( state: State ) {
+const createSelectors = ( vendor: string ) => {
+	function getState( state: State ) {
 		return state;
 	}
 
-	getDomainSuggestions(
+	function getDomainSuggestions(
 		_state: State,
 		search: string,
 		options: DomainSuggestionSelectorOptions = {}
 	) {
-		const normalizedQuery = this.normalizeDomainSuggestionQuery( search, options );
+		const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
 
 		// We need to go through the `select` store to get the resolver action
 		return select( STORE_KEY ).__internalGetDomainSuggestions( normalizedQuery );
 	}
 
-	isLoadingDomainSuggestions(
+	function isLoadingDomainSuggestions(
 		_state: State,
 		search: string,
 		options: DomainSuggestionSelectorOptions = {}
 	) {
-		const normalizedQuery = this.normalizeDomainSuggestionQuery( search, options );
+		const normalizedQuery = normalizeDomainSuggestionQuery( search, options );
 
 		return select( 'core/data' ).isResolving( STORE_KEY, '__internalGetDomainSuggestions', [
 			normalizedQuery,
@@ -60,7 +54,7 @@ export default class Selectors {
 	 * @param queryOptions Optional paramaters for the query
 	 * @returns Normalized query object
 	 */
-	normalizeDomainSuggestionQuery(
+	function normalizeDomainSuggestionQuery(
 		search: string,
 		queryOptions: DomainSuggestionSelectorOptions
 	): DomainSuggestionQuery {
@@ -70,7 +64,7 @@ export default class Selectors {
 			include_dotblogsubdomain: false,
 			only_wordpressdotcom: false,
 			quantity: 5,
-			vendor: this.vendor,
+			vendor: vendor,
 
 			// Merge options
 			...queryOptions,
@@ -89,7 +83,18 @@ export default class Selectors {
 	 * @param queryObject Normalized object representing the query
 	 * @returns suggestions
 	 */
-	__internalGetDomainSuggestions( state: State, queryObject: DomainSuggestionQuery ) {
+	function __internalGetDomainSuggestions( state: State, queryObject: DomainSuggestionQuery ) {
 		return state.domainSuggestions[ stringifyDomainQueryObject( queryObject ) ];
 	}
-}
+
+	return {
+		getState,
+		getDomainSuggestions,
+		isLoadingDomainSuggestions,
+		__internalGetDomainSuggestions,
+	};
+};
+
+export type Selectors = ReturnType< typeof createSelectors >;
+
+export default createSelectors;

--- a/packages/data-stores/src/mapped-types.ts
+++ b/packages/data-stores/src/mapped-types.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { FunctionKeys } from 'utility-types';
+
+/**
  * Mapped types
  *
  * This module should only contain mapped types, operations useful in the type system
@@ -17,8 +22,8 @@
  *
  * @template S Selector map, usually from `import * as selectors from './my-store/selectors';`
  */
-export type SelectFromMap< S extends Record< string, ( ...args: any[] ) => any > > = {
-	[ selector in keyof S ]: (
+export type SelectFromMap< S extends object > = {
+	[ selector in FunctionKeys< S > ]: (
 		...args: TailParameters< S[ selector ] >
 	) => ReturnType< S[ selector ] >;
 };
@@ -42,11 +47,8 @@ export type DispatchFromMap< A extends Record< string, ( ...args: any[] ) => any
  * This is useful for typing some @wordpres/data functions that make a leading
  * `state` argument implicit.
  */
-export type TailParameters< F extends ( head: any, ...tail: any[] ) => any > = F extends (
-	head: any,
-	...tail: infer PS
-) => any
-	? PS
+export type TailParameters< F extends Function > = F extends ( head: any, ...tail: infer T ) => any
+	? T
 	: never;
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -21999,7 +21999,7 @@ utila@^0.4.0, utila@~0.4:
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
-utility-types@3.10.0:
+utility-types@3.10.0, utility-types@^3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
   integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #40968
Related #41173

Accept a domain suggestions `vendor` on register. This will be used by default as the suggestions vendor. Can be overridden in a specific domain query via options.

You may want to hide whitespace changes to view the relevant part of the diff. The selectors are now returned from a function, so there's a lot of added indentation.

#### Testing instructions

* Domains query works in gutenboarding. ([`/new`](https://calypso.live/new?branch=data-stores/suggestions-configurable-vendor))
* Try providing another vendor and you should see it reflected in the query.
  - setting `getSuggestionsVendor( false )`
  - Writing a different vendor into the query options
