### PR TITLE
Deduplicate strip-json-comments

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20157,12 +20157,7 @@ strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-json-comments@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
-  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
-
-strip-json-comments@^3.1.0:
+strip-json-comments@^3.0.1, strip-json-comments@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
   integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `strip-json-comments` automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
# Before
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> strip-json-comments@3.0.1
< wp-calypso-monorepo@0.17.0 -> eslint@6.8.0 -> ... -> strip-json-comments@3.0.1

# After
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> strip-json-comments@3.1.0
> wp-calypso-monorepo@0.17.0 -> eslint@6.8.0 -> ... -> strip-json-comments@3.1.0
```