### PR TITLE
Tracking: fix inserter-menu issue in Atomic sites

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.js
+++ b/apps/wpcom-block-editor/src/wpcom/editor.js
@@ -16,7 +16,7 @@ import './features/fix-block-invalidation-errors';
 import './features/reorder-block-categories';
 import './features/tracking';
 
-import InserterMenuTrackingEvent from './features/tracking/wpcom-navigation-menu-search-handler';
+import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';
 
 registerPlugin( 'track-inserter-menu-events', {
 	render() {

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -1,4 +1,4 @@
-	/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */
@@ -50,7 +50,7 @@ const InserterMenuTrackingEvent = function () {
 		 * to the temporary solution below if the core version
 		 * is equal to 7.8.1.
 		 */
-		if ( pluginVersion && pluginVersion === '7.8.1' ) {
+		if ( ! pluginVersion || ( pluginVersion && pluginVersion === '7.8.1' ) ) {
 			return null;
 		}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -55,7 +55,7 @@ const InserterMenuTrackingEvent = function () {
 		}
 
 		// let's remove this line once the core version updates.
-		debug( '%o: tracking with Slot parameter', pluginVersion );
+		debug( '%s version: tracking with Slot parameter', pluginVersion );
 
 		if ( has_items ) {
 			return;
@@ -81,7 +81,7 @@ const InserterMenuTrackingEvent = function () {
 			return;
 		}
 		// let's remove this line once the core version updates.
-		debug( '%o: tracking inspecting DOM tree', pluginVersion );
+		debug( '%s: tracking inspecting DOM tree', ( pluginVersion || 'unknown' ) + ' version' );
 
 		if ( ! searchTerm || searchTerm.length < 3 ) {
 			return;

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
+	/* eslint-disable import/no-extraneous-dependencies */
 /**
  * External dependencies
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes an issue that occurs in Atomic sites. It's produced because of the client plugin version is `undefined` for these sites, which records the same `no-results` search term twice.

#### Testing instructions

**Confirm the issue.**

You need to sandbox `widgets.wp.com` and apply these changes to your sandbox
Also, open the client dev console and set up the debug

```
> localStorage.setItem( 'debug', 'wpcom-block-editor*' )
```

A hard refresh is needed.


In your Atomic site, start to type a term in the Inserter Menu.

Confirm that it records two `wpcom_block_picker_no_results` register for the same event.
(Disable cache for the requests)

![image](https://user-images.githubusercontent.com/77539/79585289-f8c76e00-80a5-11ea-959b-9e3b90866f4f.png)


<img width="672" alt="Screen Shot 2020-04-17 at 11 02 08 AM" src="https://user-images.githubusercontent.com/77539/79578086-1db6e380-809c-11ea-83a0-56441e678eb8.png">


With this patch, it should be recorded once. Also, I've improved a little bit the log lines, adding the `unknown_version`

![image](https://user-images.githubusercontent.com/77539/79578069-17c10280-809c-11ea-97ad-8c578caff8bc.png)

Next improvement is to expose the Gutenberg version also for Atomic sites.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->