### PR TITLE
Activity Log: Remove the is-boderless class selector

### DIFF
--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -38,7 +38,7 @@
 		}
 	}
 
-	.filterbar__selection.button.is-borderless {
+	.filterbar__selection.button {
 		margin: 8px;
 		padding: 8px;
 		border: 1px solid var( --color-neutral-20 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fixes the selection of the activity log componet styles to look again as expected. 

Before:
jetpack cloud:
<img width="801" alt="Screen Shot 2020-04-28 at 10 34 31 AM" src="https://user-images.githubusercontent.com/115071/80465912-174a2680-893c-11ea-988d-7ebf5e37782f.png">
.com
<img width="1165" alt="Screen Shot 2020-04-28 at 10 39 51 AM" src="https://user-images.githubusercontent.com/115071/80467344-f551a380-893d-11ea-8a84-c6a421276458.png">

After:
jetpack cloud:
<img width="785" alt="Screen Shot 2020-04-28 at 10 33 46 AM" src="https://user-images.githubusercontent.com/115071/80465920-19ac8080-893c-11ea-8a4d-8c98fbd0716a.png">
.com
<img width="1292" alt="Screen Shot 2020-04-28 at 10 48 45 AM" src="https://user-images.githubusercontent.com/115071/80467296-e965e180-893d-11ea-903e-36d3b6faa456.png">



#### Testing instructions
* Open up the Activity Log. 
* Does it look as expected when you select the a date and a activity type. 
