### PR TITLE
My Sites: Hide sidebar earn menu when in All My Sites view

### DIFF
--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -237,6 +237,10 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		if ( ! site ) {
+			return null;
+		}
+
 		if ( site && ! canUserUseEarn ) {
 			return null;
 		}

--- a/client/my-sites/sidebar/test/sidebar.js
+++ b/client/my-sites/sidebar/test/sidebar.js
@@ -135,4 +135,64 @@ describe( 'MySitesSidebar', () => {
 			expect( wrapper.html() ).toEqual( null );
 		} );
 	} );
+
+	describe( 'MySitesSidebar.earn()', () => {
+		const defaultProps = {
+			site: {
+				plan: {
+					product_slug: 'business-bundle',
+				},
+			},
+			siteSuffix: '/mysite.com',
+			translate: x => x,
+		};
+
+		test( 'Should return null item if no site selected', () => {
+			const Sidebar = new MySitesSidebar( {
+				site: null,
+				siteSuffix: '',
+				translate: x => x,
+			} );
+			const Earn = () => Sidebar.earn();
+			const wrapper = shallow( <Earn /> );
+
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( 'Should return null item if signup/wpforteams enabled and isSiteWPForTeams', () => {
+			const Sidebar = new MySitesSidebar( {
+				isSiteWPForTeams: true,
+				...defaultProps,
+			} );
+
+			const Earn = () => Sidebar.earn();
+			const wrapper = shallow( <Earn /> );
+
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( 'Should return null item if site present but user cannot earn', () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseEarn: false,
+				...defaultProps,
+			} );
+
+			const Earn = () => Sidebar.earn();
+			const wrapper = shallow( <Earn /> );
+
+			expect( wrapper.html() ).toEqual( null );
+		} );
+
+		test( 'Should return earn menu item if site present and user can earn', () => {
+			const Sidebar = new MySitesSidebar( {
+				canUserUseEarn: true,
+				...defaultProps,
+			} );
+
+			const Earn = () => Sidebar.earn();
+			const wrapper = shallow( <Earn /> );
+
+			expect( wrapper.html() ).not.toEqual( null );
+		} );
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide Earn menu item in "My Sites" sidebar when in an "All My Sites" view as we do not have an aggregated view.

#### Testing instructions

1. Visit a page that has an "All My Sites" view, like `https://wordpress.com/stats/day`
2. Confirm Earn item is not under Tools.
3. Switch to a site on which the current user can earn.
4. Re-visit page from step one and confirm Earn menu item is present.

Menu Before:

<img width="670" alt="EarnMenuBefore" src="https://user-images.githubusercontent.com/60436221/79849245-8e942d80-8405-11ea-95ad-1c57f172271f.png">

Menu After:

<img width="660" alt="EarnMenuAfter" src="https://user-images.githubusercontent.com/60436221/79849274-981d9580-8405-11ea-884b-9f25ae595d66.png">

<img width="660" alt="EarnMenuAfter2" src="https://user-images.githubusercontent.com/60436221/79849295-9d7ae000-8405-11ea-8f07-bfb93c62ba27.png">

Fixes: #41278