### PR TITLE
Site Editor: remove custom top level menu item

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/site-editor/index.php
@@ -28,22 +28,6 @@ function initialize_site_editor() {
 
 	// Force enable required Gutenberg experiments if they are not already active.
 	add_filter( 'pre_option_gutenberg-experiments', __NAMESPACE__ . '\enable_site_editor_experiment' );
-	// Add top level Site Editor menu item.
-	add_action( 'admin_menu', __NAMESPACE__ . '\add_site_editor_menu_item' );
-}
-
-/**
- * Add top level Site Editor menu item.
- */
-function add_site_editor_menu_item() {
-	add_menu_page(
-		__( 'Site Editor (beta)', 'full-site-editing' ),
-		__( 'Site Editor (beta)', 'full-site-editing' ),
-		'edit_theme_options',
-		'gutenberg-edit-site',
-		'gutenberg_edit_site_page',
-		'dashicons-edit'
-	);
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The top level menu item is now added in latest core version and we no longer need to do that manually here.

#### Testing instructions

1. Make sure that you are running Gutenberg 7.9 on your Simple site (it should have `gutenberg-edge` sticker).
2. Make sure that your test site has `core-site-editor-enabled` sticker applied.
3. Sync these changes to your sandbox.
3. Verify that the Site Editor button still appears as top level item in wp-admin and that it loads fine there and in Calypso.