### PR TITLE
Jetpack Cloud: Re-namespace the DatePicker component to BackupDatePicker

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/action-bar.tsx
+++ b/client/landing/jetpack-cloud/components/activity-card/action-bar.tsx
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { useTranslate } from 'i18n-calypso';
+import React, { FunctionComponent, useRef, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import {
+	backupDownloadPath,
+	backupRestorePath,
+} from 'landing/jetpack-cloud/sections/backups/paths';
+import { Button } from '@automattic/components';
+import Gridicon from 'components/gridicon';
+import PopoverMenu from 'components/popover/menu';
+
+interface Props {
+	rewindId: string;
+	showActions: boolean;
+	siteSlug: string;
+}
+
+const ActivityCardActionBar: FunctionComponent< Props > = ( {
+	children,
+	rewindId,
+	showActions = true,
+	siteSlug,
+} ) => {
+	const actionMenuRef = useRef( null );
+	const translate = useTranslate();
+
+	const [ showMenu, setShowMenu ] = useState( false );
+	const toggleMenu = () => setShowMenu( ! showMenu );
+	const closeMenu = () => setShowMenu( false );
+
+	const renderActions = () => (
+		<>
+			<Button
+				compact
+				borderless
+				className="activity-card__action-bar-menu-button"
+				onClick={ toggleMenu }
+				ref={ actionMenuRef }
+			>
+				<span>{ translate( 'Actions' ) }</span>
+				<Gridicon icon="add" className="activity-card__actions-icon" />
+			</Button>
+			<PopoverMenu
+				context={ actionMenuRef.current }
+				isVisible={ showMenu }
+				onClose={ closeMenu }
+				className="activity-card__action-bar-menu-popover"
+			>
+				<Button href={ backupRestorePath( siteSlug, rewindId ) }>
+					{ translate( 'Restore to this point' ) }
+				</Button>
+				<Button
+					borderless
+					className="activity-card__action-bar-download-button"
+					href={ backupDownloadPath( siteSlug, rewindId ) }
+				>
+					<img src="/calypso/images/illustrations/download.svg" role="presentation" alt="" />
+					<span>{ translate( 'Download backup' ) }</span>
+				</Button>
+			</PopoverMenu>
+		</>
+	);
+
+	return (
+		<div
+			className={
+				! children && showActions
+					? 'activity-card__action-bar-reverse'
+					: 'activity-card__action-bar'
+			}
+		>
+			{ children }
+			{ showActions && renderActions() }
+		</div>
+	);
+};
+
+export default ActivityCardActionBar;

--- a/client/landing/jetpack-cloud/components/backup-date-picker/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-date-picker/index.jsx
@@ -21,7 +21,7 @@ import { backupActivityPath } from 'landing/jetpack-cloud/sections/backups/paths
  */
 import './style.scss';
 
-class DatePicker extends Component {
+class BackupDatePicker extends Component {
 	static propTypes = {
 		siteId: PropTypes.number.isRequired,
 		selectedDate: PropTypes.object.isRequired,
@@ -107,16 +107,16 @@ class DatePicker extends Component {
 		const nextDisplayDate = this.getDisplayDate( nextDate, false );
 
 		return (
-			<div className="date-picker">
-				<div className="date-picker__select-date">
+			<div className="backup-date-picker">
+				<div className="backup-date-picker__select-date">
 					<div
-						className="date-picker__select-date--previous"
+						className="backup-date-picker__select-date--previous"
 						role="button"
 						tabIndex={ 0 }
 						onClick={ this.goToPreviousDay }
 						onKeyDown={ this.onSpace( this.goToPreviousDay ) }
 					>
-						<Button compact borderless className="date-picker__button--previous">
+						<Button compact borderless className="backup-date-picker__button--previous">
 							<Gridicon
 								icon="chevron-left"
 								className={ ! this.canGoToPreviousDay() && 'disabled' }
@@ -124,7 +124,7 @@ class DatePicker extends Component {
 						</Button>
 
 						<span
-							className={ classNames( 'date-picker__display-date', {
+							className={ classNames( 'backup-date-picker__display-date', {
 								disabled: ! this.canGoToPreviousDay(),
 							} ) }
 						>
@@ -139,26 +139,26 @@ class DatePicker extends Component {
 					/>
 
 					<div
-						className="date-picker__select-date--next"
+						className="backup-date-picker__select-date--next"
 						role="button"
 						tabIndex={ 0 }
 						onClick={ this.goToNextDay }
 						onKeyDown={ this.onSpace( this.goToNextDay ) }
 					>
 						<span
-							className={ classNames( 'date-picker__display-date', {
+							className={ classNames( 'backup-date-picker__display-date', {
 								disabled: ! this.canGoToNextDay(),
 							} ) }
 						>
 							{ nextDisplayDate }
 						</span>
 
-						<Button compact borderless className="date-picker__button--next">
+						<Button compact borderless className="backup-date-picker__button--next">
 							<Gridicon icon="chevron-right" className={ ! this.canGoToNextDay() && 'disabled' } />
 						</Button>
 
-						<a className="date-picker__search-link" href={ backupActivityPath( siteSlug ) }>
-							<Gridicon icon="search" className="date-picker__search-icon" />
+						<a className="backup-date-picker__search-link" href={ backupActivityPath( siteSlug ) }>
+							<Gridicon icon="search" className="backup-date-picker__search-icon" />
 						</a>
 					</div>
 				</div>
@@ -167,4 +167,4 @@ class DatePicker extends Component {
 	}
 }
 
-export default localize( withLocalizedMoment( DatePicker ) );
+export default localize( withLocalizedMoment( BackupDatePicker ) );

--- a/client/landing/jetpack-cloud/components/backup-date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-date-picker/style.scss
@@ -1,4 +1,4 @@
-.date-picker {
+.backup-date-picker {
 	display: flex;
 	align-items: center;
 	max-width: 30rem;
@@ -7,13 +7,13 @@
 	font-size: 16px;
 }
 
-.date-picker__select-date {
+.backup-date-picker__select-date {
 	flex-grow: 1;
 	display: flex;
 	justify-content: center;
 }
 
-.date-picker__select-date--previous {
+.backup-date-picker__select-date--previous {
 	display: flex;
 	flex: 1;
 	align-items: center;
@@ -21,7 +21,7 @@
 	cursor: pointer;
 }
 
-.date-picker__select-date--next {
+.backup-date-picker__select-date--next {
 	display: flex;
 	flex: 1;
 	align-items: center;
@@ -29,12 +29,12 @@
 	cursor: pointer;
 }
 
-.date-picker__search-link {
+.backup-date-picker__search-link {
 	display: flex;
 }
 
-.date-picker__button--next.button.is-borderless.is-compact,
-.date-picker__button--previous.button.is-borderless.is-compact {
+.backup-date-picker__button--next.button.is-borderless.is-compact,
+.backup-date-picker__button--previous.button.is-borderless.is-compact {
 	.gridicon {
 		width: 24px;
 		height: 24px;
@@ -42,47 +42,47 @@
 	}
 }
 
-.date-picker__button--previous {
+.backup-date-picker__button--previous {
 	margin-left: initial;
 	margin-right: 8px;
 }
 
-.date-picker__button--next {
+.backup-date-picker__button--next {
 	margin-left: 8px;
 	margin-right: initial;
 }
 
-.date-picker__select-date .date-range {
+.backup-date-picker__select-date .date-range {
 	flex: 1;
 	text-align: center;
 	max-width: 24px;
 }
 
-.button.is-primary.date-picker__button--previous:focus,
-.button.is-primary.date-picker__button--next:focus {
+.button.is-primary.backup-date-picker__button--previous:focus,
+.button.is-primary.backup-date-picker__button--next:focus {
 	box-shadow: none;
 }
 
-.date-picker .button,
-.date-picker .date-range {
+.backup-date-picker .button,
+.backup-date-picker .date-range {
 	display: inline-block;
 	float: none;
 }
 
-.date-picker .button .gridicon.disabled {
+.backup-date-picker .button .gridicon.disabled {
 	fill: #dcdcde;
 }
 
-.date-picker__search-icon {
+.backup-date-picker__search-icon {
 	margin-left: 0.5rem;
 	cursor: pointer;
 }
 
-.date-picker__display-date {
+.backup-date-picker__display-date {
 	flex: 1;
 }
 
-.date-picker__display-date.disabled {
+.backup-date-picker__display-date.disabled {
 	color: var( --studio-gray-10 );
 }
 
@@ -92,12 +92,12 @@
 	color: var( --studio-gray-70 );
 }
 
-.date-picker__search-icon.gridicon {
+.backup-date-picker__search-icon.gridicon {
 	fill: var( --studio-jetpack-green-40 );
 }
 
 @include breakpoint( '>660px' ) {
-	.date-picker {
+	.backup-date-picker {
 		background: transparent;
 	}
 }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -24,7 +24,7 @@ import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
 import BackupDelta from '../../components/backup-delta';
 import DailyBackupStatus from '../../components/daily-backup-status';
-import BackupDatePicker from '../../components/date-picker';
+import BackupDatePicker from '../../components/backup-date-picker';
 import getRewindState from 'state/selectors/get-rewind-state';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
 import PageViewTracker from 'lib/analytics/page-view-tracker';

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -24,7 +24,7 @@ import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
 import BackupDelta from '../../components/backup-delta';
 import DailyBackupStatus from '../../components/daily-backup-status';
-import DatePicker from '../../components/date-picker';
+import BackupDatePicker from '../../components/date-picker';
 import getRewindState from 'state/selectors/get-rewind-state';
 import getSelectedSiteSlug from 'state/ui/selectors/get-selected-site-slug';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -171,7 +171,7 @@ class BackupsPage extends Component {
 				<QueryRewindCapabilities siteId={ siteId } />
 
 				<div className="backups__last-backup-status">
-					<DatePicker
+					<BackupDatePicker
 						onDateChange={ this.onDateChange }
 						selectedDate={ this.getSelectedDate() }
 						siteId={ siteId }

--- a/static/images/illustrations/download.svg
+++ b/static/images/illustrations/download.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="17" viewBox="0 0 14 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10 6H14L7 13L0 6H4V0H10V6ZM0 17V15H14V17H0Z" fill="#3C434A"/>
+</svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renames the `DatePicker` component to `BackupDatePicker` to avoid (possible) namespace issues with the existing Date Picker component.
* Replaces all CSS classes accordingly

#### Testing instructions

* Check out the Date Picker component for a backups site (the calendar icon at the top). Does it function normally with no console errors?

#### Notes

I would have done this sooner, but I foresee a time in the **_near future_** where we need to replace this component entirely with a custom component. Addressing this immediately to put the "issue" to rest for good :-)
