### PR TITLE
Jetpack Cloud: update progress bar while scanning

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-badge/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-badge/index.tsx
@@ -3,6 +3,7 @@
  */
 import React, { FunctionComponent } from 'react';
 import { useTranslate } from 'i18n-calypso';
+import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,16 +12,16 @@ import Badge from 'components/badge';
 
 interface Props {
 	numberOfThreatsFound: number;
-	progress: number;
+	progress?: number;
 }
 
 const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress } ) => {
 	const translate = useTranslate();
-	if ( ! numberOfThreatsFound && ! progress ) {
+	if ( ! numberOfThreatsFound && ! isNumber( progress ) ) {
 		return null;
 	}
 
-	if ( progress ) {
+	if ( isNumber( progress ) ) {
 		return (
 			<Badge type="success">
 				{ translate( '%(number)d %', {

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -110,7 +110,9 @@ class ScanPage extends Component< Props > {
 		return (
 			<>
 				<SecurityIcon icon="in-progress" />
-				<h1 className="scan__header">{ translate( 'Preparing to scan' ) }</h1>
+				<h1 className="scan__header">
+					{ scanProgress === 0 ? translate( 'Preparing to scan' ) : translate( 'Scanning files' ) }
+				</h1>
 				<ProgressBar value={ scanProgress } total={ 100 } color="#069E08" />
 				<p>
 					Welcome to Jetpack Scan, we are taking a first look at your site now and the results will

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -24,6 +24,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import getSiteUrl from 'state/sites/selectors/get-site-url';
 import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
+import getSiteScanIsInitial from 'state/selectors/get-site-scan-is-initial';
 import getSiteScanState from 'state/selectors/get-site-scan-state';
 import { withLocalizedMoment } from 'components/localized-moment';
 import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
@@ -40,6 +41,7 @@ interface Props {
 	siteUrl: string | null;
 	scanState: Scan | null;
 	scanProgress?: number;
+	isInitialScan: boolean;
 	lastScanTimestamp: number;
 	nextScanTimestamp: number;
 	moment: Function;
@@ -106,7 +108,7 @@ class ScanPage extends Component< Props > {
 	}
 
 	renderScanning() {
-		const { scanProgress = 0 } = this.props;
+		const { scanProgress = 0, isInitialScan } = this.props;
 		return (
 			<>
 				<SecurityIcon icon="in-progress" />
@@ -114,10 +116,12 @@ class ScanPage extends Component< Props > {
 					{ scanProgress === 0 ? translate( 'Preparing to scan' ) : translate( 'Scanning files' ) }
 				</h1>
 				<ProgressBar value={ scanProgress } total={ 100 } color="#069E08" />
-				<p>
-					Welcome to Jetpack Scan, we are taking a first look at your site now and the results will
-					be with you soon.
-				</p>
+				{ isInitialScan && (
+					<p>
+						Welcome to Jetpack Scan, we are taking a first look at your site now and the results
+						will be with you soon.
+					</p>
+				) }
 				<p>
 					We will send you an email once the scan completes, in the meantime feel free to continue
 					to use your site as normal, you can check back on progress at any time.
@@ -224,6 +228,7 @@ export default connect(
 		const lastScanTimestamp = Date.now() - 5700000; // 1h 35m.
 		const nextScanTimestamp = Date.now() + 5700000;
 		const scanProgress = getSiteScanProgress( state, site.ID );
+		const isInitialScan = getSiteScanIsInitial( state, site.ID );
 
 		return {
 			site,
@@ -231,6 +236,7 @@ export default connect(
 			siteSlug,
 			scanState,
 			scanProgress,
+			isInitialScan,
 			lastScanTimestamp,
 			nextScanTimestamp,
 		};

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -23,6 +23,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
 import getSiteUrl from 'state/sites/selectors/get-site-url';
+import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
 import getSiteScanState from 'state/selectors/get-site-scan-state';
 import { withLocalizedMoment } from 'components/localized-moment';
 import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
@@ -38,6 +39,7 @@ interface Props {
 	siteSlug: string | null;
 	siteUrl: string | null;
 	scanState: Scan | null;
+	scanProgress?: number;
 	lastScanTimestamp: number;
 	nextScanTimestamp: number;
 	moment: Function;
@@ -104,11 +106,12 @@ class ScanPage extends Component< Props > {
 	}
 
 	renderScanning() {
+		const { scanProgress = 0 } = this.props;
 		return (
 			<>
 				<SecurityIcon icon="in-progress" />
 				<h1 className="scan__header">{ translate( 'Preparing to scan' ) }</h1>
-				<ProgressBar value={ 1 } total={ 100 } color="#069E08" />
+				<ProgressBar value={ scanProgress } total={ 100 } color="#069E08" />
 				<p>
 					Welcome to Jetpack Scan, we are taking a first look at your site now and the results will
 					be with you soon.
@@ -218,12 +221,14 @@ export default connect(
 		const scanState = getSiteScanState( state, site.ID );
 		const lastScanTimestamp = Date.now() - 5700000; // 1h 35m.
 		const nextScanTimestamp = Date.now() + 5700000;
+		const scanProgress = getSiteScanProgress( state, site.ID );
 
 		return {
 			site,
 			siteUrl,
 			siteSlug,
 			scanState,
+			scanProgress,
 			lastScanTimestamp,
 			nextScanTimestamp,
 		};

--- a/client/landing/jetpack-cloud/sections/scan/types.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/types.tsx
@@ -15,5 +15,6 @@ export type Scan = {
 		duration: number;
 		// @todo: complete the error prop when we know what the shape will it have
 		error: string | object;
+		isInitial: boolean;
 	};
 };

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -49,6 +49,7 @@ const formatScanStateRawResponse = ( { state, threats, credentials, most_recent:
 			? {
 					...mostRecent,
 					timestamp: new Date( mostRecent.timestamp ),
+					isInitial: mostRecent.is_initial,
 			  }
 			: null,
 	};

--- a/client/state/selectors/get-site-scan-is-initial.js
+++ b/client/state/selectors/get-site-scan-is-initial.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import 'state/data-layer/wpcom/sites/scan';
+
+/**
+ * Returns true if the most recent Scan is the first Scan run and false otherwise.
+ *
+ * @param {object} state	Global state tree
+ * @param {number} siteId	The ID of the site we're querying
+ * @returns {boolean}		If the most recent Scan was the first one
+ */
+export default function getSiteScanIsInitial( state, siteId ) {
+	return state.jetpackScan.scan?.[ siteId ]?.mostRecent?.isInitial ?? false;
+}

--- a/client/state/selectors/get-site-scan-progress.js
+++ b/client/state/selectors/get-site-scan-progress.js
@@ -5,15 +5,17 @@ import 'state/data-layer/wpcom/sites/scan';
 
 /**
  * Returns the current Jetpack Scan Progress for a given site only if the
- * Scan is in the 'scanning' state.
- * Returns undefined if the site is unknown, or if no information is available.
+ * Scan is in the 'scanning' state. If the Scan is in the 'scanning' state but
+ * there is no progress in its state, we return 0.
+ * Returns undefined in any other case.
  *
  * @param {object} state	Global state tree
  * @param {number} siteId	The ID of the site we're querying
  * @returns {?number}		Undefined or percentage of the scan completed
  */
 export default function getSiteScanProgress( state, siteId ) {
-	return state.jetpackScan.scan?.[ siteId ]?.state === 'scanning'
-		? state.jetpackScan.scan?.[ siteId ]?.mostRecent?.progress
-		: undefined;
+	if ( state.jetpackScan.scan?.[ siteId ]?.state === 'scanning' ) {
+		return state.jetpackScan.scan?.[ siteId ]?.mostRecent?.progress ?? 0;
+	}
+	return;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the progress bar display the current progress of the scanning process.

#### Implementation notes

* Changed a bit the behavior of the `getSiteScanProgress` to fix a bug in which the Scan can be in the `scanning` state but at the same time, don't have a progress status yet. This usually happens when the first time the `/scan` endpoint reports the Scan is `scanning`. To fix this, now the `getSiteScanProgress` returns 0 is the Scan is `scanning` and there is no progress status.

**Screenshot of the bug**

<img width="1017" alt="WrongState" src="https://user-images.githubusercontent.com/3418513/80533230-ac1c4680-8973-11ea-8a82-4b6b6cea7dbd.png">

#### Testing instructions

* Run this PR
* Select a site (the biggest the better because we want a long scanning process)
* Start a Scan (run a backup)
* Reload the page until you see the scanning process has started
* Verify the progress bar reflects the current progress % (you can see it in the sidebar as well)

#### Demo

<img width="1015" alt="S19" src="https://user-images.githubusercontent.com/3418513/80533215-a7579280-8973-11ea-8ba8-ee246d753e1f.png">
