### PR TITLE
UpsellNudge: Migrate Banners to UpsellNudge

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -29,6 +29,7 @@ export const UpsellNudge = ( {
 	canManageSite,
 	className,
 	compact,
+	customerType,
 	description,
 	disableHref,
 	dismissPreferenceName,
@@ -73,7 +74,7 @@ export const UpsellNudge = ( {
 		return null;
 	}
 
-	if ( ! href && site ) {
+	if ( ! href && site && ! customerType ) {
 		href = addQueryArgs( { feature, plan }, `/plans/${ site.slug }` );
 	}
 
@@ -82,6 +83,7 @@ export const UpsellNudge = ( {
 			callToAction={ callToAction }
 			className={ classes }
 			compact={ compact }
+			customerType={ customerType }
 			description={ description }
 			disableHref={ disableHref }
 			dismissPreferenceName={ dismissPreferenceName }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -23,7 +23,7 @@ import HeaderCake from 'components/header-cake';
 import SectionHeader from 'components/section-header';
 import ThemeDownloadCard from './theme-download-card';
 import ThemePreview from 'my-sites/themes/theme-preview';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { Button, Card } from '@automattic/components';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
@@ -661,7 +661,7 @@ class ThemeSheet extends React.Component {
 			! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip && ! retired;
 		if ( hasUpsellBanner ) {
 			pageUpsellBanner = (
-				<Banner
+				<UpsellNudge
 					plan={ PLAN_PREMIUM }
 					className="theme__page-upsell-banner"
 					title={ translate( 'Access this theme for FREE with a Premium or Business plan!' ) }
@@ -673,6 +673,7 @@ class ThemeSheet extends React.Component {
 					event="themes_plan_particular_free_with_plan"
 					forceHref={ true }
 					href={ plansUrl }
+					showIcon={ true }
 				/>
 			);
 			previewUpsellBanner = React.cloneElement( pageUpsellBanner, {

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -20,7 +20,7 @@ import { isPartnerPurchase } from 'lib/purchases';
 import JetpackReferrerMessage from './jetpack-referrer-message';
 import JetpackUpgradeMessage from './jetpack-upgrade-message';
 import { connectOptions } from './theme-options';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_JETPACK_BUSINESS } from 'lib/plans/constants';
 import QuerySitePlans from 'components/data/query-site-plans';
 import QuerySitePurchases from 'components/data/query-site-purchases';
@@ -96,7 +96,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 			/>
 			<CurrentTheme siteId={ siteId } />
 			{ ! requestingSitePlans && currentPlan && ! hasUnlimitedPremiumThemes && ! isPartnerPlan && (
-				<Banner
+				<UpsellNudge
 					plan={ PLAN_JETPACK_BUSINESS }
 					title={ translate( 'Access all our premium themes with our Professional plan!' ) }
 					description={ translate(
@@ -105,6 +105,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 							'and security scanning.'
 					) }
 					event="themes_plans_free_personal_premium"
+					showIcon={ true }
 				/>
 			) }
 			<ThemeShowcase

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -97,6 +97,7 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 			<CurrentTheme siteId={ siteId } />
 			{ ! requestingSitePlans && currentPlan && ! hasUnlimitedPremiumThemes && ! isPartnerPlan && (
 				<UpsellNudge
+					forceDisplay
 					plan={ PLAN_JETPACK_BUSINESS }
 					title={ translate( 'Access all our premium themes with our Professional plan!' ) }
 					description={ translate(

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -15,7 +15,7 @@ import FormattedHeader from 'components/formatted-header';
 import ThanksModal from 'my-sites/themes/thanks-modal';
 import AutoLoadingHomepageModal from 'my-sites/themes/auto-loading-homepage-modal';
 import { connectOptions } from './theme-options';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
 import { hasFeature, isRequestingSitePlans } from 'state/sites/plans/selectors';
 import QuerySitePlans from 'components/data/query-site-plans';
@@ -43,18 +43,19 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 	if ( displayUpsellBanner ) {
 		if ( bannerLocationBelowSearch ) {
 			upsellBanner = (
-				<Banner
+				<UpsellNudge
 					plan={ PLAN_PREMIUM }
 					customerType="business"
 					className="themes__showcase-banner"
 					title={ translate( 'Unlock ALL premium themes with our Premium and Business plans!' ) }
 					event="themes_plans_free_personal"
 					forceHref={ true }
+					showIcon={ true }
 				/>
 			);
 		} else {
 			upsellBanner = (
-				<Banner
+				<UpsellNudge
 					plan={ PLAN_PREMIUM }
 					title={ translate(
 						'Access all our premium themes with our Premium and Business plans!'
@@ -63,6 +64,7 @@ const ConnectedSingleSiteWpcom = connectOptions( ( props ) => {
 						'Get advanced customization, more storage space, and video support along with all your new themes.'
 					) }
 					event="themes_plans_free_personal"
+					showIcon={ true }
 				/>
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrating instances of `Banner` to `UpsellNudge` to consolidate components. See #38778

**Visual References**
<img width="1390" alt="Screen Shot 2020-04-21 at 1 21 25 PM" src="https://user-images.githubusercontent.com/2124984/79894165-0c8b1100-83d3-11ea-9cfa-dffefa97d873.png">
<img width="1373" alt="Screen Shot 2020-04-20 at 5 36 40 PM" src="https://user-images.githubusercontent.com/2124984/79802832-c11f2700-832e-11ea-9ef7-8f8236f01abc.png">
<img width="1254" alt="Screen Shot 2020-04-20 at 5 28 27 PM" src="https://user-images.githubusercontent.com/2124984/79802833-c1b7bd80-832e-11ea-8713-3d168f1d5f91.png">

#### Testing instructions

* Go to `/themes` on a _Jetpack site_ with a free plan; note the upsell at the top of the screen. Ensure Tracks values are the same and the visuals match production. Make sure the nudge does *not* show when viewing with a Premium or higher plan.
* Go to `/themes` on a WordPress.com site with a free plan; scroll to the bottom and click on "Show all themes" and scroll past the search to see another upsell. Make sure the Tracks events and visuals match production. This should *not* show when viewing on a site with a Premium or higher plan.
* Go to a single premium theme page like Ovation: https://wordpress.com/theme/ovation on a _WordPress.com site_ with a free plan; note the upsell at the top of the screen. Ensure Tracks values are the same and the visuals match production. Make sure the nudge does *not* show when viewing with a Premium or higher plan.