### PR TITLE
composite-checkout: Show variation picker when purchase is not a renewal

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -48,7 +48,8 @@ function WPLineItem( {
 	const onEvent = useEvents();
 	const isDisabled = formStatus !== 'ready';
 
-	const shouldShowVariantSelector = item.wpcom_meta && item.wpcom_meta.extra?.context === 'signup';
+	// Show the variation picker when this is not a renewal
+	const shouldShowVariantSelector = item.wpcom_meta && ! item.wpcom_meta.extra?.purchaseId;
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The product variation picker allows switching between one and two-year plan lengths in the review step of composite checkout. Prior to this PR, it was made visible only for products with variant pricing which were added to the cart during signup. This PR modifies the logic so that the picker will be visible for any product with variant pricing which is not a renewal, allowing new plan purchases to always choose a different variation.

Fixes #41459

![Screen Shot 2020-04-29 at 7 47 59 PM](https://user-images.githubusercontent.com/2036909/80657708-55396e80-8a52-11ea-95ae-4bf7e107c0b2.png)

#### Testing instructions

- Add a plan renewal to your cart and visit composite checkout.
- Verify that you do not see the plan length picker.
- Remove the renewal from your cart.
- Add a plan upgrade to your cart and visit composite checkout.
- Verify that you do see the plan length picker.
- Choose the two-year plan length.
- Complete checkout and verify that the correct plan length was purchased.