### PR TITLE
Checkout: add savings to CheckoutSummary

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -14,6 +14,7 @@ import { useTranslate } from 'i18n-calypso';
 export default function WPCheckoutOrderSummary() {
 	const translate = useTranslate();
 	const taxes = useLineItemsOfType( 'tax' );
+	const coupons = useLineItemsOfType( 'coupon' );
 	const total = useTotal();
 
 	return (
@@ -35,6 +36,12 @@ export default function WPCheckoutOrderSummary() {
 				</CheckoutSummaryFeaturesList>
 			</CheckoutSummaryFeatures>
 			<CheckoutSummaryAmountWrapper>
+				{ coupons.map( ( coupon ) => (
+					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + coupon.id }>
+						<span>{ coupon.label }</span>
+						<span>{ renderDisplayValueMarkdown( coupon.amount.displayValue ) }</span>
+					</CheckoutSummaryLineItem>
+				) ) }
 				{ taxes.map( ( tax ) => (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + tax.id }>
 						<span>{ tax.label }</span>


### PR DESCRIPTION
This adds the `coupon` line item to the `CheckoutSummary` when a coupon has been added to the cart.

![Screen Shot 2020-04-27 at 2 00 39 PM](https://user-images.githubusercontent.com/942359/80404829-c8df4e00-888f-11ea-8502-574ffb363357.png)

**To test:**
- add a plan and/or domain to your cart and visit Checkout with `?flags=composite-checkout-force`
- verify that the checkout summary only displays features and the total (and maybe taxes if previously computed)
- add a coupon
- verify that the checkout summary now includes the coupon line item
