### PR TITLE
Safeguards for primary site redirection

### DIFF
--- a/client/landing/jetpack-cloud/sections/home.tsx
+++ b/client/landing/jetpack-cloud/sections/home.tsx
@@ -14,6 +14,8 @@ import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import getPrimarySiteIsJetpack from 'state/selectors/get-primary-site-is-jetpack';
 import config from 'config';
 import getPrimarySiteSlug from 'state/selectors/get-primary-site-slug';
+import isSiteAtomic from 'state/selectors/is-site-wpcom-atomic';
+import isJetpackSiteMultiSite from 'state/sites/selectors/is-jetpack-site-multi-site';
 
 type Props = {
 	siteId?: number | null;
@@ -59,18 +61,21 @@ function Home( props: Props ) {
 }
 
 export default connect( ( state ) => {
-	if ( ! getPrimarySiteIsJetpack( state ) ) {
+	const siteId = getPrimarySiteId( state );
+	if (
+		! siteId ||
+		! getPrimarySiteIsJetpack( state ) ||
+		isSiteAtomic( state, siteId ) ||
+		isJetpackSiteMultiSite( state, siteId ) // TODO: Remove once multisites become Rewind compatible.
+	) {
 		return {
 			siteId: null,
 		};
 	}
-	const siteId = getPrimarySiteId( state );
-	const siteSlug = getPrimarySiteSlug( state );
-	const siteCapabilities = getRewindCapabilities( state, siteId );
 
 	return {
 		siteId,
-		siteSlug,
-		siteCapabilities,
+		siteSlug: getPrimarySiteSlug( state ),
+		siteCapabilities: getRewindCapabilities( state, siteId ),
 	};
 } )( Home );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds safeguards around redirecting to a user's primary site to exclude multisites and Atomic sites.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set your primary site to an Atomic site or multisite.
* Go to root of Cloud.
* Observe site picker appear.

Fixes 1143508703416848-as-1173582844580969.
