### PR TITLE
Modularise form state

### DIFF
--- a/client/components/redux-forms/redux-form-fieldset/index.jsx
+++ b/client/components/redux-forms/redux-form-fieldset/index.jsx
@@ -13,6 +13,8 @@ import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 
+import 'state/form/init';
+
 /*
  * Render a `FormFieldset` parametrized by the input field component type.
  * It accepts props that are compatible with what Redux Form `Field` passes down to renderers.

--- a/client/components/redux-forms/redux-form-radio/index.jsx
+++ b/client/components/redux-forms/redux-form-radio/index.jsx
@@ -10,6 +10,8 @@ import { Field } from 'redux-form';
  */
 import FormRadio from 'components/forms/form-radio';
 
+import 'state/form/init';
+
 const RadioRenderer = ( { input, meta, type, ...props } ) => (
 	<FormRadio { ...input } { ...props } />
 );

--- a/client/components/redux-forms/redux-form-select/index.jsx
+++ b/client/components/redux-forms/redux-form-select/index.jsx
@@ -10,6 +10,8 @@ import { Field } from 'redux-form';
  */
 import FormSelect from 'components/forms/form-select';
 
+import 'state/form/init';
+
 const SelectRenderer = ( { input, meta, ...props } ) => <FormSelect { ...input } { ...props } />;
 
 const ReduxFormSelect = ( props ) => <Field component={ SelectRenderer } { ...props } />;

--- a/client/components/redux-forms/redux-form-text-input/index.jsx
+++ b/client/components/redux-forms/redux-form-text-input/index.jsx
@@ -10,6 +10,8 @@ import { Field } from 'redux-form';
  */
 import FormTextInput from 'components/forms/form-text-input';
 
+import 'state/form/init';
+
 const TextInputRenderer = ( { input, meta, ...props } ) => (
 	<FormTextInput { ...input } { ...props } />
 );

--- a/client/components/redux-forms/redux-form-textarea/index.jsx
+++ b/client/components/redux-forms/redux-form-textarea/index.jsx
@@ -10,6 +10,8 @@ import { Field } from 'redux-form';
  */
 import FormTextarea from 'components/forms/form-textarea';
 
+import 'state/form/init';
+
 const TextareaRenderer = ( { input, meta, ...props } ) => (
 	<FormTextarea { ...input } { ...props } />
 );

--- a/client/components/redux-forms/redux-form-toggle/index.jsx
+++ b/client/components/redux-forms/redux-form-toggle/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Field } from 'redux-form';
@@ -10,6 +9,8 @@ import { Field } from 'redux-form';
  * Internal dependencies
  */
 import FormToggle from 'components/forms/form-toggle/compact';
+
+import 'state/form/init';
 
 const ToggleRenderer = ( { input, meta, text, type, ...otherProps } ) => (
 	<FormToggle { ...input } { ...otherProps }>

--- a/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/form.jsx
@@ -23,6 +23,8 @@ import ReduxFormFieldset, { FieldsetRenderer } from 'components/redux-forms/redu
 import ProductImagePicker from './product-image-picker';
 import { SUPPORTED_CURRENCY_LIST } from 'lib/simple-payments/constants';
 
+import 'state/form/init';
+
 export const REDUX_FORM_NAME = 'simplePaymentsForm';
 
 // Export some selectors that are needed by the code that submits the form

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -53,6 +53,8 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import { DEFAULT_CURRENCY } from 'lib/simple-payments/constants';
 import { localizeUrl } from 'lib/i18n-utils';
 
+import 'state/form/init';
+
 // Utility function for checking the state of the Payment Buttons list
 const isEmptyArray = ( a ) => Array.isArray( a ) && a.length === 0;
 

--- a/client/extensions/zoninator/components/forms/zone-content-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-content-form/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { FieldArray, reduxForm } from 'redux-form';
@@ -15,6 +14,8 @@ import { CompactCard } from '@automattic/components';
 import FormButton from 'components/forms/form-button';
 import SectionHeader from 'components/section-header';
 import PostsList from './posts-list';
+
+import 'state/form/init';
 
 const form = 'extensions.zoninator.zoneContent';
 

--- a/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
+++ b/client/extensions/zoninator/components/forms/zone-details-form/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm } from 'redux-form';
@@ -17,6 +16,8 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormTextarea from 'components/forms/form-textarea';
 import ReduxFormFieldset from 'components/redux-forms/redux-form-fieldset';
 import SectionHeader from 'components/section-header';
+
+import 'state/form/init';
 
 const form = 'extensions.zoninator.zoneDetails';
 

--- a/client/extensions/zoninator/state/data-layer/feeds/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { translate } from 'i18n-calypso';
 import { initialize, startSubmit, stopSubmit } from 'redux-form';
 
@@ -16,6 +15,8 @@ import { updateFeed } from '../../feeds/actions';
 import { resetLock } from '../../locks/actions';
 import { getZone } from '../../zones/selectors';
 import { ZONINATOR_REQUEST_FEED, ZONINATOR_SAVE_FEED } from 'zoninator/state/action-types';
+
+import 'state/form/init';
 
 const requestFeedNotice = 'zoninator-request-feed';
 const saveFeedNotice = 'zoninator-save-feed';

--- a/client/extensions/zoninator/state/data-layer/feeds/test/index.js
+++ b/client/extensions/zoninator/state/data-layer/feeds/test/index.js
@@ -22,6 +22,8 @@ import { errorNotice, removeNotice, successNotice } from 'state/notices/actions'
 import { updateFeed } from 'zoninator/state/feeds/actions';
 import { resetLock } from 'zoninator/state/locks/actions';
 
+import 'state/form/init';
+
 const dummyAction = {
 	type: 'DUMMY_ACTION',
 	form: 'test-form',

--- a/client/extensions/zoninator/state/data-layer/zones/index.js
+++ b/client/extensions/zoninator/state/data-layer/zones/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import { translate } from 'i18n-calypso';
 import { initialize, startSubmit, stopSubmit } from 'redux-form';
 
@@ -21,6 +20,8 @@ import {
 	ZONINATOR_REQUEST_ZONES,
 	ZONINATOR_SAVE_ZONE,
 } from 'zoninator/state/action-types';
+
+import 'state/form/init';
 
 const settingsPath = '/extensions/zoninator';
 

--- a/client/state/form/README.md
+++ b/client/state/form/README.md
@@ -1,0 +1,6 @@
+### Form state (DEPRECATED)
+
+This portion of state is used to store `redux-form` data, for the few parts of Calypso
+that are still making use of that library.
+
+Please do not build any new functionality on top of this.

--- a/client/state/form/init.js
+++ b/client/state/form/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import formReducer from './reducer';
+
+registerReducer( [ 'form' ], formReducer );

--- a/client/state/form/package.json
+++ b/client/state/form/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/form/reducer.js
+++ b/client/state/form/reducer.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { reducer } from 'redux-form';
+
+/**
+ * Internal dependencies
+ */
+import { withStorageKey } from 'state/utils';
+
+export default withStorageKey( 'form', reducer );

--- a/client/state/memberships/connected-accounts/actions.js
+++ b/client/state/memberships/connected-accounts/actions.js
@@ -1,12 +1,13 @@
 /**
  * Internal dependencies
  */
-
 import wpcom from 'lib/wp';
 import requestExternalAccess from 'lib/sharing';
 import { listMembershipsConnectedAccounts } from '../actions';
 import { MEMBERSHIPS_CONNECTED_ACCOUNTS_STRIPE_AUTHORIZE_REQUEST } from 'state/action-types';
 import { change } from 'redux-form';
+
+import 'state/form/init';
 
 export function authorizeStripeAccount() {
 	return ( dispatch ) => {

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -6,11 +6,6 @@
 }]*/
 
 /**
- * External dependencies
- */
-import { reducer as form } from 'redux-form';
-
-/**
  * Internal dependencies
  */
 import config from 'config';
@@ -127,7 +122,6 @@ const reducers = {
 	embeds,
 	experiments,
 	exporter,
-	form,
 	googleMyBusiness,
 	gsuiteUsers,
 	gutenbergOptInOut,

--- a/client/state/selectors/get-edited-simple-payments-stripe-account.js
+++ b/client/state/selectors/get-edited-simple-payments-stripe-account.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+import 'state/form/init';
 
 export default function getEditedSimplePaymentsStripeAccount( state, formName ) {
 	return get( state, [ 'form', formName, 'values', 'stripe_account' ], '' );

--- a/client/state/selectors/is-edited-simple-payments-recurring.js
+++ b/client/state/selectors/is-edited-simple-payments-recurring.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+import 'state/form/init';
 
 export default function isEditedSimplePaymentsRecurring( state, formName ) {
 	return !! get( state, [ 'form', formName, 'values', 'recurring' ], false );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one is a bit special, however, as it as it's modularising what's essentially third-party state, or at least state that's managed by `redux-form`.

There are a few parts of Calypso making use of this (somewhat large) library, such as a `tinymce` plugin and the `zoninator` extension. While they aren't migrated away from `redux-form`, we can at least ensure that its state is modularised, so that the library doesn't need to be loaded on boot.

For mode details on state modularisation, see #39261 and p4TIVU-9lM-p2.

#### Changes proposed in this Pull Request

* Extract form state into its own directory structure
* Add README discouraging use
* Modularise form state

#### Testing instructions

Ensure that the functionality making use of `redux-form` continues to work correctly, by e.g. testing the simple payments plugin for `tinymce` or the `zoninator` extension.