### PR TITLE
Signup: Fix the missing registration fee text in signup flows

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -23,7 +23,6 @@ import {
 	domainMapping,
 	domainTransfer,
 } from 'lib/cart-values/cart-items';
-import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
 import {
 	recordAddDomainButtonClick,
 	recordAddDomainButtonClickInMapDomain,
@@ -31,7 +30,6 @@ import {
 	recordAddDomainButtonClickInUseYourDomain,
 } from 'state/domains/actions';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import { getCurrentUser, currentUserHasFlag } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
@@ -714,9 +712,7 @@ export default connect(
 		return {
 			designType: getDesignType( state ),
 			// no user = DOMAINS_WITH_PLANS_ONLY
-			domainsWithPlansOnly: getCurrentUser( state )
-				? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
-				: true,
+			domainsWithPlansOnly: true,
 			productsList,
 			productsLoaded,
 			siteGoals: getSiteGoals( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the issue reported in p99Zz8-10j-p2#comment-3313.
* A quick fix to get the signup flow up and running. A deeper discussion on fixing this issue is in https://github.com/Automattic/wp-calypso/pull/41438. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the signup flow and verify that the "Registration fee" text with struck price is shown in the signup and site launch flow. Verify this in new user signup and Add new site flow.
* Verify in Add new site flow that adding a custom domain will hide the "Start with free" option.

Fixes #
