### PR TITLE
Deduplicate fast-glob

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9645,18 +9645,7 @@ fast-glob@^2.0.2, fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.1.1.tgz#87ee30e9e9f3eb40d6f254a7997655da753d7c82"
-  integrity sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
-    merge2 "^1.3.0"
-    micromatch "^4.0.2"
-
-fast-glob@^3.1.1:
+fast-glob@^3.0.3, fast-glob@^3.1.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.2.tgz#ade1a9d91148965d4bf7c51f72e1ca662d32e63d"
   integrity sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `fast-glob` automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
# Before
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> fast-glob@3.1.1
wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> fast-glob@3.1.1
wp-calypso-monorepo@0.17.0 -> globby@10.0.1 -> ... -> fast-glob@3.1.1
wp-calypso-monorepo@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> fast-glob@3.1.1

# After
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> fast-glob@3.2.2
wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> fast-glob@3.2.2
wp-calypso-monorepo@0.17.0 -> globby@10.0.1 -> ... -> fast-glob@3.2.2
wp-calypso-monorepo@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> fast-glob@3.2.2
```