### PR TITLE
Posts: Update PostShare nudge to use UpsellNudge

### DIFF
--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -8,7 +8,7 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { TYPE_PREMIUM, TERM_ANNUALLY } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import canCurrentUser from 'state/selectors/can-current-user';
@@ -42,14 +42,16 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 	}
 
 	return (
-		<Banner
+		<UpsellNudge
 			className="post-share__actions-list-upgrade-nudge"
 			callToAction={ translate( 'Upgrade for %s', {
 				args: formatCurrency( price, userCurrency ),
 				comment: '%s will be replaced by a formatted price, i.e $9.99',
 			} ) }
+			forceDisplay
 			list={ featureList }
 			plan={ planSlug }
+			showIcon
 			title={ translate( 'Upgrade to a Premium Plan!' ) }
 		/>
 	);

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -5,7 +5,7 @@ jest.mock( 'lib/abtest', () => ( {
 jest.mock( 'lib/analytics/tracks', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view', () => ( {} ) );
 jest.mock( 'lib/analytics/page-view-tracker', () => 'PageViewTracker' );
-jest.mock( 'components/banner', () => 'Banner' );
+jest.mock( 'blocks/upsell-nudge', () => 'UpsellNudge' );
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: ( Comp ) => ( props ) => (
@@ -60,7 +60,7 @@ const props = {
 describe( 'UpgradeToPremiumNudgePure basic tests', () => {
 	test( 'should not blow up', () => {
 		const comp = shallow( <UpgradeToPremiumNudgePure { ...props } /> );
-		expect( comp.find( 'Banner' ).length ).toBe( 1 );
+		expect( comp.find( 'UpsellNudge' ).length ).toBe( 1 );
 	} );
 
 	test( 'hide when user cannot upgrade', () => {
@@ -69,7 +69,7 @@ describe( 'UpgradeToPremiumNudgePure basic tests', () => {
 			canUserUpgrade: false,
 		};
 		const comp = shallow( <UpgradeToPremiumNudgePure { ...localProps } /> );
-		expect( comp.find( 'Banner' ).length ).toBe( 0 );
+		expect( comp.find( 'UpsellNudge' ).length ).toBe( 0 );
 	} );
 } );
 
@@ -99,7 +99,7 @@ describe( 'UpgradeToPremiumNudgePure.render()', () => {
 			const comp = shallow(
 				<UpgradeToPremiumNudgePure { ...props } isJetpack={ false } planSlug={ plan } />
 			);
-			expect( comp.find( 'Banner' ).props().plan ).toBe( plan );
+			expect( comp.find( 'UpsellNudge' ).props().plan ).toBe( plan );
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Swaps `Banner` for `UpsellNudge` in `UpgradeToPremiumNudge`
* See #38778

**Visuals**

WP.com - no visual changes

<img width="1071" alt="Screen Shot 2020-04-28 at 11 47 16 AM" src="https://user-images.githubusercontent.com/2124984/80508688-5ed5b000-8946-11ea-8c53-821644878fee.png">

Jetpack Before

<img width="1077" alt="Screen Shot 2020-04-28 at 11 50 32 AM" src="https://user-images.githubusercontent.com/2124984/80509153-ff2bd480-8946-11ea-8069-17c7e139e276.png">

Jetpack After

<img width="1063" alt="Screen Shot 2020-04-28 at 11 53 22 AM" src="https://user-images.githubusercontent.com/2124984/80509143-fb984d80-8946-11ea-8c07-afdda1c4e3c9.png">

#### Testing instructions

* Switch to this PR on a free site. Make sure you have at least one connected social account.
* Go to Posts -> three-dots menu on a single post -> Share
* You should see an upsell like the one above.
* Switch to a Jetpack free site with at least one connected social account.
* Go to Posts -> three-dots menu on a single post -> Share
* You should see another upsell like the one above.
* Make sure there are no visual regressions.
* There are no Tracks events associated with these upsells.