### PR TITLE
Jetpack Cloud: Fix link to activity log from date picker

### DIFF
--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -85,7 +85,7 @@ class DatePicker extends Component {
 	};
 
 	goToActivityLog = () => {
-		page.redirect( `/activity/${ this.props.siteSlug }` );
+		page.redirect( `/backups/activity/${ this.props.siteSlug }` );
 	};
 
 	onSpace = ( evt, fn ) => {

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -57,6 +57,7 @@
 	align-self: center;
 	margin-left: 0.5rem;
 	margin-right: 1rem;
+	cursor: pointer;
 }
 
 .date-picker__search-icon.gridicon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change link URL in date picker component from `/activity/{site}` to `/backups/activity/{site}`
* Update CSS to give pointer cursor when hovering over the magnifying glass

#### Testing instructions

Load backups page for any site. Ensure you can get to the activity log by clicking the magnifying glass at the top. Ensure the cursor is `pointer` when hovering.