### PR TITLE
Add: bundled domain notice to the checkout page

### DIFF
--- a/client/lib/i18n-utils/browser.js
+++ b/client/lib/i18n-utils/browser.js
@@ -17,6 +17,7 @@ export {
 	removeLocaleFromPath,
 	getPathParts,
 	filterLanguageRevisions,
+	translationExists,
 } from './utils';
 
 export const getLocaleSlug = () => i18n.getLocaleSlug();

--- a/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
@@ -57,22 +57,15 @@ export default function BundledDomainNotice( { cart } ) {
 	);
 
 	const oneYearCopy = translate(
-		'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name.',
-		{
-			context: 'checkout',
-		}
+		'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name.'
 	);
 	const twoYearCopy = translate(
-		'Purchasing a two-year subscription to a WordPress.com plan gives you two years of access to your plan’s features and one year of a custom domain name.',
-		{
-			context: 'checkout',
-		}
+		'Purchasing a two-year subscription to a WordPress.com plan gives you two years of access to your plan’s features and one year of a custom domain name.'
 	);
 	const afterFirstYear = translate(
 		'After the first year, you’ll continue to have access to your WordPress.com plan features but will need to renew the domain name.',
 		{
 			comment: 'After the first year of the bundled domain...',
-			context: 'checkout',
 		}
 	);
 	const registrationLink = translate(
@@ -80,7 +73,6 @@ export default function BundledDomainNotice( { cart } ) {
 		{
 			comment:
 				'The custom domain here is a free bundled domain. "To select" can be replaced with "to register" or "to claim".',
-			context: 'checkout',
 			components: {
 				domainRegistrationLink,
 			},

--- a/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
@@ -8,7 +8,12 @@ import React from 'react';
  */
 import { translate } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
-import { hasPlan, hasJetpackPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
+import {
+	hasDomainRegistration,
+	hasPlan,
+	hasJetpackPlan,
+	isNextDomainFree,
+} from 'lib/cart-values/cart-items';
 import { getPlan, getBillingMonthsForTerm } from 'lib/plans';
 import { REGISTER_DOMAIN } from 'lib/url/support';
 import { translationExists } from 'lib/i18n-utils';
@@ -47,9 +52,14 @@ export default function BundledDomainNotice( { cart } ) {
 		return null;
 	}
 
-	const domainRegistrationLink = (
+	let domainRegistrationLink = (
 		<a href={ REGISTER_DOMAIN } target="_blank" rel="noopener noreferrer" />
 	);
+
+	// Hide the registration link when the cart already has a domain registration.
+	if ( hasDomainRegistration( cart ) ) {
+		domainRegistrationLink = <React.Fragment />;
+	}
 
 	let copy = translate(
 		'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name. To select your custom domain, follow {{domainRegistrationLink}}the registration instructions{{/domainRegistrationLink}}.',

--- a/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
@@ -9,6 +9,21 @@ import React from 'react';
 import { translate } from 'i18n-calypso';
 import { hasPlan, hasJetpackPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
 import Gridicon from 'components/gridicon';
+import { getPlan, getBillingMonthsForTerm } from 'lib/plans';
+import { REGISTER_DOMAIN } from 'lib/url/support';
+
+function hasBiennialPlan( cart ) {
+	const plans = cart.products
+		.map( ( { product_slug } ) => getPlan( product_slug ) )
+		.filter( Boolean );
+	const plan = plans?.[ 0 ];
+
+	try {
+		return getBillingMonthsForTerm( plan?.term ) === 24;
+	} catch ( e ) {
+		return false;
+	}
+}
 
 export default function BundledDomainNotice( { cart } ) {
 	// A dotcom plan should exist.
@@ -21,14 +36,35 @@ export default function BundledDomainNotice( { cart } ) {
 		return null;
 	}
 
+	const domainRegistrationLink = (
+		<a href={ REGISTER_DOMAIN } target="_blank" rel="noopener noreferrer" />
+	);
+
+	let copy = translate(
+		'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name. To select your custom domain, follow {{domainRegistrationLink}}the registration instructions{{/domainRegistrationLink}}.',
+		{
+			components: {
+				domainRegistrationLink,
+			},
+		}
+	);
+
+	if ( hasBiennialPlan( cart ) ) {
+		copy = translate(
+			'Purchasing a two-year subscription to a WordPress.com plan gives you two years of access to your plan’s features and one-year of a custom domain name. To select your custom domain, follow {{domainRegistrationLink}}the registration instructions{{/domainRegistrationLink}}. ' +
+				'After the first year, you’ll continue to have access to your WordPress.com plan features but will need to renew the domain name.',
+			{
+				components: {
+					domainRegistrationLink,
+				},
+			}
+		);
+	}
+
 	return (
 		<div className="checkout__bundled-domain-notice">
 			<Gridicon icon="info-outline" size={ 18 } />
-			<p>
-				{ translate(
-					'By purchasing a year WordPress.com Plan, you will gain access to related plan features for 2 years and 1 year of custom domain name. Your domain name needs to be registered to become active.'
-				) }
-			</p>
+			<p>{ copy }</p>
 		</div>
 	);
 }

--- a/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
@@ -6,11 +6,12 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { translate, hasTranslation } from 'i18n-calypso';
-import { hasPlan, hasJetpackPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
+import { translate } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
+import { hasPlan, hasJetpackPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
 import { getPlan, getBillingMonthsForTerm } from 'lib/plans';
 import { REGISTER_DOMAIN } from 'lib/url/support';
+import { translationExists } from 'lib/i18n-utils';
 
 function hasBiennialPlan( cart ) {
 	const plans = cart.products
@@ -37,9 +38,9 @@ export default function BundledDomainNotice( { cart } ) {
 	}
 
 	// Hide non-translated text for non-English users.
-	// TODO: this line of code should be removed once all translations are ready.
+	// TODO: the following lines of code should be removed once all translations are ready.
 	if (
-		! hasTranslation(
+		! translationExists(
 			'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name. To select your custom domain, follow {{domainRegistrationLink}}the registration instructions{{/domainRegistrationLink}}.'
 		)
 	) {

--- a/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { translate } from 'i18n-calypso';
+import { translate, hasTranslation } from 'i18n-calypso';
 import { hasPlan, hasJetpackPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
 import Gridicon from 'components/gridicon';
 import { getPlan, getBillingMonthsForTerm } from 'lib/plans';
@@ -33,6 +33,16 @@ export default function BundledDomainNotice( { cart } ) {
 
 	// The plan should bundle a free domain
 	if ( ! isNextDomainFree( cart ) ) {
+		return null;
+	}
+
+	// Hide non-translated text for non-English users.
+	// TODO: this line of code should be removed once all translations are ready.
+	if (
+		! hasTranslation(
+			'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name. To select your custom domain, follow {{domainRegistrationLink}}the registration instructions{{/domainRegistrationLink}}.'
+		)
+	) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { translate } from 'i18n-calypso';
+import { hasPlan, hasJetpackPlan, isNextDomainFree } from 'lib/cart-values/cart-items';
+import Gridicon from 'components/gridicon';
+
+export default function BundledDomainNotice( { cart } ) {
+	// A dotcom plan should exist.
+	if ( ! hasPlan( cart ) || hasJetpackPlan( cart ) ) {
+		return null;
+	}
+
+	// The plan should bundle a free domain
+	if ( ! isNextDomainFree( cart ) ) {
+		return null;
+	}
+
+	return (
+		<div className="checkout__bundled-domain-notice">
+			<Gridicon icon="info-outline" size={ 18 } />
+			<p>
+				{ translate(
+					'By purchasing a year WordPress.com Plan, you will gain access to related plan features for 2 years and 1 year of custom domain name. Your domain name needs to be registered to become active.'
+				) }
+			</p>
+		</div>
+	);
+}

--- a/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
+++ b/client/my-sites/checkout/checkout/bundled-domain-notice.jsx
@@ -46,46 +46,55 @@ export default function BundledDomainNotice( { cart } ) {
 	// TODO: the following lines of code should be removed once all translations are ready.
 	if (
 		! translationExists(
-			'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name. To select your custom domain, follow {{domainRegistrationLink}}the registration instructions{{/domainRegistrationLink}}.'
+			'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name.'
 		)
 	) {
 		return null;
 	}
 
-	let domainRegistrationLink = (
+	const domainRegistrationLink = (
 		<a href={ REGISTER_DOMAIN } target="_blank" rel="noopener noreferrer" />
 	);
 
-	// Hide the registration link when the cart already has a domain registration.
-	if ( hasDomainRegistration( cart ) ) {
-		domainRegistrationLink = <React.Fragment />;
-	}
-
-	let copy = translate(
-		'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name. To select your custom domain, follow {{domainRegistrationLink}}the registration instructions{{/domainRegistrationLink}}.',
+	const oneYearCopy = translate(
+		'Purchasing a one-year subscription to a WordPress.com plan gives you one year of access to your plan’s features and one year of a custom domain name.',
 		{
+			context: 'checkout',
+		}
+	);
+	const twoYearCopy = translate(
+		'Purchasing a two-year subscription to a WordPress.com plan gives you two years of access to your plan’s features and one year of a custom domain name.',
+		{
+			context: 'checkout',
+		}
+	);
+	const afterFirstYear = translate(
+		'After the first year, you’ll continue to have access to your WordPress.com plan features but will need to renew the domain name.',
+		{
+			comment: 'After the first year of the bundled domain...',
+			context: 'checkout',
+		}
+	);
+	const registrationLink = translate(
+		'To select your custom domain, follow {{domainRegistrationLink}}the registration instructions{{/domainRegistrationLink}}.',
+		{
+			comment:
+				'The custom domain here is a free bundled domain. "To select" can be replaced with "to register" or "to claim".',
+			context: 'checkout',
 			components: {
 				domainRegistrationLink,
 			},
 		}
 	);
 
-	if ( hasBiennialPlan( cart ) ) {
-		copy = translate(
-			'Purchasing a two-year subscription to a WordPress.com plan gives you two years of access to your plan’s features and one-year of a custom domain name. To select your custom domain, follow {{domainRegistrationLink}}the registration instructions{{/domainRegistrationLink}}. ' +
-				'After the first year, you’ll continue to have access to your WordPress.com plan features but will need to renew the domain name.',
-			{
-				components: {
-					domainRegistrationLink,
-				},
-			}
-		);
-	}
-
 	return (
 		<div className="checkout__bundled-domain-notice">
 			<Gridicon icon="info-outline" size={ 18 } />
-			<p>{ copy }</p>
+			<p>
+				{ hasBiennialPlan( cart ) ? twoYearCopy : oneYearCopy }{ ' ' }
+				{ hasDomainRegistration( cart ) ? null : registrationLink }{ ' ' }
+				{ hasBiennialPlan( cart ) ? afterFirstYear : null }
+			</p>
 		</div>
 	);
 }

--- a/client/my-sites/checkout/checkout/checkout-terms.jsx
+++ b/client/my-sites/checkout/checkout/checkout-terms.jsx
@@ -12,6 +12,7 @@ import DomainRegistrationRefundPolicy from './domain-registration-refund-policy'
 import DomainRegistrationAgreement from './domain-registration-agreement';
 import DomainRegistrationHsts from './domain-registration-hsts';
 import ConciergeRefundPolicy from './concierge-refund-policy';
+import BundledDomainNotice from './bundled-domain-notice';
 import { localize } from 'i18n-calypso';
 
 class CheckoutTerms extends React.Component {
@@ -32,6 +33,7 @@ class CheckoutTerms extends React.Component {
 				<DomainRegistrationHsts cart={ cart } />
 				<DomainRegistrationRefundPolicy cart={ cart } />
 				<ConciergeRefundPolicy cart={ cart } />
+				<BundledDomainNotice cart={ cart } />
 			</Fragment>
 		);
 	}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -258,6 +258,7 @@
 
 	.checkout__terms,
 	.checkout__domain-refund-policy,
+	.checkout__bundled-domain-notice,
 	.checkout__concierge-refund-policy,
 	.checkout__domain-registration-agreement-link,
 	.checkout__domain-registration-hsts {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Shows information about bundled domains when a user purchases dotcom plans.

Requested in pau2Xa-18u-p2#comment-4655

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a dotcom paid plan to the cart.
* If the plan bundles a domain, a message about bundled domains should show up in the checkout page as follows:
  <img width="1046" alt="Checkout_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/80602841-976eaa00-8a6a-11ea-8ee5-e14a3776b3be.png">

_Note: Currently every dotcom plan provides a bundled domain._