### PR TITLE
My Home: Update copy on webinar task card

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
@@ -15,10 +15,9 @@ const Webinars = () => {
 
 	return (
 		<Task
-			title={ translate( 'Get hands-on learning' ) }
+			title={ translate( 'Learn from the pros' ) }
 			description={ translate(
-				'Join one of our live video webinars designed to help you get started ' +
-					'or learn more advanced features.'
+				'Free, live video webinars led by our experts teach you to build a website, start a blog, or make money with your site.'
 			) }
 			actionText={ translate( 'Register for free' ) }
 			actionOnClick={ () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updating copy on the webinar promo task card in the new My Home layout as per the comment in https://github.com/Automattic/wp-calypso/pull/41460#issuecomment-621377686

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/448298/80842060-ac644e00-8bce-11ea-95a3-e73cfd4ce933.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch on your local Calypso
* Return `<Webinars />` in `client/my-sites/customer-home/locations/primary/index.jsx` as a hack-y way to show the webinar promo
* Confirm the copy matches the screenshot above
