### PR TITLE
UpsellNudge: Tweak styles for dismissible compact nudges

### DIFF
--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -21,7 +21,7 @@
 	}
 	.dismissible-card__close-icon {
 		fill: var( --color-text-inverted );
-		margin-left: 0.75em;
+		margin-right: -6px;
 	}
 	.banner__content {
 		color: var( --color-text-inverted );
@@ -52,6 +52,9 @@
 	}
 }
 
+.upsell-nudge.is-dismissible.is-horizontal.is-compact .banner__action {
+	margin-right: 28px;
+}
 .upsell-nudge.banner.card.is-compact.is-card-link {
 	padding-right: 12px;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following up on #41627, this tweaks the styles for dismissible compact nudges, repositioning the CTA and the dismiss icon for better visual balance.

**Before**

<img width="300" alt="Screen Shot 2020-04-30 at 10 01 31 AM" src="https://user-images.githubusercontent.com/2124984/80719550-a33d8900-8ac9-11ea-8c1b-ecf9e24cc442.png">

**After**

<img width="310" alt="Screen Shot 2020-04-30 at 9 58 26 AM" src="https://user-images.githubusercontent.com/2124984/80719375-65406500-8ac9-11ea-9c3f-47f9fecadb72.png">

#### Testing instructions

* Switch to this PR
* Navigate to a site with a domain upsell nudge like the one shown above
* Also check out the UpsellNudge blocks in `/devdocs` to make sure there are no visual regressions for existing variations of UpsellNudge