### PR TITLE
Hides scan stats

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -199,11 +199,6 @@ class ScanPage extends Component< Props > {
 				<div className="scan__content">{ this.renderScanState() }</div>
 				<StatsFooter
 					header="Scan Summary"
-					stats={ [
-						{ name: 'Files', number: 1201 },
-						{ name: 'Plugins', number: 4 },
-						{ name: 'Themes', number: 3 },
-					] }
 					noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backup has you covered."
 					noticeLink="https://jetpack.com/upgrade/backup"
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes stats from Scan footer while data is unavailable.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit scan page.
* Look for plugin/theme/file stats in footer.

Fixes 1143508703416848-as-1173050013652923.
