### PR TITLE
Update the link on the help page to point to the webinars page.

### DIFF
--- a/client/me/help/help-teaser-button.jsx
+++ b/client/me/help/help-teaser-button.jsx
@@ -16,10 +16,10 @@ import { Card } from '@automattic/components';
  */
 import './help-teaser-button.scss';
 
-export default localize( ( { title, description, href, onClick } ) => {
+export default localize( ( { title, description, href, onClick, target } ) => {
 	return (
 		<div className="help__help-teaser-button">
-			<Card href={ href } onClick={ onClick }>
+			<Card href={ href } onClick={ onClick } target={ target }>
 				<Gridicon className="help__help-teaser-button-icon" icon="help" size={ 36 } />
 				<div className="help__help-teaser-text">
 					<span className="help__help-teaser-button-title">{ title }</span>

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -202,7 +202,8 @@ class Help extends React.PureComponent {
 		return (
 			<HelpTeaserButton
 				onClick={ this.trackCoursesButtonClick }
-				href="/help/courses"
+				href="https://wordpress.com/webinars"
+				target="_blank"
 				title={ this.props.translate( 'Courses' ) }
 				description={ this.props.translate(
 					'Learn how to make the most of your site with these courses and webinars'


### PR DESCRIPTION
#### Testing instructions

* The `Courses` link from `/help` should open up the webinars page in a new tab.

