### PR TITLE
Gutenboarding: Show fixed footer on domain picker modal for mobile view.

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -50,7 +50,11 @@
 	}
 
 	.domain-picker__header-title {
-		@include onboarding-heading-text;
+		@include onboarding-heading-text-mobile;
+
+		@include break-mobile {
+			@include onboarding-heading-text;
+		}
 	}
 
 	// Do not display domain picker footer which contains

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -66,6 +66,26 @@
 		display: none;
 	}
 
+	// Show confirm button on fixed footer on mobile view
+	@media ( max-width: $break-medium ) {
+
+		.domain-picker__header .domain-picker__confirm-button {
+			display: none;
+		}
+
+		.domain-picker__footer {
+			flex-direction: row-reverse;
+		}
+
+		.domain-picker__panel-row-footer {
+			display: block;
+			position: fixed;
+			width: 100%;
+			bottom: 0;
+			background: var( --studio-white );
+		}
+	}
+
 	.domain-picker__search {
 		margin-bottom: 60px;
 

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -84,6 +84,11 @@
 			bottom: 0;
 			background: var( --studio-white );
 		}
+
+		// Space to accomodate sticky footer
+		.domain-picker__panel-row-main {
+			margin-bottom: 85px;
+		}
 	}
 
 	.domain-picker__search {

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -87,7 +87,9 @@
 
 		// Space to accomodate sticky footer
 		.domain-picker__panel-row-main {
-			margin-bottom: 85px;
+			&.components-panel__row {
+				margin-bottom: 85px;
+			}
 		}
 	}
 

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -53,13 +53,6 @@
 		@include onboarding-heading-text;
 	}
 
-	// Move the confirm button slightly lower
-	// to align with the larger heading.
-	.domain-picker__confirm-button {
-		position: relative;
-		top: 5px;
-	}
-
 	// Do not display domain picker footer which contains
 	// the confirm button when showing inside a modal.
 	.domain-picker__panel-row-footer {

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -60,7 +60,7 @@
 	}
 
 	// Show confirm button on fixed footer on mobile view
-	@media ( max-width: $break-medium ) {
+	@media ( max-width: $break-mobile ) {
 
 		.domain-picker__header .domain-picker__confirm-button {
 			display: none;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -38,8 +38,12 @@ $domain-picker__suggestion-item-height: 24px;
 }
 
 .domain-picker__panel-row-footer {
-	padding: 24px 36px;
+	padding: 10px 20px;
 	border-top: 1px solid #f0f0f0;
+
+	@include break-small {
+		padding: 24px 36px;
+	}
 }
 
 .domain-picker__header {


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Show fixed footer on domain picker modal for mobile view.

## Testing instructions

* Open up domain picker modal in `/new`.
* Sticky footer should show in mobile view (iPhone devices).
* Also, test this in iOS simulator.

## Screenshots

![image](https://user-images.githubusercontent.com/1287077/80946272-f2e3c380-8ded-11ea-8c68-6f40edfd53db.png)
