### PR TITLE
Add isManaged prop to registrant-extra-fields component

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -40,6 +40,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		userWpcomLang: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 		updateContactDetailsCache: PropTypes.func.isRequired,
+		isManaged: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -149,7 +150,10 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 		}
 
 		this.props.updateContactDetailsCache( { ...newContactDetails } );
-		this.props.onContactDetailsChange?.( { ...newContactDetails } );
+
+		if ( this.props.isManaged ) {
+			this.props.onContactDetailsChange?.( { ...newContactDetails } );
+		}
 	};
 
 	needsOrganization() {
@@ -173,9 +177,11 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	}
 
 	getCiraAgreementAcceptedErrorMessage() {
-		const explicitError =
-			this.props.contactDetailsValidationErrors?.extra?.ca?.ciraAgreementAccepted ?? '';
-		return explicitError !== '' ? explicitError : this.props.translate( 'Required' );
+		if ( this.props.isManaged ) {
+			return this.props.contactDetailsValidationErrors?.extra?.ca?.ciraAgreementAccepted ?? '';
+		}
+
+		return this.props.translate( 'Required' );
 	}
 
 	renderOrganizationField() {

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -259,7 +259,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 						) }
 					</FormLabel>
 				</FormFieldset>
-				{ this.needsOrganization() && this.renderOrganizationField() }
+				{ this.renderOrganizationField() }
 				{ validatingSubmitButton }
 			</form>
 		);

--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -157,7 +157,7 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 	}
 
 	organizationFieldIsValid() {
-		return isEmpty( this.getOrganizationErrorMessage() );
+		return this.needsOrganization() ? isEmpty( this.getOrganizationErrorMessage() ) : true;
 	}
 
 	getOrganizationErrorMessage() {
@@ -170,6 +170,12 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 			);
 		}
 		return message;
+	}
+
+	getCiraAgreementAcceptedErrorMessage() {
+		const explicitError =
+			this.props.contactDetailsValidationErrors?.extra?.ca?.ciraAgreementAccepted ?? '';
+		return explicitError !== '' ? explicitError : this.props.translate( 'Required' );
 	}
 
 	renderOrganizationField() {
@@ -240,11 +246,14 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 							} ) }
 						</span>
 						{ ciraAgreementAccepted || (
-							<FormInputValidation text={ translate( 'Required' ) } isError={ true } />
+							<FormInputValidation
+								text={ this.getCiraAgreementAcceptedErrorMessage() }
+								isError={ true }
+							/>
 						) }
 					</FormLabel>
 				</FormFieldset>
-				{ this.renderOrganizationField() }
+				{ this.needsOrganization() && this.renderOrganizationField() }
 				{ validatingSubmitButton }
 			</form>
 		);

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -223,22 +223,18 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 				return map( uniq( validationErrors.sirenSiret ?? [] ), renderValidationError );
 			}
 
-            let sirenSiretValidationMessage = null;
-            if ( validationErrors.sirenSiret ) {
-                if (validationErrors.sirenSiret.indexOf('checksum') >= 0) {
-                    sirenSiretValidationMessage = renderValidationError(
-                        translate('This is not a valid SIREN/SIRET number')
-                    );
-                } else {
-                    sirenSiretValidationMessage = renderValidationError(
-                        translate(
-                            'The SIREN/SIRET field must be either a ' +
-                            '9 digit SIREN number, or a 14 digit SIRET number'
-                        )
-                    )
-                }
-            }
-            return sirenSiretValidationMessage;
+			if ( validationErrors.sirenSiret ) {
+				if ( validationErrors.sirenSiret.indexOf( 'checksum' ) >= 0 ) {
+					return renderValidationError( translate( 'This is not a valid SIREN/SIRET number' ) );
+				}
+
+				return renderValidationError(
+					translate(
+						'The SIREN/SIRET field must be either a ' +
+							'9 digit SIREN number, or a 14 digit SIRET number'
+					)
+				);
+			}
 		};
 
 		const sirenSiretIsError = () => {
@@ -253,7 +249,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 				return false;
 			}
 
-			return Boolean( sirenSiretValidationMessage );
+			return Boolean( sirenSiretValidationMessage() );
 		};
 
 		const trademarkNumberStrings = {

--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
-import { defaults, get, identity, isEmpty, isString, map, noop, set, toUpper } from 'lodash';
+import { defaults, get, identity, isEmpty, isString, map, noop, set, toUpper, uniq } from 'lodash';
 
 /**
  * Internal dependencies
@@ -64,6 +64,7 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		onSubmit: PropTypes.func,
 		translate: PropTypes.func.isRequired,
 		updateContactDetailsCache: PropTypes.func.isRequired,
+		isManaged: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -91,7 +92,11 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		};
 
 		this.props.updateContactDetailsCache( payload );
-		this.props.onContactDetailsChange?.( payload );
+
+		// If the state is managed, only set the default registrant type if it's empty
+		if ( this.props.isManaged && ! this.props.ccTldDetails?.registrantType ) {
+			this.props.onContactDetailsChange?.( payload );
+		}
 	}
 
 	updateContactDetails( field, value ) {
@@ -99,7 +104,13 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 		debug( 'Setting ' + field + ' to ' + value );
 		const payload = set( {}, field, sanitizedValue );
 		this.props.updateContactDetailsCache( payload );
-		this.props.onContactDetailsChange?.( payload );
+
+		if ( this.props.isManaged ) {
+			if ( field === 'extra.fr.registrantVatId' ) {
+				field = 'vatId';
+			}
+			this.props.onContactDetailsChange?.( set( {}, field, sanitizedValue ) );
+		}
 	}
 
 	handleChangeContactEvent = ( event ) => {
@@ -160,32 +171,90 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 			emptyValues
 		);
 		const validationErrors = get( contactDetailsValidationErrors, 'extra.fr', {} );
-		const registrantVatIdValidationMessage =
-			validationErrors.registrantVatId &&
-			renderValidationError(
-				translate(
-					'The VAT Number field is a pattern ' +
-						'of letters and numbers that depends on the country, ' +
-						'but it always starts with a 2 letter country code'
+
+		const registrantVatIdIsNotEmpty = Boolean(
+			ccTldDetails.registrantVatId && ccTldDetails.registrantVatId !== ''
+		);
+
+		const registrantVatIdValidationMessage = () => {
+			if ( this.props.isManaged ) {
+				if ( registrantVatIdIsNotEmpty ) {
+					return validationErrors.registrantVatId === []
+						? null
+						: map( uniq( validationErrors.registrantVatId ), renderValidationError );
+				}
+
+				return null;
+			}
+			return (
+				validationErrors.registrantVatId &&
+				renderValidationError(
+					translate(
+						'The VAT Number field is a pattern ' +
+							'of letters and numbers that depends on the country, ' +
+							'but it always starts with a 2 letter country code'
+					)
 				)
 			);
+		};
 
-		let sirenSiretValidationMessage = null;
+		const registrantVatIdIsError = () => {
+			if ( this.props.isManaged ) {
+				if ( registrantVatIdIsNotEmpty ) {
+					return (
+						Array.isArray( validationErrors.registrantVatId ) &&
+						! isEmpty( validationErrors.registrantVatId )
+					);
+				}
 
-		if ( validationErrors.sirenSiret ) {
-			if ( validationErrors.sirenSiret.indexOf( 'checksum' ) >= 0 ) {
-				sirenSiretValidationMessage = renderValidationError(
-					translate( 'This is not a valid SIREN/SIRET number' )
-				);
-			} else {
-				sirenSiretValidationMessage = renderValidationError(
-					translate(
-						'The SIREN/SIRET field must be either a ' +
-							'9 digit SIREN number, or a 14 digit SIRET number'
-					)
-				);
+				// This field is optional.
+				return false;
 			}
-		}
+
+			return Boolean( registrantVatIdValidationMessage() );
+		};
+
+		const sirenSiretIsNotEmpty = Boolean(
+			ccTldDetails.sirenSiret && ccTldDetails.sirenSiret !== ''
+		);
+
+		const sirenSiretValidationMessage = () => {
+			if ( this.props.isManaged ) {
+				return map( uniq( validationErrors.sirenSiret ?? [] ), renderValidationError );
+			}
+
+            let sirenSiretValidationMessage = null;
+            if ( validationErrors.sirenSiret ) {
+                if (validationErrors.sirenSiret.indexOf('checksum') >= 0) {
+                    sirenSiretValidationMessage = renderValidationError(
+                        translate('This is not a valid SIREN/SIRET number')
+                    );
+                } else {
+                    sirenSiretValidationMessage = renderValidationError(
+                        translate(
+                            'The SIREN/SIRET field must be either a ' +
+                            '9 digit SIREN number, or a 14 digit SIRET number'
+                        )
+                    )
+                }
+            }
+            return sirenSiretValidationMessage;
+		};
+
+		const sirenSiretIsError = () => {
+			if ( this.props.isManaged ) {
+				if ( sirenSiretIsNotEmpty ) {
+					return (
+						Array.isArray( validationErrors.sirenSiret ) && ! isEmpty( validationErrors.sirenSiret )
+					);
+				}
+
+				// This field is optional.
+				return false;
+			}
+
+			return Boolean( sirenSiretValidationMessage );
+		};
 
 		const trademarkNumberStrings = {
 			maxLength: this.props.translate( 'Too long. An EU Trademark number has 9 digits.' ),
@@ -193,9 +262,37 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 			pattern: this.props.translate( 'An EU Trademark number uses only digits.' ),
 		};
 
-		const trademarkNumberValidationMessage = map( validationErrors.trademarkNumber, ( error ) =>
-			renderValidationError( trademarkNumberStrings[ error ] )
+		const trademarkNumberIsNotEmpty = Boolean(
+			ccTldDetails.trademarkNumber && ccTldDetails.trademarkNumber !== ''
 		);
+
+		const trademarkNumberValidationMessage = () => {
+			if ( this.props.isManaged ) {
+				return map( uniq( validationErrors.trademarkNumber ?? [] ), ( error ) =>
+					renderValidationError( error )
+				);
+			}
+
+			return map( validationErrors.trademarkNumber, ( error ) =>
+				renderValidationError( trademarkNumberStrings[ error ] )
+			);
+		};
+
+		const trademarkNumberIsError = () => {
+			if ( this.props.isManaged ) {
+				if ( trademarkNumberIsNotEmpty ) {
+					return (
+						Array.isArray( validationErrors.trademarkNumber ) &&
+						! isEmpty( validationErrors.trademarkNumber )
+					);
+				}
+
+				// This field is optional.
+				return false;
+			}
+
+			return ! isEmpty( trademarkNumberValidationMessage );
+		};
 
 		// Note organization is the level above the other extra fields
 		const organizationValidationStrings = {
@@ -206,10 +303,40 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 			$ref: translate( 'Organization field is required' ),
 		};
 
-		const organizationValidationMessage = map(
-			contactDetailsValidationErrors.organization,
-			( error ) => renderValidationError( organizationValidationStrings[ error ] )
+		const organizationIsNotEmpty = Boolean(
+			contactDetails.organization && contactDetails.organization !== ''
 		);
+
+		const organizationValidationMessage = () => {
+			if ( this.props.isManaged ) {
+				if ( contactDetails.organization === '' ) {
+					return renderValidationError( 'This field is required.' );
+				}
+				return ! contactDetailsValidationErrors.organization
+					? null
+					: renderValidationError( contactDetailsValidationErrors.organization );
+			}
+
+			return map( contactDetailsValidationErrors.organization, ( error ) =>
+				renderValidationError( organizationValidationStrings[ error ] )
+			);
+		};
+
+		const organizationIsError = () => {
+			if ( this.props.isManaged ) {
+				if ( organizationIsNotEmpty ) {
+					return (
+						Array.isArray( contactDetailsValidationErrors.organization ) &&
+						! isEmpty( contactDetailsValidationErrors.organization )
+					);
+				}
+
+				// This field is not optional for registrant type 'organization'.
+				return ccTldDetails.registrantType === 'organization';
+			}
+
+			return Boolean( ! isEmpty( organizationValidationMessage ) );
+		};
 
 		return (
 			<div>
@@ -225,9 +352,9 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 						autoCorrect="off"
 						placeholder={ '' }
 						onChange={ this.handleChangeContactEvent }
-						isError={ Boolean( ! isEmpty( organizationValidationMessage ) ) }
+						isError={ organizationIsError() }
 					/>
-					{ organizationValidationMessage }
+					{ organizationValidationMessage() }
 				</FormFieldset>
 
 				<FormFieldset>
@@ -242,9 +369,9 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 						autoCorrect="off"
 						placeholder={ translate( 'ex. FRXX123456789' ) }
 						onChange={ this.handleChangeContactExtraEvent }
-						isError={ Boolean( registrantVatIdValidationMessage ) }
+						isError={ registrantVatIdIsError() }
 					/>
-					{ registrantVatIdValidationMessage }
+					{ registrantVatIdValidationMessage() }
 				</FormFieldset>
 
 				<FormFieldset>
@@ -263,10 +390,10 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 						autoCapitalize="off"
 						autoComplete="off"
 						autoCorrect="off"
-						isError={ Boolean( sirenSiretValidationMessage ) }
+						isError={ sirenSiretIsError() }
 						onChange={ this.handleChangeContactExtraEvent }
 					/>
-					{ sirenSiretValidationMessage }
+					{ sirenSiretValidationMessage() }
 				</FormFieldset>
 
 				<FormFieldset>
@@ -285,10 +412,10 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 						placeholder={ translate( 'ex. 012345678', {
 							comment: 'ex is short for example. The number is the EU trademark number format.',
 						} ) }
-						isError={ ! isEmpty( trademarkNumberValidationMessage ) }
+						isError={ trademarkNumberIsError() }
 						onChange={ this.handleChangeContactExtraEvent }
 					/>
-					{ trademarkNumberValidationMessage }
+					{ trademarkNumberValidationMessage() }
 				</FormFieldset>
 			</div>
 		);
@@ -300,9 +427,19 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 }
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
+		if ( ownProps.isManaged ) {
+			return {
+				// Treat this like a managed component.
+				contactDetails: ownProps.contactDetails ?? {},
+				ccTldDetails: ownProps.ccTldDetails ?? {},
+				contactDetailsValidationErrors: ownProps.contactDetailsValidationErrors ?? {},
+			};
+		}
+
 		const contactDetails = getContactDetailsCache( state );
 		return {
+			// Otherwise use data from redux
 			contactDetails,
 			ccTldDetails: get( contactDetails, 'extra.fr', {} ),
 			contactDetailsValidationErrors: validateContactDetails( contactDetails ),

--- a/client/components/domains/registrant-extra-info/uk-form.jsx
+++ b/client/components/domains/registrant-extra-info/uk-form.jsx
@@ -34,6 +34,7 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		contactDetailsValidationErrors: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 		updateContactDetailsCache: PropTypes.func.isRequired,
+		isManaged: PropTypes.bool,
 	};
 
 	constructor( props ) {
@@ -85,7 +86,10 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 		};
 
 		this.props.updateContactDetailsCache( payload );
-		this.props.onContactDetailsChange?.( payload );
+
+		if ( this.props.isManaged ) {
+			this.props.onContactDetailsChange?.( payload );
+		}
 	}
 
 	handleChangeEvent = ( event ) => {
@@ -95,7 +99,10 @@ export class RegistrantExtraInfoUkForm extends React.PureComponent {
 			},
 		};
 		this.props.updateContactDetailsCache( payload );
-		this.props.onContactDetailsChange?.( payload );
+
+		if ( this.props.isManaged ) {
+			this.props.onContactDetailsChange?.( payload );
+		}
 	};
 
 	isTradingNameRequired( registrantType ) {
@@ -242,7 +249,16 @@ export const ValidatedRegistrantExtraInfoUkForm = WithContactDetailsValidation(
 );
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
+		if ( ownProps.isManaged ) {
+			return {
+				// Treat this like a managed component.
+				contactDetails: ownProps.contactDetails ?? {},
+				ccTldDetails: ownProps.ccTldDetails ?? {},
+				contactDetailsValidationErrors: ownProps.contactDetailsValidationErrors ?? {},
+			};
+		}
+
 		const contactDetails = getContactDetailsCache( state );
 		return {
 			contactDetails,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds new `isManaged` props to the `registrant-extra-info` component which override the internal state management.

#### Testing instructions

This should have no observable effect in either old or new checkout or on the domain contact edit page. Verify this by proceeding through these flows with either a .ca, .uk, or .fr domain.
