### PR TITLE
Jetpack Cloud: Fix Activity Log Filterbar Styling

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -2,7 +2,7 @@
 	.filterbar {
 		margin-bottom: 2rem;
 
-		// no border on filterbar active buttons
+		// filterbar button stylings
 		.filterbar__wrap {
 			button.filterbar__selection {
 				&.is-selected,
@@ -26,7 +26,7 @@
 				}
 			}
 
-			// this is a separate mechanism for the date range
+			// this is a separate mechanism for the date range when it is active
 			div.date-range.toggle-visible button.filterbar__selection {
 				border: 1px solid var( --color-neutral-60 );
 				background-color: var( --color-neutral-60 );

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -5,11 +5,19 @@
 		// filterbar button stylings
 		.filterbar__wrap {
 			button.filterbar__selection {
+				// is-active is when the popover is expanded, but there is not a selection
 				&.is-selected,
 				&.is-active {
 					border: 1px solid var( --color-neutral-60 );
+
+					// we need to override these hover styles as well
+					&:hover {
+						color: var( --color-text-inverted );
+						background-color: var( --color-neutral-60 );
+					}
 				}
 
+				// is-selected is when there is a selection and a cancel button is rendered to the right
 				&.is-selected {
 					margin-right: 0;
 					border-radius: 3px 0 0 3px;
@@ -31,6 +39,7 @@
 				border: 1px solid var( --color-neutral-60 );
 				background-color: var( --color-neutral-60 );
 				color: var( --color-text-inverted );
+				padding-right: 8px;
 			}
 		}
 	}

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -1,6 +1,28 @@
 .activity-card-list {
 	.filterbar {
 		margin-bottom: 2rem;
+
+		// no border on filterbar active buttons
+		.filterbar__wrap {
+			button.filterbar__selection {
+				&.is-selected,
+				&.is-active {
+					border: 1px solid var( --color-neutral-60 );
+				}
+
+				&.is-selected {
+					margin-right: 0;
+					border-radius: 3px 0 0 3px;
+				}
+			}
+
+			// this is a separate mechanism for the date range
+			div.date-range.toggle-visible button.filterbar__selection {
+				border: 1px solid var( --color-neutral-60 );
+				background-color: var( --color-neutral-60 );
+				color: var( --color-text-inverted );
+			}
+		}
 	}
 
 	.pagination__list-item {

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -2,44 +2,14 @@
 	.filterbar {
 		margin-bottom: 2rem;
 
-		// filterbar button stylings
+		// filterbar button stylings fixes ( mainly undoing jetpack cloud overrides )
 		.filterbar__wrap {
-			button.filterbar__selection {
-				// is-active is when the popover is expanded, but there is not a selection
-				&.is-selected,
-				&.is-active {
-					border: 1px solid var( --color-neutral-60 );
-
-					// we need to override these hover styles as well
-					&:hover {
-						color: var( --color-text-inverted );
-						background-color: var( --color-neutral-60 );
-					}
-				}
-
-				// is-selected is when there is a selection and a cancel button is rendered to the right
-				&.is-selected {
-					margin-right: 0;
-					border-radius: 3px 0 0 3px;
-				}
-			}
-
-			// the close buttons need a little love to bring them in line with jetpack cloud styles
-			button.filterbar__selection-close {
-				border-radius: 0 3px 3px 0;
+			div.date-range.toggle-visible button.filterbar__selection,
+			button.filterbar__selection.is-active,
+			button.filterbar__selection.is-active:hover {
 				border: 1px solid var( --color-neutral-60 );
-				background-color: var( --color-neutral-60 );
-				.gridicon {
-					fill: var( --color-text-inverted );
-				}
-			}
-
-			// this is a separate mechanism for the date range when it is active
-			div.date-range.toggle-visible button.filterbar__selection {
-				border: 1px solid var( --color-neutral-60 );
-				background-color: var( --color-neutral-60 );
 				color: var( --color-text-inverted );
-				padding-right: 8px;
+				background-color: var( --color-neutral-60 );
 			}
 		}
 	}

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -16,6 +16,16 @@
 				}
 			}
 
+			// the close buttons need a little love to bring them in line with jetpack cloud styles
+			button.filterbar__selection-close {
+				border-radius: 0 3px 3px 0;
+				border: 1px solid var( --color-neutral-60 );
+				background-color: var( --color-neutral-60 );
+				.gridicon {
+					fill: var( --color-text-inverted );
+				}
+			}
+
 			// this is a separate mechanism for the date range
 			div.date-range.toggle-visible button.filterbar__selection {
 				border: 1px solid var( --color-neutral-60 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes Styling of Jetpack Cloud Activity Log filter bar ( `/backups/activity` )

<img width="742" alt="Screen Shot 2020-04-27 at 4 41 43 PM" src="https://user-images.githubusercontent.com/2810519/80431317-fd5e0480-88a5-11ea-95a4-7f9fabc5c426.png">


#### Testing instructions

1. Navigate to `/backups/activity`
2. Use the filter buttons to verify that:
   * both turn to dark gray when the popover is open and where there is a selection
   * hover does not change the state
