### PR TITLE
Jetpack Cloud: Fix realtime backups display on main page

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -20,7 +20,7 @@ import {
 	backupDownloadPath,
 	backupRestorePath,
 } from 'landing/jetpack-cloud/sections/backups/paths';
-import { isSuccessfulBackup } from 'landing/jetpack-cloud/sections/backups/utils';
+import { isSuccessfulDailyBackup } from 'landing/jetpack-cloud/sections/backups/utils';
 
 /**
  * Style dependencies
@@ -76,6 +76,7 @@ class ActivityCard extends Component {
 						<div className="activity-card__time-text">{ backupTimeDisplay }</div>
 					</div>
 				) }
+
 				<Card>
 					<ActivityActor
 						{ ...{
@@ -90,54 +91,22 @@ class ActivityCard extends Component {
 					</div>
 					<div className="activity-card__activity-title">{ activity.activityTitle }</div>
 
-					<div className="activity-card__activity-actions">
-						<a
-							className="activity-card__detail-link"
-							href={ backupDetailPath( siteSlug, activity.rewindId ) }
-						>
-							{ isSuccessfulBackup( activity )
-								? translate( 'Changes in this backup' )
-								: translate( 'See content' ) }
-						</a>
-						<Button
-							compact
-							borderless
-							className="activity-card__actions-button"
-							onClick={ this.togglePopoverMenu }
-							ref={ this.popoverContext }
-						>
-							{ translate( 'Actions' ) }
-							<Gridicon icon="add" className="activity-card__actions-icon" />
-						</Button>
-
-						<PopoverMenu
-							context={ this.popoverContext.current }
-							isVisible={ this.state.showPopoverMenu }
-							onClose={ this.closePopoverMenu }
-							className="activity-card__popover"
-						>
-							<Button
-								href={ backupRestorePath( siteSlug, activity.rewindId ) }
-								className="activity-card__restore-button"
+					{ ! summarize && (
+						<div className="activity-card__activity-actions">
+							<a
+								className="activity-card__detail-link"
+								href={ backupDetailPath( siteSlug, activity.rewindId ) }
 							>
-								{ translate( 'Restore to this point' ) }
-							</Button>
-
+								{ isSuccessfulDailyBackup( activity )
+									? translate( 'Changes in this backup' )
+									: translate( 'See content' ) }
+							</a>
 							<Button
 								compact
 								borderless
-								className="activity-card__detail-button"
-								onClick={ this.triggerDetails }
-							>
-								{ translate( 'See content' ) }
-								<Gridicon icon="chevron-down" />
-							</Button>
-							<Button
-								compact
-								isPrimary={ false }
-								href={ backupDownloadPath( siteSlug, activity.rewindId ) }
-								className="activity-card__download-button"
-
+								className="activity-card__actions-button"
+								onClick={ this.togglePopoverMenu }
+								ref={ this.popoverContext }
 							>
 								{ translate( 'Actions' ) }
 								<Gridicon icon="add" className="activity-card__actions-icon" />
@@ -149,22 +118,18 @@ class ActivityCard extends Component {
 								onClose={ this.closePopoverMenu }
 								className="activity-card__popover"
 							>
-								<Button onClick={ this.triggerRestore } className="activity-card__restore-button">
+								<Button
+									href={ backupRestorePath( siteSlug, activity.rewindId ) }
+									className="activity-card__restore-button"
+								>
 									{ translate( 'Restore to this point' ) }
 								</Button>
+
 								<Button
-									borderless
-									compact
 									isPrimary={ false }
-									onClick={ this.triggerDownload }
+									href={ backupDownloadPath( siteSlug, activity.rewindId ) }
 									className="activity-card__download-button"
 								>
-									<img
-										src={ downloadIcon }
-										className="activity-card__download-icon"
-										role="presentation"
-										alt=""
-									/>
 									{ translate( 'Download backup' ) }
 								</Button>
 							</PopoverMenu>

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -27,6 +27,7 @@ import { isSuccessfulBackup } from 'landing/jetpack-cloud/sections/backups/utils
  */
 import './style.scss';
 import downloadIcon from './download-icon.svg';
+import cloudIcon from './cloud-icon.svg';
 
 class ActivityCard extends Component {
 	constructor() {
@@ -35,6 +36,10 @@ class ActivityCard extends Component {
 			showPopoverMenu: false,
 		};
 	}
+
+	static defaultProps = {
+		summarize: false,
+	};
 
 	popoverContext = React.createRef();
 
@@ -49,6 +54,7 @@ class ActivityCard extends Component {
 			gmtOffset,
 			timezone,
 			siteSlug,
+			summarize,
 			translate,
 		} = this.props;
 
@@ -59,10 +65,17 @@ class ActivityCard extends Component {
 
 		return (
 			<div className={ classnames( className, 'activity-card' ) }>
-				<div className="activity-card__time">
-					<Gridicon icon={ activity.activityIcon } className="activity-card__time-icon" />
-					<div className="activity-card__time-text">{ backupTimeDisplay }</div>
-				</div>
+				{ ! summarize && (
+					<div className="activity-card__time">
+						<img
+							src={ cloudIcon }
+							className="activity-card__time-icon"
+							role="presentation"
+							alt=""
+						/>
+						<div className="activity-card__time-text">{ backupTimeDisplay }</div>
+					</div>
+				) }
 				<Card>
 					<ActivityActor
 						{ ...{
@@ -76,6 +89,7 @@ class ActivityCard extends Component {
 						<ActivityDescription activity={ activity } rewindIsActive={ allowRestore } />
 					</div>
 					<div className="activity-card__activity-title">{ activity.activityTitle }</div>
+
 					<div className="activity-card__activity-actions">
 						<a
 							className="activity-card__detail-link"
@@ -108,23 +122,54 @@ class ActivityCard extends Component {
 							>
 								{ translate( 'Restore to this point' ) }
 							</Button>
+
 							<Button
+								compact
 								borderless
+								className="activity-card__detail-button"
+								onClick={ this.triggerDetails }
+							>
+								{ translate( 'See content' ) }
+								<Gridicon icon="chevron-down" />
+							</Button>
+							<Button
 								compact
 								isPrimary={ false }
 								href={ backupDownloadPath( siteSlug, activity.rewindId ) }
 								className="activity-card__download-button"
+
 							>
-								<img
-									src={ downloadIcon }
-									className="activity-card__download-icon"
-									role="presentation"
-									alt=""
-								/>
-								{ translate( 'Download backup' ) }
+								{ translate( 'Actions' ) }
+								<Gridicon icon="add" className="activity-card__actions-icon" />
 							</Button>
-						</PopoverMenu>
-					</div>
+
+							<PopoverMenu
+								context={ this.popoverContext.current }
+								isVisible={ this.state.showPopoverMenu }
+								onClose={ this.closePopoverMenu }
+								className="activity-card__popover"
+							>
+								<Button onClick={ this.triggerRestore } className="activity-card__restore-button">
+									{ translate( 'Restore to this point' ) }
+								</Button>
+								<Button
+									borderless
+									compact
+									isPrimary={ false }
+									onClick={ this.triggerDownload }
+									className="activity-card__download-button"
+								>
+									<img
+										src={ downloadIcon }
+										className="activity-card__download-icon"
+										role="presentation"
+										alt=""
+									/>
+									{ translate( 'Download backup' ) }
+								</Button>
+							</PopoverMenu>
+						</div>
+					) }
 				</Card>
 			</div>
 		);

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -17,7 +17,7 @@
 	margin: 1.5rem 0 0.5rem;
 }
 
-.activity-card__time-icon.gridicon {
+.activity-card__time-icon {
 	width: 1.1rem;
 	height: 1.1rem;
 	fill: var( --color-neutral-40 );

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -24,13 +24,19 @@ import mediaImage from 'assets/images/illustrations/media.svg';
 
 class BackupDelta extends Component {
 	renderRealtime() {
-		const { allowRestore, timezone, gmtOffset, moment, siteSlug, translate } = this.props;
+		const {
+			allowRestore,
+			timezone,
+			gmtOffset,
+			moment,
+			realtimeBackups,
+			siteSlug,
+			translate,
+		} = this.props;
 
-		const realtimeEvents = this.props.realtimeEvents.filter(
-			( event ) => event.activityIsRewindable
-		);
+		realtimeBackups.shift();
 
-		const cards = realtimeEvents.map( ( activity ) => (
+		const cards = realtimeBackups.map( ( activity ) => (
 			<ActivityCard
 				key={ activity.activityId }
 				{ ...{

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -11,7 +11,10 @@ import { get } from 'lodash';
 import { withLocalizedMoment } from 'components/localized-moment';
 import Gridicon from 'components/gridicon';
 import Button from 'components/forms/form-button';
-import { isSuccessfulBackup } from 'landing/jetpack-cloud/sections/backups/utils';
+import {
+	isSuccessfulDailyBackup,
+	isSuccessfulRealtimeBackup,
+} from 'landing/jetpack-cloud/sections/backups/utils';
 import {
 	/*backupDetailPath,*/ backupDownloadPath,
 	backupRestorePath,
@@ -19,15 +22,22 @@ import {
 } from 'landing/jetpack-cloud/sections/backups/paths';
 import { applySiteOffset } from 'lib/site/timezone';
 import { Card } from '@automattic/components';
+import ActivityCard from 'landing/jetpack-cloud/components/activity-card';
+import { INDEX_FORMAT } from 'landing/jetpack-cloud/sections/backups/main';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const INDEX_FORMAT = 'YYYYMMDD';
-
 class DailyBackupStatus extends Component {
+	getValidRestoreId = () => {
+		const { dailyBackup, hasRealtimeBackups, realtimeBackups } = this.props;
+		const realtimeBackup = get( realtimeBackups, '[0]', [] );
+
+		return hasRealtimeBackups ? realtimeBackup.rewindId : dailyBackup.rewindId;
+	};
+
 	getDisplayDate = ( date, withLatest = true ) => {
 		const { translate, moment, timezone, gmtOffset } = this.props;
 
@@ -277,10 +287,21 @@ class DailyBackupStatus extends Component {
 	}
 
 	renderBackupStatus( backup ) {
-		const { selectedDate, lastDateAvailable, moment, timezone, gmtOffset } = this.props;
+		const {
+			hasRealtimeBackups,
+			selectedDate,
+			lastDateAvailable,
+			moment,
+			timezone,
+			gmtOffset,
+		} = this.props;
 
-		if ( backup ) {
-			return isSuccessfulBackup( backup )
+		if ( backup && hasRealtimeBackups ) {
+			return isSuccessfulRealtimeBackup( backup )
+				? this.renderGoodBackup( backup )
+				: this.renderFailedBackup( backup );
+		} else if ( backup && ! hasRealtimeBackups ) {
+			return isSuccessfulDailyBackup( backup )
 				? this.renderGoodBackup( backup )
 				: this.renderFailedBackup( backup );
 		}
@@ -302,12 +323,39 @@ class DailyBackupStatus extends Component {
 		return this.renderNoBackupOnDate();
 	}
 
+	renderRealtimeDetails( backup ) {
+		const { moment, allowRestore, timezone, gmtOffset, siteSlug } = this.props;
+
+		return (
+			<div className="daily-backup-status__realtime-details">
+				<div className="daily-backup-status__realtime-details-title">Backup details</div>
+				<div className="daily-backup-status__realtime-details-card">
+					<ActivityCard
+						{ ...{
+							moment,
+							activity: backup,
+							allowRestore,
+							timezone,
+							gmtOffset,
+							siteSlug,
+							summarize: true,
+						} }
+					/>
+				</div>
+			</div>
+		);
+	}
+
 	render() {
-		const backup = this.props.backup;
+		const { dailyBackup, hasRealtimeBackups, realtimeBackups } = this.props;
+		const backup = hasRealtimeBackups ? realtimeBackups[ 0 ] : dailyBackup;
 
 		return (
 			<div className="daily-backup-status">
-				<Card className="daily-backup-status__success">{ this.renderBackupStatus( backup ) }</Card>
+				<Card className="daily-backup-status__success">
+					{ this.renderBackupStatus( backup ) }
+					{ hasRealtimeBackups && backup && this.renderRealtimeDetails( backup ) }
+				</Card>
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -1,6 +1,8 @@
 .daily-backup-status {
 	text-align: center;
-	margin-top: 2rem;
+	padding-top: 2rem;
+	padding-bottom: 1rem;
+	background: #fff;
 }
 
 .daily-backup-status__status-icon.gridicon {
@@ -40,13 +42,13 @@
 .daily-backup-status__date,
 .daily-backup-status__static-title {
 	font-size: 1.4rem;
-	font-weight: 500;
+	font-weight: 400;
 	margin-bottom: 1rem;
 }
 
 .daily-backup-status__failed-message {
 	font-size: 1.4rem;
-	font-weight: 500;
+	font-weight: 400;
 	color: var( --color-scary-50 );
 	margin-bottom: 0.5rem;
 	margin-top: -0.5rem;
@@ -83,6 +85,36 @@
 	padding: 0;
 }
 
+.daily-backup-status__realtime-details {
+	text-align: left;
+}
+
+.daily-backup-status__realtime-details-title {
+	margin-top: 1rem;
+	margin-bottom: 0.5rem;
+	font-weight: 400;
+}
+
+.daily-backup-status__realtime-details-card .activity-card .card {
+	margin: 0;
+	padding: 0;
+	background: transparent;
+	box-shadow: none;
+}
+
+.daily-backup-status__realtime-details-card .activity-card .card .activity-log-item__actor .activity-log-item__actor-info {
+	display: flex;
+}
+
+.daily-backup-status__realtime-details-card .activity-card .card .activity-log-item__actor .activity-log-item__actor-info .activity-log-item__actor-name::after {
+	content: ',';
+	margin-right: 0.2rem;
+}
+
+.daily-backup-status__realtime-details-card .activity-card .card .activity-log-item__actor .gravatar {
+	width: 30px;
+}
+
 @include breakpoint( '>660px' ) {
 	.daily-backup-status__meta,
 	.daily-backup-status__title {
@@ -98,6 +130,8 @@
 
 	.daily-backup-status {
 		text-align: left;
+		background: transparent;
+		padding-bottom: 0;
 	}
 
 	.daily-backup-status__icon-section {
@@ -110,7 +144,7 @@
 	}
 
 	.daily-backup-status__title {
-		font-weight: 500;
+		font-weight: 400;
 		margin-left: 0.5rem;
 	}
 

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -1,6 +1,8 @@
 .date-picker {
 	display: flex;
 	max-width: 30rem;
+	background: #fff;
+	padding-top: 0.5rem;
 }
 
 .date-picker__select-date {
@@ -61,4 +63,10 @@
 
 .date-picker__search-icon.gridicon {
 	fill: green;
+}
+
+@include breakpoint( '>660px' ) {
+	.date-picker {
+		background: transparent;
+	}
 }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -17,7 +17,7 @@ import {
 	isActivityBackup,
 	getBackupAttemptsForDate,
 	getDailyBackupDeltas,
-	getEventsInDailyBackup,
+	getRealtimeBackups,
 	getMetaDiffForDailyBackup,
 } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -49,7 +49,7 @@ import { backupMainPath } from './paths';
  */
 import './style.scss';
 
-const INDEX_FORMAT = 'YYYYMMDD';
+export const INDEX_FORMAT = 'YYYYMMDD';
 
 const backupStatusNames = [
 	'rewind__backup_complete_full',
@@ -171,7 +171,10 @@ class BackupsPage extends Component {
 		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
 		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );
-		const realtimeEvents = getEventsInDailyBackup( logs, selectedDateString );
+		const realtimeBackups = getRealtimeBackups(
+			logs,
+			applySiteOffset( moment( selectedDateString ), { timezone, gmtOffset } )
+		);
 		const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
 		const hasRealtimeBackups = includes( siteCapabilities, 'backup-realtime' );
 
@@ -199,14 +202,18 @@ class BackupsPage extends Component {
 				{ ! isLoadingBackups && (
 					<>
 						<DailyBackupStatus
-							allowRestore={ allowRestore }
-							siteSlug={ siteSlug }
-							backup={ backupsOnSelectedDate.lastBackup }
-							lastDateAvailable={ lastDateAvailable }
-							selectedDate={ this.getSelectedDate() }
-							timezone={ timezone }
-							gmtOffset={ gmtOffset }
-							onDateChange={ this.onDateChange }
+							{ ...{
+								allowRestore,
+								siteSlug,
+								dailyBackup: backupsOnSelectedDate.lastBackup,
+								lastDateAvailable,
+								selectedDate: this.getSelectedDate(),
+								timezone,
+								gmtOffset,
+								onDateChange: this.onDateChange,
+								hasRealtimeBackups,
+								realtimeBackups,
+							} }
 						/>
 						{ doesRewindNeedCredentials && (
 							<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
@@ -216,7 +223,7 @@ class BackupsPage extends Component {
 								deltas,
 								backupAttempts,
 								hasRealtimeBackups,
-								realtimeEvents,
+								realtimeBackups,
 								allowRestore,
 								moment,
 								siteSlug,

--- a/client/landing/jetpack-cloud/sections/backups/utils.js
+++ b/client/landing/jetpack-cloud/sections/backups/utils.js
@@ -4,6 +4,11 @@
 import moment from 'moment';
 
 /**
+ * Internal dependencies
+ */
+import { INDEX_FORMAT } from 'landing/jetpack-cloud/sections/backups/main';
+
+/**
  * if the activityDateString is on the same date as we are looking at
  *
  * @param {string} activityDateString date string from activity log in ISO 8601 format
@@ -58,6 +63,30 @@ export const getEventsInDailyBackup = ( logs, date ) => {
 	const thisBackupTime = thisBackupDate.getTime();
 
 	return getChangesInRange( logs, lastBackupTime, thisBackupTime );
+};
+
+export const getRealtimeBackups = ( logs, date ) => {
+	const backups = [];
+
+	logs.forEach( ( event ) => {
+		if (
+			moment( event.activityDate ).format( INDEX_FORMAT ) === moment( date ).format( INDEX_FORMAT )
+		) {
+			if ( event.activityIsRewindable ) {
+				backups.push( event );
+			}
+
+			if ( event.streams ) {
+				event.streams.forEach( ( stream ) => {
+					if ( stream.activityIsRewindable ) {
+						backups.push( stream );
+					}
+				} );
+			}
+		}
+	} );
+
+	return backups;
 };
 
 export const metaStringToObject = ( metaString ) => {
@@ -144,9 +173,15 @@ export const isActivityBackup = ( activity ) => {
  *
  * @param backup {object} Backup to check
  */
-export const isSuccessfulBackup = ( backup ) => {
+export const isSuccessfulDailyBackup = ( backup ) => {
 	return (
 		'rewind__backup_complete_full' === backup.activityName ||
 		'rewind__backup_complete_initial' === backup.activityName
 	);
+};
+
+export const isSuccessfulRealtimeBackup = ( backup ) => {
+	const hasRestorableStreams =
+		backup.streams && !! backup.streams.filter( ( stream ) => stream.activityIsRewindable ).length;
+	return hasRestorableStreams || backup.activityIsRewindable;
 };


### PR DESCRIPTION
This PR is a remake of https://github.com/Automattic/wp-calypso/pull/41193 with hopefully less rebase drama :-) Please see that PR for history.

**Changes proposed in this Pull Request**

- Process streams inside of events in order to enumerate rewindable events for realtime backups
- Fix display of realtime backups on main backups page
- Fix a few various (related) styling issues throughout

**Testing instructions**

-Load up the backups page for a site with realtime backups. Do your restorable events appear in the proper chronological order?
-Include testing a day with streams. You can reproduce this by uploading several images at one time, and ensuring they appear as separate events on the backup page.
