### PR TITLE
Settings: Add Jetpack Instant Search toggle

### DIFF
--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -52,11 +52,9 @@ class Search extends Component {
 	};
 
 	renderInfoLink( link ) {
-		const { translate } = this.props;
-
 		return (
 			<SupportInfo
-				text={ translate(
+				text={ this.props.translate(
 					'Replaces the default WordPress search with a faster, filterable search experience.'
 				) }
 				link={ link }
@@ -66,28 +64,44 @@ class Search extends Component {
 	}
 
 	renderSearchExplanation() {
-		const { translate } = this.props;
-
 		return (
 			<FormSettingExplanation>
-				{ translate(
+				{ this.props.translate(
 					'Add the Search widget to your sidebar to configure advanced search filters.'
 				) }
 			</FormSettingExplanation>
 		);
 	}
 
-	renderSettingsContent( updatingSettings, searchActive ) {
-		const { translate } = this.props;
-
+	renderInstantSearchExplanation() {
 		return (
 			<div className="search__module-settings site-settings__child-settings">
-				{ updatingSettings && (
-					<FormSettingExplanation>{ translate( 'Updating settings…' ) }</FormSettingExplanation>
+				<FormSettingExplanation>
+					{ this.props.translate(
+						'Allow your visitors to get search results as soon as they start typing.'
+					) }{ ' ' }
+					{ this.props.hasSearchProduct
+						? this.props.translate(
+								'If deactivated, Jetpack Search will still optimize your search results but visitors will have to submit a search query before seeing any results.'
+						  )
+						: // The following notice is only shown for Professional plan holders.
+						  this.props.translate(
+								'Instant search is only available with a Jetpack Search subscription.'
+						  ) }
+				</FormSettingExplanation>
+			</div>
+		);
+	}
+
+	renderSettingsContent( isUpdating, isEnabled ) {
+		return (
+			<div className="search__module-settings site-settings__child-settings">
+				{ isUpdating && (
+					<FormSettingExplanation>
+						{ this.props.translate( 'Updating settings…' ) }
+					</FormSettingExplanation>
 				) }
-				{ searchActive && ! updatingSettings ? (
-					<div>{ this.renderSearchExplanation() }</div>
-				) : null }
+				{ isEnabled && ! isUpdating ? <div>{ this.renderSearchExplanation() }</div> : null }
 			</div>
 		);
 	}
@@ -120,10 +134,10 @@ class Search extends Component {
 
 	renderJetpackSettings() {
 		const {
+			activatingSearchModule,
 			isRequestingSettings,
 			isSavingSettings,
-			activatingSearchModule,
-			searchModuleActive,
+			isSearchModuleActive,
 			siteId,
 			translate,
 		} = this.props;
@@ -141,8 +155,23 @@ class Search extends Component {
 					) }
 					disabled={ isRequestingSettings || isSavingSettings }
 				/>
+				{ this.renderSettingsContent( activatingSearchModule, isSearchModuleActive ) }
 
-				{ this.renderSettingsContent( activatingSearchModule, searchModuleActive ) }
+				<div className="site-settings__jetpack-instant-search-toggle">
+					<CompactFormToggle
+						checked={ !! this.props.fields.instant_search_enabled }
+						disabled={
+							isRequestingSettings ||
+							isSavingSettings ||
+							! isSearchModuleActive ||
+							! this.props.hasSearchProduct
+						}
+						onChange={ this.props.handleAutosavingToggle( 'instant_search_enabled' ) }
+					>
+						{ translate( 'Enable instant search experience (recommended)' ) }
+					</CompactFormToggle>
+					{ this.renderInstantSearchExplanation() }
+				</div>
 			</FormFieldset>
 		);
 	}
@@ -183,7 +212,7 @@ class Search extends Component {
 				<CompactCard className="search__card site-settings__traffic-settings">
 					{ this.props.siteIsJetpack ? this.renderJetpackSettings() : this.renderWPComSettings() }
 				</CompactCard>
-				{ ( this.props.searchModuleActive || this.props.fields.jetpack_search_enabled ) && (
+				{ ( this.props.isSearchModuleActive || this.props.fields.jetpack_search_enabled ) && (
 					<CompactCard
 						href={ this.props.customizerUrl }
 						target={ this.props.siteIsJetpack ? 'external' : null }
@@ -218,7 +247,7 @@ class Search extends Component {
 const hasBusinessPlan = overSome( isJetpackBusiness, isBusiness, isEnterprise, isEcommerce );
 const checkForSearchProduct = ( purchase ) =>
 	purchase.active && isJetpackSearch( purchase.productSlug );
-export default connect( ( state ) => {
+export default connect( ( state, { isRequestingSettings } ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const hasSearchProduct = getSitePurchases( state, siteId ).find( checkForSearchProduct );
@@ -231,12 +260,13 @@ export default connect( ( state ) => {
 		activatingSearchModule:
 			!! isActivatingJetpackModule( state, siteId, 'search' ) ||
 			!! isDeactivatingJetpackModule( state, siteId, 'search' ),
+		hasSearchProduct,
 		isSearchEligible,
-		isLoading: isFetchingSitePurchases( state ),
+		isSearchModuleActive: !! isJetpackModuleActive( state, siteId, 'search' ),
+		isLoading: isRequestingSettings || isFetchingSitePurchases( state ),
 		site: getSelectedSite( state ),
 		siteSlug: getSelectedSiteSlug( state ),
 		siteIsJetpack: isJetpackSite( state, siteId ),
-		searchModuleActive: !! isJetpackModuleActive( state, siteId, 'search' ),
 		customizerUrl: getCustomizerUrl( state, siteId ),
 	};
 } )( localize( Search ) );

--- a/client/my-sites/site-settings/settings-performance/main.jsx
+++ b/client/my-sites/site-settings/settings-performance/main.jsx
@@ -144,6 +144,7 @@ const connectComponent = connect( ( state ) => {
 const getFormSettings = partialRight( pick, [
 	'amp_is_enabled',
 	'amp_is_supported',
+	'instant_search_enabled',
 	'jetpack_search_enabled',
 	'jetpack_search_supported',
 	'lazy-images',

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -41,7 +41,7 @@
 	label {
 		margin-bottom: 5px;
 		font-size: 14px;
-		font-weight: 600;
+		font-weight: 700;
 	}
 
 	legend + label,
@@ -51,7 +51,7 @@
 	input[type='radio'] + label,
 	label input[type='checkbox'],
 	label input[type='radio'] {
-		font-weight: normal;
+		font-weight: 400;
 	}
 
 	label a,
@@ -155,7 +155,7 @@
 
 	.verification-code-error {
 		color: var( --color-error );
-		font-weight: bold;
+		font-weight: 700;
 	}
 
 	.seo-settings__seo-form .counted-textarea {
@@ -224,7 +224,7 @@
 	}
 
 	.composing__publish-confirmation .form-toggle__label-content {
-		font-weight: 600;
+		font-weight: 700;
 	}
 
 	.eligibility-warnings {
@@ -302,7 +302,7 @@
 
 	.site-settings__moderation-settings {
 		.form-label {
-			font-weight: normal;
+			font-weight: 400;
 		}
 	}
 }
@@ -514,6 +514,17 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 
 .site-settings__search-block {
 	margin-bottom: 16px;
+
+	.site-settings__jetpack-instant-search-toggle {
+		margin-left: 36px;
+	}
+
+	.search__module-settings {
+		margin-top: 0;
+		&:not( :last-child ) {
+			margin-bottom: 1em;
+		}
+	}
 }
 
 .site-settings__speed-up-site-settings {
@@ -547,7 +558,9 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	.theme-enhancements__card {
 		.form-fieldset.minileven {
 			&.inactive {
-				p, .form-toggle__label, .support-info {
+				p,
+				.form-toggle__label,
+				.support-info {
 					opacity: 0.3;
 					transition: all 0.75s;
 				}


### PR DESCRIPTION
Fixes #40675.

#### Changes proposed in this Pull Request

* Adds Instant Search toggle for connected Jetpack sites.

#### Testing instructions

* Navigate to `/settings/performance/<site-address>` using a Jetpack site without Jetpack Professional nor Jetpack Search subscriptions. Ensure that an upgrade notice is shown.

<img width="742" alt="Screen Shot 2020-04-20 at 5 47 36 PM" src="https://user-images.githubusercontent.com/4044428/79809938-0b080d00-832f-11ea-9bdc-5ac77e28486b.png">

* Repeat the above steps with a Jetpack Professional subscription but without a Jetpack Search subscription. Ensure that the instant search toggle is not interactive.
<img width="742" alt="Screen Shot 2020-04-20 at 5 43 11 PM" src="https://user-images.githubusercontent.com/4044428/79809763-90d78880-832e-11ea-86e2-921e74a9e30e.png">

* Repeat the above steps with a Jetpack Search subscription. Ensure that both toggles are interactive.

<img width="742" alt="Screen Shot 2020-04-20 at 5 35 06 PM" src="https://user-images.githubusercontent.com/4044428/79809320-4c97b880-832d-11ea-8690-76b85973d5e1.png">