### PR TITLE
Marklines: Fixe React error where the same key is being used.

### DIFF
--- a/client/components/marked-lines/index.jsx
+++ b/client/components/marked-lines/index.jsx
@@ -19,7 +19,7 @@ import './style.scss';
  *   <mark key="be kind" className="marked-lines__mark">be kind</mark>
  *
  * @param {string} text the string to mark
- * @returns {Element} React <mark> Element
+ * @returns {React.Element} React <mark> Element
  */
 const mark = ( text ) => (
 	<mark key={ text } className="marked-lines__mark">
@@ -72,7 +72,7 @@ const MarkedLines = ( { context } ) => {
 
 					return (
 						<div
-							key={ content }
+							key={ `line-${ lineNumber }` }
 							className={ classNames( 'marked-lines__line-number', {
 								'marked-lines__marked-line': hasMarks,
 							} ) }
@@ -88,7 +88,7 @@ const MarkedLines = ( { context } ) => {
 
 					return (
 						<div
-							key={ content }
+							key={ lineNumber }
 							className={ classNames( 'marked-lines__line', {
 								'marked-lines__marked-line': hasMarks,
 							} ) }

--- a/client/components/marked-lines/index.jsx
+++ b/client/components/marked-lines/index.jsx
@@ -72,7 +72,7 @@ const MarkedLines = ( { context } ) => {
 
 					return (
 						<div
-							key={ `line-${ lineNumber }` }
+							key={ lineNumber }
 							className={ classNames( 'marked-lines__line-number', {
 								'marked-lines__marked-line': hasMarks,
 							} ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This Pr fixes an error found in the Marklines component.
<img width="870" alt="Screen Shot 2020-04-22 at 3 30 23 PM" src="https://user-images.githubusercontent.com/115071/79987870-3a915380-84ae-11ea-9c01-8b85006c17d1.png">

This PR fixes this issue by making sure that each of the keys is unique. 

#### Testing instructions
* Load up this PR in jetpack cloud. 
* Go to the /scan page where a site has a threat. Open up the threat. Nice that the error is not there any more. 