### PR TITLE
Gutenboarding: fix overlapping arrow on mobile

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -76,7 +76,9 @@
 	position: relative;
 
 	&--with-arrow {
-		margin-right: 40px; // make space for absolute positioned arrow
+		.madlib__input {
+			margin-right: 40px; // make space for absolute positioned arrow
+		}
 	}
 
 	.madlib__input:empty {
@@ -132,7 +134,7 @@
 .vertical-select__arrow {
 	position: absolute;
 	bottom: 8px;
-	margin-left: 15px;
+	margin-left: -25px;
 
 	@include break-small {
 		bottom: 25px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update vertical select arrow positioning to prevent overlapping.

#### Testing instructions

* Go to [/new](https://calypso.live/?branch=fix/gutenboarding-arrow-overlapping-vertical) on mobile
* Enter a long query without spaces in the vertical input so it fills 100% width of the screen.
* Arrow should still be displayed at the end of the line and not [like this](https://user-images.githubusercontent.com/14192054/81071138-edb96e00-8eec-11ea-9b45-760ca27cacaf.png).

Fixes #41807
