### PR TITLE
Jetpack Cloud: update UI styles

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -1,3 +1,7 @@
+.activity-card .card {
+	border-radius: 3px;
+}
+
 .activity-card .activity-log-item__actor {
     margin-left: 0;
     display: flex;

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -7,13 +7,13 @@
 .daily-backup-status__status-icon.gridicon {
 	width: 3rem;
 	height: 3rem;
-	fill: rgb( 47, 180, 31 );
+	fill: var( --color-primary-30 );
 }
 
 .daily-backup-status__gridicon-error-state.gridicon {
 	width: 3rem;
 	height: 3rem;
-	fill: rgb( 214, 54, 56 );
+	fill: var( --color-scary-50 );
 }
 
 .daily-backup-status__gridicon-no-backup {
@@ -48,7 +48,7 @@
 .daily-backup-status__failed-message {
 	font-size: 1.4rem;
 	font-weight: 500;
-	color: rgb( 214, 54, 56 );
+	color: var( --color-scary-50 );
 	margin-bottom: 0.5rem;
 	margin-top: -0.5rem;
 }

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -1,38 +1,42 @@
-// Masterbar - home link
 .masterbar.is-jetpack-cloud-masterbar {
 	justify-content: space-between;
 
+	.masterbar__item-home {
+		width: 200px;
+		padding: 0;
+		border-right: 1px solid var( --color-masterbar-border );
+
+		@include breakpoint( '>660px' ) {
+			width: $sidebar-width-min;
+		}
+
+		@include breakpoint( '>960px' ) {
+			width: $sidebar-width-max;
+		}
+
+		.masterbar__item-content {
+			display: flex;
+			justify-content: center;
+			width: 100%;
+			padding: 0 16px;
+			color: var( --color-masterbar-text );
+
+			svg {
+				fill: var( --color-black );
+			}
+		}
+	}
+
 	.masterbar__item-title {
-		padding-left: 16px;
-		font-size: 20px;
+		padding-left: 32px;
+		font-size: 18px;
 		color: var( --color-gray-70 );
 		flex: 1 0 auto;
 		text-transform: none;
 		font-weight: 500;
-	}
-}
 
-.is-jetpack-cloud-masterbar .masterbar__item-home {
-	padding: 0;
-	border-right: 1px solid var( --color-masterbar-border );
-	width: 200px;
-	@include breakpoint( '>660px' ) {
-		width: $sidebar-width-min;
-	}
-
-	@include breakpoint( '>960px' ) {
-		width: $sidebar-width-max;
-	}
-
-	.masterbar__item-content {
-		display: flex;
-		justify-content: center;
-		width: 100%;
-		padding: 0 16px;
-		color: var( --color-masterbar-text );
-
-		svg {
-			fill: var( --color-black );
+		.masterbar__item-content {
+			margin-top: 2px;
 		}
 	}
 }

--- a/client/landing/jetpack-cloud/components/scan-history-item/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-history-item/style.scss
@@ -40,7 +40,7 @@
 		@include breakpoint( '>960px' ) {
 			display: inline-block;
 			background: var( --color-threat-ignored );
-			margin: 0 20px;
+			margin: 0 12px;
 			width: 4px;
 			height: 4px;
 			border-radius: 50%;

--- a/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/index.jsx
@@ -163,7 +163,7 @@ const ServerCredentialsForm = ( {
 				</FormSettingExplanation>
 			</FormFieldset>
 
-			<FormFieldset className="server-credentials-form__buttons">
+			<FormFieldset className="dialog__action-buttons server-credentials-form__buttons">
 				<Button
 					disabled={ formIsSubmitting }
 					onClick={ onCancel }

--- a/client/landing/jetpack-cloud/components/threat-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-dialog/index.tsx
@@ -37,11 +37,12 @@ class ThreatDialog extends React.PureComponent< Props > {
 			threatDescription,
 			threatTitle,
 		} = this.props;
+		const isScary = action !== 'fix';
 		const buttons = [
 			<Button className="threat-dialog__btn" onClick={ onCloseDialog }>
 				{ translate( 'Go back' ) }
 			</Button>,
-			<Button primary className="threat-dialog__btn" onClick={ onConfirmation }>
+			<Button primary scary={ isScary } className="threat-dialog__btn" onClick={ onConfirmation }>
 				{ action === 'fix' ? translate( 'Fix threat' ) : translate( 'Ignore threat' ) }
 			</Button>,
 		];

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -37,7 +37,6 @@ class ThreatItem extends Component< Props > {
 		const { onFixThreat, isFixing } = this.props;
 		return (
 			<Button
-				primary
 				compact
 				className={ classnames( 'threat-item__fix-button', className ) }
 				onClick={ onFixThreat }
@@ -72,6 +71,7 @@ class ThreatItem extends Component< Props > {
 				<div className="threat-item__buttons">
 					{ this.renderFixThreatButton( 'is-details' ) }
 					<Button
+						scary
 						compact
 						className="threat-item__ignore-button"
 						onClick={ onIgnoreThreat }

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -20,6 +20,7 @@
 		&[disabled],
 		&:disabled {
 			color: var( --studio-gray-10 );
+			background: none;
 			border-color: var( --color-gray-10 );
 		}
 	}
@@ -27,16 +28,25 @@
 	.button.is-primary {
 		color: var( --studio-white );
 		background: var( --color-primary-40 );
-		border: none;
 
 		&:hover,
 		&:focus {
 			background: var( --color-primary-30 );
-			border: none;
+			border-color: var( --color-primary-30 );
 		}
 
 		&:active {
 			background: var( --color-primary-50 );
+			border-color: var( --color-primary-50 );
+		}
+
+		&[disabled],
+		&:disabled {
+			background: var( --studio-gray-10 );
+			border-color: var( --studio-gray-10 );
+		}
+	}
+
 	.button.is-scary {
 		color: var( --color-scary-60 );
 		border-color: var( --color-scary-50 );
@@ -78,6 +88,7 @@
 		&[disabled],
 		&:disabled {
 			background: var( --studio-gray-10 );
+			border-color: var( --studio-gray-10 );
 		}
 	}
 

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -37,6 +37,42 @@
 
 		&:active {
 			background: var( --color-primary-50 );
+	.button.is-scary {
+		color: var( --color-scary-60 );
+		border-color: var( --color-scary-50 );
+
+		&:hover,
+		&:focus {
+			background: var( --color-scary-0 );
+		}
+
+		&:active {
+			background: var( --color-scary-5 );
+			border-color: var( --color-scary-40 );
+		}
+
+		&[disabled],
+		&:disabled {
+			color: var( --studio-gray-10 );
+			background: none;
+			border-color: var( --color-gray-10 );
+		}
+	}
+
+	.button.is-primary.is-scary {
+		color: var( --studio-white );
+		background: var( --color-scary-50 );
+		border-color: var( --color-scary-50 );
+
+		&:hover,
+		&:focus {
+			background: var( --color-scary-40 );
+			border-color: var( --color-scary-40 );
+		}
+
+		&:active {
+			background: var( --color-scary-60 );
+			border-color: var( --color-scary-60 );
 		}
 
 		&[disabled],
@@ -87,4 +123,18 @@
 			color: var( --studio-gray-10 );
 		}
 	}
+
+	.button.is-borderless.is-primary.is-scary {
+		color: var( --color-scary-50 );
+
+		&:hover,
+		&:focus {
+			color: var( --color-scary-40 );
+		}
+
+		&:active {
+			color: var( --color-scary-60 );
+		}
+	}
+}
 }

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -148,4 +148,15 @@
 		}
 	}
 }
+
+.theme-jetpack-cloud .ReactModalPortal {
+	.dialog.card {
+		box-shadow: 0 0 0 1px var( --color-border-subtle ),
+					0 4px 12px var( --color-neutral-10 );
+		border-radius: 3px;
+	}
+
+	.dialog__action-buttons {
+		border-radius: 0 0 3px 3px;
+	}
 }

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -1,6 +1,7 @@
 .theme-jetpack-cloud .main,
 .color-scheme.is-jetpack-cloud .main,
-.theme-jetpack-cloud .ReactModalPortal {
+.theme-jetpack-cloud .ReactModalPortal,
+.theme-jetpack-cloud .popover {
 	.button {
 		color: var( --color-primary-60 );
 		background: var( --studio-white );

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_jetpack-cloud.scss
@@ -122,6 +122,12 @@
 	--color-sidebar-menu-hover-background: var( --studio-gray-5 );
 	--color-sidebar-menu-hover-background-rgb: var( --studio-gray-5-rgb );
 
+	--color-scary-0: var( --studio-red-0 );
+	--color-scary-5: var( --studio-red-5 );
+	--color-scary-40: var( --studio-red-40 );
+	--color-scary-50: var( --studio-red-50 );
+	--color-scary-60: var( --studio-red-60 );
+
 	--color-threat-found: var( --studio-red-50 );
 	--color-threat-fixed: var( --studio-jetpack-green-40 );
 	--color-threat-ignored: var( --studio-gray-50 );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Changes the active threats view to have a single primary CTA.
* Adds `scary` prop to “Ignore threat” buttons.
* Tweaks styles for buttons, specifically for disabled states.
* Replaces a couple of hardcoded colors for variables.
* Cleans up masterbar styles.
* Reduce spacing of information in Scan history item.
* Adds box-shadow and border-radius to the modals.
* Adds border-radius to the Activity log elements to ensure consistency with the Scan section.
* Makes sure buttons styles also apply to popovers (which would only be the datepicker for now).

### Testing instructions

* Fire up this PR.
* Open `http://jetpack.cloud.localhost:3000/`.
* Select a site.
* Visit all sections of Jetpack Cloud and ensure the screenshots below are representative of the changes.

### Screenshots

#### Secondary buttons in active threats
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/79569841-506ad700-80b0-11ea-9f38-85b2aabc4c5f.png) | ![image](https://user-images.githubusercontent.com/390760/79569836-4e087d00-80b0-11ea-8eda-b3e24321bc3b.png)

#### Scary buttons for “Ignore threat”
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/79569904-6b3d4b80-80b0-11ea-8cfd-9123ef0181c0.png) | ![image](https://user-images.githubusercontent.com/390760/79569899-69738800-80b0-11ea-853a-2261924a1e16.png)

#### Scary buttons for “Ignore threat” & modal styling (drop-shadow/border-radius)
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/79569975-88721a00-80b0-11ea-9934-b4b82d0538c6.png) | ![image](https://user-images.githubusercontent.com/390760/79569981-8a3bdd80-80b0-11ea-9da3-eed9797da3e8.png)

#### Masterbar alignment and font-size
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/79570111-c111f380-80b0-11ea-87e1-25b0489fa54c.png) | ![image](https://user-images.githubusercontent.com/390760/79570103-beaf9980-80b0-11ea-9786-65247a417561.png)

#### Spacing of information in threat history item
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/79570200-eacb1a80-80b0-11ea-9db5-44b90d5f68f9.png) | ![image](https://user-images.githubusercontent.com/390760/79570206-edc60b00-80b0-11ea-9ddb-89ba136ff8d6.png)

#### Buttons styles consistent in popovers
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/79570303-1948f580-80b1-11ea-8208-e08761f7f3e8.png) | ![image](https://user-images.githubusercontent.com/390760/79570298-16e69b80-80b1-11ea-9862-70102cd5148d.png)

#### Activity log item with border-radius
Before | After
--|--
![image](https://user-images.githubusercontent.com/390760/79570395-43021c80-80b1-11ea-84f9-f55779fb2566.png) | ![image](https://user-images.githubusercontent.com/390760/79570390-3f6e9580-80b1-11ea-9093-9e4063ad1d64.png)
