### PR TITLE
i18n: Enable use-translation-chunks config in horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -127,6 +127,7 @@
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,
+		"use-translation-chunks": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enabled `use-translation-chunks` feature flag in Horizon's config. Since we cannot test them using a `?flags` parameter on production, we'll test this on horizon.

#### Testing instructions

N/A
