### PR TITLE
i18n: Fix cache busting for translation chunks

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -3,6 +3,7 @@ const fs = require( 'fs' );
 const glob = require( 'glob' );
 const path = require( 'path' );
 const https = require( 'https' );
+const crypto = require( 'crypto' );
 const mkdirp = require( 'mkdirp' );
 const readline = require( 'readline' );
 const parse = require( 'gettext-parser' ).po.parse;
@@ -161,6 +162,11 @@ function downloadLanguagesRevions() {
 
 		https.get( `${ LANGUAGES_BASE_URL }/${ LANGUAGES_REVISIONS_FILENAME }`, ( response ) => {
 			files.forEach( ( file ) => response.pipe( file ) );
+
+			let languageRevisions = '';
+			response.on( 'data', ( chunk ) => {
+				languageRevisions += chunk;
+			} );
 			response.on( 'end', () => {
 				if ( response.statusCode !== 200 ) {
 					log( 'failed' );
@@ -169,7 +175,7 @@ function downloadLanguagesRevions() {
 				}
 
 				log( 'completed' );
-				resolve( true );
+				resolve( JSON.parse( languageRevisions ) );
 			} );
 		} );
 	} );
@@ -225,7 +231,7 @@ async function downloadLanguages() {
 }
 
 // Split language translations into chunks
-function buildLanguageChunks( downloadedLanguages ) {
+function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 	logUpdate( 'Building language chunks...' );
 
 	if ( fs.existsSync( CALYPSO_STRINGS ) ) {
@@ -244,6 +250,8 @@ function buildLanguageChunks( downloadedLanguages ) {
 			},
 			{}
 		);
+
+		const languageRevisionsHashes = {};
 
 		languagesPaths.map( ( { chunksMapPath, publicPath } ) => {
 			const chunksMap = require( path.join( '..', chunksMapPath ) );
@@ -266,10 +274,20 @@ function buildLanguageChunks( downloadedLanguages ) {
 				const translatedChunksKeys = Object.keys( languageChunks ).map(
 					( chunk ) => path.parse( chunk ).name
 				);
-				const manifestJsonData = JSON.stringify( {
+				const manifestJsonDataRaw = {
 					locale: _.pick( languageTranslations, [ '' ] ),
 					translatedChunks: translatedChunksKeys,
-				} );
+				};
+				const manifestJsonDataFingerprint =
+					JSON.stringify( manifestJsonDataRaw ) + languageRevisions[ langSlug ];
+
+				manifestJsonDataRaw.hash = crypto
+					.createHash( 'sha1' )
+					.update( manifestJsonDataFingerprint )
+					.digest( 'hex' );
+				languageRevisionsHashes[ langSlug ] = manifestJsonDataRaw.hash;
+
+				const manifestJsonData = JSON.stringify( manifestJsonDataRaw );
 				const manifestFilepathJson = path.join(
 					publicPath,
 					`${ langSlug }-${ LANGUAGE_MANIFEST_FILENAME }`
@@ -305,6 +323,20 @@ function buildLanguageChunks( downloadedLanguages ) {
 				} );
 			} );
 		} );
+
+		logUpdate( 'Updating language revisions...\n' );
+
+		const updatedLanguageRevisions = JSON.stringify( {
+			...languageRevisions,
+			hashes: languageRevisionsHashes,
+		} );
+
+		languagesPaths.forEach( ( { publicPath } ) =>
+			fs.writeFileSync(
+				`${ publicPath }/${ LANGUAGES_REVISIONS_FILENAME }`,
+				updatedLanguageRevisions
+			)
+		);
 	}
 
 	logUpdate( 'Building language chunks completed.\n' );
@@ -312,9 +344,9 @@ function buildLanguageChunks( downloadedLanguages ) {
 
 async function run() {
 	createLanguagesDir();
-	await downloadLanguagesRevions();
+	const languageRevisions = await downloadLanguagesRevions();
 	const downloadedLanguages = await downloadLanguages();
-	buildLanguageChunks( downloadedLanguages );
+	buildLanguageChunks( downloadedLanguages, languageRevisions );
 }
 
 run();

--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -278,8 +278,7 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 					locale: _.pick( languageTranslations, [ '' ] ),
 					translatedChunks: translatedChunksKeys,
 				};
-				const manifestJsonDataFingerprint =
-					JSON.stringify( manifestJsonDataRaw ) + languageRevisions[ langSlug ];
+				const manifestJsonDataFingerprint = JSON.stringify( manifestJsonDataRaw );
 
 				manifestJsonDataRaw.hash = crypto
 					.createHash( 'sha1' )

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -145,6 +145,10 @@ export function getLanguageManifestFileUrl( {
 		fileType = 'json';
 	}
 
+	if ( typeof hash === 'number' ) {
+		hash = hash.toString();
+	}
+
 	const fileBasePath = getLanguagesInternalBasePath( targetBuild );
 	const fileUrl = `${ fileBasePath }/${ localeSlug }-language-manifest.${ fileType }`;
 
@@ -196,6 +200,10 @@ export function getTranslationChunkFileUrl( {
 } = {} ) {
 	if ( ! includes( [ 'js', 'json' ], fileType ) ) {
 		fileType = 'json';
+	}
+
+	if ( typeof hash === 'number' ) {
+		hash = hash.toString();
 	}
 
 	const fileBasePath = getLanguagesInternalBasePath( targetBuild );

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -168,7 +168,7 @@ export function getLanguageManifestFile( localeSlug, targetBuild = 'evergreen' )
 		localeSlug,
 		fileType: 'json',
 		targetBuild,
-		hash: window.COMMIT_SHA || null,
+		hash: window?.languageRevisions?.hashes?.[ localeSlug ] || null,
 	} );
 
 	return getFile( url );
@@ -224,7 +224,7 @@ export function getTranslationChunkFile( chunkId, localeSlug, buildTarget = 'eve
 		localeSlug,
 		fileType: 'json',
 		buildTarget,
-		hash: window.COMMIT_SHA || null,
+		hash: window?.languageRevisions?.hashes?.[ localeSlug ] || null,
 	} );
 
 	return getFile( url );

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -130,7 +130,7 @@ export function getLanguageFile( targetLocaleSlug ) {
  * @param {string} options.localeSlug A locale slug. e.g. fr, jp, zh-tw
  * @param {string} options.fileType The desired file type, js or json. Default to json.
  * @param {string} options.targetBuild The build target. e.g. fallback, evergreen, etc.
- * @param {object} options.languageRevisions An optional language revisions map. If it exists, the function will append the revision within as cache buster.
+ * @param {string} options.hash Build hash string that will be used as cache buster.
  *
  * @returns {string} A language manifest file URL.
  */
@@ -139,17 +139,16 @@ export function getLanguageManifestFileUrl( {
 	localeSlug,
 	fileType = 'json',
 	targetBuild = 'evergreen',
-	languageRevisions = {},
+	hash = null,
 } = {} ) {
 	if ( ! includes( [ 'js', 'json' ], fileType ) ) {
 		fileType = 'json';
 	}
 
-	const revision = languageRevisions[ localeSlug ];
 	const fileBasePath = getLanguagesInternalBasePath( targetBuild );
 	const fileUrl = `${ fileBasePath }/${ localeSlug }-language-manifest.${ fileType }`;
 
-	return typeof revision === 'number' ? fileUrl + `?v=${ revision }` : fileUrl;
+	return typeof hash === 'string' ? fileUrl + `?v=${ hash }` : fileUrl;
 }
 
 /**
@@ -169,7 +168,7 @@ export function getLanguageManifestFile( localeSlug, targetBuild = 'evergreen' )
 		localeSlug,
 		fileType: 'json',
 		targetBuild,
-		languageRevisions: window.languageRevisions || {},
+		hash: window.COMMIT_SHA || null,
 	} );
 
 	return getFile( url );
@@ -184,7 +183,7 @@ export function getLanguageManifestFile( localeSlug, targetBuild = 'evergreen' )
  * @param {string} options.localeSlug A locale slug. e.g. fr, jp, zh-tw
  * @param {string} options.fileType The desired file type, js or json. Default to json.
  * @param {string} options.buildTarget The build target. e.g. fallback, evergreen, etc.
- * @param {object} options.languageRevisions An optional language revisions map. If it exists, the function will append the revision within as cache buster.
+ * @param {string} options.hash Build hash string that will be used as cache buster.
  *
  * @returns {string} A translation chunk file URL.
  */
@@ -193,18 +192,17 @@ export function getTranslationChunkFileUrl( {
 	localeSlug,
 	fileType = 'json',
 	targetBuild = 'evergreen',
-	languageRevisions = {},
+	hash = null,
 } = {} ) {
 	if ( ! includes( [ 'js', 'json' ], fileType ) ) {
 		fileType = 'json';
 	}
 
-	const revision = languageRevisions[ localeSlug ];
 	const fileBasePath = getLanguagesInternalBasePath( targetBuild );
 	const fileName = `${ localeSlug }-${ chunkId }.${ fileType }`;
 	const fileUrl = `${ fileBasePath }/${ fileName }`;
 
-	return typeof revision === 'number' ? fileUrl + `?v=${ revision }` : fileUrl;
+	return typeof hash === 'string' ? fileUrl + `?v=${ hash }` : fileUrl;
 }
 
 /**
@@ -226,7 +224,7 @@ export function getTranslationChunkFile( chunkId, localeSlug, buildTarget = 'eve
 		localeSlug,
 		fileType: 'json',
 		buildTarget,
-		languageRevisions: window.languageRevisions || {},
+		hash: window.COMMIT_SHA || null,
 	} );
 
 	return getFile( url );

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -224,7 +224,7 @@ export function getTranslationChunkFile( chunkId, localeSlug, buildTarget = 'eve
 		localeSlug,
 		fileType: 'json',
 		buildTarget,
-		hash: window?.languageRevisions?.hashes?.[ localeSlug ] || null,
+		hash: window?.languageRevisions?.[ localeSlug ] || null,
 	} );
 
 	return getFile( url );

--- a/client/lib/i18n-utils/test/switch-locale.js
+++ b/client/lib/i18n-utils/test/switch-locale.js
@@ -89,11 +89,10 @@ describe( 'getLanguageManifestFileUrl()', () => {
 	} );
 
 	test( 'should append a revision cache buster.', () => {
-		const expected = getLanguagesInternalBasePath() + '/zh-language-manifest.json?v=123';
+		const hash = '123';
+		const expected = `${ getLanguagesInternalBasePath() }/zh-language-manifest.json?v=${ hash }`;
 
-		expect(
-			getLanguageManifestFileUrl( { localeSlug: 'zh', languageRevisions: { zh: 123 } } )
-		).toEqual( expected );
+		expect( getLanguageManifestFileUrl( { localeSlug: 'zh', hash } ) ).toEqual( expected );
 	} );
 
 	test( 'should not append a revision cache buster for an unknown locale.', () => {
@@ -130,11 +129,10 @@ describe( 'getTranslationChunkFileUrl()', () => {
 	test( 'should append a revision cache buster.', () => {
 		const localeSlug = 'zh';
 		const chunkId = 'chunk-abc.min';
-		const expected = `${ getLanguagesInternalBasePath() }/${ localeSlug }-${ chunkId }.json?v=123`;
+		const hash = '123';
+		const expected = `${ getLanguagesInternalBasePath() }/${ localeSlug }-${ chunkId }.json?v=${ hash }`;
 
-		expect(
-			getTranslationChunkFileUrl( { chunkId, localeSlug, languageRevisions: { zh: 123 } } )
-		).toEqual( expected );
+		expect( getTranslationChunkFileUrl( { chunkId, localeSlug, hash } ) ).toEqual( expected );
 	} );
 
 	test( 'should not append a revision cache buster for an unknown locale.', () => {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -391,37 +391,7 @@ function setUpLoggedOutRoute( req, res, next ) {
 		'X-Frame-Options': 'SAMEORIGIN',
 	} );
 
-	const setupRequests = [];
-
-	if ( config.isEnabled( 'use-translation-chunks' ) ) {
-		const target = getBuildTargetFromRequest( req );
-		const rootPath = path.join( __dirname, '..', '..', '..' );
-		const langRevisionsPath = path.join(
-			rootPath,
-			'public',
-			target,
-			'languages',
-			'lang-revisions.json'
-		);
-		const langPromise = fs.promises
-			.readFile( langRevisionsPath, 'utf8' )
-			.then( ( languageRevisions ) => {
-				req.context.languageRevisions = filterLanguageRevisions( JSON.parse( languageRevisions ) );
-
-				return languageRevisions;
-			} )
-			.catch( ( error ) => {
-				console.error( 'Failed to read the language revision files.', error );
-
-				throw error;
-			} );
-
-		setupRequests.push( langPromise );
-	}
-
-	Promise.all( setupRequests )
-		.then( () => next() )
-		.catch( ( error ) => next( error ) );
+	next();
 }
 
 function setUpLoggedInRoute( req, res, next ) {
@@ -446,7 +416,7 @@ function setUpLoggedInRoute( req, res, next ) {
 		const langPromise = fs.promises
 			.readFile( langRevisionsPath, 'utf8' )
 			.then( ( languageRevisions ) => {
-				req.context.languageRevisions = filterLanguageRevisions( JSON.parse( languageRevisions ) );
+				req.context.languageRevisions = languageRevisions;
 
 				return languageRevisions;
 			} )

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -181,7 +181,7 @@ export function attachI18n( context ) {
 					localeSlug: context.lang,
 					fileType: 'js',
 					buildTarget: context.target,
-					hash: context?.languageRevisions?.hashes?.[ context.lang ],
+					hash: context?.languageRevisions?.[ context.lang ],
 				} )
 			);
 	}

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -166,7 +166,7 @@ export function attachI18n( context ) {
 			localeSlug: context.lang,
 			fileType: 'js',
 			targetBuild: context.target,
-			hash: context.commitSha,
+			hash: context?.languageRevisions?.hashes?.[ context.lang ],
 		} );
 
 		const translatedChunks = getLanguageManifest( context.lang, context.target ).translatedChunks;
@@ -181,7 +181,7 @@ export function attachI18n( context ) {
 					localeSlug: context.lang,
 					fileType: 'js',
 					buildTarget: context.target,
-					hash: context.commitSha,
+					hash: context?.languageRevisions?.hashes?.[ context.lang ],
 				} )
 			);
 	}

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -166,7 +166,7 @@ export function attachI18n( context ) {
 			localeSlug: context.lang,
 			fileType: 'js',
 			targetBuild: context.target,
-			languageRevisions: context.languageRevisions,
+			hash: context.commitSha,
 		} );
 
 		const translatedChunks = getLanguageManifest( context.lang, context.target ).translatedChunks;
@@ -181,7 +181,7 @@ export function attachI18n( context ) {
 					localeSlug: context.lang,
 					fileType: 'js',
 					buildTarget: context.target,
-					languageRevisions: context.languageRevisions,
+					hash: context.commitSha,
 				} )
 			);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Language revisions are not loaded on non-logged routes and not reliable as a cache buster for language manifest as chunks may differ from one build to another. 

This PR changes cache busting for translation chunks and language manifest to use commit sha.

#### Testing instructions

1. Boot Calypso with `ENABLE_FEATURES=use-translation-chunks yarn start`
2. Open http://calypso.localhost:3000/start/user/pt-br
3. Confirm that language manifest and translation chunks `.js` and `.json` files are fetched with `?v={languageManifestHash}` query param.