### PR TITLE
Rewrite PhoneInput to allow control with different formats

### DIFF
--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -121,9 +121,12 @@ PhoneInput.propTypes = {
 };
 
 function useAdjustCursorPosition( displayValue, countryCode, numberInputRef ) {
+	const cursorPosition = useRef( 0 );
 	const oldValue = useRef( displayValue );
 	const oldCountry = useRef( countryCode );
 	useEffect( () => {
+		const oldCursorPosition = cursorPosition.current;
+		cursorPosition.current = numberInputRef.current?.selectionStart ?? 0;
 		if ( ! numberInputRef.current ) {
 			return;
 		}
@@ -131,11 +134,16 @@ function useAdjustCursorPosition( displayValue, countryCode, numberInputRef ) {
 			return;
 		}
 
-		const newCursorPosition = getUpdatedCursorPosition( oldValue.current, displayValue );
+		const newCursorPosition = getUpdatedCursorPosition(
+			oldValue.current,
+			displayValue,
+			oldCursorPosition
+		);
 
 		oldValue.current = displayValue;
 		oldCountry.current = countryCode;
 
+		debug( 'moving cursor from', oldCursorPosition, 'to', newCursorPosition );
 		numberInputRef.current.setSelectionRange( newCursorPosition, newCursorPosition );
 	}, [ displayValue, numberInputRef, countryCode ] );
 }

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { find, identity } from 'lodash';
+import React, { useRef, useState, useEffect } from 'react';
+import { find } from 'lodash';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import FormCountrySelect from 'components/forms/form-country-select';
 import {
 	formatNumber,
+	toIcannFormat,
 	findCountryFromNumber,
 	processNumber,
 	MIN_LENGTH_TO_FORMAT,
@@ -25,202 +26,313 @@ import { countries } from 'components/phone-input/data';
  */
 import './style.scss';
 
-class PhoneInput extends React.PureComponent {
-	static propTypes = {
-		onChange: PropTypes.func.isRequired,
-		className: PropTypes.string,
-		isError: PropTypes.bool,
-		disabled: PropTypes.bool,
-		name: PropTypes.string,
-		value: PropTypes.string.isRequired,
-		countryCode: PropTypes.string.isRequired,
-		countriesList: PropTypes.array.isRequired,
-		enableStickyCountry: PropTypes.bool,
-	};
+function PhoneInput( {
+	translate,
+	inputRef,
+	onChange,
+	className,
+	isError,
+	disabled,
+	name,
+	value,
+	countryCode,
+	countriesList,
+	enableStickyCountry = true,
+} ) {
+	const [ freezeSelection, setFreezeSelection ] = useState( enableStickyCountry );
+	const [ phoneNumberState, setPhoneNumberState ] = usePhoneNumberState(
+		value,
+		countryCode,
+		countriesList,
+		freezeSelection
+	);
 
-	static defaultProps = {
-		enableStickyCountry: true,
-	};
+	const { displayValue } = phoneNumberState;
 
-	state = {
-		freezeSelection: false,
-	};
+	const numberInputRef = useSharedRef( inputRef );
 
-	numberInput = undefined;
+	useAdjustCursorPosition( displayValue, countryCode, numberInputRef );
 
-	setNumberInputRef = ( element ) => {
-		this.numberInput = element;
+	const handleInput = getInputHandler(
+		setPhoneNumberState,
+		onChange,
+		countryCode,
+		countriesList,
+		freezeSelection
+	);
+	const handleCountrySelection = getCountrySelectionHandler(
+		displayValue,
+		countryCode,
+		countriesList,
+		onChange,
+		setFreezeSelection,
+		enableStickyCountry
+	);
 
-		const { inputRef } = this.props;
+	return (
+		<div className={ classnames( className, 'phone-input' ) }>
+			<input
+				placeholder={ translate( 'Phone' ) }
+				onChange={ handleInput }
+				name={ name }
+				value={ displayValue }
+				ref={ numberInputRef }
+				type="tel"
+				disabled={ disabled }
+				className={ classnames( 'phone-input__number-input', {
+					'is-error': isError,
+				} ) }
+			/>
+			<div className="phone-input__select-container">
+				<div className="phone-input__select-inner-container">
+					<FormCountrySelect
+						tabIndex={ -1 }
+						className="phone-input__country-select"
+						onChange={ handleCountrySelection }
+						value={ getCountry( countryCode, countriesList ).isoCode }
+						countriesList={ countriesList }
+						disabled={ disabled }
+					/>
+					<CountryFlag
+						countryCode={ getCountry( countryCode, countriesList ).isoCode.toLowerCase() }
+					/>
+				</div>
+			</div>
+		</div>
+	);
+}
 
-		if ( ! inputRef ) {
+PhoneInput.propTypes = {
+	translate: PropTypes.func.isRequired,
+	inputRef: PropTypes.oneOfType( [ PropTypes.func, PropTypes.object ] ),
+	onChange: PropTypes.func.isRequired,
+	className: PropTypes.string,
+	isError: PropTypes.bool,
+	disabled: PropTypes.bool,
+	name: PropTypes.string,
+	value: PropTypes.string.isRequired,
+	countryCode: PropTypes.string.isRequired,
+	countriesList: PropTypes.array.isRequired,
+	enableStickyCountry: PropTypes.bool,
+};
+
+function useAdjustCursorPosition( displayValue, countryCode, numberInputRef ) {
+	const cursorPosition = useRef( 0 );
+	cursorPosition.current = numberInputRef.current?.selectionStart ?? 0;
+	const oldValue = useRef( displayValue );
+	const oldCountry = useRef( countryCode );
+	useEffect( () => {
+		if ( displayValue === oldValue.current && countryCode === oldCountry.current ) {
 			return;
 		}
+		const oldCursorPosition = cursorPosition.current;
 
-		if ( typeof inputRef === 'function' ) {
-			inputRef( element );
-		} else {
-			inputRef.current = element;
-		}
-	};
-
-	/**
-	 * Returns the country meta with default values for countries with missing metadata. Never returns null.
-	 * @param {string} [countryCode=this.props.countryCode] - The country code
-	 * @returns {countryMetadata} - Country metadata
-	 */
-	getCountry( countryCode = this.props.countryCode ) {
-		let selectedCountry = countries[ countryCode ];
-
-		if ( ! selectedCountry ) {
-			// Special cases where the country is in a disputed region and not globally recognized.
-			// At this point this should only be used for: Canary islands, Kosovo, Netherlands Antilles
-			const data = find( this.props.countriesList || [], ( { code } ) => code === countryCode );
-
-			selectedCountry = {
-				isoCode: countryCode,
-				dialCode: ( ( data && data.numeric_code ) || '' ).replace( '+', '' ),
-				nationalPrefix: '',
-			};
-		}
-		return selectedCountry;
-	}
-
-	componentDidMount() {
-		const { countryCode, value } = this.calculateInputAndCountryCode(
-			this.props.value,
-			this.props.countryCode
-		);
-		this.numberInput.value = value;
-		if ( value !== this.props.value || countryCode !== this.props.countryCode ) {
-			this.props.onChange( { value, countryCode } );
-		}
-	}
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if (
-			nextProps.value === this.props.value &&
-			nextProps.countryCode === this.props.countryCode
-		) {
-			return;
-		}
-		const { countryCode, value } = this.calculateInputAndCountryCode(
-			nextProps.value,
-			nextProps.countryCode
-		);
-		this.props.onChange( { value, countryCode } );
-	}
-
-	UNSAFE_componentWillUpdate( nextProps ) {
-		if (
-			nextProps.value === this.props.value &&
-			nextProps.countryCode === this.props.countryCode
-		) {
-			return;
-		}
-		const currentFormat = this.props.value;
-		const currentCursorPoint = this.numberInput.selectionStart;
-		const nextFormat = nextProps.value;
-
-		let newCursorPoint = currentCursorPoint;
-		/*
-		We are setting the value of numberInput here instead of using a prop because we need direct control over when and how
-		it is updated in order to move the cursor to the exact point we want. I haven't noticed any side effects of this and
-		it is working normally. In case it starts to create problems, we can try to split this logic between `componentWillUpdate`
-		and `componentDidUpdate` and store the cursor position in the state or in `this`.
-		 */
-		this.numberInput.value = nextFormat;
-
-		const nonDigitCountOld = currentFormat
-			.substring( 0, currentCursorPoint )
+		const nonDigitCountOld = oldValue.current
+			.substring( 0, oldCursorPosition )
 			.split( '' )
 			.map( ( char ) => /\D/.test( char ) )
-			.filter( identity ).length;
+			.filter( ( x ) => x ).length;
 
-		const nonDigitCountNew = nextFormat
-			.substring( 0, currentCursorPoint )
+		const nonDigitCountNew = displayValue
+			.substring( 0, oldCursorPosition )
 			.split( '' )
 			.map( ( char ) => /\D/.test( char ) )
-			.filter( identity ).length;
+			.filter( ( x ) => x ).length;
 
-		if ( currentFormat !== nextFormat ) {
-			if ( currentCursorPoint >= currentFormat.length ) {
-				newCursorPoint = nextFormat.length;
+		let newCursorPoint = oldCursorPosition;
+		if ( oldValue.current !== displayValue ) {
+			if ( oldCursorPosition >= oldValue.current.length ) {
+				newCursorPoint = displayValue.length;
 			} else {
-				newCursorPoint = currentCursorPoint + nonDigitCountNew - nonDigitCountOld;
+				newCursorPoint = oldCursorPosition + nonDigitCountNew - nonDigitCountOld;
 			}
 		}
-		this.numberInput.setSelectionRange( newCursorPoint, newCursorPoint );
-	}
 
-	/**
-	 * Decides whether to guess the country from the input value
-	 * @param {string} value - The phone number
-	 * @returns {boolean} - Whether to guess the country or not
-	 */
-	shouldGuessCountry( value ) {
-		if ( ! value || value.length < MIN_LENGTH_TO_FORMAT || this.state.freezeSelection ) {
-			return false;
+		oldValue.current = displayValue;
+		oldCountry.current = countryCode;
+		numberInputRef.current?.setSelectionRange( newCursorPoint, newCursorPoint );
+	}, [ displayValue, numberInputRef, countryCode ] );
+}
+
+function useSharedRef( inputRef ) {
+	const numberInputRef = useRef();
+	useEffect( () => {
+		if ( typeof inputRef === 'function' ) {
+			inputRef( numberInputRef.current );
+		} else {
+			inputRef.current = numberInputRef.current;
 		}
-		const dialCode = this.getCountry().countryDialCode || this.getCountry().dialCode;
-		return value[ 0 ] === '+' || ( value[ 0 ] === '1' && dialCode === '1' );
-	}
+	}, [ inputRef ] );
+	return numberInputRef;
+}
 
-	/**
-	 * Returns the selected country from dropdown or guesses the country from input
-	 * @param {string} value - Input number
-	 * @param {string} [fallbackCountryCode=this.props.countryCode] - Fallback country code in case we can't find a match
-	 * @returns {countryMetadata} - Country Metadata
-	 */
-	guessCountryFromValueOrGetSelected( value, fallbackCountryCode = this.props.countryCode ) {
-		if ( this.shouldGuessCountry( value ) ) {
-			return findCountryFromNumber( value ) || this.getCountry( 'world' );
-		}
+function usePhoneNumberState( value, countryCode, countriesList, freezeSelection ) {
+	const [ phoneNumberState, setPhoneNumberState ] = useState(
+		getPhoneNumberStatesFromProp( value, countryCode, countriesList, freezeSelection )
+	);
 
-		return this.getCountry( fallbackCountryCode );
-	}
-
-	format( value = this.props.value, countryCode = this.props.countryCode ) {
-		return formatNumber( value, this.getCountry( countryCode ) );
-	}
-
-	handleInput = ( event ) => {
-		const inputValue = event.target.value;
-		if ( inputValue === this.props.value ) {
-			// nothing changed
+	useEffect( () => {
+		const { rawValue, displayValue, icannValue } = phoneNumberState;
+		// No need to update it if the prop value is equal to one form of the current value
+		if ( value === rawValue || value === displayValue || value === icannValue ) {
 			return;
 		}
+		setPhoneNumberState(
+			getPhoneNumberStatesFromProp( value, countryCode, countriesList, freezeSelection )
+		);
+	}, [ phoneNumberState, value, countryCode, countriesList, freezeSelection ] );
 
+	return [ phoneNumberState, setPhoneNumberState ];
+}
+
+function getPhoneNumberStatesFromProp( rawValue, countryCode, countriesList, freezeSelection ) {
+	const { value: displayValue } = calculateInputAndCountryCode(
+		rawValue,
+		countryCode,
+		countriesList,
+		freezeSelection
+	);
+	const icannValue = toIcannFormat( displayValue, countries[ countryCode ] );
+	return { rawValue, displayValue, icannValue };
+}
+
+function getInputHandler(
+	setPhoneNumberState,
+	onChange,
+	countryCodeValue,
+	countriesList,
+	freezeSelection
+) {
+	return function handleInput( event ) {
 		event.preventDefault();
+		const rawValue = event.target.value;
 
-		const { countryCode, value } = this.calculateInputAndCountryCode(
-			inputValue,
-			this.props.countryCode
+		const { countryCode, value: displayValue } = calculateInputAndCountryCode(
+			rawValue,
+			countryCodeValue,
+			countriesList,
+			freezeSelection
 		);
 
-		this.props.onChange( { value, countryCode } );
+		setPhoneNumberState( { rawValue, displayValue, icannValue: toIcannFormat( displayValue ) } );
+
+		onChange( { value: displayValue, countryCode } );
 	};
+}
 
-	/**
-	 * Calculates the input and country
-	 * @param {string} value - Phone number
-	 * @param {string} countryCode - The country code
-	 * @returns {{value: string, countryCode: string}} - Result
-	 */
-	calculateInputAndCountryCode( value, countryCode ) {
-		const calculatedCountry = this.guessCountryFromValueOrGetSelected( value, countryCode ),
-			calculatedValue = this.format( value, calculatedCountry.isoCode ),
-			calculatedCountryCode = calculatedCountry.isoCode;
+/**
+ * Calculates the input and country
+ *
+ * @param {string} value - Phone number
+ * @param {string} countryCode - The country code
+ * @param {Array} countriesList - The list of countries
+ * @param {boolean} freezeSelection - True if we should never guess the country
+ * @returns {{value: string, countryCode: string}} - Result
+ */
+function calculateInputAndCountryCode( value, countryCode, countriesList, freezeSelection ) {
+	const calculatedCountry = guessCountryFromValueOrGetSelected(
+			value,
+			countryCode,
+			countriesList,
+			freezeSelection
+		),
+		calculatedValue = format( value, calculatedCountry.isoCode, countriesList ),
+		calculatedCountryCode = calculatedCountry.isoCode;
 
-		return { value: calculatedValue, countryCode: calculatedCountryCode };
+	return { value: calculatedValue, countryCode: calculatedCountryCode };
+}
+
+/**
+ * Decides whether to guess the country from the input value
+ *
+ * @param {string} value - The phone number
+ * @param {string} countryCode - The country code
+ * @param {Array} countriesList - The list of countries
+ * @param {boolean} freezeSelection - True if we should never guess
+ * @returns {boolean} - Whether to guess the country or not
+ */
+function shouldGuessCountry( value, countryCode, countriesList, freezeSelection ) {
+	if ( ! value || value.length < MIN_LENGTH_TO_FORMAT || freezeSelection ) {
+		return false;
+	}
+	const dialCode =
+		getCountry( countryCode, countriesList ).countryDialCode ||
+		getCountry( countryCode, countriesList ).dialCode;
+	return value[ 0 ] === '+' || ( value[ 0 ] === '1' && dialCode === '1' );
+}
+
+/**
+ * Returns the selected country from dropdown or guesses the country from input
+ *
+ * @param {string} value - Input number
+ * @param {string} fallbackCountryCode - Fallback country code in case we can't find a match
+ * @param {Array} countriesList - The list of countries
+ * @param {boolean} freezeSelection - True if we should never guess the country
+ * @returns {{isoCode: string, dialCode: string, nationalPrefix: string}} - Country metadata
+ */
+function guessCountryFromValueOrGetSelected(
+	value,
+	fallbackCountryCode,
+	countriesList,
+	freezeSelection
+) {
+	if ( shouldGuessCountry( value, fallbackCountryCode, countriesList, freezeSelection ) ) {
+		return findCountryFromNumber( value ) || getCountry( 'world', countriesList );
 	}
 
-	handleCountrySelection = ( event ) => {
+	return getCountry( fallbackCountryCode, countriesList );
+}
+
+/**
+ * Format the phone number for display
+ *
+ * @param {string} value - The phone number value to format
+ * @param {string} countryCode - The country code to use for the format
+ * @param {Array} countriesList - The country data
+ * @returns {string} The formatted number
+ */
+function format( value, countryCode, countriesList ) {
+	return formatNumber( value, getCountry( countryCode, countriesList ) );
+}
+
+/**
+ * Returns the country meta with default values for countries with missing metadata. Never returns null.
+ *
+ * @param {string} countryCode - The country code
+ * @param {Array} countriesList - The country data
+ * @returns {{isoCode: string, dialCode: string, nationalPrefix: string}} - Country metadata
+ */
+function getCountry( countryCode, countriesList ) {
+	let selectedCountry = countries[ countryCode ];
+
+	if ( ! selectedCountry ) {
+		// Special cases where the country is in a disputed region and not globally recognized.
+		// At this point this should only be used for: Canary islands, Kosovo, Netherlands Antilles
+		const data = find( countriesList || [], ( { code } ) => code === countryCode );
+
+		selectedCountry = {
+			isoCode: countryCode,
+			dialCode: ( ( data && data.numeric_code ) || '' ).replace( '+', '' ),
+			nationalPrefix: '',
+		};
+	}
+	return selectedCountry;
+}
+
+function getCountrySelectionHandler(
+	value,
+	countryCode,
+	countriesList,
+	onChange,
+	setFreezeSelection,
+	enableStickyCountry
+) {
+	return function handleCountrySelection( event ) {
 		const newCountryCode = event.target.value;
-		if ( newCountryCode === this.props.countryCode ) {
+		if ( newCountryCode === countryCode ) {
 			return;
 		}
-		let inputValue = this.props.value;
+		let inputValue = value;
 		/*
 		 If using national format we need to extract the national number and format it instead of the direct value
 		 This is because not all countries have the same national prefix
@@ -232,52 +344,18 @@ class PhoneInput extends React.PureComponent {
 		 format the national number, UK -> Turkmenistan will be like 05556667788 -> 85556667788, which is the expected
 		 result.
 		 */
-		const { nationalNumber } = processNumber(
-			this.props.value,
-			this.getCountry( this.props.countryCode )
-		);
-		if ( this.props.value[ 0 ] !== '+' ) {
+		const { nationalNumber } = processNumber( value, getCountry( countryCode, countriesList ) );
+		if ( value[ 0 ] !== '+' ) {
 			inputValue = nationalNumber;
 		} else {
-			inputValue = '+' + this.getCountry( newCountryCode ).dialCode + nationalNumber;
+			inputValue = '+' + getCountry( newCountryCode, countriesList ).dialCode + nationalNumber;
 		}
-		this.props.onChange( {
+		onChange( {
 			countryCode: newCountryCode,
-			value: this.format( inputValue, newCountryCode ),
+			value: format( inputValue, newCountryCode, countriesList ),
 		} );
-		this.setState( { freezeSelection: this.props.enableStickyCountry } );
+		setFreezeSelection( enableStickyCountry );
 	};
-
-	render() {
-		return (
-			<div className={ classnames( this.props.className, 'phone-input' ) }>
-				<input
-					placeholder={ this.props.translate( 'Phone' ) }
-					onChange={ this.handleInput }
-					name={ this.props.name }
-					ref={ this.setNumberInputRef }
-					type="tel"
-					disabled={ this.props.disabled }
-					className={ classnames( 'phone-input__number-input', {
-						'is-error': this.props.isError,
-					} ) }
-				/>
-				<div className="phone-input__select-container">
-					<div className="phone-input__select-inner-container">
-						<FormCountrySelect
-							tabIndex={ -1 }
-							className="phone-input__country-select"
-							onChange={ this.handleCountrySelection }
-							value={ this.getCountry().isoCode }
-							countriesList={ this.props.countriesList }
-							disabled={ this.props.disabled }
-						/>
-						<CountryFlag countryCode={ this.getCountry().isoCode.toLowerCase() } />
-					</div>
-				</div>
-			</div>
-		);
-	}
 }
 
 export default localize( PhoneInput );

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -142,18 +142,15 @@ function useAdjustCursorPosition( displayValue, countryCode, numberInputRef ) {
 			.map( ( char ) => /\D/.test( char ) )
 			.filter( ( x ) => x ).length;
 
-		let newCursorPoint = oldCursorPosition;
-		if ( oldValue.current !== displayValue ) {
-			if ( oldCursorPosition >= oldValue.current.length ) {
-				newCursorPoint = displayValue.length;
-			} else {
-				newCursorPoint = oldCursorPosition + nonDigitCountNew - nonDigitCountOld;
-			}
-		}
+		const newCursorPosition =
+			oldCursorPosition >= oldValue.current.length
+				? displayValue.length
+				: oldCursorPosition + nonDigitCountNew - nonDigitCountOld;
 
 		oldValue.current = displayValue;
 		oldCountry.current = countryCode;
-		numberInputRef.current?.setSelectionRange( newCursorPoint, newCursorPoint );
+		debug( 'moving cursor from', oldCursorPosition, 'to', newCursorPosition );
+		numberInputRef.current?.setSelectionRange( newCursorPosition, newCursorPosition );
 	}, [ displayValue, numberInputRef, countryCode ] );
 }
 

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -121,12 +121,9 @@ PhoneInput.propTypes = {
 };
 
 function useAdjustCursorPosition( displayValue, countryCode, numberInputRef ) {
-	const cursorPosition = useRef( 0 );
 	const oldValue = useRef( displayValue );
 	const oldCountry = useRef( countryCode );
 	useEffect( () => {
-		const oldCursorPosition = cursorPosition.current;
-		cursorPosition.current = numberInputRef.current?.selectionStart ?? 0;
 		if ( ! numberInputRef.current ) {
 			return;
 		}
@@ -134,17 +131,11 @@ function useAdjustCursorPosition( displayValue, countryCode, numberInputRef ) {
 			return;
 		}
 
-		const newCursorPosition = getUpdatedCursorPosition(
-			oldValue.current,
-			displayValue,
-			oldCursorPosition,
-			numberInputRef.current.selectionEnd
-		);
+		const newCursorPosition = getUpdatedCursorPosition( oldValue.current, displayValue );
 
 		oldValue.current = displayValue;
 		oldCountry.current = countryCode;
 
-		debug( 'moving cursor from', oldCursorPosition, 'to', newCursorPosition );
 		numberInputRef.current.setSelectionRange( newCursorPosition, newCursorPosition );
 	}, [ displayValue, numberInputRef, countryCode ] );
 }

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -291,6 +291,10 @@ export function getUpdatedCursorPosition( oldValue, newValue, oldCursorPosition 
 	const toList = ( str ) => str.split( '' );
 	const unmask = ( list ) => list.filter( ( char ) => /\d/.test( char ) );
 
+	if ( newValue.match( /^\+$/ ) ) {
+		return 1;
+	}
+
 	// Find the leftmost index point from the right end where
 	// the old and new (unmasked!) values agree (from right to
 	// left). We start by assuming this point is where the edits

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -282,10 +282,10 @@ export function toIcannFormat( inputNumber, country ) {
  *     position may be placed after 'i', rather than after 'a',
  *     depending on where the cursor position is before the edit.
  *
- * @param oldValue Masked original string
- * @param newValue Masked updated string
- * @param oldCursorPosition Index of the cursor in oldValue
- * @returns number
+ * @param {string} oldValue Masked original string
+ * @param {string} newValue Masked updated string
+ * @param {number} oldCursorPosition Index of the cursor in oldValue
+ * @returns {number} The new cursor position
  */
 export function getUpdatedCursorPosition( oldValue, newValue, oldCursorPosition ) {
 	const toList = ( str ) => str.split( '' );

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -262,15 +262,12 @@ export function toIcannFormat( inputNumber, country ) {
 	return '+' + countryCode + '.' + dialCode + nationalNumber;
 }
 
-export function getUpdatedCursorPosition( oldValue, newValue, selectStart, selectEnd ) {
+export function getUpdatedCursorPosition( oldValue, newValue, selectStart ) {
 	const oldDigits = oldValue.split( '' ).filter( ( char ) => /\d/.test( char ) );
 	let digitIndex = 0;
 	let foundIndex = newValue.length;
 	const newChars = newValue.split( '' );
 	let stopSearch = false;
-	if ( selectStart !== selectEnd ) {
-		return selectEnd > newChars.length ? newChars.length : selectEnd;
-	}
 	newChars.forEach( ( char, index ) => {
 		if ( stopSearch ) {
 			return;

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -261,3 +261,38 @@ export function toIcannFormat( inputNumber, country ) {
 
 	return '+' + countryCode + '.' + dialCode + nationalNumber;
 }
+
+export function getUpdatedCursorPosition( oldValue, newValue, selectStart, selectEnd = null ) {
+	const oldDigits = oldValue.split( '' ).filter( ( char ) => /\d/.test( char ) );
+	let digitIndex = 0;
+	let foundIndex = newValue.length;
+	const newChars = newValue.split( '' );
+	let stopSearch = false;
+	if ( selectEnd ) {
+		return selectEnd > newChars.length ? newChars.length : selectEnd;
+	}
+	newChars.forEach( ( char, index ) => {
+		if ( stopSearch ) {
+			return;
+		}
+		const isDigit = /\d/.test( char );
+		if ( index >= selectStart ) {
+			if ( isDigit ) {
+				if ( char !== oldDigits[ digitIndex ] ) {
+					foundIndex = index + 1;
+				} else {
+					digitIndex += 1;
+				}
+			}
+			return;
+		}
+		if ( isDigit ) {
+			if ( char !== oldDigits[ digitIndex ] ) {
+				foundIndex = index;
+				stopSearch = true;
+			}
+			digitIndex += 1;
+		}
+	} );
+	return foundIndex;
+}

--- a/client/components/phone-input/phone-number.js
+++ b/client/components/phone-input/phone-number.js
@@ -262,13 +262,13 @@ export function toIcannFormat( inputNumber, country ) {
 	return '+' + countryCode + '.' + dialCode + nationalNumber;
 }
 
-export function getUpdatedCursorPosition( oldValue, newValue, selectStart, selectEnd = null ) {
+export function getUpdatedCursorPosition( oldValue, newValue, selectStart, selectEnd ) {
 	const oldDigits = oldValue.split( '' ).filter( ( char ) => /\d/.test( char ) );
 	let digitIndex = 0;
 	let foundIndex = newValue.length;
 	const newChars = newValue.split( '' );
 	let stopSearch = false;
-	if ( selectEnd ) {
+	if ( selectStart !== selectEnd ) {
 		return selectEnd > newChars.length ? newChars.length : selectEnd;
 	}
 	newChars.forEach( ( char, index ) => {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -276,35 +276,35 @@ describe( 'metadata:', () => {
 
 describe( 'getUpdatedCursorPosition', () => {
 	test( 'should return last position for appending without special characters', () => {
-		equal( getUpdatedCursorPosition( '23', '234', 2 ), 3 );
+		equal( getUpdatedCursorPosition( '23', '234', 2, 2 ), 3 );
 	} );
 
 	test( 'should return last position for appending with special characters', () => {
-		equal( getUpdatedCursorPosition( '234', '234-5', 3 ), 5 );
+		equal( getUpdatedCursorPosition( '234', '234-5', 3, 3 ), 5 );
 	} );
 
 	test( 'should return last position for deleting from end with special characters', () => {
-		equal( getUpdatedCursorPosition( '234-5', '234', 5 ), 3 );
+		equal( getUpdatedCursorPosition( '234-5', '234', 5, 5 ), 3 );
 	} );
 
 	test( 'should return last position for appending with initial plus', () => {
-		equal( getUpdatedCursorPosition( '+1 234', '+1 234-5', 6 ), 8 );
+		equal( getUpdatedCursorPosition( '+1 234', '+1 234-5', 6, 6 ), 8 );
 	} );
 
 	test( 'should return last position for appending with initial parenthesis', () => {
-		equal( getUpdatedCursorPosition( '(802) 234', '(802) 234-5', 9 ), 11 );
+		equal( getUpdatedCursorPosition( '(802) 234', '(802) 234-5', 9, 9 ), 11 );
 	} );
 
 	test( 'should return last position for appending when initial parenthesis are added', () => {
-		equal( getUpdatedCursorPosition( '802-2343', '(802) 234-39', 8 ), 12 );
+		equal( getUpdatedCursorPosition( '802-2343', '(802) 234-39', 8, 8 ), 12 );
 	} );
 
 	test( 'should return last position for deleting when initial parenthesis are removed', () => {
-		equal( getUpdatedCursorPosition( '(802) 234-39', '802-2343', 12 ), 8 );
+		equal( getUpdatedCursorPosition( '(802) 234-39', '802-2343', 12, 12 ), 8 );
 	} );
 
 	test( 'should return last position for deleting in between special characters', () => {
-		equal( getUpdatedCursorPosition( '(802) 234-3943', '(802) 233-943', 9 ), 8 );
+		equal( getUpdatedCursorPosition( '(802) 234-3943', '(802) 233-943', 9, 9 ), 8 );
 	} );
 
 	test( 'should return last position for deleting multiple characters in between special characters', () => {
@@ -316,23 +316,23 @@ describe( 'getUpdatedCursorPosition', () => {
 	} );
 
 	test( 'should return position after cursor for inserting without special characters', () => {
-		equal( getUpdatedCursorPosition( '124', '1234', 2 ), 3 );
+		equal( getUpdatedCursorPosition( '124', '1234', 2, 2 ), 3 );
 	} );
 
 	test( 'should return position after cursor for inserting before special characters', () => {
-		equal( getUpdatedCursorPosition( '124', '123-4', 2 ), 3 );
+		equal( getUpdatedCursorPosition( '124', '123-4', 2, 2 ), 3 );
 	} );
 
 	test( 'should return position after cursor for inserting multiple numbers before special characters', () => {
-		equal( getUpdatedCursorPosition( '224', '223-764', 2 ), 6 );
+		equal( getUpdatedCursorPosition( '224', '223-764', 2, 2 ), 6 );
 	} );
 
 	test( 'should return position after cursor for inserting after special characters', () => {
-		equal( getUpdatedCursorPosition( '124-4', '124-64', 4 ), 5 );
+		equal( getUpdatedCursorPosition( '124-4', '124-64', 4, 4 ), 5 );
 	} );
 
 	test( 'should return position after cursor for inserting after parenthesis before hyphen', () => {
-		equal( getUpdatedCursorPosition( '(802) 614-21', '(802) 619-421', 8 ), 9 );
+		equal( getUpdatedCursorPosition( '(802) 614-21', '(802) 619-421', 8, 8 ), 9 );
 	} );
 
 	test( 'should return last position when replacing characters with parenthesis', () => {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -348,6 +348,14 @@ describe( 'getUpdatedCursorPosition', () => {
 		equal( getUpdatedCursorPosition( '234', '234-5', 3 ), 5 );
 	} );
 
+	test( 'should return last position for appending duplicate numbers with special characters', () => {
+		equal( getUpdatedCursorPosition( '223-2', '223-22', 5 ), 6 );
+	} );
+
+	test( 'should return last position for inserting duplicate numbers with special characters', () => {
+		equal( getUpdatedCursorPosition( '223-2', '223-22', 4 ), 5 );
+	} );
+
 	test( 'should return last position for deleting from end with special characters', () => {
 		equal( getUpdatedCursorPosition( '234-5', '234', 5 ), 3 );
 	} );

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -276,71 +276,70 @@ describe( 'metadata:', () => {
 
 describe( 'getUpdatedCursorPosition', () => {
 	test( 'should return last position for appending without special characters', () => {
-		equal( getUpdatedCursorPosition( '23', '234', 2, 2 ), 3 );
+		equal( getUpdatedCursorPosition( '23', '234', 2 ), 3 );
 	} );
 
 	test( 'should return last position for appending with special characters', () => {
-		equal( getUpdatedCursorPosition( '234', '234-5', 3, 3 ), 5 );
+		equal( getUpdatedCursorPosition( '234', '234-5', 3 ), 5 );
 	} );
 
 	test( 'should return last position for deleting from end with special characters', () => {
-		equal( getUpdatedCursorPosition( '234-5', '234', 5, 5 ), 3 );
+		equal( getUpdatedCursorPosition( '234-5', '234', 5 ), 3 );
 	} );
 
 	test( 'should return last position for appending with initial plus', () => {
-		equal( getUpdatedCursorPosition( '+1 234', '+1 234-5', 6, 6 ), 8 );
+		equal( getUpdatedCursorPosition( '+1 234', '+1 234-5', 6 ), 8 );
 	} );
 
 	test( 'should return last position for appending with initial parenthesis', () => {
-		equal( getUpdatedCursorPosition( '(802) 234', '(802) 234-5', 9, 9 ), 11 );
+		equal( getUpdatedCursorPosition( '(802) 234', '(802) 234-5', 9 ), 11 );
 	} );
 
 	test( 'should return last position for appending when initial parenthesis are added', () => {
-		equal( getUpdatedCursorPosition( '802-2343', '(802) 234-39', 8, 8 ), 12 );
+		equal( getUpdatedCursorPosition( '802-2343', '(802) 234-39', 8 ), 12 );
 	} );
 
 	test( 'should return last position for deleting when initial parenthesis are removed', () => {
-		equal( getUpdatedCursorPosition( '(802) 234-39', '802-2343', 12, 12 ), 8 );
+		equal( getUpdatedCursorPosition( '(802) 234-39', '802-2343', 12 ), 8 );
 	} );
 
 	test( 'should return last position for deleting in between special characters', () => {
-		equal( getUpdatedCursorPosition( '(802) 234-3943', '(802) 233-943', 9, 9 ), 8 );
+		equal( getUpdatedCursorPosition( '(802) 234-3943', '(802) 233-943', 9 ), 8 );
 	} );
 
-	// This is the only case not covered by the function; it would be nice to fix it but I don't know how
-	test.skip( 'should return last position for deleting multiple characters in between special characters', () => {
-		equal( getUpdatedCursorPosition( '(802) 687-6234', '802-6234', 6, 9 ), 4 );
+	test( 'should return last position for deleting multiple characters in between special characters', () => {
+		equal( getUpdatedCursorPosition( '(802) 687-6234', '802-6234', 6 ), 4 );
 	} );
 
 	test( 'should return last position for replacing multiple characters in between special characters', () => {
-		equal( getUpdatedCursorPosition( '(802) 687-6234', '(802) 555-6234', 6, 9 ), 9 );
+		equal( getUpdatedCursorPosition( '(802) 687-6234', '(802) 555-6234', 6 ), 9 );
 	} );
 
 	test( 'should return position after cursor for inserting without special characters', () => {
-		equal( getUpdatedCursorPosition( '124', '1234', 2, 2 ), 3 );
+		equal( getUpdatedCursorPosition( '124', '1234', 2 ), 3 );
 	} );
 
 	test( 'should return position after cursor for inserting before special characters', () => {
-		equal( getUpdatedCursorPosition( '124', '123-4', 2, 2 ), 3 );
+		equal( getUpdatedCursorPosition( '124', '123-4', 2 ), 3 );
 	} );
 
 	test( 'should return position after cursor for inserting multiple numbers before special characters', () => {
-		equal( getUpdatedCursorPosition( '224', '223-764', 2, 2 ), 6 );
+		equal( getUpdatedCursorPosition( '224', '223-764', 2 ), 6 );
 	} );
 
 	test( 'should return position after cursor for inserting after special characters', () => {
-		equal( getUpdatedCursorPosition( '124-4', '124-64', 4, 4 ), 5 );
+		equal( getUpdatedCursorPosition( '124-4', '124-64', 4 ), 5 );
 	} );
 
 	test( 'should return position after cursor for inserting after parenthesis before hyphen', () => {
-		equal( getUpdatedCursorPosition( '(802) 614-21', '(802) 619-421', 8, 8 ), 9 );
+		equal( getUpdatedCursorPosition( '(802) 614-21', '(802) 619-421', 8 ), 9 );
 	} );
 
 	test( 'should return last position when replacing characters with parenthesis', () => {
-		equal( getUpdatedCursorPosition( '(802) 222-2222', '6', 0, 14 ), 1 );
+		equal( getUpdatedCursorPosition( '(802) 222-2222', '6', 14 ), 1 );
 	} );
 
 	test( 'should return last position when replacing characters with a plus', () => {
-		equal( getUpdatedCursorPosition( '+1 802 222-2222', '6', 0, 15 ), 1 );
+		equal( getUpdatedCursorPosition( '+1 802 222-2222', '6', 15 ), 1 );
 	} );
 } );

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -307,7 +307,8 @@ describe( 'getUpdatedCursorPosition', () => {
 		equal( getUpdatedCursorPosition( '(802) 234-3943', '(802) 233-943', 9, 9 ), 8 );
 	} );
 
-	test( 'should return last position for deleting multiple characters in between special characters', () => {
+	// This is the only case not covered by the function; it would be nice to fix it but I don't know how
+	test.skip( 'should return last position for deleting multiple characters in between special characters', () => {
 		equal( getUpdatedCursorPosition( '(802) 687-6234', '802-6234', 6, 9 ), 4 );
 	} );
 

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -17,7 +17,10 @@ import {
 	DIGIT_PLACEHOLDER,
 	applyTemplate,
 	toE164,
+	getUpdatedCursorPosition,
 } from '../phone-number';
+
+/* eslint-disable jest/expect-expect */
 
 describe( 'metadata:', () => {
 	describe( 'data assertions:', () => {
@@ -268,5 +271,75 @@ describe( 'metadata:', () => {
 		test( 'should separate country codes properly for countries with +1 and a separate leading digit', () => {
 			equal( toIcannFormat( '+18686559999', countries.TT ), '+1.8686559999' );
 		} );
+	} );
+} );
+
+describe( 'getUpdatedCursorPosition', () => {
+	test( 'should return last position for appending without special characters', () => {
+		equal( getUpdatedCursorPosition( '23', '234', 2 ), 3 );
+	} );
+
+	test( 'should return last position for appending with special characters', () => {
+		equal( getUpdatedCursorPosition( '234', '234-5', 3 ), 5 );
+	} );
+
+	test( 'should return last position for deleting from end with special characters', () => {
+		equal( getUpdatedCursorPosition( '234-5', '234', 5 ), 3 );
+	} );
+
+	test( 'should return last position for appending with initial plus', () => {
+		equal( getUpdatedCursorPosition( '+1 234', '+1 234-5', 6 ), 8 );
+	} );
+
+	test( 'should return last position for appending with initial parenthesis', () => {
+		equal( getUpdatedCursorPosition( '(802) 234', '(802) 234-5', 9 ), 11 );
+	} );
+
+	test( 'should return last position for appending when initial parenthesis are added', () => {
+		equal( getUpdatedCursorPosition( '802-2343', '(802) 234-39', 8 ), 12 );
+	} );
+
+	test( 'should return last position for deleting when initial parenthesis are removed', () => {
+		equal( getUpdatedCursorPosition( '(802) 234-39', '802-2343', 12 ), 8 );
+	} );
+
+	test( 'should return last position for deleting in between special characters', () => {
+		equal( getUpdatedCursorPosition( '(802) 234-3943', '(802) 233-943', 9 ), 8 );
+	} );
+
+	test( 'should return last position for deleting multiple characters in between special characters', () => {
+		equal( getUpdatedCursorPosition( '(802) 687-6234', '802-6234', 6, 9 ), 4 );
+	} );
+
+	test( 'should return last position for replacing multiple characters in between special characters', () => {
+		equal( getUpdatedCursorPosition( '(802) 687-6234', '(802) 555-6234', 6, 9 ), 9 );
+	} );
+
+	test( 'should return position after cursor for inserting without special characters', () => {
+		equal( getUpdatedCursorPosition( '124', '1234', 2 ), 3 );
+	} );
+
+	test( 'should return position after cursor for inserting before special characters', () => {
+		equal( getUpdatedCursorPosition( '124', '123-4', 2 ), 3 );
+	} );
+
+	test( 'should return position after cursor for inserting multiple numbers before special characters', () => {
+		equal( getUpdatedCursorPosition( '224', '223-764', 2 ), 6 );
+	} );
+
+	test( 'should return position after cursor for inserting after special characters', () => {
+		equal( getUpdatedCursorPosition( '124-4', '124-64', 4 ), 5 );
+	} );
+
+	test( 'should return position after cursor for inserting after parenthesis before hyphen', () => {
+		equal( getUpdatedCursorPosition( '(802) 614-21', '(802) 619-421', 8 ), 9 );
+	} );
+
+	test( 'should return last position when replacing characters with parenthesis', () => {
+		equal( getUpdatedCursorPosition( '(802) 222-2222', '6', 0, 14 ), 1 );
+	} );
+
+	test( 'should return last position when replacing characters with a plus', () => {
+		equal( getUpdatedCursorPosition( '+1 802 222-2222', '6', 0, 15 ), 1 );
 	} );
 } );

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -389,6 +389,18 @@ describe( 'numDigitsBeforeIndex', () => {
 } );
 
 describe( 'getUpdatedCursorPosition', () => {
+	test( 'should return position after plus if appending only plus', () => {
+		equal( getUpdatedCursorPosition( '', '+', 1 ), 1 );
+	} );
+
+	test( 'should return position after plus if deleting to only plus', () => {
+		equal( getUpdatedCursorPosition( '+5', '+', 2 ), 1 );
+	} );
+
+	test( 'should return position after plus if replacing to only plus', () => {
+		equal( getUpdatedCursorPosition( '555', '+', 3 ), 1 );
+	} );
+
 	test( 'should return last position for appending without special characters', () => {
 		equal( getUpdatedCursorPosition( '23', '234', 2 ), 3 );
 	} );

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -17,6 +17,9 @@ import {
 	DIGIT_PLACEHOLDER,
 	applyTemplate,
 	toE164,
+	indexOfLongestCommonSuffixWith,
+	indexOfStrictSubsequenceEnd,
+	nonDigitsAtStart,
 	getUpdatedCursorPosition,
 } from '../phone-number';
 
@@ -274,6 +277,68 @@ describe( 'metadata:', () => {
 	} );
 } );
 
+describe( 'indexOfLeastCommonSuffixWith', () => {
+	test( 'if array1 === array2 === [], return 0', () => {
+		equal( indexOfLongestCommonSuffixWith( [], [] ), 0 );
+	} );
+
+	test( 'if array1 === ["a"] and array2 === [], return 0', () => {
+		equal( indexOfLongestCommonSuffixWith( [ 'a' ], [] ), 0 );
+	} );
+
+	test( 'if array1 === [] and array2 === ["a"], return 1', () => {
+		equal( indexOfLongestCommonSuffixWith( [], [ 'a' ] ), 1 );
+	} );
+
+	test( 'if array1 === array2 === ["a"], return 0', () => {
+		equal( indexOfLongestCommonSuffixWith( [ 'a' ], [ 'a' ] ), 0 );
+	} );
+
+	test( 'if array1 === array2, return 0', () => {
+		equal( indexOfLongestCommonSuffixWith( [ 'a', 'b', 'c' ], [ 'a', 'b', 'c' ] ), 0 );
+	} );
+
+	test( 'if array1 is a proper prefix of array2, return array2.length', () => {
+		equal( indexOfLongestCommonSuffixWith( [ 'a', 'b', 'c' ], [ 'a', 'b', 'c', 'd' ] ), 4 );
+	} );
+
+	test( 'if array2 is a proper suffix of array1, return 0', () => {
+		equal( indexOfLongestCommonSuffixWith( [ 'a', 'b', 'c' ], [ 'b', 'c' ] ), 0 );
+	} );
+
+	test( 'if longest common suffix of array1 and array2 is empty, return array2.length', () => {
+		equal( indexOfLongestCommonSuffixWith( [ 'x', 'y', 'z' ], [ 'a', 'b', 'c', 'd' ] ), 4 );
+	} );
+} );
+
+describe( 'indexOfStrictSubsequenceEnd', () => {
+	test( 'proper contiguous subsequence', () => {
+		equal( indexOfStrictSubsequenceEnd( [ 'a', 'b' ], [ 'a', 'b', 'c' ] )[ 0 ], 2 );
+	} );
+
+	test( 'proper noncontiguous subsequence', () => {
+		equal( indexOfStrictSubsequenceEnd( [ 'a', 'b' ], [ 'a', 'd', 'b', 'c' ] )[ 0 ], 3 );
+	} );
+} );
+
+describe( 'nonDigitsAtStart', () => {
+	test( 'if all digits, then return 0', () => {
+		equal( nonDigitsAtStart( [ '1', '2', '3' ] ), 0 );
+	} );
+
+	test( 'if all nondigits, then return length', () => {
+		equal( nonDigitsAtStart( [ 'x', 'y', 'z' ] ), 3 );
+	} );
+
+	test( 'nondigits followed by digits', () => {
+		equal( nonDigitsAtStart( [ 'x', 'y', '7' ] ), 2 );
+	} );
+
+	test( 'nondigits followed by digits followed by nondigits', () => {
+		equal( nonDigitsAtStart( [ 'x', 'y', '7', 'z' ] ), 2 );
+	} );
+} );
+
 describe( 'getUpdatedCursorPosition', () => {
 	test( 'should return last position for appending without special characters', () => {
 		equal( getUpdatedCursorPosition( '23', '234', 2 ), 3 );
@@ -308,7 +373,7 @@ describe( 'getUpdatedCursorPosition', () => {
 	} );
 
 	test( 'should return last position for deleting multiple characters in between special characters', () => {
-		equal( getUpdatedCursorPosition( '(802) 687-6234', '802-6234', 6 ), 4 );
+		equal( getUpdatedCursorPosition( '(802) 687-6234', '802-6234', 6 ), 3 );
 	} );
 
 	test( 'should return last position for replacing multiple characters in between special characters', () => {

--- a/client/components/phone-input/test/test-phone-number.js
+++ b/client/components/phone-input/test/test-phone-number.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { equal, ok } from 'assert';
+import { equal, ok, deepStrictEqual } from 'assert';
 import { groupBy, pickBy, forIn } from 'lodash';
 
 /**
@@ -17,9 +17,10 @@ import {
 	DIGIT_PLACEHOLDER,
 	applyTemplate,
 	toE164,
-	indexOfLongestCommonSuffixWith,
+	indexOfLongestCommonSuffix,
 	indexOfStrictSubsequenceEnd,
 	nonDigitsAtStart,
+	numDigitsBeforeIndex,
 	getUpdatedCursorPosition,
 } from '../phone-number';
 
@@ -277,37 +278,43 @@ describe( 'metadata:', () => {
 	} );
 } );
 
-describe( 'indexOfLeastCommonSuffixWith', () => {
-	test( 'if array1 === array2 === [], return 0', () => {
-		equal( indexOfLongestCommonSuffixWith( [], [] ), 0 );
+describe( 'indexOfLongestCommonSuffix', () => {
+	test( 'if array1 === array2 === []', () => {
+		deepStrictEqual( indexOfLongestCommonSuffix( [], [] ), [ 0, 0 ] );
 	} );
 
-	test( 'if array1 === ["a"] and array2 === [], return 0', () => {
-		equal( indexOfLongestCommonSuffixWith( [ 'a' ], [] ), 0 );
+	test( 'if array1 === ["a"] and array2 === []', () => {
+		deepStrictEqual( indexOfLongestCommonSuffix( [ 'a' ], [] ), [ 1, 0 ] );
 	} );
 
-	test( 'if array1 === [] and array2 === ["a"], return 1', () => {
-		equal( indexOfLongestCommonSuffixWith( [], [ 'a' ] ), 1 );
+	test( 'if array1 === [] and array2 === ["a"]', () => {
+		deepStrictEqual( indexOfLongestCommonSuffix( [], [ 'a' ] ), [ 0, 1 ] );
 	} );
 
-	test( 'if array1 === array2 === ["a"], return 0', () => {
-		equal( indexOfLongestCommonSuffixWith( [ 'a' ], [ 'a' ] ), 0 );
+	test( 'if array1 === array2 === ["a"]', () => {
+		deepStrictEqual( indexOfLongestCommonSuffix( [ 'a' ], [ 'a' ] ), [ 0, 0 ] );
 	} );
 
-	test( 'if array1 === array2, return 0', () => {
-		equal( indexOfLongestCommonSuffixWith( [ 'a', 'b', 'c' ], [ 'a', 'b', 'c' ] ), 0 );
+	test( 'if array1 === array2', () => {
+		deepStrictEqual( indexOfLongestCommonSuffix( [ 'a', 'b', 'c' ], [ 'a', 'b', 'c' ] ), [ 0, 0 ] );
 	} );
 
-	test( 'if array1 is a proper prefix of array2, return array2.length', () => {
-		equal( indexOfLongestCommonSuffixWith( [ 'a', 'b', 'c' ], [ 'a', 'b', 'c', 'd' ] ), 4 );
+	test( 'if array1 is a proper prefix of array2', () => {
+		deepStrictEqual( indexOfLongestCommonSuffix( [ 'a', 'b', 'c' ], [ 'a', 'b', 'c', 'd' ] ), [
+			3,
+			4,
+		] );
 	} );
 
-	test( 'if array2 is a proper suffix of array1, return 0', () => {
-		equal( indexOfLongestCommonSuffixWith( [ 'a', 'b', 'c' ], [ 'b', 'c' ] ), 0 );
+	test( 'if array2 is a proper suffix of array1', () => {
+		deepStrictEqual( indexOfLongestCommonSuffix( [ 'a', 'b', 'c' ], [ 'b', 'c' ] ), [ 1, 0 ] );
 	} );
 
-	test( 'if longest common suffix of array1 and array2 is empty, return array2.length', () => {
-		equal( indexOfLongestCommonSuffixWith( [ 'x', 'y', 'z' ], [ 'a', 'b', 'c', 'd' ] ), 4 );
+	test( 'if longest common suffix of array1 and array2 is empty', () => {
+		deepStrictEqual( indexOfLongestCommonSuffix( [ 'x', 'y', 'z' ], [ 'a', 'b', 'c', 'd' ] ), [
+			3,
+			4,
+		] );
 	} );
 } );
 
@@ -339,6 +346,48 @@ describe( 'nonDigitsAtStart', () => {
 	} );
 } );
 
+describe( 'numDigitsBeforeIndex', () => {
+	test( 'empty array', () => {
+		equal( numDigitsBeforeIndex( [], 1 ), 0 );
+	} );
+
+	test( 'all digits, index < length', () => {
+		equal( numDigitsBeforeIndex( [ '1', '2', '3', '4' ], 3 ), 3 );
+	} );
+
+	test( 'all digits, index == length', () => {
+		equal( numDigitsBeforeIndex( [ '1', '2', '3', '4' ], 4 ), 4 );
+	} );
+
+	test( 'all digits, index > length', () => {
+		equal( numDigitsBeforeIndex( [ '1', '2', '3', '4' ], 5 ), 4 );
+	} );
+
+	test( 'not all digits, index < length', () => {
+		equal( numDigitsBeforeIndex( [ '1', 'x', '3', '4' ], 3 ), 2 );
+	} );
+
+	test( 'not all digits, index == length', () => {
+		equal( numDigitsBeforeIndex( [ '1', 'x', '3', '4' ], 4 ), 3 );
+	} );
+
+	test( 'not all digits, index > length', () => {
+		equal( numDigitsBeforeIndex( [ '1', 'x', '3', '4' ], 5 ), 3 );
+	} );
+
+	test( 'no digits, index < length', () => {
+		equal( numDigitsBeforeIndex( [ 'x', 'y', 'z', 'w' ], 3 ), 0 );
+	} );
+
+	test( 'no digits, index == length', () => {
+		equal( numDigitsBeforeIndex( [ 'x', 'y', 'z', 'w' ], 4 ), 0 );
+	} );
+
+	test( 'no digits, index > length', () => {
+		equal( numDigitsBeforeIndex( [ 'x', 'y', 'z', 'w' ], 5 ), 0 );
+	} );
+} );
+
 describe( 'getUpdatedCursorPosition', () => {
 	test( 'should return last position for appending without special characters', () => {
 		equal( getUpdatedCursorPosition( '23', '234', 2 ), 3 );
@@ -352,8 +401,32 @@ describe( 'getUpdatedCursorPosition', () => {
 		equal( getUpdatedCursorPosition( '223-2', '223-22', 5 ), 6 );
 	} );
 
+	test( 'should return last position for appending duplicate substrings with special characters', () => {
+		equal( getUpdatedCursorPosition( '223-2', '223-232', 5 ), 7 );
+	} );
+
 	test( 'should return last position for inserting duplicate numbers with special characters', () => {
 		equal( getUpdatedCursorPosition( '223-2', '223-22', 4 ), 5 );
+	} );
+
+	test( 'should return last position for inserting duplicate numbers with special characters (2)', () => {
+		equal( getUpdatedCursorPosition( '223-2', '223-22', 3 ), 5 );
+	} );
+
+	test( 'should return last position for appending duplicate numbers with special characters - interior', () => {
+		equal( getUpdatedCursorPosition( '223-25', '223-225', 5 ), 6 );
+	} );
+
+	test( 'should return last position for appending duplicate substrings with special characters - interior', () => {
+		equal( getUpdatedCursorPosition( '223-25', '223-2325', 5 ), 7 );
+	} );
+
+	test( 'should return last position for inserting duplicate numbers with special characters - interior', () => {
+		equal( getUpdatedCursorPosition( '223-25', '223-225', 4 ), 5 );
+	} );
+
+	test( 'should return last position for inserting duplicate numbers with special characters (2) - interior', () => {
+		equal( getUpdatedCursorPosition( '223-25', '223-225', 3 ), 5 );
 	} );
 
 	test( 'should return last position for deleting from end with special characters', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

PhoneInput has input masking, but there was a fundamental data source problem: its input comes from a prop, and when you type, the number gets formatted before being sent upstream, but ContactDetailsFormFields then reformats that again to ICANN format when sending it further upstream. If the authorative state lives above ContactDetailsFormFields, then when the number is sent back downstream, it arrives in a different format than PhoneInput expects and can cause strange display formatting and even an infinite loop.

This change completely refactors PhoneInput so that it keeps its current number in three formats: raw (eg: '1234567899'), display (eg: '+1 (123) 456-7899'), and icann (eg: '+1.1234567899', I think?). When it receives a new value via props, it compares that value to all three old values and will not do anything if any of them match.

#### Testing instructions

We'll need to heavily test everything that uses `PhoneInput`.

Some notable previous changes (and their testing instructions) are https://github.com/Automattic/wp-calypso/pull/36881, https://github.com/Automattic/wp-calypso/pull/24870, https://github.com/Automattic/wp-calypso/pull/36541, https://github.com/Automattic/wp-calypso/pull/10447