### PR TITLE
Home: Remove illustration at 800px and 480px

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -26,6 +26,14 @@
 		margin-bottom: 0;
 		order: 1;
 		align-self: center;
+
+		@include breakpoint( '<800px' ) {
+			display: none;
+		}
+
+		@include breakpoint( '<660px' ) {
+			display: inline;
+		}
 	}
 
 	.action-panel__body p.task__description {

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -26,6 +26,7 @@
 		margin-bottom: 0;
 		order: 1;
 		align-self: center;
+		display: inline;
 
 		@include breakpoint( '<800px' ) {
 			display: none;

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -34,6 +34,10 @@
 		@include breakpoint( '<660px' ) {
 			display: inline;
 		}
+
+		@include breakpoint( '<480px' ) {
+			display: none;
+		}
 	}
 
 	.action-panel__body p.task__description {


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/41778

**Before:**
![Screen Shot 2020-05-04 at 6 12 55 PM](https://user-images.githubusercontent.com/4924246/81027952-6d373680-8e34-11ea-94f7-4ec03ebe7c89.png)

**After:**
![Screen Shot 2020-05-04 at 7 44 53 PM](https://user-images.githubusercontent.com/4924246/81031057-ce183c00-8e3f-11ea-9107-5d5de3b4d6cc.png)

The image should show back up again at <660px, but disappear at 480px.