### PR TITLE
Jetpack Cloud: translate the status of a threat

### DIFF
--- a/client/landing/jetpack-cloud/components/threat-item-subheader/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item-subheader/index.tsx
@@ -87,7 +87,9 @@ const ThreatItemSubheader: React.FC< Props > = ( { threat } ) => {
 						entryActionClassNames( threat )
 					) }
 				>
-					<small>{ threat.status }</small>
+					<small>
+						{ threat.status === 'fixed' ? translate( 'fixed' ) : translate( 'ignored' ) }
+					</small>
 				</Badge>
 			</>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Translate the status of a fixed/ignored threat.

#### Testing instructions

* Go to a site that has Scan and has fixed and ignored threats
* Go to the History section
* Verify the badges for `ignored` and `fixed` statuses look as before (nothing has changed)

#### Demo

![image](https://user-images.githubusercontent.com/3418513/80982696-0bf66f80-8e02-11ea-8384-c5a857502afe.png)
