### PR TITLE
Support: Track how often ticket config is requested

### DIFF
--- a/client/state/help/ticket/actions.js
+++ b/client/state/help/ticket/actions.js
@@ -9,6 +9,7 @@ import {
 	HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
 	HELP_TICKET_CONFIGURATION_DISMISS_ERROR,
 } from 'state/action-types';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
 export const ticketSupportConfigurationRequestSuccess = ( configuration ) => {
 	return {
@@ -25,7 +26,16 @@ export const ticketSupportConfigurationRequestFailure = ( error ) => {
 };
 
 export const ticketSupportConfigurationRequest = () => ( dispatch ) => {
-	dispatch( { type: HELP_TICKET_CONFIGURATION_REQUEST } );
+	const requestAction = {
+		type: HELP_TICKET_CONFIGURATION_REQUEST,
+	};
+
+	dispatch(
+		withAnalytics(
+			recordTracksEvent( 'calypso_ticket_support_configuration_requested' ),
+			requestAction
+		)
+	);
 
 	return wpcom
 		.undocumented()


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Simple update to add a Tracks event whenever the user's ticket support configuration is requested.

I'm working on a project that could add a Zendesk API call to this WPCOM API request, but before I do that I want an accurate representation of how often this endpoint is hit. This lets me know how it will affect our Zendesk API rate limit.

#### Testing instructions

- Open Inline Help and click "Contact Us"
- The form should appear
- In Network dev tools you should see a request to `/help/tickets/kayako/mine`
- If you show Tracks debug in console, you'll see the `calypso_ticket_support_configuration_requested` event come through