### PR TITLE
Help: Add Active Tickets notice in an AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,4 +124,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	showActiveTicketsNotice: {
+		datestamp: '20200430',
+		variations: {
+			showNotice: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/me/help/active-tickets-notice/index.jsx
+++ b/client/me/help/active-tickets-notice/index.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import { recordTracksEvent } from 'lib/analytics/tracks';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ActiveTicketsNotice extends React.Component {
+	componentDidMount() {
+		recordTracksEvent( 'calypso_help_active_requests_notice_shown', {
+			active_ticket_count: this.props.count,
+		} );
+	}
+
+	render() {
+		const { translate, compact, count } = this.props;
+
+		const text = translate(
+			'You have %(requestCount)d open request. Rest assured that your ' +
+				"email arrived safely and we'll be in touch as soon as we can.",
+			'You have %(requestCount)d open requests. Rest assured that your ' +
+				"emails arrived safely and we'll be in touch as soon as we can.",
+			{
+				count: count,
+				args: { requestCount: count },
+				comment: `An "open request" is a support email that hasn't been resolved`,
+			}
+		);
+
+		return (
+			<div className="active-tickets-notice">
+				<Notice status="is-info" showDismiss={ false } isCompact={ compact } text={ text }></Notice>
+			</div>
+		);
+	}
+}
+
+export default localize( ActiveTicketsNotice );

--- a/client/me/help/active-tickets-notice/index.jsx
+++ b/client/me/help/active-tickets-notice/index.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import Notice from 'components/notice';
 import { recordTracksEvent } from 'lib/analytics/tracks';
+import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -24,6 +25,14 @@ class ActiveTicketsNotice extends React.Component {
 	}
 
 	render() {
+		// During AB test, only show the notice to those in the test group. We're
+		// controlling the visibility here, so that we can still mount the component
+		// from the parent which fires the tracks event — we want the event to
+		// fire for both AB groups.
+		if ( abtest( 'showActiveTicketsNotice' ) !== 'showNotice' ) {
+			return null;
+		}
+
 		const { translate, compact, count } = this.props;
 
 		const text = translate(

--- a/client/me/help/active-tickets-notice/style.scss
+++ b/client/me/help/active-tickets-notice/style.scss
@@ -1,0 +1,3 @@
+.active-tickets-notice {
+	margin-bottom: 1.5em;
+}

--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -17,6 +17,7 @@ import Main from 'components/main';
 import { Card } from '@automattic/components';
 import Notice from 'components/notice';
 import HelpContactForm from 'me/help/help-contact-form';
+import ActiveTicketsNotice from 'me/help/active-tickets-notice';
 import LimitedChatAvailabilityNotice from 'me/help/contact-form-notice/limited-chat-availability';
 import HelpContactConfirmation from 'me/help/help-contact-confirmation';
 import HeaderCake from 'components/header-cake';
@@ -525,7 +526,7 @@ class HelpContact extends React.Component {
 	 */
 	getView = () => {
 		const { confirmation } = this.state;
-		const { compact, supportVariation, translate } = this.props;
+		const { activeSupportTickets, compact, supportVariation, translate } = this.props;
 
 		debug( { supportVariation } );
 
@@ -579,8 +580,14 @@ class HelpContact extends React.Component {
 		const isUserAffectedByLiveChatClosure =
 			supportVariation !== SUPPORT_DIRECTLY && supportVariation !== SUPPORT_FORUM;
 
+		const activeTicketCount = activeSupportTickets.length;
+
 		return (
 			<div>
+				{ activeTicketCount > 0 && (
+					<ActiveTicketsNotice count={ activeTicketCount } compact={ compact } />
+				) }
+
 				{ isUserAffectedByLiveChatClosure && (
 					<>
 						<LimitedChatAvailabilityNotice
@@ -590,6 +597,7 @@ class HelpContact extends React.Component {
 						/>
 					</>
 				) }
+
 				{ this.shouldShowTicketRequestErrorNotice( supportVariation ) && (
 					<Notice
 						status="is-warning"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Creates `ActiveTicketsNotice` which shows on the Contact form when the customer has one or more active requests. The goal of this feature is to create a better customer experience by reassuring them we haven't forgotten about their email support request, and hopefully reduce the number of people re-asking for help on an open issue.

Since we don't have historic data to measure against, we're launching this in a 50/50 AB test. This will let us directly compare — what % of people who have an open ticket (`calypso_help_active_requests_notice_shown`, new in this PR) still end up asking for help (`calypso_help_contact_submit_with_active_tickets`), and how does that change if they're notified of their open requests?

#### Testing instructions

For testing you need active tickets for the notice to show. If you'd like you can submit email requests (and close them yourself after) — or since that flow isn't being tested, you can simply adjust [this line](https://github.com/Automattic/wp-calypso/pull/41704/files#diff-bfbe01f0a66b1aa6a6708379328f1d66R583) from counting what's in state to any integer you need: `const activeTicketCount = 3;`

##### Verify the notice shows and hides correctly based on ticket count
- Set `const activeTicketCount = 5;`
- Open http://calypso.localhost:3000
- Make sure you're in the test group so you can see the notice. From the JS Console:
  ```
  localStorage.setItem( 'ABTests', '{"showActiveTicketsNotice_20200430":"showNotice"}' );
  ```
- Open the Inline Help widget and click Contact Us
- You should see the notice appear
- Go to http://calypso.localhost:3000/help/contact — you should see it appear there as well
- Set `const activeTicketCount = 0;` — the notice should not appear in either place

##### Verify the notice shows and hides correctly based on AB test group
- Set `const activeTicketCount = 5;`
- Open http://calypso.localhost:3000
- Make sure you're in the test group so you can see the notice. From the JS Console:
  ```
  localStorage.setItem( 'ABTests', '{"showActiveTicketsNotice_20200430":"showNotice"}' );
  ```
- Open the Inline Help widget and click Contact Us
- You should see the notice appear
- Go to http://calypso.localhost:3000/help/contact — you should see it appear there as well
- Set yourself back into the AB control group:
  ```
  localStorage.setItem( 'ABTests', '{"showActiveTicketsNotice_20200430":"control"}' );
  ```
- The notice should not appear in either place

##### Verify the translation pluralization works correctly
- Set yourself into the test group:
  ```
  localStorage.setItem( 'ABTests', '{"showActiveTicketsNotice_20200430":"showNotice"}' );
  ```
- Set `const activeTicketCount = 1;`
- View the Inline Help and Contact Us pages — the notice should be singular
- Set `const activeTicketCount = 5;`
- View the Inline Help and Contact Us pages — the notice should be plural

##### Verify that the event fires
- Set `const activeTicketCount = 5;`
- Turn on Tracks debug in the JS console: `localStorage.setItem( 'debug', 'calypso:analytics*' );` and refresh
- Set yourself into the test group:
  ```
  localStorage.setItem( 'ABTests', '{"showActiveTicketsNotice_20200430":"showNotice"}' );
  ```
- Open the Inline Help contact form and the Contact Us form — the `calypso_help_active_requests_notice_shown` event should fire on both
- Set yourself back into the AB control group:
  ```
  localStorage.setItem( 'ABTests', '{"showActiveTicketsNotice_20200430":"control"}' );
  ```
- Open the Inline Help contact form and the Contact Us form — the `calypso_help_active_requests_notice_shown` event should still fire on both (even though the notice doesn't appear)
