### PR TITLE
Jetpack Cloud: Fix scanner threat name and width

### DIFF
--- a/client/landing/jetpack-cloud/components/threat-item-subheader/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item-subheader/index.tsx
@@ -44,7 +44,7 @@ const ThreatItemSubheader: React.FC< Props > = ( { threat } ) => {
 			case 'file':
 				return (
 					<>
-						{ translate( 'Threat found {{signature/}}', {
+						{ translate( 'Threat found ({{signature/}})', {
 							components: {
 								signature: (
 									<span className="threat-item-subheader__alert-signature">

--- a/client/landing/jetpack-cloud/components/threat-item-subheader/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item-subheader/index.tsx
@@ -44,8 +44,8 @@ const ThreatItemSubheader: React.FC< Props > = ( { threat } ) => {
 			case 'file':
 				return (
 					<>
-						{ translate( 'Threat found %(signature)s', {
-							args: {
+						{ translate( 'Threat found {{signature/}}', {
+							components: {
 								signature: (
 									<span className="threat-item-subheader__alert-signature">
 										{ threat.signature }

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -1,7 +1,9 @@
 .threat-item {
 	// Override the error color to a slightly different red.
 	--color-error-20: var( --color-threat-found );
-
+	.foldable-card__main {
+		flex: auto;
+	}
 	&.is-placeholder .card-heading,
 	&.is-placeholder .log-item__subheader {
 		margin-bottom: 2px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug in the translation arguments. 
* Fixes a minor css issue so that we now take up the full thread box if there is no button.

Before:
<img width="720" alt="Screen Shot 2020-05-05 at 12 31 50 PM" src="https://user-images.githubusercontent.com/115071/81057303-74118800-8ecc-11ea-9c33-ff02f6a7efc4.png">

After:
<img width="725" alt="Screen Shot 2020-05-05 at 12 30 33 PM" src="https://user-images.githubusercontent.com/115071/81057315-783da580-8ecc-11ea-803a-389f9e8227a0.png">


#### Testing instructions
* Create a bunch of different threats. 
* Navigate to the scanner page on the jetpack cloud. 
* Notice that the threats show up as expected. 
See before and after. 
