### PR TITLE
Gutenboarding: Scroll to top on route change

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -4,7 +4,7 @@
 import { BlockEditProps } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import React, { FunctionComponent } from 'react';
-import { Redirect, Switch, Route } from 'react-router-dom';
+import { Redirect, Switch, Route, useLocation } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -30,6 +30,12 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 	const replaceHistory = useNewQueryParam();
 
 	const makePath = usePath();
+
+	const { pathname } = useLocation();
+
+	React.useEffect( () => {
+		window.scrollTo( 0, 0 );
+	}, [ pathname ] );
 
 	return (
 		<div className="onboarding-block" data-vertical={ siteVertical?.label }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Scroll the window to top when the route changes in Gutenboarding.

#### Testing instructions

* On mobile, go to /design and tap on a design. 
* When landed on Font selector you should see the header
* Press "Choose another design" link at the bottom of the page
* On design page you should see the header. 

Fixes part of #41138
