### PR TITLE
Add a new Woo-branded flow for connecting a Jetpack site

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -52,6 +52,7 @@ import { localizeUrl } from 'lib/i18n-utils';
 import TextControl from 'extensions/woocommerce/components/text-control';
 import { sendEmailLogin } from 'state/auth/actions';
 import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
+import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 
 export class LoginForm extends Component {
 	static propTypes = {
@@ -289,7 +290,7 @@ export class LoginForm extends Component {
 		this.loginUser();
 	};
 
-	renderWooCommerce() {
+	renderWooCommerce( showSocialLogin = true ) {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 		const { requestError, socialAccountIsLinking: linkingSocialUser } = this.props;
 
@@ -391,7 +392,7 @@ export class LoginForm extends Component {
 							</Button>
 						</div>
 
-						{ config.isEnabled( 'signup/social' ) && (
+						{ config.isEnabled( 'signup/social' ) && showSocialLogin && (
 							<div className="login__form-social">
 								<div className="login__form-social-divider">
 									<span>{ this.props.translate( 'or' ) }</span>
@@ -417,12 +418,14 @@ export class LoginForm extends Component {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 
 		const {
+			accountType,
 			oauth2Client,
 			redirectTo,
 			requestError,
 			socialAccountIsLinking: linkingSocialUser,
 			isJetpackWooCommerceFlow,
 			isGutenboarding,
+			isJetpackWooDnaFlow,
 			wccomFrom,
 			currentRoute,
 			currentQuery,
@@ -478,6 +481,10 @@ export class LoginForm extends Component {
 
 		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {
 			return this.renderWooCommerce();
+		}
+
+		if ( isJetpackWooDnaFlow ) {
+			return this.renderWooCommerce( !! accountType ); // Only show the social buttons after the user entered an email.
 		}
 
 		if (
@@ -667,6 +674,7 @@ export default connect(
 			oauth2Client: getCurrentOAuth2Client( state ),
 			isJetpackWooCommerceFlow:
 				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
+			isJetpackWooDnaFlow: !! wooDnaConfig[ get( getCurrentQueryArguments( state ), 'from' ) ],
 			redirectTo: getRedirectToOriginal( state ),
 			requestError: getRequestError( state ),
 			socialAccountIsLinking: getSocialAccountIsLinking( state ),

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,7 +1,7 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
 
-.layout:not( .is-jetpack-woocommerce-flow ):not( .is-wccom-oauth-flow ) {
+.layout:not( .is-jetpack-woocommerce-flow ):not( .is-jetpack-woo-dna-flow ):not( .is-wccom-oauth-flow ) {
 	.login.is-jetpack {
 		.button.is-primary {
 			background-color: var( --studio-jetpack-green-50 );
@@ -34,6 +34,7 @@
 }
 
 .layout.is-jetpack-woocommerce-flow,
+.layout.is-jetpack-woo-dna-flow,
 .layout.is-wccom-oauth-flow {
 	.login__jetpack-logo,
 	.login__woocommerce-logo {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -58,6 +58,7 @@ import { createSocialUserFailed } from 'state/login/actions';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import { getSectionName } from 'state/ui/selectors';
 import TextControl from 'extensions/woocommerce/components/text-control';
+import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 
 /**
  * Style dependencies
@@ -927,6 +928,7 @@ class SignupForm extends Component {
 		if (
 			( config.isEnabled( 'jetpack/connect/woocommerce' ) &&
 				this.props.isJetpackWooCommerceFlow ) ||
+			this.props.isJetpackWooDnaFlow ||
 			( config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 				isWooOAuth2Client( this.props.oauth2Client ) &&
 				this.props.wccomFrom )
@@ -1055,6 +1057,7 @@ export default connect(
 		sectionName: getSectionName( state ),
 		isJetpackWooCommerceFlow:
 			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
+		isJetpackWooDnaFlow: !! wooDnaConfig[ get( getCurrentQueryArguments( state ), 'from' ) ],
 		from: get( getCurrentQueryArguments( state ), 'from' ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 	} ),

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -24,11 +25,12 @@ export class JetpackHeader extends PureComponent {
 		darkColorScheme: PropTypes.bool,
 		partnerSlug: PropTypes.string,
 		isWoo: PropTypes.bool,
+		isWooDna: PropTypes.bool,
 		width: PropTypes.number,
 	};
 
 	renderLogo() {
-		const { darkColorScheme, partnerSlug, width, isWoo } = this.props;
+		const { darkColorScheme, partnerSlug, width, isWoo, isWooDna, translate } = this.props;
 
 		if ( isWoo ) {
 			// @todo Implement WooCommerce + partner co-branding in the future.
@@ -44,6 +46,23 @@ export class JetpackHeader extends PureComponent {
 						placeholder={ null }
 					/>
 				</JetpackPartnerLogoGroup>
+			);
+		}
+
+		if ( isWooDna ) {
+			return (
+				<svg width={ width } viewBox="0 0 1270 170">
+					<title>{ translate( 'WooCommerce logo' ) }</title>
+					<g fill="none" fillRule="evenodd">
+						<g transform="translate(-120)">
+							<AsyncLoad
+								require="components/jetpack-header/woocommerce"
+								darkColorScheme={ darkColorScheme }
+								placeholder={ null }
+							/>
+						</g>
+					</g>
+				</svg>
 			);
 		}
 
@@ -156,4 +175,4 @@ export class JetpackHeader extends PureComponent {
 	}
 }
 
-export default JetpackHeader;
+export default localize( JetpackHeader );

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -21,6 +21,7 @@ import { chunkCssLinks } from './utils';
 import JetpackLogo from 'components/jetpack-logo';
 import WordPressLogo from 'components/wordpress-logo';
 import { jsonStringifyForHtml } from 'server/sanitize';
+import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 
 class Document extends React.Component {
 	render() {
@@ -87,6 +88,8 @@ class Document extends React.Component {
 			'jetpack-connect' === sectionName &&
 			'woocommerce-onboarding' === requestFrom;
 
+		const isJetpackWooDnaFlow = 'jetpack-connect' === sectionName && wooDnaConfig[ requestFrom ];
+
 		const theme = config( 'theme' );
 
 		const LoadingLogo = config.isEnabled( 'jetpack-cloud' ) ? JetpackLogo : WordPressLogo;
@@ -140,6 +143,7 @@ class Document extends React.Component {
 									[ 'is-group-' + sectionGroup ]: sectionGroup,
 									[ 'is-section-' + sectionName ]: sectionName,
 									'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
+									'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 									'is-wccom-oauth-flow': isWCComConnect,
 								} ) }
 							>

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -25,6 +25,7 @@ export class AuthFormHeader extends Component {
 	static propTypes = {
 		authQuery: authQueryPropTypes.isRequired,
 		isWoo: PropTypes.bool,
+		wooDna: PropTypes.object,
 
 		// Connected props
 		translate: PropTypes.func.isRequired,
@@ -46,11 +47,15 @@ export class AuthFormHeader extends Component {
 			return 'logged-in-success';
 		}
 
+		if ( authorize.isAuthorizing ) {
+			return 'auth-in-progress';
+		}
+
 		return 'logged-in';
 	}
 
 	getHeaderText() {
-		const { translate, partnerSlug, isWoo } = this.props;
+		const { translate, partnerSlug, isWoo, wooDna } = this.props;
 
 		let host = '';
 		switch ( partnerSlug ) {
@@ -89,6 +94,10 @@ export class AuthFormHeader extends Component {
 			}
 		}
 
+		if ( wooDna ) {
+			return wooDna.name( translate );
+		}
+
 		switch ( currentState ) {
 			case 'logged-out':
 				return translate( 'Create an account to set up Jetpack' );
@@ -101,7 +110,7 @@ export class AuthFormHeader extends Component {
 	}
 
 	getSubHeaderText() {
-		const { translate, isWoo } = this.props;
+		const { translate, isWoo, wooDna } = this.props;
 		const currentState = this.getState();
 
 		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isWoo ) {
@@ -112,6 +121,16 @@ export class AuthFormHeader extends Component {
 					);
 				default:
 					return translate( "Once connected we'll continue setting up your store" );
+			}
+		}
+
+		if ( wooDna ) {
+			switch ( currentState ) {
+				case 'logged-in-success':
+				case 'auth-in-progress':
+					return translate( 'Connecting your store' );
+				default:
+					return translate( 'Approve your connection' );
 			}
 		}
 

--- a/client/jetpack-connect/auth-form-header.jsx
+++ b/client/jetpack-connect/auth-form-header.jsx
@@ -25,7 +25,7 @@ export class AuthFormHeader extends Component {
 	static propTypes = {
 		authQuery: authQueryPropTypes.isRequired,
 		isWoo: PropTypes.bool,
-		wooDna: PropTypes.object,
+		wooDnaConfig: PropTypes.object,
 
 		// Connected props
 		translate: PropTypes.func.isRequired,
@@ -55,7 +55,7 @@ export class AuthFormHeader extends Component {
 	}
 
 	getHeaderText() {
-		const { translate, partnerSlug, isWoo, wooDna } = this.props;
+		const { translate, partnerSlug, isWoo, wooDnaConfig } = this.props;
 
 		let host = '';
 		switch ( partnerSlug ) {
@@ -94,8 +94,8 @@ export class AuthFormHeader extends Component {
 			}
 		}
 
-		if ( wooDna ) {
-			return wooDna.name( translate );
+		if ( wooDnaConfig ) {
+			return wooDnaConfig.name( translate );
 		}
 
 		switch ( currentState ) {
@@ -110,7 +110,7 @@ export class AuthFormHeader extends Component {
 	}
 
 	getSubHeaderText() {
-		const { translate, isWoo, wooDna } = this.props;
+		const { translate, isWoo, wooDnaConfig } = this.props;
 		const currentState = this.getState();
 
 		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isWoo ) {
@@ -124,7 +124,7 @@ export class AuthFormHeader extends Component {
 			}
 		}
 
-		if ( wooDna ) {
+		if ( wooDnaConfig ) {
 			switch ( currentState ) {
 				case 'logged-in-success':
 				case 'auth-in-progress':

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -72,6 +72,7 @@ import {
 } from 'state/jetpack-connect/selectors';
 import getPartnerIdFromQuery from 'state/selectors/get-partner-id-from-query';
 import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
+import wooDnaConfig from './woo-dna-config';
 
 /**
  * Constants
@@ -268,21 +269,27 @@ export class JetpackAuthorize extends Component {
 		return 'sso' === from && isSsoApproved( clientId );
 	}
 
-	isWooRedirect( props = this.props ) {
+	isWooRedirect = ( props = this.props ) => {
 		const { from } = props.authQuery;
-		return includes(
-			[
-				'woocommerce-services-auto-authorize',
-				'woocommerce-setup-wizard',
-				'woocommerce-onboarding',
-			],
-			from
+		return (
+			includes(
+				[
+					'woocommerce-services-auto-authorize',
+					'woocommerce-setup-wizard',
+					'woocommerce-onboarding',
+				],
+				from
+			) || this.getWooDnaConfig( props )
 		);
-	}
+	};
 
 	isWooOnboarding( props = this.props ) {
 		const { from } = props.authQuery;
 		return 'woocommerce-onboarding' === from;
+	}
+
+	getWooDnaConfig( props = this.props ) {
+		return wooDnaConfig[ props.authQuery.from ];
 	}
 
 	shouldRedirectJetpackStart( props = this.props ) {

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -741,11 +741,13 @@ export class JetpackAuthorize extends Component {
 	}
 
 	render() {
+		const { translate } = this.props;
 		const wooDna = this.getWooDnaConfig();
 		return (
 			<MainWrapper
 				isWoo={ this.isWooOnboarding() }
 				wooDna={ wooDna }
+				pageTitle={ wooDna && wooDna.name( translate ) + ' — ' + translate( 'Connect' ) }
 			>
 				<div className="jetpack-connect__authorize-form">
 					<div className="jetpack-connect__logged-in-form">

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -719,7 +719,11 @@ export class JetpackAuthorize extends Component {
 							siteId={ this.props.authQuery.clientId }
 							siteIsOnSitesList={ this.props.isAlreadyOnSitesList }
 						/>
-						<AuthFormHeader authQuery={ this.props.authQuery } isWoo={ this.isWooOnboarding() } />
+						<AuthFormHeader
+							authQuery={ this.props.authQuery }
+							isWoo={ this.isWooOnboarding() }
+							wooDna={ this.getWooDnaConfig() }
+						/>
 						<Card className="jetpack-connect__logged-in-card">
 							<Gravatar user={ this.props.user } size={ 64 } />
 							<p className="jetpack-connect__logged-in-form-user-text">{ this.getUserText() }</p>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -630,6 +630,10 @@ export class JetpackAuthorize extends Component {
 			return null;
 		}
 
+		if ( this.getWooDnaConfig() ) {
+			return this.renderWooDnaFooterLinks();
+		}
+
 		return (
 			<LoggedOutFormLinks>
 				{ this.renderBackToWpAdminLink() }
@@ -650,6 +654,32 @@ export class JetpackAuthorize extends Component {
 				<JetpackConnectHappychatButton eventName="calypso_jpc_authorize_chat_initiated">
 					<HelpButton />
 				</JetpackConnectHappychatButton>
+			</LoggedOutFormLinks>
+		);
+	}
+
+	renderWooDnaFooterLinks() {
+		const { translate } = this.props;
+		const { name, helpUrl } = this.getWooDnaConfig();
+		/* translators: pluginName is the name of the Woo extension that initiated the connection flow */
+		const helpButtonLabel = translate( 'Get help setting up %(pluginName)s', {
+			args: {
+				pluginName: name( translate ),
+			},
+		} );
+
+		return (
+			<LoggedOutFormLinks>
+				<LoggedOutFormLinkItem onClick={ this.handleSignOut }>
+					{ translate( 'Create a new account or connect as a different user' ) }
+				</LoggedOutFormLinkItem>
+				<JetpackConnectHappychatButton
+					eventName="calypso_jpc_authorize_chat_initiated"
+					label={ helpButtonLabel }
+				>
+					<HelpButton label={ helpButtonLabel } url={ helpUrl } />
+				</JetpackConnectHappychatButton>
+				{ this.renderBackToWpAdminLink() }
 			</LoggedOutFormLinks>
 		);
 	}

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -711,8 +711,12 @@ export class JetpackAuthorize extends Component {
 	}
 
 	render() {
+		const wooDna = this.getWooDnaConfig();
 		return (
-			<MainWrapper isWoo={ this.isWooOnboarding() }>
+			<MainWrapper
+				isWoo={ this.isWooOnboarding() }
+				wooDna={ wooDna }
+			>
 				<div className="jetpack-connect__authorize-form">
 					<div className="jetpack-connect__logged-in-form">
 						<QueryUserConnection

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -630,8 +630,9 @@ export class JetpackAuthorize extends Component {
 			return null;
 		}
 
-		if ( this.getWooDnaConfig() ) {
-			return this.renderWooDnaFooterLinks();
+		const wooDnaFooterLinks = this.renderWooDnaFooterLinks();
+		if ( wooDnaFooterLinks ) {
+			return wooDnaFooterLinks;
 		}
 
 		return (
@@ -660,11 +661,14 @@ export class JetpackAuthorize extends Component {
 
 	renderWooDnaFooterLinks() {
 		const { translate } = this.props;
-		const { name, helpUrl } = this.getWooDnaConfig();
+		const wooDna = this.getWooDnaConfig();
+		if ( ! wooDna ) {
+			return null;
+		}
 		/* translators: pluginName is the name of the Woo extension that initiated the connection flow */
 		const helpButtonLabel = translate( 'Get help setting up %(pluginName)s', {
 			args: {
-				pluginName: name( translate ),
+				pluginName: wooDna.name( translate ),
 			},
 		} );
 
@@ -677,7 +681,7 @@ export class JetpackAuthorize extends Component {
 					eventName="calypso_jpc_authorize_chat_initiated"
 					label={ helpButtonLabel }
 				>
-					<HelpButton label={ helpButtonLabel } url={ helpUrl } />
+					<HelpButton label={ helpButtonLabel } url={ wooDna.helpUrl } />
 				</JetpackConnectHappychatButton>
 				{ this.renderBackToWpAdminLink() }
 			</LoggedOutFormLinks>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -279,7 +279,7 @@ export class JetpackAuthorize extends Component {
 					'woocommerce-onboarding',
 				],
 				from
-			) || this.getWooDnaConfig( props )
+			) || Boolean( this.getWooDnaConfig( props ) )
 		);
 	};
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -750,7 +750,7 @@ export class JetpackAuthorize extends Component {
 		return (
 			<MainWrapper
 				isWoo={ this.isWooOnboarding() }
-				wooDna={ wooDna }
+				wooDnaConfig={ wooDna }
 				pageTitle={ wooDna && wooDna.name( translate ) + ' — ' + translate( 'Connect' ) }
 			>
 				<div className="jetpack-connect__authorize-form">
@@ -762,7 +762,7 @@ export class JetpackAuthorize extends Component {
 						<AuthFormHeader
 							authQuery={ this.props.authQuery }
 							isWoo={ this.isWooOnboarding() }
-							wooDna={ wooDna }
+							wooDnaConfig={ wooDna }
 						/>
 						<Card className="jetpack-connect__logged-in-card">
 							<Gravatar user={ this.props.user } size={ 64 } />

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -758,7 +758,7 @@ export class JetpackAuthorize extends Component {
 						<AuthFormHeader
 							authQuery={ this.props.authQuery }
 							isWoo={ this.isWooOnboarding() }
-							wooDna={ this.getWooDnaConfig() }
+							wooDna={ wooDna }
 						/>
 						<Card className="jetpack-connect__logged-in-card">
 							<Gravatar user={ this.props.user } size={ 64 } />

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -21,6 +21,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	static propTypes = {
 		isWide: PropTypes.bool,
 		isWoo: PropTypes.bool,
+		wooDna: PropTypes.object,
 		partnerSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		pageTitle: PropTypes.string,
@@ -29,21 +30,22 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	static defaultProps = {
 		isWide: false,
 		isWoo: false,
+		wooDna: null,
 	};
 
 	render() {
-		const { isWide, className, children, partnerSlug, translate, pageTitle } = this.props;
+		const { isWide, className, children, partnerSlug, translate, wooDna, pageTitle } = this.props;
 
 		const isWoo = config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isWoo;
 
 		const wrapperClassName = classNames( 'jetpack-connect__main', {
 			'is-wide': isWide,
-			'is-woocommerce': isWoo,
+			'is-woocommerce': isWoo || wooDna,
 			'is-mobile-app-flow': !! retrieveMobileRedirect(),
 		} );
 
-		const width = isWoo ? 200 : undefined;
-		const darkColorScheme = isWoo ? false : true;
+		const width = isWoo || wooDna ? 200 : undefined;
+		const darkColorScheme = isWoo || wooDna ? false : true;
 
 		return (
 			<Main className={ classNames( className, wrapperClassName ) }>
@@ -55,6 +57,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 					<JetpackHeader
 						partnerSlug={ partnerSlug }
 						isWoo={ isWoo }
+						isWooDna={ !! wooDna }
 						width={ width }
 						darkColorScheme={ darkColorScheme }
 					/>

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -21,7 +21,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	static propTypes = {
 		isWide: PropTypes.bool,
 		isWoo: PropTypes.bool,
-		wooDna: PropTypes.object,
+		wooDnaConfig: PropTypes.object,
 		partnerSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		pageTitle: PropTypes.string,
@@ -30,22 +30,30 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	static defaultProps = {
 		isWide: false,
 		isWoo: false,
-		wooDna: null,
+		wooDnaConfig: null,
 	};
 
 	render() {
-		const { isWide, className, children, partnerSlug, translate, wooDna, pageTitle } = this.props;
+		const {
+			isWide,
+			className,
+			children,
+			partnerSlug,
+			translate,
+			wooDnaConfig,
+			pageTitle,
+		} = this.props;
 
 		const isWoo = config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isWoo;
 
 		const wrapperClassName = classNames( 'jetpack-connect__main', {
 			'is-wide': isWide,
-			'is-woocommerce': isWoo || wooDna,
+			'is-woocommerce': isWoo || wooDnaConfig,
 			'is-mobile-app-flow': !! retrieveMobileRedirect(),
 		} );
 
-		const width = isWoo || wooDna ? 200 : undefined;
-		const darkColorScheme = isWoo || wooDna ? false : true;
+		const width = isWoo || wooDnaConfig ? 200 : undefined;
+		const darkColorScheme = isWoo || wooDnaConfig ? false : true;
 
 		return (
 			<Main className={ classNames( className, wrapperClassName ) }>
@@ -57,7 +65,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 					<JetpackHeader
 						partnerSlug={ partnerSlug }
 						isWoo={ isWoo }
-						isWooDna={ !! wooDna }
+						isWooDna={ !! wooDnaConfig }
 						width={ width }
 						darkColorScheme={ darkColorScheme }
 					/>

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -13,7 +13,7 @@ import debugFactory from 'debug';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, get, noop } from 'lodash';
+import { flowRight, get, includes, noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -40,6 +40,17 @@ import {
 	createAccount as createAccountAction,
 	createSocialAccount as createSocialAccountAction,
 } from 'state/jetpack-connect/actions';
+import LoginBlock from 'blocks/login';
+import Gridicon from 'components/gridicon';
+import { decodeEntities } from 'lib/formatting';
+import {
+	getRequestError,
+	getLastCheckedUsernameOrEmail,
+	getAuthAccountType,
+} from 'state/login/selectors';
+import { resetAuthAccountType as resetAuthAccountTypeAction } from 'state/login/actions';
+import FormattedHeader from 'components/formatted-header';
+import wooDnaConfig from './woo-dna-config';
 
 const debug = debugFactory( 'calypso:jetpack-connect:authorize-form' );
 
@@ -59,6 +70,7 @@ export class JetpackSignup extends Component {
 		isCreatingAccount: false,
 		newUsername: null,
 		bearerToken: null,
+		showWooDnaLoginForm: true,
 	} );
 
 	state = this.constructor.initialState;
@@ -83,9 +95,45 @@ export class JetpackSignup extends Component {
 		} );
 	}
 
+	componentDidUpdate( prevProps ) {
+		const { requestError } = this.props;
+
+		if ( prevProps.requestError || ! requestError ) {
+			return;
+		}
+
+		if (
+			this.getWooDnaConfig() &&
+			'usernameOrEmail' === requestError.field &&
+			'unknown_user' === requestError.code
+		) {
+			this.showWooDnaSignupView();
+		}
+	}
+
+	showWooDnaSignupView = () => {
+		this.setState( {
+			showWooDnaLoginForm: false,
+		} );
+		this.props.resetAuthAccountType();
+	};
+
+	showWooDnaLoginView = ( usernameOrEmail ) => {
+		this.setState( {
+			showWooDnaLoginForm: true,
+			signUpUsernameOrEmail: usernameOrEmail || null,
+		} );
+		this.props.resetAuthAccountType();
+	};
+
 	isWoo() {
 		const { authQuery } = this.props;
 		return 'woocommerce-onboarding' === authQuery.from;
+	}
+
+	getWooDnaConfig() {
+		const { authQuery } = this.props;
+		return wooDnaConfig[ authQuery.from ];
 	}
 
 	getLoginRoute() {
@@ -212,7 +260,107 @@ export class JetpackSignup extends Component {
 			</LoggedOutFormLinks>
 		);
 	}
+
+	renderWooDna() {
+		const { authQuery, isFullLoginFormVisible, translate, usernameOrEmail } = this.props;
+		const { isCreatingAccount, signUpUsernameOrEmail } = this.state;
+		let header, subHeader, content;
+		const footerLinks = [];
+		const email = signUpUsernameOrEmail || usernameOrEmail || authQuery.userEmail;
+		const wooDna = this.getWooDnaConfig();
+
+		if ( this.state.showWooDnaLoginForm ) {
+			if ( isFullLoginFormVisible ) {
+				header = translate( 'Log in to your WordPress.com account' );
+				/* translators: pluginName is the name of the Woo extension that initiated the connection flow */
+				subHeader = translate(
+					'Your account will enable you to start using the features and benefits offered by %(pluginName)s',
+					{
+						args: {
+							pluginName: wooDna.name( translate ),
+						},
+					}
+				);
+				footerLinks.push(
+					<LoggedOutFormLinkItem key="signup" onClick={ this.showWooDnaSignupView }>
+						{ this.props.translate( 'Create a new account' ) }
+					</LoggedOutFormLinkItem>
+				);
+				footerLinks.push(
+					<LoggedOutFormLinkItem
+						key="lostpassword"
+						href={ addQueryArgs(
+							{ action: 'lostpassword' },
+							login( { locale: this.props.locale } )
+						) }
+					>
+						{ this.props.translate( 'Lost your password?' ) }
+					</LoggedOutFormLinkItem>
+				);
+			} else {
+				header = wooDna.name( translate );
+				subHeader = translate( 'Enter your email address to get started' );
+			}
+		} else {
+			header = wooDna.name( translate );
+			subHeader = translate( 'Create an account' );
+			footerLinks.push(
+				<LoggedOutFormLinkItem key="login" onClick={ () => this.showWooDnaLoginView() }>
+					{ this.props.translate( 'Log in with an existing WordPress.com account' ) }
+				</LoggedOutFormLinkItem>
+			);
+		}
+
+		footerLinks.push(
+			<LoggedOutFormLinkItem key="back" href={ authQuery.redirectAfterAuth }>
+				<Gridicon size={ 18 } icon="arrow-left" />{ ' ' }
+				{
+					// translators: eg: Return to The WordPress.com Blog
+					this.props.translate( 'Return to %(sitename)s', {
+						args: { sitename: decodeEntities( authQuery.blogname ) },
+					} )
+				}
+			</LoggedOutFormLinkItem>
+		);
+		const footer = <LoggedOutFormLinks>{ footerLinks }</LoggedOutFormLinks>;
+
+		if ( this.state.showWooDnaLoginForm ) {
+			content = <LoginBlock locale={ this.props.locale } footer={ footer } userEmail={ email } />;
+		} else {
+			content = (
+				<SignupForm
+					disabled={ isCreatingAccount }
+					email={ includes( email, '@' ) ? email : '' }
+					footerLink={ footer }
+					handleLogin={ this.showWooDnaLoginView }
+					handleSocialResponse={ this.handleSocialResponse }
+					isSocialSignupEnabled={ isEnabled( 'signup/social' ) }
+					locale={ this.props.locale }
+					redirectToAfterLoginUrl={ addQueryArgs( { auth_approved: true }, window.location.href ) }
+					submitButtonText={ this.props.translate( 'Create your account' ) }
+					submitForm={ this.handleSubmitSignup }
+					submitting={ isCreatingAccount }
+					suggestedUsername={ includes( email, '@' ) ? '' : email }
+				/>
+			);
+		}
+
+		return (
+			<MainWrapper wooDna={ wooDna }>
+				<div className="jetpack-connect__authorize-form">
+					{ this.renderLocaleSuggestions() }
+					<FormattedHeader headerText={ header } subHeaderText={ subHeader } />
+					{ content }
+					{ this.renderLoginUser() }
+				</div>
+			</MainWrapper>
+		);
+	}
+
 	render() {
+		if ( this.getWooDnaConfig() ) {
+			return this.renderWooDna();
+		}
 		const { isCreatingAccount } = this.state;
 		return (
 			<MainWrapper isWoo={ this.isWoo() }>
@@ -242,12 +390,20 @@ export class JetpackSignup extends Component {
 	}
 }
 
-const connectComponent = connect( null, {
-	createAccount: createAccountAction,
-	createSocialAccount: createSocialAccountAction,
-	errorNotice: errorNoticeAction,
-	recordTracksEvent: recordTracksEventAction,
-	warningNotice: warningNoticeAction,
-} );
+const connectComponent = connect(
+	( state ) => ( {
+		requestError: getRequestError( state ),
+		usernameOrEmail: getLastCheckedUsernameOrEmail( state ),
+		isFullLoginFormVisible: !! getAuthAccountType( state ),
+	} ),
+	{
+		createAccount: createAccountAction,
+		createSocialAccount: createSocialAccountAction,
+		errorNotice: errorNoticeAction,
+		recordTracksEvent: recordTracksEventAction,
+		warningNotice: warningNoticeAction,
+		resetAuthAccountType: resetAuthAccountTypeAction,
+	}
+);
 
 export default flowRight( connectComponent, localize )( JetpackSignup );

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -268,6 +268,7 @@ export class JetpackSignup extends Component {
 		const footerLinks = [];
 		const email = signUpUsernameOrEmail || usernameOrEmail || authQuery.userEmail;
 		const wooDna = this.getWooDnaConfig();
+		let pageTitle;
 
 		if ( this.state.showWooDnaLoginForm ) {
 			if ( isFullLoginFormVisible ) {
@@ -281,6 +282,7 @@ export class JetpackSignup extends Component {
 						},
 					}
 				);
+				pageTitle = translate( 'Login to WordPress.com' );
 				footerLinks.push(
 					<LoggedOutFormLinkItem key="signup" onClick={ this.showWooDnaSignupView }>
 						{ this.props.translate( 'Create a new account' ) }
@@ -300,10 +302,12 @@ export class JetpackSignup extends Component {
 			} else {
 				header = wooDna.name( translate );
 				subHeader = translate( 'Enter your email address to get started' );
+				pageTitle = translate( 'Connect' );
 			}
 		} else {
 			header = wooDna.name( translate );
 			subHeader = translate( 'Create an account' );
+			pageTitle = translate( 'Create a WordPress.com account' );
 			footerLinks.push(
 				<LoggedOutFormLinkItem key="login" onClick={ () => this.showWooDnaLoginView() }>
 					{ this.props.translate( 'Log in with an existing WordPress.com account' ) }
@@ -346,7 +350,7 @@ export class JetpackSignup extends Component {
 		}
 
 		return (
-			<MainWrapper wooDna={ wooDna }>
+			<MainWrapper wooDna={ wooDna } pageTitle={ wooDna.name( translate ) + ' — ' + pageTitle }>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }
 					<FormattedHeader headerText={ header } subHeaderText={ subHeader } />

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -369,7 +369,10 @@ export class JetpackSignup extends Component {
 		}
 
 		return (
-			<MainWrapper wooDna={ wooDna } pageTitle={ wooDna.name( translate ) + ' — ' + pageTitle }>
+			<MainWrapper
+				wooDnaConfig={ wooDna }
+				pageTitle={ wooDna.name( translate ) + ' — ' + pageTitle }
+			>
 				<div className="jetpack-connect__authorize-form">
 					{ this.renderLocaleSuggestions() }
 					<FormattedHeader headerText={ header } subHeaderText={ subHeader } />

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -261,6 +261,22 @@ export class JetpackSignup extends Component {
 		);
 	}
 
+	renderWooDnaFooter( footerLinks ) {
+		const { authQuery } = this.props;
+		footerLinks.push(
+			<LoggedOutFormLinkItem key="back" href={ authQuery.redirectAfterAuth }>
+				<Gridicon size={ 18 } icon="arrow-left" />{ ' ' }
+				{
+					// translators: eg: Return to The WordPress.com Blog
+					this.props.translate( 'Return to %(sitename)s', {
+						args: { sitename: decodeEntities( authQuery.blogname ) },
+					} )
+				}
+			</LoggedOutFormLinkItem>
+		);
+		return <LoggedOutFormLinks>{ footerLinks }</LoggedOutFormLinks>;
+	}
+
 	renderWooDna() {
 		const { authQuery, isFullLoginFormVisible, translate, usernameOrEmail } = this.props;
 		const { isCreatingAccount, signUpUsernameOrEmail } = this.state;
@@ -304,6 +320,13 @@ export class JetpackSignup extends Component {
 				subHeader = translate( 'Enter your email address to get started' );
 				pageTitle = translate( 'Connect' );
 			}
+			content = (
+				<LoginBlock
+					locale={ this.props.locale }
+					footer={ this.renderWooDnaFooter( footerLinks ) }
+					userEmail={ email }
+				/>
+			);
 		} else {
 			header = wooDna.name( translate );
 			subHeader = translate( 'Create an account' );
@@ -313,29 +336,11 @@ export class JetpackSignup extends Component {
 					{ this.props.translate( 'Log in with an existing WordPress.com account' ) }
 				</LoggedOutFormLinkItem>
 			);
-		}
-
-		footerLinks.push(
-			<LoggedOutFormLinkItem key="back" href={ authQuery.redirectAfterAuth }>
-				<Gridicon size={ 18 } icon="arrow-left" />{ ' ' }
-				{
-					// translators: eg: Return to The WordPress.com Blog
-					this.props.translate( 'Return to %(sitename)s', {
-						args: { sitename: decodeEntities( authQuery.blogname ) },
-					} )
-				}
-			</LoggedOutFormLinkItem>
-		);
-		const footer = <LoggedOutFormLinks>{ footerLinks }</LoggedOutFormLinks>;
-
-		if ( this.state.showWooDnaLoginForm ) {
-			content = <LoginBlock locale={ this.props.locale } footer={ footer } userEmail={ email } />;
-		} else {
 			content = (
 				<SignupForm
 					disabled={ isCreatingAccount }
 					email={ includes( email, '@' ) ? email : '' }
-					footerLink={ footer }
+					footerLink={ this.renderWooDnaFooter( footerLinks ) }
 					handleLogin={ this.showWooDnaLoginView }
 					handleSocialResponse={ this.handleSocialResponse }
 					isSocialSignupEnabled={ isEnabled( 'signup/social' ) }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -96,16 +96,16 @@ export class JetpackSignup extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { requestError } = this.props;
+		const { loginRequestError } = this.props;
 
-		if ( prevProps.requestError || ! requestError ) {
+		if ( prevProps.loginRequestError || ! loginRequestError ) {
 			return;
 		}
 
 		if (
 			this.getWooDnaConfig() &&
-			'usernameOrEmail' === requestError.field &&
-			'unknown_user' === requestError.code
+			'usernameOrEmail' === loginRequestError.field &&
+			'unknown_user' === loginRequestError.code
 		) {
 			this.showWooDnaSignupView();
 		}
@@ -415,7 +415,7 @@ export class JetpackSignup extends Component {
 
 const connectComponent = connect(
 	( state ) => ( {
-		requestError: getRequestError( state ),
+		loginRequestError: getRequestError( state ),
 		usernameOrEmail: getLastCheckedUsernameOrEmail( state ),
 		isFullLoginFormVisible: !! getAuthAccountType( state ),
 	} ),

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -122,6 +122,8 @@ export class JetpackSignup extends Component {
 		this.setState( {
 			wooDnaFormType: 'login',
 			signUpUsernameOrEmail: usernameOrEmail || null,
+			loginSocialConnect: false,
+			loginTwoFactorAuthType: null,
 		} );
 		this.props.resetAuthAccountType();
 	};
@@ -279,7 +281,12 @@ export class JetpackSignup extends Component {
 
 	renderWooDna() {
 		const { authQuery, isFullLoginFormVisible, translate, usernameOrEmail } = this.props;
-		const { isCreatingAccount, signUpUsernameOrEmail } = this.state;
+		const {
+			isCreatingAccount,
+			signUpUsernameOrEmail,
+			loginSocialConnect,
+			loginTwoFactorAuthType,
+		} = this.state;
 		let header, subHeader, content;
 		const footerLinks = [];
 		const email = signUpUsernameOrEmail || usernameOrEmail || authQuery.userEmail;
@@ -325,6 +332,12 @@ export class JetpackSignup extends Component {
 					locale={ this.props.locale }
 					footer={ this.renderWooDnaFooter( footerLinks ) }
 					userEmail={ email }
+					socialConnect={ loginSocialConnect }
+					twoFactorAuthType={ loginTwoFactorAuthType }
+					onTwoFactorRequested={ ( authType ) =>
+						this.setState( { loginTwoFactorAuthType: authType } )
+					}
+					onSocialConnectStart={ () => this.setState( { loginSocialConnect: true } ) }
 				/>
 			);
 		} else {

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -70,7 +70,7 @@ export class JetpackSignup extends Component {
 		isCreatingAccount: false,
 		newUsername: null,
 		bearerToken: null,
-		showWooDnaLoginForm: true,
+		wooDnaFormType: 'login',
 	} );
 
 	state = this.constructor.initialState;
@@ -113,14 +113,14 @@ export class JetpackSignup extends Component {
 
 	showWooDnaSignupView = () => {
 		this.setState( {
-			showWooDnaLoginForm: false,
+			wooDnaFormType: 'signup',
 		} );
 		this.props.resetAuthAccountType();
 	};
 
 	showWooDnaLoginView = ( usernameOrEmail ) => {
 		this.setState( {
-			showWooDnaLoginForm: true,
+			wooDnaFormType: 'login',
 			signUpUsernameOrEmail: usernameOrEmail || null,
 		} );
 		this.props.resetAuthAccountType();
@@ -286,7 +286,7 @@ export class JetpackSignup extends Component {
 		const wooDna = this.getWooDnaConfig();
 		let pageTitle;
 
-		if ( this.state.showWooDnaLoginForm ) {
+		if ( 'login' === this.state.wooDnaFormType ) {
 			if ( isFullLoginFormVisible ) {
 				header = translate( 'Log in to your WordPress.com account' );
 				/* translators: pluginName is the name of the Woo extension that initiated the connection flow */
@@ -328,6 +328,7 @@ export class JetpackSignup extends Component {
 				/>
 			);
 		} else {
+			// Woo DNA sign-up form
 			header = wooDna.name( translate );
 			subHeader = translate( 'Create an account' );
 			pageTitle = translate( 'Create a WordPress.com account' );

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1086,6 +1086,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			}
 		}
 
+		.login__form-change-username {
+			display: none;
+		}
+
 		.jetpack-connect__logged-in-card button {
 			border: 0;
 			box-shadow: none;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -3,11 +3,12 @@
 $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__main:not( .is-woocommerce ),
-.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ):not( .is-jetpack-woocommerce-flow ) {
+.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ):not( .is-jetpack-woocommerce-flow ):not( .is-jetpack-woo-dna-flow ) {
 	@include jetpack-connect-colors();
 }
 
-.layout.is-jetpack-woocommerce-flow {
+.layout.is-jetpack-woocommerce-flow,
+.layout.is-jetpack-woo-dna-flow {
 	@include woocommerce-colors();
 }
 
@@ -937,7 +938,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	/** WooCommerce Onboarding Styles **/
-	&.is-jetpack-woocommerce-flow {
+	&.is-jetpack-woocommerce-flow, &.is-jetpack-woo-dna-flow {
 		background-color: var( --color-woocommerce-onboarding-background );
 
 		.jetpack-connect__main-logo {
@@ -1130,11 +1131,17 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			}
 		}
 	}
+
+	&.is-jetpack-woo-dna-flow .login__form-header-wrapper {
+		display: none;
+	}
 }
 
-body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
-	.wpcom-site__logo {
-		display: none;
+body.is-section-jetpack-connect .layout {
+	&.is-jetpack-woocommerce-flow, &.is-jetpack-woo-dna-flow {
+		.wpcom-site__logo {
+			display: none;
+		}
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1043,6 +1043,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			text-decoration: underline;
 		}
 
+		.logged-out-form__links {
+			max-width: 400px;
+		}
+
 		.logged-out-form__link-item {
 			text-align: center;
 			text-decoration: underline;
@@ -1050,7 +1054,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			font-size: $font-body-small;
 		}
 
-		.signup-form__social {
+		.signup-form__social, .login__form-social {
 			padding-bottom: 0;
 			margin-top: 16px;
 			p {
@@ -1072,10 +1076,17 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				box-shadow: none;
 				max-width: 310px;
 				height: 48px;
+				margin-left: auto;
+				margin-right: auto;
+			}
+
+			.card {
+				padding: 0;
+				box-shadow: none;
 			}
 		}
 
-		.logged-out-form__footer {
+		.logged-out-form__footer, .login__form-footer {
 			text-align: center;
 
 			.button {
@@ -1084,6 +1095,16 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				margin-left: auto;
 				height: 48px;
 			}
+		}
+
+		.login__form-footer {
+			margin-top: 24px;
+		}
+
+		.login__form {
+			padding-top: 14px;
+			border-radius: 3px;
+			@include elevation( 2dp );
 		}
 
 		.login__form-change-username {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1125,9 +1125,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 			.jetpack-connect__tos-link,
 			.jetpack-connect__tos-link a {
-				text-align: left;
 				color: var( --color-neutral-60 );
 				font-size: 12px;
+			}
+
+			.jetpack-connect__tos-link a {
+				text-decoration: underline;
 			}
 		}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1128,10 +1128,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				color: var( --color-neutral-60 );
 				font-size: 12px;
 			}
-
-			.jetpack-connect__tos-link a {
-				text-decoration: underline;
-			}
 		}
 
 		.signup-form__woocommerce .card {

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -146,7 +146,7 @@ describe( 'JetpackAuthorize', () => {
 
 		test( 'returns false with non-woo from', () => {
 			const props = { authQuery: { from: 'elsewhere' } };
-			expect( isWooRedirect( props ) ).toBe( false );
+			expect( isWooRedirect( props ) ).toBeFalsy();
 		} );
 	} );
 

--- a/client/jetpack-connect/woo-dna-config.js
+++ b/client/jetpack-connect/woo-dna-config.js
@@ -1,0 +1,10 @@
+import { isEnabled } from 'config';
+
+export default isEnabled( 'jetpack/connect/woo-dna' )
+	? {
+			'woocommerce-payments': {
+				name: translate => translate( 'WooCommerce Payments' ),
+				helpUrl: 'https://docs.woocommerce.com/document/payments/', // TODO: Write a WCPay-specific page for Jetpack connection troubles
+			},
+	  }
+	: {};

--- a/client/jetpack-connect/woo-dna-config.js
+++ b/client/jetpack-connect/woo-dna-config.js
@@ -1,9 +1,12 @@
+/**
+ * Internal dependencies
+ */
 import { isEnabled } from 'config';
 
 export default isEnabled( 'jetpack/connect/woo-dna' )
 	? {
 			'woocommerce-payments': {
-				name: translate => translate( 'WooCommerce Payments' ),
+				name: ( translate ) => translate( 'WooCommerce Payments' ),
 				helpUrl: 'https://docs.woocommerce.com/document/payments/', // TODO: Write a WCPay-specific page for Jetpack connection troubles
 			},
 	  }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -50,6 +50,7 @@ import { retrieveMobileRedirect } from 'jetpack-connect/persistence-utils';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import LayoutLoader from './loader';
+import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 
 /**
  * Style dependencies
@@ -147,6 +148,7 @@ class Layout extends Component {
 				'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow,
 				'is-jetpack-woocommerce-flow':
 					config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isJetpackWooCommerceFlow,
+				'is-jetpack-woo-dna-flow': this.props.isJetpackWooDnaFlow,
 				'is-wccom-oauth-flow':
 					config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 					isWooOAuth2Client( this.props.oauth2Client ) &&
@@ -265,6 +267,9 @@ export default connect( ( state ) => {
 	const isJetpackWooCommerceFlow =
 		( 'jetpack-connect' === sectionName || 'login' === sectionName ) &&
 		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
+	const isJetpackWooDnaFlow =
+		( 'jetpack-connect' === sectionName || 'login' === sectionName ) &&
+		wooDnaConfig[ get( getCurrentQueryArguments( state ), 'from' ) ];
 	const oauth2Client = getCurrentOAuth2Client( state );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 	const isEligibleForJITM = [ 'stats', 'plans', 'themes', 'plugins' ].indexOf( sectionName ) >= 0;
@@ -276,6 +281,7 @@ export default connect( ( state ) => {
 		isJetpack,
 		isJetpackLogin,
 		isJetpackWooCommerceFlow,
+		isJetpackWooDnaFlow,
 		isJetpackMobileFlow,
 		isEligibleForJITM,
 		oauth2Client,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -156,7 +156,7 @@ export default connect( ( state ) => {
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
 	const isJetpackWooCommerceFlow =
 		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
-	const isJetpackWooDnaFlow = wooDnaConfig[ get( getCurrentQueryArguments( state ), 'from' ) ];
+	const isJetpackWooDnaFlow = Boolean( wooDnaConfig[ get( getCurrentQueryArguments( state ), 'from' ) ] );
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 
 	return {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -23,6 +23,7 @@ import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import GdprBanner from 'blocks/gdpr-banner';
 import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
+import wooDnaConfig from 'jetpack-connect/woo-dna-config';
 
 /**
  * Style dependencies
@@ -45,6 +46,7 @@ const LayoutLoggedOut = ( {
 	isGutenboardingLogin,
 	isPopup,
 	isJetpackWooCommerceFlow,
+	isJetpackWooDnaFlow,
 	wccomFrom,
 	masterbarIsHidden,
 	oauth2Client,
@@ -69,6 +71,7 @@ const LayoutLoggedOut = ( {
 		'is-popup': isPopup,
 		'is-jetpack-woocommerce-flow':
 			config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow,
+		'is-jetpack-woo-dna-flow': isJetpackWooDnaFlow,
 		'is-wccom-oauth-flow':
 			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 			isWooOAuth2Client( oauth2Client ) &&
@@ -153,6 +156,7 @@ export default connect( ( state ) => {
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
 	const isJetpackWooCommerceFlow =
 		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
+	const isJetpackWooDnaFlow = wooDnaConfig[ get( getCurrentQueryArguments( state ), 'from' ) ];
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 
 	return {
@@ -161,6 +165,7 @@ export default connect( ( state ) => {
 		isGutenboardingLogin,
 		isPopup,
 		isJetpackWooCommerceFlow,
+		isJetpackWooDnaFlow,
 		wccomFrom,
 		masterbarIsHidden:
 			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -156,7 +156,9 @@ export default connect( ( state ) => {
 	const noMasterbarForSection = 'signup' === section.name || 'jetpack-connect' === section.name;
 	const isJetpackWooCommerceFlow =
 		'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' );
-	const isJetpackWooDnaFlow = Boolean( wooDnaConfig[ get( getCurrentQueryArguments( state ), 'from' ) ] );
+	const isJetpackWooDnaFlow = Boolean(
+		wooDnaConfig[ get( getCurrentQueryArguments( state ), 'from' ) ]
+	);
 	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
 
 	return {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -43,6 +43,7 @@ import {
 	CURRENT_USER_RECEIVE,
 } from 'state/action-types';
 import { login } from 'lib/paths';
+import { addQueryArgs } from 'lib/route';
 
 export const isRequesting = withoutPersistence( ( state = false, action ) => {
 	switch ( action.type ) {
@@ -82,6 +83,8 @@ export const redirectTo = combineReducers( {
 				const { path, query } = action;
 				if ( startsWith( path, '/log-in' ) ) {
 					return query.redirect_to || state;
+				} else if ( '/jetpack/connect/authorize' === path ) {
+					return addQueryArgs( query, path );
 				}
 
 				return state;

--- a/config/development.json
+++ b/config/development.json
@@ -80,6 +80,7 @@
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,
+		"jetpack/connect/woo-dna": true,
 		"jetpack/connect/woocommerce": true,
 		"jetpack/happychat": true,
 		"jetpack/search-product": true,


### PR DESCRIPTION
See paJDYF-Ei-p2 for more context and design of the actual flow.

The intention with this flow is to provide an exclusively Woo-branded flow for connecting a site to Jetpack. It will be used in combination with the `jetpack-connection` package bundled in the WooCommerce Payments, so when the user starts going through the flow he may have never read the word "Jetpack". I've named the flow "Woo DNA", because Woo + Jetpack DNA. I'm not very creative.

I've divided this PR into separate commits as best I could, so that's the most sensible way tor review it.

In https://github.com/Automattic/wp-calypso/commit/4164b47a60d19944f62d3edf5bc208300598de6d, the "flow configuration" is added. Right now, WooCommerce Payments is the only Woo extension that will use it, but more plugins can use the Woo flow if they are added to that list.

### To test:

Checkout this branch of `wp-calypso` and run it locally (`yarn && yarn start`, add `127.0.0.1 calypso.localhost` to your `/etc/hosts`).

Add these constants to your local WordPress site:
```
define( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT', 'development' );
define( 'JETPACK__SANDBOX_DOMAIN', 'yourtestblog.wordpress.com' );
```
`yourtestblog.wordpress.com` needs to be a WordPress.com site that has its DNS pointing to your wp.com sandbox. See here how I did it: pMz3w-bfP-p2

~You'll need to add `yourtestblog.wordpress.com <YOUR_SANDBOX_IP` to `/etc/hosts`. Alternatively, you can use my test blog so you don't need to make a Systems Request. Ping me to give you my blog domain and IP address.~ This is not needed.

Follow the instructions in https://github.com/Automattic/woocommerce-payments/pull/638 to start a Jetpack connection from WooCommerce Payments.

Hopefully, you'll be redirected to `calypso.localhost:3000/...`, and the flow (behaviour, color scheme, text) will match exactly the designs on paJDYF-Ei-p2 . Ping me if you can't get it up and running.

Note that all these PRs need to be merged first, as they have tweaks and refactors needed for this one to work: #41799 #41800 #41801 #41802 #41803 #41804 #41805

### i18n

Here are all the new strings to translate. The `Woocommerce logo` one is the `alt` attribute of the Woo logo that's in the header.

<img width="511" alt="Screenshot 2020-06-13 at 19 00 25" src="https://user-images.githubusercontent.com/1715800/84575939-f123fd00-ada8-11ea-9fa2-25fc526c2ecf.png">
<img width="511" alt="Screenshot 2020-06-13 at 19 01 45" src="https://user-images.githubusercontent.com/1715800/84575943-f3865700-ada8-11ea-86fa-e14d20d37e32.png">
<img width="511" alt="Screenshot 2020-06-13 at 19 02 13" src="https://user-images.githubusercontent.com/1715800/84575945-f6814780-ada8-11ea-8a94-5ede4aab242f.png">
