### PR TITLE
composite-checkout: Support adding concierge session via URL

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -159,7 +159,14 @@ function shouldShowCompositeCheckout(
 	// products via URL, so we list those slugs here. Renewals use actual slugs,
 	// so they do not need to go through this check.
 	const isRenewal = !! purchaseId;
-	const pseudoSlugsToAllow = [ 'personal', 'premium', 'blogger', 'ecommerce', 'business' ];
+	const pseudoSlugsToAllow = [
+		'personal',
+		'premium',
+		'blogger',
+		'ecommerce',
+		'business',
+		'concierge-session',
+	];
 	const slugPrefixesToAllow = [ 'domain-mapping:', 'theme:' ];
 	if (
 		! isRenewal &&

--- a/client/my-sites/checkout/composite-checkout/add-items.ts
+++ b/client/my-sites/checkout/composite-checkout/add-items.ts
@@ -57,7 +57,6 @@ export function createItemToAddToCart( {
 	}
 
 	if ( productAlias === 'concierge-session' && product_id ) {
-		// TODO: prevent adding a conciergeSessionItem if one already exists
 		debug( 'creating concierge product' );
 		cartItem = conciergeSessionItem();
 		if ( cartItem ) {

--- a/client/my-sites/checkout/composite-checkout/add-items.ts
+++ b/client/my-sites/checkout/composite-checkout/add-items.ts
@@ -56,7 +56,7 @@ export function createItemToAddToCart( {
 		}
 	}
 
-	if ( productAlias?.startsWith( 'concierge-session' ) && product_id ) {
+	if ( productAlias === 'concierge-session' && product_id ) {
 		// TODO: prevent adding a conciergeSessionItem if one already exists
 		debug( 'creating concierge product' );
 		cartItem = conciergeSessionItem();

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -196,6 +196,12 @@ describe( 'CompositeCheckout', () => {
 							product_slug: 'premium_theme',
 							prices: {},
 						},
+						'concierge-session': {
+							product_id: 371,
+							product_name: 'Product',
+							product_slug: 'concierge-session',
+							prices: {},
+						},
 					},
 				},
 				countries: { payments: countryList, domains: countryList },
@@ -493,6 +499,37 @@ describe( 'CompositeCheckout', () => {
 		);
 	} );
 
+	it( 'does not redirect if the cart is empty when it loads but the url has a concierge session', async () => {
+		const cartChanges = { products: [] };
+		const additionalProps = { product: 'concierge-session' };
+		await act( async () => {
+			render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adds the domain mapping product to the cart when the url has a concierge session', async () => {
+		let renderResult;
+		const cartChanges = { products: [ planWithoutDomain ] };
+		const additionalProps = { product: 'concierge-session' };
+		await act( async () => {
+			renderResult = render(
+				<MyCheckout cartChanges={ cartChanges } additionalProps={ additionalProps } />,
+				container
+			);
+		} );
+		const { getAllByLabelText } = renderResult;
+		getAllByLabelText( 'WordPress.com Personal' ).map( ( element ) =>
+			expect( element ).toHaveTextContent( 'R$144' )
+		);
+		getAllByLabelText( 'Support Session' ).map( ( element ) =>
+			expect( element ).toHaveTextContent( 'R$49' )
+		);
+	} );
+
 	it( 'does not redirect if the cart is empty when it loads but the url has a theme', async () => {
 		const cartChanges = { products: [] };
 		const additionalProps = { product: 'theme:ovation' };
@@ -780,6 +817,22 @@ function convertRequestProductToResponseProduct( currency ) {
 					item_original_cost_display: 'R$69',
 					item_subtotal_integer: 69,
 					item_subtotal_display: 'R$69',
+					item_tax: 0,
+					meta: product.meta,
+					volume: 1,
+					extra: {},
+				};
+			case 371:
+				return {
+					product_id: 371,
+					product_name: 'Support Session',
+					product_slug: 'concierge-session',
+					currency: currency,
+					is_domain_registration: false,
+					item_original_cost_integer: 49,
+					item_original_cost_display: 'R$49',
+					item_subtotal_integer: 49,
+					item_subtotal_display: 'R$49',
 					item_tax: 0,
 					meta: product.meta,
 					volume: 1,

--- a/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
+++ b/client/my-sites/checkout/composite-checkout/use-prepare-product-for-cart.js
@@ -227,12 +227,19 @@ function useFetchPlansIfNotLoaded() {
 	}, [ isFetchingPlans, plans, reduxDispatch ] );
 }
 
+/**
+ * @param {string | null} productAlias - A fake slug like 'theme:ovation'
+ * @returns {string | null} A real slug like 'premium_theme'
+ */
 function getProductSlugFromAlias( productAlias ) {
 	if ( productAlias?.startsWith?.( 'domain-mapping:' ) ) {
 		return 'domain_map';
 	}
 	if ( productAlias?.startsWith?.( 'theme:' ) ) {
 		return 'premium_theme';
+	}
+	if ( productAlias === 'concierge-session' ) {
+		return 'concierge-session';
 	}
 	return null;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds support for adding concierge sessions via the special URL `/checkout/example.com/concierge-session`.

Note: old checkout includes a clause to prevent adding duplicate concierge sessions to the cart, but I think this logic belongs on the server, so that behavior has not been replicated here. Instead, see D42677-code

#### Testing instructions

- Visit a URL like this: http://calypso.localhost:3000/checkout/example.com/concierge-session except with your site instead of `example.com`.
- Verify that you see composite checkout and not old checkout. If you see old checkout it may be because your user is not in the abtest; you can change that via the dev menu in the lower right. If you change the abtest setting, be sure to empty your cart and try the above URL again.
- Verify that the "Support Session" product has been successfully added to your cart.