### PR TITLE
Add an optional parameter to JetpackConnectHelpButton to link to a different URL

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -69,6 +69,7 @@ class Login extends Component {
 		twoFactorEnabled: PropTypes.bool,
 		twoFactorNotificationSent: PropTypes.string,
 		isSecurityKeySupported: PropTypes.bool,
+		userEmail: PropTypes.string,
 	};
 
 	state = {
@@ -404,6 +405,7 @@ class Login extends Component {
 			socialServiceResponse,
 			disableAutoFocus,
 			locale,
+			userEmail,
 		} = this.props;
 
 		if ( twoFactorEnabled ) {
@@ -446,6 +448,7 @@ class Login extends Component {
 				isJetpack={ isJetpack }
 				isGutenboarding={ isGutenboarding }
 				locale={ locale }
+				userEmail={ userEmail }
 			/>
 		);
 	}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -655,7 +655,7 @@ export class LoginForm extends Component {
 }
 
 export default connect(
-	( state ) => {
+	( state, props ) => {
 		const accountType = getAuthAccountTypeSelector( state );
 
 		return {
@@ -673,6 +673,7 @@ export default connect(
 			socialAccountLinkEmail: getSocialAccountLinkEmail( state ),
 			socialAccountLinkService: getSocialAccountLinkService( state ),
 			userEmail:
+				props.userEmail ||
 				getInitialQueryArguments( state ).email_address ||
 				getCurrentQueryArguments( state ).email_address,
 			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -249,3 +249,12 @@
 .login__jetpack-plus-wpcom-logo {
 	margin: 40px 0 16px;
 }
+
+.login__form-social-divider {
+	text-align: center;
+	margin-top: 12px;
+	margin-bottom: 12px;
+	font-size: 12px;
+	position: initial;
+	text-transform: initial;
+}

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -415,8 +415,7 @@ class SignupForm extends Component {
 	getLoginLink() {
 		return login( {
 			isJetpack: this.isJetpack(),
-			isWoo:
-				config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isJetpackWooCommerceFlow,
+			from: this.props.from,
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: this.props.redirectToAfterLoginUrl,
 			locale: this.props.locale,
@@ -1056,6 +1055,7 @@ export default connect(
 		sectionName: getSectionName( state ),
 		isJetpackWooCommerceFlow:
 			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
+		from: get( getCurrentQueryArguments( state ), 'from' ),
 		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 	} ),
 	{

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -954,9 +954,11 @@ class SignupForm extends Component {
 						) }
 					</LoggedOutForm>
 
-					<LoggedOutFormLinkItem href={ logInUrl }>
-						{ this.props.translate( 'Log in with an existing WordPress.com account' ) }
-					</LoggedOutFormLinkItem>
+					{ this.props.footerLink || (
+						<LoggedOutFormLinkItem href={ logInUrl }>
+							{ this.props.translate( 'Log in with an existing WordPress.com account' ) }
+						</LoggedOutFormLinkItem>
+					) }
 				</div>
 			);
 		}

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -491,7 +491,7 @@ class SignupForm extends Component {
 									a: (
 										<a
 											href={ link }
-											onClick={ event => this.handleLoginClick( event, fieldValue ) }
+											onClick={ ( event ) => this.handleLoginClick( event, fieldValue ) }
 										/>
 									),
 								},

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -92,6 +92,7 @@ class SignupForm extends Component {
 		formHeader: PropTypes.node,
 		redirectToAfterLoginUrl: PropTypes.string.isRequired,
 		goToNextStep: PropTypes.func,
+		handleLogin: PropTypes.func,
 		handleSocialResponse: PropTypes.func,
 		isSocialSignupEnabled: PropTypes.bool,
 		locale: PropTypes.string,
@@ -312,6 +313,14 @@ class SignupForm extends Component {
 		this.setState( { form: state } );
 	};
 
+	handleLoginClick = ( event, fieldValue ) => {
+		this.props.trackLoginMidFlow( event );
+		if ( this.props.handleLogin ) {
+			event.preventDefault();
+			this.props.handleLogin( fieldValue );
+		}
+	};
+
 	handleFormControllerError( error ) {
 		if ( error ) {
 			throw error;
@@ -470,9 +479,8 @@ class SignupForm extends Component {
 
 		return map( messages, ( message, error_code ) => {
 			if ( error_code === 'taken' ) {
-				link +=
-					'&email_address=' +
-					encodeURIComponent( formState.getFieldValue( this.state.form, fieldName ) );
+				const fieldValue = formState.getFieldValue( this.state.form, fieldName );
+				link += '&email_address=' + encodeURIComponent( fieldValue );
 				return (
 					<span key={ error_code }>
 						<p>
@@ -480,7 +488,12 @@ class SignupForm extends Component {
 							&nbsp;
 							{ this.props.translate( 'If this is you {{a}}log in now{{/a}}.', {
 								components: {
-									a: <a href={ link } onClick={ this.props.trackLoginMidFlow } />,
+									a: (
+										<a
+											href={ link }
+											onClick={ event => this.handleLoginClick( event, fieldValue ) }
+										/>
+									),
 								},
 							} ) }
 						</p>

--- a/client/components/data/document-head/README.md
+++ b/client/components/data/document-head/README.md
@@ -5,7 +5,7 @@ DocumentHead
 
 ## Usage
 
-Render the component, passing `title`, `formattedTitle`, `unreadCount`, `link` or `meta`. It does not accept any children, nor does it render any elements to the page.
+Render the component, passing `title`, `skipTitleFormatting`, `unreadCount`, `link` or `meta`. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
 import React from 'react';
@@ -28,7 +28,7 @@ export default function HomeSection() {
 
 ### `title`
 
-The window title will be formatted using the `title` property plus some other internal application state (like the application name, or the number of unread messages). Use `formattedTitle` instead if you want to set the window title without any extra formatting.
+The window title will be formatted using the `title` property plus some other internal application state (like the application name, or the number of unread messages). Pass `skipTitleFormatting=true` if you want to set the window title without any extra formatting.
 
 <table>
 	<tr><th>Type</th><td>String</td></tr>
@@ -36,12 +36,12 @@ The window title will be formatted using the `title` property plus some other in
 	<tr><th>Default</th><td>""</td></tr>
 </table>
 
-### `formattedTitle`
+### `skipTitleFormatting`
 
 <table>
-	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Type</th><td>Boolean</td></tr>
 	<tr><th>Required</th><td>No</td></tr>
-	<tr><th>Default</th><td>""</td></tr>
+	<tr><th>Default</th><td>false</td></tr>
 </table>
 
 ### `unreadCount`

--- a/client/components/data/document-head/README.md
+++ b/client/components/data/document-head/README.md
@@ -5,7 +5,7 @@ DocumentHead
 
 ## Usage
 
-Render the component, passing `title`, `unreadCount`, `link` or `meta`. It does not accept any children, nor does it render any elements to the page.
+Render the component, passing `title`, `formattedTitle`, `unreadCount`, `link` or `meta`. It does not accept any children, nor does it render any elements to the page.
 
 ```jsx
 import React from 'react';
@@ -27,6 +27,16 @@ export default function HomeSection() {
 ## Props
 
 ### `title`
+
+The window title will be formatted using the `title` property plus some other internal application state (like the application name, or the number of unread messages). Use `formattedTitle` instead if you want to set the window title without any extra formatting.
+
+<table>
+	<tr><th>Type</th><td>String</td></tr>
+	<tr><th>Required</th><td>No</td></tr>
+	<tr><th>Default</th><td>""</td></tr>
+</table>
+
+### `formattedTitle`
 
 <table>
 	<tr><th>Type</th><td>String</td></tr>

--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -10,7 +10,7 @@ import { debounce, isEqual } from 'lodash';
 /**
  * Internal dependencies.
  */
-import { getDocumentHeadFormattedTitle } from 'state/document-head/selectors';
+import { getDocumentHeadTitle, getDocumentHeadFormattedTitle } from 'state/document-head/selectors';
 import {
 	setDocumentHeadTitle as setTitle,
 	setDocumentHeadLink as setLink,
@@ -81,7 +81,7 @@ class DocumentHead extends Component {
 
 DocumentHead.propTypes = {
 	title: TranslatableString,
-	formattedTitle: TranslatableString,
+	skipTitleFormatting: PropTypes.bool,
 	unreadCount: PropTypes.number,
 	link: PropTypes.array,
 	meta: PropTypes.array,
@@ -93,7 +93,9 @@ DocumentHead.propTypes = {
 
 export default connect(
 	( state, props ) => ( {
-		formattedTitle: props.formattedTitle || getDocumentHeadFormattedTitle( state ),
+		formattedTitle: props.skipTitleFormatting
+			? getDocumentHeadTitle( state )
+			: getDocumentHeadFormattedTitle( state ),
 	} ),
 	{
 		setTitle,

--- a/client/components/data/document-head/index.jsx
+++ b/client/components/data/document-head/index.jsx
@@ -81,6 +81,7 @@ class DocumentHead extends Component {
 
 DocumentHead.propTypes = {
 	title: TranslatableString,
+	formattedTitle: TranslatableString,
 	unreadCount: PropTypes.number,
 	link: PropTypes.array,
 	meta: PropTypes.array,
@@ -91,8 +92,8 @@ DocumentHead.propTypes = {
 };
 
 export default connect(
-	( state ) => ( {
-		formattedTitle: getDocumentHeadFormattedTitle( state ),
+	( state, props ) => ( {
+		formattedTitle: props.formattedTitle || getDocumentHeadFormattedTitle( state ),
 	} ),
 	{
 		setTitle,

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -617,6 +617,7 @@ export class JetpackAuthorize extends Component {
 	renderFooterLinks() {
 		const { translate } = this.props;
 		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
+		const { from } = this.props.authQuery;
 
 		if ( this.retryingAuth || isAuthorizing || authorizeSuccess || this.redirecting ) {
 			return null;
@@ -630,7 +631,7 @@ export class JetpackAuthorize extends Component {
 						isJetpack: true,
 						isNative: config.isEnabled( 'login/native-login-links' ),
 						redirectTo: window.location.href,
-						isWoo: this.isWooOnboarding(),
+						from,
 					} ) }
 					onClick={ this.handleSignIn }
 				>

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -618,18 +618,6 @@ export class JetpackAuthorize extends Component {
 	renderFooterLinks() {
 		const { translate } = this.props;
 		const { authorizeSuccess, isAuthorizing } = this.props.authorizationData;
-		const { blogname, redirectAfterAuth } = this.props.authQuery;
-		const backToWpAdminLink = (
-			<LoggedOutFormLinkItem href={ redirectAfterAuth }>
-				<Gridicon size={ 18 } icon="arrow-left" />{ ' ' }
-				{
-					// translators: eg: Return to The WordPress.com Blog
-					translate( 'Return to %(sitename)s', {
-						args: { sitename: decodeEntities( blogname ) },
-					} )
-				}
-			</LoggedOutFormLinkItem>
-		);
 
 		if ( this.retryingAuth || isAuthorizing || authorizeSuccess || this.redirecting ) {
 			return null;
@@ -637,7 +625,7 @@ export class JetpackAuthorize extends Component {
 
 		return (
 			<LoggedOutFormLinks>
-				{ this.isWaitingForConfirmation() ? backToWpAdminLink : null }
+				{ this.renderBackToWpAdminLink() }
 				<LoggedOutFormLinkItem
 					href={ login( {
 						isJetpack: true,
@@ -656,6 +644,24 @@ export class JetpackAuthorize extends Component {
 					<HelpButton />
 				</JetpackConnectHappychatButton>
 			</LoggedOutFormLinks>
+		);
+	}
+
+	renderBackToWpAdminLink() {
+		const { translate } = this.props;
+		const { blogname, redirectAfterAuth } = this.props.authQuery;
+
+		if ( ! this.isWaitingForConfirmation() ) {
+			return null;
+		}
+		return (
+			<LoggedOutFormLinkItem href={ redirectAfterAuth }>
+				<Gridicon size={ 18 } icon="arrow-left" />{ ' ' }
+				{ // translators: eg: Return to The WordPress.com Blog
+				translate( 'Return to %(sitename)s', {
+					args: { sitename: decodeEntities( blogname ) },
+				} ) }
+			</LoggedOutFormLinkItem>
 		);
 	}
 

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -656,10 +656,12 @@ export class JetpackAuthorize extends Component {
 		return (
 			<LoggedOutFormLinkItem href={ redirectAfterAuth }>
 				<Gridicon size={ 18 } icon="arrow-left" />{ ' ' }
-				{ // translators: eg: Return to The WordPress.com Blog
-				translate( 'Return to %(sitename)s', {
-					args: { sitename: decodeEntities( blogname ) },
-				} ) }
+				{
+					// translators: eg: Return to The WordPress.com Blog
+					translate( 'Return to %(sitename)s', {
+						args: { sitename: decodeEntities( blogname ) },
+					} )
+				}
 			</LoggedOutFormLinkItem>
 		);
 	}

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -22,7 +22,6 @@ import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Gravatar from 'components/gravatar';
 import Gridicon from 'components/gridicon';
 import HelpButton from './help-button';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isVipSite from 'state/selectors/is-vip-site';
 import JetpackConnectHappychatButton from './happychat-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
@@ -740,7 +739,6 @@ const connectComponent = connect(
 			hasExpiredSecretError: hasExpiredSecretErrorSelector( state ),
 			hasXmlrpcError: hasXmlrpcErrorSelector( state ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state, authQuery.site ),
-			isAtomic: isSiteAutomatedTransfer( state, authQuery.clientId ),
 			isFetchingAuthorizationSite: isRequestingSite( state, authQuery.clientId ),
 			isFetchingSites: isRequestingSites( state ),
 			isMobileAppFlow,

--- a/client/jetpack-connect/help-button.jsx
+++ b/client/jetpack-connect/help-button.jsx
@@ -13,7 +13,7 @@ import { useTranslate } from 'i18n-calypso';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-export default function JetpackConnectHelpButton( { label } ) {
+export default function JetpackConnectHelpButton( { label, url } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
@@ -24,7 +24,7 @@ export default function JetpackConnectHelpButton( { label } ) {
 	return (
 		<LoggedOutFormLinkItem
 			className="jetpack-connect__help-button"
-			href="https://jetpack.com/contact-support"
+			href={ url || 'https://jetpack.com/contact-support' }
 			target="_blank"
 			rel="noopener noreferrer"
 			onClick={ recordClick }
@@ -37,4 +37,5 @@ export default function JetpackConnectHelpButton( { label } ) {
 
 JetpackConnectHelpButton.propTypes = {
 	label: PropTypes.string,
+	url: PropTypes.string,
 };

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -48,8 +48,8 @@ export class JetpackConnectMainWrapper extends PureComponent {
 		return (
 			<Main className={ classNames( className, wrapperClassName ) }>
 				<DocumentHead
-					title={ pageTitle ? null : translate( 'Jetpack Connect' ) }
-					formattedTitle={ pageTitle }
+					title={ pageTitle || translate( 'Jetpack Connect' ) }
+					skipTitleFormatting={ Boolean( pageTitle ) }
 				/>
 				<div className="jetpack-connect__main-logo">
 					<JetpackHeader

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -23,6 +23,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 		isWoo: PropTypes.bool,
 		partnerSlug: PropTypes.string,
 		translate: PropTypes.func.isRequired,
+		pageTitle: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -31,7 +32,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	};
 
 	render() {
-		const { isWide, className, children, partnerSlug, translate } = this.props;
+		const { isWide, className, children, partnerSlug, translate, pageTitle } = this.props;
 
 		const isWoo = config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isWoo;
 
@@ -46,7 +47,10 @@ export class JetpackConnectMainWrapper extends PureComponent {
 
 		return (
 			<Main className={ classNames( className, wrapperClassName ) }>
-				<DocumentHead title={ translate( 'Jetpack Connect' ) } />
+				<DocumentHead
+					title={ pageTitle ? null : translate( 'Jetpack Connect' ) }
+					formattedTitle={ pageTitle }
+				/>
 				<div className="jetpack-connect__main-logo">
 					<JetpackHeader
 						partnerSlug={ partnerSlug }

--- a/client/jetpack-connect/signup.js
+++ b/client/jetpack-connect/signup.js
@@ -92,7 +92,7 @@ export class JetpackSignup extends Component {
 		const emailAddress = this.props.authQuery.userEmail;
 		return login( {
 			emailAddress,
-			isWoo: this.isWoo(),
+			from: this.props.authQuery.from,
 			isJetpack: true,
 			isNative: isEnabled( 'login/native-login-links' ),
 			locale: this.props.locale,

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -82,7 +82,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
           Return to %(sitename)s
         </LoggedOutFormLinkItem>
         <LoggedOutFormLinkItem
-          href="/log-in/jetpack?redirect_to=https%3A%2F%2Fexample.com%2F"
+          href="/log-in/jetpack?redirect_to=https%3A%2F%2Fexample.com%2F&from=banner-44-slide-1-dashboard"
           onClick={[Function]}
         >
           Sign in as a different user

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -36,7 +36,7 @@ exports[`JetpackSignup should render 1`] = `
       footerLink={
         <LoggedOutFormLinks>
           <LoggedOutFormLinkItem
-            href="/log-in/jetpack?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
+            href="/log-in/jetpack?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site&from=banner-44-slide-1-dashboard"
           >
             Already have an account? Sign in
           </LoggedOutFormLinkItem>
@@ -95,7 +95,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
       footerLink={
         <LoggedOutFormLinks>
           <LoggedOutFormLinkItem
-            href="/log-in/jetpack/es?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site"
+            href="/log-in/jetpack/es?redirect_to=https%3A%2F%2Fexample.com%2F&email_address=email%40an.example.site&from=banner-44-slide-1-dashboard"
           >
             Already have an account? Sign in
           </LoggedOutFormLinkItem>

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -9,7 +9,6 @@ import GUTENBOARDING_BASE_NAME from 'landing/gutenboarding/basename.json';
 export function login( {
 	isJetpack,
 	isGutenboarding,
-	isWoo,
 	isNative,
 	locale,
 	redirectTo,
@@ -21,6 +20,7 @@ export function login( {
 	wccomFrom,
 	site,
 	useMagicLink,
+	from,
 } = {} ) {
 	let url = config( 'login_url' );
 
@@ -70,12 +70,12 @@ export function login( {
 		url = addQueryArgs( { client_id: oauth2ClientId }, url );
 	}
 
-	if ( isWoo ) {
-		url = addQueryArgs( { from: 'woocommerce-onboarding' }, url );
-	}
-
 	if ( wccomFrom ) {
 		url = addQueryArgs( { 'wccom-from': wccomFrom }, url );
+	}
+
+	if ( from ) {
+		url = addQueryArgs( { from }, url );
 	}
 
 	return url;

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -74,15 +74,14 @@ describe( 'index', () => {
 			expect( url ).toEqual( '/log-in/jetpack' );
 		} );
 
+		test( 'should return the login url preserving the "form" parameter', () => {
+			const url = login( { isNative: true, isJetpack: true, from: 'potato' } );
+			expect( url ).toEqual( '/log-in/jetpack?from=potato' );
+		} );
+
 		test( 'should return the login url for Gutenboarding specific login', () => {
 			const url = login( { isNative: true, isGutenboarding: true } );
 			expect( url ).toMatchSnapshot();
-		} );
-
-		test( 'should return the login url with WooCommerce from handler', () => {
-			const url = login( { isNative: true, isJetpack: true, isWoo: true } );
-
-			expect( url ).toEqual( '/log-in/jetpack?from=woocommerce-onboarding' );
 		} );
 
 		test( 'should return the login url with WooCommerce.com handler', () => {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -283,15 +283,6 @@ $image-height: 47px;
 		font-size: 12px;
 	}
 
-	.login__form-social-divider {
-		text-align: center;
-		margin-top: 12px;
-		margin-bottom: 12px;
-		font-size: 12px;
-		position: initial;
-		text-transform: initial;
-	}
-
 	.login__social {
 		box-shadow: none;
 		padding-top: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When HappyChat is not available, the `JetpackConnectHelpButton` becomes a simple link that sends the user to `'https://jetpack.com/contact-support'`. This PR makes that URL customizable.

#### How to test

There's no code that calls `JetpackConnectHelpButton ` with a `url` prop, so there's no way to test this. You can test there has been no regression by starting the Jetpack connection flow and clicking on the "(?) Get help setting up Jetpack" link.

Note: This is a required refactor for the new "Woo DNA" flow, implemented in #41798