### PR TITLE
Make theme images cover their entire containers

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -90,7 +90,9 @@ const DesignSelector: React.FunctionComponent = () => {
 								<img
 									alt=""
 									aria-labelledby={ makeOptionId( design ) }
-									src={ getDesignUrl( design ) }
+									style={ {
+										backgroundImage: `url( ${ getDesignUrl( design ) } )`,
+									} }
 								/>
 							</span>
 							<span className="design-selector__option-overlay">

--- a/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/style.scss
@@ -113,7 +113,9 @@
 			right: 0;
 			margin: 0 auto;
 			width: 100%;
-			height: auto;
+			height: 100%;
+			background-size: cover;
+			background-position: center;
 		}
 	}
 


### PR DESCRIPTION
#### Changes

use `background-size: cover` so that small theme images are scaled up to be a consistent size. See #40711

#### Before
![Screen Shot 2020-05-04 at 12 14 32 PM](https://user-images.githubusercontent.com/22446385/80932151-870b5600-8e01-11ea-8612-ad4db1f0b948.png)

#### After
See rightmost theme: 
<img width="1409" alt="Screen Shot 2020-05-04 at 12 14 47 PM" src="https://user-images.githubusercontent.com/22446385/80932159-925e8180-8e01-11ea-8b94-d0bb84f60ee7.png">

fixes #40711
