### PR TITLE
Jetpack Cloud: add events that trigger a request for the Scan state

### DIFF
--- a/client/components/data/query-jetpack-scan/index.tsx
+++ b/client/components/data/query-jetpack-scan/index.tsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'react-redux';
  * Internal dependencies
  */
 import isRequestingJetpackScan from 'state/selectors/is-requesting-jetpack-scan';
-import { requestJetpackScanStatus } from 'state/jetpack-scan/actions';
+import { requestScanStatus } from 'state/jetpack-scan/actions';
 
 interface Props {
 	siteId: number;
@@ -24,7 +24,7 @@ const QueryJetpackScan = ( { siteId }: Props ) => {
 		if ( requestingJetpackScan ) {
 			return;
 		}
-		siteId && dispatch( requestJetpackScanStatus( siteId ) );
+		siteId && dispatch( requestScanStatus( siteId ) );
 	}, [ siteId ] );
 
 	return null;

--- a/client/components/data/query-jetpack-scan/test/index.js
+++ b/client/components/data/query-jetpack-scan/test/index.js
@@ -19,10 +19,7 @@ import { JETPACK_SCAN_REQUEST } from 'state/action-types';
 
 function setup( siteId ) {
 	// Set spy on action creator to verify it gets called when the component renders.
-	const requestJetpackScanStatusActionSpy = jest.spyOn(
-		jetpackScanActions,
-		'requestJetpackScanStatus'
-	);
+	const requestScanStatusActionSpy = jest.spyOn( jetpackScanActions, 'requestScanStatus' );
 
 	const initialState = {
 		jetpackScan: { requestStatus: siteId },
@@ -39,23 +36,23 @@ function setup( siteId ) {
 
 	const utils = render( renderUI( siteId ) );
 
-	return { renderUI, utils, requestJetpackScanStatusActionSpy };
+	return { renderUI, utils, requestScanStatusActionSpy };
 }
 
 describe( 'QueryJetpackScan', () => {
 	it( 'should not dispatch the action if the siteId is null ', () => {
 		const siteId = null;
-		const { requestJetpackScanStatusActionSpy } = setup( siteId );
-		expect( requestJetpackScanStatusActionSpy ).not.toHaveBeenCalled();
+		const { requestScanStatusActionSpy } = setup( siteId );
+		expect( requestScanStatusActionSpy ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should request Jetpack Scan status every time siteId changes', () => {
 		const siteId = 9999;
-		const { renderUI, requestJetpackScanStatusActionSpy, utils } = setup( siteId );
-		expect( requestJetpackScanStatusActionSpy ).toHaveBeenCalled();
-		expect( requestJetpackScanStatusActionSpy ).toHaveBeenCalledWith( siteId );
-		expect( requestJetpackScanStatusActionSpy ).toHaveBeenCalledTimes( 1 );
-		expect( requestJetpackScanStatusActionSpy ).toHaveReturnedWith(
+		const { renderUI, requestScanStatusActionSpy, utils } = setup( siteId );
+		expect( requestScanStatusActionSpy ).toHaveBeenCalled();
+		expect( requestScanStatusActionSpy ).toHaveBeenCalledWith( siteId );
+		expect( requestScanStatusActionSpy ).toHaveBeenCalledTimes( 1 );
+		expect( requestScanStatusActionSpy ).toHaveReturnedWith(
 			expect.objectContaining( {
 				type: JETPACK_SCAN_REQUEST,
 				siteId,
@@ -64,9 +61,9 @@ describe( 'QueryJetpackScan', () => {
 
 		const newSiteId = 10000;
 		utils.rerender( renderUI( newSiteId ) );
-		expect( requestJetpackScanStatusActionSpy ).toHaveBeenCalledWith( newSiteId );
-		expect( requestJetpackScanStatusActionSpy ).toHaveBeenCalledTimes( 2 );
-		expect( requestJetpackScanStatusActionSpy ).toHaveReturnedWith(
+		expect( requestScanStatusActionSpy ).toHaveBeenCalledWith( newSiteId );
+		expect( requestScanStatusActionSpy ).toHaveBeenCalledTimes( 2 );
+		expect( requestScanStatusActionSpy ).toHaveReturnedWith(
 			expect.objectContaining( {
 				type: JETPACK_SCAN_REQUEST,
 				siteId: newSiteId,

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -89,7 +89,7 @@ const ScanThreats = ( { site, threats }: Props ) => {
 		const actionCreator = actionToPerform === 'fix' ? fixThreatAlert : ignoreThreatAlert;
 		closeDialog();
 		setFixingThreats( ( stateThreats ) => [ ...stateThreats, selectedThreat ] );
-		dispatch( actionCreator( site.ID, selectedThreat.id ) );
+		dispatch( actionCreator( site.ID, selectedThreat.id, true ) );
 	}, [ actionToPerform, closeDialog, dispatch, selectedThreat, site ] );
 
 	const confirmFixAllThreats = React.useCallback( () => {

--- a/client/state/data-layer/wpcom/sites/alerts/fix.js
+++ b/client/state/data-layer/wpcom/sites/alerts/fix.js
@@ -12,6 +12,7 @@ import { errorNotice, successNotice } from 'state/notices/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
+import { requestScanStatus } from 'state/jetpack-scan/actions';
 
 export const request = ( action ) => {
 	const notice = successNotice( i18n.translate( 'Fixing threat…' ), { duration: 30000 } );
@@ -56,6 +57,7 @@ export const success = ( action, rewind_state ) => [
 			};
 		} catch ( e ) {}
 	} )(),
+	...( action.requestScanState ? [ requestScanStatus( action.siteId ) ] : [] ),
 ];
 
 export const failure = ( action ) =>

--- a/client/state/data-layer/wpcom/sites/alerts/fix.js
+++ b/client/state/data-layer/wpcom/sites/alerts/fix.js
@@ -57,7 +57,7 @@ export const success = ( action, rewind_state ) => [
 			};
 		} catch ( e ) {}
 	} )(),
-	...( action.requestScanState ? [ requestScanStatus( action.siteId ) ] : [] ),
+	...( action.requestScanState ? [ requestScanStatus( action.siteId, false ) ] : [] ),
 ];
 
 export const failure = ( action ) =>

--- a/client/state/data-layer/wpcom/sites/alerts/ignore.js
+++ b/client/state/data-layer/wpcom/sites/alerts/ignore.js
@@ -52,7 +52,7 @@ export const success = ( action, rewind_state ) => [
 			};
 		} catch ( e ) {}
 	} )(),
-	...( action.requestScanState ? [ requestScanStatus( action.siteId ) ] : [] ),
+	...( action.requestScanState ? [ requestScanStatus( action.siteId, false ) ] : [] ),
 ];
 
 export const failure = ( action ) =>

--- a/client/state/data-layer/wpcom/sites/alerts/ignore.js
+++ b/client/state/data-layer/wpcom/sites/alerts/ignore.js
@@ -12,6 +12,7 @@ import { errorNotice, successNotice } from 'state/notices/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { transformApi } from 'state/data-layer/wpcom/sites/rewind/api-transformer';
+import { requestScanStatus } from 'state/jetpack-scan/actions';
 
 export const request = ( action ) => {
 	const notice = successNotice( i18n.translate( 'Ignoring threat…' ), { duration: 30000 } );
@@ -51,6 +52,7 @@ export const success = ( action, rewind_state ) => [
 			};
 		} catch ( e ) {}
 	} )(),
+	...( action.requestScanState ? [ requestScanStatus( action.siteId ) ] : [] ),
 ];
 
 export const failure = ( action ) =>

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -22,8 +22,10 @@ const fetchStatus = ( action ) => {
 	);
 };
 
-const onFetchStatusSuccess = ( action, scanStatus ) => {
-	return [
+const POOL_EVERY_MILLISECONDS = 5000;
+
+const onFetchStatusSuccess = ( action, scan ) => ( dispatch ) => {
+	[
 		{
 			type: JETPACK_SCAN_REQUEST_SUCCESS,
 			siteId: action.siteId,
@@ -31,9 +33,18 @@ const onFetchStatusSuccess = ( action, scanStatus ) => {
 		{
 			type: JETPACK_SCAN_UPDATE,
 			siteId: action.siteId,
-			payload: scanStatus,
+			payload: scan,
 		},
-	];
+	].map( dispatch );
+	if ( action.pooling && scan.state === 'scanning' ) {
+		setTimeout( () => {
+			dispatch( {
+				type: JETPACK_SCAN_REQUEST,
+				siteId: action.siteId,
+				pooling: true,
+			} );
+		}, POOL_EVERY_MILLISECONDS );
+	}
 };
 
 const onFetchStatusFailure = ( ...response ) => {

--- a/client/state/data-layer/wpcom/sites/scan/test/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/test/index.js
@@ -8,10 +8,7 @@ import { JETPACK_SCAN_REQUEST } from 'state/action-types';
 
 function setup( siteId ) {
 	// Set spy on action creator to verify it gets called when the component renders.
-	const requestJetpackScanStatusActionSpy = jest.spyOn(
-		jetpackScanActions,
-		'requestJetpackScanStatus'
-	);
+	const requestScanStatusActionSpy = jest.spyOn( jetpackScanActions, 'requestScanStatus' );
 
 	// We don't want to make an HTTP request so we need to mock this utility.
 	wpcomHttpActions.http = jest.fn( () => ( {
@@ -30,17 +27,17 @@ function setup( siteId ) {
 
 	const dispatchSpy = jest.spyOn( store, 'dispatch' );
 
-	return { store, dispatchSpy, requestJetpackScanStatusActionSpy };
+	return { store, dispatchSpy, requestScanStatusActionSpy };
 }
 
 describe( 'Jetpack Scan data-layer', () => {
 	it( 'should reach the fetch handler middleware', () => {
 		const siteId = 9999;
-		const { store, dispatchSpy, requestJetpackScanStatusActionSpy } = setup( siteId );
+		const { store, dispatchSpy, requestScanStatusActionSpy } = setup( siteId );
 
 		// Dispatch action to fetch Jetpack Scan status
-		store.dispatch( jetpackScanActions.requestJetpackScanStatus( siteId ) );
-		expect( requestJetpackScanStatusActionSpy ).toHaveBeenCalled();
+		store.dispatch( jetpackScanActions.requestScanStatus( siteId ) );
+		expect( requestScanStatusActionSpy ).toHaveBeenCalled();
 
 		// Verify the dispatch function was called with the right argument
 		expect( dispatchSpy ).toHaveBeenCalled();

--- a/client/state/jetpack-scan/actions.js
+++ b/client/state/jetpack-scan/actions.js
@@ -6,7 +6,7 @@ import { JETPACK_SCAN_REQUEST } from 'state/action-types';
 import 'state/data-layer/wpcom/sites/scan';
 import 'state/jetpack-scan/init';
 
-export const requestJetpackScanStatus = ( siteId ) => ( {
+export const requestScanStatus = ( siteId ) => ( {
 	type: JETPACK_SCAN_REQUEST,
 	siteId,
 	meta: {

--- a/client/state/jetpack-scan/actions.js
+++ b/client/state/jetpack-scan/actions.js
@@ -6,9 +6,10 @@ import { JETPACK_SCAN_REQUEST } from 'state/action-types';
 import 'state/data-layer/wpcom/sites/scan';
 import 'state/jetpack-scan/init';
 
-export const requestScanStatus = ( siteId ) => ( {
+export const requestScanStatus = ( siteId, pooling = true ) => ( {
 	type: JETPACK_SCAN_REQUEST,
 	siteId,
+	pooling,
 	meta: {
 		dataLayer: {
 			trackRequest: true,

--- a/client/state/jetpack/site-alerts/actions.js
+++ b/client/state/jetpack/site-alerts/actions.js
@@ -9,14 +9,16 @@ import {
 import 'state/data-layer/wpcom/sites/alerts/fix';
 import 'state/data-layer/wpcom/sites/alerts/ignore';
 
-export const fixThreatAlert = ( siteId, threatId ) => ( {
+export const fixThreatAlert = ( siteId, threatId, requestScanState = false ) => ( {
 	type: JETPACK_SITE_ALERT_THREAT_FIX,
 	siteId,
 	threatId,
+	requestScanState,
 } );
 
-export const ignoreThreatAlert = ( siteId, threatId ) => ( {
+export const ignoreThreatAlert = ( siteId, threatId, requestScanState = false ) => ( {
 	type: JETPACK_SITE_ALERT_THREAT_IGNORE,
 	siteId,
 	threatId,
+	requestScanState,
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR has 3 goals:

1. Request the state of the Scan every time a user visits the Scanner section.
2. Request the state of the Scan after ignoring or fixing a threat.
3. Request the state of the Scan if the current state is `'scanning'` until it finishes.

#### Implementation notes

- I renamed the action creator `requestJetpackScanStatus` to `requestScanStatus`. 
- I made optional the behavior of requesting the state of the Scan after ignoring/fixing a threat. This so to preserve the behavior of other parts of the app that use the same action creators we use.
- The pooling mechanism, required by goal #3, was implemented at the data-layer level. It can be opted out by setting the `pooling` prop to `false` in the action object. So, for instance, ignoring/fixing a threat dispatch this action with `pooling` set to false, because we only want to query the state once after the action was completed. 

#### Testing instructions

Instructions for all cases:

- Run this PR
- Go to `http://jetpack.cloud.localhost:3000/`
- Select a site that has Jetpack Scan and has threats

##### 1. Request the state of the Scan every time a user visits the Scanner section

- Go to Scan -> Scanner
- Verify, in the network panel, that a request to `/scan` was sent
- Go to Scan -> History
- Go back to Scan -> Scanner
- Verify, in the network panel, that another request to `/scan` was sent

##### 2. Request the state of the Scan after ignoring or fixing a threat

- Go to Scan -> Scanner
- Ignore or fix a threat
- Verify, in the network panel, that a request to `/scan` was sent after the action was executed

##### 3. Request the state of the Scan if the current state is `'scanning'` until it finishes

- Go to Scan -> Scanner
- Verify, in the network panel, that a request to `/scan` is send every 5 seconds until the state of the Scan changes to something different than `'scanning'`

Having a test site, in which the current state of the Scan is `'scanning'` can be almost impossible right now. So, I recommend changing the pooling mechanism precondition to trigger the expected behavior. This implementation checks that `( action.pooling && scan.state === 'scanning' )` is true, so you can easily change that to something else like `( action.pooling && scan.threats > 0 )`, and see how the app keep sending request every five seconds while there are threats. After you ignore all the threats, the app should stop sending request. An example of that can be seen next:
![Kapture 2020-04-23 at 18 49 36](https://user-images.githubusercontent.com/3418513/80153129-5d496800-8593-11ea-924e-756e15d8e231.gif)
