### PR TITLE
Downgrades: Make text clear that downgrades occur immediately

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -38,8 +38,9 @@ export class DowngradeStep extends Component {
 		const canRefund = !! parseFloat( refundAmount );
 		const amount = currencySymbol + ( canRefund ? refundAmount : planCost );
 		const isEnglishLocale = [ 'en', 'en-gb' ].indexOf( userUtils.getLocaleSlug() ) >= 0;
-		const downgradeWarning =
-			'If you choose to downgrade, your plan will be downgraded immediately.';
+		const downgradeWarning = translate(
+			'If you choose to downgrade, your plan will be downgraded immediately.'
+		);
 		let refundDetails, refundTitle, refundReason;
 		if ( isEnglishLocale ) {
 			refundTitle = translate( 'Would you rather switch to a more affordable plan?' );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -38,6 +38,8 @@ export class DowngradeStep extends Component {
 		const canRefund = !! parseFloat( refundAmount );
 		const amount = currencySymbol + ( canRefund ? refundAmount : planCost );
 		const isEnglishLocale = [ 'en', 'en-gb' ].indexOf( userUtils.getLocaleSlug() ) >= 0;
+		const downgradeWarning =
+			'If you choose to downgrade, your plan will be downgraded immediately.';
 		let refundDetails, refundTitle, refundReason;
 		if ( isEnglishLocale ) {
 			refundTitle = translate( 'Would you rather switch to a more affordable plan?' );
@@ -76,7 +78,9 @@ export class DowngradeStep extends Component {
 				<FormSectionHeading>{ refundTitle }</FormSectionHeading>
 				<FormFieldset>
 					{ refundReason }
-					<p>{ refundDetails }</p>
+					<p>
+						{ refundDetails } { downgradeWarning }
+					</p>
 				</FormFieldset>
 			</div>
 		);

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -299,8 +299,7 @@ const CancelPurchaseRefundInformation = ( {
 	} else {
 		text = i18n.translate(
 			"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +
-				'Once it expires, it will be automatically removed from your site. If you choose to downgrade your ' +
-				'subscription instead, the downgrade will come into effect immediately.',
+				'Once it expires, it will be automatically removed from your site.',
 			{
 				args: {
 					productName: getName( purchase ),

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -299,7 +299,8 @@ const CancelPurchaseRefundInformation = ( {
 	} else {
 		text = i18n.translate(
 			"When you cancel your subscription, you'll be able to use %(productName)s until your subscription expires. " +
-				'Once it expires, it will be automatically removed from your site.',
+				'Once it expires, it will be automatically removed from your site. If you choose to downgrade your ' +
+				'subscription instead, the downgrade will come into effect immediately.',
 			{
 				args: {
 					productName: getName( purchase ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Make it clearer to users that downgrading a subscription will come into effect immediately. Relates to #37982

This will add a downgrade warning message to:

* First step of the cancellation process
* Downgrade selection step

Example of original text:

> When you cancel your subscription, you'll be able to use WordPress.com Premium until your subscription expires. Once it expires, it will be automatically removed from your site.

#### Testing instructions

##### Prerequisites:

* Must be a simple site (not Atomic)
* Needs to have at least Premium plan upgrade
* Auto-renewal must be enabled

##### Steps to view text changes

1. Visit URL: https://wordpress.com/me/purchases
2. Select the Business or Premium plan to be downgraded.
3. Choose "Cancel Subscription".
4. Check the cancellation information includes downgrade warning.
5. Click the "Cancel Subscription" button.
6. Choose "The plan was too expensive" for the cancellation reason.
7. Below that, select "I'm staying here and using the free plan" for your next adventure.
8. Click the "Next Step" button.
9. Confirm the displayed information contains downgrade warning.

##### Before / After Screenshots

Cancellation Step:

<img width="526" alt="OriginalCancellationText" src="https://user-images.githubusercontent.com/60436221/79721377-9381b000-8325-11ea-82fe-d71dc206fc9f.png">

<img width="527" alt="UpdatedCancellationText" src="https://user-images.githubusercontent.com/60436221/79721469-b6ac5f80-8325-11ea-8f70-74ba10382011.png">

Downgrade Step:

<img width="538" alt="OriginalDowngradeText" src="https://user-images.githubusercontent.com/60436221/79721533-d80d4b80-8325-11ea-8f30-0572ce4c9eda.png">
<img width="538" alt="UpdatedDowngradeText" src="https://user-images.githubusercontent.com/60436221/79721541-de032c80-8325-11ea-90ab-2d1a778c49cc.png">

