### PR TITLE
First iteration of plans store

### DIFF
--- a/client/landing/gutenboarding/components/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans-button/index.tsx
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { Button, Popover } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useViewportMatch } from '@wordpress/compose';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@automattic/react-i18n';
+
+/**
+ * Internal dependencies
+ */
+import JetpackLogo from 'components/jetpack-logo'; // @TODO: extract to @automattic package
+import { STORE_KEY as PLANS_STORE } from '../../stores/plans';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...buttonProps } ) => {
+	const [ isOpen, setIsOpen ] = React.useState( false );
+	const { __ } = useI18n();
+
+	// mobile first to match SCSS media query https://github.com/Automattic/wp-calypso/pull/41471#discussion_r415678275
+	const isDesktop = useViewportMatch( 'mobile', '>=' );
+	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );
+	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );
+	const { setPlan } = useDispatch( PLANS_STORE );
+
+	/* translators: Button label where %s is the WordPress.com plan name (eg: Free, Personal, Premium, Business) */
+	const planLabel = sprintf( __( '%s Plan' ), selectedPlan.getTitle() );
+
+	// This is dummy code just to test the PLANS_STORE API
+	return (
+		<>
+			<Button
+				onClick={ () => setIsOpen( ! isOpen ) }
+				label={ __( planLabel ) }
+				className="plans-button"
+				{ ...buttonProps }
+			>
+				{ isDesktop && planLabel }&nbsp;
+				<JetpackLogo className="plans-button__jetpack-logo" size={ 16 } monochrome />
+			</Button>
+			{ isOpen && (
+				<Popover
+					onClickOutside={ () => setIsOpen( false ) }
+					noArrow
+					position={ 'bottom center' }
+					expandOnMobile={ true }
+				>
+					{ supportedPlans.map( ( plan ) => (
+						<Button
+							style={ { display: 'block' } }
+							onClick={ () => {
+								setPlan( plan );
+								setIsOpen( false );
+							} }
+							label={ __( planLabel ) }
+							{ ...buttonProps }
+						>
+							{ plan.getTitle() }
+							<JetpackLogo className="plans-button__jetpack-logo" size={ 16 } monochrome />
+						</Button>
+					) ) }
+				</Popover>
+			) }
+		</>
+	);
+};
+
+export default PlansButton;

--- a/client/landing/gutenboarding/stores/onboard/persist.ts
+++ b/client/landing/gutenboarding/stores/onboard/persist.ts
@@ -1,5 +1,5 @@
 /**
  * Internal dependencies
  */
-import createPersistanceConfig from '../persistance-config';
-export default createPersistanceConfig( 'WP_ONBOARD' );
+import createPersistenceConfig from '../persistence-config';
+export default createPersistenceConfig( 'WP_ONBOARD' );

--- a/client/landing/gutenboarding/stores/persistance-config/index.ts
+++ b/client/landing/gutenboarding/stores/persistance-config/index.ts
@@ -1,0 +1,86 @@
+/*
+    Defines the options used for the @wp/data persistence plugin, 
+    which include a persistent storage implementation to add data expiration handling.
+*/
+
+/**
+ * Creates a storage config for state persistance
+ *
+ * @param storageKey Unique key to the storage
+ */
+export default function createPersistanceConfig( storageKey: string ) {
+	const PERSISTENCE_INTERVAL = 7 * 24 * 3600000; // days * hours in days * ms in hour
+	const STORAGE_KEY = storageKey;
+	const STORAGE_TS_KEY = storageKey + '_TS';
+
+	// A plain object fallback if localStorage is not available
+	const objStore: { [ key: string ]: string } = {};
+
+	const objStorage: Pick< Storage, 'getItem' | 'setItem' | 'removeItem' > = {
+		getItem( key ) {
+			if ( objStore.hasOwnProperty( key ) ) {
+				return objStore[ key ];
+			}
+
+			return null;
+		},
+		setItem( key, value ) {
+			objStore[ key ] = String( value );
+		},
+		removeItem( key ) {
+			delete objStore[ key ];
+		},
+	};
+
+	// Make sure localStorage support exists
+	const localStorageSupport = (): boolean => {
+		try {
+			window.localStorage.setItem( 'WP_ONBOARD_TEST', '1' );
+			window.localStorage.removeItem( 'WP_ONBOARD_TEST' );
+			return true;
+		} catch ( e ) {
+			return false;
+		}
+	};
+
+	// Choose the right storage implementation
+	const storageHandler = localStorageSupport() ? window.localStorage : objStorage;
+
+	// Persisted data expires after seven days
+	const isNotExpired = ( timestampStr: string ): boolean => {
+		const timestamp = Number( timestampStr );
+		return Boolean( timestamp ) && timestamp + PERSISTENCE_INTERVAL > Date.now();
+	};
+
+	// Check for "fresh" query param
+	const hasFreshParam = (): boolean => {
+		return new URLSearchParams( window.location.search ).has( 'fresh' );
+	};
+
+	// Handle data expiration by providing a storage object override to the @wp/data persistence plugin.
+	const storage: Pick< Storage, 'getItem' | 'setItem' > = {
+		getItem( key ) {
+			const timestamp = storageHandler.getItem( STORAGE_TS_KEY );
+
+			if ( timestamp && isNotExpired( timestamp ) && ! hasFreshParam() ) {
+				return storageHandler.getItem( key );
+			}
+
+			storageHandler.removeItem( STORAGE_KEY );
+			storageHandler.removeItem( STORAGE_TS_KEY );
+
+			return null;
+		},
+		setItem( key, value ) {
+			storageHandler.setItem( STORAGE_TS_KEY, JSON.stringify( Date.now() ) );
+			storageHandler.setItem( key, value );
+		},
+	};
+
+	const persistOptions = {
+		storageKey: STORAGE_KEY,
+		storage,
+	};
+
+	return persistOptions;
+}

--- a/client/landing/gutenboarding/stores/persistence-config/index.ts
+++ b/client/landing/gutenboarding/stores/persistence-config/index.ts
@@ -4,11 +4,11 @@
 */
 
 /**
- * Creates a storage config for state persistance
+ * Creates a storage config for state persistence
  *
  * @param storageKey Unique key to the storage
  */
-export default function createPersistanceConfig( storageKey: string ) {
+export default function createPersistenceConfig( storageKey: string ) {
 	const PERSISTENCE_INTERVAL = 7 * 24 * 3600000; // days * hours in days * ms in hour
 	const STORAGE_KEY = storageKey;
 	const STORAGE_TS_KEY = storageKey + '_TS';

--- a/client/landing/gutenboarding/stores/plans/actions.ts
+++ b/client/landing/gutenboarding/stores/plans/actions.ts
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { Plan } from './types';
+
+export const setPlan = ( plan: Plan | undefined ) => ( {
+	type: 'SET_PLAN' as const,
+	plan,
+} );

--- a/client/landing/gutenboarding/stores/plans/actions.ts
+++ b/client/landing/gutenboarding/stores/plans/actions.ts
@@ -1,9 +1,6 @@
-/**
- * Internal dependencies
- */
-import { Plan } from './types';
-
-export const setPlan = ( plan: Plan | undefined ) => ( {
-	type: 'SET_PLAN' as const,
-	plan,
-} );
+export const setPlan = ( slug: string | undefined ) => {
+	return {
+		type: 'SET_PLAN' as const,
+		slug,
+	};
+};

--- a/client/landing/gutenboarding/stores/plans/constants.ts
+++ b/client/landing/gutenboarding/stores/plans/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_KEY = 'automattic/onboard/plans';

--- a/client/landing/gutenboarding/stores/plans/index.ts
+++ b/client/landing/gutenboarding/stores/plans/index.ts
@@ -2,27 +2,29 @@
  * External dependencies
  */
 import { controls } from '@wordpress/data-controls';
-import { registerStore } from '@wordpress/data';
+import { plugins, registerStore, use } from '@wordpress/data';
 
 import { STORE_KEY } from './constants';
 import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
+import persistOptions from './persist';
 import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
 
-export type State = import('./reducer').State;
-export { STORE_KEY };
+use( plugins.persistence, persistOptions );
 
 registerStore< State >( STORE_KEY, {
 	actions,
 	controls,
 	reducer: reducer as any,
 	selectors,
-	// @TODO: work on persistence
-	// persist: [ 'selectedPlanSlug' ],
+	persist: [ 'selectedPlanSlug' ],
 } );
 
 declare module '@wordpress/data' {
 	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
 	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
 }
+
+export type State = import('./reducer').State;
+export { STORE_KEY };

--- a/client/landing/gutenboarding/stores/plans/index.ts
+++ b/client/landing/gutenboarding/stores/plans/index.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { controls } from '@wordpress/data-controls';
+import { registerStore } from '@wordpress/data';
+
+import { STORE_KEY } from './constants';
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+import { SelectFromMap, DispatchFromMap } from '@automattic/data-stores';
+
+export type State = import('./reducer').State;
+export { STORE_KEY };
+
+registerStore< State >( STORE_KEY, {
+	actions,
+	controls,
+	reducer: reducer as any,
+	selectors,
+	// @TODO: work on persistence
+	// persist: [ 'selectedPlan' ],
+} );
+
+declare module '@wordpress/data' {
+	function dispatch( key: typeof STORE_KEY ): DispatchFromMap< typeof actions >;
+	function select( key: typeof STORE_KEY ): SelectFromMap< typeof selectors >;
+}

--- a/client/landing/gutenboarding/stores/plans/index.ts
+++ b/client/landing/gutenboarding/stores/plans/index.ts
@@ -19,7 +19,7 @@ registerStore< State >( STORE_KEY, {
 	reducer: reducer as any,
 	selectors,
 	// @TODO: work on persistence
-	// persist: [ 'selectedPlan' ],
+	// persist: [ 'selectedPlanSlug' ],
 } );
 
 declare module '@wordpress/data' {

--- a/client/landing/gutenboarding/stores/plans/persist.ts
+++ b/client/landing/gutenboarding/stores/plans/persist.ts
@@ -2,4 +2,4 @@
  * Internal dependencies
  */
 import createPersistanceConfig from '../persistance-config';
-export default createPersistanceConfig( 'WP_ONBOARD' );
+export default createPersistanceConfig( 'WP_ONBOARD_PLANS' );

--- a/client/landing/gutenboarding/stores/plans/persist.ts
+++ b/client/landing/gutenboarding/stores/plans/persist.ts
@@ -1,5 +1,5 @@
 /**
  * Internal dependencies
  */
-import createPersistanceConfig from '../persistance-config';
-export default createPersistanceConfig( 'WP_ONBOARD_PLANS' );
+import createPersistenceConfig from '../persistence-config';
+export default createPersistenceConfig( 'WP_ONBOARD_PLANS' );

--- a/client/landing/gutenboarding/stores/plans/reducer.ts
+++ b/client/landing/gutenboarding/stores/plans/reducer.ts
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import * as plans from '../../../../lib/plans/constants';
+import { getPlan } from '../../../../lib/plans';
+
+const supportedPlanSlugs = [
+	plans.PLAN_FREE,
+	plans.PLAN_PERSONAL,
+	plans.PLAN_PREMIUM,
+	plans.PLAN_BUSINESS,
+	plans.PLAN_ECOMMERCE,
+];
+
+const supportedPlans = supportedPlanSlugs.map( getPlan );
+
+import { Plan, PlanAction } from './types';
+
+const DEFAUlT_STATE: { selectedPlan: Plan; supportedPlans: Array< Plan > } = {
+	supportedPlans,
+	selectedPlan: getPlan( supportedPlanSlugs[ 0 ] ),
+};
+
+const reducer = function ( state = DEFAUlT_STATE, action: PlanAction ) {
+	switch ( action.type ) {
+		case 'SET_PLAN':
+			return { ...state, selectedPlan: action.plan };
+		default:
+			return state;
+	}
+};
+
+export type State = ReturnType< typeof reducer >;
+
+export default reducer;

--- a/client/landing/gutenboarding/stores/plans/reducer.ts
+++ b/client/landing/gutenboarding/stores/plans/reducer.ts
@@ -2,9 +2,8 @@
  * Internal dependencies
  */
 import * as plans from '../../../../lib/plans/constants';
-import { getPlan } from '../../../../lib/plans';
 
-const supportedPlanSlugs = [
+export const supportedPlanSlugs = [
 	plans.PLAN_FREE,
 	plans.PLAN_PERSONAL,
 	plans.PLAN_PREMIUM,
@@ -12,19 +11,20 @@ const supportedPlanSlugs = [
 	plans.PLAN_ECOMMERCE,
 ];
 
-const supportedPlans = supportedPlanSlugs.map( getPlan );
+import { PlanAction } from './types';
 
-import { Plan, PlanAction } from './types';
-
-const DEFAUlT_STATE: { selectedPlan: Plan; supportedPlans: Array< Plan > } = {
-	supportedPlans,
-	selectedPlan: getPlan( supportedPlanSlugs[ 0 ] ),
+const DEFAUlT_STATE: {
+	selectedPlanSlug: string | undefined;
+	supportedPlanSlugs: Array< string >;
+} = {
+	supportedPlanSlugs,
+	selectedPlanSlug: undefined,
 };
 
 const reducer = function ( state = DEFAUlT_STATE, action: PlanAction ) {
 	switch ( action.type ) {
 		case 'SET_PLAN':
-			return { ...state, selectedPlan: action.plan };
+			return { ...state, selectedPlanSlug: action.slug };
 		default:
 			return state;
 	}

--- a/client/landing/gutenboarding/stores/plans/selectors.ts
+++ b/client/landing/gutenboarding/stores/plans/selectors.ts
@@ -5,8 +5,8 @@ import { State, supportedPlanSlugs } from './reducer';
 import * as plans from 'lib/plans/constants';
 import { getPlan, getPlanPath } from 'lib/plans';
 
-export const freePlan = plans.PLAN_FREE;
-export const defaultPaidPlan = plans.PLAN_PREMIUM;
+const freePlan = plans.PLAN_FREE;
+const defaultPaidPlan = plans.PLAN_PREMIUM;
 
 export const getSelectedPlan = ( state: State ) => getPlan( state.selectedPlanSlug );
 export const getDefaultPlan = ( state: State, hasPaidDomain: boolean ) =>

--- a/client/landing/gutenboarding/stores/plans/selectors.ts
+++ b/client/landing/gutenboarding/stores/plans/selectors.ts
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { State } from './reducer';
+
+export const getSelectedPlan = ( state: State ) => state.selectedPlan;
+export const getSupportedPlans = ( state: State ) => state.supportedPlans;

--- a/client/landing/gutenboarding/stores/plans/selectors.ts
+++ b/client/landing/gutenboarding/stores/plans/selectors.ts
@@ -1,7 +1,16 @@
 /**
  * Internal dependencies
  */
-import { State } from './reducer';
+import { State, supportedPlanSlugs } from './reducer';
+import * as plans from 'lib/plans/constants';
+import { getPlan, getPlanPath } from 'lib/plans';
 
-export const getSelectedPlan = ( state: State ) => state.selectedPlan;
-export const getSupportedPlans = ( state: State ) => state.supportedPlans;
+export const freePlan = plans.PLAN_FREE;
+export const defaultPaidPlan = plans.PLAN_PREMIUM;
+
+export const getSelectedPlan = ( state: State ) => getPlan( state.selectedPlanSlug );
+export const getDefaultPlan = ( state: State, hasPaidDomain: boolean ) =>
+	hasPaidDomain ? getPlan( defaultPaidPlan ) : getPlan( freePlan );
+export const getSupportedPlans = ( state: State ) => state.supportedPlanSlugs.map( getPlan );
+export const getPlanByPath = ( state: State, path: string | undefined ) =>
+	getPlan( supportedPlanSlugs.find( ( slug ) => getPlanPath( slug ) === path ) );

--- a/client/landing/gutenboarding/stores/plans/types.ts
+++ b/client/landing/gutenboarding/stores/plans/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { getPlan } from '../../../../lib/plans';
+
+export type Plan = ReturnType< typeof getPlan >;
+
+export type PlanAction = {
+	type: string;
+	plan?: Plan;
+};

--- a/client/landing/gutenboarding/stores/plans/types.ts
+++ b/client/landing/gutenboarding/stores/plans/types.ts
@@ -1,11 +1,4 @@
-/**
- * Internal dependencies
- */
-import { getPlan } from '../../../../lib/plans';
-
-export type Plan = ReturnType< typeof getPlan >;
-
 export type PlanAction = {
 	type: string;
-	plan?: Plan;
+	slug?: string;
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is the first iteration for the store of our plans in Gutenboarding.

Note: I put the files under `stores` dir as opposed to `gutenboarding/lib/plans.ts` for consistency. Files under `gutenboarding/lib/plans.ts` can be removed after this. 

Related to https://github.com/Automattic/wp-calypso/issues/41787.
