### PR TITLE
Jetpack Cloud: fix [object Object] sub-header in threats

### DIFF
--- a/client/landing/jetpack-cloud/components/threat-item-subheader/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item-subheader/index.tsx
@@ -44,8 +44,8 @@ const ThreatItemSubheader: React.FC< Props > = ( { threat } ) => {
 			case 'file':
 				return (
 					<>
-						{ translate( 'Threat found %(signature)s', {
-							args: {
+						{ translate( 'Threat found {{signature/}}', {
+							components: {
 								signature: (
 									<span className="threat-item-subheader__alert-signature">
 										{ threat.signature }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Threats affecting files have a broken sub-header that displays the [object Object] string instead of the name of the file.

#### Testing instructions

* Fire up this PR
* Select a site that has Scan, and at least one threat that affects a file
* Verify the name of the file is correctly displayed

1151678672052943-1174379596333369

#### Demo

**Before**
![image](https://user-images.githubusercontent.com/3418513/81118716-c9b35800-8eff-11ea-862d-c701b2e1d201.png)

**After**
![image](https://user-images.githubusercontent.com/3418513/81118707-c28c4a00-8eff-11ea-8de8-4f402787896e.png)

