### PR TITLE
i18n: Fix translation chunks setup for Gutenboarding

### DIFF
--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -102,7 +102,7 @@ window.AppBoot = async () => {
 		setLocaleData( localeData );
 
 		if ( USE_TRANSLATION_CHUNKS ) {
-			setupTranslationChunks( userLocale, translatedChunks );
+			await setupTranslationChunks( userLocale, translatedChunks );
 		}
 
 		locale = userLocale;
@@ -206,7 +206,7 @@ function getLocaleFromUser( user: User ): string {
 	return user.locale_variant || user.localeVariant || user.language || user.localeSlug;
 }
 
-function setupTranslationChunks( localeSlug: string, translatedChunks: string[] = [] ) {
+async function setupTranslationChunks( localeSlug: string, translatedChunks: string[] = [] ) {
 	if ( ! window.__requireChunkCallback__ ) {
 		return;
 	}
@@ -215,7 +215,7 @@ function setupTranslationChunks( localeSlug: string, translatedChunks: string[] 
 		[ propName: string ]: undefined | boolean;
 	}
 	const loadedTranslationChunks: TranslationChunksCache = {};
-	const loadTranslationForChunkIfNeeded = ( chunkId: string ) => {
+	const loadTranslationForChunkIfNeeded = async ( chunkId: string ) => {
 		if ( ! translatedChunks.includes( chunkId ) || loadedTranslationChunks[ chunkId ] ) {
 			return;
 		}
@@ -232,9 +232,9 @@ function setupTranslationChunks( localeSlug: string, translatedChunks: string[] 
 		( window.installedChunks || [] ).concat( window.__requireChunkCallback__.getInstalledChunks() )
 	);
 
-	installedChunks.forEach( ( chunkId ) => {
-		loadTranslationForChunkIfNeeded( chunkId );
-	} );
+	await Promise.all(
+		[ ...installedChunks ].map( ( chunkId ) => loadTranslationForChunkIfNeeded( chunkId ) )
+	);
 
 	interface RequireChunkCallbackParameters {
 		publicPath: string;

--- a/packages/data-stores/src/user/types.ts
+++ b/packages/data-stores/src/user/types.ts
@@ -14,10 +14,20 @@ export interface CurrentUser {
 	language: string;
 
 	/**
+	 * The bootstraped user's locale slug, e.g. `es`.
+	 */
+	localeSlug: string;
+
+	/**
 	 * The user's locale variant, e.g. `es-mx`.
 	 * If there is no variant, `""` empty string is returned.
 	 */
 	locale_variant: string;
+
+	/**
+	 * The bootstrapped user's locale variant, e.g. `es-mx`.
+	 */
+	localeVariant: string;
 }
 
 export interface NewUser {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes two issues with translations chunks for Gutenboarding:
1. Adds missing build target parameter in language manifest and translation chunk files calls.
2. Adds fallback for `language` as `localeSlug`, and `locale_variant` as `localeVariant` that are used to get the locale from user object, because user object from `/me` is different from bootstrapped user object.

#### Testing instructions
1. Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=wpcom-user-bootstrap,use-translation-chunks yarn start`
2. http://calypso.localhost:3000/new 
3. Confirm that translation chunks are working as expected
