### PR TITLE
JITMs: Update JITM default template to use UpsellNudge rather than Banner

### DIFF
--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -37,6 +37,7 @@ export default function DefaultTemplate( {
 				onClick={ onClick }
 				event={ get( tracks, [ 'click', 'name' ] ) || `jitm_nudge_click_${ id }` }
 				href={ CTA.link }
+				horizontal={ isJetpack }
 				target={ '_blank' }
 				showIcon={ true }
 				forceDisplay

--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -7,7 +7,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 
 export default function DefaultTemplate( {
 	id,
@@ -26,7 +26,7 @@ export default function DefaultTemplate( {
 	return (
 		<>
 			{ trackImpression && trackImpression() }
-			<Banner
+			<UpsellNudge
 				callToAction={ CTA.message }
 				title={ message }
 				description={ description }
@@ -37,9 +37,9 @@ export default function DefaultTemplate( {
 				onClick={ onClick }
 				event={ get( tracks, [ 'click', 'name' ] ) || `jitm_nudge_click_${ id }` }
 				href={ CTA.link }
-				jetpack={ isJetpack }
-				horizontal={ isJetpack }
 				target={ '_blank' }
+				showIcon={ true }
+				forceDisplay
 			/>
 		</>
 	);

--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -15,14 +15,11 @@ export default function DefaultTemplate( {
 	message,
 	description,
 	featureClass,
-	icon,
 	tracks,
 	trackImpression,
 	onClick,
 	onDismiss,
 } ) {
-	const isJetpack = icon && icon.indexOf( 'jetpack' ) !== -1;
-
 	return (
 		<>
 			{ trackImpression && trackImpression() }
@@ -37,7 +34,7 @@ export default function DefaultTemplate( {
 				onClick={ onClick }
 				event={ get( tracks, [ 'click', 'name' ] ) || `jitm_nudge_click_${ id }` }
 				href={ CTA.link }
-				horizontal={ isJetpack }
+				horizontal
 				target={ '_blank' }
 				showIcon={ true }
 				forceDisplay

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -39,6 +39,7 @@ export const UpsellNudge = ( {
 	forceDisplay,
 	forceHref,
 	href,
+	horizontal,
 	icon,
 	isJetpackDevDocs,
 	jetpack,
@@ -96,6 +97,7 @@ export const UpsellNudge = ( {
 			forceHref={ forceHref }
 			horizontal={ horizontal }
 			href={ href }
+			horizontal={ horizontal }
 			icon={ icon }
 			jetpack={ jetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
 			list={ list }

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -18,6 +18,7 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import isVipSite from 'state/selectors/is-vip-site';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite, isJetpackSite } from 'state/sites/selectors';
+import { preventWidows } from 'lib/formatting';
 
 /**
  * Style dependencies
@@ -83,7 +84,7 @@ export const UpsellNudge = ( {
 
 	return (
 		<Banner
-			callToAction={ callToAction }
+			callToAction={ preventWidows( callToAction ) }
 			className={ classes }
 			compact={ compact }
 			customerType={ customerType }

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -38,12 +38,11 @@ export const UpsellNudge = ( {
 	feature,
 	forceDisplay,
 	forceHref,
-	href,
 	horizontal,
+	href,
 	icon,
 	isJetpackDevDocs,
 	jetpack,
-	horizontal,
 	isVip,
 	list,
 	onClick,
@@ -98,7 +97,6 @@ export const UpsellNudge = ( {
 			forceHref={ forceHref }
 			horizontal={ horizontal }
 			href={ href }
-			horizontal={ horizontal }
 			icon={ icon }
 			jetpack={ jetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
 			list={ list }

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -53,6 +53,7 @@ export const UpsellNudge = ( {
 	price,
 	showIcon = false,
 	site,
+	target,
 	title,
 	tracksClickName,
 	tracksClickProperties,
@@ -106,6 +107,7 @@ export const UpsellNudge = ( {
 			plan={ plan }
 			price={ price }
 			showIcon={ showIcon }
+			target={ target }
 			title={ title }
 			tracksClickName={ tracksClickName }
 			tracksClickProperties={ tracksClickProperties }

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -30,6 +30,9 @@
 	.banner__description {
 		color: var( --color-neutral-5 );
 	}
+	.banner__info {
+		margin-right: 5px;
+	}
 	.banner__info .banner__title {
 		color: var( --color-text-inverted );
 		font-weight: 400;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Swap `Banner` for `UpsellNudge` for default JITM template
* `preventWidows()` on `UpsellNudge` CTA to prevent multi-word buttons breaking in odd places.
* This should also fix #41374 and #41001
* There may be more of these in Calypso that I'm unaware of; it's not clear in the API which upsells go where. Maybe @Automattic/martech has a better idea of which upsells need to be tested in this case?

| **Before** | After |
| ----- | ----- |
| <img width="1398" alt="Screen Shot 2020-04-23 at 4 45 09 PM" src="https://user-images.githubusercontent.com/2124984/80147645-d17b1000-8581-11ea-8976-3a6e84f24af7.png"> | <img width="1388" alt="Screen Shot 2020-04-23 at 4 41 24 PM" src="https://user-images.githubusercontent.com/2124984/80147353-63364d80-8581-11ea-9c04-c91edc525f66.png"> |
| <img width="1680" alt="Screen Shot 2020-04-23 at 4 44 59 PM" src="https://user-images.githubusercontent.com/2124984/80147648-d213a680-8581-11ea-8ba2-475c429fd885.png"> | <img width="1680" alt="Screen Shot 2020-04-23 at 4 41 48 PM" src="https://user-images.githubusercontent.com/2124984/80147348-5fa2c680-8581-11ea-9aeb-1df711b454ca.png"> |
| <img width="1406" alt="Screen Shot 2020-04-28 at 9 32 43 AM" src="https://user-images.githubusercontent.com/2124984/80493531-896a3d80-8933-11ea-9603-225cb898fb61.png"> | <img width="1378" alt="Screen Shot 2020-04-28 at 9 32 19 AM" src="https://user-images.githubusercontent.com/2124984/80493545-8d965b00-8933-11ea-941a-cf3aa304f1cb.png"> |
| <img width="1385" alt="Screen Shot 2020-04-28 at 9 37 24 AM" src="https://user-images.githubusercontent.com/2124984/80493895-fe3d7780-8933-11ea-90bc-eb7827e1c7fd.png"> | <img width="1383" alt="Screen Shot 2020-04-28 at 9 37 09 AM" src="https://user-images.githubusercontent.com/2124984/80493905-04335880-8934-11ea-9fd0-50dd2c3f1062.png"> |

#### Testing instructions

Switch to this PR and check out JITMs on a *free* Jetpack site:

* `/plugins`
* `/theme/ovation` or any single theme page
* `/themes/upload`
* `/plugins/upload`

Make sure there are no visual regressions, and make sure all Tracks events (impression, click, dismiss if available) are firing correctly.

See #38778
