### PR TITLE
FSE: readd posts carousel view js

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/newspack-blocks/index.php
@@ -64,16 +64,14 @@ function newspack_blocks_block_args( $args, $name ) {
 	wp_register_style( $block_prefix . 'editor', $editor_style, array(), NEWSPACK_BLOCKS__VERSION );
 
 	// View script.
-	if ( 'carousel' !== $name ) {
-		$script_data = require NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.asset.php';
-		wp_register_script(
-			$block_prefix . 'view',
-			plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.js', __FILE__ ),
-			$script_data['dependencies'],
-			$script_data['version'],
-			true
-		);
-	}
+	$script_data = require NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.asset.php';
+	wp_register_script(
+		$block_prefix . 'view',
+		plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.js', __FILE__ ),
+		$script_data['dependencies'],
+		$script_data['version'],
+		true
+	);
 
 	// View style.
 	$editor_style = plugins_url( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $block_prefix . 'view.css', __FILE__ );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With newspack-blocks [version 1.4.0](https://github.com/Automattic/newspack-blocks/releases/tag/v1.4.0) released, we need to include the posts carousel view js again.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With 1.4.0 applied, add Posts Carousel block to a page
* See if slider works in the frontend of the site

