### PR TITLE
Fix Jetpack Cloud verbiage

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -255,17 +255,20 @@ class DailyBackupStatus extends Component {
 		const hoursForNextBackup =
 			parseInt( lastBackupDate.format( 'H' ) ) - parseInt( today.format( 'H' ) ) + 3;
 
+		const nextBackupHoursText =
+			hoursForNextBackup === 1
+				? translate( 'In the next hour' )
+				: translate( 'In the next %d hour', 'In the next %d hours', {
+						args: [ hoursForNextBackup ],
+						count: hoursForNextBackup,
+				  } );
+
 		return (
 			<>
 				<Gridicon className="daily-backup-status__gridicon-backup-scheduled" icon="cloud-upload" />
 				<div className="daily-backup-status__static-title">
 					{ translate( 'Backup Scheduled:' ) }
-					<div>
-						{ translate( 'In the next %d hour', 'In the next %d hours', {
-							args: [ hoursForNextBackup ],
-							count: hoursForNextBackup,
-						} ) }
-					</div>
+					<div>{ nextBackupHoursText }</div>
 				</div>
 				<div className="daily-backup-status__no-backup-last-backup">
 					{ translate( 'Last daily backup: {{link}}%(lastBackupDay)s %(lastBackupTime)s{{/link}}', {

--- a/client/landing/jetpack-cloud/components/server-credentials-form/style.scss
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/style.scss
@@ -6,6 +6,10 @@
 		width: 100%;
 	}
 
+	.dialog__action-buttons::before {
+		background: initial;
+	}
+
 	&__buttons {
 		background: var( --studio-gray-0 );
 		margin: 0 -24px;

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
@@ -62,7 +62,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 			<h3 className="rewind-flow__title">{ translate( 'Create downloadable backup' ) }</h3>
 			<p className="rewind-flow__info">
 				{ translate(
-					'{{strong}}%(backupDisplayDate)s{{/strong}} is the selected point to create a download backup of. ',
+					'{{strong}}%(backupDisplayDate)s{{/strong}} is the selected point to create a downloadable backup. ',
 					{
 						args: {
 							backupDisplayDate,
@@ -166,9 +166,23 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 					alt="jetpack cloud download error"
 				/>
 			</div>
-			<h3 className="rewind-flow__title">
-				{ translate( 'An error occurred while creating your download' ) }
+			<h3 className="rewind-flow__title error">
+				{ translate( 'Download failed: %s', {
+					args: [ backupDisplayDate ],
+				} ) }
 			</h3>
+			<p className="rewind-flow__info">
+				{ translate(
+					'An error occurred while creating your downloadable backup. Please {{button}}try your download again{{/button}} or contact our support team to resolve the issue.',
+					{
+						components: {
+							button: (
+								<Button className="rewind-flow__error-retry-button" onClick={ requestDownload } />
+							),
+						},
+					}
+				) }
+			</p>
 			<Button
 				className="rewind-flow__primary-button"
 				href={ contactSupportUrl( siteUrl, 'error' ) }

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
@@ -174,9 +174,21 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					alt="jetpack cloud download error"
 				/>
 			</div>
-			<h3 className="rewind-flow__title">
-				{ translate( 'An error occurred while restoring your site' ) }
+			<h3 className="rewind-flow__title error">
+				{ translate( 'Restore failed: %s', {
+					args: [ backupDisplayDate ],
+				} ) }
 			</h3>
+			<p className="rewind-flow__info">
+				{ translate(
+					'An error occurred while restoring your site. Please {{button}}try your restore again{{/button}} or contact our support team to resolve the issue.',
+					{
+						components: {
+							button: <Button className="rewind-flow__error-retry-button" onClick={ onConfirm } />,
+						},
+					}
+				) }
+			</p>
 			<Button
 				className="rewind-flow__primary-button"
 				href={ contactSupportUrl( siteUrl, 'error' ) }

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
@@ -1,7 +1,7 @@
 .rewind-flow__header {
 	display: flex;
 	justify-content: center;
-	padding-bottom: 32px;
+	padding-bottom: 16px;
 	padding-top: 32px;
 	.gridicon {
 		fill: var( --color-primary );
@@ -13,9 +13,14 @@
 }
 
 .rewind-flow__title {
+	text-align: center;
 	font-size: 22px;
 	font-weight: 600;
 	padding-bottom: 32px;
+
+	&.error {
+		color: var( --color-error );
+	}
 }
 
 .rewind-flow__title-placeholder {
@@ -141,4 +146,29 @@ a.rewind-flow-notice__title-warning:visited {
 
 .theme-jetpack-cloud .main.rewind-flow {
 	margin-left: auto;
+}
+
+/* This is a button that's meant to be styled as a link */
+.rewind-flow__info .rewind-flow__error-retry-button {
+	padding: initial;
+	border: initial;
+	font-weight: normal;
+	vertical-align: initial;
+	font-size: initial;
+	color: var( --color-link );
+
+	&:hover, &:active, &:focus {
+		background: initial;
+		color: var( --color-link-dark );
+	}
+
+	&:hover, &:active {
+		outline: initial;
+	}
+
+	&:focus {
+		outline: thin dotted;
+		box-shadow: initial;
+		border: initial;
+	}
 }

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -7,7 +7,7 @@
 	}
 
 	.current-section {
-		margin: 0 -16px;
+		margin: 0 -16px 16px;
 
 		.site-icon {
 			display: none;

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -388,7 +388,7 @@ class ActivityLogItem extends Component {
 						disableButton={ this.state.disableDownloadButton }
 					>
 						{ translate(
-							'{{time/}} is the selected point to create a download backup of. You will get a notification when the backup is ready to download.',
+							'{{time/}} is the selected point to create a download backup. You will get a notification when the backup is ready to download.',
 							{
 								components: {
 									time: <b>{ adjustedTime.format( 'LLL' ) }</b>,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* For scheduled backups in the next hour, say "In the next hour" as opposed to "In the next 1 hour"
* On the download creation confirmation page, remove superfluous "of" from instructions.
* On the Settings page, add a link to support for "Find your server credentials."
* On the "download creation failed" page, add supplementary text
* On the "restore failed" page, add supplementary instructions for what to do next
* Tweak styling on the "restore failed" page to more closely match mockups

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check all the aforementioned pages to ensure verbiage has changed as described and matches mockups and design feedback.

#### Screenshots

##### Mobile

<img width="424" alt="image" src="https://user-images.githubusercontent.com/670067/80976459-1d7f4d80-8de9-11ea-8763-4c17566ab3fd.png">

<img width="434" alt="image" src="https://user-images.githubusercontent.com/670067/81006193-b8d9e800-8e14-11ea-8f72-351c1f2d8517.png">

##### Desktop

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/670067/80976567-3a1b8580-8de9-11ea-9708-556181a28b5a.png">

<img width="1223" alt="Screen Shot 2020-05-04 at 14 36 05" src="https://user-images.githubusercontent.com/670067/81006157-a790db80-8e14-11ea-8280-c3c7618727cd.png">



Fixes 1151678672052943-as-1172722058616305.