### PR TITLE
Checkout: Update manage domain button for single domain registration purchases

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import page from 'page';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -335,7 +334,9 @@ export class CheckoutThankYouHeader extends PureComponent {
 			isDomainTransfer( primaryPurchase ) ||
 			isSiteRedirect( primaryPurchase )
 		) {
-			return translate( 'Manage domain' );
+			return this.isSingleDomainPurchase()
+				? translate( 'Manage domain' )
+				: translate( 'Manage domains' );
 		}
 
 		if ( isGoogleApps( primaryPurchase ) ) {
@@ -365,8 +366,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 		return (
 			primaryPurchase &&
 			isDomainRegistration( primaryPurchase ) &&
-			purchases.length === 2 &&
-			get( purchases.find( isDomainMapping ), 'meta' ) === primaryPurchase.meta
+			purchases.filter( isDomainRegistration ).length === 1
 		);
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -246,6 +246,7 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		this.props.recordTracksEvent( 'calypso_thank_you_view_site', {
 			product: primaryPurchase.productName,
+			singleDomain: true,
 		} );
 
 		page( domainManagementEdit( selectedSite.slug, primaryPurchase.meta ) );

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -602,6 +602,7 @@ export class CheckoutThankYou extends React.Component {
 					upgradeIntent={ upgradeIntent }
 					primaryCta={ this.primaryCta }
 					displayMode={ displayMode }
+					purchases={ purchases }
 				>
 					{ ! isSimplified && primaryPurchase && (
 						<CheckoutThankYouFeaturesHeader


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the Manage Domain button, so that when a single domain registration is purchased, the Manage Domain button should send the user to the domain management view for that specific domain, and not the whole list of domains.

#### Testing instructions

- Purchase a single domain
- In the post checkout Thank You page, click the Manage Domain button
- The button should send you to the view for that specific domain (not the list of all domains)

- Repeat the same steps above, but this time purchasing something else along with the domain (e.g. another domain)
- The Manage Domain button should send you to the list of all domains for the site
