### PR TITLE
FSE: Make Posts Carousel block disable-able

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
@@ -92,7 +92,17 @@ require_once __DIR__ . '/synced-newspack-blocks/class-newspack-blocks.php';
 require_once __DIR__ . '/synced-newspack-blocks/class-newspack-blocks-api.php';
 
 require_once __DIR__ . '/synced-newspack-blocks/blocks/homepage-articles/view.php';
-require_once __DIR__ . '/synced-newspack-blocks/blocks/carousel/view.php';
+
+/**
+ * Can be used to disable the Posts Carousel Block.
+ *
+ * @since 1.2
+ *
+ * @param bool true if Posts Carousel Block should be disabled, false otherwise.
+ */
+if ( ! apply_filters( 'a8c_disable_posts_carousel_block', false ) ) {
+	require_once __DIR__ . '/synced-newspack-blocks/blocks/carousel/view.php';
+}
 
 // REST Controller for Articles Block.
 require_once NEWSPACK_BLOCKS__PLUGIN_DIR . 'synced-newspack-blocks/blocks/homepage-articles/class-wp-rest-newspack-articles-controller.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a feature switch for the Posts Carousel block.

Depends on #41553.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

~~This will not really work until #41553 and https://github.com/Automattic/newspack-blocks/pull/444 have been merged. Once they are merged:~~ Update: both PRs have been merged.


* Run `yarn run sync:newspack-blocks --branch=master`
* Run `yarn dev`
* Load the Editor and make sure the block shows up.
* Add this anywhere before FSE gets loaded: `add_filter( 'a8c_disable_posts_carousel_block', '__return_true' )`
* Load the Editor and make sure the block doesn't show up anymore.