### PR TITLE
Earn: Swap UpgradeNudgeExpanded for UpsellNudge

### DIFF
--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -29,7 +29,7 @@ import {
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import QueryWordadsStatus from 'components/data/query-wordads-status';
-import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, FEATURE_WORDADS_INSTANT } from 'lib/plans/constants';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { isSiteWordadsUnsafe } from 'state/wordads/status/selectors';
@@ -190,16 +190,23 @@ class AdsWrapper extends Component {
 	}
 
 	renderUpsell() {
-		const { translate } = this.props;
+		const { siteSlug, translate } = this.props;
+		const bannerURL = `/checkout/${ siteSlug }/premium`;
 		return (
-			<UpgradeNudgeExpanded
+			<UpsellNudge
+				callToAction={ translate( 'Upgrade' ) }
 				plan={ PLAN_PREMIUM }
 				title={ translate( 'Upgrade to the Premium plan and start earning' ) }
-				subtitle={ translate(
+				description={ translate(
 					"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program."
 				) }
-				highlightedFeature={ FEATURE_WORDADS_INSTANT }
-				benefits={ [
+				feature={ FEATURE_WORDADS_INSTANT }
+				href={ bannerURL }
+				showIcon
+				event="calypso_upgrade_nudge_impression"
+				tracksImpressionName="calypso_upgrade_nudge_impression"
+				tracksClickName="calypso_upgrade_nudge_click"
+				list={ [
 					translate( 'Instantly enroll into the WordAds network.' ),
 					translate( 'Earn money from your content and traffic.' ),
 				] }
@@ -208,16 +215,23 @@ class AdsWrapper extends Component {
 	}
 
 	renderjetpackUpsell() {
-		const { translate } = this.props;
+		const { siteSlug, translate } = this.props;
+		const bannerURL = `/checkout/${ siteSlug }/premium`;
 		return (
-			<UpgradeNudgeExpanded
+			<UpsellNudge
+				callToAction={ translate( 'Upgrade' ) }
 				plan={ PLAN_JETPACK_PREMIUM }
 				title={ translate( 'Upgrade to the Premium plan and start earning' ) }
-				subtitle={ translate(
+				description={ translate(
 					"By upgrading to the Premium plan, you'll be able to monetize your site through the Jetpack Ads program."
 				) }
-				highlightedFeature={ FEATURE_WORDADS_INSTANT }
-				benefits={ [
+				href={ bannerURL }
+				feature={ FEATURE_WORDADS_INSTANT }
+				showIcon
+				event="calypso_upgrade_nudge_impression"
+				tracksImpressionName="calypso_upgrade_nudge_impression"
+				tracksClickName="calypso_upgrade_nudge_click"
+				list={ [
 					translate( 'Instantly enroll into the Jetpack Ads network.' ),
 					translate( 'Earn money from your content and traffic.' ),
 				] }

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -205,9 +205,9 @@ class AdsWrapper extends Component {
 				showIcon
 				event="calypso_upgrade_nudge_impression"
 				tracksImpressionName="calypso_upgrade_nudge_impression"
-				tracksImpressionProperties={ { cta_name: '' } }
+				tracksImpressionProperties={ { cta_name: undefined, cta_size: 'regular' } }
 				tracksClickName="calypso_upgrade_nudge_cta_click"
-				tracksClickProperties={ { cta_name: '' } }
+				tracksClickProperties={ { cta_name: undefined, cta_size: 'regular' } }
 				list={ [
 					translate( 'Instantly enroll into the WordAds network.' ),
 					translate( 'Earn money from your content and traffic.' ),

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -205,7 +205,9 @@ class AdsWrapper extends Component {
 				showIcon
 				event="calypso_upgrade_nudge_impression"
 				tracksImpressionName="calypso_upgrade_nudge_impression"
-				tracksClickName="calypso_upgrade_nudge_click"
+				tracksImpressionProperties={ { cta_name: '' } }
+				tracksClickName="calypso_upgrade_nudge_cta_click"
+				tracksClickProperties={ { cta_name: '' } }
 				list={ [
 					translate( 'Instantly enroll into the WordAds network.' ),
 					translate( 'Earn money from your content and traffic.' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `UpgradeNudgeExpanded` only appears at `/earn/ads-earnings/[site]`, which only appears to be accessible for free sites by going directly to the URL. 
* `UpgradeNudgeExpanded` included more information about the Premium plan, but I don't think this is necessary. Replacing it with `UpsellNudge` makes it behave like the rest of the upsells across Calypso, even though it changes the visual appearance.

**Before**

WP.com

<img width="1109" alt="Screen Shot 2020-04-28 at 2 41 49 PM" src="https://user-images.githubusercontent.com/2124984/80527148-e8df4200-8961-11ea-8c4d-e5262dd948d3.png">

Jetpack

<img width="1080" alt="Screen Shot 2020-04-28 at 2 44 16 PM" src="https://user-images.githubusercontent.com/2124984/80527145-e846ab80-8961-11ea-8633-5343c3ad06d4.png">

**After**

WP.com

<img width="1095" alt="Screen Shot 2020-04-28 at 2 42 30 PM" src="https://user-images.githubusercontent.com/2124984/80527294-2348df00-8962-11ea-9579-9bf2e2088807.png">

Jetpack

<img width="1109" alt="Screen Shot 2020-04-28 at 3 09 47 PM" src="https://user-images.githubusercontent.com/2124984/80527419-54291400-8962-11ea-892e-ad263a61a000.png">


#### Testing instructions

* Switch to this PR and go to `/earn/ads-earnings/[site]`
* Look with a site that has a WP.com free plan to see the ad. Make sure the behavior is the same (clicking the CTA goes to the checkout for the Premium plan) and the Tracks events are the same. (This PR adds a `cta_name` property that shouldn't affect the existing props)
* Look with another site that has a Jetpack free plan to see the Jetpack ad. Make sure the behavior is the same (clicking the CTA goes to the checkout for the Premium plan) and the Tracks events are the same (This PR adds a `cta_name` property that shouldn't affect the existing props)