### PR TITLE
Signup form: Accept a custom "handleLogin" function prop

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -69,6 +69,7 @@ class Login extends Component {
 		twoFactorEnabled: PropTypes.bool,
 		twoFactorNotificationSent: PropTypes.string,
 		isSecurityKeySupported: PropTypes.bool,
+		userEmail: PropTypes.string,
 	};
 
 	state = {
@@ -404,6 +405,7 @@ class Login extends Component {
 			socialServiceResponse,
 			disableAutoFocus,
 			locale,
+			userEmail,
 		} = this.props;
 
 		if ( twoFactorEnabled ) {
@@ -446,6 +448,7 @@ class Login extends Component {
 				isJetpack={ isJetpack }
 				isGutenboarding={ isGutenboarding }
 				locale={ locale }
+				userEmail={ userEmail }
 			/>
 		);
 	}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -655,7 +655,7 @@ export class LoginForm extends Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, props ) => {
 		const accountType = getAuthAccountTypeSelector( state );
 
 		return {
@@ -673,6 +673,7 @@ export default connect(
 			socialAccountLinkEmail: getSocialAccountLinkEmail( state ),
 			socialAccountLinkService: getSocialAccountLinkService( state ),
 			userEmail:
+				props.userEmail ||
 				getInitialQueryArguments( state ).email_address ||
 				getCurrentQueryArguments( state ).email_address,
 			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -249,3 +249,12 @@
 .login__jetpack-plus-wpcom-logo {
 	margin: 40px 0 16px;
 }
+
+.login__form-social-divider {
+	text-align: center;
+	margin-top: 12px;
+	margin-bottom: 12px;
+	font-size: 12px;
+	position: initial;
+	text-transform: initial;
+}

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -954,9 +954,11 @@ class SignupForm extends Component {
 						) }
 					</LoggedOutForm>
 
-					<LoggedOutFormLinkItem href={ logInUrl }>
-						{ this.props.translate( 'Log in with an existing WordPress.com account' ) }
-					</LoggedOutFormLinkItem>
+					{ this.props.footerLink || (
+						<LoggedOutFormLinkItem href={ logInUrl }>
+							{ this.props.translate( 'Log in with an existing WordPress.com account' ) }
+						</LoggedOutFormLinkItem>
+					) }
 				</div>
 			);
 		}

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -491,7 +491,7 @@ class SignupForm extends Component {
 									a: (
 										<a
 											href={ link }
-											onClick={ event => this.handleLoginClick( event, fieldValue ) }
+											onClick={ ( event ) => this.handleLoginClick( event, fieldValue ) }
 										/>
 									),
 								},

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -92,6 +92,7 @@ class SignupForm extends Component {
 		formHeader: PropTypes.node,
 		redirectToAfterLoginUrl: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func,
+		handleLogin: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
@@ -312,6 +313,14 @@ class SignupForm extends Component {
 		this.setState( { form: state } );
 	};
 
+	handleLoginClick = ( event, fieldValue ) => {
+		this.props.trackLoginMidFlow( event );
+		if ( this.props.handleLogin ) {
+			event.preventDefault();
+			this.props.handleLogin( fieldValue );
+		}
+	};
+
 	handleFormControllerError( error ) {
 		if ( error ) {
 			throw error;
@@ -470,9 +479,8 @@ class SignupForm extends Component {
 
 		return map( messages, ( message, error_code ) => {
 			if ( error_code === 'taken' ) {
-				link +=
-					'&email_address=' +
-					encodeURIComponent( formState.getFieldValue( this.state.form, fieldName ) );
+				const fieldValue = formState.getFieldValue( this.state.form, fieldName );
+				link += '&email_address=' + encodeURIComponent( fieldValue );
 				return (
 					<span key={ error_code }>
 						<p>
@@ -480,7 +488,12 @@ class SignupForm extends Component {
 							&nbsp;
 							{ this.props.translate( 'If this is you {{a}}log in now{{/a}}.', {
 								components: {
-									a: <a href={ link } onClick={ this.props.trackLoginMidFlow } />,
+									a: (
+										<a
+											href={ link }
+											onClick={ event => this.handleLoginClick( event, fieldValue ) }
+										/>
+									),
 								},
 							} ) }
 						</p>

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -283,15 +283,6 @@ $image-height: 47px;
 		font-size: 12px;
 	}
 
-	.login__form-social-divider {
-		text-align: center;
-		margin-top: 12px;
-		margin-bottom: 12px;
-		font-size: 12px;
-		position: initial;
-		text-transform: initial;
-	}
-
 	.login__social {
 		box-shadow: none;
 		padding-top: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/commit/d9c6ba4891693cb795cdea8c38a240dc565ed726, make the WooCommerce version of the `SignupForm` block respect the `footerLink` prop. That prop already existed, but was only being used in the other branches of the SignupForm block, [here](https://github.com/Automattic/wp-calypso/blob/d9c6ba4891693cb795cdea8c38a240dc565ed726/client/blocks/signup-form/index.jsx#L1008) and [here](https://github.com/Automattic/wp-calypso/blob/d9c6ba4891693cb795cdea8c38a240dc565ed726/client/blocks/signup-form/index.jsx#L1039).

In https://github.com/Automattic/wp-calypso/commit/92d2cc0817c9f2452a2527e78a01722bb4da1873, added an optional `handleLogin` prop to the SignupForm block. This function, if it exists, will be called when the "login" link is clicked, instead of making a full-page redirect to the login form.
<img width="419" alt="Screenshot 2020-05-05 at 10 26 06" src="https://user-images.githubusercontent.com/1715800/81052186-ea0cf380-8eba-11ea-9dc3-f07a444a6d5e.png">


#### How to test

This is just a refactor, there shouldn't be any regression. At this moment, `SignupForm` is never called with a `handleLogin` prop, nor is called with a custom `footerLink` on the WooCommerce flow.

Note: This is a required refactor for the new "Woo DNA" flow, implemented in #41798