### PR TITLE
Plans: Make the Jetpack Scan Product available for purchase

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -53,6 +53,7 @@
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connection-rebranding": true,
 		"jetpack/happychat": true,
+		"jetpack/scan-product": true,
 		"jetpack_core_inline_update": true,
 		"jitms": false,
 		"lasagna": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -44,6 +44,7 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/personalPlan": true,
+		"jetpack/scan-product": false,
 		"jitms": false,
 		"lasagna": false,
 		"layout/app-banner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -52,6 +52,7 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
+		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -54,6 +54,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
+		"jetpack/scan-product": false,
 		"jetpack/search-product": true,
 		"jitms": true,
 		"lasagna": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -61,6 +61,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
+		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
 		"jitms": true,
 		"lasagna": false,

--- a/config/test.json
+++ b/config/test.json
@@ -47,6 +47,7 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
+		"jetpack/scan-product": true,
 		"jitms": true,
 		"lasagna": false,
 		"layout/app-banner": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -68,6 +68,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
+		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
 		"jitms": true,
 		"lasagna": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR add the Jetpack Scan to be available for purchase on 
Staging, desktop development, horizon, calypso.live, and wp-calypso.

The Jetpack Scan product will not be available on Production and the dasktop app.

#### Testing instructions

Look at the code. Test out the new calypso live link. 

