### PR TITLE
Gutenboarding: Fix preview scrolling

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -237,7 +237,7 @@
 
 .style-preview__preview {
 	width: calc( 100% - 163px );
-	margin: 0 auto 30px;
+	margin: 0 auto;
 	padding-left: 100px;
 
 	&.is-viewport-tablet {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove a bottom margin from the font preview that caused vertical overflow and scroll.

If this was necessary for some reason, it should be included in this calc:

https://github.com/Automattic/wp-calypso/blob/9b56310d9f0beb9b54aaf347a654d90cff619daa/client/landing/gutenboarding/onboarding-block/style-preview/style.scss#L7

#### Testing instructions

* [`/new`](https://calypso.live/new?branch=gutenboarding/fix-41324-preview-scroll)
* Design picker step desktop view does not have any vertical scrolling, it adapts to the viewport size.

Fixes #41324
