### PR TITLE
Gutenboarding: redirect to editor after emptying checkout cart 

### DIFF
--- a/client/lib/checkout/index.js
+++ b/client/lib/checkout/index.js
@@ -68,8 +68,18 @@ export function getValidDeepRedirectTo( redirectTo ) {
 	}
 }
 
-export function getExitCheckoutUrl( cart, siteSlug, upgradeIntent, redirectTo ) {
+export function getExitCheckoutUrl(
+	cart,
+	siteSlug,
+	upgradeIntent,
+	redirectTo,
+	returnToBlockEditor
+) {
 	let url = '/plans/';
+
+	if ( returnToBlockEditor ) {
+		return `/block-editor/page/${ siteSlug }/home`;
+	}
 
 	if ( hasRenewalItem( cart ) ) {
 		const { purchaseId, purchaseDomain } = getRenewalItems( cart )[ 0 ].extra,

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -76,6 +76,7 @@ class CheckoutContainer extends React.Component {
 			shouldShowCart = true,
 			clearTransaction,
 			isComingFromGutenboarding,
+			isGutenboardingCreate,
 		} = this.props;
 
 		const TransactionData = clearTransaction ? CartData : CheckoutData;
@@ -111,6 +112,7 @@ class CheckoutContainer extends React.Component {
 							redirectTo={ redirectTo }
 							upgradeIntent={ upgradeIntent }
 							hideNudge={ isComingFromGutenboarding }
+							returnToBlockEditor={ isComingFromGutenboarding || isGutenboardingCreate }
 						>
 							{ this.props.children }
 						</Checkout>

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -344,17 +344,13 @@ export class Checkout extends React.Component {
 
 		let redirectTo = '/plans/';
 
-		if ( returnToBlockEditor ) {
-			page.redirect( `/block-editor/page/${ selectedSiteSlug }/home` );
-			return true;
-		}
-
 		if ( this.state.previousCart ) {
 			redirectTo = getExitCheckoutUrl(
 				this.state.previousCart,
 				selectedSiteSlug,
 				this.props.upgradeIntent,
-				this.props.redirectTo
+				this.props.redirectTo,
+				returnToBlockEditor
 			);
 		}
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -106,6 +106,7 @@ export class Checkout extends React.Component {
 		cards: PropTypes.array.isRequired,
 		couponCode: PropTypes.string,
 		isJetpackNotAtomic: PropTypes.bool,
+		returnToBlockEditor: PropTypes.bool,
 		selectedFeature: PropTypes.string,
 		loadTrackingTool: PropTypes.func.isRequired,
 	};
@@ -312,7 +313,7 @@ export class Checkout extends React.Component {
 	}
 
 	redirectIfEmptyCart() {
-		const { selectedSiteSlug, transaction } = this.props;
+		const { selectedSiteSlug, transaction, returnToBlockEditor } = this.props;
 
 		if ( ! transaction ) {
 			return true;
@@ -342,6 +343,11 @@ export class Checkout extends React.Component {
 		}
 
 		let redirectTo = '/plans/';
+
+		if ( returnToBlockEditor ) {
+			page.redirect( `/block-editor/page/${ selectedSiteSlug }/home` );
+			return true;
+		}
 
 		if ( this.state.previousCart ) {
 			redirectTo = getExitCheckoutUrl(


### PR DESCRIPTION
## Changes proposed in this Pull Request

Here we pass down `returnToBlockEditor` to `<Checkout />` so we can redirect back to the block editor if the cart is empty for in Gutenboarding flows.

![redirect-from-cart-new-flow](https://user-images.githubusercontent.com/6458278/80698747-3f917b00-8b1e-11ea-9ce0-9019d418ed16.gif)


I'm open to alternatives for `returnToBlockEditor`.

## Testing instructions

1. From /new select a paid domain, create a site and head to checkout
2. Now empty your cart
3. You should be taken to the editor, where your new home page will be laid out bare before you, ready to succumb to your editing desires
4. Now that you're in the editor, click on **Launch** to launch your site <img width="326" alt="Screen Shot 2020-04-30 at 8 05 12 pm" src="https://user-images.githubusercontent.com/6458278/80698768-46b88900-8b1e-11ea-8bfc-ddb3b0a3254a.png">
5. Select a paid plan and let yourself be carried away to checkout
6. Empty your cart again.
7. Once again, you'll land on the editor, face to face with your sultry homepage, who pines for new content.

Fixes #41652
