### PR TITLE
WP for Teams: redirect to homepage after invite

### DIFF
--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -59,11 +59,7 @@ export function acceptInvite( context, next ) {
 				const siteId = acceptedInvite.site.ID;
 				const isWPForTeamsSite = isSiteWPForTeams( context.store.getState(), siteId );
 
-				let redirect = getRedirectAfterAccept( acceptedInvite );
-
-				if ( isWPForTeamsSite ) {
-					redirect = `https://${ acceptedInvite.site.domain }`;
-				}
+				const redirect = getRedirectAfterAccept( acceptedInvite, isWPForTeamsSite );
 
 				debug( 'Accepted invite and redirecting to:  ' + redirect );
 				page( redirect );

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -55,10 +55,7 @@ export function acceptInvite( context, next ) {
 				debug( 'Accepted invite for VIP sites' );
 				window.location.href = getRedirectAfterAccept( acceptedInvite );
 			} else {
-				const redirect = getRedirectAfterAccept(
-					acceptedInvite,
-					get( acceptedInvite, 'site.is_wpforteams_site', false )
-				);
+				const redirect = getRedirectAfterAccept( acceptedInvite );
 
 				debug( 'Accepted invite and redirecting to:  ' + redirect );
 				page( redirect );

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -57,7 +57,7 @@ export function acceptInvite( context, next ) {
 			} else {
 				const redirect = getRedirectAfterAccept(
 					acceptedInvite,
-					acceptedInvite.site.is_wpforteams_site
+					get( acceptedInvite, 'site.is_wpforteams_site', false )
 				);
 
 				debug( 'Accepted invite and redirecting to:  ' + redirect );

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -18,6 +18,7 @@ import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import { acceptInvite as acceptInviteAction } from 'lib/invites/actions';
 import _user from 'lib/user';
 import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
+import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 /**
  * Module variables
@@ -55,7 +56,15 @@ export function acceptInvite( context, next ) {
 				debug( 'Accepted invite for VIP sites' );
 				window.location.href = getRedirectAfterAccept( acceptedInvite );
 			} else {
-				const redirect = getRedirectAfterAccept( acceptedInvite );
+				const siteId = acceptedInvite.site.ID;
+				const isWPForTeamsSite = isSiteWPForTeams( context.store.getState(), siteId );
+
+				let redirect = getRedirectAfterAccept( acceptedInvite );
+
+				if ( isWPForTeamsSite ) {
+					redirect = `https://${ acceptedInvite.site.domain }`;
+				}
+
 				debug( 'Accepted invite and redirecting to:  ' + redirect );
 				page( redirect );
 			}

--- a/client/my-sites/invites/controller.js
+++ b/client/my-sites/invites/controller.js
@@ -18,7 +18,6 @@ import { getRedirectAfterAccept } from 'my-sites/invites/utils';
 import { acceptInvite as acceptInviteAction } from 'lib/invites/actions';
 import _user from 'lib/user';
 import { getLocaleFromPath, removeLocaleFromPath } from 'lib/i18n-utils';
-import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 /**
  * Module variables
@@ -56,10 +55,10 @@ export function acceptInvite( context, next ) {
 				debug( 'Accepted invite for VIP sites' );
 				window.location.href = getRedirectAfterAccept( acceptedInvite );
 			} else {
-				const siteId = acceptedInvite.site.ID;
-				const isWPForTeamsSite = isSiteWPForTeams( context.store.getState(), siteId );
-
-				const redirect = getRedirectAfterAccept( acceptedInvite, isWPForTeamsSite );
+				const redirect = getRedirectAfterAccept(
+					acceptedInvite,
+					acceptedInvite.site.is_wpforteams_site
+				);
 
 				debug( 'Accepted invite and redirecting to:  ' + redirect );
 				page( redirect );

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -8,6 +8,7 @@ import Debug from 'debug';
 import classNames from 'classnames';
 import page from 'page';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -130,8 +131,8 @@ class InviteAccept extends React.Component {
 		debug( 'Rendering invite' );
 
 		const props = {
-			redirectTo: getRedirectAfterAccept( invite, invite.site.is_wpforteams_site ),
-			invite: invite,
+			invite,
+			redirectTo: getRedirectAfterAccept( invite, get( invite, 'site.is_wpforteams_site', false ) ),
 			decline: this.decline,
 			signInLink: this.signInLink(),
 			forceMatchingEmail: this.isMatchEmailError(),

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -132,14 +132,8 @@ class InviteAccept extends React.Component {
 		}
 		debug( 'Rendering invite' );
 
-		let redirectTo = getRedirectAfterAccept( invite );
-
-		if ( isWPForTeamsSite ) {
-			redirectTo = `https://${ invite.site.domain }`;
-		}
-
 		const props = {
-			redirectTo,
+			redirectTo: getRedirectAfterAccept( invite, isWPForTeamsSite ),
 			invite: invite,
 			decline: this.decline,
 			signInLink: this.signInLink(),

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -26,8 +26,6 @@ import NoticeAction from 'components/notice/notice-action';
 import userUtils from 'lib/user/utils';
 import LocaleSuggestions from 'components/locale-suggestions';
 import { getCurrentUser } from 'state/current-user/selectors';
-import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
-import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 
 /**
  * Style dependencies
@@ -48,7 +46,7 @@ class InviteAccept extends React.Component {
 	state = {
 		invite: false,
 		error: false,
-		matchEmailError: false
+		matchEmailError: false,
 	};
 
 	UNSAFE_componentWillMount() {
@@ -72,7 +70,7 @@ class InviteAccept extends React.Component {
 			// add subscription-related keys to the invite
 			Object.assign( invite, {
 				activationKey: this.props.activationKey,
-				authKey: this.props.authKey
+				authKey: this.props.authKey,
 			} );
 		}
 		this.setState( { invite, error } );
@@ -93,7 +91,7 @@ class InviteAccept extends React.Component {
 
 	decline = () => {
 		this.props.infoNotice( this.props.translate( 'You declined to join.' ), {
-			displayOnNextPage: true
+			displayOnNextPage: true,
 		} );
 		page( '/' );
 	};
@@ -124,7 +122,6 @@ class InviteAccept extends React.Component {
 
 	renderForm = () => {
 		const { invite } = this.state;
-		const { isWPForTeamsSite } = this.props;
 
 		if ( ! invite ) {
 			debug( 'Not rendering form - Invite not set' );
@@ -133,11 +130,11 @@ class InviteAccept extends React.Component {
 		debug( 'Rendering invite' );
 
 		const props = {
-			redirectTo: getRedirectAfterAccept( invite, isWPForTeamsSite ),
+			redirectTo: getRedirectAfterAccept( invite, invite.site.is_wpforteams_site ),
 			invite: invite,
 			decline: this.decline,
 			signInLink: this.signInLink(),
-			forceMatchingEmail: this.isMatchEmailError()
+			forceMatchingEmail: this.isMatchEmailError(),
 		};
 
 		return this.props.user ? (
@@ -153,12 +150,12 @@ class InviteAccept extends React.Component {
 
 		const props = {
 			title: this.props.translate( 'Oops, that invite is not valid', {
-				context: 'Title that is display to users when attempting to accept an invalid invite.'
+				context: 'Title that is display to users when attempting to accept an invalid invite.',
 			} ),
 			line: this.props.translate( "We weren't able to verify that invitation.", {
-				context: 'Message that is displayed to users when an invitation is invalid.'
+				context: 'Message that is displayed to users when an invitation is invalid.',
 			} ),
-			illustration: whoopsImage
+			illustration: whoopsImage,
 		};
 
 		if ( error.error && error.message ) {
@@ -171,19 +168,19 @@ class InviteAccept extends React.Component {
 							'Would you like to accept the invite with a different account?'
 						),
 						action: this.props.translate( 'Switch Accounts' ),
-						actionURL: login( { redirectTo: window.location.href } )
+						actionURL: login( { redirectTo: window.location.href } ),
 					} );
 					break;
 				case 'unauthorized_created_by_self':
 					Object.assign( props, {
 						line: error.message, // "You can not use an invitation that you have created for someone else."
 						action: this.props.translate( 'Switch Accounts' ),
-						actionURL: login( { redirectTo: window.location.href } )
+						actionURL: login( { redirectTo: window.location.href } ),
 					} );
 					break;
 				default:
 					Object.assign( props, {
-						line: error.message
+						line: error.message,
 					} );
 					break;
 			}
@@ -218,7 +215,7 @@ class InviteAccept extends React.Component {
 
 	render() {
 		const formClasses = classNames( 'invite-accept__form', {
-			'is-error': !! this.isInvalidInvite()
+			'is-error': !! this.isInvalidInvite(),
 		} );
 		const { invite } = this.state;
 		const { user } = this.props;
@@ -230,7 +227,7 @@ class InviteAccept extends React.Component {
 					{ this.isMatchEmailError() && user && (
 						<Notice
 							text={ this.props.translate( 'This invite is only valid for %(email)s.', {
-								args: { email: invite.sentTo }
+								args: { email: invite.sentTo },
 							} ) }
 							status="is-error"
 							showDismiss={ false }
@@ -246,8 +243,8 @@ class InviteAccept extends React.Component {
 }
 
 export default connect(
-	state => ( {
-		user: getCurrentUser( state )
+	( state ) => ( {
+		user: getCurrentUser( state ),
 	} ),
 	{ successNotice, infoNotice }
 )( localize( InviteAccept ) );

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -26,6 +26,8 @@ import NoticeAction from 'components/notice/notice-action';
 import userUtils from 'lib/user/utils';
 import LocaleSuggestions from 'components/locale-suggestions';
 import { getCurrentUser } from 'state/current-user/selectors';
+import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
+import getSelectedSiteId from 'state/ui/selectors/get-selected-site-id';
 
 /**
  * Style dependencies
@@ -46,7 +48,7 @@ class InviteAccept extends React.Component {
 	state = {
 		invite: false,
 		error: false,
-		matchEmailError: false,
+		matchEmailError: false
 	};
 
 	UNSAFE_componentWillMount() {
@@ -70,7 +72,7 @@ class InviteAccept extends React.Component {
 			// add subscription-related keys to the invite
 			Object.assign( invite, {
 				activationKey: this.props.activationKey,
-				authKey: this.props.authKey,
+				authKey: this.props.authKey
 			} );
 		}
 		this.setState( { invite, error } );
@@ -91,7 +93,7 @@ class InviteAccept extends React.Component {
 
 	decline = () => {
 		this.props.infoNotice( this.props.translate( 'You declined to join.' ), {
-			displayOnNextPage: true,
+			displayOnNextPage: true
 		} );
 		page( '/' );
 	};
@@ -122,18 +124,26 @@ class InviteAccept extends React.Component {
 
 	renderForm = () => {
 		const { invite } = this.state;
+		const { isWPForTeamsSite } = this.props;
+
 		if ( ! invite ) {
 			debug( 'Not rendering form - Invite not set' );
 			return null;
 		}
 		debug( 'Rendering invite' );
 
+		let redirectTo = getRedirectAfterAccept( invite );
+
+		if ( isWPForTeamsSite ) {
+			redirectTo = `https://${ invite.site.domain }`;
+		}
+
 		const props = {
-			invite: this.state.invite,
-			redirectTo: getRedirectAfterAccept( this.state.invite ),
+			redirectTo,
+			invite: invite,
 			decline: this.decline,
 			signInLink: this.signInLink(),
-			forceMatchingEmail: this.isMatchEmailError(),
+			forceMatchingEmail: this.isMatchEmailError()
 		};
 
 		return this.props.user ? (
@@ -149,12 +159,12 @@ class InviteAccept extends React.Component {
 
 		const props = {
 			title: this.props.translate( 'Oops, that invite is not valid', {
-				context: 'Title that is display to users when attempting to accept an invalid invite.',
+				context: 'Title that is display to users when attempting to accept an invalid invite.'
 			} ),
 			line: this.props.translate( "We weren't able to verify that invitation.", {
-				context: 'Message that is displayed to users when an invitation is invalid.',
+				context: 'Message that is displayed to users when an invitation is invalid.'
 			} ),
-			illustration: whoopsImage,
+			illustration: whoopsImage
 		};
 
 		if ( error.error && error.message ) {
@@ -167,19 +177,19 @@ class InviteAccept extends React.Component {
 							'Would you like to accept the invite with a different account?'
 						),
 						action: this.props.translate( 'Switch Accounts' ),
-						actionURL: login( { redirectTo: window.location.href } ),
+						actionURL: login( { redirectTo: window.location.href } )
 					} );
 					break;
 				case 'unauthorized_created_by_self':
 					Object.assign( props, {
 						line: error.message, // "You can not use an invitation that you have created for someone else."
 						action: this.props.translate( 'Switch Accounts' ),
-						actionURL: login( { redirectTo: window.location.href } ),
+						actionURL: login( { redirectTo: window.location.href } )
 					} );
 					break;
 				default:
 					Object.assign( props, {
-						line: error.message,
+						line: error.message
 					} );
 					break;
 			}
@@ -214,7 +224,7 @@ class InviteAccept extends React.Component {
 
 	render() {
 		const formClasses = classNames( 'invite-accept__form', {
-			'is-error': !! this.isInvalidInvite(),
+			'is-error': !! this.isInvalidInvite()
 		} );
 		const { invite } = this.state;
 		const { user } = this.props;
@@ -226,7 +236,7 @@ class InviteAccept extends React.Component {
 					{ this.isMatchEmailError() && user && (
 						<Notice
 							text={ this.props.translate( 'This invite is only valid for %(email)s.', {
-								args: { email: invite.sentTo },
+								args: { email: invite.sentTo }
 							} ) }
 							status="is-error"
 							showDismiss={ false }
@@ -242,8 +252,8 @@ class InviteAccept extends React.Component {
 }
 
 export default connect(
-	( state ) => ( {
-		user: getCurrentUser( state ),
+	state => ( {
+		user: getCurrentUser( state )
 	} ),
 	{ successNotice, infoNotice }
 )( localize( InviteAccept ) );

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -8,7 +8,6 @@ import Debug from 'debug';
 import classNames from 'classnames';
 import page from 'page';
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -132,7 +131,7 @@ class InviteAccept extends React.Component {
 
 		const props = {
 			invite,
-			redirectTo: getRedirectAfterAccept( invite, get( invite, 'site.is_wpforteams_site', false ) ),
+			redirectTo: getRedirectAfterAccept( invite ),
 			decline: this.decline,
 			signInLink: this.signInLink(),
 			forceMatchingEmail: this.isMatchEmailError(),

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -151,7 +151,9 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 	}
 }
 
-export function getRedirectAfterAccept( invite, isWPForTeamsSite = false ) {
+export function getRedirectAfterAccept( invite ) {
+	const isWPForTeamsSite = get( invite, 'site.is_wpforteams_site', false );
+
 	if ( isWPForTeamsSite ) {
 		return `https://${ invite.site.domain }`;
 	}

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -151,7 +151,11 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 	}
 }
 
-export function getRedirectAfterAccept( invite ) {
+export function getRedirectAfterAccept( invite, isWPForTeamsSite = false ) {
+	if ( isWPForTeamsSite ) {
+		return `https://${ invite.site.domain }`;
+	}
+
 	const readerPath = '/read';
 	const postsListPath = '/posts/' + invite.site.ID;
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-for-teams/issues/174.

In this PR, we modify the redirect after accepting an invitation to a WP for Teams site so that you land on the site's homepage instead of in Calypso.

## Testing instructions

Create a new WP for Teams site through the wp.com/start/wp-for-teams signup flow (or select one if you already have one). In the Invite section, invite some other email (using a 10 min email for example). When you receive the invitation link, copy the link and change its first part from `wordpress.com` to `calypso.localhost:3000` so that you use the local code changes. Load the invitation url and create a new WP.com account when prompted. You should be redirected to the site's homepage instead of Calypso.

Do the same but for a non WP for Teams site to verify the old behavior still works.