### PR TITLE
Update Calypso apps documentation for yarn 🎉

### DIFF
--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: yarn install --frozen-lockfile
     - name: Build FSE
-      run: npx lerna run build --scope='@automattic/full-site-editing' --stream
+      run: cd apps/full-site-editing && yarn build
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:

--- a/apps/README.md
+++ b/apps/README.md
@@ -15,7 +15,12 @@ Apps (unlike packages) are not built on Calypso's `yarn`.
 You must manually build apps by running:
 
 ```bash
-npx lerna run build --scope="@automattic/app-name"
+cd apps/app-name
+yarn build
+
+# Or any other command in the app's package.json
+# E.g. for the FSE plugin dev & sync command:
+yarn dev --sync
 ```
 
 ## Validating package.json

--- a/apps/full-site-editing/README.md
+++ b/apps/full-site-editing/README.md
@@ -24,12 +24,12 @@ This plugin should not be confused with the site editor work in core Gutenberg. 
 
 ## Build System
 
-Note: these scripts must be run from the Calypso _root_ directory. You will probably want to add aliases for these since they are very verbose.
+_Note: `cd` to `apps/full-site-editing` before running these commands_
 
-- `npx lerna run dev --scope='@automattic/full-site-editing' --stream --no-prefix`<br>
+- `yarn dev`<br>
 Compiles the plugins and watches for changes.
 
-- `npx lerna run build --scope='@automattic/full-site-editing' --stream --no-prefix`<br>
+- `yarn build`<br>
 Compiles and minifies the plugins for production.
 
 Both these scripts will also move all source and PHP files into `/dist` in their respective folders.
@@ -48,7 +48,7 @@ You can also build one of the Plugins separately by appending the plugin slug on
 
 ```sh
 # Builds the `posts-list-block` Plugin only
-npx lerna run build:posts-list-block --scope='@automattic/full-site-editing' --stream`
+yarn build:posts-list-block`
 ```
 
 ## Local Development
@@ -74,12 +74,13 @@ wp-env run cli wp ... # Runs a wp-cli command.
 Once the environment running, you can use the dev script (shown above), and the environment will automatically see the updated build. It works by mounting the FSE plugin as a Docker volume.
 
 ### Other:
-Build (or `run dev`) and symlink the plugin into a local WordPress install.
+Build (or `dev`) and symlink the plugin into a local WordPress install.
 
 E.g.
 
 ```sh
-npx lerna run build --scope='@automattic/full-site-editing'
+cd apps/full-site-editing
+yarn build
 
 ln -s ~/Dev/wp-calypso/apps/full-site-editing/full-site-editing-plugin/ ~/Dev/wordpress/wp-content/plugins/full-site-editing-plugin
 ```
@@ -88,17 +89,17 @@ ln -s ~/Dev/wp-calypso/apps/full-site-editing/full-site-editing-plugin/ ~/Dev/wo
 
 The Plugin contains a suite of unit / integration tests powered by `@wordpress/scripts`.
 
-We use `lerna` to run the tests using the following basic command:
+_Run these commands from the apps/full-site-editing directory_
 
 ```shell
-npx lerna run test:js --scope='@automattic/full-site-editing' --stream
+yarn test:js
 ```
 
 If you wish to "watch" and run tests on file change then run:
 
 ```shell
 // Note the additional `:watch` below
-npx lerna run test:js:watch --scope='@automattic/full-site-editing' --stream
+yarn test:js:watch
 ```
 
 ### Updating Snapshots
@@ -106,7 +107,7 @@ npx lerna run test:js:watch --scope='@automattic/full-site-editing' --stream
 Occasionally you will need to update Jest Snapshots. This is so common that there's a dedicated script for this:
 
 ```shell
-npx lerna run test:js:update-snapshots --scope='@automattic/full-site-editing' --stream
+yarn test:js:update-snapshots
 ```
 
 ### Writing Tests

--- a/apps/full-site-editing/bin/setup-env.sh
+++ b/apps/full-site-editing/bin/setup-env.sh
@@ -47,13 +47,11 @@ fi
 
 cd wp-calypso
 nvm use
-npm ci
-
-# Run an initial FSE build so that the plugin can load correctly.
-npx lerna run build --scope='@automattic/full-site-editing' --stream --no-prefix
+yarn
 
 # Where the wp-env.json file lives:
 cd apps/full-site-editing
+yarn build
 
 echo -e "\nWould you like to use the development version of wp-env? You can checkout the correct Gutenberg branch and build it before continuing."
 read -p "Type y to use the development version of wp-env. Otherwise, it will use the published version. "

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -14,8 +14,7 @@ Enhances your page creation workflow within the Block Editor.
 == Description ==
 
 This plugin comes with a custom block to display a list of your most recent blog posts, as well as a template selector
-to give you a head start on creating new pages for your site.
-
+to give you a head start on creating new pages for your site. It also provides a way to change your font settings globally from the page editor.
 
 == Installation ==
 

--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -17,6 +17,10 @@ Alternatively you can manually build the app with `lerna` and copy the built fil
 ```bash
 # Builds files and places them in `apps/notifications/dist`
 npx lerna run build --scope="@automattic/notifications"
+
+# Or directly with yarn:
+cd apps/notifications
+yarn build
 ```
 
 You will need to follow the directions in the Field Guide to deploy these artifacts.

--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -15,6 +15,7 @@ CircleCI generates notifications panel build artifacts on every commit that it p
 Alternatively you can manually build the app with `lerna` and copy the built files to your sandbox.
 
 ```bash
+# Builds files and places them in `apps/notifications/dist`
 cd apps/notifications
 yarn build
 ```

--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -15,10 +15,6 @@ CircleCI generates notifications panel build artifacts on every commit that it p
 Alternatively you can manually build the app with `lerna` and copy the built files to your sandbox.
 
 ```bash
-# Builds files and places them in `apps/notifications/dist`
-npx lerna run build --scope="@automattic/notifications"
-
-# Or directly with yarn:
 cd apps/notifications
 yarn build
 ```

--- a/apps/o2-blocks/README.md
+++ b/apps/o2-blocks/README.md
@@ -32,6 +32,7 @@ registerBlockType( 'prefix/name', { /* settings */ } );
 To build bundle in `apps/o2-blocks/dist`, run:
 
 ```bash
+# Builds files and places them in `apps/o2-blocks/dist`
 cd apps/o2-blocks
 yarn build
 ```

--- a/apps/o2-blocks/README.md
+++ b/apps/o2-blocks/README.md
@@ -32,9 +32,6 @@ registerBlockType( 'prefix/name', { /* settings */ } );
 To build bundle in `apps/o2-blocks/dist`, run:
 
 ```bash
-npx lerna run build --scope="@automattic/o2-blocks"
-
-# or:
 cd apps/o2-blocks
 yarn build
 ```

--- a/apps/o2-blocks/README.md
+++ b/apps/o2-blocks/README.md
@@ -33,4 +33,8 @@ To build bundle in `apps/o2-blocks/dist`, run:
 
 ```bash
 npx lerna run build --scope="@automattic/o2-blocks"
+
+# or:
+cd apps/o2-blocks
+yarn build
 ```

--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -194,11 +194,18 @@ Then, each bundle contains features for different types of pages. For example, t
 
 To manually build the package, execute the command below passing the directory where the distributable files will be generated:
 
-```
-npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --output-path=/path-to-folder
-```
+```sh
+cd apps/wpcom-block-editor
 
-_Wonky double `--` is needed for first skipping Lerna args and then NPM args to reach Webpack._
+# Watch for changes:
+yarn build --watch
+
+# Production build:
+yarn build
+
+# Change output directory (default is ./dist)
+yarn build --output-path=/path-to-folder
+```
 
 ### Automatic
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Calypso apps documentation references yarn instead of npm
* Remove (most) references to lerna, which isn't needed any more. It's too verbose, a bit slow to use, and overall not worth recommending.

You can still use lerna if you need to run the `build` command across all packages at the same time, but like... that's an extremely rare use case.

#### Testing instructions
Make sure there are no typos in the documentation
