### PR TITLE
My Home: Use unique keys in educational links

### DIFF
--- a/client/my-sites/customer-home/cards/education/educational-content/index.jsx
+++ b/client/my-sites/customer-home/cards/education/educational-content/index.jsx
@@ -25,7 +25,7 @@ const EducationalContent = ( { title, description, links, illustration } ) => {
 				</p>
 				<div className="educational-content__links">
 					{ links.map( ( { postId, url, text, icon, tracksEvent, statsName } ) => (
-						<div className="educational-content__link" key={ postId }>
+						<div className="educational-content__link" key={ url }>
 							{ icon && <Gridicon icon={ icon } size={ 18 } /> }
 							<InlineSupportLink
 								supportPostId={ postId }


### PR DESCRIPTION
This PR fixes a console warning about missing keys for the education content links.

<img width="1068" alt="Screen Shot 2020-04-28 at 12 46 17" src="https://user-images.githubusercontent.com/1233880/80478846-6c8f3380-894e-11ea-9307-a935f9825a64.png">

#### Testing instructions

* Open devtools, then load My Home for the upcoming i1 with the needed flag: http://calypso.localhost:3000/home/:site?flags=home/experimental-layout
* Notice the above console warning.
* Switch to this branch.
* Load again, and verify the message is not displayed.
