### PR TITLE
Deduplicate find-cache-dir

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9818,22 +9818,13 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.0.0:
+find-cache-dir@^3.0.0, find-cache-dir@^3.2.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
   integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
   dependencies:
     commondir "^1.0.1"
     make-dir "^3.0.2"
-    pkg-dir "^4.1.0"
-
-find-cache-dir@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.2.0.tgz#e7fe44c1abc1299f516146e563108fd1006c1874"
-  integrity sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==
-  dependencies:
-    commondir "^1.0.1"
-    make-dir "^3.0.0"
     pkg-dir "^4.1.0"
 
 find-file-up@^0.1.2:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change done automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```
#Before
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> find-cache-dir@3.2.0
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> find-cache-dir@3.2.0

#After
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> find-cache-dir@3.3.1
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> find-cache-dir@3.3.1
```