### PR TITLE
FSE: Fix Block Pattern markup on call-to-action-02 when CoBlocks is active

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/patterns/call-to-action-02.php
@@ -22,8 +22,8 @@ $markup = '
             <!-- /wp:paragraph -->
 
             <!-- wp:buttons {"align":"center"} -->
-            <div class="wp-block-buttons aligncenter"><!-- wp:button {"customBackgroundColor":"#a5150f","customTextColor":"#ffffff"} -->
-               <div class="wp-block-button"><a class="wp-block-button__link has-text-color has-background" style="background-color:#a5150f;color:#ffffff">' . esc_html__( 'Order now', 'full-site-editing' ) . '</a></div>
+            <div class="wp-block-buttons aligncenter"><!-- wp:button {"style":{"color":{"text":"#ffffff","background":"#a5150f"}}} -->
+               <a class="wp-block-button wp-block-button__link has-text-color has-background" style="background-color:#a5150f;color:#ffffff">' . esc_html__( 'Order now', 'full-site-editing' ) . '</a>
             <!-- /wp:button -->
             </div>
             <!-- /wp:buttons -->


### PR DESCRIPTION
I changed the markup of the buttons block section to match what is generated by core. This fixes the broken block error in the call-to-action pattern when:
- CoBlocks (full plugin) is active
- FSE is active
- Layout Grid is active

Fixes https://github.com/Automattic/wp-calypso/issues/41380

I've tested the pattern with both CoBlocks activated and deactivated, and the pattern works correctly.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
| before  | after |
| ------------- | ------------- |
| <img width="1426" alt="Screen Shot 2020-05-06 at 9 59 05 AM" src="https://user-images.githubusercontent.com/967608/81192840-4ede5180-8f80-11ea-874d-673bd494070b.png"> | <img width="1426" alt="Screen Shot 2020-05-06 at 9 58 02 AM" src="https://user-images.githubusercontent.com/967608/81192848-50a81500-8f80-11ea-8a40-b87fdae3ebd7.png"> |


#### Testing instructions
Start the FSE dev build:
```
cd apps/full-site-editing
nvm use
yarn && yarn dev --sync
```
- Activate CoBlocks plugin
- Activate FSE plugin
- Activate Layout Grid plugin
- Go to a Post
- Click the top left Block inserter -> Block Patterns (if on a newer version of Gutenberg)
- Select the Call To Action Pattern
- The block should insert correctly
- Deactivate CoBlocks
- Test inserting the Call to Action pattern again
- Test the block pattern on WPcom as well (changes should be there already if you used `yarn dev --sync`)

