### PR TITLE
Clear filter when navigating to jetpack backup main page

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -56,7 +56,7 @@ class BackupsPage extends Component {
 	componentDidMount() {
 		const { queryDate, moment, clearFilter, siteId } = this.props;
 
-		// filters in the global state are modified by other pages, we want to enter this page with is cleared
+		// filters in the global state are modified by other pages, we want to enter this page with the filter empty
 		clearFilter( siteId );
 
 		// On first load, check if we have a selected date from the URL

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -12,7 +12,7 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import DocumentHead from 'components/data/document-head';
-import { updateFilter } from 'state/activity-log/actions';
+import { updateFilter, setFilter } from 'state/activity-log/actions';
 import {
 	isActivityBackup,
 	getBackupAttemptsForDate,
@@ -43,6 +43,7 @@ import { applySiteOffset } from 'lib/site/timezone';
 import QuerySiteSettings from 'components/data/query-site-settings'; // Required to get site time offset
 import getRewindCapabilities from 'state/selectors/get-rewind-capabilities';
 import { backupMainPath } from './paths';
+import { emptyFilter } from 'state/activity-log/reducer';
 
 /**
  * Style dependencies
@@ -53,7 +54,10 @@ export const INDEX_FORMAT = 'YYYYMMDD';
 
 class BackupsPage extends Component {
 	componentDidMount() {
-		const { queryDate, moment } = this.props;
+		const { queryDate, moment, clearFilter, siteId } = this.props;
+
+		// filters in the global state are modified by other pages, we want to enter this page with is cleared
+		clearFilter( siteId );
 
 		// On first load, check if we have a selected date from the URL
 		if ( queryDate ) {
@@ -259,7 +263,6 @@ class BackupsPage extends Component {
 
 	render() {
 		const { filter } = this.props;
-
 		return (
 			<div className="backups__page">
 				{ ! this.isEmptyFilter( filter ) ? this.renderBackupSearch() : this.renderMain() }
@@ -363,6 +366,7 @@ const mapStateToProps = ( state ) => {
 
 const mapDispatchToProps = ( dispatch ) => ( {
 	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) ),
+	clearFilter: ( siteId ) => dispatch( setFilter( siteId, emptyFilter ) ),
 } );
 
 export default connect(

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -129,19 +129,6 @@ class BackupsPage extends Component {
 		return backupsOnSelectedDate;
 	};
 
-	isEmptyFilter = ( filter ) => {
-		if ( ! filter ) {
-			return true;
-		}
-		if ( filter.group || filter.on || filter.before || filter.after ) {
-			return false;
-		}
-		if ( filter.page !== 1 ) {
-			return false;
-		}
-		return true;
-	};
-
 	TO_REMOVE_getSelectedDateString = () => {
 		const { moment } = this.props;
 
@@ -262,10 +249,10 @@ class BackupsPage extends Component {
 	}
 
 	render() {
-		const { filter } = this.props;
+		const { isEmptyFilter } = this.props;
 		return (
 			<div className="backups__page">
-				{ ! this.isEmptyFilter( filter ) ? this.renderBackupSearch() : this.renderMain() }
+				{ isEmptyFilter ? this.renderMain() : this.renderBackupSearch() }
 			</div>
 		);
 	}
@@ -323,6 +310,19 @@ const createIndexedLog = ( logs, timezone, gmtOffset ) => {
 	};
 };
 
+const getIsEmptyFilter = ( filter ) => {
+	if ( ! filter ) {
+		return true;
+	}
+	if ( filter.group || filter.on || filter.before || filter.after ) {
+		return false;
+	}
+	if ( filter.page !== 1 ) {
+		return false;
+	}
+	return true;
+};
+
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const filter = getActivityLogFilter( state, siteId );
@@ -349,6 +349,7 @@ const mapStateToProps = ( state ) => {
 		allowRestore,
 		doesRewindNeedCredentials,
 		filter,
+		isEmptyFilter: getIsEmptyFilter( filter ),
 		siteCapabilities,
 		logs: logs?.data ?? [],
 		rewind,
@@ -366,7 +367,9 @@ const mapStateToProps = ( state ) => {
 
 const mapDispatchToProps = ( dispatch ) => ( {
 	selectPage: ( siteId, pageNumber ) => dispatch( updateFilter( siteId, { page: pageNumber } ) ),
-	clearFilter: ( siteId ) => dispatch( setFilter( siteId, emptyFilter ) ),
+	clearFilter: ( siteId ) =>
+		// skipUrlUpdate prevents this action from trigger a redirect back to backups/activity in state/navigation/middleware.js
+		dispatch( { ...setFilter( siteId, emptyFilter ), meta: { skipUrlUpdate: true } } ),
 } );
 
 export default connect(


### PR DESCRIPTION
#### Issue

1. Navigate to `/backups/activity`
2. Change the filter
3. Click `Backup -> Status` in the sidebar
4. Notice that `/backups` renders with the filter enabled, clearing it returns the page to normal

#### Changes proposed in this Pull Request

* clear the filter upon loading `/backups/status`

#### Testing instructions

Try to replicate issue on branch, verify the backups status page now loads instead
