### PR TITLE
composite-checkout: Improve UI when updating cart

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -374,6 +374,7 @@ export default function CompositeCheckout( {
 					responseCart={ responseCart }
 					addItemToCart={ addItemWithEssentialProperties }
 					subtotal={ subtotal }
+					isCartPendingUpdate={ isCartPendingUpdate }
 					CheckoutTerms={ CheckoutTerms }
 				/>
 			</CheckoutProvider>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -76,6 +76,7 @@ export default function WPCheckout( {
 	responseCart,
 	addItemToCart,
 	subtotal,
+	isCartPendingUpdate,
 } ) {
 	const translate = useTranslate();
 	const couponFieldStateProps = useCouponFieldState( submitCoupon );
@@ -167,8 +168,12 @@ export default function WPCheckout( {
 						editButtonAriaLabel={ translate( 'Edit the payment method' ) }
 						nextStepButtonText={ translate( 'Continue' ) }
 						nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
-						validatingButtonText={ translate( 'Please wait…' ) }
-						validatingButtonAriaLabel={ translate( 'Please wait…' ) }
+						validatingButtonText={
+							isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
+						}
+						validatingButtonAriaLabel={
+							isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
+						}
 					/>
 					{ shouldShowContactStep && (
 						<CheckoutStep
@@ -199,8 +204,12 @@ export default function WPCheckout( {
 							editButtonAriaLabel={ translate( 'Edit the contact details' ) }
 							nextStepButtonText={ translate( 'Continue' ) }
 							nextStepButtonAriaLabel={ translate( 'Continue with the entered contact details' ) }
-							validatingButtonText={ translate( 'Please wait…' ) }
-							validatingButtonAriaLabel={ translate( 'Please wait…' ) }
+							validatingButtonText={
+								isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
+							}
+							validatingButtonAriaLabel={
+								isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
+							}
 						/>
 					) }
 					<CheckoutStep
@@ -218,8 +227,12 @@ export default function WPCheckout( {
 						editButtonAriaLabel={ translate( 'Edit the payment method' ) }
 						nextStepButtonText={ translate( 'Continue' ) }
 						nextStepButtonAriaLabel={ translate( 'Continue with the selected payment method' ) }
-						validatingButtonText={ translate( 'Please wait…' ) }
-						validatingButtonAriaLabel={ translate( 'Please wait…' ) }
+						validatingButtonText={
+							isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
+						}
+						validatingButtonAriaLabel={
+							isCartPendingUpdate ? translate( 'Updating cart…' ) : translate( 'Please wait…' )
+						}
 					/>
 				</CheckoutSteps>
 			</CheckoutStepArea>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -274,20 +274,22 @@ export function WPOrderReviewLineItems( {
 } ) {
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
-			{ items.map( ( item ) => (
-				<WPOrderReviewListItem key={ item.id }>
-					<LineItemUI
-						isSummaryVisible={ isSummaryVisible }
-						item={ item }
-						hasDeleteButton={ canItemBeDeleted( item ) }
-						removeItem={ item.type === 'coupon' ? removeCoupon : removeItem }
-						variantRequestStatus={ variantRequestStatus }
-						variantSelectOverride={ variantSelectOverride }
-						getItemVariants={ getItemVariants }
-						onChangePlanLength={ onChangePlanLength }
-					/>
-				</WPOrderReviewListItem>
-			) ) }
+			{ items
+				.filter( ( item ) => item.label ) // remove items without a label
+				.map( ( item ) => (
+					<WPOrderReviewListItem key={ item.id }>
+						<LineItemUI
+							isSummaryVisible={ isSummaryVisible }
+							item={ item }
+							hasDeleteButton={ canItemBeDeleted( item ) }
+							removeItem={ item.type === 'coupon' ? removeCoupon : removeItem }
+							variantRequestStatus={ variantRequestStatus }
+							variantSelectOverride={ variantSelectOverride }
+							getItemVariants={ getItemVariants }
+							onChangePlanLength={ onChangePlanLength }
+						/>
+					</WPOrderReviewListItem>
+				) ) }
 		</WPOrderReviewList>
 	);
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -139,7 +139,7 @@ function translateReponseCartProductToWPCOMCartItem(
 
 	return {
 		id: uuid,
-		label: product_name || '…',
+		label: product_name || '',
 		sublabel: meta,
 		type: product_slug,
 		amount: {

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/shopping-cart-endpoint.js
@@ -88,7 +88,7 @@ describe( 'addItemToResponseCart', function () {
 			item_original_cost_integer: null,
 			product_cost_display: null,
 			product_cost_integer: null,
-			product_name: '…',
+			product_name: '',
 			product_type: null,
 			uuid: 'calypso-shopping-cart-endpoint-uuid-100',
 			volume: 1,

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -313,7 +313,7 @@ function convertRequestCartProductToResponseCartProduct(
 ): TempResponseCartProduct {
 	const { product_slug, product_id, meta, extra } = product;
 	return {
-		product_name: '…',
+		product_name: '',
 		product_slug,
 		product_id,
 		currency: null,

--- a/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
+++ b/packages/composite-checkout/src/lib/payment-methods/existing-credit-card.js
@@ -293,10 +293,6 @@ function ExistingCardPayButton( { disabled, id, stripeConfiguration } ) {
 		localize,
 	] );
 
-	const buttonString =
-		formStatus === 'submitting'
-			? localize( 'Processing...' )
-			: sprintf( localize( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
 	return (
 		<Button
 			disabled={ disabled }
@@ -316,9 +312,20 @@ function ExistingCardPayButton( { disabled, id, stripeConfiguration } ) {
 			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
-			{ buttonString }
+			<ButtonContents formStatus={ formStatus } total={ total } />
 		</Button>
 	);
+}
+
+function ButtonContents( { formStatus, total } ) {
+	const localize = useLocalize();
+	if ( formStatus === 'submitting' ) {
+		return localize( 'Processing…' );
+	}
+	if ( formStatus === 'ready' ) {
+		return sprintf( localize( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
+	}
+	return localize( 'Please wait…' );
 }
 
 function ExistingCardSummary( { cardholderName, cardExpiry, brand, last4 } ) {

--- a/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
+++ b/packages/composite-checkout/src/lib/payment-methods/free-purchase.js
@@ -143,13 +143,7 @@ function FreePurchaseSubmitButton( { disabled } ) {
 			items,
 		} );
 	};
-	const buttonString =
-		formStatus === 'submitting'
-			? localize( 'Processing...' )
-			: sprintf(
-					localize( 'Complete Checkout' ),
-					renderDisplayValueMarkdown( total.amount.displayValue )
-			  );
+
 	return (
 		<Button
 			disabled={ disabled }
@@ -158,9 +152,23 @@ function FreePurchaseSubmitButton( { disabled } ) {
 			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
-			{ buttonString }
+			<ButtonContents formStatus={ formStatus } total={ total } />
 		</Button>
 	);
+}
+
+function ButtonContents( { formStatus, total } ) {
+	const localize = useLocalize();
+	if ( formStatus === 'submitting' ) {
+		return localize( 'Processing…' );
+	}
+	if ( formStatus === 'ready' ) {
+		return sprintf(
+			localize( 'Complete Checkout' ),
+			renderDisplayValueMarkdown( total.amount.displayValue )
+		);
+	}
+	return localize( 'Please wait…' );
 }
 
 function FreePurchaseSummary() {

--- a/packages/composite-checkout/src/lib/payment-methods/full-credits.js
+++ b/packages/composite-checkout/src/lib/payment-methods/full-credits.js
@@ -144,13 +144,7 @@ function FullCreditsSubmitButton( { disabled } ) {
 			items,
 		} );
 	};
-	const buttonString =
-		formStatus === 'submitting'
-			? localize( 'Processing...' )
-			: sprintf(
-					localize( 'Pay %s with WordPress.com Credits' ),
-					renderDisplayValueMarkdown( total.amount.displayValue )
-			  );
+
 	return (
 		<Button
 			disabled={ disabled }
@@ -159,9 +153,23 @@ function FullCreditsSubmitButton( { disabled } ) {
 			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
-			{ buttonString }
+			<ButtonContents formStatus={ formStatus } total={ total } />
 		</Button>
 	);
+}
+
+function ButtonContents( { formStatus, total } ) {
+	const localize = useLocalize();
+	if ( formStatus === 'submitting' ) {
+		return localize( 'Processing…' );
+	}
+	if ( formStatus === 'ready' ) {
+		return sprintf(
+			localize( 'Pay %s with WordPress.com Credits' ),
+			renderDisplayValueMarkdown( total.amount.displayValue )
+		);
+	}
+	return localize( 'Please wait…' );
 }
 
 function FullCreditsSummary() {

--- a/packages/composite-checkout/src/lib/payment-methods/paypal.js
+++ b/packages/composite-checkout/src/lib/payment-methods/paypal.js
@@ -90,7 +90,6 @@ export function PaypalLabel() {
 }
 
 export function PaypalSubmitButton( { disabled } ) {
-	const localize = useLocalize();
 	const { submitPaypalPayment } = useDispatch( 'paypal' );
 	useTransactionStatusHandler();
 	const { formStatus } = useFormStatus();
@@ -109,9 +108,20 @@ export function PaypalSubmitButton( { disabled } ) {
 			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
-			{ formStatus === 'submitting' ? localize( 'Processing...' ) : <ButtonPayPalIcon /> }
+			<PayPalButtonContents formStatus={ formStatus } />
 		</Button>
 	);
+}
+
+function PayPalButtonContents( { formStatus } ) {
+	const localize = useLocalize();
+	if ( formStatus === 'submitting' ) {
+		return localize( 'Processing…' );
+	}
+	if ( formStatus === 'ready' ) {
+		return <ButtonPayPalIcon />;
+	}
+	return localize( 'Please wait…' );
 }
 
 function useTransactionStatusHandler() {

--- a/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
+++ b/packages/composite-checkout/src/lib/payment-methods/stripe-credit-card-fields.js
@@ -556,11 +556,6 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 		localize,
 	] );
 
-	const buttonString =
-		formStatus === 'submitting'
-			? localize( 'Processing...' )
-			: sprintf( localize( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
-
 	return (
 		<Button
 			disabled={ disabled }
@@ -584,9 +579,20 @@ function StripePayButton( { disabled, store, stripe, stripeConfiguration } ) {
 			isBusy={ 'submitting' === formStatus }
 			fullWidth
 		>
-			{ buttonString }
+			<ButtonContents formStatus={ formStatus } total={ total } />
 		</Button>
 	);
+}
+
+function ButtonContents( { formStatus, total } ) {
+	const localize = useLocalize();
+	if ( formStatus === 'submitting' ) {
+		return localize( 'Processing…' );
+	}
+	if ( formStatus === 'ready' ) {
+		return sprintf( localize( 'Pay %s' ), renderDisplayValueMarkdown( total.amount.displayValue ) );
+	}
+	return localize( 'Please wait…' );
 }
 
 function StripeSummary() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR does three things to improve the UI when the cart is being updated in composite checkout:

- Temporary line items (items not yet verified on the server and for which we have no title or price data) now are hidden in the order review list (previously they had been shown as '…').
- The "Continue" buttons for each step now display "Updating cart…" when the cart is updating. Previously they had displayed "Please wait…" (which they still display if some other activity is pending).
- The submit button now displays "Please wait…" when the form is not in a ready state (including when the cart is being updated but also when validating the contact form). Previously the button was just disabled in those other states except for when the form was submitting. (It would be nice to change this to "Updating cart" as well, but that's much more complicated because that's a calypso-specific state currently and the payment methods are not inside calypso so we'll wait on that for a future update.)

#### Testing instructions

- Add a domain to your cart for an account that has no plan. 
- Visit composite checkout and verify that you see the upsell in the sidebar. 
- Verify that clicking the "Add to Cart" button causes the "Continue" button to display "Updating cart" and the submit button to display "Please wait".
- Verify that the number of items in the review step does not change until the cart finishes updating at which point you should see the plan included in the list.