### PR TITLE
Modularise preferences state

### DIFF
--- a/client/blocks/upwork-banner/test/index.js
+++ b/client/blocks/upwork-banner/test/index.js
@@ -9,11 +9,13 @@ import renderer from 'react-test-renderer';
  * Internal dependencies
  */
 import { createReduxStore } from 'state';
+import { setStore } from 'state/redux-store';
 import UpworkBanner from '../';
 
 describe( 'UpworkBanner', () => {
 	test( 'renders correctly', () => {
 		const store = createReduxStore();
+		setStore( store );
 		const tree = renderer
 			.create(
 				<Provider store={ store }>

--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -22,7 +22,6 @@ import notices from 'state/notices/reducer';
 import i18n from 'state/i18n/reducer';
 import users from 'state/users/reducer';
 import currentUser from 'state/current-user/reducer';
-import preferences from 'state/preferences/reducer';
 import oauth2Clients from 'state/oauth2-clients/reducer';
 
 // Legacy reducers
@@ -35,7 +34,6 @@ const rootReducer = combineReducers( {
 	i18n,
 	users,
 	currentUser,
-	preferences,
 	oauth2Clients,
 	ui: combineReducers( {
 		language,

--- a/client/state/preferences/actions.js
+++ b/client/state/preferences/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import {
 	PREFERENCES_SET,
@@ -14,6 +13,8 @@ import {
 	PREFERENCES_SAVE_SUCCESS,
 } from 'state/action-types';
 import { USER_SETTING_KEY } from './constants';
+
+import 'state/preferences/init';
 
 /**
  * Returns an action object signalling the remote preferences have been

--- a/client/state/preferences/init.js
+++ b/client/state/preferences/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import preferencesReducer from './reducer';
+
+registerReducer( [ 'preferences' ], preferencesReducer );

--- a/client/state/preferences/package.json
+++ b/client/state/preferences/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -14,7 +14,12 @@ import {
 	PREFERENCES_FETCH_FAILURE,
 	PREFERENCES_SAVE_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, withSchemaValidation, withoutPersistence } from 'state/utils';
+import {
+	combineReducers,
+	withoutPersistence,
+	withSchemaValidation,
+	withStorageKey,
+} from 'state/utils';
 import { remoteValuesSchema } from './schema';
 
 /**
@@ -88,9 +93,11 @@ const lastFetchedTimestamp = withoutPersistence( ( state = false, action ) => {
 	return state;
 } );
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	localValues,
 	remoteValues,
 	fetching,
 	lastFetchedTimestamp,
 } );
+const preferencesReducer = withStorageKey( 'reader', combinedReducer );
+export default preferencesReducer;

--- a/client/state/preferences/selectors.js
+++ b/client/state/preferences/selectors.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-
 import { get, find, has } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { DEFAULT_PREFERENCE_VALUES } from './constants';
+
+import 'state/preferences/init';
 
 export const isFetchingPreferences = ( state ) => !! state.preferences.fetching;
 

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -69,7 +69,6 @@ import plans from './plans/reducer';
 import plugins from './plugins/reducer';
 import postFormats from './post-formats/reducer';
 import postTypes from './post-types/reducer';
-import preferences from './preferences/reducer';
 import productsList from './products-list/reducer';
 import purchases from './purchases/reducer';
 import pushNotifications from './push-notifications/reducer';
@@ -156,7 +155,6 @@ const reducers = {
 	plugins,
 	postFormats,
 	postTypes,
-	preferences,
 	productsList,
 	purchases,
 	pushNotifications,


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles preferences.

For mode details on state modularization, see #39261 and p4TIVU-9lM-p2.

Preferences state is small, so there shouldn't be any meaningful size savings.

#### Changes proposed in this Pull Request

* Modularise preferences state

#### Testing instructions

Since preferences state seems to be loaded by most routes, there's no easy way to check that modularisation is working. To ensure correctness, try to use preferences functionality as much as possible and see if anything breaks. The unit tests and E2E tests should add a good measure of confidence.