### PR TITLE
Gutenboarding: Fix font-select Gutenberg style regressions

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -199,13 +199,19 @@
 		width: 100%;
 	}
 
-
 	// Extra specificity to override core style
 	// This is effectively a more-specific synonmy of the same selector
 	&.components-button {
 		color: var( --studio-gray-90 );
 		height: auto;
 		border-radius: 2px;
+
+		&:hover,
+		&:focus,
+		&:focus:not( :disabled ) {
+			color: var( --studio-gray-90 );
+			box-shadow: inset 0 0 0 1px var( --studio-gray-90 );
+		}
 	}
 
 	&.is-selected {
@@ -213,10 +219,6 @@
 		// `!important` is used because there are default `focus` and `hover` styles with high specificities.
 		color: var( --studio-blue-40 ) !important;
 		box-shadow: inset 0 0 0 1px var( --studio-blue-40 ) !important;
-	}
-
-	&:hover {
-		box-shadow: inset 0 0 0 1px var( --studio-gray-90 );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

From #41214

- The hover and click state for the font buttons. Hover state should be black text and outline and click state should be the same as active state or hover state.

You can see <kbd>tab</kbd> keyboard navigation focus styles at the end of the gif.

![demo](https://user-images.githubusercontent.com/841763/79861476-be770d00-83d4-11ea-96c3-64acbf59175d.gif)


#### Testing instructions



* [`/new`](https://calypso.live/new?branch=gutenboarding/41214-font-button-g7g-fix)
