### PR TITLE
Split types into their own imports / exports

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/index.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/index.js
@@ -9,8 +9,6 @@ import FormFieldAnnotation from './components/form-field-annotation';
 import { getNonProductWPCOMCartItemTypes } from './lib/translate-cart';
 import { areDomainsInLineItems } from './hooks/has-domains';
 import {
-	WPCOMCartItem,
-	CheckoutCartItem,
 	prepareDomainContactDetails,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	emptyManagedContactDetails,
@@ -30,8 +28,6 @@ export {
 	useShoppingCart,
 	useWpcomStore,
 	FormFieldAnnotation,
-	WPCOMCartItem,
-	CheckoutCartItem,
 	prepareDomainContactDetails,
 	getNonProductWPCOMCartItemTypes,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types.ts
@@ -1,18 +1,25 @@
+// Disabling duplicate imports while bugs in eslint-plugin-import TS 3.8 support remain.
+// See https://github.com/benmosher/eslint-plugin-import/issues/1667
+/* eslint-disable no-duplicate-imports */
+
 /**
  * Internal dependencies
  */
-import { CheckoutPaymentMethodSlug } from './types/checkout-payment-method-slug';
+import type { CheckoutPaymentMethodSlug } from './types/checkout-payment-method-slug';
+import type { WPCOMPaymentMethodClass } from './types/backend/payment-method';
 import {
-	WPCOMPaymentMethodClass,
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 } from './types/backend/payment-method';
-import {
+import type {
 	RequestCart,
 	RequestCartProduct,
 	ResponseCart,
 	ResponseCartProduct,
+	CartLocation,
+} from './types/backend/shopping-cart-endpoint';
+import {
 	emptyResponseCart,
 	prepareRequestCart,
 	removeItemFromResponseCart,
@@ -22,33 +29,34 @@ import {
 	removeCouponFromResponseCart,
 	addLocationToResponseCart,
 	doesCartLocationDifferFromResponseCartLocation,
-	CartLocation,
 	processRawResponse,
 } from './types/backend/shopping-cart-endpoint';
-import {
+import type {
 	DomainContactDetails,
 	PossiblyCompleteDomainContactDetails,
 	DomainContactDetailsErrors,
 } from './types/backend/domain-contact-details-components';
-import {
+import type {
 	WPCOMCart,
 	WPCOMCartItem,
 	WPCOMCartCouponItem,
-	emptyWPCOMCart,
 	CheckoutCartItem,
 	CheckoutCartItemAmount,
 } from './types/checkout-cart';
-import {
+import { emptyWPCOMCart } from './types/checkout-cart';
+import type {
 	WpcomStoreState,
-	getInitialWpcomStoreState,
 	ManagedContactDetails,
+	ManagedContactDetailsErrors,
+} from './types/wpcom-store-state';
+import {
+	getInitialWpcomStoreState,
 	emptyManagedContactDetails,
 	applyContactDetailsRequiredMask,
 	domainRequiredContactDetails,
 	taxRequiredContactDetails,
 	isCompleteAndValid,
 	isTouched,
-	ManagedContactDetailsErrors,
 	managedContactDetailsUpdaters,
 	prepareDomainContactDetails,
 	prepareDomainContactDetailsErrors,
@@ -58,16 +66,31 @@ import {
 	areRequiredFieldsNotEmpty,
 } from './types/wpcom-store-state';
 
-export {
+export type {
 	CheckoutPaymentMethodSlug,
 	WPCOMPaymentMethodClass,
-	readWPCOMPaymentMethodClass,
-	translateWpcomPaymentMethodToCheckoutPaymentMethod,
-	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	RequestCart,
 	RequestCartProduct,
 	ResponseCart,
 	ResponseCartProduct,
+	CartLocation,
+	WPCOMCart,
+	WPCOMCartItem,
+	WPCOMCartCouponItem,
+	CheckoutCartItem,
+	CheckoutCartItemAmount,
+	WpcomStoreState,
+	ManagedContactDetails,
+	ManagedContactDetailsErrors,
+	DomainContactDetails,
+	PossiblyCompleteDomainContactDetails,
+	DomainContactDetailsErrors,
+};
+
+export {
+	readWPCOMPaymentMethodClass,
+	translateWpcomPaymentMethodToCheckoutPaymentMethod,
+	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	emptyResponseCart,
 	prepareRequestCart,
 	removeItemFromResponseCart,
@@ -77,28 +100,16 @@ export {
 	removeCouponFromResponseCart,
 	addLocationToResponseCart,
 	doesCartLocationDifferFromResponseCartLocation,
-	CartLocation,
 	processRawResponse,
-	WPCOMCart,
-	WPCOMCartItem,
-	WPCOMCartCouponItem,
 	emptyWPCOMCart,
-	CheckoutCartItem,
-	CheckoutCartItemAmount,
-	WpcomStoreState,
 	getInitialWpcomStoreState,
-	ManagedContactDetails,
 	emptyManagedContactDetails,
 	applyContactDetailsRequiredMask,
 	domainRequiredContactDetails,
 	taxRequiredContactDetails,
 	isCompleteAndValid,
 	isTouched,
-	ManagedContactDetailsErrors,
 	managedContactDetailsUpdaters,
-	DomainContactDetails,
-	PossiblyCompleteDomainContactDetails,
-	DomainContactDetailsErrors,
 	prepareDomainContactDetails,
 	prepareDomainContactDetailsErrors,
 	prepareDomainContactValidationRequest,
@@ -106,3 +117,5 @@ export {
 	isValid,
 	areRequiredFieldsNotEmpty,
 };
+
+/* eslint-enable no-duplicate-imports */


### PR DESCRIPTION
There are currently a number of warnings in the build process, related to how `composite-checkout` is importing and exporting TypeScript types.

This PR fixes that, by importing and exporting types separately from actual JS constructs.

It also prevents a JS file from attempting to export TS types.

Note that this PR includes a temporary directive to disable an ESLint rule, because of an ongoing bug in its plugin (`eslint-plugin-import`) with TS 3.8 (see [this bug](https://github.com/benmosher/eslint-plugin-import/issues/1667)).

#### Changes proposed in this Pull Request

* Split types into their own imports / exports

#### Testing instructions

* Build calypso locally
* Ensure all the warnings about missing exports in `composite-checkout` are gone.
* Ensure `composite-checkout/wpcom`-related functionality still works?

This PR mostly fixes #41113, with one warning (in an external package) remaining.