### PR TITLE
Deduplicate readable-stream

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18023,15 +18023,18 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@~1.0.17:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 "readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
@@ -18052,18 +18055,15 @@ readable-stream@^1.1.8:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+readable-stream@~1.0.17:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
   dependencies:
     core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readable-stream@~2.0.0:
   version "2.0.6"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change done automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```
#Before
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> readable-stream@1.0.34
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> readable-stream@1.0.34
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> readable-stream@1.0.34
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> readable-stream@1.0.34
wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> readable-stream@1.0.34
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> readable-stream@1.0.34

#After
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> readable-stream@2.3.7
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> readable-stream@2.3.7
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> readable-stream@2.3.7
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> readable-stream@2.3.7
wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> readable-stream@2.3.7
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> readable-stream@2.3.7

```