### PR TITLE
WP for Teams: assign custom signup flow name to new invited user

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -51,9 +51,11 @@ class InviteAcceptLoggedOut extends React.Component {
 	};
 
 	submitForm = ( form, userData ) => {
+		const { invite } = this.props;
+
 		this.setState( { submitting: true } );
-		debug( 'Storing invite_accepted: ' + JSON.stringify( this.props.invite ) );
-		store.set( 'invite_accepted', this.props.invite );
+		debug( 'Storing invite_accepted: ' + JSON.stringify( invite ) );
+		store.set( 'invite_accepted', invite );
 		const createAccountCallback = ( error, bearerToken ) => {
 			debug( 'Create account error: ' + JSON.stringify( error ) );
 			debug( 'Create account bearerToken: ' + bearerToken );
@@ -66,7 +68,13 @@ class InviteAcceptLoggedOut extends React.Component {
 			}
 		};
 
-		this.props.createAccount( userData, this.props.invite, createAccountCallback );
+		const enhancedUserData = { ...userData };
+
+		if ( invite.site.is_wpforteams_site ) {
+			enhancedUserData.signup_flow_name = 'wp-for-teams';
+		}
+
+		this.props.createAccount( enhancedUserData, this.props.invite, createAccountCallback );
 	};
 
 	renderFormHeader = () => {

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -134,6 +134,10 @@ class InviteAcceptLoggedOut extends React.Component {
 	};
 
 	renderSignInLinkOnly = () => {
+		// TODO: this needs a refactor to unify it with components/logged-out-form as it's using
+		// styles from there but not the component
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="sign-up-form">
 				<Card className="logged-out-form">
@@ -145,6 +149,7 @@ class InviteAcceptLoggedOut extends React.Component {
 					</Card>
 				</Card>
 			</div>
+			/* eslint-enable */
 		);
 	};
 

--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import store from 'store';
 import debugModule from 'debug';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -70,11 +71,11 @@ class InviteAcceptLoggedOut extends React.Component {
 
 		const enhancedUserData = { ...userData };
 
-		if ( invite.site.is_wpforteams_site ) {
+		if ( get( invite, 'site.is_wpforteams_site', false ) ) {
 			enhancedUserData.signup_flow_name = 'wp-for-teams';
 		}
 
-		this.props.createAccount( enhancedUserData, this.props.invite, createAccountCallback );
+		this.props.createAccount( enhancedUserData, invite, createAccountCallback );
 	};
 
 	renderFormHeader = () => {


### PR DESCRIPTION
Addresses https://github.com/Automattic/wp-for-teams/issues/180.

In this PR, we assign the `signup_flow_name` to `wp-for-teams` for brand new wpcom users who were invited to a WP for Teams site.

## Testing instructions

Use a 10 minute email provider to get a new email address. Go to a WP for Teams site and invite your new email in an incognito window. Finish the signup process. You should not receive the WP.com Welcome email after signup (only the activation one).