### PR TITLE
Jetpack Cloud: Don't display the site indicator

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -9,6 +9,7 @@ import { noop } from 'lodash';
 import Gridicon from 'components/gridicon';
 import { localize } from 'i18n-calypso';
 import page from 'page';
+import { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -172,7 +173,9 @@ class Site extends React.Component {
 						</span>
 					) }
 				</a>
-				{ this.props.indicator ? <SiteIndicator site={ site } /> : null }
+				{ this.props.indicator && isEnabled( 'site-indicator' ) ? (
+					<SiteIndicator site={ site } />
+				) : null }
 			</div>
 		);
 	}

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -131,6 +131,7 @@
 		"signup/ecommerce-flow": false,
 		"signup/wpcc": true,
 		"signup/wpforteams": true,
+		"site-indicator": true,
 		"support-user": true,
 		"try/preconnect": true,
 		"try/preload": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -98,6 +98,7 @@
 		"signup/social": false,
 		"signup/social-management": true,
 		"signup/wpcc": true,
+		"site-indicator": true,
 		"2fa/keys-support": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,

--- a/config/development.json
+++ b/config/development.json
@@ -170,6 +170,7 @@
 		"signup/social-management": true,
 		"signup/wpcc": true,
 		"signup/wpforteams": true,
+		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
 		"tools/migrate": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -115,6 +115,7 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
 		"signup/wpcc": true,
+		"site-indicator": true,
 		"memberships": true,
 		"support-user": true,
 		"2fa/keys-support": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -26,7 +26,8 @@
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,
 		"layout/support-article-dialog": false,
-		"layout/query-selected-editor": false
+		"layout/query-selected-editor": false,
+		"site-indicator": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -24,7 +24,8 @@
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,
 		"layout/support-article-dialog": false,
-		"layout/query-selected-editor": false
+		"layout/query-selected-editor": false,
+		"site-indicator": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -24,7 +24,8 @@
 		"layout/guided-tours": false,
 		"layout/nps-survey-notice": false,
 		"layout/support-article-dialog": false,
-		"layout/query-selected-editor": false
+		"layout/query-selected-editor": false,
+		"site-indicator": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/production.json
+++ b/config/production.json
@@ -123,6 +123,7 @@
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,
 		"signup/wpcc": true,
+		"site-indicator": true,
 		"memberships": true,
 		"ssr/sample-log-cache-misses": true,
 		"support-user": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,6 +134,7 @@
 		"signup/social-management": true,
 		"signup/wpcc": true,
 		"signup/wpforteams": true,
+		"site-indicator": true,
 		"support-user": true,
 		"tools/migrate": true,
 		"2fa/keys-support": true,

--- a/config/test.json
+++ b/config/test.json
@@ -97,6 +97,7 @@
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
 		"signup/social": true,
+		"site-indicator": true,
 		"support-user": true,
 		"2fa/keys-support": true,
 		"upgrades/checkout": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -145,6 +145,7 @@
 		"signup/ecommerce-flow": false,
 		"signup/wpcc": true,
 		"signup/wpforteams": true,
+		"site-indicator": true,
 		"support-user": true,
 		"tools/migrate": true,
 		"try/preconnect": true,


### PR DESCRIPTION
The site indicator doesn't work as expected for Jetpack Cloud.

Since the cloud section doesn't currently have any place to send user that want to update plugins etc. Lets turn it off for now.

#### Changes proposed in this Pull Request

* Make it so that we can update the site indicator and activate it we see it in the different calypso environments.  

#### Testing instructions

* Load up Jetpack Cloud. Notice that the site indicator doesn't show up as expected. 
* Load up Calypso notice that the site indicator is there as expected. 
