### PR TITLE
Hide inline-help widget in the help page

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -105,30 +105,13 @@ class Layout extends Component {
 			return false;
 		}
 
-		if (
-			'jetpack-connect' === this.props.sectionName &&
-			'/jetpack/new' !== this.props.currentRoute
-		) {
-			return false;
-		}
+		const exemptedSections = [ 'jetpack-connect', 'happychat', 'devdocs', 'help' ];
+		const exemptedRoutes = [ '/jetpack/new', '/log-in/jetpack', '/me/account/closed' ];
 
-		if ( '/log-in/jetpack' === this.props.currentRoute ) {
-			return false;
-		}
-
-		if ( '/me/account/closed' === this.props.currentRoute ) {
-			return false;
-		}
-
-		if ( 'happychat' === this.props.sectionName ) {
-			return false;
-		}
-
-		if ( 'devdocs' === this.props.sectionName ) {
-			return false;
-		}
-
-		return true;
+		return (
+			! exemptedSections.includes( this.props.sectionName ) &&
+			! exemptedRoutes.includes( this.props.currentRoute )
+		);
 	}
 
 	renderMasterbar() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, the inline-help float sometimes covers key parts of the UI on mobile. See [Help: Help icon covers Send button in mobile browser](https://github.com/Automattic/wp-calypso/issues/32590) issue for details.

This PR hides the inline help widget on the help page since users are already in.. well... the help page. 

#### Testing instructions
Move around Calypso making sure the inline-help widget shows in most places. And doesn't appear on the help page. 

Fixes #32590
