### PR TITLE
Gutenboarding: Keep Intent capture user information

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -29,7 +29,7 @@ const DesignSelector: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 	const { push } = useHistory();
 	const makePath = usePath();
-	const { setSelectedDesign, setFonts, resetOnboardStore } = useDispatch( ONBOARD_STORE );
+	const { setSelectedDesign, setFonts } = useDispatch( ONBOARD_STORE );
 
 	const getDesignUrl = ( design: Design ) => {
 		// We temporarily show pre-generated screenshots until we can generate tall versions dynamically using mshots.
@@ -59,7 +59,6 @@ const DesignSelector: React.FunctionComponent = () => {
 				</div>
 				<Link
 					className="design-selector__start-over-button"
-					onClick={ () => resetOnboardStore() }
 					to={ makePath( Step.IntentGathering ) }
 					isLink
 				>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Keep user entered information when pressing 'Go back' button.

#### Testing instructions
* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-keep-intent-capture-info)
* Fill in one or both inputs and advance to Design picker step.
* Press _Go back_ button.
* Now your previously entered information should be still visible.

Fixes #41303
