### PR TITLE
Changes colors of 404 illustration

### DIFF
--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -232,3 +232,7 @@ html p {
 		border-radius: 0 0 3px 3px;
 	}
 }
+
+.empty-content__illustration {
+	filter: hue-rotate( -80deg ) saturate( 1.5 );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the color of the 404 page illustration to better match Jetpack green.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enter an invalid URL.

<img width="785" alt="Screen Shot 2020-04-30 at 3 24 41 PM" src="https://user-images.githubusercontent.com/1760168/80751578-0cd48c00-8af8-11ea-823e-6bb526aec802.png">
