### PR TITLE
FSE: remove obsolete CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ references:
         "$CIRCLE_ARTIFACTS/notifications-panel" \
         "$CIRCLE_ARTIFACTS/translate"           \
         "$CIRCLE_ARTIFACTS/screenshots"         \
-        "$CIRCLE_ARTIFACTS/full-site-editing"   \
         "$CIRCLE_ARTIFACTS/wpcom-block-editor"  \
         "$CIRCLE_TEST_REPORTS/client"           \
         "$CIRCLE_TEST_REPORTS/eslint"           \
@@ -321,18 +320,6 @@ jobs:
           command: |
             npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor
       - store-artifacts-and-test-results
-
-  build-full-site-editing:
-    <<: *defaults
-    parallelism: 1
-    steps:
-      - prepare
-      - run:
-          name: Build the Full Site Editing plugin and theme
-          command: |
-            npx lerna run build --scope='@automattic/full-site-editing'
-            tar -czvf $CIRCLE_ARTIFACTS/full-site-editing/build-archive.tar.gz -C apps/full-site-editing/full-site-editing-plugin .
-      - store-artifacts-and-test-results
   test-full-site-editing:
     <<: *defaults
     parallelism: 1
@@ -580,9 +567,6 @@ workflows:
           filters:
             branches:
               ignore: master
-      - build-full-site-editing:
-          requires:
-            - setup
       - test-full-site-editing:
           requires:
             - setup


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we moved to GitHub actions for this and removed the old sync script that was relying on CircleCI artifacts, this job should be safe to remove now.

#### Testing instructions

The CircleCI tests should pass.