### PR TITLE
Jetpack Cloud: Scanner display threats

### DIFF
--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -15,7 +15,7 @@ import './style.scss';
 export interface Props {
 	children?: ReactNode;
 	className?: string;
-	header: string | {} | React.ReactNodeArray | null;
+	header: string | i18nCalypso.TranslateResult;
 	subheader?: string | ReactNode;
 	highlight?: 'info' | 'success' | 'warning' | 'error';
 	tag?: string;

--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -15,7 +15,7 @@ import './style.scss';
 export interface Props {
 	children?: ReactNode;
 	className?: string;
-	header: string;
+	header: string | {} | React.ReactNodeArray | null;
 	subheader?: string | ReactNode;
 	highlight?: 'info' | 'success' | 'warning' | 'error';
 	tag?: string;

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -133,8 +133,8 @@ const ScanThreats = ( { site, threats }: Props ) => {
 					onCloseDialog={ closeDialog }
 					onConfirmation={ confirmAction }
 					siteName={ site.name }
-					threatTitle={ selectedThreat.title }
-					threatDescription={ selectedThreat.details }
+					threatTitle={ selectedThreat.signature }
+					threatDescription={ selectedThreat.description }
 					action={ actionToPerform }
 				/>
 			) }

--- a/client/landing/jetpack-cloud/components/threat-description/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-description/index.tsx
@@ -35,14 +35,16 @@ class ThreatDescription extends React.PureComponent< Props > {
 					<strong>{ translate( 'What was the problem?' ) }</strong>
 				</p>
 				{ this.renderTextOrNode( problem ) }
-				<p className="threat-description__section-title">
-					<strong>
-						{ ! isThreatFixedOrIgnored
-							? translate( 'How we will fix it?' )
-							: translate( 'How did Jetpack fix it?' ) }
-					</strong>
-				</p>
-				{ this.renderTextOrNode( fix ) }
+				{ fix && (
+					<p className="threat-description__section-title">
+						<strong>
+							{ ! isThreatFixedOrIgnored
+								? translate( 'How we will fix it?' )
+								: translate( 'How did Jetpack fix it?' ) }
+						</strong>
+					</p>
+				) }
+				{ fix && this.renderTextOrNode( fix ) }
 				<p className="threat-description__section-title">
 					<strong>{ translate( 'The technical details' ) }</strong>
 				</p>

--- a/client/landing/jetpack-cloud/components/threat-description/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-description/index.tsx
@@ -5,6 +5,12 @@ import React, { ReactNode } from 'react';
 import { translate } from 'i18n-calypso';
 
 /**
+ * Internal dependencies
+ */
+import MarkedLines from 'components/marked-lines';
+import DiffViewer from 'components/diff-viewer';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -12,9 +18,13 @@ import './style.scss';
 export interface Props {
 	children?: ReactNode;
 	action?: 'ignored' | 'fixed';
+	name: string;
 	details: string | ReactNode;
 	fix: string | ReactNode;
 	problem: string | ReactNode;
+	context?: object;
+	diff?: string;
+	filename?: string;
 }
 
 class ThreatDescription extends React.PureComponent< Props > {
@@ -25,8 +35,31 @@ class ThreatDescription extends React.PureComponent< Props > {
 		return content;
 	}
 
+	renderFilename(): ReactNode | null {
+		const { filename, name } = this.props;
+		if ( ! filename ) {
+			return null;
+		}
+
+		return (
+			<>
+				<p className="threat-description__section-text">
+					{ translate( 'Threat {{threatSignature/}} found in file:', {
+						comment: 'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
+						components: {
+							threatSignature: (
+								<code className="threat-description__alert-signature">{ name }</code>
+							),
+						},
+					} ) }
+				</p>
+				<pre className="threat-description__alert-filename">{ filename }</pre>
+			</>
+		);
+	}
+
 	render() {
-		const { children, action, details, problem, fix } = this.props;
+		const { children, action, details, problem, fix, diff, context } = this.props;
 		const isThreatFixedOrIgnored = !! action;
 
 		return (
@@ -49,6 +82,9 @@ class ThreatDescription extends React.PureComponent< Props > {
 					<strong>{ translate( 'The technical details' ) }</strong>
 				</p>
 				{ this.renderTextOrNode( details ) }
+				{ this.renderFilename() }
+				{ context && <MarkedLines context={ context } /> }
+				{ diff && <DiffViewer diff={ diff } /> }
 				{ children }
 			</div>
 		);

--- a/client/landing/jetpack-cloud/components/threat-description/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-description/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { ReactNode } from 'react';
-import { translate } from 'i18n-calypso';
+import { translate, TranslateResult } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,7 +18,6 @@ import './style.scss';
 export interface Props {
 	children?: ReactNode;
 	action?: 'ignored' | 'fixed';
-	name: string;
 	details: string | ReactNode;
 	fix: string | ReactNode;
 	problem: string | ReactNode;
@@ -28,15 +27,12 @@ export interface Props {
 }
 
 class ThreatDescription extends React.PureComponent< Props > {
-	renderTextOrNode( content: string | ReactNode ) {
-		if ( typeof content === 'string' ) {
-			return <p className="threat-description__section-text">{ content }</p>;
-		}
-		return content;
+	renderTextOrNode( content: string | TranslateResult | ReactNode ) {
+		return <p className="threat-description__section-text">{ content }</p>;
 	}
 
 	renderFilename(): ReactNode | null {
-		const { filename, name } = this.props;
+		const { filename } = this.props;
 		if ( ! filename ) {
 			return null;
 		}
@@ -44,13 +40,8 @@ class ThreatDescription extends React.PureComponent< Props > {
 		return (
 			<>
 				<p className="threat-description__section-text">
-					{ translate( 'Threat {{threatSignature/}} found in file:', {
+					{ translate( 'Threat found in file:', {
 						comment: 'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
-						components: {
-							threatSignature: (
-								<code className="threat-description__alert-signature">{ name }</code>
-							),
-						},
 					} ) }
 				</p>
 				<pre className="threat-description__alert-filename">{ filename }</pre>
@@ -59,7 +50,7 @@ class ThreatDescription extends React.PureComponent< Props > {
 	}
 
 	render() {
-		const { children, action, details, problem, fix, diff, context } = this.props;
+		const { children, action, details, problem, fix, diff, context, filename } = this.props;
 		const isThreatFixedOrIgnored = !! action;
 
 		return (
@@ -78,9 +69,11 @@ class ThreatDescription extends React.PureComponent< Props > {
 					</p>
 				) }
 				{ fix && this.renderTextOrNode( fix ) }
-				<p className="threat-description__section-title">
-					<strong>{ translate( 'The technical details' ) }</strong>
-				</p>
+				{ ( details || filename || context || diff ) && (
+					<p className="threat-description__section-title">
+						<strong>{ translate( 'The technical details' ) }</strong>
+					</p>
+				) }
 				{ this.renderTextOrNode( details ) }
 				{ this.renderFilename() }
 				{ context && <MarkedLines context={ context } /> }

--- a/client/landing/jetpack-cloud/components/threat-description/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-description/style.scss
@@ -1,5 +1,8 @@
 .scan-history-item .threat-description,
 .threat-item .threat-description {
+	overflow: auto;
+	flex: 1;
+
 	&__section-title {
 		margin-bottom: 20px;
 	}

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -50,7 +50,7 @@ class ThreatItem extends Component< Props > {
 		);
 	}
 
-	getDetailType( threat: object ) {
+	getDetailType( threat: Threat ) {
 		if ( threat.hasOwnProperty( 'diff' ) ) {
 			return 'core';
 		}
@@ -61,7 +61,8 @@ class ThreatItem extends Component< Props > {
 
 		if ( threat.hasOwnProperty( 'extension' ) ) {
 			// 'plugin' or 'theme'
-			return threat.extension.type;
+			const { extension = { type: 'unknown' } } = threat;
+			return extension;
 		}
 
 		if ( threat.hasOwnProperty( 'rows' ) ) {
@@ -75,7 +76,7 @@ class ThreatItem extends Component< Props > {
 		return 'none';
 	}
 
-	getSubtitle( threat ) {
+	getSubtitle( threat: Threat ) {
 		switch ( this.getDetailType( threat ) ) {
 			case 'core':
 				return translate( 'Vulnerability found in WordPress' );
@@ -102,25 +103,25 @@ class ThreatItem extends Component< Props > {
 		}
 	}
 
-	getTitle( threat: object ) {
+	getTitle( threat: Threat ): string | {} | React.ReactNodeArray | null {
 		// This should be temprary since this data should be coming from the api
 		// and not something that we should change to accompadate the results.
-		const { filename, extension } = threat;
+		const { filename, extension = { slug: 'unknown', version: 'n/a' } } = threat;
 
-		const basename = s => s.replace( /.*\//, '' );
+		const basename = filename ? filename.replace( /.*\//, '' ) : '';
 
 		switch ( this.getDetailType( threat ) ) {
 			case 'core':
 				return translate( 'Infected core file: {{filename/}} ', {
 					components: {
-						filename: <code className="threat-item__alert-filename">{ basename( filename ) }</code>,
+						filename: <code className="threat-item__alert-filename">{ basename }</code>,
 					},
 				} );
 
 			case 'file':
 				return translate( 'The file {{filename/}} contains a malicious code pattern.', {
 					components: {
-						filename: <code className="threat-item__alert-filename">{ basename( filename ) }</code>,
+						filename: <code className="threat-item__alert-filename">{ basename }</code>,
 					},
 				} );
 
@@ -141,6 +142,9 @@ class ThreatItem extends Component< Props > {
 				} );
 
 			case 'database':
+				if ( ! threat.rows ) {
+					return null;
+				}
 				return translate( 'Database %(threatCount)d threat', 'Database %(threatCount)d threats', {
 					count: Object.keys( threat.rows ).length,
 					args: {
@@ -154,14 +158,14 @@ class ThreatItem extends Component< Props > {
 		}
 	}
 
-	getThreatFix( threat ) {
+	getThreatFix( threat: Threat ): JSX.Element {
 		switch ( this.getDetailType( threat ) ) {
 			case 'database':
 				return <>TODO:FIX THIS CASE></>;
 			default:
 				return (
 					<>
-						<p className="threat-description__section-text">{ threat.description }</p>
+						<p className="threat-item__section-text">{ threat.description }</p>
 						{ threat.filename ? (
 							<>
 								<p>
@@ -170,17 +174,15 @@ class ThreatItem extends Component< Props > {
 											'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
 										components: {
 											threatSignature: (
-												<span className="threat-description__alert-signature">
-													{ threat.signature }
-												</span>
+												<span className="threat-item__alert-signature">{ threat.signature }</span>
 											),
 										},
 									} ) }
 								</p>
-								<pre className="threat-description__alert-filename">{ threat.filename }</pre>
+								<pre className="threat-item__alert-filename">{ threat.filename }</pre>
 							</>
 						) : (
-							<p className="threat-description__section-text">{ threat.signature }</p>
+							<p className="threat-item__section-text">{ threat.signature }</p>
 						) }
 						{ threat.context && <MarkedLines context={ threat.context } /> }
 						{ threat.diff && <DiffViewer diff={ threat.diff } /> }

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -12,6 +12,8 @@ import { Button } from '@automattic/components';
 import LogItem from '../log-item';
 import ThreatDescription from '../threat-description';
 import { Threat } from 'landing/jetpack-cloud/components/threat-item/types';
+import MarkedLines from 'components/marked-lines';
+import DiffViewer from 'components/diff-viewer';
 
 /**
  * Style dependencies
@@ -48,15 +50,155 @@ class ThreatItem extends Component< Props > {
 		);
 	}
 
+	getDetailType( threat: object ) {
+		if ( threat.hasOwnProperty( 'diff' ) ) {
+			return 'core';
+		}
+
+		if ( threat.hasOwnProperty( 'context' ) ) {
+			return 'file';
+		}
+
+		if ( threat.hasOwnProperty( 'extension' ) ) {
+			// 'plugin' or 'theme'
+			return threat.extension.type;
+		}
+
+		if ( threat.hasOwnProperty( 'rows' ) ) {
+			return 'database';
+		}
+
+		if ( 'Suspicious.Links' === threat.signature ) {
+			return 'database';
+		}
+
+		return 'none';
+	}
+
+	getSubtitle( threat ) {
+		switch ( this.getDetailType( threat ) ) {
+			case 'core':
+				return translate( 'Vulnerability found in WordPress' );
+
+			case 'file':
+				return translate( 'Threat found ({{signature/}})', {
+					components: {
+						signature: <span className="threat-item__alert-signature">{ threat.signature }</span>,
+					},
+				} );
+
+			case 'plugin':
+				return translate( 'Vulnerability found in plugin' );
+
+			case 'theme':
+				return translate( 'Vulnerability found in theme' );
+
+			case 'database':
+				return null;
+
+			case 'none':
+			default:
+				return translate( 'Miscellaneous vulnerability' );
+		}
+	}
+
+	getTitle( threat: object ) {
+		// This should be temprary since this data should be coming from the api
+		// and not something that we should change to accompadate the results.
+		const { filename, extension } = threat;
+
+		const basename = s => s.replace( /.*\//, '' );
+
+		switch ( this.getDetailType( threat ) ) {
+			case 'core':
+				return translate( 'Infected core file: {{filename/}} ', {
+					components: {
+						filename: <code className="threat-item__alert-filename">{ basename( filename ) }</code>,
+					},
+				} );
+
+			case 'file':
+				return translate( 'The file {{filename/}} contains a malicious code pattern.', {
+					components: {
+						filename: <code className="threat-item__alert-filename">{ basename( filename ) }</code>,
+					},
+				} );
+
+			case 'plugin':
+				return translate( 'Vulnerable Plugin: {{pluginSlug/}} (version {{version/}})', {
+					components: {
+						pluginSlug: <span className="threat-item__alert-slug">{ extension.slug }</span>,
+						version: <span className="threat-item__alert-version">{ extension.version }</span>,
+					},
+				} );
+
+			case 'theme':
+				return translate( 'Vulnerable Theme {{themeSlug/}} (version {{version/}})', {
+					components: {
+						themeSlug: <span className="threat-item__alert-slug">{ extension.slug }</span>,
+						version: <span className="threat-item__alert-version">{ extension.version }</span>,
+					},
+				} );
+
+			case 'database':
+				return translate( 'Database %(threatCount)d threat', 'Database %(threatCount)d threats', {
+					count: Object.keys( threat.rows ).length,
+					args: {
+						threatCount: Object.keys( threat.rows ).length,
+					},
+				} );
+
+			case 'none':
+			default:
+				return translate( 'Threat found' );
+		}
+	}
+
+	getThreatFix( threat ) {
+		switch ( this.getDetailType( threat ) ) {
+			case 'database':
+				return <>TODO:FIX THIS CASE></>;
+			default:
+				return (
+					<>
+						<p className="threat-description__section-text">{ threat.description }</p>
+						{ threat.filename ? (
+							<>
+								<p>
+									{ translate( 'Threat {{threatSignature/}} found in file:', {
+										comment:
+											'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
+										components: {
+											threatSignature: (
+												<span className="threat-description__alert-signature">
+													{ threat.signature }
+												</span>
+											),
+										},
+									} ) }
+								</p>
+								<pre className="threat-description__alert-filename">{ threat.filename }</pre>
+							</>
+						) : (
+							<p className="threat-description__section-text">{ threat.signature }</p>
+						) }
+						{ threat.context && <MarkedLines context={ threat.context } /> }
+						{ threat.diff && <DiffViewer diff={ threat.diff } /> }
+					</>
+				);
+		}
+	}
+
 	render() {
 		const { threat, onIgnoreThreat, isFixing } = this.props;
-		const fixThreatCTA = this.renderFixThreatButton( 'is-summary' );
+
+		const fixThreatCTA = threat.fixable ? this.renderFixThreatButton( 'is-summary' ) : null;
 
 		return (
 			<LogItem
 				className="threat-item"
-				header={ threat.title }
-				subheader={ threat.description.title }
+				header={ this.getTitle( threat ) }
+				subheader={ this.getSubtitle( threat ) }
 				summary={ fixThreatCTA }
 				expandedSummary={ fixThreatCTA }
 				key={ threat.id }
@@ -64,13 +206,13 @@ class ThreatItem extends Component< Props > {
 			>
 				<ThreatDescription
 					action={ threat.action }
-					details={ threat.description.details }
-					fix={ threat.description.fix }
-					problem={ threat.description.problem }
+					details={ this.getThreatFix( threat ) }
+					fix={ null }
+					problem={ threat.description }
 				/>
 
 				<div className="threat-item__buttons">
-					{ this.renderFixThreatButton( 'is-details' ) }
+					{ threat.fixable && this.renderFixThreatButton( 'is-details' ) }
 					<Button
 						compact
 						className="threat-item__ignore-button"

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -76,7 +76,7 @@ class ThreatItem extends Component< Props > {
 		}
 	}
 
-	getTitle( threat: Threat ): string | {} | React.ReactNodeArray {
+	getTitle( threat: Threat ): i18nCalypso.TranslateResult {
 		// This should be temprary since this data should be coming from the api
 		// and not something that we should change to accompadate the results.
 		const { filename, extension = { slug: 'unknown', version: 'n/a' } } = threat;
@@ -131,10 +131,31 @@ class ThreatItem extends Component< Props > {
 		}
 	}
 
-	getThreatFix( threat: Threat ): string {
-		switch ( getThreatType( threat ) ) {
+	getThreatFix(): null | i18nCalypso.TranslateResult {
+		const { threat } = this.props;
+		if ( ! threat.fixable ) {
+			return translate(
+				'Jetpack Scan cannot automatically fix this threat. Please {{link}}contact us{{/link}} for help.',
+				{
+					components: {
+						link: <a href="https://jetpack.com/contact-support/" />,
+					},
+				}
+			);
+		}
+		switch ( threat.fixable.fixer ) {
+			case 'replace':
+				return translate( 'Jetpack Scan will replace the affected file or directory.' );
+			case 'delete':
+				return translate( 'Jetpack Scan will delete the affected file or directory.' );
+			case 'update':
+				return translate( 'Jetpack Scan can update to a newer version (%(version)s).', {
+					args: {
+						version: threat.fixable.target || 'unknown',
+					},
+				} );
 			default:
-				return 'TODO:FIX THIS CASE';
+				return translate( 'Jetpack Scan will resolve the threat.' );
 		}
 	}
 
@@ -154,11 +175,12 @@ class ThreatItem extends Component< Props > {
 				highlight="error"
 			>
 				<ThreatDescription
-					name={ threat.signature }
 					action={ threat.action }
-					details={ this.getThreatFix( threat ) }
-					fix={ null }
+					details={ null }
+					fix={ this.getThreatFix() }
 					problem={ threat.description }
+					context={ threat.context }
+					diff={ threat.diff }
 					filename={ threat.filename }
 				/>
 

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -14,7 +14,7 @@
 	}
 
 	&__buttons {
-		display: flex;
+
 		justify-content: space-evenly;
 
 		@include breakpoint( '>800px' ) {
@@ -53,6 +53,10 @@
 
 	.foldable-card__header {
 		border-bottom: 1px solid var( --studio-gray-5 );
+	}
+
+	&.foldable-card.is-expanded .foldable-card__content {
+		display:flex;
 	}
 }
 

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -20,6 +20,7 @@
 		@include breakpoint( '>800px' ) {
 			justify-content: flex-end;
 			padding-right: 48px;
+			padding-left: 20px;
 		}
 	}
 

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -16,11 +16,13 @@
 	&__buttons {
 
 		justify-content: space-evenly;
+		order: -1;
+		padding: 20px 0;
 
 		@include breakpoint( '>800px' ) {
 			justify-content: flex-end;
-			padding-right: 48px;
-			padding-left: 20px;
+			padding: 0 48px 0 20px;
+			order: initial;
 		}
 	}
 
@@ -57,7 +59,12 @@
 	}
 
 	&.foldable-card.is-expanded .foldable-card__content {
-		display:flex;
+		display: flex;
+		flex-direction: column;
+
+		@include breakpoint( '>800px' ) {
+			flex-direction: row;
+		}
 	}
 }
 

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -14,13 +14,13 @@
 	}
 
 	&__buttons {
-
+		display: flex;
 		justify-content: space-evenly;
 		order: -1;
 		padding: 20px 0;
 
 		@include breakpoint( '>800px' ) {
-			justify-content: flex-end;
+			display: block;
 			padding: 0 48px 0 20px;
 			order: initial;
 		}

--- a/client/landing/jetpack-cloud/components/threat-item/threat.ts
+++ b/client/landing/jetpack-cloud/components/threat-item/threat.ts
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import { Threat, ThreatType } from './types';
+
+export function getThreatType( threat: Threat ): ThreatType {
+	if ( threat.hasOwnProperty( 'diff' ) ) {
+		return 'core';
+	}
+
+	if ( threat.hasOwnProperty( 'context' ) ) {
+		return 'file';
+	}
+
+	if ( threat.hasOwnProperty( 'extension' ) ) {
+		// 'plugin' or 'theme'
+		const { extension = { type: 'unknown' } } = threat;
+		return extension.type;
+	}
+
+	if ( threat.hasOwnProperty( 'rows' ) ) {
+		return 'database';
+	}
+
+	if ( 'Suspicious.Links' === threat.signature ) {
+		return 'database';
+	}
+
+	return 'none';
+}

--- a/client/landing/jetpack-cloud/components/threat-item/types.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/types.tsx
@@ -13,6 +13,7 @@ export type ThreatFixType = 'replace' | 'delete' | 'update' | string;
 export type ThreatFix = {
 	fixer: ThreatFixType;
 	file?: string;
+	target?: string;
 };
 
 export type Threat = {

--- a/client/landing/jetpack-cloud/components/threat-item/types.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/types.tsx
@@ -8,6 +8,13 @@ export type Extension = {
 
 export type ThreatType = 'core' | 'file' | 'plugin' | 'theme' | 'database' | 'none' | string;
 
+export type ThreatFixType = 'replace' | 'delete' | 'update' | string;
+
+export type ThreatFix = {
+	fixer: ThreatFixType;
+	file?: string;
+};
+
 export type Threat = {
 	id: number;
 	signature: string;
@@ -15,7 +22,7 @@ export type Threat = {
 	action?: 'fixed' | 'ignored';
 	detectionDate: string;
 	actionDate: string;
-	fixable?: boolean;
+	fixable: false | ThreatFix;
 	filename?: string;
 	extension?: Extension;
 	rows?: number;

--- a/client/landing/jetpack-cloud/components/threat-item/types.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/types.tsx
@@ -1,21 +1,22 @@
-/**
- * External dependencies
- */
-import { ReactNode } from 'react';
-
 export type ThreatAction = 'fix' | 'ignore';
+
+export type Extension = {
+	slug: string;
+	version: string;
+	type: 'plugin' | 'theme';
+};
 
 export type Threat = {
 	id: number;
-	title: string;
-	details: string;
-	action: null | 'fixed' | 'ignored';
+	signature: string;
+	description: string;
+	action?: 'fixed' | 'ignored';
 	detectionDate: string;
 	actionDate: string;
-	description: {
-		title: string;
-		problem: string | ReactNode;
-		fix: string | ReactNode;
-		details: string | ReactNode;
-	};
+	fixable?: boolean;
+	filename?: string;
+	extension?: Extension;
+	rows?: number;
+	diff?: string;
+	context?: object;
 };

--- a/client/landing/jetpack-cloud/components/threat-item/types.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/types.tsx
@@ -6,6 +6,8 @@ export type Extension = {
 	type: 'plugin' | 'theme';
 };
 
+export type ThreatType = 'core' | 'file' | 'plugin' | 'theme' | 'database' | 'none' | string;
+
 export type Threat = {
 	id: number;
 	signature: string;

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -67,11 +67,6 @@ class ScanPage extends Component {
 		);
 	}
 
-	renderThreats() {
-		const { threats, site } = this.props;
-		return <ScanThreats className="scan__threats" threats={ threats } site={ site } />;
-	}
-
 	renderScanError() {
 		const { siteSlug } = this.props;
 
@@ -100,6 +95,7 @@ class ScanPage extends Component {
 	}
 
 	renderScanState() {
+		const { site } = this.props;
 		if ( ! this.props.scanState ) {
 			return <div className="scan__is-loading" />;
 		}
@@ -115,7 +111,7 @@ class ScanPage extends Component {
 
 		const threats = this.props.scanState.threats;
 		if ( threats && threats.length ) {
-			return this.renderThreats();
+			return <ScanThreats className="scan__threats" threats={ threats } site={ site } />;
 		}
 
 		return this.renderScanOkay();

--- a/client/landing/jetpack-cloud/sections/scan/main.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.jsx
@@ -95,21 +95,21 @@ class ScanPage extends Component {
 	}
 
 	renderScanState() {
-		const { site } = this.props;
-		if ( ! this.props.scanState ) {
+		const { site, scanState } = this.props;
+		if ( ! scanState ) {
 			return <div className="scan__is-loading" />;
 		}
 
-		const status = this.props.scanState.status;
+		const status = scanState.state;
 		if ( status === 'scanning' ) {
 			return this.renderScanning();
 		}
 
-		if ( status !== 'done' ) {
+		if ( status !== 'done' && status !== 'idle' ) {
 			return this.renderScanError();
 		}
 
-		const threats = this.props.scanState.threats;
+		const threats = scanState.threats;
 		if ( threats && threats.length ) {
 			return <ScanThreats className="scan__threats" threats={ threats } site={ site } />;
 		}
@@ -143,42 +143,6 @@ export default connect( state => {
 	const site = getSelectedSite( state );
 	const siteSlug = getSelectedSiteSlug( state );
 	const scanState = getSiteScanState( state, site.ID );
-
-	// TODO: Get threats from actual API.
-	const threats = [
-		{
-			id: 1,
-			title: 'Infected core file: index.php',
-			action: null,
-			detectionDate: '23 September, 2019',
-			actionDate: null,
-			description: {
-				title: 'Unexpected string was found in: /htdocs/wp-admin/index.php',
-				problem:
-					'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
-				fix:
-					'To fix this threat, Jetpack will be deleting the file, since it’s not a part of the original WordPress.',
-				details: 'This threat was found in the file: /htdocs/index.php',
-			},
-		},
-		{
-			id: 2,
-			title: 'Infected Plugin: Contact Form 7',
-			action: null,
-			detectionDate: '17 September, 2019',
-			actionDate: null,
-			description: {
-				title:
-					'Unexpected file baaaaaad--file.php contains malicious code and is not part of the Plugin',
-				problem:
-					'Jetpack has detected code that is often used in web-based "shell" programs. If you believe the file(s) have been infected they need to be cleaned.',
-				fix:
-					'To fix this threat, Jetpack will be deleting the file, since it’s not a part of the original WordPress.',
-				details: 'This threat was found in the file: /htdocs/sx--a4bp.php',
-			},
-		},
-	];
-
 	const lastScanTimestamp = Date.now() - 5700000; // 1h 35m.
 	const nextScanTimestamp = Date.now() + 5700000;
 
@@ -188,6 +152,5 @@ export default connect( state => {
 		scanState,
 		lastScanTimestamp,
 		nextScanTimestamp,
-		threats,
 	};
 } )( withLocalizedMoment( ScanPage ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to render the treats as best as it can. 
We should move most of the treats details to the api vs figuring here. 
I reused quite a bit of code from treats-alert.jsx component to figure out nicer nameing etc. 

After:
<img width="1061" alt="Screen Shot 2020-04-17 at 12 04 37 PM" src="https://user-images.githubusercontent.com/115071/79558205-1693d380-80a4-11ea-9646-b52a211fc1c3.png">

Bonus part here is that treat ignoring works as expected 🥳 for the treat that I ignored. 

#### Testing instructions
* On a site that has treats visit 
http://jetpack.cloud.localhost:3000/scan/{example.com}

Notice the sections renders real threats. 
