### PR TITLE
Gutenboarding: Site creation tweaks

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import * as React from 'react';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import { Icon } from '@wordpress/components';
@@ -14,19 +14,41 @@ import { useNewQueryParam } from '../../path';
 import { useTrackStep } from '../../hooks/use-track-step';
 import './style.scss';
 
+// Total time to perform "loading"
+const DURATION_IN_MS = 12000;
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-const CreateSite: FunctionComponent< {} > = () => {
+const CreateSite: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const shouldTriggerCreate = useNewQueryParam();
 	const [ shouldCreateAndRedirect, setCreateAndRedirect ] = React.useState( false );
 
 	// Some very rudimentary progress illusions
 
-	const progressSteps = [
+	const progressSteps = React.useRef( [
 		__( 'Building your site' ),
 		__( 'Getting your domain' ),
 		__( 'Applying design' ),
-	];
+	] );
+
+	const [ step, setStep ] = React.useState< number >( 0 );
+	const [ progress, setProgress ] = React.useState< number >( 0 );
+
+	// Give an initial progress indication…
+	React.useEffect( () => setProgress( 7 ), [] );
+
+	React.useEffect( () => {
+		const totalSteps = progressSteps.current.length;
+		const maxIndex = totalSteps - 1;
+		if ( step >= maxIndex && progress >= 100 ) {
+			setCreateAndRedirect( true );
+		}
+		const timeoutId = window.setTimeout( () => {
+			setStep( Math.min( step + 1, maxIndex ) );
+			setProgress( Math.min( ( ( step + 1 ) / totalSteps ) * 100, 100 ) );
+		}, DURATION_IN_MS / totalSteps );
+		return () => window.clearTimeout( timeoutId );
+	}, [ progress, step ] );
 
 	useTrackStep( 'CreateSite' );
 
@@ -42,29 +64,27 @@ const CreateSite: FunctionComponent< {} > = () => {
 				<div className="create-site__content">
 					<div className="create-site__progress">
 						<div className="create-site__progress-steps">
-							{ progressSteps.map( ( step ) => (
-								<div key={ step } className="create-site__progress-step">
-									{ step }
-								</div>
-							) ) }
+							<div className="create-site__progress-step">{ progressSteps.current[ step ] }</div>
 						</div>
 					</div>
 					<div
 						className="create-site__progress-bar"
-						onAnimationEnd={ () => setCreateAndRedirect( true ) }
+						style={
+							{
+								'--progress': progress,
+							} as React.CSSProperties
+						}
 					/>
 					<div className="create-site__progress-numbered-steps">
-						{ progressSteps.map( ( _, index ) => (
-							<p>
-								{
-									// translators: these are progress steps. Eg: step 1 of 4.
-									sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
-										currentStep: index + 1,
-										totalSteps: progressSteps.length,
-									} )
-								}
-							</p>
-						) ) }
+						<p>
+							{
+								// translators: these are progress steps. Eg: step 1 of 4.
+								sprintf( __( 'Step %(currentStep)d of %(totalSteps)d' ), {
+									currentStep: step + 1,
+									totalSteps: progressSteps.current.length,
+								} )
+							}
+						</p>
 					</div>
 				</div>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@automattic/react-i18n';
 import { Icon } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useInterval } from '../../../../lib/interval/use-interval';
 
 /**
@@ -13,6 +14,7 @@ import { useInterval } from '../../../../lib/interval/use-interval';
 import CreateAndRedirect from './create-and-redirect';
 import { useNewQueryParam } from '../../path';
 import { useTrackStep } from '../../hooks/use-track-step';
+import { STORE_KEY } from '../../stores/onboard';
 import './style.scss';
 
 // Total time to perform "loading"
@@ -23,11 +25,23 @@ const CreateSite: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const shouldTriggerCreate = useNewQueryParam();
 	const [ shouldCreateAndRedirect, setCreateAndRedirect ] = React.useState( false );
+	const hasPaidDomain: boolean = useSelect( ( select ) => {
+		const domain = select( STORE_KEY ).getState().domain;
+
+		// No domain is not paid
+		if ( ! domain ) {
+			return false;
+		}
+
+		return ! domain.is_free;
+	} );
 
 	const steps = React.useRef< string[] >(
-		[ __( 'Building your site' ), __( 'Getting your domain' ), __( 'Applying design' ) ].filter(
-			Boolean
-		) as string[]
+		[
+			__( 'Building your site' ),
+			hasPaidDomain && __( 'Getting your domain' ),
+			__( 'Applying design' ),
+		].filter( Boolean ) as string[]
 	);
 	const totalSteps = steps.current.length;
 

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -74,26 +74,8 @@ const CreateSite: React.FunctionComponent = () => {
 		return () => clearTimeout( id );
 	}, [] );
 
-	// Site creation triggers a reset of the store, which causes vertical colors
-	// to clear and reset to defaults.
-	// "Clone" mainColor here so it persists through store reset and navigation.
-	const containerRef = React.useRef< HTMLDivElement >( null );
-	const [ mainColor, setMainColor ] = React.useState< string >();
-	React.useEffect( () => {
-		if ( containerRef.current ) {
-			const color = window
-				.getComputedStyle( containerRef.current )
-				.getPropertyValue( '--mainColor' );
-			setMainColor( color );
-		}
-	}, [] );
-
 	return (
-		<div
-			className="gutenboarding-page create-site__background"
-			style={ mainColor ? ( { '--mainColor': mainColor } as React.CSSProperties ) : undefined }
-			ref={ containerRef }
-		>
+		<div className="gutenboarding-page create-site__background">
 			{ shouldTriggerCreate && shouldCreateAndRedirect && <CreateAndRedirect /> }
 			<div className="create-site__layout">
 				<div className="create-site__header">

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -74,8 +74,26 @@ const CreateSite: React.FunctionComponent = () => {
 		return () => clearTimeout( id );
 	}, [] );
 
+	// Site creation triggers a reset of the store, which causes vertical colors
+	// to clear and reset to defaults.
+	// "Clone" mainColor here so it persists through store reset and navigation.
+	const containerRef = React.useRef< HTMLDivElement >( null );
+	const [ mainColor, setMainColor ] = React.useState< string >();
+	React.useEffect( () => {
+		if ( containerRef.current ) {
+			const color = window
+				.getComputedStyle( containerRef.current )
+				.getPropertyValue( '--mainColor' );
+			setMainColor( color );
+		}
+	}, [] );
+
 	return (
-		<div className="gutenboarding-page create-site__background">
+		<div
+			className="gutenboarding-page create-site__background"
+			style={ mainColor ? ( { '--mainColor': mainColor } as React.CSSProperties ) : undefined }
+			ref={ containerRef }
+		>
 			{ shouldTriggerCreate && shouldCreateAndRedirect && <CreateAndRedirect /> }
 			<div className="create-site__layout">
 				<div className="create-site__header">

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -18,7 +18,7 @@ import { STORE_KEY } from '../../stores/onboard';
 import './style.scss';
 
 // Total time to perform "loading"
-const DURATION_IN_MS = 12000;
+const DURATION_IN_MS = 6000;
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const CreateSite: React.FunctionComponent = () => {
@@ -54,20 +54,14 @@ const CreateSite: React.FunctionComponent = () => {
 	const isComplete = progress >= 1;
 
 	useInterval(
-		() => {
-			setCurrentStep( ( s ) => s + 1 );
-		},
+		() => setCurrentStep( ( s ) => s + 1 ),
 		// Enable the interval when progress is incomplete
 		isComplete ? null : DURATION_IN_MS / totalSteps
 	);
 
 	React.useEffect( () => {
 		if ( isComplete ) {
-			const id = setTimeout(
-				() => setCreateAndRedirect( true ),
-				DURATION_IN_MS / steps.current.length
-			);
-			return () => clearTimeout( id );
+			setCreateAndRedirect( true );
 		}
 	}, [ isComplete ] );
 

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -111,7 +111,7 @@ const CreateSite: React.FunctionComponent = () => {
 						className="create-site__progress-bar"
 						style={
 							{
-								'--progress': ! hasStarted ? 0 : progress,
+								'--progress': ! hasStarted ? /* initial 10% progress */ 0.1 : progress,
 							} as React.CSSProperties
 						}
 					/>

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -67,6 +67,13 @@ const CreateSite: React.FunctionComponent = () => {
 
 	useTrackStep( 'CreateSite' );
 
+	// Force animated progress bar to start at 0
+	const [ hasStarted, setHasStarted ] = React.useState( false );
+	React.useEffect( () => {
+		const id = setTimeout( () => setHasStarted( true ), 750 );
+		return () => clearTimeout( id );
+	}, [] );
+
 	return (
 		<div className="gutenboarding-page create-site__background">
 			{ shouldTriggerCreate && shouldCreateAndRedirect && <CreateAndRedirect /> }
@@ -86,7 +93,7 @@ const CreateSite: React.FunctionComponent = () => {
 						className="create-site__progress-bar"
 						style={
 							{
-								'--progress': progress,
+								'--progress': ! hasStarted ? 0 : progress,
 							} as React.CSSProperties
 						}
 					/>

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -48,7 +48,7 @@ $progress-widget-height: 300px;
 
 			&::before {
 				background: var( --mainColor );
-				transform: translateX( calc( -1% * min( 100 - var( --progress, 0 ), 100 ) ) );
+				transform: translateX( calc( -100% * min( 1 - var( --progress, 0 ), 1 ) ) );
 				position: absolute;
 				content: '';
 				top: 0;

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -47,7 +47,7 @@ $progress-widget-height: 300px;
 			--progress: 0;
 
 			&::before {
-				background: var( --mainColor );
+				background: var( --studio-blue-40 );
 				transform: translateX( calc( -100% * min( 1 - var( --progress, 0 ), 1 ) ) );
 				position: absolute;
 				content: '';

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -3,7 +3,7 @@
 
 $progress-step-title-height: 40px;
 $progress-step-number-step-height: 45px;
-$progress-duration: 5s;
+$progress-duration: 800ms;
 $progress-widget-height: 300px;
 
 .create-site__background {
@@ -35,47 +35,27 @@ $progress-widget-height: 300px;
 		padding: 1em;
 
 		.create-site__progress {
-			height: $progress-step-title-height;
-			overflow: hidden;
 			margin-bottom: 20px;
-		}
-
-		.create-site__progress-steps {
-			animation: create-site__progress-steps $progress-duration ease-out forwards;
-
-			@keyframes create-site__progress-steps {
-				@for $i from 0 through 3 {
-					#{$i / 3 * 100%} {
-						transform: translateY( -$progress-step-title-height * ( $i - 1 ) );
-					}
-				}
-			}
 		}
 
 		.create-site__progress-bar {
 			position: relative;
+			overflow: hidden;
 			height: 6px;
 			margin-top: 1em;
 			background: var( --studio-gray-10 );
+			--progress: 0;
 
 			&::before {
 				background: var( --mainColor );
-				transform: scaleX( 0 );
-				transform-origin: 0% 0%;
+				transform: translateX( calc( -1% * min( 100 - var( --progress, 0 ), 100 ) ) );
 				position: absolute;
 				content: '';
 				top: 0;
 				left: 0;
 				right: 0;
 				bottom: 0;
-				animation: create-site__progress-bar-progress-move #{$progress-duration + 1} ease-out forwards;
-				@keyframes create-site__progress-bar-progress-move {
-					@for $i from 1 through 3 {
-						#{$i / 3 * 100%} {
-							transform: scaleX( #{$i / 3} );
-						}
-					}
-				}
+				transition: transform $progress-duration ease-out;
 			}
 		}
 
@@ -84,28 +64,15 @@ $progress-widget-height: 300px;
 			text-align: center;
 			vertical-align: middle;
 			margin: 0;
-			height: $progress-step-title-height;
 		}
 
 		.create-site__progress-numbered-steps {
-			height: $progress-step-title-height;
-			overflow: hidden;
 			margin-top: 0.7em;
 
 			> p {
-				height: $progress-step-number-step-height;
 				padding: 1em;
 				text-align: center;
 				color: var( --studio-gray-40 );
-
-				animation: create-site__progress-numbered-step-up $progress-duration steps( 2, end )
-					forwards;
-
-				@keyframes create-site__progress-numbered-step-up {
-					to {
-						transform: translateY( -$progress-step-number-step-height * 2 );
-					}
-				}
 			}
 		}
 	}

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -53,7 +53,7 @@ $progress-widget-height: 300px;
 		}
 
 		.create-site__progress-bar {
-			height: 7px;
+			height: 6px;
 			background: var( --mainColor );
 			transform: scaleX( 0 );
 			transform-origin: 0% 0%;

--- a/client/landing/gutenboarding/onboarding-block/create-site/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/create-site/style.scss
@@ -53,18 +53,27 @@ $progress-widget-height: 300px;
 		}
 
 		.create-site__progress-bar {
+			position: relative;
 			height: 6px;
-			background: var( --mainColor );
-			transform: scaleX( 0 );
-			transform-origin: 0% 0%;
 			margin-top: 1em;
+			background: var( --studio-gray-10 );
 
-			animation: create-site__progress-bar-progress-move #{$progress-duration + 1} ease-out forwards;
-
-			@keyframes create-site__progress-bar-progress-move {
-				@for $i from 1 through 3 {
-					#{$i / 3 * 100%} {
-						transform: scaleX( #{$i / 3} );
+			&::before {
+				background: var( --mainColor );
+				transform: scaleX( 0 );
+				transform-origin: 0% 0%;
+				position: absolute;
+				content: '';
+				top: 0;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				animation: create-site__progress-bar-progress-move #{$progress-duration + 1} ease-out forwards;
+				@keyframes create-site__progress-bar-progress-move {
+					@for $i from 1 through 3 {
+						#{$i / 3 * 100%} {
+							transform: scaleX( #{$i / 3} );
+						}
 					}
 				}
 			}

--- a/client/lib/interval/use-interval.ts
+++ b/client/lib/interval/use-interval.ts
@@ -16,10 +16,14 @@ import { TimeoutMS } from 'types';
  * https://github.com/gaearon/overreacted.io/blob/80c0a314c5d855891220852788f662c2e8ecc7d4/src/pages/making-setinterval-declarative-with-react-hooks/index.md
  */
 
-type Callback = () => void;
-
-export function useInterval( callback: Callback, delay: TimeoutMS ) {
-	const savedCallback = useRef< Callback >();
+/**
+ * Invoke a function on an interval.
+ *
+ * @param callback Function to invoke
+ * @param delay    Interval timout in MS. `null` or `false` to stop the interval.
+ */
+export function useInterval( callback: () => void, delay: TimeoutMS | null | false ) {
+	const savedCallback = useRef( callback );
 
 	// Remember the latest callback.
 	useEffect( () => {
@@ -28,12 +32,11 @@ export function useInterval( callback: Callback, delay: TimeoutMS ) {
 
 	// Set up the interval.
 	useEffect( () => {
-		function tick() {
-			( savedCallback.current as /* savedCallback ref should never be `undefined` */ Callback )();
+		if ( delay === null || delay === false ) {
+			return;
 		}
-		if ( delay !== null ) {
-			const id = setInterval( tick, delay );
-			return () => clearInterval( id );
-		}
+		const tick = () => void savedCallback.current();
+		const id = setInterval( tick, delay );
+		return () => clearInterval( id );
 	}, [ delay ] );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Closes #40884 

Applies all changes:

- Remove the vertical text animation. It should just swap instantly between the text like in the prototype.
- Let's add a `--studio-gray-10` background behind the loading bar. See screenshot.
- Change the height of the loading bar from 7px to 6px
- Remove "Getting your domain" unless they actually got a paid domain

![demo-hd](https://user-images.githubusercontent.com/841763/79855935-ef9f0f80-83cb-11ea-942c-68f756852be8.gif)

#### Testing instructions

* [`/new`](https://calypso.live/new?branch=gutenboarding/40884-create-site-loader-tweak)
* Go through the flow without selecting a domain - there should be 2 steps (no domain).
* Go through the flow selecting a WordPress.com subdomain - there should be 2 steps (no domain)
* Go through the flow selecting a paid domain - there should be 3 steps (including domain)
