### PR TITLE
My Home: Fix logic determining the description of notices in i1.

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -154,7 +154,9 @@ const mapStateToProps = ( state ) => {
 		hasChecklistData,
 		isStaticHomePage:
 			! isClassicEditor && 'page' === getSiteOption( state, siteId, 'show_on_front' ),
-		displayChecklist: layout?.primary?.includes( 'home-primary-checklist-site-setup' ),
+		displayChecklist:
+			layout?.primary?.includes( 'home-primary-checklist-site-setup' ) ||
+			layout?.primary?.includes( 'home-task-site-setup-checklist' ),
 		user,
 		layout,
 	};


### PR DESCRIPTION
The second line description of My Home notices is currently determined, among other things, by [whether or not the checklist is being displayed](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/customer-home/cards/notices/celebrate-notice/index.jsx#L41) – but is only aware of the production checklist card. This PR adds the new task-based checklist to the check, while we transition to the new i1 layout.

Before | After
--- | --- 
 ![image](https://user-images.githubusercontent.com/349751/81115659-ed16dc80-8ed8-11ea-8c0e-f910b8d1fe46.png) | ![image](https://user-images.githubusercontent.com/349751/81115670-ef793680-8ed8-11ea-8e58-acdbe9ea48b9.png)

#### Testing instructions

* On this branch, create a new site, and launch it.
* On the celebratory page load, verify the description in the celebratory card makes sense (it should match the screenshot above).
* Load the same URL on production, and verify the same content appears in the notice.


