### PR TITLE
Modularise concierge state

### DIFF
--- a/client/state/concierge/actions.js
+++ b/client/state/concierge/actions.js
@@ -16,6 +16,8 @@ import {
 import 'state/data-layer/wpcom/concierge';
 import 'state/data-layer/wpcom/concierge/initial';
 
+import 'state/concierge/init';
+
 export const requestConciergeAppointmentDetails = ( scheduleId, appointmentId ) => ( {
 	type: CONCIERGE_APPOINTMENT_DETAILS_REQUEST,
 	scheduleId,

--- a/client/state/concierge/init.js
+++ b/client/state/concierge/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import conciergeReducer from './reducer';
+
+registerReducer( [ 'concierge' ], conciergeReducer );

--- a/client/state/concierge/package.json
+++ b/client/state/concierge/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/concierge/reducer.js
+++ b/client/state/concierge/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 import appointmentDetails from './appointment-details/reducer';
 import appointmentTimespan from './appointment-timespan/reducer';
 import availableTimes from './available-times/reducer';
@@ -10,7 +10,7 @@ import signupForm from './signup-form/reducer';
 import scheduleId from './schedule-id/reducer';
 import hasAvailableConciergeSessions from './has-available-concierge-sessions/reducer';
 
-export default combineReducers( {
+const combinedReducer = combineReducers( {
 	appointmentDetails,
 	appointmentTimespan,
 	availableTimes,
@@ -19,3 +19,6 @@ export default combineReducers( {
 	scheduleId,
 	hasAvailableConciergeSessions,
 } );
+
+const conciergeReducer = withStorageKey( 'concierge', combinedReducer );
+export default conciergeReducer;

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -23,7 +23,6 @@ import atomicHosting from './hosting/reducer';
 import atomicTransfer from './atomic-transfer/reducer';
 import billingTransactions from './billing-transactions/reducer';
 import checklist from './checklist/reducer';
-import concierge from './concierge/reducer';
 import connectedApplications from './connected-applications/reducer';
 import countries from './countries/reducer';
 import countryStates from './country-states/reducer';
@@ -98,6 +97,7 @@ import wordads from './wordads/reducer';
 
 // Legacy reducers
 // The reducers in this list are not modularized, and are always loaded on boot.
+// Please do not add to this list. See #39261 and p4TIVU-9lM-p2 for more details.
 const reducers = {
 	account,
 	accountRecovery,
@@ -109,7 +109,6 @@ const reducers = {
 	atomicTransfer,
 	billingTransactions,
 	checklist,
-	concierge,
 	connectedApplications,
 	countries,
 	countryStates,

--- a/client/state/selectors/get-concierge-appointment-details.js
+++ b/client/state/selectors/get-concierge-appointment-details.js
@@ -3,5 +3,10 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/concierge/init';
+
 export default ( state, appointmentId ) =>
 	get( state, [ 'concierge', 'appointmentDetails', appointmentId ], null );

--- a/client/state/selectors/get-concierge-appointment-timespan.js
+++ b/client/state/selectors/get-concierge-appointment-timespan.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/concierge/init';
+
 export default ( state ) => get( state, 'concierge.appointmentTimespan', null );

--- a/client/state/selectors/get-concierge-available-times.js
+++ b/client/state/selectors/get-concierge-available-times.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/concierge/init';
+
 export default ( state ) => get( state, 'concierge.availableTimes', null );

--- a/client/state/selectors/get-concierge-has-available-sessions.js
+++ b/client/state/selectors/get-concierge-has-available-sessions.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/concierge/init';
+
 export default ( state ) => get( state, 'concierge.hasAvailableConciergeSessions', null );

--- a/client/state/selectors/get-concierge-next-appointment.js
+++ b/client/state/selectors/get-concierge-next-appointment.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/concierge/init';
+
 export default ( state ) => get( state, 'concierge.nextAppointment', null );

--- a/client/state/selectors/get-concierge-schedule-id.js
+++ b/client/state/selectors/get-concierge-schedule-id.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/concierge/init';
+
 export default ( state ) => get( state, 'concierge.scheduleId', null );

--- a/client/state/selectors/get-concierge-signup-form.js
+++ b/client/state/selectors/get-concierge-signup-form.js
@@ -3,4 +3,9 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import 'state/concierge/init';
+
 export default ( state ) => get( state, 'concierge.signupForm', null );


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles concierge.

For mode details on state modularisation, see #39261 and p4TIVU-9lM-p2.

#### Changes proposed in this Pull Request

* Modularise concierge state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `concierge` key, even if you expand the list of keys. This indicates that the concierge state hasn't been loaded yet.
* Click your avatar on the masterbar, to open `/me`.
* Click `Manage purchases`, to open `/me/purchases`.
* Verify that a `concierge` key is added with the concierge state. This indicates that the concierge state has now been loaded.
* Verify that concierge-related functionality works normally. This indicates that I didn't mess up.

Please also make sure that there are no additional concierge-related action creators or selectors in the codebase, which would also need to import the concierge state init.