### PR TITLE
i18n: Fix translation chunks for 'fallback' target build

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -221,11 +221,11 @@ export function getTranslationChunkFileUrl( {
  *
  * @param {string} chunkId A chunk id. e.g. chunk-abc.min
  * @param {string} localeSlug A locale slug. e.g. fr, jp, zh-tw
- * @param {string} buildTarget The build target. e.g. fallback, evergreen, etc.
+ * @param {string} targetBuild The build target. e.g. fallback, evergreen, etc.
  *
  * @returns {Promise} Translation chunk json content
  */
-export function getTranslationChunkFile( chunkId, localeSlug, buildTarget = 'evergreen' ) {
+export function getTranslationChunkFile( chunkId, localeSlug, targetBuild = 'evergreen' ) {
 	if ( window?.i18nTranslationChunks?.[ chunkId ] ) {
 		return Promise.resolve( window.i18nTranslationChunks[ chunkId ] );
 	}
@@ -234,7 +234,7 @@ export function getTranslationChunkFile( chunkId, localeSlug, buildTarget = 'eve
 		chunkId,
 		localeSlug,
 		fileType: 'json',
-		buildTarget,
+		targetBuild,
 		hash: window?.languageRevisions?.[ localeSlug ] || null,
 	} );
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -389,7 +389,8 @@ const setupDefaultContext = ( entrypoint ) => ( req, res, next ) => {
 };
 
 function setUpLocalLanguageRevisions( req ) {
-	const target = getBuildTargetFromRequest( req );
+	const targetFromRequest = getBuildTargetFromRequest( req );
+	const target = targetFromRequest === null ? 'fallback' : targetFromRequest;
 	const rootPath = path.join( __dirname, '..', '..', '..' );
 	const langRevisionsPath = path.join(
 		rootPath,

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -180,7 +180,7 @@ export function attachI18n( context ) {
 					chunkId,
 					localeSlug: context.lang,
 					fileType: 'js',
-					buildTarget: context.target,
+					targetBuild: context.target,
 					hash: context?.languageRevisions?.[ context.lang ],
 				} )
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR addresses the issues with translation chunks on fallback target build, both of which were related to file paths resolve logic errors

#### Testing instructions

1. Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true DEV_TARGET=fallback yarn start.`
2. Open http://calypso.localhost:3000/start/user/pt-br?useTranslationChunks.
3. Confirm that translation chunks work as if it was evergreen dev target.
