### PR TITLE
Gutenboarding: add plans component to header

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -5,10 +5,6 @@ import * as React from 'react';
 import { Button, Popover } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
 import config from 'config';
-
-// Core package needs to add this to the type definitions.
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import { useViewportMatch } from '@wordpress/compose';
 
 /**

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -18,6 +18,7 @@ import { USER_STORE } from '../../stores/user';
 import { SITE_STORE } from '../../stores/site';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
+import PlansButton from '../plans-button';
 import SignupForm from '../../components/signup-form';
 import { useDomainSuggestions } from '../../hooks/use-domain-suggestions';
 import {
@@ -116,7 +117,7 @@ const Header: FunctionComponent = () => {
 			// explicitly hide the dialog.
 			setShowSignupDialog( false );
 		}
-	}, [ pathname, setShowSignupDialog ] );
+	}, [ pathname, setShowSignupDialog ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const isMobile = useViewportMatch( 'mobile', '<' );
 
@@ -198,7 +199,7 @@ const Header: FunctionComponent = () => {
 
 			window.location.replace( `/block-editor/page/${ newSite.site_slug }/home` );
 		}
-	}, [ domain, newSite, newUser, resetOnboardStore, isRedirecting ] );
+	}, [ domain, newSite, newUser, resetOnboardStore, isRedirecting, hasPaidDomain ] );
 
 	return (
 		<div
@@ -234,6 +235,9 @@ const Header: FunctionComponent = () => {
 							</DomainPickerButton>
 						)
 					}
+				</div>
+				<div className="gutenboarding__header-section-item gutenboarding__header-section-item--right">
+					{ currentStep !== 'IntentGathering' && <PlansButton /> }
 				</div>
 			</section>
 			{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -30,12 +30,17 @@ $padding--gutenboarding__header: $grid-unit-10;
 
 .gutenboarding__header-section {
 	display: flex;
+	width: 100%;
 	align-items: center;
 	font-size: 14px;
 }
 
 .gutenboarding__header-section-item {
 	margin-left: $margin-left--gutenboarding__header-section-item;
+
+	&--right {
+		margin-left: auto;
+	}
 }
 
 .gutenboarding__header-wp-logo {

--- a/client/landing/gutenboarding/components/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans-button/index.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+
+/**
+ * Internal dependencies
+ */
+import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automattic package
+import * as plans from 'lib/plans/constants';
+import { getPlan } from 'lib/plans';
+import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...buttonProps } ) => {
+	const { __ } = useI18n();
+	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
+	const isDesktop = useViewportMatch( 'mobile' );
+
+	const planLabel =
+		/* translators: Button label where %s is the WordPress.com plan name (eg: Free, Personal, Premium, Business) */
+		sprintf(
+			__( '%s plan' ),
+			getPlan( hasPaidDomain ? plans.PLAN_PERSONAL : plans.PLAN_FREE ).getTitle()
+		);
+
+	return (
+		<Button disabled label={ __( planLabel ) } className="plans-button" { ...buttonProps }>
+			{ isDesktop && planLabel }
+			<JetpackLogo className="plans-button__jetpack-logo" size={ 16 } monochrome />
+		</Button>
+	);
+};
+
+export default PlansButton;

--- a/client/landing/gutenboarding/components/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans-button/index.tsx
@@ -24,7 +24,9 @@ import './style.scss';
 const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...buttonProps } ) => {
 	const { __ } = useI18n();
 	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
-	const isDesktop = useViewportMatch( 'mobile' );
+
+	// mobile first to match SCSS media query https://github.com/Automattic/wp-calypso/pull/41471#discussion_r415678275
+	const isDesktop = useViewportMatch( 'mobile', '>=' );
 
 	const planLabel =
 		/* translators: Button label where %s is the WordPress.com plan name (eg: Free, Personal, Premium, Business) */

--- a/client/landing/gutenboarding/components/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans-button/index.tsx
@@ -29,7 +29,7 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 	const planLabel =
 		/* translators: Button label where %s is the WordPress.com plan name (eg: Free, Personal, Premium, Business) */
 		sprintf(
-			__( '%s plan' ),
+			__( '%s Plan' ),
 			getPlan( hasPaidDomain ? plans.PLAN_PERSONAL : plans.PLAN_FREE ).getTitle()
 		);
 

--- a/client/landing/gutenboarding/components/plans-button/style.scss
+++ b/client/landing/gutenboarding/components/plans-button/style.scss
@@ -1,0 +1,18 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+
+.plans-button.components-button {
+	&:disabled,
+	&[aria-disabled='true'] {
+		opacity: 1;
+
+		&:hover {
+			color: var( --studio-black );
+		}
+	}
+}
+
+.plans-button__jetpack-logo {
+	@include break-mobile {
+		margin-left: 8px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display current pre-selected plan (free / personal) in header while on Design picker and Style picker steps.
* We currently display it as a disabled button (without interaction) to serve as a hint for users that their domain selection triggered also a plan upgrade. This will prepare them for the plans page we’re displaying immediately after site creation.

#### Testing instructions

* Go to /new
* Fill in both inputs (vertical and site name).
* Open domain picker and select a paid domain.
* While still on Intent Capture step, the plans button shouldn't be visible.
* When advancing to Design picker step, Personal Plan should be displayed in header (top-right).
* After selecting a free domain or if no domain is selected, Free Plan label is displayed.
* On mobile, just the Jetpack logo should be displayed.

#### Screenshot
<img width="844" alt="Screenshot 2020-04-27 at 12 29 15" src="https://user-images.githubusercontent.com/14192054/80356983-ece86280-8882-11ea-9735-fceb4a69692c.png">

Fixes #41287 
