### PR TITLE
Include the site id in `calypso_signup_complete` event.

### DIFF
--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -41,9 +41,12 @@ export function recordSignupComplete(
 	}
 
 	// Tracks
+	// Note that Tracks expects blog_id to differntiate sites, hence using
+	// blog_id instead of site_id here. We keep using "siteId" otherwise since
+	// all the other fields still refer with "site". e.g. isNewSite
 	analytics.tracks.recordEvent( 'calypso_signup_complete', {
 		flow,
-		site_id: siteId,
+		blog_id: siteId,
 		is_new_user: isNewUser,
 		is_new_site: isNewSite,
 		has_cart_items: hasCartItems,

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -26,14 +26,16 @@ export function recordSignupStart( flow, ref ) {
 }
 
 export function recordSignupComplete(
-	{ flow, isNewUser, isNewSite, hasCartItems, isNew7DUserSite },
+	{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite },
 	now
 ) {
+	const isNewSite = !! siteId;
+
 	if ( ! now ) {
 		// Delay using the analytics localStorage queue.
 		return analytics.queue.add(
 			'recordSignupComplete',
-			{ flow, isNewUser, isNewSite, hasCartItems, isNew7DUserSite },
+			{ flow, siteId, isNewUser, hasCartItems, isNew7DUserSite },
 			true
 		);
 	}
@@ -41,6 +43,7 @@ export function recordSignupComplete(
 	// Tracks
 	analytics.tracks.recordEvent( 'calypso_signup_complete', {
 		flow,
+		site_id: siteId,
 		is_new_user: isNewUser,
 		is_new_site: isNewSite,
 		has_cart_items: hasCartItems,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -290,7 +290,7 @@ class Signup extends React.Component {
 		const { isNewishUser, existingSiteCount } = this.props;
 
 		const isNewUser = !! ( dependencies && dependencies.username );
-		const isNewSite = !! ( dependencies && dependencies.siteSlug );
+		const siteId = dependencies && dependencies.siteId;
 		const isNew7DUserSite = !! (
 			isNewUser ||
 			( isNewishUser && dependencies && dependencies.siteSlug && existingSiteCount <= 1 )
@@ -301,17 +301,17 @@ class Signup extends React.Component {
 			isNewishUser,
 			existingSiteCount,
 			isNewUser,
-			isNewSite,
 			hasCartItems,
 			isNew7DUserSite,
 			flow: this.props.flowName,
+			siteId,
 		};
 		debug( 'Tracking signup completion.', debugProps );
 
 		recordSignupComplete( {
 			flow: this.props.flowName,
+			siteId,
 			isNewUser,
-			isNewSite,
 			hasCartItems,
 			isNew7DUserSite,
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Per request by pau2Xa-12j-p2, this commit adds the site id to
`calypso_signup_complete` event. In the same vein, `isNewSite` becomes a
derived data within the function itself, hence removing it from the call
sites.

#### Testing instructions

1. Complete the signing up process as a new user. Check the request to t.gif contains `site_id` and `isNewSite` is set as `true` properly.
1. Log in and create a new site. Check the request to t.gif contains `site_id` and `isNewSite` is set as `false` properly.