### PR TITLE
Add modularized state documentation

### DIFF
--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -1,3 +1,10 @@
+// The eslint configuration below helps prevent new legacy reducers from being added.
+// See `docs/modularized-state.md` to learn more about modularized state.
+
+/*eslint no-restricted-imports: ["error", {
+    "patterns": ["./*\/reducer*", "state/*\/reducer*"]
+}]*/
+
 /**
  * External dependencies
  */

--- a/docs/modularized-state.md
+++ b/docs/modularized-state.md
@@ -24,7 +24,7 @@ In order to preserve the benefits of a Redux-based architecture while reducing t
 We opted for a synchronous, dependency-graph driven approach, where reducers are automatically loaded together with the chunks that make use of them. In a nutshell:
 
 - State is divided into top-level portions. Each of these portions is considered an atom that can't be subdivided (for the purposes of loading).
-- Each portion's reducer stores its state separately, using `withStorageKey`.
+- Each portion's reducer persists its state separately, using `withStorageKey`.
 - Each portion has an `init` module, that registers its reducer through a side-effect.
 - Each selector or action creator that accesses a portion of state must import its `init` module
 
@@ -89,14 +89,24 @@ Once this is done, you'll need to find every selector and action creator that ac
 Here's what a modified selector module could look like:
 
 ```js
-import 'state/subject/reducer';
+import 'state/subject/init';
 
 export default function getSubjectMatter( state ) {
   // ...
 }
 ```
 
-Finally, once all the modularized machinery is in place, remove the reducer from the legacy list in `client/state/reducer` (and `client/landing/login/store`, which has its own list!). It doesn't need to be there anymore, since it's now fully modularized!
+The same goes for an action creator:
+
+```js
+import 'state/subject/init';
+
+export function changeSubjectMatter( matter ) {
+  // ...
+}
+```
+
+Finally, once all the modularized machinery is in place, remove the reducer from the legacy list in `client/state/reducer` (and `client/landing/login/store`, which has its own list). It doesn't need to be there anymore, since it's now fully modularized!
 
 ## Troubleshooting
 
@@ -111,9 +121,6 @@ To explain a bit further, this error lets you know when you're registering a por
 Some unit tests may start failing once you modularize a portion of state (even if it seems unrelated, at first). This is usually because they create their own Redux store, which may have not been set up correctly for modularization. You'll find something like this:
 
 ```js
-/**
- * Internal dependencies
- */
 import { createReduxStore } from 'state';
 import Thing from '../';
 
@@ -128,9 +135,6 @@ describe( 'Thing', () => {
 Setting the store globally should be enough to solve these issues:
 
 ```js
-/**
- * Internal dependencies
- */
 import { createReduxStore } from 'state';
 import { setStore } from 'state/redux-store';
 import Thing from '../';

--- a/docs/modularized-state.md
+++ b/docs/modularized-state.md
@@ -56,6 +56,8 @@ For testing purposes, you can add the reducer to the root reducer at `client/sta
 
 Once your new state is in place, or if you're working on migrating existing state, the next step is to modularize it.
 
+### Add `init` module
+
 To start, add an `init` file to the root of that portion of state:
 
 ```text
@@ -78,11 +80,27 @@ registerReducer( [ 'subject' ], reducer );
 
 ```
 
+### Add `package.json` file
+
+It's generally a good idea to tell `webpack` when a file has side-effects, to prevent it from assuming that everything does. Our `init` file has side-effects, so create another file named `package.json` at the root of that portion of state. It may be odd to create a `package.json` file where there is no package, but it's currently the best way of letting `webpack` know about side-effects.
+
+```json
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}
+```
+
+### Persist state to a separate key
+
 For persistence to work correctly, you'll need to modify the reducer so that it stores its data separately. Change the default export to use `withStorageKey`:
 
 ```js
 export default withStorageKey( 'subject', combinedReducer );
 ```
+
+### Ensure selectors and action creators initialize state
 
 Once this is done, you'll need to find every selector and action creator that accesses this portion of state. If it follows the recommended folder structure above that's easy to do, but otherwise you'll need to look in `state/selectors`. You may also find some components accessing state directly with inline selectors (some refactoring would probably be a good idea in that situation).
 
@@ -105,6 +123,8 @@ export function changeSubjectMatter( matter ) {
   // ...
 }
 ```
+
+### Remove state from legacy root reducer
 
 Finally, once all the modularized machinery is in place, remove the reducer from the legacy list in `client/state/reducer` (and `client/landing/login/store`, which has its own list). It doesn't need to be there anymore, since it's now fully modularized!
 

--- a/docs/modularized-state.md
+++ b/docs/modularized-state.md
@@ -1,0 +1,145 @@
+Modularized State
+=================
+
+Calypso currently uses Redux for managing state (see [Our Approach to Data](./our-approach-to-data.md) for more details on the current approach, and the history that led to it). This has been a successful strategy in managing state across the application, but the standard Redux approach is not without its issues.
+
+# The issue
+
+The official recommendation is to have a single root reducer, composed of smaller reducers responsible for individual portions of state. The root reducer needs to be ready as soon as the first action is emmitted, and therefore becomes part of the critical path for the application.
+
+This approach works well for smaller applications, but the more state exists, the more code gets added to the critical path through the reducers. The reducers themselves may not be too large, but they often depend on internal and external libraries, as well as large sets of data that for various reasons are bundled with the application rather than retrieved via an API at runtime. Since reducers are usually synchronous, none of this can be asynchronously loaded, and thus everything becomes part of the critical path.
+
+This means that the standard Redux approach often has poor scalability where it comes to loading performance.
+
+# Requirements for a Solution
+
+In order to preserve the benefits of a Redux-based architecture while reducing the amount of code loaded at boot, we looked into how we could modularize state. However, any solution had to obey a few key principles:
+
+- We shouldn't have to declare which portions of Calypso use which parts of state. This is hard to determine and to maintain, since it can change very easily.
+- We shouldn't have to change large portions of code. This excludes approaches that would make state asynchronous, for example.
+- Consumers of state should not be aware of modularization. A component that makes use of a selector shouldn't need to worry about whether that state is modularized or not.
+
+# Overview of our Solution
+
+We opted for a synchronous, dependency-graph driven approach, where reducers are automatically loaded together with the chunks that make use of them. In a nutshell:
+
+- State is divided into top-level portions. Each of these portions is considered an atom that can't be subdivided (for the purposes of loading).
+- Each portion's reducer stores its state separately, using `withStorageKey`.
+- Each portion has an `init` module, that registers its reducer through a side-effect.
+- Each selector or action creator that accesses a portion of state must import its `init` module
+
+By doing this, we only need to couple selectors and action creators with the portions of state they touch, and everything else is handled automatically as part of the build process. Reducers are guaranteed to be available and registered by the time the state they manage is needed.
+
+# Step-by-step
+
+## How to add new state
+
+If you're adding a new portion of state to Calypso, start by writing the reducers, selectors, and action creators as normal. The following folder structure is preferred:
+
+```text
+client/state/
+└── { subject }/
+    ├── reducer.js
+    ├── actions/
+    |   ├── index.js
+    |   ├── action1.js
+    |   └── action1.js
+    └── selectors/
+        ├── index.js
+        ├── selector1.js
+        └── selector2.js
+```
+
+For testing purposes, you can add the reducer to the root reducer at `client/state/reducer`, but bear in mind this is the default, non-modularized approach.
+
+## Modularizing state
+
+Once your new state is in place, or if you're working on migrating existing state, the next step is to modularize it.
+
+To start, add an `init` file to the root of that portion of state:
+
+```text
+client/state/
+└── { subject }/
+    ├── init.js
+    └── reducer.js
+```
+
+The `init` file should register the reducer with the global store:
+
+```js
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import reducer from './reducer';
+
+registerReducer( [ 'subject' ], reducer );
+
+```
+
+For persistence to work correctly, you'll need to modify the reducer so that it stores its data separately. Change the default export to use `withStorageKey`:
+
+```js
+export default withStorageKey( 'subject', combinedReducer );
+```
+
+Once this is done, you'll need to find every selector and action creator that accesses this portion of state. If it follows the recommended folder structure above that's easy to do, but otherwise you'll need to look in `state/selectors`. You may also find some components accessing state directly with inline selectors (some refactoring would probably be a good idea in that situation).
+
+Here's what a modified selector module could look like:
+
+```js
+import 'state/subject/reducer';
+
+export default function getSubjectMatter( state ) {
+  // ...
+}
+```
+
+Finally, once all the modularized machinery is in place, remove the reducer from the legacy list in `client/state/reducer` (and `client/landing/login/store`, which has its own list!). It doesn't need to be there anymore, since it's now fully modularized!
+
+## Troubleshooting
+
+### Reducer with key 'foo' is already registered
+
+This error usually means that you forgot to remove the reducer for this portion of state from `client/state/reducer` or `client/landing/login/store`, or that you registered it in the `init` file using the wrong key.
+
+To explain a bit further, this error lets you know when you're registering a portion of state with a name that's already in use. Since our modularization approach prevents initialization from happening twice, that's usually only the case when the key is already present in the legacy root reducer, or when you accidentally used the name of another portion of state (due to e.g. a copy-paste error).
+
+### Failing unit tests
+
+Some unit tests may start failing once you modularize a portion of state (even if it seems unrelated, at first). This is usually because they create their own Redux store, which may have not been set up correctly for modularization. You'll find something like this:
+
+```js
+/**
+ * Internal dependencies
+ */
+import { createReduxStore } from 'state';
+import Thing from '../';
+
+describe( 'Thing', () => {
+	test( 'renders correctly', () => {
+		const store = createReduxStore();
+		// Instantiate and test component
+	} );
+} );
+```
+
+Setting the store globally should be enough to solve these issues:
+
+```js
+/**
+ * Internal dependencies
+ */
+import { createReduxStore } from 'state';
+import { setStore } from 'state/redux-store';
+import Thing from '../';
+
+describe( 'Thing', () => {
+	test( 'renders correctly', () => {
+		const store = createReduxStore();
+		setStore( store );
+		// Instantiate and test component
+	} );
+} );
+```

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -60,6 +60,26 @@ __Advantages:__
 - Encourages and often forces a developer toward writing functional, testable code
 - Extendable, supporting middlewares to suit our specific needs and [conveniences for use with React](https://github.com/reactjs/react-redux)
 
+### Fourth Era: Modularized Redux State Tree (February 2020 - Present)
+
+This era builds upon the previous, using the same selectors, reducers and action creators that were created before. However, instead of creating a single monolithic root reducer on boot, the goal is instead to have individual reducers register themselves when needed. This is done synchronously and automatically through dependency graph resolution.
+
+See [the Modularized State documentation](./modularized-state.md) for more details on how it works and how to implement it in new portions of state.
+
+__Identifying characteristics:__
+
+- Modularized reducers are not imported in the root reducer (`client/state/reducer`)
+- Modularized reducers use `withStorageKey` to store their state separately
+- Modularized portions of state include an `init` module that registers the reducer as a side effect
+- Action creators and selectors for a modularized portion of state import from the `init` module
+
+__Advantages:__
+
+- Preserves most of the advantages of Redux, with the tradeoff that action creators and selectors need to import the `init` file for the portions of state they touch
+- Significantly reduces the amount of code required to boot Calypso, improving loading performance
+- More scalable approach, as Redux state continues to grow
+
+
 ## Current Recommendations
 
 All new data requirements should be implemented as part of the global Redux state tree. The `client/state` directory contains all of the behavior describing the global application state. The folder structure of the `state` directory should directly mirror the sub-trees within the global state tree. Each sub-tree can include their own reducer and actions.

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -39,7 +39,7 @@ __Advantages:__
 - Data logic (e.g. fetching) is not intertwined with the storage of the data
 - Adopting an accepted pattern grants us access to a community-driven ecosystem of reference implementations
 
-### Third Era: Redux Global State Tree (December 2015 - Present)
+### Third Era: Redux Global State Tree (December 2015 - February 2020)
 
 [Redux](http://redux.js.org/), described as a "predictable state container", is an evolution of the principles advocated in Flux. It is not a far departure from Flux, but is distinct in many ways:
 


### PR DESCRIPTION
Some extra documentation was needed for modularized state, particularly if we want developers to start writing new state in this fashion. This should also be helpful to anyone looking to help with the migration process for existing state, or anyone reviewing those PRs.

#### Changes proposed in this Pull Request

* Update `our-approach-to-data.md` with some more info on modularized state
* Add `modularized-state.md` with a full explanation of modularized state
* Add lint rule to `client/state/reducer.js` to avoid adding new legacy reducers

#### Testing instructions

These are documentation and comment changes only, so there should be no need for testing.
