### PR TITLE
composite-checkout: Add ccTLD contact forms

### DIFF
--- a/client/components/domains/registrant-extra-info/ca-form.jsx
+++ b/client/components/domains/registrant-extra-info/ca-form.jsx
@@ -267,7 +267,17 @@ export class RegistrantExtraInfoCaForm extends React.PureComponent {
 }
 
 export default connect(
-	( state ) => {
+	( state, ownProps ) => {
+		if ( ownProps.isManaged ) {
+			return {
+				// Treat this like a managed component, except for userWpcomLang.
+				contactDetails: ownProps.contactDetails ?? {},
+				ccTldDetails: ownProps.ccTldDetails ?? {},
+				userWpcomLang: getCurrentUserLocale( state ),
+				contactDetailsValidationErrors: ownProps.contactDetailsValidationErrors ?? {},
+			};
+		}
+
 		const contactDetails = getContactDetailsCache( state );
 		return {
 			contactDetails,

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -48,11 +48,13 @@ import {
 	updateContactDetailsCache,
 } from 'state/domains/management/actions';
 import { FormCountrySelect } from 'components/forms/form-country-select';
+import RegistrantExtraInfoForm from 'components/domains/registrant-extra-info';
 import getCountries from 'state/selectors/get-countries';
 import { fetchPaymentCountries } from 'state/countries/actions';
 import { StateSelect } from 'my-sites/domains/components/form';
 import ManagedContactDetailsFormFields from 'components/domains/contact-details-form-fields/managed-contact-details-form-fields';
 import { getPlan, findPlansKeys } from 'lib/plans';
+import { getTld } from 'lib/domains';
 import { GROUP_WPCOM, TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
 import { requestProductsList } from 'state/products-list/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -293,6 +295,7 @@ export default function CompositeCheckout( {
 	} );
 
 	const renderDomainContactFields = (
+		domainNames,
 		contactDetails,
 		contactDetailsErrors,
 		updateDomainContactFields,
@@ -300,15 +303,61 @@ export default function CompositeCheckout( {
 		isDisabled
 	) => {
 		const getIsFieldDisabled = () => isDisabled;
+		const tlds = getAllTlds( domainNames );
+
 		return (
-			<ManagedContactDetailsFormFields
-				contactDetails={ contactDetails }
-				contactDetailsErrors={
-					shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
-				}
-				onContactDetailsChange={ updateDomainContactFields }
-				getIsFieldDisabled={ getIsFieldDisabled }
-			/>
+			<React.Fragment>
+				<ManagedContactDetailsFormFields
+					contactDetails={ contactDetails }
+					contactDetailsErrors={
+						shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
+					}
+					onContactDetailsChange={ updateDomainContactFields }
+					getIsFieldDisabled={ getIsFieldDisabled }
+				/>
+				{ tlds.includes( 'ca' ) && (
+					<RegistrantExtraInfoForm
+						contactDetails={ contactDetails }
+						ccTldDetails={ contactDetails?.extra?.ca ?? {} }
+						onContactDetailsChange={ updateDomainContactFields }
+						contactDetailsValidationErrors={
+							shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
+						}
+						tld={ 'ca' }
+						getDomainNames={ () => domainNames }
+						translate={ translate }
+						isManaged={ true }
+					/>
+				) }
+				{ tlds.includes( 'uk' ) && (
+					<RegistrantExtraInfoForm
+						contactDetails={ contactDetails }
+						ccTldDetails={ contactDetails?.extra?.uk ?? {} }
+						onContactDetailsChange={ updateDomainContactFields }
+						contactDetailsValidationErrors={
+							shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
+						}
+						tld={ 'uk' }
+						getDomainNames={ () => domainNames }
+						translate={ translate }
+						isManaged={ true }
+					/>
+				) }
+				{ tlds.includes( 'fr' ) && (
+					<RegistrantExtraInfoForm
+						contactDetails={ contactDetails }
+						ccTldDetails={ contactDetails?.extra?.fr ?? {} }
+						onContactDetailsChange={ updateDomainContactFields }
+						contactDetailsValidationErrors={
+							shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
+						}
+						tld={ 'fr' }
+						getDomainNames={ () => domainNames }
+						translate={ translate }
+						isManaged={ true }
+					/>
+				) }
+			</React.Fragment>
 		);
 	};
 
@@ -699,4 +748,8 @@ function getAnalyticsPath( purchaseId, product, selectedSiteSlug, selectedFeatur
 		analyticsPath = '/checkout/no-site';
 	}
 	return { analyticsPath, analyticsProps };
+}
+
+function getAllTlds( domainNames ) {
+	return Array.from( new Set( domainNames.map( getTld ) ) ).sort();
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -88,7 +88,9 @@ export default function WPCheckout( {
 
 	const [ items ] = useLineItems();
 	const firstDomainItem = items.find( isLineItemADomain );
-	const domainName = firstDomainItem ? firstDomainItem.wpcom_meta.meta : siteUrl;
+	const domainNames = items
+		.filter( isLineItemADomain )
+		.map( ( item ) => item.wpcom_meta?.meta ?? '' );
 	const isDomainFieldsVisible = !! firstDomainItem;
 	const shouldShowContactStep = isDomainFieldsVisible || total.amount.value > 0;
 
@@ -115,7 +117,7 @@ export default function WPCheckout( {
 			const hasValidationErrors = await domainContactValidationCallback(
 				activePaymentMethod.id,
 				contactInfo,
-				[ domainName ],
+				domainNames,
 				applyDomainContactValidationResults
 			);
 			return ! hasValidationErrors;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -15,7 +15,7 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { useHasDomainsInCart } from '../hooks/has-domains';
+import { useHasDomainsInCart, useDomainNamesInCart } from '../hooks/has-domains';
 import Field from './field';
 import { SummaryLine, SummaryDetails } from './summary-details';
 import { LeftColumn, RightColumn } from './ie-fallback';
@@ -268,6 +268,7 @@ function RenderContactDetails( {
 } ) {
 	const format = getContactDetailsFormat( isDomainFieldsVisible );
 	const requiresVatId = isEligibleForVat( contactInfo.countryCode.value );
+	const domainNames = useDomainNamesInCart();
 	const { updateDomainContactFields, updateCountryCode, updatePostalCode } = useDispatch( 'wpcom' );
 
 	switch ( format ) {
@@ -280,6 +281,7 @@ function RenderContactDetails( {
 						) }
 					</ContactDetailsFormDescription>
 					{ renderDomainContactFields(
+						domainNames,
 						prepareDomainContactDetails( contactInfo ),
 						prepareDomainContactDetailsErrors( contactInfo ),
 						updateDomainContactFields,

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/wpcom-store-state.ts
@@ -64,7 +64,7 @@ describe( 'updateManagedContactDetailsShape', function () {
 		'extra.uk.tradingName',
 		'extra.fr.registrantType',
 		'extra.fr.trademarkNumber',
-		'extra.fr.sirenSirat',
+		'extra.fr.sirenSiret',
 	];
 
 	const testProperty = ( merge, construct, update, data ) => {
@@ -122,7 +122,7 @@ describe( 'updateManagedContactDetailsShape', function () {
 			data.tldExtraFields.fr = {
 				registrantType: gen(),
 				trademarkNumber: gen(),
-				sirenSirat: gen(),
+				sirenSiret: gen(),
 			};
 		}
 
@@ -317,7 +317,7 @@ describe( 'flattenManagedContactDetailsShape', function () {
 					fr: {
 						registrantType: 'registrantType',
 						trademarkNumber: 'trademarkNumber',
-						sirenSirat: 'sirenSirat',
+						sirenSiret: 'sirenSiret',
 					},
 				},
 			} )
@@ -356,7 +356,7 @@ describe( 'flattenManagedContactDetailsShape', function () {
 					fr: {
 						registrantType: 'registrantType',
 						trademarkNumber: 'trademarkNumber',
-						sirenSirat: 'sirenSirat',
+						sirenSiret: 'sirenSiret',
 					},
 				},
 			} )

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-details-components.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-details-components.ts
@@ -47,7 +47,7 @@ export type FrDomainContactExtraDetails = {
 	registrantType?: string;
 	registrantVatId?: string;
 	trademarkNumber?: string;
-	sirenSirat?: string;
+	sirenSiret?: string;
 };
 
 // This is the data returned by the redux state, where the fields could have a
@@ -105,8 +105,8 @@ export type UkDomainContactExtraDetailsErrors = {
 };
 
 export type FrDomainContactExtraDetailsErrors = {
-	registrantType?: string;
-	registrantVatId?: string;
-	trademarkNumber?: string;
-	sirenSirat?: string;
+	registrantType?: string[];
+	registrantVatId?: string[];
+	trademarkNumber?: string[];
+	sirenSiret?: string[];
 };

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
@@ -39,7 +39,7 @@ export type DomainContactValidationRequestExtraFields = {
 	fr?: {
 		registrant_type: string;
 		trademark_number: string;
-		siren_sirat: string;
+		siren_siret: string;
 	};
 };
 
@@ -78,7 +78,7 @@ export type DomainContactValidationResponse = {
 			fr?: {
 				registrantType?: string[];
 				trademarkNumber?: string[];
-				sirenSirat?: string[];
+				sirenSiret?: string[];
 			};
 		};
 	};

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/backend/domain-contact-validation-endpoint.ts
@@ -38,6 +38,7 @@ export type DomainContactValidationRequestExtraFields = {
 	};
 	fr?: {
 		registrant_type: string;
+		registrant_vat_id: string;
 		trademark_number: string;
 		siren_siret: string;
 	};

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -535,6 +535,7 @@ export function prepareDomainContactValidationRequest(
 	if ( details.tldExtraFields?.fr ) {
 		extra.fr = {
 			registrant_type: details.tldExtraFields.fr.registrantType.value,
+			registrant_vat_id: details.vatId.value,
 			trademark_number: details.tldExtraFields.fr.trademarkNumber.value,
 			siren_sirat: details.tldExtraFields.fr.sirenSirat.value,
 		};

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -477,7 +477,9 @@ function prepareUkDomainContactExtraDetailsErrors(
 
 		return {
 			registrantType: details.tldExtraFields.uk?.registrantType?.errors?.map( toErrorPayload ),
-			registrationNumber: details.tldExtraFields.uk?.registrationNumber?.errors?.map( toErrorPayload ),
+			registrationNumber: details.tldExtraFields.uk?.registrationNumber?.errors?.map(
+				toErrorPayload
+			),
 			tradingName: details.tldExtraFields.uk?.tradingName?.errors?.map( toErrorPayload ),
 		};
 	}

--- a/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/types/wpcom-store-state.ts
@@ -51,7 +51,7 @@ type ManagedContactDetailsTldExtraFieldsShape< T > = {
 	fr?: {
 		registrantType: T;
 		trademarkNumber: T;
-		sirenSirat: T;
+		sirenSiret: T;
 	};
 };
 
@@ -151,9 +151,9 @@ export function updateManagedContactDetailsShape< A, B >(
 					update.tldExtraFields.fr.trademarkNumber,
 					data.tldExtraFields.fr.trademarkNumber
 				),
-				sirenSirat: combine(
-					update.tldExtraFields.fr.sirenSirat,
-					data.tldExtraFields.fr.sirenSirat
+				sirenSiret: combine(
+					update.tldExtraFields.fr.sirenSiret,
+					data.tldExtraFields.fr.sirenSiret
 				),
 			};
 		} else {
@@ -163,7 +163,7 @@ export function updateManagedContactDetailsShape< A, B >(
 		tldExtraFields.fr = {
 			registrantType: construct( update.tldExtraFields.fr.registrantType ),
 			trademarkNumber: construct( update.tldExtraFields.fr.trademarkNumber ),
-			sirenSirat: construct( update.tldExtraFields.fr.sirenSirat ),
+			sirenSiret: construct( update.tldExtraFields.fr.sirenSiret ),
 		};
 	}
 
@@ -232,7 +232,7 @@ export function flattenManagedContactDetailsShape< A, B >(
 			? [
 					f( x.tldExtraFields.fr.registrantType ),
 					f( x.tldExtraFields.fr.trademarkNumber ),
-					f( x.tldExtraFields.fr.sirenSirat ),
+					f( x.tldExtraFields.fr.sirenSiret ),
 			  ]
 			: [];
 
@@ -492,7 +492,7 @@ function prepareFrDomainContactExtraDetails(
 			registrantType: details.tldExtraFields.fr.registrantType.value,
 			registrantVatId: details.vatId.value,
 			trademarkNumber: details.tldExtraFields.fr.trademarkNumber.value,
-			sirenSirat: details.tldExtraFields.fr.sirenSirat.value,
+			sirenSiret: details.tldExtraFields.fr.sirenSiret.value,
 		};
 	}
 	return null;
@@ -503,10 +503,10 @@ function prepareFrDomainContactExtraDetailsErrors(
 ): FrDomainContactExtraDetailsErrors | null {
 	if ( details.tldExtraFields?.fr ) {
 		return {
-			registrantType: details.tldExtraFields.fr?.registrantType?.errors?.[ 0 ],
-			registrantVatId: details.vatId.errors[ 0 ],
-			trademarkNumber: details.tldExtraFields.fr?.trademarkNumber?.errors?.[ 0 ],
-			sirenSirat: details.tldExtraFields.fr?.sirenSirat?.errors?.[ 0 ],
+			registrantType: details.tldExtraFields.fr?.registrantType?.errors,
+			registrantVatId: details.vatId.errors,
+			trademarkNumber: details.tldExtraFields.fr?.trademarkNumber?.errors,
+			sirenSiret: details.tldExtraFields.fr?.sirenSiret?.errors,
 		};
 	}
 	return null;
@@ -537,7 +537,7 @@ export function prepareDomainContactValidationRequest(
 			registrant_type: details.tldExtraFields.fr.registrantType.value,
 			registrant_vat_id: details.vatId.value,
 			trademark_number: details.tldExtraFields.fr.trademarkNumber.value,
-			siren_sirat: details.tldExtraFields.fr.sirenSirat.value,
+			siren_siret: details.tldExtraFields.fr.sirenSiret.value,
 		};
 	}
 
@@ -597,7 +597,7 @@ export function formatDomainContactValidationResponse(
 			fr: {
 				registrantType: response.messages?.extra?.fr?.registrantType,
 				trademarkNumber: response.messages?.extra?.fr?.trademarkNumber,
-				sirenSirat: response.messages?.extra?.fr?.sirenSirat,
+				sirenSiret: response.messages?.extra?.fr?.sirenSiret,
 			},
 		},
 	};
@@ -636,7 +636,7 @@ function prepareManagedContactDetailsUpdate(
 			fr: {
 				registrantType: rawFields?.extra?.fr?.registrantType,
 				trademarkNumber: rawFields?.extra?.fr?.trademarkNumber,
-				sirenSirat: rawFields?.extra?.fr?.sirenSirat,
+				sirenSiret: rawFields?.extra?.fr?.sirenSiret,
 			},
 		},
 	};


### PR DESCRIPTION
This is the final PR to be broken out of #40482.

- [x] Merge #41783
- [x] Merge #42075
- [x] Merge #41813

#### Changes proposed in this Pull Request

* Include the extra ccTLD-specific contact forms in composite checkout.

#### Testing instructions

This PR only touches composite checkout, so should be easier to test.

For all cases really jerk test the validation especially -- there are a lot of invisible changes in how that works that were merged in previous patches but are only effective with this one.

- Run local calypso with `ENABLE_FEATURES=composite-checkout-force yarn start` to force composite checkout.
- Enter checkout with one of the following TLDs in your cart: (1) .ca, (2) .uk, (3) .fr. At the contact details step you should see extra form fields depending on which TLD you have.
Enter checkout with two or more of the above listed TLDs. You should see extra fields for each TLD.
- Enter checkout with a domain not belonging to one of the special TLDs; make sure you see only the usual domain contact form.
- Enter checkout without a domain; make sure you see only the usual non-domain contact form.

Not yet sure how to test completing a purchase with a non-.live domain.
