### PR TITLE
Split out `initialize` and `identifyUser` from `lib/analytics`

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -30,6 +30,7 @@ import { setReduxStore as setReduxBridgeReduxStore } from 'lib/redux-bridge';
 import { init as pushNotificationsInit } from 'state/push-notifications/actions';
 import { setSupportSessionReduxStore } from 'lib/user/support-user-interop';
 import analytics from 'lib/analytics';
+import { initializeAnalytics } from 'lib/analytics/init';
 import { bumpStat } from 'lib/analytics/mc';
 import getSuperProps from 'lib/analytics/super-props';
 import { getSiteFragment, normalize } from 'lib/route';
@@ -255,7 +256,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 	unsavedFormsMiddleware();
 
 	// The analytics module requires user (when logged in) and superProps objects. Inject these here.
-	analytics.initialize( currentUser ? currentUser.get() : undefined, getSuperProps( reduxStore ) );
+	initializeAnalytics( currentUser ? currentUser.get() : undefined, getSuperProps( reduxStore ) );
 
 	setupErrorLogger( reduxStore );
 

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -8,7 +8,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import config from 'config';
-import analytics from 'lib/analytics';
+import { initializeAnalytics } from 'lib/analytics/init';
 import getSuperProps from 'lib/analytics/super-props';
 import { bindState as bindWpLocaleState } from 'lib/wp/localization';
 import { getUrlParts } from 'lib/url';
@@ -108,7 +108,7 @@ const setRouteMiddleware = ( reduxStore ) => {
 };
 
 const setAnalyticsMiddleware = ( currentUser, reduxStore ) => {
-	analytics.initialize( currentUser ? currentUser.get() : undefined, getSuperProps( reduxStore ) );
+	initializeAnalytics( currentUser ? currentUser.get() : undefined, getSuperProps( reduxStore ) );
 };
 
 export function setupMiddlewares( currentUser, reduxStore ) {

--- a/client/lib/analytics/identify-user.js
+++ b/client/lib/analytics/identify-user.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import debugModule from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { recordAliasInFloodlight } from 'lib/analytics/ad-tracking';
+import {
+	identifyUser as baseIdentifyUser,
+	getTracksAnonymousUserId,
+	getCurrentUser,
+} from '@automattic/calypso-analytics';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:analytics:identifyUser' );
+
+export function identifyUser( userData ) {
+	baseIdentifyUser( userData );
+
+	// neccessary because calypso-analytics/initializeAnalytics no longer calls out to ad-tracking
+	const user = getCurrentUser();
+	if ( 'object' === typeof userData && user && getTracksAnonymousUserId() ) {
+		debug( 'recordAliasInFloodlight', user );
+		recordAliasInFloodlight();
+	}
+}

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -17,7 +17,6 @@ import { processQueue } from './queue';
 import {
 	recordTracksEvent,
 	analyticsEvents,
-	initializeAnalytics,
 	identifyUser,
 	getTracksAnonymousUserId,
 	recordTracksPageView,
@@ -32,18 +31,6 @@ import {
 const identifyUserDebug = debug( 'calypso:analytics:identifyUser' );
 
 const analytics = {
-	initialize: function ( currentUser, superProps ) {
-		return initializeAnalytics( currentUser, superProps ).then( () => {
-			const user = getCurrentUser();
-
-			// This block is neccessary because calypso-analytics/initializeAnalytics no longer calls out to ad-tracking
-			if ( 'object' === typeof currentUser && user && getTracksAnonymousUserId() ) {
-				identifyUserDebug( 'recordAliasInFloodlight', user );
-				recordAliasInFloodlight();
-			}
-		} );
-	},
-
 	// pageView is a wrapper for pageview events across Tracks and GA.
 	pageView: {
 		record: function ( urlPath, pageTitle, params = {} ) {

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -84,14 +84,6 @@ const analytics = {
 			}
 		},
 	},
-
-	setProperties: function ( properties ) {
-		pushEventToTracksQueue( [ 'setProperties', properties ] );
-	},
-
-	clearedIdentity: function () {
-		pushEventToTracksQueue( [ 'clearIdentity' ] );
-	},
 };
 
 emitter( analytics );

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -1,15 +1,10 @@
 /**
- * External dependencies
- */
-import debug from 'debug';
-
-/**
  * Internal dependencies
  */
 import emitter from 'lib/mixins/emitter';
 import { urlParseAmpCompatible, saveCouponQueryArgument } from 'lib/analytics/utils';
 
-import { retarget as retargetAdTrackers, recordAliasInFloodlight } from 'lib/analytics/ad-tracking';
+import { retarget as retargetAdTrackers } from 'lib/analytics/ad-tracking';
 import { updateQueryParamsTracking } from 'lib/analytics/sem';
 import { trackAffiliateReferral } from './refer';
 import { gaRecordPageView } from './ga';
@@ -17,18 +12,10 @@ import { processQueue } from './queue';
 import {
 	recordTracksEvent,
 	analyticsEvents,
-	identifyUser,
-	getTracksAnonymousUserId,
 	recordTracksPageView,
-	getCurrentUser,
 	recordTracksPageViewWithPageParams,
 	pushEventToTracksQueue,
 } from '@automattic/calypso-analytics';
-
-/**
- * Module variables
- */
-const identifyUserDebug = debug( 'calypso:analytics:identifyUser' );
 
 const analytics = {
 	// pageView is a wrapper for pageview events across Tracks and GA.
@@ -96,17 +83,6 @@ const analytics = {
 				trackAffiliateReferral( { affiliateId, campaignId, subId, referrer } );
 			}
 		},
-	},
-
-	identifyUser: function ( userData ) {
-		identifyUser( userData );
-
-		// neccessary because calypso-analytics/initializeAnalytics no longer calls out to ad-tracking
-		const user = getCurrentUser();
-		if ( 'object' === typeof userData && user && getTracksAnonymousUserId() ) {
-			identifyUserDebug( 'recordAliasInFloodlight', user );
-			recordAliasInFloodlight();
-		}
 	},
 
 	setProperties: function ( properties ) {

--- a/client/lib/analytics/init.js
+++ b/client/lib/analytics/init.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import debugModule from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import {
+	initializeAnalytics as initializeCalypsoAnalytics,
+	getTracksAnonymousUserId,
+	getCurrentUser,
+} from '@automattic/calypso-analytics';
+
+/**
+ * Module variables
+ */
+const debug = debugModule( 'calypso:analytics:init' );
+
+export async function initializeAnalytics( currentUser, superProps ) {
+	await initializeCalypsoAnalytics( currentUser, superProps );
+	const user = getCurrentUser();
+
+	// This block is necessary because calypso-analytics/initializeAnalytics no longer calls out to ad-tracking
+	if ( 'object' === typeof currentUser && user && getTracksAnonymousUserId() ) {
+		const mod = await import(
+			/* webpackChunkName: "lib-analytics-ad-tracking-record-alias-in-floodlight" */
+			'lib/analytics/ad-tracking/record-alias-in-floodlight'
+		);
+		const { recordAliasInFloodlight } = mod;
+		debug( 'recordAliasInFloodlight', user );
+		recordAliasInFloodlight();
+	}
+}

--- a/client/lib/analytics/signup.js
+++ b/client/lib/analytics/signup.js
@@ -7,6 +7,7 @@ import debug from 'debug';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { identifyUser } from 'lib/analytics/identify-user';
 import { gaRecordEvent } from 'lib/analytics/ga';
 import { addToQueue } from 'lib/analytics/queue';
 import {
@@ -97,7 +98,7 @@ export function recordRegistration( { userData, flow, type } ) {
 	signupDebug( 'recordRegistration:', { userData, flow, type } );
 
 	// Tracks user identification
-	analytics.identifyUser( userData );
+	identifyUser( userData );
 	// Tracks
 	analytics.tracks.recordEvent( 'calypso_user_registration_complete', { flow, type } );
 	// Google Analytics

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -12,6 +12,7 @@ import cookie from 'cookie';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { identifyUser } from 'lib/analytics/identify-user';
 import { initializeAnalytics } from 'lib/analytics/init';
 import { bumpStat, bumpStatWithPageView } from 'lib/analytics/mc';
 import { recordAliasInFloodlight } from 'lib/analytics/ad-tracking';
@@ -121,38 +122,38 @@ describe( 'Analytics', () => {
 		} );
 
 		test( 'should not call window._tkq.push or recordAliasInFloodlight when there is no user data', () => {
-			analytics.identifyUser( {} );
+			identifyUser( {} );
 			expect( window._tkq.push ).not.toHaveBeenCalled();
 			expect( recordAliasInFloodlight ).not.toHaveBeenCalled();
 		} );
 
 		test( 'should not call window._tkq.push and recordAliasInFloodlight when user ID is missing', () => {
-			analytics.identifyUser( { ID: undefined, username: 'eight', email: 'eight@example.com' } );
+			identifyUser( { ID: undefined, username: 'eight', email: 'eight@example.com' } );
 			expect( window._tkq.push ).not.toHaveBeenCalled();
 			expect( recordAliasInFloodlight ).not.toHaveBeenCalled();
 		} );
 
 		test( 'should not call window._tkq.push and recordAliasInFloodlight when username is missing', () => {
-			analytics.identifyUser( { ID: 8, username: undefined, email: 'eight@example.com' } );
+			identifyUser( { ID: 8, username: undefined, email: 'eight@example.com' } );
 			expect( window._tkq.push ).not.toHaveBeenCalled();
 			expect( recordAliasInFloodlight ).not.toHaveBeenCalled();
 		} );
 
 		test( 'should not call window._tkq.push and recordAliasInFloodlight when email is missing', () => {
-			analytics.identifyUser( { ID: 8, username: 'eight', email: undefined } );
+			identifyUser( { ID: 8, username: 'eight', email: undefined } );
 			expect( window._tkq.push ).not.toHaveBeenCalled();
 			expect( recordAliasInFloodlight ).not.toHaveBeenCalled();
 		} );
 
 		test( 'should call window._tkq.push and recordAliasInFloodlight when user ID, username, and email are given', () => {
-			analytics.identifyUser( { ID: '8', username: 'eight', email: 'eight@example.com' } );
+			identifyUser( { ID: '8', username: 'eight', email: 'eight@example.com' } );
 			expect( recordAliasInFloodlight ).toHaveBeenCalled();
 			expect( window._tkq.push ).toHaveBeenCalledWith( [ 'identifyUser', 8, 'eight' ] );
 		} );
 
 		test( 'should not call recordAliasInFloodlight when anonymousUserId does not exist', () => {
 			cookie.parse.mockImplementationOnce( () => ( {} ) );
-			analytics.identifyUser( { ID: 8, username: 'eight', email: 'eight@example.com' } );
+			identifyUser( { ID: 8, username: 'eight', email: 'eight@example.com' } );
 			expect( recordAliasInFloodlight ).not.toHaveBeenCalled();
 			expect( window._tkq.push ).toHaveBeenCalledWith( [ 'identifyUser', 8, 'eight' ] );
 		} );

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -12,6 +12,7 @@ import cookie from 'cookie';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { initializeAnalytics } from 'lib/analytics/init';
 import { bumpStat, bumpStatWithPageView } from 'lib/analytics/mc';
 import { recordAliasInFloodlight } from 'lib/analytics/ad-tracking';
 
@@ -164,7 +165,7 @@ describe( 'Analytics', () => {
 			cookie.serialize.mockImplementation( () => {} );
 		} );
 		test( 'if stat.js load fails, should load nostat.js', () => {
-			return analytics.initialize().then( () => {
+			return initializeAnalytics().then( () => {
 				expect( loadScript ).toHaveBeenCalledWith( expect.stringMatching( /\/nostats.js/ ) );
 			} );
 		} );
@@ -218,7 +219,7 @@ describe( 'Analytics', () => {
 			} );
 
 			test( 'should add _superProps if they are initialized', () => {
-				analytics.initialize( {}, () => {
+				initializeAnalytics( {}, () => {
 					return { super: 'prop' };
 				} );
 				analytics.tracks.recordEvent( 'calypso_abc_def' );


### PR DESCRIPTION
This is one of several PRs that will make `lib/analytics` more modular, breaking up its monolithic default export. This will result in progressively being able to contain larger parts of analytics to just the sections they're needed in, loading less of the library upfront.

The PR moves `initialize` and `identifyUser` to their own modules under `lib/analytics`, and updates all code accordingly.

It also removes two unused functions, namely `setProperties` and `clearedIdentity`. They're quite straightforward, so it shouldn't be too much of an issue to add them to a new module if they're needed in the future.

#### Changes proposed in this Pull Request

* Move `initialize` to its own module, and rename it `initializeAnalytics`.
* Move `identifyUser` to its own module.
* Update all code accordingly.
* Remove `setProperties` and `clearedIdentity`, which are currently unused.

#### Testing instructions

`identifyUser` is unchanged (only moved), so the main task is just to ensure that analytics initialisation continues to work correctly, both in the case where an alias gets recorded in floodlight, and the case where it doesn't.

I believe an easy way to test these cases is to try e.g. `/start` while logged in and while logged out, respectively.

The unit tests should already take care of this testing, but some manual verification never hurts 🙂 