### PR TITLE
WP for Teams: add descriptions to user roles and special handling for WP4Teams sites

### DIFF
--- a/client/my-sites/people/role-select/constants.js
+++ b/client/my-sites/people/role-select/constants.js
@@ -1,0 +1,51 @@
+/**
+ * External dependnecies
+ */
+import i18n from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+
+export const ROLE_ADMINISTRATOR = 'administrator';
+export const ROLE_EDITOR = 'editor';
+export const ROLE_AUTHOR = 'author';
+export const ROLE_CONTRIBUTOR = 'contributor';
+export const ROLE_FOLLOWER = 'follower';
+export const ROLE_SUBSCRIBER = 'subscriber';
+
+export const ROLES_LIST = {
+	[ ROLE_ADMINISTRATOR ]: {
+		getDescription: () =>
+			i18n.translate(
+				'Full power over the site: can invite people, modify the site settings, etc.'
+			),
+	},
+
+	[ ROLE_EDITOR ]: {
+		getDescription: ( isWPForTeamsSite ) =>
+			isWPForTeamsSite
+				? i18n.translate( 'Has access to all posts and pages (recommended).' )
+				: i18n.translate( 'Has access to all posts and pages.' ),
+	},
+
+	[ ROLE_AUTHOR ]: {
+		getDescription: ( isWPForTeamsSite ) =>
+			isWPForTeamsSite
+				? i18n.translate( 'Can write, upload files to, edit, and publish their own posts.' )
+				: i18n.translate( 'Can write, upload photos to, edit, and publish their own posts.' ),
+	},
+
+	[ ROLE_CONTRIBUTOR ]: {
+		getDescription: () =>
+			i18n.translate( "Can write and edit their own posts but can't publish them." ),
+	},
+
+	[ ROLE_FOLLOWER ]: {
+		getDescription: () => i18n.translate( 'Can read and comment on posts and pages.' ),
+	},
+
+	[ ROLE_SUBSCRIBER ]: {
+		getDescription: () => i18n.translate( 'Can read and comment on posts and pages.' ),
+	},
+};

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -18,6 +18,8 @@ import QuerySites from 'components/data/query-sites';
 import QuerySiteRoles from 'components/data/query-site-roles';
 import { getSite } from 'state/sites/selectors';
 import { getSiteRoles } from 'state/site-roles/selectors';
+import { ROLES_LIST } from './constants';
+import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 import './style.scss';
 
@@ -34,8 +36,11 @@ const getWpcomFollowerRole = ( { site, translate } ) => {
 
 const RoleSelect = ( props ) => {
 	let { siteRoles } = props;
+	const { isWPForTeamsSite } = props;
+
 	const { site, includeFollower, siteId, id, explanation, translate, value } = props;
 	const omitProps = [
+		'isWPForTeamsSite',
 		'site',
 		'key',
 		'siteId',
@@ -72,9 +77,11 @@ const RoleSelect = ( props ) => {
 								/>
 								<div className="role-select__role-name">
 									<div>{ role.display_name }</div>
-									<div className="role-select__role-name-description">
-										Full power: can invite people
-									</div>
+									{ ROLES_LIST[ role.name ] && (
+										<div className="role-select__role-name-description">
+											{ ROLES_LIST[ role.name ].getDescription( isWPForTeamsSite ) }
+										</div>
+									) }
 								</div>
 							</div>
 						</FormLabel>
@@ -88,4 +95,5 @@ const RoleSelect = ( props ) => {
 export default connect( ( state, ownProps ) => ( {
 	site: getSite( state, ownProps.siteId ),
 	siteRoles: getSiteRoles( state, ownProps.siteId ),
+	isWPForTeamsSite: isSiteWPForTeams( state, ownProps.siteId ),
 } ) )( localize( RoleSelect ) );

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -59,6 +59,10 @@ const RoleSelect = ( props ) => {
 		siteRoles = siteRoles.concat( getWpcomFollowerRole( props ) );
 	}
 
+	if ( site && siteRoles && isWPForTeamsSite ) {
+		siteRoles = siteRoles.filter( ( role ) => role.name !== 'contributor' );
+	}
+
 	return (
 		<FormFieldset key={ siteId } disabled={ ! siteRoles } id={ id }>
 			{ siteId && <QuerySites siteId={ siteId } /> }

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -19,6 +19,8 @@ import QuerySiteRoles from 'components/data/query-site-roles';
 import { getSite } from 'state/sites/selectors';
 import { getSiteRoles } from 'state/site-roles/selectors';
 
+import './style.scss';
+
 const getWpcomFollowerRole = ( { site, translate } ) => {
 	const displayName = site.is_private
 		? translate( 'Viewer', { context: 'Role that is displayed in a select' } )
@@ -61,12 +63,20 @@ const RoleSelect = ( props ) => {
 				map( siteRoles, ( role ) => {
 					return (
 						<FormLabel key={ role.name }>
-							<FormRadio
-								checked={ role.name === value }
-								value={ role.name }
-								{ ...omit( props, omitProps ) }
-							/>
-							<span>{ role.display_name }</span>
+							<div className="role-select__role-wrapper">
+								<FormRadio
+									className="role-select__role-radio"
+									checked={ role.name === value }
+									value={ role.name }
+									{ ...omit( props, omitProps ) }
+								/>
+								<div className="role-select__role-name">
+									<div>{ role.display_name }</div>
+									<div className="role-select__role-name-description">
+										Full power: can invite people
+									</div>
+								</div>
+							</div>
 						</FormLabel>
 					);
 				} ) }

--- a/client/my-sites/people/role-select/style.scss
+++ b/client/my-sites/people/role-select/style.scss
@@ -1,6 +1,12 @@
 .role-select__role-wrapper {
 	display: flex;
 	margin-bottom: 10px;
+	font-weight: 400;
+
+	input[type='radio'] {
+		margin-top: 3px;
+		margin-right: 8px;
+	}
 }
 
 .role-select__role-name-description {

--- a/client/my-sites/people/role-select/style.scss
+++ b/client/my-sites/people/role-select/style.scss
@@ -1,0 +1,11 @@
+.role-select__role-wrapper {
+	display: flex;
+	margin-bottom: 10px;
+}
+
+.role-select__role-name-description {
+	font-style: italic;
+	font-weight: normal;
+	font-size: 12px;
+	color: var( --color-text-subtle );
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-for-teams/issues/172.

In this PR, we add descriptions to most common user roles for the `people/new` Calypso page. We also add a check if site is a WP for Teams one and if yes, modify the descriptions a bit to match them for WP for Sites needs.

## Testing

Navigate to http://calypso.localhost:3000/people/new with a WP for Teams site and verify the role descriptions match the ones described in the above issue. Now, select a standard WP.com site and verify the role descriptions are more generic.

/cc @evilluendas for design improvements.