### PR TITLE
Gutenboarding: Hide unwanted border on container

### DIFF
--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -34,6 +34,10 @@ $admin-sidebar-width-collapsed: 0;
 	// overrides .edit-post-visual-editor
 	padding-top: 0;
 
+	// overrides box-shadow added on focus
+	.block-editor-block-list__block::after {
+		display: none;
+	}
 	@include break-small {
 		padding-top: $gutenboarding-header-height;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the [blue border around the whole container](https://d.pr/i/AW6pdA) visible on design step and on [style step](https://d.pr/i/72M7cI) when focused.

#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=fix/gutenboarding-border-around-container)
* Check if the border has been removed

Fixes part of #41138
