### PR TITLE
Rename the section from "Status" to "Latest Backups" (menu item and title)

### DIFF
--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -107,11 +107,11 @@ class JetpackCloudSidebar extends Component {
 							<ul>
 								<SidebarItem
 									expandSection={ this.expandBackupSection }
-									label={ translate( 'Status', {
-										comment: 'Jetpack Cloud / Backup status sidebar navigation item',
+									label={ translate( 'Latest backups', {
+										comment: 'Jetpack Cloud / Backup sidebar navigation item',
 									} ) }
 									link={ backupMainPath( selectedSiteSlug ) }
-									onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Status' ) }
+									onNavigate={ this.onNavigate( 'Jetpack Cloud Backup / Latest backups' ) }
 									selected={
 										itemLinkMatches( backupMainPath(), this.props.path ) &&
 										! itemLinkMatches( backupActivityPath(), this.props.path )

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -161,7 +161,7 @@ class BackupsPage extends Component {
 
 		return (
 			<Main>
-				<DocumentHead title={ translate( 'Backups' ) } />
+				<DocumentHead title={ translate( 'Latest Backups' ) } />
 				<SidebarNavigation />
 				<PageViewTracker path="/backups/:site" title="Backups" />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Rename the section from "Status" to "Latest Backups" (menu item and title):

![image](https://user-images.githubusercontent.com/9832440/80804592-89757200-8bad-11ea-904c-31daa860df14.png)


**Asana card:** 1142395350490785-as-1173475308570809

#### Testing instructions

- Check if the menu name change from "Status" to "Latest Backups" and also the title of the section (the tab title too) when we are on there.
