### PR TITLE
Stylelint: Use font weight 600 instead of 700 for bold

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,7 @@
 {
 	"plugins": ["@signal-noise/stylelint-scales"],
 	"rules": {
-		"scales/font-weight": [[ 400, 700 ]],
+		"scales/font-weight": [[ 400, 600 ]],
 
 		"color-hex-case": "lower",
 		"color-no-invalid-hex": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As discussed in #41234, let's use `600` instead of `700` for font weights; more stylesheets use 600 so this is less likely to throw errors for the time being. We'll work on updating the bold font across the board.

<img width="562" alt="Screen Shot 2020-04-21 at 10 50 29 AM" src="https://user-images.githubusercontent.com/2124984/79880389-f030a980-83bd-11ea-8eb3-a16e09896f6e.png">

#### Testing instructions

* Switch to this PR
* Try to commit a stylesheet with a font-weight that is not 400 or 600; you should get a warning like this:

`Expected "700" to be one of "400, 600"   scales/font-weight`
* Try to commit a stylesheet with a font-weight that is 400 or 600; you should be able to commit it without warnings.