### PR TITLE
My Home: Add stats for the CTAs of Task cards.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -57,6 +57,18 @@ const Task = ( {
 	const dismissalPreferenceKey = `dismissible-card-home-task-${ taskId }-${ siteId }`;
 	const successNoticeId = `task_remind_later_success-${ taskId }`;
 
+	const startTask = () => {
+		actionOnClick();
+		dispatch(
+			composeAnalytics(
+				recordTracksEvent( 'calypso_customer_home_task_start', {
+					task: taskId,
+				} ),
+				bumpStat( 'calypso_customer_home', 'task_start' )
+			)
+		);
+	};
+
 	const restoreTask = () => {
 		setIsTaskVisible( true );
 
@@ -118,7 +130,7 @@ const Task = ( {
 					<ActionPanelTitle>{ title }</ActionPanelTitle>
 					<p className="task__description">{ description }</p>
 					<ActionPanelCta>
-						<Button className="task__action" primary onClick={ actionOnClick } href={ actionUrl }>
+						<Button className="task__action" primary onClick={ startTask } href={ actionUrl }>
 							{ actionText }
 						</Button>
 						<Button

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -99,6 +99,7 @@ const Task = ( {
 				composeAnalytics(
 					recordTracksEvent( 'calypso_customer_home_task_skip', {
 						task: taskId,
+						reminder,
 					} ),
 					bumpStat( 'calypso_customer_home', 'task_skip' )
 				),

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -58,7 +58,9 @@ const Task = ( {
 	const successNoticeId = `task_remind_later_success-${ taskId }`;
 
 	const startTask = () => {
-		actionOnClick();
+		if ( actionOnClick instanceof Function ) {
+			actionOnClick();
+		}
 		dispatch(
 			composeAnalytics(
 				recordTracksEvent( 'calypso_customer_home_task_start', {


### PR DESCRIPTION
For any My Home card based on the `Task` component, let's collect bump and Track stats for when a user clicks on their primary call-to-action button. We already have stats that handle card dismissal/reminders.

Currently, this will apply to the `webinars`, `connect-accounts`, and `find-domains` cards.

<img width="1066" alt="Screen Shot 2020-04-30 at 10 36 49 AM" src="https://user-images.githubusercontent.com/349751/80763709-fe847100-8af3-11ea-9c75-b76f2e16a9ee.png">

#### Testing instructions

* On this branch, load My Home for an established site that hasn't dismissed the above cards yet (`/home/:site/` – the URL flag is no longer needed).
* In the console, activate analytics visibility with `localStorage.debug='calypso:analytics*'` (be sure to reload the page).
* Click the call-to-action button for each card (dismissing if necessary to move on), and verify bump and Tracks stats are collected, with the correct task identified.

<img width="857" alt="Screen Shot 2020-04-30 at 3 09 01 PM" src="https://user-images.githubusercontent.com/349751/80763999-997d4b00-8af4-11ea-9121-c065f9aa43a3.png">
