### PR TITLE
Add updated Gutenberg v8.0.0 class names for interface skeleton

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/iframe-bridge-server.scss
@@ -24,7 +24,8 @@
 	// On fullscreen mode, #wpadminbar is visible on tablet & mobile voew because
 	// fullscreen mode actually don't exists on tablet & mobile view.
 	// See: https://github.com/WordPress/gutenberg/pull/13425
-	body.is-iframed.is-fullscreen-mode .block-editor-editor-skeleton {
+	body.is-iframed.is-fullscreen-mode .block-editor-editor-skeleton, // Gutenberg >= 7.7 && < 8.0.0
+	body.is-iframed.is-fullscreen-mode .interface-interface-skeleton { // Gutenberg >= 8.0.0
 		top: 0;
 	}
 }


### PR DESCRIPTION
This ensures that on mobile the interface doesn't have the top clearance that it has in .org since we hide the masterbar on wpcom.

#### Changes proposed in this Pull Request

* Update class name used for the editor skeleton to match Gutenberg v8.0.0 class names

##### Before

![image](https://user-images.githubusercontent.com/14988353/80562619-8fdbe080-8a2b-11ea-96e5-35188bdd3b01.png)

##### After

![image](https://user-images.githubusercontent.com/14988353/80562666-bbf76180-8a2b-11ea-9a6e-06c6d8f14ec4.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox: D42609-code
* Set your site to use the Gutenberg Edge sticker
* Go to edit a page or post within Calypso and adjust the viewport to mobile width
* Confirm that there is no gap at the top of the screen
* Remove the Gutenberg Edge sticker from your site
* Reload the editor and ensure that there is still no gap at the top of the screen

Part of #41521
