### PR TITLE
Gutenboarding: Add and use hasPaidDomain selector

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -73,6 +73,7 @@ const Header: FunctionComponent = () => {
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 
 	const { domain, siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 
 	const makePath = usePath();
 
@@ -159,7 +160,7 @@ const Header: FunctionComponent = () => {
 	useEffect( () => {
 		// isRedirecting check this is needed to make sure we don't overwrite the first window.location.replace() call
 		if ( newSite && ! isRedirecting ) {
-			if ( domain && ! domain.is_free ) {
+			if ( hasPaidDomain ) {
 				// I'd rather not make my own product, but this works.
 				// lib/cart-items helpers did not perform well.
 				const domainProduct = {

--- a/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/create-site/index.tsx
@@ -25,16 +25,7 @@ const CreateSite: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const shouldTriggerCreate = useNewQueryParam();
 	const [ shouldCreateAndRedirect, setCreateAndRedirect ] = React.useState( false );
-	const hasPaidDomain: boolean = useSelect( ( select ) => {
-		const domain = select( STORE_KEY ).getState().domain;
-
-		// No domain is not paid
-		if ( ! domain ) {
-			return false;
-		}
-
-		return ! domain.is_free;
-	} );
+	const hasPaidDomain = useSelect( ( select ) => select( STORE_KEY ).hasPaidDomain() );
 
 	const steps = React.useRef< string[] >(
 		[

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -5,3 +5,10 @@ import { State } from './reducer';
 
 export const getState = ( state: State ) => state;
 export const getSelectedSite = ( state: State ) => state.selectedSite;
+
+export const hasPaidDomain = ( state: State ): boolean => {
+	if ( ! state.domain ) {
+		return false;
+	}
+	return ! state.domain.is_free;
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `hasPaidDomain` selector to the Gutenboarding store.

#### Testing instructions

* No changes in behavior.
* [`/new`]() flow works as expected with and without selecting a paid domain. 

Closes #41357
