### PR TITLE
Add managed mode to ContactDetailsFormFields

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -3,7 +3,7 @@
  *
  */
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { identity, includes, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -21,7 +21,7 @@ import EuAddressFieldset from './eu-address-fieldset';
 import UkAddressFieldset from './uk-address-fieldset';
 import { Input, HiddenInput } from 'my-sites/domains/components/form';
 
-export class RegionAddressFieldsets extends Component {
+export class RegionAddressFieldsets extends PureComponent {
 	static propTypes = {
 		getFieldProps: PropTypes.func,
 		translate: PropTypes.func,

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -176,6 +176,7 @@ export class ContactDetailsFormFields extends Component {
 		);
 
 	getMainFieldValues( form ) {
+		form = form || this.state.form;
 		const mainFieldValues = formState.getAllFieldValues( form );
 		const { needsFax } = this.props;
 		const { countryCode } = mainFieldValues;

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -172,8 +172,8 @@ export class ContactDetailsFormFields extends Component {
 			pick( this.props.contactDetails, CONTACT_DETAILS_FORM_FIELDS )
 		);
 
-	getMainFieldValues() {
-		const mainFieldValues = formState.getAllFieldValues( this.state.form );
+	getMainFieldValues( form ) {
+		const mainFieldValues = formState.getAllFieldValues( form );
 		const { needsFax } = this.props;
 		const { countryCode } = mainFieldValues;
 		let state = mainFieldValues.state;
@@ -205,8 +205,11 @@ export class ContactDetailsFormFields extends Component {
 		};
 	}
 
-	setFormState = ( form ) =>
-		this.setState( { form }, () => this.props.onContactDetailsChange( this.getMainFieldValues() ) );
+	setFormState = ( form ) => {
+		this.setState( { form }, () => {
+			this.props.onContactDetailsChange( this.getMainFieldValues( form ) );
+		} );
+	};
 
 	handleFormControllerError = ( error ) => {
 		throw error;
@@ -244,7 +247,8 @@ export class ContactDetailsFormFields extends Component {
 	};
 
 	validate = ( fieldValues, onComplete ) =>
-		this.props.onValidate && this.props.onValidate( this.getMainFieldValues(), onComplete );
+		this.props.onValidate &&
+		this.props.onValidate( this.getMainFieldValues( this.state.form ), onComplete );
 
 	getRefCallback( name ) {
 		if ( ! this.inputRefCallbacks[ name ] ) {
@@ -304,12 +308,12 @@ export class ContactDetailsFormFields extends Component {
 					this.focusFirstError();
 					return;
 				}
-				this.props.onSubmit( this.getMainFieldValues() );
+				this.props.onSubmit( this.getMainFieldValues( this.state.form ) );
 			} );
 			return;
 		}
 		this.recordSubmit();
-		this.props.onSubmit( this.getMainFieldValues() );
+		this.props.onSubmit( this.getMainFieldValues( this.state.form ) );
 	};
 
 	handleFieldChange = ( event ) => {
@@ -327,13 +331,12 @@ export class ContactDetailsFormFields extends Component {
 		if ( this.props.isManaged ) {
 			let form = updateFormWithContactChange( this.state.form, name, value );
 			if ( name === 'country-code' ) {
-				form = updateFormWithContactChange( this.state.form, 'state', '', {
+				form = updateFormWithContactChange( form, 'state', '', {
 					isShowingErrors: false,
 				} );
 			}
 
 			this.setFormState( form );
-
 			return;
 		}
 
@@ -641,18 +644,16 @@ function getStateFromContactDetails( contactDetails, contactDetailsErrors ) {
 	return { form };
 }
 
-function updateFormWithContactChange( state, key, value, additionalProperties ) {
+function updateFormWithContactChange( form, key, value, additionalProperties ) {
 	return {
-		...state,
-		form: {
-			[ key ]: {
-				value,
-				errors: [],
-				isShowingErrors: true,
-				isPendingValidation: false,
-				isValidating: false,
-				...( additionalProperties ?? {} ),
-			},
+		...form,
+		[ camelCase( key ) ]: {
+			value,
+			errors: [],
+			isShowingErrors: true,
+			isPendingValidation: false,
+			isValidating: false,
+			...( additionalProperties ?? {} ),
 		},
 	};
 }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -113,7 +113,7 @@ export class ContactDetailsFormFields extends Component {
 		super( props );
 		this.state = {
 			phoneCountryCode: this.props.countryCode || this.props.userCountryCode,
-			form: null,
+			form: {},
 			submissionCount: 0,
 		};
 
@@ -141,7 +141,7 @@ export class ContactDetailsFormFields extends Component {
 		);
 	}
 
-	UNSAFE_componentWillMount() {
+	componentDidMount() {
 		if ( ! this.props.isManaged ) {
 			this.formStateController = formState.Controller( {
 				debounceWait: 500,
@@ -338,14 +338,14 @@ export class ContactDetailsFormFields extends Component {
 		}
 
 		if ( name === 'country-code' ) {
-			this.formStateController.handleFieldChange( {
+			this.formStateController?.handleFieldChange( {
 				name: 'state',
 				value: '',
 				hideError: true,
 			} );
 		}
 
-		this.formStateController.handleFieldChange( {
+		this.formStateController?.handleFieldChange( {
 			name,
 			value,
 		} );
@@ -364,7 +364,7 @@ export class ContactDetailsFormFields extends Component {
 			return;
 		}
 
-		this.formStateController.handleFieldChange( {
+		this.formStateController?.handleFieldChange( {
 			name: 'phone',
 			value,
 		} );

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -126,6 +126,9 @@ export class ContactDetailsFormFields extends Component {
 	// `formState` forces multiple updates to `this.state`
 	// This is an attempt limit the redraws to only what we need.
 	shouldComponentUpdate( nextProps, nextState ) {
+		if ( nextProps.isManaged ) {
+			return true;
+		}
 		return (
 			nextProps.shouldForceRenderOnPropChange === true ||
 			( nextProps.isSubmitting === false && this.props.isSubmitting === true ) ||
@@ -399,7 +402,7 @@ export class ContactDetailsFormFields extends Component {
 
 	createField = ( name, componentClass, additionalProps, fieldPropOptions = {} ) => {
 		return createElement( componentClass, {
-			...this.getFieldProps( name, { ...fieldPropOptions } ),
+			...this.getFieldProps( name, fieldPropOptions ),
 			...additionalProps,
 		} );
 	};

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -204,9 +204,11 @@ export class ContactDetailsFormFields extends Component {
 			...mainFieldValues,
 			fax,
 			state,
-			phone: toIcannFormat( mainFieldValues.phone, countries[ this.state.phoneCountryCode ] ),
+			phone: mainFieldValues.phone
+				? toIcannFormat( mainFieldValues.phone, countries[ this.state.phoneCountryCode ] )
+				: '',
 		};
-	}
+	};
 
 	getFormState = () => {
 		// Primarily for tests to use

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -176,7 +176,6 @@ export class ContactDetailsFormFields extends Component {
 		);
 
 	getMainFieldValues( form ) {
-		form = form || this.state.form;
 		const mainFieldValues = formState.getAllFieldValues( form );
 		const { needsFax } = this.props;
 		const { countryCode } = mainFieldValues;
@@ -208,6 +207,11 @@ export class ContactDetailsFormFields extends Component {
 			phone: toIcannFormat( mainFieldValues.phone, countries[ this.state.phoneCountryCode ] ),
 		};
 	}
+
+	getFormState = () => {
+		// Primarily for tests to use
+		return this.state.form;
+	};
 
 	setStateAndUpdateParent = ( newState ) => {
 		this.setState( newState, () => {

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -175,7 +175,7 @@ export class ContactDetailsFormFields extends Component {
 			pick( this.props.contactDetails, CONTACT_DETAILS_FORM_FIELDS )
 		);
 
-	getMainFieldValues( form ) {
+	getMainFieldValues = ( form ) => {
 		const mainFieldValues = formState.getAllFieldValues( form );
 		const { needsFax } = this.props;
 		const { countryCode } = mainFieldValues;

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -209,10 +209,14 @@ export class ContactDetailsFormFields extends Component {
 		};
 	}
 
-	setFormState = ( form ) => {
-		this.setState( { form }, () => {
-			this.props.onContactDetailsChange( this.getMainFieldValues( form ) );
+	setStateAndUpdateParent = ( newState ) => {
+		this.setState( newState, () => {
+			this.props.onContactDetailsChange( this.getMainFieldValues( newState.form ) );
 		} );
+	};
+
+	setFormState = ( form ) => {
+		this.setStateAndUpdateParent( { form } );
 	};
 
 	handleFormControllerError = ( error ) => {
@@ -322,25 +326,21 @@ export class ContactDetailsFormFields extends Component {
 
 	handleFieldChange = ( event ) => {
 		const { name, value } = event.target;
-		const { phone = {} } = this.state.form;
+		const newState = { ...this.state };
 
-		if ( name === 'country-code' ) {
-			if ( value && ! phone.value ) {
-				this.setState( {
-					phoneCountryCode: value,
-				} );
-			}
+		if ( name === 'country-code' && value && ! newState.phone?.value ) {
+			newState.phoneCountryCode = value;
 		}
 
 		if ( this.props.isManaged ) {
-			let form = updateFormWithContactChange( this.state.form, name, value );
+			newState.form = updateFormWithContactChange( newState.form, name, value );
 			if ( name === 'country-code' ) {
-				form = updateFormWithContactChange( form, 'state', '', {
+				newState.form = updateFormWithContactChange( newState.form, 'state', '', {
 					isShowingErrors: false,
 				} );
 			}
 
-			this.setFormState( form );
+			this.setStateAndUpdateParent( newState );
 			return;
 		}
 
@@ -359,15 +359,15 @@ export class ContactDetailsFormFields extends Component {
 	};
 
 	handlePhoneChange = ( { value, countryCode } ) => {
+		const newState = { ...this.state };
+
 		if ( countries[ countryCode ] ) {
-			this.setState( {
-				phoneCountryCode: countryCode,
-			} );
+			newState.phoneCountryCode = countryCode;
 		}
 
 		if ( this.props.isManaged ) {
-			const form = updateFormWithContactChange( this.state.form, 'phone', value );
-			this.setFormState( form );
+			newState.form = updateFormWithContactChange( newState.form, 'phone', value );
+			this.setStateAndUpdateParent( newState );
 			return;
 		}
 

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -191,9 +191,9 @@ describe( 'ContactDetailsFormFields', () => {
 			);
 			wrapper.setProps( { hasCountryStates: true } );
 
-			expect( wrapper.instance().getMainFieldValues().state ).toEqual(
-				defaultProps.contactDetails.state
-			);
+			expect(
+				wrapper.instance().getMainFieldValues( wrapper.instance().getFormState() ).state
+			).toEqual( defaultProps.contactDetails.state );
 		} );
 		test( 'should return province/state value when the country does not have states', () => {
 			const onContactDetailsChange = jest.fn();
@@ -206,9 +206,9 @@ describe( 'ContactDetailsFormFields', () => {
 			);
 			wrapper.setProps( { hasCountryStates: false } );
 
-			expect( wrapper.instance().getMainFieldValues().state ).toEqual(
-				defaultProps.contactDetails.state
-			);
+			expect(
+				wrapper.instance().getMainFieldValues( wrapper.instance().getFormState() ).state
+			).toEqual( defaultProps.contactDetails.state );
 		} );
 	} );
 

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -21,8 +21,6 @@ import {
 import update from 'immutability-helper';
 
 function Controller( options ) {
-	let debounceWait;
-
 	if ( ! ( this instanceof Controller ) ) {
 		return new Controller( options );
 	}
@@ -47,7 +45,7 @@ function Controller( options ) {
 	this._pendingValidation = null;
 	this._onValidationComplete = null;
 
-	debounceWait = isUndefined( options.debounceWait ) ? 1000 : options.debounceWait;
+	const debounceWait = isUndefined( options.debounceWait ) ? 1000 : options.debounceWait;
 	this._debouncedSanitize = debounce( this.sanitize, debounceWait );
 	this._debouncedValidate = debounce( this.validate, debounceWait );
 
@@ -79,10 +77,10 @@ assign( Controller.prototype, {
 	},
 
 	handleFieldChange: function ( change ) {
-		let formState = this._currentState,
-			name = camelCase( change.name ),
-			value = change.value,
-			hideError = this._hideFieldErrorsOnChange || change.hideError;
+		const formState = this._currentState;
+		const name = camelCase( change.name );
+		const value = change.value;
+		const hideError = this._hideFieldErrorsOnChange || change.hideError;
 
 		this._setState( changeFieldValue( formState, name, value, hideError ) );
 
@@ -137,8 +135,8 @@ assign( Controller.prototype, {
 	},
 
 	validate: function () {
-		let fieldValues = getAllFieldValues( this._currentState ),
-			id = uniqueId();
+		const fieldValues = getAllFieldValues( this._currentState );
+		const id = uniqueId();
 
 		this._setState( setFieldsValidating( this._currentState ) );
 
@@ -176,13 +174,12 @@ assign( Controller.prototype, {
 } );
 
 function changeFieldValue( formState, name, value, hideFieldErrorsOnChange ) {
-	let fieldState = getField( formState, name ),
-		command = {},
-		errors;
+	const fieldState = getField( formState, name );
+	const command = {};
 
 	// We reset the errors if we weren't showing them already to avoid a flash of
 	// error messages when the user starts typing.
-	errors = fieldState.isShowingErrors ? fieldState.errors : [];
+	const errors = fieldState.isShowingErrors ? fieldState.errors : [];
 
 	command[ name ] = {
 		$merge: {

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -284,7 +284,7 @@ function createInitialFormState( fieldValues ) {
 }
 
 function getField( formState, fieldName ) {
-	return formState[ camelCase( fieldName ) ];
+	return formState[ camelCase( fieldName ) ] ?? {};
 }
 
 function getFieldValue( formState, fieldName ) {

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -309,6 +309,7 @@ export default function CompositeCheckout( {
 				onContactDetailsChange={ updateDomainContactFields }
 				shouldForceRenderOnPropChange={ true }
 				getIsFieldDisabled={ getIsFieldDisabled }
+				isManaged={ true }
 			/>
 		);
 	};

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -307,7 +307,6 @@ export default function CompositeCheckout( {
 					shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
 				}
 				onContactDetailsChange={ updateDomainContactFields }
-				shouldForceRenderOnPropChange={ true }
 				getIsFieldDisabled={ getIsFieldDisabled }
 				isManaged={ true }
 			/>

--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -15,7 +15,7 @@ import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormSelect from 'components/forms/form-select';
 
-class CountrySelect extends React.Component {
+class CountrySelect extends React.PureComponent {
 	recordCountrySelectClick = () => {
 		if ( this.props.eventFormName ) {
 			gaRecordEvent( 'Upgrades', `Clicked ${ this.props.eventFormName } Country Select` );

--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 
@@ -23,38 +23,9 @@ class CountrySelect extends React.PureComponent {
 	};
 
 	render() {
-		const { countriesList } = this.props;
-		const classes = classNames( this.props.additionalClasses, 'country' );
-
-		let options = [];
-		let { value } = this.props;
-		value = value || '';
-
-		if ( isEmpty( countriesList ) ) {
-			options.push( {
-				key: 'loading',
-				label: this.props.translate( 'Loading…' ),
-			} );
-		} else {
-			options = options.concat( [
-				{ key: 'select-country', label: this.props.translate( 'Select Country' ), value: '' },
-				{ key: 'divider1', label: '', disabled: 'disabled', value: '-' },
-			] );
-
-			options = options.concat(
-				countriesList.map( ( country ) => {
-					if ( isEmpty( country.code ) ) {
-						return { key: country.code, label: '', disabled: 'disabled', value: '-' };
-					}
-
-					return {
-						key: country.code,
-						label: country.name,
-						value: country.code,
-					};
-				} )
-			);
-		}
+		const { countriesList, value, additionalClasses } = this.props;
+		const classes = classNames( additionalClasses, 'country' );
+		const options = getOptionsFromCountriesList( countriesList );
 
 		const validationId = `validation-field-${ this.props.name }`;
 
@@ -68,7 +39,7 @@ class CountrySelect extends React.PureComponent {
 						aria-describedby={ validationId }
 						name={ this.props.name }
 						id={ this.props.name }
-						value={ value }
+						value={ value || '' }
 						disabled={ this.props.disabled }
 						inputRef={ this.props.inputRef }
 						onChange={ this.props.onChange }
@@ -89,6 +60,44 @@ class CountrySelect extends React.PureComponent {
 			</div>
 		);
 	}
+}
+
+function getOptionsFromCountriesList( countriesList ) {
+	if ( isEmpty( countriesList ) ) {
+		return [
+			{
+				key: 'loading',
+				label: translate( 'Loading…' ),
+			},
+		];
+	}
+
+	const initialOptions = [
+		{ key: 'select-country', label: translate( 'Select Country' ), value: '' },
+		{ key: 'divider1', label: '', disabled: 'disabled', value: '-' },
+	];
+
+	const countryOptions = countriesList.reduce( ( collected, country, index ) => {
+		if ( isEmpty( country.code ) ) {
+			return [
+				...collected,
+				{ key: `inner-divider${ index }`, label: '', disabled: 'disabled', value: '-' },
+			];
+		}
+
+		const duplicates = collected.filter( ( prevCountry ) => prevCountry.value === country.code );
+
+		return [
+			...collected,
+			{
+				key: `${ country.code }-${ duplicates.length }`,
+				label: country.name,
+				value: country.code,
+			},
+		];
+	}, [] );
+
+	return [ ...initialOptions, ...countryOptions ];
 }
 
 export default localize( CountrySelect );

--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -42,13 +42,13 @@ class CountrySelect extends React.PureComponent {
 			] );
 
 			options = options.concat(
-				countriesList.map( ( country, index ) => {
+				countriesList.map( ( country ) => {
 					if ( isEmpty( country.code ) ) {
-						return { key: index, label: '', disabled: 'disabled', value: '-' };
+						return { key: country.code, label: '', disabled: 'disabled', value: '-' };
 					}
 
 					return {
-						key: index,
+						key: country.code,
 						label: country.name,
 						value: country.code,
 					};

--- a/client/my-sites/domains/components/form/state-select.jsx
+++ b/client/my-sites/domains/components/form/state-select.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
@@ -20,7 +20,7 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 import scrollIntoViewport from 'lib/scroll-into-viewport';
 import Input from './input';
 
-class StateSelect extends Component {
+class StateSelect extends PureComponent {
 	static instances = 0;
 
 	inputRef = ( element ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The (rather old) `ContactDetailsFormFields` component is currently being used in two ways. 

Its original incarnation, still used by old checkout and payment management screens, uses a state management object created by `lib/form-state` as a singleton form state manager that deals with updates, validation, etc.

For composite checkout, we have need to keep our form state external to the `ContactDetailsFormFields`, so we had added several props to make it more like a partially managed component. I say "partially" because the flow worked as follows: 

- On initial render, the props were used to set the state, which was used to set the field values.
- When a field changed, the state was changed, and a callback was called so the parent could receive the updated data.
- If the data in the props changed, _nothing happened_.

This means that the component was still managing itself for the most part, and just informing its parent about the new state.

This PR modifies the component by adding a new prop called `isManaged`. If true, the prop actually sidesteps the state management object entirely, using only the component's local state as a cache, and updating it whenever the props change.

It also improves the performance of `ContactDetailsFormFields` which was rather slow when rendering large select lists (eg: countries, states).

Depends on #41783 being merged first.

#### Testing instructions

Since this heavily modifies the component, we'll need to test both its modes.

First, to test the original behavior (which should not be affected by this PR), visit old checkout with a domain in your cart. Fill out the form fields and be sure that they update as expected when you type. Try setting invalid data and blurring the fields to be sure that you see a validation error. Leave a field blank and try to submit the form and verify that the blank field is marked and focused. Try changing the country and make sure that the fields change. Fill in all fields correctly and verify that submitting the form works as expected.

Next, to test the managed behavior, visit composite checkout with a domain in your cart. Fill out the form fields and be sure that they update as expected when you type. Try setting invalid data and pressing Continue to be sure that you see a validation error. Leave a field blank and try to press Continue and verify that the blank field is marked. Try changing the country and make sure that the fields change. Fill in all fields correctly and verify that pressing "Continue" works as expected.