### PR TITLE
<PlanFeaturesMain>: When `hidePersonalPlan` and `hidePremiumPlan` are both set, hide the segment toggle and show only the business and eCommerce plans.

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -302,6 +302,11 @@ export class PlansFeaturesMain extends Component {
 		}, [] );
 	}
 
+	isPersonalCustomerPlanVisible() {
+		const { hidePersonalPlan, hidePremiumPlan } = this.props;
+		return ! hidePersonalPlan || ! hidePremiumPlan;
+	}
+
 	getVisiblePlansForPlanFeatures( plans ) {
 		const { displayJetpackPlans, customerType, plansWithScroll, withWPPlanTabs } = this.props;
 
@@ -330,7 +335,7 @@ export class PlansFeaturesMain extends Component {
 			);
 		}
 
-		if ( customerType === 'personal' ) {
+		if ( customerType === 'personal' && this.isPersonalCustomerPlanVisible() ) {
 			return plans.filter( ( plan ) =>
 				isPlanOneOfType( plan, [ TYPE_FREE, TYPE_BLOGGER, TYPE_PERSONAL, TYPE_PREMIUM ] )
 			);
@@ -447,13 +452,14 @@ export class PlansFeaturesMain extends Component {
 
 	renderToggle() {
 		const { displayJetpackPlans, withWPPlanTabs } = this.props;
+
 		if ( this.isDisplayingPlansNeededForFeature() ) {
 			return null;
 		}
 		if ( displayJetpackPlans ) {
 			return this.getIntervalTypeToggle();
 		}
-		if ( withWPPlanTabs ) {
+		if ( withWPPlanTabs && this.isPersonalCustomerPlanVisible() ) {
 			return this.getCustomerTypeToggle();
 		}
 		return false;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -302,7 +302,7 @@ export class PlansFeaturesMain extends Component {
 		}, [] );
 	}
 
-	isPersonalCustomerPlanVisible() {
+	isPersonalCustomerTypePlanVisible() {
 		const { hidePersonalPlan, hidePremiumPlan } = this.props;
 		return ! hidePersonalPlan || ! hidePremiumPlan;
 	}
@@ -335,7 +335,7 @@ export class PlansFeaturesMain extends Component {
 			);
 		}
 
-		if ( customerType === 'personal' && this.isPersonalCustomerPlanVisible() ) {
+		if ( customerType === 'personal' && this.isPersonalCustomerTypePlanVisible() ) {
 			return plans.filter( ( plan ) =>
 				isPlanOneOfType( plan, [ TYPE_FREE, TYPE_BLOGGER, TYPE_PERSONAL, TYPE_PREMIUM ] )
 			);
@@ -459,7 +459,7 @@ export class PlansFeaturesMain extends Component {
 		if ( displayJetpackPlans ) {
 			return this.getIntervalTypeToggle();
 		}
-		if ( withWPPlanTabs && this.isPersonalCustomerPlanVisible() ) {
+		if ( withWPPlanTabs && this.isPersonalCustomerTypePlanVisible() ) {
 			return this.getCustomerTypeToggle();
 		}
 		return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
*This PR depends on https://github.com/Automattic/wp-calypso/pull/41507*

This PR enhances `<PlanFeaturesMain>` component by handling the case when `hidePersonalPlan` and `hidePremiumPlan` are set. Currently, an empty tab is left so users have to navigate to the other segment to reveal the Business plan and the eCommerce plan.

Before:
![image](https://user-images.githubusercontent.com/1842898/80473520-da505500-8978-11ea-9472-a181252ba07e.png)

After:
![image](https://user-images.githubusercontent.com/1842898/80473204-6150fd80-8978-11ea-915b-025ed0536d02.png)

#### Testing instructions
1. Set both `hidePersonalPlan` and `hidePremiumPlan` by updating the defaultProps of PlansFeaturesMain directly.
1. Visit `/plans`, and you should see the Business plan and eCommerce plan directly, without the segment toggle.
