### PR TITLE
Checkout: update line item design

### DIFF
--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -203,7 +203,6 @@ export default function CompositeCheckout( {
 		couponCodeFromUrl,
 		setCart || wpcomSetCart,
 		getCart || wpcomGetCart,
-		translate,
 		showAddCouponSuccessMessage,
 		recordEvent
 	);

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -587,7 +587,7 @@ describe( 'CompositeCheckout', () => {
 		getAllByLabelText( 'WordPress.com Personal' ).map( ( element ) =>
 			expect( element ).toHaveTextContent( 'R$144' )
 		);
-		getAllByLabelText( 'Domain Mapping: bar.com' ).map( ( element ) =>
+		getAllByLabelText( 'bar.com' ).map( ( element ) =>
 			expect( element ).toHaveTextContent( 'R$0' )
 		);
 	} );
@@ -618,8 +618,8 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		const { getByLabelText } = renderResult;
-		expect( getByLabelText( 'Domain Registration: foo.cash' ) ).toBeInTheDocument();
+		const { getByText } = renderResult;
+		expect( getByText( 'Domain Registration: billed yearly' ) ).toBeInTheDocument();
 	} );
 
 	it( 'adds renewal product to the cart when the url has a renewal with a domain mapping', async () => {
@@ -632,8 +632,8 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		const { getByLabelText } = renderResult;
-		expect( getByLabelText( 'Domain Mapping: bar.com' ) ).toBeInTheDocument();
+		const { getByText } = renderResult;
+		expect( getByText( 'Domain Mapping: billed yearly' ) ).toBeInTheDocument();
 	} );
 
 	it( 'adds renewal products to the cart when the url has multiple renewals', async () => {
@@ -649,9 +649,9 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		const { getByLabelText } = renderResult;
-		expect( getByLabelText( 'Domain Mapping: bar.com' ) ).toBeInTheDocument();
-		expect( getByLabelText( 'Domain Registration: bar.com' ) ).toBeInTheDocument();
+		const { getByText } = renderResult;
+		expect( getByText( 'Domain Mapping: billed yearly' ) ).toBeInTheDocument();
+		expect( getByText( 'Domain Registration: billed yearly' ) ).toBeInTheDocument();
 	} );
 
 	it( 'adds the coupon to the cart when the url has a coupon code', async () => {

--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -583,10 +583,11 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		const { getAllByLabelText } = renderResult;
+		const { getAllByLabelText, getByText } = renderResult;
 		getAllByLabelText( 'WordPress.com Personal' ).map( ( element ) =>
 			expect( element ).toHaveTextContent( 'R$144' )
 		);
+		expect( getByText( 'Domain Mapping: billed annually' ) ).toBeInTheDocument();
 		getAllByLabelText( 'bar.com' ).map( ( element ) =>
 			expect( element ).toHaveTextContent( 'R$0' )
 		);
@@ -619,7 +620,8 @@ describe( 'CompositeCheckout', () => {
 			);
 		} );
 		const { getByText } = renderResult;
-		expect( getByText( 'Domain Registration: billed yearly' ) ).toBeInTheDocument();
+		expect( getByText( 'Domain Registration: billed annually' ) ).toBeInTheDocument();
+		expect( getByText( 'foo.cash' ) ).toBeInTheDocument();
 	} );
 
 	it( 'adds renewal product to the cart when the url has a renewal with a domain mapping', async () => {
@@ -633,7 +635,8 @@ describe( 'CompositeCheckout', () => {
 			);
 		} );
 		const { getByText } = renderResult;
-		expect( getByText( 'Domain Mapping: billed yearly' ) ).toBeInTheDocument();
+		expect( getByText( 'Domain Mapping: billed annually' ) ).toBeInTheDocument();
+		expect( getByText( 'bar.com' ) ).toBeInTheDocument();
 	} );
 
 	it( 'adds renewal products to the cart when the url has multiple renewals', async () => {
@@ -649,9 +652,10 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		const { getByText } = renderResult;
-		expect( getByText( 'Domain Mapping: billed yearly' ) ).toBeInTheDocument();
-		expect( getByText( 'Domain Registration: billed yearly' ) ).toBeInTheDocument();
+		const { getByText, getAllByText } = renderResult;
+		expect( getByText( 'Domain Mapping: billed annually' ) ).toBeInTheDocument();
+		expect( getByText( 'Domain Registration: billed annually' ) ).toBeInTheDocument();
+		expect( getAllByText( 'bar.com' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'adds the coupon to the cart when the url has a coupon code', async () => {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-review.js
@@ -33,7 +33,7 @@ export default function WPCheckoutOrderReview( {
 	const isPurchaseFree = total.amount.value === 0;
 
 	const firstDomainItem = items.find( isLineItemADomain );
-	const domainUrl = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
+	const domainUrl = firstDomainItem ? firstDomainItem.label : siteUrl;
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-review-order' ] ) }>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -312,8 +312,8 @@ function InactiveOrderReview() {
 				{ items.filter( shouldItemBeInSummary ).map( ( product ) => {
 					return (
 						<ProductListItem key={ product.id }>
-							<ProductListItemLabel>{ product.label }</ProductListItemLabel>
-							<ProductListItemSublabel product={ product } />
+							<ProductListItemSublabel>{ product.sublabel }</ProductListItemSublabel>
+							<ProductListItemLabel product={ product } />
 						</ProductListItem>
 					);
 				} ) }
@@ -322,15 +322,15 @@ function InactiveOrderReview() {
 	);
 }
 
-function ProductListItemSublabel( { product } ) {
+function ProductListItemLabel( { product } ) {
 	if ( isLineItemADomain( product ) ) {
 		return (
-			<ProductListItemSublabelUI>
-				<strong>{ product.sublabel }</strong>
-			</ProductListItemSublabelUI>
+			<ProductListItemLabelUI>
+				<strong>{ product.label }</strong>
+			</ProductListItemLabelUI>
 		);
 	}
-	return <ProductListItemSublabelUI>{ product.sublabel }</ProductListItemSublabelUI>;
+	return <ProductListItemLabelUI>{ product.label }</ProductListItemLabelUI>;
 }
 
 function shouldItemBeInSummary( item ) {
@@ -390,21 +390,21 @@ const ProductList = styled.ul`
 `;
 
 const ProductListItem = styled.li`
-	margin: 0;
+	margin: 0 0 8px;
 	padding: 0;
 	list-style-type: none;
 
-	&:first-of-type {
-		margin-bottom: 8px;
+	&:last-of-type {
+		margin-bottom: 0;
 	}
 `;
 
-const ProductListItemLabel = styled.div`
+const ProductListItemSublabel = styled.div`
 	color: ${( props ) => props.theme.colors.textColorLight};
 	font-size: 13px;
 `;
 
-const ProductListItemSublabelUI = styled.div`
+const ProductListItemLabelUI = styled.div`
 	color: ${( props ) => props.theme.colors.textColor};
 	font-size: 15px;
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -310,7 +310,15 @@ function InactiveOrderReview() {
 		<SummaryContent>
 			<ProductList>
 				{ items.filter( shouldItemBeInSummary ).map( ( product ) => {
-					return <ProductListItem key={ product.id }>{ product.label }</ProductListItem>;
+					return (
+						<ProductListItem key={ product.id }>
+							{ isLineItemADomain( product ) ? (
+								<strong>{ product.sublabel }</strong>
+							) : (
+								product.label
+							) }
+						</ProductListItem>
+					);
 				} ) }
 			</ProductList>
 		</SummaryContent>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -312,17 +312,25 @@ function InactiveOrderReview() {
 				{ items.filter( shouldItemBeInSummary ).map( ( product ) => {
 					return (
 						<ProductListItem key={ product.id }>
-							{ isLineItemADomain( product ) ? (
-								<strong>{ product.sublabel }</strong>
-							) : (
-								product.label
-							) }
+							<ProductListItemLabel>{ product.label }</ProductListItemLabel>
+							<ProductListItemSublabel product={ product } />
 						</ProductListItem>
 					);
 				} ) }
 			</ProductList>
 		</SummaryContent>
 	);
+}
+
+function ProductListItemSublabel( { product } ) {
+	if ( isLineItemADomain( product ) ) {
+		return (
+			<ProductListItemSublabelUI>
+				<strong>{ product.sublabel }</strong>
+			</ProductListItemSublabelUI>
+		);
+	}
+	return <ProductListItemSublabelUI>{ product.sublabel }</ProductListItemSublabelUI>;
 }
 
 function shouldItemBeInSummary( item ) {
@@ -385,4 +393,18 @@ const ProductListItem = styled.li`
 	margin: 0;
 	padding: 0;
 	list-style-type: none;
+
+	&:first-of-type {
+		margin-bottom: 8px;
+	}
+`;
+
+const ProductListItemLabel = styled.div`
+	color: ${( props ) => props.theme.colors.textColorLight};
+	font-size: 13px;
+`;
+
+const ProductListItemSublabelUI = styled.div`
+	color: ${( props ) => props.theme.colors.textColor};
+	font-size: 15px;
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -312,25 +312,14 @@ function InactiveOrderReview() {
 				{ items.filter( shouldItemBeInSummary ).map( ( product ) => {
 					return (
 						<ProductListItem key={ product.id }>
-							<ProductListItemSublabel>{ product.sublabel }</ProductListItemSublabel>
-							<ProductListItemLabel product={ product } />
+							{ product.sublabel && product.sublabel + ': ' }
+							{ isLineItemADomain( product ) ? <strong>{ product.label }</strong> : product.label }
 						</ProductListItem>
 					);
 				} ) }
 			</ProductList>
 		</SummaryContent>
 	);
-}
-
-function ProductListItemLabel( { product } ) {
-	if ( isLineItemADomain( product ) ) {
-		return (
-			<ProductListItemLabelUI>
-				<strong>{ product.label }</strong>
-			</ProductListItemLabelUI>
-		);
-	}
-	return <ProductListItemLabelUI>{ product.label }</ProductListItemLabelUI>;
 }
 
 function shouldItemBeInSummary( item ) {
@@ -390,21 +379,13 @@ const ProductList = styled.ul`
 `;
 
 const ProductListItem = styled.li`
-	margin: 0 0 8px;
+	color: ${( props ) => props.theme.colors.textColor};
+	font-size: 15px;
+	margin: 0 0 6px;
 	padding: 0;
 	list-style-type: none;
 
 	&:last-of-type {
 		margin-bottom: 0;
 	}
-`;
-
-const ProductListItemSublabel = styled.div`
-	color: ${( props ) => props.theme.colors.textColorLight};
-	font-size: 13px;
-`;
-
-const ProductListItemLabelUI = styled.div`
-	color: ${( props ) => props.theme.colors.textColor};
-	font-size: 15px;
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -85,7 +85,7 @@ export default function WPCheckout( {
 
 	const [ items ] = useLineItems();
 	const firstDomainItem = items.find( isLineItemADomain );
-	const domainName = firstDomainItem ? firstDomainItem.sublabel : siteUrl;
+	const domainName = firstDomainItem ? firstDomainItem.wpcom_meta.meta : siteUrl;
 	const isDomainFieldsVisible = !! firstDomainItem;
 	const shouldShowContactStep = isDomainFieldsVisible || total.amount.value > 0;
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -312,7 +312,6 @@ function InactiveOrderReview() {
 				{ items.filter( shouldItemBeInSummary ).map( ( product ) => {
 					return (
 						<ProductListItem key={ product.id }>
-							{ product.sublabel && product.sublabel + ': ' }
 							{ isLineItemADomain( product ) ? <strong>{ product.label }</strong> : product.label }
 						</ProductListItem>
 					);
@@ -380,7 +379,7 @@ const ProductList = styled.ul`
 
 const ProductListItem = styled.li`
 	color: ${( props ) => props.theme.colors.textColor};
-	font-size: 15px;
+	font-size: 14px;
 	margin: 0 0 6px;
 	padding: 0;
 	list-style-type: none;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -59,9 +59,15 @@ function WPLineItem( {
 			</span>
 			{ item.sublabel && (
 				<LineItemMeta>
-					{ item.sublabel }
-					{ ( 'plan' !== item.type || ! shouldShowVariantSelector ) &&
-						': ' + translate( 'billed yearly' ) }
+					{ 'plan' !== item.type || ! shouldShowVariantSelector
+						? translate( '%(sublabel)s: %(interval)s', {
+								args: {
+									sublabel: item.sublabel,
+									interval: translate( 'billed annually' ),
+								},
+								comment: 'product type and billing interval, separated by a colon',
+						  } )
+						: item.sublabel }
 					{ item.wpcom_meta?.is_bundled && item.amount.value === 0 && (
 						<BundledDomainFreeUI>{ translate( 'First year free' ) }</BundledDomainFreeUI>
 					) }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -54,7 +54,9 @@ function WPLineItem( {
 	return (
 		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>
 			<LineItemTitle id={ itemSpanId }>{ item.label }</LineItemTitle>
-			<LineItemPrice item={ item } aria-labelledby={ itemSpanId } />
+			<span aria-labelledby={ itemSpanId }>
+				<LineItemPrice item={ item } />
+			</span>
 			{ item.sublabel && (
 				<LineItemMeta>
 					{ item.sublabel }: { translate( 'billed yearly' ) }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -53,11 +53,14 @@ function WPLineItem( {
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>
-			<LineItemHeader>
-				{ item.label }: <LineItemMessage item={ item } />
-			</LineItemHeader>
-			<LineItemTitle id={ itemSpanId } item={ item } />
+			<LineItemTitle id={ itemSpanId }>{ item.sublabel }</LineItemTitle>
 			<LineItemPrice item={ item } aria-labelledby={ itemSpanId } />
+			<LineItemMeta>
+				{ item.label }: { translate( 'billed yearly' ) }
+				{ item.wpcom_meta?.is_bundled && item.amount.value === 0 && (
+					<BundledDomainFreeUI>{ translate( 'First year free' ) }</BundledDomainFreeUI>
+				) }
+			</LineItemMeta>
 			{ hasDeleteButton && formStatus === 'ready' && (
 				<>
 					<DeleteButton
@@ -131,26 +134,6 @@ WPLineItem.propTypes = {
 	onChangePlanLength: PropTypes.func,
 };
 
-function LineItemMessage( { item } ) {
-	const translate = useTranslate();
-	return (
-		<LineItemMessageUI>
-			{ 'plan' === item.type && translate( 'Billed yearly' ) }
-			{ item.wpcom_meta?.is_bundled && item.amount.value === 0 && (
-				<BundledDomainFreeUI>{ translate( 'First year free' ) }</BundledDomainFreeUI>
-			) }
-		</LineItemMessageUI>
-	);
-}
-
-function LineItemTitle( { item, id } ) {
-	return (
-		<LineItemTitleUI>
-			<ProductTitleUI id={ id }>{ item.sublabel }</ProductTitleUI>
-		</LineItemTitleUI>
-	);
-}
-
 function LineItemPrice( { item } ) {
 	return (
 		<LineItemPriceUI>
@@ -179,7 +162,7 @@ export const LineItemUI = styled( WPLineItem )`
 	position: relative;
 `;
 
-const LineItemHeader = styled.div`
+const LineItemMeta = styled.div`
 	color: ${( props ) => props.theme.colors.textColorLight};
 	display: flex;
 	font-size: 13px;
@@ -187,15 +170,12 @@ const LineItemHeader = styled.div`
 	width: 100%;
 `;
 
-const LineItemMessageUI = styled.span`
+const BundledDomainFreeUI = styled.div`
+	color: ${( props ) => props.theme.colors.success};
 	text-align: right;
 `;
 
-const BundledDomainFreeUI = styled.div`
-	color: ${( props ) => props.theme.colors.success};
-`;
-
-const LineItemTitleUI = styled.div`
+const LineItemTitle = styled.div`
 	flex: 1;
 	word-break: break-word;
 `;
@@ -204,15 +184,11 @@ const LineItemPriceUI = styled.span`
 	margin-left: 12px;
 `;
 
-const ProductTitleUI = styled.div`
-	flex: 1;
-`;
-
 const DeleteButton = styled( Button )`
 	position: absolute;
 	padding: 10px;
 	right: -50px;
-	top: 26px;
+	top: 8px;
 
 	:hover rect {
 		fill: ${( props ) => props.theme.colors.error};

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -59,7 +59,9 @@ function WPLineItem( {
 			</span>
 			{ item.sublabel && (
 				<LineItemMeta>
-					{ item.sublabel }: { translate( 'billed yearly' ) }
+					{ item.sublabel }
+					{ ( 'plan' !== item.type || ! shouldShowVariantSelector ) &&
+						': ' + translate( 'billed yearly' ) }
 					{ item.wpcom_meta?.is_bundled && item.amount.value === 0 && (
 						<BundledDomainFreeUI>{ translate( 'First year free' ) }</BundledDomainFreeUI>
 					) }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -53,14 +53,16 @@ function WPLineItem( {
 
 	return (
 		<div className={ joinClasses( [ className, 'checkout-line-item' ] ) }>
-			<LineItemTitle id={ itemSpanId }>{ item.sublabel }</LineItemTitle>
+			<LineItemTitle id={ itemSpanId }>{ item.label }</LineItemTitle>
 			<LineItemPrice item={ item } aria-labelledby={ itemSpanId } />
-			<LineItemMeta>
-				{ item.label }: { translate( 'billed yearly' ) }
-				{ item.wpcom_meta?.is_bundled && item.amount.value === 0 && (
-					<BundledDomainFreeUI>{ translate( 'First year free' ) }</BundledDomainFreeUI>
-				) }
-			</LineItemMeta>
+			{ item.sublabel && (
+				<LineItemMeta>
+					{ item.sublabel }: { translate( 'billed yearly' ) }
+					{ item.wpcom_meta?.is_bundled && item.amount.value === 0 && (
+						<BundledDomainFreeUI>{ translate( 'First year free' ) }</BundledDomainFreeUI>
+					) }
+				</LineItemMeta>
+			) }
 			{ hasDeleteButton && formStatus === 'ready' && (
 				<>
 					<DeleteButton
@@ -188,7 +190,7 @@ const DeleteButton = styled( Button )`
 	position: absolute;
 	padding: 10px;
 	right: -50px;
-	top: 8px;
+	top: 7px;
 
 	:hover rect {
 		fill: ${( props ) => props.theme.colors.error};

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-order-review-line-items.js
@@ -169,7 +169,7 @@ export const LineItemUI = styled( WPLineItem )`
 const LineItemMeta = styled.div`
 	color: ${( props ) => props.theme.colors.textColorLight};
 	display: flex;
-	font-size: 13px;
+	font-size: 14px;
 	justify-content: space-between;
 	width: 100%;
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -443,10 +443,10 @@ export function useShoppingCart(
 	useCartUpdateAndRevalidate( cacheStatus, responseCart, setServerCart, hookDispatch, onEvent );
 
 	// Translate the responseCart into the format needed in checkout.
-	const cart: WPCOMCart = useMemo(
-		() => translateResponseCartToWPCOMCart( translate, responseCart ),
-		[ translate, responseCart ]
-	);
+	const cart: WPCOMCart = useMemo( () => translateResponseCartToWPCOMCart( responseCart ), [
+		translate,
+		responseCart,
+	] );
 
 	useShowAddCouponSuccessMessage(
 		shouldShowNotification.didAddCoupon,

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/use-shopping-cart.ts
@@ -388,8 +388,6 @@ type ReactStandardAction = { type: string; payload?: any }; // eslint-disable-li
  *     An asynchronous wrapper around the wpcom shopping cart GET
  *     endpoint. We pass this in to make testing easier.
  *     @see WPCOM_JSON_API_Me_Shopping_Cart_Endpoint
- * @param translate
- *     Localization function
  * @param showAddCouponSuccessMessage
  *     Takes a coupon code and displays a translated notice that
  *     the coupon was successfully applied.
@@ -404,7 +402,6 @@ export function useShoppingCart(
 	couponToAdd: string | null,
 	setCart: ( arg0: string, arg1: RequestCart ) => Promise< ResponseCart >,
 	getCart: ( arg0: string ) => Promise< ResponseCart >,
-	translate: ( arg0: string ) => string,
 	showAddCouponSuccessMessage: ( arg0: string ) => void,
 	onEvent?: ( arg0: ReactStandardAction ) => void
 ): ShoppingCartManager {
@@ -444,7 +441,6 @@ export function useShoppingCart(
 
 	// Translate the responseCart into the format needed in checkout.
 	const cart: WPCOMCart = useMemo( () => translateResponseCartToWPCOMCart( responseCart ), [
-		translate,
 		responseCart,
 	] );
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -143,13 +143,12 @@ function translateReponseCartProductToWPCOMCartItem(
 	const sublabel = isPlan( serverCartItem )
 		? String( translate( 'Plan Subscription' ) )
 		: product_name || '';
-	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;
 
 	return {
 		id: uuid,
 		label,
 		sublabel,
-		type,
+		type: product_slug,
 		amount: {
 			currency: currency || '',
 			value: item_subtotal_integer || 0,

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -139,10 +139,10 @@ function translateReponseCartProductToWPCOMCartItem(
 		product_cost_display,
 	} = serverCartItem;
 
-	const label = isPlan( serverCartItem )
+	const label = isPlan( serverCartItem ) ? product_name || '' : meta;
+	const sublabel = isPlan( serverCartItem )
 		? String( translate( 'Plan Subscription' ) )
 		: product_name || '';
-	const sublabel = isPlan( serverCartItem ) ? product_name || '' : meta;
 	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;
 
 	return {

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -143,12 +143,13 @@ function translateReponseCartProductToWPCOMCartItem(
 	const sublabel = isPlan( serverCartItem )
 		? String( translate( 'Plan Subscription' ) )
 		: product_name || '';
+	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;
 
 	return {
 		id: uuid,
 		label,
 		sublabel,
-		type: product_slug,
+		type,
 		amount: {
 			currency: currency || '',
 			value: item_subtotal_integer || 0,

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
  * Internal dependencies
  */
 import {
@@ -12,19 +17,16 @@ import {
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
 } from '../types';
+import { isPlan } from 'lib/products-values';
 
 /**
  * Translate a cart object as returned by the WPCOM cart endpoint to
  * the format required by the composite checkout component.
  *
- * @param translate Localization function
  * @param serverCart Cart object returned by the WPCOM cart endpoint
  * @returns Cart object suitable for passing to the checkout component
  */
-export function translateResponseCartToWPCOMCart(
-	translate: ( arg0: string, arg1?: any ) => string, //eslint-disable-line @typescript-eslint/no-explicit-any
-	serverCart: ResponseCart
-): WPCOMCart {
+export function translateResponseCartToWPCOMCart( serverCart: ResponseCart ): WPCOMCart {
 	const {
 		products,
 		total_tax_integer,
@@ -46,7 +48,7 @@ export function translateResponseCartToWPCOMCart(
 
 	const taxLineItem: CheckoutCartItem = {
 		id: 'tax-line-item',
-		label: translate( 'Tax' ),
+		label: String( translate( 'Tax' ) ),
 		type: 'tax', // TODO: does this need to be localized, e.g. tax-us?
 		amount: {
 			currency: currency,
@@ -57,7 +59,7 @@ export function translateResponseCartToWPCOMCart(
 
 	const couponLineItem: WPCOMCartCouponItem = {
 		id: 'coupon-line-item',
-		label: translate( 'Coupon: %s', { args: coupon } ),
+		label: String( translate( 'Coupon: %s', { args: coupon } ) ),
 		type: 'coupon',
 		amount: {
 			currency: currency,
@@ -72,7 +74,7 @@ export function translateResponseCartToWPCOMCart(
 	const totalItem: CheckoutCartItem = {
 		id: 'total',
 		type: 'total',
-		label: translate( 'Total' ),
+		label: String( translate( 'Total' ) ),
 		amount: {
 			currency: currency,
 			value: total_cost_integer,
@@ -83,7 +85,7 @@ export function translateResponseCartToWPCOMCart(
 	const subtotalItem: CheckoutCartItem = {
 		id: 'subtotal',
 		type: 'subtotal',
-		label: translate( 'Subtotal' ),
+		label: String( translate( 'Subtotal' ) ),
 		amount: {
 			currency: currency,
 			value: sub_total_integer,
@@ -100,7 +102,7 @@ export function translateResponseCartToWPCOMCart(
 		credits: {
 			id: 'credits',
 			type: 'credits',
-			label: translate( 'Credits' ),
+			label: String( translate( 'Credits' ) ),
 			amount: { value: credits_integer, displayValue: credits_display, currency },
 		},
 		allowedPaymentMethods: allowed_payment_methods
@@ -137,11 +139,17 @@ function translateReponseCartProductToWPCOMCartItem(
 		product_cost_display,
 	} = serverCartItem;
 
+	const label = isPlan( serverCartItem )
+		? String( translate( 'Plan Subscription' ) )
+		: product_name || '';
+	const sublabel = isPlan( serverCartItem ) ? product_name || '' : meta;
+	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;
+
 	return {
 		id: uuid,
-		label: product_name || '',
-		sublabel: meta,
-		type: product_slug,
+		label,
+		sublabel,
+		type,
 		amount: {
 			currency: currency || '',
 			value: item_subtotal_integer || 0,

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -139,10 +139,19 @@ function translateReponseCartProductToWPCOMCartItem(
 		product_cost_display,
 	} = serverCartItem;
 
-	const label = isPlan( serverCartItem ) ? product_name || '' : meta;
-	const sublabel = isPlan( serverCartItem )
-		? String( translate( 'Plan Subscription' ) )
-		: product_name || '';
+	let label;
+	let sublabel;
+	if ( isPlan( serverCartItem ) ) {
+		label = product_name || '';
+		sublabel = String( translate( 'Plan Subscription' ) );
+	} else if ( 'premium_theme' === product_slug || 'concierge-session' === product_slug ) {
+		label = product_name || '';
+		sublabel = '';
+	} else {
+		label = meta;
+		sublabel = product_name || '';
+	}
+
 	const type = isPlan( serverCartItem ) ? 'plan' : product_slug;
 
 	return {

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
@@ -70,7 +70,7 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			coupon_discounts_integer: [],
 		};
 
-		const clientCart = translateResponseCartToWPCOMCart( ( x ) => x, serverResponse );
+		const clientCart = translateResponseCartToWPCOMCart( serverResponse );
 
 		it( 'has a total property', function () {
 			expect( clientCart.total.amount ).toBeDefined();
@@ -253,7 +253,7 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			coupon_discounts_integer: [],
 		};
 
-		const clientCart = translateResponseCartToWPCOMCart( ( x ) => x, serverResponse );
+		const clientCart = translateResponseCartToWPCOMCart( serverResponse );
 
 		it( 'has a total property', function () {
 			expect( clientCart.total.amount ).toBeDefined();
@@ -501,7 +501,7 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			coupon_discounts_integer: [],
 		};
 
-		const clientCart = translateResponseCartToWPCOMCart( ( x ) => x, serverResponse );
+		const clientCart = translateResponseCartToWPCOMCart( serverResponse );
 
 		it( 'has a total property', function () {
 			expect( clientCart.total.amount ).toBeDefined();
@@ -666,9 +666,7 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			is_coupon_applied: true,
 		};
 
-		const clientCart = translateResponseCartToWPCOMCart( ( string, substitution ) => {
-			return substitution ? string.replace( '%s', substitution.args ) : string;
-		}, serverResponse );
+		const clientCart = translateResponseCartToWPCOMCart( serverResponse );
 
 		it( 'has a total property', function () {
 			expect( clientCart.total.amount ).toBeDefined();

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
@@ -110,7 +110,7 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
 			} );
 			it( 'has the expected type', function () {
-				expect( clientCart.items[ 0 ].type ).toBe( 'personal-bundle' );
+				expect( clientCart.items[ 0 ].type ).toBe( 'plan' );
 			} );
 			it( 'has the expected currency', function () {
 				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'BRL' );
@@ -285,7 +285,7 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
 			} );
 			it( 'has the expected type', function () {
-				expect( clientCart.items[ 0 ].type ).toBe( 'personal-bundle' );
+				expect( clientCart.items[ 0 ].type ).toBe( 'plan' );
 			} );
 			it( 'has the expected currency', function () {
 				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'BRL' );
@@ -706,7 +706,7 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 				expect( clientCart.items[ 0 ].label ).toBe( 'WordPress.com Personal' );
 			} );
 			it( 'has the expected type', function () {
-				expect( clientCart.items[ 0 ].type ).toBe( 'personal-bundle' );
+				expect( clientCart.items[ 0 ].type ).toBe( 'plan' );
 			} );
 			it( 'has the expected currency', function () {
 				expect( clientCart.items[ 0 ].amount.currency ).toBe( 'USD' );

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
@@ -302,11 +302,11 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 			it( 'has an id', function () {
 				expect( clientCart.items[ 1 ].id ).toBeDefined();
 			} );
-			it( 'has the expected label', function () {
-				expect( clientCart.items[ 1 ].label ).toBe( '.cash Domain Registration' );
+			it( 'has the expected label (the domain name)', function () {
+				expect( clientCart.items[ 1 ].label ).toBe( 'foo.cash' );
 			} );
-			it( 'has the expected sublabel (the domain name)', function () {
-				expect( clientCart.items[ 1 ].sublabel ).toBe( 'foo.cash' );
+			it( 'has the expected sublabel', function () {
+				expect( clientCart.items[ 1 ].sublabel ).toBe( '.cash Domain Registration' );
 			} );
 			it( 'has the expected meta (the domain name)', function () {
 				expect( clientCart.items[ 1 ].wpcom_meta?.meta ).toBe( 'foo.cash' );
@@ -530,7 +530,7 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 				expect( clientCart.items[ 2 ].id ).toBeDefined();
 			} );
 			it( 'has the expected label', function () {
-				expect( clientCart.items[ 2 ].label ).toBe( 'G Suite' );
+				expect( clientCart.items[ 2 ].sublabel ).toBe( 'G Suite' );
 			} );
 			it( 'has the expected product_id', function () {
 				expect( clientCart.items[ 2 ].wpcom_meta?.product_id ).toBe( 69 );


### PR DESCRIPTION
This started as a PR to highlight a purchased domain in the review step's summary, but ultimately incorporated the line item changes from our usability testing.

The PR does a few things:

- Attempts to consolidate how product labels and sub-labels are used between different products. Plans are given a sub-label of "Plan Subscription" with labels of the specific plan (i.e. "WordPress Personal"). Domains and domain-related purchases are given sub-labels of "{tld} Domain {Registration|Mapping|Transfer}" and labels of the domain in question (i.e. "example.com"). Some products, like support sessions and premium themes, return special cases and will require a follow-up backend diff with additional testing
- Introduces some messaging ("billed yearly") for the monthly/yearly price discrepancy from previous screens.
- Makes the plan line item type consistent for all plans. This fixes a bug where the cart removal messaging was falling back to the default, instead of mentioning the plan removal and additional messaging around bundled domains/plans.
- and last but not least… highlights domain purchases on the step summary.

For the review summary:
![Screen Shot 2020-05-04 at 5 24 04 PM](https://user-images.githubusercontent.com/942359/81015353-8b009d80-8e2c-11ea-9540-83ec47e28e08.png)

For the active line items, you can see the different product variations here:
![Screen Shot 2020-05-04 at 5 13 14 PM](https://user-images.githubusercontent.com/942359/81015453-bdaa9600-8e2c-11ea-946f-063c6ee3ec6f.png)

**To test:**
- visit checkout with a domain (and other items) in your cart
- verify that the line items match the designs below
- complete the first step of checkout
- verify that the summary of the step now displays a bolded url
- proceed through checkout
- verify that the line items in the final step and the sidebar summary are rendered correctly
- finish checkout
- verify that the products were correctly purchased