### PR TITLE
Activity Log: Add more specificity to the close borderless button

### DIFF
--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -69,7 +69,7 @@
 		color: var( --color-text-inverted );
 	}
 
-	.filterbar__selection-close {
+	.filterbar__selection-close.button {
 		margin: 8px 8px 8px 0;
 		padding: 8px 8px 8px 0;
 		background-color: var( --color-neutral-60 );
@@ -85,7 +85,7 @@
 		}
 	}
 
-	.filterbar__selection-close:hover {
+	.filterbar__selection-close.button:hover {
 		color: var( --color-text-inverted );
 		background-color: var( --color-neutral-60 );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix the close button by adding more css specificity.
In https://github.com/Automattic/wp-calypso/pull/41523 we tried to fix the same issue but it turns out that the specificity wasn't high enought on the fix the issue on jetpack cloud staging.

Before: 
<img width="229" alt="Screen Shot 2020-04-28 at 12 09 20 PM" src="https://user-images.githubusercontent.com/115071/80475580-59c63000-8949-11ea-8712-f35f3693a011.png">

After:
<img width="221" alt="Screen Shot 2020-04-28 at 12 09 28 PM" src="https://user-images.githubusercontent.com/115071/80475587-5c288a00-8949-11ea-8fe1-0347c2113bf0.png">

#### Testing instructions
Use the new jetpack calypso live link. 
https://jetpack-hash-77fddec7ce2f16df4951a341f2e0d4c3afebda47.calypso.live

Does it look as expected? 

