### PR TITLE
Domains: Hide propagation message when email has not been verified

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/registered-domain-type.jsx
@@ -212,7 +212,7 @@ class RegisteredDomainType extends React.Component {
 
 		const recentlyRegistered = isRecentlyRegistered( registrationDate );
 
-		if ( ! recentlyRegistered || domain.pendingTransfer ) {
+		if ( ! recentlyRegistered || domain.pendingTransfer || domain.isPendingIcannVerification ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updated the domain card to hide the propagation message when the email verification message is showing, to avoid any confusion.

#### Testing instructions

Register a domain with an email address that you haven't used before, so that the contact info is not verified.

Before the fix, you should see something like this:

<img width="716" alt="Screenshot 2020-04-30 at 2 29 13 PM" src="https://user-images.githubusercontent.com/13062352/80710562-3e952500-8aef-11ea-86eb-c6b46d2998c4.png">

After the fix, you should only see the verification message:

<img width="718" alt="Screenshot 2020-04-30 at 2 30 14 PM" src="https://user-images.githubusercontent.com/13062352/80710585-4785f680-8aef-11ea-800e-0713e681cb43.png">

