### PR TITLE
My Home: Quick links expanded by default

### DIFF
--- a/client/state/home/reducer.js
+++ b/client/state/home/reducer.js
@@ -24,7 +24,7 @@ const schema = {
 
 export const quickLinksToggleStatus = withSchemaValidation(
 	schema,
-	( state = 'collapsed', action ) => {
+	( state = 'expanded', action ) => {
 		switch ( action.type ) {
 			case HOME_QUICK_LINKS_EXPAND:
 				return 'expanded';

--- a/client/state/selectors/is-home-quick-links-expanded.js
+++ b/client/state/selectors/is-home-quick-links-expanded.js
@@ -4,4 +4,4 @@
  * @param  {object}  state   Global state tree
  * @returns {object} Whether Quick Links are expanded
  */
-export default ( state ) => state.home?.quickLinksToggleStatus === 'expanded';
+export default ( state ) => state.home?.quickLinksToggleStatus !== 'collapsed';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following feedback from p7DVsv-8zA-p2, this PRs ensures the quick links are expanded by default.

<img width="200" alt="Screen Shot 2020-05-04 at 13 30 34" src="https://user-images.githubusercontent.com/1233880/80961550-7364ed00-8e0b-11ea-8dc5-49bdc48e6db6.png">

#### Testing instructions

* Open My Home in an incognito/private window (to ensure you start off with a clean state).
* Make sure the quick links are expanded by default.
* Collapse them and reload the page.
* Make sure the quick links remain collapsed.
* Expand them and reload the page.
* Make sure the quick links remain expanded.

Part of https://github.com/Automattic/dotcom-private/issues/51
