### PR TITLE
add extra props to GB analytics

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -137,7 +137,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	}, [ allSuggestions, currentDomain ] );
 
 	useTrackModal( 'DomainPicker', () => ( {
-		selected_domain: onboardingStore.getSelectedDomain(),
+		selected_domain: onboardingStore.getSelectedDomain()?.domain_name,
 	} ) );
 
 	return (

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -70,7 +70,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 } ) => {
 	const { __, i18nLocale } = useI18n();
 	const label = __( 'Search for a domain' );
-	const onboardingStore = useSelect( ( select ) => select( STORE_KEY ) );
+	const { getSelectedDomain } = useSelect( ( select ) => select( STORE_KEY ) );
 
 	const { domainSearch, domainCategory } = useSelect( ( select ) =>
 		select( STORE_KEY ).getState()
@@ -137,7 +137,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	}, [ allSuggestions, currentDomain ] );
 
 	useTrackModal( 'DomainPicker', () => ( {
-		selected_domain: onboardingStore.getSelectedDomain()?.domain_name,
+		selected_domain: getSelectedDomain()?.domain_name,
 	} ) );
 
 	return (

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -70,6 +70,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 } ) => {
 	const { __, i18nLocale } = useI18n();
 	const label = __( 'Search for a domain' );
+	const onboardingStore = useSelect( ( select ) => select( STORE_KEY ) );
 
 	const { domainSearch, domainCategory } = useSelect( ( select ) =>
 		select( STORE_KEY ).getState()
@@ -135,7 +136,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		}
 	}, [ allSuggestions, currentDomain ] );
 
-	useTrackModal( 'DomainPicker' );
+	useTrackModal( 'DomainPicker', () => ( {
+		selected_domain: onboardingStore.getSelectedDomain(),
+	} ) );
 
 	return (
 		<Panel className="domain-picker">

--- a/client/landing/gutenboarding/hooks/use-on-unmount.ts
+++ b/client/landing/gutenboarding/hooks/use-on-unmount.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, DependencyList } from 'react';
+import { useEffect } from 'react';
 
 /**
  * The user can either leave the page by navigating within the react app, or with browser navigation
@@ -9,9 +9,8 @@ import { useEffect, DependencyList } from 'react';
  * https://angelos.dev/2019/05/custom-react-hook-to-prevent-window-unload/
  *
  * @param onUnmount The function to be called when the component is unmounted
- * @param deps The react dependencies to be passed in to useEffect
  **/
-export const useOnUnmount = ( onUnmount: () => void, deps?: DependencyList ) => {
+export const useOnUnmount = ( onUnmount: () => void ) => {
 	const onUnload = () => {
 		onUnmount();
 	};
@@ -24,5 +23,5 @@ export const useOnUnmount = ( onUnmount: () => void, deps?: DependencyList ) => 
 			onUnload();
 			window.removeEventListener( 'beforeunload', onUnload );
 		};
-	}, deps );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 };

--- a/client/landing/gutenboarding/hooks/use-track-modal.ts
+++ b/client/landing/gutenboarding/hooks/use-track-modal.ts
@@ -8,18 +8,23 @@ import { useEffect, DependencyList } from 'react';
  */
 import { useOnUnmount } from './use-on-unmount';
 import { recordEnterModal, recordCloseModal } from '../lib/analytics';
+import { TracksEventProperties } from '../lib/analytics/types';
 
 /**
  * Records events in tracks on opening and closing the modal
  * When closing the modal, additional properties can be recorded e.g. which domain was selected.
  *
  * @param modalName The name of the modal as will be sent to tracks
- * @param eventProperties Additional properties to be recorded on completing the modal
+ * @param getEventProperties Returns additional properties to be recorded on completing the modal
  * @param deps Dependencies as will be passeed into react's useEffect
  */
-export function useTrackModal( modalName: string, eventProperties?: any, deps?: DependencyList ) {
+export function useTrackModal(
+	modalName: string,
+	getEventProperties?: () => TracksEventProperties,
+	deps?: DependencyList
+) {
 	useOnUnmount( () => {
-		recordCloseModal( modalName, eventProperties );
+		recordCloseModal( modalName, getEventProperties && getEventProperties() );
 	}, deps || [] );
 	useEffect( () => {
 		recordEnterModal( modalName );

--- a/client/landing/gutenboarding/hooks/use-track-modal.ts
+++ b/client/landing/gutenboarding/hooks/use-track-modal.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, DependencyList } from 'react';
+import { useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -16,19 +16,15 @@ import { TracksEventProperties } from '../lib/analytics/types';
  *
  * @param modalName The name of the modal as will be sent to tracks
  * @param getEventProperties Returns additional properties to be recorded on completing the modal
- * @param deps Dependencies as will be passeed into react's useEffect
  */
 export function useTrackModal(
 	modalName: string,
-	getEventProperties?: () => TracksEventProperties,
-	deps?: DependencyList
+	getEventProperties?: () => TracksEventProperties
 ) {
-	// eslint-disable-line react-hooks/exhaustive-deps
 	useOnUnmount( () => {
 		recordCloseModal( modalName, getEventProperties && getEventProperties() );
-	}, deps || [] );
-	// eslint-disable-line react-hooks/exhaustive-deps
+	} );
 	useEffect( () => {
 		recordEnterModal( modalName );
-	}, [] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/client/landing/gutenboarding/hooks/use-track-modal.ts
+++ b/client/landing/gutenboarding/hooks/use-track-modal.ts
@@ -23,9 +23,11 @@ export function useTrackModal(
 	getEventProperties?: () => TracksEventProperties,
 	deps?: DependencyList
 ) {
+	// eslint-disable-line react-hooks/exhaustive-deps
 	useOnUnmount( () => {
 		recordCloseModal( modalName, getEventProperties && getEventProperties() );
 	}, deps || [] );
+	// eslint-disable-line react-hooks/exhaustive-deps
 	useEffect( () => {
 		recordEnterModal( modalName );
 	}, [] );

--- a/client/landing/gutenboarding/hooks/use-track-step.ts
+++ b/client/landing/gutenboarding/hooks/use-track-step.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, DependencyList } from 'react';
+import { useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -17,17 +17,15 @@ import { TracksEventProperties } from '../lib/analytics/types';
  *
  * @param stepName The name of the signup step to track
  * @param getEventProperties Returns additional properties to be recorded on completing the step
- * @param deps Dependencies as will be passeed into react's useEffect
  */
 export function useTrackStep(
 	stepName: StepNameType,
-	getEventProperties?: () => TracksEventProperties,
-	deps?: DependencyList
+	getEventProperties?: () => TracksEventProperties
 ) {
 	useOnUnmount( () => {
 		recordLeaveStep( stepName, getEventProperties && getEventProperties() );
-	}, deps || [] );
+	} );
 	useEffect( () => {
 		recordEnterStep( stepName );
-	}, [] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/client/landing/gutenboarding/hooks/use-track-step.ts
+++ b/client/landing/gutenboarding/hooks/use-track-step.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect } from 'react';
+import { useEffect, DependencyList } from 'react';
 
 /**
  * Internal dependencies
@@ -9,18 +9,23 @@ import { useEffect } from 'react';
 import { useOnUnmount } from './use-on-unmount';
 import { StepNameType } from '../path';
 import { recordEnterStep, recordLeaveStep } from '../lib/analytics';
+import { TracksEventProperties } from '../lib/analytics/types';
 
 /**
  * Records an event in tracks on entering and leaving the step.
  * When completing the step, additional properties can be recorded e.g. which theme was selected.
  *
  * @param stepName The name of the signup step to track
- * @param eventProperties Additional properties to be recorded on completing the step
+ * @param getEventProperties Returns additional properties to be recorded on completing the step
  * @param deps Dependencies as will be passeed into react's useEffect
  */
-export function useTrackStep( stepName: StepNameType, eventProperties?: any, deps?: any ) {
+export function useTrackStep(
+	stepName: StepNameType,
+	getEventProperties?: () => TracksEventProperties,
+	deps?: DependencyList
+) {
 	useOnUnmount( () => {
-		recordLeaveStep( stepName, eventProperties );
+		recordLeaveStep( stepName, getEventProperties && getEventProperties() );
 	}, deps || [] );
 	useEffect( () => {
 		recordEnterStep( stepName );

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -3,14 +3,13 @@
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { v4 as uuid } from 'uuid';
-import { DependencyList } from 'react';
 
 /**
  * Internal dependencies
  */
 import { FLOW_ID } from '../../constants';
 import { StepNameType } from '../../path';
-import { ErrorParameters, OnboardingCompleteParameters } from './types';
+import { ErrorParameters, OnboardingCompleteParameters, TracksEventProperties } from './types';
 
 /**
  * Make tracks call with embedded flow.
@@ -127,7 +126,7 @@ export function getNewRailcarId( suffix = 'suggestion' ) {
  * @param modalName The name of the modal to record in tracks
  * @param eventProperties Additional properties to record on closing the modal
  */
-export function recordCloseModal( modalName: string, eventProperties?: DependencyList ) {
+export function recordCloseModal( modalName: string, eventProperties?: TracksEventProperties ) {
 	trackEventWithFlow( 'calypso_signup_modal_close', {
 		name: modalName,
 		...eventProperties,
@@ -151,7 +150,7 @@ export function recordEnterModal( modalName: string ) {
  * @param stepName The name of the step to record in tracks
  * @param eventProperties Additional properties to record on leaving the step
  */
-export function recordLeaveStep( stepName: StepNameType, eventProperties?: DependencyList ) {
+export function recordLeaveStep( stepName: StepNameType, eventProperties?: TracksEventProperties ) {
 	trackEventWithFlow( 'calypso_signup_step_leave', {
 		step: stepName,
 		...eventProperties,

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -32,3 +32,47 @@ export interface OnboardingCompleteParameters {
 	 */
 	blogId: number | string | undefined;
 }
+
+type TracksVerticalSelectEventProperties = {
+	/**
+	 * The Vertical selected on the intent gathering page
+	 */
+	selected_vertical: string | undefined;
+
+	/**
+	 * The site title that was selected on the intent gathering page
+	 */
+	selected_site_title: string | undefined;
+};
+
+type TracksStyleSelectEventProperties = {
+	/**
+	 * The font selected for headings on the style page
+	 */
+	selected_heading_font: string | undefined;
+
+	/**
+	 * The font selected for body text on the style page
+	 */
+	selected_body_font: string | undefined;
+};
+
+type TracksDesignSelectEventProperties = {
+	/**
+	 * The selected theme
+	 */
+	selected_design: string | undefined;
+};
+
+type TracksDomainSelectEventProperties = {
+	/**
+	 * The selected level domain name
+	 */
+	selected_domain: string | undefined;
+};
+
+export type TracksEventProperties =
+	| TracksVerticalSelectEventProperties
+	| TracksStyleSelectEventProperties
+	| TracksDesignSelectEventProperties
+	| TracksDomainSelectEventProperties;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -26,9 +26,13 @@ import './style.scss';
 
 const AcquireIntent: React.FunctionComponent = () => {
 	const { __ } = useI18n();
-	const onboardingStore = useSelect( ( select ) => select( STORE_KEY ) );
+	const { getSelectedVertical, getSelectedSiteTitle } = useSelect( ( select ) =>
+		select( STORE_KEY )
+	);
 
-	const { siteVertical, siteTitle, wasVerticalSkipped } = onboardingStore.getState();
+	const { siteVertical, siteTitle, wasVerticalSkipped } = useSelect( ( select ) =>
+		select( STORE_KEY ).getState()
+	);
 
 	const { skipSiteVertical } = useDispatch( STORE_KEY );
 
@@ -44,8 +48,8 @@ const AcquireIntent: React.FunctionComponent = () => {
 	};
 
 	useTrackStep( 'IntentGathering', () => ( {
-		selected_vertical: onboardingStore.getSelectedVertical()?.slug,
-		selected_site_title: onboardingStore.getSelectedSiteTitle(),
+		selected_vertical: getSelectedVertical()?.slug,
+		selected_site_title: getSelectedSiteTitle(),
 	} ) );
 
 	// translators: Button label for skipping filling an optional input in onboarding

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -45,7 +45,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 
 	useTrackStep( 'IntentGathering', () => ( {
 		selected_vertical: onboardingStore.getSelectedVertical()?.slug,
-		selected_site_title: onboardingStore.getSelectedSiteTitle()
+		selected_site_title: onboardingStore.getSelectedSiteTitle(),
 	} ) );
 
 	// translators: Button label for skipping filling an optional input in onboarding

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -26,10 +26,12 @@ import './style.scss';
 
 const AcquireIntent: React.FunctionComponent = () => {
 	const { __ } = useI18n();
-	const { siteVertical, siteTitle, wasVerticalSkipped } = useSelect( ( select ) =>
-		select( STORE_KEY ).getState()
-	);
+	const onboardingStore = useSelect( ( select ) => select( STORE_KEY ) );
+
+	const { siteVertical, siteTitle, wasVerticalSkipped } = onboardingStore.getState();
+
 	const { skipSiteVertical } = useDispatch( STORE_KEY );
+
 	const makePath = usePath();
 
 	const [ isSiteTitleActive, setIsSiteTitleActive ] = React.useState( false );
@@ -41,7 +43,10 @@ const AcquireIntent: React.FunctionComponent = () => {
 		setIsSiteTitleActive( true );
 	};
 
-	useTrackStep( 'IntentGathering' );
+	useTrackStep( 'IntentGathering', () => ( {
+		selected_vertical: onboardingStore.getSelectedVertical()?.slug,
+		selected_site_title: onboardingStore.getSelectedSiteTitle()
+	} ) );
 
 	// translators: Button label for skipping filling an optional input in onboarding
 	const skipLabel = __( 'I donʼt know' );

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -29,7 +29,7 @@ const DesignSelector: React.FunctionComponent = () => {
 	const makePath = usePath();
 
 	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
-	const onboardingStore = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { getSelectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 	const getDesignUrl = ( design: Design ) => {
 		// We temporarily show pre-generated screenshots until we can generate tall versions dynamically using mshots.
@@ -49,7 +49,7 @@ const DesignSelector: React.FunctionComponent = () => {
 	};
 
 	useTrackStep( 'DesignSelection', () => ( {
-		selected_design: onboardingStore.getSelectedDesign()?.slug,
+		selected_design: getSelectedDesign()?.slug,
 	} ) );
 
 	return (

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useI18n } from '@automattic/react-i18n';
 import { useHistory } from 'react-router-dom';
@@ -24,12 +24,12 @@ type Design = import('../../stores/onboard/types').Design;
 const makeOptionId = ( { slug }: Design ): string => `design-selector__option-name__${ slug }`;
 
 const DesignSelector: React.FunctionComponent = () => {
-	useTrackStep( 'DesignSelection' );
-
 	const { __ } = useI18n();
 	const { push } = useHistory();
 	const makePath = usePath();
+
 	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
+	const onboardingStore = useSelect( ( select ) => select( ONBOARD_STORE ) );
 
 	const getDesignUrl = ( design: Design ) => {
 		// We temporarily show pre-generated screenshots until we can generate tall versions dynamically using mshots.
@@ -47,6 +47,10 @@ const DesignSelector: React.FunctionComponent = () => {
 		} );
 		return mshotsUrl + encodeURIComponent( previewUrl );
 	};
+
+	useTrackStep( 'DesignSelection', () => ( {
+		selected_design: onboardingStore.getSelectedDesign()?.slug,
+	} ) );
 
 	return (
 		<div className="gutenboarding-page design-selector">

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -25,8 +25,8 @@ import { useTrackStep } from '../../hooks/use-track-step';
 import './style.scss';
 
 const StylePreview: React.FunctionComponent = () => {
-	const onboardingStore = useSelect( ( select ) => select( ONBOARD_STORE ) );
-	const { selectedDesign } = onboardingStore.getState();
+	const { getSelectedFonts } = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { selectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 
 	const [ showSignupDialog, setShowSignupDialog ] = useState( false );
 
@@ -43,8 +43,8 @@ const StylePreview: React.FunctionComponent = () => {
 	const freeDomainSuggestion = useFreeDomainSuggestion();
 
 	useTrackStep( 'Style', () => ( {
-		selected_heading_font: onboardingStore.getSelectedFonts()?.headings,
-		selected_body_font: onboardingStore.getSelectedFonts()?.base,
+		selected_heading_font: getSelectedFonts()?.headings,
+		selected_body_font: getSelectedFonts()?.base,
 	} ) );
 
 	const handleSignup = () => {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -25,7 +25,8 @@ import { useTrackStep } from '../../hooks/use-track-step';
 import './style.scss';
 
 const StylePreview: React.FunctionComponent = () => {
-	const { selectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const onboardingStore = useSelect( ( select ) => select( ONBOARD_STORE ) );
+	const { selectedDesign } = onboardingStore.getState();
 
 	const [ showSignupDialog, setShowSignupDialog ] = useState( false );
 
@@ -41,7 +42,10 @@ const StylePreview: React.FunctionComponent = () => {
 
 	const freeDomainSuggestion = useFreeDomainSuggestion();
 
-	useTrackStep( 'Style' );
+	useTrackStep( 'Style', () => ( {
+		selected_heading_font: onboardingStore.getSelectedFonts()?.headings,
+		selected_body_font: onboardingStore.getSelectedFonts()?.base,
+	} ) );
 
 	const handleSignup = () => {
 		setShowSignupDialog( true );

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -2,13 +2,18 @@
  * Internal dependencies
  */
 import { State } from './reducer';
+import { DomainName } from '@automattic/data-stores/dist/types/domain-suggestions';
 
 export const getState = ( state: State ) => state;
 export const getSelectedSite = ( state: State ) => state.selectedSite;
-
 export const hasPaidDomain = ( state: State ): boolean => {
 	if ( ! state.domain ) {
 		return false;
 	}
-	return ! state.domain.is_free;
-};
+    return ! state.domain.is_free;
+}
+export const getSelectedDesign = ( state: State ) => state.selectedDesign;
+export const getSelectedFonts = ( state: State ) => state.selectedFonts;
+export const getSelectedVertical = ( state: State ) => state.siteVertical;
+export const getSelectedDomain = ( state: State ) => state.domain;
+export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { State } from './reducer';
-import { DomainName } from '@automattic/data-stores/dist/types/domain-suggestions';
 
 export const getState = ( state: State ) => state;
 export const getSelectedSite = ( state: State ) => state.selectedSite;
@@ -10,8 +9,8 @@ export const hasPaidDomain = ( state: State ): boolean => {
 	if ( ! state.domain ) {
 		return false;
 	}
-    return ! state.domain.is_free;
-}
+	return ! state.domain.is_free;
+};
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedFonts = ( state: State ) => state.selectedFonts;
 export const getSelectedVertical = ( state: State ) => state.siteVertical;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Include extra properties in the tracks analytics calls based on this discussion in pbAok1-Ao-p2#comment-1316

I tried to use useEffect with values selected from the redux store. e.g.

```ts
let selectedStyle = useSelect( ( select ) => select( ONBOARDING_STORE ).getSelectedStyle() )
useEffect(()=> {
    console.log(selectedStyle);
}, [selectedStyle] )
```
but with that method, the useEffect block is not re-evaluated when the value changes.

Now in the useEffect, it re-evaluates the redux selector each time using a reference to the store e.g.

```ts
const onboardingStore = useSelect( ( select ) => select( ONBOARD_STORE ) );
useEffect( () => {
  console.log( onboardingStore.getSelectedStyle() );
}, [ ] )
```

This works but It doesn't feel as nice to have a direct reference to the onboarding store like that.

What do you think, maybe I'm missing something simple.


#### Testing instructions

The following extra info should be recorded on leaving gutenboarding steps

* intent gathering page 
    * `selected_vertical`
    * `selected_site_title`
* Design page
    * `selected_design`
* Style page
    * `selected_heading_font`
    * `selected_body_font`
* Domain picker
    * `selected_domain`