### PR TITLE
Home: try enabling new layout on dev and horizon

### DIFF
--- a/config/desktop.json
+++ b/config/desktop.json
@@ -37,6 +37,7 @@
 		"google-my-business": false,
 		"help": true,
 		"help/courses": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/development.json
+++ b/config/development.json
@@ -70,6 +70,7 @@
 		"gutenboarding/domain-picker-modal": true,
 		"help": true,
 		"help/courses": true,
+		"home/experimental-layout": true,
 		"inline-help": true,
 		"i18n/community-translator": false,
 		"i18n/translation-scanner": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -40,6 +40,7 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": false,
+		"home/experimental-layout": true,
 		"happychat": false,
 		"help": true,
 		"help/courses": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,6 +42,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -49,6 +49,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/test.json
+++ b/config/test.json
@@ -40,6 +40,7 @@
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"help": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,6 +56,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,


### PR DESCRIPTION
Enables the new My Home layout in dev and horizon for easier testing.

<img width="1024" alt="screen-shot-2020-04-29-at-10 43 19-am" src="https://user-images.githubusercontent.com/1270189/80758703-ed833200-8aea-11ea-82b1-ca4614d0a2d7.png">

### Testing Instructions

- Verify that we see the new home layout on dev/horizon
- No changes to stage, production, or wpcalypso 
