### PR TITLE
Jetpack Cloud: Add images to activity cards

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -13,6 +13,7 @@ import Button from 'components/forms/form-button';
 import { Card } from '@automattic/components';
 import ActivityActor from 'my-sites/activity/activity-log-item/activity-actor';
 import ActivityDescription from 'my-sites/activity/activity-log-item/activity-description';
+import ActivityMedia from 'my-sites/activity/activity-log-item/activity-media';
 import { applySiteOffset } from 'lib/site/timezone';
 import PopoverMenu from 'components/popover/menu';
 import {
@@ -62,6 +63,8 @@ class ActivityCard extends Component {
 			gmtOffset,
 		} ).format( 'LT' );
 
+		const { activityMedia } = activity;
+
 		return (
 			<div className={ classnames( className, 'activity-card' ) }>
 				{ ! summarize && (
@@ -80,6 +83,13 @@ class ActivityCard extends Component {
 						} }
 					/>
 					<div className="activity-card__activity-description">
+						{ activityMedia && activityMedia.available && (
+							<ActivityMedia
+								name={ activityMedia.name }
+								thumbnail={ activityMedia.medium_url || activityMedia.thumbnail_url }
+								fullImage={ false }
+							/>
+						) }
 						<ActivityDescription activity={ activity } rewindIsActive={ allowRestore } />
 					</div>
 					<div className="activity-card__activity-title">{ activity.activityTitle }</div>

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -49,7 +49,7 @@
 }
 
 .activity-card__activity-description {
-	margin: 0.5rem 0;
+	margin: 1rem 0 0.5rem;
 }
 
 .activity-card__activity-actions {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add ActivityMedia blocks to the ActivityCards where available.

![Screen Shot 2020-04-23 at 11 28 39 AM](https://user-images.githubusercontent.com/5528445/80117728-83501780-8555-11ea-8a19-f38ba6c12e28.png)

#### Testing instructions

* View the backups page for a realtime backups site, or the Activity Log section for any site. Ensure that image uploads/attachments display the actual image, full-width, per Figma.
* Please note, there are further revisions that will be done to grouped/stream events. That is not up for review here.
