### PR TITLE
FSE: sync-bash script agonistic from running-command.

### DIFF
--- a/apps/full-site-editing/bin/sync-newspack-blocks.sh
+++ b/apps/full-site-editing/bin/sync-newspack-blocks.sh
@@ -26,10 +26,8 @@ then
 elif [[ $1 =~ ^--path= ]]
 then
 	MODE=path
-fi
-
+elif [[ $1 =~ ^--nodemodules ]]
 # try whether user passed --nodemodules
-if [ -n "$npm_config_nodemodules" ]
 then
 	MODE=npm
 fi

--- a/apps/full-site-editing/bin/sync-newspack-blocks.sh
+++ b/apps/full-site-editing/bin/sync-newspack-blocks.sh
@@ -9,24 +9,21 @@ case "$(uname)" in
 	Darwin*) sedi=(-i "")
 esac
 
-# try whether user passed --release
-if [ -n "$npm_config_release" ]
+# pick up value considering that the argument
+# has the --key=value shape.
+key_value=$(echo ${1} | cut -d'=' -f 2)
+# Set mode depending on first argument
+if [[ $1 =~ ^--release= ]]
 then
 	MODE=release
-	NAME=$npm_config_release
+	NAME=${key_value}
 	URL=https://github.com/Automattic/newspack-blocks/releases/download/$NAME/newspack-blocks.zip
-fi
-
-# try whether user passed --branch
-if [ -n "$npm_config_branch" ]
+elif [[ $1 =~ ^--branch= ]]
 then
 	MODE=branch
-	NAME=$npm_config_branch
+	NAME=${key_value}
 	URL=https://github.com/Automattic/newspack-blocks/archive/$NAME.zip
-fi
-
-# try whether user passed --path
-if [ -n "$npm_config_path" ]
+elif [[ $1 =~ ^--path= ]]
 then
 	MODE=path
 fi

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -58,7 +58,7 @@
 		"predev": "check-npm-client && yarn run clean",
 		"sync:newspack-blocks": "check-npm-client && ./bin/sync-newspack-blocks.sh",
 		"wpcom-sync": "check-npm-client && ./bin/wpcom-watch-and-sync.sh",
-		"prepare": "check-npm-client && npm run sync:newspack-blocks --nodemodules"
+		"prepare": "check-npm-client && yarn run sync:newspack-blocks --nodemodules"
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "*",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Initially, the bash script was implemented to be executed via `npm`. Now, it's being executed via `yarn`.The way to get command variables isn't working with `yarn`, for instance

```
> yarn run sync:newspack-blocks --branch=master
```

`--branch` and `master` aren't properly gotten.

This PR attempts that the bash script is agnostic of the running-command, at least in terms of getting arguments.

#### Testing instructions

Sync the newspack-blocks using the following commands:

```
> yarn run sync:newspack-blocks --branch=master
```

```
> yarn run sync:newspack-blocks --release=v1.3.0
```


```
> yarn run sync:newspack-blocks --nodemodules
```
