### PR TITLE
My Home: Wire in the Webinars card to the API response.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
@@ -8,9 +8,9 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import Task from '../task';
-import webinarIllustration from 'assets/images/customer-home/illustration-webinars.svg';
+import webinarsIllustration from 'assets/images/customer-home/illustration-webinars.svg';
 
-const Webinar = () => {
+const Webinars = () => {
 	const translate = useTranslate();
 
 	return (
@@ -24,11 +24,11 @@ const Webinar = () => {
 			actionOnClick={ () => {
 				window.open( 'https://wordpress.com/webinars/', '_blank' );
 			} }
-			illustration={ webinarIllustration }
+			illustration={ webinarsIllustration }
 			timing={ 2 }
 			taskId="webinar"
 		/>
 	);
 };
 
-export default Webinar;
+export default Webinars;

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -12,6 +12,7 @@ import MasteringGutenberg from 'my-sites/customer-home/cards/education/mastering
 import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links';
 import WpForTeamsQuickLinks from 'my-sites/customer-home/cards/actions/wp-for-teams-quick-links';
 import ConnectAccounts from 'my-sites/customer-home/cards/tasks/connect-accounts';
+import Webinars from 'my-sites/customer-home/cards/tasks/webinars';
 import FindDomain from 'my-sites/customer-home/cards/tasks/find-domain';
 import config from 'config';
 
@@ -24,6 +25,7 @@ const cardComponents = {
 	'home-task-site-setup-checklist': ChecklistSiteSetup,
 	'home-task-connect-accounts': ConnectAccounts,
 	'home-task-find-domain': FindDomain,
+	'home-task-webinars': Webinars,
 };
 
 const Primary = ( { checklistMode, cards } ) => {


### PR DESCRIPTION
This PR wires in the Webinars card to the API response that now includes it (with the recent merge of D42514-code). We also rename `webinar` instances to `webinars` for consistency.

<img width="1066" alt="Screen Shot 2020-04-30 at 10 36 49 AM" src="https://user-images.githubusercontent.com/349751/80741480-8bb4cf00-8ace-11ea-85da-c06f98f3a203.png">


#### Testing instructions
* On this branch with an established site, load the new experimental My Home view at `/home/:site?flags=home/experimental-layout`.
* Verify the Webinars card shows up in the primary Tasks location.
