### PR TITLE
Plans: Stop promoting enhanced search for Jetpack Professional

### DIFF
--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -921,20 +921,6 @@ export const FEATURES_LIST = {
 			),
 	},
 
-	[ constants.FEATURE_SEARCH ]: {
-		getSlug: () => constants.FEATURE_SEARCH,
-		getTitle: () =>
-			i18n.translate( '{{strong}}Enhanced{{/strong}} Site-wide Search', {
-				components: {
-					strong: <strong />,
-				},
-			} ),
-		getDescription: () =>
-			i18n.translate(
-				'Fast, relevant search results with custom filtering, powered by Elasticsearch.'
-			),
-	},
-
 	[ constants.FEATURE_ACCEPT_PAYMENTS ]: {
 		getSlug: () => constants.FEATURE_ACCEPT_PAYMENTS,
 		getTitle: () => i18n.translate( 'Accept Payments in 60+ Countries' ),

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -929,7 +929,6 @@ export const PLANS_LIST = {
 				constants.FEATURE_SPAM_AKISMET_PLUS,
 				constants.FEATURE_EASY_SITE_MIGRATION,
 				constants.FEATURE_PREMIUM_SUPPORT,
-				constants.FEATURE_SEARCH,
 				isEnabled( 'republicize' ) && constants.FEATURE_REPUBLICIZE,
 				constants.FEATURE_SIMPLE_PAYMENTS,
 				constants.FEATURE_WORDADS_INSTANT,
@@ -943,7 +942,6 @@ export const PLANS_LIST = {
 		getSignupFeatures: () =>
 			compact( [
 				constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-				constants.FEATURE_SEARCH,
 				constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 				constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
 			] ),
@@ -1014,7 +1012,6 @@ export const PLANS_LIST = {
 		getSignupFeatures: () =>
 			compact( [
 				constants.FEATURE_OFFSITE_BACKUP_VAULTPRESS_REALTIME,
-				constants.FEATURE_SEARCH,
 				constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 				constants.FEATURE_ALL_PREMIUM_FEATURES_JETPACK,
 			] ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes "Enhanced Site-wide Search" from the Plans list, but keeps `FEATURE_SEARCH ` for the upsell nudges

#### Testing instructions

It looks like https://jurassic.ninja/create/ isn't currently working, but try to spin up a Jetpack site so that you can access the Plans page, and verify that the feature has been removed from the "Professional" column.

<img width="1616" alt="Screenshot 2020-04-24 at 11 28 43" src="https://user-images.githubusercontent.com/43215253/80203630-5a945480-861f-11ea-9f4c-7e6796984068.png">

cc @keoshi 

Fixes #41336
