### PR TITLE
Gutenboarding pre-launch: Update CTA button label in the editor

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -46,7 +46,7 @@ function updateSettingsBar() {
 		launchLink.target = '_top';
 		launchLink.className =
 			'gutenboarding-editor-overrides__launch-button components-button is-primary';
-		const textContent = document.createTextNode( __( 'Launch' ) );
+		const textContent = document.createTextNode( __( 'Complete Setup' ) );
 		launchLink.appendChild( textContent );
 
 		// Put 'Launch' and 'Save' back on bar in desired order.

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -46,7 +46,7 @@ function updateSettingsBar() {
 		launchLink.target = '_top';
 		launchLink.className =
 			'gutenboarding-editor-overrides__launch-button components-button is-primary';
-		const textContent = document.createTextNode( __( 'Complete Setup' ) );
+		const textContent = document.createTextNode( __( 'Update' ) );
 		launchLink.appendChild( textContent );
 
 		// Put 'Launch' and 'Save' back on bar in desired order.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After CfT we received some feedback regarding this button label (eg: p1586430673306700-slack-gutenboarding) which currently suggest an immediate _launch_ action which isn't actually happening when clicking on it. 

The suggestion to change it to "Complete Setup" is coming from p58i-8UC-p2#comment-46048

With the change deployed to wpblock-editor-plugin, when landing in the Editor after creating a site in Gutenboarding, the header should look like this:

<img width="800" alt="Screenshot 2020-04-17 at 09 40 59" src="https://user-images.githubusercontent.com/14192054/79543514-43d98500-8096-11ea-91a0-8fff5bd23987.png">
<img width="250" alt="Screenshot 2020-04-17 at 09 39 40" src="https://user-images.githubusercontent.com/14192054/79543522-476d0c00-8096-11ea-8c79-79268cd18d37.png">
