### PR TITLE
Revert "Gutenboarding pre-launch: Update CTA button label in the editor"

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -46,7 +46,7 @@ function updateSettingsBar() {
 		launchLink.target = '_top';
 		launchLink.className =
 			'gutenboarding-editor-overrides__launch-button components-button is-primary';
-		const textContent = document.createTextNode( __( 'Update' ) );
+		const textContent = document.createTextNode( __( 'Launch' ) );
 		launchLink.appendChild( textContent );
 
 		// Put 'Launch' and 'Save' back on bar in desired order.


### PR DESCRIPTION
Reverts Automattic/wp-calypso#41211