### PR TITLE
My Home: Add a Find Domain task card for i1.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/domains/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domains/index.jsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { isMobile } from '@automattic/viewport';
+
+/**
+ * Internal dependencies
+ */
+import QueryPublicizeConnections from 'components/data/query-publicize-connections';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import Task from '../task';
+
+const ConnectAccountsTask = ( { siteSlug } ) => {
+	const translate = useTranslate();
+
+	return (
+		<>
+			<QueryPublicizeConnections selectedSite />
+			<Task
+				title={ translate( 'Look more professional' ) }
+				description={ translate(
+					"Get a custom domain and show the world you're serious. Sites with custom domains look more professional and rank higher in search engine results."
+				) }
+				actionText={ translate( 'Find a domain' ) }
+				actionUrl={
+					isMobile()
+						? `/marketing/connections/${ siteSlug }`
+						: `/marketing/connections/${ siteSlug }?tour=marketingConnectionsTour`
+				}
+				illustration="/calypso/images/stats/tasks/social-links.svg"
+				timing={ 10 }
+				taskId="connect-accounts"
+			/>
+		</>
+	);
+};
+
+const mapStateToProps = ( state ) => {
+	return {
+		siteSlug: getSelectedSiteSlug( state ),
+	};
+};
+
+export default connect( mapStateToProps )( ConnectAccountsTask );

--- a/client/my-sites/customer-home/cards/tasks/find-domain/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/find-domain/index.jsx
@@ -4,16 +4,16 @@
 import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { isMobile } from '@automattic/viewport';
 
 /**
  * Internal dependencies
  */
 import QueryPublicizeConnections from 'components/data/query-publicize-connections';
+import { preventWidows } from 'lib/formatting';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import Task from '../task';
 
-const ConnectAccountsTask = ( { siteSlug } ) => {
+const FindDomain = ( { siteSlug } ) => {
 	const translate = useTranslate();
 
 	return (
@@ -21,18 +21,16 @@ const ConnectAccountsTask = ( { siteSlug } ) => {
 			<QueryPublicizeConnections selectedSite />
 			<Task
 				title={ translate( 'Look more professional' ) }
-				description={ translate(
-					"Get a custom domain and show the world you're serious. Sites with custom domains look more professional and rank higher in search engine results."
+				description={ preventWidows(
+					translate(
+						"Get a custom domain and show the world you're serious. Sites with custom domains look more professional and rank higher in search engine results."
+					)
 				) }
 				actionText={ translate( 'Find a domain' ) }
-				actionUrl={
-					isMobile()
-						? `/marketing/connections/${ siteSlug }`
-						: `/marketing/connections/${ siteSlug }?tour=marketingConnectionsTour`
-				}
+				actionUrl={ `/domains/add/${ siteSlug }` }
 				illustration="/calypso/images/stats/tasks/social-links.svg"
 				timing={ 10 }
-				taskId="connect-accounts"
+				taskId="find-domain"
 			/>
 		</>
 	);
@@ -44,4 +42,4 @@ const mapStateToProps = ( state ) => {
 	};
 };
 
-export default connect( mapStateToProps )( ConnectAccountsTask );
+export default connect( mapStateToProps )( FindDomain );

--- a/client/my-sites/customer-home/cards/tasks/find-domain/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/find-domain/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import QueryPublicizeConnections from 'components/data/query-publicize-connections';
 import { preventWidows } from 'lib/formatting';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import Task from '../task';
@@ -17,22 +16,19 @@ const FindDomain = ( { siteSlug } ) => {
 	const translate = useTranslate();
 
 	return (
-		<>
-			<QueryPublicizeConnections selectedSite />
-			<Task
-				title={ translate( 'Look more professional' ) }
-				description={ preventWidows(
-					translate(
-						"Get a custom domain and show the world you're serious. Sites with custom domains look more professional and rank higher in search engine results."
-					)
-				) }
-				actionText={ translate( 'Find a domain' ) }
-				actionUrl={ `/domains/add/${ siteSlug }` }
-				illustration="/calypso/images/stats/tasks/social-links.svg"
-				timing={ 10 }
-				taskId="find-domain"
-			/>
-		</>
+		<Task
+			title={ translate( 'Look more professional' ) }
+			description={ preventWidows(
+				translate(
+					"Get a custom domain and show the world you're serious. Sites with custom domains look more professional and rank higher in search engine results."
+				)
+			) }
+			actionText={ translate( 'Find a domain' ) }
+			actionUrl={ `/domains/add/${ siteSlug }` }
+			illustration="/calypso/images/stats/tasks/social-links.svg"
+			timing={ 10 }
+			taskId="find-domain"
+		/>
 	);
 };
 

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -12,6 +12,7 @@ import MasteringGutenberg from 'my-sites/customer-home/cards/education/mastering
 import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links';
 import WpForTeamsQuickLinks from 'my-sites/customer-home/cards/actions/wp-for-teams-quick-links';
 import ConnectAccounts from 'my-sites/customer-home/cards/tasks/connect-accounts';
+import FindDomain from 'my-sites/customer-home/cards/tasks/find-domain';
 import config from 'config';
 
 const cardComponents = {
@@ -22,6 +23,7 @@ const cardComponents = {
 	'home-action-wp-for-teams-quick-links': WpForTeamsQuickLinks,
 	'home-task-site-setup-checklist': ChecklistSiteSetup,
 	'home-task-connect-accounts': ConnectAccounts,
+	'home-task-find-domain': FindDomain,
 };
 
 const Primary = ( { checklistMode, cards } ) => {


### PR DESCRIPTION
This PR adds a "Look more professional" task card, prompting the user to find a domain for their site.

<img width="1104" alt="Screen Shot 2020-04-23 at 4 00 37 PM" src="https://user-images.githubusercontent.com/349751/80157715-9d045580-857b-11ea-9a2d-78771c81b375.png">

#### Testing instructions

* Sandbox the API and apply D42369-code.
* On this branch, load `http://calypso.localhost:3000/home/:site?flags=home/experimental-layout` with a launched site that has a Premium or higher plan that hasn't used its domain credit yet.
* Verify the card appears.
* Use the "free domain available" upsell in the sidebar to attach a domain to the site.
* reload Home, and verify the card does not appear.
* Verify the card does not appear for sites without plans, nor sites that already have a domain attached.

Fixes https://github.com/Automattic/dotcom-private/issues/39
