### PR TITLE
Jetpack Cloud: Fix up misc design items for daily backups

### DIFF
--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -192,11 +192,18 @@ class BackupDelta extends Component {
 
 		return (
 			<div className="backup-delta__daily">
-				{ hasChanges && (
-					<div className="backup-delta__changes-header">
-						{ translate( 'Changes in this backup' ) }
+				<div className="backup-delta__changes-header">
+					{ translate( 'Changes in this backup' ) }
+				</div>
+
+				{ ! hasChanges && (
+					<div className="backup-delta__daily-no-changes">
+						{ translate(
+							'Looks like there have been no new site changes since your last backup.'
+						) }
 					</div>
 				) }
+
 				{ !! deltas.mediaCreated.length && (
 					<Fragment>
 						<div className="backup-delta__section-header">{ translate( 'Media' ) }</div>

--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -7,9 +7,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { backupDetailPath } from 'landing/jetpack-cloud/sections/backups/paths';
 import Gridicon from 'components/gridicon';
-import Button from 'components/forms/form-button';
 import ActivityCard from '../../components/activity-card';
 
 /**
@@ -86,8 +84,7 @@ class BackupDelta extends Component {
 	}
 
 	renderDaily() {
-		const { backupAttempts, deltas, metaDiff, siteSlug, translate } = this.props;
-		const mainBackup = backupAttempts.complete && backupAttempts.complete[ 0 ];
+		const { deltas, metaDiff, translate } = this.props;
 
 		const mediaCreated = deltas.mediaCreated.map( ( item ) => (
 			<div key={ item.activityId } className="backup-delta__media-image">
@@ -231,15 +228,6 @@ class BackupDelta extends Component {
 					</Fragment>
 				) }
 				{ this.renderMetaDiff() }
-				{ mainBackup && (
-					<Button
-						isPrimary={ false }
-						className="backup-delta__view-all-button"
-						href={ backupDetailPath( siteSlug, mainBackup.rewindId ) }
-					>
-						{ translate( 'View all backup details' ) }
-					</Button>
-				) }
 			</div>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -140,14 +140,13 @@
     margin-top: 1rem;
 }
 
-.backup-delta__daily {
-    margin: 0 -16px;
-    padding: 0 16px;
-    background: var( --studio-white );
-}
-
 .backup-delta__daily .backup-delta__changes-header:first-child {
     margin-top: 0;
+}
+
+.backup-delta__daily-no-changes {
+    font-style: italic;
+    padding: 1rem 0;
 }
 
 @media ( max-width: 660px ) {
@@ -158,5 +157,11 @@
 
     .backup-delta__metas {
         margin-top: 0;
+    }
+
+    .backup-delta__daily {
+        margin: 0 -16px;
+        padding: 0 16px;
+        background: var( --studio-white );
     }
 }

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -13,7 +13,7 @@
 
 .backup-delta__changes-header {
     margin-top: 2rem;
-    font-weight: 700;
+    font-weight: 600;
 }
 
 .backup-delta__section-header {
@@ -132,7 +132,7 @@
 
 .backup-delta__realtime-header {
     font-size: 1.3rem;
-    font-weight: 500;
+    font-weight: 400;
     margin: 2rem 0 0.5rem;
 }
 
@@ -140,9 +140,23 @@
     margin-top: 1rem;
 }
 
+.backup-delta__daily {
+    margin: 0 -16px;
+    padding: 0 16px;
+    background: var( --studio-white );
+}
+
+.backup-delta__daily .backup-delta__changes-header:first-child {
+    margin-top: 0;
+}
+
 @media ( max-width: 660px ) {
     .backup-delta__view-all-button {
         display: block;
         text-align: center;
+    }
+
+    .backup-delta__metas {
+        margin-top: 0;
     }
 }

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -79,7 +79,6 @@ class DailyBackupStatus extends Component {
 		const { allowRestore, hasRealtimeBackups, siteSlug, translate } = this.props;
 
 		const displayDate = this.getDisplayDate( backup.activityTs );
-
 		const meta = get( backup, 'activityDescription[2].children[0]', '' );
 
 		return (

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -76,7 +76,7 @@ class DailyBackupStatus extends Component {
 	};
 
 	renderGoodBackup( backup ) {
-		const { allowRestore, siteSlug, translate } = this.props;
+		const { allowRestore, hasRealtimeBackups, siteSlug, translate } = this.props;
 
 		const displayDate = this.getDisplayDate( backup.activityTs );
 
@@ -95,7 +95,7 @@ class DailyBackupStatus extends Component {
 					siteSlug={ siteSlug }
 					disabledRestore={ ! allowRestore }
 				/>
-				{ this.renderBackupDetails( backup ) }
+				{ hasRealtimeBackups && this.renderBackupDetails( backup ) }
 			</>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -73,7 +73,6 @@
 	margin: 1rem 0;
 }
 
-.daily-backup-status__meta,
 .daily-backup-status__title {
 	display: none;
 }
@@ -115,6 +114,14 @@
 	width: 30px;
 }
 
+.daily-backup-status__meta {
+	margin-bottom: 1.6rem;
+	margin-top: -0.3rem;
+	color: var( --studio-gray-40 );
+	font-weight: 400;
+	font-size: 0.9rem;
+}
+
 @include breakpoint( '>660px' ) {
 	.daily-backup-status__meta,
 	.daily-backup-status__title {
@@ -150,6 +157,7 @@
 
 	.daily-backup-status__meta {
 		margin-bottom: 1rem;
+		margin-top: 0;
 		color: var( --studio-gray-40 );
 		font-weight: 400;
     	font-size: 0.9rem;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove links for backup detail pages, will reintroduce on a case-by-case basis with proper logic for whether to show or not.
* Show meta again.
* Change messaging when there are no changes for a day.
* Misc style tweaks throughout to match latest Figmas.

#### Testing instructions

* Take a look around for a daily backup site. Does everything match the Figmas? Is anything broken? Any console errors?
