### PR TITLE
Jetpack Cloud: Position fix/ignore buttons below threat details

### DIFF
--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -16,14 +16,7 @@
 	&__buttons {
 		display: flex;
 		justify-content: space-evenly;
-		order: -1;
 		padding: 20px 0;
-
-		@include breakpoint( '>800px' ) {
-			display: block;
-			padding: 0 48px 0 20px;
-			order: initial;
-		}
 	}
 
 	&__fix-button {
@@ -57,15 +50,6 @@
 	.foldable-card__header {
 		border-bottom: 1px solid var( --studio-gray-5 );
 	}
-
-	&.foldable-card.is-expanded .foldable-card__content {
-		display: flex;
-		flex-direction: column;
-
-		@include breakpoint( '>800px' ) {
-			flex-direction: row;
-		}
-	}
 }
 
 .button.is-compact {
@@ -73,6 +57,8 @@
 	&.threat-item__ignore-button {
 		width: 170px;
 		padding: 10px 30px;
+		margin-inline-start: 5px;
+		margin-inline-end: 5px;
 		border-width: 1px;
 		border-style: solid;
 		border-radius: 3px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the "Fix threat" and "Ignore threat" buttons down, so they're below the threat details.
* Center-align the button(s) horizontally.
* Add 5px of inline/left-right margin to these buttons so they don't sit against each other on mobile

#### Questions/discussion

* Do we want to center-align the buttons, or is there a better/more conventional alignment we should use?
* On mobile, do we want the outside edge of each button to align with the edge of the content? In this PR, currently, they are set inward by 5px.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load Jetpack Cloud for a site with a threat. Expand the threat details.
* On desktops, ensure that the "Ignore threat" button is positioned below the threat details.
* On mobile devices, ensure that both the "Fix threat" and "Ignore threat" buttons are positioned below the threat details.
* On mobile devices, ensure that there is a small space between the "Fix threat" and "Ignore threat" buttons.

#### Screenshots

##### Desktop layout

<img width="726" alt="Desktop layout" src="https://user-images.githubusercontent.com/670067/79874557-20704c00-83ae-11ea-88d8-1f0c7e667e75.png">

##### Mobile layout

<img width="403" alt="Mobile layout" src="https://user-images.githubusercontent.com/670067/79874607-30882b80-83ae-11ea-891e-30c8a490b58f.png">


Fixes 1151678672052943-as-1172171151925059