### PR TITLE
My Home: Add a video icon beside the Free Photo Library prompt.

### DIFF
--- a/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
+++ b/client/my-sites/customer-home/cards/education/free-photo-library/index.jsx
@@ -29,6 +29,7 @@ const FreePhotoLibrary = () => {
 					postId: 145498,
 					url: localizeUrl( 'https://wordpress.com/support/free-photo-library/' ),
 					text: translate( 'Learn more' ),
+					icon: 'video',
 					tracksEvent: 'calypso_customer_home_free_photo_library_video_support_page_view',
 					statsName: 'view_free_photo_library_video',
 				},


### PR DESCRIPTION
Both the Mastering Gutenberg and Free Photo Library cards involve text links that open a modal to a video. The former has video icons before the links, the latter does not; this PR adds the same icon to the latter for consistency.

Before | After
--- | --- 
 ![image](https://user-images.githubusercontent.com/349751/81110318-3dd60780-8ed0-11ea-97ce-4fb0b4312189.png) | ![image](https://user-images.githubusercontent.com/349751/81110324-40386180-8ed0-11ea-8eef-23ac8e0eeab4.png)


#### Testing instructions

* Go to My Home either on this branch or via the calypso.live link (any site will do).
* Verify the video icon beside "Learn more" in the Free Photo Library card under Learn and Grow.

