### PR TITLE
Deduplicate ajv

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4780,17 +4780,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.5.5:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.11.0.tgz#c3607cbc8ae392d8a5a536f25b21f8e5f3f87fe9"
-  integrity sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.12.0:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.0, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `ajv` automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
# Before 
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> eslint@6.8.0 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> node-sass@4.13.0 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> react-docgen-typescript-loader@3.6.0 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> webpack-dev-server@3.10.3 -> ... -> ajv@6.11.0
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> ajv@6.11.0

# After 
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> eslint@6.8.0 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> node-sass@4.13.0 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> react-docgen-typescript-loader@3.6.0 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> stylelint@9.10.1 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> webpack-dev-server@3.10.3 -> ... -> ajv@6.12.2
wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> ajv@6.12.2
```