### PR TITLE
Gutenboarding: 'Sticky' launch Button 

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -29,6 +29,12 @@ function updateEditor() {
 }
 
 function updateSettingsBar() {
+
+	// TODO: check what we need to show in an unlaunched state in Gutenboarding
+	if ( calypsoifyGutenberg.isSiteLaunched ) {
+		return false;
+	}
+
 	const awaitSettingsBar = setInterval( () => {
 		const settingsBar = document.querySelector( '.edit-post-header__settings' );
 		if ( ! settingsBar ) {
@@ -51,6 +57,8 @@ function updateSettingsBar() {
 
 		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( launchLink );
+
+
 		settingsBar.prepend( saveButton );
 	} );
 }

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -29,12 +29,6 @@ function updateEditor() {
 }
 
 function updateSettingsBar() {
-
-	// TODO: check what we need to show in an unlaunched state in Gutenboarding
-	if ( calypsoifyGutenberg.isSiteLaunched ) {
-		return false;
-	}
-
 	const awaitSettingsBar = setInterval( () => {
 		const settingsBar = document.querySelector( '.edit-post-header__settings' );
 		if ( ! settingsBar ) {
@@ -57,8 +51,6 @@ function updateSettingsBar() {
 
 		// Put 'Launch' and 'Save' back on bar in desired order.
 		settingsBar.prepend( launchLink );
-
-
 		settingsBar.prepend( saveButton );
 	} );
 }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -297,7 +297,9 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {
 			const isGutenboarding =
-				config.isEnabled( 'gutenboarding' ) && this.props.siteCreationFlow === 'gutenboarding';
+				config.isEnabled( 'gutenboarding' ) &&
+				this.props.siteCreationFlow === 'gutenboarding' &&
+				this.props.isSiteUnlaunched;
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				isSiteLaunched: ! this.props.isSiteUnlaunched,
@@ -721,7 +723,7 @@ const mapStateToProps = (
 		),
 		unmappedSiteUrl: getSiteOption( state, siteId, 'unmapped_url' ),
 		siteCreationFlow: getSiteOption( state, siteId, 'site_creation_flow' ),
-		isSiteUnlaunched: isUnlaunchedSite( state, siteId )
+		isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 	};
 };
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -44,6 +44,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ConvertToBlocksDialog from 'components/convert-to-blocks';
 import config from 'config';
 import EditorDocumentHead from 'post-editor/editor-document-head';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 
 /**
  * Types
@@ -295,12 +296,11 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		}
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {
-			// TODO - In future iterations, replace window param with gutenboarding site info.
-			const urlParams = new URLSearchParams( window.location.search );
 			const isGutenboarding =
-				config.isEnabled( 'gutenboarding' ) && urlParams.has( 'is-gutenboarding' );
+				config.isEnabled( 'gutenboarding' ) && this.props.siteCreationFlow === 'gutenboarding';
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
+				isSiteLaunched: ! this.props.isSiteUnlaunched,
 				frankenflowUrl: `${ window.location.origin }/start/frankenflow?siteSlug=${ this.props.siteId }`,
 			} );
 		}
@@ -720,6 +720,8 @@ const mapStateToProps = (
 			'wp_template_part'
 		),
 		unmappedSiteUrl: getSiteOption( state, siteId, 'unmapped_url' ),
+		siteCreationFlow: getSiteOption( state, siteId, 'site_creation_flow' ),
+		isSiteUnlaunched: isUnlaunchedSite( state, siteId )
 	};
 };
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -302,7 +302,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				this.props.isSiteUnlaunched;
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
-				isSiteLaunched: ! this.props.isSiteUnlaunched,
 				frankenflowUrl: `${ window.location.origin }/start/frankenflow?siteSlug=${ this.props.siteId }`,
 			} );
 		}

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -196,7 +196,7 @@ const Header: FunctionComponent = () => {
 			setIsRedirecting( true );
 			resetOnboardStore();
 
-			window.location.replace( `/block-editor/page/${ newSite.site_slug }/home?is-gutenboarding` );
+			window.location.replace( `/block-editor/page/${ newSite.site_slug }/home` );
 		}
 	}, [ domain, newSite, newUser, resetOnboardStore, isRedirecting ] );
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -17,7 +17,7 @@ export function generateFlows( {
 	getLaunchDestination = noop,
 	getThankYouNoSiteDestination = noop,
 	getChecklistThemeDestination = noop,
-	getPreLaunchEditorDestination = noop,
+	getEditorDestination = noop,
 } = {} ) {
 	const flows = {
 		account: {
@@ -357,7 +357,7 @@ export function generateFlows( {
 	if ( isEnabled( 'gutenboarding' ) ) {
 		flows.prelaunch = {
 			steps: [ 'plans-with-domain' ],
-			destination: getPreLaunchEditorDestination,
+			destination: getEditorDestination,
 			description: 'Gutenboarding flow for creating a site with a paid domain',
 			lastModified: '2020-04-06',
 			pageTitle: translate( 'Get a domain for your site' ),

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -75,10 +75,6 @@ function getEditorDestination( dependencies ) {
 	return `/block-editor/page/${ dependencies.siteSlug }/home`;
 }
 
-function getPreLaunchEditorDestination( dependencies ) {
-	return `/block-editor/page/${ dependencies.siteSlug }/home?is-gutenboarding`;
-}
-
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
@@ -87,7 +83,6 @@ const flows = generateFlows( {
 	getThankYouNoSiteDestination,
 	getChecklistThemeDestination,
 	getEditorDestination,
-	getPreLaunchEditorDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -66,4 +66,5 @@ export const SITE_REQUEST_OPTIONS = [
 	'videopress_enabled',
 	'woocommerce_is_active',
 	'wordads',
+	'site_creation_flow',
 ].join();


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR makes sure the context of the block editor is always 'gutenboarding' for new _created-via-the-gutenboarding-flow_ sites **until they are launched**.

We're doing this by:

- Ensuring that we're returning the `site_creation_option` for me/sites
- Sending `isGutenboarding === true` to the wpcom block editor iframe only when a site:
    - has been created by Gutenboarding and
    - the site is unlaunched

## Testing instructions

Apply D42191-code

Create a new site at http://calypso.localhost:3000/new

You'll land on

http://calypso.localhost:3000/block-editor/page/{your_new_site_url}/home

In the `post.php` context, take a look at `window.calypsoifyGutenberg`. 

`isGutenboarding` should be `true`

<img width="780" alt="Screen Shot 2020-04-23 at 11 33 51 am" src="https://user-images.githubusercontent.com/6458278/80049491-5bad7f00-8556-11ea-9917-8dbce30e6ff1.png">

Make note of the header buttons

<img width="736" alt="Screen Shot 2020-04-22 at 7 51 16 pm" src="https://user-images.githubusercontent.com/6458278/79968063-fc5a5b00-84d2-11ea-8477-9fc856551abc.png">

And CSS classes
<img width="710" alt="Screen Shot 2020-04-22 at 7 51 38 pm" src="https://user-images.githubusercontent.com/6458278/79968077-011f0f00-84d3-11ea-8192-e48594782576.png">

Launch your site, and return to http://calypso.localhost:3000/block-editor/page/{your_new_site_url}/home

Behold! No more Gutenboarding

<img width="740" alt="Screen Shot 2020-04-22 at 7 52 22 pm" src="https://user-images.githubusercontent.com/6458278/79968089-04b29600-84d3-11ea-9b00-027460178afd.png">

<img width="591" alt="Screen Shot 2020-04-22 at 7 52 26 pm" src="https://user-images.githubusercontent.com/6458278/79968105-067c5980-84d3-11ea-9a91-27153d52701d.png">

Return to http://calypso.localhost:3000/new and add a paid domain

Create a site. You'll land on the `prelaunch` flow, e.g., 

http://calypso.localhost:3000/start/prelaunch/plans-with-domain?siteSlug={your_new_site_id}

Select free plan, and you'll be redirected to the editor.

Check that the Gutenboarding context is applied. 👍 

Fixes #41300
