### PR TITLE
composite-checkout: Pass coupon code to paypal submit function

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -257,6 +257,7 @@ export default function CompositeCheckout( {
 		stripe,
 		credits,
 		items,
+		couponItem,
 		isApplePayAvailable,
 		isApplePayLoading,
 		storedCards,

--- a/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
+++ b/client/my-sites/checkout/composite-checkout/use-create-payment-methods.js
@@ -38,7 +38,7 @@ import {
 const debug = debugFactory( 'calypso:composite-checkout:use-create-payment-methods' );
 const { select, dispatch } = defaultRegistry;
 
-function useCreatePayPal( { onlyLoadPaymentMethods, getThankYouUrl, getItems } ) {
+function useCreatePayPal( { onlyLoadPaymentMethods, getThankYouUrl, getItems, getCouponItem } ) {
 	const shouldLoadPayPalMethod = onlyLoadPaymentMethods
 		? onlyLoadPaymentMethods.includes( 'paypal' )
 		: true;
@@ -73,7 +73,7 @@ function useCreatePayPal( { onlyLoadPaymentMethods, getThankYouUrl, getItems } )
 					cancelUrl,
 					siteId: select( 'wpcom' )?.getSiteId?.() ?? '',
 					domainDetails: getDomainDetails( select ),
-					couponId: null, // TODO: get couponId
+					couponId: getCouponItem()?.wpcom_meta?.couponCode,
 					country: select( 'wpcom' )?.getContactInfo?.()?.countryCode?.value ?? '',
 					postalCode: select( 'wpcom' )?.getContactInfo?.()?.postalCode?.value ?? '',
 					subdivisionCode: select( 'wpcom' )?.getContactInfo?.()?.state?.value ?? '',
@@ -323,6 +323,7 @@ export default function useCreatePaymentMethods( {
 	stripe,
 	credits,
 	items,
+	couponItem,
 	isApplePayAvailable,
 	isApplePayLoading,
 	storedCards,
@@ -331,6 +332,7 @@ export default function useCreatePaymentMethods( {
 		onlyLoadPaymentMethods,
 		getThankYouUrl,
 		getItems: () => items,
+		getCouponItem: () => couponItem,
 	} );
 
 	const stripeMethod = useCreateStripe( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When coupon codes were added to composite checkout, there was a place that was missed: paypal transactions do not submit the coupon code which causes the full purchase price to be sent to paypal. This PR fixes that oversight by sending the coupon code to the WPCOM paypal url endpoint.

![Screen Shot 2020-04-28 at 6 36 29 PM](https://user-images.githubusercontent.com/2036909/80544746-b80e0580-897f-11ea-8595-1798ab2460c3.png)

#### Testing instructions

- Sandbox the store.
- Create a sandboxed coupon code.
- Visit composite checkout and add the coupon code.
- Verify that composite checkout displays a discounted price; remember this number for later.
- Choose PayPal as the payment method and press the submit button.
- Use your PayPal sandbox credentials (contact me if you don't know how to get these) to log in to PayPal when prompted.
- Verify that the price displayed on PayPal's site is the discounted price you saw before.
- Complete the form to complete the payment.
- Verify that the payment completes successfully.