### PR TITLE
Gutenboarding: Added experimental cancel button on domain picker.

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -51,6 +51,11 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 		setDomainModalVisibility( false );
 	};
 
+	const handleModalCancel = () => {
+		setDomainModalVisibility( false );
+		setDomainPopoverVisibility( true );
+	};
+
 	const handleMoreOptions = () => {
 		setDomainPopoverVisibility( false );
 		setDomainModalVisibility( true );
@@ -94,6 +99,7 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 				currentDomain={ currentDomain }
 				onDomainSelect={ onDomainSelect }
 				onClose={ handleModalClose }
+				onCancel={ handleModalCancel }
 				recordAnalytics={ recordAnalytics }
 			/>
 		</>

--- a/client/landing/gutenboarding/components/domain-picker-button/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker-button/index.tsx
@@ -53,7 +53,6 @@ const DomainPickerButton: FunctionComponent< Props > = ( {
 
 	const handleModalCancel = () => {
 		setDomainModalVisibility( false );
-		setDomainPopoverVisibility( true );
 	};
 
 	const handleMoreOptions = () => {

--- a/client/landing/gutenboarding/components/domain-picker-modal/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-modal/style.scss
@@ -66,12 +66,8 @@
 	// Show confirm button on fixed footer on mobile view
 	@media ( max-width: $break-mobile ) {
 
-		.domain-picker__header .domain-picker__confirm-button {
+		.domain-picker__header .domain-picker__header-buttons {
 			display: none;
-		}
-
-		.domain-picker__footer {
-			flex-direction: row-reverse;
 		}
 
 		.domain-picker__panel-row-footer {

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -51,6 +51,8 @@ export interface Props {
 	 */
 	onClose: () => void;
 
+	onCancel?: () => void;
+
 	onMoreOptions?: () => void;
 
 	recordAnalytics?: ( event: RecordTrainTracksEventProps ) => void;
@@ -70,6 +72,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	showDomainCategories,
 	onDomainSelect,
 	onClose,
+	onCancel,
 	onMoreOptions,
 	quantity = PAID_DOMAINS_TO_SHOW,
 	currentDomain,
@@ -104,6 +107,20 @@ const DomainPicker: FunctionComponent< Props > = ( {
 				{ ...props }
 			>
 				{ __( 'Confirm' ) }
+			</Button>
+		);
+	};
+
+	const CancelButton: FunctionComponent< Button.ButtonProps > = ( { ...props } ) => {
+		return (
+			<Button
+				className="domain-picker__cancel-button"
+				onClick={ () => {
+					onCancel && onCancel();
+				} }
+				{ ...props }
+			>
+				{ __( 'Cancel' ) }
 			</Button>
 		);
 	};
@@ -158,6 +175,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							) }
 						</div>
 						<ConfirmButton />
+						<CancelButton />
 						<CloseButton
 							className="domain-picker__close-button"
 							onClick={ onClose }
@@ -225,6 +243,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							{ __( 'More Options' ) }
 						</Button>
 						<ConfirmButton />
+						<CancelButton />
 					</div>
 				</PanelRow>
 			</PanelBody>

--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -114,6 +114,7 @@ const DomainPicker: FunctionComponent< Props > = ( {
 	const CancelButton: FunctionComponent< Button.ButtonProps > = ( { ...props } ) => {
 		return (
 			<Button
+				isLink
 				className="domain-picker__cancel-button"
 				onClick={ () => {
 					onCancel && onCancel();
@@ -174,13 +175,15 @@ const DomainPicker: FunctionComponent< Props > = ( {
 								<p>{ __( 'Free for the first year with any paid plan.' ) }</p>
 							) }
 						</div>
-						<ConfirmButton />
-						<CancelButton />
-						<CloseButton
-							className="domain-picker__close-button"
-							onClick={ onClose }
-							tabIndex={ -1 }
-						/>
+						<div className="domain-picker__header-buttons">
+							<CancelButton />
+							<ConfirmButton />
+							<CloseButton
+								className="domain-picker__close-button"
+								onClick={ onClose }
+								tabIndex={ -1 }
+							/>
+						</div>
 					</div>
 					<div className="domain-picker__search">
 						<SearchIcon />
@@ -242,8 +245,8 @@ const DomainPicker: FunctionComponent< Props > = ( {
 						<Button className="domain-picker__more-button" isTertiary onClick={ onMoreOptions }>
 							{ __( 'More Options' ) }
 						</Button>
-						<ConfirmButton />
 						<CancelButton />
+						<ConfirmButton />
 					</div>
 				</PanelRow>
 			</PanelBody>

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -57,6 +57,11 @@ $domain-picker__suggestion-item-height: 24px;
 	flex-grow: 1;
 }
 
+.domain-picker__header-buttons {
+	display: flex;
+	align-items: center;
+}
+
 .domain-picker__header-title {
 	@include onboarding-font-recoleta;
 	font-size: 26px;
@@ -259,8 +264,15 @@ $domain-picker__suggestion-item-height: 24px;
 	}
 }
 
-.domain-picker__cancel-button {
+.domain-picker__confirm-button {
 	&.components-button {
-		margin-left: 10px;
+		padding: 0 40px;
+	}
+}
+
+.domain-picker__cancel-button {
+	&.components-button.is-link {
+		margin: 0 1em;
+		color: var( --studio-gray-40 );
 	}
 }

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -53,6 +53,10 @@ $domain-picker__suggestion-item-height: 24px;
 	margin-bottom: 27px;
 }
 
+.domain-picker__header-group {
+	flex-grow: 1;
+}
+
 .domain-picker__header-title {
 	@include onboarding-font-recoleta;
 	font-size: 26px;
@@ -252,5 +256,11 @@ $domain-picker__suggestion-item-height: 24px;
 		@include onboarding-medium-text;
 		color: var( --color-neutral-100 );
 		align-items: center;
+	}
+}
+
+.domain-picker__cancel-button {
+	&.components-button {
+		margin-left: 10px;
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

I feel trapped when I enter domain picker modal, like there's no way out. This PR adds an experimental cancel button to see how it feels.

Also, when this other PR https://github.com/Automattic/wp-calypso/pull/41731 is merged, the cancel button will also appear on the sticky footer.

## Testing instructions

* Open up domain picker modal.
* Clicking on "Cancel" button will close the domain picker modal. (It no longer go back to popover.)

## Screenshots

![image](https://user-images.githubusercontent.com/1287077/81062972-441bb200-8ed7-11ea-8ced-cf0322b2cbf8.png)

Fixes https://github.com/Automattic/wp-calypso/issues/41542#issuecomment-621879136
