### PR TITLE
WordAds Settings: Add better error notice for missing PayPal

### DIFF
--- a/client/state/data-layer/wpcom/wordads/settings/index.js
+++ b/client/state/data-layer/wpcom/wordads/settings/index.js
@@ -90,13 +90,23 @@ export const handleSaveSuccess = ( { siteId } ) => [
 	} ),
 ];
 
-export const handleSaveFailure = ( { siteId, meta: { settings: previousSettings } } ) => [
+export const handleSaveFailure = ( {
+	siteId,
+	meta: { settings: previousSettings },
+	meta: {
+		dataLayer: {
+			error: { error },
+		},
+	},
+} ) => [
 	saveWordadsSettingsFailure( siteId ),
 	updateWordadsSettings( siteId, previousSettings ),
-	errorNotice( translate( 'An unexpected error occurred. Please try again later.' ), {
-		id: `wordads-notice-error-${ siteId }`,
-		duration: 5000,
-	} ),
+	errorNotice(
+		error === 'invalid_paypal'
+			? translate( 'Please enter a valid PayPal email address.' )
+			: translate( 'An unexpected error occurred. Please try again later.' ),
+		{ id: `wordads-notice-error-${ siteId }`, duration: 5000 }
+	),
 ];
 
 registerHandlers( 'state/data-layer/wpcom/wordads/settings/index.js', {

--- a/client/state/data-layer/wpcom/wordads/settings/index.js
+++ b/client/state/data-layer/wpcom/wordads/settings/index.js
@@ -92,8 +92,8 @@ export const handleSaveSuccess = ( { siteId } ) => [
 
 export const handleSaveFailure = ( {
 	siteId,
-	meta: { settings: previousSettings },
 	meta: {
+		settings: previousSettings,
 		dataLayer: {
 			error: { error },
 		},


### PR DESCRIPTION
The WordAds settings form won't save if the PayPal field isn't set. This will alert the user that they need to enter a valid PayPal email.

#### Changes proposed in this Pull Request

* Gives descriptive error for missing PayPal email.

#### Testing instructions

* Go to `Tools -> Earn -> Ad Dashboard -> Settings`.
* Delete any entry in PayPal field and try to save.
* Notice `Please enter a valid PayPal email address.` should show.
* Enter valid email address and save -> should be successful.

<img width="288" alt="Screen Shot 2020-04-22 at 1 48 56 PM" src="https://user-images.githubusercontent.com/273708/80032511-20507900-84a0-11ea-99c6-9de56e39dd25.png">

