### PR TITLE
Hosting: Let Upsell Appear for Personal & Premium Sites

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -36,7 +36,7 @@ import {
 import { transferStates } from 'state/automated-transfer/constants';
 import { requestSite } from 'state/sites/actions';
 import FeatureExample from 'components/feature-example';
-import { PLAN_BUSINESS } from 'lib/plans/constants';
+import { PLAN_BUSINESS, FEATURE_SFTP } from 'lib/plans/constants';
 
 /**
  * Style dependencies
@@ -83,6 +83,7 @@ class Hosting extends Component {
 				event="calypso_hosting_configuration_upgrade_click"
 				href={ `/checkout/${ siteId }/business` }
 				plan={ PLAN_BUSINESS }
+				feature={ FEATURE_SFTP }
 				showIcon={ true }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This should ensure the upsell nudge appears on the Hosting page for Personal & Premium sites.

#### Testing instructions

Verify that the upsell appears for sites on the Personal & Premium plan, but not any higher plans. 

Note: I've not tested with the Premium plan as I don't have access to such a site, but this should work with it 

<img width="1176" alt="Screenshot 2020-04-23 at 20 52 50" src="https://user-images.githubusercontent.com/43215253/80143262-727ac280-85a4-11ea-8d67-50b23256d569.png">

cc @sixhours 

Fixes #41416
