### PR TITLE
Sibyl: Make it show again for all sites

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -31,7 +31,7 @@
 	"port": 3000,
 	"happychat_url": "https://happychat.io/customer",
 	"jetpack_support_blog": "jetpackme.wordpress.com",
-	"wpcom_support_blog": "wordpress.com/support",
+	"wpcom_support_blog": "en.support.wordpress.com",
 	"apple_pay_merchant_id": "merchant.com.wordpress",
 	"apple_oauth_client_id": "com.wordpress.siwa",
 	"google_oauth_client_id": "108380595987-j91sm1alavcdgd81i2655kp8q1lbtvrc.apps.googleusercontent.com",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This reverts a small change made in #40542 that broke Sibyl / Q and A since April 10, which was deflecting ~1,000 support contacts a week. After this change, Sibly was only serving support page suggestions for sites with a Jetpack plan.

That PR updated `wpcom_support_blog` to the new support site because the URL for support pages has recently changed — but this config value is not used to generate URLs, it's actually only used right now for Sibyl. The underlying blog is still `en.support.wordpress.com`, so this should have stayed as-is.

/cc @arunsathiya — your commit was massive and this was easy to miss, but just worth double-checking the usage of things like config vars to see what they're wired to before changing them.

#### Testing instructions

Before: 
- Pick a site of yours that has no Jetpack plan
- Go to http://calypso.localhost:3000/help/contact
- Type "css" under "How can we help?"
- No suggestions will show

After:
- Pick a site of yours that has no Jetpack plan
- Go to http://calypso.localhost:3000/help/contact
- Type "css" under "How can we help?"
- You should get suggestions for support articles that answer your question
