### PR TITLE
Gutenboarding: sends null for extra.username_hint to users/new endpoint

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -49,16 +49,14 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 	const handleSignUp = async ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 
-		const username_hint = siteTitle || siteVertical?.label;
+		const username_hint = siteTitle || siteVertical?.label || null;
 
 		const result = await createAccount( {
 			email: emailVal,
 			password: passwordVal,
 			signup_flow_name: 'gutenboarding',
 			locale: langParam,
-			...( username_hint && {
-				extra: { username_hint },
-			} ),
+			extra: { username_hint },
 			is_passwordless: false,
 		} );
 

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -55,7 +55,7 @@ export interface CreateAccountParams {
 	extra?: {
 		first_name?: string;
 		last_name?: string;
-		username_hint?: string;
+		username_hint: string | null | undefined;
 	};
 }
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR deliberately sends `null` for the property`extra.username_hint`, and therefore  an invalid value to `users/new`. 😱 

We're doing this to force the endpoint to designate an auto-generated username. 🛠

It's a quick fix to get things working. 👍

A cleaner solution would be to send a `generate_username`  flag to `users/new`, or some such thing. 🧹

Here's another emoji! 🍻

## Testing instructions

1. Head over to `/new`. 
2. Enter neither a vertical nor a site title.
3. Go on to create a new site.

You should be able to create a new site.




