### PR TITLE
Jetpack Cloud: Fix jetpack scanner last scan time

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -119,7 +119,7 @@ class ScanPage extends Component< Props > {
 		const { siteSlug, moment, scanState } = this.props;
 
 		const lastScanTimestamp = scanState?.mostRecent?.timestamp
-			? Date.parse( scanState?.mostRecent?.timestamp )
+			? scanState?.mostRecent?.timestamp.getTime()
 			: '';
 		return (
 			<>

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -208,7 +208,7 @@ class ScanPage extends Component< Props > {
 				{ this.renderHeader( translate( 'Something went wrong' ) ) }
 				<p>
 					{ translate(
-						'The scan was unable to process the themes directory and did not complete ' +
+						'The scan did not complete ' +
 							'successfully. In order to complete the scan you will need ' +
 							'to speak to support who can help determine what went wrong.'
 					) }

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -47,8 +47,6 @@ interface Props {
 	scanState: Scan | null;
 	scanProgress?: number;
 	isInitialScan: boolean;
-	lastScanTimestamp: number;
-	nextScanTimestamp: number;
 	moment: Function;
 	dispatchRecordTracksEvent: Function;
 	dispatchRequestScanEnqueue: Function;
@@ -118,8 +116,11 @@ class ScanPage extends Component< Props > {
 	}
 
 	renderScanOkay() {
-		const { siteSlug, moment, lastScanTimestamp } = this.props;
+		const { siteSlug, moment, scanState } = this.props;
 
+		const lastScanTimestamp = scanState?.mostRecent?.timestamp
+			? Date.parse( scanState?.mostRecent?.timestamp )
+			: '';
 		return (
 			<>
 				<SecurityIcon />
@@ -288,8 +289,6 @@ export default connect(
 		const siteUrl = getSiteUrl( state, siteID );
 		const siteSlug = getSelectedSiteSlug( state );
 		const scanState = getSiteScanState( state, siteID );
-		const lastScanTimestamp = Date.now() - 5700000; // 1h 35m.
-		const nextScanTimestamp = Date.now() + 5700000;
 		const scanProgress = getSiteScanProgress( state, siteID );
 		const isInitialScan = getSiteScanIsInitial( state, siteID );
 
@@ -301,8 +300,6 @@ export default connect(
 			scanState,
 			scanProgress,
 			isInitialScan,
-			lastScanTimestamp,
-			nextScanTimestamp,
 		};
 	},
 	{


### PR DESCRIPTION
Currently we don't show a real time for when the last scan happened. It always defaults to 2 hours ago. 

This PR fixes this by making sure that the scan most Recent scan results get used. 

<img width="680" alt="Screen Shot 2020-05-04 at 11 53 42 AM" src="https://user-images.githubusercontent.com/115071/80954695-2c242f80-8dfe-11ea-9131-a14bd6fe3e31.png">


#### Testing instructions
Load up the scanner page. Notice that it doesn't break. 
Make sure that the new time looks as expected. 
