### PR TITLE
Gutenboarding: get plan from URL param

### DIFF
--- a/client/landing/gutenboarding/components/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans-button/index.tsx
@@ -12,9 +12,9 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automattic package
-import * as plans from 'lib/plans/constants';
-import { getPlan } from 'lib/plans';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
+import { freePlan, defaultPaidPlan, getPlanSlugByPath, getPlanTitle } from '../../lib/plans';
+import { usePlanRouteParam } from '../../path';
 
 /**
  * Style dependencies
@@ -23,16 +23,16 @@ import './style.scss';
 
 const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...buttonProps } ) => {
 	const { __ } = useI18n();
-	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
 
 	// mobile first to match SCSS media query https://github.com/Automattic/wp-calypso/pull/41471#discussion_r415678275
 	const isDesktop = useViewportMatch( 'mobile', '>=' );
 
-	const planLabel = sprintf(
-		/* translators: Button label where %s is the WordPress.com plan name (eg: Free, Personal, Premium, Business) */
-		__( '%s Plan' ),
-		getPlan( hasPaidDomain ? plans.PLAN_PREMIUM : plans.PLAN_FREE ).getTitle()
-	);
+	const hasPaidDomain = useSelect( ( select ) => select( ONBOARD_STORE ).hasPaidDomain() );
+	const planPath = usePlanRouteParam();
+	const plan = getPlanSlugByPath( planPath ) || ( hasPaidDomain ? defaultPaidPlan : freePlan );
+
+	/* translators: Button label where %s is the WordPress.com plan name (eg: Free, Personal, Premium, Business) */
+	const planLabel = sprintf( __( '%s Plan' ), getPlanTitle( plan ) );
 
 	return (
 		<Button disabled label={ __( planLabel ) } className="plans-button" { ...buttonProps }>

--- a/client/landing/gutenboarding/lib/plans.ts
+++ b/client/landing/gutenboarding/lib/plans.ts
@@ -5,6 +5,7 @@ import * as plans from 'lib/plans/constants';
 import { getPlan, getPlanPath } from 'lib/plans';
 
 const supportedPlans = [
+	plans.PLAN_FREE,
 	plans.PLAN_PERSONAL,
 	plans.PLAN_PREMIUM,
 	plans.PLAN_BUSINESS,

--- a/client/landing/gutenboarding/lib/plans.ts
+++ b/client/landing/gutenboarding/lib/plans.ts
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import * as plans from 'lib/plans/constants';
+import { getPlan, getPlanPath } from 'lib/plans';
+
+const supportedPlans = [
+	plans.PLAN_PERSONAL,
+	plans.PLAN_PREMIUM,
+	plans.PLAN_BUSINESS,
+	plans.PLAN_ECOMMERCE,
+];
+
+export const freePlan = plans.PLAN_FREE;
+export const defaultPaidPlan = plans.PLAN_PREMIUM;
+
+export const supportedPlansPaths: string[] = supportedPlans.map( getPlanPath );
+
+export function getPlanSlugByPath( path?: string ): string | undefined {
+	return supportedPlans.find( ( plan ) => getPlanPath( plan ) === path );
+}
+
+export function getPlanTitle( planSlug: string ): string {
+	return getPlan( planSlug ).getTitle();
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Reques
* Update path handling in Gutenboarding to include `plan` as an optional param.
* So it should be possible to set the plan via URL argument like so: `/new/PLAN_SLUG` where the slug is `beginner`, `personal`, `premium`, `business`, or `ecommerce`.
* The existing mechanism to set a Free / Premium Plan using the type of selected domain (free/paid) only if there isn't a valid plan param.

#### Testing instructions
* Go to [/new/beginner](https://calypso.live/new/beginner?branch=add/gutenboarding-set-plan-using-url-param).
* _Free plan_ should be displayed in top-right corner.
* After entering a site title and choosing a paid domain using Domain picker, _Free plan_ should still be displayed.
* Go to [/new/business](https://calypso.live/new/business?branch=add/gutenboarding-set-plan-using-url-param).
* _Business Plan_ should be displayed.
* Go to [/new/business/it](https://calypso.live/new/business/it?branch=add/gutenboarding-set-plan-using-url-param).
* _Piano Business_ should be displayed (locale param should still work).
* Go to [/new/unknownplan/it](https://calypso.live/new/unknownplan/it?branch=add/gutenboarding-set-plan-using-url-param).
* A redirect to `/new` will happen but language should be set correctly.

#### Screenshot

<img width="980" alt="Screenshot 2020-04-30 at 16 59 24" src="https://user-images.githubusercontent.com/14192054/80725416-b5d8b200-8b0b-11ea-9a7c-2b49380dd0f8.png">

Fixes #41576