### PR TITLE
Remove margin-left override on block-editor-inserter__toggle in wpcom-block-editor

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
@@ -45,16 +45,3 @@ body.is-fullscreen-mode {
 .components-notice-list {
 	z-index: 29; // Ensure notices are placed behind the editor header (z-index: 30).
 }
-
-// The parent element .edit-post-header__toolbar provides
-// a padding-left of 24px. However, the right side of the header
-// only has a padding-right of 16px.
-//
-// To make the toolbar buttons look more balanced, an left offset of -8px
-// is added to this custom block inserter button (24px - 16px = 8px). This
-// -8px offset also contributes in solving spacing issue in mobile/tablet view.
-//
-// Specific to Gutenberg >= 7.7.
-.block-editor-editor-skeleton__header .block-editor-inserter__toggle {
-	margin-left: -8px;
-}


### PR DESCRIPTION
This removes the left margin override on the block inserter in the header within the editor (The big plus button), which should return the alignment to match what's in core, and also resolve a mobile styling issue with this button.

### Before

#### Mobile

![image](https://user-images.githubusercontent.com/14988353/80059047-45132200-856e-11ea-8da4-7aab56cc25ac.png)

#### Desktop

![image](https://user-images.githubusercontent.com/14988353/80061436-9cb48c00-8574-11ea-81e9-621e1dbb1f7f.png)

### After

#### Mobile

![image](https://user-images.githubusercontent.com/14988353/80060612-5827f100-8572-11ea-8c35-b692d99c95c9.png)

#### Desktop

![image](https://user-images.githubusercontent.com/14988353/80061473-bc4bb480-8574-11ea-9cc0-ae397dfa6d4b.png)

#### Changes proposed in this Pull Request

* Remove margin-left override on `. block-editor-inserter__toggle` in wpcom-block-editor as requested in https://github.com/Automattic/wp-calypso/pull/40361#issuecomment-617685289

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build and sync to your sandbox, or sandbox D42316-code (a pre-generated build)
* Sandbox your test site and widgets.wp.com
* Go to your test site in the block editor in Calypso, e.g. https://wordpress.com/block-editor/post/andysgutenbergedgetestsite.wordpress.com/243 and ensure the spacing looks like in the screenshots above (a little more margin for the plus button in the header)
* Go to the same page in wp-admin (e.g. https://andysgutenbergedgetestsite.wordpress.com/wp-admin/post.php?post=243&action=edit ) and ensure that the button margin remains the same
* As above but with a dotcom-fse site, ensure that the spacing looks okay, e.g.

![image](https://user-images.githubusercontent.com/14988353/80061653-4267fb00-8575-11ea-806f-34ab4fc0dab4.png)

Fixes #41386 
