### PR TITLE
Support removal of autorenewing domain registrations

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -140,6 +140,10 @@ function hasIncludedDomain( purchase ) {
 	return Boolean( purchase.includedDomain );
 }
 
+function isAutoRenewing( purchase ) {
+	return 'autoRenewing' === purchase.expiryStatus;
+}
+
 /**
  * Checks if a purchase can be cancelled.
  * Returns true for purchases that aren't expired
@@ -322,7 +326,8 @@ function isRemovable( purchase ) {
 		isJetpackPlan( purchase ) ||
 		isExpiring( purchase ) ||
 		isExpired( purchase ) ||
-		( isDomainTransfer( purchase ) && isPurchaseCancelable( purchase ) )
+		( isDomainTransfer( purchase ) && isPurchaseCancelable( purchase ) ) ||
+		( isDomainRegistration( purchase ) && isAutoRenewing( purchase ) )
 	);
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the `isRemovable()` logic to allow for removing non-refundable domain subscriptions that have `expiryStatus === 'autoRenewing'`. This is a highly uncommon status, as it only applies to a small number of TLDs that don't support explicit renewals, and is only set when the corresponding store subscription is set to auto-renew.

The core issue is that in some cases, we don't show an option to cancel or remove the domain, when we should always show exactly one of those two items. The issue definitely applies to cases where the domain is bought entirely using credits, but may also apply to situations where the domain purchase is no longer refundable.

#### Testing instructions

Register a new `.jp` domain using credits.
Using an unpatched Calypso UI, verify that if you navigate to the domain settings for the new domain, or to the purchase details under `/me/purchases`, you don't see an option to cancel or remove the domain. (The expected button would be to remove the domain, though the domain settings page may be using slightly different language.)

Using the patched Calypso UI, verify that the button *does* appear for the same domain.

Here is a screenshot of the missing element:
<img width="751" alt="Domain Purchase" src="https://user-images.githubusercontent.com/3376401/79914578-d1fe9400-8425-11ea-8a71-bb53e01951a6.png">
