### PR TITLE
Domains: Replace claim domain notice with UpsellNudge

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -115,6 +115,7 @@ export class List extends React.Component {
 				forceDisplay
 				href={ `/domains/add/${ this.props.selectedSite.slug }` }
 				showIcon
+				event="calypso_domain_credit_reminder_impression"
 				tracksClickName="calypso_domain_credit_reminder_click"
 				tracksClickProperties={ { cta_name: 'domain_info_notice' } }
 				tracksImpressionName="calypso_domain_credit_reminder_impression"

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -105,15 +105,15 @@ export class List extends React.Component {
 			return null;
 		}
 
-		const { translate } = this.props;
+		const { translate, selectedSite } = this.props;
 
 		return (
 			<UpsellNudge
-				callToAction={ translate( 'Claim Free Domain' ) }
+				callToAction={ translate( 'Claim free domain' ) }
 				title={ translate( 'Free domain available' ) }
 				className="domain-management__claim-free-domain"
 				forceDisplay
-				href={ `/domains/add/${ this.props.selectedSite.slug }` }
+				href={ `/domains/add/${ selectedSite.slug }` }
 				showIcon
 				event="calypso_domain_credit_reminder_impression"
 				tracksClickName="calypso_domain_credit_reminder_click"

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -30,11 +30,9 @@ import { Button } from '@automattic/components';
 import PlansNavigation from 'my-sites/plans/navigation';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { setPrimaryDomain } from 'state/sites/domains/actions';
-import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
+import UpsellNudge from 'blocks/upsell-nudge';
 import EmptyContent from 'components/empty-content';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
-import TrackComponentView from 'lib/analytics/track-component-view';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
@@ -110,24 +108,18 @@ export class List extends React.Component {
 		const { translate } = this.props;
 
 		return (
-			<Notice
-				status="is-success"
-				showDismiss={ false }
-				text={ translate( 'Free domain available' ) }
-				icon="info-outline"
+			<UpsellNudge
+				callToAction={ translate( 'Claim Free Domain' ) }
+				title={ translate( 'Free domain available' ) }
 				className="domain-management__claim-free-domain"
-			>
-				<NoticeAction
-					onClick={ this.props.clickClaimDomainNotice }
-					href={ `/domains/add/${ this.props.selectedSite.slug }` }
-				>
-					{ translate( 'Claim Free Domain' ) }
-					<TrackComponentView
-						eventName={ 'calypso_domain_credit_reminder_impression' }
-						eventProperties={ { cta_name: 'domain_info_notice' } }
-					/>
-				</NoticeAction>
-			</Notice>
+				forceDisplay
+				href={ `/domains/add/${ this.props.selectedSite.slug }` }
+				showIcon
+				tracksClickName="calypso_domain_credit_reminder_click"
+				tracksClickProperties={ { cta_name: 'domain_info_notice' } }
+				tracksImpressionName="calypso_domain_credit_reminder_impression"
+				tracksImpressionProperties={ { cta_name: 'domain_info_notice' } }
+			/>
 		);
 	}
 
@@ -499,12 +491,6 @@ export default connect(
 	},
 	( dispatch ) => {
 		return {
-			clickClaimDomainNotice: () =>
-				dispatch(
-					recordTracksEvent( 'calypso_domain_credit_reminder_click', {
-						cta_name: 'domain_info_notice',
-					} )
-				),
 			setPrimaryDomain: ( ...props ) => setPrimaryDomain( ...props )( dispatch ),
 			addDomainClick: () => dispatch( addDomainClick() ),
 			enablePrimaryDomainMode: () => dispatch( enablePrimaryDomainMode() ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the `Notice` component to an `UpsellNudge` block following along with the work in #38778

Some notes:
* Consider this more a "try" than a formal change. :)
* This makes for two primary calls to action one after the other, which is confusing/looks weird, and it doesn't make sense to me to display this notice when there's a prominent nudge in the sidebar. I'm guessing the reasoning is because people would add yet *another* domain instead of claiming the free one first?
* Maybe we roll this notice into @jancavan 's notices work, rather than making it an upsell?

**Before**

<img width="1680" alt="Screen Shot 2020-04-24 at 2 07 38 PM" src="https://user-images.githubusercontent.com/2124984/80244420-df3e9d00-8636-11ea-9bf1-8ae087620324.png">

**After**

<img width="1680" alt="Screen Shot 2020-04-24 at 2 07 51 PM" src="https://user-images.githubusercontent.com/2124984/80244437-e36aba80-8636-11ea-9765-bd6392f34bbe.png">

#### Testing instructions

* Switch to this PR on a site with a Premium or Business plan that does not yet have a domain attached
* Go to Manage -> Domains
* You should see the upsell at the top of the screen. Tracks events (impression and click) should remain the same.
