### PR TITLE
Update `diff` and work around tree-shaking issues

### DIFF
--- a/client/components/diff-viewer/index.jsx
+++ b/client/components/diff-viewer/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import { parsePatch } from 'diff';
+import { parsePatch } from 'diff/lib/patch/parse';
 
 /**
  * Style dependencies
@@ -31,9 +31,10 @@ const decompose = ( path ) => {
  * from the right when looking at the contents of a single
  * file over time.
  *
- * @param {string} oldFileName filename of left contents
- * @param {string} newFileName filename of right contents
- * @returns {Element} description of the file or files in the diff
+ * @param {object} options deconstructed argument
+ * @param {string} options.oldFileName filename of left contents
+ * @param {string} options.newFileName filename of right contents
+ * @returns {window.Element} description of the file or files in the diff
  */
 const filename = ( { oldFileName, newFileName } ) => {
 	// if we think the diff utility added a bogus

--- a/client/lib/text-utils/index.js
+++ b/client/lib/text-utils/index.js
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-
 import { reduce } from 'lodash';
 
-export { diffWords } from 'diff';
+export { diffWords } from 'diff/lib/diff/word';
 
 export function countWords( content ) {
 	// Adapted from TinyMCE wordcount plugin:
@@ -21,7 +20,7 @@ export function countWords( content ) {
 		content = content.replace( /&.+?;/g, ' ' ); // turn all other entities into spaces
 
 		// remove numbers and punctuation
-		content = content.replace( /[0-9.(),;:!?%#$\x27\x22_+=\\\/\-]*/g, '' );
+		content = content.replace( /[0-9.(),;:!?%#$\x27\x22_+=\\/-]*/g, '' );
 
 		const words = content.match( /[\w\u2019\x27\-\u00C0-\u1FFF]+/g );
 		if ( words ) {

--- a/client/package.json
+++ b/client/package.json
@@ -81,7 +81,7 @@
 		"d3-shape": "1.3.7",
 		"debug": "4.1.1",
 		"deep-freeze": "0.0.1",
-		"diff": "4.0.1",
+		"diff": "^4.0.2",
 		"doctrine": "3.0.0",
 		"dom-helpers": "5.1.3",
 		"dompurify": "2.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8227,11 +8227,6 @@ diff-sequences@^25.2.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
 
-diff@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
-  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
-
 diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"


### PR DESCRIPTION
`diff` doesn't tree-shake properly, so we import directly from its inner modules to work around the issue.

#### Changes proposed in this Pull Request

* Update `diff` to 4.0.2
* Import `diff` modules directly, to work around tree-shaking issues
* Minor lint fixes

#### Testing instructions

It should be enough to ensure that there are no build errors or warnings, given that the change only deals with imports.
