### PR TITLE
Adds Jetpack routing for homepage

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -173,6 +173,7 @@ const mapStateToProps = ( state ) => {
 	const allowRestore =
 		'active' === rewind.state &&
 		! ( 'queued' === restoreStatus || 'running' === restoreStatus ) &&
+		Array.isArray( siteCapabilities ) &&
 		siteCapabilities.includes( 'restore' );
 
 	return {

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -7,9 +7,22 @@ import page from 'page';
  * Internal dependencies
  */
 import config from 'config';
+import { getCurrentUser } from 'state/current-user/selectors';
+import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
+import { getSitePurchases } from 'state/purchases/selectors';
+import { fetchSitePurchases } from 'state/purchases/actions';
+import {
+	JETPACK_SCAN_PRODUCTS,
+	PRODUCT_JETPACK_SCAN,
+	JETPACK_BACKUP_PRODUCTS,
+	PRODUCT_JETPACK_BACKUP_DAILY,
+} from 'lib/products-values/constants';
+import { getPlan, planHasFeature } from 'lib/plans';
+import { requestSite } from 'state/sites/actions';
 
-export default function() {
-	page( '/', context => {
+export default function () {
+	page( '/', async ( context ) => {
 		let redirectPath = '/error';
 
 		if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
@@ -18,10 +31,73 @@ export default function() {
 			redirectPath = '/scan';
 		}
 
-		if ( context.querystring ) {
-			redirectPath += `?${ context.querystring }`;
+		const { querystring } = context;
+		if ( querystring ) {
+			redirectPath += `?${ querystring }`;
+		}
+
+		// Gets the primary blog and checks if it's Jetpack.
+		const { getState, dispatch } = context.store;
+		const user = getCurrentUser( getState() );
+		if ( ! user.primary_blog_is_jetpack ) {
+			page.redirect( redirectPath );
+			return;
+		}
+
+		// If it is, get the slug.
+		const primarySiteId = getPrimarySiteId( getState() );
+		let primarySiteSlug = getPrimarySiteSlug( getState() );
+		if ( ! primarySiteSlug ) {
+			await dispatch( requestSite( primarySiteId ) );
+			primarySiteSlug = getPrimarySiteSlug( getState() );
+		}
+
+		// Get purchases for primary site.
+		// TODO: Use better method to detect capabilities.
+		let purchases = getSitePurchases( getState(), primarySiteId );
+		if ( ! purchases.length ) {
+			await dispatch( fetchSitePurchases( primarySiteId ) );
+			purchases = getSitePurchases( getState(), primarySiteId );
+		}
+
+		// From purchases, build proper URL.
+		const primarySiteManageUrl = getRedirectFromPurchases( purchases, primarySiteSlug );
+		if ( primarySiteManageUrl ) {
+			redirectPath = `${ primarySiteManageUrl }?${ querystring }`;
 		}
 
 		page.redirect( redirectPath );
 	} );
+}
+
+function getRedirectFromPurchases( purchases, primarySiteSlug ) {
+	let redirectPath = null;
+
+	// Iterate over each purchase and determine if it has scan or backups.
+	let hasBackupProduct = false;
+	let hasScanProduct = false;
+	purchases.forEach( ( { productSlug } ) => {
+		if (
+			! hasBackupProduct && // Don't test for backups if we already have it.
+			( JETPACK_BACKUP_PRODUCTS.includes( productSlug ) ||
+				( getPlan( productSlug ) && planHasFeature( productSlug, PRODUCT_JETPACK_BACKUP_DAILY ) ) )
+		) {
+			hasBackupProduct = true;
+			return;
+		}
+		if (
+			! hasScanProduct &&
+			( JETPACK_SCAN_PRODUCTS.includes( productSlug ) ||
+				( getPlan( productSlug ) && planHasFeature( productSlug, PRODUCT_JETPACK_SCAN ) ) )
+		) {
+			hasScanProduct = true;
+		}
+	} );
+	if ( hasBackupProduct && config.isEnabled( 'jetpack-cloud/backups' ) ) {
+		redirectPath = `/backups/${ primarySiteSlug }/`;
+	} else if ( hasScanProduct && config.isEnabled( 'jetpack-cloud/scan' ) ) {
+		redirectPath = `/scan/${ primarySiteSlug }/`;
+	}
+
+	return redirectPath;
 }

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -8,8 +8,8 @@ import page from 'page';
  */
 import config from 'config';
 
-export default function () {
-	page( '/', ( context ) => {
+export default function() {
+	page( '/', context => {
 		let redirectPath = '/error';
 
 		if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {

--- a/client/landing/jetpack-cloud/index.js
+++ b/client/landing/jetpack-cloud/index.js
@@ -2,102 +2,18 @@
  * External dependencies
  */
 import page from 'page';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import config from 'config';
-import { getCurrentUser } from 'state/current-user/selectors';
-import getPrimarySiteId from 'state/selectors/get-primary-site-id';
-import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
-import { getSitePurchases } from 'state/purchases/selectors';
-import { fetchSitePurchases } from 'state/purchases/actions';
-import {
-	JETPACK_SCAN_PRODUCTS,
-	PRODUCT_JETPACK_SCAN,
-	JETPACK_BACKUP_PRODUCTS,
-	PRODUCT_JETPACK_BACKUP_DAILY,
-} from 'lib/products-values/constants';
-import { getPlan, planHasFeature } from 'lib/plans';
-import { requestSite } from 'state/sites/actions';
+import { makeLayout, render as clientRender } from 'controller';
+import Home from './sections/home';
 
 export default function () {
-	page( '/', async ( context ) => {
-		let redirectPath = '/error';
-
-		if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
-			redirectPath = '/backups';
-		} else if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
-			redirectPath = '/scan';
-		}
-
-		const { querystring } = context;
-		if ( querystring ) {
-			redirectPath += `?${ querystring }`;
-		}
-
-		// Gets the primary blog and checks if it's Jetpack.
-		const { getState, dispatch } = context.store;
-		const user = getCurrentUser( getState() );
-		if ( ! user.primary_blog_is_jetpack ) {
-			page.redirect( redirectPath );
-			return;
-		}
-
-		// If it is, get the slug.
-		const primarySiteId = getPrimarySiteId( getState() );
-		let primarySiteSlug = getPrimarySiteSlug( getState() );
-		if ( ! primarySiteSlug ) {
-			await dispatch( requestSite( primarySiteId ) );
-			primarySiteSlug = getPrimarySiteSlug( getState() );
-		}
-
-		// Get purchases for primary site.
-		// TODO: Use better method to detect capabilities.
-		let purchases = getSitePurchases( getState(), primarySiteId );
-		if ( ! purchases.length ) {
-			await dispatch( fetchSitePurchases( primarySiteId ) );
-			purchases = getSitePurchases( getState(), primarySiteId );
-		}
-
-		// From purchases, build proper URL.
-		const primarySiteManageUrl = getRedirectFromPurchases( purchases, primarySiteSlug );
-		if ( primarySiteManageUrl ) {
-			redirectPath = `${ primarySiteManageUrl }?${ querystring }`;
-		}
-
-		page.redirect( redirectPath );
-	} );
-}
-
-function getRedirectFromPurchases( purchases, primarySiteSlug ) {
-	let redirectPath = null;
-
-	// Iterate over each purchase and determine if it has scan or backups.
-	let hasBackupProduct = false;
-	let hasScanProduct = false;
-	purchases.forEach( ( { productSlug } ) => {
-		if (
-			! hasBackupProduct && // Don't test for backups if we already have it.
-			( JETPACK_BACKUP_PRODUCTS.includes( productSlug ) ||
-				( getPlan( productSlug ) && planHasFeature( productSlug, PRODUCT_JETPACK_BACKUP_DAILY ) ) )
-		) {
-			hasBackupProduct = true;
-			return;
-		}
-		if (
-			! hasScanProduct &&
-			( JETPACK_SCAN_PRODUCTS.includes( productSlug ) ||
-				( getPlan( productSlug ) && planHasFeature( productSlug, PRODUCT_JETPACK_SCAN ) ) )
-		) {
-			hasScanProduct = true;
-		}
-	} );
-	if ( hasBackupProduct && config.isEnabled( 'jetpack-cloud/backups' ) ) {
-		redirectPath = `/backups/${ primarySiteSlug }/`;
-	} else if ( hasScanProduct && config.isEnabled( 'jetpack-cloud/scan' ) ) {
-		redirectPath = `/scan/${ primarySiteSlug }/`;
-	}
-
-	return redirectPath;
+	const homeController = ( context, next ) => {
+		context.primary = <Home />;
+		next();
+	};
+	page( '/', homeController, makeLayout, clientRender );
 }

--- a/client/landing/jetpack-cloud/sections/home.tsx
+++ b/client/landing/jetpack-cloud/sections/home.tsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
+import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
+import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import getPrimarySiteIsJetpack from 'state/selectors/get-primary-site-is-jetpack';
+import config from 'config';
+import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
+
+type Props = {
+	siteId?: number | null;
+	siteSlug?: string | null;
+	siteCapabilities?: string[];
+};
+
+function Home( props: Props ) {
+	const { siteId, siteSlug, siteCapabilities } = props;
+
+	useEffect( () => {
+		const redirectUrl = new URL( '/error', window.location.href );
+		redirectUrl.search = window.location.search;
+
+		if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
+			redirectUrl.pathname = '/backups';
+		} else if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
+			redirectUrl.pathname = '/scan';
+		}
+		if ( ! siteId ) {
+			return page.redirect( redirectUrl.toString() );
+		}
+
+		if ( ! siteSlug || ! Array.isArray( siteCapabilities ) ) {
+			return;
+		}
+
+		// From capabilities, build proper URL.
+		if ( config.isEnabled( 'jetpack-cloud/backups' ) && siteCapabilities.includes( 'backup' ) ) {
+			redirectUrl.pathname = `/backups/${ siteSlug }`;
+		} else if ( config.isEnabled( 'jetpack-cloud/scan' ) && siteCapabilities.includes( 'scan' ) ) {
+			redirectUrl.pathname = `/scan/${ siteSlug }`;
+		}
+
+		page.redirect( redirectUrl.toString() );
+	}, [ siteId, siteSlug, siteCapabilities ] );
+
+	return (
+		<>
+			<QueryRewindCapabilities siteId={ siteId } />
+		</>
+	);
+}
+
+export default connect( ( state ) => {
+	if ( ! getPrimarySiteIsJetpack( state ) ) {
+		return {
+			siteId: null,
+		};
+	}
+	const siteId = getPrimarySiteId( state );
+	const siteSlug = getPrimarySiteSlug( state );
+	const siteCapabilities = getRewindCapabilities( state, siteId );
+
+	return {
+		siteId,
+		siteSlug,
+		siteCapabilities,
+	};
+} )( Home );

--- a/client/state/selectors/get-primary-site-is-jetpack.js
+++ b/client/state/selectors/get-primary-site-is-jetpack.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser } from 'state/current-user/selectors';
+
+/**
+ * Returns whether the current user's primary site's is Jetpack or not.
+ *
+ * @param  {object}  state Global state tree
+ * @returns {?boolean}     The current user's primary site Jetpack status.
+ */
+export default function getPrimarySiteIsJetpack( state ) {
+	const currentUser = getCurrentUser( state );
+	return get( currentUser, 'primary_blog_is_jetpack', null );
+}

--- a/client/state/selectors/get-rewind-capabilities.js
+++ b/client/state/selectors/get-rewind-capabilities.js
@@ -1,8 +1,3 @@
-/**
- * External Dependencies
- */
-import { get } from 'lodash';
-
 export default function getRewindCapabilities( state, siteId ) {
-	return get( state, [ 'rewind', siteId, 'capabilities' ], [] );
+	return state?.rewind?.[ siteId ]?.capabilities;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates routing logic for Jetpack landing page to direct users to primary site.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Expected results:
* With a primary site of WP.com: Redirect to site picker for backups.
* With a primary site of JP:
  * Redirect to backups for site if backups purchased.
  * Redirect to scan for site if scan and **not** backups purchased.
  * Redirect to site picker for backups if neither purchased.


Fixes 1156570014567299-as-1170686186292217.
