### PR TITLE
Update terser to 4.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
 		"stylelint": "^9.10.1",
 		"supertest": "^4.0.2",
 		"svgstore-cli": "^1.3.1",
-		"terser": "^4.4.3",
+		"terser": "^4.6.11",
 		"ts-loader": "^6.2.1",
 		"typescript": "^3.8.3",
 		"vfile-message": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20510,19 +20510,10 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@^4.1.2, terser@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.4.3.tgz#401abc52b88869cf904412503b1eb7da093ae2f0"
-  integrity sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==
-  dependencies:
-    commander "^2.20.0"
-    source-map "~0.6.1"
-    source-map-support "~0.5.12"
-
-terser@^4.6.3:
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.6.tgz#da2382e6cafbdf86205e82fb9a115bd664d54863"
-  integrity sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==
+terser@^4.1.2, terser@^4.4.3, terser@^4.6.11, terser@^4.6.3:
+  version "4.6.11"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.11.tgz#12ff99fdd62a26de2a82f508515407eb6ccd8a9f"
+  integrity sha512-76Ynm7OXUG5xhOpblhytE7X58oeNSmC8xnNhjWVo8CksHit0U0kO4hfNbPrrYwowLWFgM2n9L176VNx2QaHmtA==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Updates terser to 4.6.11.

This is the manual version of #40070 which renovate keeps auto-closing. Check there for relevant discussions.

---

### Testing instructions

* Check the live site and verify there are no errors in the Console. Be sure to try with different browsers.

---

### Release Notes

<details>
<summary>terser/terser</summary>

### [`v4.6.11`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v4611)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.10...v4.6.11)

-   Read unused classes' properties and method keys, to figure out if they use other variables.
-   Prevent inlining into block scopes when there are name collisions
-   Functions are no longer inlined into parameter defaults, because they live in their own special scope.
-   When inlining identity functions, take into account the fact they may be used to drop `this` in function calls.
-   Nullish coalescing operator (`x ?? y`), plus basic optimization for it.
-   Template literals in binary expressions such as `+` have been further optimized

### [`v4.6.10`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v4610)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.9...v4.6.10)

-   Do not use reduce_vars when classes are present

### [`v4.6.9`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v469)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.8...v4.6.9)

-   Check if block scopes actually exist in blocks

### [`v4.6.8`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v468)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.7...v4.6.8)

-   Take into account "executed bits" of classes like static properties or computed keys, when checking if a class evaluation might throw or have side effects.

### [`v4.6.7`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v467)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.6...v4.6.7)

-   Some new performance gains through a `AST_Node.size()` method which measures a node's source code length without printing it to a string first.
-   An issue with setting `--comments` to `false` in the CLI has been fixed.
-   Fixed some issues with inlining
-   `unsafe_symbols` compress option was added, which turns `Symbol("name")` into just `Symbol()`
-   Brought back compress performance improvement through the `AST_Node.equivalent_to(other)` method (which was reverted in v4.6.6).

### [`v4.6.6`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v466)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.5...v4.6.6)

(hotfix release)

-   Reverted code to 4.6.4 to allow for more time to investigate an issue.

### [`v4.6.5`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v465-REVERTED)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.4...v4.6.5)

-   Improved compress performance through using a new method to see if two nodes are equivalent, instead of printing them to a string.

### [`v4.6.4`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v464)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.3...v4.6.4)

-   The `"some"` value in the `comments` output option now preserves `@lic` and other important comments when using `//`
-   `</script>` is now better escaped in regex, and in comments, when using the `inline_script` output option
-   Fixed an issue when transforming `new RegExp` into `/.../` when slashes are included in the source
-   `AST_Node.prototype.constructor` now exists, allowing for easier debugging of crashes
-   Multiple if statements with the same consequents are now collapsed
-   Typescript typings improvements
-   Optimizations while looking for surrogate pairs in strings

### [`v4.6.3`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v463)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.2...v4.6.3)

-   Annotations such as `/*#__NOINLINE__*/` and `/*#__PURE__*/` may now be preserved using the `preserve_annotations` output option
-   A TypeScript definition update for the `keep_quoted` output option.

### [`v4.6.2`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v462)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.1...v4.6.2)

-   A bug where functions were inlined into other functions with scope conflicts has been fixed.
-   `/*#__NOINLINE__*/` annotation fixed for more use cases where inlining happens.

### [`v4.6.1`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v4611)

[Compare Source](https://togithub.com/terser/terser/compare/v4.6.0...v4.6.1)

-   Read unused classes' properties and method keys, to figure out if they use other variables.
-   Prevent inlining into block scopes when there are name collisions
-   Functions are no longer inlined into parameter defaults, because they live in their own special scope.
-   When inlining identity functions, take into account the fact they may be used to drop `this` in function calls.
-   Nullish coalescing operator (`x ?? y`), plus basic optimization for it.
-   Template literals in binary expressions such as `+` have been further optimized

### [`v4.6.0`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v460)

[Compare Source](https://togithub.com/terser/terser/compare/v4.5.1...v4.6.0)

-   Fixed issues with recursive class references.
-   BigInt evaluation has been prevented, stopping Terser from evaluating BigInts like it would do regular numbers.
-   Class property support has been added

### [`v4.5.1`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v451)

[Compare Source](https://togithub.com/terser/terser/compare/v4.5.0...v4.5.1)

(hotfix release)

-   Fixed issue where `() => ({})[something]` was not parenthesised correctly.

### [`v4.5.0`](https://togithub.com/terser/terser/blob/master/CHANGELOG.md#v450)

[Compare Source](https://togithub.com/terser/terser/compare/v4.4.3...v4.5.0)

-   Inlining has been improved
-   An issue where keep_fnames combined with functions declared through variables was causing name shadowing has been fixed
-   You can now set the ES version through their year
-   The output option `keep_numbers` has been added, which prevents Terser from turning `1000` into `1e3` and such
-   Internal small optimisations and refactors

</details>


