### PR TITLE
Jetpack Cloud: show the Scan progress in the sidebar when scanning

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-badge/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-badge/index.tsx
@@ -20,6 +20,18 @@ const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress
 		return null;
 	}
 
+	if ( progress ) {
+		return (
+			<Badge type="success">
+				{ translate( '%(number)d %', {
+					args: {
+						number: progress,
+					},
+				} ) }
+			</Badge>
+		);
+	}
+
 	if ( numberOfThreatsFound ) {
 		return (
 			<Badge type="error">
@@ -33,18 +45,6 @@ const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress
 		);
 	}
 
-	if ( 100 !== progress ) {
-		// No need to show a badge when there is no progress.
-		return (
-			<Badge type="success">
-				{ translate( '%(number)d %', {
-					args: {
-						number: progress,
-					},
-				} ) }
-			</Badge>
-		);
-	}
 	return null;
 };
 

--- a/client/state/selectors/get-site-scan-progress.js
+++ b/client/state/selectors/get-site-scan-progress.js
@@ -4,7 +4,8 @@
 import 'state/data-layer/wpcom/sites/scan';
 
 /**
- * Returns the current Jetpack Progress for a given site.
+ * Returns the current Jetpack Scan Progress for a given site only if the
+ * Scan is in the 'scanning' state.
  * Returns undefined if the site is unknown, or if no information is available.
  *
  * @param {object} state	Global state tree
@@ -12,5 +13,7 @@ import 'state/data-layer/wpcom/sites/scan';
  * @returns {?number}		Undefined or percentage of the scan completed
  */
 export default function getSiteScanProgress( state, siteId ) {
-	return state.jetpackScan.scan?.[ siteId ]?.mostRecent?.progress;
+	return state.jetpackScan.scan?.[ siteId ]?.state === 'scanning'
+		? state.jetpackScan.scan?.[ siteId ]?.mostRecent?.progress
+		: undefined;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display in the sidebar, the current Scan progress when the Scan is in the `scanning` state.

#### Implementation notes

* I made the `getSiteScanProgress` selector return the progress only when the Scan is in the `scanning` state. It returns undefined in any other case. I can't see a case in which we would need the progress when the Scan is not running.
* I made the `ScanBadge` component prioritize showing the current progress over the number of threats. This will happen only when the Scan is in the `scanning` state as it was explained in the previous point.

#### Testing instructions

- Run this PR
- Go to `http://jetpack.cloud.localhost:3000/`
- Select a site that has Jetpack Scan
- Trigger a Scan execution (I triggered a Backup from VaultPress)
- Refresh the browser until you see the UI for the `scanning` state
- Verify the current progress is being displayed in the sidebar
- Watch how it gets updated every ~5 seconds

#### Demo
![Kapture 2020-04-24 at 13 52 24](https://user-images.githubusercontent.com/3418513/80238020-0fd10780-8634-11ea-95fa-72ce9af8dc41.gif)

