### PR TITLE
Fix bug in reader tracking

### DIFF
--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -23,7 +23,7 @@ let tracks = { recordEvent: () => {} };
 let pageViewForPost = () => {};
 if ( process.env.NODE_ENV !== 'test' ) {
 	pageViewForPost = require( 'reader/stats' ).pageViewForPost;
-	tracks = require( 'lib/analytics/tracks' ).default;
+	tracks = require( 'lib/analytics/tracks' );
 }
 
 function trackRailcarRender( post ) {


### PR DESCRIPTION
Reader is currently erroring out with a JS error related to not finding the `recordTracksEvent` method. This PR fixes that.

Introduced by #41476.

#### Changes proposed in this Pull Request

* Fix bug accessing `recordTracksEvent` in reader

#### Testing instructions

* Load `/read`
* Ensure there are no console errors
