### PR TITLE
Jetpack Cloud: Display product-based DocumentHead title

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -161,7 +161,7 @@ class BackupsPage extends Component {
 
 		return (
 			<Main>
-				<DocumentHead title={ translate( 'Backups' ) } />
+				<DocumentHead title={ hasRealtimeBackups ? translate( 'Real-time Backups' ) : translate( 'Daily Backups' ) } />
 				<SidebarNavigation />
 				<PageViewTracker path="/backups/:site" title="Backups" />
 

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -161,7 +161,12 @@ class BackupsPage extends Component {
 
 		return (
 			<Main>
-				<DocumentHead title={ hasRealtimeBackups ? translate( 'Real-time Backups' ) : translate( 'Daily Backups' ) } />
+				<DocumentHead title={
+					hasRealtimeBackups
+						? translate( 'Real-time Backups' )
+						: translate( 'Daily Backups' ) 
+					}
+				/>
 				<SidebarNavigation />
 				<PageViewTracker path="/backups/:site" title="Backups" />
 

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -161,10 +161,9 @@ class BackupsPage extends Component {
 
 		return (
 			<Main>
-				<DocumentHead title={
-					hasRealtimeBackups
-						? translate( 'Real-time Backups' )
-						: translate( 'Daily Backups' ) 
+				<DocumentHead
+					title={
+						hasRealtimeBackups ? translate( 'Real-time Backups' ) : translate( 'Daily Backups' )
 					}
 				/>
 				<SidebarNavigation />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Instead of simply "Backups", the page header should specify "Real-time Backups" or "Daily Backups".

![Screen Shot 2020-04-22 at 9 38 16 AM](https://user-images.githubusercontent.com/5528445/79988686-ede15480-847c-11ea-951a-d450b62cd591.png)
![Screen Shot 2020-04-22 at 9 38 01 AM](https://user-images.githubusercontent.com/5528445/79988689-ee79eb00-847c-11ea-9cab-d6cd040efb22.png)

#### Testing instructions

Load up the main Backups page and ensure that either "Real-time Backups" or "Daily Backups" appears at the top of the page. This should reflect the actual product you have purchased for the site.
