### PR TITLE
Fix the styles in the buttons when they are disabled

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -54,7 +54,7 @@
 }
 
 .daily-backup-status__no-backup-last-backup {
-	margin-top: 1rem;
+	margin-bottom: 1rem;
 	font-style: italic;
 }
 

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -21,6 +21,7 @@
 		&:disabled {
 			color: var( --studio-gray-10 );
 			border-color: var( --color-gray-10 );
+			background: var( --studio-white );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
**Very small**

Use the correct style when a non-primary button is disabled. Before, if you move the cursor over it you see a green background, and it should stay white.

Before (mouse is over the "Download backup" button)
![image](https://user-images.githubusercontent.com/9832440/79460289-82b30080-7fec-11ea-8b81-b24176c876de.png)

After (mouse is over the "Download backup" button):
![image](https://user-images.githubusercontent.com/9832440/79460228-68792280-7fec-11ea-91ed-847dd1c62c81.png)


#### Testing instructions

- Apply the changes
- Go to the Backup section and to the Backup Scheduled view (today), move the cursor over the buttons "Download backup" and "Restore to this point" and see that the colors don't change. If you have a backup from today, move your time zone.
