### PR TITLE
Jetpack Cloud: Add spacing to elements of ActivityActor on Real-Time Backup Summary

### DIFF
--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -101,15 +101,31 @@
 	box-shadow: none;
 }
 
-.daily-backup-status__realtime-details-card .activity-card .card .activity-log-item__actor .activity-log-item__actor-info {
+.daily-backup-status__realtime-details-card
+	.activity-card
+	.card
+	.activity-log-item__actor
+	.activity-log-item__actor-info {
 	display: flex;
+	& > *:not( :last-child ) {
+		margin-right: 8px;
+	}
 }
 
-.daily-backup-status__realtime-details-card .activity-card .card .activity-log-item__actor .activity-log-item__actor-info .activity-log-item__actor-name::after {
+.daily-backup-status__realtime-details-card
+	.activity-card
+	.card
+	.activity-log-item__actor
+	.activity-log-item__actor-info
+	.activity-log-item__actor-name::after {
 	margin-right: 0.2rem;
 }
 
-.daily-backup-status__realtime-details-card .activity-card .card .activity-log-item__actor .gravatar,
+.daily-backup-status__realtime-details-card
+	.activity-card
+	.card
+	.activity-log-item__actor
+	.gravatar,
 .daily-backup-status__realtime-details-card .activity-card .card .activity-log-item__actor svg {
 	width: 30px;
 }
@@ -160,7 +176,7 @@
 		margin-top: 0;
 		color: var( --studio-gray-40 );
 		font-weight: 400;
-    	font-size: 0.9rem;
+		font-size: 0.9rem;
 	}
 
 	.form-button.daily-backup-status__download-button,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a style rule to space out elements of ActivityActor on Daily Backup Summary

![Untitled 11](https://user-images.githubusercontent.com/2810519/81123039-06268a00-8ee7-11ea-82bc-c1d68315d1a9.png)


#### Testing instructions

1. Navigate to `/backups` for a site with real-time backups
2. You may be able to find a backup that does not have "Jetpack" as the actor, but I ended up just modifying the props via React Dev Tools
   a. ) Open React Dev Tools and Search for `ActivityActor`
   b. ) Set the `actorType` to User and the `actorRole` to whatever ( I used "Administrator" in the example )
<img width="410" alt="Screen Shot 2020-05-05 at 3 39 23 PM" src="https://user-images.githubusercontent.com/2810519/81123279-8816b300-8ee7-11ea-9af9-10e084473fb1.png">
3. Verify the screen matched the "after" above

