### PR TITLE
Jetpack Cloud: Conditionally Hide Activity Card Content Link

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -78,6 +78,11 @@ class ActivityCardList extends Component {
 	renderLogs( actualPage ) {
 		const { allowRestore, pageSize, logs, moment, siteSlug, showDateSeparators } = this.props;
 
+		const getPrimaryCardClassName = ( hasMore, dateLogsLength ) =>
+			hasMore && dateLogsLength === 1
+				? 'activity-card-list__primary-card-with-more'
+				: 'activity-card-list__primary-card';
+
 		const getSecondaryCardClassName = ( hasMore ) =>
 			hasMore
 				? 'activity-card-list__secondary-card-with-more'
@@ -104,7 +109,7 @@ class ActivityCardList extends Component {
 									allowRestore,
 									siteSlug,
 									className: isActivityBackup( activity )
-										? 'activity-card-list__primary-card'
+										? getPrimaryCardClassName( hasMore, dateLogs.length )
 										: getSecondaryCardClassName( hasMore ),
 								} }
 							/>

--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -54,24 +54,25 @@ class ActivityCardList extends Component {
 		const logsByDate = [];
 		let lastDate = null;
 		let logsAdded = 0;
-		if ( applySiteOffset ) {
-			for ( const log of logs ) {
-				const activityDateMoment = applySiteOffset( moment( log.activityDate ) );
-				if ( logsAdded === pageSize ) {
-					if ( lastDate && lastDate.isSame( activityDateMoment, 'day' ) ) {
-						logsByDate[ logsByDate.length - 1 ].hasMore = true;
-					}
-				} else {
-					if ( lastDate && lastDate.isSame( activityDateMoment, 'day' ) ) {
-						logsByDate[ logsByDate.length - 1 ].logs.push( log );
-					} else {
-						logsByDate.push( { date: activityDateMoment, logs: [ log ], hasMore: false } );
-						lastDate = activityDateMoment;
-					}
-					logsAdded++;
+
+		for ( const log of logs ) {
+			const activityDateMoment = applySiteOffset( moment( log.activityDate ) );
+			if ( logsAdded >= pageSize ) {
+				if ( lastDate && lastDate.isSame( activityDateMoment, 'day' ) ) {
+					logsByDate[ logsByDate.length - 1 ].hasMore = true;
 				}
+				break;
+			} else {
+				if ( lastDate && lastDate.isSame( activityDateMoment, 'day' ) ) {
+					logsByDate[ logsByDate.length - 1 ].logs.push( log );
+				} else {
+					logsByDate.push( { date: activityDateMoment, logs: [ log ], hasMore: false } );
+					lastDate = activityDateMoment;
+				}
+				logsAdded++;
 			}
 		}
+
 		return logsByDate;
 	}
 

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -77,10 +77,41 @@
 }
 
 // primary cards get primary card emphasis on the left
-.activity-card-list__primary-card {
+.activity-card-list__primary-card,
+.activity-card-list__primary-card-with-more {
 	.card {
 		padding-left: 20px; // reduce standard 24px padding by 4
 		border-left: 4px solid var( --color-primary-40 );
+	}
+}
+
+.activity-card-list__primary-card-with-more {
+	// draw vertical line after the card
+	&::before {
+		background: var( --color-neutral-5 );
+		content: '';
+		height: 16px;
+		// center on the icons ( they render @ 1.1rem, so half that )
+		left: 0.55rem;
+		position: absolute;
+		top: 100%;
+		width: 1px;
+		z-index: -2;
+	}
+	// draw ball on the end of the line
+	&::after {
+		background: var( --color-neutral-5 );
+		content: '';
+		// make sure we stay in our element
+		height: 9px;
+		width: 9px;
+		left: calc( 0.55rem - 4px );
+		position: absolute;
+		// immediately after the existing horizontal line draw on over the top of it
+		top: calc( 100% + 16px );
+		visibility: visible;
+		z-index: -1;
+		border-radius: 50%;
 	}
 }
 

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -43,7 +43,7 @@
 }
 
 .activity-card-list__date-group-date {
-	font-weight: 700;
+	font-weight: 600;
 	font-size: 16px;
 	line-height: 23px;
 	border-bottom: 1px solid #000000;
@@ -85,7 +85,8 @@
 }
 
 // work happens in the secondary cards
-.activity-card-list__secondary-card {
+.activity-card-list__secondary-card,
+.activity-card-list__secondary-card-with-more {
 	// this brings in the right side, otherwise the translated elements would look the same
 	// 32px to adjust for the scooch, 16px to make the card shorted than the primary one
 	width: calc( 100% - 32px - 16px );
@@ -110,7 +111,9 @@
 			z-index: -2;
 		}
 	}
+}
 
+.activity-card-list__secondary-card {
 	// draw over the line that goes off the screen on the last card
 	&:last-of-type {
 		.card {
@@ -126,6 +129,28 @@
 				visibility: visible;
 				width: 1px;
 				z-index: -1;
+			}
+		}
+	}
+}
+
+.activity-card-list__secondary-card-with-more {
+	// a tiny circle at the end of the line, indicating there is more on the next pagination
+	&:last-of-type {
+		.card {
+			&::after {
+				background: var( --color-neutral-5 );
+				content: '';
+				// make sure we stay in our element
+				height: 9px;
+				width: 9px;
+				left: calc( 0.55rem - 32px - 4px );
+				position: absolute;
+				// immediately after the existing horizontal line draw on over the top of it
+				top: calc( 100% - 9px );
+				visibility: visible;
+				z-index: -1;
+				border-radius: 50%;
 			}
 		}
 	}

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -29,18 +30,23 @@ import './style.scss';
 import downloadIcon from './download-icon.svg';
 
 class ActivityCard extends Component {
+	static propTypes = {
+		showActions: PropTypes.bool,
+		showContentLink: PropTypes.bool,
+		summarize: PropTypes.bool,
+	};
+
 	static defaultProps = {
+		showActions: true,
+		showContentLink: true,
 		summarize: false,
 	};
 
 	popoverContext = React.createRef();
 
-	constructor() {
-		super();
-		this.state = {
-			showPopoverMenu: false,
-		};
-	}
+	state = {
+		showPopoverMenu: false,
+	};
 
 	togglePopoverMenu = () => this.setState( { showPopoverMenu: ! this.state.showPopoverMenu } );
 	closePopoverMenu = () => this.setState( { showPopoverMenu: false } );
@@ -51,9 +57,11 @@ class ActivityCard extends Component {
 			allowRestore,
 			className,
 			gmtOffset,
-			timezone,
+			showActions,
+			showContentLink,
 			siteSlug,
 			summarize,
+			timezone,
 			translate,
 		} = this.props;
 
@@ -85,54 +93,66 @@ class ActivityCard extends Component {
 					<div className="activity-card__activity-title">{ activity.activityTitle }</div>
 
 					{ ! summarize && (
-						<div className="activity-card__activity-actions">
-							<a
-								className="activity-card__detail-link"
-								href={ backupDetailPath( siteSlug, activity.rewindId ) }
-							>
-								{ isSuccessfulDailyBackup( activity )
-									? translate( 'Changes in this backup' )
-									: translate( 'See content' ) }
-							</a>
-							<Button
-								compact
-								borderless
-								className="activity-card__actions-button"
-								onClick={ this.togglePopoverMenu }
-								ref={ this.popoverContext }
-							>
-								{ translate( 'Actions' ) }
-								<Gridicon icon="add" className="activity-card__actions-icon" />
-							</Button>
-
-							<PopoverMenu
-								context={ this.popoverContext.current }
-								isVisible={ this.state.showPopoverMenu }
-								onClose={ this.closePopoverMenu }
-								className="activity-card__popover"
-							>
-								<Button
-									href={ backupRestorePath( siteSlug, activity.rewindId ) }
-									className="activity-card__restore-button"
+						<div
+							// force the actions to stay in the left if we aren't showing the content link
+							className={
+								! showContentLink && showActions
+									? 'activity-card__activity-actions-reverse'
+									: 'activity-card__activity-actions'
+							}
+						>
+							{ showContentLink && (
+								<a
+									className="activity-card__detail-link"
+									href={ backupDetailPath( siteSlug, activity.rewindId ) }
 								>
-									{ translate( 'Restore to this point' ) }
-								</Button>
-								<Button
-									borderless
-									compact
-									isPrimary={ false }
-									href={ backupDownloadPath( siteSlug, activity.rewindId ) }
-									className="activity-card__download-button"
-								>
-									<img
-										src={ downloadIcon }
-										className="activity-card__download-icon"
-										role="presentation"
-										alt=""
-									/>
-									{ translate( 'Download backup' ) }
-								</Button>
-							</PopoverMenu>
+									{ isSuccessfulDailyBackup( activity )
+										? translate( 'Changes in this backup' )
+										: translate( 'See content' ) }
+								</a>
+							) }
+							{ showActions && (
+								<>
+									<Button
+										compact
+										borderless
+										className="activity-card__actions-button"
+										onClick={ this.togglePopoverMenu }
+										ref={ this.popoverContext }
+									>
+										{ translate( 'Actions' ) }
+										<Gridicon icon="add" className="activity-card__actions-icon" />
+									</Button>
+									<PopoverMenu
+										context={ this.popoverContext.current }
+										isVisible={ this.state.showPopoverMenu }
+										onClose={ this.closePopoverMenu }
+										className="activity-card__popover"
+									>
+										<Button
+											href={ backupRestorePath( siteSlug, activity.rewindId ) }
+											className="activity-card__restore-button"
+										>
+											{ translate( 'Restore to this point' ) }
+										</Button>
+										<Button
+											borderless
+											compact
+											isPrimary={ false }
+											href={ backupDownloadPath( siteSlug, activity.rewindId ) }
+											className="activity-card__download-button"
+										>
+											<img
+												src={ downloadIcon }
+												className="activity-card__download-icon"
+												role="presentation"
+												alt=""
+											/>
+											{ translate( 'Download backup' ) }
+										</Button>
+									</PopoverMenu>
+								</>
+							) }
 						</div>
 					) }
 				</Card>

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -52,13 +52,18 @@
 	margin: 0.5rem 0;
 }
 
-.activity-card__activity-actions {
+.activity-card__activity-actions,
+.activity-card__activity-actions-reverse {
 	position: relative;
 	top: 0.5rem;
 	border-top: 1px solid #e4e4e6;
 	padding-top: 0.7rem;
 	display: flex;
 	justify-content: space-between;
+}
+
+.activity-card__activity-actions-reverse {
+	flex-direction: row-reverse;
 }
 
 .activity-card__detail-link {

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
@@ -89,7 +89,7 @@ const BackupActivityLogPage: FunctionComponent< Props > = ( {
 						) }
 					</p>
 				</div>
-				{ logs && <ActivityCardList logs={ logs } pageSize={ 10 } /> }
+				{ logs && <ActivityCardList logs={ logs } pageSize={ 9 } /> }
 			</div>
 		</Main>
 	);

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
@@ -89,7 +89,7 @@ const BackupActivityLogPage: FunctionComponent< Props > = ( {
 						) }
 					</p>
 				</div>
-				{ logs && <ActivityCardList logs={ logs } pageSize={ 9 } /> }
+				{ logs && <ActivityCardList logs={ logs } pageSize={ 10 } /> }
 			</div>
 		</Main>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* control activity card rendering content links and action buttons
* add more content orbs 

<img width="600" src="https://user-images.githubusercontent.com/2810519/80029268-6820d180-849b-11ea-9196-4ad3855f8a7f.png">
<img width="600" src="https://user-images.githubusercontent.com/2810519/80029279-6bb45880-849b-11ea-9283-99f0181114a8.png">

#### Testing instructions

1. Navigate to `backups/activity`
2. Verify that the "changes in this backup" link is hidden for backups with no content
3. See that the pagination orbs appear when content rolls over to the next page ( you may need to adjust the pageSize variable in activity log to summon the orbs )
