### PR TITLE
Update domain button

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -311,7 +311,7 @@ export class List extends React.Component {
 				className="domain-management-list__add-a-domain"
 				onClick={ this.clickAddDomain }
 			>
-				{ this.props.translate( 'Add domain' ) }
+				{ this.props.translate( 'Add a domain to this site' ) }
 			</Button>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the Add domain button so that it more explicitly adds them to the site you're managing.

Before:
![image](https://user-images.githubusercontent.com/6981253/81135098-ced6ce00-8f24-11ea-9fb2-6d4e3bd3242e.png)

After:
![image](https://user-images.githubusercontent.com/6981253/81135064-ba92d100-8f24-11ea-89f0-5f68088fe45c.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calpso.live and visit /domains/manage for any site. 
* The button should say "Add a domain to this site"

cc @eltongo @hambai 
