### PR TITLE
Deduplicate domutils

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8408,7 +8408,7 @@ dompurify@2.0.7:
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.7.tgz#f8266ad38fe1602fb5b3222f31eedbf5c16c4fd5"
   integrity sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A==
 
-domutils@1.5.1, domutils@^1.5.1:
+domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
   integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
@@ -8416,7 +8416,7 @@ domutils@1.5.1, domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^1.7.0:
+domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change done automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```
#Before
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> domutils@1.5.1
wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> domutils@1.5.1
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> domutils@1.5.1
wp-calypso-monorepo@0.17.0 -> enzyme@3.11.0 -> ... -> domutils@1.5.1
wp-calypso-monorepo@0.17.0 -> html-webpack-plugin@3.2.0 -> ... -> domutils@1.5.1
wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> domutils@1.5.1
wp-calypso-monorepo@0.17.0 -> svgstore-cli@1.3.1 -> ... -> domutils@1.5.1

#After
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.14 -> ... -> domutils@1.7.0
wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> domutils@1.7.0
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> domutils@1.7.0
wp-calypso-monorepo@0.17.0 -> enzyme@3.11.0 -> ... -> domutils@1.7.0
wp-calypso-monorepo@0.17.0 -> html-webpack-plugin@3.2.0 -> ... -> domutils@1.7.0
wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> domutils@1.7.0
wp-calypso-monorepo@0.17.0 -> svgstore-cli@1.3.1 -> ... -> domutils@1.7.0
```