### PR TITLE
Plans: display "Manage Product" CTA irrespective of payment frequency in JP product cards.

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -579,7 +579,7 @@ export class ProductSelector extends Component {
 					purchase={ purchase }
 					subtitle={ this.getSubtitleByProduct( product ) }
 				>
-					{ hasProductPurchase && isCurrent && this.renderManageButton( product, purchase ) }
+					{ hasProductPurchase && this.renderManageButton( product, purchase ) }
 					{ ! hasProductPurchase && ! isCurrent && (
 						<Fragment>
 							{ product.hasPromo && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Include "Manage Product" on the Jetpack product cards in Plans tab for both monthly and yearly toggle.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* purchase monthly or yearly Jetpack Search (or Scan)
* go to `/plans` in Calypso
* verify that the Manage Product CTA appears under both monthly and yearly options

Fixes https://github.com/Automattic/wp-calypso/issues/40549
