### PR TITLE
Jetpack Cloud: fix activity log selecteion on hover

### DIFF
--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -48,6 +48,7 @@
 	}
 
 	.filterbar__selection.is-selected,
+	.filterbar__selection.is-selected:focus,
 	.filterbar__selection.is-selected:hover {
 		margin: 8px;
 		border-radius: 5px;

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -47,7 +47,8 @@
 		white-space: nowrap;
 	}
 
-	.filterbar__selection.is-selected {
+	.filterbar__selection.is-selected,
+	.filterbar__selection.is-selected:hover {
 		margin: 8px;
 		border-radius: 5px;
 		border: 1px solid var( --color-neutral-60 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR fixes the hover state on Jetpack Cloud to match the activity log in calypso. When you hover over the selected filter. The fix increase the specificity of the selector in the activity log. 

Before:
<img width="522" alt="Screen Shot 2020-04-28 at 1 56 12 PM" src="https://user-images.githubusercontent.com/115071/80484527-25a63b80-8958-11ea-8aa2-922063a1a3dc.png">

After:
<img width="593" alt="Screen Shot 2020-04-28 at 1 55 59 PM" src="https://user-images.githubusercontent.com/115071/80484530-26d76880-8958-11ea-88a1-f4f1b44fc59c.png">

#### Testing instructions
* Load up the calypso live link.
* Does it look like you would expect? 

