### PR TITLE
Page list: Display a <span/> instead of a <a/> if the page is trashed

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -184,7 +184,7 @@ class PostItem extends React.Component {
 							onClick={ this.clickHandler( 'title' ) }
 							onMouseOver={ preloadEditor }
 						>
-							{ ! externalPostLink && (
+							{ ! externalPostLink && ! isTrashed && (
 								<a
 									href={ enabledPostLink }
 									className="post-item__title-link"
@@ -193,6 +193,13 @@ class PostItem extends React.Component {
 									{ title || translate( 'Untitled' ) }
 								</a>
 							) }
+
+							{ ! externalPostLink && isTrashed && (
+								<span className="post-item__title-link" data-e2e-title={ title }>
+									{ title || translate( 'Untitled' ) }
+								</span>
+							) }
+
 							{ ! isPlaceholder && externalPostLink && (
 								<ExternalLink
 									icon={ true }

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -497,6 +497,8 @@ class Page extends Component {
 			</EllipsisMenu>
 		);
 
+		const isTrashed = page.status === 'trash';
+
 		const shadowNotice = shadowStatus && (
 			<ShadowNotice shadowStatus={ shadowStatus } onUndoClick={ this.undoPostStatus } />
 		);
@@ -521,34 +523,45 @@ class Page extends Component {
 			<div className={ classNames( hierarchyIndentClasses ) } />
 		);
 
+		const innerPageTitle = (
+			<>
+				{ depthIndicator }
+				{ title }
+				{ ! isTrashed && latestPostsPage && (
+					<InfoPopover position="right">
+						{ translate(
+							'The content of your latest posts page is automatically generated and cannot be edited.'
+						) }
+					</InfoPopover>
+				) }
+			</>
+		);
+
 		return (
 			<CompactCard className={ classNames( cardClasses ) }>
 				{ hierarchyIndent }
 				{ this.props.multisite ? <SiteIcon siteId={ page.site_ID } size={ 34 } /> : null }
 				<div className="page__main">
-					<a
-						className="page__title"
-						href={ canEdit ? editorUrl : page.URL }
-						title={
-							canEdit
-								? translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } )
-								: translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } )
-						}
-						onClick={ this.props.recordPageTitle }
-						onMouseOver={ preloadEditor }
-						onFocus={ preloadEditor }
-						data-tip-target={ 'page-' + page.slug }
-					>
-						{ depthIndicator }
-						{ title }
-						{ latestPostsPage && (
-							<InfoPopover position="right">
-								{ translate(
-									'The content of your latest posts page is automatically generated and cannot be edited.'
-								) }
-							</InfoPopover>
-						) }
-					</a>
+					{ ! isTrashed && (
+						<a
+							className="page__title"
+							href={ canEdit ? editorUrl : page.URL }
+							title={
+								canEdit
+									? translate( 'Edit %(title)s', { textOnly: true, args: { title: page.title } } )
+									: translate( 'View %(title)s', { textOnly: true, args: { title: page.title } } )
+							}
+							onClick={ this.props.recordPageTitle }
+							onMouseOver={ preloadEditor }
+							onFocus={ preloadEditor }
+							data-tip-target={ 'page-' + page.slug }
+						>
+							{ innerPageTitle }
+						</a>
+					) }
+
+					{ isTrashed && <span className="page__title">{ innerPageTitle }</span> }
+
 					<PageCardInfo
 						page={ page }
 						showTimestamp


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Page list: Display a  un-clickable text (a <span/>) when the page item is deleted,. to prevent a 404 

#### Testing instructions

* Go to page list
* Either when searching or in the "deleted" tab, page items cannot be clicked


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #41640
cc @kwight 
