### PR TITLE
Gutenboarding: Fix domain picker styling

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -8,6 +8,17 @@
 		padding: 9px 12px;
 		height: auto; // prevent clipping when there are 2 lines
 		text-align: left;
+		border-radius: $radius-round-rectangle;
+
+		&:focus,
+		&:hover[type] {
+			box-shadow: 0 0 0 1px var( --studio-gray-100 );
+			outline: 0;
+		}
+
+		&:disabled {
+			opacity: 1;
+		}
 	}
 
 	&__label {
@@ -27,4 +38,10 @@
 	&.is-modal-open {
 		display: none; // Hide domain picker button when modal is open
 	}
+}
+
+// Remove focus styling from clicking a button
+// Keep keyboard-focused focus style
+html:not( .accessible-focus ) .domain-picker-button:focus:not( :disabled ):not( :hover ) {
+	box-shadow: none;
 }

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -47,17 +47,6 @@ $padding--gutenboarding__header: $grid-unit-10;
 
 .gutenboarding__header-domain-picker-button {
 	padding: 0.3em 0.5em;
-	border-radius: $radius-round-rectangle;
-
-	&:focus,
-	&:hover {
-		box-shadow: 0 0 0 2px $blue-medium-focus;
-		outline: 0;
-	}
-
-	&:disabled {
-		opacity: 1;
-	}
 }
 
 .gutenboarding__header-domain-picker-button-domain {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -352,7 +352,7 @@ $gutenboarding-style-preview-bar-height: 30px;
 
 // Remove focus styling from clicking a button
 // Keep keyboard-focused focus style
-html:not( .accessible-focus ) .components-button:focus:not( :disabled ) {
+html:not( .accessible-focus ) .style-preview__viewport-select-button:focus:not( :disabled ) {
 	box-shadow: none;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Domain picker. Hover state should be 1px solid --studio-gray-100 instead of the 2px solid blue
- Domain picker. When clicking the domain picker and clicking it again to close it it gets this blue border. Lets remove that

![demo](https://user-images.githubusercontent.com/841763/80001846-26098700-84bf-11ea-97a4-b57fd6138833.gif)


#### Testing instructions

* [`/new`](https://calypso.live/new?branch=gutenboarding/41214-domain-picker-style)
* Check the domain picker styling.

Fixes #41214
