### PR TITLE
Refactors upsell to use state machine API

### DIFF
--- a/client/landing/jetpack-cloud/components/upsell-switch/README.md
+++ b/client/landing/jetpack-cloud/components/upsell-switch/README.md
@@ -1,14 +1,19 @@
 # UpsellSwitch
 
-`<UpsellSwitch />` is a component to show an upsell page if a given site does not have a capability.
+`<UpsellSwitch />` is a component to show an upsell page if a given site's state is unavailable.
 
-It functions by querying the Rewind capabilities for a site and checks for a target capability. If the site does not have that capability it displays the upsell component, otherwise the children components.
+It functions by being passed a query component and function, which is used to query the site state. If the state is `unavailable`, it shows the upsell component with a `reason` passed as a prop.
 
 It is designed to be wrapped around a page like so:
 ```jsx
 const Page = (
-	<UpsellSwitch upsell={ <UpsellPage /> } targetCapability="test">
-		<ContentPage />
+	<UpsellSwitch
+		UpsellComponent={ UpsellPage }
+		QueryComponent={ QuerySite }
+		getStateForSite={ getStateBySiteId }
+		display={ <ContentPage /> }
+	>
+		<div>Loading...</div>
 	</UpsellSwitch>
 );
 ```
@@ -16,8 +21,13 @@ Alternatively, it can be inserted into a controller callback stack like so:
 ```jsx
 export function showUpsellTest( context, next ) {
 	context.primary = (
-		<UpsellSwitch upsell={ <UpsellPage /> } targetCapability="test">
-			{ context.primary }
+		<UpsellSwitch
+			UpsellComponent={ UpsellPage }
+			QueryComponent={ QuerySite }
+			getStateForSite={ getStateBySiteId }
+			display={ context.primary }
+		>
+			<div>Loading...</div>
 		</UpsellSwitch>
 	);
 	next();
@@ -37,7 +47,13 @@ page(
 ```
 ## Props
 The following props can be passed to the `<UpsellSwitch />` component:
-### `upsell`
-Required. A component to display when an upsell is required.
-### `targetCapability`
-Required. String to look for in list of site capabilities returned by API.
+### `UpsellComponent`
+Required. A component to display when an upsell is required. Will be passed `reason` as a prop, if any.
+### `QueryComponent`
+Required. A data component to query the site state.
+### `getStateForSite`
+Required. Function to pull the state of the system from the store. Should take the Redux state as the first arg, and the site ID as the second.
+### `display`
+Required. A component to display with the site has a valid status.
+### `children`
+Optional. Components to display while loading site state.

--- a/client/landing/jetpack-cloud/components/upsell-switch/README.md
+++ b/client/landing/jetpack-cloud/components/upsell-switch/README.md
@@ -1,0 +1,43 @@
+# UpsellSwitch
+
+`<UpsellSwitch />` is a component to show an upsell page if a given site does not have a capability.
+
+It functions by querying the Rewind capabilities for a site and checks for a target capability. If the site does not have that capability it displays the upsell component, otherwise the children components.
+
+It is designed to be wrapped around a page like so:
+```jsx
+const Page = (
+	<UpsellSwitch upsell={ <UpsellPage /> } targetCapability="test">
+		<ContentPage />
+	</UpsellSwitch>
+);
+```
+Alternatively, it can be inserted into a controller callback stack like so:
+```jsx
+export function showUpsellTest( context, next ) {
+	context.primary = (
+		<UpsellSwitch upsell={ <UpsellPage /> } targetCapability="test">
+			{ context.primary }
+		</UpsellSwitch>
+	);
+	next();
+}
+```
+and used in the page callbacks _after_ the page is declared:
+```js
+page(
+	'/test/:site',
+	siteSelection,
+	navigation,
+	test,
+	showUpsellTest,
+	makeLayout,
+	clientRender
+);
+```
+## Props
+The following props can be passed to the `<UpsellSwitch />` component:
+### `upsell`
+Required. A component to display when an upsell is required.
+### `targetCapability`
+Required. String to look for in list of site capabilities returned by API.

--- a/client/landing/jetpack-cloud/components/upsell-switch/index.tsx
+++ b/client/landing/jetpack-cloud/components/upsell-switch/index.tsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  */
 import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
 import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
+import JetpackLogo from 'components/jetpack-logo';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
 interface Props {
@@ -42,7 +43,13 @@ function UpsellSwitch( props: Props ): React.ReactElement {
 	}, [ siteCapabilities, targetCapability, siteId ] );
 
 	if ( isLoading ) {
-		return <QueryRewindCapabilities siteId={ siteId } />;
+		return (
+			<>
+				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+				<JetpackLogo size={ 72 } className="wpcom-site__logo" />
+				<QueryRewindCapabilities siteId={ siteId } />
+			</>
+		);
 	}
 	if ( showUpsell ) {
 		return upsell;

--- a/client/landing/jetpack-cloud/components/upsell-switch/index.tsx
+++ b/client/landing/jetpack-cloud/components/upsell-switch/index.tsx
@@ -1,68 +1,87 @@
 /**
  * External dependencies
  */
-import React, { useEffect, ReactElement, useState } from 'react';
-import { connect } from 'react-redux';
+import React, { ReactElement, useState, ReactNode, useEffect, ComponentType } from 'react';
+import { connect, DefaultRootState } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
-import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
-import JetpackLogo from 'components/jetpack-logo';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import Main from 'components/main';
 
-interface Props {
-	children: ReactElement;
-	upsell: ReactElement;
+type QueryComponentProps = {
 	siteId: number | null;
-	siteCapabilities?: string[];
-	targetCapability: string;
-}
+};
+
+type QueryFunction = ( arg0: DefaultRootState, arg1: number | null ) => SiteState;
+
+type UpsellComponentProps = {
+	reason?: string;
+};
+
+type SiteState = {
+	state: string;
+	reason?: string;
+};
+
+type Props = {
+	children: ReactNode;
+	UpsellComponent: ComponentType< UpsellComponentProps >;
+	display: ReactElement;
+	QueryComponent: ComponentType< QueryComponentProps >;
+	getStateForSite: QueryFunction;
+	siteId: number | null;
+	siteState: SiteState | null;
+};
 
 function UpsellSwitch( props: Props ): React.ReactElement {
-	const { siteCapabilities, targetCapability, upsell, children, siteId } = props;
+	const { UpsellComponent, display, children, QueryComponent, siteId, siteState } = props;
 
 	const [ { showUpsell, isLoading }, setState ] = useState( {
 		showUpsell: true,
 		isLoading: true,
 	} );
 	useEffect( () => {
-		if ( ! Array.isArray( siteCapabilities ) ) {
-			setState( {
-				showUpsell: true,
+		if ( ! siteState ) {
+			return setState( {
 				isLoading: true,
+				showUpsell: true,
 			} );
-			return;
 		}
-
-		setState( {
-			showUpsell: ! siteCapabilities.includes( targetCapability ),
+		const { state } = siteState;
+		if ( state === 'unavailable' ) {
+			return setState( {
+				isLoading: false,
+				showUpsell: true,
+			} );
+		}
+		return setState( {
 			isLoading: false,
+			showUpsell: false,
 		} );
-	}, [ siteCapabilities, targetCapability, siteId ] );
+	}, [ siteState ] );
 
 	if ( isLoading ) {
 		return (
-			<>
-				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-				<JetpackLogo size={ 72 } className="wpcom-site__logo" />
-				<QueryRewindCapabilities siteId={ siteId } />
-			</>
+			<Main className="upsell-switch__loading">
+				<QueryComponent siteId={ siteId } />
+				{ children }
+			</Main>
 		);
 	}
 	if ( showUpsell ) {
-		return upsell;
+		return <UpsellComponent reason={ siteState?.reason } />;
 	}
-	return children;
+	return display;
 }
 
-export default connect( ( state ) => {
+export default connect( ( state, ownProps: Props ) => {
 	const siteId = getSelectedSiteId( state );
-	const siteCapabilities = getRewindCapabilities( state, siteId );
+	const siteState = ownProps.getStateForSite( state, siteId );
 
 	return {
 		siteId,
-		siteCapabilities,
+		siteState,
 	};
 } )( UpsellSwitch );

--- a/client/landing/jetpack-cloud/components/upsell-switch/index.tsx
+++ b/client/landing/jetpack-cloud/components/upsell-switch/index.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, ReactElement, useState } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import QueryRewindCapabilities from 'components/data/query-rewind-capabilities';
+import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+interface Props {
+	children: ReactElement;
+	upsell: ReactElement;
+	siteId: number | null;
+	siteCapabilities?: string[];
+	targetCapability: string;
+}
+
+function UpsellSwitch( props: Props ): React.ReactElement {
+	const { siteCapabilities, targetCapability, upsell, children, siteId } = props;
+
+	const [ { showUpsell, isLoading }, setState ] = useState( {
+		showUpsell: true,
+		isLoading: true,
+	} );
+	useEffect( () => {
+		if ( ! Array.isArray( siteCapabilities ) ) {
+			setState( {
+				showUpsell: true,
+				isLoading: true,
+			} );
+			return;
+		}
+
+		setState( {
+			showUpsell: ! siteCapabilities.includes( targetCapability ),
+			isLoading: false,
+		} );
+	}, [ siteCapabilities, targetCapability, siteId ] );
+
+	if ( isLoading ) {
+		return <QueryRewindCapabilities siteId={ siteId } />;
+	}
+	if ( showUpsell ) {
+		return upsell;
+	}
+	return children;
+}
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteCapabilities = getRewindCapabilities( state, siteId );
+
+	return {
+		siteId,
+		siteCapabilities,
+	};
+} )( UpsellSwitch );

--- a/client/landing/jetpack-cloud/sections/scan/controller.js
+++ b/client/landing/jetpack-cloud/sections/scan/controller.js
@@ -10,11 +10,20 @@ import UpsellSwitch from 'landing/jetpack-cloud/components/upsell-switch';
 import ScanPage from './main';
 import ScanHistoryPage from './history';
 import ScanUpsellPage from './upsell';
+import getSiteScanState from 'state/selectors/get-site-scan-state';
+import QueryJetpackScan from 'components/data/query-jetpack-scan';
 
 export function showUpsellIfNoScan( context, next ) {
 	context.primary = (
-		<UpsellSwitch upsell={ <ScanUpsellPage /> } targetCapability="scan">
-			{ context.primary }
+		<UpsellSwitch
+			UpsellComponent={ ScanUpsellPage }
+			display={ context.primary }
+			getStateForSite={ getSiteScanState }
+			QueryComponent={ QueryJetpackScan }
+		>
+			<div className="scan__content">
+				<div className="scan__is-loading" />
+			</div>
 		</UpsellSwitch>
 	);
 	next();

--- a/client/landing/jetpack-cloud/sections/scan/controller.js
+++ b/client/landing/jetpack-cloud/sections/scan/controller.js
@@ -11,21 +11,22 @@ import ScanPage from './main';
 import ScanHistoryPage from './history';
 import ScanUpsellPage from './upsell';
 
-export function scan( context, next ) {
+export function showUpsellIfNoScan( context, next ) {
 	context.primary = (
 		<UpsellSwitch upsell={ <ScanUpsellPage /> } targetCapability="scan">
-			<ScanPage />
+			{ context.primary }
 		</UpsellSwitch>
 	);
 	next();
 }
 
+export function scan( context, next ) {
+	context.primary = <ScanPage />;
+	next();
+}
+
 export function scanHistory( context, next ) {
 	const { filter } = context.params;
-	context.primary = (
-		<UpsellSwitch upsell={ <ScanUpsellPage /> } targetCapability="scan">
-			<ScanHistoryPage filter={ filter } />
-		</UpsellSwitch>
-	);
+	context.primary = <ScanHistoryPage filter={ filter } />;
 	next();
 }

--- a/client/landing/jetpack-cloud/sections/scan/controller.js
+++ b/client/landing/jetpack-cloud/sections/scan/controller.js
@@ -11,22 +11,21 @@ import ScanPage from './main';
 import ScanHistoryPage from './history';
 import ScanUpsellPage from './upsell';
 
-export function showUpsellIfNoScan( context, next ) {
+export function scan( context, next ) {
 	context.primary = (
 		<UpsellSwitch upsell={ <ScanUpsellPage /> } targetCapability="scan">
-			{ context.primary }
+			<ScanPage />
 		</UpsellSwitch>
 	);
 	next();
 }
 
-export function scan( context, next ) {
-	context.primary = <ScanPage />;
-	next();
-}
-
 export function scanHistory( context, next ) {
 	const { filter } = context.params;
-	context.primary = <ScanHistoryPage filter={ filter } />;
+	context.primary = (
+		<UpsellSwitch upsell={ <ScanUpsellPage /> } targetCapability="scan">
+			<ScanHistoryPage filter={ filter } />
+		</UpsellSwitch>
+	);
 	next();
 }

--- a/client/landing/jetpack-cloud/sections/scan/controller.js
+++ b/client/landing/jetpack-cloud/sections/scan/controller.js
@@ -2,49 +2,22 @@
  * External dependencies
  */
 import React from 'react';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import UpsellSwitch from 'landing/jetpack-cloud/components/upsell-switch';
 import ScanPage from './main';
 import ScanHistoryPage from './history';
 import ScanUpsellPage from './upsell';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSitePurchases } from 'state/purchases/selectors';
-import { JETPACK_SCAN_PRODUCTS, PRODUCT_JETPACK_SCAN } from 'lib/products-values/constants';
-import { getPlan, planHasFeature } from 'lib/plans';
-import { fetchSitePurchases } from 'state/purchases/actions';
-import { makeLayout, render as clientRender } from 'controller';
 
 export function showUpsellIfNoScan( context, next ) {
-	const getState = context.store.getState;
-	const dispatch = context.store.dispatch;
-	const siteId = getSelectedSiteId( getState() );
-	let purchases = getSitePurchases( getState(), siteId );
-
-	const showUpsellOrNext = () => {
-		const hasScan = purchases.find(
-			( purchase ) =>
-				JETPACK_SCAN_PRODUCTS.includes( purchase.productSlug ) ||
-				( getPlan( purchase.productSlug ) &&
-					planHasFeature( purchase.productSlug, PRODUCT_JETPACK_SCAN ) )
-		);
-		if ( hasScan ) {
-			return next();
-		}
-		context.primary = <ScanUpsellPage />;
-		makeLayout( context, noop );
-		clientRender( context );
-	};
-
-	if ( purchases.length ) {
-		return showUpsellOrNext();
-	}
-	dispatch( fetchSitePurchases( siteId ) ).then( () => {
-		purchases = getSitePurchases( getState(), siteId );
-		showUpsellOrNext();
-	} );
+	context.primary = (
+		<UpsellSwitch upsell={ <ScanUpsellPage /> } targetCapability="scan">
+			{ context.primary }
+		</UpsellSwitch>
+	);
+	next();
 }
 
 export function scan( context, next ) {

--- a/client/landing/jetpack-cloud/sections/scan/index.js
+++ b/client/landing/jetpack-cloud/sections/scan/index.js
@@ -23,8 +23,8 @@ export default function () {
 			'/scan/:site',
 			siteSelection,
 			navigation,
-			showUpsellIfNoScan,
 			scan,
+			showUpsellIfNoScan,
 			makeLayout,
 			clientRender
 		);
@@ -34,8 +34,8 @@ export default function () {
 				'/scan/history/:site/:filter?',
 				siteSelection,
 				navigation,
-				showUpsellIfNoScan,
 				scanHistory,
+				showUpsellIfNoScan,
 				makeLayout,
 				clientRender
 			);

--- a/client/landing/jetpack-cloud/sections/scan/index.js
+++ b/client/landing/jetpack-cloud/sections/scan/index.js
@@ -10,24 +10,12 @@ import config from 'config';
 
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
-import {
-	showUpsellIfNoScan,
-	scan,
-	scanHistory,
-} from 'landing/jetpack-cloud/sections/scan/controller';
+import { scan, scanHistory } from 'landing/jetpack-cloud/sections/scan/controller';
 
 export default function () {
 	if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
 		page( '/scan', siteSelection, sites, navigation, makeLayout, clientRender );
-		page(
-			'/scan/:site',
-			siteSelection,
-			navigation,
-			scan,
-			showUpsellIfNoScan,
-			makeLayout,
-			clientRender
-		);
+		page( '/scan/:site', siteSelection, navigation, scan, makeLayout, clientRender );
 
 		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
 			page(
@@ -35,7 +23,6 @@ export default function () {
 				siteSelection,
 				navigation,
 				scanHistory,
-				showUpsellIfNoScan,
 				makeLayout,
 				clientRender
 			);

--- a/client/landing/jetpack-cloud/sections/scan/index.js
+++ b/client/landing/jetpack-cloud/sections/scan/index.js
@@ -10,12 +10,24 @@ import config from 'config';
 
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
-import { scan, scanHistory } from 'landing/jetpack-cloud/sections/scan/controller';
+import {
+	showUpsellIfNoScan,
+	scan,
+	scanHistory,
+} from 'landing/jetpack-cloud/sections/scan/controller';
 
 export default function () {
 	if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
 		page( '/scan', siteSelection, sites, navigation, makeLayout, clientRender );
-		page( '/scan/:site', siteSelection, navigation, scan, makeLayout, clientRender );
+		page(
+			'/scan/:site',
+			siteSelection,
+			navigation,
+			scan,
+			showUpsellIfNoScan,
+			makeLayout,
+			clientRender
+		);
 
 		if ( config.isEnabled( 'jetpack-cloud/scan-history' ) ) {
 			page(
@@ -23,6 +35,7 @@ export default function () {
 				siteSelection,
 				navigation,
 				scanHistory,
+				showUpsellIfNoScan,
 				makeLayout,
 				clientRender
 			);

--- a/client/state/selectors/get-rewind-capabilities.js
+++ b/client/state/selectors/get-rewind-capabilities.js
@@ -1,8 +1,3 @@
-/**
- * External Dependencies
- */
-import { get } from 'lodash';
-
 export default function getRewindCapabilities( state, siteId ) {
-	return get( state, [ 'rewind', siteId, 'capabilities' ], [] );
+	return state?.rewind?.[ siteId ]?.capabilities;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This changes the scan upsell logic to use a new flexible upsell component.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In Jetpack, load a site _with_ Scan and observe if it loads.
* Check Scan History as well.
* Load site without Scan and see if upsell displays.

Fixes 1151678672052943-as-1172451663334993.