### PR TITLE
My Home: Menu Task - Update Action

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -7,6 +7,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import InlineSupportLink from 'components/inline-support-link';
 import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
@@ -169,19 +170,23 @@ export const getTask = (
 				timing: 10,
 				title: translate( 'Create a site menu' ),
 				description: translate(
-					"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
-				),
-				actionText: translate( 'View tutorial' ),
-				isSkippable: true,
-				actionDispatch: openSupportArticleDialog,
-				actionDispatchArgs: [
+					"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings. {{supportLink/}}.",
 					{
-						postId: 59580,
-						postUrl: localizeUrl( 'https://wordpress.com/support/menus/' ),
-						actionLabel: translate( 'Go to the Customizer' ),
-						actionUrl: menusUrl,
-					},
-				],
+						components: {
+							supportLink: (
+								<InlineSupportLink
+									supportPostId={ 59580 }
+									supportLink={ localizeUrl( 'https://wordpress.com/support/menus/' ) }
+									showIcon={ false }
+									text={ translate( 'View tutorial' ) }
+								/>
+							),
+						},
+					}
+				),
+				actionText: translate( 'Add a menu' ),
+				isSkippable: true,
+				actionUrl: menusUrl,
 			};
 			break;
 	}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -168,20 +168,18 @@ export const getTask = (
 			taskData = {
 				timing: 10,
 				title: translate( 'Create a site menu' ),
-				description: translate(
-					"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings. {{supportLink/}}.",
-					{
-						components: {
-							supportLink: (
-								<InlineSupportLink
-									supportPostId={ 59580 }
-									supportLink={ localizeUrl( 'https://wordpress.com/support/menus/' ) }
-									showIcon={ false }
-									text={ translate( 'View tutorial' ) }
-								/>
-							),
-						},
-					}
+				description: (
+					<>
+						{ translate(
+							"Building an effective navigation menu makes it easier for someone to find what they're looking for and improve search engine rankings."
+						) }{ ' ' }
+						<InlineSupportLink
+							supportPostId={ 59580 }
+							supportLink={ localizeUrl( 'https://wordpress.com/support/menus/' ) }
+							showIcon={ false }
+							text={ translate( 'View tutorial.' ) }
+						/>
+					</>
 				),
 				actionText: translate( 'Add a menu' ),
 				isSkippable: true,

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -178,6 +178,9 @@ export const getTask = (
 							supportLink={ localizeUrl( 'https://wordpress.com/support/menus/' ) }
 							showIcon={ false }
 							text={ translate( 'View tutorial.' ) }
+							tracksEvent="calypso_customer_home_menus_support_page_view"
+							statsGroup="calypso_customer_home"
+							statsName="menus_view_tutorial"
 						/>
 					</>
 				),

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -12,7 +12,6 @@ import { domainManagementEdit, domainManagementList } from 'my-sites/domains/pat
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
 import { launchSiteOrRedirectToLaunchSignupFlow } from 'state/sites/launch/actions';
 import { localizeUrl } from 'lib/i18n-utils';
-import { openSupportArticleDialog } from 'state/inline-support-article/actions';
 import { verifyEmail } from 'state/current-user/email-verification/actions';
 
 const getTaskDescription = ( task, { isDomainUnverified, isEmailUnverified } ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the action of the Menu task to redirect to the Customizer, with a support link in the description

#### Testing instructions

Verify that the action redirects you to Menus in the Customizer, and the link brings open the "Site Menus" support dialog.

<img width="1133" alt="Screenshot 2020-05-05 at 08 50 17" src="https://user-images.githubusercontent.com/43215253/81045357-efb00c80-8ead-11ea-93ef-a582a633a160.png">

Fixes #41775
