### PR TITLE
Try adding e2e tests for gutenberg tracking

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -39,7 +39,7 @@ export default ( eventName, eventProperties ) => {
 	const customProperties = {
 		blog_id: window._currentSiteId,
 		site_type: window._currentSiteType,
-		user_locale: window._currentUserLocale,
+		user_locale: window._currentUserLocale
 	};
 
 	eventProperties = eventProperties || {};

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/track-record-event.js
@@ -39,7 +39,7 @@ export default ( eventName, eventProperties ) => {
 	const customProperties = {
 		blog_id: window._currentSiteId,
 		site_type: window._currentSiteType,
-		user_locale: window._currentUserLocale
+		user_locale: window._currentUserLocale,
 	};
 
 	eventProperties = eventProperties || {};

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -822,7 +822,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarMenu className="sidebar__wp-admin">
 				<ul>
-					<li>
+					<li data-tip-target="wpadmin">
 						<ExternalLink
 							className="sidebar__menu-link"
 							href={ adminUrl }
@@ -830,9 +830,7 @@ export class MySitesSidebar extends Component {
 							onClick={ this.trackWpadminClick }
 						>
 							<Gridicon className={ 'sidebar__menu-icon' } icon="my-sites" size={ 24 } />
-							<span className="menu-link-text" data-e2e-sidebar="WP Admin">
-								{ this.props.translate( 'WP Admin' ) }
-							</span>
+							<span className="menu-link-text">{ this.props.translate( 'WP Admin' ) }</span>
 						</ExternalLink>
 					</li>
 				</ul>

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -830,7 +830,9 @@ export class MySitesSidebar extends Component {
 							onClick={ this.trackWpadminClick }
 						>
 							<Gridicon className={ 'sidebar__menu-icon' } icon="my-sites" size={ 24 } />
-							<span className="menu-link-text">{ this.props.translate( 'WP Admin' ) }</span>
+							<span className="menu-link-text" data-e2e-sidebar="WP Admin">
+								{ this.props.translate( 'WP Admin' ) }
+							</span>
 						</ExternalLink>
 					</li>
 				</ul>

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -56,10 +56,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectWPAdmin() {
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.menu-link-text[data-e2e-sidebar="WP Admin"]' )
-		); // TODO: data-tip-target target is missing
+		return await this._scrollToAndClickMenuItem( 'wpadmin' );
 	}
 
 	async customizeTheme() {

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -55,6 +55,13 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		); // TODO: data-tip-target target is missing
 	}
 
+	async selectWPAdmin() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.menu-link-text[data-e2e-sidebar="WP Admin"]' )
+		); // TODO: data-tip-target target is missing
+	}
+
 	async customizeTheme() {
 		return await this._scrollToAndClickMenuItem( 'themes' );
 	}

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -263,6 +263,12 @@ export default class LoginFlow {
 		return await StoreDashboardPage.Expect( this.driver );
 	}
 
+	async loginAndSelectWPAdmin() {
+		await this.loginAndSelectMySite();
+		this.sideBarComponent = await SidebarComponent.Expect( this.driver );
+		return await this.sideBarComponent.selectWPAdmin();
+	}
+
 	end() {
 		if ( typeof this.account !== 'string' ) {
 			dataHelper.releaseAccount( this.account );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -257,6 +257,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			case 'Heading':
 				ariaLabel = 'Write heading…';
 				break;
+			case 'Heading':
+				ariaLabel = 'Write heading…';
+				break;
 		}
 
 		const selectorAriaLabel = ariaLabel || `Block: ${ name }`;

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -257,9 +257,6 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			case 'Heading':
 				ariaLabel = 'Write heading…';
 				break;
-			case 'Heading':
-				ariaLabel = 'Write heading…';
-				break;
 		}
 
 		const selectorAriaLabel = ariaLabel || `Block: ${ name }`;
@@ -458,9 +455,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		);
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css(
-				'.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button'
-			)
+			By.css( '.wpcom-block-editor-nav-sidebar-nav-sidebar__home-button' )
 		);
 	}
 

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -1,0 +1,79 @@
+/**
+ * External dependencies
+ */
+import assert from 'assert';
+import config from 'config';
+
+/**
+ * Internal dependencies
+ */
+import LoginFlow from '../lib/flows/login-flow.js';
+
+import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
+import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
+
+import * as driverManager from '../lib/driver-manager.js';
+import * as dataHelper from '../lib/data-helper.js';
+import * as driverHelper from '../lib/driver-helper';
+
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
+const screenSize = driverManager.currentScreenSize();
+const host = dataHelper.getJetpackHost();
+const gutenbergUser =
+	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
+
+let driver;
+
+before( async function () {
+	this.timeout( startBrowserTimeoutMS );
+	driver = await driverManager.startBrowser();
+} );
+
+describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function () {
+	this.timeout( mochaTimeOut );
+
+	describe( 'Tracking: @parallel', function () {
+		let fileDetails;
+		const pageTitle = dataHelper.randomPhrase();
+		const pageQuote =
+			'If you have the same problem for a long time, maybe it’s not a problem. Maybe it’s a fact..\n— Itzhak Rabin';
+
+		// Create image file for upload
+		before( async function () {} );
+
+		step( 'Can log in', async function () {
+			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+			if ( host !== 'WPCOM' ) {
+				this.loginFlow = new LoginFlow( driver );
+			}
+			return await this.loginFlow.loginAndStartNewPage( null, true );
+		} );
+
+		step( 'Can enter page title, content and image', async function () {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+
+			await driver.executeScript(
+				`window.localStorage.setItem( 'debug', 'wpcom-block-editor*' );`
+			);
+
+			const debugConfig = await driver.executeScript(
+				`return window.localStorage.getItem('debug');`
+			);
+
+			console.log( 'Using Tracks debug: ' + debugConfig );
+
+			await gEditorComponent.enterTitle( pageTitle );
+			await gEditorComponent.enterText( pageQuote );
+			await gEditorComponent.addBlock( 'Columns' );
+
+			await driver.sleep( 50000 );
+			const logs = await driver.manage().logs().get( 'browser' );
+
+			console.log( logs );
+			driver.quit();
+		} );
+
+		after( async function () {} );
+	} );
+} );

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -12,7 +12,8 @@ import LoginFlow from '../lib/flows/login-flow.js';
 
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
-import WPAdminDashboardPage from '../lib/pages/wp-admin/wp-admin-dashboard-page';
+import SidebarComponent from '../lib/components/sidebar-component.js';
+import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';
 
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
@@ -22,6 +23,7 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
 const screenSize = driverManager.currentScreenSize();
 const host = dataHelper.getJetpackHost();
+
 const gutenbergUser =
 	process.env.GUTENBERG_EDGE === 'true' ? 'gutenbergSimpleSiteEdgeUser' : 'gutenbergSimpleSiteUser';
 
@@ -36,11 +38,6 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 	this.timeout( mochaTimeOut );
 
 	describe( 'Tracking: @parallel', function () {
-		let fileDetails;
-		const pageTitle = dataHelper.randomPhrase();
-		const pageQuote =
-			'If you have the same problem for a long time, maybe it’s not a problem. Maybe it’s a fact..\n— Itzhak Rabin';
-
 		// Create image file for upload
 		before( async function () {} );
 
@@ -49,6 +46,8 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 			if ( host !== 'WPCOM' ) {
 				this.loginFlow = new LoginFlow( driver );
 			}
+			// await this.loginFlow.loginAndStartNewPage();
+
 			await this.loginFlow.loginAndSelectWPAdmin();
 
 			//Wait for the new window or tab
@@ -59,7 +58,11 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 
 			await driver.switchTo().window( windows[ 1 ] );
 
-			await driverHelper.clickWhenClickable( driver, By.css( '#menu-pages > a' ) ); //
+			const wpadminSidebarComponent = await WPAdminSidebar.Expect( driver );
+			await wpadminSidebarComponent.selectNewPost();
+
+			// const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			// await gEditorComponent.initEditor( { dismissPageTemplateSelector } );
 
 			await driver.sleep( 5000 );
 		} );

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -59,12 +59,9 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 
 			await driver.switchTo().window( windows[ 1 ] );
 
-			await driverHelper.clickWhenClickable(
-				this.driver,
-				By.css( '#menu-pages ul li:last-child > a]' )
-			); //
+			await driverHelper.clickWhenClickable( driver, By.css( '#menu-pages > a' ) ); //
 
-			await driver.sleep( 50000 );
+			await driver.sleep( 5000 );
 		} );
 
 		// step( 'Can enter page title, content and image', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -41,7 +41,7 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 		// Create image file for upload
 		before( async function () {} );
 
-		step( 'Can log in', async function () {
+		step( 'Can log in to WPAdmin and create new Post', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			if ( host !== 'WPCOM' ) {
 				this.loginFlow = new LoginFlow( driver );
@@ -60,37 +60,32 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 
 			const wpadminSidebarComponent = await WPAdminSidebar.Expect( driver );
 			await wpadminSidebarComponent.selectNewPost();
-
-			// const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			// await gEditorComponent.initEditor( { dismissPageTemplateSelector } );
-
-			await driver.sleep( 5000 );
 		} );
 
-		// step( 'Can enter page title, content and image', async function () {
+		step( 'Can enter page title, content and image', async function () {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
 
-		// 	// const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			await driver.executeScript(
+				`window.localStorage.setItem( 'debug', 'wpcom-block-editor*' );`
+			);
 
-		// 	// await driver.executeScript(
-		// 	// 	`window.localStorage.setItem( 'debug', 'wpcom-block-editor*' );`
-		// 	// );
+			const debugConfig = await driver.executeScript(
+				`return window.localStorage.getItem('debug');`
+			);
 
-		// 	// const debugConfig = await driver.executeScript(
-		// 	// 	`return window.localStorage.getItem('debug');`
-		// 	// );
+			console.log( 'Using Tracks debug: ' + debugConfig );
 
-		// 	// console.log( 'Using Tracks debug: ' + debugConfig );
+			await gEditorComponent.addBlock( 'Markdown' );
+			await gEditorComponent.addBlock( 'Columns' );
 
-		// 	// await gEditorComponent.enterTitle( pageTitle );
-		// 	// await gEditorComponent.enterText( pageQuote );
-		// 	// await gEditorComponent.addBlock( 'Columns' );
+			await driver.sleep( 30000 );
 
-		// 	// await driver.sleep( 50000 );
-		// 	// const logs = await driver.manage().logs().get( 'browser' );
+			// await driver.sleep( 50000 );
+			const logs = await driver.manage().logs().get( 'browser' );
 
-		// 	// console.log( logs );
-		// 	// driver.quit();
-		// } );
+			console.log( logs );
+			driver.quit();
+		} );
 
 		after( async function () {} );
 	} );

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -3,6 +3,7 @@
  */
 import assert from 'assert';
 import config from 'config';
+import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import LoginFlow from '../lib/flows/login-flow.js';
 
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
+import WPAdminDashboardPage from '../lib/pages/wp-admin/wp-admin-dashboard-page';
 
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
@@ -47,32 +49,48 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 			if ( host !== 'WPCOM' ) {
 				this.loginFlow = new LoginFlow( driver );
 			}
-			return await this.loginFlow.loginAndStartNewPage( null, true );
-		} );
+			await this.loginFlow.loginAndSelectWPAdmin();
 
-		step( 'Can enter page title, content and image', async function () {
-			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			//Wait for the new window or tab
+			await driver.wait( async () => ( await driver.getAllWindowHandles() ).length === 2, 10000 );
 
-			await driver.executeScript(
-				`window.localStorage.setItem( 'debug', 'wpcom-block-editor*' );`
-			);
+			//Loop through until we find a new window handle
+			const windows = await driver.getAllWindowHandles();
 
-			const debugConfig = await driver.executeScript(
-				`return window.localStorage.getItem('debug');`
-			);
+			await driver.switchTo().window( windows[ 1 ] );
 
-			console.log( 'Using Tracks debug: ' + debugConfig );
-
-			await gEditorComponent.enterTitle( pageTitle );
-			await gEditorComponent.enterText( pageQuote );
-			await gEditorComponent.addBlock( 'Columns' );
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '#menu-pages ul li:last-child > a]' )
+			); //
 
 			await driver.sleep( 50000 );
-			const logs = await driver.manage().logs().get( 'browser' );
-
-			console.log( logs );
-			driver.quit();
 		} );
+
+		// step( 'Can enter page title, content and image', async function () {
+
+		// 	// const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+
+		// 	// await driver.executeScript(
+		// 	// 	`window.localStorage.setItem( 'debug', 'wpcom-block-editor*' );`
+		// 	// );
+
+		// 	// const debugConfig = await driver.executeScript(
+		// 	// 	`return window.localStorage.getItem('debug');`
+		// 	// );
+
+		// 	// console.log( 'Using Tracks debug: ' + debugConfig );
+
+		// 	// await gEditorComponent.enterTitle( pageTitle );
+		// 	// await gEditorComponent.enterText( pageQuote );
+		// 	// await gEditorComponent.addBlock( 'Columns' );
+
+		// 	// await driver.sleep( 50000 );
+		// 	// const logs = await driver.manage().logs().get( 'browser' );
+
+		// 	// console.log( logs );
+		// 	// driver.quit();
+		// } );
 
 		after( async function () {} );
 	} );

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -3,7 +3,6 @@
  */
 import assert from 'assert';
 import config from 'config';
-import { By } from 'selenium-webdriver';
 
 /**
  * Internal dependencies
@@ -11,13 +10,10 @@ import { By } from 'selenium-webdriver';
 import LoginFlow from '../lib/flows/login-flow.js';
 
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
-import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
-import SidebarComponent from '../lib/components/sidebar-component.js';
 import WPAdminSidebar from '../lib/pages/wp-admin/wp-admin-sidebar';
 
 import * as driverManager from '../lib/driver-manager.js';
 import * as dataHelper from '../lib/data-helper.js';
-import * as driverHelper from '../lib/driver-helper';
 
 const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 const startBrowserTimeoutMS = config.get( 'startBrowserTimeoutMS' );
@@ -62,7 +58,7 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 			await wpadminSidebarComponent.selectNewPost();
 		} );
 
-		step( 'Can track block editor events', async function () {
+		step( 'Tracks "wpcom_block_inserted" event', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
 
 			// Insert some Blocks
@@ -76,18 +72,13 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 
 			// Assert that Insertion Events were tracked.
 			assert.strictEqual(
-				eventsStack[ 0 ][ 0 ] === 'wpcom_block_inserted',
+				eventsStack.some(
+					( [ eventName, eventData ] ) =>
+						eventName === 'wpcom_block_inserted' && eventData.block_name === 'core/columns'
+				),
 				true,
-				`"wpcom_block_inserted" failed for ${ eventsStack[ 0 ][ 1 ].block_name }`
+				`"wpcom_block_inserted" event failed to fire for ${ eventsStack[ 0 ][ 1 ].block_name }`
 			);
-
-			assert.strictEqual(
-				eventsStack[ 0 ][ 1 ].block_name === 'core/columns',
-				true,
-				`Failed to track "block_name" property for "wpcom_block_inserted" event`
-			);
-
-			// await driver.sleep( 100000 );
 		} );
 
 		after( async function () {} );

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -67,6 +67,10 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 			assert( eventsStack, 'tracking events stack missing from window._e2eEventsStack' );
 		} );
 
-		after( async function () {} );
+		afterEach( async function () {
+			// Reset e2e tests events stack after each step in order
+			// that we have a test specific stack to assert against.
+			await driver.executeScript( `window._e2eEventsStack = [];` );
+		} );
 	} );
 } );

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -75,7 +75,7 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
 			const eventsStack = await driver.executeScript( `return window._e2eEventsStack;` );
 			// Check evaluates to truthy
-			assert( eventsStack, 'tracking events stack missing from window._e2eEventsStack' );
+			assert( eventsStack, 'Tracking events stack missing from window._e2eEventsStack' );
 		} );
 
 		step( 'Tracks "wpcom_block_inserted" event', async function () {

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -50,9 +50,6 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 	this.timeout( mochaTimeOut );
 
 	describe( 'Tracking: @parallel', function () {
-		// Create image file for upload
-		before( async function () {} );
-
 		step( 'Can log in to WPAdmin and create new Post', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
 			if ( host !== 'WPCOM' ) {

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -71,7 +71,7 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 			await wpadminSidebarComponent.selectNewPost();
 		} );
 
-		step( 'Test for presence of e2e specific tracking events stack on global', async function () {
+		step( 'Check for presence of e2e specific tracking events stack on global', async function () {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver, 'wp-admin' );
 			const eventsStack = await driver.executeScript( `return window._e2eEventsStack;` );
 			// Check evaluates to truthy

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -52,10 +52,10 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 	describe( 'Tracking: @parallel', function () {
 		step( 'Can log in to WPAdmin and create new Post', async function () {
 			this.loginFlow = new LoginFlow( driver, gutenbergUser );
+
 			if ( host !== 'WPCOM' ) {
 				this.loginFlow = new LoginFlow( driver );
 			}
-			// await this.loginFlow.loginAndStartNewPage();
 
 			await this.loginFlow.loginAndSelectWPAdmin();
 

--- a/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-editor-tracking-spec.js
@@ -90,17 +90,17 @@ describe( `[${ host }] Calypso Gutenberg Tracking: (${ screenSize })`, function 
 			// see: https://github.com/Automattic/wp-calypso/pull/41329
 			const eventsStack = await driver.executeScript( `return window._e2eEventsStack;` );
 
-			// Assert that Insertion Events were tracked for core/columns
-			assert.strictEqual(
-				getTotalEventsFiredForBlock( eventsStack, 'wpcom_block_inserted', 'core/columns' ),
-				2,
-				`"wpcom_block_inserted" editor tracking event failed to fire twice for core/columns`
-			);
-
+			// Assert that all block insertion events were tracked correctly
 			assert.strictEqual(
 				getTotalEventsFiredForBlock( eventsStack, 'wpcom_block_inserted', 'core/heading' ),
 				1,
 				`"wpcom_block_inserted" editor tracking event failed to fire for core/heading`
+			);
+
+			assert.strictEqual(
+				getTotalEventsFiredForBlock( eventsStack, 'wpcom_block_inserted', 'core/columns' ),
+				2,
+				`"wpcom_block_inserted" editor tracking event failed to fire twice for core/columns`
 			);
 		} );
 


### PR DESCRIPTION
**Important:** if you haven't already, you should probably read: `paYJgx-Es-p2`.

This PR aims to address part of https://github.com/Automattic/wp-calypso/issues/41189. Namely **it aims to validate that all Block Editor tracking events are firing correctly for a given version of Gutenberg**. 

This should help avoid regressions in tracking upon updates to the Gutenberg Plugin on Dotcom.

To do this we are using [the existing Calypso e2e framework](https://github.com/Automattic/wp-calypso/blob/6823c601c858437a481178a63c0668c2b30b7788/test/e2e/README.md). The aim is to simulate the current manual process of verifying that tracking events fire for a given action within the Block Editor. This goes something like:

* Log in to the `/wp-admin` version of the test site (_not_ Calypso).
* Start a new Page in Gutenberg.
* Set a debug line in the console.
* Grab the logs and assert on the results.

However...the Tracks implementation will not fire events to the console on the e2e environment. For this reason we don't use the console output to verify events have fired. Instead on e2e environments [we create a global on the `window`](https://github.com/Automattic/wp-calypso/pull/41329/files#diff-ec49cb03bc5b2ce3c5cc924e5d2222f9R24) into which are [pushed all the events that are tracked just before they are sent to tracks](https://github.com/Automattic/wp-calypso/pull/41329/files#diff-ec49cb03bc5b2ce3c5cc924e5d2222f9R84). We can then [interrogate this global from the e2e test runner](https://github.com/Automattic/wp-calypso/pull/41329/files#diff-be8dda0cd6079f0f0d748361f4857a88R75) and [assert on the contents to verify particular events were fired](https://github.com/Automattic/wp-calypso/pull/41329/files#diff-be8dda0cd6079f0f0d748361f4857a88R78).

It's hacky, but it's probably the best of the options available. Moreover, it is far better than having no test coverage.

#### Current limitations

Please note that this is currently ~a proof of concept~ only adding a single assertion - that the `wpcom_block_inserted` event is being fired correctly. That's checking against that event only - there are many more! Once approved the test suite will be augmented to ensure it captures _**all**_ track events types. Moreover, documentation will be produced. This is an incremental step.

#### Did you consider using Redux?

@retrofox has mentioned that we could consider using a Redux store to hold all tracking events and then interrogate this Redux store to check which events have fired. However, this would be a lesser option, given that this would still leave us open to errors as there is a still a requirement that Redux actions are mapped correctly to Tracks events. Therefore, the best and most resilience and robust way to assert events are fired is that used in this PR.

Fixes https://github.com/Automattic/wp-calypso/issues/41189.

## Changes proposed in this Pull Request


* ~Adds a new global to the `window` in the WPCom Block Editor tracking library on e2e environments in order to capture fired events for the purposes of e2e test assertions.~ handled in  https://github.com/Automattic/wp-calypso/pull/44865
* Adds e2e test suite to check that events being tracked in the Dotcom Block Editor will fire correctly for a given version of Gutenberg.
* Asserts that the `wpcom_block_inserted` event is tracked correctly. It's only this event for now.

## Testing instructions

This is ~hard~ really easy now that D48009-co is merged. I'm ~sorry~ not sorry anymore...

### Setup
* Checkout this PR branch!
* Start Calypso locally - from the root dir run `yarn && yarn start`. Wait until booted.

### Configure e2e tests

* Configure the Calypso local e2e testing environment [as per the docs](https://github.com/Automattic/wp-calypso/blob/6823c601c858437a481178a63c0668c2b30b7788/test/e2e/README.md). 
* Setup to run against Gutenberg "Edge" by adding `export GUTENBERG_EDGE=true` to your `~/.zshrc` (don't forget to `source ~/.zshrc` to reload).

### Running
* Go to the `test/e2e` directory on your local machine.
* Run `./node_modules/.bin/mocha specs/wp-calypso-gutenberg-editor-tracking-spec.js`
* You should see the remotely controlled test browser popup and run through the testing steps. If everything works then you could see something like.
* The key is asserting that the test was able to:
    - pick up on the `window._e2eEventsStack` global.
    - assert that the `wpcom_block_inserted` was fired the requisite number of times for the insertion of the Columns (twice) and Headings (once) blocks.

<img width="687" alt="Screenshot 2020-08-19 at 13 12 49" src="https://user-images.githubusercontent.com/444434/90633308-ba8db700-e21d-11ea-8032-b29e6ae452fd.png">


## Todo

The following items are outstanding on this PR:

- [x] Remove fix to allow `core/heading` block to be inserted into the editor once https://github.com/Automattic/wp-calypso/pull/44862 is merged.
- [x] Remove unnecessary addition of Columns block in `test/e2e/lib/gutenberg/gutenberg-editor-component.js`. Simplifies the PR.
- [x] Remove changes to Block editor tracking library once https://github.com/Automattic/wp-calypso/pull/44865 is merged.
- [x] Add test helper to reset the `eventsStack` after each `step`. This way we'll have a clean stack for each assertion we need to run.
- [x] Update assertions to check the entire `eventsStack` rather than a particular index. See https://github.com/Automattic/wp-calypso/pull/41329/files#r414621150