### PR TITLE
i18n: Add standalone query param to enable translation chunks via URL

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -14,6 +14,7 @@ import {
 	getLanguageManifestFile,
 	getTranslationChunkFile,
 } from 'lib/i18n-utils/switch-locale';
+import { getUrlParts } from 'lib/url/url-parts';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 
 const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
@@ -68,7 +69,7 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 
 	const useTranslationChunks =
 		config.isEnabled( 'use-translation-chunks' ) ||
-		/[?,&]useTranslationChunks(=.*)?$/.test( document.location.search );
+		getUrlParts( document.location.href ).searchParams.has( 'useTranslationChunks' );
 
 	if ( useTranslationChunks && '__requireChunkCallback__' in window ) {
 		const userLocaleSlug = currentUser && currentUser.localeSlug;

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -66,7 +66,11 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
 	}
 
-	if ( config.isEnabled( 'use-translation-chunks' ) && '__requireChunkCallback__' in window ) {
+	const useTranslationChunks =
+		config.isEnabled( 'use-translation-chunks' ) ||
+		/[?,&]useTranslationChunks(=.*)?$/.test( document.location.search );
+
+	if ( useTranslationChunks && '__requireChunkCallback__' in window ) {
 		const userLocaleSlug = currentUser && currentUser.localeSlug;
 		const lastPathSegment = window.location.pathname.substr(
 			window.location.pathname.lastIndexOf( '/' ) + 1

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -11,6 +11,7 @@ import {
 	getTranslationChunkFile,
 	switchWebpackCSS,
 } from '../../lib/i18n-utils/switch-locale';
+import { getUrlParts } from '../../lib/url/url-parts';
 import React from 'react';
 import ReactDom from 'react-dom';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
@@ -49,7 +50,7 @@ function generateGetSuperProps() {
 const DEFAULT_LOCALE_SLUG: string = config( 'i18n_default_locale_slug' );
 const USE_TRANSLATION_CHUNKS: string =
 	config.isEnabled( 'use-translation-chunks' ) ||
-	/[?,&]useTranslationChunks(=.*)?$/.test( document.location.search );
+	getUrlParts( document.location.href ).searchParams.has( 'useTranslationChunks' );
 
 type User = import('@automattic/data-stores').User.CurrentUser;
 

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -47,7 +47,9 @@ function generateGetSuperProps() {
 }
 
 const DEFAULT_LOCALE_SLUG: string = config( 'i18n_default_locale_slug' );
-const USE_TRANSLATION_CHUNKS: string = config.isEnabled( 'use-translation-chunks' );
+const USE_TRANSLATION_CHUNKS: string =
+	config.isEnabled( 'use-translation-chunks' ) ||
+	/[?,&]useTranslationChunks(=.*)?$/.test( document.location.search );
 
 type User = import('@automattic/data-stores').User.CurrentUser;
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -258,10 +258,14 @@ export default function switchLocale( localeSlug ) {
 
 	lastRequestedLocale = localeSlug;
 
+	const useTranslationChunks =
+		config.isEnabled( 'use-translation-chunks' ) ||
+		/[?,&]useTranslationChunks(=.*)?$/.test( document.location.search );
+
 	if ( isDefaultLocale( localeSlug ) ) {
 		i18n.configure( { defaultLocaleSlug: localeSlug } );
 		setLocaleInDOM();
-	} else if ( config.isEnabled( 'use-translation-chunks' ) ) {
+	} else if ( useTranslationChunks ) {
 		// If requested locale is same as current locale, we don't need to
 		// re-fetch the manifest and translation chunks.
 		if ( localeSlug === i18n.getLocaleSlug() ) {

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -10,7 +10,7 @@ import { forEach, includes } from 'lodash';
  */
 import config from 'config';
 import { isDefaultLocale, getLanguage } from './utils';
-import { getUrlFromParts } from 'lib/url/url-parts';
+import { getUrlFromParts, getUrlParts } from 'lib/url/url-parts';
 
 const debug = debugFactory( 'calypso:i18n' );
 
@@ -260,7 +260,7 @@ export default function switchLocale( localeSlug ) {
 
 	const useTranslationChunks =
 		config.isEnabled( 'use-translation-chunks' ) ||
-		/[?,&]useTranslationChunks(=.*)?$/.test( document.location.search );
+		getUrlParts( document.location.href ).searchParams.has( 'useTranslationChunks' );
 
 	if ( isDefaultLocale( localeSlug ) ) {
 		i18n.configure( { defaultLocaleSlug: localeSlug } );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -328,7 +328,9 @@ function getDefaultContext( request, entrypoint = 'entry-main' ) {
 		addEvergreenCheck: target === 'evergreen' && calypsoEnv !== 'development',
 		target: target || 'fallback',
 		useTranslationChunks:
-			config.isEnabled( 'use-translation-chunks' ) || flags.includes( 'use-translation-chunks' ),
+			config.isEnabled( 'use-translation-chunks' ) ||
+			flags.includes( 'use-translation-chunks' ) ||
+			request.query.hasOwnProperty( 'useTranslationChunks' ),
 	} );
 
 	context.app = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds standalone query param that can enable translation chunks feature via URL. It will allow us to enable translation chunks feature via URL and run performance tests on production, as feature flags are disabled in production.

#### Testing instructions

1. Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true yarn start`.
2. Open http://calypso.localhost:3000/start/user/pt-br?useTranslationChunks.
3. Confirm that translation chunks feature is being used.