### PR TITLE
Deduplicate webpack-cli

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -21867,7 +21867,7 @@ webpack-bundle-analyzer@^3.6.1, webpack-bundle-analyzer@^3.7.0:
     opener "^1.5.1"
     ws "^6.0.0"
 
-webpack-cli@3.3.10, webpack-cli@^3.3.10:
+webpack-cli@3.3.10:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.10.tgz#17b279267e9b4fb549023fae170da8e6e766da13"
   integrity sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==
@@ -21884,7 +21884,7 @@ webpack-cli@3.3.10, webpack-cli@^3.3.10:
     v8-compile-cache "2.0.3"
     yargs "13.2.4"
 
-webpack-cli@^3.3.11:
+webpack-cli@^3.3.10, webpack-cli@^3.3.11:
   version "3.3.11"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.11.tgz#3bf21889bf597b5d82c38f215135a411edfdc631"
   integrity sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `webpack-cli`, done automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< master
> branch
---
< wp-calypso-monorepo@0.17.0 -> webpack-cli@3.3.10
> wp-calypso-monorepo@0.17.0 -> webpack-cli@3.3.11
```