### PR TITLE
Cloud: Changes scan error text

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -208,8 +208,8 @@ class ScanPage extends Component< Props > {
 				{ this.renderHeader( translate( 'Something went wrong' ) ) }
 				<p>
 					{ translate(
-						'Jetpack Scan was unable to complete a scan of your site. Please check the status of your ' +
-							'site and contact support if you continue to experience problems.'
+						"Jetpack Scan couldn't complete a scan of your site. Please check to see if your site is down " +
+							"– if it's not, try again. If it is, or if Jetpack Scan is still having problems, contact our support team."
 					) }
 				</p>
 				{ this.renderContactSupportButton() }

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -208,9 +208,8 @@ class ScanPage extends Component< Props > {
 				{ this.renderHeader( translate( 'Something went wrong' ) ) }
 				<p>
 					{ translate(
-						'The scan did not complete ' +
-							'successfully. In order to complete the scan you will need ' +
-							'to speak to support who can help determine what went wrong.'
+						'Jetpack Scan was unable to communicate with your site. Please check the status of your ' +
+							'site and contact support if you continue to experience problems.'
 					) }
 				</p>
 				{ this.renderContactSupportButton() }

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -208,7 +208,7 @@ class ScanPage extends Component< Props > {
 				{ this.renderHeader( translate( 'Something went wrong' ) ) }
 				<p>
 					{ translate(
-						'Jetpack Scan was unable to communicate with your site. Please check the status of your ' +
+						'Jetpack Scan was unable to complete a scan of your site. Please check the status of your ' +
 							'site and contact support if you continue to experience problems.'
 					) }
 				</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates copy for scan error text to be more generic.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Scan in JP Cloud.
* Alter the state so `most_recent` has an `error` that's not falsey. Example event:
```json
{
   "type":"JETPACK_SCAN_UPDATE",
   "siteId":"[your site id here]",
   "payload":{
      "state":"idle",
      "threats":[],
      "credentials":["test"],
      "mostRecent":{
         "timestamp":"foo",
         "progress":49,
         "duration":25,
         "error":"test"
      }
   }
}
```
* Observe copy.

**Note** that right now, the Scan API doesn't provide meaningful errors, so a generic error is displayed. Once we get more meaningful errors additional error messaging can be added.

<img width="740" alt="Screen Shot 2020-05-05 at 12 49 22 PM" src="https://user-images.githubusercontent.com/1760168/81092694-0155dc00-8ecf-11ea-8d9d-0ec8dc9de577.png">

Fixes 1143508703416848-as-1173255039677553.
