### PR TITLE
FSE: Posts Carousel: Small fixes

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
@@ -64,14 +64,16 @@ function newspack_blocks_block_args( $args, $name ) {
 	wp_register_style( $block_prefix . 'editor', $editor_style, array(), NEWSPACK_BLOCKS__VERSION );
 
 	// View script.
-	$script_data = require NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.asset.php';
-	wp_register_script(
-		$block_prefix . 'view',
-		plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.js', __FILE__ ),
-		$script_data['dependencies'],
-		$script_data['version'],
-		true
-	);
+	if ( 'carousel' !== $name ) {
+		$script_data = require NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.asset.php';
+		wp_register_script(
+			$block_prefix . 'view',
+			plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.js', __FILE__ ),
+			$script_data['dependencies'],
+			$script_data['version'],
+			true
+		);
+	}
 
 	// View style.
 	$editor_style = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.css', __FILE__ );

--- a/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
@@ -40,7 +40,7 @@ add_filter( 'newspack_blocks_block_name', __NAMESPACE__ . '\blog_posts_block_nam
  * @param string $name Block name.
  * @return array
  */
-function blog_posts_block_args( $args, $name ) {
+function newspack_blocks_block_args( $args, $name ) {
 	if ( 'homepage-articles' !== $name && 'carousel' !== $name ) {
 		return $args;
 	}
@@ -86,7 +86,7 @@ function blog_posts_block_args( $args, $name ) {
 
 	return $args;
 }
-add_filter( 'newspack_blocks_block_args', __NAMESPACE__ . '\blog_posts_block_args', 10, 2 );
+add_filter( 'newspack_blocks_block_args', __NAMESPACE__ . '\newspack_blocks_block_args', 10, 2 );
 
 require_once __DIR__ . '/synced-newspack-blocks/class-newspack-blocks.php';
 require_once __DIR__ . '/synced-newspack-blocks/class-newspack-blocks-api.php';

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -85,7 +85,6 @@
 		"classnames": "2.2.6",
 		"lodash": "*",
 		"moment": "*",
-		"newspack-blocks": "github:Automattic/newspack-blocks#v1.3.1",
-		"swiper": "4.5.1"
+		"newspack-blocks": "github:Automattic/newspack-blocks#v1.3.1"
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Addresses my feedback in #41423.

  * universal function name, no longer handling just a single block
  * removes extraneous swiper dependency (it's already installed as a sub-dependency of `newspack-blocks`, even in the current master)
  * disables view.js enqueue for the Carousel - it has no JS and the JS file is essentially empty (only contains webpack module wrapper and no actual code)

#### Testing instructions

* run `yarn` to update dependencies
* run `yarn build` in FSE to make production builds
* on the frontend with Posts Carousel - confirm there is no JS for carousel (only CSS + AMP script tags)
* in the editor, confirm the carousel still swipes between posts. this ensures swiper is still present in the build. You can also check built CSS of the post carousel and search `swiper` to confirm it was included