### PR TITLE
<PlansFeaturesMain>: Center the only 1 remaing plan card.

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -72,6 +72,8 @@ $plan-features-sidebar-width: 272px;
 }
 
 .plan-features__table.has-1-cols {
+	margin-left: auto;
+	margin-right: auto;
 	max-width: 337px;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request
*This PR depends on https://github.com/Automattic/wp-calypso/pull/41507*

Since introducing of `hidePersonalPlan` and `hidePremiumPlan`, it's now possible that the first tab can only have one column. This PR centers the card when such a case occurs.

Before:
![image](https://user-images.githubusercontent.com/1842898/80454601-e62e1e00-895c-11ea-958b-54005d7687ee.png)

After:
![image](https://user-images.githubusercontent.com/1842898/80454552-d6163e80-895c-11ea-8132-44efc917d957.png)

#### Testing instructions

1. Hide either the Personal plan card or the Premium plan card by updating the defaultProps of PlansFeaturesMain directly.
1. Go to /plans and see the remaining plan card centered correctly.
1. Toggle different simulated device screens and make sure there is no responsiveness issue.
