### PR TITLE
Change button alignment on auto-renew disable dialog

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -192,18 +192,29 @@ class AutoRenewDisablingDialog extends Component {
 		const { isVisible, translate } = this.props;
 		const description = this.getCopy( this.getVariation() );
 
+		const buttons = [
+			{
+				action: 'close',
+				label: translate( "I'll keep it" ),
+				onClick: this.closeAndCleanup,
+			},
+			{
+				action: 'confirm',
+				label: translate( 'Confirm cancellation' ),
+				onClick: this.onClickGeneralConfirm,
+				isPrimary: true,
+			},
+		];
+
 		return (
 			<Dialog
 				isVisible={ isVisible }
 				additionalClassNames="auto-renew-disabling-dialog"
 				onClose={ this.closeAndCleanup }
+				buttons={ buttons }
 			>
 				<h2 className="auto-renew-disabling-dialog__header">{ translate( 'Before you go…' ) }</h2>
 				<p>{ description }</p>
-				<Button onClick={ this.closeAndCleanup }>{ translate( "I'll keep it" ) }</Button>
-				<Button onClick={ this.onClickGeneralConfirm } primary>
-					{ translate( 'Confirm cancellation' ) }
-				</Button>
 			</Dialog>
 		);
 	};

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -1,12 +1,5 @@
 .dialog.auto-renew-disabling-dialog {
 	max-width: 440px;
-
-	.button {
-		margin-right: 10px;
-		margin-bottom: 8px;
-		padding: 8px 10px;
-		text-align: left;
-	}
 }
 
 .auto-renew-disabling-dialog__header {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -14,4 +14,11 @@
 		list-style-type: none;
 		margin: 0;
 	}
+
+	.button {
+		margin-bottom: 8px;
+		padding: 8px 10px;
+		text-align: center;
+		width: 100%;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the button alignment on the dialog shown when disabling auto-renew. 

<img width="473" alt="Screenshot 2020-04-30 at 3 34 24 PM" src="https://user-images.githubusercontent.com/13062352/80716581-1958e480-8af8-11ea-8cb5-9d240a057911.png">

Also some styling update is included for the followup dialog when disabling auto-renew for Atomic sites:

<img width="601" alt="Screenshot 2020-04-30 at 3 50 43 PM" src="https://user-images.githubusercontent.com/13062352/80718512-88373d00-8afa-11ea-9589-801d5e825dbe.png">


#### Testing instructions

* Find a purchase for which you have auto-renew enabled, and try to disable it. The buttons should now appear to the right, as shown in the screenshot above.
* Verify functionality of the dialog is intact
