### PR TITLE
Checkout: expand the definition of Jetpack Products redirected to the checklist/Thank You modal

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -536,10 +536,9 @@ export class Checkout extends React.Component {
 		// We want to be product-specific, as the same path will likely be used for
 		// WP.com sites purchasing Search.
 		if (
-			product === 'jetpack_search' ||
-			product === 'jetpack_scan' ||
-			product === 'jetpack_backup_daily' ||
-			product === 'jetpack_backup_monthly'
+			startsWith( product, 'jetpack_backup' ) ||
+			startsWith( product, 'jetpack_search' ) ||
+			startsWith( product, 'jetpack_scan' )
 		) {
 			signupDestination = this.getFallbackDestination( pendingOrReceiptId );
 		} else {


### PR DESCRIPTION
Sequel to https://github.com/Automattic/wp-calypso/pull/41123
#### Changes proposed in this Pull Request

* Including  daily, early and real-time plans.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


  -   Start at /jetpack/connect/plans/:site, for a CONNECTED site (else we cannot reach that url)
   -  purchase a product
   -  verify that the checkout url contains product info
   - verify the relevance of the Thank you note

Verify that the upsell flow works for the WP.com sites.

