### PR TITLE
My Home: Disable the "launch site" action on completion.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -151,6 +151,7 @@ export const getTask = (
 				actionText: translate( 'Launch site' ),
 				actionDispatch: launchSiteOrRedirectToLaunchSignupFlow,
 				actionDispatchArgs: [ siteId ],
+				actionDisableOnComplete: true,
 			};
 			break;
 		case 'front_page_updated':

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -232,7 +232,10 @@ const SiteSetupList = ( {
 									className="site-setup-list__task-action task__action"
 									primary
 									onClick={ () => startTask( dispatch, currentTask, siteId ) }
-									disabled={ currentTask.isDisabled }
+									disabled={
+										currentTask.isDisabled ||
+										( currentTask.isCompleted && currentTask.actionDisableOnComplete )
+									}
 								>
 									{ currentTask.actionText }
 								</Button>


### PR DESCRIPTION
We've been leaving the checklist items' CTAs as-is in the completed state, with the idea that users can go back and update the task afterwards if they want to. While this works for steps like changing the site title, it's confusing for one-time tasks like launching the site. In its current completed state, the "Launch site" CTA is an enabled primary button that does nothing.

This PR allows adding a `actionDisableOnComplete` flag on a checklist item to have its CTA disabled once it's complete.

<img width="1176" alt="Screen Shot 2020-05-04 at 3 35 18 PM" src="https://user-images.githubusercontent.com/349751/81020080-e460d080-8e1c-11ea-89cf-2986477d381e.png">
