### PR TITLE
Me: Social Login, replace transient Zi usage w/ getAuthResponse

### DIFF
--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -51,14 +51,20 @@ class SocialLoginActionButton extends Component {
 		};
 
 		if ( service === 'google' ) {
-			if ( ! response.Zi || ! response.Zi.access_token || ! response.Zi.id_token ) {
+			if ( ! response.getAuthResponse ) {
+				return;
+			}
+
+			const tokens = response.getAuthResponse();
+
+			if ( ! tokens || ! tokens.access_token || ! tokens.id_token ) {
 				return;
 			}
 
 			socialInfo = {
 				...socialInfo,
-				access_token: response.Zi.access_token,
-				id_token: response.Zi.id_token,
+				access_token: tokens.access_token,
+				id_token: tokens.id_token,
 			};
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace transient Zi usage w/ getAuthResponse similar to https://github.com/Automattic/wp-calypso/pull/39291

#### Testing instructions

1. Starting at URL: https://wordpress.com/me/security/social-login
2. Select "Connect" next to Google, to connect a Google account to your existing WordPress.com account.
3. Login/select your Google account in the pop-up window that appears.
4. Verify you are now connected or disconnected

Fixes #39459 CC @rachelmcr 
