### PR TITLE
My Home: Janitorial enhancements

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -43,27 +43,6 @@ const getTaskDescription = ( task, { isDomainUnverified, isEmailUnverified } ) =
 	}
 };
 
-const getTaskActionText = ( task, { emailVerificationStatus } ) => {
-	switch ( task.id ) {
-		case 'email_verified':
-			if ( emailVerificationStatus === 'requesting' ) {
-				return translate( 'Sending…' );
-			}
-
-			if ( emailVerificationStatus === 'error' ) {
-				return translate( 'Error' );
-			}
-
-			if ( emailVerificationStatus === 'sent' ) {
-				return translate( 'Email sent' );
-			}
-
-			return task.actionText;
-		default:
-			return task.actionText;
-	}
-};
-
 const isTaskDisabled = (
 	task,
 	{ emailVerificationStatus, isDomainUnverified, isEmailUnverified }
@@ -131,7 +110,7 @@ export const getTask = (
 				),
 				actionText: translate( 'Resend email' ),
 				actionDispatch: verifyEmail,
-				actionDispatchArgs: [],
+				actionDispatchArgs: [ { showGlobalNotices: true } ],
 			};
 			break;
 		case 'blogname_set':
@@ -214,7 +193,6 @@ export const getTask = (
 	return {
 		...enhancedTask,
 		description: getTaskDescription( enhancedTask, { isDomainUnverified, isEmailUnverified } ),
-		actionText: getTaskActionText( enhancedTask, { emailVerificationStatus } ),
 		isDisabled: isTaskDisabled( enhancedTask, {
 			emailVerificationStatus,
 			isDomainUnverified,

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -85,23 +85,6 @@ const trackTaskDisplay = ( dispatch, task, siteId ) => {
 	);
 };
 
-const getActionText = ( currentTask, emailVerificationStatus ) => {
-	if ( currentTask.id === 'email_verified' ) {
-		if ( emailVerificationStatus === 'requesting' ) {
-			return translate( 'Sending…' );
-		}
-
-		if ( emailVerificationStatus === 'error' ) {
-			return translate( 'Error' );
-		}
-
-		if ( emailVerificationStatus === 'sent' ) {
-			return translate( 'Email sent' );
-		}
-	}
-	return currentTask.actionText;
-};
-
 const SiteSetupList = ( {
 	emailVerificationStatus,
 	isEmailUnverified,
@@ -162,7 +145,17 @@ const SiteSetupList = ( {
 			setCurrentTask( newCurrentTask );
 			trackTaskDisplay( dispatch, newCurrentTask, siteId );
 		}
-	}, [ currentTaskId ] );
+	}, [
+		currentTaskId,
+		emailVerificationStatus,
+		isDomainUnverified,
+		isEmailUnverified,
+		menusUrl,
+		siteId,
+		siteSlug,
+		taskUrls,
+		userEmail,
+	] );
 
 	useEffect( () => {
 		if ( isWithinBreakpoint( '<960px' ) ) {
@@ -241,7 +234,7 @@ const SiteSetupList = ( {
 									onClick={ () => startTask( dispatch, currentTask, siteId ) }
 									disabled={ currentTask.isDisabled }
 								>
-									{ getActionText( currentTask, emailVerificationStatus ) }
+									{ currentTask.actionText }
 								</Button>
 								{ currentTask.isSkippable && ! currentTask.isCompleted && (
 									<Button

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -215,23 +215,21 @@ const SiteSetupList = ( {
 				<ActionPanel className="site-setup-list__task task">
 					<ActionPanelBody>
 						<div className="site-setup-list__task-text task__text">
-							<div className="site-setup-list__task-timing task__timing">
-								{ currentTask.isCompleted ? (
-									<Badge className="site-setup-list__badge" type="info">
-										{ translate( 'Complete' ) }
-									</Badge>
-								) : (
-									<>
-										<Gridicon icon="time" size={ 18 } />
-										<p>
-											{ translate( '%d minute', '%d minutes', {
-												count: currentTask.timing,
-												args: [ currentTask.timing ],
-											} ) }
-										</p>
-									</>
-								) }
-							</div>
+							{ currentTask.isCompleted ? (
+								<Badge type="info" className="site-setup-list__task-badge task__badge">
+									{ translate( 'Complete' ) }
+								</Badge>
+							) : (
+								<div className="site-setup-list__task-timing task__timing">
+									<Gridicon icon="time" size={ 18 } />
+									<p>
+										{ translate( '%d minute', '%d minutes', {
+											count: currentTask.timing,
+											args: [ currentTask.timing ],
+										} ) }
+									</p>
+								</div>
+							) }
 							<ActionPanelTitle>{ currentTask.title }</ActionPanelTitle>
 							<p className="site-setup-list__task-description task__description">
 								{ currentTask.description }

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -101,11 +101,6 @@
 		}
 	}
 
-	.site-setup-list__badge {
-		background-color: var( --color-neutral-dark );
-		color: var( --color-text-inverted );
-	}
-
 	.site-setup-list__nav-back {
 		padding: 2px 4px;
 		margin: 0 4px 0 -8px;

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -42,7 +42,7 @@
 
 	.action-panel__body .task__timing {
 		display: flex;
-		margin-bottom: 8px;
+		margin-bottom: 10px;
 
 		.gridicon {
 			margin-right: 4px;
@@ -70,5 +70,5 @@
 .badge--info.task__badge {
 	background-color: var( --studio-gray-80 );
 	color: var( --color-text-inverted );
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 }

--- a/client/state/current-user/email-verification/actions.js
+++ b/client/state/current-user/email-verification/actions.js
@@ -6,6 +6,9 @@ import { EMAIL_VERIFY_REQUEST, EMAIL_VERIFY_STATE_RESET } from 'state/action-typ
 
 import 'state/data-layer/wpcom/me/send-verification-email';
 
-export const verifyEmail = () => ( { type: EMAIL_VERIFY_REQUEST } );
+export const verifyEmail = ( { showGlobalNotices = false } = {} ) => ( {
+	type: EMAIL_VERIFY_REQUEST,
+	showGlobalNotices,
+} );
 
 export const resetVerifyEmailState = () => ( { type: EMAIL_VERIFY_STATE_RESET } );

--- a/client/state/current-user/email-verification/test/actions.js
+++ b/client/state/current-user/email-verification/test/actions.js
@@ -13,7 +13,12 @@ describe( 'actions', () => {
 	describe( '#verifyEmail', () => {
 		test( 'returns request action', () => {
 			const result = verifyEmail();
-			expect( result ).to.eql( { type: EMAIL_VERIFY_REQUEST } );
+			expect( result ).to.eql( { type: EMAIL_VERIFY_REQUEST, showGlobalNotices: false } );
+		} );
+
+		test( 'returns request action with notices', () => {
+			const result = verifyEmail( { showGlobalNotices: true } );
+			expect( result ).to.eql( { type: EMAIL_VERIFY_REQUEST, showGlobalNotices: true } );
 		} );
 	} );
 

--- a/client/state/data-layer/wpcom/me/send-verification-email/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/index.js
@@ -14,7 +14,7 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 import { translate } from 'i18n-calypso';
 import { infoNotice, errorNotice, successNotice, removeNotice } from 'state/notices/actions';
 
-const infoNoticeId = 'email-verification-sending';
+const infoNoticeId = 'email-verification-info-notice';
 
 /**
  * Creates an action for request for email verification
@@ -23,7 +23,7 @@ const infoNoticeId = 'email-verification-sending';
  * @returns {object} Redux action
  */
 export const requestEmailVerification = ( action ) => [
-	...( action.showGlobalNotices
+	...( action?.showGlobalNotices
 		? [ infoNotice( translate( 'Sending email…' ), { id: infoNoticeId, duration: 4000 } ) ]
 		: [] ),
 	http(
@@ -48,10 +48,11 @@ export const handleError = ( action, rawError ) => [
 		type: EMAIL_VERIFY_REQUEST_FAILURE,
 		message: rawError.message,
 	},
-	...( action.showGlobalNotices
+	...( action?.showGlobalNotices
 		? [
 				removeNotice( infoNoticeId ),
 				errorNotice( translate( 'Sorry, we couldn’t send the email.' ), {
+					id: 'email-verification-error-notice',
 					duration: 4000,
 				} ),
 		  ]
@@ -66,10 +67,11 @@ export const handleError = ( action, rawError ) => [
  */
 export const handleSuccess = ( action ) => [
 	{ type: EMAIL_VERIFY_REQUEST_SUCCESS },
-	...( action.showGlobalNotices
+	...( action?.showGlobalNotices
 		? [
 				removeNotice( infoNoticeId ),
 				successNotice( translate( 'Email sent' ), {
+					id: 'email-verification-success-notice',
 					duration: 4000,
 				} ),
 		  ]

--- a/client/state/data-layer/wpcom/me/send-verification-email/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/index.js
@@ -11,6 +11,10 @@ import {
 } from 'state/action-types';
 
 import { registerHandlers } from 'state/data-layer/handler-registry';
+import { translate } from 'i18n-calypso';
+import { infoNotice, errorNotice, successNotice, removeNotice } from 'state/notices/actions';
+
+const infoNoticeId = 'email-verification-sending';
 
 /**
  * Creates an action for request for email verification
@@ -18,7 +22,10 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
  * @param 	{object} action The action to dispatch next
  * @returns {object} Redux action
  */
-export const requestEmailVerification = ( action ) =>
+export const requestEmailVerification = ( action ) => [
+	...( action.showGlobalNotices
+		? [ infoNotice( translate( 'Sending email…' ), { id: infoNoticeId, duration: 4000 } ) ]
+		: [] ),
 	http(
 		{
 			apiVersion: '1.1',
@@ -26,7 +33,8 @@ export const requestEmailVerification = ( action ) =>
 			path: '/me/send-verification-email',
 		},
 		action
-	);
+	),
+];
 
 /**
  * Creates an action for handling email verification error
@@ -35,10 +43,20 @@ export const requestEmailVerification = ( action ) =>
  * @param   {object} rawError The error object
  * @returns {object} Redux action
  */
-export const handleError = ( action, rawError ) => ( {
-	type: EMAIL_VERIFY_REQUEST_FAILURE,
-	message: rawError.message,
-} );
+export const handleError = ( action, rawError ) => [
+	{
+		type: EMAIL_VERIFY_REQUEST_FAILURE,
+		message: rawError.message,
+	},
+	...( action.showGlobalNotices
+		? [
+				removeNotice( infoNoticeId ),
+				errorNotice( translate( 'Sorry, we couldn’t send the email.' ), {
+					duration: 4000,
+				} ),
+		  ]
+		: [] ),
+];
 
 /**
  * Creates an action for email verification success
@@ -46,7 +64,17 @@ export const handleError = ( action, rawError ) => ( {
  * @param 	{object} action The action to dispatch next
  * @returns {object} Redux action
  */
-export const handleSuccess = () => ( { type: EMAIL_VERIFY_REQUEST_SUCCESS } );
+export const handleSuccess = ( action ) => [
+	{ type: EMAIL_VERIFY_REQUEST_SUCCESS },
+	...( action.showGlobalNotices
+		? [
+				removeNotice( infoNoticeId ),
+				successNotice( translate( 'Email sent' ), {
+					duration: 4000,
+				} ),
+		  ]
+		: [] ),
+];
 
 export const dispatchEmailVerification = dispatchRequest( {
 	fetch: requestEmailVerification,

--- a/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
+++ b/client/state/data-layer/wpcom/me/send-verification-email/test/index.js
@@ -4,13 +4,13 @@
 import { requestEmailVerification, handleSuccess, handleError } from '../';
 import { EMAIL_VERIFY_REQUEST_SUCCESS, EMAIL_VERIFY_REQUEST_FAILURE } from 'state/action-types';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { infoNotice, errorNotice, successNotice, removeNotice } from 'state/notices/actions';
+import { translate } from 'i18n-calypso';
 
 describe( 'send-email-verification', () => {
 	describe( '#requestEmailVerification', () => {
-		const dummyAction = { type: 'DUMMY' };
-
 		test( 'should dispatch HTTP request to me/send-verification-email endpoint', () => {
-			expect( requestEmailVerification( dummyAction ) ).toEqual(
+			expect( requestEmailVerification( { type: 'DUMMY' } ) ).toContainEqual(
 				expect.objectContaining(
 					http(
 						{
@@ -18,9 +18,20 @@ describe( 'send-email-verification', () => {
 							method: 'POST',
 							path: '/me/send-verification-email',
 						},
-						dummyAction
+						{ type: 'DUMMY' }
 					)
 				)
+			);
+		} );
+
+		test( 'should dispatch info notice when showing global notices', () => {
+			expect(
+				requestEmailVerification( { type: 'DUMMY', showGlobalNotices: true } )
+			).toContainEqual(
+				infoNotice( translate( 'Sending email…' ), {
+					id: 'email-verification-info-notice',
+					duration: 4000,
+				} )
 			);
 		} );
 	} );
@@ -30,18 +41,48 @@ describe( 'send-email-verification', () => {
 		const rawError = Error( message );
 
 		test( 'should dispatch failure action with error message', () => {
-			expect( handleError( null, rawError ) ).toMatchObject( {
+			expect( handleError( null, rawError ) ).toContainEqual( {
 				type: EMAIL_VERIFY_REQUEST_FAILURE,
 				message,
 			} );
+		} );
+
+		test( 'should dispatch error notice when showing global notices', () => {
+			expect( handleError( { showGlobalNotices: true }, rawError ) ).toContainEqual(
+				errorNotice( translate( 'Sorry, we couldn’t send the email.' ), {
+					id: 'email-verification-error-notice',
+					duration: 4000,
+				} )
+			);
+		} );
+
+		test( 'should remove info notice when showing global notices', () => {
+			expect( handleError( { showGlobalNotices: true }, rawError ) ).toContainEqual(
+				removeNotice( 'email-verification-info-notice' )
+			);
 		} );
 	} );
 
 	describe( '#handleSuccess', () => {
 		test( 'should dispatch failure action with error message', () => {
-			expect( handleSuccess() ).toMatchObject( {
+			expect( handleSuccess() ).toContainEqual( {
 				type: EMAIL_VERIFY_REQUEST_SUCCESS,
 			} );
+		} );
+
+		test( 'should dispatch success notice when showing global notices', () => {
+			expect( handleSuccess( { showGlobalNotices: true } ) ).toContainEqual(
+				successNotice( translate( 'Email sent' ), {
+					id: 'email-verification-success-notice',
+					duration: 4000,
+				} )
+			);
+		} );
+
+		test( 'should remove info notice when showing global notices', () => {
+			expect( handleSuccess( { showGlobalNotices: true } ) ).toContainEqual(
+				removeNotice( 'email-verification-info-notice' )
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the badge styles used in completed tasks and replaces it with the badge styles added to the generic task card in #41653. Margins have been adjusted to avoid jumping text when switching between pending and completed tasks.

![May-01-2020 12-47-03](https://user-images.githubusercontent.com/1233880/80802490-c6426880-8baf-11ea-9034-183cbb182db0.gif)

* Ensures the current task data is updated whenever any of its dependencies changes. This is useful for example for disabling the "Resend email" button while the verification email is being sent.
* Adds global notices support to the action that sends a verification email. This allowed to remove the dynamic action text depending on the verification email status.

Before | After
--- | ---
![May-01-2020 13-24-54](https://user-images.githubusercontent.com/1233880/80802728-72844f00-8bb0-11ea-8815-abac2d78d1f2.gif) | ![May-01-2020 13-23-24](https://user-images.githubusercontent.com/1233880/80802714-6ac4aa80-8bb0-11ea-809a-b2c02ac677f2.gif)

#### Testing instructions
- Go to `/start` and create a new user and site.
- Do not confirm your email (you'll need to test with a non-`@automattic.com` account).
- Select the "Confirm your email address" task.
- Click on "Resend email".
- Make sure a global notice shows up indicating the email is being/has been sent.
- Make sure the button is disabled when the email is being sent and is enabled again when the email has been sent.

