### PR TITLE
Customer Home: Updating Timing of Connect Accounts Task

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/connect-accounts.jsx
+++ b/client/my-sites/customer-home/cards/tasks/connect-accounts.jsx
@@ -43,7 +43,7 @@ const ConnectAccountsTask = ( { skipTask, siteSlug } ) => {
 				) }
 				<div className="tasks__timing">
 					<Gridicon icon="time" size={ 18 } />
-					<p>{ translate( '3 minutes' ) }</p>
+					<p>{ translate( '%d minute', '%d minutes', { count: 3, args: [ 3 ] } ) }</p>
 				</div>
 				<ActionPanelTitle>{ translate( 'Drive traffic to your site' ) }</ActionPanelTitle>
 				<p className="tasks__description">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This just makes the change suggested here: https://github.com/Automattic/wp-calypso/pull/41018#discussion_r411120993

cc @akirk 

#### Testing instructions

Check that the Connect Accounts Task (details in #41018 on how to display it) still shows "3 minutes" as the timestamp.

<img width="274" alt="Screenshot 2020-04-20 at 09 13 36" src="https://user-images.githubusercontent.com/43215253/79729336-3cf58100-82e7-11ea-9c8a-0c0626078977.png">

