### PR TITLE
Deduplicate terser

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20553,7 +20553,7 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@4.4.3, terser@^4.1.2, terser@^4.4.3:
+terser@4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.4.3.tgz#401abc52b88869cf904412503b1eb7da093ae2f0"
   integrity sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==
@@ -20562,7 +20562,7 @@ terser@4.4.3, terser@^4.1.2, terser@^4.4.3:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^4.6.3:
+terser@^4.1.2, terser@^4.4.3, terser@^4.6.3:
   version "4.6.6"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.6.tgz#da2382e6cafbdf86205e82fb9a115bd664d54863"
   integrity sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change done automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```
# Before
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> terser@4.4.3
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> terser@4.4.3
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> terser@4.4.3
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> terser@4.4.3
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> terser@4.4.3

# After
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> terser@4.6.6
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> terser@4.6.6
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> terser@4.6.6
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> terser@4.6.6
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> terser@4.6.6
```