### PR TITLE
Jetpack Connect: Add a new condition to force redirect to wp-admin

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -210,6 +210,7 @@ export class JetpackAuthorize extends Component {
 			this.isSso() ||
 			this.isWooRedirect() ||
 			this.isFromJpo() ||
+			this.isFromBlockEditor() ||
 			this.shouldRedirectJetpackStart() ||
 			getRoleFromScope( scope ) === 'subscriber'
 		) {
@@ -248,6 +249,11 @@ export class JetpackAuthorize extends Component {
 	isFromJpo( props = this.props ) {
 		const { from } = props.authQuery;
 		return startsWith( from, 'jpo' );
+	}
+
+	isFromBlockEditor( props = this.props ) {
+		const { from } = props.authQuery;
+		return 'jetpack-block-editor' === from;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Required by https://github.com/Automattic/jetpack/pull/15470

* Add a new condition to the Jetpack Connect authorization flow: if the request has a `from=jetpack-block-editor` query parameter, redirect to the provided `redirect_uri` once the authorization is complete.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and `yarn start` Calypso.
* On a Jetpack site, checkout [`update/instagram-gallery-disconnected-users`](https://github.com/Automattic/jetpack/pull/15470), and run `yarn build-extensions`.
* Create a secondary user (author or above), and then connect the site to Jetpack.
* Open a **guest window** of the browser to simplify testing with secondary accounts of both the JP site and WPCOM. Make sure it's **not incognito**, since you'll need cookies.
* Log in to the site with the secondary account.
* Head to the block editor and insert an Instagram Gallery block. Since the user is not linked to any WPCOM accounts, it will show a notice prompting to do so.

<img width="577" alt="Screenshot 2020-04-23 at 12 40 45" src="https://user-images.githubusercontent.com/2070010/80095486-eba3f680-855f-11ea-8105-288f314eb7f8.png">

* Open the "Link your account to WordPress.com" in a new tab. Eventually you'll land on the JP Connect signup form.
* Copy the URL and replace `https://wordpress.com/` with `http://calypso.localhost:3000/`. (I haven't found an easier way to test on dev). Paste the URL and reload.
* Log in with a secondary WPCOM account (meaning, not the one used by the site owner).
* Authorize the connection, then eventually you'll get a "Return to site" button. Click it!

<img width="378" alt="Screenshot 2020-04-23 at 12 41 38" src="https://user-images.githubusercontent.com/2070010/80095509-f2cb0480-855f-11ea-873e-13590954bc66.png">

* Make sure you are redirected to the post editor, open to the post you were editing.
* Make sure the Instagram Gallery block is there, and doesn't show the "link to WPCOM" notice anymore, but it's ready to be connected to Instagram.

<img width="598" alt="Screenshot 2020-04-23 at 12 40 50" src="https://user-images.githubusercontent.com/2070010/80095514-f5c5f500-855f-11ea-91b5-4322f362424c.png">