### PR TITLE
Jetpack Scan: Updates to the Main Scan component with wording. 

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -56,12 +56,9 @@ class ScanPage extends Component< Props > {
 				<SecurityIcon icon="in-progress" />
 				{ this.renderHeader( translate( 'Preparing to scan' ) ) }
 				<p>
-					{ translate(
-						'Lorem ipsum. We need to change this text. The scan was unable to process ' +
-							'the themes directory and did not completed successfully. In order to ' +
-							'complete the scan you will need to speak to support who can help ' +
-							'determine what went wrong.'
-					) }
+					Lorem ipsum. We need to change this text. The scan was unable to process the themes
+					directory and did not completed successfully. In order to complete the scan you will need
+					to speak to support who can help determine what went wrong.
 				</p>
 				{ this.renderContactSupportButton() }
 			</>

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -56,9 +56,12 @@ class ScanPage extends Component< Props > {
 				<SecurityIcon icon="in-progress" />
 				{ this.renderHeader( translate( 'Preparing to scan' ) ) }
 				<p>
-					Lorem ipsum. We need to change this text. The scan was unable to process the themes
-					directory and did not completed successfully. In order to complete the scan you will need
-					to speak to support who can help determine what went wrong.
+					{ translate(
+						'Lorem ipsum. We need to change this text. The scan was unable to process ' +
+							'the themes directory and did not completed successfully. In order to ' +
+							'complete the scan you will need to speak to support who can help ' +
+							'determine what went wrong.'
+					) }
 				</p>
 				{ this.renderContactSupportButton() }
 			</>
@@ -100,9 +103,11 @@ class ScanPage extends Component< Props > {
 				<SecurityIcon icon="scan-error" />
 				{ this.renderHeader( 'Scan is unavailable' ) }
 				<p>
-					The scan was unable to process the themes directory and did not completed successfully. In
-					order to complete the scan you will need to speak to support who can help determine what
-					went wrong.
+					{ translate(
+						'The scan was unable to process the themes directory and did not completed ' +
+							'successfully. In order to complete the scan you will need to speak to support ' +
+							'who can help determine what went wrong.'
+					) }
 				</p>
 				{ this.renderContactSupportButton() }
 			</>
@@ -117,10 +122,20 @@ class ScanPage extends Component< Props > {
 				<SecurityIcon />
 				{ this.renderHeader( translate( 'Don’t worry about a thing' ) ) }
 				<p>
-					The last Jetpack scan ran <strong>{ moment( lastScanTimestamp ).fromNow() }</strong> and
-					everything looked great.
-					<br />
-					Run a manual scan now or wait for Jetpack to scan your site later today.
+					{ translate(
+						/* translators: %s is a time string relative to now */
+						'The last Jetpack scan ran {{strong}}%s{{/strong}} and everything ' +
+							'looked great.' +
+							'{{br/}}' +
+							'Run a manual scan now or wait for Jetpack to scan your site later today.',
+						{
+							args: [ moment( lastScanTimestamp ).fromNow() ],
+							components: {
+								strong: <strong />,
+								br: <br />,
+							},
+						}
+					) }
 				</p>
 				{ isEnabled( 'jetpack-cloud/on-demand-scan' ) && (
 					<Button
@@ -153,13 +168,18 @@ class ScanPage extends Component< Props > {
 				<ProgressBar value={ scanProgress } total={ 100 } color="#069E08" />
 				{ isInitialScan && (
 					<p>
-						Welcome to Jetpack Scan, we are taking a first look at your site now and the results
-						will be with you soon.
+						{ translate(
+							'Welcome to Jetpack Scan, we are taking a first look at your site now ' +
+								'and the results will be with you soon.'
+						) }
 					</p>
 				) }
 				<p>
-					We will send you an email once the scan completes, in the meantime feel free to continue
-					to use your site as normal, you can check back on progress at any time.
+					{ translate(
+						'We will send you an email once the scan completes, in the meantime feel ' +
+							'free to continue to use your site as normal, you can check back on ' +
+							'progress at any time.'
+					) }
 				</p>
 			</>
 		);
@@ -171,9 +191,11 @@ class ScanPage extends Component< Props > {
 				<SecurityIcon icon="scan-error" />
 				{ this.renderHeader( translate( 'Something went wrong' ) ) }
 				<p>
-					The scan was unable to process the themes directory and did not completed successfully. In
-					order to complete the scan you will need to speak to support who can help determine what
-					went wrong.
+					{ translate(
+						'The scan was unable to process the themes directory and did not complete ' +
+							'successfully. In order to complete the scan you will need ' +
+							'to speak to support who can help determine what went wrong.'
+					) }
 				</p>
 				{ this.renderContactSupportButton() }
 			</>
@@ -233,7 +255,10 @@ class ScanPage extends Component< Props > {
 				<div className="scan__content">{ this.renderScanState() }</div>
 				<StatsFooter
 					header="Scan Summary"
-					noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backup has you covered."
+					noticeText={ translate(
+						'Failing to plan is planning to fail. Regular backups ensure that should ' +
+							'the worst happen, you are prepared. Jetpack Backup has you covered.'
+					) }
 					noticeLink="https://jetpack.com/upgrade/backup"
 				/>
 			</Main>


### PR DESCRIPTION
* add a new provision state
* add Scan Header and Contact Us button render functions. 

#### Changes proposed in this Pull Request
Here are the different states right now:

**Provisioning**
<img width="819" alt="Screen Shot 2020-04-30 at 1 55 53 PM" src="https://user-images.githubusercontent.com/115071/80723291-bcadf780-8b00-11ea-9f11-6a72de8e557f.png">


**Idle** no threats
<img width="731" alt="Screen Shot 2020-04-30 at 3 49 36 PM" src="https://user-images.githubusercontent.com/115071/80723273-b881da00-8b00-11ea-94ff-57bedf0131ce.png">

**Idle** with threats
<img width="838" alt="Screen Shot 2020-04-30 at 3 49 06 PM" src="https://user-images.githubusercontent.com/115071/80723280-ba4b9d80-8b00-11ea-9548-9c10895c496c.png">

**Scan Error**
<img width="797" alt="Screen Shot 2020-04-30 at 3 48 29 PM" src="https://user-images.githubusercontent.com/115071/80723283-bb7cca80-8b00-11ea-9ddc-24ccf21e4194.png">

**Scanning**
<img width="888" alt="Screen Shot 2020-04-30 at 3 47 33 PM" src="https://user-images.githubusercontent.com/115071/80723285-bc156100-8b00-11ea-800f-610c06599168.png">

**Unavailable**
<img width="780" alt="Screen Shot 2020-04-30 at 3 47 07 PM" src="https://user-images.githubusercontent.com/115071/80723289-bc156100-8b00-11ea-8080-7fe019f902bd.png">



#### Testing instructions
* I use a `true ||` so that I can replicae each of the scan states that are returned by the api. 
* Do the states look as expected? 
