### PR TITLE
Deduplicate eslint-config-prettier

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8973,17 +8973,10 @@ escodegen@^1.11.1, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^6.10.0:
+eslint-config-prettier@^6.10.0, eslint-config-prettier@^6.9.0:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz#129ef9ec575d5ddc0e269667bf09defcd898642a"
   integrity sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==
-  dependencies:
-    get-stdin "^6.0.0"
-
-eslint-config-prettier@^6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.9.0.tgz#430d24822e82f7deb1e22a435bfa3999fae4ad64"
-  integrity sha512-k4E14HBtcLv0uqThaI6I/n1LEqROp8XaPu6SO9Z32u5NlGRC07Enu1Bh2KEFw4FNHbekH8yzbIU9kUGxbiGmCA==
   dependencies:
     get-stdin "^6.0.0"
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate eslint-config-prettier, automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< master
> branch
---
< wp-calypso-monorepo@0.17.0 eslint-config-prettier@6.9.0
< wp-calypso-monorepo@0.17.0 eslint-config-prettier@6.9.0 get-stdin@6.0.0
---
> wp-calypso-monorepo@0.17.0 eslint-config-prettier@6.10.1
> wp-calypso-monorepo@0.17.0 eslint-config-prettier@6.10.1 get-stdin@6.0.0
```