### PR TITLE
Fix failing tests on ticket config actions

### DIFF
--- a/client/state/help/ticket/test/actions.js
+++ b/client/state/help/ticket/test/actions.js
@@ -60,7 +60,7 @@ describe( 'ticket-support/configuration actions', () => {
 		test( 'should be successful.', () => {
 			const action = ticketSupportConfigurationRequest()( spy );
 
-			assert( spy.calledWith( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) );
+			assert( spy.calledWith( sinon.match( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) ) );
 
 			action.then( () => {
 				assert(
@@ -81,7 +81,7 @@ describe( 'ticket-support/configuration actions', () => {
 		test( 'should be failed.', () => {
 			const action = ticketSupportConfigurationRequest()( spy );
 
-			assert( spy.calledWith( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) );
+			assert( spy.calledWith( sinon.match( { type: HELP_TICKET_CONFIGURATION_REQUEST } ) ) );
 
 			action.then( () => {
 				assert(


### PR DESCRIPTION
Fixes the tests I broke in #41571 — I'm out of practice committing to Calypso and got overeager when the merge button was green.

These tests broke because I added Tracks analytics to the action, so the sinon match wasn't expecting the action it was watching for to have the extra `meta` properties.