### PR TITLE
Jetpack Cloud: Make the button, and text style less specific.

### DIFF
--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -27,6 +27,7 @@
 	&:active {
 		background: var( --color-primary-5 );
 		border-color: var( --color-primary-40 );
+		border-width: 1px;
 	}
 
 	&[disabled],

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -12,7 +12,6 @@
 	}
 }
 
-
 .button {
 	color: var( --color-primary-60 );
 	background: var( --studio-white );
@@ -41,6 +40,7 @@
 .button.is-primary {
 	color: var( --studio-white );
 	background: var( --color-primary-40 );
+	border-color: var( --color-primary-40 );
 
 	&:hover,
 	&:focus {
@@ -194,7 +194,6 @@ p {
 		line-height: 24px;
 	}
 }
-
 
 .theme-jetpack-cloud .ReactModalPortal {
 	.dialog.card {

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -12,191 +12,188 @@
 	}
 }
 
-.theme-jetpack-cloud .main,
-.color-scheme.is-jetpack-cloud .main,
-.theme-jetpack-cloud .ReactModalPortal,
-.theme-jetpack-cloud .popover {
-	.button {
-		color: var( --color-primary-60 );
+
+.button {
+	color: var( --color-primary-60 );
+	background: var( --studio-white );
+	border: 1px solid var( --color-primary-40 );
+	border-radius: 3px;
+
+	&:hover,
+	&:focus {
+		background: var( --color-primary-0 );
+	}
+
+	&:active {
+		background: var( --color-primary-5 );
+		border-color: var( --color-primary-40 );
+	}
+
+	&[disabled],
+	&:disabled {
+		color: var( --studio-gray-10 );
+		border-color: var( --color-gray-10 );
 		background: var( --studio-white );
-		border: 1px solid var( --color-primary-40 );
-		border-radius: 3px;
+	}
+}
 
-		&:hover,
-		&:focus {
-			background: var( --color-primary-0 );
-		}
+.button.is-primary {
+	color: var( --studio-white );
+	background: var( --color-primary-40 );
 
-		&:active {
-			background: var( --color-primary-5 );
-			border-color: var( --color-primary-40 );
-		}
-
-		&[disabled],
-		&:disabled {
-			color: var( --studio-gray-10 );
-			border-color: var( --color-gray-10 );
-			background: var( --studio-white );
-		}
+	&:hover,
+	&:focus {
+		background: var( --color-primary-30 );
+		border-color: var( --color-primary-30 );
 	}
 
-	.button.is-primary {
-		color: var( --studio-white );
-		background: var( --color-primary-40 );
-
-		&:hover,
-		&:focus {
-			background: var( --color-primary-30 );
-			border-color: var( --color-primary-30 );
-		}
-
-		&:active {
-			background: var( --color-primary-50 );
-			border-color: var( --color-primary-50 );
-		}
-
-		&[disabled],
-		&:disabled {
-			background: var( --studio-gray-10 );
-			border-color: var( --studio-gray-10 );
-		}
+	&:active {
+		background: var( --color-primary-50 );
+		border-color: var( --color-primary-50 );
 	}
 
-	.button.is-scary {
-		color: var( --color-scary-60 );
-		border-color: var( --color-scary-50 );
+	&[disabled],
+	&:disabled {
+		background: var( --studio-gray-10 );
+		border-color: var( --studio-gray-10 );
+	}
+}
 
-		&:hover,
-		&:focus {
-			background: var( --color-scary-0 );
-		}
+.button.is-scary {
+	color: var( --color-scary-60 );
+	border-color: var( --color-scary-50 );
 
-		&:active {
-			background: var( --color-scary-5 );
-			border-color: var( --color-scary-40 );
-		}
-
-		&[disabled],
-		&:disabled {
-			color: var( --studio-gray-10 );
-			background: none;
-			border-color: var( --color-gray-10 );
-		}
+	&:hover,
+	&:focus {
+		background: var( --color-scary-0 );
 	}
 
-	.button.is-primary.is-scary {
-		color: var( --studio-white );
-		background: var( --color-scary-50 );
-		border-color: var( --color-scary-50 );
-
-		&:hover,
-		&:focus {
-			background: var( --color-scary-40 );
-			border-color: var( --color-scary-40 );
-		}
-
-		&:active {
-			background: var( --color-scary-60 );
-			border-color: var( --color-scary-60 );
-		}
-
-		&[disabled],
-		&:disabled {
-			background: var( --studio-gray-10 );
-			border-color: var( --studio-gray-10 );
-		}
+	&:active {
+		background: var( --color-scary-5 );
+		border-color: var( --color-scary-40 );
 	}
 
-	.button.is-borderless {
-		border: none;
+	&[disabled],
+	&:disabled {
+		color: var( --studio-gray-10 );
 		background: none;
-		color: var( --studio-gray-80 );
-		padding-left: 0;
-		padding-right: 0;
+		border-color: var( --color-gray-10 );
+	}
+}
 
-		&:hover,
-		&:focus {
-			background: none;
-			color: var( --studio-gray-70 );
-		}
+.button.is-primary.is-scary {
+	color: var( --studio-white );
+	background: var( --color-scary-50 );
+	border-color: var( --color-scary-50 );
 
-		&[disabled],
-		&:disabled {
-			color: var( --color-neutral-20 );
-			cursor: default;
-
-			&:active,
-			&.is-active {
-				border-width: 0;
-			}
-		}
+	&:hover,
+	&:focus {
+		background: var( --color-scary-40 );
+		border-color: var( --color-scary-40 );
 	}
 
-	.button.is-borderless.is-primary {
-		color: var( --color-primary-40 );
-
-		&:hover,
-		&:focus {
-			color: var( --color-primary-30 );
-		}
-
-		&:active {
-			color: var( --color-primary-50 );
-		}
-
-		&[disabled],
-		&:disabled {
-			color: var( --studio-gray-10 );
-		}
+	&:active {
+		background: var( --color-scary-60 );
+		border-color: var( --color-scary-60 );
 	}
 
-	.button.is-borderless.is-primary.is-scary {
-		color: var( --color-scary-50 );
+	&[disabled],
+	&:disabled {
+		background: var( --studio-gray-10 );
+		border-color: var( --studio-gray-10 );
+	}
+}
 
-		&:hover,
-		&:focus {
-			color: var( --color-scary-40 );
-		}
+.button.is-borderless {
+	border: none;
+	background: none;
+	color: var( --studio-gray-80 );
+	padding-left: 0;
+	padding-right: 0;
 
-		&:active {
-			color: var( --color-scary-60 );
-		}
+	&:hover,
+	&:focus {
+		background: none;
+		color: var( --studio-gray-70 );
 	}
 
-	// Universal Text Styles
+	&[disabled],
+	&:disabled {
+		color: var( --color-neutral-20 );
+		cursor: default;
 
-	h2 {
-		font-size: 22px;
-		font-weight: 700;
-		line-height: 32px;
-
-		@include breakpoint( '>660px' ) {
-			font-size: 36px;
-			line-height: 40px;
-		}
-	}
-
-	h3 {
-		font-size: 16px;
-		font-weight: 700;
-		line-height: 23px;
-
-		@include breakpoint( '>660px' ) {
-			font-size: 18px;
-			line-height: 23px;
-		}
-	}
-
-	p {
-		font-size: 16px;
-		line-height: 24px;
-
-		@include breakpoint( '>660px' ) {
-			font-size: 18px;
-			line-height: 24px;
+		&:active,
+		&.is-active {
+			border-width: 0;
 		}
 	}
 }
+
+.button.is-borderless.is-primary {
+	color: var( --color-primary-40 );
+
+	&:hover,
+	&:focus {
+		color: var( --color-primary-30 );
+	}
+
+	&:active {
+		color: var( --color-primary-50 );
+	}
+
+	&[disabled],
+	&:disabled {
+		color: var( --studio-gray-10 );
+	}
+}
+
+.button.is-borderless.is-primary.is-scary {
+	color: var( --color-scary-50 );
+
+	&:hover,
+	&:focus {
+		color: var( --color-scary-40 );
+	}
+
+	&:active {
+		color: var( --color-scary-60 );
+	}
+}
+
+// Universal Text Styles
+
+h2 {
+	font-size: 22px;
+	font-weight: 700;
+	line-height: 32px;
+
+	@include breakpoint( '>660px' ) {
+		font-size: 36px;
+		line-height: 40px;
+	}
+}
+
+h3 {
+	font-size: 16px;
+	font-weight: 700;
+	line-height: 23px;
+
+	@include breakpoint( '>660px' ) {
+		font-size: 18px;
+		line-height: 23px;
+	}
+}
+
+p {
+	font-size: 16px;
+	line-height: 24px;
+
+	@include breakpoint( '>660px' ) {
+		font-size: 18px;
+		line-height: 24px;
+	}
+}
+
 
 .theme-jetpack-cloud .ReactModalPortal {
 	.dialog.card {


### PR DESCRIPTION
Since the Jetpack Cloud section only gets loaded via the sidebar.
These styles should not be bleeding into calypso so we can make them less jetpack cloud specific. Which will make them easier to overwrite.

Before: 
<img width="810" alt="Screen Shot 2020-04-21 at 11 09 22 AM" src="https://user-images.githubusercontent.com/115071/79847868-9f6e8000-83c0-11ea-95d7-2df97f3714a1.png">

After:
<img width="752" alt="Screen Shot 2020-04-21 at 11 08 18 AM" src="https://user-images.githubusercontent.com/115071/79847855-9b426280-83c0-11ea-8c88-8c42476667e8.png">

#### Changes proposed in this Pull Request
* Remove the specificity around links, and h3, h2, and paragraphs. 

#### Testing instructions

Load up jetpack cloud does it still look like before? As expected?
Load up wpcalypso does it still look like as before? As exected? 

