### PR TITLE
My Home: Add a Quick Start card.

### DIFF
--- a/client/my-sites/customer-home/cards/features/quick-start/index.js
+++ b/client/my-sites/customer-home/cards/features/quick-start/index.js
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+import { Button, Card } from '@automattic/components';
+import { connect } from 'react-redux';
+import 'moment-timezone';
+
+/**
+ * Internal dependencies
+ */
+import HappinessEngineersTray from 'components/happiness-engineers-tray';
+import CardHeading from 'components/card-heading';
+import {
+	withAnalytics,
+	composeAnalytics,
+	recordTracksEvent,
+	bumpStat,
+} from 'state/analytics/actions';
+import { navigate } from 'state/ui/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import QueryConciergeInitial from 'components/data/query-concierge-initial';
+import getConciergeNextAppointment from 'state/selectors/get-concierge-next-appointment';
+import { withLocalizedMoment } from 'components/localized-moment';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const QuickStart = ( {
+	moment,
+	nextSession,
+	reschedule,
+	siteId,
+	siteSlug,
+	translate,
+	viewDetails,
+} ) => {
+	return (
+		<>
+			{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
+			<Card className="quick-start next-session">
+				<HappinessEngineersTray />
+				<CardHeading>{ translate( 'Your scheduled Quick Start support session:' ) }</CardHeading>
+				<table>
+					<thead>
+						<tr>
+							<th>{ translate( 'Date' ) }</th>
+							<th>{ translate( 'Time' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>
+								{ nextSession ? (
+									moment( nextSession.beginTimestamp ).format( 'LL' )
+								) : (
+									<div className="quick-start__placeholder"></div>
+								) }
+							</td>
+							<td>
+								{ nextSession ? (
+									moment.tz( nextSession.beginTimestamp, moment.tz.guess() ).format( 'LT z' )
+								) : (
+									<div className="quick-start__placeholder"></div>
+								) }
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<div className="quick-start__buttons">
+					<Button disabled={ ! nextSession } onClick={ () => viewDetails( siteId, siteSlug ) }>
+						{ translate( 'View details' ) }
+					</Button>
+					<Button
+						className={ 'quick-start__reschedule' }
+						onClick={ () => reschedule( siteId, siteSlug, nextSession.id ) }
+						borderless
+						disabled={ ! nextSession }
+					>
+						{ translate( 'Reschedule' ) }
+					</Button>
+				</div>
+			</Card>
+		</>
+	);
+};
+
+export default connect(
+	( state ) => ( {
+		siteId: getSelectedSiteId( state ),
+		siteSlug: getSelectedSiteSlug( state ),
+		nextSession: getConciergeNextAppointment( state ),
+	} ),
+	( dispatch ) => ( {
+		viewDetails: ( siteId, siteSlug ) =>
+			dispatch(
+				withAnalytics(
+					composeAnalytics(
+						recordTracksEvent( 'calypso_customer_home_quick_start_view_details_click', {
+							site_id: siteId,
+						} ),
+						bumpStat( 'calypso_customer_home', 'view_quick_start_session_details' )
+					),
+					navigate( `/me/concierge/${ siteSlug }/book` )
+				)
+			),
+		reschedule: ( siteId, siteSlug, sessionId ) =>
+			dispatch(
+				withAnalytics(
+					composeAnalytics(
+						recordTracksEvent( 'calypso_customer_home_quick_start_reschedule_click', {
+							site_id: siteId,
+						} ),
+						bumpStat( 'calypso_customer_home', 'reschedule_quick_start_session' )
+					),
+					navigate( `/me/concierge/${ siteSlug }/${ sessionId }/cancel` )
+				)
+			),
+	} )
+)( localize( withLocalizedMoment( QuickStart ) ) );

--- a/client/my-sites/customer-home/cards/features/quick-start/style.scss
+++ b/client/my-sites/customer-home/cards/features/quick-start/style.scss
@@ -1,0 +1,24 @@
+.quick-start p,
+.quick-start .happiness-engineers-tray,
+.quick-start table {
+	margin-bottom: 1.1rem;
+}
+
+.quick-start th {
+	color: var( --color-text-subtle );
+	font-size: 14px;
+	font-weight: 400;
+}
+
+.quick-start__reschedule.is-borderless,
+.quick-start__reschedule.is-borderless:visited {
+	color: var( --color-link );
+	margin: 7px 14px 9px;
+	padding: 0;
+}
+
+.quick-start__placeholder {
+	@include placeholder();
+	width: 100px;
+	max-width: 80%;
+}

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -13,9 +13,10 @@ import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import { canCurrentUserUseCustomerHome } from 'state/sites/selectors';
 import isRecentlyMigratedSite from 'state/selectors/is-site-recently-migrated';
 
-export default function ( context, next ) {
-	const state = context.store.getState();
-	const siteId = getSelectedSiteId( state );
+export default async function ( context, next ) {
+	const state = await context.store.getState();
+	const siteId = await getSelectedSiteId( state );
+
 	// Scroll to the top
 	if ( typeof window !== 'undefined' ) {
 		window.scrollTo( 0, 0 );

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -10,6 +10,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import GoMobile from 'my-sites/customer-home/cards/features/go-mobile';
 import Support from 'my-sites/customer-home/cards/features/support';
+import QuickStart from 'my-sites/customer-home/cards/features/quick-start';
 import QuickLinks from 'my-sites/customer-home/cards/actions/quick-links-compact';
 import WpForTeamsQuickLinks from 'my-sites/customer-home/cards/actions/wp-for-teams-quick-links-compact';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -19,6 +20,7 @@ const cardComponents = {
 	'home-feature-go-mobile': GoMobile,
 	'home-feature-support': Support,
 	'home-action-quick-links': QuickLinks,
+	'home-feature-quick-start': QuickStart,
 	'home-action-wp-for-teams-quick-links': WpForTeamsQuickLinks,
 };
 

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -94,6 +94,7 @@
 }
 
 .customer-home__main .card-heading {
+	line-height: 1.3;
 	margin-top: -8px;
 }
 


### PR DESCRIPTION
This is take two of #41112 .

This PR adds a Quick Start Sessions card to My Home. The card is only displayed if a session exists for the current site.

<img width="394" alt="Screen Shot 2020-05-04 at 12 20 16 PM" src="https://user-images.githubusercontent.com/349751/81004706-a7d3ab80-8e01-11ea-8a6e-af49adc15ae7.png">

#### Testing instructions

* Switch to this branch, and cherry-pick 8a2ee7505833f3423d67987862cac6af32b84231 from #41761 if it's not yet merged.
* On prod, take a test site with a Business plan and register for a Quick Start session at `/me/concierge/:site/book`. (Be sure to comment that we're just testing. 🙃)
* Back on this branch for the Business test site, load `/home/:business-site` and verify the card shows up, with the correct data.
* Verify the "View details" button goes to `/me/concierge/:site/book`.
* Verify the "Reschedule" link goes to `/me/concierge/:site/:sessionId/cancel`.

Fixes #38998