### PR TITLE
Add the selector to extract marketing price group value.

### DIFF
--- a/client/state/current-user/constants.js
+++ b/client/state/current-user/constants.js
@@ -1,2 +1,6 @@
 export const DOMAINS_WITH_PLANS_ONLY = 'calypso_domains_with_plans_only';
 export const NON_PRIMARY_DOMAINS_TO_FREE_USERS = 'calypso_allow_nonprimary_domains_without_plan';
+
+export const MARKETING_PRICE_GROUP_2020_Q2_TEST_1 = 'marketing_price_group_2020_q2_test_1';
+export const MARKETING_PRICE_GROUP_2020_Q2_TEST_2 = 'marketing_price_group_2020_q2_test_2';
+export const MARKETING_PRICE_GROUP_2020_Q2_TEST_3 = 'marketing_price_group_2020_q2_test_3';

--- a/client/state/current-user/constants.js
+++ b/client/state/current-user/constants.js
@@ -1,6 +1,6 @@
 export const DOMAINS_WITH_PLANS_ONLY = 'calypso_domains_with_plans_only';
 export const NON_PRIMARY_DOMAINS_TO_FREE_USERS = 'calypso_allow_nonprimary_domains_without_plan';
 
-export const MARKETING_PRICE_GROUP_2020_Q2_TEST_1 = 'marketing_price_group_2020_q2_test_1';
-export const MARKETING_PRICE_GROUP_2020_Q2_TEST_2 = 'marketing_price_group_2020_q2_test_2';
-export const MARKETING_PRICE_GROUP_2020_Q2_TEST_3 = 'marketing_price_group_2020_q2_test_3';
+export const MARKETING_PRICE_GROUP_2020_Q2_TEST_1 = 'price_2020_q2_test_1';
+export const MARKETING_PRICE_GROUP_2020_Q2_TEST_2 = 'price_2020_q2_test_2';
+export const MARKETING_PRICE_GROUP_2020_Q2_TEST_3 = 'price_2020_q2_test_3';

--- a/client/state/selectors/get-current-user-marketing-price-group.js
+++ b/client/state/selectors/get-current-user-marketing-price-group.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { getCurrentUser } from 'state/current-user/selectors';
+
+/**
+ * Returns the marketing price group of the current user.
+ *
+ * @param {object} state Global state tree
+ * @returns {string?} The price group slug
+ */
+export default ( state ) => {
+	const currentUser = getCurrentUser( state );
+
+	return ( currentUser && currentUser.meta.marketing_price_group ) || null;
+};

--- a/client/state/selectors/test/get-current-user-marketing-price-group.js
+++ b/client/state/selectors/test/get-current-user-marketing-price-group.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import getCurrentUserMarketingPriceGroup from 'state/selectors/get-current-user-marketing-price-group';
+
+describe( 'getCurrentUserMarketingPriceGroup()', () => {
+	test( 'should return null as default', () => {
+		expect( getCurrentUserMarketingPriceGroup( {} ) ).toBeNull();
+	} );
+
+	test( 'should return the marketing price group value', () => {
+		const marketingPriceGroup = 'Profit!';
+
+		expect(
+			getCurrentUserMarketingPriceGroup( {
+				currentUser: {
+					id: 12345,
+				},
+				users: {
+					items: {
+						[ 12345 ]: {
+							meta: {
+								marketing_price_group: marketingPriceGroup,
+							},
+						},
+					},
+				},
+			} )
+		).toEqual( marketingPriceGroup );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a `getCurrentUserMarketingPriceGroup` to extract the marketing price group meta data from the user state tree. The meta data is from `/me` response, added to indicating which price group a user belongs to. 

The backend diff that updates the response can be found in code-D42721.
More context about the flag can be found in p2-pau2Xa-1de#comment-4645.

#### Testing instructions

`yarn test-client client/state/selectors/tests/get-current-user-marketing-price-group.js` should pass.
