### PR TITLE
Block editor: remove page layout preview from sidebar

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -153,17 +153,12 @@ class Starter_Page_Templates {
 		wp_enqueue_script( 'starter-page-templates' );
 		wp_set_script_translations( 'starter-page-templates', 'full-site-editing' );
 
-		$default_info      = [
-			'title'    => get_bloginfo( 'name' ),
-			'vertical' => $vertical['name'],
-		];
 		$default_templates = [
 			[
 				'title' => 'Blank',
 				'slug'  => 'blank',
 			],
 		];
-		$site_info         = get_option( 'site_contact_info', [] );
 		/**
 		 * Filters the config before it's passed to the frontend.
 		 *
@@ -172,16 +167,15 @@ class Starter_Page_Templates {
 		$config = apply_filters(
 			'fse_starter_page_templates_config',
 			[
-				'siteInformation' 		=> array_merge( $default_info, $site_info ),
-				'templates'       		=> array_merge( $default_templates, $vertical_templates ),
-				'vertical'        		=> $vertical,
-				'segment'         		=> $segment,
-				// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-				'screenAction'    		=> isset( $_GET['new-homepage'] ) ? 'add' : $screen->action,
-				'theme'           		=> normalize_theme_slug( get_stylesheet() ),
-				// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-				'isFrontPage'     		=> isset( $_GET['post'] ) && get_option( 'page_on_front' ) === $_GET['post'],
-				'hideFrontPageTitle'	=> get_theme_mod( 'hide_front_page_title' ),
+				'templates'          => array_merge( $default_templates, $vertical_templates ),
+				'vertical'           => $vertical,
+				'segment'            => $segment,
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'screenAction'       => isset( $_GET['new-homepage'] ) ? 'add' : $screen->action,
+				'theme'              => normalize_theme_slug( get_stylesheet() ),
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'isFrontPage'        => isset( $_GET['post'] ) && get_option( 'page_on_front' ) === $_GET['post'],
+				'hideFrontPageTitle' => get_theme_mod( 'hide_front_page_title' ),
 			]
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
@@ -22,7 +22,6 @@ const {
 	vertical,
 	segment,
 	tracksUserData,
-	siteInformation = {},
 	screenAction,
 	theme,
 	isFrontPage,
@@ -62,10 +61,7 @@ registerPlugin( 'page-templates-sidebar', {
 				className="page-template-modal__sidebar" // eslint-disable-line wpcalypso/jsx-classname-namespace
 				icon="none"
 			>
-				<SidebarTemplatesPlugin
-					{ ...templatesPluginSharedProps }
-					siteInformation={ siteInformation }
-				/>
+				<SidebarTemplatesPlugin { ...templatesPluginSharedProps } />
 			</PluginDocumentSettingPanel>
 		);
 	},

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/sidebar-modal-opener.js
@@ -12,8 +12,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { PageTemplatesPlugin } from '../index';
-import TemplateSelectorItem from './template-selector-item';
-import replacePlaceholders from '../utils/replace-placeholders';
 /* eslint-enable import/no-extraneous-dependencies */
 class SidebarModalOpener extends Component {
 	state = {
@@ -28,57 +26,12 @@ class SidebarModalOpener extends Component {
 		this.setState( { isWarningOpen: ! this.state.isWarningOpen } );
 	};
 
-	getLastTemplateUsed = () => {
-		const { isFrontPage, templates, theme } = this.props;
-		let { lastTemplateUsedSlug } = this.props;
-		// Try to match the homepage of the theme. Note that as folks transition
-		// to using the slug-based version of the homepage (e.g. "shawburn"), the
-		// slug will work normally without going through this check.
-		if ( ! lastTemplateUsedSlug && isFrontPage ) {
-			lastTemplateUsedSlug = theme;
-		}
-
-		if ( ! lastTemplateUsedSlug || lastTemplateUsedSlug === 'blank' ) {
-			// If no template used or 'blank', preview any other template (1 is currently 'Home' template).
-			return templates[ 0 ];
-		}
-		const matchingTemplate = templates.find( ( temp ) => temp.slug === lastTemplateUsedSlug );
-		// If no matching template, return the blank template.
-		if ( ! matchingTemplate ) {
-			return templates[ 0 ];
-		}
-		return matchingTemplate;
-	};
-
 	render() {
-		const { slug, title, preview, previewAlt } = this.getLastTemplateUsed();
-		const {
-			templates,
-			theme,
-			vertical,
-			segment,
-			siteInformation,
-			hidePageTitle,
-			isFrontPage,
-			isOpen,
-		} = this.props;
+		const { templates, theme, vertical, segment, hidePageTitle, isFrontPage, isOpen } = this.props;
 
 		return (
 			<div className="sidebar-modal-opener">
-				<TemplateSelectorItem
-					id="sidebar-modal-opener__last-template-used-preview"
-					value={ slug }
-					label={ replacePlaceholders( title, siteInformation ) }
-					staticPreviewImg={ preview }
-					staticPreviewImgAlt={ previewAlt }
-					onSelect={ this.toggleWarningModal }
-				/>
-
-				<Button
-					isPrimary
-					onClick={ this.toggleWarningModal }
-					className="sidebar-modal-opener__button"
-				>
+				<Button isSecondary onClick={ this.toggleWarningModal }>
 					{ __( 'Change Layout' ) }
 				</Button>
 
@@ -125,8 +78,6 @@ class SidebarModalOpener extends Component {
 
 const SidebarTemplatesPlugin = compose(
 	withSelect( ( select ) => ( {
-		lastTemplateUsedSlug: select( 'core/editor' ).getEditedPostAttribute( 'meta' )
-			._starter_page_template,
 		isOpen: select( 'automattic/starter-page-layouts' ).isOpen(),
 	} ) ),
 	withDispatch( ( dispatch ) => ( {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -360,10 +360,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 }
 
-.sidebar-modal-opener__button {
-	margin-top: 20px;
-}
-
 .sidebar-modal-opener__warning-modal {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For the reasons outlined in #41793

**Before**
<img width="273" alt="Screenshot 2020-05-06 at 7 38 55 PM" src="https://user-images.githubusercontent.com/1500769/81148984-6eea3100-8fd1-11ea-87e3-de6ceee52a31.png">

**After**
<img width="273" alt="Screenshot 2020-05-06 at 7 39 21 PM" src="https://user-images.githubusercontent.com/1500769/81149013-7d384d00-8fd1-11ea-8f23-9a097b1545d4.png">

* Page layout screenshot removed from document settings sidebar
* "Change Layout" button changed to secondary button style and margin removed
* removed `siteInformation` from the `window.starterPageTemplatesConfig` global sent from server (no longer used)
* Formatting changes from the pre-commit hook

The FSE plugin will need to be deployed after this is merged.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clone branch
* `cd apps/full-site-editing && yarn dev`
* `cd apps/full-site-editing && wp-env start` in another terminal
* `localhost:4013/wp-admin` and edit a page
* See changes in the document settings sidebar

You can also see changes as they would appear on wpcom by using `yarn wpcom-sync` and sandboxing a site.

Fixes #40766
Fixes #41793
