### PR TITLE
Deduplicate yargs-parser

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22514,15 +22514,7 @@ yargs-parser@^15.0.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^18.1.0:
-  version "18.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.0.tgz#1b0ab1118ebd41f68bb30e729f4c83df36ae84c3"
-  integrity sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^18.1.1:
+yargs-parser@^18.1.0, yargs-parser@^18.1.1:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `yargs-parser` automatically with `npx yarn-deduplicate`

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
# Before
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> yargs-parser@18.1.0
< wp-calypso-monorepo@0.17.0 -> @automattic/effective-module-tree@0.1.0 -> ... -> yargs-parser@18.1.0
< wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> yargs-parser@18.1.0

# After
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> yargs-parser@18.1.3
> wp-calypso-monorepo@0.17.0 -> @automattic/effective-module-tree@0.1.0 -> ... -> yargs-parser@18.1.3
> wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> yargs-parser@18.1.3
```