### PR TITLE
Jetpack Cloud: update logic for action buttons

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -104,7 +104,7 @@ class ActivityCardList extends Component {
 									key: activity.activityId,
 									showContentLink: isActivityBackup( activity )
 										? dateLogs.length > 1 || hasMore
-										: true,
+										: undefined,
 									moment,
 									activity,
 									allowRestore,

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -39,7 +39,6 @@ class ActivityCard extends Component {
 
 	static defaultProps = {
 		showActions: true,
-		showContentLink: true,
 		summarize: false,
 	};
 
@@ -105,19 +104,15 @@ class ActivityCard extends Component {
 		);
 	}
 
+	shouldRenderContentLink() {
+		const { activity, showContentLink } = this.props;
+		return showContentLink !== undefined
+			? showContentLink
+			: !! activity.streams || isSuccessfulDailyBackup( activity );
+	}
+
 	renderContentLink() {
 		const { activity, siteSlug, translate } = this.props;
-
-		if ( isSuccessfulDailyBackup( activity ) ) {
-			return (
-				<a
-					className="activity-card__detail-link"
-					href={ backupDetailPath( siteSlug, activity.rewindId ) }
-				>
-					{ translate( 'Changes in this backup' ) }
-				</a>
-			);
-		}
 
 		// todo: handle the rest of cases
 		if ( activity.streams ) {
@@ -138,6 +133,14 @@ class ActivityCard extends Component {
 				</Button>
 			);
 		}
+		return (
+			<a
+				className="activity-card__detail-link"
+				href={ backupDetailPath( siteSlug, activity.rewindId ) }
+			>
+				{ translate( 'Changes in this backup' ) }
+			</a>
+		);
 	}
 
 	renderActionButton( isTopToolbar = true ) {
@@ -199,19 +202,19 @@ class ActivityCard extends Component {
 	renderBottomToolbar = () => this.renderToolbar( false );
 
 	renderToolbar( isTopToolbar = true ) {
-		const { showActions, showContentLink } = this.props;
+		const { showActions } = this.props;
 
 		return (
 			<>
 				<div
 					// force the actions to stay in the left if we aren't showing the content link
 					className={
-						! showContentLink && showActions
+						! this.shouldRenderContentLink() && showActions
 							? 'activity-card__activity-actions-reverse'
 							: 'activity-card__activity-actions'
 					}
 				>
-					{ showContentLink && this.renderContentLink() }
+					{ this.shouldRenderContentLink() && this.renderContentLink() }
 					{ showActions && this.renderActionButton( isTopToolbar ) }
 				</div>
 			</>

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -64,6 +64,7 @@
 
 .activity-card__activity-actions,
 .activity-card__activity-actions-reverse {
+	display: flex;
 	position: relative;
 	top: 0.5rem;
 	border-top: 1px solid #e4e4e6;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update logic for showing content links
* make activity card actions a flex display

**BEFORE**

<img width="450" alt="Screen Shot 2020-04-27 at 3 07 18 PM" src="https://user-images.githubusercontent.com/2810519/80425593-ce8d6180-8898-11ea-9034-8eba0aac0f7b.png">

**AFTER**
<img width="450" alt="Screen Shot 2020-04-27 at 3 07 06 PM" src="https://user-images.githubusercontent.com/2810519/80425610-d816c980-8898-11ea-8a88-b320796ea499.png">


#### Testing instructions

Navigate the Activity Log, making sure that the content links ( "changes in this backup" and "See ontent" ) always appear where expected and the actions button is always on the right
