### PR TITLE
Devdocs: Update docs for Banners and fix UpsellNudge

### DIFF
--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -11,12 +11,14 @@ import UpsellNudge from 'blocks/upsell-nudge';
 const UpsellNudgeExample = () => (
 	<>
 		<UpsellNudge
+			forceDisplay
 			href="#"
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a regular nudge with an icon."
 			showIcon={ true }
 		/>
 		<UpsellNudge
+			forceDisplay
 			href="#"
 			compact
 			callToAction="Upgrade"

--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -8,14 +8,9 @@ import React from 'react';
  * Internal dependencies
  */
 import {
-	PLAN_BLOGGER,
-	PLAN_PERSONAL,
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
-	PLAN_ECOMMERCE,
 	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_BUSINESS,
 	FEATURE_ADVANCED_SEO,
 } from 'lib/plans/constants';
 import Banner from 'components/banner';
@@ -30,10 +25,7 @@ const BannerExample = () => (
 			title="Banner unrelated to any plan"
 		/>
 		<Banner showIcon={ false } title="Banner with showIcon set to false" />
-		<Banner href="#" plan={ PLAN_BLOGGER } title="Upgrade to a Blogger Plan!" />
-		<Banner href="#" plan={ PLAN_PERSONAL } title="Upgrade to a Personal Plan!" />
 		<Banner href="#" plan={ PLAN_PREMIUM } title="Upgrade to a Premium Plan!" />
-		<Banner href="#" plan={ PLAN_BUSINESS } title="Upgrade to a Business Plan!" />
 		<Banner
 			callToAction="Upgrade for $9.99"
 			feature={ FEATURE_ADVANCED_SEO }
@@ -52,11 +44,12 @@ const BannerExample = () => (
 			plan={ PLAN_BUSINESS }
 			title="Upgrade to a Business Plan!"
 		/>
-		<Banner href="#" plan={ PLAN_ECOMMERCE } title="Upgrade to an eCommerce Plan!" />
-
-		<Banner href="#" plan={ PLAN_JETPACK_PERSONAL } title="Upgrade to a Jetpack Personal Plan!" />
-		<Banner href="#" plan={ PLAN_JETPACK_PREMIUM } title="Upgrade to a Jetpack Premium Plan!" />
-		<Banner href="#" plan={ PLAN_JETPACK_BUSINESS } title="Upgrade to a Jetpack Business Plan!" />
+		<Banner
+			href="#"
+			plan={ PLAN_JETPACK_PERSONAL }
+			title="Upgrade to a Jetpack Personal Plan!"
+			jetpack={ true }
+		/>
 		<Banner
 			callToAction="Get Backups"
 			description="New plugins can lead to unexpected changes. Ensure you can restore your site if something goes wrong."


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set `forceDisplay` on `UpsellNudge` examples or they won't show
* Remove unnecessary `Banner` examples since we no longer show them in multiple colors for different plans

**Before**

<img width="316" alt="Screen Shot 2020-04-21 at 10 36 12 AM" src="https://user-images.githubusercontent.com/2124984/79878903-f9b91200-83bb-11ea-91e5-e6387108356e.png">

<img width="1345" alt="Screen Shot 2020-04-21 at 10 36 24 AM" src="https://user-images.githubusercontent.com/2124984/79878901-f887e500-83bb-11ea-89fb-cd0998d16db2.png">

**After**

<img width="664" alt="Screen Shot 2020-04-21 at 10 31 50 AM" src="https://user-images.githubusercontent.com/2124984/79878517-83b4ab00-83bb-11ea-829d-a6329b0e6bda.png">

<img width="1349" alt="Screen Shot 2020-04-21 at 10 29 34 AM" src="https://user-images.githubusercontent.com/2124984/79878520-84e5d800-83bb-11ea-8751-491f4d0f3a11.png">

#### Testing instructions

* Switch to this PR
* Check out `/devdocs` under Blocks, search for `UpsellNudge`, note two examples that should display correctly
* Check out Components, search for `Banner`, see the number of examples has been reduced.
