### PR TITLE
Add two new properties to <PlansFeaturesMain> component for hiding Personal and Premium plans.

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -213,6 +213,8 @@ export class PlansFeaturesMain extends Component {
 			intervalType,
 			selectedPlan,
 			hideFreePlan,
+			hidePersonalPlan,
+			hidePremiumPlan,
 			sitePlanSlug,
 		} = this.props;
 
@@ -267,6 +269,14 @@ export class PlansFeaturesMain extends Component {
 
 		if ( hideFreePlan ) {
 			plans = plans.filter( ( planSlug ) => ! isFreePlan( planSlug ) );
+		}
+
+		if ( hidePersonalPlan ) {
+			plans = plans.filter( ( planSlug ) => ! isPersonalPlan( planSlug ) );
+		}
+
+		if ( hidePremiumPlan ) {
+			plans = plans.filter( ( planSlug ) => ! isPremiumPlan( planSlug ) );
 		}
 
 		if ( ! isEnabled( 'plans/personal-plan' ) && ! displayJetpackPlans ) {
@@ -556,6 +566,8 @@ PlansFeaturesMain.propTypes = {
 	basePlansPath: PropTypes.string,
 	displayJetpackPlans: PropTypes.bool.isRequired,
 	hideFreePlan: PropTypes.bool,
+	hidePersonalPlan: PropTypes.bool,
+	hidePremiumPlan: PropTypes.bool,
 	customerType: PropTypes.string,
 	flowName: PropTypes.string,
 	intervalType: PropTypes.string,
@@ -578,6 +590,8 @@ PlansFeaturesMain.propTypes = {
 PlansFeaturesMain.defaultProps = {
 	basePlansPath: null,
 	hideFreePlan: false,
+	hidePersonalPlan: false,
+	hidePremiumPlan: false,
 	intervalType: 'yearly',
 	isChatAvailable: false,
 	showFAQ: true,

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -61,6 +61,7 @@ import {
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
 	TYPE_FREE,
+	TYPE_PERSONAL,
 	TERM_ANNUALLY,
 	TYPE_PREMIUM,
 } from 'lib/plans/constants';
@@ -95,6 +96,24 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 			...props,
 			planTypes: [ TYPE_BUSINESS, TYPE_FREE, TYPE_ECOMMERCE ],
 			hideFreePlan: true,
+		} );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );
+	} );
+	test( 'Should render <PlanFeatures /> removing the Personal plan when hidePersonalPlan prop is present, regardless of its position', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			planTypes: [ TYPE_BUSINESS, TYPE_PERSONAL, TYPE_ECOMMERCE ],
+			hidePersonalPlan: true,
+		} );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );
+	} );
+	test( 'Should render <PlanFeatures /> removing the Premium plan when hidePremiumPlan prop is present, regardless of its position', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			planTypes: [ TYPE_BUSINESS, TYPE_PREMIUM, TYPE_ECOMMERCE ],
+			hidePremiumPlan: true,
 		} );
 		const plans = instance.getPlansForPlanFeatures();
 		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -118,6 +118,17 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 		const plans = instance.getPlansForPlanFeatures();
 		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );
 	} );
+	test( 'Should render <PlanFeatures /> with the Personal plan and the Premium plan when hidePersonalPlan and hidePremiumPlan are false.', () => {
+		const planTypes = [ TYPE_BUSINESS, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_ECOMMERCE ];
+		const instance = new PlansFeaturesMain( {
+			...props,
+			planTypes,
+			hidePersonalPlan: false,
+			hidePremiumPlan: false,
+		} );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_ECOMMERCE ] );
+	} );
 	test( 'Should render <PlanFeatures /> with Jetpack monthly plans when called with jetpack props', () => {
 		const instance = new PlansFeaturesMain( {
 			...props,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds `hidePersonalPlan` and `hidePremuimPlan` to<PlansFeaturesMain>, which can be used to hide the respective plan feature card.

**Note that the following UI issues are expected and will be addressed in follow-up PRs:**

* When hiding personal & premium plans with these properties, the "popular" badge would be hidden as well. Ideally it should be shifted to the next available plan.
* When hiding, either Personal or Premium, the remaining plan card shown in `/plans` should be centered, instead of aligning to the left.
* When hiding the both, the "Blogs and Personal Sites" tab shown in `/plans` becomes empty. Under this circumstance, the segmented control is meaningless and should be removed, with just Business and eCommerce plans shown.

e.g. when `hidePersonalPlan` is set:
![image](https://user-images.githubusercontent.com/1842898/80451713-15da2780-8957-11ea-9aa0-f017935b7f46.png)

when `hidePremiumPlan` is set:
![image](https://user-images.githubusercontent.com/1842898/80451734-24c0da00-8957-11ea-86cc-18c11660719a.png)

when the both are set:
![image](https://user-images.githubusercontent.com/1842898/80451754-34402300-8957-11ea-9671-a99e472fd369.png)

#### Testing instructions
##### Unit tests
`yarn test-client client/my-sites/plans-features-main/` should pass without warnings.

##### e2e tests
1. Set the property you'd like to test from the `defaultProps`:
1. Go through the signing up flow or the new site creation flow and reach the `start/plans` step. You should see the respected plan being hidden.
1. Go to /plans, and you should see the respected plan card being hidden.