### PR TITLE
composite-checkout: Make contact fields valid when errors is undefined

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -268,7 +268,7 @@ interface ManagedValue {
 }
 
 export function isValid( arg: ManagedValue ): boolean {
-	return arg.errors?.length <= 0 && ( arg.value?.length > 0 || ! arg.isRequired );
+	return ( arg.errors?.length ?? 0 ) <= 0 && ( arg.value?.length > 0 || ! arg.isRequired );
 }
 
 function getInitialManagedValue( initialProperties?: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When validating contact fields, composite checkout has two separate systems: when a domain product is in the cart, the form uses the `validate` endpoint on the server to determine if the data is valid; when there is no domain, the form uses a relatively simple check for required empty fields or for existing errors.

If the cart changes during checkout, it's possible to switch from the validate endpoint to the simple check. In this case, the (empty) extra field data from the larger domain form is still present, with `undefined` as the `errors` property for each field. The simple check, when looking for any errors, has the condition `arg.errors?.length <= 0`, but if `errors` is undefined for these extra fields, this becomes `undefined <= 0`, which evaluates to `false`. The result is that the form has no errors to display but the "Continue" button appears to have no effect.

In this PR, I change the condition to be `( arg.errors?.length ?? 0 ) <= 0`, which in the above case will become `0 <= 0`, which evaluates to `true`, allowing us to continue past the step.

Ideally, when the cart changes, the unused extra field data should be somehow removed, or perhaps we can use the validate endpoint for the simple form also. While those options are considered, however, this will at least remove a place where it's possible to get stuck during the checkout process.

#### Testing instructions

- Add a domain and a plan to your cart and visit composite checkout.
- Proceed to the contact form step and fill out the fields, but make something invalid.
- Press "Continue"; you should see a validation error.
- Click "Edit" on the first step and remove the domain from your cart.
- Proceed to the contact form step, make sure it is valid, and press "Continue".
- Verify that you continue to the next step.