### PR TITLE
Deduplicate @sinonjs/commons

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,14 +2402,7 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.7.0":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
-  integrity sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==
-  dependencies:
-    type-detect "4.0.8"
-
-"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.2":
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.2.tgz#505f55c74e0272b43f6c52d81946bed7058fc0e2"
   integrity sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change done automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```
#Before
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> @sinonjs/commons@1.7.1
wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> @sinonjs/commons@1.7.1
wp-calypso-monorepo@0.17.0 -> sinon@7.5.0 -> ... -> @sinonjs/commons@1.7.1
wp-calypso-monorepo@0.17.0 -> sinon@9.0.2 -> ... -> @sinonjs/commons@1.7.1

#Afer
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> @sinonjs/commons@1.7.2
wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> @sinonjs/commons@1.7.2
wp-calypso-monorepo@0.17.0 -> sinon@9.0.2 -> ... -> @sinonjs/commons@1.7.2
```
