### PR TITLE
composite-checkout: Add isValidating prop to CheckoutProvider

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -138,7 +138,8 @@ It has the following props.
 - `onEvent?: (action) => null`. A function called for all sorts of events in the code. The callback will be called with a [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action).
 - `paymentMethods: object[]`: An array of [Payment Method objects](#payment-methods).
 - `registry?: object`. An object returned by [createRegistry](#createRegistry). If not provided, the default registry will be used.
-- `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder.
+- `isLoading?: boolean`. If set and true, the form will be replaced with a loading placeholder and the form status will be set to 'loading' (see [useFormStatus](#useFormStatus)).
+- `isValidating?: boolean`. If set and true, the form status will be set to 'validating' (see [useFormStatus](#useFormStatus)).
 
 The line items are for display purposes only. They should also include subtotals, discounts, and taxes. No math will be performed on the line items. Instead, the amount to be charged will be specified by the required prop `total`, which is another line item.
 
@@ -335,7 +336,7 @@ A React Hook that will return an object with the following properties:
 - `setFormSubmitting: () => void`. Function to change the form status to 'submitting'.
 - `setFormComplete: () => void`. Function to change the form status to 'complete'. Note that this will trigger `onPaymentComplete` from [CheckoutProvider](#CheckoutProvider).
 
-Only works within [CheckoutProvider](#CheckoutProvider).
+Only works within [CheckoutProvider](#CheckoutProvider) which may sometimes change the status itself based on its props.
 
 ### useIsStepActive
 

--- a/packages/composite-checkout/src/components/checkout-provider.js
+++ b/packages/composite-checkout/src/components/checkout-provider.js
@@ -39,6 +39,7 @@ export const CheckoutProvider = ( props ) => {
 		registry,
 		onEvent,
 		isLoading,
+		isValidating,
 		children,
 	} = props;
 	const [ paymentMethodId, setPaymentMethodId ] = useState(
@@ -53,7 +54,7 @@ export const CheckoutProvider = ( props ) => {
 		}
 	}, [ paymentMethods, prevPaymentMethods ] );
 
-	const [ formStatus, setFormStatus ] = useFormStatusManager( isLoading );
+	const [ formStatus, setFormStatus ] = useFormStatusManager( isLoading, isValidating );
 	const didCallOnPaymentComplete = useRef( false );
 	useEffect( () => {
 		if ( formStatus === 'complete' && ! didCallOnPaymentComplete.current ) {

--- a/packages/composite-checkout/src/lib/form-status.js
+++ b/packages/composite-checkout/src/lib/form-status.js
@@ -26,7 +26,7 @@ export function useFormStatus() {
 	);
 }
 
-export function useFormStatusManager( isLoading ) {
+export function useFormStatusManager( isLoading, isValidating ) {
 	const [ formStatus, dispatchFormStatus ] = useReducer(
 		formStatusReducer,
 		isLoading ? 'loading' : 'ready'
@@ -34,11 +34,13 @@ export function useFormStatusManager( isLoading ) {
 	const setFormStatus = useCallback( ( payload ) => {
 		return dispatchFormStatus( { type: 'FORM_STATUS_CHANGE', payload } );
 	}, [] );
+
 	useEffect( () => {
-		const newStatus = isLoading ? 'loading' : 'ready';
-		debug( `isLoading has changed to ${ isLoading }; setting form status to ${ newStatus }` );
+		const newStatus = getNewStatusFromProps( { isLoading, isValidating } );
+		debug( `props have changed; setting form status to ${ newStatus }` );
 		setFormStatus( newStatus );
-	}, [ isLoading, setFormStatus ] );
+	}, [ isLoading, isValidating, setFormStatus ] );
+
 	debug( `form status is ${ formStatus }` );
 	return [ formStatus, setFormStatus ];
 }
@@ -59,4 +61,14 @@ function validateStatus( status ) {
 	if ( ! validStatuses.includes( status ) ) {
 		throw new Error( `Invalid form status '${ status }'` );
 	}
+}
+
+function getNewStatusFromProps( { isLoading, isValidating } ) {
+	if ( isLoading ) {
+		return 'loading';
+	}
+	if ( isValidating ) {
+		return 'validating';
+	}
+	return 'ready';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates `CheckoutProvider` in the composite-checkout package to add an optional `isValidating` prop. If set, this prop will set the form's status to 'validating' and can be used to disable the form for situations like when the cart items are being updated.

#### Testing instructions

This should have no effect on composite checkout and is split off from #41456 

Verify that you can load composite checkout without any issues, that the pulsing "loading" page is displayed briefly before we see the actual checkout form, and that changing steps works as expected.