### PR TITLE
Gutenboarding: Plans grid HTML mockup.

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -14,6 +14,7 @@ import { SITE_STORE } from '../stores/site';
 import { USER_STORE } from '../stores/user';
 import DesignSelector from './design-selector';
 import CreateSite from './create-site';
+import Plans from './plans';
 import { Attributes } from './types';
 import { Step, usePath, useNewQueryParam } from '../path';
 import AcquireIntent from './acquire-intent';
@@ -116,6 +117,10 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 					) : (
 						<Redirect to={ makePath( Step.DesignSelection ) } />
 					) }
+				</Route>
+
+				<Route path={ makePath( Step.Plans ) }>
+					<Plans />
 				</Route>
 
 				<Route path={ makePath( Step.CreateSite ) }>

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import { Button, Icon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import { Title, SubTitle } from '../../components/titles';
+import PlanItem from './plan-item';
+
+const Plans: React.FunctionComponent = () => {
+	const { __ } = useI18n();
+
+	return (
+		<div className="plans">
+			<div className="plans__header">
+				<div className="plans__heading">
+					<Title>{ __( 'Choose a plan' ) }</Title>
+					<SubTitle>
+						{ __( "Pick a plan that's right for you. Switch plans as your needs change." ) }
+					</SubTitle>
+					<SubTitle>
+						{ __( "There's no risk, you can cancel for a full refund within 30 days." ) }
+					</SubTitle>
+				</div>
+				<div className="plans__actions">
+					<Button className="plans__back-button" isLink>
+						Back
+					</Button>
+					<Button className="plans__continue-button" isPrimary isLarge>
+						{ __( 'Continue' ) }
+					</Button>
+				</div>
+			</div>
+			<div className="plans__body">
+				<div className="plans__items">
+					<PlanItem
+						name="Free"
+						price="$0"
+						domainName="roastingbeans.wordpress.com"
+						featureCount={ 1 }
+					></PlanItem>
+					<PlanItem name="Personal" price="$5" isSelected featureCount={ 4 }></PlanItem>
+					<PlanItem name="Premium" price="$8" featureCount={ 9 }></PlanItem>
+					<PlanItem name="Business" price="$25" featureCount={ 10 }></PlanItem>
+					<PlanItem name="Commerce" price="$45" featureCount={ 11 }></PlanItem>
+				</div>
+				<Button className="plans__details-toggle-button" isLarge>
+					<span>More details</span>
+					<Icon icon="arrow-down" size={ 20 }></Icon>
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default Plans;

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -11,6 +11,7 @@ import { Button, Icon } from '@wordpress/components';
 import './style.scss';
 import { Title, SubTitle } from '../../components/titles';
 import PlanItem from './plan-item';
+import { plans } from './mock-data';
 
 const Plans: React.FunctionComponent = () => {
 	const { __ } = useI18n();
@@ -38,16 +39,9 @@ const Plans: React.FunctionComponent = () => {
 			</div>
 			<div className="plans__body">
 				<div className="plans__items">
-					<PlanItem
-						name="Free"
-						price="$0"
-						domainName="roastingbeans.wordpress.com"
-						featureCount={ 1 }
-					></PlanItem>
-					<PlanItem name="Personal" price="$5" isSelected featureCount={ 4 }></PlanItem>
-					<PlanItem name="Premium" price="$8" featureCount={ 9 }></PlanItem>
-					<PlanItem name="Business" price="$25" featureCount={ 10 }></PlanItem>
-					<PlanItem name="Commerce" price="$45" featureCount={ 11 }></PlanItem>
+					{ plans.map( ( { id, ...props } ) => (
+						<PlanItem key={ id } { ...props }></PlanItem>
+					) ) }
 				</div>
 				<Button className="plans__details-toggle-button" isLarge>
 					<span>More details</span>

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { Button, Icon } from '@wordpress/components';
 
@@ -11,10 +11,16 @@ import { Button, Icon } from '@wordpress/components';
 import './style.scss';
 import { Title, SubTitle } from '../../components/titles';
 import PlanItem from './plan-item';
+import PlanDetails from './plan-details';
 import { plans } from './mock-data';
 
 const Plans: React.FunctionComponent = () => {
 	const { __ } = useI18n();
+	const [ showDetails, setShowDetails ] = useState( false );
+
+	const handleDetailsToggleButtonClick = () => {
+		setShowDetails( ! showDetails );
+	};
 
 	return (
 		<div className="plans">
@@ -43,9 +49,28 @@ const Plans: React.FunctionComponent = () => {
 						<PlanItem key={ id } { ...props }></PlanItem>
 					) ) }
 				</div>
-				<Button className="plans__details-toggle-button" isLarge>
-					<span>More details</span>
-					<Icon icon="arrow-down" size={ 20 }></Icon>
+				{ showDetails && (
+					<div className="plans__details">
+						<Title>{ __( 'Detailed comparison' ) }</Title>
+						<PlanDetails />
+					</div>
+				) }
+				<Button
+					className="plans__details-toggle-button"
+					isLarge
+					onClick={ handleDetailsToggleButtonClick }
+				>
+					{ showDetails ? (
+						<>
+							<span>{ __( 'Less details' ) } </span>
+							<Icon icon="arrow-up" size={ 20 }></Icon>
+						</>
+					) : (
+						<>
+							<span>{ __( 'More details' ) } </span>
+							<Icon icon="arrow-down" size={ 20 }></Icon>
+						</>
+					) }
 				</Button>
 			</div>
 		</div>

--- a/client/landing/gutenboarding/onboarding-block/plans/mock-data.ts
+++ b/client/landing/gutenboarding/onboarding-block/plans/mock-data.ts
@@ -1,0 +1,212 @@
+export type PlanFeature = { name: string; type: string; data: Array< boolean | string > };
+
+export type PlanDetail = { id: string; name: string | null; features: Array< PlanFeature > };
+
+export type PlanDetails = Array< PlanDetail >;
+
+export type Plan = {
+	id: string;
+	name: string;
+	price: string;
+	features: Array< string >;
+	isPopular?: boolean;
+	isSelected?: boolean;
+	domainName?: string;
+};
+
+export type Plans = Array< Plan >;
+
+const mainFeatures = [
+	'Remove WordPress ads',
+	'Email & basic Live Chat Support',
+	'Collect recurring payments',
+	'Collect one-time payments',
+	'Earn ad revenue',
+	'Premium themes',
+	'Upload videos',
+	'Google Analytics support',
+	'Business features (incl. SEO)',
+	'Accept Payments in 60+ Countries',
+];
+
+export const plans: Plans = [
+	{
+		id: 'free',
+		name: 'Free',
+		price: '$0',
+		features: [ '3 GB', ...mainFeatures.slice( 0, 1 ) ],
+		domainName: 'roastingbeans.wordpress.com',
+	},
+	{
+		id: 'personal',
+		name: 'Personal',
+		price: '$5',
+		features: [ '6 GB', ...mainFeatures.slice( 0, 4 ) ],
+		isSelected: true,
+	},
+	{
+		id: 'premium',
+		name: 'Premium',
+		price: '$8',
+		features: [ '13 GB', ...mainFeatures.slice( 0, 9 ) ],
+		isPopular: true,
+	},
+	{
+		id: 'business',
+		name: 'Business',
+		price: '$25',
+		features: [ '200 GB', ...mainFeatures.slice( 0, 10 ) ],
+	},
+	{
+		id: 'commerce',
+		name: 'Commerce',
+		price: '$45',
+		features: [ '200 GB', ...mainFeatures.slice( 0, 11 ) ],
+	},
+];
+
+export const details: PlanDetails = [
+	{
+		id: 'general',
+		name: null,
+		features: [
+			{
+				name: 'Free domain for One Year',
+				type: 'checkbox',
+				data: [ false, true, true, true, true ],
+			},
+			{
+				name: '24/7 Email and live chat support',
+				type: 'checkbox',
+				data: [ false, true, true, true, true ],
+			},
+			{
+				name: 'Preinstalled SSL security',
+				type: 'checkbox',
+				data: [ false, true, true, true, true ],
+			},
+			{
+				name: 'Jetpack essential features',
+				type: 'checkbox',
+				data: [ false, true, true, true, true ],
+			},
+			{
+				name: 'Storage',
+				type: 'text',
+				data: [ '3 GB', '6 GB', '13 GB', '200 GB', '200 GB' ],
+			},
+			{
+				name: 'Dozens of free designs',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Remove Wordpress.com ads',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Unlimited premium themes',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Advanced design customization',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Get personalized help',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Install plugins',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Upload themesRemove WordPress.com branding',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Automated backup & one-click rewind',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'SFTP and database access',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+		],
+	},
+	{
+		id: 'commerce',
+		name: 'Commerce',
+		features: [
+			{
+				name: 'Sell subscriptions (recurring payments)',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Sell single items (simple payments',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Accept payments in 60+ countries',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Integrations with top shipping carriers',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Sell anything (products and/or services)',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Premium customizable starter themes',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+		],
+	},
+	{
+		id: 'marketing',
+		name: 'Marketing',
+		features: [
+			{
+				name: 'WordAds',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Advanced social media tools',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Video support',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'SEO tools',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+			{
+				name: 'Commerce marketing tools',
+				type: 'checkbox',
+				data: [ true, true, true, true, true ],
+			},
+		],
+	},
+];

--- a/client/landing/gutenboarding/onboarding-block/plans/plan-details.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/plan-details.tsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import { Icon } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { details, PlanFeature, PlanDetail } from './mock-data';
+
+const PlanDetails: React.FunctionComponent = () => {
+	const { __ } = useI18n();
+
+	return (
+		<table className="plan-details">
+			<thead>
+				<tr className="plan-details__header-row">
+					<th>{ __( 'Feature' ) }</th>
+					<th>{ __( 'Free' ) }</th>
+					<th>{ __( 'Personal' ) }</th>
+					<th>{ __( 'Premium' ) }</th>
+					<th>{ __( 'Business' ) }</th>
+					<th>{ __( 'Commerce' ) }</th>
+				</tr>
+			</thead>
+			{ details.map( ( detail: PlanDetail ) => (
+				<tbody key={ detail.id }>
+					{ detail.name && (
+						<tr className="plan-details__header-row">
+							<th colSpan={ 6 }>{ detail.name }</th>
+						</tr>
+					) }
+					{ detail.features.map( ( feature: PlanFeature, i ) => (
+						<tr className="plan-details__feature-row" key={ i }>
+							<th>{ feature.name }</th>
+							{ feature.data.map( ( value, j ) => (
+								<td key={ j }>
+									{ feature.type === 'checkbox' &&
+										( value ? (
+											<>
+												{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+												<span className="hidden">{ __( 'Available' ) }</span>
+												<Icon icon="yes-alt" />
+											</>
+										) : (
+											<>
+												{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+												<span className="hidden">{ __( 'Unavailable' ) } </span>
+											</>
+										) ) }
+									{ feature.type === 'text' && value }
+								</td>
+							) ) }
+						</tr>
+					) ) }
+				</tbody>
+			) ) }
+		</table>
+	);
+};
+
+export default PlanDetails;

--- a/client/landing/gutenboarding/onboarding-block/plans/plan-item.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/plan-item.tsx
@@ -31,27 +31,13 @@ const TickIcon = () => (
 	/>
 );
 
-const featureExamples = [
-	'200 GB storage',
-	'Remove WordPress ads',
-	'Email & basic Live Chat Support',
-	'Collect recurring payments',
-	'Collect one-time payments',
-	'Earn ad revenue',
-	'Premium themes',
-	'Upload videos',
-	'Google Analytics support',
-	'Business features (incl. SEO)',
-	'Accept Payments in 60+ Countries',
-];
-
 export interface Props {
 	name: string;
 	price: string;
+	features: Array< string >;
+	domainName?: string;
 	isPopular?: boolean;
 	isSelected?: boolean;
-	domainName?: string;
-	featureCount?: number; // temporary for mockup purposes
 }
 
 const PlanItem: React.FunctionComponent< Props > = ( {
@@ -60,13 +46,11 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 	isPopular = false,
 	isSelected = false,
 	domainName,
-	featureCount = 10,
+	features,
 } ) => {
 	const { __ } = useI18n();
 
 	const hasDomain = !! domainName;
-
-	const features = featureExamples.slice( 0, featureCount );
 
 	return (
 		<div className="plan-item">
@@ -109,8 +93,10 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 			</div>
 			<div className="plan-item__features">
 				<ul className="plan-item__feature-item-group">
-					{ features.map( ( feature ) => (
-						<li className="plan-item__feature-item">{ feature }</li>
+					{ features.map( ( feature, i ) => (
+						<li key={ i } className="plan-item__feature-item">
+							{ feature }
+						</li>
 					) ) }
 				</ul>
 			</div>

--- a/client/landing/gutenboarding/onboarding-block/plans/plan-item.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/plan-item.tsx
@@ -56,7 +56,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 		<div className="plan-item">
 			<div className="plan-item__heading">
 				<div className="plan-item__name">{ name }</div>
-				{ isPopular && <div className="plan-item__badge">Popular</div> }
+				{ isPopular && <div className="plan-item__badge">{ __( 'Popular' ) }</div> }
 			</div>
 			<div className="plan-item__price">
 				<div className="plan-item__price-amount">{ price }</div>

--- a/client/landing/gutenboarding/onboarding-block/plans/plan-item.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/plan-item.tsx
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import { Button, Icon } from '@wordpress/components';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+
+const TickIcon = () => (
+	<Icon
+		icon={ () => (
+			<svg
+				width="16"
+				height="12"
+				viewBox="0 0 16 12"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					fill-rule="evenodd"
+					clip-rule="evenodd"
+					d="M5.4987 9.50033L1.9987 6.00033L0.832031 7.16699L5.4987 11.8337L15.4987 1.83366L14.332 0.666992L5.4987 9.50033Z"
+					fill="white"
+				/>
+			</svg>
+		) }
+	/>
+);
+
+const featureExamples = [
+	'200 GB storage',
+	'Remove WordPress ads',
+	'Email & basic Live Chat Support',
+	'Collect recurring payments',
+	'Collect one-time payments',
+	'Earn ad revenue',
+	'Premium themes',
+	'Upload videos',
+	'Google Analytics support',
+	'Business features (incl. SEO)',
+	'Accept Payments in 60+ Countries',
+];
+
+export interface Props {
+	name: string;
+	price: string;
+	isPopular?: boolean;
+	isSelected?: boolean;
+	domainName?: string;
+	featureCount?: number; // temporary for mockup purposes
+}
+
+const PlanItem: React.FunctionComponent< Props > = ( {
+	name,
+	price,
+	isPopular = false,
+	isSelected = false,
+	domainName,
+	featureCount = 10,
+} ) => {
+	const { __ } = useI18n();
+
+	const hasDomain = !! domainName;
+
+	const features = featureExamples.slice( 0, featureCount );
+
+	return (
+		<div className="plan-item">
+			<div className="plan-item__heading">
+				<div className="plan-item__name">{ name }</div>
+				{ isPopular && <div className="plan-item__badge">Popular</div> }
+			</div>
+			<div className="plan-item__price">
+				<div className="plan-item__price-amount">{ price }</div>
+				<div className="plan-item__price-note">{ __( 'per month, billed yearly' ) }</div>
+			</div>
+			<div className="plan-item__actions">
+				<Button
+					className={ classNames( 'plan-item__select-button', { 'is-selected': isSelected } ) }
+					isLarge
+				>
+					{ isSelected ? (
+						<>
+							<TickIcon></TickIcon>
+							<span>{ __( 'Selected' ) }</span>
+						</>
+					) : (
+						<span>{ __( 'Select' ) }</span>
+					) }
+				</Button>
+			</div>
+			<div className="plan-item__domain">
+				<div className="plan-item__domain-summary">{ __( 'Free domain for 1 year' ) }</div>
+				<div className="plan-item__domain-name">
+					<Button
+						className={ classNames( 'plan-item__domain-picker-button', {
+							'has-domain': hasDomain,
+						} ) }
+						isLink
+					>
+						<span>{ hasDomain ? domainName : __( 'Choose domain' ) }</span>
+						<Icon icon="arrow-down-alt2" size={ 14 }></Icon>
+					</Button>
+				</div>
+			</div>
+			<div className="plan-item__features">
+				<ul className="plan-item__feature-item-group">
+					{ features.map( ( feature ) => (
+						<li className="plan-item__feature-item">{ feature }</li>
+					) ) }
+				</ul>
+			</div>
+		</div>
+	);
+};
+
+export default PlanItem;

--- a/client/landing/gutenboarding/onboarding-block/plans/plan-item.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/plan-item.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 
-const TickIcon = () => (
+const TickIcon = (
 	<Icon
 		icon={ () => (
 			<svg
@@ -21,8 +21,8 @@ const TickIcon = () => (
 				xmlns="http://www.w3.org/2000/svg"
 			>
 				<path
-					fill-rule="evenodd"
-					clip-rule="evenodd"
+					fillRule="evenodd"
+					clipRule="evenodd"
 					d="M5.4987 9.50033L1.9987 6.00033L0.832031 7.16699L5.4987 11.8337L15.4987 1.83366L14.332 0.666992L5.4987 9.50033Z"
 					fill="white"
 				/>
@@ -69,7 +69,7 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 				>
 					{ isSelected ? (
 						<>
-							<TickIcon></TickIcon>
+							{ TickIcon }
 							<span>{ __( 'Selected' ) }</span>
 						</>
 					) : (

--- a/client/landing/gutenboarding/onboarding-block/plans/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/plans/style.scss
@@ -1,0 +1,166 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../mixins.scss';
+@import '../../variables.scss';
+
+.plans {
+	margin: 60px 0;
+}
+
+.plans__header {
+	display: flex;
+	flex-direction: row;
+	margin-top: 60px;
+}
+
+.plans__heading {
+	flex-grow: 1;
+	margin-bottom: 80px;
+
+	.gutenboarding-title {
+		color: var( --studio-black );
+	}
+
+	.gutenboarding-subtitle {
+		font-size: 16px;
+		line-height: 24px;
+		letter-spacing: 0.2px;
+		color: var( --studio-gray-60 );
+	}
+}
+
+.plans__items {
+	display: flex;
+	flex-direction: row;
+	margin-bottom: 70px;
+
+	.plan-item {
+		width: 20%;
+	}
+}
+
+.plan-item__name {
+	font-weight: 700;
+	font-size: 20px;
+	line-height: 24px;
+	margin-bottom: 16px;
+}
+
+.plan-item__price-amount {
+	font-weight: 600;
+	font-size: 32px;
+	line-height: 24px;
+}
+
+.plan-item__price-note {
+	font-size: 12px;
+	line-height: 19px;
+	letter-spacing: -0.4px;
+	color: var( --studio-gray-40 );
+	margin-top: 8px;
+}
+
+.plan-item__price {
+	margin-bottom: 26px;
+}
+
+.plan-item__actions {
+	margin-bottom: 32px;
+}
+
+.plan-item__domain {
+	margin-bottom: 20px;
+}
+
+.plan-item__domain-summary {
+	font-size: 16px;
+	line-height: 24px;
+}
+
+.plan-item__select-button.components-button {
+	border: 1px solid var( --studio-blue-40 );
+	border-radius: 4px;
+	color: var( --studio-blue-40 );
+	padding: 0 24px;
+	height: 40px;
+
+	&.is-selected {
+		background: var( --studio-black );
+		color: var( --studio-white );
+		border: 0;
+	}
+
+	svg {
+		margin-left: -8px;
+		margin-right: 10px;
+	}
+}
+
+.plan-item__domain-picker-button.components-button {
+	font-size: 16px;
+	line-height: 19px;
+	letter-spacing: 0.2px;
+	word-break: break-word;
+
+	&.has-domain {
+		color: var( --studio-gray-50 );
+		text-decoration: none;
+	}
+
+	svg {
+		margin-left: 2px;
+	}
+}
+
+.plan-item__features {
+	&::before {
+		display: block;
+		content: '';
+		border-top: 1px solid var( --studio-gray-5 );
+		width: 40px;
+		height: 1px;
+		position: relative;
+		top: 0;
+		left: 0;
+		margin: 20px 0;
+	}
+}
+
+.plan-item__feature-item {
+	font-size: 16px;
+	line-height: 24px;
+	letter-spacing: 0.2px;
+	margin: 12px 0;
+}
+
+.plans__back-button.components-button.is-link {
+	margin-right: 32px;
+	color: var( --studio-gray-40 );
+}
+
+.plans__continue-button.components-button {
+	height: 42px;
+	padding: 0 45px;
+}
+
+.plans__details-toggle-button.components-button {
+	display: block;
+	width: 100%;
+	height: 60px;
+	font-size: 16px;
+	line-height: 19px;
+	letter-spacing: 0.2px;
+	border: 1px solid var( --studio-gray-5 );
+	border-left: 0;
+	border-right: 0;
+	border-radius: 0;
+	padding: 0;
+	text-align: center;
+
+	> * {
+		vertical-align: middle;
+	}
+
+	svg {
+		margin-left: 2px;
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/plans/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/plans/style.scss
@@ -184,3 +184,62 @@
 		margin-left: 2px;
 	}
 }
+
+.plans__details {
+	.gutenboarding-title {
+		color: var( --studio-black );
+		margin-bottom: 40px;
+		font-size: 32px;
+		line-height: 40px;
+		letter-spacing: 0.2px;
+	}
+}
+
+.plan-details {
+	width: 100%;
+	table-layout: fixed;
+	margin-bottom: 110px;
+
+	th,
+	td {
+		padding: 16px 24px;
+
+		&:first-child {
+			padding-left: 0;
+			width: 40%;
+		}
+
+		&:not( :first-child ) {
+			white-space: nowrap;
+		}
+	}
+
+	// TODO: Deal with a11y later.
+	.hidden {
+		display: none;
+	}
+}
+
+.plan-details__header-row {
+	th {
+		font-weight: 600;
+		font-size: 14px;
+		line-height: 20px;
+		text-transform: uppercase;
+		color: var( --studio-gray-20 );
+		padding-top: 5px;
+		padding-bottom: 5px;
+		border-bottom: 1px solid #eaeaeb;
+	}
+}
+
+.plan-details__feature-row {
+	th,
+	td {
+		font-size: 14px;
+		line-height: 17px;
+		letter-spacing: 0.2px;
+		border-bottom: 1px solid #eaeaeb;
+		vertical-align: top;
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/plans/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/plans/style.scss
@@ -38,11 +38,31 @@
 	}
 }
 
+.plan-item__heading {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	margin-bottom: 16px;
+}
+
 .plan-item__name {
 	font-weight: 700;
 	font-size: 20px;
 	line-height: 24px;
-	margin-bottom: 16px;
+	display: inline-block;
+}
+
+.plan-item__badge {
+	display: inline-block;
+	background: var( --studio-blue-40 );
+	border-radius: 2px;
+	padding: 4px 8px;
+	color: var( --studio-white );
+	margin-left: 8px;
+
+	> * {
+		vertical-align: middle;
+	}
 }
 
 .plan-item__price-amount {

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -21,6 +21,7 @@ export const Step = {
 	Signup: 'signup',
 	Login: 'login',
 	CreateSite: 'create-site',
+	Plans: 'plans',
 } as const;
 
 // We remove falsey `steps` with `.filter( Boolean )` as they'd mess up our |-separated route pattern.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* [x] HTML & CSS mockup for plans grid.
* [ ] WIP: Detailed comparison table.

#### Testing instructions

* Go to `/new/plans` to see the mockup.

![image](https://user-images.githubusercontent.com/1287077/81187296-240df080-8fb4-11ea-9557-02847b907f2d.png)

Fixes https://github.com/Automattic/wp-calypso/issues/41787
