### PR TITLE
composite-checkout: Allow adding temporary products to the cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
+++ b/client/my-sites/checkout/composite-checkout/types/paypal-express.ts
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import {
-	WPCOMCartItem,
-	getNonProductWPCOMCartItemTypes,
-} from 'my-sites/checkout/composite-checkout/wpcom';
+import { getNonProductWPCOMCartItemTypes } from 'my-sites/checkout/composite-checkout/wpcom';
+import { WPCOMCartItem } from 'my-sites/checkout/composite-checkout/wpcom/types';
 
 /**
  * Internal dependencies
@@ -29,7 +27,6 @@ export type PayPalExpressEndpointRequestPayload = {
 };
 
 export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
-	debug,
 	successUrl,
 	cancelUrl,
 	siteId,
@@ -40,7 +37,6 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 	domainDetails,
 	items,
 }: {
-	debug: ( _0: string, _1: any ) => void;
 	successUrl: string;
 	cancelUrl: string;
 	siteId: string;
@@ -55,7 +51,6 @@ export function createPayPalExpressEndpointRequestPayloadFromLineItems( {
 		successUrl,
 		cancelUrl,
 		cart: createTransactionEndpointCartFromLineItems( {
-			debug,
 			siteId,
 			couponId,
 			country,

--- a/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/types/transaction-endpoint.ts
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import {
-	WPCOMCartItem,
-	getNonProductWPCOMCartItemTypes,
-} from 'my-sites/checkout/composite-checkout/wpcom';
+import { getNonProductWPCOMCartItemTypes } from 'my-sites/checkout/composite-checkout/wpcom';
+import { WPCOMCartItem } from 'my-sites/checkout/composite-checkout/wpcom/types';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:transaction-endpoint' );

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/form-field-annotation.tsx
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/form-field-annotation.tsx
@@ -90,7 +90,12 @@ const FormFieldWrapper = styled.div< FormFieldWrapperProps >`
 	}
 `;
 
-function RenderedDescription( { descriptionText, descriptionId, isError, errorMessage } ) {
+function RenderedDescription( {
+	descriptionText,
+	descriptionId,
+	isError,
+	errorMessage,
+}: RenderedDescriptionProps ) {
 	if ( descriptionText || isError ) {
 		return (
 			<Description isError={ isError } id={ descriptionId }>
@@ -101,8 +106,15 @@ function RenderedDescription( { descriptionText, descriptionId, isError, errorMe
 	return null;
 }
 
+type RenderedDescriptionProps = {
+	descriptionText?: string;
+	descriptionId?: string;
+	isError?: boolean;
+	errorMessage?: string;
+};
+
 type DescriptionProps = {
-	isError: boolean;
+	isError?: boolean;
 	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/item-variation-picker.tsx
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/item-variation-picker.tsx
@@ -25,8 +25,8 @@ export type ItemVariationPickerProps = {
 	selectedItem: WPCOMCartItem;
 	variantRequestStatus: VariantRequestStatus;
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[];
-	getItemVariants: ( WPCOMProductSlug ) => WPCOMProductVariant[];
-	onChangeItemVariant: ( WPCOMCartItem, WPCOMProductSlug, number ) => void;
+	getItemVariants: ( arg0: WPCOMProductSlug ) => WPCOMProductVariant[];
+	onChangeItemVariant: ( arg0: string, arg1: WPCOMProductSlug, arg2: number ) => void;
 	isDisabled: boolean;
 };
 
@@ -54,7 +54,7 @@ export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > 
 
 function renderProductVariant(
 	selectedItem: WPCOMCartItem,
-	onChangeItemVariant: ( string, WPCOMProductSlug, number ) => void,
+	onChangeItemVariant: ( arg0: string, arg1: WPCOMProductSlug, arg2: number ) => void,
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[],
 	isDisabled: boolean
 ): ( _0: WPCOMProductVariant, _1: number ) => JSX.Element {

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-coupon-field-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-coupon-field-state.ts
@@ -6,14 +6,16 @@ import { useEvents } from '@automattic/composite-checkout';
 
 export type CouponFieldStateProps = {
 	couponFieldValue: string;
-	setCouponFieldValue: ( string ) => void;
+	setCouponFieldValue: ( arg0: string ) => void;
 	isApplyButtonActive: boolean;
 	isFreshOrEdited: boolean;
-	setIsFreshOrEdited: ( boolean ) => void;
+	setIsFreshOrEdited: ( arg0: boolean ) => void;
 	handleCouponSubmit: () => void;
 };
 
-export default function useCouponFieldState( submitCoupon ): CouponFieldStateProps {
+export default function useCouponFieldState(
+	submitCoupon: ( arg0: string ) => void
+): CouponFieldStateProps {
 	const onEvent = useEvents();
 	const [ couponFieldValue, setCouponFieldValue ] = useState< string >( '' );
 
@@ -61,7 +63,7 @@ export default function useCouponFieldState( submitCoupon ): CouponFieldStatePro
 	};
 }
 
-function isCouponValid( coupon ) {
+function isCouponValid( coupon: string ) {
 	// TODO: figure out some basic validation here
 	return coupon.match( /^[a-zA-Z0-9_-]+$/ );
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -399,20 +399,20 @@ type ReactStandardAction = { type: string; payload?: any }; // eslint-disable-li
 export function useShoppingCart(
 	cartKey: string | null,
 	canInitializeCart: boolean,
-	productsToAdd: ResponseCartProduct[] | null,
+	productsToAdd: RequestCartProduct[] | null,
 	couponToAdd: string | null,
-	setCart: ( string, RequestCart ) => Promise< ResponseCart >,
-	getCart: ( string ) => Promise< ResponseCart >,
-	translate: ( string ) => string,
-	showAddCouponSuccessMessage: ( string ) => void,
-	onEvent?: ( ReactStandardAction ) => void
+	setCart: ( arg0: string, arg1: RequestCart ) => Promise< ResponseCart >,
+	getCart: ( arg0: string ) => Promise< ResponseCart >,
+	translate: ( arg0: string ) => string,
+	showAddCouponSuccessMessage: ( arg0: string ) => void,
+	onEvent?: ( arg0: ReactStandardAction ) => void
 ): ShoppingCartManager {
-	cartKey = cartKey || 'no-site';
-	const setServerCart = useCallback( ( cartParam ) => setCart( cartKey, cartParam ), [
-		cartKey,
+	const cartKeyString: string = cartKey || 'no-site';
+	const setServerCart = useCallback( ( cartParam ) => setCart( cartKeyString, cartParam ), [
+		cartKeyString,
 		setCart,
 	] );
-	const getServerCart = useCallback( () => getCart( cartKey ), [ cartKey, getCart ] );
+	const getServerCart = useCallback( () => getCart( cartKeyString ), [ cartKeyString, getCart ] );
 
 	const [ hookState, hookDispatch ] = useReducer(
 		shoppingCartHookReducer,
@@ -512,12 +512,12 @@ export function useShoppingCart(
 function useInitializeCartFromServer(
 	cacheStatus: CacheStatus,
 	canInitializeCart: boolean,
-	productsToAdd: ResponseCartProduct[] | null,
+	productsToAdd: RequestCartProduct[] | null,
 	couponToAdd: string | null,
 	getServerCart: () => Promise< ResponseCart >,
-	setServerCart: ( RequestCart ) => Promise< ResponseCart >,
-	hookDispatch: ( ShoppingCartHookAction ) => void,
-	onEvent?: ( ReactStandardAction ) => void
+	setServerCart: ( arg0: RequestCart ) => Promise< ResponseCart >,
+	hookDispatch: ( arg0: ShoppingCartHookAction ) => void,
+	onEvent?: ( arg0: ReactStandardAction ) => void
 ): void {
 	const isInitialized = useRef( false );
 	useEffect( () => {

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -10,7 +10,8 @@ import debugFactory from 'debug';
 import {
 	prepareRequestCart,
 	ResponseCart,
-	ResponseCartProduct,
+	RequestCart,
+	RequestCartProduct,
 	emptyResponseCart,
 	removeItemFromResponseCart,
 	addItemToResponseCart,
@@ -73,7 +74,7 @@ const getInitialShoppingCartHookState: () => ShoppingCartHookState = () => {
 
 type ShoppingCartHookAction =
 	| { type: 'REMOVE_CART_ITEM'; uuidToRemove: string }
-	| { type: 'ADD_CART_ITEM'; responseCartProductToAdd: ResponseCartProduct }
+	| { type: 'ADD_CART_ITEM'; requestCartProductToAdd: RequestCartProduct }
 	| { type: 'SET_LOCATION'; location: CartLocation }
 	| {
 			type: 'REPLACE_CART_ITEM';
@@ -108,11 +109,11 @@ function shoppingCartHookReducer(
 			};
 		}
 		case 'ADD_CART_ITEM': {
-			const responseCartProductToAdd = action.responseCartProductToAdd;
-			debug( 'adding item to cart', responseCartProductToAdd );
+			const { requestCartProductToAdd } = action;
+			debug( 'adding item to cart', requestCartProductToAdd );
 			return {
 				...state,
-				responseCart: addItemToResponseCart( state.responseCart, responseCartProductToAdd ),
+				responseCart: addItemToResponseCart( state.responseCart, requestCartProductToAdd ),
 				cacheStatus: 'invalid',
 			};
 		}
@@ -296,13 +297,13 @@ export interface ShoppingCartManager {
 	subtotal: CheckoutCartItem;
 	couponItem: WPCOMCartCouponItem;
 	credits: CheckoutCartItem;
-	addItem: ( ResponseCartProduct ) => void;
-	removeItem: ( string ) => void;
-	submitCoupon: ( string ) => void;
+	addItem: ( arg0: RequestCartProduct ) => void;
+	removeItem: ( arg0: string ) => void;
+	submitCoupon: ( arg0: string ) => void;
 	removeCoupon: () => void;
 	couponStatus: CouponStatus;
 	couponCode: string | null;
-	updateLocation: ( CartLocation ) => void;
+	updateLocation: ( arg0: CartLocation ) => void;
 	variantRequestStatus: VariantRequestStatus;
 	variantSelectOverride: { uuid: string; overrideSelectedProductSlug: string }[];
 	responseCart: ResponseCart;
@@ -453,11 +454,14 @@ export function useShoppingCart(
 		hookDispatch
 	);
 
-	const addItem: ( ResponseCartProduct ) => void = useCallback( ( responseCartProductToAdd ) => {
-		hookDispatch( { type: 'ADD_CART_ITEM', responseCartProductToAdd } );
-	}, [] );
+	const addItem: ( arg0: RequestCartProduct ) => void = useCallback(
+		( requestCartProductToAdd ) => {
+			hookDispatch( { type: 'ADD_CART_ITEM', requestCartProductToAdd } );
+		},
+		[]
+	);
 
-	const removeItem: ( string ) => void = useCallback( ( uuidToRemove ) => {
+	const removeItem: ( arg0: string ) => void = useCallback( ( uuidToRemove ) => {
 		hookDispatch( { type: 'REMOVE_CART_ITEM', uuidToRemove } );
 	}, [] );
 
@@ -469,11 +473,11 @@ export function useShoppingCart(
 		hookDispatch( { type: 'REPLACE_CART_ITEM', uuidToReplace, newProductSlug, newProductId } );
 	}, [] );
 
-	const updateLocation: ( CartLocation ) => void = useCallback( ( location ) => {
+	const updateLocation: ( arg0: CartLocation ) => void = useCallback( ( location ) => {
 		hookDispatch( { type: 'SET_LOCATION', location } );
 	}, [] );
 
-	const submitCoupon: ( string ) => void = useCallback( ( newCoupon ) => {
+	const submitCoupon: ( arg0: string ) => void = useCallback( ( newCoupon ) => {
 		hookDispatch( { type: 'ADD_COUPON', couponToAdd: newCoupon } );
 	}, [] );
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -20,8 +20,8 @@ import {
  * @param serverCart Cart object returned by the WPCOM cart endpoint
  * @returns Cart object suitable for passing to the checkout component
  */
-export function translateWpcomCartToCheckoutCart(
-	translate: ( string, any? ) => string,
+export function translateResponseCartToWPCOMCart(
+	translate: ( arg0: string, arg1?: any ) => string, //eslint-disable-line @typescript-eslint/no-explicit-any
 	serverCart: ResponseCart
 ): WPCOMCart {
 	const {

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -4,6 +4,7 @@
 import {
 	ResponseCart,
 	ResponseCartProduct,
+	TempResponseCartProduct,
 	WPCOMCart,
 	WPCOMCartItem,
 	WPCOMCartCouponItem,
@@ -91,7 +92,7 @@ export function translateResponseCartToWPCOMCart(
 	};
 
 	return {
-		items: products.map( translateWpcomCartItemToCheckoutCartItem ),
+		items: products.map( translateReponseCartProductToWPCOMCartItem ),
 		tax: tax.display_taxes ? taxLineItem : null,
 		coupon: is_coupon_applied ? couponLineItem : null,
 		total: totalItem,
@@ -114,8 +115,8 @@ export function translateResponseCartToWPCOMCart(
 }
 
 // Convert a backend cart item to a checkout cart item
-function translateWpcomCartItemToCheckoutCartItem(
-	serverCartItem: ResponseCartProduct
+function translateReponseCartProductToWPCOMCartItem(
+	serverCartItem: ResponseCartProduct | TempResponseCartProduct
 ): WPCOMCartItem {
 	const {
 		product_id,
@@ -138,13 +139,13 @@ function translateWpcomCartItemToCheckoutCartItem(
 
 	return {
 		id: uuid,
-		label: product_name,
+		label: product_name || '…',
 		sublabel: meta,
 		type: product_slug,
 		amount: {
-			currency,
-			value: item_subtotal_integer,
-			displayValue: item_subtotal_display,
+			currency: currency || '',
+			value: item_subtotal_integer || 0,
+			displayValue: item_subtotal_display || '',
 		},
 		wpcom_meta: {
 			uuid: uuid,
@@ -153,12 +154,12 @@ function translateWpcomCartItemToCheckoutCartItem(
 			product_slug,
 			extra,
 			volume,
-			is_domain_registration,
-			is_bundled,
-			item_original_cost_display,
-			item_original_cost_integer,
-			product_cost_integer,
-			product_cost_display,
+			is_domain_registration: is_domain_registration || false,
+			is_bundled: is_bundled || false,
+			item_original_cost_display: item_original_cost_display || '',
+			item_original_cost_integer: item_original_cost_integer || 0,
+			product_cost_integer: product_cost_integer || 0,
+			product_cost_display: product_cost_display || '',
 		},
 	};
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
@@ -1,31 +1,244 @@
 /**
  * Internal dependencies
  */
-import { removeItemFromResponseCart, addCouponToResponseCart } from '../types';
+import {
+	removeItemFromResponseCart,
+	addCouponToResponseCart,
+	removeCouponFromResponseCart,
+	replaceItemInResponseCart,
+	addItemToResponseCart,
+	addLocationToResponseCart,
+	doesCartLocationDifferFromResponseCartLocation,
+} from '../types';
 
-describe( 'removeItemFromResponseCart', function () {
-	const baseResponseCart = {
-		total_tax_integer: 0,
-		total_tax_display: '$0',
-		total_cost_integer: 0,
-		total_cost_display: '$0',
-		currency: 'USD',
-		credits_integer: 0,
-		credits_display: '$0',
-		allowed_payment_methods: [],
-		coupon: '',
-		is_coupon_applied: false,
-		coupon_discounts_integer: [],
-		locale: 'en-us',
+const cart = {
+	products: [],
+	total_tax_integer: 0,
+	total_tax_display: '$0',
+	total_cost_integer: 0,
+	total_cost_display: '$0',
+	currency: 'USD',
+	credits_integer: 0,
+	credits_display: '$0',
+	allowed_payment_methods: [],
+	coupon: '',
+	is_coupon_applied: false,
+	coupon_discounts_integer: [],
+	locale: 'en-us',
+	tax: {
+		location: {},
+		display_taxes: false,
+	},
+};
+
+const product1 = {
+	product_slug: 'moo',
+	product_id: 25,
+	uuid: '09',
+};
+const product2 = {
+	product_slug: 'moof',
+	product_id: 88,
+	uuid: '08',
+};
+const product3 = {
+	product_slug: 'hello',
+	product_id: 15,
+	uuid: '10',
+};
+
+describe( 'replaceItemInResponseCart', function () {
+	it( 'replaces an item in the  with a matching uuid', function () {
+		const product1B = { ...product3, uuid: product1.uuid };
+		const result = replaceItemInResponseCart(
+			{ ...cart, products: [ product1, product2 ] },
+			product1.uuid,
+			product1B.product_id,
+			product1B.product_slug
+		);
+		expect( result ).toEqual( { ...cart, products: [ product1B, product2 ] } );
+	} );
+	it( 'does nothing if there is no matching uuid', function () {
+		const result = replaceItemInResponseCart(
+			{ ...cart, products: [ product1, product2 ] },
+			'22',
+			product3.product_id,
+			product3.product_slug
+		);
+		expect( result ).toEqual( { ...cart, products: [ product1, product2 ] } );
+	} );
+} );
+
+describe( 'addItemToResponseCart', function () {
+	it( 'adds the requested item to the product list with placeholder properties', function () {
+		const result = addItemToResponseCart( { ...cart, products: [ product1, product2 ] }, product3 );
+		const product3B = {
+			...product3,
+			cost: null,
+			currency: null,
+			extra: undefined,
+			included_domain_purchase_amount: null,
+			is_bundled: null,
+			is_domain_registration: null,
+			item_subtotal_display: null,
+			item_subtotal_integer: null,
+			meta: undefined,
+			price: null,
+			product_cost_display: null,
+			product_cost_integer: null,
+			product_name: '…',
+			product_type: null,
+			uuid: 'calypso-shopping-cart-endpoint-uuid-100',
+			volume: 1,
+		};
+		expect( result.products[ 0 ] ).toEqual( product1 );
+		expect( result.products[ 1 ] ).toEqual( product2 );
+		expect( result.products[ 2 ] ).toEqual( product3B );
+	} );
+} );
+
+describe( 'addLocationToResponseCart', function () {
+	it( 'adds the new location countryCode if set', function () {
+		const result = addLocationToResponseCart( cart, { countryCode: 'US' } );
+		expect( result.tax.location ).toEqual( {
+			country_code: 'US',
+			postal_code: undefined,
+			subdivision_code: undefined,
+		} );
+	} );
+	it( 'resets existing codes not replaced', function () {
+		const result = addLocationToResponseCart(
+			{ ...cart, tax: { ...cart.tax, location: { ...cart.tax.location, postal_code: '10001' } } },
+			{ countryCode: 'US' }
+		);
+		expect( result.tax.location ).toEqual( {
+			country_code: 'US',
+			postal_code: undefined,
+			subdivision_code: undefined,
+		} );
+	} );
+	it( 'adds the new location postalCode if set', function () {
+		const result = addLocationToResponseCart( cart, { postalCode: '90210' } );
+		expect( result.tax.location ).toEqual( {
+			country_code: undefined,
+			postal_code: '90210',
+			subdivision_code: undefined,
+		} );
+	} );
+	it( 'adds the new location subdivisionCode if set', function () {
+		const result = addLocationToResponseCart( cart, { subdivisionCode: 'CA' } );
+		expect( result.tax.location ).toEqual( {
+			country_code: undefined,
+			postal_code: undefined,
+			subdivision_code: 'CA',
+		} );
+	} );
+	it( 'adds all new location codes if set', function () {
+		const result = addLocationToResponseCart( cart, {
+			subdivisionCode: 'CA',
+			postalCode: '90210',
+			countryCode: 'US',
+		} );
+		expect( result.tax.location ).toEqual( {
+			country_code: 'US',
+			postal_code: '90210',
+			subdivision_code: 'CA',
+		} );
+	} );
+	it( 'resets all codes when no codes are set', function () {
+		const result = addLocationToResponseCart(
+			{
+				...cart,
+				tax: {
+					...cart.tax,
+					location: { ...cart.tax.location, postal_code: '90210', country_code: 'US' },
+				},
+			},
+			{}
+		);
+		expect( result.tax.location ).toEqual( {
+			country_code: undefined,
+			postal_code: undefined,
+			subdivision_code: undefined,
+		} );
+	} );
+} );
+
+describe( 'doesCartLocationDifferFromResponseCartLocation', function () {
+	const cartWithLocation = {
+		...cart,
 		tax: {
-			location: {},
-			display_taxes: false,
+			...cart.tax,
+			location: {
+				...cart.tax.location,
+				country_code: 'US',
+				subdivision_code: 'CA',
+				postal_code: '90210',
+			},
 		},
 	};
 
+	it( 'returns true if countryCode differs', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: 'CA',
+			subdivisionCode: 'CA',
+			postalCode: '90210',
+		} );
+		expect( result ).toBe( true );
+	} );
+	it( 'returns true if postalCode differs', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: 'US',
+			subdivisionCode: 'CA',
+			postalCode: '10001',
+		} );
+		expect( result ).toBe( true );
+	} );
+	it( 'returns true if subdivisionCode differs', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: 'US',
+			subdivisionCode: 'MA',
+			postalCode: '90210',
+		} );
+		expect( result ).toBe( true );
+	} );
+	it( 'returns false if all are the same', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: 'US',
+			subdivisionCode: 'CA',
+			postalCode: '90210',
+		} );
+		expect( result ).toBe( false );
+	} );
+	it( 'returns false if no location codes are provided', function () {
+		const result = doesCartLocationDifferFromResponseCartLocation( cartWithLocation, {
+			countryCode: undefined,
+			subdivisionCode: undefined,
+			postalCode: undefined,
+		} );
+		expect( result ).toBe( false );
+	} );
+} );
+
+describe( 'removeCouponFromResponseCart', function () {
+	it( 'removes an applied coupon', function () {
+		const result = removeCouponFromResponseCart( {
+			...cart,
+			coupon: 'ABVD',
+			is_coupon_applied: true,
+		} );
+		expect( result ).toEqual( cart );
+	} );
+	it( 'has no effect on an unapplied coupon', function () {
+		const result = removeCouponFromResponseCart( cart );
+		expect( result ).toEqual( cart );
+	} );
+} );
+
+describe( 'removeItemFromResponseCart', function () {
 	describe( 'cart with two items and item present', function () {
 		const responseCart = {
-			...baseResponseCart,
+			...cart,
 			products: [
 				{
 					product_name: 'WordPress.com Personal',
@@ -65,7 +278,7 @@ describe( 'removeItemFromResponseCart', function () {
 
 	describe( 'cart with two items and item not present', function () {
 		const responseCart = {
-			...baseResponseCart,
+			...cart,
 			products: [
 				{
 					product_name: 'WordPress.com Personal',
@@ -105,27 +318,7 @@ describe( 'removeItemFromResponseCart', function () {
 } );
 
 describe( 'addCouponToResponseCart', function () {
-	const responseCart = {
-		products: [],
-		total_tax_integer: 0,
-		total_tax_display: '$0',
-		total_cost_integer: 0,
-		total_cost_display: '$0',
-		currency: 'USD',
-		credits_integer: 0,
-		credits_display: '$0',
-		allowed_payment_methods: [],
-		coupon: '',
-		is_coupon_applied: false,
-		coupon_discounts_integer: [],
-		locale: 'en-us',
-		tax: {
-			location: {},
-			display_taxes: false,
-		},
-	};
-
-	const result = addCouponToResponseCart( responseCart, 'fakecoupon' );
+	const result = addCouponToResponseCart( cart, 'fakecoupon' );
 
 	it( 'has the expected coupon', function () {
 		expect( result.coupon ).toEqual( 'fakecoupon' );

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
@@ -84,6 +84,8 @@ describe( 'addItemToResponseCart', function () {
 			item_subtotal_integer: null,
 			meta: undefined,
 			price: null,
+			item_original_cost_display: null,
+			item_original_cost_integer: null,
 			product_cost_display: null,
 			product_cost_integer: null,
 			product_name: '…',

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-import { translateWpcomCartToCheckoutCart } from '../lib/translate-cart';
+import { translateResponseCartToWPCOMCart } from '../lib/translate-cart';
 
-describe( 'translateWpcomCartToCheckoutCart', function () {
+describe( 'translateResponseCartToWPCOMCart', function () {
 	describe( 'Cart with one plan only (BRL)', function () {
 		const serverResponse = {
 			blog_id: 123,
@@ -70,7 +70,7 @@ describe( 'translateWpcomCartToCheckoutCart', function () {
 			coupon_discounts_integer: [],
 		};
 
-		const clientCart = translateWpcomCartToCheckoutCart( ( x ) => x, serverResponse );
+		const clientCart = translateResponseCartToWPCOMCart( ( x ) => x, serverResponse );
 
 		it( 'has a total property', function () {
 			expect( clientCart.total.amount ).toBeDefined();
@@ -253,7 +253,7 @@ describe( 'translateWpcomCartToCheckoutCart', function () {
 			coupon_discounts_integer: [],
 		};
 
-		const clientCart = translateWpcomCartToCheckoutCart( ( x ) => x, serverResponse );
+		const clientCart = translateResponseCartToWPCOMCart( ( x ) => x, serverResponse );
 
 		it( 'has a total property', function () {
 			expect( clientCart.total.amount ).toBeDefined();
@@ -501,7 +501,7 @@ describe( 'translateWpcomCartToCheckoutCart', function () {
 			coupon_discounts_integer: [],
 		};
 
-		const clientCart = translateWpcomCartToCheckoutCart( ( x ) => x, serverResponse );
+		const clientCart = translateResponseCartToWPCOMCart( ( x ) => x, serverResponse );
 
 		it( 'has a total property', function () {
 			expect( clientCart.total.amount ).toBeDefined();
@@ -666,7 +666,7 @@ describe( 'translateWpcomCartToCheckoutCart', function () {
 			is_coupon_applied: true,
 		};
 
-		const clientCart = translateWpcomCartToCheckoutCart( ( string, substitution ) => {
+		const clientCart = translateResponseCartToWPCOMCart( ( string, substitution ) => {
 			return substitution ? string.replace( '%s', substitution.args ) : string;
 		}, serverResponse );
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/types.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types.ts
@@ -21,7 +21,6 @@ import type {
 } from './types/backend/shopping-cart-endpoint';
 import {
 	emptyResponseCart,
-	prepareRequestCart,
 	removeItemFromResponseCart,
 	addItemToResponseCart,
 	replaceItemInResponseCart,
@@ -29,7 +28,8 @@ import {
 	removeCouponFromResponseCart,
 	addLocationToResponseCart,
 	doesCartLocationDifferFromResponseCartLocation,
-	processRawResponse,
+	convertRawResponseCartToResponseCart,
+	convertResponseCartToRequestCart,
 } from './types/backend/shopping-cart-endpoint';
 import type {
 	DomainContactDetails,
@@ -92,7 +92,7 @@ export {
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
 	translateCheckoutPaymentMethodToWpcomPaymentMethod,
 	emptyResponseCart,
-	prepareRequestCart,
+	convertResponseCartToRequestCart,
 	removeItemFromResponseCart,
 	addItemToResponseCart,
 	replaceItemInResponseCart,
@@ -100,7 +100,7 @@ export {
 	removeCouponFromResponseCart,
 	addLocationToResponseCart,
 	doesCartLocationDifferFromResponseCartLocation,
-	processRawResponse,
+	convertRawResponseCartToResponseCart,
 	emptyWPCOMCart,
 	getInitialWpcomStoreState,
 	emptyManagedContactDetails,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types.ts
@@ -17,6 +17,7 @@ import type {
 	RequestCartProduct,
 	ResponseCart,
 	ResponseCartProduct,
+	TempResponseCartProduct,
 	CartLocation,
 } from './types/backend/shopping-cart-endpoint';
 import {
@@ -73,6 +74,7 @@ export type {
 	RequestCartProduct,
 	ResponseCart,
 	ResponseCartProduct,
+	TempResponseCartProduct,
 	CartLocation,
 	WPCOMCart,
 	WPCOMCartItem,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -33,6 +33,7 @@ export interface RequestCart {
 	is_coupon_applied: boolean;
 	temporary: false;
 	extra: string;
+	is_update?: boolean;
 }
 
 /**
@@ -135,36 +136,37 @@ interface RequestCartOptions {
 	is_update?: boolean;
 }
 
-export const prepareRequestCartProduct: ( ResponseCartProduct ) => RequestCartProduct = ( {
-	product_slug,
-	meta,
-	product_id,
-	extra,
-}: ResponseCartProduct ) => {
+export function convertResponseCartProductToRequestCartProduct(
+	product: ResponseCartProduct
+): RequestCartProduct {
+	const { product_slug, meta, product_id, extra } = product;
 	return {
 		product_slug,
 		meta,
 		product_id,
 		extra,
 	} as RequestCartProduct;
-};
+}
 
-export const prepareRequestCart: ( ResponseCart, RequestCartOptions ) => RequestCart = (
-	{ products, currency, locale, coupon, is_coupon_applied, tax }: ResponseCart,
-	{ is_update = false }: RequestCartOptions
-) => {
+export function convertResponseCartToRequestCart( {
+	products,
+	currency,
+	locale,
+	coupon,
+	is_coupon_applied,
+	tax,
+}: ResponseCart ): RequestCart {
 	return {
-		products: products.map( prepareRequestCartProduct ),
+		products: products.map( convertResponseCartProductToRequestCartProduct ),
 		currency,
 		locale,
 		coupon,
 		is_coupon_applied,
 		temporary: false,
 		tax,
-		is_update,
 		extra: '', // TODO: fix this
 	} as RequestCart;
-};
+}
 
 export function removeItemFromResponseCart(
 	cart: ResponseCart,
@@ -234,7 +236,9 @@ export interface CartLocation {
 	subdivisionCode: string | null;
 }
 
-export function processRawResponse( rawResponseCart ): ResponseCart {
+export function convertRawResponseCartToResponseCart(
+	rawResponseCart: ResponseCart
+): ResponseCart {
 	return {
 		...rawResponseCart,
 		// If tax.location is an empty PHP associative array, it will be JSON serialized to [] but we need {}

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -292,17 +292,16 @@ export function addItemToResponseCart(
 }
 
 export function replaceItemInResponseCart(
-	responseCart: ResponseCart,
+	cart: ResponseCart,
 	uuidToReplace: string,
 	newProductId: number,
 	newProductSlug: string
-) {
+): ResponseCart {
 	return {
-		...responseCart,
-		products: responseCart.products.map( ( item ) => {
+		...cart,
+		products: cart.products.map( ( item ) => {
 			if ( item.uuid === uuidToReplace ) {
-				item.product_id = newProductId;
-				item.product_slug = newProductSlug;
+				return { ...item, product_id: newProductId, product_slug: newProductSlug };
 			}
 			return item;
 		} ),

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -201,7 +201,7 @@ export function removeItemFromResponseCart(
 		products: cart.products.filter( ( product ) => {
 			return product.uuid !== uuidToRemove;
 		} ),
-	};
+	} as ResponseCart;
 }
 
 export function addCouponToResponseCart( cart: ResponseCart, couponToAdd: string ): ResponseCart {
@@ -209,7 +209,7 @@ export function addCouponToResponseCart( cart: ResponseCart, couponToAdd: string
 		...cart,
 		coupon: couponToAdd,
 		is_coupon_applied: false,
-	};
+	} as ResponseCart;
 }
 
 export function removeCouponFromResponseCart( cart: ResponseCart ): ResponseCart {
@@ -217,7 +217,7 @@ export function removeCouponFromResponseCart( cart: ResponseCart ): ResponseCart
 		...cart,
 		coupon: '',
 		is_coupon_applied: false,
-	};
+	} as ResponseCart;
 }
 
 export function addLocationToResponseCart(
@@ -234,7 +234,7 @@ export function addLocationToResponseCart(
 				subdivision_code: location.subdivisionCode || undefined,
 			},
 		},
-	};
+	} as ResponseCart;
 }
 
 export function doesCartLocationDifferFromResponseCartLocation(
@@ -277,7 +277,7 @@ export function convertRawResponseCartToResponseCart(
 				uuid: index.toString(),
 			};
 		} ),
-	};
+	} as ResponseCart;
 }
 
 export function addItemToResponseCart(
@@ -288,7 +288,7 @@ export function addItemToResponseCart(
 	return {
 		...responseCart,
 		products: [ ...responseCart.products, convertedProduct ],
-	};
+	} as ResponseCart;
 }
 
 export function replaceItemInResponseCart(
@@ -305,7 +305,7 @@ export function replaceItemInResponseCart(
 			}
 			return item;
 		} ),
-	};
+	} as ResponseCart;
 }
 
 function convertRequestCartProductToResponseCartProduct(

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -317,6 +317,8 @@ function convertRequestCartProductToResponseCartProduct(
 		product_slug,
 		product_id,
 		currency: null,
+		item_original_cost_display: null,
+		item_original_cost_integer: null,
 		product_cost_integer: null,
 		product_cost_display: null,
 		item_subtotal_integer: null,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/checkout-cart.ts
@@ -42,8 +42,8 @@ export type WPCOMCartItem = CheckoutCartItem & {
 		is_bundled?: boolean;
 		is_domain_registration?: boolean;
 		couponCode?: string;
-		product_cost_integer: number;
-		product_cost_display: string;
+		product_cost_integer?: number;
+		product_cost_display?: string;
 	};
 };
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -188,7 +188,7 @@ export function updateManagedContactDetailsShape< A, B >(
 }
 
 export function flattenManagedContactDetailsShape< A, B >(
-	f: ( A ) => B,
+	f: ( arg0: A ) => B,
 	x: ManagedContactDetailsShape< A >
 ): Array< B > {
 	const values = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR refactors the `useShoppingCart` hook so that when its `addItem` function is used to add an item to the cart, it is added as a fully fleshed-out, but with null data, response cart object. This way, while the cart is being synchronized with the server, all the rendering machinery will still operate with the optimistically-added new cart item. 

Prior to this change, if a cart item was added with the typical data available for adding new cart items (generally just `product_id` and `product_slug`), the page would throw an error as it tried to convert the missing data into objects suitable for the UI. With this change, a placeholder item (with the label `…`) will be displayed instead. In a future PR we can improve the UI for these placeholder items.

#### Testing instructions

This PR should not change anything, and is extracted from #41456. There is currently no code that uses the `addItem` function. If you'd like you can merge this branch with the commits in #41456 and perform the testing instructions there to see these changes in action.

Load composite checkout and verify that there are no issues. Remove an item from the cart and verify that it gets removed successfully. Add items to the cart via URL (eg: by clicking the purchase buttons on the plans page) and verify that the item gets added successfully.