### PR TITLE
Block Editor: Remove 7.8.1 fallback in search

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -3,12 +3,11 @@
  * External dependencies
  */
 import { debounce } from 'lodash';
-import debugFactory from 'debug';
 
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __experimentalInserterMenuExtension as InserterMenuExtension } from '@wordpress/block-editor';
 
@@ -19,16 +18,11 @@ import { __experimentalInserterMenuExtension as InserterMenuExtension } from '@w
  */
 import tracksRecordEvent from './track-record-event';
 
-// let's remove this line once the core version updates.
-const debug = debugFactory( 'wpcom-block-editor:tracking:inserter-menu' );
-
 const InserterMenuTrackingEvent = function () {
 	const [ searchTerm, setSearchTerm ] = useState( '' );
 	const { selectedBlock } = useSelect( ( select ) => ( {
 		selectedBlock: select( 'core/block-editor' ).getSelectedBlock(),
 	} ) );
-
-	const pluginVersion = window.wpcomGutenberg ? window.wpcomGutenberg.pluginVersion : null;
 
 	const debouncedSetFilterValue = debounce( ( search_term, has_items ) => {
 		setSearchTerm( search_term );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-inserter-menu-search-term.js
@@ -45,65 +45,12 @@ const InserterMenuTrackingEvent = function () {
 
 		tracksRecordEvent( 'wpcom_block_picker_search_term', eventProperties );
 
-		/*
-		 * Let's delegate registering no-results search event
-		 * to the temporary solution below if the core version
-		 * is equal to 7.8.1.
-		 */
-		if ( ! pluginVersion || ( pluginVersion && pluginVersion === '7.8.1' ) ) {
-			return null;
-		}
-
-		// let's remove this line once the core version updates.
-		debug( '%s version: tracking with Slot parameter', pluginVersion );
-
 		if ( has_items ) {
 			return;
 		}
 
 		tracksRecordEvent( 'wpcom_block_picker_no_results', eventProperties );
 	}, 500 );
-
-	/*
-	 * Hacky temporal solution to detect no-results search result.
-	 * Unfortunately, __experimentalInserterMenuExtension has a bug
-	 * in the 7.8.1 core version.
-	 * The `hasItems` property is always true so it isn't possible
-	 * to rely on this value.
-	 *
-	 * @TODO: The following is a temporary solution and it should be removed
-	 *   and replaced by the usage of the `hasItems` property,
-	 *   once a new version of core is available in dotcom.
-	 */
-	useEffect( () => {
-		// Skip whether isn't the 7.8.1 version.
-		if ( pluginVersion && pluginVersion !== '7.8.1' ) {
-			return;
-		}
-		// let's remove this line once the core version updates.
-		debug( '%s: tracking inspecting DOM tree', ( pluginVersion || 'unknown' ) + ' version' );
-
-		if ( ! searchTerm || searchTerm.length < 3 ) {
-			return;
-		}
-
-		const eventProperties = {
-			search_term: searchTerm,
-			context: 'inserter_menu',
-			selected_block: selectedBlock ? selectedBlock.name : null,
-		};
-
-		const hasResultsEl = document.querySelectorAll( '.block-editor-inserter__results' );
-		const hasNoResultsEl =
-			document.querySelectorAll( '.block-editor-inserter__no-results' ).length !== 0;
-
-		if (
-			hasNoResultsEl ||
-			( hasResultsEl && hasResultsEl[ 0 ] && hasResultsEl[ 0 ].children.length === 0 )
-		) {
-			tracksRecordEvent( 'wpcom_block_picker_no_results', eventProperties );
-		}
-	}, [ searchTerm, pluginVersion, selectedBlock ] );
 
 	return (
 		<InserterMenuExtension>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes fallback code to track empty search results in block inserter search

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Update your testing site with these changes (SB)
2) In your testing site, open the client dev console and set up the debug

```
> localStorage.setItem( 'debug', 'wpcom-block-editor*' )
```

A hard refresh is needed.

3) Open the Inserter Menu
4) Open the `Inserter Menu` selector
5) Generate event typing there
6) Confirm that it behaves as expected. It means when you get results, it should trigger a `wpcom_block_picker_search_term` event, as the screenshot shows below.

**blocks found** event
<img width="1463" alt="Screen Shot 2020-04-15 at 10 13 04 PM" src="https://user-images.githubusercontent.com/77539/79403892-8e5be400-7f66-11ea-95f5-790706ff3f87.png">

When there aren't blocks there, it also should trigger the `wpcom_block_picker_no_results` event too:

**blocks not found** event
<img width="1221" alt="Screen Shot 2020-04-15 at 10 13 58 PM" src="https://user-images.githubusercontent.com/77539/79403878-87cd6c80-7f66-11ea-8e51-64de9b20618f.png">


