### PR TITLE
Login block: Accept the user email as a prop

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -69,6 +69,7 @@ class Login extends Component {
 		twoFactorEnabled: PropTypes.bool,
 		twoFactorNotificationSent: PropTypes.string,
 		isSecurityKeySupported: PropTypes.bool,
+		userEmail: PropTypes.string,
 	};
 
 	state = {
@@ -404,6 +405,7 @@ class Login extends Component {
 			socialServiceResponse,
 			disableAutoFocus,
 			locale,
+			userEmail,
 		} = this.props;
 
 		if ( twoFactorEnabled ) {
@@ -446,6 +448,7 @@ class Login extends Component {
 				isJetpack={ isJetpack }
 				isGutenboarding={ isGutenboarding }
 				locale={ locale }
+				userEmail={ userEmail }
 			/>
 		);
 	}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -655,7 +655,7 @@ export class LoginForm extends Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, props ) => {
 		const accountType = getAuthAccountTypeSelector( state );
 
 		return {
@@ -673,6 +673,7 @@ export default connect(
 			socialAccountLinkEmail: getSocialAccountLinkEmail( state ),
 			socialAccountLinkService: getSocialAccountLinkService( state ),
 			userEmail:
+				props.userEmail ||
 				getInitialQueryArguments( state ).email_address ||
 				getCurrentQueryArguments( state ).email_address,
 			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -249,3 +249,12 @@
 .login__jetpack-plus-wpcom-logo {
 	margin: 40px 0 16px;
 }
+
+.login__form-social-divider {
+	text-align: center;
+	margin-top: 12px;
+	margin-bottom: 12px;
+	font-size: 12px;
+	position: initial;
+	text-transform: initial;
+}

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -283,15 +283,6 @@ $image-height: 47px;
 		font-size: 12px;
 	}
 
-	.login__form-social-divider {
-		text-align: center;
-		margin-top: 12px;
-		margin-bottom: 12px;
-		font-size: 12px;
-		position: initial;
-		text-transform: initial;
-	}
-
 	.login__social {
 		box-shadow: none;
 		padding-top: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/commit/3bec7b892d5bc4457481081e0c34992df587c101, added an optional `userEmail` prop to the `LoginBlock`. If present, the form will be prefilled with that email instead of relying on the current route querystring.

In https://github.com/Automattic/wp-calypso/commit/9f540c3ad293cbc34312ca2bea2690d1bfdf3709, moved the styles for the social divider ([this](https://user-images.githubusercontent.com/1715800/81049022-4e2cb900-8eb5-11ea-94d4-211347c00d08.png)) to the login block styles, since that block can be used outside of `wp-login`.

#### How to test

This is just a refactor, there shouldn't be any regression. At this moment, `LoginBlock` is never called with a `userEmail` prop. The "social divider" is only used in the WooCommerce login flow, so to test that the styles still look good, go to `http://calypso.localhost:3000/log-in?from=woocommerce-onboarding`.

Note: This is a required refactor for the new "Woo DNA" flow, implemented in #41798