### PR TITLE
Jetpack Cloud: Scan, fix response when jetpack scan api doesn't return most_recent

### DIFF
--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -40,15 +40,18 @@ export const formatScanThreat = ( threat ) => ( {
  * @param {object} scanState Raw Scan state object from Scan endpoint
  * @returns {object} Processed Scan state
  */
-const formatScanStateRawResponse = ( { state, threats, credentials, most_recent: mostRecent } ) => {
+const formatScanStateRawResponse = ( { state, threats, credentials, most_recent } ) => {
+	const mostRecent = most_recent
+		? {
+				...most_recent,
+				timestamp: new Date( most_recent.timestamp ),
+		  }
+		: null;
 	return {
 		state,
 		threats: threats.map( formatScanThreat ),
 		credentials,
-		mostRecent: {
-			...mostRecent,
-			timestamp: new Date( mostRecent.timestamp ),
-		},
+		mostRecent,
 	};
 };
 

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -40,18 +40,17 @@ export const formatScanThreat = ( threat ) => ( {
  * @param {object} scanState Raw Scan state object from Scan endpoint
  * @returns {object} Processed Scan state
  */
-const formatScanStateRawResponse = ( { state, threats, credentials, most_recent } ) => {
-	const mostRecent = most_recent
-		? {
-				...most_recent,
-				timestamp: new Date( most_recent.timestamp ),
-		  }
-		: null;
+const formatScanStateRawResponse = ( { state, threats, credentials, most_recent: mostRecent } ) => {
 	return {
 		state,
 		threats: threats.map( formatScanThreat ),
 		credentials,
-		mostRecent,
+		mostRecent: mostRecent
+			? {
+					...mostRecent,
+					timestamp: new Date( mostRecent.timestamp ),
+			  }
+			: null,
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug where a site can end up in limbo (permanenet placeholder state) 
because the jetpack scan api doesn't always return the 'most_recent' parameter. 

This PR fixes this by making sure that the value is always set. 

#### Testing instructions
* Visit Jetpack Cloud scan section for exotic-wasps.jurassic.ninja. 
* Notice that the correct view shoes up. 

<img width="809" alt="Screen Shot 2020-04-28 at 2 50 34 PM" src="https://user-images.githubusercontent.com/115071/80489084-a0bf2000-895f-11ea-99b0-f10ff4974be5.png">


