### PR TITLE
Support whitespaces in wp-calypso path in FSE setup script

### DIFF
--- a/apps/full-site-editing/bin/setup-env.sh
+++ b/apps/full-site-editing/bin/setup-env.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 # Make sure we run the script from the wp-calypso root so the paths work correctly.
 dir_path=`pwd`
-cur_dir=`basename $dir_path`
+cur_dir=`basename "$dir_path"`
 if [[ $cur_dir != "wp-calypso" ]] ; then
 	echo "Please run this script from the wp-calypso root."
 	exit 1


### PR DESCRIPTION
Currently, if any of wp-calypso ancestor dirs has a whitespace in its name the script fails. 

Assuming wp-calypso lives in `/some/we have a white space/wp-calypso`. Then 

```sh
dir_path=`pwd`
cur_dir=`basename "$dir_path"` # -> we
```

Adding double quotes fixes the issue.