### PR TITLE
My Home: Mark webinars task as completed when clicking on action button

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -36,10 +36,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import './style.scss';
 
 const Task = ( {
-	actionOnClick,
+	actionTarget,
 	actionText,
 	actionUrl,
 	badgeText,
+	completeOnStart = false,
 	description,
 	illustration,
 	enableSkipOptions = true,
@@ -62,9 +63,11 @@ const Task = ( {
 	const successNoticeId = `task_remind_later_success-${ taskId }`;
 
 	const startTask = () => {
-		if ( actionOnClick instanceof Function ) {
-			actionOnClick();
+		if ( completeOnStart ) {
+			setIsTaskVisible( false );
+			dispatch( savePreference( dismissalPreferenceKey, true ) );
 		}
+
 		dispatch(
 			composeAnalytics(
 				recordTracksEvent( 'calypso_customer_home_task_start', {
@@ -144,7 +147,13 @@ const Task = ( {
 					<ActionPanelTitle>{ title }</ActionPanelTitle>
 					<p className="task__description">{ description }</p>
 					<ActionPanelCta>
-						<Button className="task__action" primary onClick={ startTask } href={ actionUrl }>
+						<Button
+							className="task__action"
+							primary
+							onClick={ startTask }
+							href={ actionUrl }
+							target={ actionTarget }
+						>
 							{ actionText }
 						</Button>
 

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -36,6 +36,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import './style.scss';
 
 const Task = ( {
+	actionOnClick,
 	actionTarget,
 	actionText,
 	actionUrl,
@@ -63,6 +64,10 @@ const Task = ( {
 	const successNoticeId = `task_remind_later_success-${ taskId }`;
 
 	const startTask = () => {
+		if ( actionOnClick instanceof Function ) {
+			actionOnClick();
+		}
+
 		if ( completeOnStart ) {
 			setIsTaskVisible( false );
 			dispatch( savePreference( dismissalPreferenceKey, true ) );

--- a/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/webinars/index.jsx
@@ -20,9 +20,9 @@ const Webinars = () => {
 				'Free, live video webinars led by our experts teach you to build a website, start a blog, or make money with your site.'
 			) }
 			actionText={ translate( 'Register for free' ) }
-			actionOnClick={ () => {
-				window.open( 'https://wordpress.com/webinars/', '_blank' );
-			} }
+			actionUrl="https://wordpress.com/webinars/"
+			actionTarget="_blank"
+			completeOnStart={ true }
 			illustration={ webinarsIllustration }
 			timing={ 2 }
 			taskId="webinars"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

AFAIK we don't have any way of identifying server-side users already registered for webinars, so we currently always display the webinars task card as long as it has not been dismissed, even if users started the task by clicking on "Register for free".

This PR ensures the task is marked as completed when clicking on that button (actually, it marks it as dismissed) so the task doesn't show up again.

#### Testing instructions

* Go to My Home for an established site with the webinars task card not dismissed.
* The webinar task card should show up.
* Click on "Register for free".
* Make sure the browser opens `wordpress.com/webinars` in a new tab.
* Switch back to the tab with My Home open.
* Make sure the webinars task card has disappeared.
* Reload My Home.
* Make sure the webinars task card doesn't show up again.
