### PR TITLE
Jetpack Connect: adapt the Search card copy on the plans page in the absence of site info.

### DIFF
--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -355,7 +355,7 @@ export class ProductSelector extends Component {
 		return (
 			<ProductCardAction
 				onClick={ this.handleCheckoutForProduct( productObject ) }
-				intro={ this.getIntervalDiscount( selectedProductSlug ) }
+				intro={ this.props.selectedSiteSlug && this.getIntervalDiscount( selectedProductSlug ) }
 				label={ translate( 'Get %(productName)s', {
 					args: {
 						productName: this.getActionButtonName( product, productObject.product_slug ),

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -499,6 +499,22 @@ export class ProductSelector extends Component {
 		return null;
 	}
 
+	getPromo() {
+		return (
+			<ProductCardPromoNudge
+				badgeText={ this.props.translate( 'Up to %(discount)s off!', {
+					args: { discount: '70%' },
+				} ) }
+				text={ this.props.translate(
+					'Hurry, these are {{strong}}Limited time introductory prices!{{/strong}}',
+					{
+						components: { strong: <strong /> },
+					}
+				) }
+			/>
+		);
+	}
+
 	renderProducts() {
 		const {
 			fetchingPlans,
@@ -508,7 +524,6 @@ export class ProductSelector extends Component {
 			products,
 			selectedSiteSlug,
 			storeProducts,
-			translate,
 		} = this.props;
 
 		if ( isEmpty( storeProducts ) || fetchingSitePurchases || fetchingSitePlans || fetchingPlans ) {
@@ -579,36 +594,34 @@ export class ProductSelector extends Component {
 					purchase={ purchase }
 					subtitle={ this.getSubtitleByProduct( product ) }
 				>
-					{ hasProductPurchase && this.renderManageButton( product, purchase ) }
-					{ ! hasProductPurchase && ! isCurrent && (
+					{ selectedSiteSlug &&
+						hasProductPurchase &&
+						isCurrent &&
+						this.renderManageButton( product, purchase ) }
+					{ ! selectedSiteSlug && product.id === 'jetpack_search' && (
 						<Fragment>
-							{ product.hasPromo && (
-								<ProductCardPromoNudge
-									badgeText={ translate( 'Up to %(discount)s off!', {
-										args: { discount: '70%' },
-									} ) }
-									text={ translate(
-										'Hurry, these are {{strong}}Limited time introductory prices!{{/strong}}',
-										{
-											components: { strong: <strong /> },
-										}
-									) }
-								/>
-							) }
-
-							<ProductCardOptions
-								optionsLabel={ optionsLabel }
-								options={ this.getProductOptions( product ) }
-								selectedSlug={ selectedSlug }
-								handleSelect={ ( productSlug ) =>
-									this.handleProductOptionSelect( stateKey, productSlug, product.id )
-								}
-								forceRadiosEvenIfOnlyOneOption={ !! product.forceRadios }
-							/>
-
+							{ product.hasPromo && this.getPromo() }
 							{ this.renderCheckoutButton( product ) }
 						</Fragment>
 					) }
+					{ ( selectedSiteSlug || ( ! selectedSiteSlug && product.id !== 'jetpack_search' ) ) &&
+						! hasProductPurchase &&
+						! isCurrent && (
+							<Fragment>
+								{ product.hasPromo && this.getPromo() }
+								<ProductCardOptions
+									optionsLabel={ optionsLabel }
+									options={ this.getProductOptions( product ) }
+									selectedSlug={ selectedSlug }
+									handleSelect={ productSlug =>
+										this.handleProductOptionSelect( stateKey, productSlug, product.id )
+									}
+									forceRadiosEvenIfOnlyOneOption={ !! product.forceRadios }
+								/>
+
+								{ this.renderCheckoutButton( product ) }
+							</Fragment>
+						) }
 				</ProductCard>
 			);
 		} );

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -234,8 +234,9 @@ export class ProductSelector extends Component {
 		if ( ! this.props.selectedSiteSlug ) {
 			return (
 				description +
-				`The price of this subscription is based on \
-       the number of records you have on your site.`
+				this.props.translate(
+					'The price of this subscription is based on the number of records you have on your site.'
+				)
 			);
 		}
 
@@ -508,7 +509,7 @@ export class ProductSelector extends Component {
 		return null;
 	}
 
-	getPromo() {
+	renderPromo() {
 		return (
 			<ProductCardPromoNudge
 				badgeText={ this.props.translate( 'Up to %(discount)s off!', {
@@ -609,7 +610,7 @@ export class ProductSelector extends Component {
 						this.renderManageButton( product, purchase ) }
 					{ ! selectedSiteSlug && product.id === 'jetpack_search' && (
 						<Fragment>
-							{ product.hasPromo && this.getPromo() }
+							{ product.hasPromo && this.renderPromo() }
 							{ this.renderCheckoutButton( product ) }
 						</Fragment>
 					) }
@@ -617,7 +618,7 @@ export class ProductSelector extends Component {
 						! hasProductPurchase &&
 						! isCurrent && (
 							<Fragment>
-								{ product.hasPromo && this.getPromo() }
+								{ product.hasPromo && this.renderPromo() }
 								<ProductCardOptions
 									optionsLabel={ optionsLabel }
 									options={ this.getProductOptions( product ) }

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -604,10 +604,7 @@ export class ProductSelector extends Component {
 					purchase={ purchase }
 					subtitle={ this.getSubtitleByProduct( product ) }
 				>
-					{ selectedSiteSlug &&
-						hasProductPurchase &&
-						isCurrent &&
-						this.renderManageButton( product, purchase ) }
+					{ selectedSiteSlug && hasProductPurchase && this.renderManageButton( product, purchase ) }
 					{ ! selectedSiteSlug && product.id === 'jetpack_search' && (
 						<Fragment>
 							{ product.hasPromo && this.renderPromo() }

--- a/client/blocks/product-selector/index.jsx
+++ b/client/blocks/product-selector/index.jsx
@@ -230,6 +230,15 @@ export class ProductSelector extends Component {
 			return optionDescriptions[ planProductSlug ];
 		}
 
+		// Plans landing page at /jetpack/connect/store
+		if ( ! this.props.selectedSiteSlug ) {
+			return (
+				description +
+				`The price of this subscription is based on \
+       the number of records you have on your site.`
+			);
+		}
+
 		// Default product description.
 		return description;
 	}
@@ -613,7 +622,7 @@ export class ProductSelector extends Component {
 									optionsLabel={ optionsLabel }
 									options={ this.getProductOptions( product ) }
 									selectedSlug={ selectedSlug }
-									handleSelect={ productSlug =>
+									handleSelect={ ( productSlug ) =>
 										this.handleProductOptionSelect( stateKey, productSlug, product.id )
 									}
 									forceRadiosEvenIfOnlyOneOption={ !! product.forceRadios }


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* When accessing the canonical plans page at `jetpack/connect/store`, we do not have site information available. Thus, we cannot estimate record size to be indexed nor price of the Search product. Here, we remove the relevant parts from the copy.

After:

![image](https://user-images.githubusercontent.com/13561163/79751068-434d2280-8312-11ea-826f-3ff3e8bfd864.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- go to `http://calypso.localhost:3000/jetpack/connect/store` for the local build
-  verify that the copy for Search agrees with the above design and does not affect the remaining product and plans


Fixes https://github.com/Automattic/wp-calypso/issues/41025
