### PR TITLE
Gutenboarding: show HSTS info for specific TLDs

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/hsts-info.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/hsts-info.tsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { sprintf } from '@wordpress/i18n';
+import React, { FunctionComponent, useState, useRef } from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import { Button, Popover, SVG, Path, ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { HTTPS_SSL } from 'lib/url/support';
+
+interface Props {
+	tld: string;
+}
+
+const icon = (
+	<SVG width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M15.4995 8C15.4995 3.85775 12.1418 0.5 7.99951 0.5C3.85726 0.5 0.499512 3.85775 0.499512 8C0.499512 12.1422 3.85726 15.5 7.99951 15.5C12.1418 15.5 15.4995 12.1422 15.4995 8ZM7.99883 2.00059C4.69133 2.00059 1.99883 4.69309 1.99883 8.00059C1.99883 11.3081 4.69133 14.0006 7.99883 14.0006C11.3063 14.0006 13.9988 11.3081 13.9988 8.00059C13.9988 4.69309 11.3063 2.00059 7.99883 2.00059ZM7.24941 5.75059H8.74941V4.25059H7.24941V5.75059ZM7.24941 7.25029H8.74941V11.7503H7.24941V7.25029Z"
+			fill="currentColor"
+		/>
+	</SVG>
+);
+
+const HstsInfo: FunctionComponent< Props > = ( { tld } ) => {
+	const { __ } = useI18n();
+	const [ isPopoverVisible, setPopoverVisibility ] = useState( false );
+	const buttonRef = useRef();
+
+	return (
+		<>
+			<Button
+				aria-label={ __( 'Additional information about this domain ending.' ) }
+				className="domain-picker__hsts-button"
+				icon={ icon }
+				isSmall
+				isTertiary
+				onClick={ () => {
+					setPopoverVisibility( ! isPopoverVisible );
+				} }
+				ref={ buttonRef }
+			>
+				{ isPopoverVisible && (
+					<Popover position="center right" noArrow={ false }>
+						{ createInterpolateElement(
+							sprintf(
+								/* translators: %s: domain TLD such as .dev. */
+								__(
+									'All domains ending in <strong>%s</strong> require an SSL certificate to host a website. When you host this domain at WordPress.com an SSL certificate is included.'
+								),
+								tld
+							),
+							{ strong: <strong /> }
+						) }
+						<ExternalLink href={ HTTPS_SSL }>{ __( 'Learn more.' ) }</ExternalLink>
+					</Popover>
+				) }
+			</Button>
+		</>
+	);
+};
+
+export default HstsInfo;

--- a/client/landing/gutenboarding/components/domain-picker/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker/style.scss
@@ -8,7 +8,7 @@ $domain-picker__suggestion-item-height: 24px;
 .domain-picker.components-panel {
 	border: none;
 
-	.components-panel__body {
+	> .components-panel__body {
 		display: flex;
 		flex-direction: column;
 		padding: 0;
@@ -275,4 +275,26 @@ $domain-picker__suggestion-item-height: 24px;
 		margin: 0 1em;
 		color: var( --studio-gray-40 );
 	}
+}
+
+.domain-picker__hsts-button {
+	&.components-button.is-tertiary {
+		align-items: center;
+		display: inline-flex;
+		height: 100%;
+		line-height: 100%;
+		padding: 0 10px;
+
+		&, &:hover:not( :disabled ) {
+			color: var( --color-neutral-100 );
+			background: none;
+			border: none;
+		}
+	}
+}
+
+// Remove focus styling from clicking a button
+// Keep keyboard-focused focus style
+html:not( .accessible-focus ) .domain-picker__hsts-button:focus:not( :disabled ):not( :hover ) {
+	box-shadow: none;
 }

--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -17,8 +17,8 @@ import { STORE_KEY } from '../../stores/onboard';
 import { FLOW_ID } from '../../constants';
 import { RecordTrainTracksEventProps } from '../../lib/analytics';
 import { getSignupDomainsSuggestionsVendor } from '../../utils/domain-suggestions';
-
 const DOMAIN_SUGGESTION_VENDOR = getSignupDomainsSuggestionsVendor();
+import HstsInfo from './hsts-info';
 
 interface Props {
 	suggestion: DomainSuggestion;
@@ -113,6 +113,7 @@ const DomainPickerSuggestionItem: FunctionComponent< Props > = ( {
 				{ isRecommended && (
 					<div className="domain-picker__badge is-recommended">{ __( 'Recommended' ) }</div>
 				) }
+				{ suggestion.hsts_required && <HstsInfo tld={ domainTld } /> }
 			</div>
 			<div
 				className={ classnames( 'domain-picker__price', {

--- a/client/landing/gutenboarding/gutenboard.tsx
+++ b/client/landing/gutenboarding/gutenboard.tsx
@@ -7,10 +7,7 @@ import { Popover, DropZoneProvider } from '@wordpress/components';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import '@wordpress/format-library';
 import React, { useRef, useEffect } from 'react';
-
-// Uncomment and remove the redundant sass import from `./style.css` when a release after @wordpress/components@8.5.0 is published.
-// See https://github.com/WordPress/gutenberg/pull/19535
-// import '@wordpress/components/build-style/style.css';
+import '@wordpress/components/build-style/style.css';
 
 /**
  * Internal dependencies

--- a/client/landing/gutenboarding/style.scss
+++ b/client/landing/gutenboarding/style.scss
@@ -1,6 +1,3 @@
-// @TODO: Remove this line and restore the import in `./gutenboard.tsx` when a release after @wordpress/components@8.5.0 is published.
-// See https://github.com/WordPress/gutenberg/pull/19535
-@import '~@wordpress/components/build-style/style';
 @import 'assets/stylesheets/gutenberg-base-styles';
 
 @font-face {

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -67,6 +67,11 @@ export interface DomainSuggestion {
 	domain_name: DomainName;
 
 	/**
+	 * Whether TLD requires HSTS notice displayed
+	 */
+	hsts_required?: boolean
+
+	/**
 	 * Relevance as a percent: 0 <= relevance <= 1
 	 *
 	 * @example 0.9


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/40973

It should look somewhat like this:

<img width="241" alt="image" src="https://user-images.githubusercontent.com/87168/81926753-280cc480-95eb-11ea-9019-b24572c79865.png">


#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
