### PR TITLE
Add Earth Day Live setting

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { flowRight, get, has } from 'lodash';
+import moment from 'moment-timezone';
 
 /**
  * Internal dependencies

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -513,11 +513,12 @@ export class SiteSettingsFormGeneral extends Component {
 							onChange={ this.handleEarthDayLiveToggle }
 						>
 							{ translate(
-								'From April 22 - 24, activists, performers, thought leaders and artists will come together ' +
-									'for a {{earthDayLiveLink}}massive 3 day live stream{{/earthDayLiveLink}} for the future ' +
-									'of our planet. Show your support by displaying the {{earthDayLiveBannerLink}}Earth Day ' +
-									'Live banner{{/earthDayLiveBannerLink}} on your site. On April 22, the 50th anniversary ' +
-									'of Earth Day, the banner will expand to a full-screen overlay that site visitors can dismiss.',
+								'From April 22-24, experts, activists, artists, and performers will run a ' +
+									'{{earthDayLiveLink}}massive, three-day livestream{{/earthDayLiveLink}} to inspire people ' +
+									'around the world to join the movement and take action against climate change. Show your support! ' +
+									'Display the {{earthDayLiveBannerLink}}Earth Day Live Banner{{/earthDayLiveBannerLink}} on your ' +
+									'site. On April 22 – the 50th anniversary of Earth Day – the banner will become a full-site ' +
+									'overlay that your visitors can dismiss.',
 								{
 									components: {
 										earthDayLiveLink: (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

![Screenshot from 2020-04-20 15-57-58](https://user-images.githubusercontent.com/751476/79766347-c45ee680-831f-11ea-84d7-83e7876a5e80.png)

This PR introduces a new temporary setting for controlling the Earth Day Live banner.

#### Testing instructions

With both the API and plugin in place and your site and the API sandboxed, you can test this PR on any WordPress.com site. The setting will not show for Jetpack sites which can install the [plugin directly](https://wordpress.org/plugins/earth-day-live-wp/).

- Go to My Sites > Manage > Settings on a WordPress.com site and confirm that the setting is available under the general tab, and that toggling it activates and deactivates the Earth Day Live banner on the front-end of the site.

#### Dependencies

D42135-code