### PR TITLE
Fixes links from Activity Cards on Activity Log Page

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { updateFilter } from 'state/activity-log/actions';
 import { withApplySiteOffset } from '../site-offset';
 import { withLocalizedMoment } from 'components/localized-moment';
@@ -166,6 +166,7 @@ class ActivityCardList extends Component {
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
 	const filter = getActivityLogFilter( state, siteId );
 	const rewind = getRewindState( state, siteId );
 	const siteCapabilities = getRewindCapabilities( state, siteId );
@@ -177,6 +178,7 @@ const mapStateToProps = ( state ) => {
 
 	return {
 		siteId,
+		siteSlug,
 		filter,
 		rewind,
 		allowRestore,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix Detail, Download, and Restore links on `/backups/activity`

#### Testing instructions

1. Navigate to `/backups/activity`
2. Verify the action buttons and content detail links to you to each type of page
