### PR TITLE
Move asset loading to render_callback for Event Countdown and Timeline blocks

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/event-countdown-block/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/event-countdown-block/index.php
@@ -48,10 +48,10 @@ add_action(
 			array(
 				'editor_script'   => 'jetpack-event-countdown',
 				'editor_style'    => 'jetpack-event-countdown-style',
-				'render_callback' => function( $attribs ) {
+				'render_callback' => function( $attribs, $content ) {
 					wp_enqueue_style( 'jetpack-event-countdown-style' );
 					wp_enqueue_script( 'jetpack-event-countdown-js' );
-					return $attribs->inner_html;
+					return $content;
 
 				},
 			)

--- a/apps/full-site-editing/full-site-editing-plugin/event-countdown-block/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/event-countdown-block/index.php
@@ -14,6 +14,17 @@ add_action(
 		$dependencies = isset( $asset['dependencies'] ) ? $asset['dependencies'] : array();
 		$version      = isset( $asset['version'] ) ? $asset['version'] : filemtime( __DIR__ . '/dist/event-countdown-block.js' );
 
+		$style_file = is_rtl()
+		? 'event-countdown-block.rtl.css'
+		: 'event-countdown-block.css';
+
+		wp_register_style(
+			'jetpack-event-countdown-style',
+			plugins_url( 'dist/' . $style_file, __FILE__ ),
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
+		);
+
 		// Block JS.
 		wp_register_script(
 			'jetpack-event-countdown',
@@ -23,10 +34,26 @@ add_action(
 			true
 		);
 
+		// JavaScript that triggers countdown on front-end.
+		wp_register_script(
+			'jetpack-event-countdown-js',
+			plugins_url( 'event-countdown.js', __FILE__ ),
+			array(), // No dependencies.
+			filemtime( plugin_dir_path( __FILE__ ) . 'event-countdown.js' ),
+			true // In footer.
+		);
+
 		register_block_type(
 			'jetpack/event-countdown',
 			array(
-				'editor_script' => 'jetpack-event-countdown',
+				'editor_script'   => 'jetpack-event-countdown',
+				'editor_style'    => 'jetpack-event-countdown-style',
+				'render_callback' => function( $attribs ) {
+					wp_enqueue_style( 'jetpack-event-countdown-style' );
+					wp_enqueue_script( 'jetpack-event-countdown-js' );
+					return $attribs->inner_html;
+
+				},
 			)
 		);
 
@@ -35,36 +62,3 @@ add_action(
 	}
 );
 
-
-// Load block assets.
-add_action(
-	'enqueue_block_assets',
-	function() {
-
-		$style_file = is_rtl()
-		? 'event-countdown-block.rtl.css'
-		: 'event-countdown-block.css';
-
-		wp_enqueue_style(
-			'event-countdown-block',
-			plugins_url( 'dist/' . $style_file, __FILE__ ),
-			array(),
-			filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
-		);
-
-	}
-);
-
-// JavaScript that triggers countdown on front-end.
-add_action(
-	'wp_enqueue_scripts',
-	function() {
-		wp_enqueue_script(
-			'event-countdown-js',
-			plugins_url( 'event-countdown.js', __FILE__ ),
-			array(), // No dependencies.
-			filemtime( plugin_dir_path( __FILE__ ) . 'event-countdown.js' ),
-			true // In footer.
-		);
-	}
-);

--- a/apps/full-site-editing/full-site-editing-plugin/jetpack-timeline/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/jetpack-timeline/index.php
@@ -23,11 +23,27 @@ add_action(
 			true
 		);
 
+		$style_file = is_rtl()
+		? 'jetpack-timeline.rtl.css'
+		: 'jetpack-timeline.css';
+
+		wp_register_style(
+			'jetpack-timeline',
+			plugins_url( 'dist/' . $style_file, __FILE__ ),
+			array(),
+			filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
+		);
+
 		// Register block.
 		register_block_type(
 			'jetpack/timeline',
 			array(
-				'editor_script' => 'jetpack-timeline',
+				'editor_script'   => 'jetpack-timeline',
+				'editor_style'    => 'jetpack-timeline',
+				'render_callback' => function( $attribs, $content ) {
+					wp_enqueue_style( 'jetpack-timeline' );
+					return $content;
+				},
 			)
 		);
 
@@ -48,19 +64,3 @@ add_action(
 	}
 );
 
-// Register block assets.
-add_action(
-	'enqueue_block_assets',
-	function() {
-		$style_file = is_rtl()
-		? 'jetpack-timeline.rtl.css'
-		: 'jetpack-timeline.css';
-
-		wp_enqueue_style(
-			'jetpack-timeline',
-			plugins_url( 'dist/' . $style_file, __FILE__ ),
-			array(),
-			filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
-		);
-	}
-);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update Event Countdown and Timeline blocks to move the asset loading to `render_callback`
This also requires rendering the content out of PHP.

#### Testing instructions

* Prior to applying change: create a post with the Event Countdown and Timeline blocks.

* Confirm when loading this post, the assets event-countdown.js, event-countdown-block.css, and jetpack-timeline.css all load. Also confirm that these assets load when viewing any post on the site.

* Apply this change, its just PHP, so no build required.

* Reload the post with the Event Countdown and Timeline blocks. Confirm it looks fine, and the js and css assets load properly. View any other posts and confirm the assets do not load there.

* Confirm properly loading on index and other pages the block may show up.


Related; #40987
