### PR TITLE
DevDocs: Add more comprehensive UpsellNudge examples

### DIFF
--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -31,7 +31,7 @@ const UpsellNudgeExample = () => (
 			forceDisplay
 			href="#"
 			callToAction="Upgrade"
-			title="Free domain with a plan! This is a dismissable nudge with a description."
+			title="Free domain with a plan! This is a dismissible nudge with a description."
 			showIcon={ true }
 		/>
 		<UpsellNudge

--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -18,6 +18,31 @@ const UpsellNudgeExample = () => (
 			showIcon={ true }
 		/>
 		<UpsellNudge
+			description="Domain registration is free for a year with purchase of a Premium or Business plan."
+			forceDisplay
+			href="#"
+			callToAction="Upgrade"
+			title="Free domain with a plan! This is a regular nudge with a description."
+			showIcon={ true }
+		/>
+		<UpsellNudge
+			description="Domain registration is free for a year with purchase of a Premium or Business plan."
+			dismissPreferenceName="calypso_upsell_nudge_devdocs_dismiss"
+			forceDisplay
+			href="#"
+			callToAction="Upgrade"
+			title="Free domain with a plan! This is a dismissable nudge with a description."
+			showIcon={ true }
+		/>
+		<UpsellNudge
+			forceDisplay
+			isJetpackDevDocs
+			showIcon
+			href="#"
+			callToAction="Upgrade"
+			title="Free domain with a plan! This is a Jetpack nudge."
+		/>
+		<UpsellNudge
 			forceDisplay
 			href="#"
 			compact

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -39,6 +39,7 @@ export const UpsellNudge = ( {
 	forceHref,
 	href,
 	icon,
+	isJetpackDevDocs,
 	jetpack,
 	isVip,
 	list,
@@ -92,7 +93,7 @@ export const UpsellNudge = ( {
 			forceHref={ forceHref }
 			href={ href }
 			icon={ icon }
-			jetpack={ jetpack }
+			jetpack={ jetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
 			list={ list }
 			onClick={ onClick }
 			onDismissClick={ onDismissClick }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a few more upsell nudges to Devdocs for clarity, including a Jetpack-styled nudge.

**Before**

<img width="846" alt="Screen Shot 2020-04-24 at 12 03 29 PM" src="https://user-images.githubusercontent.com/2124984/80232887-a1844900-8623-11ea-88bd-7e7e16a39348.png">

**After**

<img width="962" alt="Screen Shot 2020-04-24 at 11 59 39 AM" src="https://user-images.githubusercontent.com/2124984/80232798-7994e580-8623-11ea-9cdc-a583801b0582.png">

#### Testing instructions

* Switch to this PR, navigate to `/devdocs`
* Go to Blocks -> Search for `UpsellNudge`
* Note the added nudges, look for visual or console errors
