### PR TITLE
Jetpack Connect: add a separate notice for WP.com sites purchasing Search

### DIFF
--- a/client/jetpack-connect/connection-notice-types.js
+++ b/client/jetpack-connect/connection-notice-types.js
@@ -11,6 +11,7 @@ export const ALREADY_OWNED = 'alreadyOwned';
 export const DEFAULT_AUTHORIZE_ERROR = 'defaultAuthorizeError';
 export const INSTALL_RESPONSE_ERROR = 'unableToInstall';
 export const IS_DOT_COM = 'isDotCom';
+export const IS_DOT_COM_GET_SEARCH = 'isDotComGetSearch';
 export const JETPACK_IS_DISCONNECTED = 'jetpackIsDisconnected';
 export const JETPACK_IS_VALID = 'jetpackIsValid';
 export const LOGIN_FAILURE = 'loginFailure';

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -111,7 +111,7 @@ export class JetpackConnectNotices extends Component {
 				noticeValues.status = 'is-success';
 				noticeValues.icon = 'status';
 				noticeValues.text = translate(
-					'Good news! Search for WordPress.com sites is coming soon.'
+					'Good news! Jetpack Search is coming soon to WordPress.com sites.'
 				);
 				return noticeValues;
 

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -16,6 +16,7 @@ import {
 	INSTALL_RESPONSE_ERROR,
 	INVALID_CREDENTIALS,
 	IS_DOT_COM,
+	IS_DOT_COM_GET_SEARCH,
 	JETPACK_IS_DISCONNECTED,
 	JETPACK_IS_VALID,
 	NOT_ACTIVE_JETPACK,
@@ -49,6 +50,7 @@ export class JetpackConnectNotices extends Component {
 			INSTALL_RESPONSE_ERROR,
 			INVALID_CREDENTIALS,
 			IS_DOT_COM,
+			IS_DOT_COM_GET_SEARCH,
 			JETPACK_IS_DISCONNECTED,
 			JETPACK_IS_VALID,
 			NOT_ACTIVE_JETPACK,
@@ -103,6 +105,14 @@ export class JetpackConnectNotices extends Component {
 				noticeValues.status = 'is-success';
 				noticeValues.icon = 'plugins';
 				noticeValues.text = translate( 'Good news! WordPress.com sites already have Jetpack.' );
+				return noticeValues;
+
+			case IS_DOT_COM_GET_SEARCH:
+				noticeValues.status = 'is-success';
+				noticeValues.icon = 'status';
+				noticeValues.text = translate(
+					'Good news! Search for WordPress.com sites is coming soon.'
+				);
 				return noticeValues;
 
 			case NOT_WORDPRESS:

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -6,7 +6,7 @@ import config from 'config';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { concat, flowRight, get, includes } from 'lodash';
+import { concat, flowRight, get, includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -33,6 +33,7 @@ import { isRequestingSites } from 'state/sites/selectors';
 import { persistSession, retrieveMobileRedirect } from './persistence-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { urlToSlug } from 'lib/url';
+
 import {
 	JPC_PATH_PLANS,
 	JPC_PATH_REMOTE_INSTALL,
@@ -43,6 +44,7 @@ import {
 	ALREADY_CONNECTED,
 	ALREADY_OWNED,
 	IS_DOT_COM,
+	IS_DOT_COM_GET_SEARCH,
 	NOT_ACTIVE_JETPACK,
 	NOT_CONNECTED_JETPACK,
 	NOT_EXISTS,
@@ -284,7 +286,13 @@ export class JetpackConnectMain extends Component {
 		) {
 			return WORDPRESS_DOT_COM;
 		}
+
 		if ( this.checkProperty( 'isWordPressDotCom' ) ) {
+			const product = window.location.href.split( '/' )[ 5 ];
+
+			if ( startsWith( product, 'jetpack_search' ) ) {
+				return IS_DOT_COM_GET_SEARCH;
+			}
 			return IS_DOT_COM;
 		}
 		if ( ! this.checkProperty( 'exists' ) ) {


### PR DESCRIPTION
Atm, Search is a Jetpack product, but it will become available for WP.com sites in the future. 

#### Changes proposed in this Pull Request

* Here,  we add a notice when users arrive at the connection step following Search purchase flow and input their WP.com site address. 


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* start at the url input form of the JPC flow: `/jetpack/connect/jetpack_search`  (try with parameters e.g. being redirected from the LP `?cta_id=landing-page-search-primary-cta&cta_from=upgrade_search`
* input a WP.com site
* verify that the notice appears:

![wpcomsearch](https://user-images.githubusercontent.com/13561163/79693343-4987c400-826a-11ea-9818-20a9fdd1ea93.png)

