### PR TITLE
Fix Sass bug in gutenboarding domain picker modal

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -20,7 +20,7 @@
 	// than the viewport height, it will expand taller
 	// than the provided min-height, triggering
 	// the appearance of the <body> element's scrollbar.
-	min-height: calc( 100vh - $gutenboarding-header-height );
+	min-height: calc( 100vh - #{$gutenboarding-header-height} );
 	width: 100%;
 
 	background: var( --studio-white );


### PR DESCRIPTION
This bug was introduced in #41212 and prevents ICFY builds (as well as `yarn analyze-bundles` and `yarn whybundled`) from working correctly. See e.g. [this run](https://github.com/Automattic/wp-calypso/runs/595694428).

I believe it may also be resulting  in invalid CSS being output, at least going by [what Sassmeister tells me](https://www.sassmeister.com/gist/09206c405fc60d8c6ecde1f988de0e09).

#### Changes proposed in this Pull Request

* Fix escaping bug in `domain-picker-modal/style.scss`

#### Testing instructions

Ensure that the ICFY build completes successfully and doesn't error out like in #41212.
