### PR TITLE
Jetpack Cloud: Remove fix all threat button if there is nothing to fix

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -45,6 +45,9 @@ const ScanThreats = ( { site, threats }: Props ) => {
 	);
 	const dispatch = useDispatch();
 
+	const allFixableThreats = threats.filter( ( threat ) => threat.fixable );
+	const hasFixableThreats = !! allFixableThreats.length;
+
 	const openFixAllThreatsDialog = React.useCallback( () => {
 		dispatch(
 			recordTracksEvent( `calypso_scan_all_threats_dialog_open`, {
@@ -96,10 +99,10 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		dispatch(
 			recordTracksEvent( `calypso_scan_all_threats_fix`, {
 				site_id: site.ID,
-				threats_number: threats.length,
+				threats_number: allFixableThreats.length,
 			} )
 		);
-		threats.forEach( ( threat ) => {
+		allFixableThreats.forEach( ( threat ) => {
 			dispatch( fixThreatAlert( site.ID, threat.id ) );
 		} );
 		setShowFixAllThreatsDialog( false );
@@ -130,7 +133,13 @@ const ScanThreats = ( { site, threats }: Props ) => {
 					'Please review them below and take action. We are {{a}}here to help{{/a}} if you need us.',
 					{
 						components: {
-							a: <a href={ contactSupportUrl( site.URL ) } />,
+							a: (
+								<a
+									href={ contactSupportUrl( site.URL ) }
+									rel="noopener noreferrer"
+									target="_blank"
+								/>
+							),
 						},
 						comment: 'The {{a}} tag is a link that goes to a contact support page.',
 					}
@@ -138,21 +147,16 @@ const ScanThreats = ( { site, threats }: Props ) => {
 			</p>
 			<div className="scan-threats__threats">
 				<div className="scan-threats__buttons">
-					<Button
-						primary
-						className="scan-threats__fix-all-threats-button"
-						onClick={ openFixAllThreatsDialog }
-						disabled={ fixingThreats.length === threats.length }
-					>
-						{ translate( 'Fix all' ) }
-					</Button>
-					<Button
-						className="scan-threats__options-button"
-						onClick={ openFixAllThreatsDialog }
-						disabled={ fixingThreats.length === threats.length }
-					>
-						...
-					</Button>
+					{ hasFixableThreats && (
+						<Button
+							primary
+							className="scan-threats__fix-all-threats-button"
+							onClick={ openFixAllThreatsDialog }
+							disabled={ fixingThreats.length === threats.length }
+						>
+							{ translate( 'Fix all' ) }
+						</Button>
+					) }
 				</div>
 				{ threats.map( ( threat ) => (
 					<ThreatItem
@@ -161,6 +165,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 						onFixThreat={ () => openDialog( 'fix', threat ) }
 						onIgnoreThreat={ () => openDialog( 'ignore', threat ) }
 						isFixing={ !! fixingThreats.find( ( t ) => t.id === threat.id ) }
+						contactSupportUrl={ contactSupportUrl( site.URL ) }
 					/>
 				) ) }
 			</div>
@@ -176,7 +181,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 				/>
 			) }
 			<FixAllThreatsDialog
-				threats={ threats }
+				threats={ allFixableThreats }
 				showDialog={ showFixAllThreatsDialog }
 				siteId={ site.ID }
 				onCloseDialog={ () => setShowFixAllThreatsDialog( false ) }

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -25,6 +25,7 @@ interface Props {
 	onFixThreat?: Function;
 	onIgnoreThreat?: Function;
 	isFixing: boolean;
+	contactSupportUrl?: string;
 }
 
 class ThreatItem extends Component< Props > {
@@ -78,13 +79,13 @@ class ThreatItem extends Component< Props > {
 	}
 
 	getThreatFix(): i18nCalypso.TranslateResult {
-		const { threat } = this.props;
+		const { threat, contactSupportUrl } = this.props;
 		if ( ! threat.fixable ) {
 			return translate(
 				'Jetpack Scan cannot automatically fix this threat. Please {{link}}contact us{{/link}} for help.',
 				{
 					components: {
-						link: <a href="https://jetpack.com/contact-support/" />,
+						link: <a href={ contactSupportUrl } rel="noopener noreferrer" target="_blank" />,
 					},
 				}
 			);

--- a/client/state/selectors/get-jetpack-credentials.js
+++ b/client/state/selectors/get-jetpack-credentials.js
@@ -4,5 +4,9 @@
 import { get } from 'lodash';
 
 export default function getJetpackCredentials( state, siteId, role ) {
+	const scanCredentials = get( state, [ 'jetpackScan', 'scan', siteId, 'credentials' ], false );
+	if ( scanCredentials ) {
+		return scanCredentials.filter( ( credential ) => credential.role === role );
+	}
 	return get( state, [ 'jetpack', 'credentials', 'items', siteId, role ], {} );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* This PR removes the fix all threat button if there is no threats to fix. 
* It also make sure that we only try to fix only the threats that are fixable. 
* It also removed the ... button since it s not used yet. cc @keoshi what should happen when you click on that button?
* It removed how we get the credentials form. It shouldn't be there if the credentials are set. 
* It also updates the contact us links. 

Before:
<img width="838" alt="Screen Shot 2020-04-23 at 2 21 07 PM" src="https://user-images.githubusercontent.com/115071/80098746-aedefc00-856d-11ea-9a50-7d2e2e161fd0.png">

After:
<img width="804" alt="Screen Shot 2020-04-23 at 2 02 51 PM" src="https://user-images.githubusercontent.com/115071/80098679-953db480-856d-11ea-8d6e-884b25d82f54.png">

#### Testing instructions

* On a site that only has threats that can't be fixed. Do not show the "Fix all button"
* Notice that the button is still there if a site needs has items that needs fixing. 
* Notice that the Credentials form is not displayed if the correct credentials are shown. 
* Notice that the contact us link in the item description that for the treat we can't fix contains the updated contact us link. 




Fixes #
