### PR TITLE
Dial down concierge upsell offer

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -72,10 +72,10 @@ export default {
 	},
 	conciergeUpsellDial: {
 		//this test is used to dial down the upsell offer
-		datestamp: '20190429',
+		datestamp: '20200421',
 		variations: {
-			offer: 100,
-			noOffer: 0,
+			offer: 50,
+			noOffer: 50,
 		},
 		defaultVariation: 'noOffer',
 		allowExistingUsers: true,

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -94,6 +94,7 @@ import {
 } from 'signup/utils';
 import { isExternal } from 'lib/url';
 import { withLocalizedMoment } from 'components/localized-moment';
+import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -464,9 +465,9 @@ export class Checkout extends React.Component {
 			// The conciergeUpsellDial test is used when we need to quickly dial back the volume of concierge sessions
 			// being offered and so sold, to be inline with HE availability.
 			// To dial back, uncomment the condition below and modify the test config.
-			// if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
-			return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ selectedSiteSlug }`;
-			// }
+			if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
+				return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ selectedSiteSlug }`;
+			}
 		}
 	}
 

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -23,6 +23,7 @@ jest.mock( 'config', () => {
 	return mock;
 } );
 
+// Temporary A/B test to dial down the concierge upsell, check pau2Xa-1bk-p2.
 jest.mock( 'lib/abtest', () => ( {
 	abtest: jest.fn( () => {
 		return 'offer';

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout-thank-you.js
@@ -13,7 +13,7 @@ import { isEnabled } from 'config';
 let mockGSuiteCountryIsValid = true;
 jest.mock( 'lib/user', () =>
 	jest.fn( () => ( {
-		get: () => ( { is_valid_google_apps_country: mockGSuiteCountryIsValid } ),
+		get: () => ( { is_valid_google_apps_country: mockGSuiteCountryIsValid } )
 	} ) )
 );
 
@@ -23,9 +23,15 @@ jest.mock( 'config', () => {
 	return mock;
 } );
 
+jest.mock( 'lib/abtest', () => ( {
+	abtest: jest.fn( () => {
+		return 'offer';
+	} )
+} ) );
+
 const defaultArgs = {
 	getUrlFromCookie: jest.fn( () => null ),
-	saveUrlToCookie: jest.fn(),
+	saveUrlToCookie: jest.fn()
 };
 
 describe( 'getThankYouPageUrl', () => {
@@ -38,7 +44,7 @@ describe( 'getThankYouPageUrl', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
-			purchaseId: '1234abcd',
+			purchaseId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
@@ -47,7 +53,7 @@ describe( 'getThankYouPageUrl', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
-			receiptId: '1234abcd',
+			receiptId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
@@ -68,7 +74,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			feature: 'all-free-features',
-			purchaseId: '1234abcd',
+			purchaseId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/thank-you/features/all-free-features/foo.bar/1234abcd' );
 	} );
@@ -78,7 +84,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			feature: 'all-free-features',
-			receiptId: '1234abcd',
+			receiptId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/thank-you/features/all-free-features/foo.bar/1234abcd' );
 	} );
@@ -88,7 +94,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			feature: 'all-free-features',
-			orderId: '1234abcd',
+			orderId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/thank-you/features/all-free-features/foo.bar/pending/1234abcd' );
 	} );
@@ -99,7 +105,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			feature: 'all-free-features',
-			cart,
+			cart
 		} );
 		expect( url ).toBe( '/checkout/thank-you/features/all-free-features/foo.bar/:receiptId' );
 	} );
@@ -109,7 +115,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			feature: 'fake-key',
-			purchaseId: '1234abcd',
+			purchaseId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
@@ -120,7 +126,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			purchaseId: '1234abcd',
 			isJetpackNotAtomic: true,
-			product: 'jetpack_backup_daily',
+			product: 'jetpack_backup_daily'
 		} );
 		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&product=jetpack_backup_daily' );
 	} );
@@ -130,7 +136,7 @@ describe( 'getThankYouPageUrl', () => {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			purchaseId: '1234abcd',
-			isJetpackNotAtomic: true,
+			isJetpackNotAtomic: true
 		} );
 		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&install=all' );
 	} );
@@ -141,7 +147,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			purchaseId: '1234abcd',
 			feature: 'all-free-features',
-			isJetpackNotAtomic: true,
+			isJetpackNotAtomic: true
 		} );
 		expect( url ).toBe( '/plans/my-plan/foo.bar?thank-you=true&install=all' );
 	} );
@@ -150,7 +156,7 @@ describe( 'getThankYouPageUrl', () => {
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
-			redirectTo: '/foo/bar',
+			redirectTo: '/foo/bar'
 		} );
 		expect( url ).toBe( '/foo/bar' );
 	} );
@@ -172,8 +178,8 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'redirects to manage purchase page if there is a renewal', () => {
 		const cart = {
 			products: [
-				{ extra: { purchaseType: 'renewal', purchaseDomain: 'foo.bar', purchaseId: '123abc' } },
-			],
+				{ extra: { purchaseType: 'renewal', purchaseDomain: 'foo.bar', purchaseId: '123abc' } }
+			]
 		};
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', cart } );
 		expect( url ).toBe( '/me/purchases/foo.bar/123abc' );
@@ -182,14 +188,14 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'does not redirect to url from cookie if isEligibleForSignupDestination is false', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			products: [ { product_slug: 'foo' } ],
+			products: [ { product_slug: 'foo' } ]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
 			getUrlFromCookie,
-			isEligibleForSignupDestination: false,
+			isEligibleForSignupDestination: false
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId' );
 	} );
@@ -197,14 +203,14 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'redirects to url from cookie if isEligibleForSignupDestination is set', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			products: [ { product_slug: 'foo' } ],
+			products: [ { product_slug: 'foo' } ]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
 			getUrlFromCookie,
-			isEligibleForSignupDestinationResult: true,
+			isEligibleForSignupDestinationResult: true
 		} );
 		expect( url ).toBe( '/cookie' );
 	} );
@@ -212,14 +218,14 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'redirects to url from cookie if cart is empty and no receipt is set', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
-			products: [],
+			products: []
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
 			getUrlFromCookie,
-			isEligibleForSignupDestination: true,
+			isEligibleForSignupDestination: true
 		} );
 		expect( url ).toBe( '/cookie' );
 	} );
@@ -228,14 +234,14 @@ describe( 'getThankYouPageUrl', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
 			create_new_blog: true,
-			products: [ { id: '123' } ],
+			products: [ { id: '123' } ]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
 			getUrlFromCookie,
-			purchaseId: '1234abcd',
+			purchaseId: '1234abcd'
 		} );
 		expect( url ).toBe( '/cookie/1234abcd' );
 	} );
@@ -244,14 +250,14 @@ describe( 'getThankYouPageUrl', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
 			create_new_blog: true,
-			products: [ { id: '123' } ],
+			products: [ { id: '123' } ]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: '1234abcd',
-			getUrlFromCookie,
+			getUrlFromCookie
 		} );
 		expect( url ).toBe( '/cookie/1234abcd' );
 	} );
@@ -260,14 +266,14 @@ describe( 'getThankYouPageUrl', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
 			create_new_blog: true,
-			products: [ { id: '123' } ],
+			products: [ { id: '123' } ]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
 			orderId: '1234abcd',
-			getUrlFromCookie,
+			getUrlFromCookie
 		} );
 		expect( url ).toBe( '/cookie/pending/1234abcd' );
 	} );
@@ -276,13 +282,13 @@ describe( 'getThankYouPageUrl', () => {
 		const getUrlFromCookie = jest.fn( () => '/cookie' );
 		const cart = {
 			create_new_blog: true,
-			products: [ { id: '123' } ],
+			products: [ { id: '123' } ]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
-			getUrlFromCookie,
+			getUrlFromCookie
 		} );
 		expect( url ).toBe( '/cookie/:receiptId' );
 	} );
@@ -291,7 +297,7 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'redirects to thank-you page followed by placeholder receiptId twice if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
 		const cart = {
 			create_new_blog: true,
-			products: [ { id: '123' } ],
+			products: [ { id: '123' } ]
 		};
 		const url = getThankYouPageUrl( { ...defaultArgs, siteSlug: 'foo.bar', cart } );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/:receiptId/:receiptId' );
@@ -301,13 +307,13 @@ describe( 'getThankYouPageUrl', () => {
 	it( 'redirects to thank-you page followed by purchase id twice if no cookie url is set, create_new_blog is set, and there is no receipt', () => {
 		const cart = {
 			create_new_blog: true,
-			products: [ { id: '123' } ],
+			products: [ { id: '123' } ]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			purchaseId: '1234abcd',
-			cart,
+			cart
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd/1234abcd' );
 	} );
@@ -319,9 +325,9 @@ describe( 'getThankYouPageUrl', () => {
 					product_slug: 'some_domain',
 					is_domain_registration: true,
 					extra: { context: 'signup' },
-					meta: 'my.site',
-				},
-			],
+					meta: 'my.site'
+				}
+			]
 		};
 		mockGSuiteCountryIsValid = true;
 		const url = getThankYouPageUrl( {
@@ -330,7 +336,7 @@ describe( 'getThankYouPageUrl', () => {
 			cart,
 			receiptId: '1234abcd',
 			didPurchaseFail: true,
-			isNewlyCreatedSite: true,
+			isNewlyCreatedSite: true
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
@@ -342,9 +348,9 @@ describe( 'getThankYouPageUrl', () => {
 					product_slug: 'some_domain',
 					is_domain_registration: false,
 					extra: { context: 'signup' },
-					meta: 'my.site',
-				},
-			],
+					meta: 'my.site'
+				}
+			]
 		};
 		mockGSuiteCountryIsValid = false;
 		const url = getThankYouPageUrl( {
@@ -352,7 +358,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: '1234abcd',
-			isNewlyCreatedSite: true,
+			isNewlyCreatedSite: true
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
@@ -365,9 +371,9 @@ describe( 'getThankYouPageUrl', () => {
 					product_slug: 'some_domain',
 					is_domain_registration: true,
 					extra: { context: 'signup' },
-					meta: 'my.site',
-				},
-			],
+					meta: 'my.site'
+				}
+			]
 		};
 		mockGSuiteCountryIsValid = false;
 		const url = getThankYouPageUrl( {
@@ -375,7 +381,7 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: '1234abcd',
-			isNewlyCreatedSite: true,
+			isNewlyCreatedSite: true
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=concierge' );
 	} );
@@ -387,9 +393,9 @@ describe( 'getThankYouPageUrl', () => {
 					product_slug: 'some_domain',
 					is_domain_registration: true,
 					extra: { context: 'signup' },
-					meta: 'my.site',
-				},
-			],
+					meta: 'my.site'
+				}
+			]
 		};
 		mockGSuiteCountryIsValid = false;
 		const url = getThankYouPageUrl( {
@@ -397,117 +403,117 @@ describe( 'getThankYouPageUrl', () => {
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: '1234abcd',
-			isNewlyCreatedSite: true,
+			isNewlyCreatedSite: true
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
 
 	// We are temporarily disabling the premium bump offer, so skipping this test for now. Check pNEWy-cIg-p2.
 	it.skip( 'redirects to premium upgrade nudge if concierge and jetpack are not in the cart, personal is in the cart, and the previous route is not the nudge', () => {
-		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
 		const cart = {
 			products: [
 				{
-					product_slug: 'personal-bundle',
-				},
-			],
+					product_slug: 'personal-bundle'
+				}
+			]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
-			receiptId: '1234abcd',
+			receiptId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/foo.bar/offer-plan-upgrade/premium/1234abcd' );
 	} );
 
 	it( 'redirects to concierge nudge if concierge and jetpack are not in the cart, blogger is in the cart, and the previous route is not the nudge', () => {
-		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
 		const cart = {
 			products: [
 				{
-					product_slug: 'blogger-bundle',
-				},
-			],
+					product_slug: 'blogger-bundle'
+				}
+			]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
-			receiptId: '1234abcd',
+			receiptId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/offer-quickstart-session/1234abcd/foo.bar' );
 	} );
 
 	it( 'redirects to concierge nudge if concierge and jetpack are not in the cart, premium is in the cart, and the previous route is not the nudge', () => {
-		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
 		const cart = {
 			products: [
 				{
-					product_slug: 'value_bundle',
-				},
-			],
+					product_slug: 'value_bundle'
+				}
+			]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
-			receiptId: '1234abcd',
+			receiptId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/offer-quickstart-session/1234abcd/foo.bar' );
 	} );
 
 	it( 'redirects to thank-you page (with concierge display mode) if concierge is in the cart', () => {
-		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
 		const cart = {
 			products: [
 				{
-					product_slug: 'concierge-session',
-				},
-			],
+					product_slug: 'concierge-session'
+				}
+			]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
-			receiptId: '1234abcd',
+			receiptId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd?d=concierge' );
 	} );
 
 	it( 'redirects to thank-you page if jetpack is in the cart', () => {
-		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
 		const cart = {
 			products: [
 				{
-					product_slug: 'jetpack_premium',
-				},
-			],
+					product_slug: 'jetpack_premium'
+				}
+			]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
-			receiptId: '1234abcd',
+			receiptId: '1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );
 
 	it( 'redirects to thank you page if concierge and jetpack are not in the cart, personal is in the cart, but the previous route is the nudge', () => {
-		isEnabled.mockImplementation( ( flag ) => flag === 'upsell/concierge-session' );
+		isEnabled.mockImplementation( flag => flag === 'upsell/concierge-session' );
 		const cart = {
 			products: [
 				{
-					product_slug: 'personal-bundle',
-				},
-			],
+					product_slug: 'personal-bundle'
+				}
+			]
 		};
 		const url = getThankYouPageUrl( {
 			...defaultArgs,
 			siteSlug: 'foo.bar',
 			cart,
 			receiptId: '1234abcd',
-			previousRoute: '/checkout/foo.bar/offer-plan-upgrade/premium/1234abcd',
+			previousRoute: '/checkout/foo.bar/offer-plan-upgrade/premium/1234abcd'
 		} );
 		expect( url ).toBe( '/checkout/thank-you/foo.bar/1234abcd' );
 	} );

--- a/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
+++ b/client/my-sites/checkout/composite-checkout/use-get-thank-you-url.js
@@ -24,7 +24,7 @@ import {
 	hasBloggerPlan,
 	hasPersonalPlan,
 	hasPremiumPlan,
-	hasEcommercePlan,
+	hasEcommercePlan
 } from 'lib/cart-values/cart-items';
 import { managePurchase } from 'me/purchases/paths';
 import { isValidFeatureKey } from 'lib/plans/features-list';
@@ -33,6 +33,7 @@ import { persistSignupDestination, retrieveSignupDestination } from 'signup/util
 import { getSelectedSite } from 'state/ui/selectors';
 import isEligibleForSignupDestination from 'state/selectors/is-eligible-for-signup-destination';
 import getPreviousPath from 'state/selectors/get-previous-path.js';
+import { abtest } from 'lib/abtest';
 
 export function getThankYouPageUrl( {
 	siteSlug,
@@ -48,7 +49,7 @@ export function getThankYouPageUrl( {
 	getUrlFromCookie = retrieveSignupDestination,
 	saveUrlToCookie = persistSignupDestination,
 	previousRoute,
-	isEligibleForSignupDestinationResult,
+	isEligibleForSignupDestinationResult
 } ) {
 	// If we're given an explicit `redirectTo` query arg, make sure it's either internal
 	// (i.e. on WordPress.com), or a Jetpack or WP.com site's block editor (in wp-admin).
@@ -70,8 +71,8 @@ export function getThankYouPageUrl( {
 				query: {
 					post: parseInt( query.post, 10 ),
 					action: 'edit',
-					plan_upgraded: 1,
-				},
+					plan_upgraded: 1
+				}
 			} );
 			return sanitizedRedirectTo;
 		}
@@ -87,7 +88,7 @@ export function getThankYouPageUrl( {
 		feature,
 		cart,
 		isJetpackNotAtomic,
-		product,
+		product
 	} );
 
 	saveUrlToCookieIfEcomm( saveUrlToCookie, cart, fallbackUrl );
@@ -118,7 +119,7 @@ export function getThankYouPageUrl( {
 		pendingOrReceiptId,
 		cart,
 		siteSlug,
-		previousRoute,
+		previousRoute
 	} );
 	if ( redirectPathForConciergeUpsell ) {
 		return redirectPathForConciergeUpsell;
@@ -149,7 +150,7 @@ function getFallbackDestination( {
 	feature,
 	cart,
 	isJetpackNotAtomic,
-	product,
+	product
 } ) {
 	const isCartEmpty = getAllCartItems( cart ).length === 0;
 	const isReceiptEmpty = ':receiptId' === pendingOrReceiptId;
@@ -195,9 +196,9 @@ function getRedirectUrlForConciergeNudge( { pendingOrReceiptId, cart, siteSlug, 
 		// The conciergeUpsellDial test is used when we need to quickly dial back the volume of concierge sessions
 		// being offered and so sold, to be inline with HE availability.
 		// To dial back, uncomment the condition below and modify the test config.
-		// if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
-		return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ siteSlug }`;
-		// }
+		if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
+			return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ siteSlug }`;
+		}
 	}
 
 	return;
@@ -221,8 +222,8 @@ function getUrlWithQueryParam( url, queryParams ) {
 		pathname,
 		query: {
 			...query,
-			...queryParams,
-		},
+			...queryParams
+		}
 	} );
 }
 
@@ -266,14 +267,14 @@ export function useGetThankYouUrl( {
 	cart,
 	isJetpackNotAtomic,
 	product,
-	siteId,
+	siteId
 } ) {
-	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
+	const selectedSiteData = useSelector( state => getSelectedSite( state ) );
 	const adminUrl = selectedSiteData?.options?.admin_url;
-	const isEligibleForSignupDestinationResult = useSelector( ( state ) =>
+	const isEligibleForSignupDestinationResult = useSelector( state =>
 		isEligibleForSignupDestination( state, siteId, cart )
 	);
-	const previousRoute = useSelector( ( state ) => getPreviousPath( state ) );
+	const previousRoute = useSelector( state => getPreviousPath( state ) );
 
 	const getThankYouUrl = useCallback( () => {
 		const transactionResult = select( 'wpcom' ).getTransactionResult();
@@ -293,7 +294,7 @@ export function useGetThankYouUrl( {
 			isJetpackNotAtomic,
 			product,
 			previousRoute,
-			isEligibleForSignupDestinationResult,
+			isEligibleForSignupDestinationResult
 		} );
 		const url = getThankYouPageUrl( {
 			siteSlug,
@@ -307,7 +308,7 @@ export function useGetThankYouUrl( {
 			isJetpackNotAtomic,
 			product,
 			previousRoute,
-			isEligibleForSignupDestinationResult,
+			isEligibleForSignupDestinationResult
 		} );
 		debug( 'getThankYouUrl returned', url );
 		return url;
@@ -321,7 +322,7 @@ export function useGetThankYouUrl( {
 		redirectTo,
 		feature,
 		purchaseId,
-		cart,
+		cart
 	] );
 	return getThankYouUrl;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Per the request in pau2Xa-1bk-p2, we are dialling down the concierge upsell offers. It will now be shown only to 50% of EN users.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow at /start and purchase a Personal or Premium plan.
* When in the "offer" variation, you should be shown the concierge upsell. When in "noOffer" variation, you should not be shown the upsell. 
* For non-EN locale, you should not be assigned to the AB test and not shown the concierge upsell.
* Make sure that you test all of the above steps in both the old checkout and new checkout flow. For the new checkout flow, you need to have a US IP address and assign yourself to the `composite` variation of the showCompositeCheckout AB test. 
