### PR TITLE
record click events in gutenboarding

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -16,6 +16,7 @@ import { useViewportMatch } from '@wordpress/compose';
  */
 import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
 import CloseButton from '../close-button';
+import { recordButtonClick } from '../../lib/analytics';
 
 /**
  * Style dependencies
@@ -37,7 +38,12 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( {
 
 	// Popover expands at medium viewport width
 	const isMobile = useViewportMatch( 'medium', '<' );
-
+	const onClickMoreOptions = () => {
+		recordButtonClick( 'DomainPicker', 'more_options' );
+		if ( onMoreOptions ) {
+			onMoreOptions();
+		}
+	};
 	// Don't render popover when isOpen is false.
 	// We need this component to be hot because useViewportMatch
 	// returns false on initial mount before returning true,
@@ -60,7 +66,7 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( {
 						<Button
 							className="domain-picker-popover__more-button"
 							isTertiary
-							onClick={ onMoreOptions }
+							onClick={ onClickMoreOptions }
 						>
 							{ __( 'More Options' ) }
 						</Button>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -22,7 +22,11 @@ import {
 } from '../../utils/domain-suggestions';
 import { useDomainSuggestions } from '../../hooks/use-domain-suggestions';
 import { PAID_DOMAINS_TO_SHOW } from '../../constants';
-import { getNewRailcarId, RecordTrainTracksEventProps } from '../../lib/analytics';
+import {
+	getNewRailcarId,
+	RecordTrainTracksEventProps,
+	recordButtonClick,
+} from '../../lib/analytics';
 import { useTrackModal } from '../../hooks/use-track-modal';
 
 /**
@@ -99,13 +103,18 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	const recommendedSuggestion = getRecommendedDomainSuggestion( paidSuggestions );
 	const hasSuggestions = freeSuggestions?.length || paidSuggestions?.length;
 
+	const onConfirmClick = () => {
+		recordButtonClick( 'DomainPicker', 'confirm' );
+		onClose();
+	};
+
 	const ConfirmButton: FunctionComponent< Button.ButtonProps > = ( { ...props } ) => {
 		return (
 			<Button
 				className="domain-picker__confirm-button"
 				isPrimary
 				disabled={ ! hasSuggestions }
-				onClick={ onClose }
+				onClick={ onConfirmClick }
 				{ ...props }
 			>
 				{ __( 'Confirm' ) }

--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -17,7 +17,7 @@ import ModalSubmitButton from '../modal-submit-button';
 import './style.scss';
 import SignupFormHeader from './header';
 import GUTENBOARDING_BASE_NAME from '../../basename.json';
-import { recordOnboardingError } from '../../lib/analytics';
+import { recordOnboardingError, recordButtonClick } from '../../lib/analytics';
 import { localizeUrl } from '../../../../lib/i18n-utils';
 import { useTrackModal } from '../../hooks/use-track-modal';
 
@@ -48,6 +48,8 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 
 	const handleSignUp = async ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
+
+		recordButtonClick( 'Signup', 'create_account' );
 
 		const username_hint = siteTitle || siteVertical?.label;
 

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -10,7 +10,7 @@ import { DependencyList } from 'react';
  */
 import { FLOW_ID } from '../../constants';
 import { StepNameType } from '../../path';
-import { ErrorParameters, OnboardingCompleteParameters } from './types';
+import { ErrorParameters, OnboardingCompleteParameters, ModalNameType } from './types';
 
 /**
  * Make tracks call with embedded flow.
@@ -127,7 +127,7 @@ export function getNewRailcarId( suffix = 'suggestion' ) {
  * @param modalName The name of the modal to record in tracks
  * @param eventProperties Additional properties to record on closing the modal
  */
-export function recordCloseModal( modalName: string, eventProperties?: DependencyList ) {
+export function recordCloseModal( modalName: ModalNameType, eventProperties?: DependencyList ) {
 	trackEventWithFlow( 'calypso_signup_modal_close', {
 		name: modalName,
 		...eventProperties,
@@ -139,7 +139,7 @@ export function recordCloseModal( modalName: string, eventProperties?: Dependenc
  *
  * @param modalName The name of the modal to record in tracks
  */
-export function recordEnterModal( modalName: string ) {
+export function recordEnterModal( modalName: ModalNameType ) {
 	trackEventWithFlow( 'calypso_signup_modal_open', {
 		name: modalName,
 	} );
@@ -166,5 +166,21 @@ export function recordLeaveStep( stepName: StepNameType, eventProperties?: Depen
 export function recordEnterStep( stepName: StepNameType ) {
 	trackEventWithFlow( 'calypso_signup_step_enter', {
 		step: stepName,
+	} );
+}
+
+/**
+ * Records a button being clicked
+ *
+ * @param stepOrModalName The step that the user was on or the modal that they had open
+ * @param buttonName An identifier for the button that was clicked
+ */
+export function recordButtonClick(
+	stepOrModalName: StepNameType | ModalNameType,
+	buttonName: string
+) {
+	trackEventWithFlow( 'calypso_button_clicked', {
+		step_or_modal: stepOrModalName,
+		button: buttonName,
 	} );
 }

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -1,3 +1,5 @@
+export type ModalNameType = 'DomainPicker';
+
 export interface ErrorParameters {
 	/**
 	 * A unique string in snakecase describing the error event.

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -17,6 +17,7 @@ import VerticalSelect from './vertical-select';
 import SiteTitle from './site-title';
 import Arrow from './arrow';
 import { useTrackStep } from '../../hooks/use-track-step';
+import { recordButtonClick } from '../../lib/analytics/index';
 
 /**
  * Style dependencies
@@ -35,6 +36,10 @@ const AcquireIntent: React.FunctionComponent = () => {
 	const displayVerticalSelect = ! isSiteTitleActive || ! isMobile;
 
 	useTrackStep( 'IntentGathering' );
+
+	const onNextClick = () => {
+		recordButtonClick( 'IntentGathering', siteTitle ? 'next' : 'skip' );
+	};
 
 	return (
 		<div
@@ -61,6 +66,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 						<Link
 							className="acquire-intent__question-skip"
 							isPrimary
+							onClick={ onNextClick }
 							to={ siteVertical && makePath( Step.DesignSelection ) }
 						>
 							{ siteTitle ? __( 'Choose a design' ) : __( 'Donʼt know yet' ) }

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -18,6 +18,7 @@ import Link from '../../components/link';
 import { SubTitle, Title } from '../../components/titles';
 import { useTrackStep } from '../../hooks/use-track-step';
 import './style.scss';
+import { recordButtonClick } from '../../lib/analytics';
 
 type Design = import('../../stores/onboard/types').Design;
 
@@ -47,7 +48,10 @@ const DesignSelector: React.FunctionComponent = () => {
 		} );
 		return mshotsUrl + encodeURIComponent( previewUrl );
 	};
-
+	const onBackClick = () => {
+		recordButtonClick( 'DesignSelection', 'back' );
+		resetOnboardStore();
+	};
 	return (
 		<div className="gutenboarding-page design-selector">
 			<div className="design-selector__header">
@@ -59,7 +63,7 @@ const DesignSelector: React.FunctionComponent = () => {
 				</div>
 				<Link
 					className="design-selector__start-over-button"
-					onClick={ () => resetOnboardStore() }
+					onClick={ onBackClick }
 					to={ makePath( Step.IntentGathering ) }
 					isLink
 				>
@@ -73,6 +77,8 @@ const DesignSelector: React.FunctionComponent = () => {
 							key={ design.slug }
 							className="design-selector__design-option"
 							onClick={ () => {
+								recordButtonClick( 'DesignSelection', 'select_design' );
+
 								setSelectedDesign( design );
 
 								// Update fonts to the design defaults

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -21,6 +21,7 @@ import { USER_STORE } from '../../stores/user';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 import SignupForm from '../../components/signup-form';
 import { useTrackStep } from '../../hooks/use-track-step';
+import { recordButtonClick } from '../../lib/analytics';
 
 import './style.scss';
 
@@ -58,6 +59,11 @@ const StylePreview: React.FunctionComponent = () => {
 		[ createSite, freeDomainSuggestion ]
 	);
 
+	const onContinueClick = () => {
+		recordButtonClick( 'Signup', 'continue' );
+		currentUser ? handleCreateSite( currentUser.username ) : handleSignup();
+	};
+
 	return (
 		<div className="gutenboarding-page style-preview">
 			<div className="style-preview__header">
@@ -69,7 +75,13 @@ const StylePreview: React.FunctionComponent = () => {
 				</div>
 				<ViewportSelect selected={ selectedViewport } onSelect={ setSelectedViewport } />
 				<div className="style-preview__actions">
-					<Link isLink to={ makePath( Step.DesignSelection ) }>
+					<Link
+						isLink
+						to={ makePath( Step.DesignSelection ) }
+						onClick={ () => {
+							recordButtonClick( 'Signup', 'back' );
+						} }
+					>
 						{ __( 'Choose another design' ) }
 					</Link>
 					{ hasSelectedDesign && (
@@ -77,9 +89,7 @@ const StylePreview: React.FunctionComponent = () => {
 							className="style-preview__actions-continue-button"
 							isPrimary
 							isLarge
-							onClick={ () =>
-								currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
-							}
+							onClick={ onContinueClick }
 						>
 							{ __( 'Continue' ) }
 						</Button>

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -60,7 +60,7 @@ const StylePreview: React.FunctionComponent = () => {
 	);
 
 	const onContinueClick = () => {
-		recordButtonClick( 'Signup', 'continue' );
+		recordButtonClick( 'Style', 'continue' );
 		currentUser ? handleCreateSite( currentUser.username ) : handleSignup();
 	};
 
@@ -79,7 +79,7 @@ const StylePreview: React.FunctionComponent = () => {
 						isLink
 						to={ makePath( Step.DesignSelection ) }
 						onClick={ () => {
-							recordButtonClick( 'Signup', 'back' );
+							recordButtonClick( 'Style', 'back' );
 						} }
 					>
 						{ __( 'Choose another design' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Adding tracks analytics to button click events in gutenboarding
Discussed here pbAok1-Ao-p2#comment-1340

I'm currently waiting for Martin Remy to confirm that he's ok with the shape of the events.

#### Testing instructions

Forward and back buttons in gutenboarding should trigger `calypso_button_clicked` tracks events
