### PR TITLE
Hide "More backups from today" when we don't have backup today

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -199,7 +199,7 @@ class BackupsPage extends Component {
 					) }
 				</div>
 
-				{ ! isLoadingBackups && realtimeBackups.length > 0 && (
+				{ ! isLoadingBackups && lastBackup && (
 					<BackupDelta
 						{ ...{
 							deltas,

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -13,12 +13,7 @@ import { includes } from 'lodash';
  */
 import DocumentHead from 'components/data/document-head';
 import { updateFilter, setFilter } from 'state/activity-log/actions';
-import {
-	isActivityBackup,
-	getBackupAttemptsForDate,
-	getDailyBackupDeltas,
-	getMetaDiffForDailyBackup,
-} from './utils';
+import { isActivityBackup, getDailyBackupDeltas, getMetaDiffForDailyBackup } from './utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { requestActivityLogs } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
@@ -154,7 +149,6 @@ class BackupsPage extends Component {
 
 		const selectedDateString = moment.parseZone( this.getSelectedDate() ).toISOString( true );
 		const today = applySiteOffset( moment(), { timezone, gmtOffset } );
-		const backupAttempts = getBackupAttemptsForDate( logs, selectedDateString );
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );
 		const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
 		const hasRealtimeBackups = includes( siteCapabilities, 'backup-realtime' );
@@ -205,11 +199,10 @@ class BackupsPage extends Component {
 					) }
 				</div>
 
-				{ ! isLoadingBackups && (
+				{ ! isLoadingBackups && realtimeBackups.length > 0 && (
 					<BackupDelta
 						{ ...{
 							deltas,
-							backupAttempts,
 							hasRealtimeBackups,
 							realtimeBackups,
 							allowRestore,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hide the "More backups from today" block from the Main page when we don't have a backup today (Scheduled backup, no backup yet...), 

A day with backup:
![image](https://user-images.githubusercontent.com/9832440/81203323-bd8ecf80-8fbf-11ea-90c9-06a707597612.png)

Backup scheduled:
![image](https://user-images.githubusercontent.com/9832440/81203360-c8e1fb00-8fbf-11ea-83e7-b959a56a3530.png)

No backups yet:
![image](https://user-images.githubusercontent.com/9832440/81207247-2f1d4c80-8fc5-11ea-8112-7f06593c751b.png)


**Asana card:** 1142395350490785-as-1173737050079912

#### Testing instructions

- On a Backup Scheduled status, you shouldn't see "More backups from today" (Move your site timezone until match this scenario)
- Simulate the first time when you subscribe to a Backup product. With the same scenario as before, go to your React Chrome Devtool and go to the `DailyBackupStatus` component and set to null the `lastDateAvailable` property.
