### PR TITLE
Jetpack Cloud: Fix Activity Log page number spacing on desktop browsers

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -2,6 +2,13 @@
 	margin-bottom: 2rem;
 }
 
+.activity-card-list__pagination-bottom,
+.activity-card-list__pagination-top {
+	.pagination__list .pagination__list-item .button {
+		padding: 5px 8px;
+	}
+}
+
 .activity-card-list__pagination-bottom {
 	margin-bottom: 1rem;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add spacing around pagination controls on the Activity Log for desktop browsers. (This issue doesn't seem to affect mobile browsers.) Currently, there is no spacing around page numbers or the Newer/Older buttons, which makes pagination look cramped and difficult to use.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load the Activity Log in Jetpack Cloud in a desktop browserfor a site with one page of records. Does it look reasonable? Try again with a mobile browser.
* Load the Activity Log in Jetpack Cloud in a desktop browser for a site with several pages of records. Does it look reasonable? Try again with a mobile browser.

#### Screenshots

##### Before

![Page numbers without spacing](https://user-images.githubusercontent.com/670067/79899694-c2a22b00-83d2-11ea-997b-db9ed9e3ed17.png)

##### After

<img width="714" alt="Page numbers with spacing" src="https://user-images.githubusercontent.com/670067/79899602-a30b0280-83d2-11ea-8f39-d4ea120c9795.png">


Fixes 1151678672052943-as-1172245033931857
