### PR TITLE
Fix Starter Page Template title centration for Gutenberg 8.0

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-preview.js
@@ -24,7 +24,7 @@ export default function ( { blocks, settings, hidePageTitle, recomputeBlockListK
 		<BlockEditorProvider value={ blocks } settings={ settings }>
 			<Disabled key={ recomputeBlockListKey }>
 				{ ! hidePageTitle && (
-					<div className="block-iframe-preview__template-title">
+					<div className="block-iframe-preview__template-title edit-post-visual-editor__post-title-wrapper">
 						<PostTitle />
 					</div>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add class name to allow title to be centered in Gutenberg 8.0 (noted in [41719](https://github.com/Automattic/wp-calypso/issues/41719#issuecomment-623234636))

It seems the css rules for the margin of `.editor-post-title` is now nested under `.edit-post-visual-editor__post-title-wrapper` as opposed to `.edit-post-visual-editor`.  Meaning with 8.0 active the title for a starter page template preview looks off-center:

![Screen Shot 2020-05-04 at 7 01 52 PM](https://user-images.githubusercontent.com/28742426/81021906-4aa81c00-8e3a-11ea-917e-68e3f49b1bbf.png)

After changes:
![Screen Shot 2020-05-04 at 7 00 05 PM](https://user-images.githubusercontent.com/28742426/81021931-54318400-8e3a-11ea-8df3-d957d3a4bcbd.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build/sync FSE and test starter page templates on `gutenberg-edge`
* Verify title is now centered.

