### PR TITLE
My Home: New site setup list for experimental layout

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
@@ -1,0 +1,180 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
+import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
+import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
+import { localizeUrl } from 'lib/i18n-utils';
+import { openSupportArticleDialog } from 'state/inline-support-article/actions';
+
+export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userEmail } = {} ) => {
+	let taskData = {};
+	switch ( task.id ) {
+		case 'domain_verified':
+			taskData = {
+				todo: {
+					timing: 2,
+					title:
+						task.unverifiedDomains.length === 1
+							? translate( 'Verify the email address for %(domainName)s', {
+									args: { domainName: task.unverifiedDomains[ 0 ] },
+							  } )
+							: translate( 'Verify the email address for your domains' ),
+					description: translate(
+						'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
+					),
+					actionUrl:
+						task.unverifiedDomains.length === 1
+							? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
+							: domainManagementList( siteSlug ),
+					actionText: translate( 'Verify' ),
+				},
+				completed: {
+					title:
+						task.unverifiedDomains.length === 1
+							? translate( 'Verify the email address for %(domainName)s', {
+									args: { domainName: task.unverifiedDomains[ 0 ] },
+							  } )
+							: translate( 'Verify the email address for your domains' ),
+					description: translate(
+						'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
+					),
+					actionUrl:
+						task.unverifiedDomains.length === 1
+							? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
+							: domainManagementList( siteSlug ),
+					actionText: translate( 'Verify' ),
+				},
+			};
+			break;
+		case 'email_verified':
+			taskData = {
+				todo: {
+					timing: 1,
+					title: translate( 'Confirm your email address' ),
+					description: translate(
+						'Please click the link in the email we sent to %(email)s.' +
+							'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
+						{
+							args: {
+								email: userEmail,
+							},
+							components: {
+								br: <br />,
+								changeButton: <a href="/me/account" />,
+							},
+						}
+					),
+					//TODO: looks like there's some more complicated text states here
+					actionText: translate( 'Verify email' ),
+				},
+				completed: {},
+			};
+			break;
+		case 'blogname_set':
+			taskData = {
+				todo: {
+					timing: 1,
+					title: translate( 'Name your site' ),
+					description: translate(
+						'Give your new site a title to let people know what your site is about. A good title introduces your brand and the primary topics of your site.'
+					),
+					actionText: translate( 'Name your site' ),
+					actionUrl: `/settings/general/${ siteSlug }`,
+					tour: 'checklistSiteTitle',
+				},
+				completed: {},
+			};
+			break;
+		case 'mobile_app_installed':
+			taskData = {
+				todo: {
+					timing: 3,
+					title: translate( 'Get the WordPress app' ),
+					description: translate(
+						'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
+					),
+					actionText: translate( 'Download mobile app' ),
+					actionUrl: '/me/get-apps',
+					...( ! task.isCompleted && {
+						actionDispatch: requestSiteChecklistTaskUpdate,
+						actionDispatchArgs: [ siteId, task.id ],
+					} ),
+					isSkippable: true,
+				},
+				completed: {
+					title: translate( 'You downloaded the WordPress app' ),
+					description: translate( 'You can re-download the app at any time.' ),
+					actionText: translate( 'Re-download mobile app' ),
+					actionUrl: '/me/get-apps',
+					...( ! task.isCompleted && {
+						actionDispatch: requestSiteChecklistTaskUpdate,
+						actionDispatchArgs: [ siteId, task.id ],
+					} ),
+				},
+			};
+			break;
+		case 'site_launched':
+			taskData = {
+				todo: {
+					timing: 1,
+					title: translate( 'Launch your site' ),
+					description: translate(
+						"Your site is private and only visible to you. When you're ready, launch your site to make it public."
+					),
+					actionText: translate( 'Launch site' ),
+					actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
+					actionDispatchArgs: [ siteId ],
+				},
+				completed: {},
+			};
+			break;
+		case 'front_page_updated':
+			taskData = {
+				todo: {
+					timing: 20,
+					title: translate( 'Update your Home page' ),
+					description: translate(
+						"We've created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
+					),
+					actionText: translate( 'Edit homepage' ),
+				},
+				completed: {},
+			};
+			break;
+		case 'site_menu_updated':
+			taskData = {
+				todo: {
+					timing: 10,
+					title: translate( 'Create a site menu' ),
+					description: translate(
+						"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
+					),
+					actionText: translate( 'View tutorial' ),
+					isSkippable: true,
+					actionDispatch: openSupportArticleDialog,
+					actionDispatchArgs: [
+						{
+							postId: 59580,
+							postUrl: localizeUrl( 'https://wordpress.com/support/menus/' ),
+							actionLabel: translate( 'Go to the Customizer' ),
+							actionUrl: menusUrl,
+						},
+					],
+				},
+				completed: {},
+			};
+			break;
+	}
+	return {
+		...task,
+		actionUrl: taskUrls[ task.id ],
+		...taskData,
+	};
+};

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
@@ -41,7 +41,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 				timing: 1,
 				title: translate( 'Confirm your email address' ),
 				description: translate(
-					'Please click the link in the email we sent to %(email)s.' +
+					'Please click the link in the email we sent to %(email)s. ' +
 						'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
 					{
 						args: {
@@ -53,7 +53,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 						},
 					}
 				),
-				actionText: translate( 'Verify email' ),
+				actionText: translate( 'Resend email' ),
 				actionDispatch: verifyEmail,
 				actionDispatchArgs: [],
 			};

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
@@ -55,6 +55,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 				),
 				actionText: translate( 'Verify email' ),
 				actionDispatch: verifyEmail,
+				actionDispatchArgs: [],
 			};
 			break;
 		case 'blogname_set':

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
@@ -19,7 +19,6 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 	switch ( task.id ) {
 		case 'domain_verified':
 			taskData = {
-				id: 'domain_verified',
 				timing: 2,
 				title:
 					task.unverifiedDomains.length === 1
@@ -39,7 +38,6 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'email_verified':
 			taskData = {
-				id: 'email_verified',
 				timing: 1,
 				title: translate( 'Confirm your email address' ),
 				description: translate(
@@ -62,7 +60,6 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'blogname_set':
 			taskData = {
-				id: 'blogname_set',
 				timing: 1,
 				title: translate( 'Name your site' ),
 				description: translate(
@@ -75,7 +72,6 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'mobile_app_installed':
 			taskData = {
-				id: 'mobile_app_installed',
 				timing: 3,
 				title: translate( 'Get the WordPress app' ),
 				description: translate(
@@ -92,7 +88,6 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'site_launched':
 			taskData = {
-				id: 'site_launched',
 				timing: 1,
 				title: translate( 'Launch your site' ),
 				description: translate(
@@ -116,7 +111,6 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'site_menu_updated':
 			taskData = {
-				id: 'site_menu_updated',
 				timing: 10,
 				title: translate( 'Create a site menu' ),
 				description: translate(

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
@@ -19,6 +19,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 	switch ( task.id ) {
 		case 'domain_verified':
 			taskData = {
+				id: 'domain_verified',
 				timing: 2,
 				title:
 					task.unverifiedDomains.length === 1
@@ -38,6 +39,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'email_verified':
 			taskData = {
+				id: 'email_verified',
 				timing: 1,
 				title: translate( 'Confirm your email address' ),
 				description: translate(
@@ -60,6 +62,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'blogname_set':
 			taskData = {
+				id: 'blogname_set',
 				timing: 1,
 				title: translate( 'Name your site' ),
 				description: translate(
@@ -72,6 +75,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'mobile_app_installed':
 			taskData = {
+				id: 'mobile_app_installed',
 				timing: 3,
 				title: translate( 'Get the WordPress app' ),
 				description: translate(
@@ -88,6 +92,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'site_launched':
 			taskData = {
+				id: 'site_launched',
 				timing: 1,
 				title: translate( 'Launch your site' ),
 				description: translate(
@@ -100,6 +105,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'front_page_updated':
 			taskData = {
+				id: 'front_page_updated',
 				timing: 20,
 				title: translate( 'Update your Home page' ),
 				description: translate(
@@ -110,6 +116,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 			break;
 		case 'site_menu_updated':
 			taskData = {
+				id: 'site_menu_updated',
 				timing: 10,
 				title: translate( 'Create a site menu' ),
 				description: translate(

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
@@ -36,12 +36,20 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					actionText: translate( 'Verify' ),
 				},
 				completed: {
-					title: translate( 'You verified your email for your doamins.' ),
+					title:
+						task.unverifiedDomains.length === 1
+							? translate( 'Verify the email address for %(domainName)s', {
+									args: { domainName: task.unverifiedDomains[ 0 ] },
+							  } )
+							: translate( 'Verify the email address for your domains' ),
 					description: translate(
-						'You can always update your domain information on the Domains page.'
+						'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
 					),
-					actionUrl: `/domains/manage/${ siteSlug }`,
-					actionText: translate( 'Manage domains' ),
+					actionUrl:
+						task.unverifiedDomains.length === 1
+							? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
+							: domainManagementList( siteSlug ),
+					actionText: translate( 'Verify' ),
 				},
 			};
 			break;
@@ -66,14 +74,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					//TODO: looks like there's some more complicated text states here
 					actionText: translate( 'Verify email' ),
 				},
-				completed: {
-					title: translate( 'You validated your email address' ),
-					description: translate(
-						'Need to change something? You can update your email at any time.'
-					),
-					actionUrl: '/me/account',
-					actionText: translate( 'Manage email' ),
-				},
+				completed: {},
 			};
 			break;
 		case 'blogname_set':
@@ -88,12 +89,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					actionUrl: `/settings/general/${ siteSlug }`,
 					tour: 'checklistSiteTitle',
 				},
-				completed: {
-					title: translate( 'You updated your site title' ),
-					description: translate( 'You can edit your site title whenever you like.' ),
-					actionText: translate( 'Edit' ),
-					actionUrl: `/settings/general/${ siteSlug }`,
-				},
+				completed: {},
 			};
 			break;
 		case 'mobile_app_installed':
@@ -117,6 +113,10 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					description: translate( 'You can re-download the app at any time.' ),
 					actionText: translate( 'Re-download mobile app' ),
 					actionUrl: '/me/get-apps',
+					...( ! task.isCompleted && {
+						actionDispatch: requestSiteChecklistTaskUpdate,
+						actionDispatchArgs: [ siteId, task.id ],
+					} ),
 				},
 			};
 			break;
@@ -132,12 +132,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
 					actionDispatchArgs: [ siteId ],
 				},
-				completed: {
-					title: translate( 'You launched your site' ),
-					description: translate( 'Your site is is now public! Good work.' ),
-					actionText: translate( 'View site' ),
-					actionUrl: '/',
-				},
+				completed: {},
 			};
 			break;
 		case 'front_page_updated':
@@ -150,11 +145,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					),
 					actionText: translate( 'Edit homepage' ),
 				},
-				completed: {
-					title: translate( 'You updated your homepage' ),
-					description: translate( 'Edit your page anytime you want to change the text or images.' ),
-					actionText: translate( 'Edit homepage' ),
-				},
+				completed: {},
 			};
 			break;
 		case 'site_menu_updated':
@@ -177,20 +168,7 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 						},
 					],
 				},
-				completed: {
-					title: translate( 'You created a site menu' ),
-					description: translate( 'You can edit your site menu whenever you like.' ),
-					actionText: translate( 'View tutorial' ),
-					actionDispatch: openSupportArticleDialog,
-					actionDispatchArgs: [
-						{
-							postId: 59580,
-							postUrl: localizeUrl( 'https://wordpress.com/support/menus/' ),
-							actionLabel: translate( 'Go to the Customizer' ),
-							actionUrl: menusUrl,
-						},
-					],
-				},
+				completed: {},
 			};
 			break;
 	}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
@@ -18,157 +18,112 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 	switch ( task.id ) {
 		case 'domain_verified':
 			taskData = {
-				todo: {
-					timing: 2,
-					title:
-						task.unverifiedDomains.length === 1
-							? translate( 'Verify the email address for %(domainName)s', {
-									args: { domainName: task.unverifiedDomains[ 0 ] },
-							  } )
-							: translate( 'Verify the email address for your domains' ),
-					description: translate(
-						'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
-					),
-					actionUrl:
-						task.unverifiedDomains.length === 1
-							? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
-							: domainManagementList( siteSlug ),
-					actionText: translate( 'Verify' ),
-				},
-				completed: {
-					title:
-						task.unverifiedDomains.length === 1
-							? translate( 'Verify the email address for %(domainName)s', {
-									args: { domainName: task.unverifiedDomains[ 0 ] },
-							  } )
-							: translate( 'Verify the email address for your domains' ),
-					description: translate(
-						'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
-					),
-					actionUrl:
-						task.unverifiedDomains.length === 1
-							? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
-							: domainManagementList( siteSlug ),
-					actionText: translate( 'Verify' ),
-				},
+				timing: 2,
+				title:
+					task.unverifiedDomains.length === 1
+						? translate( 'Verify the email address for %(domainName)s', {
+								args: { domainName: task.unverifiedDomains[ 0 ] },
+						  } )
+						: translate( 'Verify the email address for your domains' ),
+				description: translate(
+					'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
+				),
+				actionUrl:
+					task.unverifiedDomains.length === 1
+						? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
+						: domainManagementList( siteSlug ),
+				actionText: translate( 'Verify' ),
 			};
 			break;
 		case 'email_verified':
 			taskData = {
-				todo: {
-					timing: 1,
-					title: translate( 'Confirm your email address' ),
-					description: translate(
-						'Please click the link in the email we sent to %(email)s.' +
-							'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
-						{
-							args: {
-								email: userEmail,
-							},
-							components: {
-								br: <br />,
-								changeButton: <a href="/me/account" />,
-							},
-						}
-					),
-					//TODO: looks like there's some more complicated text states here
-					actionText: translate( 'Verify email' ),
-				},
-				completed: {},
+				timing: 1,
+				title: translate( 'Confirm your email address' ),
+				description: translate(
+					'Please click the link in the email we sent to %(email)s.' +
+						'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
+					{
+						args: {
+							email: userEmail,
+						},
+						components: {
+							br: <br />,
+							changeButton: <a href="/me/account" />,
+						},
+					}
+				),
+				//TODO: looks like there's some more complicated text states here
+				actionText: translate( 'Verify email' ),
 			};
 			break;
 		case 'blogname_set':
 			taskData = {
-				todo: {
-					timing: 1,
-					title: translate( 'Name your site' ),
-					description: translate(
-						'Give your new site a title to let people know what your site is about. A good title introduces your brand and the primary topics of your site.'
-					),
-					actionText: translate( 'Name your site' ),
-					actionUrl: `/settings/general/${ siteSlug }`,
-					tour: 'checklistSiteTitle',
-				},
-				completed: {},
+				timing: 1,
+				title: translate( 'Name your site' ),
+				description: translate(
+					'Give your new site a title to let people know what your site is about. A good title introduces your brand and the primary topics of your site.'
+				),
+				actionText: translate( 'Name your site' ),
+				actionUrl: `/settings/general/${ siteSlug }`,
+				tour: 'checklistSiteTitle',
 			};
 			break;
 		case 'mobile_app_installed':
 			taskData = {
-				todo: {
-					timing: 3,
-					title: translate( 'Get the WordPress app' ),
-					description: translate(
-						'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
-					),
-					actionText: translate( 'Download mobile app' ),
-					actionUrl: '/me/get-apps',
-					...( ! task.isCompleted && {
-						actionDispatch: requestSiteChecklistTaskUpdate,
-						actionDispatchArgs: [ siteId, task.id ],
-					} ),
-					isSkippable: true,
-				},
-				completed: {
-					title: translate( 'You downloaded the WordPress app' ),
-					description: translate( 'You can re-download the app at any time.' ),
-					actionText: translate( 'Re-download mobile app' ),
-					actionUrl: '/me/get-apps',
-					...( ! task.isCompleted && {
-						actionDispatch: requestSiteChecklistTaskUpdate,
-						actionDispatchArgs: [ siteId, task.id ],
-					} ),
-				},
+				timing: 3,
+				title: translate( 'Get the WordPress app' ),
+				description: translate(
+					'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
+				),
+				actionText: translate( 'Download mobile app' ),
+				actionUrl: '/me/get-apps',
+				...( ! task.isCompleted && {
+					actionDispatch: requestSiteChecklistTaskUpdate,
+					actionDispatchArgs: [ siteId, task.id ],
+				} ),
+				isSkippable: true,
 			};
 			break;
 		case 'site_launched':
 			taskData = {
-				todo: {
-					timing: 1,
-					title: translate( 'Launch your site' ),
-					description: translate(
-						"Your site is private and only visible to you. When you're ready, launch your site to make it public."
-					),
-					actionText: translate( 'Launch site' ),
-					actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
-					actionDispatchArgs: [ siteId ],
-				},
-				completed: {},
+				timing: 1,
+				title: translate( 'Launch your site' ),
+				description: translate(
+					"Your site is private and only visible to you. When you're ready, launch your site to make it public."
+				),
+				actionText: translate( 'Launch site' ),
+				actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
+				actionDispatchArgs: [ siteId ],
 			};
 			break;
 		case 'front_page_updated':
 			taskData = {
-				todo: {
-					timing: 20,
-					title: translate( 'Update your Home page' ),
-					description: translate(
-						"We've created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
-					),
-					actionText: translate( 'Edit homepage' ),
-				},
-				completed: {},
+				timing: 20,
+				title: translate( 'Update your Home page' ),
+				description: translate(
+					"We've created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
+				),
+				actionText: translate( 'Edit homepage' ),
 			};
 			break;
 		case 'site_menu_updated':
 			taskData = {
-				todo: {
-					timing: 10,
-					title: translate( 'Create a site menu' ),
-					description: translate(
-						"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
-					),
-					actionText: translate( 'View tutorial' ),
-					isSkippable: true,
-					actionDispatch: openSupportArticleDialog,
-					actionDispatchArgs: [
-						{
-							postId: 59580,
-							postUrl: localizeUrl( 'https://wordpress.com/support/menus/' ),
-							actionLabel: translate( 'Go to the Customizer' ),
-							actionUrl: menusUrl,
-						},
-					],
-				},
-				completed: {},
+				timing: 10,
+				title: translate( 'Create a site menu' ),
+				description: translate(
+					"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
+				),
+				actionText: translate( 'View tutorial' ),
+				isSkippable: true,
+				actionDispatch: openSupportArticleDialog,
+				actionDispatchArgs: [
+					{
+						postId: 59580,
+						postUrl: localizeUrl( 'https://wordpress.com/support/menus/' ),
+						actionLabel: translate( 'Go to the Customizer' ),
+						actionUrl: menusUrl,
+					},
+				],
 			};
 			break;
 	}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
@@ -36,20 +36,12 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					actionText: translate( 'Verify' ),
 				},
 				completed: {
-					title:
-						task.unverifiedDomains.length === 1
-							? translate( 'Verify the email address for %(domainName)s', {
-									args: { domainName: task.unverifiedDomains[ 0 ] },
-							  } )
-							: translate( 'Verify the email address for your domains' ),
+					title: translate( 'You verified your email for your doamins.' ),
 					description: translate(
-						'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
+						'You can always update your domain information on the Domains page.'
 					),
-					actionUrl:
-						task.unverifiedDomains.length === 1
-							? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
-							: domainManagementList( siteSlug ),
-					actionText: translate( 'Verify' ),
+					actionUrl: `/domains/manage/${ siteSlug }`,
+					actionText: translate( 'Manage domains' ),
 				},
 			};
 			break;
@@ -74,7 +66,14 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					//TODO: looks like there's some more complicated text states here
 					actionText: translate( 'Verify email' ),
 				},
-				completed: {},
+				completed: {
+					title: translate( 'You validated your email address' ),
+					description: translate(
+						'Need to change something? You can update your email at any time.'
+					),
+					actionUrl: '/me/account',
+					actionText: translate( 'Manage email' ),
+				},
 			};
 			break;
 		case 'blogname_set':
@@ -89,7 +88,12 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					actionUrl: `/settings/general/${ siteSlug }`,
 					tour: 'checklistSiteTitle',
 				},
-				completed: {},
+				completed: {
+					title: translate( 'You updated your site title' ),
+					description: translate( 'You can edit your site title whenever you like.' ),
+					actionText: translate( 'Edit' ),
+					actionUrl: `/settings/general/${ siteSlug }`,
+				},
 			};
 			break;
 		case 'mobile_app_installed':
@@ -113,10 +117,6 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					description: translate( 'You can re-download the app at any time.' ),
 					actionText: translate( 'Re-download mobile app' ),
 					actionUrl: '/me/get-apps',
-					...( ! task.isCompleted && {
-						actionDispatch: requestSiteChecklistTaskUpdate,
-						actionDispatchArgs: [ siteId, task.id ],
-					} ),
 				},
 			};
 			break;
@@ -132,7 +132,12 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
 					actionDispatchArgs: [ siteId ],
 				},
-				completed: {},
+				completed: {
+					title: translate( 'You launched your site' ),
+					description: translate( 'Your site is is now public! Good work.' ),
+					actionText: translate( 'View site' ),
+					actionUrl: '/',
+				},
 			};
 			break;
 		case 'front_page_updated':
@@ -145,7 +150,11 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 					),
 					actionText: translate( 'Edit homepage' ),
 				},
-				completed: {},
+				completed: {
+					title: translate( 'You updated your homepage' ),
+					description: translate( 'Edit your page anytime you want to change the text or images.' ),
+					actionText: translate( 'Edit homepage' ),
+				},
 			};
 			break;
 		case 'site_menu_updated':
@@ -168,7 +177,20 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 						},
 					],
 				},
-				completed: {},
+				completed: {
+					title: translate( 'You created a site menu' ),
+					description: translate( 'You can edit your site menu whenever you like.' ),
+					actionText: translate( 'View tutorial' ),
+					actionDispatch: openSupportArticleDialog,
+					actionDispatchArgs: [
+						{
+							postId: 59580,
+							postUrl: localizeUrl( 'https://wordpress.com/support/menus/' ),
+							actionLabel: translate( 'Go to the Customizer' ),
+							actionUrl: menusUrl,
+						},
+					],
+				},
 			};
 			break;
 	}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task-data.js
@@ -12,6 +12,7 @@ import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { localizeUrl } from 'lib/i18n-utils';
 import { openSupportArticleDialog } from 'state/inline-support-article/actions';
+import { verifyEmail } from 'state/current-user/email-verification/actions';
 
 export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userEmail } = {} ) => {
 	let taskData = {};
@@ -52,8 +53,8 @@ export const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userE
 						},
 					}
 				),
-				//TODO: looks like there's some more complicated text states here
 				actionText: translate( 'Verify email' ),
+				actionDispatch: verifyEmail,
 			};
 			break;
 		case 'blogname_set':

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -70,7 +70,7 @@ const isTaskDisabled = (
 ) => {
 	switch ( task.id ) {
 		case 'email_verified':
-			return 'requesting' === emailVerificationStatus;
+			return 'requesting' === emailVerificationStatus || ! isEmailUnverified;
 		case 'site_launched':
 			return isDomainUnverified || isEmailUnverified;
 		default:
@@ -78,7 +78,7 @@ const isTaskDisabled = (
 	}
 };
 
-export const getTaskData = (
+export const getTask = (
 	task,
 	{
 		emailVerificationStatus,
@@ -89,7 +89,7 @@ export const getTaskData = (
 		siteSlug,
 		taskUrls,
 		userEmail,
-	}
+	} = {}
 ) => {
 	let taskData = {};
 	switch ( task.id ) {
@@ -182,7 +182,7 @@ export const getTaskData = (
 					"We've created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
 				),
 				actionText: translate( 'Edit homepage' ),
-				actionUrl: taskUrls.front_page_updated,
+				actionUrl: taskUrls?.front_page_updated,
 			};
 			break;
 		case 'site_menu_updated':

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, useState } from 'react';
+import { translate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { Card } from '@automattic/components';
+
+/**
+ * Internal dependencies
+ */
+import ActionPanel from 'components/action-panel';
+import ActionPanelTitle from 'components/action-panel/title';
+import ActionPanelBody from 'components/action-panel/body';
+import CardHeading from 'components/card-heading';
+import { getTaskList } from 'lib/checklist';
+import getSiteChecklist from 'state/selectors/get-site-checklist';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { getSiteOption } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import NavItem from './nav-item';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const TASKS = {
+	domain_verified: {
+		title: translate( 'Verify the email address for your domains' ),
+	},
+	email_verified: {
+		title: translate( 'Confirm your email address' ),
+	},
+	blogname_set: {
+		title: translate( 'Name your site' ),
+	},
+	mobile_app_installed: {
+		title: translate( 'Get the WordPress app' ),
+	},
+	site_launched: {
+		title: translate( 'Launch your site' ),
+	},
+	front_page_updated: {
+		title: translate( 'Update your Home page' ),
+	},
+	site_menu_updated: {
+		title: translate( 'Create a site menu' ),
+	},
+};
+
+const SiteSetupList = ( { tasks } ) => {
+	const [ currentTask, setCurrentTask ] = useState( null );
+
+	useEffect( () => {
+		if ( tasks.length ) {
+			setCurrentTask( tasks[ 0 ].id );
+		}
+	}, [ tasks ] );
+
+	if ( ! tasks.length || ! currentTask ) {
+		return null;
+	}
+
+	return (
+		<Card className="site-setup-list">
+			<div className="site-setup-list__nav">
+				<CardHeading>{ translate( 'Site setup' ) }</CardHeading>
+				{ tasks.map( ( task ) => (
+					<NavItem
+						key={ task.id }
+						text={ TASKS[ task.id ].title }
+						isCompleted={ task.isCompleted }
+						isCurrent={ task.id === currentTask }
+						onClick={ () => setCurrentTask( task.id ) }
+					/>
+				) ) }
+			</div>
+			<ActionPanel className="site-setup-list__task task">
+				<ActionPanelBody>
+					<ActionPanelTitle>{ TASKS[ currentTask ].title }</ActionPanelTitle>
+				</ActionPanelBody>
+			</ActionPanel>
+		</Card>
+	);
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	const designType = getSiteOption( state, siteId, 'design_type' );
+	const siteChecklist = getSiteChecklist( state, siteId );
+	const siteSegment = siteChecklist?.segment;
+	const siteVerticals = siteChecklist?.vertical;
+	const taskStatuses = siteChecklist?.tasks;
+	const siteIsUnlaunched = isUnlaunchedSite( state, siteId );
+	const taskList = getTaskList( {
+		taskStatuses,
+		designType,
+		siteIsUnlaunched,
+		siteSegment,
+		siteVerticals,
+	} );
+
+	return {
+		tasks: taskList.getAll(),
+	};
+} )( SiteSetupList );

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -22,6 +22,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import getChecklistTaskUrls from 'state/selectors/get-checklist-task-urls';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
+import { getCurrentUser } from 'state/current-user/selectors';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import getMenusUrl from 'state/selectors/get-menus-url';
 import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
@@ -71,7 +72,7 @@ const skipTask = ( dispatch, task, siteId ) => {
 	);
 };
 
-const SiteSetupList = ( { menusUrl, siteId, siteSlug, tasks, taskUrls } ) => {
+const SiteSetupList = ( { menusUrl, siteId, siteSlug, tasks, taskUrls, userEmail } ) => {
 	const [ currentTask, setCurrentTask ] = useState( null );
 	const dispatch = useDispatch();
 
@@ -81,6 +82,7 @@ const SiteSetupList = ( { menusUrl, siteId, siteSlug, tasks, taskUrls } ) => {
 			siteId,
 			siteSlug,
 			taskUrls,
+			userEmail,
 		} );
 
 	useEffect( () => {
@@ -169,6 +171,7 @@ const SiteSetupList = ( { menusUrl, siteId, siteSlug, tasks, taskUrls } ) => {
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
+	const user = getCurrentUser( state );
 	const designType = getSiteOption( state, siteId, 'design_type' );
 	const siteChecklist = getSiteChecklist( state, siteId );
 	const siteSegment = siteChecklist?.segment;
@@ -189,5 +192,6 @@ export default connect( ( state ) => {
 		siteSlug: getSiteSlug( state, siteId ),
 		tasks: taskList.getAll(),
 		taskUrls: getChecklistTaskUrls( state, siteId ),
+		userEmail: user?.email,
 	};
 } )( SiteSetupList );

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -27,42 +27,82 @@ import NavItem from './nav-item';
  */
 import './style.scss';
 
-const getTaskCopy = ( task ) => {
+const getTaskCopy = ( task, taskOptions ) => {
 	switch ( task ) {
 		case 'domain_verified':
 			return {
+				duration: translate( '%d minute', '%d minutes', { count: 2, args: [ 2 ] } ),
 				title: translate( 'Verify the email address for your domains' ),
+				description: translate(
+					'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
+				),
 			};
 		case 'email_verified':
 			return {
+				duration: translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ),
 				title: translate( 'Confirm your email address' ),
+				description: translate(
+					'Please click the link in the email we sent to %(email)s.' +
+						'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
+					{
+						args: {
+							email: taskOptions?.userEmail,
+						},
+						components: {
+							br: <br />,
+							changeButton: <a href="/me/account" />,
+						},
+					}
+				),
+				//TODO: looks like there's some more complicated text states here
+				actionText: translate( 'Verify email' ),
 			};
 		case 'blogname_set':
 			return {
-				time: 1,
+				duration: translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ),
 				title: translate( 'Name your site' ),
 				description: translate(
 					'Give your new site a title to let people know what your site is about. ' +
 						'A good title introduces your brand and the primary topics of your site.'
 				),
-				actionText: translate( 'Start' ),
+				actionText: translate( 'Name your site' ),
 				actionUrl: null,
 			};
 		case 'mobile_app_installed':
 			return {
+				duration: translate( '%d minute', '%d minutes', { count: 3, args: [ 3 ] } ),
 				title: translate( 'Get the WordPress app' ),
+				description: translate(
+					'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
+				),
+				actionText: translate( 'Download mobile app' ),
 			};
 		case 'site_launched':
 			return {
+				duration: translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ),
 				title: translate( 'Launch your site' ),
+				description: translate(
+					"Your site is private and only visible to you. When you're ready, launch your site to make it public."
+				),
+				actionText: translate( 'Launch site' ),
 			};
 		case 'front_page_updated':
 			return {
+				duration: translate( '%d minute', '%d minutes', { count: 20, args: [ 20 ] } ),
 				title: translate( 'Update your Home page' ),
+				description: translate(
+					"We’ve created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
+				),
+				actionText: translate( 'Create a menu' ),
 			};
 		case 'site_menu_updated':
 			return {
+				duration: translate( '%d minute', '%d minutes', { count: 10, args: [ 10 ] } ),
 				title: translate( 'Create a site menu' ),
+				description: translate(
+					'Building an effective navigation menu makes it easier for someone to find what they’re looking for and improve search engine rankings.'
+				),
+				actionText: translate( 'Create a menu' ),
 			};
 		default:
 			return {};
@@ -81,6 +121,8 @@ const SiteSetupList = ( { tasks } ) => {
 	if ( ! tasks.length || ! currentTask ) {
 		return null;
 	}
+
+	const taskCopy = getTaskCopy( currentTask );
 
 	return (
 		<Card className="site-setup-list">
@@ -101,24 +143,17 @@ const SiteSetupList = ( { tasks } ) => {
 					<div className="site-setup-list__task task__text">
 						<div className="site-setup-list__task task__timing">
 							<Gridicon icon="time" size={ 18 } />
-							<p>
-								{ translate( '%d minute', '%d minutes', {
-									count: getTaskCopy( currentTask ).time,
-									args: [ getTaskCopy( currentTask ).time ],
-								} ) }
-							</p>
+							<p>{ taskCopy.duration }</p>
 						</div>
 						<ActionPanelTitle>{ getTaskCopy( currentTask ).title }</ActionPanelTitle>
-						<p className="site-setup-list__task task__description">
-							{ getTaskCopy( currentTask ).description }
-						</p>
+						<p className="site-setup-list__task task__description">{ taskCopy.description }</p>
 						<ActionPanelCta>
 							<Button
 								className="site-setup-list__task task__action"
 								primary
-								href={ getTaskCopy( currentTask ).actionUrl }
+								href={ taskCopy.actionUrl }
 							>
-								{ getTaskCopy( currentTask ).actionText }
+								{ taskCopy.actionText }
 							</Button>
 						</ActionPanelCta>
 					</div>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -73,6 +73,18 @@ const skipTask = ( dispatch, task, siteId ) => {
 	);
 };
 
+const trackTaskDisplay = ( dispatch, task, siteId ) => {
+	dispatch(
+		recordTracksEvent( 'calypso_checklist_task_display', {
+			checklist_name: 'new_blog',
+			site_id: siteId,
+			step_name: task.id,
+			completed: task.isCompleted,
+			location: 'home',
+		} )
+	);
+};
+
 const SiteSetupList = ( {
 	emailVerificationStatus,
 	isEmailUnverified,
@@ -129,6 +141,7 @@ const SiteSetupList = ( {
 				userEmail,
 			} );
 			setCurrentTask( newCurrentTask );
+			trackTaskDisplay( dispatch, newCurrentTask, siteId );
 		}
 	}, [ currentTaskId ] );
 
@@ -147,7 +160,9 @@ const SiteSetupList = ( {
 						text={ getTask( task ).title }
 						isCompleted={ task.isCompleted }
 						isCurrent={ task.id === currentTask.id }
-						onClick={ () => setCurrentTaskId( task.id ) }
+						onClick={ () => {
+							setCurrentTaskId( task.id );
+						} }
 					/>
 				) ) }
 			</div>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -108,77 +108,52 @@ const SiteSetupList = ( { menusUrl, siteId, siteSlug, tasks, taskUrls } ) => {
 		<Card className="site-setup-list">
 			<div className="site-setup-list__nav">
 				<CardHeading>{ translate( 'Site setup' ) }</CardHeading>
-				{ tasks.map( ( task ) => {
-					const taskData = getTask( task );
-					return (
-						<NavItem
-							key={ task.id }
-							text={ task.isCompleted ? taskData.completed.title : taskData.todo.title }
-							isCompleted={ task.isCompleted }
-							isCurrent={ task.id === currentTask.id }
-							onClick={ () => setCurrentTask( taskData ) }
-						/>
-					);
-				} ) }
+				{ tasks.map( ( task ) => (
+					<NavItem
+						key={ task.id }
+						text={ getTask( task ).title }
+						isCompleted={ task.isCompleted }
+						isCurrent={ task.id === currentTask.id }
+						onClick={ () => setCurrentTask( getTask( task ) ) }
+					/>
+				) ) }
 			</div>
-			{ ! currentTask.isCompleted ? (
-				<ActionPanel className="site-setup-list__task task">
-					<ActionPanelBody>
-						<div className="site-setup-list__task-text task__text">
-							<div className="site-setup-list__task-timing task__timing">
-								<Gridicon icon="time" size={ 18 } />
-								<p>
-									{ translate( '%d minute', '%d minutes', {
-										count: currentTask.todo.timing,
-										args: [ currentTask.todo.timing ],
-									} ) }
-								</p>
-							</div>
-							<ActionPanelTitle>{ currentTask.todo.title }</ActionPanelTitle>
-							<p className="site-setup-list__task-description task__description">
-								{ currentTask.todo.description }
+			<ActionPanel className="site-setup-list__task task">
+				<ActionPanelBody>
+					<div className="site-setup-list__task-text task__text">
+						<div className="site-setup-list__task-timing task__timing">
+							<Gridicon icon="time" size={ 18 } />
+							<p>
+								{ translate( '%d minute', '%d minutes', {
+									count: currentTask.timing,
+									args: [ currentTask.timing ],
+								} ) }
 							</p>
-							<ActionPanelCta>
-								<Button
-									className="site-setup-list__task-action task__action"
-									primary
-									onClick={ () => startTask( dispatch, currentTask, siteId ) }
-								>
-									{ currentTask.todo.actionText }
-								</Button>
-								{ currentTask.todo.isSkippable && (
-									<Button
-										className="site-setup-list__task-skip task__skip is-link"
-										onClick={ () => skipTask( dispatch, currentTask.todo, siteId ) }
-									>
-										{ translate( 'Skip for now' ) }
-									</Button>
-								) }
-							</ActionPanelCta>
 						</div>
-					</ActionPanelBody>
-				</ActionPanel>
-			) : (
-				<ActionPanel className="site-setup-list__task task">
-					<ActionPanelBody>
-						<div className="site-setup-list__task-text task__text">
-							<ActionPanelTitle>{ currentTask.completed.title }</ActionPanelTitle>
-							<p className="site-setup-list__task-description task__description">
-								{ currentTask.completed.description }
-							</p>
-							<ActionPanelCta>
+						<ActionPanelTitle>{ currentTask.title }</ActionPanelTitle>
+						<p className="site-setup-list__task-description task__description">
+							{ currentTask.description }
+						</p>
+						<ActionPanelCta>
+							<Button
+								className="site-setup-list__task-action task__action"
+								primary
+								onClick={ () => startTask( dispatch, currentTask, siteId ) }
+							>
+								{ currentTask.actionText }
+							</Button>
+							{ currentTask.isSkippable && ! currentTask.isCompleted && (
 								<Button
-									className="site-setup-list__task-action task__action"
-									primary
-									onClick={ () => startTask( dispatch, currentTask, siteId ) }
+									className="site-setup-list__task-skip task__skip is-link"
+									onClick={ () => skipTask( dispatch, currentTask, siteId ) }
 								>
-									{ currentTask.completed.actionText }
+									{ translate( 'Skip for now' ) }
 								</Button>
-							</ActionPanelCta>
-						</div>
-					</ActionPanelBody>
-				</ActionPanel>
-			) }
+							) }
+						</ActionPanelCta>
+					</div>
+				</ActionPanelBody>
+			</ActionPanel>
 		</Card>
 	);
 };

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -17,147 +17,23 @@ import ActionPanelBody from 'components/action-panel/body';
 import ActionPanelCta from 'components/action-panel/cta';
 import CardHeading from 'components/card-heading';
 import { getTaskList } from 'lib/checklist';
-import { localizeUrl } from 'lib/i18n-utils';
 import Gridicon from 'components/gridicon';
-import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
-import { openSupportArticleDialog } from 'state/inline-support-article/actions';
 import getChecklistTaskUrls from 'state/selectors/get-checklist-task-urls';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import getMenusUrl from 'state/selectors/get-menus-url';
-import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import NavItem from './nav-item';
+import { getTaskData } from './get-task-data';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userEmail } = {} ) => {
-	let taskData = {};
-	switch ( task.id ) {
-		case 'domain_verified':
-			taskData = {
-				timing: 2,
-				title:
-					task.unverifiedDomains.length === 1
-						? translate( 'Verify the email address for %(domainName)s', {
-								args: { domainName: task.unverifiedDomains[ 0 ] },
-						  } )
-						: translate( 'Verify the email address for your domains' ),
-				description: translate(
-					'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
-				),
-				actionUrl:
-					task.unverifiedDomains.length === 1
-						? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
-						: domainManagementList( siteSlug ),
-				actionText: translate( 'Verify' ),
-			};
-			break;
-		case 'email_verified':
-			taskData = {
-				timing: 1,
-				title: translate( 'Confirm your email address' ),
-				description: translate(
-					'Please click the link in the email we sent to %(email)s.' +
-						'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
-					{
-						args: {
-							email: userEmail,
-						},
-						components: {
-							br: <br />,
-							changeButton: <a href="/me/account" />,
-						},
-					}
-				),
-				//TODO: looks like there's some more complicated text states here
-				actionText: translate( 'Verify email' ),
-			};
-			break;
-		case 'blogname_set':
-			taskData = {
-				timing: 1,
-				title: translate( 'Name your site' ),
-				description: translate(
-					'Give your new site a title to let people know what your site is about. A good title introduces your brand and the primary topics of your site.'
-				),
-				actionText: translate( 'Name your site' ),
-				actionUrl: `/settings/general/${ siteSlug }`,
-				tour: 'checklistSiteTitle',
-			};
-			break;
-		case 'mobile_app_installed':
-			taskData = {
-				timing: 3,
-				title: translate( 'Get the WordPress app' ),
-				description: translate(
-					'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
-				),
-				actionText: translate( 'Download mobile app' ),
-				actionUrl: '/me/get-apps',
-				...( ! task.isCompleted && {
-					actionDispatch: requestSiteChecklistTaskUpdate,
-					actionDispatchArgs: [ siteId, task.id ],
-				} ),
-				isSkippable: true,
-			};
-			break;
-		case 'site_launched':
-			taskData = {
-				timing: 1,
-				title: translate( 'Launch your site' ),
-				description: translate(
-					"Your site is private and only visible to you. When you're ready, launch your site to make it public."
-				),
-				actionText: translate( 'Launch site' ),
-				actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
-				actionDispatchArgs: [ siteId ],
-			};
-			break;
-		case 'front_page_updated':
-			taskData = {
-				timing: 20,
-				title: translate( 'Update your Home page' ),
-				description: translate(
-					"We've created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
-				),
-				actionText: translate( 'Edit homepage' ),
-			};
-			break;
-		case 'site_menu_updated':
-			taskData = {
-				timing: 10,
-				title: translate( 'Create a site menu' ),
-				description: translate(
-					"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
-				),
-				actionText: translate( 'View tutorial' ),
-				isSkippable: true,
-				actionDispatch: openSupportArticleDialog,
-				actionDispatchArgs: [
-					{
-						postId: 59580,
-						postUrl: localizeUrl( 'https://wordpress.com/support/menus/' ),
-						actionLabel: translate( 'Go to the Customizer' ),
-						actionUrl: menusUrl,
-					},
-				],
-			};
-			break;
-	}
-	return {
-		...task,
-		actionUrl: taskUrls[ task.id ],
-		...taskData,
-	};
-};
 
 const startTask = ( dispatch, task, siteId ) => {
 	dispatch(

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -4,7 +4,7 @@
 import React, { useEffect, useState } from 'react';
 import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { Card } from '@automattic/components';
+import { Card, Button } from '@automattic/components';
 
 /**
  * Internal dependencies
@@ -12,8 +12,10 @@ import { Card } from '@automattic/components';
 import ActionPanel from 'components/action-panel';
 import ActionPanelTitle from 'components/action-panel/title';
 import ActionPanelBody from 'components/action-panel/body';
+import ActionPanelCta from 'components/action-panel/cta';
 import CardHeading from 'components/card-heading';
 import { getTaskList } from 'lib/checklist';
+import Gridicon from 'components/gridicon';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { getSiteOption } from 'state/sites/selectors';
@@ -37,11 +39,14 @@ const getTaskCopy = ( task ) => {
 			};
 		case 'blogname_set':
 			return {
+				time: 1,
 				title: translate( 'Name your site' ),
 				description: translate(
 					'Give your new site a title to let people know what your site is about. ' +
 						'A good title introduces your brand and the primary topics of your site.'
 				),
+				actionText: translate( 'Start' ),
+				actionUrl: null,
 			};
 		case 'mobile_app_installed':
 			return {
@@ -84,7 +89,7 @@ const SiteSetupList = ( { tasks } ) => {
 				{ tasks.map( ( task ) => (
 					<NavItem
 						key={ task.id }
-						text={ getTaskCopy( task.id )?.title }
+						text={ getTaskCopy( task.id ).title }
 						isCompleted={ task.isCompleted }
 						isCurrent={ task.id === currentTask }
 						onClick={ () => setCurrentTask( task.id ) }
@@ -93,7 +98,30 @@ const SiteSetupList = ( { tasks } ) => {
 			</div>
 			<ActionPanel className="site-setup-list__task task">
 				<ActionPanelBody>
-					<ActionPanelTitle>{ getTaskCopy( currentTask )?.title }</ActionPanelTitle>
+					<div className="site-setup-list__task task__text">
+						<div className="site-setup-list__task task__timing">
+							<Gridicon icon="time" size={ 18 } />
+							<p>
+								{ translate( '%d minute', '%d minutes', {
+									count: getTaskCopy( currentTask ).time,
+									args: [ getTaskCopy( currentTask ).time ],
+								} ) }
+							</p>
+						</div>
+						<ActionPanelTitle>{ getTaskCopy( currentTask ).title }</ActionPanelTitle>
+						<p className="site-setup-list__task task__description">
+							{ getTaskCopy( currentTask ).description }
+						</p>
+						<ActionPanelCta>
+							<Button
+								className="site-setup-list__task task__action"
+								primary
+								href={ getTaskCopy( currentTask ).actionUrl }
+							>
+								{ getTaskCopy( currentTask ).actionText }
+							</Button>
+						</ActionPanelCta>
+					</div>
 				</ActionPanelBody>
 			</ActionPanel>
 		</Card>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -114,6 +114,7 @@ const SiteSetupList = ( { menusUrl, siteId, siteSlug, tasks, taskUrls, userEmail
 				{ tasks.map( ( task ) => (
 					<NavItem
 						key={ task.id }
+						taskId={ task.id }
 						text={ getTask( task ).title }
 						isCompleted={ task.isCompleted }
 						isCurrent={ task.id === currentTask.id }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -29,6 +29,7 @@ import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import NavItem from './nav-item';
 import { getTaskData } from './get-task-data';
+import Badge from 'components/badge';
 
 /**
  * Style dependencies
@@ -122,13 +123,21 @@ const SiteSetupList = ( { menusUrl, siteId, siteSlug, tasks, taskUrls } ) => {
 				<ActionPanelBody>
 					<div className="site-setup-list__task-text task__text">
 						<div className="site-setup-list__task-timing task__timing">
-							<Gridicon icon="time" size={ 18 } />
-							<p>
-								{ translate( '%d minute', '%d minutes', {
-									count: currentTask.timing,
-									args: [ currentTask.timing ],
-								} ) }
-							</p>
+							{ currentTask.isCompleted ? (
+								<Badge className="site-setup-list__badge" type="info">
+									{ translate( 'Complete' ) }
+								</Badge>
+							) : (
+								<>
+									<Gridicon icon="time" size={ 18 } />
+									<p>
+										{ translate( '%d minute', '%d minutes', {
+											count: currentTask.timing,
+											args: [ currentTask.timing ],
+										} ) }
+									</p>
+								</>
+							) }
 						</div>
 						<ActionPanelTitle>{ currentTask.title }</ActionPanelTitle>
 						<p className="site-setup-list__task-description task__description">

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -25,28 +25,43 @@ import NavItem from './nav-item';
  */
 import './style.scss';
 
-const TASKS = {
-	domain_verified: {
-		title: translate( 'Verify the email address for your domains' ),
-	},
-	email_verified: {
-		title: translate( 'Confirm your email address' ),
-	},
-	blogname_set: {
-		title: translate( 'Name your site' ),
-	},
-	mobile_app_installed: {
-		title: translate( 'Get the WordPress app' ),
-	},
-	site_launched: {
-		title: translate( 'Launch your site' ),
-	},
-	front_page_updated: {
-		title: translate( 'Update your Home page' ),
-	},
-	site_menu_updated: {
-		title: translate( 'Create a site menu' ),
-	},
+const getTaskCopy = ( task ) => {
+	switch ( task ) {
+		case 'domain_verified':
+			return {
+				title: translate( 'Verify the email address for your domains' ),
+			};
+		case 'email_verified':
+			return {
+				title: translate( 'Confirm your email address' ),
+			};
+		case 'blogname_set':
+			return {
+				title: translate( 'Name your site' ),
+				description: translate(
+					'Give your new site a title to let people know what your site is about. ' +
+						'A good title introduces your brand and the primary topics of your site.'
+				),
+			};
+		case 'mobile_app_installed':
+			return {
+				title: translate( 'Get the WordPress app' ),
+			};
+		case 'site_launched':
+			return {
+				title: translate( 'Launch your site' ),
+			};
+		case 'front_page_updated':
+			return {
+				title: translate( 'Update your Home page' ),
+			};
+		case 'site_menu_updated':
+			return {
+				title: translate( 'Create a site menu' ),
+			};
+		default:
+			return {};
+	}
 };
 
 const SiteSetupList = ( { tasks } ) => {
@@ -69,7 +84,7 @@ const SiteSetupList = ( { tasks } ) => {
 				{ tasks.map( ( task ) => (
 					<NavItem
 						key={ task.id }
-						text={ TASKS[ task.id ].title }
+						text={ getTaskCopy( task.id )?.title }
 						isCompleted={ task.isCompleted }
 						isCurrent={ task.id === currentTask }
 						onClick={ () => setCurrentTask( task.id ) }
@@ -78,7 +93,7 @@ const SiteSetupList = ( { tasks } ) => {
 			</div>
 			<ActionPanel className="site-setup-list__task task">
 				<ActionPanelBody>
-					<ActionPanelTitle>{ TASKS[ currentTask ].title }</ActionPanelTitle>
+					<ActionPanelTitle>{ getTaskCopy( currentTask )?.title }</ActionPanelTitle>
 				</ActionPanelBody>
 			</ActionPanel>
 		</Card>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -85,6 +85,23 @@ const trackTaskDisplay = ( dispatch, task, siteId ) => {
 	);
 };
 
+const getActionText = ( currentTask, emailVerificationStatus ) => {
+	if ( currentTask.id === 'email_verified' ) {
+		if ( emailVerificationStatus === 'requesting' ) {
+			return translate( 'Sending…' );
+		}
+
+		if ( emailVerificationStatus === 'error' ) {
+			return translate( 'Error' );
+		}
+
+		if ( emailVerificationStatus === 'sent' ) {
+			return translate( 'Email sent' );
+		}
+	}
+	return currentTask.actionText;
+};
+
 const SiteSetupList = ( {
 	emailVerificationStatus,
 	isEmailUnverified,
@@ -226,7 +243,7 @@ const SiteSetupList = ( {
 									onClick={ () => startTask( dispatch, currentTask, siteId ) }
 									disabled={ currentTask.isDisabled }
 								>
-									{ currentTask.actionText }
+									{ getActionText( currentTask, emailVerificationStatus ) }
 								</Button>
 								{ currentTask.isSkippable && ! currentTask.isCompleted && (
 									<Button

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -108,52 +108,77 @@ const SiteSetupList = ( { menusUrl, siteId, siteSlug, tasks, taskUrls } ) => {
 		<Card className="site-setup-list">
 			<div className="site-setup-list__nav">
 				<CardHeading>{ translate( 'Site setup' ) }</CardHeading>
-				{ tasks.map( ( task ) => (
-					<NavItem
-						key={ task.id }
-						text={ getTask( task ).title }
-						isCompleted={ task.isCompleted }
-						isCurrent={ task.id === currentTask.id }
-						onClick={ () => setCurrentTask( getTask( task ) ) }
-					/>
-				) ) }
+				{ tasks.map( ( task ) => {
+					const taskData = getTask( task );
+					return (
+						<NavItem
+							key={ task.id }
+							text={ task.isCompleted ? taskData.completed.title : taskData.todo.title }
+							isCompleted={ task.isCompleted }
+							isCurrent={ task.id === currentTask.id }
+							onClick={ () => setCurrentTask( taskData ) }
+						/>
+					);
+				} ) }
 			</div>
-			<ActionPanel className="site-setup-list__task task">
-				<ActionPanelBody>
-					<div className="site-setup-list__task-text task__text">
-						<div className="site-setup-list__task-timing task__timing">
-							<Gridicon icon="time" size={ 18 } />
-							<p>
-								{ translate( '%d minute', '%d minutes', {
-									count: currentTask.timing,
-									args: [ currentTask.timing ],
-								} ) }
+			{ ! currentTask.isCompleted ? (
+				<ActionPanel className="site-setup-list__task task">
+					<ActionPanelBody>
+						<div className="site-setup-list__task-text task__text">
+							<div className="site-setup-list__task-timing task__timing">
+								<Gridicon icon="time" size={ 18 } />
+								<p>
+									{ translate( '%d minute', '%d minutes', {
+										count: currentTask.todo.timing,
+										args: [ currentTask.todo.timing ],
+									} ) }
+								</p>
+							</div>
+							<ActionPanelTitle>{ currentTask.todo.title }</ActionPanelTitle>
+							<p className="site-setup-list__task-description task__description">
+								{ currentTask.todo.description }
 							</p>
-						</div>
-						<ActionPanelTitle>{ currentTask.title }</ActionPanelTitle>
-						<p className="site-setup-list__task-description task__description">
-							{ currentTask.description }
-						</p>
-						<ActionPanelCta>
-							<Button
-								className="site-setup-list__task-action task__action"
-								primary
-								onClick={ () => startTask( dispatch, currentTask, siteId ) }
-							>
-								{ currentTask.actionText }
-							</Button>
-							{ currentTask.isSkippable && ! currentTask.isCompleted && (
+							<ActionPanelCta>
 								<Button
-									className="site-setup-list__task-skip task__skip is-link"
-									onClick={ () => skipTask( dispatch, currentTask, siteId ) }
+									className="site-setup-list__task-action task__action"
+									primary
+									onClick={ () => startTask( dispatch, currentTask, siteId ) }
 								>
-									{ translate( 'Skip for now' ) }
+									{ currentTask.todo.actionText }
 								</Button>
-							) }
-						</ActionPanelCta>
-					</div>
-				</ActionPanelBody>
-			</ActionPanel>
+								{ currentTask.todo.isSkippable && (
+									<Button
+										className="site-setup-list__task-skip task__skip is-link"
+										onClick={ () => skipTask( dispatch, currentTask.todo, siteId ) }
+									>
+										{ translate( 'Skip for now' ) }
+									</Button>
+								) }
+							</ActionPanelCta>
+						</div>
+					</ActionPanelBody>
+				</ActionPanel>
+			) : (
+				<ActionPanel className="site-setup-list__task task">
+					<ActionPanelBody>
+						<div className="site-setup-list__task-text task__text">
+							<ActionPanelTitle>{ currentTask.completed.title }</ActionPanelTitle>
+							<p className="site-setup-list__task-description task__description">
+								{ currentTask.completed.description }
+							</p>
+							<ActionPanelCta>
+								<Button
+									className="site-setup-list__task-action task__action"
+									primary
+									onClick={ () => startTask( dispatch, currentTask, siteId ) }
+								>
+									{ currentTask.completed.actionText }
+								</Button>
+							</ActionPanelCta>
+						</div>
+					</ActionPanelBody>
+				</ActionPanel>
+			) }
 		</Card>
 	);
 };

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
-import { translate } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import { Card, Button } from '@automattic/components';
+import { isDesktop } from '@automattic/viewport';
+import { translate } from 'i18n-calypso';
+import React, { useEffect, useState } from 'react';
+import { connect, useDispatch } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -15,10 +17,19 @@ import ActionPanelBody from 'components/action-panel/body';
 import ActionPanelCta from 'components/action-panel/cta';
 import CardHeading from 'components/card-heading';
 import { getTaskList } from 'lib/checklist';
+import { localizeUrl } from 'lib/i18n-utils';
 import Gridicon from 'components/gridicon';
+import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
+import { openSupportArticleDialog } from 'state/inline-support-article/actions';
+import getChecklistTaskUrls from 'state/selectors/get-checklist-task-urls';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { getSiteOption } from 'state/sites/selectors';
+import getMenusUrl from 'state/selectors/get-menus-url';
+import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
+import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
+import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import NavItem from './nav-item';
 
@@ -27,26 +38,38 @@ import NavItem from './nav-item';
  */
 import './style.scss';
 
-const getTaskCopy = ( task, taskOptions ) => {
-	switch ( task ) {
+const getTaskData = ( task, { menusUrl, siteId, siteSlug, taskUrls, userEmail } = {} ) => {
+	let taskData = {};
+	switch ( task.id ) {
 		case 'domain_verified':
-			return {
-				duration: translate( '%d minute', '%d minutes', { count: 2, args: [ 2 ] } ),
-				title: translate( 'Verify the email address for your domains' ),
+			taskData = {
+				timing: 2,
+				title:
+					task.unverifiedDomains.length === 1
+						? translate( 'Verify the email address for %(domainName)s', {
+								args: { domainName: task.unverifiedDomains[ 0 ] },
+						  } )
+						: translate( 'Verify the email address for your domains' ),
 				description: translate(
 					'We need to check your contact information to make sure you can be reached. Please verify your details using the email we sent you, or your domain will stop working.'
 				),
+				actionUrl:
+					task.unverifiedDomains.length === 1
+						? domainManagementEdit( siteSlug, task.unverifiedDomains[ 0 ] )
+						: domainManagementList( siteSlug ),
+				actionText: translate( 'Verify' ),
 			};
+			break;
 		case 'email_verified':
-			return {
-				duration: translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ),
+			taskData = {
+				timing: 1,
 				title: translate( 'Confirm your email address' ),
 				description: translate(
 					'Please click the link in the email we sent to %(email)s.' +
 						'Typo in your email address? {{changeButton}}Change it here{{/changeButton}}.',
 					{
 						args: {
-							email: taskOptions?.userEmail,
+							email: userEmail,
 						},
 						components: {
 							br: <br />,
@@ -57,72 +80,153 @@ const getTaskCopy = ( task, taskOptions ) => {
 				//TODO: looks like there's some more complicated text states here
 				actionText: translate( 'Verify email' ),
 			};
+			break;
 		case 'blogname_set':
-			return {
-				duration: translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ),
+			taskData = {
+				timing: 1,
 				title: translate( 'Name your site' ),
 				description: translate(
-					'Give your new site a title to let people know what your site is about. ' +
-						'A good title introduces your brand and the primary topics of your site.'
+					'Give your new site a title to let people know what your site is about. A good title introduces your brand and the primary topics of your site.'
 				),
 				actionText: translate( 'Name your site' ),
-				actionUrl: null,
+				actionUrl: `/settings/general/${ siteSlug }`,
+				tour: 'checklistSiteTitle',
 			};
+			break;
 		case 'mobile_app_installed':
-			return {
-				duration: translate( '%d minute', '%d minutes', { count: 3, args: [ 3 ] } ),
+			taskData = {
+				timing: 3,
 				title: translate( 'Get the WordPress app' ),
 				description: translate(
 					'Download the WordPress app to your mobile device to manage your site and follow your stats on the go.'
 				),
 				actionText: translate( 'Download mobile app' ),
+				actionUrl: '/me/get-apps',
+				...( ! task.isCompleted && {
+					actionDispatch: requestSiteChecklistTaskUpdate,
+					actionDispatchArgs: [ siteId, task.id ],
+				} ),
+				isSkippable: true,
 			};
+			break;
 		case 'site_launched':
-			return {
-				duration: translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ),
+			taskData = {
+				timing: 1,
 				title: translate( 'Launch your site' ),
 				description: translate(
 					"Your site is private and only visible to you. When you're ready, launch your site to make it public."
 				),
 				actionText: translate( 'Launch site' ),
+				actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
+				actionDispatchArgs: [ siteId ],
 			};
+			break;
 		case 'front_page_updated':
-			return {
-				duration: translate( '%d minute', '%d minutes', { count: 20, args: [ 20 ] } ),
+			taskData = {
+				timing: 20,
 				title: translate( 'Update your Home page' ),
 				description: translate(
-					"We’ve created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
+					"We've created the basics, now it's time for you to update the images and text. Make a great first impression. Everything you do can be changed anytime."
 				),
-				actionText: translate( 'Create a menu' ),
+				actionText: translate( 'Edit homepage' ),
 			};
+			break;
 		case 'site_menu_updated':
-			return {
-				duration: translate( '%d minute', '%d minutes', { count: 10, args: [ 10 ] } ),
+			taskData = {
+				timing: 10,
 				title: translate( 'Create a site menu' ),
 				description: translate(
-					'Building an effective navigation menu makes it easier for someone to find what they’re looking for and improve search engine rankings.'
+					"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
 				),
-				actionText: translate( 'Create a menu' ),
+				actionText: translate( 'View tutorial' ),
+				isSkippable: true,
+				actionDispatch: openSupportArticleDialog,
+				actionDispatchArgs: [
+					{
+						postId: 59580,
+						postUrl: localizeUrl( 'https://wordpress.com/support/menus/' ),
+						actionLabel: translate( 'Go to the Customizer' ),
+						actionUrl: menusUrl,
+					},
+				],
 			};
-		default:
-			return {};
+			break;
+	}
+	return {
+		...task,
+		actionUrl: taskUrls[ task.id ],
+		...taskData,
+	};
+};
+
+const startTask = ( dispatch, task, siteId ) => {
+	dispatch(
+		recordTracksEvent( 'calypso_checklist_task_start', {
+			checklist_name: 'new_blog',
+			site_id: siteId,
+			location: 'checklist_show',
+			step_name: task.id,
+			completed: task.isCompleted,
+		} )
+	);
+
+	if ( task.tour && ! task.isCompleted && isDesktop() ) {
+		dispatch( requestGuidedTour( task.tour ) );
+	}
+
+	if ( task.actionUrl ) {
+		page.show( task.actionUrl );
+	}
+
+	if ( task.actionDispatch ) {
+		dispatch( task.actionDispatch( ...task.actionDispatchArgs ) );
 	}
 };
 
-const SiteSetupList = ( { tasks } ) => {
+const skipTask = ( dispatch, task, siteId ) => {
+	dispatch( requestSiteChecklistTaskUpdate( siteId, task.id ) );
+	dispatch(
+		recordTracksEvent( 'calypso_checklist_task_dismiss', {
+			checklist_name: 'new_blog',
+			site_id: siteId,
+			step_name: task.id,
+		} )
+	);
+};
+
+const SiteSetupList = ( { menusUrl, siteId, siteSlug, tasks, taskUrls } ) => {
 	const [ currentTask, setCurrentTask ] = useState( null );
+	const dispatch = useDispatch();
+
+	const getTask = ( task ) =>
+		getTaskData( task, {
+			menusUrl,
+			siteId,
+			siteSlug,
+			taskUrls,
+		} );
 
 	useEffect( () => {
-		if ( tasks.length ) {
-			setCurrentTask( tasks[ 0 ].id );
+		// Initial task.
+		if ( ! currentTask && tasks.length ) {
+			const initialTask = getTask( tasks.find( ( task ) => ! task.isCompleted ) );
+			setCurrentTask( initialTask );
 		}
-	}, [ tasks ] );
+
+		// Move to next task after after completing current one.
+		if ( currentTask && tasks.length ) {
+			const isCurrentTaskCompleted = tasks.find( ( task ) => task.id === currentTask.id )
+				.isCompleted;
+			if ( isCurrentTaskCompleted && ! currentTask.isCompleted ) {
+				const nextTask = getTask( tasks.find( ( task ) => ! task.isCompleted ) );
+				setCurrentTask( nextTask );
+			}
+		}
+	}, [ currentTask, tasks ] );
 
 	if ( ! tasks.length || ! currentTask ) {
 		return null;
 	}
-
-	const taskCopy = getTaskCopy( currentTask );
 
 	return (
 		<Card className="site-setup-list">
@@ -131,30 +235,45 @@ const SiteSetupList = ( { tasks } ) => {
 				{ tasks.map( ( task ) => (
 					<NavItem
 						key={ task.id }
-						text={ getTaskCopy( task.id ).title }
+						text={ getTask( task ).title }
 						isCompleted={ task.isCompleted }
-						isCurrent={ task.id === currentTask }
-						onClick={ () => setCurrentTask( task.id ) }
+						isCurrent={ task.id === currentTask.id }
+						onClick={ () => setCurrentTask( getTask( task ) ) }
 					/>
 				) ) }
 			</div>
 			<ActionPanel className="site-setup-list__task task">
 				<ActionPanelBody>
-					<div className="site-setup-list__task task__text">
-						<div className="site-setup-list__task task__timing">
+					<div className="site-setup-list__task-text task__text">
+						<div className="site-setup-list__task-timing task__timing">
 							<Gridicon icon="time" size={ 18 } />
-							<p>{ taskCopy.duration }</p>
+							<p>
+								{ translate( '%d minute', '%d minutes', {
+									count: currentTask.timing,
+									args: [ currentTask.timing ],
+								} ) }
+							</p>
 						</div>
-						<ActionPanelTitle>{ getTaskCopy( currentTask ).title }</ActionPanelTitle>
-						<p className="site-setup-list__task task__description">{ taskCopy.description }</p>
+						<ActionPanelTitle>{ currentTask.title }</ActionPanelTitle>
+						<p className="site-setup-list__task-description task__description">
+							{ currentTask.description }
+						</p>
 						<ActionPanelCta>
 							<Button
-								className="site-setup-list__task task__action"
+								className="site-setup-list__task-action task__action"
 								primary
-								href={ taskCopy.actionUrl }
+								onClick={ () => startTask( dispatch, currentTask, siteId ) }
 							>
-								{ taskCopy.actionText }
+								{ currentTask.actionText }
 							</Button>
+							{ currentTask.isSkippable && ! currentTask.isCompleted && (
+								<Button
+									className="site-setup-list__task-skip task__skip is-link"
+									onClick={ () => skipTask( dispatch, currentTask, siteId ) }
+								>
+									{ translate( 'Skip for now' ) }
+								</Button>
+							) }
 						</ActionPanelCta>
 					</div>
 				</ActionPanelBody>
@@ -180,6 +299,10 @@ export default connect( ( state ) => {
 	} );
 
 	return {
+		menusUrl: getMenusUrl( state, siteId ),
+		siteId,
+		siteSlug: getSiteSlug( state, siteId ),
 		tasks: taskList.getAll(),
+		taskUrls: getChecklistTaskUrls( state, siteId ),
 	};
 } )( SiteSetupList );

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -73,8 +73,8 @@ const skipTask = ( dispatch, task, siteId ) => {
 	);
 };
 
-const getActionText = ( currentTask, emailVerificationStatus ) => {
-	if ( currentTask.id === 'email_verified' ) {
+const getActionText = ( task, { emailVerificationStatus } ) => {
+	if ( task.id === 'email_verified' ) {
 		if ( emailVerificationStatus === 'requesting' ) {
 			return translate( 'Sending…' );
 		}
@@ -87,8 +87,11 @@ const getActionText = ( currentTask, emailVerificationStatus ) => {
 			return translate( 'Email sent' );
 		}
 	}
-	return currentTask.actionText;
+	return task.actionText;
 };
+
+const isTaskDisabled = ( task, { emailVerificationStatus } ) =>
+	task.id === 'email_verified' && 'requesting' === emailVerificationStatus;
 
 const SiteSetupList = ( {
 	menusUrl,
@@ -180,11 +183,9 @@ const SiteSetupList = ( {
 								className="site-setup-list__task-action task__action"
 								primary
 								onClick={ () => startTask( dispatch, currentTask, siteId ) }
-								disabled={
-									currentTask.id === 'email_verified' && 'requesting' === emailVerificationStatus
-								}
+								disabled={ isTaskDisabled( currentTask, { emailVerificationStatus } ) }
 							>
-								{ getActionText( currentTask, emailVerificationStatus ) }
+								{ getActionText( currentTask, { emailVerificationStatus } ) }
 							</Button>
 							{ currentTask.isSkippable && ! currentTask.isCompleted && (
 								<Button

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
+
+const NavItem = ( { text, isCompleted, isCurrent, onClick } ) => {
+	return (
+		<button
+			className={ classnames( 'nav-item', {
+				'is-current': isCurrent,
+			} ) }
+			onClick={ onClick }
+		>
+			<div className="nav-item__status">
+				{ isCompleted && <Gridicon icon="checkmark" size={ 18 } /> }
+			</div>
+			<div className="nav-item__text">
+				<h6>{ text }</h6>
+			</div>
+		</button>
+	);
+};
+
+export default NavItem;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -11,7 +11,7 @@ import classnames from 'classnames';
 import Gridicon from 'components/gridicon';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick } ) => {
+const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, showChevron } ) => {
 	const dispatch = useDispatch();
 
 	const trackExpand = () =>
@@ -42,6 +42,7 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick } ) => {
 			<div className="nav-item__text">
 				<h6>{ text }</h6>
 			</div>
+			{ showChevron && <Gridicon className="nav-item__chevron" icon="chevron-right" size={ 18 } /> }
 		</button>
 	);
 };

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -2,20 +2,22 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
+import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
 
-const NavItem = ( { text, isCompleted, isCurrent, onClick } ) => {
+const NavItem = ( { text, isCompleted, isCurrent, onClickAndTrack } ) => {
 	return (
 		<button
 			className={ classnames( 'nav-item', {
 				'is-current': isCurrent,
 			} ) }
-			onClick={ onClick }
+			onClick={ onClickAndTrack }
 		>
 			<div className="nav-item__status">
 				{ isCompleted ? (
@@ -31,4 +33,26 @@ const NavItem = ( { text, isCompleted, isCurrent, onClick } ) => {
 	);
 };
 
-export default NavItem;
+export default connect(
+	null,
+	( dispatch ) => ( {
+		trackAction: ( taskId ) =>
+			dispatch(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_checklist_task_expand', {
+						step_name: taskId,
+						product: 'WordPress.com',
+					} ),
+					bumpStat( 'calypso_customer_home', 'checklist_task_expand' )
+				)
+			),
+	} ),
+	( stateProps, dispatchProps, ownProps ) => ( {
+		...ownProps,
+		...stateProps,
+		onClickAndTrack: () => {
+			ownProps.onClick();
+			dispatchProps.trackAction( ownProps.taskId );
+		},
+	} )
+)( NavItem );

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -2,22 +2,35 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Gridicon from 'components/gridicon';
-import { bumpStat, composeAnalytics, recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
-const NavItem = ( { text, isCompleted, isCurrent, onClickAndTrack } ) => {
+const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick } ) => {
+	const dispatch = useDispatch();
+
+	const trackExpand = () =>
+		dispatch(
+			recordTracksEvent( 'calypso_checklist_task_expand', {
+				step_name: taskId,
+				product: 'WordPress.com',
+			} )
+		);
+
 	return (
 		<button
 			className={ classnames( 'nav-item', {
 				'is-current': isCurrent,
 			} ) }
-			onClick={ onClickAndTrack }
+			onClick={ () => {
+				trackExpand();
+				onClick();
+			} }
 		>
 			<div className="nav-item__status">
 				{ isCompleted ? (
@@ -33,26 +46,4 @@ const NavItem = ( { text, isCompleted, isCurrent, onClickAndTrack } ) => {
 	);
 };
 
-export default connect(
-	null,
-	( dispatch ) => ( {
-		trackAction: ( taskId ) =>
-			dispatch(
-				composeAnalytics(
-					recordTracksEvent( 'calypso_checklist_task_expand', {
-						step_name: taskId,
-						product: 'WordPress.com',
-					} ),
-					bumpStat( 'calypso_customer_home', 'checklist_task_expand' )
-				)
-			),
-	} ),
-	( stateProps, dispatchProps, ownProps ) => ( {
-		...ownProps,
-		...stateProps,
-		onClickAndTrack: () => {
-			ownProps.onClick();
-			dispatchProps.trackAction( ownProps.taskId );
-		},
-	} )
-)( NavItem );
+export default NavItem;

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -18,7 +18,11 @@ const NavItem = ( { text, isCompleted, isCurrent, onClick } ) => {
 			onClick={ onClick }
 		>
 			<div className="nav-item__status">
-				{ isCompleted && <Gridicon icon="checkmark" size={ 18 } /> }
+				{ isCompleted ? (
+					<Gridicon className="nav-item__complete" icon="checkmark" size={ 18 } />
+				) : (
+					<div className="nav-item__pending" />
+				) }
 			</div>
 			<div className="nav-item__text">
 				<h6>{ text }</h6>

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -36,6 +36,7 @@
 
 	&.is-current {
 		background-color: var( --color-primary-5 );
+		font-weight: 600;
 	}
 }
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -2,16 +2,30 @@
 	padding: 0;
 	display: flex;
 
+	@include breakpoint( '<960px' ) {
+		display: block;
+	}
+
 	.site-setup-list__nav {
 		width: 328px;
 		flex-shrink: 0;
 		border-right: 1px solid var( --color-border-subtle );
+
+		@include breakpoint( '<1280px' ) {
+			width: 260px;
+		}
+
+		@include breakpoint( '<960px' ) {
+			width: 100%;
+		}
 	}
 
 	.card-heading {
 		padding: 16px 24px;
 		margin-bottom: 0;
 		border-bottom: 1px solid var( --color-border-subtle );
+		display: flex;
+		align-items: center;
 	}
 
 	.nav-item {
@@ -29,11 +43,19 @@
 
 		&:hover {
 			background-color: var( --color-neutral-0 );
+
+			@include breakpoint( '<960px' ) {
+				background-color: transparent;
+			}
 		}
 
 		&.is-current {
 			background-color: var( --color-primary-0 );
 			font-weight: 600;
+
+			@include breakpoint( '<960px' ) {
+				background-color: transparent;
+			}
 		}
 	}
 
@@ -65,16 +87,28 @@
 		line-height: 20px;
 	}
 
+	.nav-item__chevron {
+		margin-left: auto;
+	}
+
 	.site-setup-list__task {
 		box-shadow: none;
 		margin: 0;
 		padding: 40px;
-		width: calc( 100% - 328px );
+
+		@include breakpoint( '<1040px' ) {
+			padding: 24px;
+		}
 	}
 
 	.site-setup-list__badge {
 		background-color: var( --color-neutral );
 		color: var( --color-text-inverted );
+	}
+
+	.site-setup-list__nav-back {
+		padding: 2px 4px;
+		margin: 0 4px 0 -8px;
 	}
 }
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -70,6 +70,11 @@
 		margin: 0;
 		padding: 40px;
 	}
+
+	.site-setup-list__badge {
+		background-color: var( --color-neutral );
+		color: var( --color-text-inverted );	
+	}
 }
 
 .customer-home__main.is-experimental .site-setup-list .card-heading {

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -69,11 +69,12 @@
 		box-shadow: none;
 		margin: 0;
 		padding: 40px;
+		width: calc( 100% - 328px );
 	}
 
 	.site-setup-list__badge {
 		background-color: var( --color-neutral );
-		color: var( --color-text-inverted );	
+		color: var( --color-text-inverted );
 	}
 }
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -3,7 +3,8 @@
 	display: flex;
 
 	.site-setup-list__nav {
-		width: 300px;
+		width: 328px;
+		flex-shrink: 0;
 		border-right: 1px solid var( --color-border-subtle );
 	}
 
@@ -15,6 +16,7 @@
 
 	.nav-item {
 		display: flex;
+		align-items: center;
 		padding: 16px 24px;
 		border-bottom: 1px solid var( --color-border-subtle );
 		transition: all 0.1s;
@@ -30,7 +32,7 @@
 		}
 
 		&.is-current {
-			background-color: var( --color-primary-5 );
+			background-color: var( --color-primary-0 );
 			font-weight: 600;
 		}
 	}
@@ -58,9 +60,15 @@
 		vertical-align: text-bottom;
 	}
 
+	.nav-item__text {
+		text-align: left;
+		line-height: 20px;
+	}
+
 	.site-setup-list__task {
 		box-shadow: none;
 		margin: 0;
+		padding: 40px;
 	}
 }
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -1,0 +1,54 @@
+.site-setup-list {
+	padding: 0;
+	display: flex;
+}
+
+.site-setup-list__nav {
+	width: 300px;
+	border-right: 1px solid var( --color-border-subtle );
+}
+
+.site-setup-list .card-heading {
+	padding: 16px 24px;
+	margin-bottom: 0;
+	border-bottom: 1px solid var( --color-border-subtle );
+}
+
+.customer-home__main.is-experimental .site-setup-list .card-heading {
+	margin-bottom: 0;
+}
+
+.site-setup-list .nav-item {
+	display: flex;
+	padding: 16px 24px;
+	border-bottom: 1px solid var( --color-border-subtle );
+	transition: all 0.1s;
+	cursor: pointer;
+	width: 100%;
+
+	&:last-child {
+		border-bottom: none;
+	}
+
+	&:hover {
+		background-color: var( --color-neutral-0 );
+	}
+
+	&.is-current {
+		background-color: var( --color-primary-5 );
+	}
+}
+
+.site-setup-list .nav-item__status {
+	margin-right: 8px;
+}
+
+.site-setup-list .nav-item__status .gridicons-checkmark {
+	fill: var( --color-success );
+	vertical-align: text-bottom;
+}
+
+.site-setup-list__task {
+	box-shadow: none;
+	margin: 0;
+}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -102,7 +102,7 @@
 	}
 
 	.site-setup-list__badge {
-		background-color: var( --color-neutral );
+		background-color: var( --color-neutral-dark );
 		color: var( --color-text-inverted );
 	}
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -1,55 +1,69 @@
 .site-setup-list {
 	padding: 0;
 	display: flex;
-}
 
-.site-setup-list__nav {
-	width: 300px;
-	border-right: 1px solid var( --color-border-subtle );
-}
+	.site-setup-list__nav {
+		width: 300px;
+		border-right: 1px solid var( --color-border-subtle );
+	}
 
-.site-setup-list .card-heading {
-	padding: 16px 24px;
-	margin-bottom: 0;
-	border-bottom: 1px solid var( --color-border-subtle );
+	.card-heading {
+		padding: 16px 24px;
+		margin-bottom: 0;
+		border-bottom: 1px solid var( --color-border-subtle );
+	}
+
+	.nav-item {
+		display: flex;
+		padding: 16px 24px;
+		border-bottom: 1px solid var( --color-border-subtle );
+		transition: all 0.1s;
+		cursor: pointer;
+		width: 100%;
+
+		&:last-child {
+			border-bottom: none;
+		}
+
+		&:hover {
+			background-color: var( --color-neutral-0 );
+		}
+
+		&.is-current {
+			background-color: var( --color-primary-5 );
+			font-weight: 600;
+		}
+	}
+
+	.nav-item__status {
+		margin-right: 8px;
+	}
+
+	.nav-item__pending {
+		display: block;
+		width: 8px;
+		height: 8px;
+		background-color: var( --color-neutral-20 );
+		border-radius: 50%;
+		margin: 5px;
+		transition: all 0.1s;
+	}
+
+	.nav-item.is-current .nav-item__pending {
+		background-color: var( --color-neutral-80 );
+	}
+
+	.nav-item__complete {
+		fill: var( --color-success );
+		vertical-align: text-bottom;
+	}
+
+	.site-setup-list__task {
+		box-shadow: none;
+		margin: 0;
+	}
 }
 
 .customer-home__main.is-experimental .site-setup-list .card-heading {
 	margin-bottom: 0;
-}
-
-.site-setup-list .nav-item {
-	display: flex;
-	padding: 16px 24px;
-	border-bottom: 1px solid var( --color-border-subtle );
-	transition: all 0.1s;
-	cursor: pointer;
-	width: 100%;
-
-	&:last-child {
-		border-bottom: none;
-	}
-
-	&:hover {
-		background-color: var( --color-neutral-0 );
-	}
-
-	&.is-current {
-		background-color: var( --color-primary-5 );
-		font-weight: 600;
-	}
-}
-
-.site-setup-list .nav-item__status {
-	margin-right: 8px;
-}
-
-.site-setup-list .nav-item__status .gridicons-checkmark {
-	fill: var( --color-success );
-	vertical-align: text-bottom;
-}
-
-.site-setup-list__task {
-	box-shadow: none;
-	margin: 0;
 }

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -7,14 +7,13 @@
 
 	.action-panel__body {
 		display: flex;
-		align-items: center;
 	}
 
 	.action-panel__title {
 		font-family: 'Recoleta', serif;
 		font-size: 32px;
 		line-height: 40px;
-		margin-bottom: 0;
+		margin-bottom: 4px;
 
 		@include breakpoint( '>800px' ) {
 			font-size: 40px;
@@ -26,37 +25,41 @@
 		max-width: 33.3333%;
 		margin-bottom: 0;
 		order: 1;
+		align-self: center;
+	}
+
+	.action-panel__body p.task__description {
+		margin-bottom: 32px;
+		font-size: 16px;
+		line-height: 24px;
+		color: var( --color-text );
+
+		@include breakpoint( '>800px' ) {
+			font-size: 20px;
+			line-height: 32px;
+		}
+	}
+
+	.action-panel__body .task__timing {
+		display: flex;
+		margin-bottom: 8px;
+
+		.gridicon {
+			margin-right: 4px;
+		}
+
+		p {
+			margin-bottom: 0;
+		}
 	}
 
 	.action-panel__cta {
 		display: flex;
+		padding-top: 0;
 
 		.task__skip {
 			margin: auto 16px;
 		}
-	}
-}
-
-.task__timing {
-	display: flex;
-
-	.gridicon {
-		margin-right: 4px;
-	}
-
-	p {
-		margin-bottom: 8px;
-	}
-}
-
-.task__description {
-	font-size: 16px;
-	line-height: 24px;
-	color: var( --color-text );
-
-	@include breakpoint( '>800px' ) {
-		font-size: 20px;
-		line-height: 32px;
 	}
 }
 

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -13,6 +13,7 @@ import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links';
 import WpForTeamsQuickLinks from 'my-sites/customer-home/cards/actions/wp-for-teams-quick-links';
 import ConnectAccounts from 'my-sites/customer-home/cards/tasks/connect-accounts';
 import FindDomain from 'my-sites/customer-home/cards/tasks/find-domain';
+import SiteSetupList from 'my-sites/customer-home/cards/tasks/site-setup-list';
 import config from 'config';
 
 const cardComponents = {
@@ -21,7 +22,7 @@ const cardComponents = {
 	'home-primary-quick-links': QuickLinks,
 	'home-education-mastering-gutenberg': MasteringGutenberg,
 	'home-action-wp-for-teams-quick-links': WpForTeamsQuickLinks,
-	'home-task-site-setup-checklist': ChecklistSiteSetup,
+	'home-task-site-setup-checklist': SiteSetupList,
 	'home-task-connect-accounts': ConnectAccounts,
 	'home-task-find-domain': FindDomain,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

<img width="1423" alt="Screen Shot 2020-04-29 at 2 29 35 PM" src="https://user-images.githubusercontent.com/1270189/80648989-0675df80-8a26-11ea-8ab4-170658e12180.png">

Adds a Site Setup List component that visually works well with the new My Home Layout.

#### Testing instructions
- Checkout this branch
- Create a new site
- Visit `http://calypso.localhost:3000/home/:siteId:?flags=home/experimental-layout`
- Verify that Site Setup Steps look visually good, no regressions in task behavior, and that analytics events still fire
