### PR TITLE
My Home: Clean up margins and typography

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links-compact/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links-compact/style.scss
@@ -6,8 +6,12 @@
 	}
 
 	.foldable-card__header {
-		padding: 16px 22px;
+		padding: 16px;
 		min-height: auto;
+
+		@include breakpoint( '>480px' ) {
+			padding: 16px 24px;
+		}
 	}
 
 	.foldable-card__action {

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -51,13 +51,15 @@
 	display: flex;
 	align-items: center;
 	transition: all 0.1s;
+	padding-top: 12px;
+	padding-bottom: 12px;
 
 	.quick-links__action-box-image {
 		display: flex;
 		flex-shrink: 0;
 		align-items: center;
-		width: 24px;
-		margin-right: 16px;
+		width: 20px;
+		margin-right: 12px;
 	}
 
 	.quick-links__action-box-icon {
@@ -69,7 +71,7 @@
 
 	.quick-links__action-box-label {
 		color: var( --color-text );
-		font-size: 16px;
+		font-size: 15px;
 	}
 
 	.quick-links__action-box-subtitle {

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -84,6 +84,11 @@
 		}
 	}
 
+	.card__link-indicator {
+		fill: var( --color-neutral-20 );
+		right: 20px;
+	}
+
 	&:hover {
 		background: var( --color-neutral-0 );
 

--- a/client/my-sites/customer-home/cards/education/educational-content/style.scss
+++ b/client/my-sites/customer-home/cards/education/educational-content/style.scss
@@ -13,6 +13,7 @@
 
 	h3 {
 		font-weight: 600;
+		font-size: 16px;
 		margin-bottom: 8px;
 	}
 

--- a/client/my-sites/customer-home/cards/features/support/style.scss
+++ b/client/my-sites/customer-home/cards/features/support/style.scss
@@ -1,3 +1,7 @@
+.customer-home__layout .support.card {
+	padding-bottom: 16px;
+}
+
 .customer-home__layout .support .support__content {
 	display: flex;
 	justify-content: space-between;

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -12,13 +12,13 @@
 
 	.action-panel__title {
 		font-family: 'Recoleta', serif;
-		font-size: 32px;
-		line-height: 40px;
+		font-size: 28px;
+		line-height: 36px;
 		margin-bottom: 4px;
 
 		@include breakpoint( '>800px' ) {
-			font-size: 40px;
-			line-height: 48px;
+			font-size: 32px;
+			line-height: 40px;
 		}
 	}
 
@@ -30,14 +30,15 @@
 	}
 
 	.action-panel__body p.task__description {
-		margin-bottom: 32px;
+		margin-bottom: 24px;
 		font-size: 16px;
 		line-height: 24px;
 		color: var( --color-text );
 
 		@include breakpoint( '>800px' ) {
-			font-size: 20px;
-			line-height: 32px;
+			font-size: 18px;
+			line-height: 28px;
+			margin-bottom: 32px;
 		}
 	}
 

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -1,4 +1,5 @@
 .task {
+	margin-bottom: 0;
 	padding-bottom: 24px;
 
 	@include breakpoint( '>480px' ) {

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -131,7 +131,7 @@
 	.card-heading,
 	.foldable-card__header {
 		margin-top: 0;
-		font-size: inherit;
+		font-size: 16px;
 		font-weight: 600;
 	}
 
@@ -142,5 +142,12 @@
 	.customer-home__card-subheader {
 		margin: 0 0 1rem;
 		font-size: inherit;
+	}
+
+	.customer-home__layout-col-right {
+		& > .card,
+		& > .foldable-card {
+			margin-bottom: 24px;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Clean up some margins and typography on the new My Home layout for more consistency and balance. They're relatively minor things but the little things add up.

* Reduce the font size of the main primary task card a little bit for better balance.
* More consistent margins and padding between cards.
* Update secondary/tertiary card heading and copy font sizes for stronger hierarchy.

**Full page before**
![image](https://user-images.githubusercontent.com/448298/81203260-c10d6100-8f95-11ea-9411-453add0c37c9.png)

**Full page after**
![image](https://user-images.githubusercontent.com/448298/81208937-d090a800-8f9d-11ea-96ea-e71ada814b1e.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch or visit the calypso.live link
* Go to My Home for any site and make sure of the following:
    * Bottom margin on task card now matches bottom margin of other sections.
    * The links under Quick links are both smaller than the card header and the same size as the content in the other tertiary cards.
    * Bottom margin on tertiary cards match the gutter between the left and right column.
    * Font sizes on the task card are slightly smaller rather than overly large.
