### PR TITLE
Jetpack Cloud: Add site URL to all 'contact support' links

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -142,7 +142,7 @@ class DailyBackupStatus extends Component {
 					</p>
 					<Button
 						className="daily-backup-status__support-button"
-						href={ `https://jetpack.com/contact-support/?site=${ siteUrl }` }
+						href={ `https://jetpack.com/contact-support/?url=${ siteUrl }` }
 						target="_blank"
 						rel="noopener noreferrer"
 						isPrimary={ false }
@@ -173,7 +173,7 @@ class DailyBackupStatus extends Component {
 
 				<Button
 					className="daily-backup-status__support-button"
-					href={ `https://jetpack.com/contact-support/?site=${ siteUrl }` }
+					href={ `https://jetpack.com/contact-support/?url=${ siteUrl }` }
 					target="_blank"
 					rel="noopener noreferrer"
 					isPrimary={ false }
@@ -224,7 +224,7 @@ class DailyBackupStatus extends Component {
 
 				<Button
 					className="daily-backup-status__support-button"
-					href={ `https://jetpack.com/contact-support/?site=${ siteUrl }` }
+					href={ `https://jetpack.com/contact-support/?url=${ siteUrl }` }
 					target="_blank"
 					rel="noopener noreferrer"
 					isPrimary={ false }

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -99,7 +99,7 @@ class DailyBackupStatus extends Component {
 	}
 
 	renderFailedBackup( backup ) {
-		const { translate, timezone, gmtOffset } = this.props;
+		const { translate, timezone, gmtOffset, siteUrl } = this.props;
 
 		const backupTitleDate = this.getDisplayDate( backup.activityTs, false );
 		const backupDate = applySiteOffset( backup.activityTs, { timezone, gmtOffset } );
@@ -142,7 +142,7 @@ class DailyBackupStatus extends Component {
 					</p>
 					<Button
 						className="daily-backup-status__support-button"
-						href="https://jetpack.com/contact-support/"
+						href={ `https://jetpack.com/contact-support/?site=${ siteUrl }` }
 						target="_blank"
 						rel="noopener noreferrer"
 						isPrimary={ false }
@@ -155,7 +155,7 @@ class DailyBackupStatus extends Component {
 	}
 
 	renderNoBackupEver() {
-		const { translate } = this.props;
+		const { translate, siteUrl } = this.props;
 
 		return (
 			<>
@@ -173,7 +173,7 @@ class DailyBackupStatus extends Component {
 
 				<Button
 					className="daily-backup-status__support-button"
-					href="https://jetpack.com/contact-support/"
+					href={ `https://jetpack.com/contact-support/?site=${ siteUrl }` }
 					target="_blank"
 					rel="noopener noreferrer"
 					isPrimary={ false }
@@ -185,7 +185,7 @@ class DailyBackupStatus extends Component {
 	}
 
 	renderNoBackupOnDate() {
-		const { translate, selectedDate, siteSlug } = this.props;
+		const { translate, selectedDate, siteSlug, siteUrl } = this.props;
 
 		const displayDate = selectedDate.format( 'll' );
 		const nextDate = selectedDate.clone().add( 1, 'days' );
@@ -224,7 +224,7 @@ class DailyBackupStatus extends Component {
 
 				<Button
 					className="daily-backup-status__support-button"
-					href="https://jetpack.com/contact-support/"
+					href={ `https://jetpack.com/contact-support/?site=${ siteUrl }` }
 					target="_blank"
 					rel="noopener noreferrer"
 					isPrimary={ false }

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -29,6 +29,7 @@ import { INDEX_FORMAT } from 'landing/jetpack-cloud/sections/backups/main';
  * Style dependencies
  */
 import './style.scss';
+import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
 
 class DailyBackupStatus extends Component {
 	getValidRestoreId = () => {
@@ -142,7 +143,7 @@ class DailyBackupStatus extends Component {
 					</p>
 					<Button
 						className="daily-backup-status__support-button"
-						href={ `https://jetpack.com/contact-support/?url=${ siteUrl }` }
+						href={ contactSupportUrl( siteUrl ) }
 						target="_blank"
 						rel="noopener noreferrer"
 						isPrimary={ false }
@@ -173,7 +174,7 @@ class DailyBackupStatus extends Component {
 
 				<Button
 					className="daily-backup-status__support-button"
-					href={ `https://jetpack.com/contact-support/?url=${ siteUrl }` }
+					href={ contactSupportUrl( siteUrl ) }
 					target="_blank"
 					rel="noopener noreferrer"
 					isPrimary={ false }
@@ -224,7 +225,7 @@ class DailyBackupStatus extends Component {
 
 				<Button
 					className="daily-backup-status__support-button"
-					href={ `https://jetpack.com/contact-support/?url=${ siteUrl }` }
+					href={ contactSupportUrl( siteUrl ) }
 					target="_blank"
 					rel="noopener noreferrer"
 					isPrimary={ false }

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -96,7 +96,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 					'Please review them below and take action. We are {{a}}here to help{{/a}} if you need us.',
 					{
 						components: {
-							a: <a href={ `https://jetpack.com/contact-support/?site=${ site.URL }` } />,
+							a: <a href={ `https://jetpack.com/contact-support/?url=${ site.URL }` } />,
 						},
 						comment: 'The {{a}} tag is a link that goes to a contact support page.',
 					}

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -27,6 +27,7 @@ interface Props {
 	site: {
 		ID: number;
 		name: string;
+		URL: string;
 	};
 	threats: Array< Threat >;
 }
@@ -94,7 +95,9 @@ const ScanThreats = ( { site, threats }: Props ) => {
 				{ translate(
 					'Please review them below and take action. We are {{a}}here to help{{/a}} if you need us.',
 					{
-						components: { a: <a href="https://jetpack.com/contact-support/" /> },
+						components: {
+							a: <a href={ `https://jetpack.com/contact-support/?site=${ site.URL }` } />,
+						},
 						comment: 'The {{a}} tag is a link that goes to a contact support page.',
 					}
 				) }

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -17,6 +17,7 @@ import ThreatItem from 'landing/jetpack-cloud/components/threat-item';
 import { Threat, ThreatAction } from 'landing/jetpack-cloud/components/threat-item/types';
 import getJetpackCredentials from 'state/selectors/get-jetpack-credentials';
 import { fixThreatAlert, ignoreThreatAlert } from 'state/jetpack/site-alerts/actions';
+import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
 
 /**
  * Style dependencies
@@ -96,7 +97,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 					'Please review them below and take action. We are {{a}}here to help{{/a}} if you need us.',
 					{
 						components: {
-							a: <a href={ `https://jetpack.com/contact-support/?url=${ site.URL }` } />,
+							a: <a href={ contactSupportUrl( site.URL ) } />,
 						},
 						comment: 'The {{a}} tag is a link that goes to a contact support page.',
 					}

--- a/client/landing/jetpack-cloud/lib/contact-support-url.js
+++ b/client/landing/jetpack-cloud/lib/contact-support-url.js
@@ -20,7 +20,7 @@ export default function contactSupportUrl( siteUrl, scanState ) {
 	return addQueryArgs(
 		{
 			url: siteUrl,
-			'scan-state': scanState
+			'scan-state': scanState,
 		},
 		JETPACK_CONTACT_SUPPORT
 	);

--- a/client/landing/jetpack-cloud/lib/contact-support-url.js
+++ b/client/landing/jetpack-cloud/lib/contact-support-url.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
+import { addQueryArgs } from 'lib/url';
 
 /**
  * Creates a URL that refers to the Jetpack 'Contact Support' page,
@@ -16,16 +17,11 @@ export default function contactSupportUrl( siteUrl, scanState ) {
 	// NOTE: This is an extremely simple, early implementation;
 	// if we add more options in the future, we'll want
 	// to come back and change how we build this query string
-	const params = [];
-	if ( siteUrl ) {
-		params.push( `url=${ siteUrl }` );
-	}
-
-	if ( scanState ) {
-		params.push( `scan-state=${ scanState }` );
-	}
-
-	// At present, JETPACK_CONTACT_SUPPORT already contains an initial query string
-	// parameter, so we can safely append all our parameters using '&'
-	return [ JETPACK_CONTACT_SUPPORT, ...params ].join( '&' );
+	return addQueryArgs(
+		{
+			url: siteUrl,
+			'scan-state': scanState
+		},
+		JETPACK_CONTACT_SUPPORT
+	);
 }

--- a/client/landing/jetpack-cloud/lib/contact-support-url.js
+++ b/client/landing/jetpack-cloud/lib/contact-support-url.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
+
+/**
+ * Creates a URL that refers to the Jetpack 'Contact Support' page,
+ * with accompanying useful information about the reason for the
+ * support request.
+ *
+ * @param {string} [siteUrl]	A site URL
+ * @param {string} [scanState]	The current state of Jetpack Scan/Backup
+ * @returns {string} 			The support request URL
+ */
+export default function contactSupportUrl( siteUrl, scanState ) {
+	// NOTE: This is an extremely simple, early implementation;
+	// if we add more options in the future, we'll want
+	// to come back and change how we build this query string
+	const params = [];
+	if ( siteUrl ) {
+		params.push( `url=${ siteUrl }` );
+	}
+
+	if ( scanState ) {
+		params.push( `scan-state=${ scanState }` );
+	}
+
+	// At present, JETPACK_CONTACT_SUPPORT already contains an initial query string
+	// parameter, so we can safely append all our parameters using '&'
+	return [ JETPACK_CONTACT_SUPPORT, ...params ].join( '&' );
+}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -36,6 +36,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import getActivityLogFilter from 'state/selectors/get-activity-log-filter';
 import ActivityCardList from 'landing/jetpack-cloud/components/activity-card-list';
 import MissingCredentialsWarning from '../../components/missing-credentials';
+import getSiteUrl from 'state/sites/selectors/get-site-url';
 import getDoesRewindNeedCredentials from 'state/selectors/get-does-rewind-need-credentials.js';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
@@ -157,6 +158,7 @@ class BackupsPage extends Component {
 			logs,
 			moment,
 			siteId,
+			siteUrl,
 			siteSlug,
 			isLoadingBackups,
 			oldestDateAvailable,
@@ -204,6 +206,7 @@ class BackupsPage extends Component {
 						<DailyBackupStatus
 							{ ...{
 								allowRestore,
+								siteUrl,
 								siteSlug,
 								dailyBackup: backupsOnSelectedDate.lastBackup,
 								lastDateAvailable,
@@ -350,6 +353,7 @@ const mapStateToProps = ( state ) => {
 		logs: logs?.data ?? [],
 		rewind,
 		siteId,
+		siteUrl: getSiteUrl( state, siteId ),
 		siteSlug: getSelectedSiteSlug( state ),
 		timezone,
 		gmtOffset,

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
@@ -20,6 +20,7 @@ import ProgressBar from './progress-bar';
 import QueryRewindBackupStatus from 'components/data/query-rewind-backup-status';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
+import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
 
 interface Props {
 	backupDisplayDate: string;
@@ -170,7 +171,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 			</h3>
 			<Button
 				className="rewind-flow__primary-button"
-				href={ `https://jetpack.com/contact-support/?url=${ siteUrl }&scan-state=error` }
+				href={ contactSupportUrl( siteUrl, 'error' ) }
 				primary
 				rel="noopener noreferrer"
 				target="_blank"

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
@@ -25,14 +25,14 @@ interface Props {
 	backupDisplayDate: string;
 	rewindId: string;
 	siteId: number;
-	siteSlug: string;
+	siteUrl: string;
 }
 
 const BackupDownloadFlow: FunctionComponent< Props > = ( {
 	backupDisplayDate,
 	rewindId,
 	siteId,
-	siteSlug,
+	siteUrl,
 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -170,7 +170,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 			</h3>
 			<Button
 				className="rewind-flow__primary-button"
-				href={ `https://jetpack.com/contact-support/?scan-state=error&site-slug=${ siteSlug }` }
+				href={ `https://jetpack.com/contact-support/?site=${ siteUrl }&scan-state=error` }
 				primary
 				rel="noopener noreferrer"
 				target="_blank"

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
@@ -170,7 +170,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 			</h3>
 			<Button
 				className="rewind-flow__primary-button"
-				href={ `https://jetpack.com/contact-support/?site=${ siteUrl }&scan-state=error` }
+				href={ `https://jetpack.com/contact-support/?url=${ siteUrl }&scan-state=error` }
 				primary
 				rel="noopener noreferrer"
 				target="_blank"

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
@@ -10,11 +10,11 @@ import { useSelector } from 'react-redux';
  */
 import { Card } from '@automattic/components';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import getSiteUrl from 'state/sites/selectors/get-site-url';
 import { RewindFlowPurpose } from './types';
 import {
 	applySiteOffsetType,
-	useApplySiteOffset,
+	useApplySiteOffset
 } from 'landing/jetpack-cloud/components/site-offset';
 import BackupDownloadFlow from './download';
 import BackupRestoreFlow from './restore';
@@ -40,9 +40,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( ( state ) =>
-		siteId !== null ? getSiteSlug( state, siteId ) : ''
-	);
+	const siteUrl = useSelector( state => ( siteId && getSiteUrl( state, siteId ) ) || '' );
 
 	const render = ( loadedApplySiteOffset: applySiteOffsetType ) => {
 		const backupDisplayDate = loadedApplySiteOffset(
@@ -54,14 +52,14 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 					backupDisplayDate={ backupDisplayDate }
 					rewindId={ rewindId }
 					siteId={ siteId }
-					siteSlug={ siteSlug }
+					siteUrl={ siteUrl }
 				/>
 			) : (
 				<BackupDownloadFlow
 					backupDisplayDate={ backupDisplayDate }
 					rewindId={ rewindId }
 					siteId={ siteId }
-					siteSlug={ siteSlug }
+					siteUrl={ siteUrl }
 				/>
 			);
 		}

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
@@ -14,7 +14,7 @@ import getSiteUrl from 'state/sites/selectors/get-site-url';
 import { RewindFlowPurpose } from './types';
 import {
 	applySiteOffsetType,
-	useApplySiteOffset
+	useApplySiteOffset,
 } from 'landing/jetpack-cloud/components/site-offset';
 import BackupDownloadFlow from './download';
 import BackupRestoreFlow from './restore';
@@ -40,7 +40,7 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 	const translate = useTranslate();
 
 	const siteId = useSelector( getSelectedSiteId );
-	const siteUrl = useSelector( state => ( siteId && getSiteUrl( state, siteId ) ) || '' );
+	const siteUrl = useSelector( ( state ) => ( siteId && getSiteUrl( state, siteId ) ) || '' );
 
 	const render = ( loadedApplySiteOffset: applySiteOffsetType ) => {
 		const backupDisplayDate = loadedApplySiteOffset(

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
@@ -21,6 +21,7 @@ import QueryRewindState from 'components/data/query-rewind-state';
 import RewindConfigEditor from './rewind-config-editor';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 import Spinner from 'components/spinner';
+import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
 
 interface Props {
 	backupDisplayDate: string;
@@ -178,7 +179,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			</h3>
 			<Button
 				className="rewind-flow__primary-button"
-				href={ `https://jetpack.com/contact-support/?url=${ siteUrl }&scan-state=error` }
+				href={ contactSupportUrl( siteUrl, 'error' ) }
 				primary
 				rel="noopener noreferrer"
 				target="_blank"

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
@@ -42,7 +42,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	backupDisplayDate,
 	rewindId,
 	siteId,
-	siteUrl
+	siteUrl,
 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -50,14 +50,14 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const [ rewindConfig, setRewindConfig ] = useState< RewindConfig >( defaultRewindConfig );
 	const [ userHasRequestedRestore, setUserHasRequestedRestore ] = useState< boolean >( false );
 
-	const rewindState = useSelector( state => getRewindState( state, siteId ) ) as RewindState;
+	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
 
 	const loading = rewindState.state === 'uninitialized';
 
-	const inProgressRewindStatus = useSelector( state =>
+	const inProgressRewindStatus = useSelector( ( state ) =>
 		getInProgressRewindStatus( state, siteId, rewindId )
 	);
-	const inProgressRewindPercentComplete = useSelector( state =>
+	const inProgressRewindPercentComplete = useSelector( ( state ) =>
 		getInProgressRewindPercentComplete( state, siteId, rewindId )
 	);
 
@@ -82,11 +82,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					'{{strong}}%(backupDisplayDate)s{{/strong}} is the selected point for your restore. ',
 					{
 						args: {
-							backupDisplayDate
+							backupDisplayDate,
 						},
 						components: {
-							strong: <strong />
-						}
+							strong: <strong />,
+						},
 					}
 				) }
 			</p>
@@ -101,7 +101,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				className="rewind-flow__primary-button"
 				primary
 				onClick={ onConfirm }
-				disabled={ Object.values( rewindConfig ).every( setting => ! setting ) }
+				disabled={ Object.values( rewindConfig ).every( ( setting ) => ! setting ) }
 			>
 				{ translate( 'Confirm restore' ) }
 			</Button>
@@ -120,11 +120,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					'We are restoring your site back to {{strong}}%(backupDisplayDate)s{{/strong}}.',
 					{
 						args: {
-							backupDisplayDate
+							backupDisplayDate,
 						},
 						components: {
-							strong: <strong />
-						}
+							strong: <strong />,
+						},
 					}
 				) }
 			</p>
@@ -152,11 +152,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					'All of your selected files are now restored back to {{strong}}%(backupDisplayDate)s{{/strong}}.',
 					{
 						args: {
-							backupDisplayDate
+							backupDisplayDate,
 						},
 						components: {
-							strong: <strong />
-						}
+							strong: <strong />,
+						},
 					}
 				) }
 			</p>
@@ -185,7 +185,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				target="_blank"
 			>
 				{ translate( 'Contact Support {{externalIcon/}}', {
-					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> }
+					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
 				} ) }
 			</Button>
 		</>

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
@@ -178,7 +178,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			</h3>
 			<Button
 				className="rewind-flow__primary-button"
-				href={ `https://jetpack.com/contact-support/?site=${ siteUrl }&scan-state=error` }
+				href={ `https://jetpack.com/contact-support/?url=${ siteUrl }&scan-state=error` }
 				primary
 				rel="noopener noreferrer"
 				target="_blank"

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
@@ -15,7 +15,6 @@ import CheckYourEmail from './rewind-flow-notice/check-your-email';
 import getInProgressRewindPercentComplete from 'state/selectors/get-in-progress-rewind-percent-complete';
 import getInProgressRewindStatus from 'state/selectors/get-in-progress-rewind-status';
 import getRewindState from 'state/selectors/get-rewind-state';
-import getSiteUrl from 'state/selectors/get-site-url';
 import Gridicon from 'components/gridicon';
 import ProgressBar from './progress-bar';
 import QueryRewindState from 'components/data/query-rewind-state';
@@ -27,7 +26,7 @@ interface Props {
 	backupDisplayDate: string;
 	rewindId: string;
 	siteId: number;
-	siteSlug: string;
+	siteUrl: string;
 }
 
 //todo: move to dedicated types file
@@ -42,7 +41,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	backupDisplayDate,
 	rewindId,
 	siteId,
-	siteSlug,
+	siteUrl
 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -50,15 +49,14 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 	const [ rewindConfig, setRewindConfig ] = useState< RewindConfig >( defaultRewindConfig );
 	const [ userHasRequestedRestore, setUserHasRequestedRestore ] = useState< boolean >( false );
 
-	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) );
-	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
+	const rewindState = useSelector( state => getRewindState( state, siteId ) ) as RewindState;
 
 	const loading = rewindState.state === 'uninitialized';
 
-	const inProgressRewindStatus = useSelector( ( state ) =>
+	const inProgressRewindStatus = useSelector( state =>
 		getInProgressRewindStatus( state, siteId, rewindId )
 	);
-	const inProgressRewindPercentComplete = useSelector( ( state ) =>
+	const inProgressRewindPercentComplete = useSelector( state =>
 		getInProgressRewindPercentComplete( state, siteId, rewindId )
 	);
 
@@ -83,11 +81,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					'{{strong}}%(backupDisplayDate)s{{/strong}} is the selected point for your restore. ',
 					{
 						args: {
-							backupDisplayDate,
+							backupDisplayDate
 						},
 						components: {
-							strong: <strong />,
-						},
+							strong: <strong />
+						}
 					}
 				) }
 			</p>
@@ -102,7 +100,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 				className="rewind-flow__primary-button"
 				primary
 				onClick={ onConfirm }
-				disabled={ Object.values( rewindConfig ).every( ( setting ) => ! setting ) }
+				disabled={ Object.values( rewindConfig ).every( setting => ! setting ) }
 			>
 				{ translate( 'Confirm restore' ) }
 			</Button>
@@ -121,11 +119,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					'We are restoring your site back to {{strong}}%(backupDisplayDate)s{{/strong}}.',
 					{
 						args: {
-							backupDisplayDate,
+							backupDisplayDate
 						},
 						components: {
-							strong: <strong />,
-						},
+							strong: <strong />
+						}
 					}
 				) }
 			</p>
@@ -153,11 +151,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					'All of your selected files are now restored back to {{strong}}%(backupDisplayDate)s{{/strong}}.',
 					{
 						args: {
-							backupDisplayDate,
+							backupDisplayDate
 						},
 						components: {
-							strong: <strong />,
-						},
+							strong: <strong />
+						}
 					}
 				) }
 			</p>
@@ -180,13 +178,13 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			</h3>
 			<Button
 				className="rewind-flow__primary-button"
-				href={ `https://jetpack.com/contact-support/?scan-state=error&site-slug=${ siteSlug }` }
+				href={ `https://jetpack.com/contact-support/?site=${ siteUrl }&scan-state=error` }
 				primary
 				rel="noopener noreferrer"
 				target="_blank"
 			>
 				{ translate( 'Contact Support {{externalIcon/}}', {
-					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
+					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> }
 				} ) }
 			</Button>
 		</>

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -22,6 +22,7 @@ import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import getSiteUrl from 'state/sites/selectors/get-site-url';
 import getSiteScanState from 'state/selectors/get-site-scan-state';
 import { withLocalizedMoment } from 'components/localized-moment';
+import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
 
 /**
  * Style dependencies
@@ -84,7 +85,7 @@ class ScanPage extends Component {
 					primary
 					target="_blank"
 					rel="noopener noreferrer"
-					href={ `https://jetpack.com/contact-support/?url=${ siteUrl }&scan-state=error` }
+					href={ contactSupportUrl( siteUrl, 'error' ) }
 					className="scan__button"
 				>
 					{ translate( 'Contact Support {{externalIcon/}}', {

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -84,7 +84,7 @@ class ScanPage extends Component {
 					primary
 					target="_blank"
 					rel="noopener noreferrer"
-					href={ `https://jetpack.com/contact-support/?site=${ siteUrl }&scan-state=error` }
+					href={ `https://jetpack.com/contact-support/?url=${ siteUrl }&scan-state=error` }
 					className="scan__button"
 				>
 					{ translate( 'Contact Support {{externalIcon/}}', {

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -19,6 +19,7 @@ import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
+import getSiteUrl from 'state/sites/selectors/get-site-url';
 import getSiteScanState from 'state/selectors/get-site-scan-state';
 import { withLocalizedMoment } from 'components/localized-moment';
 
@@ -68,7 +69,7 @@ class ScanPage extends Component {
 	}
 
 	renderScanError() {
-		const { siteSlug } = this.props;
+		const { siteUrl } = this.props;
 
 		return (
 			<>
@@ -83,7 +84,7 @@ class ScanPage extends Component {
 					primary
 					target="_blank"
 					rel="noopener noreferrer"
-					href={ `https://jetpack.com/contact-support/?scan-state=error&site-slug=${ siteSlug }` }
+					href={ `https://jetpack.com/contact-support/?site=${ siteUrl }&scan-state=error` }
 					className="scan__button"
 				>
 					{ translate( 'Contact Support {{externalIcon/}}', {
@@ -141,6 +142,7 @@ class ScanPage extends Component {
 
 export default connect( ( state ) => {
 	const site = getSelectedSite( state );
+	const siteUrl = getSiteUrl( state, site.ID );
 	const siteSlug = getSelectedSiteSlug( state );
 	const scanState = getSiteScanState( state, site.ID );
 	const lastScanTimestamp = Date.now() - 5700000; // 1h 35m.
@@ -148,6 +150,7 @@ export default connect( ( state ) => {
 
 	return {
 		site,
+		siteUrl,
 		siteSlug,
 		scanState,
 		lastScanTimestamp,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a query parameter `site` to every "Contact Support"-type link in Jetpack Cloud, which indicates the currently selected site.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that all 'contact support' link URLs contain a query parameter of the form `?site=<site url>`. This includes (but may not be limited to) the following places:
  * **Daily Backup Status**: "Contact support" button (when a backup failed for a specific day, no backup exists for a specific day, or if no backups are available at all)
  * **Main Scan page**: "Contact support" button (when scan encountered an error)
  * **Threats**: (when threats are found) "Please review them below and take action. We are `here to help` ..."
  * **Download backup**: "Contact support" button (when an error occurs creating the download)
  * **Restore backup**: "Contact support" button (when an error occurs during restore)

##### Example screenshot (see lower left for link URL)
<img width="724" alt="Link URL with site embedded in query string" src="https://user-images.githubusercontent.com/670067/79468315-6602d280-7fc4-11ea-9a79-51ebd8c1dd44.png">

Fixes 1151678672052943-as-1171538115001098