### PR TITLE
Jetpack: Add scan to the connect page

### DIFF
--- a/client/jetpack-connect/controller.js
+++ b/client/jetpack-connect/controller.js
@@ -47,6 +47,8 @@ import {
 	PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
 	PRODUCT_JETPACK_SEARCH,
 	PRODUCT_JETPACK_SEARCH_MONTHLY,
+	PRODUCT_JETPACK_SCAN,
+	PRODUCT_JETPACK_SCAN_MONTHLY,
 } from 'lib/products-values/constants';
 
 /**
@@ -58,7 +60,10 @@ const analyticsPageTitleByType = {
 	personal: 'Jetpack Connect Personal',
 	premium: 'Jetpack Connect Premium',
 	pro: 'Jetpack Install Pro',
+	realtimebackup: 'Jetpack Realtime Backup',
+	backup: 'Jetpack Daily Backup',
 	jetpack_search: 'Jetpack Search',
+	scan: 'Jetpack Scan',
 };
 
 const removeSidebar = context => context.store.dispatch( hideSidebar() );
@@ -72,6 +77,7 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 			realtimebackup: PRODUCT_JETPACK_BACKUP_REALTIME,
 			backup: PRODUCT_JETPACK_BACKUP_DAILY,
 			jetpack_search: PRODUCT_JETPACK_SEARCH,
+			scan: PRODUCT_JETPACK_SCAN,
 		},
 		monthly: {
 			personal: PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -80,6 +86,7 @@ const getPlanSlugFromFlowType = ( type, interval = 'yearly' ) => {
 			realtimebackup: PRODUCT_JETPACK_BACKUP_REALTIME_MONTHLY,
 			backup: PRODUCT_JETPACK_BACKUP_DAILY_MONTHLY,
 			jetpack_search: PRODUCT_JETPACK_SEARCH_MONTHLY,
+			scan: PRODUCT_JETPACK_SCAN_MONTHLY,
 		},
 	};
 

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -25,7 +25,7 @@ export default function() {
 	const locale = getLanguageRouteParam( 'locale' );
 
 	page(
-		'/jetpack/connect/:type(personal|premium|pro|backup|realtimebackup|jetpack_search)/:interval(yearly|monthly)?',
+		'/jetpack/connect/:type(personal|premium|pro|backup|scan|realtimebackup|jetpack_search)/:interval(yearly|monthly)?',
 		controller.persistMobileAppFlow,
 		controller.setMasterbar,
 		controller.connect,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds the ability for Jetpack to purchase Jetpack Scan via the URL when the site is not connected yet. 

#### Testing instructions

Load up this PR. 
1. Go to http://calypso.localhost:3000/jetpack/connect/scan
2. Enter a url of a connected site. 
3. notice that you end up on the correct checkout page (scan yearly)

1. Go to http://calypso.localhost:3000/jetpack/connect/scan/monthly
2. Enter a url of a connected site. 
3. notice that you end up on the correct checkout page (scan monthly)

