### PR TITLE
Remove editor import in gutenboard

### DIFF
--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import '@wordpress/editor'; // This shouldn't be necessary
 import { useI18n } from '@automattic/react-i18n';
 import { BlockEditorProvider, BlockList as OriginalBlockList } from '@wordpress/block-editor';
 import { Popover, DropZoneProvider } from '@wordpress/components';


### PR DESCRIPTION
Looks like this legacy import is no longer needed.

This was severely impacting Gutenboarding entry point size, inflating it by ~670KB uncompressed, or ~140KB gzipped!! (two exclamation marks required)
It was pulling in a number of large components and dependencies, e.g. date picking stuff.

Local testing seems to indicate everything works fine after removal, as I was able to complete the creation process up until the full editor popped up.

#### Changes proposed in this Pull Request

* Remove unnecessary `@wordpress/editor` import

#### Testing instructions

Ensure that Gutenboarding continues to work normally. Team Luna will know a lot better than me exactly what that entails 🙂
