### PR TITLE
Gutenboarding: render plans button on every route

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -234,7 +234,7 @@ const Header: React.FunctionComponent = () => {
 					}
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-section-item--right">
-					{ currentStep !== 'IntentGathering' && <PlansButton /> }
+					<PlansButton />
 				</div>
 			</section>
 			{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make plans button visible since the user lands on Gutenboarding.

#### Testing instructions

* Go to [/new](https://calypso.live/new?branch=update/gutenboarding-plans-button-always-visible).
* Plans button should be in header (top-right) on every step.

<img width="700" alt="Screenshot 2020-04-30 at 10 58 39" src="https://user-images.githubusercontent.com/14192054/80686578-9329a780-8ad1-11ea-8186-926a41483379.png">

Fixes #41577

