### PR TITLE
Search & Social: Replace Banner with Upsell Nudge

### DIFF
--- a/client/blocks/upsell-nudge/README.md
+++ b/client/blocks/upsell-nudge/README.md
@@ -29,6 +29,7 @@ Name | Type | Default | Description
 ---- | ---- | ---- | ----
 `callToAction` | `string` | null | Message to show on the upsell call to action.
 `compact` | `bool` | false | Show a small version of the nudge. Best for places like the sidebar.
+`disableHref` | `bool` | false | Ensure the nudge doesn't link to anywhere. Ideal for nudges shown to non-admins.
 `dismissPreferenceName` | `string` | empty | Enables dismiss functionality, using this value as the dismiss event name.
 `href` | `string` | null | The URL/path that the user is taken to when clicked.
 `icon` | `string` | null | Optional reference to a Gridicon.

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -60,7 +60,15 @@ export const UpsellNudge = ( {
 		href = addQueryArgs( { feature, plan }, `/plans/${ site.slug }` );
 	}
 
-	return <Banner { ...props } showIcon={ showIcon } className={ classes } href={ href } />;
+	return (
+		<Banner
+			{ ...props }
+			showIcon={ showIcon }
+			disableHref={ ! canManageSite }
+			className={ classes }
+			href={ href }
+		/>
+	);
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -35,6 +35,7 @@ export const UpsellNudge = ( {
 	href,
 	plan,
 	planHasFeature,
+	disableHref,
 	forceDisplay,
 	...props
 } ) => {
@@ -64,7 +65,7 @@ export const UpsellNudge = ( {
 		<Banner
 			{ ...props }
 			showIcon={ showIcon }
-			disableHref={ ! canManageSite }
+			disableHref={ disableHref }
 			className={ classes }
 			href={ href }
 		/>

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -56,6 +56,7 @@ export const SeoPreviewNudge = ( {
 						  )
 				}
 				forceDisplay
+				disableHref={ ! canCurrentUserUpgrade }
 				event="site_preview_seo_plan_upgrade"
 				className="preview-upgrade-nudge__banner"
 				feature={ FEATURE_SEO_PREVIEW_TOOLS }

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -18,9 +18,9 @@ import { isJetpackSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import FeatureExample from 'components/feature-example';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { findFirstSimilarPlanKey } from 'lib/plans';
-import { TERM_ANNUALLY, TYPE_BUSINESS } from 'lib/plans/constants';
+import { TERM_ANNUALLY, TYPE_BUSINESS, FEATURE_SEO_PREVIEW_TOOLS } from 'lib/plans/constants';
 
 /**
  * Style dependencies
@@ -39,7 +39,8 @@ export const SeoPreviewNudge = ( {
 			<QueryPlans />
 			<TrackComponentView eventName="calypso_seo_preview_upgrade_nudge_impression" />
 
-			<Banner
+			<UpsellNudge
+				showIcon
 				plan={
 					site &&
 					findFirstSimilarPlanKey( site.plan.product_slug, {
@@ -54,8 +55,10 @@ export const SeoPreviewNudge = ( {
 								"Unlock powerful SEO tools! Contact your site's administrator to upgrade to a Business plan."
 						  )
 				}
+				forceDisplay
 				event="site_preview_seo_plan_upgrade"
 				className="preview-upgrade-nudge__banner"
+				feature={ FEATURE_SEO_PREVIEW_TOOLS }
 			/>
 
 			<div className="preview-upgrade-nudge__features">

--- a/client/components/seo/preview-upgrade-nudge/test/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/test/index.jsx
@@ -5,7 +5,7 @@ jest.mock( 'lib/abtest', () => ( {
 jest.mock( 'lib/analytics/index', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
 jest.mock( 'lib/analytics/track-component-view', () => 'TrackComponentView' );
-jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: Comp => props => (
@@ -68,14 +68,14 @@ describe( 'SeoPreviewNudge basic tests', () => {
 	} );
 } );
 
-describe( 'Upsell Banner should get appropriate plan constant', () => {
+describe( 'UpsellNudge should get appropriate plan constant', () => {
 	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( product_slug => {
 		test( `Business 1 year for (${ product_slug })`, () => {
 			const comp = shallow(
 				<SeoPreviewNudge { ...props } isJetpack={ false } site={ { plan: { product_slug } } } />
 			);
-			expect( comp.find( 'Banner' ).length ).toBe( 1 );
-			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS );
+			expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
+			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_BUSINESS );
 		} );
 	} );
 
@@ -84,8 +84,8 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 			const comp = shallow(
 				<SeoPreviewNudge { ...props } isJetpack={ false } site={ { plan: { product_slug } } } />
 			);
-			expect( comp.find( 'Banner' ).length ).toBe( 1 );
-			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_BUSINESS_2_YEARS );
+			expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
+			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_BUSINESS_2_YEARS );
 		} );
 	} );
 
@@ -101,8 +101,8 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 			const comp = shallow(
 				<SeoPreviewNudge { ...props } isJetpack={ true } site={ { plan: { product_slug } } } />
 			);
-			expect( comp.find( 'Banner' ).length ).toBe( 1 );
-			expect( comp.find( 'Banner' ).props().plan ).toBe( PLAN_JETPACK_BUSINESS );
+			expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
+			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( PLAN_JETPACK_BUSINESS );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes the Upsell Nudge compatible for cases where non-admins are advised to contact someone who can upgrade, and updates a usage of this which I noticed in #41044. It'll also the nudge to benefit from any changes in that PR.

#### Testing instructions

Visit `/view/site` and toggle the dropdown at the top left to "Search & Social".

**As an admin:**
<img width="737" alt="Screenshot 2020-04-16 at 17 52 06" src="https://user-images.githubusercontent.com/43215253/79484229-40e58280-800b-11ea-8023-60ea99a788b1.png">

**As a non-admin:**
<img width="907" alt="Screenshot 2020-04-16 at 17 51 58" src="https://user-images.githubusercontent.com/43215253/79484258-480c9080-800b-11ea-8a00-de72fa80286e.png">

As a non-admin, you shouldn't be able to click the nudge, but you should be able to as an admin!

cc @mmtr, @sixhours 