### PR TITLE
Enable real-time full post view comments for a12s

### DIFF
--- a/client/state/lasagna/post-channel/middleware.js
+++ b/client/state/lasagna/post-channel/middleware.js
@@ -17,7 +17,7 @@ import { lasagna } from '../middleware';
 
 const debug = debugFactory( 'lasagna:channel' );
 const topicPrivateScheme = 'push';
-const topicPublicScheme = 'push:no_auth';
+const topicPublicScheme = 'push-no_auth';
 const topicIss = 'wordpress.com';
 const topicSubPrefix = 'wp_post';
 

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -22,7 +22,7 @@
 	"hotjar_enabled": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",
-	"lasagna_url": "wss://lasagna.pub/socket",
+	"lasagna_url": "wss://rt-api.wordpress.com/socket",
 	"login_url": false,
 	"logout_url": false,
 	"mc_analytics_enabled": false,

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -22,7 +22,7 @@
 	"hotjar_enabled": false,
 	"hostname": false,
 	"i18n_default_locale_slug": "en",
-	"lasagna_url": "wss://horizon.lasagna.pub/socket",
+	"lasagna_url": "wss://lasagna.pub/socket",
 	"login_url": false,
 	"logout_url": false,
 	"mc_analytics_enabled": false,

--- a/config/development.json
+++ b/config/development.json
@@ -26,7 +26,6 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
-	"lasagna_url": "wss://horizon.lasagna.pub/socket",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"async-payments": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -57,7 +57,7 @@
 		"jetpack/search-product": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
-		"lasagna": false,
+		"lasagna": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/nps-survey-notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -63,7 +63,7 @@
 		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
 		"jitms": true,
-		"lasagna": false,
+		"lasagna": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/nps-survey-notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -71,7 +71,7 @@
 		"jetpack/scan-product": true,
 		"jetpack/search-product": true,
 		"jitms": true,
-		"lasagna": false,
+		"lasagna": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/nps-survey-notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -14,7 +14,6 @@
 	"facebook_api_key": "249643311490",
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"rebrand_cities_prefix": "rebrandcitiestestsite",
-	"lasagna_url": "wss://horizon.lasagna.pub/socket",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"async-payments": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make all environments connect to prod (our only in house instance).
* Enable real-time full post view comments for a12s

#### Testing instructions

1. Boot the calypso.live branch below.
2. Click out of the Reader section. Click into the Reader section. Make sure it successfully connects to `rt-api.wordpress.com` (`101` response) in your web inspector.
3. Go to a post full view. Comment from wherever else you'd like (another tab in Calypso, the front of the blog, whatever). You should see the comments popping in live as you'd expect.