### PR TITLE
composite-checkout: Add personal plan upsell (3)

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -130,7 +130,7 @@ class CartFreeUserPlanUpsell extends React.Component {
 
 	addPlanToCart = () => {
 		const planCartItem = planItem( PLAN_PERSONAL, {} );
-		addItem( planCartItem );
+		this.props.addItemToCart( planCartItem );
 		this.props.clickUpsellAddToCart();
 	};
 
@@ -154,7 +154,7 @@ class CartFreeUserPlanUpsell extends React.Component {
 	}
 }
 
-const mapStateToProps = ( state, { cart } ) => {
+const mapStateToProps = ( state, { cart, addItemToCart } ) => {
 	const selectedSite = getSelectedSite( state );
 	const selectedSiteId = selectedSite ? selectedSite.ID : null;
 	const isPlansListFetching = isRequestingPlans( state );
@@ -175,6 +175,7 @@ const mapStateToProps = ( state, { cart } ) => {
 		showPlanUpsell: getCurrentUser( state )
 			? selectedSiteId && currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
 			: false,
+		addItemToCart: addItemToCart || addItem,
 	};
 };
 

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -185,6 +185,7 @@ export default function CompositeCheckout( {
 		errors,
 		subtotal,
 		isLoading: isLoadingCart,
+		isPendingUpdate: isCartPendingUpdate,
 		allowedPaymentMethods: serverAllowedPaymentMethods,
 		variantRequestStatus,
 		variantSelectOverride,
@@ -336,6 +337,7 @@ export default function CompositeCheckout( {
 				isLoading={
 					isLoadingCart || isLoadingStoredCards || paymentMethods.length < 1 || items.length < 1
 				}
+				isValidating={ isCartPendingUpdate }
 			>
 				<WPCheckout
 					removeItem={ removeItem }

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -26,13 +26,15 @@ import { CheckoutProvider, defaultRegistry } from '@automattic/composite-checkou
  * Internal dependencies
  */
 import { requestPlans } from 'state/plans/actions';
-import { computeProductsWithPrices } from 'state/products-list/selectors';
+import { computeProductsWithPrices, isProductsListFetching } from 'state/products-list/selectors';
 import {
 	useStoredCards,
 	useIsApplePayAvailable,
 	filterAppropriatePaymentMethods,
 } from './payment-method-helpers';
-import usePrepareProductsForCart from './use-prepare-product-for-cart';
+import usePrepareProductsForCart, {
+	useFetchProductsIfNotLoaded,
+} from './use-prepare-product-for-cart';
 import notices from 'notices';
 import { isJetpackSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
@@ -165,6 +167,9 @@ export default function CompositeCheckout( {
 		isJetpackNotAtomic,
 	} );
 
+	useFetchProductsIfNotLoaded();
+	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
+
 	const {
 		items,
 		tax,
@@ -186,7 +191,7 @@ export default function CompositeCheckout( {
 		responseCart,
 	} = useShoppingCart(
 		siteSlug,
-		canInitializeCart && ! isLoadingCartSynchronizer,
+		canInitializeCart && ! isLoadingCartSynchronizer && ! isFetchingProducts,
 		productsForCart,
 		couponCodeFromUrl,
 		setCart || wpcomSetCart,

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -43,7 +43,6 @@ export default function usePrepareProductsForCart( {
 		productsForCart: [],
 	} );
 
-	useFetchProductsIfNotLoaded();
 	useFetchPlansIfNotLoaded();
 
 	useAddPlanFromSlug( { planSlug, setState, isJetpackNotAtomic, originalPurchaseId } );
@@ -198,7 +197,7 @@ function useAddProductFromSlug( {
 	] );
 }
 
-function useFetchProductsIfNotLoaded() {
+export function useFetchProductsIfNotLoaded() {
 	const reduxDispatch = useDispatch();
 	const isFetchingProducts = useSelector( ( state ) => isProductsListFetching( state ) );
 	const products = useSelector( ( state ) => getProductsList( state ) );

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -236,7 +236,7 @@ const CheckoutSummaryUI = styled( CheckoutSummaryArea )`
 `;
 
 const UpsellWrapperUI = styled.div`
-	margin-top: 1.5em;
+	margin-top: 24px;
 	background: ${( props ) => props.theme.colors.surface};
 
 	& > div {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -30,6 +30,7 @@ import WPCheckoutOrderSummary from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import { isCompleteAndValid } from '../types';
 import { WPOrderReviewTotal, WPOrderReviewSection, LineItemUI } from './wp-order-review-line-items';
+import CartFreeUserPlanUpsell from 'my-sites/checkout/cart/cart-free-user-plan-upsell';
 
 const ContactFormTitle = () => {
 	const translate = useTranslate();
@@ -73,6 +74,7 @@ export default function WPCheckout( {
 	getItemVariants,
 	domainContactValidationCallback,
 	responseCart,
+	addItemToCart,
 	subtotal,
 } ) {
 	const translate = useTranslate();
@@ -129,10 +131,17 @@ export default function WPCheckout( {
 		setActiveStepNumber( 1 );
 	};
 
+	// By this point we have definitely loaded the cart using useShoppingCart
+	// so we mock the loaded property the CartStore would inject.
+	const mockCart = { ...responseCart, hasLoadedFromServer: true };
+
 	return (
 		<Checkout>
 			<CheckoutSummaryUI>
 				<WPCheckoutOrderSummary />
+				<UpsellWrapperUI>
+					<CartFreeUserPlanUpsell cart={ mockCart } addItemToCart={ addItemToCart } />
+				</UpsellWrapperUI>
 			</CheckoutSummaryUI>
 			<CheckoutStepArea>
 				<CheckoutSteps>
@@ -223,6 +232,18 @@ const CheckoutSummaryUI = styled( CheckoutSummaryArea )`
 
 	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
 		display: block;
+	}
+`;
+
+const UpsellWrapperUI = styled.div`
+	margin-top: 1.5em;
+	background: ${( props ) => props.theme.colors.surface};
+
+	& > div {
+		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+	}
+	& .card.cart__header {
+		border: none;
 	}
 `;
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -290,6 +290,7 @@ function getUpdatedCouponStatus( currentCouponStatus: CouponStatus, responseCart
  */
 export interface ShoppingCartManager {
 	isLoading: boolean;
+	isPendingUpdate: boolean;
 	allowedPaymentMethods: string[];
 	items: WPCOMCartItem[];
 	tax: CheckoutCartItem;
@@ -487,6 +488,7 @@ export function useShoppingCart(
 
 	return {
 		isLoading: cacheStatus === 'fresh',
+		isPendingUpdate: cacheStatus !== 'valid',
 		items: cart.items,
 		tax: cart.tax,
 		couponItem: cart.coupon,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds the free/domain > personal plan upsell added in #39610 to composite checkout as well.

Requires:

- [x] #41492
- [x] #41493
- [x] #41498

#### Screenshots

**Regular checkout with the upsell**

<img width="1024" alt="Screen Shot 2020-04-24 at 8 32 43 PM" src="https://user-images.githubusercontent.com/2036909/80268319-2bf49900-8674-11ea-8771-7ec35ba92f9e.png">

**Composite checkout with the upsell**

<img width="921" alt="Screen Shot 2020-04-24 at 9 11 52 PM" src="https://user-images.githubusercontent.com/2036909/80268328-37e05b00-8674-11ea-9f63-e39d2903b20b.png">

Fixes #41430

#### Testing instructions

Add a domain to your cart for an account that has no plan. Visit composite checkout and verify that you see the upsell in the sidebar (note that it will only display at wider resolutions; smaller widths will be handled in a separate PR which will collapse the sidebar into the main column). Verify that clicking the CTA button successfully adds the Personal Plan to the cart and verify that the upsell disappears.