### PR TITLE
Fix/jetpack cloud statusbackup padding and background

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -190,50 +190,55 @@ class BackupsPage extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<QueryRewindCapabilities siteId={ siteId } />
 
-				<DatePicker
-					onDateChange={ this.onDateChange }
-					selectedDate={ this.getSelectedDate() }
-					siteId={ siteId }
-					oldestDateAvailable={ oldestDateAvailable }
-					today={ today }
-					siteSlug={ siteSlug }
-				/>
+				<div className="backups__last-backup-status">
+					<DatePicker
+						onDateChange={ this.onDateChange }
+						selectedDate={ this.getSelectedDate() }
+						siteId={ siteId }
+						oldestDateAvailable={ oldestDateAvailable }
+						today={ today }
+						siteSlug={ siteSlug }
+					/>
 
-				{ isLoadingBackups && <div className="backups__is-loading" /> }
+					{ isLoadingBackups && <div className="backups__is-loading" /> }
+
+					{ ! isLoadingBackups && (
+						<>
+							<DailyBackupStatus
+								{ ...{
+									allowRestore,
+									siteUrl,
+									siteSlug,
+									dailyBackup: backupsOnSelectedDate.lastBackup,
+									lastDateAvailable,
+									selectedDate: this.getSelectedDate(),
+									timezone,
+									gmtOffset,
+									onDateChange: this.onDateChange,
+									hasRealtimeBackups,
+									realtimeBackups,
+								} }
+							/>
+							{ doesRewindNeedCredentials && (
+								<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
+							) }
+						</>
+					) }
+				</div>
 
 				{ ! isLoadingBackups && (
-					<>
-						<DailyBackupStatus
-							{ ...{
-								allowRestore,
-								siteUrl,
-								siteSlug,
-								dailyBackup: backupsOnSelectedDate.lastBackup,
-								lastDateAvailable,
-								selectedDate: this.getSelectedDate(),
-								timezone,
-								gmtOffset,
-								onDateChange: this.onDateChange,
-								hasRealtimeBackups,
-								realtimeBackups,
-							} }
-						/>
-						{ doesRewindNeedCredentials && (
-							<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
-						) }
-						<BackupDelta
-							{ ...{
-								deltas,
-								backupAttempts,
-								hasRealtimeBackups,
-								realtimeBackups,
-								allowRestore,
-								moment,
-								siteSlug,
-								metaDiff,
-							} }
-						/>
-					</>
+					<BackupDelta
+						{ ...{
+							deltas,
+							backupAttempts,
+							hasRealtimeBackups,
+							realtimeBackups,
+							allowRestore,
+							moment,
+							siteSlug,
+							metaDiff,
+						} }
+					/>
 				) }
 			</Main>
 		);

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -1,5 +1,27 @@
-.backups__page .filterbar .filterbar__wrap.card {
-    display: flex;
+.backups__page {
+	.current-section {
+		margin-bottom: 0;
+	}
+	.filterbar .filterbar__wrap.card {
+		display: flex;
+	}
+	.main {
+		padding-bottom: 0;
+	}
+}
+
+.backups__last-backup-status {
+	background: var( --studio-white );
+	margin-left: -16px;
+	margin-right: -16px;
+	padding-left: 16px;
+	padding-right: 16px;
+
+	@include breakpoint( '>660px' ) {
+		background: var( --color-surface-backdrop );
+		padding: 0;
+		margin: 0;
+	}
 }
 
 .backups__search {
@@ -8,7 +30,7 @@
 
 .backups__search-header {
     font-size: 1.3rem;
-    font-weight: 500;
+    font-weight: 400;
     margin-top: 2rem;
     margin-bottom: 0.5rem;
 }

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -29,6 +29,10 @@
 		border-width: 1px;
 	}
 
+	&[disabled]:active {
+		border-width: 1px;
+	}
+
 	&[disabled],
 	&:disabled {
 		color: var( --studio-gray-10 );
@@ -55,6 +59,7 @@
 
 	&[disabled],
 	&:disabled {
+		color: var( --studio-white );
 		background: var( --studio-gray-10 );
 		border-color: var( --studio-gray-10 );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change fixes the padding issue with the Backup Status card in the mobile view. Also, it fixes minor style issues with the disabled primary button, the color must be white.

Before:
![image](https://user-images.githubusercontent.com/9832440/80011079-3c194680-84c3-11ea-9052-fffd922dd41f.png)


After:
![image](https://user-images.githubusercontent.com/9832440/80011042-33287500-84c3-11ea-9331-fdc857311967.png)

**Next**
This is a temporal solution. We should expand the card to the bottom when we don't have elements below.

#### Testing instructions

- Apply the changes
- Check the space between the card and the screen limit, you should see white color instead gray