### PR TITLE
Use 'preserveSemverRanges' so renovate doesn't pin our deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-	"extends": [ "config:base", "default:pinDigestsDisabled" ],
+	"extends": [ "config:base", "default:pinDigestsDisabled", "default:preserveSemverRanges" ],
 	"packageRules": [
 		{
 			"paths": [ "packages/**" ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update renovate config to not pin dependencies. Source: 

- https://github.com/Automattic/wp-calypso/pull/41361
- https://docs.renovatebot.com/presets-default/#preservesemverranges

#### Testing instructions

Nothing to test, just wait for the next renovate PR and check it makes sense.
