### PR TITLE
Jetpack Cloud: Use the same font attributes in ActivityCard bottom bar

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -8,11 +8,6 @@
 	align-items: center;
 }
 
-.activity-card .button.is-borderless.is-primary {
-	float: none;
-	display: inline-block;
-}
-
 .activity-card__time {
 	margin: 1.5rem 0 0.5rem;
 }
@@ -64,19 +59,29 @@
 
 .activity-card__activity-actions,
 .activity-card__activity-actions-reverse {
+	align-items: center;
+	border-top: 1px solid var( --color-neutral-5 );
 	display: flex;
+	justify-content: space-between;
+	padding-top: 0.7rem;
 	position: relative;
 	top: 0.5rem;
-	border-top: 1px solid #e4e4e6;
-	padding-top: 0.7rem;
-	justify-content: space-between;
 
 	a,
-	button.button {
+	button.button.is-borderless.is-compact {
 		font-weight: 400;
 		font-size: 12px;
+		display: flex;
+		align-items: center;
 		@include breakpoint( '>660px' ) {
 			font-size: 16px;
+		}
+
+		// gridicons within buttons have very specific rules for font sizes, disable them to let flex take care of it
+		.gridicon {
+			display: block;
+			margin-top: 0;
+			top: 0;
 		}
 	}
 }

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -70,45 +70,28 @@
 	border-top: 1px solid #e4e4e6;
 	padding-top: 0.7rem;
 	justify-content: space-between;
+
+	a,
+	button.button {
+		font-weight: 400;
+		font-size: 12px;
+		@include breakpoint( '>660px' ) {
+			font-size: 16px;
+		}
+	}
 }
 
 .activity-card__activity-actions-reverse {
 	flex-direction: row-reverse;
 }
 
-.activity-card__detail-link {
-	font-size: 0.75rem;
-
-	@include breakpoint( '>660px' ) {
-		font-size: 1rem;
-	}
-}
-
-.activity-card__detail-button.button.is-borderless.is-primary {
-	color: #3d444a;
-	font-size: 0.9rem;
-	font-weight: 400;
-	margin-left: 0;
-}
-
 .backup-delta__realtime .activity-card__actions-button.button.is-borderless.is-primary {
 	float: right;
-	font-size: 0.75rem;
-	font-weight: 400;
-
-	@include breakpoint( '>660px' ) {
-		font-size: 1rem;
-	}
 }
 
 .button.activity-card__see-content-link {
-	font-size: 12px;
 	margin-left: 0;
 	color: var( --studio-jetpack-green-40 );
-
-	@include breakpoint( '>660px' ) {
-		font-size: 16px;
-	}
 }
 
 .button.is-borderless.is-primary:focus {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change styling of bottom of Activity Cards so that font attributes are always the same

![Untitled 5](https://user-images.githubusercontent.com/2810519/81222612-66760400-8f99-11ea-8daf-7effc7f400c1.png)


#### Testing instructions

1. Navigate to `/backups/activity`
2. Test that the text on the left of certain cards matched the font attributes of the "Actions" buttons on the right.
