### PR TITLE
 Typography: Swap font-weight: 500 for font-weight: 600

### DIFF
--- a/client/blocks/app-banner/style.scss
+++ b/client/blocks/app-banner/style.scss
@@ -47,7 +47,7 @@
 	margin-top: 8px;
 	padding: 7px 0 9px 14px;
 	text-decoration: none;
-	font-weight: 500;
+	font-weight: 600;
 	font-size: 14px;
 	line-height: 24px;
 }

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -60,7 +60,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	font-size: 14px;
-	font-weight: 500;
+	font-weight: 600;
 
 	.gravatar {
 		border-radius: 48px;
@@ -133,7 +133,7 @@ a.comments__comment-username {
 
 .comments__comment-respondee .comments__comment-respondee-link {
 	color: var( --color-text-subtle );
-	font-weight: normal;
+	font-weight: 400;
 	margin-left: -2px;
 
 	&:hover {
@@ -143,7 +143,7 @@ a.comments__comment-username {
 
 .comments__comment-timestamp a {
 	color: var( --color-text-subtle );
-	font-weight: normal;
+	font-weight: 400;
 	text-decoration: none;
 
 	&:hover {

--- a/client/blocks/plan-storage/style.scss
+++ b/client/blocks/plan-storage/style.scss
@@ -20,7 +20,7 @@
 
 .plan-storage__storage-label {
 	color: var( --color-neutral-70 );
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .plan-storage__storage-link {

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -191,7 +191,7 @@
 
 		.reader-post-card__post-details .reader-excerpt {
 			font-size: 15px;
-			font-weight: 100;
+			font-weight: 400;
 			margin-top: 4px;
 			max-height: 16px * 1.4;
 			overflow: hidden;
@@ -281,7 +281,7 @@
 
 .reader-post-card__byline-author-site {
 	font-family: $sans;
-	font-weight: 500;
+	font-weight: 600;
 	overflow: hidden;
 	position: relative;
 	height: 20px;
@@ -429,7 +429,7 @@
 	color: var( --color-neutral-70 );
 	cursor: pointer;
 	font-size: 19px;
-	font-weight: 700;
+	font-weight: 600;
 	display: block;
 
 	&:hover {
@@ -444,7 +444,7 @@
 .reader-post-card .reader-excerpt {
 	font-size: 16px;
 	line-height: 1.55;
-	font-weight: 100;
+	font-weight: 400;
 	margin-top: 9px;
 	word-break: break-word;
 	position: relative;

--- a/client/blocks/upgrade-nudge/style.scss
+++ b/client/blocks/upgrade-nudge/style.scss
@@ -59,7 +59,7 @@
 
 .upgrade-nudge__title {
 	color: var( --color-neutral-70 );
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .upgrade-nudge__message {

--- a/client/blocks/upwork-banner/style.scss
+++ b/client/blocks/upwork-banner/style.scss
@@ -16,7 +16,7 @@
 
 	h1 {
 		font-size: 1.6em;
-		font-weight: 500;
+		font-weight: 600;
 		letter-spacing: 0.01em;
 		line-height: 1.3;
 		margin: -0.1em 0;

--- a/client/components/diff-viewer/style.scss
+++ b/client/components/diff-viewer/style.scss
@@ -1,7 +1,7 @@
 .diff-viewer__filename {
 	padding: 2px 4px;
 	background-color: var( --color-neutral-10 );
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .diff-viewer__file {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -63,7 +63,7 @@
 
 .register-domain-step__filter-reset-notice {
 	color: var( --color-primary );
-	font-weight: 500;
+	font-weight: 600;
 	width: 100%;
 	position: relative;
 	margin-bottom: 0;

--- a/client/components/domains/trademark-claims-notice/style.scss
+++ b/client/components/domains/trademark-claims-notice/style.scss
@@ -37,7 +37,7 @@
 			}
 
 			.trademark-claims-notice__claim-item-label {
-				font-weight: 500;
+				font-weight: 600;
 			}
 
 			.trademark-claims-notice__claim-item-data {

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -13,7 +13,7 @@
 .pie-chart__title {
 	margin-top: 15px;
 	font-size: 16px;
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .pie-chart__chart-section-0,

--- a/client/components/seo/facebook-preview/style.scss
+++ b/client/components/seo/facebook-preview/style.scss
@@ -33,6 +33,7 @@
 	color: #1d2129;
 	font-family: Georgia, serif;
 	font-size: 18px;
+	/* stylelint-disable-next-line scales/font-weight */
 	font-weight: 500;
 	line-height: 22px;
 	max-height: 100px;

--- a/client/components/site-verticals-suggestion-search/style.scss
+++ b/client/components/site-verticals-suggestion-search/style.scss
@@ -7,7 +7,7 @@
 
 .site-verticals-suggestion-search__heading {
 	font-size: 10px;
-	font-weight: 500;
+	font-weight: 600;
 	text-transform: uppercase;
 	padding: 12px 24px 8px 42px;
 	color: var( --color-neutral-40 );

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -57,7 +57,7 @@
 
 .thank-you-card__name {
 	font-size: 18px;
-	font-weight: 500;
+	font-weight: 600;
 	margin-bottom: 5px;
 
 	&.is-placeholder {
@@ -72,7 +72,7 @@
 
 .thank-you-card__price {
 	font-size: 15px;
-	font-weight: 500;
+	font-weight: 600;
 	color: var( --color-success-5 );
 
 	&.is-placeholder {

--- a/client/extensions/woocommerce/app/order/order-customer/style.scss
+++ b/client/extensions/woocommerce/app/order/order-customer/style.scss
@@ -9,7 +9,7 @@
 	}
 
 	h4 {
-		font-weight: bold;
+		font-weight: 600;
 	}
 
 	.order-customer__shipping {
@@ -35,7 +35,7 @@
 	color: var( --color-text-subtle );
 	font-size: 12px;
 	text-transform: uppercase;
-	font-weight: 500;
+	font-weight: 600;
 	display: flex;
 	align-items: baseline;
 	justify-content: space-between;

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -30,7 +30,7 @@
 
 .mailchimp__getting-started-title-text {
 	font-size: 18px;
-	font-weight: 500;
+	font-weight: 600;
 	padding-bottom: 4px;
 }
 
@@ -63,7 +63,7 @@
 }
 
 .mailchimp__getting-started-list-header {
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .mailchimp__getting-started-list {
@@ -125,7 +125,7 @@
 
 .setup-steps__login-title {
 	font-size: 18px;
-	font-weight: 500;
+	font-weight: 600;
 	margin-bottom: 8px;
 }
 
@@ -147,13 +147,13 @@
 
 .setup-steps__campaign-defaults-title {
 	font-size: 16px;
-	font-weight: 500;
+	font-weight: 600;
 	margin-bottom: 8px;
 }
 
 .setup-steps__mailchimp-api-intro-notice {
 	font-size: 16px;
-	font-weight: 500;
+	font-weight: 600;
 	margin-bottom: 16px;
 }
 

--- a/client/me/help/help-teaser-button.scss
+++ b/client/me/help/help-teaser-button.scss
@@ -28,7 +28,7 @@
 .help__help-teaser-button-title {
 	color: var( --color-neutral-70 );
 	font-size: 14px;
-	font-weight: 500;
+	font-weight: 600;
 	padding-right: 15px;
 }
 

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -47,7 +47,7 @@
 }
 
 .notification-settings-push-notification-settings__instruction-title {
-	font-weight: 500;
+	font-weight: 600;
 	display: block;
 	margin-bottom: 24px;
 }
@@ -103,7 +103,7 @@
 
 .notification-settings-push-notification-settings__settings-state {
 	font-size: 13px;
-	font-weight: 500;
+	font-weight: 600;
 	margin-left: 8px;
 	text-transform: uppercase;
 	color: var( --color-text-subtle );

--- a/client/my-sites/activity/activity-log-tasklist/style.scss
+++ b/client/my-sites/activity/activity-log-tasklist/style.scss
@@ -42,7 +42,7 @@
 .activity-log-tasklist__update-text {
 	margin-bottom: 8px;
 	a, span {
-		font-weight: 500;
+		font-weight: 600;
 	}
 }
 .activity-log-tasklist__update-text

--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -35,7 +35,7 @@
 	margin: 8px 0;
 	padding: 6px 0 4px;
 	background: var( --color-surface-backdrop );
-	font-weight: 500;
+	font-weight: 600;
 
 	@include breakpoint( '<660px' ) {
 		margin-left: 10px;

--- a/client/my-sites/activity/activity-log/threat-alert.scss
+++ b/client/my-sites/activity/activity-log/threat-alert.scss
@@ -67,7 +67,7 @@
 
 .activity-log__threat-alert-title {
 	padding-right: 16px;
-	font-weight: 500;
+	font-weight: 600;
 	color: var( --color-neutral-70 );
 
 	.activity-log__threat-alert-filename {
@@ -78,17 +78,17 @@
 }
 
 .activity-log__threat-alert-slug {
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .activity-log__threat-alert-signature {
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .activity-log__threat-alert-filename {
 	padding: 4px;
 	font-size: 13px;
-	font-weight: 500;
+	font-weight: 600;
 
 	@include breakpoint( '>480px' ) {
 		font-size: 14px;

--- a/client/my-sites/guided-transfer/style.scss
+++ b/client/my-sites/guided-transfer/style.scss
@@ -64,7 +64,7 @@
 
 .guided-transfer__issue-title {
 	margin-left: -24px;
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .guided-transfer__issue-icon {

--- a/client/my-sites/migrate/components/import-type-choice/style.scss
+++ b/client/my-sites/migrate/components/import-type-choice/style.scss
@@ -42,7 +42,7 @@
 
 				.import-type-choice__option-title {
 					font-size: 16px;
-					font-weight: 500;
+					font-weight: 600;
 					line-height: 1.3;
 					margin: 0 10px 0 0;
 				}

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -27,13 +27,13 @@
 
 .plan-compare-card__title {
 	font-size: 16px;
-	font-weight: 500;
+	font-weight: 600;
 	color: var( --color-neutral-60 );
 }
 
 .plan-compare-card__line {
 	font-size: 12px;
-	font-weight: normal;
+	font-weight: 400;
 	color: var( --color-text-subtle );
 	font-style: italic;
 }

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -73,5 +73,5 @@
 }
 
 .plan-price__fraction {
-	font-weight: 500;
+	font-weight: 600;
 }

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -101,7 +101,7 @@
 		right: 16px;
 	color: var( --color-success );
 	font-size: 12px;
-	font-weight: 500;
+	font-weight: 600;
 	animation: appear 0.15s ease-in;
 
 	.gridicon {

--- a/client/my-sites/resume-editing/style.scss
+++ b/client/my-sites/resume-editing/style.scss
@@ -32,7 +32,7 @@
 .resume-editing__label {
 	color: var( --color-text-inverted );
 	font-size: 10px;
-	font-weight: 500;
+	font-weight: 600;
 	opacity: 0.7;
 	text-transform: uppercase;
 }

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -38,7 +38,7 @@
 
 	h1 {
 		font-size: 1.6em;
-		font-weight: 500;
+		font-weight: 600;
 		letter-spacing: 0.01em;
 		margin: -0.1em 0;
 		line-height: 1.3;

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -72,7 +72,7 @@
 	display: flex;
 	flex-shrink: 0;
 	font-size: 13px;
-	font-weight: 500;
+	font-weight: 600;
 	justify-content: space-between;
 	padding: 11px 15px 11px 16px;
 }

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -19,7 +19,7 @@
 	}
 
 	.reader-post-card__byline-author-site {
-		font-weight: 500;
+		font-weight: 600;
 		margin-right: 5px;
 	}
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -75,7 +75,7 @@
 .tag-stream__header-image-byline {
 	color: var( --color-text-inverted );
 	font-size: 12px;
-	font-weight: 500;
+	font-weight: 600;
 	padding-top: 24px;
 	text-align: right;
 	text-shadow: 0 1px rgba( 0, 0, 0, 0.3 );

--- a/client/signup/flow-progress-indicator/style.scss
+++ b/client/signup/flow-progress-indicator/style.scss
@@ -1,7 +1,7 @@
 .flow-progress-indicator {
 	color: var( --color-text-inverted );
 	font-size: 14px;
-	font-weight: 500;
+	font-weight: 600;
 }
 
 .flow-progress-indicator__rebrand-cities {

--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -2,7 +2,7 @@
 	padding: 0;
 	color: var( --color-text-inverted );
 	font-size: 14px;
-	font-weight: 500;
+	font-weight: 600;
 
 	svg {
 		fill: var( --color-text-inverted );

--- a/client/signup/steps/import-url-onboarding/style.scss
+++ b/client/signup/steps/import-url-onboarding/style.scss
@@ -12,7 +12,7 @@
 		padding: 0;
 		color: var( --color-text-inverted );
 		font-size: 14px;
-		font-weight: 500;
+		font-weight: 600;
 		text-decoration: underline;
 	}
 }

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -93,7 +93,7 @@
 		padding: 0;
 		color: var( --color-text-inverted );
 		font-size: 14px;
-		font-weight: 500;
+		font-weight: 600;
 		text-decoration: underline;
 	}
 }

--- a/packages/components/src/suggestions/style.scss
+++ b/packages/components/src/suggestions/style.scss
@@ -23,13 +23,13 @@
 
 .suggestions__label {
 	&.is-emphasized {
-		font-weight: bold;
+		font-weight: 600;
 	}
 }
 
 .suggestions__category-heading {
 	font-size: 10px;
-	font-weight: 500;
+	font-weight: 600;
 	text-transform: uppercase;
 	padding: 12px 24px 8px 42px;
 	color: var( --color-neutral-400 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Swaps `font-weight: 500` for `font-weight: 600` in several instances across Calypso.
* To move quickly, and since this is a relatively small visual change, I'm not offering a comprehensive before/after. The main goal is to introduce consistency and make sure no visual bugs have been introduced as a result.
* Also replaces a couple instances of `font-weight: 100` (wut?) to 400 in the Reader.
* Also replaces a handful of instances of `normal` with `400` to appease the linting gods.

**Visual Examples**

| Before | After |
| ---- | ----- |
| <img width="858" alt="Screen Shot 2020-04-27 at 5 06 28 PM" src="https://user-images.githubusercontent.com/2124984/80421117-f3d69b80-88a9-11ea-863f-f72cd9c87493.png"> | <img width="857" alt="Screen Shot 2020-04-27 at 5 06 42 PM" src="https://user-images.githubusercontent.com/2124984/80421128-f89b4f80-88a9-11ea-96ea-d3c06841570e.png"> |
| <img width="1074" alt="Screen Shot 2020-04-27 at 5 11 54 PM" src="https://user-images.githubusercontent.com/2124984/80421385-634c8b00-88aa-11ea-87c1-bcbfc0283f2e.png"> | <img width="1071" alt="Screen Shot 2020-04-27 at 5 12 40 PM" src="https://user-images.githubusercontent.com/2124984/80421395-66e01200-88aa-11ea-988c-cd8a617c52fd.png"> |
| <img width="1070" alt="Screen Shot 2020-04-27 at 5 15 28 PM" src="https://user-images.githubusercontent.com/2124984/80421659-d5bd6b00-88aa-11ea-882d-7a9ba5f299d3.png"> | <img width="1071" alt="Screen Shot 2020-04-27 at 5 15 40 PM" src="https://user-images.githubusercontent.com/2124984/80421672-d8b85b80-88aa-11ea-9e35-51182e6cbdfe.png"> |




#### Testing instructions

Switch to this PR and check out a few areas of Calypso to see where font weights have been upped slightly. A few of the areas this PR touches (doesn't necessarily mean I was able to find them):

* App Banners block
* Plan Storage block
* Upwork Banner block
* Pie chart component
* Diff viewer
* Me/notification settings
* Activity log
* Site migration
* Compare plans cards
* Reader tags and conversations
* WooCommerce MailChimp and Order Customer settings

Note, I wasn't actually able to find many of these. Doesn't mean they don't exist, just means I haven't found the way to trigger those classes to show. But I hope the visual examples convey the very, very slight nature of this change.

See #41234
