### PR TITLE
My Home: Fix dismissal settings of the Webinars card.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
@@ -26,7 +26,7 @@ const Webinars = () => {
 			} }
 			illustration={ webinarsIllustration }
 			timing={ 2 }
-			taskId="webinar"
+			taskId="webinars"
 		/>
 	);
 };


### PR DESCRIPTION
This PR fixes the dismissal behaviour of the Webinars card (fix found by @gwwar ).

#### Testing instructions

* Load an established site on this branch with `/home/:site/?flags=home/experimental-layout`.
* Dismiss the Webinars task.
* Reload, and verify it does not display again right away.
