### PR TITLE
WPCOM Block Editor: hide Gutenberg preview button

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
@@ -12,6 +12,7 @@
 		display: inline-flex;
 	}
 	// Normally visible on desktops, make it always hidden
+	// .block-editor-post-preview__dropdown is the class name in versions >= 8.0
 	.editor-post-preview__dropdown,
 	.block-editor-post-preview__dropdown {
 		display: none;

--- a/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
@@ -12,6 +12,7 @@
 		display: inline-flex;
 	}
 	// Normally visible on desktops, make it always hidden
+	.editor-post-preview__dropdown,
 	.block-editor-post-preview__dropdown {
 		display: none;
 	}

--- a/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/legacy-preview-button.scss
@@ -12,7 +12,7 @@
 		display: inline-flex;
 	}
 	// Normally visible on desktops, make it always hidden
-	.editor-post-preview__dropdown {
+	.block-editor-post-preview__dropdown {
 		display: none;
 	}
 }


### PR DESCRIPTION

## Changes proposed in this Pull Request

We hide the Gutenberg preview dropdown list because the style overrides don't work on WordPress.com. See: https://github.com/Automattic/wp-calypso/pull/40388

In `v8.0.0-rc.1` the class name for this element has changed. Let's update the class and keep hiding it!

## Testing instructions

Check out this branch and build it:

`npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --watch`

Upload the files in `apps/wpcom-block-editor/dist` to your sandbox.

1. `YOUR_TEST_SITE_URL` should be running Gutenberg Edge (`8.0.0-rc.1`)
2. `YOUR_TEST_SITE_URL` should be sandboxed
3. 80s glam rock will make a come back one day, you'll see 🎸  

Try creating a post:

https://wordpress.com/block-editor/post/[YOUR_TEST_SITE_URL]

Check that the preview button in the editor always defaults always to the mobile version

<img width="640" alt="Screen Shot 2020-04-28 at 7 58 54 pm" src="https://user-images.githubusercontent.com/6458278/80474568-f3fa9800-898a-11ea-9461-2ac9ad42e1cd.png">

Fixes #41519
