### PR TITLE
Deduplicate picomatch

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16375,12 +16375,7 @@ phone@2.4.2:
   resolved "https://registry.yarnpkg.com/phone/-/phone-2.4.2.tgz#74d6a54288280470d0cefa31e2f0720b7e59005d"
   integrity sha512-d9oLwWCnInj5wJIZjSyAvyBd4SWM4p3C6VmZVAhAlWG8q0dLANTEfRLMn2ybL/TdXbTuOCY4GJbePf3ujPmVvQ==
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
-  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
-
-picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.0.7, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `picomatch` automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
# Before
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> babel-jest@25.1.0 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> chokidar-cli@2.1.0 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> eslint-plugin-jest@23.6.0 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> fork-ts-checker-webpack-plugin@3.1.1 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> globby@10.0.1 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> micromatch@4.0.2 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> npm-package-json-lint@5.0.0 -> ... -> picomatch@2.2.1
wp-calypso-monorepo@0.17.0 -> ts-loader@6.2.1 -> ... -> picomatch@2.2.1

# After
wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> babel-jest@25.1.0 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> chokidar-cli@2.1.0 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> eslint-plugin-jest@23.6.0 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> fork-ts-checker-webpack-plugin@3.1.1 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> globby@10.0.1 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> i18n-calypso-cli@1.0.0 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> micromatch@4.0.2 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> npm-package-json-lint@5.0.0 -> ... -> picomatch@2.2.2
wp-calypso-monorepo@0.17.0 -> ts-loader@6.2.1 -> ... -> picomatch@2.2.2
```