### PR TITLE
Gutenboarding: don't allow empty confirm in domain picker

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -75,6 +75,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		select( STORE_KEY ).getState()
 	);
 	const { setDomainSearch, setDomainCategory } = useDispatch( STORE_KEY );
+	const [ currentSelection, setCurrentSelection ] = useState( currentDomain );
 
 	const allSuggestions = useDomainSuggestions( { locale: i18nLocale } );
 	const freeSuggestions = getFreeDomainSuggestions( allSuggestions );
@@ -91,7 +92,10 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				className="domain-picker__confirm-button"
 				isPrimary
 				disabled={ ! hasSuggestions }
-				onClick={ onClose }
+				onClick={ () => {
+					currentSelection && onDomainSelect( currentSelection );
+					onClose();
+				} }
 				{ ...props }
 			>
 				{ __( 'Confirm' ) }
@@ -111,23 +115,23 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	useEffect( () => {
 		if (
 			freeSuggestions &&
-			currentDomain?.is_free === true &&
-			currentDomain?.domain_name !== freeSuggestions[ 0 ].domain_name
+			currentSelection?.is_free === true &&
+			currentSelection?.domain_name !== freeSuggestions[ 0 ].domain_name
 		) {
-			onDomainSelect( freeSuggestions[ 0 ] );
+			setCurrentSelection( freeSuggestions[ 0 ] );
 		}
 
 		if (
 			paidSuggestions &&
 			recommendedSuggestion &&
-			currentDomain?.is_free !== true &&
+			currentSelection?.is_free !== true &&
 			! paidSuggestions.find(
-				( suggestion ) => suggestion.domain_name === currentDomain?.domain_name
+				( suggestion ) => suggestion.domain_name === currentSelection?.domain_name
 			)
 		) {
-			onDomainSelect( recommendedSuggestion );
+			setCurrentSelection( recommendedSuggestion );
 		}
-	}, [ currentDomain, freeSuggestions, onDomainSelect, paidSuggestions, recommendedSuggestion ] );
+	}, [ currentSelection, freeSuggestions, paidSuggestions, recommendedSuggestion ] );
 
 	useTrackModal( 'DomainPicker' );
 
@@ -168,8 +172,10 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								( freeSuggestions.length ? (
 									<SuggestionItem
 										suggestion={ freeSuggestions[ 0 ] }
-										isSelected={ currentDomain?.domain_name === freeSuggestions[ 0 ].domain_name }
-										onSelect={ onDomainSelect }
+										isSelected={
+											currentSelection?.domain_name === freeSuggestions[ 0 ].domain_name
+										}
+										onSelect={ setCurrentSelection }
 										railcarId={ railcarId ? `${ railcarId }0` : undefined }
 										recordAnalytics={ recordAnalytics || undefined }
 										uiPosition={ 0 }
@@ -187,10 +193,10 @@ const DomainPicker: FunctionComponent< Props > = ( {
 										<SuggestionItem
 											suggestion={ suggestion }
 											isRecommended={ suggestion === recommendedSuggestion }
-											isSelected={ currentDomain?.domain_name === suggestion.domain_name }
-											onSelect={ onDomainSelect }
+											isSelected={ currentSelection?.domain_name === suggestion.domain_name }
+											onSelect={ setCurrentSelection }
 											key={ suggestion.domain_name }
-											railcarId={ railcarId ? `${ railcarId }${ i + 1 }` : undefined }
+											railcarId={ railcarId ? `${ railcarId }${ i + 1}` : undefined }
 											recordAnalytics={ recordAnalytics || undefined }
 											uiPosition={ i + 1 }
 										/>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -113,25 +113,27 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	}, [ allSuggestions ] );
 
 	useEffect( () => {
-		if (
-			freeSuggestions &&
-			currentSelection?.is_free === true &&
-			currentSelection?.domain_name !== freeSuggestions[ 0 ].domain_name
-		) {
-			setCurrentSelection( freeSuggestions[ 0 ] );
-		}
+		// Auto-select one of the domains when the search results change. If the currently
+		// confirmed domain is in the search results then select it. The user probably
+		// re-ran their previous query. Otherwise select the free domain suggestion.
 
 		if (
-			paidSuggestions &&
-			recommendedSuggestion &&
-			currentSelection?.is_free !== true &&
-			! paidSuggestions.find(
-				( suggestion ) => suggestion.domain_name === currentSelection?.domain_name
+			allSuggestions?.find(
+				( suggestion ) => currentDomain?.domain_name === suggestion.domain_name
 			)
 		) {
-			setCurrentSelection( recommendedSuggestion );
+			setCurrentSelection( currentDomain );
+			return;
 		}
-	}, [ currentSelection, freeSuggestions, paidSuggestions, recommendedSuggestion ] );
+
+		// Recalculate free-domain suggestions inside the closure. `getFreeDomainSuggestions()`
+		// always returns a new object so it can't be used in `useEffects()` dependencies list.
+		const latestFreeSuggestion = getFreeDomainSuggestions( allSuggestions );
+
+		if ( latestFreeSuggestion ) {
+			setCurrentSelection( latestFreeSuggestion[ 0 ] );
+		}
+	}, [ allSuggestions, currentDomain ] );
 
 	useTrackModal( 'DomainPicker' );
 

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -4,7 +4,7 @@
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { Button, Panel, PanelBody, PanelRow, TextControl, Icon } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { times, find } from 'lodash';
+import { times } from 'lodash';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
@@ -107,17 +107,23 @@ const DomainPicker: FunctionComponent< Props > = ( {
 			setRailcarId( getNewRailcarId() );
 		}
 
-		if ( freeSuggestions && recommendedSuggestion ) {
-			if ( currentDomain?.is_free === true && currentDomain?.domain_name !== freeSuggestions[ 0 ].domain_name ) {
+		if ( freeSuggestions && recommendedSuggestion && paidSuggestions ) {
+			if (
+				currentDomain?.is_free === true &&
+				currentDomain?.domain_name !== freeSuggestions[ 0 ].domain_name
+			) {
 				onDomainSelect( freeSuggestions[ 0 ] );
 			}
 
-			if ( currentDomain?.is_free !== true && ! find( paidSuggestions, ['domain_name', currentDomain?.domain_name ] ) ) {
-				// but if it's not free, select the corresponding recommended?
+			if (
+				currentDomain?.is_free !== true &&
+				! paidSuggestions.find(
+					( suggestion ) => suggestion.domain_name === currentDomain?.domain_name
+				)
+			) {
 				onDomainSelect( recommendedSuggestion );
 			}
 		}
-
 	}, [ allSuggestions ] );
 
 	useTrackModal( 'DomainPicker' );

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -198,7 +198,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 											isSelected={ currentSelection?.domain_name === suggestion.domain_name }
 											onSelect={ setCurrentSelection }
 											key={ suggestion.domain_name }
-											railcarId={ railcarId ? `${ railcarId }${ i + 1}` : undefined }
+											railcarId={ railcarId ? `${ railcarId }${ i + 1 }` : undefined }
 											recordAnalytics={ recordAnalytics || undefined }
 											uiPosition={ i + 1 }
 										/>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -4,7 +4,7 @@
 import React, { FunctionComponent, useState, useEffect } from 'react';
 import { Button, Panel, PanelBody, PanelRow, TextControl, Icon } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { times } from 'lodash';
+import { times, find } from 'lodash';
 import { useI18n } from '@automattic/react-i18n';
 
 /**
@@ -106,6 +106,18 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		if ( allSuggestions ) {
 			setRailcarId( getNewRailcarId() );
 		}
+
+		if ( freeSuggestions && recommendedSuggestion ) {
+			if ( currentDomain?.is_free === true && currentDomain?.domain_name !== freeSuggestions[ 0 ].domain_name ) {
+				onDomainSelect( freeSuggestions[ 0 ] );
+			}
+
+			if ( currentDomain?.is_free !== true && ! find( paidSuggestions, ['domain_name', currentDomain?.domain_name ] ) ) {
+				// but if it's not free, select the corresponding recommended?
+				onDomainSelect( recommendedSuggestion );
+			}
+		}
+
 	}, [ allSuggestions ] );
 
 	useTrackModal( 'DomainPicker' );

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -127,7 +127,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		}
 
 		// Recalculate free-domain suggestions inside the closure. `getFreeDomainSuggestions()`
-		// always returns a new object so it can't be used in `useEffects()` dependencies list.
+		// always returns a new object so it shouldn't be used in `useEffects()` dependencies list.
 		const latestFreeSuggestion = getFreeDomainSuggestions( allSuggestions );
 
 		if ( latestFreeSuggestion ) {

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -106,25 +106,28 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		if ( allSuggestions ) {
 			setRailcarId( getNewRailcarId() );
 		}
-
-		if ( freeSuggestions && recommendedSuggestion && paidSuggestions ) {
-			if (
-				currentDomain?.is_free === true &&
-				currentDomain?.domain_name !== freeSuggestions[ 0 ].domain_name
-			) {
-				onDomainSelect( freeSuggestions[ 0 ] );
-			}
-
-			if (
-				currentDomain?.is_free !== true &&
-				! paidSuggestions.find(
-					( suggestion ) => suggestion.domain_name === currentDomain?.domain_name
-				)
-			) {
-				onDomainSelect( recommendedSuggestion );
-			}
-		}
 	}, [ allSuggestions ] );
+
+	useEffect( () => {
+		if (
+			freeSuggestions &&
+			currentDomain?.is_free === true &&
+			currentDomain?.domain_name !== freeSuggestions[ 0 ].domain_name
+		) {
+			onDomainSelect( freeSuggestions[ 0 ] );
+		}
+
+		if (
+			paidSuggestions &&
+			recommendedSuggestion &&
+			currentDomain?.is_free !== true &&
+			! paidSuggestions.find(
+				( suggestion ) => suggestion.domain_name === currentDomain?.domain_name
+			)
+		) {
+			onDomainSelect( recommendedSuggestion );
+		}
+	}, [ currentDomain, freeSuggestions, onDomainSelect, paidSuggestions, recommendedSuggestion ] );
 
 	useTrackModal( 'DomainPicker' );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Searching for a specific domain in the domain picker (free or paid) returns a list of results complete with radio buttons. 

The confirm buttons stands ready to smash, though no input is select.

This change makes sure one of the radio buttons is selected after the domain search.

* `<DomainPickerPopover>` doesn't update the current domain until the user clicks "Confirm"
* After searching, the free domain is the default radio button selection https://github.com/Automattic/wp-calypso/issues/40885#issuecomment-610840787 (but it won't be confirmed yet)
* If the search results contain the confirmed domain (the one stored in the onboarding store) then that's the better default selection.

![Animation of user searching from domain names using popover](https://user-images.githubusercontent.com/1500769/80445247-e2ec5f80-8967-11ea-904c-ccbcc50ce78e.gif)

## Testing instructions

* Fire up the branch and head to `/new`
* Create a site, filling in the vertical _and_ title (see known issue)
* Search for some domains in the domain picker.
* Confirm button should be disabled while loading results
* Domain isn't updated until confirm button is clicked (the selected domain is the one in the header, not the popover)
* After each search one of the radio buttons should be selected
  * If the search results contain the domain from the store then it should be auto-selected (this situation happens most naturally when you clear the search field)
  * Otherwise the free domain should be selected https://github.com/Automattic/wp-calypso/issues/40885#issuecomment-610840787

### Known issue

If no title was filled in during intent gathering, then the popover auto-closes when you type in the search box. This bug exists on `master` too.

Fixes #40885 (maybe)
