### PR TITLE
Gutenboarding: Fix viewport selector colors

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -54,7 +54,6 @@
 	}
 }
 
-
 .style-preview__actions {
 	position: absolute;
 	top: 50%;
@@ -96,7 +95,7 @@
 	}
 }
 
-@supports (display: grid) {
+@supports ( display: grid ) {
 	.style-preview__header {
 		display: grid;
 		grid-template-areas: 'title viewport-select actions';
@@ -147,7 +146,7 @@
 	}
 }
 
-@supports (display: grid) {
+@supports ( display: grid ) {
 	.style-preview__content {
 		display: block;
 		width: 100%;
@@ -199,7 +198,6 @@
 		width: 100%;
 	}
 
-
 	// Extra specificity to override core style
 	// This is effectively a more-specific synonmy of the same selector
 	&.components-button {
@@ -248,7 +246,7 @@
 	}
 }
 
-@supports (display: grid) {
+@supports ( display: grid ) {
 	.style-preview__preview {
 		grid-area: preview;
 		width: 100%;

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -331,25 +331,25 @@ $gutenboarding-style-preview-bar-height: 30px;
 
 	// Need the extra specificity here to override core
 	&.components-button {
+		color: var( --studio-gray-10 );
 		height: auto;
 		padding: 4px;
 
-		color: var( --studio-gray-10 );
+		&.is-selected,
+		&:hover,
+		&:focus {
+			color: var( --studio-black );
+		}
 
 		svg {
 			fill: none;
 		}
 	}
-
-	&.is-selected {
-		color: var( --studio-black );
-	}
 }
 
 // Remove focus styling from clicking a button
 // Keep keyboard-focused focus style
-html:not( .accessible-focus )
-	.style-preview__viewport-select-button.is-selected:focus:not( :hover ) {
+html:not( .accessible-focus ) .components-button:focus:not( :disabled ) {
 	box-shadow: none;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request


- [x] The device buttons. The hover state should be dark black and active state the same. Remove the border that exist on hovering the active state.

This does maintain an accessible focus style with blue (default) outlines when tab navigation occurs. You can see it at the end of this gif:

![demo](https://user-images.githubusercontent.com/841763/79860603-38a69200-83d3-11ea-9ec5-b76f63a5d8ff.gif)


#### Testing instructions

* [`/new`](https://calypso.live/new?branch=gutenboarding/41214-latest-g7g-fixes)