### PR TITLE
Jetpack Cloud: Remove summarized backup card from real-time backup for some cases

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -81,6 +81,10 @@ class DailyBackupStatus extends Component {
 		const displayDate = this.getDisplayDate( backup.activityTs );
 		const meta = get( backup, 'activityDescription[2].children[0]', '' );
 
+		// We should only showing the summarized ActivityCard for Real-time sites when the latest backup is not a full backup
+		const showBackupDetails =
+			hasRealtimeBackups && 'rewind__backup_complete_full' !== backup.activityName;
+
 		return (
 			<>
 				<div className="daily-backup-status__icon-section">
@@ -94,7 +98,7 @@ class DailyBackupStatus extends Component {
 					siteSlug={ siteSlug }
 					disabledRestore={ ! allowRestore }
 				/>
-				{ hasRealtimeBackups && this.renderBackupDetails( backup ) }
+				{ showBackupDetails && this.renderBackupDetails( backup ) }
 			</>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the summarized ActivityCard from DailyBackupStatus when the latest backup is a full backup.  It only shows redundant meta information.

#### Testing instructions

* Load up backups view for a realtime site whose latest backup is a full backup. The summarized backup card should not appear in the `DailyBackupStatus` component.

Fixes 1142395350490785-as-1172046985906148
