### PR TITLE
Export Media: Hide when No Files are Present

### DIFF
--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -11,8 +11,11 @@ import { localize } from 'i18n-calypso';
  */
 import FoldableCard from 'components/foldable-card';
 import { Button } from '@automattic/components';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import QueryMediaStorage from 'components/data/query-media-storage';
 import QueryMediaExport from 'components/data/query-media-export';
 import getMediaExportUrl from 'state/selectors/get-media-export-url';
+import getMediaStorageUsed from 'state/selectors/get-media-storage-used';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class ExportMediaCard extends Component {
@@ -26,6 +29,8 @@ class ExportMediaCard extends Component {
 	render() {
 		const { mediaExportUrl, siteId, translate, recordMediaExportClick } = this.props;
 
+		const hasNoMediaFiles = this.props.mediaStorageUsed === 0 && ! mediaExportUrl;
+
 		const exportMediaButton = (
 			<Button
 				href={ mediaExportUrl }
@@ -33,13 +38,14 @@ class ExportMediaCard extends Component {
 				disabled={ ! mediaExportUrl }
 				onClick={ recordMediaExportClick }
 			>
-				{ translate( 'Download' ) }
+				{ hasNoMediaFiles ? translate( 'Upload files first' ) : translate( 'Download' ) }
 			</Button>
 		);
 
 		return (
 			<div className="export-media-card">
-				<QueryMediaExport siteId={ siteId } />
+				<QueryMediaStorage siteId={ siteId } />
+				{ ! hasNoMediaFiles && <QueryMediaExport siteId={ siteId } /> }
 				<FoldableCard
 					header={
 						<div>
@@ -61,6 +67,7 @@ class ExportMediaCard extends Component {
 export default connect(
 	state => ( {
 		mediaExportUrl: getMediaExportUrl( state ),
+		mediaStorageUsed: getMediaStorageUsed( state, getSelectedSiteId( state ) ),
 	} ),
 	{
 		recordMediaExportClick: () => recordTracksEvent( 'calypso_export_media_download_button_click' ),

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -27,9 +27,13 @@ class ExportMediaCard extends Component {
 	};
 
 	render() {
-		const { mediaExportUrl, siteId, translate, recordMediaExportClick } = this.props;
-
-		const hasNoMediaFiles = this.props.mediaStorageUsed === 0 && ! mediaExportUrl;
+		const {
+			mediaExportUrl,
+			hasNoMediaFiles,
+			siteId,
+			translate,
+			recordMediaExportClick,
+		} = this.props;
 
 		const exportMediaButton = (
 			<Button
@@ -38,28 +42,34 @@ class ExportMediaCard extends Component {
 				disabled={ ! mediaExportUrl }
 				onClick={ recordMediaExportClick }
 			>
-				{ hasNoMediaFiles ? translate( 'Upload files first' ) : translate( 'Download' ) }
+				{ translate( 'Download' ) }
 			</Button>
 		);
 
 		return (
-			<div className="export-media-card">
+			<Fragment>
 				<QueryMediaStorage siteId={ siteId } />
-				{ ! hasNoMediaFiles && <QueryMediaExport siteId={ siteId } /> }
-				<FoldableCard
-					header={
-						<div>
-							<h1 className="export-media-card__title">{ translate( 'Export media library' ) }</h1>
-							<h2 className="export-media-card__subtitle">
-								{ translate(
-									'Download all the media library files (images, videos, audio and documents) from your site.'
-								) }
-							</h2>
-						</div>
-					}
-					summary={ exportMediaButton }
-				/>
-			</div>
+				{ ! hasNoMediaFiles && (
+					<div className="export-media-card">
+						<QueryMediaExport siteId={ siteId } />
+						<FoldableCard
+							header={
+								<div>
+									<h1 className="export-media-card__title">
+										{ translate( 'Export media library' ) }
+									</h1>
+									<h2 className="export-media-card__subtitle">
+										{ translate(
+											'Download all the media library files (images, videos, audio and documents) from your site.'
+										) }
+									</h2>
+								</div>
+							}
+							summary={ exportMediaButton }
+						/>
+					</div>
+				) }
+			</Fragment>
 		);
 	}
 }
@@ -67,7 +77,7 @@ class ExportMediaCard extends Component {
 export default connect(
 	state => ( {
 		mediaExportUrl: getMediaExportUrl( state ),
-		mediaStorageUsed: getMediaStorageUsed( state, getSelectedSiteId( state ) ),
+		hasNoMediaFiles: getMediaStorageUsed( state, getSelectedSiteId( state ) ) === 0,
 	} ),
 	{
 		recordMediaExportClick: () => recordTracksEvent( 'calypso_export_media_download_button_click' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the "Export media library" section from the Exporter when no media files are available.

#### Testing instructions

1. Start on a site with no media files
2. Head to the Exporter and verify you can't export your Media Library
3. Upload a file
4. Verify the Exporter works as usual 

cc @arunsathiya, @creativecoder, @southp 

Fixes #32109
