### PR TITLE
Modularise signup state

### DIFF
--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -27,7 +27,6 @@ jest.mock( 'lib/user', () => {
 } );
 
 jest.mock( 'signup/config/steps', () => require( './mocks/signup/config/steps' ) );
-jest.mock( 'signup/config/steps-pure', () => require( './mocks/signup/config/steps-pure' ) );
 jest.mock( 'signup/config/flows', () => require( './mocks/signup/config/flows' ) );
 jest.mock( 'signup/config/flows-pure', () => require( './mocks/signup/config/flows-pure' ) );
 

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -78,7 +78,6 @@ import rewind from './rewind/reducer';
 import selectedEditor from './selected-editor/reducer';
 import sharing from './sharing/reducer';
 import shortcodes from './shortcodes/reducer';
-import signup from './signup/reducer';
 import simplePayments from './simple-payments/reducer';
 import siteAddressChange from './site-address-change/reducer';
 import siteKeyrings from './site-keyrings/reducer';
@@ -165,7 +164,6 @@ const reducers = {
 	selectedEditor,
 	sharing,
 	shortcodes,
-	signup,
 	simplePayments,
 	siteAddressChange,
 	siteKeyrings,

--- a/client/state/signup/actions.js
+++ b/client/state/signup/actions.js
@@ -3,6 +3,8 @@
  */
 import { SIGNUP_DEPENDENCY_STORE_UPDATE, SIGNUP_COMPLETE_RESET } from 'state/action-types';
 
+import 'state/signup/init';
+
 export function updateDependencies( dependencies ) {
 	return { type: SIGNUP_DEPENDENCY_STORE_UPDATE, dependencies };
 }

--- a/client/state/signup/dependency-store/selectors.js
+++ b/client/state/signup/dependency-store/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
 
 const initialState = {};
 export function getSignupDependencyStore( state ) {

--- a/client/state/signup/flow/actions.js
+++ b/client/state/signup/flow/actions.js
@@ -3,6 +3,8 @@
  */
 import { SIGNUP_CURRENT_FLOW_NAME_SET } from 'state/action-types';
 
+import 'state/signup/init';
+
 export function setCurrentFlowName( flowName ) {
 	return {
 		type: SIGNUP_CURRENT_FLOW_NAME_SET,

--- a/client/state/signup/flow/selectors.js
+++ b/client/state/signup/flow/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
 
 export function getCurrentFlowName( state ) {
 	return get( state, 'signup.flow.currentFlowName', '' );

--- a/client/state/signup/init.js
+++ b/client/state/signup/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import signupReducer from './reducer';
+
+registerReducer( [ 'signup' ], signupReducer );

--- a/client/state/signup/optional-dependencies/actions.js
+++ b/client/state/signup/optional-dependencies/actions.js
@@ -4,6 +4,8 @@
 import wpcom from 'lib/wp';
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
 
+import 'state/signup/init';
+
 export const setUsernameSuggestion = ( data ) => ( {
 	type: SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET,
 	data,
@@ -18,7 +20,7 @@ export const setUsernameSuggestion = ( data ) => ( {
  * If there is no error from the API, then the username is free.
  *
  * @param {string} username The username to get suggestions for.
- * @returns {ActionThunk} Redux action thunk
+ * @returns {Function} Redux action thunk
  */
 export const fetchUsernameSuggestion = ( username ) => async ( dispatch ) => {
 	// Clear out the state variable before sending the call.

--- a/client/state/signup/optional-dependencies/selectors.js
+++ b/client/state/signup/optional-dependencies/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
 
 export function getSuggestedUsername( state ) {
 	return get( state, 'signup.optionalDependencies.suggestedUsername', '' );

--- a/client/state/signup/package.json
+++ b/client/state/signup/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/signup/preview/actions.js
+++ b/client/state/signup/preview/actions.js
@@ -4,6 +4,11 @@
 import { SIGNUP_SITE_PREVIEW_SHOW, SIGNUP_SITE_PREVIEW_HIDE } from 'state/action-types';
 
 /**
+ * Internal dependencies
+ */
+import 'state/signup/init';
+
+/**
  * Action creator: Hide signup site preview
  *
  * @returns {object} The action object.

--- a/client/state/signup/preview/selectors.js
+++ b/client/state/signup/preview/selectors.js
@@ -4,6 +4,11 @@
 import { get } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import 'state/signup/init';
+
+/**
  * Whether the signup site preview is visible
  *
  * @param   {object}  state The current client state

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -17,6 +17,8 @@ import { assertValidDependencies } from 'lib/signup/asserts';
 import { getCurrentFlowName } from 'state/signup/flow/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+import 'state/signup/init';
+
 function addProvidedDependencies( step, providedDependencies ) {
 	if ( isEmpty( providedDependencies ) ) {
 		return step;

--- a/client/state/signup/progress/selectors.ts
+++ b/client/state/signup/progress/selectors.ts
@@ -6,6 +6,11 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import 'state/signup/init';
+
+/**
+ * Internal dependencies
+ */
 import { ProgressState } from './schema';
 
 const initialState: ProgressState = {};

--- a/client/state/signup/segments/actions.js
+++ b/client/state/signup/segments/actions.js
@@ -4,6 +4,7 @@
 import { SIGNUP_SEGMENTS_REQUEST, SIGNUP_SEGMENTS_SET } from 'state/action-types';
 
 import 'state/data-layer/wpcom/signup/segments';
+import 'state/signup/init';
 
 /**
  * Action creator: Request segments data.

--- a/client/state/signup/segments/selectors.js
+++ b/client/state/signup/segments/selectors.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
+
 export const getSegments = ( state ) => get( state, [ 'signup', 'segments' ], null );

--- a/client/state/signup/steps/design-type/actions.js
+++ b/client/state/signup/steps/design-type/actions.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_STEPS_DESIGN_TYPE_SET } from 'state/action-types';
+
+import 'state/signup/init';
 
 export function setDesignType( designType ) {
 	return {

--- a/client/state/signup/steps/design-type/selectors.js
+++ b/client/state/signup/steps/design-type/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
 
 export function getDesignType( state ) {
 	return get( state, 'signup.steps.designType', '' );

--- a/client/state/signup/steps/site-goals/actions.js
+++ b/client/state/signup/steps/site-goals/actions.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_STEPS_SITE_GOALS_SET } from 'state/action-types';
+
+import 'state/signup/init';
 
 export function setSiteGoals( siteGoals ) {
 	return {

--- a/client/state/signup/steps/site-goals/selectors.js
+++ b/client/state/signup/steps/site-goals/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
 
 export function getSiteGoals( state ) {
 	return get( state, 'signup.steps.siteGoals', '' );

--- a/client/state/signup/steps/site-style/actions.js
+++ b/client/state/signup/steps/site-style/actions.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_STEPS_SITE_STYLE_SET } from 'state/action-types';
+
+import 'state/signup/init';
 
 export function setSiteStyle( siteStyle ) {
 	return {

--- a/client/state/signup/steps/site-style/selectors.js
+++ b/client/state/signup/steps/site-style/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
 
 export function getSiteStyle( state ) {
 	return get( state, 'signup.steps.siteStyle', '' );

--- a/client/state/signup/steps/site-title/actions.js
+++ b/client/state/signup/steps/site-title/actions.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_STEPS_SITE_TITLE_SET } from 'state/action-types';
+
+import 'state/signup/init';
 
 export function setSiteTitle( siteTitle ) {
 	return {

--- a/client/state/signup/steps/site-title/selectors.js
+++ b/client/state/signup/steps/site-title/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
 
 export function getSiteTitle( state ) {
 	return get( state, 'signup.steps.siteTitle', '' );

--- a/client/state/signup/steps/site-type/actions.js
+++ b/client/state/signup/steps/site-type/actions.js
@@ -1,10 +1,11 @@
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_STEPS_SITE_TYPE_SET } from 'state/action-types';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { submitSignupStep } from 'state/signup/progress/actions';
+
+import 'state/signup/init';
 
 export function setSiteType( siteType ) {
 	return {

--- a/client/state/signup/steps/site-type/selectors.js
+++ b/client/state/signup/steps/site-type/selectors.js
@@ -1,14 +1,14 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+
+import 'state/signup/init';
 
 export function getSiteType( state ) {
 	return get( state, 'signup.steps.siteType', '' );

--- a/client/state/signup/steps/site-vertical/actions.js
+++ b/client/state/signup/steps/site-vertical/actions.js
@@ -1,9 +1,10 @@
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_STEPS_SITE_VERTICAL_SET } from 'state/action-types';
 import { submitSignupStep } from 'state/signup/progress/actions';
+
+import 'state/signup/init';
 
 /**
  * Action creator: Set site vertical data

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { get, find } from 'lodash';
 
 /**
@@ -10,6 +9,8 @@ import { get, find } from 'lodash';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
+
+import 'state/signup/init';
 
 export function getSiteVerticalName( state ) {
 	return get( state, 'signup.steps.siteVertical.name', '' );

--- a/client/state/signup/steps/survey/actions.js
+++ b/client/state/signup/steps/survey/actions.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_STEPS_SURVEY_SET } from 'state/action-types';
 import {
 	composeAnalytics,
@@ -9,6 +8,8 @@ import {
 	recordCustomFacebookConversionEvent,
 	withAnalytics,
 } from 'state/analytics/actions';
+
+import 'state/signup/init';
 
 export function setSurvey( survey ) {
 	const vertical = survey.vertical;

--- a/client/state/signup/steps/survey/selectors.js
+++ b/client/state/signup/steps/survey/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
 
 export function getSurveyVertical( state ) {
 	return get( state, 'signup.steps.survey.vertical', '' );

--- a/client/state/signup/steps/user-experience/actions.js
+++ b/client/state/signup/steps/user-experience/actions.js
@@ -1,8 +1,9 @@
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_STEPS_USER_EXPERIENCE_SET } from 'state/action-types';
+
+import 'state/signup/init';
 
 export function setUserExperience( userExperience ) {
 	return {

--- a/client/state/signup/steps/user-experience/selectors.js
+++ b/client/state/signup/steps/user-experience/selectors.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
 
 export function getUserExperience( state ) {
 	return get( state, 'signup.steps.userExperience', '' );

--- a/client/state/signup/verticals/actions.js
+++ b/client/state/signup/verticals/actions.js
@@ -4,6 +4,7 @@
 import { SIGNUP_VERTICALS_REQUEST, SIGNUP_VERTICALS_SET } from 'state/action-types';
 
 import 'state/data-layer/wpcom/signup/verticals';
+import 'state/signup/init';
 
 /**
  * Action creator: Request verticals data.

--- a/client/state/signup/verticals/selectors.js
+++ b/client/state/signup/verticals/selectors.js
@@ -3,5 +3,10 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/signup/init';
+
 export const getVerticals = ( state, searchTerm = '', siteType = '' ) =>
 	get( state, [ 'signup', 'verticals', siteType, searchTerm.trim().toLowerCase() ], null );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -18,6 +18,7 @@ import { isSupportSession } from 'lib/user/support-user-interop';
 import { SERIALIZE, DESERIALIZE } from 'state/action-types';
 import { createReduxStore } from 'state';
 import initialReducer from 'state/reducer';
+import signupReducer from 'state/signup/reducer';
 import {
 	getInitialState,
 	persistOnChange,
@@ -429,7 +430,7 @@ describe( 'initial-state', () => {
 						.mockResolvedValue( storedState );
 
 					await loadAllState();
-					state = getInitialState( initialReducer );
+					state = getInitialState( combineReducers( { signup: signupReducer } ) );
 				} );
 
 				afterAll( () => {
@@ -500,7 +501,7 @@ describe( 'initial-state', () => {
 						.mockResolvedValue( storedState );
 
 					await loadAllState();
-					state = getInitialState( initialReducer );
+					state = getInitialState( combineReducers( { signup: signupReducer } ) );
 				} );
 
 				afterAll( () => {


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles signup.

For mode details on state modularisation, see #39261 and p4TIVU-9lM-p2.

Signup state imports from `signup/config`, so modularising it should see a small reduction in `entry-main`, by virtue of that no longer being in the critical path.

#### Changes proposed in this Pull Request

* Modularise signup state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read`.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `signup` key, even if you expand the list of keys. This indicates that the signup state hasn't been loaded.
* Open `/start`.
* Verify that a `signup` key is present with the signup state. This indicates that the signup state has been loaded for this route.
* Verify that signup functionality works normally. This indicates that I didn't mess up.