### PR TITLE
i18n: Use hash as key for translations

### DIFF
--- a/bin/build-languages.js
+++ b/bin/build-languages.js
@@ -266,9 +266,18 @@ function buildLanguageChunks( downloadedLanguages, languageRevisions ) {
 
 			downloadedLanguages.forEach( ( { langSlug, languageTranslations } ) => {
 				const languageChunks = _.chain( chunks )
-					.mapValues( ( stringIds ) => _.pick( languageTranslations, stringIds ) )
+					.mapValues( ( stringIds ) =>
+						_.chain( languageTranslations )
+							.pick( stringIds )
+							.mapKeys( ( value, key ) =>
+								crypto.createHash( 'sha1' ).update( key ).digest( 'hex' ).substr( 0, 8 )
+							)
+							.value()
+					)
 					.omitBy( _.isEmpty )
 					.value();
+
+				languageTranslations[ '' ][ 'key-hash' ] = 'sha1-8';
 
 				// Write language translated chunks map
 				const translatedChunksKeys = Object.keys( languageChunks ).map(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR switches from using the original English string as a key for translations to using hash. 

It uses the first 8 characters of the hash to ensure no key conflicts. Could've gone as low as 7 characters as it seemed fine as well, but added the extra character just to be safer.

The results are ~33% overall translation chunks file size reduce, however it highly depends on the file content so the percentage may vary per individual chunk.


#### Testing instructions
1. Boot Calypso with `ENABLE_FEATURES=use-translation-chunks yarn start`
2. Open http://calypso.localhost:3000/ and confirm strings are getting translated


#### Related
https://github.com/Automattic/wp-calypso/pull/21790
