### PR TITLE
 Search: Define the number of records in the purchase product card.

### DIFF
--- a/client/components/product-card/options.jsx
+++ b/client/components/product-card/options.jsx
@@ -5,12 +5,14 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { isEmpty } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
+import InfoPopover from 'components/info-popover';
 import ProductCardPriceGroup from './price-group';
 
 const ProductCardOptions = ( {
@@ -20,6 +22,8 @@ const ProductCardOptions = ( {
 	selectedSlug,
 	forceRadiosEvenIfOnlyOneOption,
 } ) => {
+	const translate = useTranslate();
+
 	if ( isEmpty( options ) ) {
 		return null;
 	}
@@ -29,7 +33,14 @@ const ProductCardOptions = ( {
 	return (
 		<Fragment>
 			{ ! hideRadios && optionsLabel && (
-				<h4 className="product-card__options-label">{ optionsLabel }</h4>
+				<h4 className="product-card__options-label">
+					{ optionsLabel }
+					<InfoPopover position="right">
+						{ translate(
+							'Records are all posts, pages, custom post types and other types of content indexed by Jetpack Search.'
+						) }
+					</InfoPopover>
+				</h4>
 			) }
 			<div className="product-card__options">
 				{ options.map( ( option ) => (

--- a/client/components/product-card/options.jsx
+++ b/client/components/product-card/options.jsx
@@ -37,7 +37,7 @@ const ProductCardOptions = ( {
 					{ optionsLabel }
 					<InfoPopover position="right">
 						{ translate(
-							'Records are all posts, pages, custom post types and other types of content indexed by Jetpack Search.'
+							'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.'
 						) }
 					</InfoPopover>
 				</h4>

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -198,6 +198,11 @@
 	@include breakpoint( '>960px' ) {
 		flex: 0 0 100%;
 	}
+
+	.info-popover {
+		margin-left: 4px;
+		vertical-align: middle;
+	}
 }
 
 // We need a higher specificity here to override .form-label styles


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Match to https://github.com/Automattic/jetpack/pull/15558.

* Add an info popover with record definition to the Search product card.

#### Testing instructions

* go to /plans and verify that the info icon displays the definition of Search records

![js](https://user-images.githubusercontent.com/13561163/80430735-cd3b5380-88ef-11ea-871b-849ac4e50e9c.png)


