### PR TITLE
Add Jetpack Cloud Activity Lines

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -85,7 +85,11 @@ class ActivityCardList extends Component {
 									moment,
 									activity,
 									allowRestore,
-									siteSlug
+									siteSlug,
+									className:
+										activity.activityType === 'Backup'
+											? 'activity-card-list__primary-card'
+											: 'activity-card-list__secondary-card'
 								} }
 							/>
 						) ) }

--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -4,7 +4,7 @@
 import { connect } from 'react-redux';
 import { isMobile } from '@automattic/viewport';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -33,16 +33,16 @@ class ActivityCardList extends Component {
 		pageSize: PropTypes.number.isRequired,
 		showDateSeparators: PropTypes.bool,
 		showFilter: PropTypes.bool,
-		showPagination: PropTypes.bool,
+		showPagination: PropTypes.bool
 	};
 
 	static defaultProps = {
 		showDateSeparators: true,
 		showFilter: true,
-		showPagination: true,
+		showPagination: true
 	};
 
-	changePage = ( pageNumber ) => {
+	changePage = pageNumber => {
 		this.props.selectPage( this.props.siteId, pageNumber );
 		window.scrollTo( 0, 0 );
 	};
@@ -71,22 +71,26 @@ class ActivityCardList extends Component {
 
 		return logsByDate.map( ( { date, logs: dateLogs }, index ) => {
 			return (
-				<Fragment key={ `activity-card-list__date-group-${ index }` }>
+				<div key={ `activity-card-list__date-group-${ index }` }>
 					{ showDateSeparators && (
-						<div className="activity-card-list__date">{ date && date.format( 'MMM Do' ) }</div>
+						<div className="activity-card-list__date-group-date">
+							{ date && date.format( 'MMM Do' ) }
+						</div>
 					) }
-					{ dateLogs.map( ( activity ) => (
-						<ActivityCard
-							{ ...{
-								key: activity.activityId,
-								moment,
-								activity,
-								allowRestore,
-								siteSlug,
-							} }
-						/>
-					) ) }
-				</Fragment>
+					<div className="activity-card-list__date-group-content">
+						{ dateLogs.map( activity => (
+							<ActivityCard
+								{ ...{
+									key: activity.activityId,
+									moment,
+									activity,
+									allowRestore,
+									siteSlug
+								} }
+							/>
+						) ) }
+					</div>
+				</div>
 			);
 		} );
 	}
@@ -108,7 +112,7 @@ class ActivityCardList extends Component {
 							siteId,
 							filter,
 							isLoading: false,
-							isVisible: true,
+							isVisible: true
 						} }
 					/>
 				) }
@@ -156,7 +160,7 @@ class ActivityCardList extends Component {
 	}
 }
 
-const mapStateToProps = ( state ) => {
+const mapStateToProps = state => {
 	const siteId = getSelectedSiteId( state );
 	const filter = getActivityLogFilter( state, siteId );
 	const rewind = getRewindState( state, siteId );
@@ -171,12 +175,12 @@ const mapStateToProps = ( state ) => {
 		siteId,
 		filter,
 		rewind,
-		allowRestore,
+		allowRestore
 	};
 };
 
-const mapDispatchToProps = ( dispatch ) => ( {
-	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) ),
+const mapDispatchToProps = dispatch => ( {
+	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) )
 } );
 
 export default connect(

--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -33,16 +33,16 @@ class ActivityCardList extends Component {
 		pageSize: PropTypes.number.isRequired,
 		showDateSeparators: PropTypes.bool,
 		showFilter: PropTypes.bool,
-		showPagination: PropTypes.bool
+		showPagination: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		showDateSeparators: true,
 		showFilter: true,
-		showPagination: true
+		showPagination: true,
 	};
 
-	changePage = pageNumber => {
+	changePage = ( pageNumber ) => {
 		this.props.selectPage( this.props.siteId, pageNumber );
 		window.scrollTo( 0, 0 );
 	};
@@ -78,7 +78,7 @@ class ActivityCardList extends Component {
 						</div>
 					) }
 					<div className="activity-card-list__date-group-content">
-						{ dateLogs.map( activity => (
+						{ dateLogs.map( ( activity ) => (
 							<ActivityCard
 								{ ...{
 									key: activity.activityId,
@@ -89,7 +89,7 @@ class ActivityCardList extends Component {
 									className:
 										activity.activityType === 'Backup'
 											? 'activity-card-list__primary-card'
-											: 'activity-card-list__secondary-card'
+											: 'activity-card-list__secondary-card',
 								} }
 							/>
 						) ) }
@@ -116,7 +116,7 @@ class ActivityCardList extends Component {
 							siteId,
 							filter,
 							isLoading: false,
-							isVisible: true
+							isVisible: true,
 						} }
 					/>
 				) }
@@ -164,7 +164,7 @@ class ActivityCardList extends Component {
 	}
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const filter = getActivityLogFilter( state, siteId );
 	const rewind = getRewindState( state, siteId );
@@ -179,12 +179,12 @@ const mapStateToProps = state => {
 		siteId,
 		filter,
 		rewind,
-		allowRestore
+		allowRestore,
 	};
 };
 
-const mapDispatchToProps = dispatch => ( {
-	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) )
+const mapDispatchToProps = ( dispatch ) => ( {
+	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) ),
 } );
 
 export default connect(

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -43,8 +43,11 @@
 
 // make sure the vertical lines don't appear through the transparent backgrounds of the icons
 .activity-card-list {
-	.activity-card .activity-card__time-icon.gridicon {
-		background: var( --color-surface-backdrop );
+	.activity-card {
+		margin-bottom: 32px;
+		.activity-card__time-icon.gridicon {
+			background: var( --color-surface-backdrop );
+		}
 	}
 }
 

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -44,7 +44,7 @@
 }
 
 .activity-card-list {
-	.activity-card .gridicon {
+	.activity-card .activity-card__time-icon.gridicon {
 		background: var( --color-surface-backdrop );
 	}
 }
@@ -57,14 +57,21 @@
 }
 
 .activity-card-list__secondary-card {
-	transform: translate( 32px, 0 );
+	width: calc( 100% - 32px - 16px );
+
+	.activity-card__time,
+	.card {
+		transform: translateX( 32px );
+		// width: calc( auto - 32px );
+	}
+
 	position: relative;
 
 	&::before {
 		content: '';
 		position: absolute;
 		// center on the icons ( 1px is half the width )
-		left: calc( -32px + 0.55rem + 0.5px );
+		left: calc( 0.55rem + 0.5px );
 		height: 1px;
 	}
 
@@ -73,5 +80,23 @@
 		width: 100%;
 		z-index: -2;
 		background: var( --color-neutral-5 );
+	}
+
+	// draw over the line that goes off the screen
+	&:last-of-type {
+		&::after {
+			content: '';
+			position: absolute;
+			// center on the icons ( .5px is half the width )
+			left: 0.55rem;
+			width: 1px;
+		}
+
+		&::after {
+			top: calc( 50% + 1px );
+			height: 100%;
+			z-index: -1;
+			background: var( --color-surface-backdrop );
+		}
 	}
 }

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -39,8 +39,7 @@
 		top: 0;
 		height: 100%;
 		z-index: -2;
-		// background: var( --color-neutral-10 );
-		background: red;
+		background: var( --color-neutral-5 );
 	}
 }
 
@@ -73,7 +72,6 @@
 		top: 50%;
 		width: 100%;
 		z-index: -2;
-		// background: var( --color-neutral-10 );
-		background: blue;
+		background: var( --color-neutral-5 );
 	}
 }

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -31,7 +31,7 @@
 		content: '';
 		position: absolute;
 		// center on the icons ( .5px is half the width )
-		left: calc( 0.55rem - 0.5px );
+		left: 0.55rem;
 		width: 1px;
 	}
 
@@ -41,6 +41,12 @@
 		z-index: -2;
 		// background: var( --color-neutral-10 );
 		background: red;
+	}
+}
+
+.activity-card-list {
+	.activity-card .gridicon {
+		background: var( --color-surface-backdrop );
 	}
 }
 

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -17,10 +17,29 @@
 	}
 }
 
-.activity-card-list__date {
-	font-style: normal;
-	font-weight: bold;
+.activity-card-list__date-group-date {
+	font-weight: 700;
 	font-size: 16px;
 	line-height: 23px;
 	border-bottom: 1px solid #000000;
+}
+
+.activity-card-list__date-group-content {
+	position: relative;
+
+	&::before {
+		content: '';
+		position: absolute;
+		// center on the icons ( 1px is half the width )
+		left: calc( 0.55rem - 1px );
+		width: 2px;
+	}
+
+	&::before {
+		top: 0;
+		height: 100%;
+		z-index: -2;
+		// background: var( --color-neutral-10 );
+		background: red;
+	}
 }

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -24,79 +24,81 @@
 	border-bottom: 1px solid #000000;
 }
 
+// draw vertical lines through each date "group"
 .activity-card-list__date-group-content {
 	position: relative;
 
 	&::before {
-		content: '';
-		position: absolute;
-		// center on the icons ( .5px is half the width )
-		left: 0.55rem;
-		width: 1px;
-	}
-
-	&::before {
-		top: 0;
-		height: 100%;
-		z-index: -2;
 		background: var( --color-neutral-5 );
+		content: '';
+		height: 100%;
+		// center on the icons ( they render @ 1.1rem, so half that )
+		left: 0.55rem;
+		position: absolute;
+		top: 0;
+		width: 1px;
+		z-index: -2;
 	}
 }
 
+// make sure the vertical lines don't appear through the transparent backgrounds of the icons
 .activity-card-list {
 	.activity-card .activity-card__time-icon.gridicon {
 		background: var( --color-surface-backdrop );
 	}
 }
 
+// primary cards get primary card emphasis on the left
 .activity-card-list__primary-card {
 	.card {
-		padding-left: 21px; // reduce standard 24px padding by 3
-		border-left: 3px solid var( --color-primary-40 );
+		padding-left: 20px; // reduce standard 24px padding by 4
+		border-left: 4px solid var( --color-primary-40 );
 	}
 }
 
+// work happens in the secondary cards
 .activity-card-list__secondary-card {
+	// this brings in the right side, otherwise the translated elements would look the same
+	// 32px to adjust for the scooch, 16px to make the card shorted than the primary one
 	width: calc( 100% - 32px - 16px );
 
+	// scooch secondary card elements over
 	.activity-card__time,
 	.card {
 		transform: translateX( 32px );
-		// width: calc( auto - 32px );
 	}
 
-	position: relative;
-
-	&::before {
-		content: '';
-		position: absolute;
-		// center on the icons ( 1px is half the width )
-		left: calc( 0.55rem + 0.5px );
-		height: 1px;
-	}
-
-	&::before {
-		top: 50%;
-		width: 100%;
-		z-index: -2;
-		background: var( --color-neutral-5 );
-	}
-
-	// draw over the line that goes off the screen
-	&:last-of-type {
-		&::after {
+	.card {
+		// this draws the horizontal line
+		&::before {
+			// same as the left on the vertical line above
+			background: var( --color-neutral-5 );
 			content: '';
+			height: 1px;
+			left: calc( 0.55rem - 32px );
 			position: absolute;
-			// center on the icons ( .5px is half the width )
-			left: 0.55rem;
-			width: 1px;
+			top: 50%;
+			width: calc( 32px - 0.55rem );
+			z-index: -2;
 		}
+	}
 
-		&::after {
-			top: calc( 50% + 1px );
-			height: 100%;
-			z-index: -1;
-			background: var( --color-surface-backdrop );
+	// draw over the line that goes off the screen on the last card
+	&:last-of-type {
+		.card {
+			&::after {
+				background: var( --color-surface-backdrop );
+				content: '';
+				// make sure we stay in our element
+				height: calc( 50% - 1px );
+				left: calc( 0.55rem - 32px );
+				position: absolute;
+				// immediately after the existing horizontal line draw on over the top of it
+				top: calc( 50% + 1px );
+				visibility: visible;
+				width: 1px;
+				z-index: -1;
+			}
 		}
 	}
 }

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -30,9 +30,9 @@
 	&::before {
 		content: '';
 		position: absolute;
-		// center on the icons ( 1px is half the width )
-		left: calc( 0.55rem - 1px );
-		width: 2px;
+		// center on the icons ( .5px is half the width )
+		left: calc( 0.55rem - 0.5px );
+		width: 1px;
 	}
 
 	&::before {
@@ -41,5 +41,33 @@
 		z-index: -2;
 		// background: var( --color-neutral-10 );
 		background: red;
+	}
+}
+
+.activity-card-list__primary-card {
+	.card {
+		padding-left: 21px; // reduce standard 24px padding by 3
+		border-left: 3px solid var( --color-primary-40 );
+	}
+}
+
+.activity-card-list__secondary-card {
+	transform: translate( 32px, 0 );
+	position: relative;
+
+	&::before {
+		content: '';
+		position: absolute;
+		// center on the icons ( 1px is half the width )
+		left: calc( -32px + 0.55rem + 0.5px );
+		height: 1px;
+	}
+
+	&::before {
+		top: 50%;
+		width: 100%;
+		z-index: -2;
+		// background: var( --color-neutral-10 );
+		background: blue;
 	}
 }

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -49,7 +50,7 @@ class ActivityCard extends Component {
 		page.redirect( backupDetailPath( this.props.siteSlug, this.props.activity.rewindId ) );
 
 	render() {
-		const { activity, allowRestore, gmtOffset, timezone, translate } = this.props;
+		const { activity, allowRestore, className, gmtOffset, timezone, translate } = this.props;
 
 		const backupTimeDisplay = applySiteOffset( activity.activityTs, {
 			timezone,
@@ -57,7 +58,7 @@ class ActivityCard extends Component {
 		} ).format( 'LT' );
 
 		return (
-			<div className="activity-card">
+			<div className={ classnames( className, 'activity-card' ) }>
 				<div className="activity-card__time">
 					<img src={ cloudIcon } className="activity-card__time-icon" role="presentation" alt="" />
 					<div className="activity-card__time-text">{ backupTimeDisplay }</div>

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -27,7 +27,6 @@ import {
  */
 import './style.scss';
 import downloadIcon from './download-icon.svg';
-import cloudIcon from './cloud-icon.svg';
 
 class ActivityCard extends Component {
 	constructor() {
@@ -60,7 +59,7 @@ class ActivityCard extends Component {
 		return (
 			<div className={ classnames( className, 'activity-card' ) }>
 				<div className="activity-card__time">
-					<img src={ cloudIcon } className="activity-card__time-icon" role="presentation" alt="" />
+					<Gridicon icon={ activity.activityIcon } className="activity-card__time-icon" />
 					<div className="activity-card__time-text">{ backupTimeDisplay }</div>
 				</div>
 				<Card>

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -3,23 +3,24 @@
 }
 
 .activity-card .activity-log-item__actor {
-    margin-left: 0;
-    display: flex;
-    align-items: center;
+	margin-left: 0;
+	display: flex;
+	align-items: center;
 }
 
 .activity-card .button.is-borderless.is-primary {
-    float: none;
-    display: inline-block;
+	float: none;
+	display: inline-block;
 }
 
 .activity-card__time {
 	margin: 1.5rem 0 0.5rem;
 }
 
-.activity-card__time-icon {
+.activity-card__time-icon.gridicon {
 	width: 1.1rem;
 	height: 1.1rem;
+	fill: var( --color-neutral-40 );
 }
 
 .activity-card__time-text {
@@ -63,7 +64,7 @@
 .activity-card__detail-button.button.is-borderless.is-primary {
 	color: #3d444a;
 	font-size: 0.9rem;
-	font-weight: normal;
+	font-weight: 400;
 	margin-left: 0;
 }
 

--- a/client/state/data-layer/wpcom/sites/activity/from-api.js
+++ b/client/state/data-layer/wpcom/sites/activity/from-api.js
@@ -70,6 +70,7 @@ export function processItem( item ) {
 		item.rewind_id && { rewindId: item.rewind_id },
 		item.status && { activityStatus: item.status },
 		object && object.target_ts && { activityTargetTs: object.target_ts },
+		object && object.type && { activityType: object.type },
 		item.is_aggregate && { isAggregate: item.is_aggregate },
 		item.streams && { streams: item.streams.map( processItem ) },
 		item.stream_count && { streamCount: item.stream_count },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add primary color emphasis to the left of Activity Cards that are backups
* Move over non-backup cards and add connecting lines

<img width="400" alt="Screen Shot 2020-04-17 at 4 32 38 PM" src="https://user-images.githubusercontent.com/2810519/79621943-2a523080-80ca-11ea-9965-39d2b6b4db6a.png">


#### Testing instructions

1. Navigate to `/backups/activity`
2. Inspect page and various widths and compare to design