### PR TITLE
 Gutenboarding: update `frankenflow`flow id and route fragment

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -302,7 +302,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				this.props.isSiteUnlaunched;
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
-				frankenflowUrl: `${ window.location.origin }/start/frankenflow?siteSlug=${ this.props.siteId }&source=editor`,
+				frankenflowUrl: `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteId }&source=editor`,
 			} );
 		}
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -278,7 +278,7 @@ export default connect( ( state ) => {
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
 	const isFrankenflow =
-		startsWith( currentRoute, '/start/frankenflow' ) ||
+		startsWith( currentRoute, '/start/new-launch' ) ||
 		startsWith( currentRoute, '/start/prelaunch' );
 
 	return {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -171,8 +171,8 @@ class Layout extends Component {
 		const optionalBodyProps = () => {
 			const optionalProps = {};
 
-			if ( this.props.isFrankenflow || this.props.isCheckoutFromGutenboarding ) {
-				optionalProps.bodyClass = 'is-frankenflow';
+			if ( this.props.isNewLaunchFlow || this.props.isCheckoutFromGutenboarding ) {
+				optionalProps.bodyClass = 'is-new-launch-flow';
 			}
 
 			return optionalProps;
@@ -277,7 +277,7 @@ export default connect( ( state ) => {
 	const oauth2Client = getCurrentOAuth2Client( state );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
-	const isFrankenflow =
+	const isNewLaunchFlow =
 		startsWith( currentRoute, '/start/new-launch' ) ||
 		startsWith( currentRoute, '/start/prelaunch' );
 
@@ -308,7 +308,7 @@ export default connect( ( state ) => {
 		authorization, it would remove the newly connected site that has been fetched separately.
 		See https://github.com/Automattic/wp-calypso/pull/31277 for more details. */
 		shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
-		isFrankenflow,
+		isNewLaunchFlow,
 		isCheckoutFromGutenboarding,
 	};
 } )( Layout );

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1230,7 +1230,7 @@
 	}
 }
 
-.is-section-checkout.is-frankenflow {
+.is-section-checkout.is-new-launch-flow {
 	.layout__content {
 		padding-top: 48px;
 	}

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -344,11 +344,11 @@ export function generateFlows( {
 	}
 
 	if ( isEnabled( 'gutenboarding' ) ) {
-		flows.frankenflow = {
+		flows[ 'new-launch' ] = {
 			steps: [ 'domains-launch', 'plans-launch', 'launch' ],
 			destination: getLaunchDestination,
-			description: 'Frankenflow launch for a site created from Gutenboarding',
-			lastModified: '2020-01-22',
+			description: 'Launch flow for a site created from /new',
+			lastModified: '2020-04-28',
 			pageTitle: translate( 'Launch your site' ),
 			providesDependenciesInQuery: [ 'siteSlug', 'source' ],
 		};

--- a/client/signup/steps/launch-site/index.jsx
+++ b/client/signup/steps/launch-site/index.jsx
@@ -14,7 +14,7 @@ class LaunchSiteComponent extends Component {
 		const { flowName, stepName } = this.props;
 		this.props.submitSignupStep(
 			{ stepName },
-			{ isPreLaunch: this.props.flowName === 'frankenflow' }
+			{ isPreLaunch: this.props.flowName === 'new-launch' }
 		);
 		this.props.goToNextStep( flowName );
 	}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -107,7 +107,7 @@ export class PlansStep extends Component {
 	};
 
 	isGutenboarding = () =>
-		this.props.flowName === 'frankenflow' || this.props.flowName === 'prelaunch'; // signup flows coming from Gutenboarding
+		this.props.flowName === 'new-launch' || this.props.flowName === 'prelaunch'; // signup flows coming from Gutenboarding
 
 	getGutenboardingHeader() {
 		if ( this.isGutenboarding() ) {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -298,7 +298,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 }
 
 // Background color and plans grid overrides for new flow
-body.is-section-signup.is-frankenflow {
+body.is-section-signup.is-new-launch-flow {
 	background: var( --color-white );
 
 	.signup-header {
@@ -321,7 +321,7 @@ body.is-section-signup.is-frankenflow {
 		}
 	}
 
-	.flow-progress-indicator.flow-progress-indicator__frankenflow {
+	.flow-progress-indicator.flow-progress-indicator__new-launch {
 		color: var( --color-text );
 	}
 
@@ -371,7 +371,7 @@ body.is-section-signup.is-frankenflow {
 }
 
 // Text and heading color override for new flow
-body.is-section-signup.is-frankenflow .layout:not( .dops ):not( .is-wccom-oauth-flow ) {
+body.is-section-signup.is-new-launch-flow .layout:not( .dops ):not( .is-wccom-oauth-flow ) {
 	&.gravatar .formatted-header, .formatted-header {
 		.formatted-header__title {
 			color: var( --color-text );

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -38,7 +38,7 @@ export const launchSiteOrRedirectToLaunchSignupFlow = ( siteId ) => ( dispatch, 
 	const isGutenboarding =
 		getSiteOption( getState(), siteId, 'site_creation_flow' ) === 'gutenboarding';
 	if ( isGutenboarding ) {
-		window.location.href = `/start/frankenflow?siteSlug=${ siteSlug }&source=home`;
+		window.location.href = `/start/new-launch?siteSlug=${ siteSlug }&source=home`;
 	} else {
 		window.location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
 	}


### PR DESCRIPTION
## Changes proposed in this Pull Request

Hey.

This PR changes the Gutenboarding from-editor launch flow name from `frankenflow` to `new-launch`

![pete's pesty pals](https://user-images.githubusercontent.com/6458278/79521294-2ad3d280-809c-11ea-8328-67f69ee094e5.gif)

Alternatives to `new-launch` are very welcome. Some other options I've gathered from randoms at the local bicycle repair shop are:

- `new-site-launch`
- `80-130-psi`
- `i-look-cool-in-lycra`

#### Testing instructions

Head on over to `http://calypso.localhost:3000/new` and create a site as a new user

Once in the editor, launch the site 🎉 

Confirm that launching a free and paid site works

Check the url to make sure the `new-launch` URL fragment is there

Take a peek at the tracking events, e.g., `calypso_signup_step_start`. The flow name should also be  `new-launch`

<img width="993" alt="Screen Shot 2020-04-17 at 11 04 31 am" src="https://user-images.githubusercontent.com/6458278/79521416-71c1c800-809c-11ea-868e-fe79254067a5.png">

Be well.