### PR TITLE
My Home: Update illustration for domain task card

### DIFF
--- a/client/assets/images/customer-home/illustration--task-find-domain.svg
+++ b/client/assets/images/customer-home/illustration--task-find-domain.svg
@@ -1,0 +1,17 @@
+<svg width="225" height="227" viewBox="0 0 225 227" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="112" cy="127" r="100" fill="#E6F2E8"/>
+<path d="M0.5 108C0.5 108.276 0.723858 108.5 1 108.5H224C224.276 108.5 224.5 108.276 224.5 108V91.3333C224.5 88.9524 223.331 86.6966 221.3 85.0522C219.272 83.41 216.54 82.5 213.708 82.5H11.2923C8.46018 82.5 5.72809 83.41 3.69991 85.0522C1.66889 86.6966 0.5 88.9524 0.5 91.3333V108Z" fill="white" stroke="#2C3338" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M224 91.3333V108H13.5L52 83H213.708C216.437 83 219.055 83.878 220.985 85.4408C222.916 87.0036 224 89.1232 224 91.3333Z" fill="#E9EFF5"/>
+<path d="M14.5 100C16.9853 100 19 97.9853 19 95.5C19 93.0147 16.9853 91 14.5 91C12.0147 91 10 93.0147 10 95.5C10 97.9853 12.0147 100 14.5 100Z" fill="#FFABAF" stroke="#E65054" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M31.5 100C33.9853 100 36 97.9853 36 95.5C36 93.0147 33.9853 91 31.5 91C29.0147 91 27 93.0147 27 95.5C27 97.9853 29.0147 100 31.5 100Z" fill="#F2CF75" stroke="#B69000" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M48.5 100C50.9853 100 53 97.9853 53 95.5C53 93.0147 50.9853 91 48.5 91C46.0147 91 44 93.0147 44 95.5C44 97.9853 46.0147 100 48.5 100Z" fill="#68DE86" stroke="#00A32A" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="0.5" y="108.5" width="224" height="40" fill="white" stroke="#2C3338"/>
+<rect x="47.5" y="115.5" width="170" height="26" fill="white" stroke="#72AEE6" stroke-linejoin="round"/>
+<rect x="48.5" y="116.5" width="168" height="24" fill="white" stroke="#135E96"/>
+<rect x="57" y="125" width="103" height="7" fill="#2C3338"/>
+<path d="M13.3065 121L7.5 127M7.5 127L13.3065 133M7.5 127H19.5" stroke="#A7AAAD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M33.1935 121L39 127M39 127L33.1935 133M39 127H27" stroke="#A7AAAD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M112 189L112 167.693M112 1L112 68.68" stroke="#F0C930" stroke-width="2" stroke-linecap="round"/>
+<path d="M204 206.652L197.465 200.116M31.7998 34.4515L37.6991 40.3507M64.6838 67.3354L43.7148 46.3664M166.087 168.739L190.821 193.473" stroke="#F0C930" stroke-width="2" stroke-linecap="round"/>
+<path d="M39.8201 202.458L46.4139 194.468M185.222 26.2822L160.699 55.9955M66.6133 169.994L51.0753 188.82" stroke="#F0C930" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/client/my-sites/customer-home/cards/tasks/find-domain/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/find-domain/index.jsx
@@ -12,6 +12,11 @@ import { preventWidows } from 'lib/formatting';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import Task from '../task';
 
+/**
+ * Image dependencies
+ */
+import findDomainIllustration from 'assets/images/customer-home/illustration--task-find-domain.svg';
+
 const FindDomain = ( { siteSlug } ) => {
 	const translate = useTranslate();
 
@@ -25,7 +30,7 @@ const FindDomain = ( { siteSlug } ) => {
 			) }
 			actionText={ translate( 'Find a domain' ) }
 			actionUrl={ `/domains/add/${ siteSlug }` }
-			illustration="/calypso/images/stats/tasks/social-links.svg"
+			illustration={ findDomainIllustration }
 			timing={ 10 }
 			taskId="find-domain"
 		/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the illustration for the "Find a domain" task card in the new My Home layout.

Before | After
------------ | -------------
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/448298/80838026-057bb400-8bc6-11ea-82a2-45e47cf4261b.png"> | <img width="1159" alt="Screen Shot 2020-05-01 at 4 02 01 PM" src="https://user-images.githubusercontent.com/448298/80837940-ce0d0780-8bc5-11ea-9e5a-be709e70b975.png">


#### Testing instructions
I'm sure there's a proper way to do it, but I just hacked my local branch:

* Checkout this branch
* Return `<FindDomain />` in `client/my-sites/customer-home/locations/primary/index.jsx`
* Visit My Home on any site using the `home/experimental-layout` feature flag
* Confirm the correct illustration shows.

Fixes https://github.com/Automattic/dotcom-private/issues/49