### PR TITLE
Gutenboarding: Show 10 domain suggestions in domain picker modal.

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-modal/index.tsx
@@ -32,7 +32,7 @@ const DomainPickerModal: React.FunctionComponent< Props > = ( { isOpen, ...props
 			overlayClassName="domain-picker-modal-overlay"
 			bodyOpenClassName="has-domain-picker-modal"
 		>
-			<DomainPicker showDomainConnectButton showDomainCategories { ...props } />
+			<DomainPicker showDomainConnectButton showDomainCategories quantity={ 10 } { ...props } />
 		</Modal>
 	);
 };

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -61,6 +61,8 @@ export interface Props {
 	queryParameters?: Partial< DomainSuggestions.DomainSuggestionQuery >;
 
 	currentDomain?: DomainSuggestion;
+
+	quantity?: number;
 }
 
 const DomainPicker: FunctionComponent< Props > = ( {
@@ -69,6 +71,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	onDomainSelect,
 	onClose,
 	onMoreOptions,
+	quantity = PAID_DOMAINS_TO_SHOW,
 	currentDomain,
 	recordAnalytics,
 } ) => {
@@ -82,12 +85,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	const { setDomainSearch, setDomainCategory } = useDispatch( STORE_KEY );
 	const [ currentSelection, setCurrentSelection ] = useState( currentDomain );
 
-	const allSuggestions = useDomainSuggestions( { locale: i18nLocale } );
+	const allSuggestions = useDomainSuggestions( { locale: i18nLocale, quantity } );
 	const freeSuggestions = getFreeDomainSuggestions( allSuggestions );
-	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice(
-		0,
-		PAID_DOMAINS_TO_SHOW
-	);
+	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice( 0, quantity );
 	const recommendedSuggestion = getRecommendedDomainSuggestion( paidSuggestions );
 	const hasSuggestions = freeSuggestions?.length || paidSuggestions?.length;
 
@@ -198,9 +198,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 									<SuggestionNone />
 								) ) }
 							{ ! paidSuggestions &&
-								times( PAID_DOMAINS_TO_SHOW - 1, ( i ) => (
-									<SuggestionItemPlaceholder key={ i } />
-								) ) }
+								times( quantity - 1, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
 							{ paidSuggestions &&
 								( paidSuggestions?.length ? (
 									paidSuggestions.map( ( suggestion, i ) => (

--- a/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
+++ b/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
@@ -11,11 +11,15 @@ import { useI18n } from '@automattic/react-i18n';
 import { DOMAIN_SUGGESTIONS_STORE } from '../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
-import { DOMAIN_SUGGESTION_VENDOR, selectorDebounce } from '../constants';
+import { DOMAIN_SUGGESTION_VENDOR, PAID_DOMAINS_TO_SHOW, selectorDebounce } from '../constants';
 import { useCurrentStep } from '../path';
 import { domainTldsByCategory } from '../domains-constants';
 
-export function useDomainSuggestions( { searchOverride = '', locale = 'en' } ) {
+export function useDomainSuggestions( {
+	searchOverride = '',
+	locale = 'en',
+	quantity = PAID_DOMAINS_TO_SHOW,
+} ) {
 	const { __ } = useI18n();
 	const { siteTitle, siteVertical, domainSearch, domainCategory } = useSelect( ( select ) =>
 		select( ONBOARD_STORE ).getState()
@@ -48,12 +52,13 @@ export function useDomainSuggestions( { searchOverride = '', locale = 'en' } ) {
 				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
 				include_wordpressdotcom: true,
 				include_dotblogsubdomain: false,
+				quantity,
 				locale,
 				vendor: DOMAIN_SUGGESTION_VENDOR,
 				...( siteVertical && { vertical: siteVertical?.id } ),
 				...( tlds && { tlds } ),
 			} );
 		},
-		[ searchTerm, siteVertical, tlds ]
+		[ searchTerm, siteVertical, tlds, quantity ]
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show 10 domain suggestion items in domain picker in modal view.

#### Testing instructions

* Open up domain picker in modal view, you should see 10 items for both placeholder loading items and actual items.

Fixes #41542

![image](https://user-images.githubusercontent.com/1287077/80729893-27633100-8b09-11ea-9581-9455c743d405.png)

