### PR TITLE
Stats: Update Domain Tip to UpsellNudge

### DIFF
--- a/client/blocks/domain-tip/index.jsx
+++ b/client/blocks/domain-tip/index.jsx
@@ -15,7 +15,7 @@ import { getDomainsSuggestions } from 'state/domains/suggestions/selectors';
 import { currentUserHasFlag } from 'state/current-user/selectors';
 import QueryDomainsSuggestions from 'components/data/query-domains-suggestions';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import UpgradeNudge from 'blocks/upgrade-nudge';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { FEATURE_CUSTOM_DOMAIN } from 'lib/plans/constants';
 import { isFreePlan } from 'lib/products-values';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
@@ -55,12 +55,15 @@ class DomainTip extends React.Component {
 
 	renderPlanUpgradeNudge() {
 		return (
-			<UpgradeNudge
+			<UpsellNudge
 				event={ `domain_tip_${ this.props.event }` }
 				feature={ FEATURE_CUSTOM_DOMAIN }
-				shouldDisplay
-				message={ this.props.translate( 'Upgrade your plan to register a custom domain.' ) }
+				forceDisplay
+				description={ this.props.translate( 'Upgrade your plan to register a custom domain.' ) }
+				showIcon
 				title={ this.props.translate( 'Get a custom domain' ) }
+				tracksImpressionName="calypso_upgrade_nudge_impression"
+				tracksClickName="calypso_upgrade_nudge_cta_click"
 			/>
 		);
 	}
@@ -86,19 +89,22 @@ class DomainTip extends React.Component {
 		return (
 			<Fragment>
 				<QueryDomainsSuggestions { ...this.props.queryObject } />
-				<UpgradeNudge
+				<UpsellNudge
 					event={ `domain_tip_${ this.props.event }` }
+					tracksImpressionName="calypso_upgrade_nudge_impression"
+					tracksClickName="calypso_upgrade_nudge_cta_click"
 					feature={ FEATURE_CUSTOM_DOMAIN }
 					href={ `/domains/add/${ this.props.siteSlug }` }
-					message={
+					description={
 						this.props.hasDomainCredit
 							? this.props.translate(
 									'Your plan includes a free custom domain for one year. Grab this one!'
 							  )
 							: this.props.translate( 'Purchase a custom domain for your site.' )
 					}
-					shouldDisplay
+					forceDisplay
 					title={ title }
+					showIcon
 				/>
 			</Fragment>
 		);

--- a/client/blocks/domain-tip/index.jsx
+++ b/client/blocks/domain-tip/index.jsx
@@ -20,11 +20,6 @@ import { FEATURE_CUSTOM_DOMAIN } from 'lib/plans/constants';
 import { isFreePlan } from 'lib/products-values';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 
-/**
- * Style dependencies
- */
-import './style.scss';
-
 function getQueryObject( site, siteSlug, vendor ) {
 	if ( ! site || ! siteSlug ) {
 		return null;

--- a/client/blocks/domain-tip/style.scss
+++ b/client/blocks/domain-tip/style.scss
@@ -1,3 +1,0 @@
-.domain-tip__suggestion {
-	color: var( --color-primary );
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Swaps `UpgradeNudge` for `UpsellNudge` in the `DomainTip`, which appears on the Stats -> Insights page for free sites.
* Also removes the extra color in the domain name to match existing upsell nudges.
* See #38778 

**Before**

<img width="1104" alt="Screen Shot 2020-04-28 at 1 52 36 PM" src="https://user-images.githubusercontent.com/2124984/80520572-9dc03180-8957-11ea-9bbc-3587b8958ecf.png">

**After**

<img width="1135" alt="Screen Shot 2020-04-28 at 1 52 28 PM" src="https://user-images.githubusercontent.com/2124984/80520537-90a34280-8957-11ea-91ce-aa611426aa65.png">

There's another variation of this nudge on that screen, but I'm unable to get it to appear. I think it only shows up for DWOP sites, and I haven't figured out how to set that flag aside from fudging it in the code.

<img width="1149" alt="Screen Shot 2020-04-28 at 1 54 28 PM" src="https://user-images.githubusercontent.com/2124984/80520692-cd6f3980-8957-11ea-8558-1f7930c5cf70.png">

#### Testing instructions

* Switch to this PR on a free WP.com site
* Navigate to Stats -> Insights
* Note the upsell nudge; there should be no visual discrepancies and all Tracks events and props (impression and click) should be the same.
* To test the other nudge, switch to a domains-with-plans-only site (I think this means a site that has a custom domain but no plan). Or you can fudge it in `client/blocks/domain-tip/index.jsx` by commenting out this condition:

https://github.com/Automattic/wp-calypso/blob/d9fcbe9ad95cab35076a46d710bb24bd1b11cabf/client/blocks/domain-tip/index.jsx#L76