### PR TITLE
Disable page transitions when user prefers reduced motion

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style.scss
@@ -8,6 +8,10 @@
 .gutenboarding-page {
 	transform-origin: center center;
 	animation: gutenboarding-page-appear 300ms ease-out forwards;
+
+	@media ( prefers-reduced-motion: reduce ) {
+		animation: none;
+	}
 }
 
 @keyframes gutenboarding-page-appear {


### PR DESCRIPTION
_2 mins review_

#### Testing instructions

1. Simulate prefers-reduced-motion like this https://d.pr/v/RZZTBv
2. Move from page to page and see if the app honors your preference.

Fixes https://github.com/Automattic/wp-calypso/issues/41664
