### PR TITLE
e2e: Skip the premium them test

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1127,7 +1127,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function () {
 		} );
 	} );
 
-	describe( 'Sign up while purchasing premium theme in AUD currency @signup @email', function () {
+	describe.skip( 'Sign up while purchasing premium theme in AUD currency @signup @email', function () {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedBlogAddresses = dataHelper.getExpectedFreeAddresses( blogName );
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This just skips the premium theme purchase test as it is causing problems with revenue reporting in the themes shop

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure CI tests pass
