### PR TITLE
i18n: Trim down language manifest hashes

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -284,7 +284,9 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 					.createHash( 'sha1' )
 					.update( manifestJsonDataFingerprint )
 					.digest( 'hex' );
-				languageRevisionsHashes[ langSlug ] = manifestJsonDataRaw.hash;
+
+				// Trim hash in language revisions to 5 characters to reduce file size
+				languageRevisionsHashes[ langSlug ] = manifestJsonDataRaw.hash.substr( 0, 5 );
 
 				const manifestJsonData = JSON.stringify( manifestJsonDataRaw );
 				const manifestFilepathJson = path.join(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the build translation chunks script to trim down hashes to 5 characters to reduce the file size of `lang-revisions.json`.

#### Testing instructions

1. Boot Calypso with `ENABLE_FEATURES=use-translation-chunks yarn start`
2. Confirm that `/public/evergreen/languages/lang-revisions.json` contains the trimmed hashes
