### PR TITLE
Fix the DatePicker styles to match the design

### DIFF
--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -157,7 +157,7 @@ class DatePicker extends Component {
 							<Gridicon icon="chevron-right" className={ ! this.canGoToNextDay() && 'disabled' } />
 						</Button>
 
-						<a href={ backupActivityPath( siteSlug ) }>
+						<a className="date-picker__search-link" href={ backupActivityPath( siteSlug ) }>
 							<Gridicon icon="search" className="date-picker__search-icon" />
 						</a>
 					</div>

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -82,7 +82,7 @@ class DatePicker extends Component {
 	canGoToNextDay = () => {
 		const { today, moment, selectedDate } = this.props;
 
-		return ! moment( selectedDate ).isSame( moment( today ), 'day' );
+		return ! moment( today ).isSame( moment( selectedDate ), 'day' );
 	};
 
 	goToActivityLog = () => {

--- a/client/landing/jetpack-cloud/components/date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/date-picker/index.jsx
@@ -14,6 +14,7 @@ import { withLocalizedMoment } from 'components/localized-moment';
 import Button from 'components/forms/form-button';
 import DateRangeSelector from 'my-sites/activity/filterbar/date-range-selector';
 import Gridicon from 'components/gridicon';
+import { backupActivityPath } from 'landing/jetpack-cloud/sections/backups/paths';
 
 /**
  * Style dependencies
@@ -97,7 +98,7 @@ class DatePicker extends Component {
 	};
 
 	render() {
-		const { selectedDate, siteId, moment } = this.props;
+		const { selectedDate, siteId, siteSlug, moment } = this.props;
 
 		const previousDate = moment( selectedDate ).subtract( 1, 'days' );
 		const nextDate = moment( selectedDate ).add( 1, 'days' );
@@ -155,14 +156,12 @@ class DatePicker extends Component {
 						<Button compact borderless className="date-picker__button--next">
 							<Gridicon icon="chevron-right" className={ ! this.canGoToNextDay() && 'disabled' } />
 						</Button>
+
+						<a href={ backupActivityPath( siteSlug ) }>
+							<Gridicon icon="search" className="date-picker__search-icon" />
+						</a>
 					</div>
 				</div>
-
-				<Gridicon
-					icon="search"
-					className="date-picker__search-icon"
-					onClick={ this.goToActivityLog }
-				/>
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -1,8 +1,10 @@
 .date-picker {
 	display: flex;
+	align-items: center;
 	max-width: 30rem;
 	background: #fff;
 	padding-top: 0.5rem;
+	font-size: 16px;
 }
 
 .date-picker__select-date {
@@ -12,17 +14,27 @@
 }
 
 .date-picker__select-date--previous {
-	width: 45%;
-	padding-left: 0.5rem;
+	display: flex;
+	flex: 1;
+	align-items: center;
 	text-align: left;
 	cursor: pointer;
 }
 
 .date-picker__select-date--next {
-	width: 45%;
-	padding-right: 0.5rem;
+	display: flex;
+	flex: 1;
+	align-items: center;
 	text-align: right;
 	cursor: pointer;
+}
+.date-picker__button--next.button.is-borderless.is-compact,
+.date-picker__button--previous.button.is-borderless.is-compact {
+	.gridicon {
+		width: 24px;
+		height: 24px;
+		color: var( --studio-gray-70 );
+	}
 }
 
 .date-picker__button--previous {
@@ -36,8 +48,9 @@
 }
 
 .date-picker__select-date .date-range {
+	flex: 1;
 	text-align: center;
-	width: 10%;
+	max-width: 24px;
 }
 
 .button.is-primary.date-picker__button--previous:focus,
@@ -56,14 +69,26 @@
 }
 
 .date-picker__search-icon {
-	align-self: center;
 	margin-left: 0.5rem;
-	margin-right: 1rem;
 	cursor: pointer;
 }
 
+.date-picker__display-date {
+	flex: 1;
+}
+
+.date-picker__display-date.disabled {
+	color: var( --studio-gray-10 );
+}
+
+.filterbar__selection.button.is-borderless.is-compact .gridicon {
+	width: 24px;
+	height: 24px;
+	color: var( --studio-gray-70 );
+}
+
 .date-picker__search-icon.gridicon {
-	fill: green;
+	fill: var( --studio-jetpack-green-40 );
 }
 
 @include breakpoint( '>660px' ) {

--- a/client/landing/jetpack-cloud/components/date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/date-picker/style.scss
@@ -28,6 +28,11 @@
 	text-align: right;
 	cursor: pointer;
 }
+
+.date-picker__search-link {
+	display: flex;
+}
+
 .date-picker__button--next.button.is-borderless.is-compact,
 .date-picker__button--previous.button.is-borderless.is-compact {
 	.gridicon {

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -72,12 +72,13 @@ class BackupsPage extends Component {
 		const { siteSlug, moment, timezone, gmtOffset } = this.props;
 
 		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
+		const selectedDate = applySiteOffset( date, { timezone, gmtOffset } );
 
-		if ( date && date.isValid() && date <= today ) {
+		if ( selectedDate && selectedDate.isValid() && selectedDate <= today ) {
 			// Valid dates
 			page(
 				backupMainPath( siteSlug, {
-					date: date.format( INDEX_FORMAT ),
+					date: selectedDate.format( INDEX_FORMAT ),
 				} )
 			);
 		} else {
@@ -94,7 +95,10 @@ class BackupsPage extends Component {
 			gmtOffset: gmtOffset,
 		} );
 
-		const selectedDate = moment( queryDate, INDEX_FORMAT );
+		const selectedDate = applySiteOffset( moment( queryDate, INDEX_FORMAT ), {
+			timezone: timezone,
+			gmtOffset: gmtOffset,
+		} );
 
 		return ( selectedDate.isValid() && selectedDate ) || today;
 	}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -72,13 +72,12 @@ class BackupsPage extends Component {
 		const { siteSlug, moment, timezone, gmtOffset } = this.props;
 
 		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
-		const selectedDate = applySiteOffset( date, { timezone, gmtOffset } );
 
-		if ( selectedDate && selectedDate.isValid() && selectedDate <= today ) {
+		if ( date && date.isValid() && date <= today ) {
 			// Valid dates
 			page(
 				backupMainPath( siteSlug, {
-					date: selectedDate.format( INDEX_FORMAT ),
+					date: date.format( INDEX_FORMAT ),
 				} )
 			);
 		} else {
@@ -95,10 +94,7 @@ class BackupsPage extends Component {
 			gmtOffset: gmtOffset,
 		} );
 
-		const selectedDate = applySiteOffset( moment( queryDate, INDEX_FORMAT ), {
-			timezone: timezone,
-			gmtOffset: gmtOffset,
-		} );
+		const selectedDate = moment( queryDate, INDEX_FORMAT );
 
 		return ( selectedDate.isValid() && selectedDate ) || today;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

 Improve the styles to match with Figma design (mobile view):

- Search icon should match the expected color and the size 24x24px
- The chevron icons should be color gray-70 and the size 24px
- Next display text should be gray-10 if the selected date is today
- Calendar icon should be centered with a size of 24x24px
- Font size should be 16px
- Add a link to the search icon with the Activity log path

**Figma design:**
![image](https://user-images.githubusercontent.com/9832440/80121498-4b13fd80-8584-11ea-874f-2483dc53aab5.png)

**Our previous design:**
![image](https://user-images.githubusercontent.com/9832440/80122346-53206d00-8585-11ea-812b-9307817ae327.png)

**Now:**
![image](https://user-images.githubusercontent.com/9832440/80122796-ed80b080-8585-11ea-8631-79a7d1234cd7.png)

*Desktop view must be improved in general

#### Testing instructions

- Apply these change
- Check if the styles match the design specification