### PR TITLE
Domains Use enhanced navigation for free subdomains

### DIFF
--- a/client/my-sites/domains/domain-management/edit/domain-types/wpcom-domain-type.jsx
+++ b/client/my-sites/domains/domain-management/edit/domain-types/wpcom-domain-type.jsx
@@ -7,15 +7,22 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import DomainStatus from '../card/domain-status';
 import DomainManagementNavigation from '../navigation';
+import DomainManagementNavigationEnhanced from '../navigation/enhanced';
 
 class WpcomDomainType extends React.Component {
 	render() {
 		const {
 			domain: { name: domain_name },
 			domain,
+			selectedSite,
 		} = this.props;
+
+		const newDomainManagementNavigation = config.isEnabled(
+			'domains/new-status-design/new-options'
+		);
 
 		return (
 			<div className="domain-types__container">
@@ -25,7 +32,11 @@ class WpcomDomainType extends React.Component {
 					statusClass="status-success"
 					icon="check_circle"
 				/>
-				<DomainManagementNavigation domain={ domain } selectedSite={ this.props.selectedSite } />
+				{ newDomainManagementNavigation ? (
+					<DomainManagementNavigationEnhanced domain={ domain } selectedSite={ selectedSite } />
+				) : (
+					<DomainManagementNavigation domain={ domain } selectedSite={ selectedSite } />
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
+++ b/client/my-sites/domains/domain-management/edit/navigation/enhanced.jsx
@@ -309,6 +309,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				onClick={ this.handlePickCustomDomainClick }
 				materialIcon="search"
 				text={ translate( 'Pick a custom domain' ) }
+				description={ translate( 'Matches available' ) }
 			/>
 		);
 	}
@@ -327,6 +328,7 @@ class DomainManagementNavigationEnhanced extends React.Component {
 				onClick={ this.handleChangeSiteAddressClick }
 				materialIcon="create"
 				text={ translate( 'Change site address' ) }
+				description={ domain.name }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the free subdomain view to use the enhanced navigation view instead (use `domains/new-status-design/new-options` feature flag)

<img width="730" alt="Screenshot 2020-05-04 at 3 14 40 PM" src="https://user-images.githubusercontent.com/13062352/80969513-ff7e1100-8e19-11ea-9e6d-21f42d50ad7d.png">


#### Testing instructions

For a site you own, go to Domains, click on the free ".wordpress.com" subdomain, and you should see something similar to the screenshot above.

Make sure clicking the items will work as expected.
