### PR TITLE
Domains: Add Luhn check for SIREN/SIRET values

### DIFF
--- a/client/components/domains/registrant-extra-info/fr-form.jsx
+++ b/client/components/domains/registrant-extra-info/fr-form.jsx
@@ -170,14 +170,22 @@ class RegistrantExtraInfoFrForm extends React.PureComponent {
 				)
 			);
 
-		const sirenSiretValidationMessage =
-			validationErrors.sirenSiret &&
-			renderValidationError(
-				translate(
-					'The SIREN/SIRET field must be either a ' +
-						'9 digit SIREN number, or a 14 digit SIRET number'
-				)
-			);
+		let sirenSiretValidationMessage = null;
+
+		if ( validationErrors.sirenSiret ) {
+			if ( validationErrors.sirenSiret.indexOf( 'checksum' ) >= 0 ) {
+				sirenSiretValidationMessage = renderValidationError(
+					translate( 'This is not a valid SIREN/SIRET number' )
+				);
+			} else {
+				sirenSiretValidationMessage = renderValidationError(
+					translate(
+						'The SIREN/SIRET field must be either a ' +
+							'9 digit SIREN number, or a 14 digit SIRET number'
+					)
+				);
+			}
+		}
 
 		const trademarkNumberStrings = {
 			maxLength: this.props.translate( 'Too long. An EU Trademark number has 9 digits.' ),

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -178,6 +178,21 @@ describe( 'validateContactDetails', () => {
 			} );
 		} );
 
+		test( 'should reject values that fail Luhn check', () => {
+			const badSiretNumbers = [ '123456789', '12345678901234' ];
+
+			badSiretNumbers.forEach( ( sirenSiret ) => {
+				const testDetails = Object.assign( {}, contactDetails, { extra: { fr: { sirenSiret } } } );
+
+				const result = validateContactDetails( testDetails );
+				expect( result, `expected to reject '${ sirenSiret }'` )
+					.to.have.property( 'extra' )
+					.with.property( 'fr' )
+					.with.property( 'sirenSiret' )
+					.to.deep.equal( [ 'checksum' ] );
+			} );
+		} );
+
 		test( 'should accept an empty value', () => {
 			const testDetails = contactWithExtraProperty( 'sirenSiret', '' );
 

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -25,7 +25,7 @@ describe( 'validateContactDetails', () => {
 		extra: {
 			fr: {
 				registrantType: 'individual',
-				sirenSiret: '123456789',
+				sirenSiret: '123456782',
 				registrantVatId: 'FRXX123456789',
 				trademarkNumber: '123456789',
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates validation checks for .fr domains, to include a Luhn check on the SIREN/SIRET value provided by the user.

#### Testing instructions
 - Run tests and make sure they pass (`yarn run test-client "client/components/domains/registrant-extra-info/test"`)
 - Add a .fr domain to cart
 - After submitting the contact info, you will be asked "Who's this domain for?". Choose "Organization"
 - Provide different values to the SIREN/SIRET field, and ensure that error messages appear when appropriate

This error should appear when the value is not valid (i.e. invalid characters or length):

<img width="683" alt="Screenshot 2020-05-05 at 5 32 35 PM" src="https://user-images.githubusercontent.com/13062352/81085226-37a75180-8ef7-11ea-9621-e84dff259ccd.png">


This error should appear when everything else is OK, but the Luhn check fails:

<img width="680" alt="Screenshot 2020-05-05 at 5 32 53 PM" src="https://user-images.githubusercontent.com/13062352/81085230-38d87e80-8ef7-11ea-98f6-569010d099db.png">

