### PR TITLE
Lasagna: switch socket connect to preloaded JWT

### DIFF
--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -33,6 +33,7 @@ const allowedKeys = [
 	'is_new_reader',
 	'social_login_connections',
 	'abtests',
+	'lasagna_jwt',
 ];
 const requiredKeys = [ 'ID' ];
 const decodedKeys = [ 'display_name', 'description', 'user_URL' ];

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -15,7 +15,13 @@ import {
 	PRODUCTS_LIST_RECEIVE,
 } from 'state/action-types';
 import { combineReducers, withSchemaValidation } from 'state/utils';
-import { idSchema, capabilitiesSchema, currencyCodeSchema, flagsSchema } from './schema';
+import {
+	capabilitiesSchema,
+	currencyCodeSchema,
+	flagsSchema,
+	idSchema,
+	lasagnaSchema,
+} from './schema';
 import gravatarStatus from './gravatar-status/reducer';
 import emailVerification from './email-verification/reducer';
 
@@ -114,6 +120,15 @@ export const capabilities = withSchemaValidation( capabilitiesSchema, ( state = 
 	return state;
 } );
 
+export const lasagnaJwt = withSchemaValidation( lasagnaSchema, ( state = null, action ) => {
+	switch ( action.type ) {
+		case CURRENT_USER_RECEIVE:
+			return action.user.lasagna_jwt;
+	}
+
+	return state;
+} );
+
 export default combineReducers( {
 	id,
 	currencyCode,
@@ -121,4 +136,5 @@ export default combineReducers( {
 	flags,
 	gravatarStatus,
 	emailVerification,
+	lasagnaJwt,
 } );

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -123,7 +123,7 @@ export const capabilities = withSchemaValidation( capabilitiesSchema, ( state = 
 export const lasagnaJwt = withSchemaValidation( lasagnaSchema, ( state = null, action ) => {
 	switch ( action.type ) {
 		case CURRENT_USER_RECEIVE:
-			return action.user.lasagna_jwt;
+			return action.user.lasagna_jwt || null;
 	}
 
 	return state;

--- a/client/state/current-user/schema.js
+++ b/client/state/current-user/schema.js
@@ -39,3 +39,7 @@ export const capabilitiesSchema = {
 export const flagsSchema = {
 	type: 'array',
 };
+
+export const lasagnaSchema = {
+	type: [ 'string', 'null' ],
+};

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -181,3 +181,13 @@ export function currentUserHasFlag( state, flagName ) {
  * @returns {boolean}       Whether the current user is email-verified.
  */
 export const isCurrentUserEmailVerified = createCurrentUserSelector( 'email_verified', false );
+
+/**
+ * Returns the Lasagna JWT for the current user.
+ *
+ * @param  {object}  state  Global state tree
+ * @returns {?string}       Lasagna JWT
+ */
+export function getCurrentUserLasagnaJwt( state ) {
+	return state.currentUser.lasagnaJwt;
+}

--- a/client/state/current-user/test/reducer.js
+++ b/client/state/current-user/test/reducer.js
@@ -32,6 +32,7 @@ describe( 'reducer', () => {
 			'flags',
 			'gravatarStatus',
 			'emailVerification',
+			'lasagnaJwt',
 		] );
 	} );
 

--- a/client/state/lasagna/middleware.js
+++ b/client/state/lasagna/middleware.js
@@ -1,8 +1,7 @@
 /**
  * Internal dependencies
  */
-import wpcom from 'lib/wp';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUserLasagnaJwt } from 'state/current-user/selectors';
 import { socket, socketConnect, socketDisconnect } from './socket';
 import privatePostChannelMiddleware from './private-post-channel/actions-to-events';
 import publicPostChannelMiddleware from './public-post-channel/actions-to-events';
@@ -37,18 +36,8 @@ const connectMiddleware = store => next => action => {
 	// connect if we are going to the reader without a socket
 	if ( ! socket && ! socketConnecting && action.section.name === 'reader' ) {
 		socketConnecting = true;
-		const user = getCurrentUser( store.getState() );
-
-		wpcom
-			.request( {
-				method: 'POST',
-				path: '/jwt/sign',
-				body: { payload: JSON.stringify( { user } ) },
-			} )
-			.then( ( { jwt } ) => {
-				socketConnect( store, jwt, user.ID );
-				socketConnecting = false;
-			} );
+		socketConnect( store, getCurrentUserLasagnaJwt( store.getState() ) );
+		socketConnecting = false;
 	}
 
 	// disconnect if we are leaving the reader with a socket

--- a/client/state/lasagna/middleware.js
+++ b/client/state/lasagna/middleware.js
@@ -35,7 +35,7 @@ const connectMiddleware = store => next => action => {
 
 	// we match the ROUTE_SET path because SECTION_SET can fire all over
 	// the place on hard loads of full post views and conversations
-	const readerPathRegex = RegExp( '^/read$|^/read/' );
+	const readerPathRegex = new RegExp( '^/read$|^/read/' );
 
 	// connect if we are going to the reader without a socket
 	if ( ! socket && ! socketConnecting && readerPathRegex.test( action.path ) ) {

--- a/client/state/lasagna/middleware.js
+++ b/client/state/lasagna/middleware.js
@@ -28,20 +28,24 @@ const combineMiddleware = ( ...m ) => {
  * @param store middleware store
  */
 const connectMiddleware = store => next => action => {
-	// bail unless this is a section set with the section definition
-	if ( action.type !== 'SECTION_SET' || ! action.section ) {
+	// bail unless this is a route set
+	if ( action.type !== 'ROUTE_SET' ) {
 		return next( action );
 	}
 
+	// we match the ROUTE_SET path because SECTION_SET can fire all over
+	// the place on hard loads of full post views and conversations
+	const readerPathRegex = RegExp( '^/read$|^/read/' );
+
 	// connect if we are going to the reader without a socket
-	if ( ! socket && ! socketConnecting && action.section.name === 'reader' ) {
+	if ( ! socket && ! socketConnecting && readerPathRegex.test( action.path ) ) {
 		socketConnecting = true;
 		socketConnect( store, getCurrentUserLasagnaJwt( store.getState() ) );
 		socketConnecting = false;
 	}
 
 	// disconnect if we are leaving the reader with a socket
-	else if ( socket && action.section.name !== 'reader' ) {
+	else if ( socket && ! readerPathRegex.test( action.path ) ) {
 		socketDisconnect( store );
 	}
 

--- a/client/state/lasagna/socket.js
+++ b/client/state/lasagna/socket.js
@@ -17,13 +17,13 @@ export let socket = null;
 const debug = createDebug( 'lasagna:socket' );
 const url = config( 'lasagna_url' );
 
-export const socketConnect = ( store, jwt, userId ) => {
+export const socketConnect = ( store, jwt ) => {
 	if ( socket !== null ) {
 		return;
 	}
 
 	import( /* webpackChunkName: "phoenix" */ 'phoenix' ).then( ( { Socket } ) => {
-		socket = new Socket( url, { params: { jwt, user_id: userId } } );
+		socket = new Socket( url, { params: { jwt } } );
 
 		socket.onOpen( () => {
 			debug( 'socket opened' );

--- a/client/state/lasagna/socket.js
+++ b/client/state/lasagna/socket.js
@@ -18,7 +18,7 @@ const debug = createDebug( 'lasagna:socket' );
 const url = config( 'lasagna_url' );
 
 export const socketConnect = ( store, jwt ) => {
-	if ( socket !== null ) {
+	if ( socket !== null || ! jwt ) {
 		return;
 	}
 

--- a/client/state/reader/full-view/reducer.js
+++ b/client/state/reader/full-view/reducer.js
@@ -1,7 +1,8 @@
 /**
  * Internal dependencies
  */
-import { READER_FULL_VIEW_POST_KEY_SET, SERIALIZE } from 'state/reader/action-types';
+import { READER_FULL_VIEW_POST_KEY_SET } from 'state/reader/action-types';
+import { SERIALIZE } from 'state/action-types';
 import { combineReducers } from 'state/utils';
 
 /**

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -22,7 +22,7 @@
 	"hotjar_enabled": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",
-	"lasagna_url": "wss://staging.lasagna.pub/socket",
+	"lasagna_url": "wss://horizon.lasagna.pub/socket",
 	"login_url": false,
 	"logout_url": false,
 	"mc_analytics_enabled": false,

--- a/config/development.json
+++ b/config/development.json
@@ -26,6 +26,7 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
+	"lasagna_url": "wss://horizon.lasagna.pub/socket",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"async-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -14,6 +14,7 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
+	"lasagna_url": "wss://horizon.lasagna.pub/socket",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"async-payments": false,


### PR DESCRIPTION
The Lasagna service is moving to [JWKS](https://tools.ietf.org/html/rfc7517) to manage auth concerns more nimbly than its initial Calypso-coupled implementation. 

#### Changes proposed in this Pull Request

* Switch Lasagna websocket connect to a preloaded JWT sidecar'd in the `/me` response.
* Move to keying socket connect/disconnect events off `ROUTE_SET`, as `SECTION_SET` spams us on hard refreshes in Reader full post view, conversations.
* Point the Calypso `development` (active) and `horizon` (currently disabled with feature flag) environments at the Lasagna `horizon` environment. Lasagna `horizon` is the only environment that gets CD of `master` at the moment. (And likely into the future.)

#### Testing instructions

1. Apply D41855-code.
2. Boot this branch locally.
3. Verify you see a successful websocket connection when you go to Reader.