### PR TITLE
Add suffix to railcar identifier

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -85,7 +85,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			}
 
 			this.props.recordTracksEvent( 'calypso_traintracks_render', {
-				railcar: this.props.railcarId + '-' + this.props.uiPosition.toString(),
+				railcar: this.props.railcarId,
 				ui_position: this.props.uiPosition,
 				fetch_algo: `${ this.props.fetchAlgo }/${ this.props.suggestion.vendor }`,
 				rec_result: `${ this.props.suggestion.domain_name }${ resultSuffix }`,

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -85,7 +85,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			}
 
 			this.props.recordTracksEvent( 'calypso_traintracks_render', {
-				railcar: this.props.railcarId,
+				railcar: this.props.railcarId + '-' + this.props.uiPosition.toString(),
 				ui_position: this.props.uiPosition,
 				fetch_algo: `${ this.props.fetchAlgo }/${ this.props.suggestion.vendor }`,
 				rec_result: `${ this.props.suggestion.domain_name }${ resultSuffix }`,

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -274,7 +274,7 @@ class DomainSearchResults extends React.Component {
 						isSignupStep={ this.props.isSignupStep }
 						selectedSite={ this.props.selectedSite }
 						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						railcarId={ this.props.railcarId }
+						railcarId={ this.props.railcarId + '-' + ( i + 2 ) }
 						uiPosition={ i + 2 }
 						fetchAlgo={ suggestion.fetch_algo ? suggestion.fetch_algo : this.props.fetchAlgo }
 						query={ this.props.lastDomainSearched }

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -115,7 +115,7 @@ export class FeaturedDomainSuggestions extends Component {
 					<DomainRegistrationSuggestion
 						suggestion={ primarySuggestion }
 						isFeatured
-						railcarId={ this.props.railcarId }
+						railcarId={ this.props.railcarId + '-0' }
 						isSignupStep={ this.props.isSignupStep }
 						uiPosition={ 0 }
 						fetchAlgo={ this.getFetchAlgorithm( primarySuggestion ) }
@@ -128,7 +128,7 @@ export class FeaturedDomainSuggestions extends Component {
 					<DomainRegistrationSuggestion
 						suggestion={ secondarySuggestion }
 						isFeatured
-						railcarId={ this.props.railcarId }
+						railcarId={ this.props.railcarId + '-1' }
 						isSignupStep={ this.props.isSignupStep }
 						uiPosition={ 1 }
 						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change ensures that we have a positional suffix for the TrainTracks data we log for domain suggestions.

#### Testing instructions

* Navigate to `/start/domains` and open the network inspector of your browser.
* Enter a search term for a domain.
* Verify that we make logging requests for each of the suggestion items with a form of `<uuid>-domain-suggestion-<n>`, where <n> is a digit starting from 0.
* Select one of the rows in the table, and verify that we log an event with the 0-indexed position of that item as the suffix after `domain-suggestion-`. (Note that the recommended and alternative options are in positions 0 and 1.)

Repeat the steps above from within the main Calypso UI at `/domains/add/<your-site-slug>/`.