### PR TITLE
Try/e2e coblocks 1 23 0

### DIFF
--- a/test/e2e/specs/remove-me.txt
+++ b/test/e2e/specs/remove-me.txt
@@ -1,0 +1,1 @@
+Remove this file

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -256,7 +256,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 	} );
 
-	describe.only( 'Password Protected Pages: @parallel', function () {
+	describe( 'Password Protected Pages: @parallel', function () {
 		const pageTitle = dataHelper.randomPhrase();
 		const pageQuote =
 			'If you don’t like something, change it. If you can’t change it, change the way you think about it.\n— Mary Engelbreit';

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -256,7 +256,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 	} );
 
-	describe( 'Password Protected Pages: @parallel', function () {
+	describe.only( 'Password Protected Pages: @parallel', function () {
 		const pageTitle = dataHelper.randomPhrase();
 		const pageQuote =
 			'If you don’t like something, change it. If you can’t change it, change the way you think about it.\n— Mary Engelbreit';


### PR DESCRIPTION
This superceeds https://github.com/Automattic/wp-calypso/pull/41174 (i accidentally closed the other PR - sorry!).

See #40598.

The aim is to run the e2e tests against the latest CoBlocks against Gutenberg Edge. We are applying the label to trigger runs against Gutenberg Edge.

# ⚠️ Warning

If this PR changes to become mergeable then please ensure that the following file is removed

`test/e2e/specs/remove-me.txt`


#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
