### PR TITLE
Adds jetpack redirects npm package

### DIFF
--- a/packages/jetpack-redirects/README.md
+++ b/packages/jetpack-redirects/README.md
@@ -1,0 +1,54 @@
+# Jetpack Redirects
+
+A helper function to build URLs using the `jetpack.com/redirect` service.
+
+## Usage
+
+`getRedirectUrl( required source, optional args );`
+
+### $source (required)
+
+Source can be either a “source handler” or a URL.
+
+A “source handler” must be registered in the Jetpack Redirects service, on the server side. It’s a slug that points to an URL that may or may not have dynamic parts in it.
+
+A “URL” is a string that must start with “https://" and doesn’t need to be registered on the server. However, if it is registered, it will point to the URL set as target there rather than to the source. (Note: It will only work for whitelisted domains)
+
+### $args (optional)
+
+This is optional and allows you to pass an array (or object in JS) with more parameters to build the URL:
+
+* **site**: This is used to identify the site and also to fill in the `[site]` placeholder in the target. 
+
+* **path**: Optional. Used to fill in the `[path]` placeholder in the target.
+
+* **query**: Optional. A string with additional variables to be added in the query string. Must be passed as a string in `key=value&foo=bar` format.
+
+* **anchor**: Optional. An anchor to be added to the final URL. Must be a single string. Example: `section1`
+
+## Examples
+
+### Example 1
+
+`getRedirectUrl( 'jetpack', { query: 'foo=bar', anchor: 'section' } );`
+
+This will create: `https://jetpack.com/redirect?source=jetpack&anchor=section&query=foo%3Dbar`
+
+That will point to: `https://jetpack.com/?foo=bar#section`
+
+### Example 2 (placeholders):
+
+```	
+getRedirectUrl( 
+	'calypso-edit-post',
+	{
+		path: '1234',
+		site: 'example.org'
+	}
+)
+```
+This will create: h`ttps://jetpack.com/redirect?site=example.org&source=calypso-edit-post&path=1234`
+
+The calypso-edit-post source points to `https://wordpress.com/post/[site]/[path]`, so the final URL will be:
+
+`https://wordpress.com/post/example.org/1234`

--- a/packages/jetpack-redirects/README.md
+++ b/packages/jetpack-redirects/README.md
@@ -2,11 +2,13 @@
 
 A helper function to build URLs using the `jetpack.com/redirect` service.
 
+If you are an automattician, refer to PCYsg-pY7-p2 for all related information and links to our internal tools.
+
 ## Usage
 
 `getRedirectUrl( required source, optional args );`
 
-### $source (required)
+### source (required)
 
 Source can be either a “source handler” or a URL.
 
@@ -14,7 +16,7 @@ A “source handler” must be registered in the Jetpack Redirects service, on t
 
 A “URL” is a string that must start with “https://" and doesn’t need to be registered on the server. However, if it is registered, it will point to the URL set as target there rather than to the source. (Note: It will only work for whitelisted domains)
 
-### $args (optional)
+### args (optional)
 
 This is optional and allows you to pass an array (or object in JS) with more parameters to build the URL:
 
@@ -32,9 +34,9 @@ This is optional and allows you to pass an array (or object in JS) with more par
 
 `getRedirectUrl( 'jetpack', { query: 'foo=bar', anchor: 'section' } );`
 
-This will create: `https://jetpack.com/redirect?source=jetpack&anchor=section&query=foo%3Dbar`
+This will return the following URL: `https://jetpack.com/redirect?source=jetpack&anchor=section&query=foo%3Dbar`
 
-That will point to: `https://jetpack.com/?foo=bar#section`
+When accessing this URL, the user will redirected to: `https://jetpack.com/?foo=bar#section`
 
 ### Example 2 (placeholders):
 
@@ -47,8 +49,8 @@ getRedirectUrl(
 	}
 )
 ```
-This will create: h`ttps://jetpack.com/redirect?site=example.org&source=calypso-edit-post&path=1234`
+This will return the following URL: `ttps://jetpack.com/redirect?site=example.org&source=calypso-edit-post&path=1234`
 
-The calypso-edit-post source points to `https://wordpress.com/post/[site]/[path]`, so the final URL will be:
+The `calypso-edit-post` source is registered in the server and it points to `https://wordpress.com/post/[site]/[path]`, so the final URL that the user will be redirected to is:
 
 `https://wordpress.com/post/example.org/1234`

--- a/packages/jetpack-redirects/README.md
+++ b/packages/jetpack-redirects/README.md
@@ -14,13 +14,13 @@ Source can be either a “source handler” or a URL.
 
 A “source handler” must be registered in the Jetpack Redirects service, on the server side. It’s a slug that points to an URL that may or may not have dynamic parts in it.
 
-A “URL” is a string that must start with “https://" and doesn’t need to be registered on the server. However, if it is registered, it will point to the URL set as target there rather than to the source. (Note: It will only work for whitelisted domains)
+A “URL” is a string that must start with “https://" and doesn’t need to be registered on the server. However, if it is registered, it will point to the URL set as target there rather than to the source. (Note: It will only work for whitelisted domains, unless the URL is explicitly registered on the server)
 
 ### args (optional)
 
-This is optional and allows you to pass an array (or object in JS) with more parameters to build the URL:
+This is optional and allows you to pass an object with more parameters to build the URL:
 
-* **site**: This is used to identify the site and also to fill in the `[site]` placeholder in the target. 
+* **site**: Optional (but recommended). This is used to identify the site and also to fill in the `[site]` placeholder in the target. 
 
 * **path**: Optional. Used to fill in the `[path]` placeholder in the target.
 

--- a/packages/jetpack-redirects/jest.config.js
+++ b/packages/jetpack-redirects/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = { preset: '@automattic/calypso-build', rootDir: __dirname };

--- a/packages/jetpack-redirects/package.json
+++ b/packages/jetpack-redirects/package.json
@@ -10,9 +10,6 @@
 		"jetpack"
 	],
 	"author": "Automattic Inc.",
-	"contributors": [
-		"leogermani"
-	],
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
 	"repository": {

--- a/packages/jetpack-redirects/package.json
+++ b/packages/jetpack-redirects/package.json
@@ -28,7 +28,7 @@
 	},
 	"files": [
 		"dist",
-		"src"
+		"README.md"
 	],
 	"scripts": {
 		"clean": "check-npm-client && npx rimraf dist",

--- a/packages/jetpack-redirects/package.json
+++ b/packages/jetpack-redirects/package.json
@@ -1,0 +1,38 @@
+{
+	"name": "@automattic/jetpack-redirects",
+	"version": "1.0.0",
+	"description": "Jetpack Redirects helper",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"sideEffects": false,
+	"keywords": [
+		"wordpress",
+		"jetpack"
+	],
+	"author": "Automattic Inc.",
+	"contributors": [
+		"leogermani"
+	],
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/jetpack-redirects"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"files": [
+		"dist",
+		"src"
+	],
+	"scripts": {
+		"clean": "npx rimraf dist",
+		"prepublish": "yarn run clean",
+		"prepare": "transpile"
+	}
+}

--- a/packages/jetpack-redirects/package.json
+++ b/packages/jetpack-redirects/package.json
@@ -31,8 +31,8 @@
 		"src"
 	],
 	"scripts": {
-		"clean": "npx rimraf dist",
-		"prepublish": "yarn run clean",
-		"prepare": "transpile"
+		"clean": "check-npm-client && npx rimraf dist",
+		"prepublish": "check-npm-client && yarn run clean",
+		"prepare": "check-npm-client && transpile"
 	}
 }

--- a/packages/jetpack-redirects/src/index.js
+++ b/packages/jetpack-redirects/src/index.js
@@ -21,23 +21,30 @@
  * @returns {string} The redirect URL
  */
 export default function getRedirectUrl( source, args = {} ) {
+	let params = {};
+
 	if ( source.startsWith( 'https://' ) ) {
 		const parsedUrl = new URL( source );
 
 		// discard any query and fragments.
 		source = `https://${ parsedUrl.host }${ parsedUrl.pathname }`;
-		args.url = source;
+		params.url = source;
 	} else {
-		args.source = source;
+		params.source = source;
 	}
+
+	params = {
+		...args,
+		...params,
+	};
 
 	const acceptedArgs = [ 'site', 'path', 'query', 'anchor', 'source', 'url' ];
 
-	const pairs = Object.keys( args )
+	const pairs = Object.keys( params )
 		.filter( ( key ) => acceptedArgs.includes( key ) )
-		.map( ( key ) => [ key, args[ key ] ] );
-	const params = new globalThis.URLSearchParams( pairs );
-	const queryString = params.toString();
+		.map( ( key ) => [ key, params[ key ] ] );
+	const urlParams = new globalThis.URLSearchParams( pairs );
+	const queryString = urlParams.toString();
 
 	return `https://jetpack.com/redirect/?${ queryString }`;
 }

--- a/packages/jetpack-redirects/src/index.js
+++ b/packages/jetpack-redirects/src/index.js
@@ -1,0 +1,43 @@
+/**
+ * Builds an URL using the jetpack.com/redirect service
+ *
+ * @param {string}  source The URL handler registered in the server
+ * @param {object}  args {
+ *
+ * 		Additional arguments to build the url
+ *
+ * 		@type {string} site URL of the current site.
+ * 		@type {string} path Additional path to be appended to the URL
+ * 		@type {string} query Query parameters to be added to the URL
+ * 		@type {string} anchor Anchor to be added to the URL
+ * }
+ *
+ * @return {string} The redirect URL
+ */
+export default function getRedirectUrl( source, args = {} ) {
+	const queryVars = {};
+
+	if ( source.search( 'https://' ) === 0 ) {
+		const parsedUrl = new URL( source );
+
+		// discard any query and fragments.
+		source = `https://${ parsedUrl.host }${ parsedUrl.pathname }`;
+		queryVars.url = encodeURIComponent( source );
+	} else {
+		queryVars.source = encodeURIComponent( source );
+	}
+
+	const acceptedArgs = [ 'site', 'path', 'query', 'anchor' ];
+
+	Object.keys( args ).map( ( argName ) => {
+		if ( acceptedArgs.includes( argName ) ) {
+			queryVars[ argName ] = encodeURIComponent( args[ argName ] );
+		}
+	} );
+
+	const queryString = Object.keys( queryVars )
+		.map( ( key ) => key + '=' + queryVars[ key ] )
+		.join( '&' );
+
+	return `https://jetpack.com/redirect/?` + queryString;
+}

--- a/packages/jetpack-redirects/src/index.js
+++ b/packages/jetpack-redirects/src/index.js
@@ -1,11 +1,11 @@
 /**
  * Builds an URL using the jetpack.com/redirect service
  *
- * If $source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect?source=slug
+ * If source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect?source=slug
  *
- * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect?url=https://wordpress.com
+ * If source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect?url=https://wordpress.com
  *
- * Note: if using full URL, query parameters and anchor must be passed in $args. Any querystring of url fragment in the URL will be discarded.
+ * Note: if using full URL, query parameters and anchor must be passed in args. Any querystring of url fragment in the URL will be discarded.
  *
  * @param {string}  source The URL handler registered in the server or the full destination URL (starting with https://).
  * @param {object}  args {

--- a/packages/jetpack-redirects/src/index.js
+++ b/packages/jetpack-redirects/src/index.js
@@ -12,7 +12,7 @@
  *
  * 		Additional arguments to build the url
  *
- * 		@type {string} site URL of the current site.
+ * 		@type {string} site URL of the current site, without protocol.
  * 		@type {string} path Additional path to be appended to the URL
  * 		@type {string} query Query parameters to be added to the URL
  * 		@type {string} anchor Anchor to be added to the URL
@@ -21,29 +21,23 @@
  * @returns {string} The redirect URL
  */
 export default function getRedirectUrl( source, args = {} ) {
-	const queryVars = {};
-
-	if ( source.search( 'https://' ) === 0 ) {
+	if ( source.startsWith( 'https://' ) ) {
 		const parsedUrl = new URL( source );
 
 		// discard any query and fragments.
 		source = `https://${ parsedUrl.host }${ parsedUrl.pathname }`;
-		queryVars.url = encodeURIComponent( source );
+		args.url = source;
 	} else {
-		queryVars.source = encodeURIComponent( source );
+		args.source = source;
 	}
 
-	const acceptedArgs = [ 'site', 'path', 'query', 'anchor' ];
+	const acceptedArgs = [ 'site', 'path', 'query', 'anchor', 'source', 'url' ];
 
-	Object.keys( args ).map( ( argName ) => {
-		if ( acceptedArgs.includes( argName ) ) {
-			queryVars[ argName ] = encodeURIComponent( args[ argName ] );
-		}
-	} );
-
-	const queryString = Object.keys( queryVars )
-		.map( ( key ) => `${ key }=${ queryVars[ key ] }` )
-		.join( '&' );
+	const pairs = Object.keys( args )
+		.filter( ( key ) => acceptedArgs.includes( key ) )
+		.map( ( key ) => [ key, args[ key ] ] );
+	const params = new globalThis.URLSearchParams( pairs );
+	const queryString = params.toString();
 
 	return `https://jetpack.com/redirect/?${ queryString }`;
 }

--- a/packages/jetpack-redirects/src/index.js
+++ b/packages/jetpack-redirects/src/index.js
@@ -21,7 +21,7 @@
  * @returns {string} The redirect URL
  */
 export default function getRedirectUrl( source, args = {} ) {
-	let params = {};
+	const params = { ...args };
 
 	if ( source.startsWith( 'https://' ) ) {
 		const parsedUrl = new URL( source );
@@ -32,11 +32,6 @@ export default function getRedirectUrl( source, args = {} ) {
 	} else {
 		params.source = source;
 	}
-
-	params = {
-		...args,
-		...params,
-	};
 
 	const acceptedArgs = [ 'site', 'path', 'query', 'anchor', 'source', 'url' ];
 

--- a/packages/jetpack-redirects/src/index.js
+++ b/packages/jetpack-redirects/src/index.js
@@ -1,7 +1,13 @@
 /**
  * Builds an URL using the jetpack.com/redirect service
  *
- * @param {string}  source The URL handler registered in the server
+ * If $source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect?source=slug
+ *
+ * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect?url=https://wordpress.com
+ *
+ * Note: if using full URL, query parameters and anchor must be passed in $args. Any querystring of url fragment in the URL will be discarded.
+ *
+ * @param {string}  source The URL handler registered in the server or the full destination URL (starting with https://).
  * @param {object}  args {
  *
  * 		Additional arguments to build the url
@@ -12,7 +18,7 @@
  * 		@type {string} anchor Anchor to be added to the URL
  * }
  *
- * @return {string} The redirect URL
+ * @returns {string} The redirect URL
  */
 export default function getRedirectUrl( source, args = {} ) {
 	const queryVars = {};
@@ -36,8 +42,8 @@ export default function getRedirectUrl( source, args = {} ) {
 	} );
 
 	const queryString = Object.keys( queryVars )
-		.map( ( key ) => key + '=' + queryVars[ key ] )
+		.map( ( key ) => `${ key }=${ queryVars[ key ] }` )
 		.join( '&' );
 
-	return `https://jetpack.com/redirect/?` + queryString;
+	return `https://jetpack.com/redirect/?${ queryString }`;
 }

--- a/packages/jetpack-redirects/test/index.js
+++ b/packages/jetpack-redirects/test/index.js
@@ -1,0 +1,78 @@
+/**
+ * Internal dependencies
+ */
+import getRedirectUrl from '../src';
+
+describe( 'getRedirectUrl', () => {
+	test( 'simple url', () => {
+		const url = getRedirectUrl( 'simple' );
+		expect( url ).toBe( 'https://jetpack.com/redirect/?source=simple' );
+	} );
+
+	test( 'Invalid param', () => {
+		const url = getRedirectUrl( 'simple', { invalid: 'asd' } );
+		expect( url ).toBe( 'https://jetpack.com/redirect/?source=simple' );
+	} );
+
+	test( 'Test path', () => {
+		const url = getRedirectUrl( 'simple', { path: '1234' } );
+		expect( url ).toBe( 'https://jetpack.com/redirect/?source=simple&path=1234' );
+	} );
+
+	test( 'Test path with special chars', () => {
+		const url = getRedirectUrl( 'simple', { path: 'weird value!' } );
+		const value = encodeURIComponent( 'weird value!' );
+		expect( url ).toBe( `https://jetpack.com/redirect/?source=simple&path=${ value }` );
+	} );
+
+	test( 'Test query', () => {
+		const url = getRedirectUrl( 'simple', { query: 'key=1234&other=super' } );
+		const value = encodeURIComponent( 'key=1234&other=super' );
+		expect( url ).toBe( `https://jetpack.com/redirect/?source=simple&query=${ value }` );
+	} );
+
+	test( 'Test anchor', () => {
+		const url = getRedirectUrl( 'simple', { anchor: 'section' } );
+		expect( url ).toBe( 'https://jetpack.com/redirect/?source=simple&anchor=section' );
+	} );
+
+	test( 'Test all', () => {
+		const url = getRedirectUrl( 'simple', {
+			query: 'key=1234&other=super',
+			anchor: 'section',
+			site: 'example.org',
+			path: 123,
+		} );
+		const parsedUrl = new URL( url );
+
+		expect( parsedUrl.searchParams.get( 'source' ) ).toBe( 'simple' );
+		expect( parsedUrl.searchParams.get( 'anchor' ) ).toBe( 'section' );
+		expect( parsedUrl.searchParams.get( 'query' ) ).toBe( 'key=1234&other=super' );
+		expect( parsedUrl.searchParams.get( 'site' ) ).toBe( 'example.org' );
+		expect( parsedUrl.searchParams.get( 'path' ) ).toBe( '123' );
+	} );
+
+	test( 'Test informing URL', () => {
+		const url = getRedirectUrl( 'https://wordpress.com/support' );
+		const value = encodeURIComponent( 'https://wordpress.com/support' );
+		expect( url ).toBe( `https://jetpack.com/redirect/?url=${ value }` );
+	} );
+
+	test( 'Test informing URL and query', () => {
+		const url = getRedirectUrl( 'https://wordpress.com/support', {
+			query: 'key=1234&other=super',
+		} );
+		const value = encodeURIComponent( 'https://wordpress.com/support' );
+		const query = encodeURIComponent( 'key=1234&other=super' );
+		expect( url ).toBe( `https://jetpack.com/redirect/?url=${ value }&query=${ query }` );
+	} );
+
+	test( 'Test informing URL and query discarding info from url', () => {
+		const url = getRedirectUrl( 'https://wordpress.com/support?super=mega&key=value#section1', {
+			query: 'key=1234&other=super',
+		} );
+		const value = encodeURIComponent( 'https://wordpress.com/support' );
+		const query = encodeURIComponent( 'key=1234&other=super' );
+		expect( url ).toBe( `https://jetpack.com/redirect/?url=${ value }&query=${ query }` );
+	} );
+} );

--- a/packages/jetpack-redirects/test/index.js
+++ b/packages/jetpack-redirects/test/index.js
@@ -64,13 +64,13 @@ describe( 'getRedirectUrl', () => {
 		expect( parsedUrl.searchParams.get( 'path' ) ).toBe( '123' );
 	} );
 
-	test( 'Test informing URL', () => {
+	test( 'Test passing an URL as the first parameter', () => {
 		const url = getRedirectUrl( 'https://wordpress.com/support' );
 		const value = encodeURIComponent( 'https://wordpress.com/support' );
 		expect( url ).toBe( `https://jetpack.com/redirect/?url=${ value }` );
 	} );
 
-	test( 'Test informing URL and query', () => {
+	test( 'Test passing an URL as the first parameter and query', () => {
 		const url = getRedirectUrl( 'https://wordpress.com/support', {
 			query: 'key=1234&other=super',
 		} );
@@ -80,7 +80,7 @@ describe( 'getRedirectUrl', () => {
 		expect( parsedUrl.searchParams.get( 'query' ) ).toBe( 'key=1234&other=super' );
 	} );
 
-	test( 'Test informing URL and query discarding info from url', () => {
+	test( 'Test passing an URL as the first parameter and query discarding info from url', () => {
 		const url = getRedirectUrl( 'https://wordpress.com/support?super=mega&key=value#section1', {
 			query: 'key=1234&other=super',
 		} );

--- a/packages/jetpack-redirects/test/index.js
+++ b/packages/jetpack-redirects/test/index.js
@@ -6,7 +6,9 @@ import getRedirectUrl from '../src';
 describe( 'getRedirectUrl', () => {
 	test( 'simple url', () => {
 		const url = getRedirectUrl( 'simple' );
-		expect( url ).toBe( 'https://jetpack.com/redirect/?source=simple' );
+		const parsedUrl = new URL( url );
+
+		expect( parsedUrl.searchParams.get( 'source' ) ).toBe( 'simple' );
 	} );
 
 	test( 'Invalid param', () => {
@@ -16,24 +18,34 @@ describe( 'getRedirectUrl', () => {
 
 	test( 'Test path', () => {
 		const url = getRedirectUrl( 'simple', { path: '1234' } );
-		expect( url ).toBe( 'https://jetpack.com/redirect/?source=simple&path=1234' );
+		const parsedUrl = new URL( url );
+
+		expect( parsedUrl.searchParams.get( 'source' ) ).toBe( 'simple' );
+		expect( parsedUrl.searchParams.get( 'path' ) ).toBe( '1234' );
 	} );
 
 	test( 'Test path with special chars', () => {
 		const url = getRedirectUrl( 'simple', { path: 'weird value!' } );
-		const value = encodeURIComponent( 'weird value!' );
-		expect( url ).toBe( `https://jetpack.com/redirect/?source=simple&path=${ value }` );
+		const parsedUrl = new URL( url );
+
+		expect( parsedUrl.searchParams.get( 'source' ) ).toBe( 'simple' );
+		expect( parsedUrl.searchParams.get( 'path' ) ).toBe( 'weird value!' );
 	} );
 
 	test( 'Test query', () => {
 		const url = getRedirectUrl( 'simple', { query: 'key=1234&other=super' } );
-		const value = encodeURIComponent( 'key=1234&other=super' );
-		expect( url ).toBe( `https://jetpack.com/redirect/?source=simple&query=${ value }` );
+		const parsedUrl = new URL( url );
+
+		expect( parsedUrl.searchParams.get( 'source' ) ).toBe( 'simple' );
+		expect( parsedUrl.searchParams.get( 'query' ) ).toBe( 'key=1234&other=super' );
 	} );
 
 	test( 'Test anchor', () => {
 		const url = getRedirectUrl( 'simple', { anchor: 'section' } );
-		expect( url ).toBe( 'https://jetpack.com/redirect/?source=simple&anchor=section' );
+		const parsedUrl = new URL( url );
+
+		expect( parsedUrl.searchParams.get( 'source' ) ).toBe( 'simple' );
+		expect( parsedUrl.searchParams.get( 'anchor' ) ).toBe( 'section' );
 	} );
 
 	test( 'Test all', () => {
@@ -62,17 +74,19 @@ describe( 'getRedirectUrl', () => {
 		const url = getRedirectUrl( 'https://wordpress.com/support', {
 			query: 'key=1234&other=super',
 		} );
-		const value = encodeURIComponent( 'https://wordpress.com/support' );
-		const query = encodeURIComponent( 'key=1234&other=super' );
-		expect( url ).toBe( `https://jetpack.com/redirect/?url=${ value }&query=${ query }` );
+		const parsedUrl = new URL( url );
+
+		expect( parsedUrl.searchParams.get( 'url' ) ).toBe( 'https://wordpress.com/support' );
+		expect( parsedUrl.searchParams.get( 'query' ) ).toBe( 'key=1234&other=super' );
 	} );
 
 	test( 'Test informing URL and query discarding info from url', () => {
 		const url = getRedirectUrl( 'https://wordpress.com/support?super=mega&key=value#section1', {
 			query: 'key=1234&other=super',
 		} );
-		const value = encodeURIComponent( 'https://wordpress.com/support' );
-		const query = encodeURIComponent( 'key=1234&other=super' );
-		expect( url ).toBe( `https://jetpack.com/redirect/?url=${ value }&query=${ query }` );
+		const parsedUrl = new URL( url );
+
+		expect( parsedUrl.searchParams.get( 'url' ) ).toBe( 'https://wordpress.com/support' );
+		expect( parsedUrl.searchParams.get( 'query' ) ).toBe( 'key=1234&other=super' );
 	} );
 } );


### PR DESCRIPTION
Creates the Jetpack Redirects package

This is a helper function to build URLs using the `jetpack.com/redirect` service.

For context on why we are doing this, check this Master Thread: p1HpG7-8QE-p2

For further documentation, check PCYsg-pY7-p2

#### Changes proposed in this Pull Request

* Creates the Jetpack Redirects npm package to be used in different contexts

#### Testing instructions

* Run the tests
* Import this package in some other js and try to add links and see if they work as expected (Check the Field guide page for more info and a list of registered sources)
