### PR TITLE
Domains: Add link to change email when domain is pending verification

### DIFF
--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -134,15 +134,20 @@ class EmailVerificationCard extends React.Component {
 	}
 
 	renderCompact() {
-		const { translate } = this.props;
+		const { changeEmailHref, translate } = this.props;
 		const { submitting } = this.state;
 
 		return (
 			<div>
 				<p>{ this.props.verificationExplanation }</p>
-				<Button busy={ submitting } disabled={ submitting } onClick={ this.handleSubmit }>
-					{ submitting ? translate( 'Sending…' ) : translate( 'Resend email' ) }
-				</Button>
+				<div className="email-verification__actions">
+					<Button busy={ submitting } disabled={ submitting } onClick={ this.handleSubmit }>
+						{ submitting ? translate( 'Sending…' ) : translate( 'Resend email' ) }
+					</Button>
+					{ changeEmailHref && (
+						<a href={ changeEmailHref }>{ translate( 'Change your email address' ) }</a>
+					) }
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/components/email-verification/style.scss
+++ b/client/my-sites/domains/domain-management/components/email-verification/style.scss
@@ -66,6 +66,15 @@
 	}
 }
 
+.email-verification__actions {
+	display: flex;
+	align-items: center;
+
+	a {
+		margin-left: 16px;
+	}
+}
+
 .sent .email-verification__status {
 	position: relative;
 	animation: fadeIn 0.3s ease-out;

--- a/client/my-sites/domains/domain-management/components/icann-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/index.jsx
@@ -32,7 +32,7 @@ class IcannVerificationCard extends React.Component {
 
 		if ( 'new-status' === explanationContext ) {
 			return translate(
-				'We sent {{strong}}%(email)s{{/strong}} an email to verify your contact information. Please complete the verification or your domain will stop working in {{strong}}10 days{{/strong}}.',
+				'We sent you an email at {{strong}}%(email)s{{/strong}} to verify your contact information. Please complete the verification or your domain will stop working in {{strong}}10 days{{/strong}}.',
 				{
 					args: { email: contactDetails.email },
 					components: {

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -15,7 +15,7 @@ import { Card, Dialog } from '@automattic/components';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
 import notices from 'notices';
-import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
+import { domainManagementContactsPrivacy, domainManagementEdit } from 'my-sites/domains/paths';
 import wp from 'lib/wp';
 import { successNotice } from 'state/notices/actions';
 import { UPDATE_CONTACT_INFORMATION_EMAIL_OR_NAME_CHANGES } from 'lib/url/support';
@@ -32,6 +32,7 @@ import {
 	getWhoisSaveSuccess,
 } from 'state/domains/management/selectors';
 import { findRegistrantWhois } from 'lib/domains/whois/utils';
+import getPreviousPath from '../../../../state/selectors/get-previous-path';
 
 const wpcom = wp.undocumented();
 
@@ -44,6 +45,7 @@ class EditContactInfoFormCard extends React.Component {
 		currentUser: PropTypes.object.isRequired,
 		domainRegistrationAgreementUrl: PropTypes.string.isRequired,
 		isUpdatingWhois: PropTypes.bool,
+		previousPath: PropTypes.string,
 		whoisData: PropTypes.array,
 		whoisSaveError: PropTypes.object,
 		whoisSaveSuccess: PropTypes.bool,
@@ -336,18 +338,24 @@ class EditContactInfoFormCard extends React.Component {
 		this.showNoticeAndGoBack( message );
 	};
 
+	getReturnDestination = () => {
+		const domainName = this.props.selectedDomain.name;
+		const siteSlug = this.props.selectedSite.slug;
+		const domainSettingsPage = domainManagementEdit( siteSlug, domainName );
+		const contactsPrivacyPage = domainManagementContactsPrivacy( siteSlug, domainName );
+
+		return this.props.previousPath?.startsWith( domainSettingsPage )
+			? domainSettingsPage
+			: contactsPrivacyPage;
+	};
+
 	showNoticeAndGoBack = ( message ) => {
 		this.props.successNotice( message, {
 			showDismiss: true,
 			isPersistent: true,
 			duration: 5000,
 		} );
-		page(
-			domainManagementContactsPrivacy(
-				this.props.selectedSite.slug,
-				this.props.selectedDomain.name
-			)
-		);
+		page( this.getReturnDestination() );
 	};
 
 	onWhoisUpdateError = () => {
@@ -438,6 +446,7 @@ export default connect(
 		return {
 			currentUser: getCurrentUser( state ),
 			isUpdatingWhois: isUpdatingWhois( state, ownProps.selectedDomain.name ),
+			previousPath: getPreviousPath( state ),
 			whoisData: getWhoisData( state, ownProps.selectedDomain.name ),
 			whoisSaveError: getWhoisSaveError( state, ownProps.selectedDomain.name ),
 			whoisSaveSuccess: getWhoisSaveSuccess( state, ownProps.selectedDomain.name ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a link to change the email address when the domain is pending verification.

#### Testing instructions

Change the email address for a domain you own. You should see something similar to the screenshot below:

<img width="727" alt="Screenshot 2020-05-06 at 3 50 21 PM" src="https://user-images.githubusercontent.com/13062352/81188786-12c5e380-8fb6-11ea-8c9d-7a1c3eabb2a2.png">

Make sure clicking the link sends you to the contact info form.
