### PR TITLE
Price group: hiding plans according to the price group.

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -445,7 +445,7 @@ export function createAccount(
 			email,
 		};
 
-		const marketing_price_group = ( response && response.marketing_price_group ) || '';
+		const marketing_price_group = response?.marketing_price_group ?? '';
 
 		// Fire after a new user registers.
 		recordRegistration( {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -445,6 +445,8 @@ export function createAccount(
 			email,
 		};
 
+		const marketing_price_group = ( response && response.marketing_price_group ) || '';
+
 		// Fire after a new user registers.
 		recordRegistration( {
 			userData: registrationUserData,
@@ -452,7 +454,7 @@ export function createAccount(
 			type: signupType,
 		} );
 
-		const providedDependencies = assign( { username }, bearerToken );
+		const providedDependencies = assign( { username, marketing_price_group }, bearerToken );
 
 		if ( signupType === SIGNUP_TYPE_DEFAULT && oauth2Signup ) {
 			assign( providedDependencies, {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -14,6 +14,7 @@ import page from 'page';
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
+import getCurrentUserMarketingPriceGroup from 'state/selectors/get-current-user-marketing-price-group';
 import Main from 'components/main';
 import EmptyContent from 'components/empty-content';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -31,6 +32,10 @@ import QuerySitePurchases from 'components/data/query-site-purchases';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { isPartnerPurchase, getPartnerName } from 'lib/purchases';
 import CartData from 'components/data/cart';
+import {
+	MARKETING_PRICE_GROUP_2020_Q2_TEST_2,
+	MARKETING_PRICE_GROUP_2020_Q2_TEST_3,
+} from 'state/current-user/constants';
 
 class Plans extends React.Component {
 	static propTypes = {
@@ -118,7 +123,14 @@ class Plans extends React.Component {
 	};
 
 	render() {
-		const { selectedSite, translate, displayJetpackPlans, canAccessPlans, purchase } = this.props;
+		const {
+			selectedSite,
+			translate,
+			displayJetpackPlans,
+			canAccessPlans,
+			purchase,
+			marketingPriceGroup,
+		} = this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() ) {
 			return this.renderPlaceholder();
@@ -126,6 +138,16 @@ class Plans extends React.Component {
 
 		if ( purchase && isPartnerPurchase( purchase ) ) {
 			return this.renderPlanWithPartner();
+		}
+
+		let hidePersonalPlan = false,
+			hidePremiumPlan = false;
+
+		if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_2 ) {
+			hidePersonalPlan = true;
+		} else if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_3 ) {
+			hidePersonalPlan = true;
+			hidePremiumPlan = true;
 		}
 
 		return (
@@ -153,6 +175,8 @@ class Plans extends React.Component {
 								<PlansFeaturesMain
 									displayJetpackPlans={ displayJetpackPlans }
 									hideFreePlan={ true }
+									hidePersonalPlan={ hidePersonalPlan }
+									hidePremiumPlan={ hidePremiumPlan }
 									customerType={ this.props.customerType }
 									intervalType={ this.props.intervalType }
 									selectedFeature={ this.props.selectedFeature }
@@ -184,5 +208,6 @@ export default connect( ( state ) => {
 		selectedSite: getSelectedSite( state ),
 		displayJetpackPlans: ! isSiteAutomatedTransfer && jetpackSite,
 		canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
+		marketingPriceGroup: getCurrentUserMarketingPriceGroup( state ),
 	};
 } )( localize( withTrackingTool( 'HotJar' )( Plans ) ) );

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -146,7 +146,7 @@ export function generateSteps( {
 			stepName: 'user',
 			apiRequestFunction: createAccount,
 			providesToken: true,
-			providesDependencies: [ 'bearer_token', 'username' ],
+			providesDependencies: [ 'bearer_token', 'username', 'marketing_price_group' ],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 			},

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -27,6 +27,11 @@ import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
+import getCurrentUserMarketingPriceGroup from 'state/selectors/get-current-user-marketing-price-group';
+import {
+	MARKETING_PRICE_GROUP_2020_Q2_TEST_2,
+	MARKETING_PRICE_GROUP_2020_Q2_TEST_3,
+} from 'state/current-user/constants';
 
 /**
  * Style dependencies
@@ -134,7 +139,18 @@ export class PlansStep extends Component {
 			selectedSite,
 			planTypes,
 			flowName,
+			marketingPriceGroup,
 		} = this.props;
+
+		let hidePersonalPlan = false,
+			hidePremiumPlan = false;
+
+		if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_2 ) {
+			hidePersonalPlan = true;
+		} else if ( marketingPriceGroup === MARKETING_PRICE_GROUP_2020_Q2_TEST_3 ) {
+			hidePersonalPlan = true;
+			hidePremiumPlan = true;
+		}
 
 		return (
 			<div>
@@ -143,6 +159,8 @@ export class PlansStep extends Component {
 				<PlansFeaturesMain
 					site={ selectedSite || {} } // `PlanFeaturesMain` expects a default prop of `{}` if no site is provided
 					hideFreePlan={ hideFreePlan }
+					hidePersonalPlan={ hidePersonalPlan }
+					hidePremiumPlan={ hidePremiumPlan }
 					isInSignup={ true }
 					isLaunchPage={ isLaunchPage }
 					onUpgradeClick={ this.onSelectPlan }
@@ -242,7 +260,7 @@ export const isDotBlogDomainRegistration = ( domainItem ) => {
 };
 
 export default connect(
-	( state, { path, signupDependencies: { siteSlug, domainItem } } ) => ( {
+	( state, { path, signupDependencies: { siteSlug, domainItem, marketing_price_group } } ) => ( {
 		// Blogger plan is only available if user chose either a free domain or a .blog domain registration
 		disableBloggerPlanWithNonBlogDomain:
 			domainItem && ! isSubdomain( domainItem.meta ) && ! isDotBlogDomainRegistration( domainItem ),
@@ -254,6 +272,9 @@ export default connect(
 		siteGoals: getSiteGoals( state ) || '',
 		siteType: getSiteType( state ),
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
+
+		// the former is for signing up; the latter is for the logged-in case
+		marketingPriceGroup: marketing_price_group || getCurrentUserMarketingPriceGroup( state ),
 	} ),
 	{ recordTracksEvent, saveSignupStep, submitSignupStep }
 )( localize( PlansStep ) );

--- a/client/state/selectors/get-current-user-marketing-price-group.js
+++ b/client/state/selectors/get-current-user-marketing-price-group.js
@@ -9,8 +9,4 @@ import { getCurrentUser } from 'state/current-user/selectors';
  * @param {object} state Global state tree
  * @returns {string?} The price group slug
  */
-export default ( state ) => {
-	const currentUser = getCurrentUser( state );
-
-	return ( currentUser && currentUser.meta.marketing_price_group ) || null;
-};
+export default ( state ) => getCurrentUser( state )?.meta.marketing_price_group || null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
**Description update: May. 7th.**

*This is part of the Global Pricing Optimization project. More context can be found in p2-pau2Xa-1de.*

This PR implements the plan hiding logic based on the marketing price group, for hiding plans accordingly in the signup flow, the site creation flow, and viewing `/plans` as a logged-in user.

#### Dependency

* https://github.com/Automattic/wp-calypso/pull/41871
* #41670 (shipped)
* code-D43026
* code-D42721 (shipped)

#### Testing instructions

Please refer to the test section of code-D42721 to see how to enforce a user into either test pricing group.

1. Enforce a test account to the test pricing group 1.
    1. Go through the sign up flow and stop at the plans step.
    1. While there shouldn't be any visible difference, `getState().signup.dependencyStore` should include a `marketing_price_group` property, with value `price_2020_q2_test_1`.
    1. Stay logged-in, go through the site creation flow and stop at the plans step. 
    1. Stay logged-in, go to `/plans`.     
1. Enforce a test account to the test pricing group 2.
    1. Go through the sign up flow and stop at the plans step.
    1. The Personal plan should be hidden.
    1. Stay logged-in, go through the site creation flow and stop at the plans step. The Personal plan should be hidden.
    1. Stay logged-in, go to `/plans`. The Personal plan should be hidden.
1. Enforce a test account to the test pricing group 3.
    1. Go through the sign up flow and stop at the plans step.
    1. The Personal plan and the Premium plan should be hidden.
    1. Stay logged-in, go through the site creation flow and stop at the plans step. The Personal plan and the Premium plan should be hidden.
    1. Stay logged-in, go to `/plans`. The Personal plan and the Premium plan should be hidden.