### PR TITLE
DevDocs: Update instances of Banner

### DIFF
--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -4,6 +4,8 @@ Banner
 
 This component renders a customizable banner.
 
+(Need to add an upsell? Use `UpsellNudge` instead.)
+
 ## Usage
 
 ```jsx

--- a/client/components/banner/docs/example.jsx
+++ b/client/components/banner/docs/example.jsx
@@ -7,58 +7,28 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import {
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_JETPACK_PERSONAL,
-	FEATURE_ADVANCED_SEO,
-} from 'lib/plans/constants';
 import Banner from 'components/banner';
 
 const BannerExample = () => (
 	<div>
-		<Banner disableHref title="Banner unrelated to any plan" />
+		<Banner disableHref title="A simple banner" />
 		<Banner
-			description="And with a description."
+			callToAction="Update"
+			description="This is the description."
 			disableHref
-			icon="star"
-			title="Banner unrelated to any plan"
+			showIcon
+			title="Simple banner with description and call to action"
 		/>
 		<Banner showIcon={ false } title="Banner with showIcon set to false" />
-		<Banner href="#" plan={ PLAN_PREMIUM } title="Upgrade to a Premium Plan!" />
 		<Banner
-			callToAction="Upgrade for $9.99"
-			feature={ FEATURE_ADVANCED_SEO }
-			href="#"
-			list={ [ 'Live chat support', 'No advertising' ] }
-			plan={ PLAN_BUSINESS }
-			price={ [ 10.99, 9.99 ] }
-			title="Upgrade to a Business Plan!"
-		/>
-		<Banner
-			callToAction="Upgrade for $9.99"
-			description="Live chat support and no advertising."
-			dismissPreferenceName="devdocs-banner-example"
-			dismissTemporary
-			list={ [ 'Live chat support', 'No advertising' ] }
-			plan={ PLAN_BUSINESS }
-			title="Upgrade to a Business Plan!"
-		/>
-		<Banner
-			href="#"
-			plan={ PLAN_JETPACK_PERSONAL }
-			title="Upgrade to a Jetpack Personal Plan!"
-			jetpack={ true }
-		/>
-		<Banner
-			callToAction="Get Backups"
+			callToAction="Backup"
 			description="New plugins can lead to unexpected changes. Ensure you can restore your site if something goes wrong."
 			dismissPreferenceName="devdocs-banner-backups-example"
 			dismissTemporary
 			horizontal
 			href="#"
 			jetpack
-			title="Make sure your site is backed up before installing a new plugin."
+			title="A Jetpack banner with a call to action"
 		/>
 	</div>
 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update `Banner` examples in /devdocs to indicate non-upsell use cases.
* Update `Banner` readme to point to `UpsellNudge` if one is trying to add an upsell.

**Before**

<img width="1363" alt="Screen Shot 2020-05-05 at 11 04 27 AM" src="https://user-images.githubusercontent.com/2124984/81081669-34dd3a00-8ec0-11ea-957c-ccd6de8603ab.png">

**After**

<img width="1367" alt="Screen Shot 2020-05-05 at 11 03 48 AM" src="https://user-images.githubusercontent.com/2124984/81081619-21ca6a00-8ec0-11ea-980d-29a3822c42a9.png">


#### Testing instructions

* Switch to this PR
* Navigate to `/devdocs` and search for `Banner` under components.
* Look for visual issues or errors.

See #38778 