### PR TITLE
Swap Banner for UpsellNudge in DomainsToPlanNudge

### DIFF
--- a/client/blocks/domain-to-plan-nudge/index.jsx
+++ b/client/blocks/domain-to-plan-nudge/index.jsx
@@ -10,7 +10,7 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSite } from 'state/sites/selectors';
 import { PLAN_PERSONAL, FEATURE_NO_ADS } from 'lib/plans/constants';
@@ -61,7 +61,7 @@ class DomainToPlanNudge extends Component {
 
 		const prices = discountedRawPrice ? [ rawPrice, discountedRawPrice ] : null;
 		return (
-			<Banner
+			<UpsellNudge
 				callToAction={ translate( 'Upgrade for %s', {
 					args: formatCurrency( discountedRawPrice || rawPrice, userCurrency ),
 					comment: '%s will be replaced by a formatted price, i.e $9.99',
@@ -77,6 +77,7 @@ class DomainToPlanNudge extends Component {
 				] }
 				plan={ PLAN_PERSONAL }
 				price={ prices }
+				showIcon
 				title={ translate( 'Upgrade to a Personal Plan and Save!' ) }
 			/>
 		);

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -47,6 +47,7 @@ export const UpsellNudge = ( {
 	onDismissClick,
 	plan,
 	planHasFeature,
+	price,
 	showIcon = false,
 	site,
 	title,
@@ -98,6 +99,7 @@ export const UpsellNudge = ( {
 			onClick={ onClick }
 			onDismissClick={ onDismissClick }
 			plan={ plan }
+			price={ price }
 			showIcon={ showIcon }
 			title={ title }
 			tracksClickName={ tracksClickName }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Swap out Banner for UpsellNudge in DomainToPlanNudge
* See #38778

**Before**

<img width="1106" alt="Screen Shot 2020-04-24 at 2 43 58 PM" src="https://user-images.githubusercontent.com/2124984/80246291-2b3f1100-863a-11ea-8ed6-26a17b57d8af.png">

**After**

TBD

#### Testing instructions

* Switch to this PR
* Navigate to `/domains` on an eligible free site, OR...
* ...I was unable to get this nudge to appear without fudging it by removing the `this.isSiteEligible()` condition on this line:
