### PR TITLE
 redirect passwordless login users to /create-site?new

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -100,7 +100,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 
 	const langFragment = lang ? `/${ lang }` : '';
 	const loginRedirectUrl = encodeURIComponent(
-		`${ window.location.origin }/${ GUTENBOARDING_BASE_NAME }${ makePath( Step[ currentStep ] ) }`
+		`${ window.location.origin }/${ GUTENBOARDING_BASE_NAME }${ makePath( Step.CreateSite ) }?new`
 	);
 	const signupUrl = encodeURIComponent(
 		`/${ GUTENBOARDING_BASE_NAME }${ makePath( Step[ currentStep ] ) }?signup`


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Redirect passwordless users to create-site?new so that they keep their place in the flow if they use the same browser session to open the email link.

#### Testing instructions

* Create a user with passwordless authentication.
* Go through the `/new` flow and select the `login` frankenflow 
* Enter the email address of the passwordless user

You will recieve a login link via email. Copy the link and try these two cases.

a) Open the link in a new incognito session:
    *You will be on the `/new` aquire intent page. restarting the gutenboarding flow. However you will now be logged in and will not be prompted again
b) Open the link in the same browser session that you were previously using:
    * You will be taken to the `create-site?new` endpoint. your site will be created with the details you entered earlier

Fixes #41771
