### PR TITLE
Live chat: add closure for this weekend

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -555,7 +555,7 @@ class HelpContact extends React.Component {
 							hideAt="2020-04-20 06:00Z"
 							heading="Live Chat closed"
 							message={
-								<p>
+								<div>
 									<p>
 										Live Chat will be closed between Saturday, April 18 00:00 UTC and Monday, April
 										20 06:00 UTC.
@@ -569,7 +569,7 @@ class HelpContact extends React.Component {
 										Thank you for patience and we aim to return to normal weekend chat coverage
 										soon.
 									</p>
-								</p>
+								</div>
 							}
 							compact={ compact }
 						/>

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -17,10 +17,7 @@ import Main from 'components/main';
 import { Card } from '@automattic/components';
 import Notice from 'components/notice';
 import HelpContactForm from 'me/help/help-contact-form';
-import LimitedChatAvailabilityNotice from 'me/help/contact-form-notice/limited-chat-availability';
-import LiveChatClosureNotice, {
-	easterHolidayName,
-} from 'me/help/contact-form-notice/live-chat-closure';
+import ContactFormNotice from 'me/help/contact-form-notice/index';
 import HelpContactConfirmation from 'me/help/help-contact-confirmation';
 import HeaderCake from 'components/header-cake';
 import wpcomLib from 'lib/wp';
@@ -553,24 +550,28 @@ class HelpContact extends React.Component {
 			<div>
 				{ isUserAffectedByLiveChatClosure && (
 					<>
-						<LimitedChatAvailabilityNotice
+						<ContactFormNotice
+							showAt="2020-04-18 00:00Z"
+							hideAt="2020-04-20 06:00Z"
+							heading="Live Chat closed"
+							message={
+								<p>
+									<p>
+										Live Chat will be closed between Saturday, April 18 00:00 UTC and Monday, April
+										20 06:00 UTC.
+									</p>
+									<p>
+										Our Happiness Engineers will continue to be available by email during this time.
+										While we are not immediately available in chat, we will respond to your email as
+										soon as we can.
+									</p>
+									<p>
+										Thank you for patience and we aim to return to normal weekend chat coverage
+										soon.
+									</p>
+								</p>
+							}
 							compact={ compact }
-							showAt="2020-03-27 00:00Z"
-							hideAt="2020-04-12 00:00Z"
-						/>
-
-						<LiveChatClosureNotice
-							compact={ compact }
-							holidayName={ easterHolidayName }
-							displayAt="2020-04-12 00:00Z"
-							closesAt="2020-04-12 06:00Z"
-							reopensAt="2020-04-13 06:00Z"
-						/>
-
-						<LimitedChatAvailabilityNotice
-							compact={ compact }
-							showAt="2020-04-13 06:00Z"
-							hideAt="2021-01-01 00:00Z"
 						/>
 					</>
 				) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/hg/issues/786


#### Testing instructions

0. Use an account with live chat access (pro, etc).
1. Set computer date before 2020-04-18 00:00Z. Chat should be available.
2. Set computer after 2020-04-18 00:00Z. Banner should show.
3. Set computer after 2020-04-20 06:00Z. Chat should be available.