### PR TITLE
My Home: Activate new layout on production

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -31,6 +31,7 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, showChevron }
 				trackExpand();
 				onClick();
 			} }
+			data-task={ taskId }
 		>
 			<div className="nav-item__status">
 				{ isCompleted ? (

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -37,7 +37,7 @@
 		"google-my-business": false,
 		"help": true,
 		"help/courses": true,
-		"home/experimental-layout": false,
+		"home/experimental-layout": true,
 		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -42,7 +42,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"home/experimental-layout": false,
+		"home/experimental-layout": true,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -49,7 +49,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"home/experimental-layout": false,
+		"home/experimental-layout": true,
 		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/test.json
+++ b/config/test.json
@@ -40,7 +40,7 @@
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"help": true,
-		"home/experimental-layout": false,
+		"home/experimental-layout": true,
 		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,7 +56,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"home/experimental-layout": false,
+		"home/experimental-layout": true,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,

--- a/test/e2e/lib/pages/checklist-page.js
+++ b/test/e2e/lib/pages/checklist-page.js
@@ -16,13 +16,11 @@ const mochaTimeOut = config.get( 'mochaTimeoutMS' );
 
 export default class ChecklistPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
-		super( driver, By.css( '.customer-home__layout .checklist' ), url );
-		this.headerSelector = By.css( '.customer-home__layout .checklist-site-setup__heading' );
-		this.updateHomepageTaskSelector = By.css(
-			'.customer-home__layout .checklist__task button.checklist__task-title-button'
-		);
+		super( driver, By.css( '.customer-home__main .site-setup-list' ), url );
+		this.headerSelector = By.css( '.customer-home__main .site-setup-list .card-heading' );
+		this.taskNavItemSelector = By.css( '.customer-home__main .site-setup-list__nav .nav-item' );
 		this.updateHomepageButtonSelector = By.css(
-			'.customer-home__layout button[data-e2e-action="update-homepage"]'
+			'.customer-home__main button[data-task="front_page_updated"]'
 		);
 	}
 
@@ -42,7 +40,7 @@ export default class ChecklistPage extends AsyncBaseContainer {
 	}
 
 	async updateHomepage() {
-		const items = await this.driver.findElements( this.updateHomepageTaskSelector );
+		const items = await this.driver.findElements( this.taskNavItemSelector );
 		for ( let i = 0; i < items.length; i++ ) {
 			await items[ i ].click();
 			if (
@@ -52,10 +50,10 @@ export default class ChecklistPage extends AsyncBaseContainer {
 					mochaTimeOut / 2
 				)
 			) {
-				return await driverHelper.clickWhenClickable(
-					this.driver,
+				const updateHomePageButton = await this.driver.findElement(
 					this.updateHomepageButtonSelector
 				);
+				return this.driver.executeScript( 'arguments[0].click()', updateHomePageButton );
 			}
 		}
 	}

--- a/test/e2e/lib/pages/checklist-page.js
+++ b/test/e2e/lib/pages/checklist-page.js
@@ -50,10 +50,10 @@ export default class ChecklistPage extends AsyncBaseContainer {
 					mochaTimeOut / 2
 				)
 			) {
-				const updateHomePageButton = await this.driver.findElement(
+				return await driverHelper.clickWhenClickable(
+					this.driver,
 					this.updateHomepageButtonSelector
 				);
-				return this.driver.executeScript( 'arguments[0].click()', updateHomePageButton );
 			}
 		}
 	}

--- a/test/e2e/lib/pages/checklist-page.js
+++ b/test/e2e/lib/pages/checklist-page.js
@@ -3,7 +3,6 @@
  */
 import assert from 'assert';
 import { By } from 'selenium-webdriver';
-import config from 'config';
 
 /**
  * Internal dependencies
@@ -12,16 +11,14 @@ import * as driverHelper from '../driver-helper.js';
 
 import AsyncBaseContainer from '../async-base-container';
 
-const mochaTimeOut = config.get( 'mochaTimeoutMS' );
-
 export default class ChecklistPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
 		super( driver, By.css( '.customer-home__main .site-setup-list' ), url );
 		this.headerSelector = By.css( '.customer-home__main .site-setup-list .card-heading' );
-		this.taskNavItemSelector = By.css( '.customer-home__main .site-setup-list__nav .nav-item' );
-		this.updateHomepageButtonSelector = By.css(
-			'.customer-home__main button[data-task="front_page_updated"]'
+		this.updateHomepageTaskSelector = By.css(
+			'.customer-home__main [data-task="front_page_updated"]'
 		);
+		this.startTaskButtonSelector = By.css( '.customer-home__main .site-setup-list__task-action' );
 	}
 
 	async headerExists() {
@@ -40,21 +37,7 @@ export default class ChecklistPage extends AsyncBaseContainer {
 	}
 
 	async updateHomepage() {
-		const items = await this.driver.findElements( this.taskNavItemSelector );
-		for ( let i = 0; i < items.length; i++ ) {
-			await items[ i ].click();
-			if (
-				await driverHelper.isEventuallyPresentAndDisplayed(
-					this.driver,
-					this.updateHomepageButtonSelector,
-					mochaTimeOut / 2
-				)
-			) {
-				return await driverHelper.clickWhenClickable(
-					this.driver,
-					this.updateHomepageButtonSelector
-				);
-			}
-		}
+		await driverHelper.clickWhenClickable( this.driver, this.updateHomepageTaskSelector );
+		return await driverHelper.clickWhenClickable( this.driver, this.startTaskButtonSelector );
 	}
 }


### PR DESCRIPTION
Do not merge before release date (May 6). See p7DVsv-8zA-p2.

#### Changes proposed in this Pull Request

Activates the new My Home layout in production. It also updates the selectors for the "update homepage" task used in the signup E2E tests. 

Fixes https://github.com/Automattic/wp-calypso/issues/41696