### PR TITLE
Concierge: Remove async loading of the reducer.

### DIFF
--- a/client/me/concierge/index.js
+++ b/client/me/concierge/index.js
@@ -10,15 +10,12 @@ import page from 'page';
 import controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { siteSelection, sites } from 'my-sites/controller';
-import reducer from 'state/concierge/reducer';
 
 const redirectToBooking = ( context ) => {
 	page.redirect( `/me/concierge/${ context.params.siteSlug }/book` );
 };
 
-export default async ( _, addReducer ) => {
-	await addReducer( [ 'concierge' ], reducer );
-
+export default () => {
 	page( '/me/concierge', controller.siteSelector, siteSelection, sites, makeLayout, clientRender );
 
 	// redirect to booking page after site selection

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -15,11 +15,8 @@ import * as paths from './paths';
 import { makeLayout, render as clientRender } from 'controller';
 import { sidebar } from 'me/controller';
 import { siteSelection } from 'my-sites/controller';
-import reducer from 'state/concierge/reducer';
 
-export default async ( router, addReducer ) => {
-	await addReducer( [ 'concierge' ], reducer );
-
+export default ( router ) => {
 	if ( config.isEnabled( 'manage/payment-methods' ) ) {
 		router( paths.addCreditCard, sidebar, controller.addCreditCard, makeLayout, clientRender );
 

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -23,6 +23,7 @@ import atomicHosting from './hosting/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import checklist from './checklist/reducer';
+import concierge from './concierge/reducer';
 import connectedApplications from './connected-applications/reducer';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
@@ -108,6 +109,7 @@ const reducers = {
 	atomicTransfer,
 	billingTransactions,
 	checklist,
+	concierge,
 	connectedApplications,
 	countries,
 	countryStates,


### PR DESCRIPTION
Concierge currently has its reducer loaded async by the two places that use it: Concierge itself, and `/me/purchases`. Now that it's also being used by My Home (the default landing page for logged-in users), it makes sense to handle it normally in the root reducer (it can also avoid mistakes like mine in #41112 🙃 ).

**Testing Instructions**
* Apply this branch.
* Go to `/me/concierge`, and verify it loads properly, without console errors referring to `Reducer with key 'concierge' is already registered`.
* Go to `/me/purchases`, and verify the same.
* Check the Calypso codebase for any missed instances of async loading for this reducer.