### PR TITLE
Editor: Update Switch to Classic Editor link

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -40,6 +40,7 @@ import { getEditedPostValue } from 'state/posts/selectors';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled';
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
+import getWpAdminClassicEditorRedirectionUrl from 'state/selectors/get-wp-admin-classic-editor-redirection-url';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -279,7 +280,7 @@ const optIn = ( siteId, gutenbergUrl ) => {
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
-	const classicRoute = currentRoute.replace( '/block-editor/', '' );
+	const classicUrl = getWpAdminClassicEditorRedirectionUrl( state, siteId );
 	const section = getSection( state );
 	const isCalypsoClassic = section.group && section.group === 'editor';
 	const optInEnabled = isGutenbergOptInEnabled( state, siteId );
@@ -293,7 +294,7 @@ function mapStateToProps( state ) {
 		isEligibleForChecklist: isEligibleForDotcomChecklist( state, siteId ),
 		selectedSite: getHelpSelectedSite( state ),
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
-		classicUrl: `/${ classicRoute }`,
+		classicUrl,
 		siteId,
 		showOptOut: showSwitchEditorButton && isGutenbergOptOutEnabled( state, siteId ),
 		showOptIn: showSwitchEditorButton && optInEnabled && isCalypsoClassic,

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { flowRight as compose, noop, find } from 'lodash';
+import { flowRight as compose, noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -42,9 +42,6 @@ import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
 import getWpAdminClassicEditorRedirectionUrl from 'state/selectors/get-wp-admin-classic-editor-redirection-url';
 import { isEnabled } from 'config';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import { activatePlugin } from 'state/plugins/installed/actions';
-import { getPlugins } from 'state/plugins/installed/selectors';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -57,9 +54,6 @@ class InlineHelpPopover extends Component {
 		optIn: PropTypes.func,
 		redirect: PropTypes.func,
 		isEligibleForChecklist: PropTypes.bool.isRequired,
-		isAtomic: PropTypes.bool,
-		activatePlugin: PropTypes.func,
-		sitePlugins: PropTypes.array,
 	};
 
 	static defaultProps = {
@@ -211,23 +205,12 @@ class InlineHelpPopover extends Component {
 		);
 	};
 
-	checkForClassicEditorOnAtomic( siteId, sitePlugins ) {
-		const classicPlugin = find( sitePlugins, { slug: 'classic-editor' } );
-		if ( ! classicPlugin.isActive ) {
-			this.props.activatePlugin( siteId, classicPlugin );
-		}
-	}
-
 	switchToClassicEditor = () => {
-		const { siteId, onClose, optOut, classicUrl, translate, isAtomic, sitePlugins } = this.props;
+		const { siteId, onClose, optOut, classicUrl, translate } = this.props;
 		const proceed =
 			typeof window === 'undefined' ||
 			window.confirm( translate( 'Are you sure you wish to leave this page?' ) );
-
 		if ( proceed ) {
-			if ( isAtomic ) {
-				this.checkForClassicEditorOnAtomic( siteId, sitePlugins );
-			}
 			optOut( siteId, classicUrl );
 			onClose();
 		}
@@ -308,8 +291,6 @@ function mapStateToProps( state ) {
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );
 	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
 	const showSwitchEditorButton = currentRoute.match( /^\/(block-editor|post|page)\// );
-	const isAtomic = isAtomicSite( state, siteId );
-	const sitePlugins = getPlugins( state, [ siteId ] );
 
 	return {
 		searchQuery: getSearchQuery( state ),
@@ -322,8 +303,6 @@ function mapStateToProps( state ) {
 		showOptIn: showSwitchEditorButton && optInEnabled && isCalypsoClassic,
 		gutenbergUrl,
 		isCheckout: section.name && section.name === 'checkout',
-		isAtomic,
-		sitePlugins,
 	};
 }
 
@@ -333,7 +312,6 @@ const mapDispatchToProps = {
 	recordTracksEvent,
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,
-	activatePlugin,
 };
 
 export default compose(

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { flowRight as compose, noop } from 'lodash';
+import { flowRight as compose, noop, find } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -42,6 +42,9 @@ import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
 import getWpAdminClassicEditorRedirectionUrl from 'state/selectors/get-wp-admin-classic-editor-redirection-url';
 import { isEnabled } from 'config';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import { activatePlugin } from 'state/plugins/installed/actions';
+import { getPlugins } from 'state/plugins/installed/selectors';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -54,6 +57,9 @@ class InlineHelpPopover extends Component {
 		optIn: PropTypes.func,
 		redirect: PropTypes.func,
 		isEligibleForChecklist: PropTypes.bool.isRequired,
+		isAtomic: PropTypes.bool,
+		activatePlugin: PropTypes.func,
+		sitePlugins: PropTypes.array,
 	};
 
 	static defaultProps = {
@@ -205,12 +211,23 @@ class InlineHelpPopover extends Component {
 		);
 	};
 
+	checkForClassicEditorOnAtomic( siteId, sitePlugins ) {
+		const classicPlugin = find( sitePlugins, { slug: 'classic-editor' } );
+		if ( ! classicPlugin.isActive ) {
+			this.props.activatePlugin( siteId, classicPlugin );
+		}
+	}
+
 	switchToClassicEditor = () => {
-		const { siteId, onClose, optOut, classicUrl, translate } = this.props;
+		const { siteId, onClose, optOut, classicUrl, translate, isAtomic, sitePlugins } = this.props;
 		const proceed =
 			typeof window === 'undefined' ||
 			window.confirm( translate( 'Are you sure you wish to leave this page?' ) );
+
 		if ( proceed ) {
+			if ( isAtomic ) {
+				this.checkForClassicEditorOnAtomic( siteId, sitePlugins );
+			}
 			optOut( siteId, classicUrl );
 			onClose();
 		}
@@ -291,6 +308,8 @@ function mapStateToProps( state ) {
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );
 	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
 	const showSwitchEditorButton = currentRoute.match( /^\/(block-editor|post|page)\// );
+	const isAtomic = isAtomicSite( state, siteId );
+	const sitePlugins = getPlugins( state, [ siteId ] );
 
 	return {
 		searchQuery: getSearchQuery( state ),
@@ -303,6 +322,8 @@ function mapStateToProps( state ) {
 		showOptIn: showSwitchEditorButton && optInEnabled && isCalypsoClassic,
 		gutenbergUrl,
 		isCheckout: section.name && section.name === 'checkout',
+		isAtomic,
+		sitePlugins,
 	};
 }
 
@@ -312,6 +333,7 @@ const mapDispatchToProps = {
 	recordTracksEvent,
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,
+	activatePlugin,
 };
 
 export default compose(

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -41,6 +41,7 @@ import QueryActiveTheme from 'components/data/query-active-theme';
 import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled';
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
 import getWpAdminClassicEditorRedirectionUrl from 'state/selectors/get-wp-admin-classic-editor-redirection-url';
+import { isEnabled } from 'config';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -280,7 +281,9 @@ const optIn = ( siteId, gutenbergUrl ) => {
 function mapStateToProps( state ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
-	const classicUrl = getWpAdminClassicEditorRedirectionUrl( state, siteId );
+	const classicUrl = isEnabled( 'editor/after-deprecation' )
+		? getWpAdminClassicEditorRedirectionUrl( state, siteId )
+		: `/${ currentRoute.replace( '/block-editor/', '' ) }`;
 	const section = getSection( state );
 	const isCalypsoClassic = section.group && section.group === 'editor';
 	const optInEnabled = isGutenbergOptInEnabled( state, siteId );

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -70,6 +70,10 @@ const setSelectedEditorAndRedirect = (
 	if ( has( window, 'location.replace' ) && -1 !== redirectUrl.indexOf( 'calypsoify=1' ) ) {
 		return window.location.replace( redirectUrl );
 	}
+	if ( has( window, 'location.replace' ) && 'classic' === editor ) {
+		return window.location.replace( redirectUrl );
+	}
+
 	dispatch( replaceHistory( redirectUrl ) );
 };
 

--- a/client/state/data-layer/wpcom/sites/gutenberg/index.js
+++ b/client/state/data-layer/wpcom/sites/gutenberg/index.js
@@ -3,6 +3,7 @@
  */
 
 import { has, noop } from 'lodash';
+import { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -70,7 +71,11 @@ const setSelectedEditorAndRedirect = (
 	if ( has( window, 'location.replace' ) && -1 !== redirectUrl.indexOf( 'calypsoify=1' ) ) {
 		return window.location.replace( redirectUrl );
 	}
-	if ( has( window, 'location.replace' ) && 'classic' === editor ) {
+	if (
+		isEnabled( 'editor/after-deprecation' ) &&
+		has( window, 'location.replace' ) &&
+		'classic' === editor
+	) {
 		return window.location.replace( redirectUrl );
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -59,6 +59,7 @@
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
+		"editor/after-deprecation": false,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/development.json
+++ b/config/development.json
@@ -59,7 +59,7 @@
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
-		"editor/after-deprecation": true,
+		"editor/after-deprecation": false,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/development.json
+++ b/config/development.json
@@ -59,7 +59,7 @@
 		"domains/new-status-design": true,
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
-		"editor/after-deprecation": false,
+		"editor/after-deprecation": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Update the "Switch to Classic Editor" link for the context-sensitive help menu to redirect to the WP Admin classic editor.

## Requirements

- **WordPress.com editor has been deprecated.**

## Testing instructions

1. Set "editor/after-deprecation" feature flag to true
2. Start up local Calypso
3. Visit http://calypso.localhost:3000
4. Navigate to edit or add a new post
5. Switch to the block editor if it isn't the current editor
6. Click on the "?" help button in the bottom right 
7. Click on the "Switch to Classic Editor" button and confirm you wish to leave the page if asked
8. You should be taken to the WP Admin classic editor for the post you were editing

<img width="354" alt="Screen Shot 2020-04-29 at 7 52 48 pm" src="https://user-images.githubusercontent.com/60436221/80583074-15bf5200-8a53-11ea-8a0d-24fead683919.png">


