### PR TITLE
Jetpack Cloud: Update Scan UI to match the API states 

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-history-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.tsx
@@ -41,7 +41,7 @@ class ScanHistoryItem extends Component< ThreatsProps & PlaceholderProps > {
 		};
 	}
 
-	formatDate( date: string ) {
+	formatDate( date: Date ) {
 		return this.props.moment( date ).format( 'LL' );
 	}
 

--- a/client/landing/jetpack-cloud/components/scan-history-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-history-item/index.tsx
@@ -51,11 +51,11 @@ class ScanHistoryItem extends Component< ThreatsProps & PlaceholderProps > {
 				<div className="scan-history-item__subheader">
 					<span className="scan-history-item__date">
 						{ translate( 'Threat found on %s', {
-							args: this.formatDate( threat.first_detected ),
+							args: this.formatDate( threat.firstDetected ),
 						} ) }
 					</span>
-					{ threat.fixed_on && <span className="scan-history-item__date-separator"></span> }
-					{ threat.fixed_on && (
+					{ threat.fixedOn && <span className="scan-history-item__date-separator"></span> }
+					{ threat.fixedOn && (
 						<span
 							className={ classnames(
 								'scan-history-item__date',
@@ -63,7 +63,7 @@ class ScanHistoryItem extends Component< ThreatsProps & PlaceholderProps > {
 							) }
 						>
 							{ translate( 'Threat %(action)s on %(fixedOn)s', {
-								args: { action: threat.status, fixedOn: this.formatDate( threat.fixed_on ) },
+								args: { action: threat.status, fixedOn: this.formatDate( threat.fixedOn ) },
 							} ) }
 						</span>
 					) }

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -35,7 +35,16 @@ interface Props {
 	error: boolean;
 }
 
-const ScanThreats = ( { site, threats }: Props ) => {
+// @todo: once we have designs for the "error+threats found" case, we should update this component
+const ScanError = () => (
+	<Card highlight="error">
+		Something went wrong with the most recent Scan. Please, get in touch with support to get more
+		information. <br />
+		Despite this error, we can inform you we have found threats in your site.
+	</Card>
+);
+
+const ScanThreats = ( { error, site, threats }: Props ) => {
 	const [ fixingThreats, setFixingThreats ] = React.useState< Array< Threat > >( [] );
 	const [ selectedThreat, setSelectedThreat ] = React.useState< Threat >( threats[ 0 ] );
 	const [ showThreatDialog, setShowThreatDialog ] = React.useState( false );
@@ -114,11 +123,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		<>
 			<SecurityIcon icon="error" />
 			<h1 className="scan-threats scan__header">{ translate( 'Your site may be at risk' ) }</h1>
-			<Card highlight="error">
-				Something went wrong with the most recent Scan. Please, get in touch with support to get
-				more information. <br />
-				Despite this error, we can inform you we have found threats in your site.
-			</Card>
+			{ error && <ScanError /> }
 			<p>
 				{ translate(
 					'The scan found {{strong}}%(threatCount)s{{/strong}} potential threat with {{strong}}%(siteName)s{{/strong}}.',

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { numberFormat, translate } from 'i18n-calypso';
 import { isEmpty } from 'lodash';
-import { Button } from '@automattic/components';
+import { Button, Card } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -32,6 +32,7 @@ interface Props {
 		URL: string;
 	};
 	threats: Array< Threat >;
+	error: boolean;
 }
 
 const ScanThreats = ( { site, threats }: Props ) => {
@@ -113,6 +114,11 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		<>
 			<SecurityIcon icon="error" />
 			<h1 className="scan-threats scan__header">{ translate( 'Your site may be at risk' ) }</h1>
+			<Card highlight="error">
+				Something went wrong with the most recent Scan. Please, get in touch with support to get
+				more information. <br />
+				Despite this error, we can inform you we have found threats in your site.
+			</Card>
 			<p>
 				{ translate(
 					'The scan found {{strong}}%(threatCount)s{{/strong}} potential threat with {{strong}}%(siteName)s{{/strong}}.',

--- a/client/landing/jetpack-cloud/components/threat-item/types.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/types.tsx
@@ -18,15 +18,14 @@ export type ThreatFix = {
 
 export type ThreatStatus = 'fixed' | 'ignored' | 'current';
 
-// @todo: we should transform any snake case key to camel case before the data touches the store
 // @todo: make the history API response use a number for a threat ID instead of a string
 export type Threat = {
 	id: number;
 	signature: string;
 	description: string;
 	status: ThreatStatus;
-	firstDetected: string;
-	fixedOn?: string;
+	firstDetected: Date;
+	fixedOn?: Date;
 	fixable: false | ThreatFix;
 	filename?: string;
 	extension?: Extension;

--- a/client/landing/jetpack-cloud/components/threat-item/types.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/types.tsx
@@ -25,8 +25,8 @@ export type Threat = {
 	signature: string;
 	description: string;
 	status: ThreatStatus;
-	first_detected: string;
-	fixed_on?: string;
+	firstDetected: string;
+	fixedOn?: string;
 	fixable: false | ThreatFix;
 	filename?: string;
 	extension?: Extension;

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -34,16 +34,16 @@ import './style.scss';
 interface Props {
 	site: object | null;
 	siteSlug: string | null;
+	siteUrl: string | null;
 	scanState: Scan | null;
 	lastScanTimestamp: number;
 	nextScanTimestamp: number;
 	moment: Function;
+	dispatchRecordTracksEvent: Function;
 }
 
 class ScanPage extends Component< Props > {
-	// @todo: understand when this state can happen
-	// It seems, the user won't ever get to this place because it they don't have
-	// Scan they won't get this far in the app.
+	// @todo: missing copy and design for this state
 	renderUnavailable() {
 		const { siteSlug } = this.props;
 
@@ -159,8 +159,7 @@ class ScanPage extends Component< Props > {
 
 		const { state, mostRecent, threats } = scanState;
 
-		// @todo: find out what should we do when the scan state is 'provisioning' (design missing)
-		// @todo: figure out if these states can happen at all
+		// @todo: missing copy and design for these states
 		if ( state === 'unavailable' || state === 'provisioning' ) {
 			return this.renderUnavailable();
 		}

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -41,6 +41,9 @@ interface Props {
 }
 
 class ScanPage extends Component< Props > {
+	// @todo: understand when this state can happen
+	// It seems, the user won't ever get to this place because it they don't have
+	// Scan they won't get this far in the app.
 	renderUnavailable() {
 		const { siteSlug } = this.props;
 
@@ -154,10 +157,10 @@ class ScanPage extends Component< Props > {
 			return <div className="scan__is-loading" />;
 		}
 
-		// @todo: make most_recent camelCase
-		const { state, most_recent: mostRecent, threats } = scanState;
+		const { state, mostRecent, threats } = scanState;
 
 		// @todo: find out what should we do when the scan state is 'provisioning' (design missing)
+		// @todo: figure out if these states can happen at all
 		if ( state === 'unavailable' || state === 'provisioning' ) {
 			return this.renderUnavailable();
 		}

--- a/client/landing/jetpack-cloud/sections/scan/types.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/types.tsx
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { Threat } from 'landing/jetpack-cloud/components/threat-item/types';
+
+type ScanState = 'unavailable' | 'provisioning' | 'idle' | 'scanning';
+
+export type Scan = {
+	state: ScanState;
+	threats: [ Threat ];
+	credentials: [ object ];
+	most_recent: {
+		timestamp: string;
+		progress: number;
+		duration: number;
+		// @todo: complete the error prop when we know what the shape will it have
+		error: string | object;
+	};
+};

--- a/client/landing/jetpack-cloud/sections/scan/types.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/types.tsx
@@ -9,8 +9,8 @@ export type Scan = {
 	state: ScanState;
 	threats: [ Threat ];
 	credentials: [ object ];
-	most_recent: {
-		timestamp: string;
+	mostRecent: {
+		timestamp: Date;
 		progress: number;
 		duration: number;
 		// @todo: complete the error prop when we know what the shape will it have

--- a/client/state/data-layer/wpcom/sites/scan/history/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/history/index.js
@@ -10,6 +10,12 @@ import {
 	JETPACK_SCAN_HISTORY_REQUEST_SUCCESS,
 	JETPACK_SCAN_HISTORY_REQUEST_FAILURE,
 } from 'state/action-types';
+import { formatScanThreat } from 'state/data-layer/wpcom/sites/scan';
+
+const formatScanHistoryRawResponse = ( { threats, ...rest } ) => ( {
+	...rest,
+	threats: threats.map( formatScanThreat ),
+} );
 
 const fetchStatus = ( action ) => {
 	return http(
@@ -51,6 +57,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/scan/history', {
 			fetch: fetchStatus,
 			onSuccess: onFetchStatusSuccess,
 			onError: onFetchStatusFailure,
+			fromApi: formatScanHistoryRawResponse,
 		} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -11,10 +11,39 @@ import {
 	JETPACK_SCAN_REQUEST_FAILURE,
 } from 'state/action-types';
 
+/**
+ * Make a Threat object response contain only camel-case keys and transform
+ * dates represented as string to Date object.
+ *
+ * @param {object} threat Raw threat object from Scan endpoint
+ * @returns {object} Processed threat object
+ */
+export const formatScanThreat = ( threat ) => ( {
+	id: threat.id,
+	signature: threat.signature,
+	description: threat.description,
+	status: threat.status,
+	firstDetected: new Date( threat.first_detected ),
+	fixedOn: new Date( threat.fixed_on ),
+	fixable: threat.fixable,
+	filename: threat.filename,
+	extension: threat.extension,
+	rows: threat.rows,
+	diff: threat.diff,
+	context: threat.context,
+} );
+
+/**
+ * Make a Scan object response contain only camel-case keys and transform
+ * dates represented as string to Date object.
+ *
+ * @param {object} scanState Raw Scan state object from Scan endpoint
+ * @returns {object} Processed Scan state
+ */
 const formatScanStateRawResponse = ( { state, threats, credentials, most_recent: mostRecent } ) => {
 	return {
 		state,
-		threats,
+		threats: threats.map( formatScanThreat ),
 		credentials,
 		mostRecent: {
 			...mostRecent,

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -11,6 +11,18 @@ import {
 	JETPACK_SCAN_REQUEST_FAILURE,
 } from 'state/action-types';
 
+const formatScanStateRawResponse = ( { state, threats, credentials, most_recent: mostRecent } ) => {
+	return {
+		state,
+		threats,
+		credentials,
+		mostRecent: {
+			...mostRecent,
+			timestamp: new Date( mostRecent.timestamp ),
+		},
+	};
+};
+
 const fetchStatus = ( action ) => {
 	return http(
 		{
@@ -51,6 +63,7 @@ registerHandlers( 'state/data-layer/wpcom/sites/scan', {
 			fetch: fetchStatus,
 			onSuccess: onFetchStatusSuccess,
 			onError: onFetchStatusFailure,
+			fromApi: formatScanStateRawResponse,
 		} ),
 	],
 } );

--- a/client/state/selectors/get-site-scan-progress.js
+++ b/client/state/selectors/get-site-scan-progress.js
@@ -12,5 +12,5 @@ import 'state/data-layer/wpcom/sites/scan';
  * @returns {?number}		Undefined or percentage of the scan completed
  */
 export default function getSiteScanProgress( state, siteId ) {
-	return state.jetpackScan.scan?.[ siteId ]?.most_recent?.progress;
+	return state.jetpackScan.scan?.[ siteId ]?.mostRecent?.progress;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Update the Scan main section to make it handle the states provided by the latest version of the API.

#### Implementation notes

I took the opportunity to fix snake case keys and string dates at the data-layer for Scan and Scan History endpoints. For this to work, I had to update the Threat type and the Scan type.

#### Testing instructions

- Run this PR
- Go to http://jetpack.cloud.localhost:3000/

#### Case 1: Threats + Scan error

- Select a site that has Jetpack Scan which has threats and the Scan is reporting an error (one can force this in the code or editing the ScanThreats component props)
- Verify you see the normal Threats state and there is card that notifies you that an error happened

#### Case 2: Scan unavailable

- Select a site that has Jetpack Scan and its state is `unavailable` ([read this to understand of the Scan can be in that state](https://github.com/Automattic/wp-calypso/pull/41344#discussion_r414490080))
- Verify you see the Scan error state UI

See 1151678672052943-as-1172213533219281.