### PR TITLE
Docs: Update more `npm run ...` commands in docs to `yarn`

### DIFF
--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -12,7 +12,7 @@ Calypso is [broken up into sections](https://github.com/Automattic/wp-calypso/bl
 This can take a long time and slow down incremental builds as your work. To speed things up,
 you can choose to build and run specific sections of Calypso using the `SECTION_LIMIT` environment variable.
 
-For instance, `SECTION_LIMIT=reader,login npm start` would start Calypso and only build the `reader` and `login` sections.
+For instance, `SECTION_LIMIT=reader,login yarn start` would start Calypso and only build the `reader` and `login` sections.
 
 To find all available sections in the main entry point, you can refer to the [sections.js file](https://github.com/Automattic/wp-calypso/blob/master/client/sections.js). Note that the other entry points are likely to register and handle additional sections.
 

--- a/docs/fallback-development-workflow.md
+++ b/docs/fallback-development-workflow.md
@@ -5,9 +5,9 @@ The Calypso build has two outputs: **evergreen**, for browsers that are always k
 
 ## Build
 
-Running `npm run start-fallback` will do the "fallback" build of all the code and continuously watch the front-end JS and CSS/Sass for changes and rebuild accordingly.
+Running `yarn start-fallback` will do the "fallback" build of all the code and continuously watch the front-end JS and CSS/Sass for changes and rebuild accordingly.
 
-You may need to run `npm run clean` between evergreen and fallback debug sessions.
+You may need to run `yarn clean` between evergreen and fallback debug sessions.
 
 ## Debugging with Internet Explorer
 
@@ -31,4 +31,4 @@ The VM's network uses NAT mode by default, which means the host machine is acces
 
 ### 3. View in IE
 
-Run `npm run start-fallback` on the host machine. Open Internet Explorer in the your VM (you'll need to search using the Start menu because Edge is the default browser) and navigate to `calypso.localhost:3000`.
+Run `yarn start-fallback` on the host machine. Open Internet Explorer in the your VM (you'll need to search using the Start menu because Edge is the default browser) and navigate to `calypso.localhost:3000`.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates more markdown docs to use yarn build command, specifically the IE dev workflow docs that just got added.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check typos

