### PR TITLE
Checkout: update sidebar whitespace

### DIFF
--- a/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
+++ b/client/my-sites/checkout/cart/cart-free-user-plan-upsell.jsx
@@ -142,9 +142,12 @@ class CartFreeUserPlanUpsell extends React.Component {
 		const { translate } = this.props;
 
 		return (
-			<div>
-				<SectionHeader className="cart__header" label={ translate( 'Upgrade and save' ) } />
-				<div style={ { padding: '16px' } }>
+			<div className="cart__upsell-wrapper">
+				<SectionHeader
+					className="cart__header cart__upsell-header"
+					label={ translate( 'Upgrade and save' ) }
+				/>
+				<div className="cart__upsell-body">
 					<p>{ this.getUpgradeText() }</p>
 					<Button onClick={ this.addPlanToCart }>{ translate( 'Add to Cart' ) }</Button>
 				</div>

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -228,7 +228,7 @@
 
 	.button.is-borderless {
 		color: var( --color-link );
-		font-weight: initial;
+		font-weight: 600;
 	}
 }
 
@@ -429,6 +429,10 @@ div.popover-cart__popover {
 		max-height: 100%;
 		position: relative;
 		top: 0;
+	}
+
+	.cart__upsell-body {
+		padding: 16px;
 	}
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -104,6 +104,7 @@ const CheckoutSummaryLineItem = styled.div`
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
+	margin-bottom: 4px;
 `;
 
 const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -252,11 +252,29 @@ const UpsellWrapperUI = styled.div`
 	margin-top: 24px;
 	background: ${( props ) => props.theme.colors.surface};
 
-	& > div {
+	.cart__upsell-wrapper {
 		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 	}
-	& .card.cart__header {
-		border: none;
+
+	.cart__upsell-header {
+		border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+		border-top: none;
+		box-shadow: none;
+		padding-left: 20px;
+		padding-right: 20px;
+
+		.section-header__label {
+			color: ${( props ) => props.theme.colors.textColor};
+			font-size: 16px;
+		}
+	}
+
+	.cart__upsell-body {
+		padding: 20px;
+
+		p {
+			margin-bottom: 1.2em;
+		}
 	}
 `;
 


### PR DESCRIPTION
This increases the space between `CheckoutSummary` line items, and styles the up-sell added in #41456 to more closely match the rest of the sidebar items.

**Before:**
![before](https://user-images.githubusercontent.com/942359/80611243-5e055280-8a08-11ea-881c-e9f83020cb28.png)

**After:**
![after](https://user-images.githubusercontent.com/942359/80611192-4d54dc80-8a08-11ea-977d-68c328a6318c.png)

**Legacy Checkout:**
![Screen Shot 2020-04-29 at 10 46 54 AM](https://user-images.githubusercontent.com/942359/80611478-a4f34800-8a08-11ea-933f-a1506e7dfbab.png)

**To test:**
- add a domain to a site without a plan
- visit checkout and verify that the screenshot matches the one above
- visit legacy checkout and verify that the up-sell isn't broken
