### PR TITLE
Update e2e tests for Gutenberg 8.0.0

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -190,7 +190,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const categorySelector =
 			'.block-editor-inserter__results .components-panel__body-title, .block-editor-inserter__block-list .block-editor-inserter__panel-title';
 		const categoryName = await this.driver.findElement( By.css( categorySelector ) ).getText();
-		return categoryName === name;
+		return categoryName.toLowerCase() === name.toLowerCase();
 	}
 
 	async closeBlockInserter() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -195,9 +195,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async closeBlockInserter() {
 		// @TODO: Remove `.edit-post-header .block-editor-inserter__toggle` selector in favor of the `.edit-post-header-toolbar__inserter-toggle` selector when Gutenberg 8.0.0 is deployed.
+		// @TODO: Remove `.block-editor-inserter__popover .components-popover__close` selector in favor of the `.edit-post-layout__inserter-panel-header .components-button` selector when Gutenberg 8.0.0 is deployed.
 		const inserterCloseSelector = By.css(
 			driverManager.currentScreenSize() === 'mobile'
-				? '.block-editor-inserter__popover .components-popover__close'
+				? '.block-editor-inserter__popover .components-popover__close, .edit-post-layout__inserter-panel-header .components-button'
 				: '.edit-post-header .block-editor-inserter__toggle, .edit-post-header .edit-post-header-toolbar__inserter-toggle'
 		);
 		const inserterMenuSelector = By.css( '.block-editor-inserter__menu' );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -173,7 +173,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			'.edit-post-header .block-editor-inserter__toggle, .edit-post-header .edit-post-header-toolbar__inserter-toggle'
 		);
 		const inserterMenuSelector = By.css( '.block-editor-inserter__menu' );
-		const inserterSearchInputSelector = By.css( 'input.block-editor-inserter__search' );
+		// @TODO: Remove `input.block-editor-inserter__search` selector in favor of the `input.block-editor-inserter__search-input` selector when Gutenberg 8.0.0 is deployed.
+		const inserterSearchInputSelector = By.css(
+			'input.block-editor-inserter__search, input.block-editor-inserter__search-input'
+		);
 		if ( await driverHelper.elementIsNotPresent( this.driver, inserterMenuSelector ) ) {
 			await driverHelper.waitTillPresentAndDisplayed( this.driver, inserterToggleSelector );
 			await driverHelper.clickWhenClickable( this.driver, inserterToggleSelector );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -185,8 +185,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		await driverHelper.setWhenSettable( this.driver, inserterSearchInputSelector, searchTerm );
 	}
 
+	// @TODO: Remove `.block-editor-inserter__results .components-panel__body-title` selector in favor of the `.block-editor-inserter__block-list .block-editor-inserter__panel-title` selector when Gutenberg 8.0.0 is deployed.
 	async isBlockCategoryPresent( name ) {
-		const categorySelector = '.block-editor-inserter__results .components-panel__body-title';
+		const categorySelector =
+			'.block-editor-inserter__results .components-panel__body-title, .block-editor-inserter__block-list .block-editor-inserter__panel-title';
 		const categoryName = await this.driver.findElement( By.css( categorySelector ) ).getText();
 		return categoryName === name;
 	}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -168,7 +168,10 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			By.css( '.block-editor-writing-flow' ),
 			'start'
 		);
-		const inserterToggleSelector = By.css( '.edit-post-header .block-editor-inserter__toggle' );
+		// @TODO: Remove `.edit-post-header .block-editor-inserter__toggle` selector in favor of the `.edit-post-header-toolbar__inserter-toggle` selector when Gutenberg 8.0.0 is deployed.
+		const inserterToggleSelector = By.css(
+			'.edit-post-header .block-editor-inserter__toggle, .edit-post-header .edit-post-header-toolbar__inserter-toggle'
+		);
 		const inserterMenuSelector = By.css( '.block-editor-inserter__menu' );
 		const inserterSearchInputSelector = By.css( 'input.block-editor-inserter__search' );
 		if ( await driverHelper.elementIsNotPresent( this.driver, inserterMenuSelector ) ) {
@@ -186,10 +189,11 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async closeBlockInserter() {
+		// @TODO: Remove `.edit-post-header .block-editor-inserter__toggle` selector in favor of the `.edit-post-header-toolbar__inserter-toggle` selector when Gutenberg 8.0.0 is deployed.
 		const inserterCloseSelector = By.css(
 			driverManager.currentScreenSize() === 'mobile'
 				? '.block-editor-inserter__popover .components-popover__close'
-				: '.edit-post-header .block-editor-inserter__toggle'
+				: '.edit-post-header .block-editor-inserter__toggle, .edit-post-header .edit-post-header-toolbar__inserter-toggle'
 		);
 		const inserterMenuSelector = By.css( '.block-editor-inserter__menu' );
 		await driverHelper.clickWhenClickable( this.driver, inserterCloseSelector );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR exists to run the e2e tests against Gutenberg 8.0.0-RC1 on Edge sites
* Update e2e tests for compatibility where needed
* Keep e2e tests backwards compatible for Gutenberg v7.8.1 so that we can merge in fixes prior to deploying Gutenberg 8.0.0
* Make `isBlockCategoryPresent` check case insensitive due to v8.0.0 using uppercase for block categories, but v7.8.1 uses sentence case (it's either that or title case).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure all e2e tests and GB Edge e2e tests pass

Related to issue: #41504 
