### PR TITLE
UpsellNudge: Add horizontal prop and example in devdocs

### DIFF
--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -27,12 +27,31 @@ const UpsellNudgeExample = () => (
 		/>
 		<UpsellNudge
 			description="Domain registration is free for a year with purchase of a Premium or Business plan."
+			forceDisplay
+			href="#"
+			callToAction="Upgrade"
+			title="Free domain with a plan! This is a regular nudge with a description."
+			showIcon={ true }
+		/>
+		<UpsellNudge
+			description="Domain registration is free for a year with purchase of a Premium or Business plan."
 			dismissPreferenceName="calypso_upsell_nudge_devdocs_dismiss"
 			forceDisplay
 			href="#"
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a dismissible nudge with a description."
 			showIcon={ true }
+			horizontal
+		/>
+		<UpsellNudge
+			description="Domain registration is free for a year with purchase of a Premium or Business plan."
+			dismissPreferenceName="calypso_upsell_nudge_devdocs_dismiss"
+			forceDisplay
+			href="#"
+			callToAction="Upgrade"
+			title="Free domain with a plan! This is a dismissible nudge with a description."
+			showIcon={ true }
+			price={ [ 48, 50 ] }
 		/>
 		<UpsellNudge
 			forceDisplay

--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -48,6 +48,11 @@ const UpsellNudgeExample = () => (
 			dismissPreferenceName="calypso_upsell_nudge_devdocs_dismiss"
 			forceDisplay
 			href="#"
+			list={ [
+				'24/7 live chat support',
+				'Free domain with your plan purchase',
+				'Extra customization options',
+			] }
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a dismissible nudge with a description."
 			showIcon={ true }

--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -39,7 +39,7 @@ const UpsellNudgeExample = () => (
 			forceDisplay
 			href="#"
 			callToAction="Upgrade"
-			title="Free domain with a plan! This is a dismissible nudge with a description."
+			title="Free domain with a plan! This is a dismissible nudge with a description and the horizontal layout."
 			showIcon={ true }
 			horizontal
 		/>
@@ -54,7 +54,7 @@ const UpsellNudgeExample = () => (
 				'Extra customization options',
 			] }
 			callToAction="Upgrade"
-			title="Free domain with a plan! This is a dismissible nudge with a description."
+			title="Free domain with a plan! This is a dismissible nudge with a description, prices, and a list of features."
 			showIcon={ true }
 			price={ [ 48, 50 ] }
 		/>

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -41,6 +41,7 @@ export const UpsellNudge = ( {
 	icon,
 	isJetpackDevDocs,
 	jetpack,
+	horizontal,
 	isVip,
 	list,
 	onClick,
@@ -92,6 +93,7 @@ export const UpsellNudge = ( {
 			event={ event }
 			feature={ feature }
 			forceHref={ forceHref }
+			horizontal={ horizontal }
 			href={ href }
 			icon={ icon }
 			jetpack={ jetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -189,6 +189,7 @@ export class SiteNotice extends React.Component {
 				dismissPreferenceName="calypso_upgrade_nudge_cta_click"
 				event="calypso_upgrade_nudge_impression"
 				forceDisplay={ true }
+				horizontal={ true }
 				title={ preventWidows( noticeText ) }
 				tracksClickName="calypso_upgrade_nudge_cta_click"
 				tracksClickProperties={ { cta_name: 'domain-upsell-nudge' } }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following up on #41453 this adds the `horizontal` prop and passes it through to match `Banner`'s functionality. This should only affect upsells that have dismiss functionality alongside a CTA.
* Also adds an example to `/devdocs` for parity
* The only example of this prop in active use is Jetpack JITMs, which are handled in #41419 and have not yet been deployed, so this change shouldn't have any impact on existing nudges.

**Before**

<img width="1369" alt="Screen Shot 2020-04-29 at 3 11 22 PM" src="https://user-images.githubusercontent.com/2124984/80636591-ba2d9e00-8a2b-11ea-8300-e404d39dc169.png">

**After**

<img width="1365" alt="Screen Shot 2020-04-29 at 3 16 56 PM" src="https://user-images.githubusercontent.com/2124984/80637152-83a45300-8a2c-11ea-8c8d-ff9cf87d7c31.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/devdocs`, go to Blocks, find UpsellNudge
* Note the visual differences between an upsell with the `horizontal` prop vs. one without.
* Check other upsells across Calypso to make sure the changes did not cause visual regressions. Notably the sidebar nudges, anything under Marketing, Settings, Media/Video, Media/Audio, etc. on a Free site. Also check Jetpack notices under Marketing, Settings, etc. on a Jetpack Free site.