### PR TITLE
Fix/jetpack cloud activitycard actions buttons and style

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -43,15 +43,25 @@ class ActivityCard extends Component {
 		summarize: false,
 	};
 
-	popoverContext = React.createRef();
+	topPopoverContext = React.createRef();
+	bottomPopoverContext = React.createRef();
 
 	state = {
-		showPopoverMenu: false,
+		showTopPopoverMenu: false,
+		showBottomPopoverMenu: false,
 		showContent: false,
 	};
 
-	togglePopoverMenu = () => this.setState( { showPopoverMenu: ! this.state.showPopoverMenu } );
-	closePopoverMenu = () => this.setState( { showPopoverMenu: false } );
+	togglePopoverMenu = ( topPopoverMenu = true ) => {
+		if ( topPopoverMenu ) {
+			this.setState( { showTopPopoverMenu: ! this.state.showTopPopoverMenu } );
+		} else {
+			this.setState( { showBottomPopoverMenu: ! this.state.showBottomPopoverMenu } );
+		}
+	};
+
+	closePopoverMenu = () =>
+		this.setState( { showTopPopoverMenu: false, showBottomPopoverMenu: false } );
 	toggleSeeContent = () => this.setState( { showContent: ! this.state.showContent } );
 
 	onSpace = ( evt, fn ) => {
@@ -69,15 +79,13 @@ class ActivityCard extends Component {
 			return (
 				activityMedia &&
 				activityMedia.available && (
-					<>
-						<div className="activity-card__streams-item" key={ item.activityId }>
-							<div className="activity-card__streams-item-title">{ activityMedia.name }</div>
-							<ActivityMedia
-								name={ activityMedia.name }
-								fullImage={ activityMedia.medium_url || activityMedia.thumbnail_url }
-							/>
-						</div>
-					</>
+					<div key={ item.rewindId } className="activity-card__streams-item">
+						<div className="activity-card__streams-item-title">{ activityMedia.name }</div>
+						<ActivityMedia
+							name={ activityMedia.name }
+							fullImage={ activityMedia.medium_url || activityMedia.thumbnail_url }
+						/>
+					</div>
 				)
 			);
 		} );
@@ -91,7 +99,7 @@ class ActivityCard extends Component {
 			<div className="activity-card__content">
 				{ !! activity.streams && [
 					...this.renderStreams( activity.streams ),
-					this.renderToolbar(),
+					this.renderToolbar( false ),
 				] }
 			</div>
 		);
@@ -132,8 +140,14 @@ class ActivityCard extends Component {
 		}
 	}
 
-	renderActionButton() {
+	renderActionButton( isTopToolbar = true ) {
 		const { activity, siteSlug, translate } = this.props;
+
+		const context = isTopToolbar ? this.topPopoverContext : this.bottomPopoverContext;
+
+		const showPopoverMenu = isTopToolbar
+			? this.state.showTopPopoverMenu
+			: this.state.showBottomPopoverMenu;
 
 		return (
 			<>
@@ -141,15 +155,17 @@ class ActivityCard extends Component {
 					compact
 					borderless
 					className="activity-card__actions-button"
-					onClick={ this.togglePopoverMenu }
-					ref={ this.popoverContext }
+					onClick={ () => {
+						return this.togglePopoverMenu( isTopToolbar );
+					} }
+					ref={ context }
 				>
 					{ translate( 'Actions' ) }
 					<Gridicon icon="add" className="activity-card__actions-icon" />
 				</Button>
 				<PopoverMenu
-					context={ this.popoverContext.current }
-					isVisible={ this.state.showPopoverMenu }
+					context={ context.current }
+					isVisible={ showPopoverMenu }
 					onClose={ this.closePopoverMenu }
 					className="activity-card__popover"
 				>
@@ -179,7 +195,7 @@ class ActivityCard extends Component {
 		);
 	}
 
-	renderToolbar() {
+	renderToolbar( isTopToolbar = true ) {
 		const { showActions, showContentLink } = this.props;
 
 		return (
@@ -193,7 +209,7 @@ class ActivityCard extends Component {
 					}
 				>
 					{ showContentLink && this.renderContentLink() }
-					{ showActions && this.renderActionButton() }
+					{ showActions && this.renderActionButton( isTopToolbar ) }
 				</div>
 			</>
 		);

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -99,7 +99,7 @@ class ActivityCard extends Component {
 			<div className="activity-card__content">
 				{ !! activity.streams && [
 					...this.renderStreams( activity.streams ),
-					this.renderToolbar( false ),
+					this.renderBottomToolbar(),
 				] }
 			</div>
 		);
@@ -195,6 +195,9 @@ class ActivityCard extends Component {
 		);
 	}
 
+	renderTopToolbar = () => this.renderToolbar( true );
+	renderBottomToolbar = () => this.renderToolbar( false );
+
 	renderToolbar( isTopToolbar = true ) {
 		const { showActions, showContentLink } = this.props;
 
@@ -257,7 +260,7 @@ class ActivityCard extends Component {
 					</div>
 					<div className="activity-card__activity-title">{ activity.activityTitle }</div>
 
-					{ ! summarize && this.renderToolbar() }
+					{ ! summarize && this.renderTopToolbar() }
 
 					{ showActivityContent && this.renderActivityContent() }
 				</Card>

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -129,7 +129,7 @@ class ActivityCard extends Component {
 					onClick={ this.toggleSeeContent }
 					onKeyDown={ this.onSpace( this.toggleSeeContent ) }
 				>
-					{ translate( 'See content' ) }
+					{ this.state.showContent ? translate( 'Hide content' ) : translate( 'See content' ) }
 					<Gridicon
 						size={ 18 }
 						icon={ this.state.showContent ? 'chevron-up' : 'chevron-down' }
@@ -247,6 +247,7 @@ class ActivityCard extends Component {
 					<div className="activity-card__activity-description">
 						{ activityMedia && activityMedia.available && (
 							<ActivityMedia
+								className="activity-card__activity-media"
 								name={ activityMedia.name }
 								thumbnail={ activityMedia.medium_url || activityMedia.thumbnail_url }
 								fullImage={ false }

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -45,11 +45,21 @@
 }
 
 .activity-card__activity-title {
+	margin: 16px 0;
 	font-style: italic;
 }
 
 .activity-card__activity-description {
 	margin: 1rem 0 0.5rem;
+	font-size: 16px;
+
+	@include breakpoint( '>660px' ) {
+		font-size: 18px;
+	}
+}
+
+.activity-card__activity-media {
+	margin-bottom: 16px;
 }
 
 .activity-card__activity-actions,

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -100,7 +100,7 @@
 	}
 }
 
-.button.is-borderless.is-primary.activity-card__see-content-link:focus {
+.button.is-borderless.is-primary:focus {
 	box-shadow: none;
 }
 

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -90,7 +90,7 @@
 	}
 }
 
-.activity-card__see-content-link {
+.button.activity-card__see-content-link {
 	font-size: 12px;
 	margin-left: 0;
 	color: var( --studio-jetpack-green-40 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the Activity Card component, if you have streams of images (grouped) you can see the list of the images inside of the card by clicking on "See Content". Now, if you click o Actions at the top, you see the expected menu Download/Restore menu options at the bottom. This PR fixes the issue to see each menu correctly at the top or at the bottom depending on where you click the Actions button.

![image](https://user-images.githubusercontent.com/9832440/80367894-c37c0680-8883-11ea-9741-7422b49635a9.png)

**Fixed Styles:**

- "See content" font-size should be 16px on desktop views
- Remove on Actions button the border that appears when it's focused.
- activity-description font-size to 16px (mobile) and 18px (desktop)
- Spacing between activity main image and the description should be 16px
- Added "Hide content" copy when the activity content is expanded.

Before:
![image](https://user-images.githubusercontent.com/9832440/80368188-39806d80-8884-11ea-8e1f-aa9c9e8ffb81.png)

#### Testing instructions

- Apply these changes
- Go to date with an upload of image stream (images grouped)
- Click on Actions button and you can see the Download/Restore menu options
- Click on See Content (font-size: 12px on mobile and 16px on desktop), and then go to the end of the images list and click on the Actions button at the bottom. You can see again the Download/Restore menu options.
