### PR TITLE
My Home: Update mobile card to align the action style with established pattern

### DIFF
--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -44,9 +44,9 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 		<Card className="go-mobile">
 			<div className={ classnames( 'go-mobile__row', { 'has-2-cols': showOnlyOneBadge } ) }>
 				<div className="go-mobile__title">
-					<CardHeading>{ translate( 'Go Mobile' ) }</CardHeading>
+					<CardHeading>{ translate( 'WordPress app' ) }</CardHeading>
 					<h6 className="go-mobile__subheader customer-home__card-subheader">
-						{ translate( 'Make updates on the go' ) }
+						{ translate( 'Make updates on the go.' ) }
 					</h6>
 				</div>
 				<div className="go-mobile__app-badges">
@@ -74,11 +74,9 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 			</div>
 			{ isDesktopView && ! isDesktopApp && (
 				<div className="go-mobile__email-link">
-					{ translate(
-						'We can email a link to open on your phone to instantly download the app.'
-					) }
-					<Button className="go-mobile__email-link-button" onClick={ emailLogin } borderless>
-						{ translate( 'Email download link' ) }
+					{ translate( 'Get a download link via email — click it on your phone to get the app.' ) }
+					<Button className="go-mobile__email-link-button is-link" onClick={ emailLogin }>
+						{ translate( 'Send my download link' ) }
 					</Button>
 				</div>
 			) }

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -74,9 +74,11 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 			</div>
 			{ isDesktopView && ! isDesktopApp && (
 				<div className="go-mobile__email-link">
-					{ translate( 'Get a download link via email — click it on your phone to get the app.' ) }
-					<Button className="go-mobile__email-link-button is-link" onClick={ emailLogin }>
-						{ translate( 'Send my download link' ) }
+					{ translate(
+						'We can email a link to open on your phone to instantly download the app.'
+					) }
+					<Button className="go-mobile__email-link-button" onClick={ emailLogin } borderless>
+						{ translate( 'Email download link' ) }
 					</Button>
 				</div>
 			) }

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -74,11 +74,9 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 			</div>
 			{ isDesktopView && ! isDesktopApp && (
 				<div className="go-mobile__email-link">
-					{ translate(
-						'We can email a link to open on your phone to instantly download the app.'
-					) }
-					<Button className="go-mobile__email-link-button" onClick={ emailLogin } borderless>
-						{ translate( 'Email download link' ) }
+					{ translate( 'Get a download link via email — click it on your phone to get the app.' ) }
+					<Button className="go-mobile__email-link-button is-link" onClick={ emailLogin }>
+						{ translate( 'Send my download link' ) }
 					</Button>
 				</div>
 			) }

--- a/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
+++ b/client/my-sites/customer-home/cards/features/go-mobile/index.jsx
@@ -73,9 +73,14 @@ export const GoMobile = ( { email, sendMobileLoginEmail } ) => {
 				</div>
 			</div>
 			{ isDesktopView && ! isDesktopApp && (
-				<Button className="go-mobile__email-link-button" onClick={ emailLogin }>
-					{ translate( 'Email download link' ) }
-				</Button>
+				<div className="go-mobile__email-link">
+					{ translate(
+						'We can email a link to open on your phone to instantly download the app.'
+					) }
+					<Button className="go-mobile__email-link-button" onClick={ emailLogin } borderless>
+						{ translate( 'Email download link' ) }
+					</Button>
+				</div>
 			) }
 		</Card>
 	);

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -1,12 +1,7 @@
 .customer-home__layout-col-right {
-	.go-mobile {
-		// reduce padding to allow for padding on button for better click target
-		padding-bottom: 16px;
-
-		@include breakpoint('<480px') {
-			.go-mobile__subheader.customer-home__card-subheader {
-				margin-bottom: 0;
-			}
+	@include breakpoint( '<480px' ) {
+		.go-mobile__subheader.customer-home__card-subheader {
+			margin-bottom: 0;
 		}
 	}
 }
@@ -26,12 +21,9 @@
 	color: var( --color-text-subtle );
 }
 
-.go-mobile__email-link-button.button {
-	color: var( --color-primary );
-	font-size: 15px;
-	font-weight: 400;
-	margin-top: 8px;
-	padding: 8px 0;
+.go-mobile__email-link-button {
+	cursor: pointer;
+	margin-top: 16px;
 }
 
 .go-mobile__row.has-2-cols {

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -1,3 +1,16 @@
+.customer-home__layout-col-right {
+ .go-mobile {
+		// reduce padding to allow for padding on button for better click target
+		padding-bottom: 16px;
+
+		@include breakpoint( '<480px' ) {
+			.go-mobile__subheader.customer-home__card-subheader {
+				margin-bottom: 0;
+			}
+		}
+	}
+}
+
 .go-mobile__app-badges {
 	display: flex;
 }
@@ -6,9 +19,19 @@
 	width: 50%;
 }
 
-.go-mobile__email-link-button {
-	margin-top: 1rem;
-	width: 100%;
+.go-mobile__email-link {
+	margin: 24px 0 0;
+	padding-top: 20px;
+	border-top: 1px solid var( --color-neutral-5 );
+	color: var( --color-text-subtle );
+}
+
+.go-mobile__email-link-button.button {
+	color: var( --color-primary );
+	font-size: 15px;
+	font-weight: 400;
+	margin-top: 8px;
+	padding: 8px 0;
 }
 
 .go-mobile__row.has-2-cols {

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -22,7 +22,7 @@
 }
 
 .go-mobile__email-link-button {
-	cursor: pointer;
+	display: block;
 	margin-top: 16px;
 }
 

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -1,7 +1,12 @@
 .customer-home__layout-col-right {
-	@include breakpoint( '<480px' ) {
-		.go-mobile__subheader.customer-home__card-subheader {
-			margin-bottom: 0;
+	.go-mobile {
+		// reduce padding to allow for padding on button for better click target
+		padding-bottom: 16px;
+
+		@include breakpoint('<480px') {
+			.go-mobile__subheader.customer-home__card-subheader {
+				margin-bottom: 0;
+			}
 		}
 	}
 }
@@ -21,9 +26,12 @@
 	color: var( --color-text-subtle );
 }
 
-.go-mobile__email-link-button {
-	display: block;
-	margin-top: 16px;
+.go-mobile__email-link-button.button {
+	color: var( --color-primary );
+	font-size: 15px;
+	font-weight: 400;
+	margin-top: 8px;
+	padding: 8px 0;
 }
 
 .go-mobile__row.has-2-cols {

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -1,12 +1,7 @@
 .customer-home__layout-col-right {
- .go-mobile {
-		// reduce padding to allow for padding on button for better click target
-		padding-bottom: 16px;
-
-		@include breakpoint( '<480px' ) {
-			.go-mobile__subheader.customer-home__card-subheader {
-				margin-bottom: 0;
-			}
+	@include breakpoint( '<480px' ) {
+		.go-mobile__subheader.customer-home__card-subheader {
+			margin-bottom: 0;
 		}
 	}
 }
@@ -26,12 +21,9 @@
 	color: var( --color-text-subtle );
 }
 
-.go-mobile__email-link-button.button {
-	color: var( --color-primary );
-	font-size: 15px;
-	font-weight: 400;
-	margin-top: 8px;
-	padding: 8px 0;
+.go-mobile__email-link-button {
+	cursor: pointer;
+	margin-top: 16px;
 }
 
 .go-mobile__row.has-2-cols {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the button to a borderless button/link on the My Home mobile card to adhere to the pattern we've established with actions at the bottom of other cards on the screen.
* Add an explanation to help users understand they should open the download link on their phone.

#### Screenshots

Before | After
------------ | -------------
<img width="347" alt="image" src="https://user-images.githubusercontent.com/448298/81206793-9a9df480-8f9a-11ea-9ee1-e15479609849.png"> | <img width="327" alt="Screen Shot 2020-05-13 at 16 21 36" src="https://user-images.githubusercontent.com/1233880/81824518-d81ff600-9535-11ea-96f7-78937f3635a3.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch or visit calypso.live link
* Visit My Home for any site
* Make sure the the style of the email download link action looks like the screenshot above and is consistent with the other cards.
