### PR TITLE
Jetpack Cloud: Remove TO_REMOVE method from `BackupsPage`

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -130,12 +130,6 @@ class BackupsPage extends Component {
 		return backupsOnSelectedDate;
 	};
 
-	TO_REMOVE_getSelectedDateString = () => {
-		const { moment } = this.props;
-
-		return moment.parseZone( this.getSelectedDate() ).toISOString( true );
-	};
-
 	renderMain() {
 		const {
 			allowRestore,
@@ -158,7 +152,7 @@ class BackupsPage extends Component {
 		const lastBackup = backupsFromSelectedDate.lastBackup;
 		const realtimeBackups = backupsFromSelectedDate.rewindableActivities;
 
-		const selectedDateString = this.TO_REMOVE_getSelectedDateString();
+		const selectedDateString = moment.parseZone( this.getSelectedDate() ).toISOString( true );
 		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
 		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I added the `TO_REMOVE_getSelectedDateString` method as a shim to `BackupsPage`, since it is only used once let's get rid of it.

#### Testing instructions

1. Navigate to `/backups`
2. Verify nothing has changed vs production ( `cloud.jetpack.com` )
