### PR TITLE
Remove code-owners status for a couple folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,11 +105,10 @@
 /docs/coding-guidelines/typescript* @Automattic/type-review
 
 # FSE (Full Site Editing)
-/apps/full-site-editing/* @Automattic/cylon @Automattic/ajax
-/apps/full-site-editing/full-site-editing-plugin/* @Automattic/cylon @Automattic/ajax
+/apps/full-site-editing/* @Automattic/cylon
+/apps/full-site-editing/full-site-editing-plugin/* @Automattic/cylon
 /apps/full-site-editing/full-site-editing-plugin/full-site-editing @Automattic/cylon
 /apps/full-site-editing/full-site-editing-plugin/posts-list-block @Automattic/ajax
-/apps/full-site-editing/full-site-editing-plugin/starter-page-templates @Automattic/ajax
 /apps/full-site-editing/full-site-editing-plugin/global-styles @Automattic/cylon @nosolosw
 
 # FSE Workflow Files

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,9 +59,6 @@
 /client/state/data-layer/wpcom/gsuite-users @Automattic/larimar
 /client/state/gsuite-users @Automattic/larimar
 
-# Gutenberg editor (Gutenframe)
-/client/gutenberg @Automattic/cylon @Automattic/ajax
-
 # Payments
 /client/blocks/credit-card-form/ @Automattic/payments
 /client/blocks/payment-methods/ @Automattic/payments
@@ -118,9 +115,6 @@
 # FSE Workflow Files
 /.github/workflows/full-site-editing-plugin.yml @Automattic/cylon
 /.github/workflows/send-calypso-app-build-trigger.sh @Automattic/cylon
-
-# WPcom Block Editor
-/apps/wpcom-block-editor @Automattic/cylon @Automattic/ajax
 
 # Gutenboarding
 /client/landing/gutenboarding @Automattic/luna


### PR DESCRIPTION
Time to let go ;-)
- `/client/gutenberg`
- `/apps/wpcom-block-editor`

I realized I'm pinging you all for changes in these folders and not really expecting code-owner reviews back. Let me know if you'd prefer to keep them as-is.

Should I remove any entries under "FSE (Full Site Editing)"?