### PR TITLE
Gutenboarding: fix intent capture inputs visual glitches

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -79,10 +79,13 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile } ) 
 	);
 
 	return (
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 		<form
 			className={ classnames( 'site-title', {
 				'site-title--hidden': ! isVisible,
 			} ) }
+			onClick={ () => inputRef.current.focus() } // focus the input when clicking label or next to it
 		>
 			{ madlib }
 		</form>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -60,6 +60,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile } ) 
 		{
 			Input: (
 				<span className="site-title__input-wrapper">
+					{ ! isMobile && ' ' }
 					<span
 						contentEditable
 						tabIndex={ 0 }
@@ -80,7 +81,6 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile } ) 
 	return (
 		<form
 			className={ classnames( 'site-title', {
-				'site-title--without-value': ! siteTitle.length,
 				'site-title--hidden': ! isVisible,
 			} ) }
 		>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -82,21 +82,10 @@
 }
 
 .madlib__input:empty {
-	width: 100%;
-	display: inline-block;
 	border-bottom: 2px solid transparent;
 	position: relative;
-	z-index: 2;
+	z-index: 1;
 	vertical-align: middle;
-
-	@include break-small {
-		width: 400px;
-	}
-}
-
-/* hide the placeholder when input is not empty */
-.madlib__input:not( :empty ) ~ .vertical-select__placeholder {
-	visibility: hidden;
 }
 
 // Themed core button component
@@ -107,6 +96,7 @@
 	box-shadow: none;
 	color: var( --contrastColor );
 	font-size: 14px;
+	// stylelint-disable-next-line scales/font-weight
 	font-weight: 500;
 	letter-spacing: 0;
 	padding: 20px 32px;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -129,6 +129,7 @@
 
 .site-title__input-wrapper {
 	display: block;
+	min-height: 40px; // make sure there is a tappable area on mobile when the input is empty
 
 	@include break-small {
 		display: inline;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -243,10 +243,13 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 	);
 
 	return (
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 		<form
 			className={ classnames( 'vertical-select', {
 				'vertical-select--with-suggestions': !! suggestions.length && isMobile,
 			} ) }
+			onClick={ () => inputRef.current.focus() } // focus the input when clicking label or placeholder
 		>
 			{ madlib }
 		</form>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -201,7 +201,12 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		{
 			Input: (
 				<span className="vertical-select__suggestions-wrapper">
-					<span className="vertical-select__input-wrapper">
+					{ ! isMobile && ' ' }
+					<span
+						className={ classnames( 'vertical-select__input-wrapper', {
+							'vertical-select__input-wrapper--with-arrow': showArrow,
+						} ) }
+					>
 						<span
 							contentEditable
 							tabIndex={ 0 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -6,6 +6,7 @@
 	transition: flex-grow $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 	display: flex;
 	flex-direction: column;
+
 	&--with-suggestions {
 		flex-grow: 1;
 	}
@@ -40,12 +41,10 @@
 .vertical-select__suggestions-wrapper {
 	position: relative;
 	display: block;
-	padding-right: 20px; // prevent arrow overflow on mobile
 	flex: 1;
 
 	@include break-small {
 		display: inline;
-		padding-right: 0;
 	}
 }
 
@@ -65,16 +64,21 @@
 
 .vertical-select__input-wrapper {
 	position: relative;
+
+	&--with-arrow {
+		margin-right: 40px; // make space for absolute positioned arrow
+	}
 }
 
 .vertical-select__placeholder {
+	display: inline-block;
+	width: 400px;
 	color: var( --studio-gray-5 );
-	position: absolute;
-	left: 0;
+}
 
-	@include break-small {
-		width: 400px;
-	}
+/* hide the placeholder when input is not empty */
+.madlib__input:not( :empty ) ~ .vertical-select__placeholder {
+	display: none;
 }
 
 .vertical-select__arrow {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fix jumping text when entering the first letter in vertical input.
* Trigger input focus for both inputs when clicking/tapping on labels or placeholder.
* Trigger site title input focus on mobile when tapping below the label.

#### Testing instructions
* Go to [/new](https://calypso.live/new?branch=fix/gutenboarding-intent-capture-input-jump).
* Make sure no user data is already entered.
* Type the first letter in _My site is about_ input and existing text characters shouldn't jump like in the [video](https://d.pr/v/lwB23B).
* Try focusing the inputs (empty and filled) by clicking on labels or placeholder on desktop.
* Try focusing the inputs (empty and filled) by tapping below the labels on mobile.
* Check both intent capture inputs for regressions in Firefox, Safari, Safari iOS.

Fixes #40917
