### PR TITLE
Jetpack Cloud: Backup status design tweaks

### DIFF
--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -1,3 +1,8 @@
+.backup-delta {
+    text-align: left;
+    margin-top: 1rem;
+}
+
 .backup-delta__view-all-button {
     float: none;
 }
@@ -115,10 +120,6 @@
     margin-bottom: -0.5rem;
 }
 
-.backup-delta__metas {
-    margin: 1rem 0;
-}
-
 .backup-delta__extension-block-text {
     display: inline-block;
     position: relative;
@@ -146,6 +147,7 @@
 
 .backup-delta__daily-no-changes {
     font-style: italic;
+    color: var( --studio-gray );
     padding: 1rem 0;
 }
 

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -167,3 +167,12 @@
         background: var( --studio-white );
     }
 }
+
+@include breakpoint( '>660px' ) {
+    .backup-delta__daily .backup-delta__changes-header:first-child {
+        margin-top: 28px;
+        border-bottom: 1px solid var( --studio-gray-20 );
+        padding-bottom: 8px;
+        margin-bottom: 24px;
+    }
+}

--- a/client/landing/jetpack-cloud/components/daily-backup-status/backup-complete-icon.svg
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/backup-complete-icon.svg
@@ -1,0 +1,21 @@
+<svg width="160" height="165" viewBox="0 0 160 165" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="160" height="164.12" fill="white"/>
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="27" width="160" height="110">
+<path d="M129 68.6572C124.467 45.065 104.267 27.3537 80 27.3537C60.7333 27.3537 44 38.5685 35.6667 54.9805C15.6 57.1688 0 74.6065 0 95.7369C0 118.372 17.9333 136.767 40 136.767H126.667C145.067 136.767 160 121.449 160 102.575C160 84.5221 146.333 69.8881 129 68.6572Z" fill="#A7AAAD"/>
+</mask>
+<g mask="url(#mask0)">
+<rect width="160" height="164.12" fill="#069E08"/>
+</g>
+<mask id="mask1" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="27" width="160" height="110">
+<path d="M129 68.6572C124.467 45.065 104.267 27.3537 80 27.3537C60.7333 27.3537 44 38.5685 35.6667 54.9805C15.6 57.1688 0 74.6065 0 95.7369C0 118.372 17.9333 136.767 40 136.767H126.667C145.067 136.767 160 121.449 160 102.575C160 84.5221 146.333 69.8881 129 68.6572Z" fill="white"/>
+</mask>
+<g mask="url(#mask1)">
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M73.2022 97.6014L54.2802 81.8509L49.1619 88.3206L74.3909 109.321L74.391 109.321L74.3912 109.321L105.101 70.5031L98.7939 65.253L73.2022 97.6014Z" fill="#D8D8D8"/>
+<mask id="mask2" mask-type="alpha" maskUnits="userSpaceOnUse" x="49" y="65" width="57" height="45">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M73.2022 97.6014L54.2802 81.8509L49.1619 88.3206L74.3909 109.321L74.391 109.321L74.3912 109.321L105.101 70.5031L98.7939 65.253L73.2022 97.6014Z" fill="white"/>
+</mask>
+<g mask="url(#mask2)">
+<rect width="65" height="66.6373" transform="matrix(0.994352 -0.106135 0.100928 0.994894 42.2938 57.9995)" fill="white"/>
+</g>
+</svg>

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -30,6 +30,7 @@ import { INDEX_FORMAT } from 'landing/jetpack-cloud/sections/backups/main';
  */
 import './style.scss';
 import contactSupportUrl from 'landing/jetpack-cloud/lib/contact-support-url';
+import backupCompleteIcon from './backup-complete-icon.svg';
 
 class DailyBackupStatus extends Component {
 	getValidRestoreId = () => {
@@ -79,7 +80,12 @@ class DailyBackupStatus extends Component {
 		return (
 			<>
 				<div className="daily-backup-status__icon-section">
-					<Gridicon className="daily-backup-status__status-icon" icon="cloud-upload" />
+					<img
+						src={ backupCompleteIcon }
+						role="presentation"
+						alt=""
+						className="daily-backup-status__status-icon"
+					/>
 					<div className="daily-backup-status__title">{ translate( 'Latest backup' ) }</div>
 				</div>
 				<div className="daily-backup-status__date">{ displayDate }</div>

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -38,7 +38,7 @@ class DailyBackupStatus extends Component {
 		return hasRealtimeBackups ? realtimeBackup.rewindId : dailyBackup.rewindId;
 	};
 
-	getDisplayDate = ( date, withLatest = true ) => {
+	getDisplayDate = ( date ) => {
 		const { translate, moment, timezone, gmtOffset } = this.props;
 
 		//Apply the time offset
@@ -54,19 +54,10 @@ class DailyBackupStatus extends Component {
 
 		let displayableDate;
 
-		if ( isToday && withLatest ) {
-			displayableDate = translate( 'Latest: Today %s', {
-				args: [ displayBackupTime ],
-				comment: '%s is the time of the last backup from today',
-			} );
-		} else if ( isToday ) {
+		if ( isToday ) {
 			displayableDate = translate( 'Today %s', {
 				args: [ displayBackupTime ],
 				comment: '%s is the time of the last backup from today',
-			} );
-		} else if ( withLatest ) {
-			displayableDate = translate( 'Latest: %s', {
-				args: [ backupDate.format( dateFormat + ', LT' ) ],
 			} );
 		} else {
 			displayableDate = backupDate.format( dateFormat + ', LT' );
@@ -76,7 +67,7 @@ class DailyBackupStatus extends Component {
 	};
 
 	renderGoodBackup( backup ) {
-		const { allowRestore, hasRealtimeBackups, siteSlug, translate } = this.props;
+		const { allowRestore, backupDelta, hasRealtimeBackups, siteSlug, translate } = this.props;
 
 		const displayDate = this.getDisplayDate( backup.activityTs );
 		const meta = get( backup, 'activityDescription[2].children[0]', '' );
@@ -99,6 +90,7 @@ class DailyBackupStatus extends Component {
 					disabledRestore={ ! allowRestore }
 				/>
 				{ showBackupDetails && this.renderBackupDetails( backup ) }
+				{ ! hasRealtimeBackups && backupDelta }
 			</>
 		);
 	}
@@ -106,7 +98,7 @@ class DailyBackupStatus extends Component {
 	renderFailedBackup( backup ) {
 		const { translate, timezone, gmtOffset, siteUrl } = this.props;
 
-		const backupTitleDate = this.getDisplayDate( backup.activityTs, false );
+		const backupTitleDate = this.getDisplayDate( backup.activityTs );
 		const backupDate = applySiteOffset( backup.activityTs, { timezone, gmtOffset } );
 
 		const displayDate = backupDate.format( 'L' );

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -5,10 +5,9 @@
 	background: #fff;
 }
 
-.daily-backup-status__status-icon.gridicon {
+.daily-backup-status__status-icon {
 	width: 3rem;
 	height: 3rem;
-	fill: var( --color-primary-30 );
 }
 
 .daily-backup-status__gridicon-error-state.gridicon {
@@ -171,5 +170,22 @@
 		margin-right: 1rem;
 		padding-left: 2rem;
 		padding-right: 2rem;
+	}
+
+	.daily-backup-status__title {
+		font-weight: bold;
+	}
+
+	.daily-backup-status__date {
+		font-size: 36px;
+		font-weight: 600;
+	}
+
+	.daily-backup-status__icon-section {
+		margin-bottom: -8px;
+	}
+
+	.daily-backup-status__meta {
+		margin: 12px 0 28px;
 	}
 }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -159,6 +159,21 @@ class BackupsPage extends Component {
 		const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
 		const hasRealtimeBackups = includes( siteCapabilities, 'backup-realtime' );
 
+		const backupDelta = (
+			<BackupDelta
+				{ ...{
+					deltas,
+					backupAttempts,
+					hasRealtimeBackups,
+					realtimeBackups,
+					allowRestore,
+					moment,
+					siteSlug,
+					metaDiff,
+				} }
+			/>
+		);
+
 		return (
 			<Main>
 				<DocumentHead title={ translate( 'Latest Backups' ) } />
@@ -196,6 +211,7 @@ class BackupsPage extends Component {
 									gmtOffset,
 									hasRealtimeBackups,
 									onDateChange: this.onDateChange,
+									backupDelta,
 								} }
 							/>
 							{ doesRewindNeedCredentials && (
@@ -205,20 +221,7 @@ class BackupsPage extends Component {
 					) }
 				</div>
 
-				{ ! isLoadingBackups && (
-					<BackupDelta
-						{ ...{
-							deltas,
-							backupAttempts,
-							hasRealtimeBackups,
-							realtimeBackups,
-							allowRestore,
-							moment,
-							siteSlug,
-							metaDiff,
-						} }
-					/>
-				) }
+				{ ! isLoadingBackups && hasRealtimeBackups && backupDelta }
 			</Main>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move `BackupDelta` component into the `DailyBackupStatus` component for daily backups. This makes it much easier to enclose it in the same `Card` element, per the designs. BackupDelta remains outside `DailyBackupStatus` for real-time backups. I realize this is not ideal, let's fix later :-)
* A few other design tweaks, per notes in 1142395350490785-as-1173118334902067

#### Testing instructions

1. Strap your seatbelt. It's going to get bumpy.
2. For a Real-time site: Check all types of backup statuses (pending, complete, error). Make sure that what is displayed is correct per the linked task. Do this for both mobile and desktop breakpoints.
3. For a Daily Backup site: Check all types of backup statuses (pending, complete, error). Make sure that what is displayed is correct per the linked task. Do this for both mobile and desktop breakpoints.

Fixes 1142395350490785-as-1173118334902067
