### PR TITLE
Gutenboarding: fix vertical selector on iOS

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -186,6 +186,12 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		inputRef.current.innerText = siteVertical?.label || '';
 	}, [ siteVertical, inputRef ] );
 
+	React.useEffect( () => {
+		if ( !! suggestions.length && isMobile ) {
+			window.scrollTo( 0, 0 );
+		}
+	}, [ suggestions, isMobile ] );
+
 	// translators: Form input for a site's topic where "<Input />" is replaced by user input and must be preserved verbatim in translated string.
 	const madlibTemplate = __( 'My site is about <Input />' );
 	// translators: Form input for a site's topic where "<Input />" is replaced with the topic selected by the user.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Scroll the window to top when vertical suggestions are rendered on mobile. In this way we prevent this bug on iOS: https://d.pr/v/11OyBC

#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=fix/gutenboarding-vertical-select-ios) on iOS.
* When typing to enter a vertical and suggestions list becomes visible, I should also see what I'm typing without having to scroll.

Follow up of #41146, addressing https://github.com/Automattic/wp-calypso/pull/41146#pullrequestreview-395237653
