### PR TITLE
composite-checkout: Add logstash to error boundary errors

### DIFF
--- a/client/my-sites/checkout/checkout-system-decider.js
+++ b/client/my-sites/checkout/checkout-system-decider.js
@@ -51,6 +51,7 @@ export default function CheckoutSystemDecider( {
 				logToLogstash( {
 					feature: 'calypso_client',
 					message: 'CheckoutSystemDecider saw productSlug to add',
+					severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
 					extra: {
 						productSlug: product,
 					},

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -10,6 +10,8 @@ import { defaultRegistry } from '@automattic/composite-checkout';
  * Internal dependencies
  */
 import { recordPurchase } from 'lib/analytics/record-purchase';
+import { logToLogstash } from 'state/logstash/actions';
+import config from 'config';
 
 const { select } = defaultRegistry;
 const debug = debugFactory( 'calypso:composite-checkout:record-analytics' );
@@ -71,6 +73,18 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'STEP_LOAD_ERROR':
+				reduxDispatch(
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: 'composite checkout load error',
+						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+						extra: {
+							type: 'step_load',
+							message: String( action.payload ),
+						},
+					} )
+				);
+
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
 						error_message: String( action.payload ),
@@ -78,6 +92,18 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'SUBMIT_BUTTON_LOAD_ERROR':
+				reduxDispatch(
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: 'composite checkout load error',
+						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+						extra: {
+							type: 'submit_button_load',
+							message: String( action.payload ),
+						},
+					} )
+				);
+
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_submit_button_load_error', {
 						error_message: String( action.payload ),
@@ -85,6 +111,18 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'PAYMENT_METHOD_LOAD_ERROR':
+				reduxDispatch(
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: 'composite checkout load error',
+						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+						extra: {
+							type: 'payment_method_load',
+							message: String( action.payload ),
+						},
+					} )
+				);
+
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_payment_method_load_error', {
 						error_message: String( action.payload ),
@@ -92,6 +130,18 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'PAGE_LOAD_ERROR':
+				reduxDispatch(
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: 'composite checkout load error',
+						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+						extra: {
+							type: 'page_load',
+							message: String( action.payload ),
+						},
+					} )
+				);
+
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_page_load_error', {
 						error_message: String( action.payload ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When an error boundary is triggered due to a JS error in the code, it would be nice to be notified of it. We can do that by having the error in logstash.

This PR adds logstash calls to each of the error boundary errors. In production, these entries will have `severity: error`, and other environments will have `severity: debug`.

#### Testing instructions

- Edit the code to cause an Error to be thrown inside composite checkout.
- Load the page to cause the error and verify that you see an error boundary.
- Visit logstash for the string `composite checkout load error` and verify that you see the error you triggered (and verify that its severity is `debug`).