### PR TITLE
Themes: Advise Switching to Gutenberg for Template-First Themes

### DIFF
--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -26,6 +26,8 @@ import {
 import { clearActivated } from 'state/themes/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestSite } from 'state/sites/actions';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
+import { setSelectedEditor } from 'state/selected-editor/actions';
 import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 import shouldCustomizeHomepageWithGutenberg from 'state/selectors/should-customize-homepage-with-gutenberg';
 import getSiteUrl from 'state/selectors/get-site-url';
@@ -107,13 +109,25 @@ class ThanksModal extends Component {
 		page( this.props.detailsUrl );
 	};
 
-	goToCustomizer = () => {
-		const { customizeUrl, shouldEditHomepageWithGutenberg } = this.props;
+	primaryAction = () => {
+		const {
+			activateGutenberg,
+			customizeUrl,
+			isUsingClassicEditor,
+			shouldEditHomepageWithGutenberg,
+			siteId,
+		} = this.props;
 
 		this.trackClick( 'thanks modal customize' );
 		this.onCloseModal();
 
-		shouldEditHomepageWithGutenberg ? page( customizeUrl ) : window.open( customizeUrl, '_blank' );
+		if ( isUsingClassicEditor && shouldEditHomepageWithGutenberg ) {
+			activateGutenberg( siteId, customizeUrl );
+		} else {
+			shouldEditHomepageWithGutenberg
+				? page( customizeUrl )
+				: window.open( customizeUrl, '_blank' );
+		}
 	};
 
 	renderThemeInfo = () => {
@@ -156,6 +170,8 @@ class ThanksModal extends Component {
 
 	renderContent = () => {
 		const { name: themeName, author: themeAuthor } = this.props.currentTheme;
+		const { isUsingClassicEditor, shouldEditHomepageWithGutenberg } = this.props;
+		const shouldSwitchEditors = isUsingClassicEditor && shouldEditHomepageWithGutenberg;
 
 		return (
 			<div>
@@ -163,7 +179,7 @@ class ThanksModal extends Component {
 					{ translate( 'Thanks for choosing {{br/}} %(themeName)s', {
 						args: { themeName },
 						components: {
-							br: <br />,
+							br: shouldSwitchEditors ? null : <br />,
 						},
 					} ) }
 				</h1>
@@ -172,6 +188,13 @@ class ThanksModal extends Component {
 						args: { themeAuthor },
 					} ) }
 				</span>
+				{ shouldSwitchEditors && (
+					<p className="thanks-modal__gutenberg-warning">
+						{ translate(
+							'This theme is intended to work with the Block Editor, so we recommend activating that first.'
+						) }
+					</p>
+				) }
 			</div>
 		);
 	};
@@ -185,12 +208,14 @@ class ThanksModal extends Component {
 	};
 
 	getEditSiteLabel = () => {
-		const { shouldEditHomepageWithGutenberg, hasActivated } = this.props;
+		const { isUsingClassicEditor, shouldEditHomepageWithGutenberg, hasActivated } = this.props;
 		if ( ! hasActivated ) {
 			return translate( 'Activating theme…' );
 		}
 
-		const gutenbergContent = translate( 'Edit Homepage' );
+		const gutenbergContent = isUsingClassicEditor
+			? translate( 'Activate the Block Editor and edit homepage' )
+			: translate( 'Edit Homepage' );
 		const customizerContent = (
 			<>
 				<Gridicon icon="external" />
@@ -208,7 +233,7 @@ class ThanksModal extends Component {
 	getViewSiteLabel = () => (
 		<span className="thanks-modal__button-customize">
 			<Gridicon icon="external" />
-			{ translate( 'View Site' ) }
+			{ translate( 'View site' ) }
 		</span>
 	);
 
@@ -237,7 +262,7 @@ class ThanksModal extends Component {
 				label: this.getEditSiteLabel(),
 				isPrimary: true,
 				disabled: ! hasActivated,
-				onClick: this.goToCustomizer,
+				onClick: this.primaryAction,
 			},
 		];
 	};
@@ -279,12 +304,15 @@ export default connect(
 			isActivating: !! isActivatingTheme( state, siteId ),
 			hasActivated: !! hasActivatedTheme( state, siteId ),
 			isThemeWpcom: isWpcomTheme( state, currentThemeId ),
+			isUsingClassicEditor: getSelectedEditor( state, siteId ) === 'classic',
 		};
 	},
 	dispatch => {
 		return {
 			clearActivated: siteId => dispatch( clearActivated( siteId ) ),
 			refreshSite: siteId => dispatch( requestSite( siteId ) ),
+			activateGutenberg: ( siteId, customizeUrl ) =>
+				dispatch( setSelectedEditor( siteId, 'gutenberg', customizeUrl ) ),
 		};
 	}
 )( ThanksModal );

--- a/client/my-sites/themes/thanks-modal.scss
+++ b/client/my-sites/themes/thanks-modal.scss
@@ -53,6 +53,12 @@
 		}
 	}
 
+	.thanks-modal__gutenberg-warning {
+		color: var( --color-text-subtle );
+		font-size: 14px;
+		margin-top: 12px;
+	}
+
 	ul {
 		display: block;
 		margin-left: 10px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds an option to switch to Gutenberg after activating a theme intended to be used with the Block Editor

#### Testing instructions

1. Firstly, activate a theme with the Gutenberg editor enabled and verify that nothing has changed
2. Switch to the Classic Editor 
3. Activate a Template-First theme, like Barnsbury
4. Verify that the primary button activates Gutenberg

<img width="803" alt="Screenshot 2020-04-18 at 13 27 20" src="https://user-images.githubusercontent.com/43215253/79637636-0ac61100-8179-11ea-9b6c-2ce46b4521e0.png">

The only thing this changes on the other modal is that "View Site" becomes "View site"; part of #40120. 

cc @rickybanister, @noahtallen 

Fixes #41235
