### PR TITLE
Checkout: add ability to toggle summary on mobile

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -20,7 +20,6 @@ export default function WPCheckoutOrderSummary() {
 
 	return (
 		<CheckoutSummaryCard>
-			<CheckoutSummaryTitle>{ translate( 'Purchase Details' ) }</CheckoutSummaryTitle>
 			<CheckoutSummaryFeatures>
 				<CheckoutSummaryFeaturesTitle>
 					{ translate( 'Included with your purchase' ) }
@@ -57,17 +56,6 @@ export default function WPCheckoutOrderSummary() {
 		</CheckoutSummaryCard>
 	);
 }
-
-const CheckoutSummaryTitle = styled.h2`
-	color: ${( props ) => props.theme.colors.textColor};
-	display: none;
-	font-weight: ${( props ) => props.theme.weights.bold};
-	padding: 20px 20px 0;
-
-	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
-		display: none;
-	}
-`;
 
 const CheckoutSummaryFeatures = styled.div`
 	padding: 20px;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -19,7 +19,7 @@ export default function WPCheckoutOrderSummary() {
 	const total = useTotal();
 
 	return (
-		<CheckoutSummaryCard>
+		<CheckoutSummaryCardUI>
 			<CheckoutSummaryFeatures>
 				<CheckoutSummaryFeaturesTitle>
 					{ translate( 'Included with your purchase' ) }
@@ -53,9 +53,13 @@ export default function WPCheckoutOrderSummary() {
 					<span>{ renderDisplayValueMarkdown( total.amount.displayValue ) }</span>
 				</CheckoutSummaryTotal>
 			</CheckoutSummaryAmountWrapper>
-		</CheckoutSummaryCard>
+		</CheckoutSummaryCardUI>
 	);
 }
+
+const CheckoutSummaryCardUI = styled( CheckoutSummaryCard )`
+	border-bottom: none 0;
+`;
 
 const CheckoutSummaryFeatures = styled.div`
 	padding: 20px 20px 0;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -58,7 +58,11 @@ export default function WPCheckoutOrderSummary() {
 }
 
 const CheckoutSummaryFeatures = styled.div`
-	padding: 20px;
+	padding: 20px 20px 0;
+
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+		padding: 20px;
+	}
 `;
 
 const CheckoutSummaryFeaturesTitle = styled.h3`
@@ -84,8 +88,11 @@ const CheckoutSummaryFeaturesListItem = styled.li`
 `;
 
 const CheckoutSummaryAmountWrapper = styled.div`
-	border-top: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 	padding: 20px;
+
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+		border-top: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+	}
 `;
 
 const CheckoutSummaryLineItem = styled.div`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -322,15 +322,22 @@ const UpsellWrapperUI = styled.div`
 	}
 
 	.cart__upsell-wrapper {
-		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+		border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+
+		@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+			border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+		}
 	}
 
 	.cart__upsell-header {
-		border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 		border-top: none;
 		box-shadow: none;
 		padding-left: 20px;
 		padding-right: 20px;
+
+		@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+			border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+		}
 
 		.section-header__label {
 			color: ${( props ) => props.theme.colors.textColor};
@@ -339,7 +346,11 @@ const UpsellWrapperUI = styled.div`
 	}
 
 	.cart__upsell-body {
-		padding: 20px;
+		padding: 0 20px 20px;
+
+		@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+			padding: 20px;
+		}
 
 		p {
 			margin-bottom: 1.2em;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -18,6 +18,7 @@ import {
 	useDispatch,
 	useTotal,
 	usePaymentMethod,
+	renderDisplayValueMarkdown,
 } from '@automattic/composite-checkout';
 
 /**
@@ -31,6 +32,7 @@ import WPContactForm from './wp-contact-form';
 import { isCompleteAndValid } from '../types';
 import { WPOrderReviewTotal, WPOrderReviewSection, LineItemUI } from './wp-order-review-line-items';
 import CartFreeUserPlanUpsell from 'my-sites/checkout/cart/cart-free-user-plan-upsell';
+import MaterialIcon from 'components/material-icon';
 
 const ContactFormTitle = () => {
 	const translate = useTranslate();
@@ -121,6 +123,8 @@ export default function WPCheckout( {
 		return isCompleteAndValid( contactInfo );
 	};
 
+	const [ isSummaryVisible, setIsSummaryVisible ] = useState( false );
+
 	// Copy siteId to the store so it can be more easily accessed during payment submission
 	useEffect( () => {
 		setSiteId( siteId );
@@ -136,14 +140,27 @@ export default function WPCheckout( {
 	// so we mock the loaded property the CartStore would inject.
 	const mockCart = { ...responseCart, hasLoadedFromServer: true };
 
+	//...( isSummaryVisible ? [ 'is-visible' ] : [] ),
+
 	return (
 		<Checkout>
-			<CheckoutSummaryUI>
-				<WPCheckoutOrderSummary />
-				<UpsellWrapperUI>
-					<CartFreeUserPlanUpsell cart={ mockCart } addItemToCart={ addItemToCart } />
-				</UpsellWrapperUI>
-			</CheckoutSummaryUI>
+			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
+				<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
+					<span>
+						{ translate( 'Purchase Details' ) }
+						<CheckoutSummaryIcon icon="keyboard_arrow_down" />
+					</span>
+					<CheckoutSummaryTitlePrice>
+						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
+					</CheckoutSummaryTitlePrice>
+				</CheckoutSummaryTitleLink>
+				<CheckoutSummaryBody>
+					<WPCheckoutOrderSummary />
+					<UpsellWrapperUI>
+						<CartFreeUserPlanUpsell cart={ mockCart } addItemToCart={ addItemToCart } />
+					</UpsellWrapperUI>
+				</CheckoutSummaryBody>
+			</CheckoutSummaryArea>
 			<CheckoutStepArea>
 				<CheckoutSteps>
 					<CheckoutStep
@@ -240,17 +257,63 @@ export default function WPCheckout( {
 	);
 }
 
-const CheckoutSummaryUI = styled( CheckoutSummaryArea )`
-	display: none;
+const CheckoutSummaryTitleLink = styled.button`
+	background: ${( props ) => props.theme.colors.background};
+	border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+	color: ${( props ) => props.theme.colors.textColor};
+	display: flex;
+	font-weight: ${( props ) => props.theme.weights.bold};
+	justify-content: space-between;
+	padding: 20px;
+	width: 100%;
+
+	.is-visible & {
+		border-bottom: none;
+	}
 
 	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+		display: none;
+	}
+`;
+
+const CheckoutSummaryIcon = styled( MaterialIcon )`
+	fill: ${( props ) => props.theme.colors.textColor};
+	margin-left: 4px;
+	transition: transform 0.1s linear;
+	width: 16px;
+	height: 16px;
+	vertical-align: bottom;
+
+	.is-visible & {
+		transform: rotate( 180deg );
+	}
+`;
+
+const CheckoutSummaryTitlePrice = styled.span`
+	.is-visible & {
+		display: none;
+	}
+`;
+
+const CheckoutSummaryBody = styled.div`
+	display: none;
+
+	.is-visible & {
+		display: block;
+	}
+
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+		border-bottom: none;
 		display: block;
 	}
 `;
 
 const UpsellWrapperUI = styled.div`
-	margin-top: 24px;
 	background: ${( props ) => props.theme.colors.surface};
+
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+		margin-top: 24px;
+	}
 
 	.cart__upsell-wrapper {
 		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -272,7 +272,7 @@ const CheckoutSummaryTitleLink = styled.button`
 		border-bottom: none;
 	}
 
-	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
+	@media ( ${( props ) => props.theme.breakpoints.smallPhoneUp} ) {
 		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 		border-bottom: none 0;
 	}
@@ -317,7 +317,7 @@ const CheckoutSummaryBody = styled.div`
 		display: block;
 	}
 
-	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
+	@media ( ${( props ) => props.theme.breakpoints.smallPhoneUp} ) {
 		border-bottom: none;
 	}
 
@@ -334,8 +334,10 @@ const UpsellWrapperUI = styled.div`
 	}
 
 	.cart__upsell-wrapper {
-		border-left: 1px solid ${( props ) => props.theme.colors.borderColorLight};
-		border-right: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+		@media ( ${( props ) => props.theme.breakpoints.smallPhoneUp} ) {
+			border-left: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+			border-right: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+		}
 
 		@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
 			border: 1px solid ${( props ) => props.theme.colors.borderColorLight};

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -141,8 +141,6 @@ export default function WPCheckout( {
 	// so we mock the loaded property the CartStore would inject.
 	const mockCart = { ...responseCart, hasLoadedFromServer: true };
 
-	//...( isSummaryVisible ? [ 'is-visible' ] : [] ),
-
 	return (
 		<Checkout>
 			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -262,6 +262,7 @@ const CheckoutSummaryTitleLink = styled.button`
 	border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 	color: ${( props ) => props.theme.colors.textColor};
 	display: flex;
+	font-size: 16px;
 	font-weight: ${( props ) => props.theme.weights.bold};
 	justify-content: space-between;
 	padding: 20px;
@@ -285,8 +286,8 @@ const CheckoutSummaryIcon = styled( MaterialIcon )`
 	fill: ${( props ) => props.theme.colors.textColor};
 	margin-left: 4px;
 	transition: transform 0.1s linear;
-	width: 16px;
-	height: 16px;
+	width: 18px;
+	height: 18px;
 	vertical-align: bottom;
 
 	.is-visible & {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -271,6 +271,11 @@ const CheckoutSummaryTitleLink = styled.button`
 		border-bottom: none;
 	}
 
+	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
+		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+		border-bottom: none 0;
+	}
+
 	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
 		display: none;
 	}

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -33,6 +33,7 @@ import { isCompleteAndValid } from '../types';
 import { WPOrderReviewTotal, WPOrderReviewSection, LineItemUI } from './wp-order-review-line-items';
 import CartFreeUserPlanUpsell from 'my-sites/checkout/cart/cart-free-user-plan-upsell';
 import MaterialIcon from 'components/material-icon';
+import Gridicon from 'components/gridicon';
 
 const ContactFormTitle = () => {
 	const translate = useTranslate();
@@ -146,10 +147,11 @@ export default function WPCheckout( {
 		<Checkout>
 			<CheckoutSummaryArea className={ isSummaryVisible ? 'is-visible' : '' }>
 				<CheckoutSummaryTitleLink onClick={ () => setIsSummaryVisible( ! isSummaryVisible ) }>
-					<span>
+					<CheckoutSummaryTitle>
+						<CheckoutSummaryTitleIcon icon="info-outline" size={ 20 } />
 						{ translate( 'Purchase Details' ) }
-						<CheckoutSummaryIcon icon="keyboard_arrow_down" />
-					</span>
+						<CheckoutSummaryTitleToggle icon="keyboard_arrow_down" />
+					</CheckoutSummaryTitle>
 					<CheckoutSummaryTitlePrice>
 						{ renderDisplayValueMarkdown( total.amount.displayValue ) }
 					</CheckoutSummaryTitlePrice>
@@ -282,7 +284,15 @@ const CheckoutSummaryTitleLink = styled.button`
 	}
 `;
 
-const CheckoutSummaryIcon = styled( MaterialIcon )`
+const CheckoutSummaryTitle = styled.span`
+	display: flex;
+`;
+
+const CheckoutSummaryTitleIcon = styled( Gridicon )`
+	margin-right: 6px;
+`;
+
+const CheckoutSummaryTitleToggle = styled( MaterialIcon )`
 	fill: ${( props ) => props.theme.colors.textColor};
 	margin-left: 4px;
 	transition: transform 0.1s linear;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -289,7 +289,7 @@ const CheckoutSummaryTitle = styled.span`
 `;
 
 const CheckoutSummaryTitleIcon = styled( Gridicon )`
-	margin-right: 6px;
+	margin-right: 4px;
 `;
 
 const CheckoutSummaryTitleToggle = styled( MaterialIcon )`
@@ -312,14 +312,18 @@ const CheckoutSummaryTitlePrice = styled.span`
 `;
 
 const CheckoutSummaryBody = styled.div`
+	border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 	display: none;
 
 	.is-visible & {
 		display: block;
 	}
 
-	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
 		border-bottom: none;
+	}
+
+	@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
 		display: block;
 	}
 `;
@@ -332,7 +336,8 @@ const UpsellWrapperUI = styled.div`
 	}
 
 	.cart__upsell-wrapper {
-		border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+		border-left: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+		border-right: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 
 		@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
 			border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
@@ -340,13 +345,20 @@ const UpsellWrapperUI = styled.div`
 	}
 
 	.cart__upsell-header {
-		border-top: none;
+		border-top: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 		box-shadow: none;
-		padding-left: 20px;
-		padding-right: 20px;
+		margin-left: 20px;
+		margin-right: 20px;
+		padding-left: 0;
+		padding-right: 0;
 
 		@media ( ${( props ) => props.theme.breakpoints.desktopUp} ) {
+			border-top: none;
 			border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+			margin-left: 0;
+			margin-right: 0;
+			padding-left: 20px;
+			padding-right: 20px;
 		}
 
 		.section-header__label {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -265,7 +265,7 @@ const CheckoutSummaryTitleLink = styled.button`
 	font-size: 16px;
 	font-weight: ${( props ) => props.theme.weights.bold};
 	justify-content: space-between;
-	padding: 20px;
+	padding: 20px 23px 20px 14px;
 	width: 100%;
 
 	.is-visible & {

--- a/packages/composite-checkout/src/components/checkout-steps.js
+++ b/packages/composite-checkout/src/components/checkout-steps.js
@@ -135,7 +135,7 @@ export const CheckoutSummaryCard = styled.div`
 	background: ${( props ) => props.theme.colors.surface};
 	border-bottom: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 
-	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
+	@media ( ${( props ) => props.theme.breakpoints.smallPhoneUp} ) {
 		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
 		border-bottom: none 0;
 	}
@@ -462,8 +462,11 @@ const CheckoutStepAreaUI = styled.div`
 	margin: 0 auto ${( props ) => ( props.isLastStepActive ? '100px' : 0) };
 	width: 100%;
 
-	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
+	@media ( ${( props ) => props.theme.breakpoints.smallPhoneUp} ) {
 		border: 1px solid ${( props ) => props.theme.colors.borderColorLight};
+	}
+
+	@media ( ${( props ) => props.theme.breakpoints.tabletUp} ) {
 		max-width: 556px;
 	}
 


### PR DESCRIPTION
Currently, the checkout summary (with plan features, cost summary, and happiness callout) is hidden on mobile devices. This allows it to be toggled on mobile devices, behind the "purchase details" header.

Changes from the design:
- I used `MaterialIcon` arrow component to match the sidebar toggle pattern in Calypso
- I left the cart total visible. I think this information will be valuable (especially with tax and coupon items) in steps after the review step

Collapsed | Expanded
------------ | -------------
<img width="374" alt="mobile-collapsed" src="https://user-images.githubusercontent.com/942359/81110817-13914380-8eea-11ea-8e36-2d22f7ee4ebc.png"> | <img width="372" alt="mobile-expanded" src="https://user-images.githubusercontent.com/942359/81110832-18ee8e00-8eea-11ea-9a3d-32bc4fbd26c1.png">
<img width="781" alt="tablet-collapsed" src="https://user-images.githubusercontent.com/942359/81110858-2146c900-8eea-11ea-89d8-fbc714ddbbc9.png"> | <img width="780" alt="tablet-expanded" src="https://user-images.githubusercontent.com/942359/81110867-260b7d00-8eea-11ea-8e04-c936aea89ad5.png">

**To test:**
- view Checkout with a viewport `<960px`
- verify that the "Purchase Details" header is visible with the current cart total
- verify that the checkout summary is collapsed by default
- verify that clicking on the "Purchase Details" header toggles the checkout summary
- verify that in a viewport `>960px` the header is hidden and the summary is permanently visible (floated to the side)