### PR TITLE
Gutenboarding: remove site name period on mobile

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -52,7 +52,7 @@ const AcquireIntent: FunctionComponent = () => {
 							onClick={ () => setIsSiteTitleActive( false ) }
 						/>
 					) }
-					<SiteTitle isVisible={ !! ( siteVertical || siteTitle ) } />
+					<SiteTitle isVisible={ !! ( siteVertical || siteTitle ) } isMobile={ isMobile } />
 					<div
 						className={ classnames( 'acquire-intent__footer', {
 							'acquire-intent__footer--hidden': ! siteVertical,

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import * as React from 'react';
 import classnames from 'classnames';
 import { useSelect } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
@@ -23,7 +23,7 @@ import { useTrackStep } from '../../hooks/use-track-step';
  */
 import './style.scss';
 
-const AcquireIntent: FunctionComponent = () => {
+const AcquireIntent: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const { siteVertical, siteTitle } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const makePath = usePath();

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -17,7 +17,7 @@ import { Step, usePath } from '../../path';
 
 interface Props {
 	isVisible?: boolean;
-	isMobile: boolean; // needed as a prop to be defined when component mounts
+	isMobile?: boolean; // needed as a prop to be defined when component mounts
 }
 
 const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile } ) => {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useI18n } from '@automattic/react-i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
+import { useI18n } from '@automattic/react-i18n';
 
 /**
  * Internal dependencies
@@ -17,9 +17,10 @@ import { Step, usePath } from '../../path';
 
 interface Props {
 	isVisible: boolean;
+	isMobile: boolean; // needed as a prop to be defined when component mounts
 }
 
-const SiteTitle: React.FunctionComponent< Props > = ( { isVisible } ) => {
+const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile } ) => {
 	const { __ } = useI18n();
 	const { siteTitle, siteVertical } = useSelect( ( select ) => select( STORE_KEY ).getState() );
 	const { setSiteTitle } = useDispatch( STORE_KEY );
@@ -55,7 +56,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible } ) => {
 	// translators: Form input for a site's title where "<Input />" is replaced by user input with an existing value.
 	const madlibTemplateWithPeriod = __( 'Itʼs called <Input />.' );
 	const madlib = createInterpolateElement(
-		siteTitle.trim().length ? madlibTemplateWithPeriod : madlibTemplate,
+		siteTitle.trim().length && ! isMobile ? madlibTemplateWithPeriod : madlibTemplate,
 		{
 			Input: (
 				<span className="site-title__input-wrapper">

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -16,7 +16,7 @@ import { STORE_KEY } from '../../stores/onboard';
 import { Step, usePath } from '../../path';
 
 interface Props {
-	isVisible: boolean;
+	isVisible?: boolean;
 	isMobile: boolean; // needed as a prop to be defined when component mounts
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
 import { useDispatch, useSelect } from '@wordpress/data';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The vertical and site name are displayed on a separate line on mobile according to designs. In #41146 we removed period from Vertical Select step. It should also be removed for site name.
<img width="205" alt="Screenshot 2020-04-21 at 19 06 14" src="https://user-images.githubusercontent.com/14192054/79887497-a36fc180-8403-11ea-8918-0f3b2e4a70d4.png">


#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-remove-site-name-period) on mobile. Fill in a vertical and a site title. 
* There should be no period displayed below the input.
