### PR TITLE
Fix Empty Stream Content

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -122,7 +122,7 @@ class ActivityCard extends Component {
 		// todo: handle the rest of cases
 		if (
 			activity.streams &&
-			activity.streams.some( ( { activityMedia: { available } } ) => available )
+			activity.streams.some( ( stream ) => stream.activityMedia && stream.activityMedia.available )
 		) {
 			return (
 				<Button

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -120,7 +120,10 @@ class ActivityCard extends Component {
 		}
 
 		// todo: handle the rest of cases
-		if ( activity.streams ) {
+		if (
+			activity.streams &&
+			activity.streams.some( ( { activityMedia: { available } } ) => available )
+		) {
 			return (
 				<Button
 					compact


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide Streams expand button if no streams media is available
![Untitled 10](https://user-images.githubusercontent.com/2810519/80547183-6ad46880-896c-11ea-858c-bbdc033120bb.png)


#### Testing instructions

1. find an example with no available stream content and verify it does not give the option to expand
2. find an example with some stream media content and verify if does give the option to expand
