### PR TITLE
My Home: Make "View my site" button always visible

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -25,7 +25,6 @@ import getSiteChecklist from 'state/selectors/get-site-checklist';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import QueryHomeLayout from 'components/data/query-home-layout';
@@ -49,7 +48,6 @@ const Home = ( {
 	layout,
 	site,
 	siteId,
-	siteIsUnlaunched,
 	trackViewSiteAction,
 } ) => {
 	const translate = useTranslate();
@@ -79,13 +77,11 @@ const Home = ( {
 					) }
 					align="left"
 				/>
-				{ ! siteIsUnlaunched && (
-					<div className="customer-home__view-site-button">
-						<Button href={ site.URL } onClick={ trackViewSiteAction }>
-							{ translate( 'View site' ) }
-						</Button>
-					</div>
-				) }
+				<div className="customer-home__view-site-button">
+					<Button href={ site.URL } onClick={ trackViewSiteAction }>
+						{ translate( 'View site' ) }
+					</Button>
+				</div>
 			</div>
 			{ layout ? (
 				<>
@@ -154,7 +150,6 @@ const mapStateToProps = ( state ) => {
 		isStaticHomePage:
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
 		displayChecklist: layout?.primary?.includes( 'home-primary-checklist-site-setup' ),
-		siteIsUnlaunched: isUnlaunchedSite( state, siteId ),
 		user,
 		layout,
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We currently display a button for viewing a site within My Home only when a site is launched making hard for new users to view their sites while they are building it.

This PR ensures the button is always visible, despite the site status.

Before | After
--- | ---
<img width="977" alt="Screen Shot 2020-04-20 at 17 00 29" src="https://user-images.githubusercontent.com/1233880/79766598-79959c80-8328-11ea-8d3f-c54ba8fab332.png"> | <img width="978" alt="Screen Shot 2020-04-20 at 17 00 34" src="https://user-images.githubusercontent.com/1233880/79766613-7e5a5080-8328-11ea-97cd-2cedbb6e68a2.png">

#### Testing instructions

- Create a new site.
- Make sure the "View my site" button is visible when you land in My Home.

Fixes #41280
