### PR TITLE
composite-checkout: Support adding premium themes via URL

### DIFF
--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -69,9 +69,14 @@ import {
 import { getTermDuration } from 'lib/plans/constants';
 
 /**
+ * @typedef { import("./types").CartItemValue} CartItemValue
+ * @typedef { import("./types").CartValue } CartValue
+ */
+
+/**
  * Adds the specified item to a shopping cart.
  *
- * @param {object} newCartItem - new item as `CartItemValue` object
+ * @param {CartItemValue} newCartItem - new item as `CartItemValue` object
  * @returns {Function} the function that adds the item to a shopping cart
  */
 export function addCartItem( newCartItem ) {
@@ -103,7 +108,7 @@ export function clearCart() {
 /**
  * Adds the specified item to a shopping cart without replacing the cart
  *
- * @param {object} newCartItem - new item as `CartItemValue` object
+ * @param {CartItemValue} newCartItem - new item as `CartItemValue` object
  * @returns {Function} the function that adds the item to a shopping cart
  */
 export function addCartItemWithoutReplace( newCartItem ) {
@@ -128,7 +133,7 @@ export function addCartItemWithoutReplace( newCartItem ) {
  * - will result in mixed renewals/non-renewals or multiple renewals (excluding privacy protection).
  * - is a free trial plan
  *
- * @param {object} cartItem - `CartItemValue` object
+ * @param {CartItemValue} cartItem - `CartItemValue` object
  * @param {object} cart - the existing shopping cart
  * @returns {boolean} whether or not the item should replace the cart
  */
@@ -165,7 +170,7 @@ export function cartItemShouldReplaceCart( cartItem, cart ) {
 /**
  * Removes the specified item from a shopping cart.
  *
- * @param {object} cartItemToRemove - item as `CartItemValue` object
+ * @param {CartItemValue} cartItemToRemove - item as `CartItemValue` object
  * @returns {Function} the function that removes the item from a shopping cart
  */
 export function remove( cartItemToRemove ) {
@@ -200,8 +205,8 @@ export function remove( cartItemToRemove ) {
 /**
  * Removes the specified item and its dependency items from a shopping cart.
  *
- * @param {object} cartItemToRemove - item as `CartItemValue` object
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartItemValue} cartItemToRemove - item as `CartItemValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @param {boolean} domainsWithPlansOnly - Whether we should consider domains as dependents of products
  * @returns {Function} the function that removes the items from a shopping cart
  */
@@ -215,8 +220,8 @@ export function removeItemAndDependencies( cartItemToRemove, cart, domainsWithPl
 /**
  * Removes the specified item and its dependency items from a shopping cart.
  *
- * @param {object} oldItem - item as `CartItemValue` object
- * @param {object} newItem - item as `CartItemValue` object
+ * @param {CartItemValue} oldItem - item as `CartItemValue` object
+ * @param {CartItemValue} newItem - item as `CartItemValue` object
  * @returns {Function} the function that removes the items from a shopping cart
  */
 export function replaceItem( oldItem, newItem ) {
@@ -228,8 +233,8 @@ export function replaceItem( oldItem, newItem ) {
 /**
  * Retrieves the dependency items from the shopping cart for the given cart item.
  *
- * @param {object} cartItem - item as `CartItemValue` object
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartItemValue} cartItem - item as `CartItemValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @param {boolean} domainsWithPlansOnly - Whether we should consider domains as dependents of products
  * @returns {object[]} the list of dependency items in the shopping cart
  */
@@ -252,8 +257,8 @@ export function getDependentProducts( cartItem, cart, domainsWithPlansOnly ) {
 /**
  * Retrieves all the items in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
- * @returns {object[]} the list of items in the shopping cart as `CartItemValue` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of items in the shopping cart as `CartItemValue` objects
  */
 export function getAllCartItems( cart ) {
 	return ( cart && cart.products ) || [];
@@ -262,8 +267,7 @@ export function getAllCartItems( cart ) {
 /**
  * Retrieves all the items in the shopping cart sorted
  *
- * @param {object} cart - cart as `CartValue` object
- *
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {object[]} the sorted list of items in the shopping cart
  */
 export function getAllCartItemsSorted( cart ) {
@@ -273,7 +277,7 @@ export function getAllCartItemsSorted( cart ) {
 /**
  * Gets the renewal items from the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {Array} an array of renewal items
  */
 export function getRenewalItems( cart ) {
@@ -283,7 +287,7 @@ export function getRenewalItems( cart ) {
 /**
  * Determines whether there is at least one item with free trial in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one item with free trial, false otherwise
  */
 export function hasFreeTrial( cart ) {
@@ -293,7 +297,7 @@ export function hasFreeTrial( cart ) {
 /**
  * Determines whether there is any kind of plan (e.g. Premium or Business) in the shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one plan, false otherwise
  */
 export function hasPlan( cart ) {
@@ -303,7 +307,7 @@ export function hasPlan( cart ) {
 /**
  * Determines whether there is a Jetpack plan in the shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one Jetpack plan, false otherwise
  */
 export function hasJetpackPlan( cart ) {
@@ -313,7 +317,7 @@ export function hasJetpackPlan( cart ) {
 /**
  * Determines whether there is an ecommerce plan in the shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one plan, false otherwise
  */
 export function hasEcommercePlan( cart ) {
@@ -323,7 +327,7 @@ export function hasEcommercePlan( cart ) {
 /**
  * Does the cart contain only bundled domains and transfers
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there are only bundled domains and transfers
  */
 export function hasOnlyBundledDomainProducts( cart ) {
@@ -351,7 +355,7 @@ export function hasDomainCredit( cart ) {
 /**
  * Whether the cart has a registration with a specific TLD
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @param {string} tld - TLD to look for, no leading dot
  *
  * @returns {boolean} - Whether or not the cart contains a domain with that TLD
@@ -371,7 +375,7 @@ export function getTlds( cart ) {
 /**
  * Determines whether all items in the specified shopping are free trial or free domains
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if all items have free trial, false otherwise
  * @todo This will fail when a domain is purchased with a plan, as the domain will be included in the free trial
  */
@@ -382,8 +386,8 @@ export function hasOnlyFreeTrial( cart ) {
 /**
  * Determines whether there is at least one item of a given product in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
- * @param {object} productSlug - the unique string that identifies the product
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @param {string} productSlug - the unique string that identifies the product
  * @returns {boolean} true if there is at least one item of the specified product type, false otherwise
  */
 export function hasProduct( cart, productSlug ) {
@@ -396,8 +400,8 @@ export function hasProduct( cart, productSlug ) {
  * Determines whether every product in the specified shopping cart is of the same productSlug.
  * Will return false if the cart is empty.
  *
- * @param {object} cart - cart as `CartValue` object
- * @param {object} productSlug - the unique string that identifies the product
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @param {string} productSlug - the unique string that identifies the product
  * @returns {boolean} true if all the products in the cart are of the productSlug type
  */
 export function hasOnlyProductsOf( cart, productSlug ) {
@@ -407,7 +411,7 @@ export function hasOnlyProductsOf( cart, productSlug ) {
 /**
  * Determines whether there is at least one domain registration item in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one domain registration item, false otherwise
  */
 export function hasDomainRegistration( cart ) {
@@ -441,7 +445,7 @@ export function hasDomainBeingUsedForPlan( cart ) {
 /**
  * Determines whether there is at least one renewal item in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one renewal item, false otherwise
  */
 export function hasRenewalItem( cart ) {
@@ -451,7 +455,7 @@ export function hasRenewalItem( cart ) {
 /**
  * Determines whether there is at least one domain transfer item in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one domain transfer item, false otherwise
  */
 export function hasTransferProduct( cart ) {
@@ -461,8 +465,8 @@ export function hasTransferProduct( cart ) {
 /**
  * Retrieves all the domain transfer items in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
- * @returns {object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getDomainTransfers( cart ) {
 	return filter( getAllCartItems( cart ), { product_slug: domainProductSlugs.TRANSFER_IN } );
@@ -471,7 +475,7 @@ export function getDomainTransfers( cart ) {
 /**
  * Determines whether all items are renewal items in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there are only renewal items, false otherwise
  */
 export function hasOnlyRenewalItems( cart ) {
@@ -481,7 +485,7 @@ export function hasOnlyRenewalItems( cart ) {
 /**
  * Determines whether there is at least one concierge session item in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one concierge session item, false otherwise
  */
 export function hasConciergeSession( cart ) {
@@ -509,7 +513,7 @@ export function getCartItemBillPeriod( cartItem ) {
  * Determines whether any product in the specified shopping cart is a renewable subscription.
  * Will return false if the cart is empty.
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if any product in the cart renews
  */
 export function hasRenewableSubscription( cart ) {
@@ -522,9 +526,9 @@ export function hasRenewableSubscription( cart ) {
 /**
  * Creates a new shopping cart item for a plan.
  *
- * @param {object} productSlug - the unique string that identifies the product
- * @param {object} properties - list of properties
- * @returns {object} the new item as `CartItemValue` object
+ * @param {string} productSlug - the unique string that identifies the product
+ * @param {object} [properties] - list of properties
+ * @returns {CartItemValue | null} the new item as `CartItemValue` object
  */
 export function planItem( productSlug, properties ) {
 	// Free plan doesn't have shopping cart.
@@ -545,8 +549,8 @@ export function planItem( productSlug, properties ) {
  * Creates a new shopping cart item for a Personal plan.
  *
  * @param {string} slug - e.g. value_bundle, jetpack_premium
- * @param {object} properties - list of properties
- * @returns {object} the new item as `CartItemValue` object
+ * @param {object} [properties] - list of properties
+ * @returns {CartItemValue | null} the new item as `CartItemValue` object
  */
 export function personalPlan( slug, properties ) {
 	return planItem( slug, properties );
@@ -556,8 +560,8 @@ export function personalPlan( slug, properties ) {
  * Creates a new shopping cart item for a Premium plan.
  *
  * @param {string} slug - e.g. value_bundle, jetpack_premium
- * @param {object} properties - list of properties
- * @returns {object} the new item as `CartItemValue` object
+ * @param {object} [properties] - list of properties
+ * @returns {CartItemValue | null} the new item as `CartItemValue` object
  */
 export function premiumPlan( slug, properties ) {
 	return planItem( slug, properties );
@@ -567,8 +571,8 @@ export function premiumPlan( slug, properties ) {
  * Creates a new shopping cart item for a Business plan.
  *
  * @param {string} slug - e.g. business-bundle, jetpack_business
- * @param {object} properties - list of properties
- * @returns {object} the new item as `CartItemValue` object
+ * @param {object} [properties] - list of properties
+ * @returns {CartItemValue | null} the new item as `CartItemValue` object
  */
 export function businessPlan( slug, properties ) {
 	return planItem( slug, properties );
@@ -589,10 +593,10 @@ export function supportsPrivacyProtectionPurchase( productSlug, productsList ) {
 /**
  * Creates a new shopping cart item for a domain.
  *
- * @param {object} productSlug - the unique string that identifies the product
+ * @param {string} productSlug - the unique string that identifies the product
  * @param {string} domain - domain name
  * @param {string} source - optional source for the domain item, e.g. `getdotblog`.
- * @returns {object} the new item as `CartItemValue` object
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainItem( productSlug, domain, source ) {
 	const extra = source ? { extra: { source: source } } : undefined;
@@ -606,6 +610,13 @@ export function domainItem( productSlug, domain, source ) {
 	);
 }
 
+/**
+ * Creates a new shopping cart item for a premium theme.
+ *
+ * @param {string} themeSlug - the unique string that identifies the product
+ * @param {string} [source] - optional source for the domain item, e.g. `getdotblog`.
+ * @returns {CartItemValue} the new item as `CartItemValue` object
+ */
 export function themeItem( themeSlug, source ) {
 	return {
 		product_slug: 'premium_theme',
@@ -620,7 +631,7 @@ export function themeItem( themeSlug, source ) {
  * Creates a new shopping cart item for a domain registration.
  *
  * @param {object} properties - list of properties
- * @returns {object} the new item as `CartItemValue` object
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainRegistration( properties ) {
 	return assign( domainItem( properties.productSlug, properties.domain, properties.source ), {
@@ -633,7 +644,7 @@ export function domainRegistration( properties ) {
  * Creates a new shopping cart item for a domain mapping.
  *
  * @param {object} properties - list of properties
- * @returns {object} the new item as `CartItemValue` object
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainMapping( properties ) {
 	return domainItem( 'domain_map', properties.domain, properties.source );
@@ -643,7 +654,7 @@ export function domainMapping( properties ) {
  * Creates a new shopping cart item for Site Redirect.
  *
  * @param {object} properties - list of properties
- * @returns {object} the new item as `CartItemValue` object
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function siteRedirect( properties ) {
 	return domainItem( 'offsite_redirect', properties.domain, properties.source );
@@ -653,7 +664,7 @@ export function siteRedirect( properties ) {
  * Creates a new shopping cart item for an incoming domain transfer.
  *
  * @param {object} properties - list of properties
- * @returns {object} the new item as `CartItemValue` object
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function domainTransfer( properties ) {
 	return assign(
@@ -668,8 +679,8 @@ export function domainTransfer( properties ) {
  * Retrieves all the G Suite items in the specified shopping cart.
  * Out-dated name Google Apps is still used here for consistency in naming.
  *
- * @param {object} cart - cart as `CartValue` object
- * @returns {object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getGoogleApps( cart ) {
 	return filter( getAllCartItems( cart ), isGoogleApps );
@@ -787,12 +798,23 @@ export function spaceUpgradeItem( slug ) {
 	};
 }
 
+/**
+ * Creates a new shopping cart item for a concierge session.
+ *
+ * @returns {CartItemValue} the new item as `CartItemValue` object
+ */
 export function conciergeSessionItem() {
 	return {
 		product_slug: 'concierge-session',
 	};
 }
 
+/**
+ * Creates a new shopping cart item for a jetpack product.
+ *
+ * @param {string} slug - the slug for the product
+ * @returns {CartItemValue} the new item as `CartItemValue` object
+ */
 export function jetpackProductItem( slug ) {
 	return {
 		product_slug: slug,
@@ -803,8 +825,8 @@ export function jetpackProductItem( slug ) {
  * Creates a new shopping cart item for the specified plan.
  *
  * @param {object} plan - plan provided by the `PlansList` object
- * @param {object} properties - list of properties
- * @returns {object} the new item as `CartItemValue` object
+ * @param {object} [properties] - list of properties
+ * @returns {CartItemValue} the new item as `CartItemValue` object
  */
 export function getItemForPlan( plan, properties ) {
 	properties = properties || {};
@@ -827,8 +849,8 @@ export function getItemForPlan( plan, properties ) {
 /**
  * Retrieves the first item with free trial in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
- * @returns {object} the corresponding item in the shopping cart as `CartItemValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue} the corresponding item in the shopping cart as `CartItemValue` object
  */
 export function findFreeTrial( cart ) {
 	return find( getAllCartItems( cart ), { free_trial: true } );
@@ -837,8 +859,8 @@ export function findFreeTrial( cart ) {
 /**
  * Retrieves all the domain registration items in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
- * @returns {object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getDomainRegistrations( cart ) {
 	return filter( getAllCartItems( cart ), { is_domain_registration: true } );
@@ -847,8 +869,8 @@ export function getDomainRegistrations( cart ) {
 /**
  * Retrieves all the domain mapping items in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
- * @returns {object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getDomainMappings( cart ) {
 	return filter( getAllCartItems( cart ), { product_slug: 'domain_map' } );
@@ -859,7 +881,7 @@ export function getDomainMappings( cart ) {
  *
  * @param {string} product - the product object
  * @param {object} [properties] - properties to be included in the new CartItem object
- * @returns {object} a CartItem object
+ * @returns {CartItemValue} a CartItem object
  */
 export function getRenewalItemFromProduct( product, properties ) {
 	product = formatProduct( product );
@@ -920,9 +942,9 @@ export function getRenewalItemFromProduct( product, properties ) {
 /**
  * Returns a renewal CartItem object from the given cartItem and properties.
  *
- * @param {object} cartItem - item as `CartItemValue` object
+ * @param {CartItemValue} cartItem - item as `CartItemValue` object
  * @param {object} properties - properties to be included in the new CartItem object
- * @returns {object} a CartItem object
+ * @returns {CartItemValue} a CartItem object
  */
 export function getRenewalItemFromCartItem( cartItem, properties ) {
 	return merge( {}, cartItem, {
@@ -938,8 +960,8 @@ export function getRenewalItemFromCartItem( cartItem, properties ) {
 /**
  * Retrieves all the site redirect items in the specified shopping cart.
  *
- * @param {object} cart - cart as `CartValue` object
- * @returns {object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getSiteRedirects( cart ) {
 	return filter( getAllCartItems( cart ), { product_slug: 'offsite_redirect' } );
@@ -953,8 +975,8 @@ export function hasDomainInCart( cart, domain ) {
  * Retrieves the domain registration items in the specified shopping cart that do not have corresponding
  * private whois items.
  *
- * @param {object} cart - cart as `CartValue` object
- * @returns {object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getDomainRegistrationsWithoutPrivacy( cart ) {
 	return getDomainRegistrations( cart ).filter( function ( cartItem ) {
@@ -969,8 +991,8 @@ export function getDomainRegistrationsWithoutPrivacy( cart ) {
  * Retrieves the domain incoming transfer items in the specified shopping cart that do not have corresponding
  * private incoming transfer item.
  *
- * @param {object} cart - cart as `CartValue` object
- * @returns {object[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @returns {CartItemValue[]} the list of the corresponding items in the shopping cart as `CartItemValue` objects
  */
 export function getDomainTransfersWithoutPrivacy( cart ) {
 	return getDomainTransfers( cart ).filter( function ( cartItem ) {
@@ -984,8 +1006,8 @@ export function getDomainTransfersWithoutPrivacy( cart ) {
 /**
  * Changes presence of a privacy protection for the given domain cart items.
  *
- * @param {object} cart - cart as `CartValue` object
- * @param {object[]} domainItems - the list of `CartItemValue` objects for domain registrations
+ * @param {CartValue} cart - cart as `CartValue` object
+ * @param {CartItemValue[]} domainItems - the list of `CartItemValue` objects for domain registrations
  * @param {Function} changeFunction - the function that adds/removes the privacy protection to a shopping cart
  * @param {boolean} value - whether privacy is on or off
  *
@@ -1003,10 +1025,10 @@ export function changePrivacyForDomains( cart, domainItems, changeFunction, valu
 /**
  * Changes presence of a privacy protection for the given domain cart item.
  *
- * @param {object} item - the `CartItemValue` object for domain registrations
+ * @param {CartItemValue} item - the `CartItemValue` object for domain registrations
  * @param {boolean} value - whether privacy is on or off
  *
- * @returns {object} the new `CartItemValue` with added/removed privacy
+ * @returns {CartItemValue} the new `CartItemValue` with added/removed privacy
  */
 export function updatePrivacyForDomain( item, value ) {
 	return merge( {}, item, {
@@ -1040,7 +1062,7 @@ export function removePrivacyFromAllDomains( cart ) {
 /**
  * Determines whether a cart item is a renewal
  *
- * @param {object} cartItem - `CartItemValue` object
+ * @param {CartItemValue} cartItem - `CartItemValue` object
  * @returns {boolean} true if item is a renewal
  */
 export function isRenewal( cartItem ) {
@@ -1050,7 +1072,7 @@ export function isRenewal( cartItem ) {
 /**
  * Determines whether a cart item supports privacy
  *
- * @param {object} cartItem - `CartItemValue` object
+ * @param {CartItemValue} cartItem - `CartItemValue` object
  * @returns {boolean} true if item supports privacy
  */
 export function privacyAvailable( cartItem ) {
@@ -1060,7 +1082,7 @@ export function privacyAvailable( cartItem ) {
 /**
  * Get the included domain for a cart item
  *
- * @param {object} cartItem - `CartItemValue` object
+ * @param {CartItemValue} cartItem - `CartItemValue` object
  * @returns {string} the included domain
  */
 export function getIncludedDomain( cartItem ) {
@@ -1226,7 +1248,7 @@ export function getDomainPriceRule( withPlansOnly, selectedSite, cart, suggestio
 /**
  * Determines whether any items in the cart were added more than X time ago (10 minutes)
  *
- * @param {object} cart - cart as `CartValue` object
+ * @param {CartValue} cart - cart as `CartValue` object
  * @returns {boolean} true if there is at least one cart item added more than X time ago, false otherwise
  */
 export function hasStaleItem( cart ) {

--- a/client/lib/cart-values/types.ts
+++ b/client/lib/cart-values/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Internal dependencies
+ */
+import type { GSuiteProductUser } from 'lib/gsuite/new-users';
+
+export type CartItemValue = {
+	product_id?: number;
+	product_name?: string;
+	product_slug?: string;
+	meta?: string;
+	cost?: number;
+	orig_cost?: number | null;
+	currency?: string;
+	volume?: number;
+	free_trial?: boolean;
+	is_domain_registration?: boolean;
+	extra?: CartItemExtra;
+};
+
+export type CartItemExtra = {
+	context?: string;
+	source?: string;
+	domain_to_bundle?: string;
+	google_apps_users?: GSuiteProductUser[];
+	purchaseId?: string;
+	purchaseDomain?: string;
+	purchaseType?: string;
+	includedDomain?: string;
+	privacy?: boolean;
+};
+
+export type CartValue = {
+	blog_id: number;
+	products: CartItemValue[];
+	total_cost?: number;
+	temporary?: boolean;
+	currency?: string;
+	coupon?: string;
+	bundled_domain?: string;
+	is_coupon_applied?: boolean;
+	has_bundle_credit?: boolean;
+	next_domain_is_free?: boolean;
+	next_domain_condition?: string;
+	messages?: {
+		errors?: string[];
+		success?: string[];
+	};
+	client_metadata?: ClientMetadata;
+};
+
+export type ClientMetadata = {
+	lastServerResponseDate: string;
+};

--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -160,7 +160,7 @@ function shouldShowCompositeCheckout(
 	// so they do not need to go through this check.
 	const isRenewal = !! purchaseId;
 	const pseudoSlugsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
-	const slugPrefixesToAllow = [ 'domain-mapping:' ];
+	const slugPrefixesToAllow = [ 'domain-mapping:', 'theme:' ];
 	if (
 		! isRenewal &&
 		productSlug &&

--- a/client/my-sites/checkout/composite-checkout/add-items.ts
+++ b/client/my-sites/checkout/composite-checkout/add-items.ts
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import {
+	conciergeSessionItem,
+	domainMapping,
+	planItem,
+	themeItem,
+	jetpackProductItem,
+} from 'lib/cart-values/cart-items';
+import type { RequestCartProduct } from './wpcom/types';
+
+const debug = debugFactory( 'calypso:composite-checkout:add-items' );
+
+export function createItemToAddToCart( {
+	planSlug,
+	productAlias,
+	product_id,
+	isJetpackNotAtomic,
+}: {
+	planSlug: string | undefined;
+	productAlias: string | undefined;
+	product_id: number;
+	isJetpackNotAtomic: boolean | undefined;
+} ): RequestCartProduct | null {
+	let cartItem, cartMeta;
+
+	if ( planSlug && product_id ) {
+		debug( 'creating plan product' );
+		cartItem = planItem( planSlug );
+		if ( cartItem ) {
+			cartItem.product_id = product_id;
+		}
+	}
+
+	if ( productAlias?.startsWith( 'theme:' ) && product_id ) {
+		debug( 'creating theme product' );
+		cartMeta = productAlias.split( ':' )[ 1 ];
+		cartItem = themeItem( cartMeta );
+		if ( cartItem ) {
+			cartItem.product_id = product_id;
+		}
+	}
+
+	if ( productAlias?.startsWith( 'domain-mapping:' ) && product_id ) {
+		debug( 'creating domain mapping product' );
+		cartMeta = productAlias.split( ':' )[ 1 ];
+		cartItem = domainMapping( { domain: cartMeta } );
+		if ( cartItem ) {
+			cartItem.product_id = product_id;
+		}
+	}
+
+	if ( productAlias?.startsWith( 'concierge-session' ) && product_id ) {
+		// TODO: prevent adding a conciergeSessionItem if one already exists
+		debug( 'creating concierge product' );
+		cartItem = conciergeSessionItem();
+		if ( cartItem ) {
+			cartItem.product_id = product_id;
+		}
+	}
+
+	if (
+		( productAlias?.startsWith( 'jetpack_backup' ) ||
+			productAlias?.startsWith( 'jetpack_search' ) ) &&
+		isJetpackNotAtomic &&
+		product_id
+	) {
+		debug( 'creating jetpack product' );
+		cartItem = jetpackProductItem( productAlias );
+		if ( cartItem ) {
+			cartItem.product_id = product_id;
+		}
+	}
+
+	if ( ! cartItem ) {
+		debug( 'no product created' );
+		return null;
+	}
+
+	cartItem.extra = { ...cartItem.extra, context: 'calypstore' };
+
+	const defaultProduct = {
+		product_id: 0,
+		product_slug: '',
+		meta: '',
+		extra: {},
+	};
+
+	return { ...defaultProduct, ...cartItem };
+}

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -190,6 +190,12 @@ describe( 'CompositeCheckout', () => {
 							product_slug: 'domain_reg',
 							prices: {},
 						},
+						premium_theme: {
+							product_id: 39,
+							product_name: 'Product',
+							product_slug: 'premium_theme',
+							prices: {},
+						},
 					},
 				},
 				countries: { payments: countryList, domains: countryList },
@@ -487,6 +493,37 @@ describe( 'CompositeCheckout', () => {
 		);
 	} );
 
+	it( 'does not redirect if the cart is empty when it loads but the url has a theme', async () => {
+		const cartChanges = { products: [] };
+		const additionalProps = { product: 'theme:ovation' };
+		await act( async () => {
+			render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adds the domain mapping product to the cart when the url has a theme', async () => {
+		let renderResult;
+		const cartChanges = { products: [ planWithoutDomain ] };
+		const additionalProps = { product: 'theme:ovation' };
+		await act( async () => {
+			renderResult = render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		const { getAllByLabelText } = renderResult;
+		getAllByLabelText( 'WordPress.com Personal' ).map( ( element ) =>
+			expect( element ).toHaveTextContent( 'R$144' )
+		);
+		getAllByLabelText( 'Premium Theme: Ovation' ).map( ( element ) =>
+			expect( element ).toHaveTextContent( 'R$69' )
+		);
+	} );
+
 	it( 'does not redirect if the cart is empty when it loads but the url has a domain map', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { product: 'domain-mapping:bar.com' };
@@ -727,6 +764,22 @@ function convertRequestProductToResponseProduct( currency ) {
 					item_original_cost_display: 'R$70',
 					item_subtotal_integer: 70,
 					item_subtotal_display: 'R$70',
+					item_tax: 0,
+					meta: product.meta,
+					volume: 1,
+					extra: {},
+				};
+			case 39:
+				return {
+					product_id: 39,
+					product_name: 'Premium Theme: Ovation',
+					product_slug: 'premium_theme',
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: 69,
+					item_original_cost_display: 'R$69',
+					item_subtotal_integer: 69,
+					item_subtotal_display: 'R$69',
 					item_tax: 0,
 					meta: product.meta,
 					volume: 1,

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -9,14 +9,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { getSelectedSiteSlug } from 'state/ui/selectors';
-import {
-	conciergeSessionItem,
-	domainMapping,
-	planItem,
-	themeItem,
-	jetpackProductItem,
-	getRenewalItemFromCartItem,
-} from 'lib/cart-values/cart-items';
+import { getRenewalItemFromCartItem } from 'lib/cart-values/cart-items';
 import { requestPlans } from 'state/plans/actions';
 import { getPlanBySlug, getPlans, isRequestingPlans } from 'state/plans/selectors';
 import {
@@ -26,6 +19,7 @@ import {
 } from 'state/products-list/selectors';
 import { requestProductsList } from 'state/products-list/actions';
 import getUpgradePlanSlugFromPath from 'state/selectors/get-upgrade-plan-slug-from-path';
+import { createItemToAddToCart } from './add-items';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-prepare-product-for-cart' );
 
@@ -231,69 +225,6 @@ function getProductSlugFromAlias( productAlias ) {
 		return 'premium_theme';
 	}
 	return null;
-}
-
-/**
- * Create and return an object to be added to the cart
- *
- * @returns RequestCartProduct | null
- */
-function createItemToAddToCart( {
-	planSlug = null,
-	productAlias = '',
-	product_id = null,
-	isJetpackNotAtomic = false,
-} ) {
-	let cartItem, cartMeta;
-
-	if ( planSlug && product_id ) {
-		debug( 'creating plan product' );
-		cartItem = planItem( planSlug );
-		cartItem.product_id = product_id;
-	}
-
-	if ( productAlias.startsWith( 'theme:' ) && product_id ) {
-		debug( 'creating theme product' );
-		cartMeta = productAlias.split( ':' )[ 1 ];
-		cartItem = themeItem( cartMeta );
-		cartItem.product_id = product_id;
-	}
-
-	if ( productAlias.startsWith( 'domain-mapping:' ) && product_id ) {
-		debug( 'creating domain mapping product' );
-		cartMeta = productAlias.split( ':' )[ 1 ];
-		cartItem = domainMapping( { domain: cartMeta } );
-		cartItem.product_id = product_id;
-	}
-
-	if ( productAlias.startsWith( 'concierge-session' ) && product_id ) {
-		// TODO: prevent adding a conciergeSessionItem if one already exists
-		debug( 'creating concierge product' );
-		cartItem = conciergeSessionItem();
-		cartItem.product_id = product_id;
-	}
-
-	if (
-		( productAlias.startsWith( 'jetpack_backup' ) ||
-			productAlias.startsWith( 'jetpack_search' ) ) &&
-		isJetpackNotAtomic &&
-		product_id
-	) {
-		debug( 'creating jetpack product' );
-		cartItem = jetpackProductItem( productAlias );
-		cartItem.product_id = product_id;
-	}
-
-	if ( ! cartItem ) {
-		debug( 'no product created' );
-		return null;
-	}
-
-	cartItem.extra = { ...cartItem.extra, context: 'calypstore' };
-
-	cartItem.uuid = 'unknown'; // This must be filled-in later
-
-	return cartItem;
 }
 
 function createRenewalItemToAddToCart( productAlias, productId, purchaseId, selectedSiteSlug ) {

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -227,13 +227,16 @@ function getProductSlugFromAlias( productAlias ) {
 	if ( productAlias?.startsWith?.( 'domain-mapping:' ) ) {
 		return 'domain_map';
 	}
+	if ( productAlias?.startsWith?.( 'theme:' ) ) {
+		return 'premium_theme';
+	}
 	return null;
 }
 
 /**
  * Create and return an object to be added to the cart
  *
- * @returns ResponseCartProduct | null
+ * @returns RequestCartProduct | null
  */
 function createItemToAddToCart( {
 	planSlug = null,
@@ -249,10 +252,11 @@ function createItemToAddToCart( {
 		cartItem.product_id = product_id;
 	}
 
-	if ( productAlias.startsWith( 'theme:' ) ) {
+	if ( productAlias.startsWith( 'theme:' ) && product_id ) {
 		debug( 'creating theme product' );
 		cartMeta = productAlias.split( ':' )[ 1 ];
 		cartItem = themeItem( cartMeta );
+		cartItem.product_id = product_id;
 	}
 
 	if ( productAlias.startsWith( 'domain-mapping:' ) && product_id ) {
@@ -262,19 +266,22 @@ function createItemToAddToCart( {
 		cartItem.product_id = product_id;
 	}
 
-	if ( productAlias.startsWith( 'concierge-session' ) ) {
+	if ( productAlias.startsWith( 'concierge-session' ) && product_id ) {
 		// TODO: prevent adding a conciergeSessionItem if one already exists
 		debug( 'creating concierge product' );
 		cartItem = conciergeSessionItem();
+		cartItem.product_id = product_id;
 	}
 
 	if (
 		( productAlias.startsWith( 'jetpack_backup' ) ||
 			productAlias.startsWith( 'jetpack_search' ) ) &&
-		isJetpackNotAtomic
+		isJetpackNotAtomic &&
+		product_id
 	) {
 		debug( 'creating jetpack product' );
 		cartItem = jetpackProductItem( productAlias );
+		cartItem.product_id = product_id;
 	}
 
 	if ( ! cartItem ) {

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -125,6 +125,11 @@ function useAddPlanFromSlug( { planSlug, setState, isJetpackNotAtomic, originalP
 			product_id: plan.product_id,
 			isJetpackNotAtomic,
 		} );
+		if ( ! cartProduct ) {
+			debug( 'there is a request to add a plan but creating an item failed', planSlug );
+			setState( { canInitializeCart: true } );
+			return;
+		}
 		debug(
 			'preparing plan that was requested in url',
 			{ planSlug, plan, isJetpackNotAtomic },
@@ -173,6 +178,11 @@ function useAddProductFromSlug( {
 			product_id: product.product_id,
 			isJetpackNotAtomic,
 		} );
+		if ( ! cartProduct ) {
+			debug( 'there is a request to add a product but creating an item failed', productAlias );
+			setState( { canInitializeCart: true } );
+			return;
+		}
 		debug(
 			'preparing product that was requested in url',
 			{ productAlias, isJetpackNotAtomic },

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/shopping-cart-endpoint.ts
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import type { CartItemExtra } from 'lib/cart-values/types';
+
+/**
  * There are three different concepts of "cart" relevant to the shopping cart endpoint:
  *
  *     1. The response format of the cart endpoint (GET)
@@ -45,7 +50,7 @@ export interface RequestCartProduct {
 	product_slug: string;
 	product_id: number;
 	meta: string;
-	extra: object;
+	extra: CartItemExtra;
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds support for adding premium themes via the special URL `/checkout/example.com/theme:themename`.

To improve the reliability of this process in the future, it also moves the `createItemToAddToCart` function to a Typescript file and cleans up quite a few incorrect or missing types in `lib/cart-items`.

#### Testing instructions

- Visit a URL like this: http://calypso.localhost:3000/checkout/example.com/theme:ovation except with your site instead of `example.com`.
- Verify that you see composite checkout and not old checkout. If you see old checkout it may be because your user is not in the abtest; you can change that via the dev menu in the lower right. If you change the abtest setting, be sure to empty your cart and try the above URL again.
- Verify that the "Ovation" premium theme has been successfully added to your cart.