### PR TITLE
Do not show console logs for lux operations

### DIFF
--- a/client/lib/performance-tracking/api.js
+++ b/client/lib/performance-tracking/api.js
@@ -10,7 +10,7 @@ const getLux = () => {
 
 	// Don't send the first navigation automatically, we'll do it.
 	lux.auto = false;
-	lux.debug = true;
+	lux.debug = false;
 	return lux;
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevent Lux logs to appear in the console:

![image](https://user-images.githubusercontent.com/975703/81045073-c6937a00-8eb5-11ea-9a5b-87a5a0ca34e0.png)

More info: https://support.speedcurve.com/en/articles/867066-lux-api#luxdebug

#### Testing instructions

* Checkout branch, start calypso and verify nothing appears in the console when you go to Stats, Plans or My Home
