### PR TITLE
i18n: Add initial translation chunks as script tag

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -266,20 +266,42 @@ function buildLanguageChunks( downloadedLanguages ) {
 				const translatedChunksKeys = Object.keys( languageChunks ).map(
 					( chunk ) => path.parse( chunk ).name
 				);
-				fs.writeFileSync(
-					path.join( publicPath, `${ langSlug }-${ LANGUAGE_MANIFEST_FILENAME }` ),
-					JSON.stringify( {
-						locale: _.pick( languageTranslations, [ '' ] ),
-						translatedChunks: translatedChunksKeys,
-					} )
+				const manifestJsonData = JSON.stringify( {
+					locale: _.pick( languageTranslations, [ '' ] ),
+					translatedChunks: translatedChunksKeys,
+				} );
+				const manifestFilepathJson = path.join(
+					publicPath,
+					`${ langSlug }-${ LANGUAGE_MANIFEST_FILENAME }`
 				);
+				fs.writeFileSync( manifestFilepathJson, manifestJsonData );
+
+				const manifestJsData = `var i18nLanguageManifest = ${ manifestJsonData }`;
+				const manifestFilepathJs = path.format( {
+					...path.parse( manifestFilepathJson ),
+					base: null,
+					ext: '.js',
+				} );
+				fs.writeFileSync( manifestFilepathJs, manifestJsData );
 
 				// Write language translation chunks
-				_.forEach( languageChunks, ( chunkTranslations, chunkId ) => {
-					const chunkFilename = path.basename( chunkId, path.extname( chunkId ) ) + '.json';
-					const chunkFilepath = path.join( publicPath, `${ langSlug }-${ chunkFilename }` );
+				_.forEach( languageChunks, ( chunkTranslations, chunkFilename ) => {
+					const chunkId = path.basename( chunkFilename, path.extname( chunkFilename ) );
+					const chunkJsonData = JSON.stringify( chunkTranslations );
+					const chunkJsData = `var i18nTranslationChunks = i18nTranslationChunks || {}; i18nTranslationChunks[${ JSON.stringify(
+						chunkId
+					) }] = ${ chunkJsonData }`;
 
-					fs.writeFileSync( chunkFilepath, JSON.stringify( chunkTranslations ) );
+					const chunkFilenameJson = chunkId + '.json';
+					const chunkFilepathJson = path.join( publicPath, `${ langSlug }-${ chunkFilenameJson }` );
+					fs.writeFileSync( chunkFilepathJson, chunkJsonData );
+
+					const chunkFilepathJs = path.format( {
+						...path.parse( chunkFilepathJson ),
+						base: null,
+						ext: '.js',
+					} );
+					fs.writeFileSync( chunkFilepathJs, chunkJsData );
 				} );
 			} );
 		} );

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -17,7 +17,10 @@ import {
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 
 const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
-	const { translatedChunks, locale } = await getLanguageManifestFile( localeSlug );
+	const { translatedChunks, locale } = await getLanguageManifestFile(
+		localeSlug,
+		window.BUILD_TARGET
+	);
 
 	reduxStore.dispatch( setLocaleRawData( locale ) );
 
@@ -27,10 +30,12 @@ const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
 			return;
 		}
 
-		return getTranslationChunkFile( chunkId, localeSlug ).then( ( translations ) => {
-			i18n.addTranslations( translations );
-			loadedTranslationChunks[ chunkId ] = true;
-		} );
+		return getTranslationChunkFile( chunkId, localeSlug, window.BUILD_TARGET ).then(
+			( translations ) => {
+				i18n.addTranslations( translations );
+				loadedTranslationChunks[ chunkId ] = true;
+			}
+		);
 	};
 	const installedChunks = new Set(
 		( window.installedChunks || [] ).concat( window.__requireChunkCallback__.getInstalledChunks() )

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -8,7 +8,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import { getLanguageSlugs } from 'lib/i18n-utils';
+import { getLanguageSlugs, isDefaultLocale } from 'lib/i18n-utils';
 import {
 	loadUserUndeployedTranslations,
 	getLanguageManifestFile,
@@ -71,7 +71,10 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		const lastPathSegment = window.location.pathname.substr(
 			window.location.pathname.lastIndexOf( '/' ) + 1
 		);
-		const pathLocaleSlug = getLanguageSlugs().includes( lastPathSegment ) && lastPathSegment;
+		const pathLocaleSlug =
+			getLanguageSlugs().includes( lastPathSegment ) &&
+			! isDefaultLocale( lastPathSegment ) &&
+			lastPathSegment;
 		const localeSlug = userLocaleSlug || pathLocaleSlug;
 
 		if ( localeSlug ) {

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -16,10 +16,10 @@ import {
 } from 'lib/i18n-utils/switch-locale';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 
-const setupTranslationChunks = async ( localeSlug ) => {
+const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
 	const { translatedChunks, locale } = await getLanguageManifestFile( localeSlug );
 
-	i18n.setLocale( locale );
+	reduxStore.dispatch( setLocaleRawData( locale ) );
 
 	const loadedTranslationChunks = {};
 	const loadTranslationForChunkIfNeeded = ( chunkId ) => {
@@ -70,7 +70,7 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		const localeSlug = userLocaleSlug || pathLocaleSlug;
 
 		if ( localeSlug ) {
-			setupTranslationChunks( localeSlug );
+			setupTranslationChunks( localeSlug, reduxStore );
 		}
 	}
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -69,6 +69,7 @@ class Document extends React.Component {
 		const inlineScript =
 			`var COMMIT_SHA = ${ jsonStringifyForHtml( commitSha ) };\n` +
 			`var BUILD_TIMESTAMP = ${ jsonStringifyForHtml( buildTimestamp ) };\n` +
+			`var BUILD_TARGET = ${ jsonStringifyForHtml( target ) };\n` +
 			( user ? `var currentUser = ${ jsonStringifyForHtml( user ) };\n` : '' ) +
 			( isSupportSession ? 'var isSupportSession = true;\n' : '' ) +
 			( app ? `var app = ${ jsonStringifyForHtml( app ) };\n` : '' ) +

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -218,9 +218,17 @@ class Document extends React.Component {
 							} }
 						/>
 					) }
+
+					{ entrypoint?.language?.manifest && <script src={ entrypoint.language.manifest } /> }
+
+					{ ( entrypoint?.language?.translations || [] ).map( ( translationChunk ) => (
+						<script key={ translationChunk } src={ translationChunk } />
+					) ) }
+
 					{ entrypoint.js.map( ( asset ) => (
 						<script key={ asset } src={ asset } />
 					) ) }
+
 					{ chunkFiles.js.map( ( chunk ) => (
 						<script key={ chunk } src={ chunk } />
 					) ) }

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -48,14 +48,11 @@ export function getLanguageFilePathUrl() {
 /**
  * Get the base path for language related files that are served from within Calypso.
  *
+ * @param {string} targetBuild The build target. e.g. fallback, evergreen, etc.
  * @returns {string} The internal base file path for language files.
  */
-export function getLanguagesInternalBasePath() {
-	if ( typeof window === 'undefined' || ! window?.__requireChunkCallback__ ) {
-		return '/calypso/evergreen/languages';
-	}
-
-	return window.__requireChunkCallback__.getPublicPath() + 'languages';
+export function getLanguagesInternalBasePath( targetBuild = 'evergreen' ) {
+	return `/calypso/${ targetBuild }/languages`;
 }
 
 /**
@@ -129,23 +126,28 @@ export function getLanguageFile( targetLocaleSlug ) {
  * Get the language manifest file URL for the given locale.
  * A revision cache buster will be appended automatically if `setLangRevisions` has been called beforehand.
  *
- * @param {string} localeSlug A locale slug. e.g. fr, jp, zh-tw
- * @param {string} fileType The desired file type, js or json. Default to json.
- * @param {object} languageRevisions An optional language revisions map. If it exists, the function will append the revision within as cache buster.
+ * @param {string} options Funciton options object
+ * @param {string} options.localeSlug A locale slug. e.g. fr, jp, zh-tw
+ * @param {string} options.fileType The desired file type, js or json. Default to json.
+ * @param {string} options.targetBuild The build target. e.g. fallback, evergreen, etc.
+ * @param {object} options.languageRevisions An optional language revisions map. If it exists, the function will append the revision within as cache buster.
  *
  * @returns {string} A language manifest file URL.
  */
-export function getLanguageManifestFileUrl(
+
+export function getLanguageManifestFileUrl( {
 	localeSlug,
 	fileType = 'json',
-	languageRevisions = {}
-) {
+	targetBuild = 'evergreen',
+	languageRevisions = {},
+} = {} ) {
 	if ( ! includes( [ 'js', 'json' ], fileType ) ) {
 		fileType = 'json';
 	}
 
 	const revision = languageRevisions[ localeSlug ];
-	const fileUrl = `${ getLanguagesInternalBasePath() }/${ localeSlug }-language-manifest.${ fileType }`;
+	const fileBasePath = getLanguagesInternalBasePath( targetBuild );
+	const fileUrl = `${ fileBasePath }/${ localeSlug }-language-manifest.${ fileType }`;
 
 	return typeof revision === 'number' ? fileUrl + `?v=${ revision }` : fileUrl;
 }
@@ -153,20 +155,22 @@ export function getLanguageManifestFileUrl(
 /**
  * Get the language manifest file for the given locale.
  *
- * @param  {string} targetLocaleSlug A locale slug. e.g. fr, jp, zh-tw
+ * @param  {string} localeSlug A locale slug. e.g. fr, jp, zh-tw
+ * @param  {string} targetBuild The build target. e.g. fallback, evergreen, etc.
  *
  * @returns {Promise} Language manifest json content
  */
-export function getLanguageManifestFile( targetLocaleSlug ) {
+export function getLanguageManifestFile( localeSlug, targetBuild = 'evergreen' ) {
 	if ( window?.i18nLanguageManifest ) {
 		return Promise.resolve( window.i18nLanguageManifest );
 	}
 
-	const url = getLanguageManifestFileUrl(
-		targetLocaleSlug,
-		'json',
-		window.languageRevisions || {}
-	);
+	const url = getLanguageManifestFileUrl( {
+		localeSlug,
+		fileType: 'json',
+		targetBuild,
+		languageRevisions: window.languageRevisions || {},
+	} );
 
 	return getFile( url );
 }
@@ -175,25 +179,30 @@ export function getLanguageManifestFile( targetLocaleSlug ) {
  * Get the translation chunk file URL for the given chunk id and locale.
  * A revision cache buster will be appended automatically if `setLangRevisions` has been called beforehand.
  *
- * @param {string} chunkId A chunk id. e.g. chunk-abc.min
- * @param {string} localeSlug A locale slug. e.g. fr, jp, zh-tw
- * @param {string} fileType The desired file type, js or json. Default to json.
- * @param {object} languageRevisions An optional language revisions map. If it exists, the function will append the revision within as cache buster.
+ * @param {string} options Funciton options object
+ * @param {string} options.chunkId A chunk id. e.g. chunk-abc.min
+ * @param {string} options.localeSlug A locale slug. e.g. fr, jp, zh-tw
+ * @param {string} options.fileType The desired file type, js or json. Default to json.
+ * @param {string} options.buildTarget The build target. e.g. fallback, evergreen, etc.
+ * @param {object} options.languageRevisions An optional language revisions map. If it exists, the function will append the revision within as cache buster.
  *
  * @returns {string} A translation chunk file URL.
  */
-export function getTranslationChunkFileUrl(
+export function getTranslationChunkFileUrl( {
 	chunkId,
 	localeSlug,
 	fileType = 'json',
-	languageRevisions = {}
-) {
+	targetBuild = 'evergreen',
+	languageRevisions = {},
+} = {} ) {
 	if ( ! includes( [ 'js', 'json' ], fileType ) ) {
 		fileType = 'json';
 	}
 
 	const revision = languageRevisions[ localeSlug ];
-	const fileUrl = `${ getLanguagesInternalBasePath() }/${ localeSlug }-${ chunkId }.${ fileType }`;
+	const fileBasePath = getLanguagesInternalBasePath( targetBuild );
+	const fileName = `${ localeSlug }-${ chunkId }.${ fileType }`;
+	const fileUrl = `${ fileBasePath }/${ fileName }`;
 
 	return typeof revision === 'number' ? fileUrl + `?v=${ revision }` : fileUrl;
 }
@@ -202,21 +211,23 @@ export function getTranslationChunkFileUrl(
  * Get the translation chunk file for the given chunk id and locale.
  *
  * @param {string} chunkId A chunk id. e.g. chunk-abc.min
- * @param  {string} targetLocaleSlug A locale slug. e.g. fr, jp, zh-tw
+ * @param {string} localeSlug A locale slug. e.g. fr, jp, zh-tw
+ * @param {string} buildTarget The build target. e.g. fallback, evergreen, etc.
  *
  * @returns {Promise} Translation chunk json content
  */
-export function getTranslationChunkFile( chunkId, targetLocaleSlug ) {
+export function getTranslationChunkFile( chunkId, localeSlug, buildTarget = 'evergreen' ) {
 	if ( window?.i18nTranslationChunks?.[ chunkId ] ) {
 		return Promise.resolve( window.i18nTranslationChunks[ chunkId ] );
 	}
 
-	const url = getTranslationChunkFileUrl(
+	const url = getTranslationChunkFileUrl( {
 		chunkId,
-		targetLocaleSlug,
-		'json',
-		window.languageRevisions || {}
-	);
+		localeSlug,
+		fileType: 'json',
+		buildTarget,
+		languageRevisions: window.languageRevisions || {},
+	} );
 
 	return getFile( url );
 }

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -251,6 +251,7 @@ export default function switchLocale( localeSlug ) {
 
 	// Todo: Handle switch locale with translation chunks
 	if ( config.isEnabled( 'use-translation-chunks' ) ) {
+		setLocaleInDOM();
 		return;
 	}
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -51,7 +51,7 @@ export function getLanguageFilePathUrl() {
  * @returns {string} The internal base file path for language files.
  */
 export function getLanguagesInternalBasePath() {
-	if ( typeof window === 'undefined' || ! window.__requireChunkCallback__ ) {
+	if ( typeof window === 'undefined' || ! window?.__requireChunkCallback__ ) {
 		return '/calypso/evergreen/languages';
 	}
 

--- a/client/lib/i18n-utils/test/switch-locale.js
+++ b/client/lib/i18n-utils/test/switch-locale.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { set, startsWith } from 'lodash';
+import { startsWith } from 'lodash';
 
 /**
  * Internal dependencies
@@ -69,34 +69,8 @@ describe( 'getLanguageFileUrl()', () => {
 
 describe( 'getLanguagesInternalBasePath()', () => {
 	test( 'should return base path for languages.', () => {
-		if ( ! global.window || ! global.__requireChunkCallback__ ) {
-			const expected = '/calypso/evergreen/languages';
-
-			expect( getLanguagesInternalBasePath() ).toEqual( expected );
-		}
-
-		let hasMockedWindow = false;
-		let hasMockedRequireChunkCallback = false;
-
-		if ( ! global.window || ! global.window.__requireChunkCallback__ ) {
-			hasMockedWindow = ! global.window;
-			hasMockedRequireChunkCallback = ! global.window || ! global.window.__requireChunkCallback__;
-
-			const mockFn = jest.fn( () => '/calypso/fallback/' );
-			set( global, [ 'window', '__requireChunkCallback__', 'getPublicPath' ], mockFn );
-
-			const expected = '/calypso/fallback/languages';
-			expect( getLanguagesInternalBasePath() ).toEqual( expected );
-			expect( mockFn ).toHaveBeenCalled();
-		}
-
-		if ( hasMockedRequireChunkCallback ) {
-			global.window.__requireChunkCallback__ = null;
-		}
-
-		if ( hasMockedWindow ) {
-			global.window = null;
-		}
+		expect( getLanguagesInternalBasePath() ).toEqual( '/calypso/evergreen/languages' );
+		expect( getLanguagesInternalBasePath( 'fallback' ) ).toEqual( '/calypso/fallback/languages' );
 	} );
 } );
 
@@ -104,44 +78,72 @@ describe( 'getLanguageManifestFileUrl()', () => {
 	test( 'should return language manifest url for a given locale.', () => {
 		const expected = getLanguagesInternalBasePath() + '/ja-language-manifest.json';
 
-		expect( getLanguageManifestFileUrl( 'ja' ) ).toEqual( expected );
+		expect( getLanguageManifestFileUrl( { localeSlug: 'ja' } ) ).toEqual( expected );
+	} );
+
+	test( 'should return language manifest url for a given locale and target build.', () => {
+		const targetBuild = 'fallback';
+		const expected = getLanguagesInternalBasePath( targetBuild ) + '/ja-language-manifest.json';
+
+		expect( getLanguageManifestFileUrl( { localeSlug: 'ja', targetBuild } ) ).toEqual( expected );
 	} );
 
 	test( 'should append a revision cache buster.', () => {
 		const expected = getLanguagesInternalBasePath() + '/zh-language-manifest.json?v=123';
 
-		expect( getLanguageManifestFileUrl( 'zh', { zh: 123 } ) ).toEqual( expected );
+		expect(
+			getLanguageManifestFileUrl( { localeSlug: 'zh', languageRevisions: { zh: 123 } } )
+		).toEqual( expected );
 	} );
 
 	test( 'should not append a revision cache buster for an unknown locale.', () => {
 		const expected = getLanguagesInternalBasePath() + '/kr-language-manifest.json';
 
-		expect( getLanguageManifestFileUrl( 'kr', { xd: 222 } ) ).toEqual( expected );
+		expect(
+			getLanguageManifestFileUrl( { localeSlug: 'kr', languageRevisions: { xd: 222 } } )
+		).toEqual( expected );
 	} );
 } );
 
 describe( 'getTranslationChunkFileUrl()', () => {
-	test( 'should return language manifest url for a given locale.', () => {
-		const locale = 'ja';
+	test( 'should return translation chunk url for a given locale.', () => {
+		const localeSlug = 'ja';
 		const chunkId = 'chunk-abc.min';
-		const expected = `${ getLanguagesInternalBasePath() }/${ locale }-${ chunkId }.json`;
+		const expected = `${ getLanguagesInternalBasePath() }/${ localeSlug }-${ chunkId }.json`;
 
-		expect( getTranslationChunkFileUrl( chunkId, locale ) ).toEqual( expected );
+		expect( getTranslationChunkFileUrl( { chunkId, localeSlug } ) ).toEqual( expected );
+	} );
+
+	test( 'should return translation chunk url for a given locale and target build.', () => {
+		const targetBuild = 'fallback';
+		const localeSlug = 'ja';
+		const chunkId = 'chunk-abc.min';
+		const expected = `${ getLanguagesInternalBasePath(
+			targetBuild
+		) }/${ localeSlug }-${ chunkId }.json`;
+
+		expect( getTranslationChunkFileUrl( { chunkId, localeSlug, targetBuild } ) ).toEqual(
+			expected
+		);
 	} );
 
 	test( 'should append a revision cache buster.', () => {
-		const locale = 'zh';
+		const localeSlug = 'zh';
 		const chunkId = 'chunk-abc.min';
-		const expected = `${ getLanguagesInternalBasePath() }/${ locale }-${ chunkId }.json?v=123`;
+		const expected = `${ getLanguagesInternalBasePath() }/${ localeSlug }-${ chunkId }.json?v=123`;
 
-		expect( getTranslationChunkFileUrl( chunkId, locale, { zh: 123 } ) ).toEqual( expected );
+		expect(
+			getTranslationChunkFileUrl( { chunkId, localeSlug, languageRevisions: { zh: 123 } } )
+		).toEqual( expected );
 	} );
 
 	test( 'should not append a revision cache buster for an unknown locale.', () => {
-		const locale = 'kr';
+		const localeSlug = 'kr';
 		const chunkId = 'chunk-abc.min';
-		const expected = `${ getLanguagesInternalBasePath() }/${ locale }-${ chunkId }.json`;
+		const expected = `${ getLanguagesInternalBasePath() }/${ localeSlug }-${ chunkId }.json`;
 
-		expect( getTranslationChunkFileUrl( chunkId, locale, { xd: 222 } ) ).toEqual( expected );
+		expect(
+			getTranslationChunkFileUrl( { chunkId, localeSlug, languageRevisions: { xd: 222 } } )
+		).toEqual( expected );
 	} );
 } );

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -7,13 +7,19 @@ import superagent from 'superagent';
 import Lru from 'lru';
 import { get, pick } from 'lodash';
 import debugFactory from 'debug';
+import path from 'path';
+import fs from 'fs';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
 import { isDefaultLocale, isLocaleRtl } from 'lib/i18n-utils';
-import { getLanguageFileUrl } from 'lib/i18n-utils/switch-locale';
+import {
+	getLanguageFileUrl,
+	getLanguageManifestFileUrl,
+	getTranslationChunkFileUrl,
+} from 'lib/i18n-utils/switch-locale';
 import { isSectionIsomorphic } from 'state/ui/selectors';
 import {
 	getDocumentHeadFormattedTitle,
@@ -124,11 +130,51 @@ export function render( element, key = JSON.stringify( element ), req ) {
 	//todo: render an error?
 }
 
+const cachedLanguageManifest = {};
+const getLanguageManifest = ( langSlug, target ) => {
+	if ( ! cachedLanguageManifest[ target ] ) {
+		const languageManifestFilepath = path.join(
+			__dirname,
+			'..',
+			'..',
+			'..',
+			'public',
+			target,
+			'languages',
+			`${ langSlug }-language-manifest.json`
+		);
+		cachedLanguageManifest[ target ] = JSON.parse(
+			fs.readFileSync( languageManifestFilepath, 'utf8' )
+		);
+	}
+	return cachedLanguageManifest[ target ];
+};
+
 export function attachI18n( context ) {
 	if ( ! isDefaultLocale( context.lang ) ) {
 		const langFileName = getCurrentLocaleVariant( context.store.getState() ) || context.lang;
 
 		context.i18nLocaleScript = getLanguageFileUrl( langFileName, 'js', context.languageRevisions );
+	}
+
+	if ( ! isDefaultLocale( context.lang ) && context.useTranslationChunks ) {
+		context.entrypoint.language = {};
+
+		context.entrypoint.language.manifest = getLanguageManifestFileUrl(
+			context.lang,
+			'js',
+			context.languageRevisions
+		);
+
+		const translatedChunks = getLanguageManifest( context.lang, context.target ).translatedChunks;
+
+		context.entrypoint.language.translations = context.entrypoint.js
+			.concat( context.chunkFiles.js )
+			.map( chunk => path.parse( chunk ).name )
+			.filter( chunkId => translatedChunks.includes( chunkId ) )
+			.map( chunkId =>
+				getTranslationChunkFileUrl( chunkId, context.lang, 'js', context.languageRevisions )
+			);
 	}
 
 	if ( context.store ) {

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -160,11 +160,12 @@ export function attachI18n( context ) {
 	if ( ! isDefaultLocale( context.lang ) && context.useTranslationChunks ) {
 		context.entrypoint.language = {};
 
-		context.entrypoint.language.manifest = getLanguageManifestFileUrl(
-			context.lang,
-			'js',
-			context.languageRevisions
-		);
+		context.entrypoint.language.manifest = getLanguageManifestFileUrl( {
+			localeSlug: context.lang,
+			fileType: 'js',
+			targetBuild: context.target,
+			languageRevisions: context.languageRevisions,
+		} );
 
 		const translatedChunks = getLanguageManifest( context.lang, context.target ).translatedChunks;
 
@@ -173,7 +174,13 @@ export function attachI18n( context ) {
 			.map( chunk => path.parse( chunk ).name )
 			.filter( chunkId => translatedChunks.includes( chunkId ) )
 			.map( chunkId =>
-				getTranslationChunkFileUrl( chunkId, context.lang, 'js', context.languageRevisions )
+				getTranslationChunkFileUrl( {
+					chunkId,
+					localeSlug: context.lang,
+					fileType: 'js',
+					buildTarget: context.target,
+					languageRevisions: context.languageRevisions,
+				} )
 			);
 	}
 

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -173,9 +173,9 @@ export function attachI18n( context ) {
 
 		context.entrypoint.language.translations = context.entrypoint.js
 			.concat( context.chunkFiles.js )
-			.map( chunk => path.parse( chunk ).name )
-			.filter( chunkId => translatedChunks.includes( chunkId ) )
-			.map( chunkId =>
+			.map( ( chunk ) => path.parse( chunk ).name )
+			.filter( ( chunkId ) => translatedChunks.includes( chunkId ) )
+			.map( ( chunkId ) =>
 				getTranslationChunkFileUrl( {
 					chunkId,
 					localeSlug: context.lang,

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -132,7 +132,9 @@ export function render( element, key = JSON.stringify( element ), req ) {
 
 const cachedLanguageManifest = {};
 const getLanguageManifest = ( langSlug, target ) => {
-	if ( ! cachedLanguageManifest[ target ] ) {
+	const key = `${ target }/${ langSlug }`;
+
+	if ( ! cachedLanguageManifest[ key ] ) {
 		const languageManifestFilepath = path.join(
 			__dirname,
 			'..',
@@ -143,11 +145,11 @@ const getLanguageManifest = ( langSlug, target ) => {
 			'languages',
 			`${ langSlug }-language-manifest.json`
 		);
-		cachedLanguageManifest[ target ] = JSON.parse(
+		cachedLanguageManifest[ key ] = JSON.parse(
 			fs.readFileSync( languageManifestFilepath, 'utf8' )
 		);
 	}
-	return cachedLanguageManifest[ target ];
+	return cachedLanguageManifest[ key ];
 };
 
 export function attachI18n( context ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, when translation chunks are enabled, translations are being requested after app is booted, which is causing strings to initially render in English and get updated when translation request completes.

This PR adds translation chunks required for initial page render as script tags which will prevent the initial rendering of strings in English.

#### Todo

- [x] Build JS version for language manifest and translation chunks
- [x] Use language manifest and translation chunks provided from script tags for initial i18n setup
- [x] Add support for different build targets

#### Testing instructions

1. Boot Calypso with `ENABLE_FEATURES=use-translation-chunks yarn start`
2. Open http://calypso.localhost:3000/start/user/pt-br
3. Strings should appear in Portuguese from the initial page render 
