### PR TITLE
Gutenboarding: add back preview button

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
@@ -1,6 +1,5 @@
 .gutenboarding-editor-overrides {
-    .editor-post-switch-to-draft,
-    .editor-post-preview {
+    .editor-post-switch-to-draft {
         display: none;
     }
     


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/41288

#### Changes proposed in this Pull Request

* Add back preview button in gutenboarding flow:

Before
<img width="494" alt="image" src="https://user-images.githubusercontent.com/87168/80352946-4ea5ce00-887d-11ea-9339-f941586dd63f.png">

After
<img width="499" alt="image" src="https://user-images.githubusercontent.com/87168/80353327-de4b7c80-887d-11ea-9fd7-ed05b33f94b7.png">


#### Testing instructions

- Read [how to build this to right place in sandbox](https://github.com/Automattic/wp-calypso/tree/5a704a23f746595eb7d6fc2b82120d2d323d4a44/apps/wpcom-block-editor#build)
- Create a site via Gutenboarding and confirm it works
- Have a regular site and confirm they also work