### PR TITLE
i18n: Fix translation chunks build flow from server bundler

### DIFF
--- a/client/server/bundler/index.js
+++ b/client/server/bundler/index.js
@@ -45,7 +45,7 @@ function middleware( app ) {
 	// feature is enabled.
 	if ( shouldBuildChunksMap ) {
 		callbacks.push( () => {
-			execSync( 'node bin/build-languages' );
+			execSync( 'yarn run build-languages' );
 		} );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the command that server bundler executes in order to build translation chunks from `node bin/build-languages` to `yarn run build-languages` as it also runs `yarn run translate` to ensure `calypso-string.pot` will be generated.

#### Testing instructions

1. Clean up `chunks-map.{target}.json` and `calypso-strings.pot` if they exist in root directory. 
2. Boot Calypso with `ENABLE_FEATURES=use-translation-chunks yarn start`.
3. Confirm that translation chunks and language manifest and built successfully in `public/evergreen/languages`.