### PR TITLE
Jetpack Cloud: Fix Activity Log Header Styling

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/index.tsx
@@ -82,7 +82,7 @@ const BackupActivityLogPage: FunctionComponent< Props > = ( {
 			<SidebarNavigation />
 			<div className="backup-activity-log__content">
 				<div className="backup-activity-log__header">
-					<h3>{ translate( 'Find a backup or restore point' ) }</h3>
+					<h2>{ translate( 'Find a backup or restore point' ) }</h2>
 					<p>
 						{ translate(
 							'This is the complete event history for your site. Filter by date range and/or activity type.'

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/style.scss
@@ -13,4 +13,13 @@
 			margin-top: 16px;
 		}
 	}
+
+	// use sub-section styling at mobile sizes
+	@include breakpoint( '<660px' ) {
+		h2 {
+			font-size: 16px;
+			font-weight: 600;
+			line-height: 23px;
+		}
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use section heading styling on the Jetpack Cloud Activity Log header when wide

![Untitled 4](https://user-images.githubusercontent.com/2810519/80511707-50c96480-8931-11ea-822f-b9bd6cb6099d.png)


#### Testing instructions

1. Navigate to `/backups/activity`
2. Compare the heading that states "Find a backup or restore point" to the Jetpack Cloud Style Guide. Greater than ( or equal to ) 660px it should match "Desktop Page Heading",  less than should match "Mobile Section Heading"
