### PR TITLE
Set Universal Text Styles more specific. Move it into .theme-jetpack-cloud

### DIFF
--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -4,6 +4,39 @@
 		box-sizing: border-box;
 		padding-left: 16px;
 		padding-right: 16px;
+
+		// Universal Text Styles
+		h2 {
+			font-size: 22px;
+			font-weight: 700;
+			line-height: 32px;
+
+			@include breakpoint( '>660px' ) {
+				font-size: 36px;
+				line-height: 40px;
+			}
+		}
+
+		h3 {
+			font-size: 16px;
+			font-weight: 700;
+			line-height: 23px;
+
+			@include breakpoint( '>660px' ) {
+				font-size: 18px;
+				line-height: 23px;
+			}
+		}
+
+		p {
+			font-size: 16px;
+			line-height: 24px;
+
+			@include breakpoint( '>660px' ) {
+				font-size: 18px;
+				line-height: 24px;
+			}
+		}
 	}
 
 	.current-section {
@@ -163,40 +196,6 @@
 
 	&:active {
 		color: var( --color-scary-60 );
-	}
-}
-
-// Universal Text Styles
-
-h2 {
-	font-size: 22px;
-	font-weight: 700;
-	line-height: 32px;
-
-	@include breakpoint( '>660px' ) {
-		font-size: 36px;
-		line-height: 40px;
-	}
-}
-
-h3 {
-	font-size: 16px;
-	font-weight: 700;
-	line-height: 23px;
-
-	@include breakpoint( '>660px' ) {
-		font-size: 18px;
-		line-height: 23px;
-	}
-}
-
-p {
-	font-size: 16px;
-	line-height: 24px;
-
-	@include breakpoint( '>660px' ) {
-		font-size: 18px;
-		line-height: 24px;
 	}
 }
 

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -4,39 +4,6 @@
 		box-sizing: border-box;
 		padding-left: 16px;
 		padding-right: 16px;
-
-		// Universal Text Styles
-		h2 {
-			font-size: 22px;
-			font-weight: 600;
-			line-height: 32px;
-
-			@include breakpoint( '>660px' ) {
-				font-size: 36px;
-				line-height: 40px;
-			}
-		}
-
-		h3 {
-			font-size: 16px;
-			font-weight: 600;
-			line-height: 23px;
-
-			@include breakpoint( '>660px' ) {
-				font-size: 18px;
-				line-height: 23px;
-			}
-		}
-
-		p {
-			font-size: 16px;
-			line-height: 24px;
-
-			@include breakpoint( '>660px' ) {
-				font-size: 18px;
-				line-height: 24px;
-			}
-		}
 	}
 
 	.current-section {
@@ -196,6 +163,40 @@
 
 	&:active {
 		color: var( --color-scary-60 );
+	}
+}
+
+// Universal Text Styles
+
+html h2 {
+	font-size: 22px;
+	font-weight: 600;
+	line-height: 32px;
+
+	@include breakpoint( '>660px' ) {
+		font-size: 36px;
+		line-height: 40px;
+	}
+}
+
+html h3 {
+	font-size: 16px;
+	font-weight: 600;
+	line-height: 23px;
+
+	@include breakpoint( '>660px' ) {
+		font-size: 18px;
+		line-height: 23px;
+	}
+}
+
+html p {
+	font-size: 16px;
+	line-height: 24px;
+
+	@include breakpoint( '>660px' ) {
+		font-size: 18px;
+		line-height: 24px;
 	}
 }
 

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -8,7 +8,7 @@
 		// Universal Text Styles
 		h2 {
 			font-size: 22px;
-			font-weight: 700;
+			font-weight: 600;
 			line-height: 32px;
 
 			@include breakpoint( '>660px' ) {
@@ -19,7 +19,7 @@
 
 		h3 {
 			font-size: 16px;
-			font-weight: 700;
+			font-weight: 600;
 			line-height: 23px;
 
 			@include breakpoint( '>660px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Set the Universal Text Styles introduced by Caleb more specific, so let's move it inside of `.theme-jetpack-cloud` class. Currently, they don't work well because is less specific in the inheritance of CSS.

#### Testing instructions

- Apply changes
- Now you can use the text styles `h2`, `h3` and `p` without problems
