### PR TITLE
FSE Plugin: Only load common module assets if they are required

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * File for various functionality which needs to be added to Simple and Atomic
- * sites. The code in this file is always loaded.
+ * sites. The code in this file is always loaded in the block editor.
+ *
+ * Currently, this module may not be the best place if you need to load
+ * front-end assets, but you could always add a separate action for that.
  *
  * @package A8C\FSE
  */
@@ -16,6 +19,7 @@ namespace A8C\FSE\Common;
 function is_block_editor_screen() {
 	return is_callable( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor();
 }
+
 
 /**
  * Detects if the current page is the homepage post editor, and if the homepage
@@ -95,4 +99,4 @@ function enqueue_script_and_style() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
 	);
 }
-add_action( 'init', __NAMESPACE__ . '\enqueue_script_and_style' );
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_script_and_style' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
No longer load common module assets on views where they are not required.

Context: p55Cj4-Ty-p2

#### Testing instructions
1. Sync this PR to your sandbox using `yarn dev --sync`
2. Activate a Varia child theme and in the Customizer, make sure the homepage title is set to hidden.
3. Verify that in the homepage editor, the title is hidden. (This verifies that the assets are loaded when needed.)
4. In a non-homepage editor, verify the assets are _not_ loaded
5. On the front end of your site, both on the homepage or any other page/post, the assets should _not_ be loaded.


I was able to tell when the assets were loaded by using the debugger in Firefox:

_with common assets:_
<img width="344" alt="Screen Shot 2020-04-24 at 2 36 36 PM" src="https://user-images.githubusercontent.com/6265975/80258880-2c237300-8639-11ea-8869-37c97cfc6e8c.png">

_without:_
<img width="378" alt="Screen Shot 2020-04-24 at 2 37 13 PM" src="https://user-images.githubusercontent.com/6265975/80258895-32195400-8639-11ea-92cd-efd907192548.png">
