### PR TITLE
Post-checkout: adapt the buttons in the Search Thank you modal

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -109,14 +109,7 @@ export class ThankYouCard extends Component {
 								href={ siteAdminUrl + 'customize.php?autofocus[section]=jetpack_search' }
 								onClick={ () => recordThankYouClick( 'customizer' ) }
 							>
-								{ translate( 'Customize Search now' ) }
-							</Button>
-
-							<Button
-								href={ siteAdminUrl + 'admin.php?page=jetpack#/dashboard' }
-								onClick={ () => recordThankYouClick( 'my_site' ) }
-							>
-								{ translate( 'Go back to my site' ) }
+								{ translate( 'Try Search and customize it now' ) }
 							</Button>
 						</p>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Removes wp-admin dashboard link.
* Rewords link to the customizer.

#### Testing instructions
* Go to `/plans/my-plan/:site?thank-you=&product=jetpack_search` for a connected JP site
* Verify the change in copy:
![thanku](https://user-images.githubusercontent.com/13561163/80036760-a5fd1480-84f2-11ea-8e40-fa643396dc44.png)


Fixes https://github.com/Automattic/wp-calypso/issues/41029
