### PR TITLE
Add/rum monitoring

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -21,6 +21,7 @@ import { chunkCssLinks } from './utils';
 import JetpackLogo from 'components/jetpack-logo';
 import WordPressLogo from 'components/wordpress-logo';
 import { jsonStringifyForHtml } from 'server/sanitize';
+import { PerformanceTrackerInstall } from 'lib/performance-tracking';
 
 class Document extends React.Component {
 	render() {
@@ -104,6 +105,8 @@ class Document extends React.Component {
 					branchName={ branchName }
 					inlineScriptNonce={ inlineScriptNonce }
 				>
+					<PerformanceTrackerInstall nonce={ inlineScriptNonce } />
+
 					{ head.metas.map( ( props, index ) => (
 						<meta { ...props } key={ index } />
 					) ) }

--- a/client/lib/performance-tracking/api.js
+++ b/client/lib/performance-tracking/api.js
@@ -1,0 +1,36 @@
+const getLux = () => {
+	const lux = window.LUX || {};
+	// Reassign it so changes in LUX are picked when Lux starts
+	window.LUX = lux;
+
+	// Don't send the first navigation automatically, we'll do it.
+	lux.auto = false;
+	lux.debug = true;
+	return lux;
+};
+
+export const startNavigation = ( { label, metadata = {} } ) => {
+	const lux = getLux();
+
+	if ( typeof lux.init !== 'function' ) {
+		// Not initialized yet, we'll skip this navigation.
+		return;
+	}
+
+	lux.init();
+	lux.label = label;
+	Object.entries( metadata ).forEach( ( [ key, value ] ) => {
+		lux.addData( key, value );
+	} );
+};
+
+export const stopNavigation = () => {
+	const lux = getLux();
+
+	if ( typeof lux.init !== 'function' ) {
+		// Not initialized yet, we'll skip this navigation.
+		return;
+	}
+
+	lux.send();
+};

--- a/client/lib/performance-tracking/api.js
+++ b/client/lib/performance-tracking/api.js
@@ -14,6 +14,15 @@ const getLux = () => {
 	return lux;
 };
 
+/**
+ * Adds metadata to LUX request.
+ *
+ * WARNING: please double check you don't send any Private Personal Information. A good rule of thumb is to only send booleans or numbers.
+ *
+ * LUX has a limit of 255 bytes of all metadata concatenated, so you may want to keep they names short.
+ *
+ * @param {object} metadata Object with key:values to add as metadata
+ */
 const addMetadata = ( metadata ) => {
 	const lux = getLux();
 

--- a/client/lib/performance-tracking/api.js
+++ b/client/lib/performance-tracking/api.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
 const getLux = () => {
 	const lux = window.LUX || {};
 	// Reassign it so changes in LUX are picked when Lux starts
@@ -18,6 +23,8 @@ const addMetadata = ( metadata ) => {
 };
 
 export const startNavigation = ( { label, metadata = {} } = {} ) => {
+	if ( ! config.isEnabled( 'rum-tracking/speedcurve' ) ) return;
+
 	const lux = getLux();
 
 	if ( typeof lux.init !== 'function' ) {
@@ -31,6 +38,8 @@ export const startNavigation = ( { label, metadata = {} } = {} ) => {
 };
 
 export const stopNavigation = ( { metadata = {} } = {} ) => {
+	if ( ! config.isEnabled( 'rum-tracking/speedcurve' ) ) return;
+
 	const lux = getLux();
 
 	if ( typeof lux.send !== 'function' ) {

--- a/client/lib/performance-tracking/api.js
+++ b/client/lib/performance-tracking/api.js
@@ -9,7 +9,15 @@ const getLux = () => {
 	return lux;
 };
 
-export const startNavigation = ( { label, metadata = {} } ) => {
+const addMetadata = ( metadata ) => {
+	const lux = getLux();
+
+	Object.entries( metadata ).forEach( ( [ key, value ] ) => {
+		lux.addData( key, value );
+	} );
+};
+
+export const startNavigation = ( { label, metadata = {} } = {} ) => {
 	const lux = getLux();
 
 	if ( typeof lux.init !== 'function' ) {
@@ -19,18 +27,17 @@ export const startNavigation = ( { label, metadata = {} } ) => {
 
 	lux.init();
 	lux.label = label;
-	Object.entries( metadata ).forEach( ( [ key, value ] ) => {
-		lux.addData( key, value );
-	} );
+	addMetadata( metadata );
 };
 
-export const stopNavigation = () => {
+export const stopNavigation = ( { metadata = {} } = {} ) => {
 	const lux = getLux();
 
-	if ( typeof lux.init !== 'function' ) {
+	if ( typeof lux.send !== 'function' ) {
 		// Not initialized yet, we'll skip this navigation.
 		return;
 	}
 
+	addMetadata( metadata );
 	lux.send();
 };

--- a/client/lib/performance-tracking/components/performance-tracker-install.jsx
+++ b/client/lib/performance-tracking/components/performance-tracker-install.jsx
@@ -1,0 +1,43 @@
+/* eslint-disable react/no-danger */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+
+const performanceTrackerInstall = ( { nonce } ) => {
+	const serviceId = config( 'speedcurve_id' );
+	if ( ! config.isEnabled( 'rum-tracking/speedcurve' ) || ! serviceId ) return null;
+
+	return (
+		<>
+			<script
+				type="text/javascript"
+				nonce={ nonce }
+				dangerouslySetInnerHTML={ {
+					__html:
+						'LUX=(function(){var a=("undefined"!==typeof(LUX)&&"undefined"!==typeof(LUX.gaMarks)?LUX.gaMarks:[]);var d=("undefined"!==typeof(LUX)&&"undefined"!==typeof(LUX.gaMeasures)?LUX.gaMeasures:[]);var j="LUX_start";var k=window.performance;var l=("undefined"!==typeof(LUX)&&LUX.ns?LUX.ns:(Date.now?Date.now():+(new Date())));if(k&&k.timing&&k.timing.navigationStart){l=k.timing.navigationStart}function f(){if(k&&k.now){return k.now()}var o=Date.now?Date.now():+(new Date());return o-l}function b(n){if(k){if(k.mark){return k.mark(n)}else{if(k.webkitMark){return k.webkitMark(n)}}}a.push({name:n,entryType:"mark",startTime:f(),duration:0});return}function m(p,t,n){if("undefined"===typeof(t)&&h(j)){t=j}if(k){if(k.measure){if(t){if(n){return k.measure(p,t,n)}else{return k.measure(p,t)}}else{return k.measure(p)}}else{if(k.webkitMeasure){return k.webkitMeasure(p,t,n)}}}var r=0,o=f();if(t){var s=h(t);if(s){r=s.startTime}else{if(k&&k.timing&&k.timing[t]){r=k.timing[t]-k.timing.navigationStart}else{return}}}if(n){var q=h(n);if(q){o=q.startTime}else{if(k&&k.timing&&k.timing[n]){o=k.timing[n]-k.timing.navigationStart}else{return}}}d.push({name:p,entryType:"measure",startTime:r,duration:(o-r)});return}function h(n){return c(n,g())}function c(p,o){for(i=o.length-1;i>=0;i--){var n=o[i];if(p===n.name){return n}}return undefined}function g(){if(k){if(k.getEntriesByType){return k.getEntriesByType("mark")}else{if(k.webkitGetEntriesByType){return k.webkitGetEntriesByType("mark")}}}return a}return{mark:b,measure:m,gaMarks:a,gaMeasures:d}})();LUX.ns=(Date.now?Date.now():+(new Date()));LUX.ac=[];LUX.cmd=function(a){LUX.ac.push(a)};LUX.init=function(){LUX.cmd(["init"])};LUX.send=function(){LUX.cmd(["send"])};LUX.addData=function(a,b){LUX.cmd(["addData",a,b])};LUX_ae=[];window.addEventListener("error",function(a){LUX_ae.push(a)});LUX_al=[];if("function"===typeof(PerformanceObserver)&&"function"===typeof(PerformanceLongTaskTiming)){var LongTaskObserver=new PerformanceObserver(function(c){var b=c.getEntries();for(var a=0;a<b.length;a++){var d=b[a];LUX_al.push(d)}});try{LongTaskObserver.observe({type:["longtask"]})}catch(e){}};',
+				} }
+			/>
+			<script
+				src={ `https://cdn.speedcurve.com/js/lux.js?id=${ serviceId }` }
+				async
+				defer
+				crossOrigin="anonymous"
+			/>
+		</>
+	);
+};
+
+performanceTrackerInstall.propTypes = {
+	nonce: PropTypes.string,
+};
+
+export default performanceTrackerInstall;

--- a/client/lib/performance-tracking/components/performance-tracker-install.jsx
+++ b/client/lib/performance-tracking/components/performance-tracker-install.jsx
@@ -36,7 +36,7 @@ const PerformanceTrackerInstall = ( { nonce } ) => {
 };
 
 PerformanceTrackerInstall.propTypes = {
-	nonce: PropTypes.string.isRequired,
+	nonce: PropTypes.string,
 };
 
 export default PerformanceTrackerInstall;

--- a/client/lib/performance-tracking/components/performance-tracker-install.jsx
+++ b/client/lib/performance-tracking/components/performance-tracker-install.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -12,7 +11,7 @@ import PropTypes from 'prop-types';
  */
 import config from 'config';
 
-const performanceTrackerInstall = ( { nonce } ) => {
+const PerformanceTrackerInstall = ( { nonce } ) => {
 	const serviceId = config( 'speedcurve_id' );
 	if ( ! config.isEnabled( 'rum-tracking/speedcurve' ) || ! serviceId ) return null;
 
@@ -36,8 +35,8 @@ const performanceTrackerInstall = ( { nonce } ) => {
 	);
 };
 
-performanceTrackerInstall.propTypes = {
-	nonce: PropTypes.string,
+PerformanceTrackerInstall.propTypes = {
+	nonce: PropTypes.string.isRequired,
 };
 
-export default performanceTrackerInstall;
+export default PerformanceTrackerInstall;

--- a/client/lib/performance-tracking/components/performance-tracker-stop.jsx
+++ b/client/lib/performance-tracking/components/performance-tracker-stop.jsx
@@ -3,16 +3,58 @@
  */
 
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { isSingleUserSite, isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isSiteStore from 'state/selectors/is-site-store';
 import { stopNavigation } from '../api';
 
-export default class PerformanceTrackerStop extends React.Component {
-	static propTypes = {};
+class PerformanceTrackerStop extends React.Component {
+	static propTypes = {
+		// Indicates if the site is a Single site
+		single: PropTypes.bool,
+
+		// Indicates if the site is Atomic
+		at: PropTypes.bool,
+
+		// Indicates if the site has Jetpack
+		jetpack: PropTypes.bool,
+
+		// Indicates if the site has WooCommerce
+		store: PropTypes.bool,
+	};
 
 	componentDidMount() {
-		stopNavigation();
+		stopNavigation( {
+			metadata: {
+				single: this.props.single,
+				at: this.props.at,
+				jetpack: this.props.jetpack,
+				store: this.props.store,
+			},
+		} );
 	}
 
 	render() {
 		return null;
 	}
 }
+
+const mapStateToProps = ( state ) => {
+	const siteId = getSelectedSiteId( state );
+
+	return {
+		single: isSingleUserSite( state, siteId ),
+		at: isSiteAutomatedTransfer( state, siteId ),
+		jetpack: isJetpackSite( state, siteId ),
+		store: isSiteStore( state, siteId ),
+	};
+};
+
+export default connect( mapStateToProps )( PerformanceTrackerStop );

--- a/client/lib/performance-tracking/components/performance-tracker-stop.jsx
+++ b/client/lib/performance-tracking/components/performance-tracker-stop.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -14,36 +14,35 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
 import isSiteStore from 'state/selectors/is-site-store';
 import { stopNavigation } from '../api';
 
-class PerformanceTrackerStop extends React.Component {
-	static propTypes = {
-		// Indicates if the site is a Single site
-		single: PropTypes.bool,
-
-		// Indicates if the site is Atomic
-		at: PropTypes.bool,
-
-		// Indicates if the site has Jetpack
-		jetpack: PropTypes.bool,
-
-		// Indicates if the site has WooCommerce
-		store: PropTypes.bool,
-	};
-
-	componentDidMount() {
+const PerformanceTrackerStop = ( { single, at, jetpack, store } ) => {
+	useEffect( () => {
 		stopNavigation( {
 			metadata: {
-				single: this.props.single,
-				at: this.props.at,
-				jetpack: this.props.jetpack,
-				store: this.props.store,
+				single,
+				at,
+				jetpack,
+				store,
 			},
 		} );
-	}
+	} );
 
-	render() {
-		return null;
-	}
-}
+	// Nothing to render, this component is all about side effects
+	return null;
+};
+
+PerformanceTrackerStop.propTypes = {
+	// Indicates if the site is a Single site
+	single: PropTypes.bool,
+
+	// Indicates if the site is Atomic
+	at: PropTypes.bool,
+
+	// Indicates if the site has Jetpack
+	jetpack: PropTypes.bool,
+
+	// Indicates if the site has WooCommerce
+	store: PropTypes.bool,
+};
 
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );

--- a/client/lib/performance-tracking/components/performance-tracker-stop.jsx
+++ b/client/lib/performance-tracking/components/performance-tracker-stop.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';

--- a/client/lib/performance-tracking/components/performance-tracker-stop.jsx
+++ b/client/lib/performance-tracking/components/performance-tracker-stop.jsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { stopNavigation } from '../api';
+
+export default class PerformanceTrackerStop extends React.Component {
+	static propTypes = {};
+
+	componentDidMount() {
+		stopNavigation();
+	}
+
+	render() {
+		return null;
+	}
+}

--- a/client/lib/performance-tracking/index.js
+++ b/client/lib/performance-tracking/index.js
@@ -8,7 +8,6 @@ export const trackNavigationStart = ( pageName ) => {
 		startNavigation( {
 			label: pageName || 'calypso',
 			metadata: {
-				// Defines if it is a full page load or a SPA load
 				init: context.init || false,
 			},
 		} );

--- a/client/lib/performance-tracking/index.js
+++ b/client/lib/performance-tracking/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { startNavigation } from './api';
+
+export const trackNavigationStart = ( pageName ) => {
+	return ( context, next ) => {
+		startNavigation( {
+			label: pageName || 'calypso',
+			metadata: {
+				// Defines if it is a full page load or a SPA load
+				init: context.init || false,
+			},
+		} );
+		next();
+	};
+};
+
+export { default as PerformanceTrackerInstall } from './components/performance-tracker-install';
+export { default as PerformanceTrackerStop } from './components/performance-tracker-stop';

--- a/client/my-sites/customer-home/index.js
+++ b/client/my-sites/customer-home/index.js
@@ -9,9 +9,19 @@ import page from 'page';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import home, { maybeRedirect } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { trackNavigationStart } from 'lib/performance-tracking';
 
 export default function () {
-	page( '/home', siteSelection, sites, makeLayout, clientRender );
+	page( '/home', trackNavigationStart( 'home' ), siteSelection, sites, makeLayout, clientRender );
 
-	page( '/home/:siteId', siteSelection, maybeRedirect, navigation, home, makeLayout, clientRender );
+	page(
+		'/home/:siteId',
+		trackNavigationStart( 'home' ),
+		siteSelection,
+		maybeRedirect,
+		navigation,
+		home,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -15,6 +15,7 @@ import ConnectAccounts from 'my-sites/customer-home/cards/tasks/connect-accounts
 import Webinars from 'my-sites/customer-home/cards/tasks/webinars';
 import FindDomain from 'my-sites/customer-home/cards/tasks/find-domain';
 import SiteSetupList from 'my-sites/customer-home/cards/tasks/site-setup-list';
+import { PerformanceTrackerStop } from 'lib/performance-tracking';
 import config from 'config';
 
 const cardComponents = {
@@ -52,6 +53,7 @@ const Primary = ( { checklistMode, cards } ) => {
 								: null,
 						} )
 				) }
+			<PerformanceTrackerStop />
 		</>
 	);
 };

--- a/client/my-sites/index.js
+++ b/client/my-sites/index.js
@@ -11,14 +11,15 @@ import { get } from 'lodash';
 import { siteSelection, sites } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { getSiteBySlug, getSiteHomeUrl } from 'state/sites/selectors';
+import { trackNavigationStart } from 'lib/performance-tracking';
 
 export default function () {
-	page( '/sites/:site', ( context ) => {
+	page( '/sites/:site', trackNavigationStart( 'sites' ), ( context ) => {
 		const state = context.store.getState();
 		const site = getSiteBySlug( state, context.params.site );
 		// The site may not be loaded into state yet.
 		const siteId = get( site, 'ID' );
 		page.redirect( getSiteHomeUrl( state, siteId ) );
 	} );
-	page( '/sites', siteSelection, sites, makeLayout, clientRender );
+	page( '/sites', trackNavigationStart( 'sites' ), siteSelection, sites, makeLayout, clientRender );
 }

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -70,6 +70,7 @@ import {
 } from 'lib/plans/constants';
 import { getPlanFeaturesObject } from 'lib/plans/features-list';
 import PlanFeaturesScroller from './scroller';
+import { PerformanceTrackerStop } from 'lib/performance-tracking';
 
 /**
  * Style dependencies
@@ -182,6 +183,7 @@ export class PlanFeatures extends Component {
 								</tbody>
 							</table>
 						</PlanFeaturesScroller>
+						<PerformanceTrackerStop />
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -12,87 +12,21 @@ import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { trackNavigationStart } from 'lib/performance-tracking';
 
+const trackedPage = ( url, ...rest ) => {
+	page( url, trackNavigationStart( 'plans' ), ...rest, makeLayout, clientRender );
+};
+
 export default function () {
-	page( '/plans', trackNavigationStart( 'plans' ), siteSelection, sites, makeLayout, clientRender );
-	page(
-		'/plans/compare',
-		trackNavigationStart( 'plans' ),
-		siteSelection,
-		navigation,
-		redirectToPlans,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/plans/compare/:domain',
-		trackNavigationStart( 'plans' ),
-		siteSelection,
-		navigation,
-		redirectToPlans,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/plans/features',
-		trackNavigationStart( 'plans' ),
-		siteSelection,
-		navigation,
-		redirectToPlans,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/plans/features/:domain',
-		trackNavigationStart( 'plans' ),
-		siteSelection,
-		navigation,
-		redirectToPlans,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/plans/features/:feature/:domain',
-		trackNavigationStart( 'plans' ),
-		features,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/plans/my-plan',
-		trackNavigationStart( 'plans' ),
-		siteSelection,
-		sites,
-		navigation,
-		currentPlan,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/plans/my-plan/:site',
-		trackNavigationStart( 'plans' ),
-		siteSelection,
-		navigation,
-		currentPlan,
-		makeLayout,
-		clientRender
-	);
-	page(
-		'/plans/select/:plan/:domain',
-		trackNavigationStart( 'plans' ),
-		siteSelection,
-		redirectToCheckout,
-		makeLayout,
-		clientRender
-	);
+	trackedPage( '/plans', siteSelection, sites );
+	trackedPage( '/plans/compare', siteSelection, navigation, redirectToPlans );
+	trackedPage( '/plans/compare/:domain', siteSelection, navigation, redirectToPlans );
+	trackedPage( '/plans/features', siteSelection, navigation, redirectToPlans );
+	trackedPage( '/plans/features/:domain', siteSelection, navigation, redirectToPlans );
+	trackedPage( '/plans/features/:feature/:domain', features );
+	trackedPage( '/plans/my-plan', siteSelection, sites, navigation, currentPlan );
+	trackedPage( '/plans/my-plan/:site', siteSelection, navigation, currentPlan );
+	trackedPage( '/plans/select/:plan/:domain', siteSelection, redirectToCheckout );
 
 	// This route renders the plans page for both WPcom and Jetpack sites.
-	page(
-		'/plans/:intervalType?/:site',
-		trackNavigationStart( 'plans' ),
-		siteSelection,
-		navigation,
-		plans,
-		makeLayout,
-		clientRender
-	);
+	trackedPage( '/plans/:intervalType?/:site', siteSelection, navigation, plans );
 }

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -10,32 +10,75 @@ import { features, plans, redirectToCheckout, redirectToPlans } from './controll
 import { currentPlan } from './current-plan/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { trackNavigationStart } from 'lib/performance-tracking';
 
 export default function () {
-	page( '/plans', siteSelection, sites, makeLayout, clientRender );
-	page( '/plans/compare', siteSelection, navigation, redirectToPlans, makeLayout, clientRender );
+	page( '/plans', trackNavigationStart( 'plans' ), siteSelection, sites, makeLayout, clientRender );
+	page(
+		'/plans/compare',
+		trackNavigationStart( 'plans' ),
+		siteSelection,
+		navigation,
+		redirectToPlans,
+		makeLayout,
+		clientRender
+	);
 	page(
 		'/plans/compare/:domain',
+		trackNavigationStart( 'plans' ),
 		siteSelection,
 		navigation,
 		redirectToPlans,
 		makeLayout,
 		clientRender
 	);
-	page( '/plans/features', siteSelection, navigation, redirectToPlans, makeLayout, clientRender );
+	page(
+		'/plans/features',
+		trackNavigationStart( 'plans' ),
+		siteSelection,
+		navigation,
+		redirectToPlans,
+		makeLayout,
+		clientRender
+	);
 	page(
 		'/plans/features/:domain',
+		trackNavigationStart( 'plans' ),
 		siteSelection,
 		navigation,
 		redirectToPlans,
 		makeLayout,
 		clientRender
 	);
-	page( '/plans/features/:feature/:domain', features, makeLayout, clientRender );
-	page( '/plans/my-plan', siteSelection, sites, navigation, currentPlan, makeLayout, clientRender );
-	page( '/plans/my-plan/:site', siteSelection, navigation, currentPlan, makeLayout, clientRender );
+	page(
+		'/plans/features/:feature/:domain',
+		trackNavigationStart( 'plans' ),
+		features,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/plans/my-plan',
+		trackNavigationStart( 'plans' ),
+		siteSelection,
+		sites,
+		navigation,
+		currentPlan,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/plans/my-plan/:site',
+		trackNavigationStart( 'plans' ),
+		siteSelection,
+		navigation,
+		currentPlan,
+		makeLayout,
+		clientRender
+	);
 	page(
 		'/plans/select/:plan/:domain',
+		trackNavigationStart( 'plans' ),
 		siteSelection,
 		redirectToCheckout,
 		makeLayout,
@@ -43,5 +86,13 @@ export default function () {
 	);
 
 	// This route renders the plans page for both WPcom and Jetpack sites.
-	page( '/plans/:intervalType?/:site', siteSelection, navigation, plans, makeLayout, clientRender );
+	page(
+		'/plans/:intervalType?/:site',
+		trackNavigationStart( 'plans' ),
+		siteSelection,
+		navigation,
+		plans,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/my-sites/plans/test/index.js
+++ b/client/my-sites/plans/test/index.js
@@ -1,11 +1,25 @@
-jest.mock( 'page' );
-jest.mock( '../controller' );
-jest.mock( '../current-plan/controller' );
-jest.mock( 'controller' );
-jest.mock( 'my-sites/controller' );
-jest.mock( 'lib/performance-tracking' );
-
-const router = require( '../index' );
+jest.mock( 'page', () => jest.fn() );
+jest.mock( '../controller', () => ( {
+	features: jest.fn(),
+	plans: jest.fn(),
+	redirectToCheckout: jest.fn(),
+	redirectToPlans: jest.fn(),
+} ) );
+jest.mock( '../current-plan/controller', () => ( {
+	currentPlan: jest.fn(),
+} ) );
+jest.mock( 'controller', () => ( {
+	makeLayout: jest.fn(),
+	render: jest.fn(),
+} ) );
+jest.mock( 'my-sites/controller', () => ( {
+	navigation: jest.fn(),
+	siteSelection: jest.fn(),
+	sites: jest.fn(),
+} ) );
+jest.mock( 'lib/performance-tracking', () => ( {
+	trackNavigationStart: jest.fn(),
+} ) );
 
 /**
  * External dependencies
@@ -20,6 +34,8 @@ import { currentPlan } from '../current-plan/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { trackNavigationStart } from 'lib/performance-tracking';
+
+import router from '../index';
 
 // Return the same tag so we can make assertions in the tets
 trackNavigationStart.mockImplementation( ( tag ) => tag );

--- a/client/my-sites/plans/test/index.js
+++ b/client/my-sites/plans/test/index.js
@@ -1,0 +1,104 @@
+jest.mock( 'page' );
+jest.mock( '../controller' );
+jest.mock( '../current-plan/controller' );
+jest.mock( 'controller' );
+jest.mock( 'my-sites/controller' );
+jest.mock( 'lib/performance-tracking' );
+
+const router = require( '../index' );
+
+/**
+ * External dependencies
+ */
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { features, plans, redirectToCheckout, redirectToPlans } from '../controller';
+import { currentPlan } from '../current-plan/controller';
+import { makeLayout, render as clientRender } from 'controller';
+import { navigation, siteSelection, sites } from 'my-sites/controller';
+import { trackNavigationStart } from 'lib/performance-tracking';
+
+// Return the same tag so we can make assertions in the tets
+trackNavigationStart.mockImplementation( ( tag ) => tag );
+
+const routes = {
+	'/plans': [ 'plans', siteSelection, sites, makeLayout, clientRender ],
+	'/plans/compare': [
+		'plans',
+		siteSelection,
+		navigation,
+		redirectToPlans,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/compare/:domain': [
+		'plans',
+		siteSelection,
+		navigation,
+		redirectToPlans,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/features': [
+		'plans',
+		siteSelection,
+		navigation,
+		redirectToPlans,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/features/:domain': [
+		'plans',
+		siteSelection,
+		navigation,
+		redirectToPlans,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/features/:feature/:domain': [ 'plans', features, makeLayout, clientRender ],
+	'/plans/my-plan': [
+		'plans',
+		siteSelection,
+		sites,
+		navigation,
+		currentPlan,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/my-plan/:site': [
+		'plans',
+		siteSelection,
+		navigation,
+		currentPlan,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/select/:plan/:domain': [
+		'plans',
+		siteSelection,
+		redirectToCheckout,
+		makeLayout,
+		clientRender,
+	],
+	'/plans/:intervalType?/:site': [
+		'plans',
+		siteSelection,
+		navigation,
+		plans,
+		makeLayout,
+		clientRender,
+	],
+};
+
+describe( 'Sets all routes', () => {
+	Object.entries( routes ).forEach( ( [ route, expectedMiddleware ] ) => {
+		it( `Route ${ route } uses the correct middleware`, () => {
+			router();
+			const [ , ...actualMiddleware ] = page.mock.calls.find( ( [ path ] ) => path === route );
+			expect( actualMiddleware ).toEqual( expectedMiddleware );
+		} );
+	} );
+} );

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -13,7 +13,7 @@ import { Card } from '@automattic/components';
 import Main from 'components/main';
 import SiteSelector from 'components/site-selector';
 import VisitSite from 'blocks/visit-site';
-
+import { PerformanceTrackerStop } from 'lib/performance-tracking';
 /**
  * Style dependencies
  */
@@ -132,6 +132,7 @@ class Sites extends Component {
 						groups
 					/>
 				</Card>
+				<PerformanceTrackerStop />
 			</Main>
 		);
 	}

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -12,6 +12,7 @@ import statsController from './controller';
 import { redirect as redirectToAcivity } from 'my-sites/activity/controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
+import { trackNavigationStart } from 'lib/performance-tracking';
 
 /**
  * Style dependencies
@@ -29,6 +30,7 @@ export default function () {
 		// Stat Overview Page
 		page(
 			'/stats/day',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.overview,
@@ -37,6 +39,7 @@ export default function () {
 		);
 		page(
 			'/stats/week',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.overview,
@@ -45,6 +48,7 @@ export default function () {
 		);
 		page(
 			'/stats/month',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.overview,
@@ -53,6 +57,7 @@ export default function () {
 		);
 		page(
 			'/stats/year',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.overview,
@@ -60,11 +65,20 @@ export default function () {
 			clientRender
 		);
 
-		page( '/stats/insights', siteSelection, navigation, sites, makeLayout, clientRender );
+		page(
+			'/stats/insights',
+			trackNavigationStart( 'stats' ),
+			siteSelection,
+			navigation,
+			sites,
+			makeLayout,
+			clientRender
+		);
 
 		// Stat Insights Page
 		page(
 			'/stats/insights/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.insights,
@@ -75,6 +89,7 @@ export default function () {
 		// Stat Site Pages
 		page(
 			'/stats/day/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.site,
@@ -83,6 +98,7 @@ export default function () {
 		);
 		page(
 			'/stats/week/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.site,
@@ -91,6 +107,7 @@ export default function () {
 		);
 		page(
 			'/stats/month/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.site,
@@ -99,6 +116,7 @@ export default function () {
 		);
 		page(
 			'/stats/year/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.site,
@@ -129,6 +147,7 @@ export default function () {
 		// Stat Summary Pages
 		page(
 			`/stats/day/:module(${ validModules.join( '|' ) })/:site`,
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.summary,
@@ -137,6 +156,7 @@ export default function () {
 		);
 		page(
 			`/stats/week/:module(${ validModules.join( '|' ) })/:site`,
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.summary,
@@ -145,6 +165,7 @@ export default function () {
 		);
 		page(
 			`/stats/month/:module(${ validModules.join( '|' ) })/:site`,
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.summary,
@@ -153,6 +174,7 @@ export default function () {
 		);
 		page(
 			`/stats/year/:module(${ validModules.join( '|' ) })/:site`,
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.summary,
@@ -163,6 +185,7 @@ export default function () {
 		// Stat Single Post Page
 		page(
 			'/stats/post/:post_id/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.post,
@@ -171,6 +194,7 @@ export default function () {
 		);
 		page(
 			'/stats/page/:post_id/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.post,
@@ -181,6 +205,7 @@ export default function () {
 		// Stat Follows Page
 		page(
 			'/stats/follows/comment/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.follows,
@@ -189,6 +214,7 @@ export default function () {
 		);
 		page(
 			'/stats/follows/comment/:page_num/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.follows,
@@ -196,10 +222,19 @@ export default function () {
 			clientRender
 		);
 
-		page( '/stats/activity', siteSelection, sites, redirectToAcivity, makeLayout, clientRender );
+		page(
+			'/stats/activity',
+			trackNavigationStart( 'stats' ),
+			siteSelection,
+			sites,
+			redirectToAcivity,
+			makeLayout,
+			clientRender
+		);
 
 		page(
 			'/stats/activity/:site',
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			redirectToAcivity,
@@ -209,6 +244,7 @@ export default function () {
 
 		page(
 			`/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`,
+			trackNavigationStart( 'stats' ),
 			siteSelection,
 			navigation,
 			statsController.wordAds,

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -19,6 +19,18 @@ import { trackNavigationStart } from 'lib/performance-tracking';
  */
 import './style.scss';
 
+const trackedPage = ( url, controller ) => {
+	page(
+		url,
+		trackNavigationStart( 'stats' ),
+		siteSelection,
+		navigation,
+		controller,
+		makeLayout,
+		clientRender
+	);
+};
+
 export default function () {
 	const validPeriods = [ 'day', 'week', 'month', 'year' ];
 
@@ -28,101 +40,21 @@ export default function () {
 		page( '/stats', () => page.redirect( getStatsDefaultSitePage() ) );
 
 		// Stat Overview Page
-		page(
-			'/stats/day',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.overview,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/stats/week',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.overview,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/stats/month',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.overview,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/stats/year',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.overview,
-			makeLayout,
-			clientRender
-		);
+		trackedPage( '/stats/day', statsController.overview );
+		trackedPage( '/stats/week', statsController.overview );
+		trackedPage( '/stats/month', statsController.overview );
+		trackedPage( '/stats/year', statsController.overview );
 
-		page(
-			'/stats/insights',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			sites,
-			makeLayout,
-			clientRender
-		);
+		trackedPage( '/stats/insights', sites );
 
 		// Stat Insights Page
-		page(
-			'/stats/insights/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.insights,
-			makeLayout,
-			clientRender
-		);
+		trackedPage( '/stats/insights/:site', statsController.insights );
 
 		// Stat Site Pages
-		page(
-			'/stats/day/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.site,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/stats/week/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.site,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/stats/month/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.site,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/stats/year/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.site,
-			makeLayout,
-			clientRender
-		);
+		trackedPage( '/stats/day/:site', statsController.site );
+		trackedPage( '/stats/week/:site', statsController.site );
+		trackedPage( '/stats/month/:site', statsController.site );
+		trackedPage( '/stats/year/:site', statsController.site );
 
 		const validModules = [
 			'posts',
@@ -145,83 +77,32 @@ export default function () {
 		);
 
 		// Stat Summary Pages
-		page(
+		trackedPage(
 			`/stats/day/:module(${ validModules.join( '|' ) })/:site`,
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.summary,
-			makeLayout,
-			clientRender
+			statsController.summary
 		);
-		page(
+		trackedPage(
 			`/stats/week/:module(${ validModules.join( '|' ) })/:site`,
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.summary,
-			makeLayout,
-			clientRender
+			statsController.summary
 		);
-		page(
+		trackedPage(
 			`/stats/month/:module(${ validModules.join( '|' ) })/:site`,
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.summary,
-			makeLayout,
-			clientRender
+			statsController.summary
 		);
-		page(
+		trackedPage(
 			`/stats/year/:module(${ validModules.join( '|' ) })/:site`,
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.summary,
-			makeLayout,
-			clientRender
+			statsController.summary
 		);
 
 		// Stat Single Post Page
-		page(
-			'/stats/post/:post_id/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.post,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/stats/page/:post_id/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.post,
-			makeLayout,
-			clientRender
-		);
+		trackedPage( '/stats/post/:post_id/:site', statsController.post );
+		trackedPage( '/stats/page/:post_id/:site', statsController.post );
 
 		// Stat Follows Page
-		page(
-			'/stats/follows/comment/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.follows,
-			makeLayout,
-			clientRender
-		);
-		page(
-			'/stats/follows/comment/:page_num/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.follows,
-			makeLayout,
-			clientRender
-		);
+		trackedPage( '/stats/follows/comment/:site', statsController.follows );
+		trackedPage( '/stats/follows/comment/:page_num/:site', statsController.follows );
 
+		// Can't convert to trackedPage because it uses `sites` instead of `navigation`
 		page(
 			'/stats/activity',
 			trackNavigationStart( 'stats' ),
@@ -232,24 +113,11 @@ export default function () {
 			clientRender
 		);
 
-		page(
-			'/stats/activity/:site',
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			redirectToAcivity,
-			makeLayout,
-			clientRender
-		);
+		trackedPage( '/stats/activity/:site', redirectToAcivity );
 
-		page(
+		trackedPage(
 			`/stats/ads/:period(${ validPeriods.join( '|' ) })/:site`,
-			trackNavigationStart( 'stats' ),
-			siteSelection,
-			navigation,
-			statsController.wordAds,
-			makeLayout,
-			clientRender
+			statsController.wordAds
 		);
 
 		// Anything else should redirect to default WordAds stats page

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -39,7 +39,6 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import EmptyContent from 'components/empty-content';
 import { activateModule } from 'state/jetpack/modules/actions';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
-import { PerformanceTrackerStop } from 'lib/performance-tracking';
 
 function updateQueryString( query = {} ) {
 	return {
@@ -261,7 +260,6 @@ class StatsSite extends Component {
 					</div>
 				</div>
 				<JetpackColophon />
-				<PerformanceTrackerStop />
 			</>
 		);
 	}

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -39,6 +39,7 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import EmptyContent from 'components/empty-content';
 import { activateModule } from 'state/jetpack/modules/actions';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+import { PerformanceTrackerStop } from 'lib/performance-tracking';
 
 function updateQueryString( query = {} ) {
 	return {
@@ -260,6 +261,7 @@ class StatsSite extends Component {
 					</div>
 				</div>
 				<JetpackColophon />
+				<PerformanceTrackerStop />
 			</>
 		);
 	}

--- a/client/my-sites/stats/stats-chart-tabs/index.jsx
+++ b/client/my-sites/stats/stats-chart-tabs/index.jsx
@@ -25,6 +25,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { buildChartData, getQueryDate } from './utility';
 import StatTabs from '../stats-tabs';
 import memoizeLast from 'lib/memoize-last';
+import { PerformanceTrackerStop } from 'lib/performance-tracking';
 
 /**
  * Style dependencies
@@ -129,6 +130,7 @@ class StatModuleChartTabs extends Component {
 					activeIndex={ this.props.queryDate }
 					activeKey="period"
 				/>
+				<PerformanceTrackerStop />
 			</Card>
 		);
 	}

--- a/client/my-sites/stats/test/index.js
+++ b/client/my-sites/stats/test/index.js
@@ -1,0 +1,230 @@
+jest.mock( 'page', () => jest.fn() );
+jest.mock( '../controller', () => jest.fn() );
+jest.mock( 'my-sites/controller', () => ( {
+	navigation: jest.fn(),
+	siteSelection: jest.fn(),
+	sites: jest.fn(),
+} ) );
+
+jest.mock( 'lib/route', () => ( {
+	getStatsDefaultSitePage: jest.fn(),
+} ) );
+jest.mock( 'my-sites/activity/controller', () => ( {
+	redirect: jest.fn(),
+} ) );
+jest.mock( 'config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+jest.mock( 'controller', () => ( {
+	makeLayout: jest.fn(),
+	render: jest.fn(),
+} ) );
+jest.mock( 'lib/performance-tracking', () => ( {
+	trackNavigationStart: jest.fn(),
+} ) );
+
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import { navigation, siteSelection, sites } from 'my-sites/controller';
+import statsController from '../controller';
+import { redirect as redirectToAcivity } from 'my-sites/activity/controller';
+import config from 'config';
+import { makeLayout, render as clientRender } from 'controller';
+import { trackNavigationStart } from 'lib/performance-tracking';
+
+import router from '../index';
+
+// Return the same tag so we can make assertions in the tets
+trackNavigationStart.mockImplementation( ( tag ) => tag );
+config.isEnabled.mockImplementation( ( flag ) => flag === 'manage/stats' );
+
+const validModules = [
+	'posts',
+	'referrers',
+	'clicks',
+	'countryviews',
+	'authors',
+	'videoplays',
+	'videodetails',
+	'filedownloads',
+	'searchterms',
+	'annualstats',
+];
+const validPeriods = [ 'day', 'week', 'month', 'year' ];
+
+const routes = {
+	'/stats/day': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.overview,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/week': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.overview,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/month': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.overview,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/year': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.overview,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/insights': [ 'stats', siteSelection, navigation, sites, makeLayout, clientRender ],
+	'/stats/insights/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.insights,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/day/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.site,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/week/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.site,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/month/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.site,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/year/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.site,
+		makeLayout,
+		clientRender,
+	],
+	[ `/stats/:module(${ validModules.join( '|' ) })/:site` ]: [
+		statsController.redirectToDefaultModulePage,
+	],
+	[ `/stats/day/:module(${ validModules.join( '|' ) })/:site` ]: [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.summary,
+		makeLayout,
+		clientRender,
+	],
+	[ `/stats/week/:module(${ validModules.join( '|' ) })/:site` ]: [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.summary,
+		makeLayout,
+		clientRender,
+	],
+	[ `/stats/month/:module(${ validModules.join( '|' ) })/:site` ]: [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.summary,
+		makeLayout,
+		clientRender,
+	],
+	[ `/stats/year/:module(${ validModules.join( '|' ) })/:site` ]: [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.summary,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/post/:post_id/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.post,
+		makeLayout,
+		clientRender,
+	],
+
+	'/stats/page/:post_id/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.post,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/follows/comment/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.follows,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/follows/comment/:page_num/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.follows,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/activity': [ 'stats', siteSelection, sites, redirectToAcivity, makeLayout, clientRender ],
+	'/stats/activity/:site': [
+		'stats',
+		siteSelection,
+		navigation,
+		redirectToAcivity,
+		makeLayout,
+		clientRender,
+	],
+	[ `/stats/ads/:period(${ validPeriods.join( '|' ) })/:site` ]: [
+		'stats',
+		siteSelection,
+		navigation,
+		statsController.wordAds,
+		makeLayout,
+		clientRender,
+	],
+	'/stats/wordads/(.*)': [ statsController.redirectToDefaultWordAdsPeriod ],
+	'/stats/ads/(.*)': [ statsController.redirectToDefaultWordAdsPeriod ],
+	'/stats/(.*)': [ statsController.redirectToDefaultSitePage ],
+};
+
+describe( 'Sets all routes', () => {
+	Object.entries( routes ).forEach( ( [ route, expectedMiddleware ] ) => {
+		it( `Route ${ route } uses the correct middleware`, () => {
+			router();
+			const [ , ...actualMiddleware ] = page.mock.calls.find( ( [ path ] ) => path === route );
+			expect( actualMiddleware ).toEqual( expectedMiddleware );
+		} );
+	} );
+} );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -139,5 +139,6 @@
 	},
 	"site_filter": [],
 	"theme": "default",
-	"site_name": "WordPress.com"
+	"site_name": "WordPress.com",
+	"speedcurve_id": "511719913"
 }

--- a/config/development.json
+++ b/config/development.json
@@ -154,6 +154,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"rum-tracking/speedcurve": true,
 		"safari-idb-mitigation": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/production.json
+++ b/config/production.json
@@ -113,6 +113,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"rum-tracking/speedcurve": false,
 		"safari-idb-mitigation": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -121,6 +121,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"rum-tracking/speedcurve": true,
 		"safari-idb-mitigation": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -94,6 +94,7 @@
 		"reader/user-mention-suggestions": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"rum-tracking/speedcurve": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -131,6 +131,7 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
+		"rum-tracking/speedcurve": true,
 		"safari-idb-mitigation": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds integration with Speedcurve's [LUX](https://speedcurve.com/features/lux/) for Real User Monitoring.

### Plan

This is a proof of concept. Only the pages Home, Stats and Plans are tracked for now.

The plan is to enable this **only in staging** and have it online for a few days to collect data from a12s. Then, check the dashboards and decide if it provides the value we want. If yes, then decide which pages we want to track, which metadata to collect and a plan to deploy it to production.

### Testing instructions

**Ask @scinos for access to Speedcurve dashboard if you want to see how this data is used**

For all these tests you'll need to checkout the branch, run `yarn start`, open calypso locally and open the dev tools. Alternatively, you can use http://hash-ac2b75542434c4b5cca8ca4d00d12293d4d4e961.calypso.live/

* Basic stats: Navigate to 'My Home'. You should see some logs in the console about Lux.

```
LUX: Enter LUX.init().
lux.js?id=511719913:1 LUX: Enter LUX.mark(), name = LUX_start
lux.js?id=511719913:1 LUX: Enter LUX.addData(), name = init, value = false
lux.js?id=511719913:1 LUX: Enter LUX.addData(), name = single, value = true
lux.js?id=511719913:1 LUX: Enter LUX.addData(), name = at, value = false
lux.js?id=511719913:1 LUX: Enter LUX.addData(), name = jetpack, value = false
lux.js?id=511719913:1 LUX: Enter LUX.addData(), name = store, value = false
lux.js?id=511719913:1 LUX: Enter LUX.send().
lux.js?id=511719913:1 LUX: Enter LUX.mark(), name = LUX_end
```

* Multi page: Try these actions, for each one you should Lux traffic in the console:
   * Go to 'My home'
   * Go to 'Stats'
   * Change to 'Days', 'Weeks', 'Months', or 'Years'
   * Go to 'Plans'
   * Switch to 'All my sites'
   * Switch to another site

* Page load vs SPAs:
   * Go to the URL `http://calypso.localhost:3000/plans/<id>` (as in, type that URL). You should see `LUX: Enter LUX.addData(), name = init, value = true` in the console
   * Refresh the page. You should see `LUX: Enter LUX.addData(), name = init, value = true` in the console
   * Click on 'Stats' and back to 'My Home'. You should see `value = false` now.
   * Verify the above is true for Stats and Plans too.

* User data: Try different sites, and verify that all those lines `LUX: Enter LUX.addData()` should the correct data:
    * `name = single`: true for single user sites.
    * `name = at`: true for atomic sites
    * `name = jetpack`: true for sites with Jetpack installed
    * `name = store`: true for sites with WooCommerce installed.

* Probe URL: For each of the interactions above, you should will see a network request to `lux.speedcurve.com`. Verify it contains the query params `id=511719913` and `l=<value>` (`value` being `plans`, `home` or `stats`)

* Feature flag protection: Add `?flags=-rum-tracking/speedcurve` to the URL, verify there is no LUX traffic at all.