### PR TITLE
Gutenboarding: Fix vertical suggestions not matching/highlighting input with trailing spaces. 

### DIFF
--- a/packages/components/src/suggestions/item.jsx
+++ b/packages/components/src/suggestions/item.jsx
@@ -6,6 +6,10 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { escapeRegExp } from 'lodash';
 
+function escapeRegExpWithSpace( str ) {
+	return escapeRegExp( str ).replace( /\s/g, '\\s' );
+}
+
 class Item extends PureComponent {
 	static propTypes = {
 		label: PropTypes.string.isRequired,
@@ -34,14 +38,17 @@ class Item extends PureComponent {
 	 * @returns {Array< ReactElement< JSX.IntrinsicElements[ 'span' ] > >} An element including the highlighted text.
 	 */
 	createTextWithHighlight( text, query ) {
-		const re = new RegExp( '(' + escapeRegExp( query ) + ')', 'gi' );
+		const re = new RegExp( '(' + escapeRegExpWithSpace( query ) + ')', 'gi' );
 		const parts = text.split( re );
+
+		// Replaces char code 160 (&nbsp;) with 32 (space)
+		const match = query.toLowerCase().replace( /\s/g, ' ' );
 
 		return parts.map( ( part, i ) => {
 			const key = text + i;
 			const lowercasePart = part.toLowerCase();
 			const spanClass = classNames( 'suggestions__label', {
-				'is-emphasized': lowercasePart === query.toLowerCase(),
+				'is-emphasized': lowercasePart === match,
 			} );
 
 			return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix vertical suggestions not matching/highlighting input with trailing spaces.

#### Testing instructions

* Open `/new`.
* Enter a suggestion with trailing space, like `Travel ` or `Botanical `.

#### Screenshots

![image](https://user-images.githubusercontent.com/1287077/80959952-25021f00-8e08-11ea-950a-18731346459f.png)
![image](https://user-images.githubusercontent.com/1287077/80959959-27647900-8e08-11ea-9a41-bb8defa043de.png)

Fixes #41132