### PR TITLE
Implement A/B test for showing `.jp` domains to users in Japan

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -126,4 +126,13 @@ export default {
 		localeTargets: [ 'en' ],
 		countryCodeTargets: [ 'US', 'ID', 'NG', 'BD', 'NL', 'SE', 'SG', 'LK', 'NZ', 'IE' ],
 	},
+	domainShowJPResultsInJapan: {
+		datestamp: '20200506',
+		variations: {
+			variantShowJPResults: 50,
+			control: 50,
+		},
+		localeTargets: 'any',
+		countryCodeTargets: [ 'JP' ],
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -132,6 +132,7 @@ export default {
 			variantShowJPResults: 50,
 			control: 50,
 		},
+		defaultVariation: 'control',
 		localeTargets: 'any',
 		countryCodeTargets: [ 'JP' ],
 	},

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,13 +1,26 @@
 /**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+
+/**
  * Get the suggestions vendor
  *
  * @param {boolean} [isSignup=false] Whether the query is part of a signup flow.
+ * @param {string|null} [countryCodeForABTests=null] The country code to be used for A/B tests.
  *
- * @returns {string} Vendor string to pass as part of the query.
+ * @returns {string} Vendor string to pass as part of the domain suggestions query.
  */
-export const getSuggestionsVendor = ( isSignup = false ) => {
+export const getSuggestionsVendor = ( isSignup = false, countryCodeForABTests = null ) => {
 	if ( isSignup ) {
-		return 'variation4_front';
+		let vendor = 'variation4_front';
+		if (
+			countryCodeForABTests &&
+			abtest( 'domainShowJPResultsInJapan', countryCodeForABTests ) === 'variantShowJPResults'
+		) {
+			vendor = 'variation6_front';
+		}
+		return vendor;
 	}
 	return 'variation2_front';
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -54,6 +54,7 @@ import { abtest } from 'lib/abtest';
  * Style dependencies
  */
 import './style.scss';
+import { requestGeoLocation } from '../../../state/data-getters';
 
 class DomainsStep extends React.Component {
 	static propTypes = {
@@ -70,6 +71,7 @@ class DomainsStep extends React.Component {
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
+		userGeoCountryCode: PropTypes.string,
 		vertical: PropTypes.string,
 	};
 
@@ -474,7 +476,7 @@ class DomainsStep extends React.Component {
 				isEligibleVariantForDomainTest={ this.isEligibleVariantForDomainTest() }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
-				vendor={ getSuggestionsVendor( true ) }
+				vendor={ getSuggestionsVendor( true, this.props.userGeoCountryCode ) }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }
@@ -727,6 +729,7 @@ export default connect(
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 			isSitePreviewVisible: isSitePreviewVisible( state ),
 			hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
+			userGeoCountryCode: requestGeoLocation().data,
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set up an A/B test to allow us to measure the impact of promoting `.jp` domains to users.

The actual test will only launch once we can support the TLD. Furthermore, this test depends on corresponding changes to the domain suggestions back end in D43045-code.

More context in https://wp.me/pbxNRc-hA

#### Testing instructions

This needs to be tested in conjunction with D43045-code, which includes fairly extensive testing instructions.
