### PR TITLE
Deduplicate mkdirp

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -14781,19 +14781,19 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  dependencies:
-    minimist "0.0.8"
-
-mkdirp@^0.5.4:
+mkdirp@*, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
 
 mkpath@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change done automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```
#Before
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> babel-jest@25.1.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> eslint@6.8.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> jest-junit@9.0.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> nock@11.7.2 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> node-sass@4.13.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> webpack-bundle-analyzer@3.7.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> webpack-dev-middleware@3.7.2 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> webpack-dev-server@3.10.3 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> mkdirp@0.5.1
wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> mkdirp@0.5.1

#After
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> babel-jest@25.1.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> eslint@6.8.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> jest-junit@9.0.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> nock@11.7.2 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> node-sass@4.13.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> webpack-bundle-analyzer@3.7.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> webpack-dev-middleware@3.7.2 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> webpack-dev-server@3.10.3 -> ... -> mkdi@0.5.5
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> mkdirp@0.5.5
wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> mkdirp@0.5.5
```