### PR TITLE
Use NPM to install test/e2e deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ references:
     key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-yarn-modules-{{ checksum ".nvmrc" }}-{{ checksum "yarn.lock" }}
     paths:
       - ~/.cache/yarn
-  yarn-e2e-install: &yarn-e2e-install
+  npm-e2e-install: &npm-e2e-install
     name: Install e2e npm dependencies
     command: |
       cd test/e2e &&
@@ -198,7 +198,7 @@ jobs:
       # npm dependencies
       - restore_cache: *restore-yarn-cache
       - run: *yarn-install
-      - run: *yarn-e2e-install
+      - run: *npm-e2e-install
       - save_cache: *save-yarn-cache
       - run: yarn run build-packages
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,10 +129,10 @@ references:
     paths:
       - ~/.cache/yarn
   yarn-e2e-install: &yarn-e2e-install
-    name: Install e2e yarn dependencies
+    name: Install e2e npm dependencies
     command: |
       cd test/e2e &&
-      CHROMEDRIVER_VERSION=$(<.chromedriver_version) yarn install --frozen-lockfile
+      CHROMEDRIVER_VERSION=$(<.chromedriver_version) npm ci
 
   # Babel cache
   # More about the CircleCI cache: https://circleci.com/docs/2.0/caching

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -984,6 +984,11 @@
 			"resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
 			"integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw=="
 		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2420,6 +2425,62 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
+		},
+		"check-npm-client": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/check-npm-client/-/check-npm-client-1.1.1.tgz",
+			"integrity": "sha512-Hp/zYhGknq4lFF5kTri+6ALSue5mgePy6RP2VjaUolKuWVeB2NdnhLNsqRaekJMKvTKMWgO5JKEJjy5+oXFn3Q==",
+			"requires": {
+				"chalk": "^3.0.0",
+				"debug": "^4.1.1",
+				"npm-config-user-agent-parser": "^1.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
 		},
 		"chromedriver": {
 			"version": "80.0.2",
@@ -6463,6 +6524,14 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
 			"integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
+		},
+		"npm-config-user-agent-parser": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/npm-config-user-agent-parser/-/npm-config-user-agent-parser-1.0.0.tgz",
+			"integrity": "sha512-9cODT2ALnKGiNU4OR/dCnsEiZDzFEPMiEXD69pVH38FEzbF/GzP+MlJPIYVMjx5bzbP5sbMA7b7Wgo8MGfIncA==",
+			"requires": {
+				"semver": "^5.5.0"
+			}
 		},
 		"npm-run-path": {
 			"version": "1.0.0",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -25,6 +25,7 @@
 		"@babel/runtime": "7.3.1",
 		"asana-phrase": "0.0.8",
 		"cached-path-relative": ">=1.0.2",
+		"check-npm-client": "^1.1.1",
 		"chromedriver": "^80.0.0",
 		"concurrently": "^3.6.1",
 		"config": "1.28.0",


### PR DESCRIPTION
#### Fixes

This fixes a bug where I ported npm scripts inside `test/e2e` to use yarn as part of the repo migration, but `test/e2e` is still using npm because it is not part of the same dependency tree (to be fixed in #41398).

#### Changes proposed in this Pull Request

* Change CircleCI config to use `npm` to install `test/e2e` dependencies. This sub-project has not been ported to `yarn` yet.
* Adds dependency `check-npm-client` to ensure we are using the right package manager to run commands.

#### Testing instructions

* Nothing special, check that e2e tests passes

