### PR TITLE
Gutenboarding: Domain picker modal follow-up fixes + feature flag removal.

### DIFF
--- a/client/landing/gutenboarding/components/domain-categories/style.scss
+++ b/client/landing/gutenboarding/components/domain-categories/style.scss
@@ -16,7 +16,7 @@
 
 	&.is-selected {
 		.components-button {
-			font-weight: 700;
+			font-weight: 600;
 			text-decoration: underline;
 		}
 	}

--- a/client/landing/gutenboarding/components/domain-categories/style.scss
+++ b/client/landing/gutenboarding/components/domain-categories/style.scss
@@ -10,7 +10,6 @@
 		&:focus {
 			color: var( --studio-gray-100 );
 			box-shadow: none;
-			font-weight: 700;
 			text-decoration: underline;
 		}
 	}

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -82,7 +82,7 @@
 	// Increase specificity
 	.components-panel__row {
 
-		label.domain-picker__suggestion-item {
+		.domain-picker__suggestion-item {
 			border: 1px solid var( --studio-gray-5 );
 			padding: 14px;
 			margin-bottom: 0;

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -66,6 +66,11 @@
 		input[type='text'].components-text-control__input {
 			height: 44px;
 		}
+
+	// Don't show close button & more button when inside a modal.
+	.domain-picker__close-button,
+	.domain-picker__more-button {
+		display: none;
 	}
 
 	// Increase specificity

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -67,6 +67,12 @@
 			height: 44px;
 		}
 
+		svg {
+			top: 9px;
+			right: 12px;
+		}
+	}
+
 	// Don't show close button & more button when inside a modal.
 	.domain-picker__close-button,
 	.domain-picker__more-button {

--- a/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-popover/index.tsx
@@ -2,16 +2,13 @@
  * External dependencies
  */
 import * as React from 'react';
-import { Button, Popover } from '@wordpress/components';
-import { useI18n } from '@automattic/react-i18n';
-import config from 'config';
+import { Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import DomainPicker, { Props as DomainPickerProps } from '../domain-picker';
-import CloseButton from '../close-button';
 
 /**
  * Style dependencies
@@ -20,15 +17,9 @@ import './style.scss';
 
 interface Props extends DomainPickerProps {
 	isOpen: boolean;
-	onMoreOptions?: () => void;
 }
 
-const DomainPickerPopover: React.FunctionComponent< Props > = ( {
-	isOpen,
-	onMoreOptions,
-	...props
-} ) => {
-	const { __ } = useI18n();
+const DomainPickerPopover: React.FunctionComponent< Props > = ( { isOpen, ...props } ) => {
 	const onClose = props.onClose;
 
 	// Popover expands at medium viewport width
@@ -51,18 +42,6 @@ const DomainPickerPopover: React.FunctionComponent< Props > = ( {
 				expandOnMobile={ true }
 			>
 				<DomainPicker { ...props } />
-				<div className="domain-picker-popover__addons">
-					{ config.isEnabled( 'gutenboarding/domain-picker-modal' ) && (
-						<Button
-							className="domain-picker-popover__more-button"
-							isTertiary
-							onClick={ onMoreOptions }
-						>
-							{ __( 'More Options' ) }
-						</Button>
-					) }
-					<CloseButton className="domain-picker-popover__close-button" onClick={ onClose } />
-				</div>
 			</Popover>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/domain-picker-popover/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-popover/style.scss
@@ -16,6 +16,8 @@
 		border: 1px solid var( --studio-gray-5 );
 		box-shadow: 0 4px 10px rgba( 0, 0, 0, 0.12 );
 		border-radius: 4px;
+		overflow: hidden;
+		overflow-y: auto;
 	}
 
 	// Popover component adds a .is-expanded class under mobile view.

--- a/client/landing/gutenboarding/components/domain-picker-popover/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-popover/style.scss
@@ -16,12 +16,6 @@
 		border: 1px solid var( --studio-gray-5 );
 		box-shadow: 0 4px 10px rgba( 0, 0, 0, 0.12 );
 		border-radius: 4px;
-
-		// Increase specificity
-		> div.domain-picker-popover__addons {
-			height: 0;
-			overflow: visible;
-		}
 	}
 
 	// Popover component adds a .is-expanded class under mobile view.
@@ -45,20 +39,13 @@
 		}
 	}
 
-	.domain-picker-popover__close-button {
-		position: absolute;
-		top: 36px;
-		right: 36px;
+	.domain-picker__close-button {
+		position: relative;
+		right: -8px;
 	}
 
-	.domain-picker-popover__more-button {
-		position: relative;
-		left: 36px;
-		top: -60px; // 24px padding - 36px button height 
-
-		&.components-button {
-			@include onboarding-medium-text;
-			color: var( --color-neutral-100 );
-		}
+	// Don't show cancel button when in popover.
+	.domain-picker__cancel-button {
+		display: none;
 	}
 }

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -25,6 +25,7 @@ import { PAID_DOMAINS_TO_SHOW } from '../../constants';
 import { getNewRailcarId, RecordTrainTracksEventProps } from '../../lib/analytics';
 import { useTrackModal } from '../../hooks/use-track-modal';
 import DomainCategories from '../domain-categories';
+import CloseButton from '../close-button';
 
 /**
  * Style dependencies
@@ -50,6 +51,8 @@ export interface Props {
 	 */
 	onClose: () => void;
 
+	onMoreOptions?: () => void;
+
 	recordAnalytics?: ( event: RecordTrainTracksEventProps ) => void;
 
 	/**
@@ -65,6 +68,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	showDomainCategories,
 	onDomainSelect,
 	onClose,
+	onMoreOptions,
 	currentDomain,
 	recordAnalytics,
 } ) => {
@@ -154,6 +158,11 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							) }
 						</div>
 						<ConfirmButton />
+						<CloseButton
+							className="domain-picker__close-button"
+							onClick={ onClose }
+							tabIndex={ -1 }
+						/>
 					</div>
 					<div className="domain-picker__search">
 						<SearchIcon />
@@ -214,6 +223,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				</PanelRow>
 				<PanelRow className="domain-picker__panel-row-footer">
 					<div className="domain-picker__footer">
+						<Button className="domain-picker__more-button" isTertiary onClick={ onMoreOptions }>
+							{ __( 'More Options' ) }
+						</Button>
 						<ConfirmButton />
 					</div>
 				</PanelRow>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -152,9 +152,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 						<div className="domain-picker__header-group">
 							<div className="domain-picker__header-title">{ __( 'Choose a domain' ) }</div>
 							{ showDomainConnectButton ? (
-								<p>TODO: Show domain connect text.</p>
+								<p>{ __( 'Free for the first year with any paid plan.' ) }</p>
 							) : (
-								<p>{ __( 'Free for the first year with any paid plan or connect a domain.' ) }</p>
+								<p>{ __( 'Free for the first year with any paid plan.' ) }</p>
 							) }
 						</div>
 						<ConfirmButton />

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -88,7 +88,7 @@ $domain-picker__suggestion-item-height: 24px;
 
 .domain-picker__footer {
 	display: flex;
-	justify-content: flex-end;
+	justify-content: space-between;
 }
 
 .domain-picker__suggestion-item-group {
@@ -229,4 +229,17 @@ $domain-picker__suggestion-item-height: 24px;
 .domain-picker__aside {
 	width: 220px;
 	padding-right: 30px;
+}
+
+.domain-picker__confirm-button {
+	position: relative;
+	top: 5px;
+}
+
+.domain-picker__more-button {
+
+	&.components-button {
+		@include onboarding-medium-text;
+		color: var( --color-neutral-100 );
+	}
 }

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -19,6 +19,7 @@ $domain-picker__suggestion-item-height: 24px;
 	.components-panel__row {
 		flex-direction: column;
 		align-items: stretch;
+		justify-content: flex-start;
 		margin: 0;
 
 		label {

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -237,6 +237,11 @@ $domain-picker__suggestion-item-height: 24px;
 }
 
 .domain-picker__more-button {
+	visibility: hidden; // @TODO: remove this once mobile layout is ready
+
+	@include break-mobile {
+		visibility: visible;
+	}
 
 	&.components-button {
 		@include onboarding-medium-text;

--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,6 @@
 		"google-drive": true,
 		"gutenboarding": true,
 		"gutenboarding/style-preview": true,
-		"gutenboarding/domain-picker-modal": true,
 		"help": true,
 		"help/courses": true,
 		"inline-help": true,


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Fixed scrollbars showing unnecessarily on Firefox in popover view.
* Fixed X icon mispositioned in popover view.
* Fixed Search icon mispositioned in modal view.
* Domain suggestion loading placeholder should have borders around it in modal view.
* Hovering domain category item should underline the text, not bold the text.
* TODO text for domain connect has been removed. Both modal and popover view shows the same text for now. (Another PR for domain connect).
* Feature flag for modal view is now removed.

**Technical Notes:**
- Due to difficulty in getting Firefox scrollbars to play well with **Close button** and **More Options button** decorated from `DomainPickerPopover` component, which I originally intended it to live outside of the `DomainPicker` component, I moved these 2 buttons back inside `DomainPicker` component.
  - The drawback of doing so is that close button is no longer tabbable again. Not a big deal as pressing <kbd>ESC</kbd> or clicking outside of popover will still work.

## Testing instructions

- Just go through the list of changes above and verify if they are working on both Chrome & Firefox.
- You can refer to the screenshots in https://github.com/Automattic/wp-calypso/issues/41542.

Fixes #41542
