### PR TITLE
Show new checkout in the Gutenboarding launch flow

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -14,7 +14,7 @@ import MediaLibrarySelectedData from 'components/data/media-library-selected-dat
 import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
 import EditorMediaModal from 'post-editor/editor-media-modal';
-import { getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
 	getCustomizerUrl,
 	getSiteOption,
@@ -302,7 +302,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				this.props.isSiteUnlaunched;
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
-				frankenflowUrl: `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteId }&source=editor`,
+				frankenflowUrl: `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`,
 			} );
 		}
 
@@ -660,6 +660,7 @@ const mapStateToProps = (
 	}: Props
 ) => {
 	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
 	const currentRoute = getCurrentRoute( state );
 	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
 	const siteOption = isJetpackSite( state, siteId ) ? 'jetpack_frame_nonce' : 'frame_nonce';
@@ -711,6 +712,7 @@ const mapStateToProps = (
 		shouldLoadIframe,
 		siteAdminUrl,
 		siteId,
+		siteSlug,
 		customizerUrl: getCustomizerUrl( state, siteId ),
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		getTemplateEditorUrl: partial(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Gutenboarding launch flow does not assign user to the new checkout flow. Also, the checkout URL is incorrect - it looks like this to me `http://calypso.localhost:3000/checkout/176916103?signup=1&preLaunch=1`. The /176916103 part is the siteId which should not be there, and is wrongly assumed to be product ID in this line:

https://github.com/Automattic/wp-calypso/blob/e03f5098b80a372efd26e2a5f7fe69c6772b5cbf/client/my-sites/checkout/controller.jsx#L40

* This PR fixes the above issues.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Proxy through US IP, , go through Gutenboarding at /new and reach the editor.
* Assign yourself to the "composite" variation of the showCompositeCheckout A/B test and click the Launch button
* Add a domain or plan item to cart, and verify that you are shown the new checkout.
