### PR TITLE
Sidebar: move site switcher to bottom

### DIFF
--- a/client/components/site-selector/add-site.jsx
+++ b/client/components/site-selector/add-site.jsx
@@ -26,7 +26,7 @@ class SiteSelectorAddSite extends Component {
 		return (
 			<span className="site-selector__add-new-site">
 				<Button borderless href={ this.getAddNewSiteUrl() } onClick={ this.recordAddNewSite }>
-					<Gridicon icon="add-outline" /> { translate( 'Add new site' ) }
+					<Gridicon icon="add-outline" size={ 18 } /> { translate( 'Add new site' ) }
 				</Button>
 			</span>
 		);

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -128,12 +128,12 @@
 
 // The actual list of sites
 .site-selector__sites {
-	max-height: calc( 100% - 93px );
+	max-height: calc( 100% - 90px );
 	overflow-y: auto;
 	background: var( --color-surface );
 
 	@include breakpoint( '<660px' ) {
-		max-height: calc( 100% - 109px );
+		max-height: calc( 100% - 107px );
 	}
 }
 
@@ -144,23 +144,20 @@
 }
 
 .site-selector__add-new-site {
-	padding: 0;
 	border-top: 1px solid var( --color-neutral-5 );
 	margin: auto 0 0;
 	display: flex;
 	flex-direction: row;
-	padding-left: 10px;
 }
 
 .site-selector__add-new-site .button {
 	box-sizing: border-box;
 	display: inline-block;
-	text-transform: uppercase;
-	font-size: 11px;
+	font-size: 12px;
 	font-weight: 600;
-	padding: 8px;
+	padding: 8px 16px;
+	width: 100%;
 	color: var( --color-neutral-40 );
-	line-height: 2.1;
 
 	&:hover {
 		color: var( --color-neutral-70 );
@@ -171,10 +168,12 @@
 	}
 
 	.gridicon {
+		height: 18px;
+		width: 18px;
 		display: block;
 		float: left;
 		margin-right: 6px;
-		top: auto;
+		top: 2px;
 		margin-top: auto;
 	}
 }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -186,10 +186,46 @@
 	}
 }
 
+.sidebar__switch-sites {
+	.button {
+		padding: 16px;
+		width: 100%;
+		text-align: left;
+		color: var( --color-sidebar-text-alternative );
+
+		&:hover {
+			color: var( --color-sidebar-text );
+		}
+
+		&.is-borderless .gridicon {
+			height: 18px;
+			width: 18px;
+			top: 4px;
+		}
+
+		@include breakpoint( '>660px' ) {
+			padding: 8px 16px;
+		}
+	}
+}
+
+.sidebar__switch-sites-label {
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.sidebar__region {
+	height: 100%;
+	overflow-y: auto;
+}
+
+.sidebar__footer {
+	border-top: 1px solid var( --color-neutral-5 );
+}
+
 // Sometimes we show info at the bottom of the sidebar. For
 // example on My Site(s), for users with a single site, we
 // show a button to add a new site.
-.sidebar__wp-admin,
-.sidebar__footer {
+.sidebar__wp-admin {
 	margin-top: 16px;
 }

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -12,14 +12,10 @@ import { isEnabled } from 'config';
  */
 import AllSites from 'blocks/all-sites';
 import AsyncLoad from 'components/async-load';
-import { Button, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
 import Site from 'blocks/site';
-import Gridicon from 'components/gridicon';
-import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSite } from 'state/ui/selectors';
 import getSelectedOrAllSites from 'state/selectors/get-selected-or-all-sites';
-import { getCurrentUserSiteCount } from 'state/current-user/selectors';
-import { recordGoogleEvent } from 'state/analytics/actions';
 import { hasAllSitesList } from 'state/sites/selectors';
 
 /**
@@ -29,18 +25,9 @@ import './style.scss';
 
 class CurrentSite extends Component {
 	static propTypes = {
-		siteCount: PropTypes.number.isRequired,
-		setLayoutFocus: PropTypes.func.isRequired,
 		selectedSite: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 		anySiteSelected: PropTypes.array,
-	};
-
-	switchSites = ( event ) => {
-		event.preventDefault();
-		event.stopPropagation();
-		this.props.setLayoutFocus( 'sites' );
-		this.props.recordGoogleEvent( 'Sidebar', 'Clicked Switch Site' );
 	};
 
 	render() {
@@ -65,17 +52,6 @@ class CurrentSite extends Component {
 
 		return (
 			<Card className="current-site">
-				{ this.props.siteCount > 1 && (
-					<span className="current-site__switch-sites">
-						<Button borderless onClick={ this.switchSites }>
-							<Gridicon icon="chevron-left" />
-							<span className="current-site__switch-sites-label">
-								{ translate( 'Switch Site' ) }
-							</span>
-						</Button>
-					</span>
-				) }
-
 				{ selectedSite ? (
 					<div>
 						<Site site={ selectedSite } homeLink={ true } />
@@ -101,12 +77,8 @@ class CurrentSite extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		selectedSite: getSelectedSite( state ),
-		anySiteSelected: getSelectedOrAllSites( state ),
-		siteCount: getCurrentUserSiteCount( state ),
-		hasAllSitesList: hasAllSitesList( state ),
-	} ),
-	{ recordGoogleEvent, setLayoutFocus }
-)( localize( CurrentSite ) );
+export default connect( ( state ) => ( {
+	selectedSite: getSelectedSite( state ),
+	anySiteSelected: getSelectedOrAllSites( state ),
+	hasAllSitesList: hasAllSitesList( state ),
+} ) )( localize( CurrentSite ) );

--- a/client/my-sites/sidebar/index.jsx
+++ b/client/my-sites/sidebar/index.jsx
@@ -14,6 +14,7 @@ import { memoize } from 'lodash';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
+import { Button } from '@automattic/components';
 import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import ExternalLink from 'components/external-link';
@@ -808,6 +809,30 @@ export class MySitesSidebar extends Component {
 		);
 	}
 
+	renderSwitchSites() {
+		const { translate } = this.props;
+
+		if ( this.props.currentUser.site_count < 2 ) {
+			return null;
+		}
+
+		return (
+			<span className="sidebar__switch-sites">
+				<Button borderless onClick={ this.switchSites }>
+					<Gridicon icon="chevron-left" size={ 18 } />
+					<span className="sidebar__switch-sites-label">{ translate( 'Switch site' ) }</span>
+				</Button>
+			</span>
+		);
+	}
+
+	switchSites = ( event ) => {
+		event.preventDefault();
+		event.stopPropagation();
+		this.props.setLayoutFocus( 'sites' );
+		this.props.recordGoogleEvent( 'Sidebar', 'Clicked Switch Site' );
+	};
+
 	render() {
 		return (
 			<Sidebar>
@@ -815,7 +840,10 @@ export class MySitesSidebar extends Component {
 					<CurrentSite />
 					{ this.renderSidebarMenus() }
 				</SidebarRegion>
-				<SidebarFooter>{ this.addNewSite() }</SidebarFooter>
+				<SidebarFooter>
+					{ this.addNewSite() }
+					{ this.renderSwitchSites() }
+				</SidebarFooter>
 			</Sidebar>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
As mentioned in #41340, we should move the site switcher to the bottom of the sidebar to move closer to implementing the sidebar slideout inside the editor.

This PR moves the site switcher to the bottom of the sidebar and aligns the styles between the site switcher and add new site button. The site switcher functionality and animation remains the same.

Before | After
------------ | -------------
<img width="278" alt="Screen Shot 2020-04-22 at 11 48 16 AM" src="https://user-images.githubusercontent.com/448298/80004318-2c343f00-8490-11ea-9a7b-9a923a8b94bd.png"> | <img width="281" alt="Screen Shot 2020-04-22 at 11 47 26 AM" src="https://user-images.githubusercontent.com/448298/80004291-250d3100-8490-11ea-8db9-4ac3896e1272.png">

**Gif to show transition**
![Kapture 2020-04-22 at 11 57 25](https://user-images.githubusercontent.com/448298/80004574-7e756000-8490-11ea-9d22-a284463e312b.gif)

#### Testing instructions

* Checkout this branch or visit the calypso.live link
* Load a site with an account that has multiple sites
* Make sure the site switch button is at the bottom of the sidebar
* Click to make sure the button still works as expected and fires the tracking event
* Test on mobile viewports

Fixes #41340 
