### PR TITLE
Checkout: add support link to summary

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -470,7 +470,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 			}
 
-			case 'CHECKOUT_SUMMARY_HELP_CLICK': {
+			case 'calypso_checkout_composite_summary_help_click': {
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_summary_help_click', {
 						is_support_chat_user: action.payload.isSupportChatUser,

--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -470,6 +470,14 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				return reduxDispatch( recordTracksEvent( 'calypso_checkout_modal_authorization', {} ) );
 			}
 
+			case 'CHECKOUT_SUMMARY_HELP_CLICK': {
+				return reduxDispatch(
+					recordTracksEvent( 'calypso_checkout_composite_summary_help_click', {
+						is_support_chat_user: action.payload.isSupportChatUser,
+					} )
+				);
+			}
+
 			default:
 				debug( 'unknown checkout event', action );
 				return reduxDispatch(

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import styled from '@emotion/styled';
 import {
@@ -10,6 +10,7 @@ import {
 	renderDisplayValueMarkdown,
 	useLineItemsOfType,
 	useTotal,
+	useEvents,
 } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
@@ -21,7 +22,6 @@ import getSupportVariation, {
 	SUPPORT_FORUM,
 	SUPPORT_DIRECTLY,
 } from 'state/selectors/get-inline-help-support-variation';
-import createAnalyticsEventHandler from '../../record-analytics';
 
 export default function WPCheckoutOrderSummary() {
 	const reduxDispatch = useDispatch();
@@ -36,9 +36,14 @@ export default function WPCheckoutOrderSummary() {
 			SUPPORT_DIRECTLY !== getSupportVariation( state )
 		);
 	} );
-	const recordEvent = useCallback( createAnalyticsEventHandler( reduxDispatch ), [] );
+	const onEvent = useEvents();
 	const handleHelpButtonClicked = () => {
-		recordEvent( { type: 'CHECKOUT_SUMMARY_HELP_CLICK', payload: { isSupportChatUser } } );
+		onEvent( {
+			type: 'calypso_checkout_composite_summary_help_click',
+			payload: {
+				isSupportChatUser,
+			},
+		} );
 		reduxDispatch( showInlineHelpPopover() );
 	};
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import styled from '@emotion/styled';
 import {
 	CheckoutCheckIcon,
@@ -12,11 +13,19 @@ import {
 } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
+/**
+ * Internal dependencies
+ */
+import { showInlineHelpPopover } from 'state/inline-help/actions';
+
 export default function WPCheckoutOrderSummary() {
+	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 	const taxes = useLineItemsOfType( 'tax' );
 	const coupons = useLineItemsOfType( 'coupon' );
 	const total = useTotal();
+
+	const handleHelpButtonClicked = () => reduxDispatch( showInlineHelpPopover() );
 
 	return (
 		<CheckoutSummaryCard>
@@ -35,6 +44,13 @@ export default function WPCheckoutOrderSummary() {
 						{ translate( 'Money back guarantee' ) }
 					</CheckoutSummaryFeaturesListItem>
 				</CheckoutSummaryFeaturesList>
+				<CheckoutSummaryHelp>
+					{ translate( 'Questions? {{link}}Ask a Happiness Engineer.{{/link}}', {
+						components: {
+							link: <button onClick={ handleHelpButtonClicked } />,
+						},
+					} ) }
+				</CheckoutSummaryHelp>
 			</CheckoutSummaryFeatures>
 			<CheckoutSummaryAmountWrapper>
 				{ coupons.map( ( coupon ) => (
@@ -83,6 +99,15 @@ const CheckoutSummaryFeaturesList = styled.ul`
 	margin: 0;
 	list-style: none;
 	font-size: 14px;
+`;
+
+const CheckoutSummaryHelp = styled.div`
+	margin-top: 16px;
+
+	button {
+		cursor: pointer;
+		text-decoration: underline;
+	}
 `;
 
 const WPCheckoutCheckIcon = styled( CheckoutCheckIcon )`

--- a/client/state/help/ticket/selectors.js
+++ b/client/state/help/ticket/selectors.js
@@ -1,15 +1,15 @@
 export const isTicketSupportEligible = ( state ) => {
-	return state.help.ticket.isUserEligible;
+	return state.help?.ticket?.isUserEligible;
 };
 
 export const isTicketSupportConfigurationReady = ( state ) => {
-	return state.help.ticket.isReady;
+	return state.help?.ticket?.isReady;
 };
 
 export const isRequestingTicketSupportConfiguration = ( state ) => {
-	return state.help.ticket.isRequesting;
+	return state.help?.ticket?.isRequesting;
 };
 
 export const getTicketSupportRequestError = ( state ) => {
-	return state.help.ticket.requestError;
+	return state.help?.ticket?.requestError;
 };


### PR DESCRIPTION
This adds a link to the Checkout Summary that triggers the inline help popover, where there are quick links to plan and purchase support, and the ability to contact support directly.

![checkout-inline-help](https://user-images.githubusercontent.com/942359/81080600-ebd8b600-8ebe-11ea-83a4-f7265fdbb192.gif)

**To Test:**
- visit Checkout
- click the "Ask a Happiness Engineer" link in the sidebar
- verify that the inline help popover opens
- verify that the inline help links are plan- and purchase-related
- verify that clicking outside of the popover will close the popover
- verify that Checkout steps complete as expected