### PR TITLE
Gutenboarding: update launch flow

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -302,7 +302,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				this.props.isSiteUnlaunched;
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
-				frankenflowUrl: `${ window.location.origin }/start/frankenflow?siteSlug=${ this.props.siteId }`,
+				frankenflowUrl: `${ window.location.origin }/start/frankenflow?siteSlug=${ this.props.siteId }&source=editor`,
 			} );
 		}
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -345,12 +345,12 @@ export function generateFlows( {
 
 	if ( isEnabled( 'gutenboarding' ) ) {
 		flows.frankenflow = {
-			steps: [ 'plans-launch', 'launch' ],
+			steps: [ 'domains-launch', 'plans-launch', 'launch' ],
 			destination: getLaunchDestination,
 			description: 'Frankenflow launch for a site created from Gutenboarding',
 			lastModified: '2020-01-22',
 			pageTitle: translate( 'Launch your site' ),
-			providesDependenciesInQuery: [ 'siteSlug' ],
+			providesDependenciesInQuery: [ 'siteSlug', 'source' ],
 		};
 	}
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -60,6 +60,9 @@ function getSignupDestination( dependencies ) {
 }
 
 function getLaunchDestination( dependencies ) {
+	if ( dependencies.source === 'editor' ) {
+		return `/block-editor/page/${ dependencies.siteSlug }/home`;
+	}
 	return `/home/${ dependencies.siteSlug }?d=launched`;
 }
 

--- a/client/state/sites/launch/actions.js
+++ b/client/state/sites/launch/actions.js
@@ -4,7 +4,7 @@
 import { SITE_LAUNCH } from 'state/action-types';
 import 'state/data-layer/wpcom/sites/launch';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { getSiteSlug, isCurrentPlanPaid } from 'state/sites/selectors';
+import { getSiteSlug, isCurrentPlanPaid, getSiteOption } from 'state/sites/selectors';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 
 export const launchSite = ( siteId ) => ( {
@@ -34,5 +34,12 @@ export const launchSiteOrRedirectToLaunchSignupFlow = ( siteId ) => ( dispatch, 
 	const siteSlug = getSiteSlug( getState(), siteId );
 
 	// TODO: consider using the `page` library instead of calling using `location.href` here
-	window.location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
+
+	const isGutenboarding =
+		getSiteOption( getState(), siteId, 'site_creation_flow' ) === 'gutenboarding';
+	if ( isGutenboarding ) {
+		window.location.href = `/start/frankenflow?siteSlug=${ siteSlug }&source=home`;
+	} else {
+		window.location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
+	}
 };


### PR DESCRIPTION
The scope of this PR is just to align post-Gutenboarding launch flow steps, entry points and redirects. Design updates (domains, plans, and purchase) will be implemented separately.

#### Changes proposed in this Pull Request

* Add domain step to Gutenboarding launch flow.
* Use Gutenboarding styled launch when launching from customer home a site previously created in Gutenboarding.
* Redirect back to Block Editor after launching a site starting from there.

#### Testing instructions

**Scenario 1**
* Create a site starting from [/new](https://calypso.live/new?branch=update/gutenboarding-launch-flow).
* When landing in the editor press [Update button](https://cloudup.com/cU4SXhyKCg3) to launch the site. 
* After launching you should land back to the editor.

**Scenario 2**
* Create a new site starting from [/new](https://calypso.live/new?branch=update/gutenboarding-launch-flow).
* When landing in the editor press W to go to customer home.
* Press [Launch my site button](https://cloudup.com/c2KNknvmCOT) and check if the launch steps are styled exactly like in the first scenario.
* After launching you should land back to customer home.

More context for this change: pbAok1-El-p2#comment-1403
Related to: #41300