### PR TITLE
Disable dotcom FSE by default on local sites.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/helpers.php
+++ b/apps/full-site-editing/full-site-editing-plugin/dotcom-fse/helpers.php
@@ -106,6 +106,8 @@ function normalize_theme_slug( $theme_slug ) {
  * Whether or not the site is eligible for FSE. This is essentially a feature
  * gate to disable FSE on some sites which could theoretically otherwise use it.
  *
+ * By default, sites should not be eligible. 
+ *
  * @return bool True if current site is eligible for FSE, false otherwise.
  */
 function is_site_eligible_for_full_site_editing() {
@@ -116,7 +118,7 @@ function is_site_eligible_for_full_site_editing() {
 	 *
 	 * @param bool true if Full Site Editing should be disabled, false otherwise.
 	 */
-	return ! apply_filters( 'a8c_disable_full_site_editing', false );
+	return ! apply_filters( 'a8c_disable_full_site_editing', true );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Believe it or not, dotcom FSE is turned on by default. It made sense at the time -- anyone with the plugin installed would want to be seeing dotcom FSE, right!?

Wrong. The plugin is almost entirely _not_ for dotcom FSE any more.

Currently, the only thing stopping dotcom FSE showing up for people on Atomic sites is this code in wpcomsh:

```
function wpcomsh_maybe_disable_fse() {
	// Always disable FSE if the site is not eligible:
	return ! get_option( 'a8c-fse-is-eligible' );
}
add_filter( 'a8c_disable_full_site_editing', 'wpcomsh_maybe_disable_fse' );
```
(source: wpcomsh `feature-plugins/full-site-editing.php#L11-L15`)

These changes should not affect dotcom fse in production. This "disable FSE" filter currently always receives a result on both simple and atomic sites via mu plugins and wpcomsh respectively. This just changes the default value for situations in which the filter doesn't return a result. I think this is good, because we are now handling this situation directly in the plugin. I think relying on outside code which could break is a bad idea.

Going forward, to turn on dotcom-fse in a self-hosted site, you will have to do `add_option( a8c-fse-is-eligible, true )`. Then, you'd probably need to activate Maywood, and then deactivate and reactivate the FSE plugin.

