### PR TITLE
Task Card: Adds additional config options

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -66,3 +66,12 @@
 .task__skip-popover .popover__menu {
 	min-width: 130px;
 }
+
+.task__chip {
+	background-color: var( --color-text );
+	width: fit-content;
+	border-radius: 12px;
+	padding: 2px 8px;
+	color: var( --color-text-inverted );
+	margin-bottom: 16px;
+}

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -67,7 +67,8 @@
 	min-width: 130px;
 }
 
-.task__chip {
-	background-color: var( --studio-gray-8 );
+.badge--info.task__badge {
+	background-color: var( --studio-gray-80 );
 	color: var( --color-text-inverted );
+	margin-bottom: 16px;
 }

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -68,7 +68,7 @@
 }
 
 .task__chip {
-	background-color: var( --color-text );
+	background-color: var( --color-neutral-80 );
 	width: fit-content;
 	border-radius: 12px;
 	padding: 2px 8px;

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -68,10 +68,6 @@
 }
 
 .task__chip {
-	background-color: var( --color-neutral-80 );
-	width: fit-content;
-	border-radius: 12px;
-	padding: 2px 8px;
+	background-color: var( --studio-gray-8 );
 	color: var( --color-text-inverted );
-	margin-bottom: 16px;
 }

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -4,7 +4,7 @@
 import React, { useRef, useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { connect, useDispatch } from 'react-redux';
-import { Button, Badge } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 
@@ -19,6 +19,7 @@ import ActionPanelCta from 'components/action-panel/cta';
 import Gridicon from 'components/gridicon';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
+import Badge from 'components/badge';
 import {
 	bumpStat,
 	composeAnalytics,
@@ -120,7 +121,11 @@ const Task = ( {
 							<p>{ translate( '%d minute', '%d minutes', { count: timing, args: [ timing ] } ) }</p>
 						</div>
 					) }
-					{ badgeText && <Badge className="task__badge">{ badgeText }</Badge> }
+					{ badgeText && (
+						<Badge type="info" className="task__badge">
+							{ badgeText }
+						</Badge>
+					) }
 					<ActionPanelTitle>{ title }</ActionPanelTitle>
 					<p className="task__description">{ description }</p>
 					<ActionPanelCta>

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { connect, useDispatch } from 'react-redux';
 import { Button } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -106,7 +107,7 @@ const Task = ( {
 	};
 
 	return (
-		<ActionPanel className="task">
+		<ActionPanel className={ classNames( 'task', taskId ) }>
 			<ActionPanelBody>
 				{ isDesktop() && (
 					<ActionPanelFigure align="right">

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -42,7 +42,7 @@ const Task = ( {
 	badgeText,
 	description,
 	illustration,
-	areSkipOptionsEnabled = true,
+	enableSkipOptions = true,
 	siteId,
 	taskId,
 	timing,
@@ -137,14 +137,14 @@ const Task = ( {
 							className="task__skip is-link"
 							ref={ skipButtonRef }
 							onClick={ () =>
-								areSkipOptionsEnabled ? setSkipOptionsVisible( true ) : skipTask( 'never' )
+								enableSkipOptions ? setSkipOptionsVisible( true ) : skipTask( 'never' )
 							}
 						>
-							{ areSkipOptionsEnabled ? translate( 'Remind me' ) : translate( 'Dismiss' ) }
-							{ areSkipOptionsEnabled && <Gridicon icon="dropdown" size={ 18 } /> }
+							{ enableSkipOptions ? translate( 'Remind me' ) : translate( 'Dismiss' ) }
+							{ enableSkipOptions && <Gridicon icon="dropdown" size={ 18 } /> }
 						</Button>
 
-						{ areSkipOptionsEnabled && areSkipOptionsVisible && (
+						{ enableSkipOptions && areSkipOptionsVisible && (
 							<PopoverMenu
 								context={ skipButtonRef.current }
 								isVisible={ areSkipOptionsVisible }

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -37,8 +37,11 @@ const Task = ( {
 	actionOnClick,
 	actionText,
 	actionUrl,
+	chipText,
 	description,
 	illustration,
+	dismissable,
+	skippable = true,
 	siteId,
 	taskId,
 	timing,
@@ -111,27 +114,33 @@ const Task = ( {
 					</ActionPanelFigure>
 				) }
 				<div className="task__text">
-					<div className="task__timing">
-						<Gridicon icon="time" size={ 18 } />
-						<p>{ translate( '%d minute', '%d minutes', { count: timing, args: [ timing ] } ) }</p>
-					</div>
+					{ timing && (
+						<div className="task__timing">
+							<Gridicon icon="time" size={ 18 } />
+							<p>{ translate( '%d minute', '%d minutes', { count: timing, args: [ timing ] } ) }</p>
+						</div>
+					) }
+					{ chipText && <div className="task__chip">{ chipText }</div> }
 					<ActionPanelTitle>{ title }</ActionPanelTitle>
 					<p className="task__description">{ description }</p>
 					<ActionPanelCta>
 						<Button className="task__action" primary onClick={ actionOnClick } href={ actionUrl }>
 							{ actionText }
 						</Button>
-						<Button
-							className="task__skip is-link"
-							ref={ skipButtonRef }
-							onClick={ () => {
-								setSkipOptionsVisible( true );
-							} }
-						>
-							{ translate( 'Remind me' ) }
-							<Gridicon icon="dropdown" size={ 18 } />
-						</Button>
-						{ areSkipOptionsVisible && (
+
+						{ skippable && (
+							<Button
+								className="task__skip is-link"
+								ref={ skipButtonRef }
+								onClick={ () => {
+									setSkipOptionsVisible( true );
+								} }
+							>
+								{ translate( 'Remind me' ) }
+								<Gridicon icon="dropdown" size={ 18 } />
+							</Button>
+						) }
+						{ skippable && areSkipOptionsVisible && (
 							<PopoverMenu
 								context={ skipButtonRef.current }
 								isVisible={ areSkipOptionsVisible }
@@ -149,6 +158,11 @@ const Task = ( {
 									{ translate( 'Never' ) }
 								</PopoverMenuItem>
 							</PopoverMenu>
+						) }
+						{ dismissable && (
+							<Button className="task__dismiss is-link" onClick={ () => skipTask( 'never' ) }>
+								{ translate( 'Dismiss' ) }
+							</Button>
 						) }
 					</ActionPanelCta>
 				</div>

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -4,7 +4,7 @@
 import React, { useRef, useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { connect, useDispatch } from 'react-redux';
-import { Button } from '@automattic/components';
+import { Button, Badge } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
 import classNames from 'classnames';
 
@@ -38,11 +38,10 @@ const Task = ( {
 	actionOnClick,
 	actionText,
 	actionUrl,
-	chipText,
+	badgeText,
 	description,
 	illustration,
-	dismissable,
-	skippable = true,
+	areSkipOptionsEnabled = true,
 	siteId,
 	taskId,
 	timing,
@@ -121,7 +120,7 @@ const Task = ( {
 							<p>{ translate( '%d minute', '%d minutes', { count: timing, args: [ timing ] } ) }</p>
 						</div>
 					) }
-					{ chipText && <div className="task__chip">{ chipText }</div> }
+					{ badgeText && <Badge className="task__badge">{ badgeText }</Badge> }
 					<ActionPanelTitle>{ title }</ActionPanelTitle>
 					<p className="task__description">{ description }</p>
 					<ActionPanelCta>
@@ -129,19 +128,18 @@ const Task = ( {
 							{ actionText }
 						</Button>
 
-						{ skippable && (
-							<Button
-								className="task__skip is-link"
-								ref={ skipButtonRef }
-								onClick={ () => {
-									setSkipOptionsVisible( true );
-								} }
-							>
-								{ translate( 'Remind me' ) }
-								<Gridicon icon="dropdown" size={ 18 } />
-							</Button>
-						) }
-						{ skippable && areSkipOptionsVisible && (
+						<Button
+							className="task__skip is-link"
+							ref={ skipButtonRef }
+							onClick={ () =>
+								areSkipOptionsEnabled ? setSkipOptionsVisible( true ) : skipTask( 'never' )
+							}
+						>
+							{ areSkipOptionsEnabled ? translate( 'Remind me' ) : translate( 'Dismiss' ) }
+							{ areSkipOptionsEnabled && <Gridicon icon="dropdown" size={ 18 } /> }
+						</Button>
+
+						{ areSkipOptionsEnabled && areSkipOptionsVisible && (
 							<PopoverMenu
 								context={ skipButtonRef.current }
 								isVisible={ areSkipOptionsVisible }
@@ -159,11 +157,6 @@ const Task = ( {
 									{ translate( 'Never' ) }
 								</PopoverMenuItem>
 							</PopoverMenu>
-						) }
-						{ dismissable && (
-							<Button className="task__dismiss is-link" onClick={ () => skipTask( 'never' ) }>
-								{ translate( 'Dismiss' ) }
-							</Button>
 						) }
 					</ActionPanelCta>
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add props to display chip heading instead of time, dismiss instead of skip, and action callback instead of url for call to action button.

#### Testing instructions

* Check out this PR - all existing cards should still works as expected - these changes should be backwards compatible so no changes to existing cards should be needed.
* Also check out  #41570 and check that a chip style heading displays at top of card instead of the time estimate, and a `Dismiss` link instead of the skip options

<img width="696" alt="Screen Shot 2020-04-30 at 2 40 20 PM" src="https://user-images.githubusercontent.com/3629020/80666556-b283fd00-8af0-11ea-9a0d-28bfed9bcded.png">

Also check that the 'Try now' button fires the callback to launch the editor

Additional config options needed initially for #41570
