### PR TITLE
Jetpack Cloud: Add Scan Alert and scan progress in the sidebar all the time.

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-badge/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-badge/index.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Badge from 'components/badge';
+
+interface Props {
+	numberOfThreatsFound: number;
+	progress: number;
+}
+
+const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress } ) => {
+	const translate = useTranslate();
+	if ( ! numberOfThreatsFound && ! progress ) {
+		return null;
+	}
+
+	if ( numberOfThreatsFound ) {
+		return (
+			<Badge type="error">
+				{ translate( '%(number)d threat', '%(number)d threats', {
+					count: numberOfThreatsFound,
+					args: {
+						number: numberOfThreatsFound,
+					},
+				} ) }
+			</Badge>
+		);
+	}
+
+	if ( 100 !== progress ) {
+		// No need to show a badge when there is no progress.
+		return (
+			<Badge type="success">
+				{ translate( '%(number)d %', {
+					args: {
+						number: progress,
+					},
+				} ) }
+			</Badge>
+		);
+	}
+	return null;
+};
+
+export default ScanBadge;

--- a/client/landing/jetpack-cloud/components/sidebar/style.scss
+++ b/client/landing/jetpack-cloud/components/sidebar/style.scss
@@ -16,6 +16,7 @@
 		.sidebar__heading {
 			padding-top: 15px;
 			padding-bottom: 15px;
+			line-height: 24px;
 		}
 
 		&.is-toggle-open {
@@ -35,6 +36,7 @@
 
 	.sidebar__expandable-title .badge {
 		float: right;
+		font-weight: 400;
 	}
 
 	// Footer

--- a/client/landing/jetpack-cloud/components/sidebar/style.scss
+++ b/client/landing/jetpack-cloud/components/sidebar/style.scss
@@ -33,6 +33,10 @@
 		}
 	}
 
+	.sidebar__expandable-title .badge {
+		float: right;
+	}
+
 	// Footer
 	.sidebar__footer {
 		margin-top: auto;

--- a/client/state/selectors/get-site-scan-progress.js
+++ b/client/state/selectors/get-site-scan-progress.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import 'state/data-layer/wpcom/sites/scan';
+
+/**
+ * Returns the current Jetpack Progress for a given site.
+ * Returns undefined if the site is unknown, or if no information is available.
+ *
+ * @param {object} state	Global state tree
+ * @param {number} siteId	The ID of the site we're querying
+ * @returns {?number}		Undefined or percentage of the scan completed
+ */
+export default function getSiteScanProgress( state, siteId ) {
+	return state.jetpackScan.scan?.[ siteId ]?.most_recent?.progress;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* This PR queries the scan api endpoint and displays 2 different states. 

Scan Alerts:
<img width="448" alt="Screen Shot 2020-04-21 at 6 05 24 PM" src="https://user-images.githubusercontent.com/115071/79975490-5b9c7900-849b-11ea-9798-acf45fd24a5d.png">
<img width="455" alt="Screen Shot 2020-04-21 at 6 05 18 PM" src="https://user-images.githubusercontent.com/115071/79975496-5dfed300-849b-11ea-95ff-288e4a3772c9.png">

Scan Progress:
<img width="475" alt="Screen Shot 2020-04-22 at 1 16 32 PM" src="https://user-images.githubusercontent.com/115071/79975636-956d7f80-849b-11ea-9793-8c4e932a71ea.png">
<img width="420" alt="Screen Shot 2020-04-22 at 1 16 25 PM" src="https://user-images.githubusercontent.com/115071/79975644-98687000-849b-11ea-8d05-9b025c18fbfe.png">


#### Testing instructions
* Load up this PR. 
* Load any section in the Jetpack Cloud for a site and notice that the sidebar looks as expected. 
* If there is a Threat found and the site support scan you should see a threat. 
* If you starts a scan (This part I tested by modifying the progress) you should see the sidebar update with the progress.

