### PR TITLE
Gutenboarding: position vertical select cursor correctly

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -221,7 +221,9 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 							onFocus={ () => setIsFocused( true ) }
 							onBlur={ selectLastInputValue }
 						/>
-						<span className="vertical-select__placeholder">{ animatedPlaceholder }</span>
+						<span className="vertical-select__placeholder">
+							<span className="vertical-select__placeholder-text">{ animatedPlaceholder }</span>
+						</span>
 						{ showArrow && (
 							<Arrow className="vertical-select__arrow" onClick={ handleArrowClick } />
 						) }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -70,6 +70,12 @@
 	&--with-arrow {
 		margin-right: 40px; // make space for absolute positioned arrow
 	}
+
+	.madlib__input:empty {
+		@include break-small {
+			padding-right: 400px;
+		}
+	}
 }
 
 .vertical-select__placeholder {
@@ -78,7 +84,10 @@
 	color: var( --studio-gray-5 );
 
 	@include break-small {
-		width: 400px;
+		height: 80px;
+		position: absolute;
+		left: 0;
+		z-index: 2;
 	}
 
 	&::after {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -73,6 +73,9 @@
 
 	.madlib__input:empty {
 		@include break-small {
+			padding-right: 300px; // there's not enough container width on smaller screens
+		}
+		@include break-medium {
 			padding-right: 400px;
 		}
 	}
@@ -88,6 +91,14 @@
 		position: absolute;
 		left: 0;
 		z-index: 2;
+
+		.vertical-select__placeholder-text {
+			position: absolute;
+			white-space: nowrap; // force placeholder on a single line
+			width: 100%;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
 	}
 
 	&::after {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Fix vertical select placeholder positioning to prevent visual glitches.

#### Testing instructions
* Go to [wpcalypso.wordpress.com/new](https://wpcalypso.wordpress.com/new)
* While the vertical input is empty, resize the window until the grey line disappears and the blue cursor is on a different line like this:
<img width="1199" alt="Screenshot 2020-05-05 at 18 15 41" src="https://user-images.githubusercontent.com/14192054/81083042-be126200-8efc-11ea-9668-fbc3f956bb3d.png"/>

* Now go to [/new](https://calypso.live/new?branch=fix/gutenboarding-acquire-intent-cursor-position) in the same window and it should be fixed.

Fixes #41795
