### PR TITLE
Gutenboarding: Show first time notice when user enters editor.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -60,6 +60,11 @@ function updateSettingsBar() {
 }
 
 function showFirstTimeNotice() {
+	// Skip on older atomic sites.
+	if ( typeof createInterpolateElement !== 'function' ) {
+		return;
+	}
+
 	const getPreviewButton = () => document.querySelector( '.editor-post-preview' );
 
 	const awaitPreviewButton = setInterval( () => {

--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.scss
@@ -19,4 +19,10 @@
             opacity: 0.3 !important;
         }
     }
+
+	.gutenboarding-editor-overrides__first-time-notice {
+		border-top: 1px solid #e2e4e7;
+		margin: 0;
+		padding-right: 5px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show first time notice when user enters editor.

#### Testing instructions

Note: You'll need to test this via sandbox.

* Go through the gutenboarding steps at `/new` until you reach the editor, you should see the first-time notice.
* Clicking on the **Preview link**, it should display preview in a popup.
* Resize the window, and click on the **Preview link** again, it should also work.
* Clicking on the **Close button** should make the notice dissappear.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/80690302-e8b08500-8ace-11ea-86b8-f871a2958c94.png)

Fixes #41290
