### PR TITLE
Gutenboarding: Add preview to font selection page in mobile view

### DIFF
--- a/client/landing/gutenboarding/components/bottom-bar-mobile/index.tsx
+++ b/client/landing/gutenboarding/components/bottom-bar-mobile/index.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import Link from '../link';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	backUrl: string;
+	onContinue: () => void;
+}
+
+const BottomBarMobile: React.FunctionComponent< Props > = ( { backUrl, onContinue } ) => {
+	const { __ } = useI18n();
+	return (
+		<div className="bottom-bar-mobile">
+			<Link className="bottom-bar-mobile__go-back-button" isLink to={ backUrl }>
+				{ __( 'Go back' ) }
+			</Link>
+			<Button
+				className="bottom-bar-mobile__continue-button"
+				isPrimary
+				isLarge
+				onClick={ onContinue }
+			>
+				{ __( 'Continue' ) }
+			</Button>
+		</div>
+	);
+};
+
+export default BottomBarMobile;

--- a/client/landing/gutenboarding/components/bottom-bar-mobile/style.scss
+++ b/client/landing/gutenboarding/components/bottom-bar-mobile/style.scss
@@ -1,0 +1,31 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../variables.scss';
+
+.bottom-bar-mobile {
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	height: $gutenboarding-footer-height;
+	background-color: $white;
+	border-top: 1px solid $light-gray-500;
+	padding: 0 20px;
+	display: flex;
+	align-items: center;
+
+	.bottom-bar-mobile__go-back-button.is-link {
+		color: var( --color-text-subtle );
+	}
+
+	.bottom-bar-mobile__continue-button {
+		margin-left: auto;
+		width: auto;
+		height: auto;
+		padding: 13px 29px;
+	}
+
+	@include break-small {
+		display: none;
+	}
+
+}

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -21,6 +21,7 @@ import { USER_STORE } from '../../stores/user';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 import SignupForm from '../../components/signup-form';
 import { useTrackStep } from '../../hooks/use-track-step';
+import BottomBarMobile from '../../components/bottom-bar-mobile';
 
 import './style.scss';
 
@@ -63,56 +64,47 @@ const StylePreview: React.FunctionComponent = () => {
 	);
 
 	return (
-		<div className="gutenboarding-page style-preview">
-			<div className="style-preview__header">
-				<div className="style-preview__titles">
-					<Title>{ __( 'Pick a font pairing' ) }</Title>
-					<SubTitle>
-						{ __( 'Customize your design with typography. You can always fine-tune it later.' ) }
-					</SubTitle>
+		<>
+			<div className="gutenboarding-page style-preview">
+				<div className="style-preview__header">
+					<div className="style-preview__titles">
+						<Title>{ __( 'Pick a font pairing' ) }</Title>
+						<SubTitle>
+							{ __( 'Customize your design with typography. You can always fine-tune it later.' ) }
+						</SubTitle>
+					</div>
+					<ViewportSelect selected={ selectedViewport } onSelect={ setSelectedViewport } />
+					<div className="style-preview__actions">
+						<Link isLink to={ makePath( Step.DesignSelection ) }>
+							{ __( 'Choose another design' ) }
+						</Link>
+						{ hasSelectedDesign && (
+							<Button
+								className="style-preview__actions-continue-button"
+								isPrimary
+								isLarge
+								onClick={ () =>
+									currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
+								}
+							>
+								{ __( 'Continue' ) }
+							</Button>
+						) }
+					</div>
 				</div>
-				<ViewportSelect selected={ selectedViewport } onSelect={ setSelectedViewport } />
-				<div className="style-preview__actions">
-					<Link isLink to={ makePath( Step.DesignSelection ) }>
-						{ __( 'Choose another design' ) }
-					</Link>
-					{ hasSelectedDesign && (
-						<Button
-							className="style-preview__actions-continue-button"
-							isPrimary
-							isLarge
-							onClick={ () =>
-								currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
-							}
-						>
-							{ __( 'Continue' ) }
-						</Button>
-					) }
+				<div className="style-preview__content">
+					<FontSelect />
+					<Preview viewport={ selectedViewport } />
 				</div>
+				{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }
 			</div>
-			<div className="style-preview__content">
-				<FontSelect />
-				<Preview viewport={ selectedViewport } />
-				<div className="style-preview__actions-mobile">
-					{ hasSelectedDesign && (
-						<Button
-							className="style-preview__actions-mobile-continue-button"
-							isPrimary
-							isLarge
-							onClick={ () =>
-								currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
-							}
-						>
-							{ __( 'Continue' ) }
-						</Button>
-					) }
-					<Link isLink to={ makePath( Step.DesignSelection ) }>
-						{ __( 'Choose another design' ) }
-					</Link>
-				</div>
-			</div>
-			{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }
-		</div>
+			<BottomBarMobile
+				backUrl={ makePath( Step.DesignSelection ) }
+				onContinue={ () =>
+					currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
+				}
+			/>
+		</>
 	);
 };
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -3,10 +3,14 @@
 @import '../../variables.scss';
 
 .style-preview {
-	// Full height comes from viewport heigh - header - some space for the preview's box-shadow (20px)
-	height: calc( 100vh - #{$gutenboarding-header-height + 20px} );
+	height: auto;
 	display: flex;
 	flex-direction: column;
+
+	@include break-small {
+		// Full height comes from viewport heigh - header - some space for the preview's box-shadow (20px)
+		height: calc( 100vh - #{$gutenboarding-header-height + 20px} );
+	}
 }
 
 .style-preview__header {
@@ -134,8 +138,7 @@
 }
 
 .style-preview__content {
-	height: 100%;
-	padding-bottom: $gutenboarding-footer-height + 8px;
+	padding-bottom: $gutenboarding-footer-height + 28px;
 
 	@include break-small {
 		padding-bottom: 0;
@@ -157,13 +160,14 @@
 		width: 100%;
 		grid-template-areas: 'preview' 'fonts';
 		grid-template-columns: auto;
-		grid-template-rows: auto;
+		grid-template-rows: 240px auto;
 
 		@include break-small {
 			column-gap: 50px;
 			flex: 1;
 			grid-template-areas: 'fonts preview';
 			grid-template-columns: 163px auto;
+			grid-template-rows: auto;
 		}
 
 		@include break-medium {
@@ -236,7 +240,6 @@
 	float: left;
 	width: 100%;
 	max-width: 100%;
-	height: calc( ( 100vw - 20px ) / 1.667 );
 	margin-bottom: 28px;
 	padding-left: 0;
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -135,6 +135,11 @@
 
 .style-preview__content {
 	height: 100%;
+	margin-bottom: $gutenboarding-footer-height + 8px;
+
+	@include break-small {
+		margin-bottom: 0;
+	}
 }
 
 .style-preview__font-options {
@@ -303,13 +308,14 @@
 }
 
 $gutenboarding-style-preview-bar-height: 30px;
+$gutenboarding-style-preview-bar-height-mobile: 15px;
 
 // This and the following dot class render the browser chrome
 .style-preview__preview-bar {
 	position: absolute;
 	top: 0;
 	width: 100%;
-	height: $gutenboarding-style-preview-bar-height / 2;
+	height: $gutenboarding-style-preview-bar-height-mobile;
 	background: var( --studio-white );
 	border-bottom: 1px solid var( --studio-gray-5 );
 	display: flex;
@@ -387,9 +393,15 @@ html:not( .accessible-focus ) .style-preview__viewport-select-button:focus:not( 
 	transform-origin: 0 0;
 
 	.is-viewport-desktop & {
-		top: $gutenboarding-style-preview-bar-height;
+		top: $gutenboarding-style-preview-bar-height-mobile;
 		height: calc(
-			#{100% / $scale-factor} - #{$gutenboarding-style-preview-bar-height / $scale-factor}
+			#{100% / $scale-factor} - #{$gutenboarding-style-preview-bar-height-mobile / $scale-factor}
 		);
+		@include break-small {
+			top: $gutenboarding-style-preview-bar-height;
+			height: calc(
+				#{100% / $scale-factor} - #{$gutenboarding-style-preview-bar-height / $scale-factor}
+			);
+		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -148,14 +148,16 @@
 
 @supports ( display: grid ) {
 	.style-preview__content {
-		display: block;
+		display: grid;
 		width: 100%;
+		grid-template-areas: 'preview' 'fonts';
+		grid-template-columns: auto;
+		grid-template-rows: auto;
 
 		@include break-small {
-			display: grid;
-			grid-template-areas: 'fonts preview';
 			column-gap: 50px;
 			flex: 1;
+			grid-template-areas: 'fonts preview';
 			grid-template-columns: 163px auto;
 		}
 
@@ -227,25 +229,25 @@
 
 .style-preview__preview {
 	float: left;
-	height: 100%;
-	display: none;
+	width: 100%;
+	max-width: 100%;
+	height: calc( ( 100vw - 20px ) / 1.667 );
+	margin-bottom: 28px;
+	padding-left: 0;
 
 	@include break-small {
-		display: block;
-	}
-}
+		width: calc( 100% - 163px );
+		height: 100%;
+		margin: 0 auto;
+		padding-left: 100px;
 
-.style-preview__preview {
-	width: calc( 100% - 163px );
-	margin: 0 auto;
-	padding-left: 100px;
+		&.is-viewport-tablet {
+			max-width: 1024px;
+		}
 
-	&.is-viewport-tablet {
-		max-width: 1024px;
-	}
-
-	&.is-viewport-mobile {
-		max-width: 351px;
+		&.is-viewport-mobile {
+			max-width: 351px;
+		}
 	}
 }
 
@@ -267,7 +269,7 @@
 
 .style-preview__preview-wrapper {
 	background: var( --studio-white );
-	box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.1 );
+	box-shadow: 0 0 0 1px var( --studio-gray-5 );
 	border-radius: 4px;
 	overflow: hidden;
 	position: relative;
@@ -294,6 +296,10 @@
 	.is-viewport-mobile & {
 		padding-top: 691 / 351 * 100%;
 	}
+
+	@include break-small {
+		box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.1 );
+	}
 }
 
 $gutenboarding-style-preview-bar-height: 30px;
@@ -309,15 +315,24 @@ $gutenboarding-style-preview-bar-height: 30px;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	padding: 10px;
+	padding: 5px;
+
+	@include break-small {
+		padding: 10px;
+	}
 }
 
 .style-preview__preview-bar-dot {
 	background: var( --studio-gray-5 );
-	width: 6px;
-	height: 6px;
+	width: 3px;
+	height: 3px;
 	border-radius: 50%;
 	margin: 0 2px;
+
+	@include break-small {
+		width: 6px;
+		height: 6px;
+	}
 }
 
 .style-preview__viewport-select {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -135,10 +135,10 @@
 
 .style-preview__content {
 	height: 100%;
-	margin-bottom: $gutenboarding-footer-height + 8px;
+	padding-bottom: $gutenboarding-footer-height + 8px;
 
 	@include break-small {
-		margin-bottom: 0;
+		padding-bottom: 0;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -309,7 +309,7 @@ $gutenboarding-style-preview-bar-height: 30px;
 	position: absolute;
 	top: 0;
 	width: 100%;
-	height: $gutenboarding-style-preview-bar-height;
+	height: $gutenboarding-style-preview-bar-height / 2;
 	background: var( --studio-white );
 	border-bottom: 1px solid var( --studio-gray-5 );
 	display: flex;
@@ -319,6 +319,7 @@ $gutenboarding-style-preview-bar-height: 30px;
 
 	@include break-small {
 		padding: 10px;
+		height: $gutenboarding-style-preview-bar-height;
 	}
 }
 

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -1,4 +1,5 @@
 // Reusable style variables
+$gutenboarding-footer-height: 64px;
 $gutenboarding-header-height: 64px;
 $gutenboarding-heading-padding-desktop: 64px 0 80px;
 $gutenboarding-heading-padding-mobile: 44px 0 50px;


### PR DESCRIPTION
This PR adds back in the preview to the style step in on mobile, to approximate the design in the Figma. It needs some testing to determine how it feels on a mobile device, and whether or not the user should be able to scroll the preview.

#### Changes proposed in this Pull Request

* Add preview to style step
* Re-order fonts and preview components in mobile view
* Add fixed footer `bottom-bar-mobile` component

#### Screenshot

Currently looks like:

![image](https://user-images.githubusercontent.com/14988353/81146813-5c193180-8fbc-11ea-87a3-1d5d56b2df24.png)

####

Still to do:

* [x] ~Add fixed footer for continue buttons~
* [ ] Determine correct "size" of content within the preview
* [ ] Determine whether or not you should be able to scroll the design on mobile, or if we should prevent scroll

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` and complete the steps until you get to the Style step.
* Test in a variety of viewport sizes
* Make sure the desktop viewport layout is unaffected by this PR
* Test on a real device, how does it feel to use?

Fixes #40900 
