### PR TITLE
Update header button styling and full width block margins for Gutenberg v8.0.0

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/editor/style.scss
@@ -43,7 +43,8 @@
 		padding-left: 0;
 		padding-right: 0;
 
-		.block-editor-block-list__block[data-align='full'] {
+		.block-editor-block-list__block[data-align='full'],
+		.wp-block[data-align='full'] { // Gutenberg >= 8.0.0
 			margin-left: 0;
 			margin-right: 0;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/plugins/close-button-override/style.scss
@@ -53,6 +53,7 @@
 }
 
 // add an extra class specific for the new Gutenberg plugin version so the main override above stays compatible with < v7.7
+// includes additional `.interface-interface-skeleton__header` classes for compatibility with Gutenberg >= 8.0.0
 .post-type-wp_template_part
 	.block-editor-editor-skeleton__header
 	.edit-post-fullscreen-mode-close__toolbar__override,
@@ -61,6 +62,15 @@
 	.edit-post-fullscreen-mode-close__toolbar__override,
 .post-type-post
 	.block-editor-editor-skeleton__header
+	.edit-post-fullscreen-mode-close__toolbar__override,
+.post-type-wp_template_part
+	.interface-interface-skeleton__header
+	.edit-post-fullscreen-mode-close__toolbar__override,
+.post-type-page
+	.interface-interface-skeleton__header
+	.edit-post-fullscreen-mode-close__toolbar__override,
+.post-type-post
+	.interface-interface-skeleton__header
 	.edit-post-fullscreen-mode-close__toolbar__override {
 	// Close button override doesn't need the extraneous left-padding
 	// provided by .edit-post-header__toolbar from WP. So here we


### PR DESCRIPTION
This PR updates the FSE plugin with class names to add support for Gutenberg v8.0.0.

#### Changes proposed in this Pull Request

* Update class names used for hiding the close button on mobile viewports
* Update class names for removing additional margins on full width blocks

#### Testing instructions

Note: the whitespace at the top is dealt with separately in #41572 

| Mobile before | Mobile after |
| -------------- | ------------ |
| ![image](https://user-images.githubusercontent.com/14988353/80566393-447aff80-8a36-11ea-9661-0d380e657cbf.png) | ![image](https://user-images.githubusercontent.com/14988353/80566579-a0de1f00-8a36-11ea-8f3e-d3a8a7520c35.png) |

| Full width blocks before | Full width blocks after |
| ------------------------ | ---------------------- |
| ![image](https://user-images.githubusercontent.com/14988353/80566622-bf441a80-8a36-11ea-9c7a-aad512f28ca1.png) | ![image](https://user-images.githubusercontent.com/14988353/80566705-eac70500-8a36-11ea-96d1-524f4797ce07.png) |

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site using dotcom FSE, enable the Edge sticker and sandbox this PR using the diff automatically generated below ( D42611-code )
* Edit a page, and on mobile the close / back button should be hidden as in the above screenshot
* Edit a page that contains full width blocks, and they should not overflow the page 'container', as in the above screenshot
* Remove the Edge sticker from your site and reload the editor, and make sure the styling still looks correct

Fixes #41513 
Fixes part of #41521 (the other part is dealt with in #41572)