### PR TITLE
Tests: Re-enable ie11canary tests

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -244,7 +244,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Basic Public Post @canary @parallel', function () {
+	describe( 'Basic Public Post @canary @ie11canary @parallel', function () {
 		describe( 'Publish a New Post', function () {
 			const blogPostTitle = dataHelper.randomPhrase();
 			const blogPostQuote =

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1096,11 +1096,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can update the homepage', async function () {
-			// Skipping if IE11 due to JS errors caused by missing DOMRect polyfill.
-			// See https://github.com/Automattic/wp-calypso/issues/40502
-			if ( dataHelper.getTargetType() === 'IE11' ) {
-				return this.skip();
-			}
 			const myHomePage = await MyHomePage.Expect( this.driver );
 			await myHomePage.updateHomepageFromSiteSetup();
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The "Basic Public Post" and "Basic sign up for a free site" tests both work in IE11 when tested manually. Previously the tests were failing because the block editor was opening in the wp-admin rather than the iframe.

#41006 fixed the actual bug, but the e2e tests were failing for what looked like unrelated reasons. Re-enabling the canary tests in this new PR so we can fix in isolation.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ie canary tests should run in CI and pass