### PR TITLE
Jetpack Cloud: update layout structure to center all sections

### DIFF
--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -1,7 +1,3 @@
-.backup-delta {
-    margin: 0 1rem;
-}
-
 .backup-delta__view-all-button {
     float: none;
 }

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -1,5 +1,4 @@
 .daily-backup-status {
-	padding: 0 1rem;
 	text-align: center;
 	margin-top: 2rem;
 }

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -17,10 +17,6 @@
     margin-bottom: 2rem;
 }
 
-.backups__page .main {
-	margin-left: auto;
-}
-
 .backups__is-loading {
 	margin: 2rem 1rem;
 	height: 245px;

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -141,7 +141,7 @@ class ScanHistoryPage extends Component {
 		const logEntries = this.filteredEntries();
 		const { value: filter } = this.getCurrentFilter();
 		return (
-			<Main wideLayout className="history">
+			<Main className="history">
 				<QueryJetpackScanHistory siteId={ this.props.siteId } />
 				<DocumentHead title={ translate( 'History' ) } />
 				<SidebarNavigation />

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -26,12 +26,6 @@
 		}
 	}
 
-	&__header,
-	&__description,
-	&__entries {
-		padding: 0 16px;
-	}
-
 	p {
 		font-size: 18px;
 		margin-bottom: 16px;

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -116,7 +116,7 @@ class ScanPage extends Component {
 
 	render() {
 		return (
-			<Main wideLayout className="scan__main">
+			<Main className="scan__main">
 				<DocumentHead title="Scanner" />
 				<SidebarNavigation />
 				<div className="scan__content">{ this.renderScanState() }</div>

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -1,6 +1,3 @@
-.theme-jetpack-cloud .main {
-	margin-left: 0;
-}
 .theme-jetpack-cloud .main.sites {
 	margin-left: auto;
 }

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -3,7 +3,6 @@
 }
 
 .scan__main {
-	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
@@ -21,7 +20,7 @@
 }
 
 .scan__content {
-	padding: 40px 16px 0;
+	padding-top: 40px;
 	flex: 1 0 auto;
 
 	.security-icon {

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -19,7 +19,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 function ScanUpsellPage( props ) {
 	return (
-		<Main wideLayout className="scan__main">
+		<Main className="scan__main">
 			<DocumentHead title="Scanner" />
 			<SidebarNavigation />
 			<div className="scan__content">

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -1,4 +1,11 @@
 .theme-jetpack-cloud .main,
+.color-scheme.is-jetpack-cloud .main {
+	box-sizing: border-box;
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
+.theme-jetpack-cloud .main,
 .color-scheme.is-jetpack-cloud .main,
 .theme-jetpack-cloud .ReactModalPortal {
 	.button {

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -1,8 +1,16 @@
-.theme-jetpack-cloud .main,
-.color-scheme.is-jetpack-cloud .main {
-	box-sizing: border-box;
-	padding-left: 16px;
-	padding-right: 16px;
+.theme-jetpack-cloud,
+.color-scheme.is-jetpack-cloud {
+
+	.main {
+		box-sizing: border-box;
+		padding-left: 16px;
+		padding-right: 16px;
+	}
+
+	.current-section {
+		margin-left: -16px;
+		margin-right: -16px;
+	}
 }
 
 .theme-jetpack-cloud .main,


### PR DESCRIPTION
### Changes proposed in this Pull Request

Up until now, each section of the Cloud had their own sizes and alignments; for example: Backup was centered, Scan was left-aligned, Backup had a `max-width: 720px` while Scan was set at `1040px`.

This change ensures the foundational structure for all current and future Cloud sections is consistent. This is important because:

* Global styles gives us much more control over multiple sections at the same time.
* It ensures compatibility with Calypso, backwards and future alike. This is relevant not only because the Cloud is built on top of Calypso, but also in case we migrate a feature to/from Calypso at any point.
* It more closely aligns to the mobile paradigm and so less tweaks will be needed in the future.

#### Breakdown of the changes:

* Reduces app width in the Scan section.
* Centers the content on all Cloud sections.
* Cleans up styles and groups global ones together.
* Adds an offset margin to the `current-section` element.

### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/`
* Select a site.
* Visit all Cloud sections and ensures the layout is consistent across the board, from large screenn on desktop to mobile devices.

### Before / After

Scanner | Scanner
--|--
![image](https://user-images.githubusercontent.com/390760/79469294-e5f66000-7ff7-11ea-9b04-3a0656174cb3.png) | ![image](https://user-images.githubusercontent.com/390760/79469344-f4dd1280-7ff7-11ea-800f-ee1f14f71c3d.png)

History | History
--|--
![image](https://user-images.githubusercontent.com/390760/79469944-b4ca5f80-7ff8-11ea-8959-a9dc777fb6b3.png) | ![image](https://user-images.githubusercontent.com/390760/79470000-cb70b680-7ff8-11ea-9679-91517ac37f5d.png)

Backup Status | Backup Status
--|--
![image](https://user-images.githubusercontent.com/390760/79469444-150cd180-7ff8-11ea-98ea-f373682e8e50.png) | ![image](https://user-images.githubusercontent.com/390760/79469501-248c1a80-7ff8-11ea-97c5-81d5aa08831d.png)

Activity Log | Activity Log
--|--
![image](https://user-images.githubusercontent.com/390760/79469600-49808d80-7ff8-11ea-89d2-2790298ba4d1.png) | ![image](https://user-images.githubusercontent.com/390760/79469559-3bcb0800-7ff8-11ea-8dde-8700e11ff743.png)

Settings | Settings
--|--
![image](https://user-images.githubusercontent.com/390760/79470252-18ed2380-7ff9-11ea-8d48-d08b617f5311.png) | ![image](https://user-images.githubusercontent.com/390760/79470314-27d3d600-7ff9-11ea-8bc8-84979f166844.png)
