### PR TITLE
My Home: Prevent Double Border with Quick Links

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -89,6 +89,10 @@
 			fill: var( --color-neutral-80 );
 		}
 	}
+
+	&:last-of-type {
+		box-shadow: 0 -1px 0 0px var( --color-border-subtle );
+	}
 }
 
 .quick-links__action-box-label {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the double border at the bottom of Quick Links in the Customer Home

#### Testing instructions

Verify that the bottom box of Quick Links has no double border.

**Before:**
<img width="374" alt="Screenshot 2020-05-06 at 15 39 02" src="https://user-images.githubusercontent.com/43215253/81190430-beb80080-8faf-11ea-86e4-f1965de54aae.png">

**After:**
<img width="402" alt="Screenshot 2020-05-06 at 15 37 22" src="https://user-images.githubusercontent.com/43215253/81190383-af38b780-8faf-11ea-9770-66cf9377eb41.png">

Fixes #41865
