### PR TITLE
Gutenboarding: Domain Picker Modal

### DIFF
--- a/client/landing/gutenboarding/components/close-button/index.tsx
+++ b/client/landing/gutenboarding/components/close-button/index.tsx
@@ -5,17 +5,10 @@ import React from 'react';
 import { Button, Path, SVG } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 
-interface CloseButtonProps extends Button.ButtonProps {
-	onClose: () => void;
-}
-
-const CloseButton: React.FunctionComponent< CloseButtonProps > = ( {
-	onClose,
-	...buttonProps
-} ) => {
+const CloseButton: React.FunctionComponent< Button.ButtonProps > = ( { ...buttonProps } ) => {
 	const { __ } = useI18n();
 	return (
-		<Button onClick={ onClose } label={ __( 'Close dialog' ) } { ...buttonProps }>
+		<Button label={ __( 'Close dialog' ) } { ...buttonProps }>
 			<SVG
 				width="12"
 				height="12"

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -20,7 +20,7 @@ import './style.scss';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
-interface Props extends DomainPickerProps, Button.BaseProps {
+interface Props extends Omit< DomainPickerProps, 'onClose' >, Button.BaseProps {
 	className?: string;
 	currentDomain?: DomainSuggestion;
 }
@@ -29,7 +29,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	children,
 	className,
 	onDomainSelect,
-	onDomainConfirm,
 	currentDomain,
 	...buttonProps
 } ) => {
@@ -77,7 +76,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 					showDomainCategories={ false }
 					currentDomain={ currentDomain }
 					onDomainSelect={ onDomainSelect }
-					onDomainConfirm={ onDomainConfirm }
 					onMoreOptions={ handleMoreOptions }
 					onClose={ handlePopoverClose }
 				/>
@@ -88,7 +86,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 					showDomainCategories
 					currentDomain={ currentDomain }
 					onDomainSelect={ onDomainSelect }
-					onDomainConfirm={ onDomainConfirm }
 					onClose={ handleModalClose }
 				/>
 			) }

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -71,25 +71,23 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<span className="domain-picker-button__label">{ children }</span>
 				<Dashicon icon="arrow-down-alt2" size={ 16 } />
 			</Button>
-			{ isDomainPopoverVisible && (
-				<DomainPickerPopover
-					showDomainConnectButton={ false }
-					showDomainCategories={ false }
-					currentDomain={ currentDomain }
-					onDomainSelect={ onDomainSelect }
-					onMoreOptions={ handleMoreOptions }
-					onClose={ handlePopoverClose }
-				/>
-			) }
-			{ isDomainModalVisible && (
-				<DomainPickerModal
-					showDomainConnectButton
-					showDomainCategories
-					currentDomain={ currentDomain }
-					onDomainSelect={ onDomainSelect }
-					onClose={ handleModalClose }
-				/>
-			) }
+			<DomainPickerPopover
+				isOpen={ isDomainPopoverVisible }
+				showDomainConnectButton={ false }
+				showDomainCategories={ false }
+				currentDomain={ currentDomain }
+				onDomainSelect={ onDomainSelect }
+				onMoreOptions={ handleMoreOptions }
+				onClose={ handlePopoverClose }
+			/>
+			<DomainPickerModal
+				isOpen={ isDomainModalVisible }
+				showDomainConnectButton
+				showDomainCategories
+				currentDomain={ currentDomain }
+				onDomainSelect={ onDomainSelect }
+				onClose={ handleModalClose }
+			/>
 		</>
 	);
 };

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -48,7 +48,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 
 	const handleModalClose = () => {
 		setDomainModalVisibility( false );
-		setDomainPopoverVisibility( true );
 	};
 
 	const handleMoreOptions = () => {

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -2,18 +2,16 @@
  * External dependencies
  */
 import React, { createRef, FunctionComponent, useState } from 'react';
-import { Button, Popover, Dashicon } from '@wordpress/components';
-import classnames from 'classnames';
+import { Button, Dashicon } from '@wordpress/components';
 
-// Core package needs to add this to the type definitions.
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-import { useViewportMatch } from '@wordpress/compose';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
+import { Props as DomainPickerProps } from '../domain-picker';
+import DomainPickerPopover from '../domain-picker-popover';
+import DomainPickerModal from '../domain-picker-modal';
 
 /**
  * Style dependencies
@@ -22,7 +20,7 @@ import './style.scss';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
-interface Props extends Omit< DomainPickerProps, 'onClose' >, Button.BaseProps {
+interface Props extends DomainPickerProps, Button.BaseProps {
 	className?: string;
 	currentDomain?: DomainSuggestion;
 }
@@ -31,22 +29,31 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 	children,
 	className,
 	onDomainSelect,
+	onDomainConfirm,
 	currentDomain,
 	...buttonProps
 } ) => {
 	const buttonRef = createRef< HTMLButtonElement >();
 
 	const [ isDomainPopoverVisible, setDomainPopoverVisibility ] = useState( false );
+	const [ isDomainModalVisible, setDomainModalVisibility ] = useState( false );
 
-	// Popover expands at medium viewport width
-	const isMobile = useViewportMatch( 'medium', '<' );
-
-	const handleClose = ( e?: React.FocusEvent ) => {
+	const handlePopoverClose = ( e?: React.FocusEvent ) => {
 		// Don't collide with button toggling
 		if ( e?.relatedTarget === buttonRef.current ) {
 			return;
 		}
 		setDomainPopoverVisibility( false );
+	};
+
+	const handleModalClose = () => {
+		setDomainModalVisibility( false );
+		setDomainPopoverVisibility( true );
+	};
+
+	const handleMoreOptions = () => {
+		setDomainPopoverVisibility( false );
+		setDomainModalVisibility( true );
 	};
 
 	return (
@@ -66,23 +73,25 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				<Dashicon icon="arrow-down-alt2" size={ 16 } />
 			</Button>
 			{ isDomainPopoverVisible && (
-				<div className="domain-picker-button__popover-container">
-					<Popover
-						className="domain-picker-button__popover"
-						focusOnMount={ isMobile ? 'container' : 'firstElement' }
-						noArrow
-						onClose={ handleClose }
-						onFocusOutside={ handleClose }
-						position={ 'bottom center' }
-						expandOnMobile={ true }
-					>
-						<DomainPicker
-							currentDomain={ currentDomain }
-							onClose={ handleClose }
-							onDomainSelect={ onDomainSelect }
-						/>
-					</Popover>
-				</div>
+				<DomainPickerPopover
+					showDomainConnectButton={ false }
+					showDomainCategories={ false }
+					currentDomain={ currentDomain }
+					onDomainSelect={ onDomainSelect }
+					onDomainConfirm={ onDomainConfirm }
+					onMoreOptions={ handleMoreOptions }
+					onClose={ handlePopoverClose }
+				/>
+			) }
+			{ isDomainModalVisible && (
+				<DomainPickerModal
+					showDomainConnectButton
+					showDomainCategories
+					currentDomain={ currentDomain }
+					onDomainSelect={ onDomainSelect }
+					onDomainConfirm={ onDomainConfirm }
+					onClose={ handleModalClose }
+				/>
 			) }
 		</>
 	);

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -63,6 +63,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				aria-pressed={ isDomainPopoverVisible }
 				className={ classnames( 'domain-picker-button', className, {
 					'is-open': isDomainPopoverVisible,
+					'is-modal-open': isDomainModalVisible,
 				} ) }
 				onClick={ () => setDomainPopoverVisibility( s => ! s ) }
 				ref={ buttonRef }

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -21,27 +21,3 @@
 		transform: rotate( 180deg );
 	}
 }
-
-.domain-picker-button__popover {
-	.components-popover__content {
-		border: 1px solid var( --studio-gray-5 );
-		box-shadow: 0 4px 10px rgba( 0, 0, 0, 0.12 );
-		border-radius: 4px;
-	}
-}
-
-.domain-picker-button__popover-container {
-	.components-popover__header {
-		display: none;
-	}
-
-	.components-popover.is-expanded .components-popover__content {
-		height: 100%;
-	}
-
-	@include break-small {
-		position: fixed;
-		left: 72px;
-		top: 54px;
-	}
-}

--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -9,15 +9,22 @@
 		height: auto; // prevent clipping when there are 2 lines
 		text-align: left;
 	}
+
 	&__label {
 		word-break: break-word;
 	}
+
 	.dashicon {
 		margin-left: 0.5em;
 		margin-top: 2px;
 		transition: transform 100ms ease-in-out;
 	}
+
 	&.is-open .dashicon {
 		transform: rotate( 180deg );
+	}
+
+	&.is-modal-open {
+		display: none; // Hide domain picker button when modal is open
 	}
 }

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -20,7 +20,11 @@ interface Props extends DomainPickerProps {
 }
 
 const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, ...props } ) => {
+	// This is needed otherwise it throws a warning.
+	Modal.setAppElement( '#wpcom' );
+
 	if ( ! isOpen ) return null;
+
 	return (
 		<Modal
 			isOpen

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -14,7 +14,13 @@ import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
  */
 import './style.scss';
 
-const DomainPickerModal: React.FunctionComponent< DomainPickerProps > = props => {
+interface Props extends DomainPickerProps {
+	isOpen: boolean;
+	onMoreOptions?: () => void;
+}
+
+const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, ...props } ) => {
+	if ( ! isOpen ) return null;
 	return (
 		<Modal isOpen className="domain-picker-modal" overlayClassName="domain-picker-modal-overlay">
 			<DomainPicker showDomainConnectButton showDomainCategories { ...props } />

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import Modal from 'react-modal';
+
+/**
+ * Internal dependencies
+ */
+import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
+
+interface Props extends DomainPickerProps {
+	onClose?: () => void;
+}
+
+const DomainPickerModal: FunctionComponent< Props > = ( { currentDomain } ) => {
+	return (
+		<Modal
+			isOpen={ true }
+			className="domain-picker-modal"
+			overlayClassName="domain-picker-modal-overlay"
+		>
+			<DomainPicker
+				currentDomain={ currentDomain }
+				showDomainConnectButton
+				showDomainCategories
+			></DomainPicker>
+		</Modal>
+	);
+};
+
+export default DomainPickerModal;

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -8,7 +8,6 @@ import Modal from 'react-modal';
  * Internal dependencies
  */
 import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
-import CloseButton from '../close-button';
 
 /**
  * Style dependencies
@@ -37,8 +36,8 @@ const DomainPickerModal: FunctionComponent< DomainPickerProps > = ( {
 				showDomainCategories
 				currentDomain={ currentDomain }
 				onDomainSelect={ onDomainSelect }
+				onClose={ onClose }
 			/>
-			<CloseButton className="domain-picker-modal__close-button" onClick={ onClose } />
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -8,6 +8,7 @@ import Modal from 'react-modal';
  * Internal dependencies
  */
 import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
+import CloseButton from '../close-button';
 
 /**
  * Style dependencies
@@ -20,7 +21,12 @@ interface Props extends DomainPickerProps {
 	onClose?: () => void;
 }
 
-const DomainPickerModal: FunctionComponent< Props > = ( { currentDomain } ) => {
+const DomainPickerModal: FunctionComponent< Props > = ( {
+	currentDomain,
+	onDomainSelect,
+	onDomainConfirm,
+	onClose,
+} ) => {
 	return (
 		<Modal
 			isOpen={ true }
@@ -28,10 +34,13 @@ const DomainPickerModal: FunctionComponent< Props > = ( { currentDomain } ) => {
 			overlayClassName="domain-picker-modal-overlay"
 		>
 			<DomainPicker
-				currentDomain={ currentDomain }
 				showDomainConnectButton
 				showDomainCategories
-			></DomainPicker>
+				currentDomain={ currentDomain }
+				onDomainSelect={ onDomainSelect }
+				onDomainConfirm={ onDomainConfirm }
+			/>
+			<CloseButton className="domain-picker-modal__close-button" onClick={ onClose } />
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -17,14 +17,13 @@ import './style.scss';
 
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
-interface Props extends DomainPickerProps {
-	onClose?: () => void;
-}
+// TODO: Extend modal props?
+// interface Props extends DomainPickerProps {
+// }
 
-const DomainPickerModal: FunctionComponent< Props > = ( {
+const DomainPickerModal: FunctionComponent< DomainPickerProps > = ( {
 	currentDomain,
 	onDomainSelect,
-	onDomainConfirm,
 	onClose,
 } ) => {
 	return (
@@ -38,7 +37,6 @@ const DomainPickerModal: FunctionComponent< Props > = ( {
 				showDomainCategories
 				currentDomain={ currentDomain }
 				onDomainSelect={ onDomainSelect }
-				onDomainConfirm={ onDomainConfirm }
 			/>
 			<CloseButton className="domain-picker-modal__close-button" onClick={ onClose } />
 		</Modal>

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -22,7 +22,12 @@ interface Props extends DomainPickerProps {
 const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, ...props } ) => {
 	if ( ! isOpen ) return null;
 	return (
-		<Modal isOpen className="domain-picker-modal" overlayClassName="domain-picker-modal-overlay">
+		<Modal
+			isOpen
+			className="domain-picker-modal"
+			overlayClassName="domain-picker-modal-overlay"
+			bodyOpenClassName="has-domain-picker-modal"
+		>
 			<DomainPicker showDomainConnectButton showDomainCategories { ...props } />
 		</Modal>
 	);

--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import * as React from 'react';
 import Modal from 'react-modal';
 
 /**
@@ -14,30 +14,10 @@ import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
  */
 import './style.scss';
 
-type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
-
-// TODO: Extend modal props?
-// interface Props extends DomainPickerProps {
-// }
-
-const DomainPickerModal: FunctionComponent< DomainPickerProps > = ( {
-	currentDomain,
-	onDomainSelect,
-	onClose,
-} ) => {
+const DomainPickerModal: React.FunctionComponent< DomainPickerProps > = props => {
 	return (
-		<Modal
-			isOpen={ true }
-			className="domain-picker-modal"
-			overlayClassName="domain-picker-modal-overlay"
-		>
-			<DomainPicker
-				showDomainConnectButton
-				showDomainCategories
-				currentDomain={ currentDomain }
-				onDomainSelect={ onDomainSelect }
-				onClose={ onClose }
-			/>
+		<Modal isOpen className="domain-picker-modal" overlayClassName="domain-picker-modal-overlay">
+			<DomainPicker showDomainConnectButton showDomainCategories { ...props } />
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -49,3 +49,10 @@
 	top: 0;
 	left: 0;
 }
+
+// Hide onboarding block when domain picker modal is open
+body.has-domain-picker-modal {
+	.onboarding-block {
+		display: none;
+	}
+}

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -31,3 +31,10 @@
 		display: none;
 	}
 }
+
+.domain-picker-modal__close-button {
+	// Temporarily place this here so there is a way to close this modal.
+	position: absolute;
+	top: 0;
+	left: 0;
+}

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -43,13 +43,6 @@
 	}
 }
 
-.domain-picker-modal__close-button {
-	// Temporarily place this here so there is a way to close this modal.
-	position: absolute;
-	top: 0;
-	left: 0;
-}
-
 // Hide onboarding block when domain picker modal is open
 body.has-domain-picker-modal {
 	.onboarding-block {

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -1,0 +1,33 @@
+.domain-picker-modal-overlay {
+	// Absolute positioning allows the modal
+	// to reuse the <body> element's scrollbar.
+	position: absolute;
+
+	// This positions the domain picker modal
+	// right below the gutenboarding header,
+	// keeping the header clickable.
+	top: 64px;
+	left: 0;
+
+	// Using min-height lets the overlay cover
+	// the entire viewport ensuring nothing behind
+	// it can be seen.
+	//
+	// When the domain picker's content is taller
+	// than the viewport height, it will expand taller
+	// than the provided min-height, triggering
+	// the appearance of the <body> element's scrollbar.
+	min-height: calc( 100vh - 64px );
+	width: 100%;
+
+	background: var( --studio-white );
+}
+
+.domain-picker-modal {
+
+	// Do not display domain picker footer which contains
+	// the confirm button when showing inside a modal.
+	.domain-picker__panel-row-footer {
+		display: none;
+	}
+}

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -1,3 +1,6 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../mixins.scss';
+
 .domain-picker-modal-overlay {
 	// Absolute positioning allows the modal
 	// to reuse the <body> element's scrollbar.
@@ -24,6 +27,14 @@
 }
 
 .domain-picker-modal {
+
+	.domain-picker__panel-row-main {
+		padding: 64px 88px;
+	}
+
+	.domain-picker__header-title {
+		@include onboarding-heading-text;
+	}
 
 	// Do not display domain picker footer which contains
 	// the confirm button when showing inside a modal.

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -9,7 +9,7 @@
 	// This positions the domain picker modal
 	// right below the gutenboarding header,
 	// keeping the header clickable.
-	top: 64px;
+	top: $gutenboarding-header-height;
 	left: 0;
 
 	// Using min-height lets the overlay cover
@@ -20,7 +20,7 @@
 	// than the viewport height, it will expand taller
 	// than the provided min-height, triggering
 	// the appearance of the <body> element's scrollbar.
-	min-height: calc( 100vh - 64px );
+	min-height: calc( 100vh - $gutenboarding-header-height );
 	width: 100%;
 
 	background: var( --studio-white );
@@ -28,8 +28,25 @@
 
 .domain-picker-modal {
 
+
 	.domain-picker__panel-row-main {
-		padding: 64px 88px;
+
+		// Replace domain picker's padding with onboarding block margins
+		padding: 0;
+
+		// Increase specificity to override margin: 0 from .components-panel__row
+		&.components-panel__row {
+			@include onboarding-block-margin;
+		}
+	}
+
+	.domain-picker__header {
+		@include onboarding-heading-padding;
+		margin-bottom: 27px; // Maintain the same 27px bottom margin as in the original domain picker
+
+		@include break-mobile {
+			margin-bottom: 27px;
+		}
 	}
 
 	.domain-picker__header-title {

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { Button, Popover } from '@wordpress/components';
+import { useI18n } from '@automattic/react-i18n';
+import config from 'config';
+
+// Core package needs to add this to the type definitions.
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import { useViewportMatch } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
+import CloseButton from '../close-button';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+// TODO: Extend popover props?
+interface Props extends DomainPickerProps {
+	onClose?: () => void;
+	onMoreOptions?: () => void;
+}
+
+const DomainPickerPopover: FunctionComponent< Props > = ( {
+	showDomainConnectButton,
+	showDomainCategories,
+	onDomainSelect,
+	onDomainConfirm,
+	onMoreOptions,
+	onClose,
+	currentDomain,
+} ) => {
+	const { __ } = useI18n();
+
+	// Popover expands at medium viewport width
+	const isMobile = useViewportMatch( 'medium', '<' );
+
+	return (
+		<div className="domain-picker-popover">
+			<Popover
+				focusOnMount={ isMobile ? 'container' : 'firstElement' }
+				noArrow
+				onClose={ onClose }
+				onFocusOutside={ onClose }
+				position={ 'bottom center' }
+				expandOnMobile={ true }
+			>
+				<DomainPicker
+					showDomainConnectButton={ showDomainConnectButton }
+					showDomainCategories={ showDomainCategories }
+					currentDomain={ currentDomain }
+					onDomainSelect={ onDomainSelect }
+					onDomainConfirm={ onDomainConfirm }
+				/>
+				{ config.isEnabled( 'gutenboarding/domain-picker-modal' ) && (
+					<Button
+						className="domain-picker-popover__more-button"
+						isTertiary
+						onClick={ onMoreOptions }
+					>
+						{ __( 'More Options' ) }
+					</Button>
+				) }
+				<CloseButton className="domain-picker-popover__close-button" onClick={ onClose } />
+			</Popover>
+		</div>
+	);
+};
+
+export default DomainPickerPopover;

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -24,7 +24,6 @@ import './style.scss';
 
 // TODO: Extend popover props?
 interface Props extends DomainPickerProps {
-	onClose?: () => void;
 	onMoreOptions?: () => void;
 }
 
@@ -32,7 +31,6 @@ const DomainPickerPopover: FunctionComponent< Props > = ( {
 	showDomainConnectButton,
 	showDomainCategories,
 	onDomainSelect,
-	onDomainConfirm,
 	onMoreOptions,
 	onClose,
 	currentDomain,
@@ -57,7 +55,7 @@ const DomainPickerPopover: FunctionComponent< Props > = ( {
 					showDomainCategories={ showDomainCategories }
 					currentDomain={ currentDomain }
 					onDomainSelect={ onDomainSelect }
-					onDomainConfirm={ onDomainConfirm }
+					onClose={ onClose }
 				/>
 				{ config.isEnabled( 'gutenboarding/domain-picker-modal' ) && (
 					<Button

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -44,16 +44,18 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( { onMoreOptions,
 				expandOnMobile={ true }
 			>
 				<DomainPicker { ...props } />
-				{ config.isEnabled( 'gutenboarding/domain-picker-modal' ) && (
-					<Button
-						className="domain-picker-popover__more-button"
-						isTertiary
-						onClick={ onMoreOptions }
-					>
-						{ __( 'More Options' ) }
-					</Button>
-				) }
-				<CloseButton className="domain-picker-popover__close-button" onClick={ onClose } />
+				<div class="domain-picker-popover__addons">
+					{ config.isEnabled( 'gutenboarding/domain-picker-modal' ) && (
+						<Button
+							className="domain-picker-popover__more-button"
+							isTertiary
+							onClick={ onMoreOptions }
+						>
+							{ __( 'More Options' ) }
+						</Button>
+					) }
+					<CloseButton className="domain-picker-popover__close-button" onClick={ onClose } />
+				</div>
 			</Popover>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -44,7 +44,7 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( { onMoreOptions,
 				expandOnMobile={ true }
 			>
 				<DomainPicker { ...props } />
-				<div class="domain-picker-popover__addons">
+				<div className="domain-picker-popover__addons">
 					{ config.isEnabled( 'gutenboarding/domain-picker-modal' ) && (
 						<Button
 							className="domain-picker-popover__more-button"

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -23,15 +23,26 @@ import CloseButton from '../close-button';
 import './style.scss';
 
 interface Props extends DomainPickerProps {
+	isOpen: boolean;
 	onMoreOptions?: () => void;
 }
 
-const DomainPickerPopover: React.FunctionComponent< Props > = ( { onMoreOptions, ...props } ) => {
+const DomainPickerPopover: React.FunctionComponent< Props > = ( {
+	isOpen,
+	onMoreOptions,
+	...props
+} ) => {
 	const { __ } = useI18n();
 	const onClose = props.onClose;
 
 	// Popover expands at medium viewport width
 	const isMobile = useViewportMatch( 'medium', '<' );
+
+	// Don't render popover when isOpen is false.
+	// We need this component to be hot because useViewportMatch
+	// returns false on initial mount before returning true,
+	// causing search input to be automatically focused.
+	if ( ! isOpen ) return null;
 
 	return (
 		<div className="domain-picker-popover">

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import * as React from 'react';
 import { Button, Popover } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 import config from 'config';
@@ -22,20 +22,13 @@ import CloseButton from '../close-button';
  */
 import './style.scss';
 
-// TODO: Extend popover props?
 interface Props extends DomainPickerProps {
 	onMoreOptions?: () => void;
 }
 
-const DomainPickerPopover: FunctionComponent< Props > = ( {
-	showDomainConnectButton,
-	showDomainCategories,
-	onDomainSelect,
-	onMoreOptions,
-	onClose,
-	currentDomain,
-} ) => {
+const DomainPickerPopover: React.FunctionComponent< Props > = ( { onMoreOptions, ...props } ) => {
 	const { __ } = useI18n();
+	const onClose = props.onClose;
 
 	// Popover expands at medium viewport width
 	const isMobile = useViewportMatch( 'medium', '<' );
@@ -50,13 +43,7 @@ const DomainPickerPopover: FunctionComponent< Props > = ( {
 				position={ 'bottom center' }
 				expandOnMobile={ true }
 			>
-				<DomainPicker
-					showDomainConnectButton={ showDomainConnectButton }
-					showDomainCategories={ showDomainCategories }
-					currentDomain={ currentDomain }
-					onDomainSelect={ onDomainSelect }
-					onClose={ onClose }
-				/>
+				<DomainPicker { ...props } />
 				{ config.isEnabled( 'gutenboarding/domain-picker-modal' ) && (
 					<Button
 						className="domain-picker-popover__more-button"

--- a/client/landing/gutenboarding/components/domain-picker-popover/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-popover/style.scss
@@ -1,0 +1,58 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../mixins.scss';
+
+.domain-picker-popover {
+
+	// This prevents popover's position from jumping
+	// caused by the width of the domain picker button changing
+	// when the currently selected domain has changed.
+	@include break-small {
+		position: fixed;
+		left: 72px;
+		top: 54px;
+	}
+
+	.components-popover__content {
+		border: 1px solid var( --studio-gray-5 );
+		box-shadow: 0 4px 10px rgba( 0, 0, 0, 0.12 );
+		border-radius: 4px;
+	}
+
+	// Popover component adds a .is-expanded class under mobile view.
+	.components-popover.is-expanded {
+
+		// Hide popover header which is rendered under mobile view.
+		.components-popover__header {
+			display: none;
+		}
+
+		.components-popover__content {
+			height: 100%;
+		}
+	}
+
+	// Do not display confirm button on header
+	// when domain picker is displayed in a popover.
+	.domain-picker__header {
+		.domain-picker__confirm-button {
+			display: none;
+		}
+	}
+
+	.domain-picker-popover__close-button {
+		position: absolute;
+		top: 36px;
+		right: 36px;
+	}
+
+	.domain-picker-popover__more-button {
+		position: absolute;
+		bottom: 24px;
+		left: 36px;
+
+		&.components-button {
+			@include onboarding-medium-text;
+			color: var( --color-neutral-100 );
+		}
+	}
+}

--- a/client/landing/gutenboarding/components/domain-picker-popover/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-popover/style.scss
@@ -16,6 +16,12 @@
 		border: 1px solid var( --studio-gray-5 );
 		box-shadow: 0 4px 10px rgba( 0, 0, 0, 0.12 );
 		border-radius: 4px;
+
+		// Increase specificity
+		> div.domain-picker-popover__addons {
+			height: 0;
+			overflow: visible;
+		}
 	}
 
 	// Popover component adds a .is-expanded class under mobile view.
@@ -46,9 +52,9 @@
 	}
 
 	.domain-picker-popover__more-button {
-		position: absolute;
-		bottom: 24px;
+		position: relative;
 		left: 36px;
+		top: -60px; // 24px padding - 36px button height 
 
 		&.components-button {
 			@include onboarding-medium-text;

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -20,7 +20,6 @@ import {
 	getPaidDomainSuggestions,
 	getRecommendedDomainSuggestion,
 } from '../../utils/domain-suggestions';
-import CloseButton from '../close-button';
 import { useDomainSuggestions } from '../../hooks/use-domain-suggestions';
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
 
@@ -93,13 +92,6 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 							<div className="domain-picker__header-title">{ __( 'Choose a domain' ) }</div>
 							<p>{ __( 'Free for the first year with any paid plan' ) }</p>
 						</div>
-						<CloseButton
-							onClose={ onClose }
-							// removing from tab flow as discussed in p1586489720342200-slack-gutenboarding
-							// @wordpress/popover finds and focuses on the first found focusable element which will be TextControl
-							// footer-button serve the same purpose and also ESC key in closing the popover
-							tabIndex={ -1 }
-						/>
 					</div>
 					<div className="domain-picker__search">
 						<SearchIcon />

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -43,9 +43,9 @@ export interface Props {
 	onDomainSelect: ( domainSuggestion: DomainSuggestion ) => void;
 
 	/**
-	 * Callback that will be invoked when confirm button is clicked
+	 * Callback that will be invoked when close button is clicked
 	 */
-	onDomainConfirm: ( domainSuggestion: DomainSuggestion ) => void;
+	onClose: () => void;
 
 	/**
 	 * Additional parameters for the domain suggestions query.
@@ -76,7 +76,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	showDomainConnectButton,
 	showDomainCategories,
 	onDomainSelect,
-	onDomainConfirm,
+	onClose,
 	currentDomain,
 } ) => {
 	const { __, i18nLocale } = useI18n();
@@ -100,7 +100,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				className="domain-picker__confirm-button"
 				isPrimary
 				disabled={ ! hasSuggestions }
-				onClick={ onDomainConfirm }
+				onClick={ onClose }
 				{ ...props }
 			>
 				{ __( 'Confirm' ) }

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -31,6 +31,10 @@ import './style.scss';
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 
 export interface Props {
+	showDomainConnectButton?: boolean;
+
+	showDomainCategories?: boolean;
+
 	/**
 	 * Callback that will be invoked when a domain is selected.
 	 *
@@ -39,9 +43,9 @@ export interface Props {
 	onDomainSelect: ( domainSuggestion: DomainSuggestion ) => void;
 
 	/**
-	 * Callback that will be invoked when a close button is clicked
+	 * Callback that will be invoked when confirm button is clicked
 	 */
-	onClose: () => void;
+	onDomainConfirm: ( domainSuggestion: DomainSuggestion ) => void;
 
 	/**
 	 * Additional parameters for the domain suggestions query.
@@ -68,7 +72,13 @@ const SearchIcon = () => (
 	/>
 );
 
-const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, currentDomain } ) => {
+const DomainPicker: FunctionComponent< Props > = ( {
+	showDomainConnectButton,
+	showDomainCategories,
+	onDomainSelect,
+	onDomainConfirm,
+	currentDomain,
+} ) => {
 	const { __, i18nLocale } = useI18n();
 	const label = __( 'Search for a domain' );
 
@@ -82,6 +92,21 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 		PAID_DOMAINS_TO_SHOW
 	);
 	const recommendedSuggestion = getRecommendedDomainSuggestion( paidSuggestions );
+	const hasSuggestions = freeSuggestions?.length || paidSuggestions?.length;
+
+	const ConfirmButton: FunctionComponent< Button.ButtonProps > = ( { ...props } ) => {
+		return (
+			<Button
+				className="domain-picker__confirm-button"
+				isPrimary
+				disabled={ ! hasSuggestions }
+				onClick={ onDomainConfirm }
+				{ ...props }
+			>
+				{ __( 'Confirm' ) }
+			</Button>
+		);
+	};
 
 	return (
 		<Panel className="domain-picker">
@@ -90,8 +115,13 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 					<div className="domain-picker__header">
 						<div className="domain-picker__header-group">
 							<div className="domain-picker__header-title">{ __( 'Choose a domain' ) }</div>
-							<p>{ __( 'Free for the first year with any paid plan' ) }</p>
+							{ showDomainConnectButton ? (
+								<p>TODO: Show domain connect text.</p>
+							) : (
+								<p>{ __( 'Free for the first year with any paid plan or connect a domain.' ) }</p>
+							) }
 						</div>
+						<ConfirmButton />
 					</div>
 					<div className="domain-picker__search">
 						<SearchIcon />
@@ -103,6 +133,7 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 							value={ domainSearch }
 						/>
 					</div>
+					{ showDomainCategories && <div>TODO: Show domain categories.</div> }
 					<div className="domain-picker__suggestion-item-group">
 						{ ! freeSuggestions && <SuggestionItemPlaceholder /> }
 						{ freeSuggestions &&
@@ -135,15 +166,8 @@ const DomainPicker: FunctionComponent< Props > = ( { onDomainSelect, onClose, cu
 				</PanelRow>
 				<PanelRow className="domain-picker__panel-row-footer">
 					<div className="domain-picker__footer">
-						<div className="domain-picker__footer-options"></div>
-						<Button
-							className="domain-picker__footer-button"
-							disabled={ ! freeSuggestions?.length && ! paidSuggestions?.length }
-							isPrimary
-							onClick={ onClose }
-						>
-							{ __( 'Confirm' ) }
-						</Button>
+						<div></div>
+						<ConfirmButton />
 					</div>
 				</PanelRow>
 			</PanelBody>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -166,7 +166,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				</PanelRow>
 				<PanelRow className="domain-picker__panel-row-footer">
 					<div className="domain-picker__footer">
-						<div></div>
 						<ConfirmButton />
 					</div>
 				</PanelRow>

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -93,29 +93,6 @@ $domain-picker__suggestion-item-height: 24px;
 	align-items: center;
 }
 
-.domain-picker__footer-options.components-button {
-	@include onboarding-medium-text;
-	color: var( --color-neutral-100 );
-}
-
-.domain-picker__footer-button.components-button {
-	@include onboarding-medium-text;
-	padding: 0 24px;
-	height: 38px;
-}
-
-.domain-picker__connect-domain {
-	text-align: center;
-	margin-top: 14px;
-	color: var( --color-neutral-40 );
-}
-
-.domain-picker__connect-button {
-	&.components-button.is-link {
-		color: var( --color-neutral-40 );
-	}
-}
-
 .domain-picker__suggestion-item-group {
 	flex-grow: 1;
 }
@@ -211,14 +188,6 @@ $domain-picker__suggestion-item-height: 24px;
 	// be placed on the badge because if the badge falls
 	// on a newline, it will have whitespace on the left.
 	margin-right: 10px;
-}
-
-.domain-picker__has-domain {
-	align-items: center;
-
-	.components-button {
-		color: var( --studio-blue-30 );
-	}
 }
 
 .domain-picker__badge {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -89,8 +89,7 @@ $domain-picker__suggestion-item-height: 24px;
 
 .domain-picker__footer {
 	display: flex;
-	justify-content: space-between;
-	align-items: center;
+	justify-content: flex-end;
 }
 
 .domain-picker__suggestion-item-group {

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -39,6 +39,18 @@
 	line-height: 13px;
 }
 
+@mixin onboarding-block-margin {
+	margin: 0 20px;
+
+	@include break-small {
+		margin: 0 44px;
+	}
+
+	@include break-medium {
+		margin: 0 88px;
+	}
+}
+
 @mixin onboarding-heading-padding {
 	margin: $gutenboarding-heading-padding-mobile;
 

--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -1,15 +1,8 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
+@import '../mixins.scss';
 
 .onboarding-block {
-	margin: 0 20px;
-
-	@include break-small {
-		margin: 0 44px;
-	}
-
-	@include break-medium {
-		margin: 0 88px;
-	}
+	@include onboarding-block-margin;
 }
 
 .gutenboarding-page {
@@ -22,6 +15,7 @@
 		opacity: 0;
 		transform: translateY( 10px );
 	}
+
 	to {
 		opacity: 1;
 		transform: translateY( 0 );

--- a/config/development.json
+++ b/config/development.json
@@ -66,6 +66,7 @@
 		"google-drive": true,
 		"gutenboarding": true,
 		"gutenboarding/style-preview": true,
+		"gutenboarding/domain-picker-modal": true,
 		"help": true,
 		"help/courses": true,
 		"inline-help": true,

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
 		"@types/page": "1.8.0",
 		"@types/qs": "6.9.1",
 		"@types/react": "16.9.23",
+		"@types/react-modal": "3.10.5",
 		"@types/react-redux": "7.1.7",
 		"@types/react-router-dom": "5.1.3",
 		"@types/react-transition-group": "4.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3600,6 +3600,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-modal@3.10.5":
+  version "3.10.5"
+  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.10.5.tgz#5aa40bcb71b59243126069330856eb430ed3adcc"
+  integrity sha512-iLL9afYbcgYlboW2J8mFNKH2tFgErIHR0q+JgHotKrFK99+d97v+V/dxL5LVoxt1OjlnWsuwj8sZuBMVsI1MtQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-redux@7.1.7":
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.7.tgz#12a0c529aba660696947384a059c5c6e08185c7a"


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR introduces **Domain Picker Modal** which is enabled via the `gutenboarding/domain-picker-modal` feature flag.

There are some architectural decisions being made here so feel free to review & discuss them in this PR.

### The component tree looks like this:

```
DomainPickerButton
   |_DomainPickerPopover
     |_DomainPicker
   |_DomainPickerModal
     |_DomainPicker
```

### Here are the list of changes:

* **DomainPickerModal component.**
   This new component uses the `react-modal` component and reuses the `DomainPicker` component. It reuses `<html>` element's scrollbar to scroll down modal's content while keeping the gutenboarding header visible. https://github.com/Automattic/wp-calypso/pull/41212/files#diff-3b763db88828368a2cd772bdcb184e7bR1-R24
* **DomainPickerPopover component.**  
   This is refactored from the existing code in `DomainPickerButton` component.
* **New props showDomainConnectButton & showDomainCategories introduced in DomainPicker component.** 
    The parent component DomainPickerPopover and DomainPickerModal decides what to show and what to hide. https://github.com/Automattic/wp-calypso/pull/41212/files#diff-9fb3f50c91d02f132bfab858e87cb792R74-R93
* **Close Button & More Options Button is now outside of DomainPicker component**
   These 2 buttons are specific to DomainPickerPopover, therefore it make sense that DomainPickerPopover component should play the role of decorating the DomainPicker component with these 2 additional buttons. https://github.com/Automattic/wp-calypso/pull/41212/files#diff-3acfaab9099bccb32e73498b4be055a4R55-R72 This also fixes the accessibility issue with close button needing a `tabIndex={ -1 }` to fix incorrect autofocusing. p1586489720342200-slack-gutenboarding

### Other changes:

* **onClose event removed from CloseButton component**
  onClose is basically the same as onClick. It was removed to prevent typing issues as `onClose` did not accept undefined values. This component is only used by DomainPicker component so far.

## Testing instructions

Note: You need to test this locally. Can't access the modal via the live test page as this is hiding behind a feature flag.

1. Go to `/new` and enter your site name.
2. Click on domain picker button.
3. Domain picker popover should appear.
    - Due to refactoring, please test all functionalities of domain picker inside a popover, it should behave like before.
    - You should now be able to cycle-tab all the form elements in the domain picker popover, including the close button.
4. Click on the **More Options** button
5. Domain picker modal should appear.
    - Domain picker button should disappear.
    - Resize the browser viewport height until a scrollbar appears.
    - Try scrolling the modal content.
6. Try opening the domain picker modal on every other gutenboarding pages.

## Screenshot

![image](https://user-images.githubusercontent.com/1287077/79568731-f803fb80-80e8-11ea-8f9e-cf5f075ad66d.png)

Fixes #41081
