### PR TITLE
Revert "My Home: Activate new layout on production"

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/nav-item.jsx
@@ -31,7 +31,6 @@ const NavItem = ( { text, taskId, isCompleted, isCurrent, onClick, showChevron }
 				trackExpand();
 				onClick();
 			} }
-			data-task={ taskId }
 		>
 			<div className="nav-item__status">
 				{ isCompleted ? (

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -37,7 +37,7 @@
 		"google-my-business": false,
 		"help": true,
 		"help/courses": true,
-		"home/experimental-layout": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/production.json
+++ b/config/production.json
@@ -42,7 +42,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"home/experimental-layout": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -49,7 +49,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"home/experimental-layout": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/test.json
+++ b/config/test.json
@@ -40,7 +40,7 @@
 		"gdpr-banner": false,
 		"google-my-business": false,
 		"help": true,
-		"home/experimental-layout": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"ive/me": false,
 		"ive/use-external-defs": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,7 +56,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
-		"home/experimental-layout": true,
+		"home/experimental-layout": false,
 		"inline-help": true,
 		"i18n/translation-scanner": true,
 		"ive/me": false,

--- a/test/e2e/lib/pages/checklist-page.js
+++ b/test/e2e/lib/pages/checklist-page.js
@@ -3,6 +3,7 @@
  */
 import assert from 'assert';
 import { By } from 'selenium-webdriver';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -11,14 +12,18 @@ import * as driverHelper from '../driver-helper.js';
 
 import AsyncBaseContainer from '../async-base-container';
 
+const mochaTimeOut = config.get( 'mochaTimeoutMS' );
+
 export default class ChecklistPage extends AsyncBaseContainer {
 	constructor( driver, url ) {
-		super( driver, By.css( '.customer-home__main .site-setup-list' ), url );
-		this.headerSelector = By.css( '.customer-home__main .site-setup-list .card-heading' );
+		super( driver, By.css( '.customer-home__layout .checklist' ), url );
+		this.headerSelector = By.css( '.customer-home__layout .checklist-site-setup__heading' );
 		this.updateHomepageTaskSelector = By.css(
-			'.customer-home__main [data-task="front_page_updated"]'
+			'.customer-home__layout .checklist__task button.checklist__task-title-button'
 		);
-		this.startTaskButtonSelector = By.css( '.customer-home__main .site-setup-list__task-action' );
+		this.updateHomepageButtonSelector = By.css(
+			'.customer-home__layout button[data-e2e-action="update-homepage"]'
+		);
 	}
 
 	async headerExists() {
@@ -37,7 +42,21 @@ export default class ChecklistPage extends AsyncBaseContainer {
 	}
 
 	async updateHomepage() {
-		await driverHelper.clickWhenClickable( this.driver, this.updateHomepageTaskSelector );
-		return await driverHelper.clickWhenClickable( this.driver, this.startTaskButtonSelector );
+		const items = await this.driver.findElements( this.updateHomepageTaskSelector );
+		for ( let i = 0; i < items.length; i++ ) {
+			await items[ i ].click();
+			if (
+				await driverHelper.isEventuallyPresentAndDisplayed(
+					this.driver,
+					this.updateHomepageButtonSelector,
+					mochaTimeOut / 2
+				)
+			) {
+				return await driverHelper.clickWhenClickable(
+					this.driver,
+					this.updateHomepageButtonSelector
+				);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#41712

Brings back the previous My Home layout. Merge only in case a critical regression is found and a revert is needed.