### PR TITLE
Deduplicate through2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20643,7 +20643,7 @@ throttle-debounce@^2.1.0:
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
   integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
 
-through2@2.0.0, through2@^2.0.0:
+through2@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.0.tgz#f41a1c31df5e129e4314446f66eca05cd6a30480"
   integrity sha1-9BocMd9eEp5DFERvZuygXNajBIA=
@@ -20651,7 +20651,7 @@ through2@2.0.0, through2@^2.0.0:
     readable-stream "~2.0.0"
     xtend "~4.0.0"
 
-through2@^2.0.2:
+through2@^2.0.0, through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change done automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```
# Before
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> through2@2.0.0
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> through2@2.0.0
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> through2@2.0.0
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> through2@2.0.0
wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> through2@2.0.0
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> through2@2.0.0

# After
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> through2@2.0.5
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> through2@2.0.5
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> through2@2.0.5
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> through2@2.0.5
wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> through2@2.0.5
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> through2@2.0.5
```