### PR TITLE
FSE GitHub action cache for lerna

### DIFF
--- a/.github/workflows/full-site-editing-plugin.yml
+++ b/.github/workflows/full-site-editing-plugin.yml
@@ -16,14 +16,27 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@master
+
+    # https://github.com/actions/cache/blob/master/examples.md#node---lerna
+    - name: Restore lerna
+      uses: actions/cache@master
+      with:
+        path: |
+          node_modules
+          */*/node_modules
+        key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
     - name: Install dependencies
       run: yarn install --frozen-lockfile
+
     - name: Build FSE
       run: cd apps/full-site-editing && yarn build
+
     - name: Upload build artifact
       uses: actions/upload-artifact@v1
       with:
         name: fse-build-archive
         path: apps/full-site-editing/full-site-editing-plugin
+
     - name: Send hook to Mission Control
       run: .github/workflows/send-calypso-app-build-trigger.sh

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -10,7 +10,6 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Enhances your page creation workflow within the Block Editor.
 
-
 == Description ==
 
 This plugin comes with a custom block to display a list of your most recent blog posts, as well as a template selector

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -16,7 +16,6 @@ Enhances your page creation workflow within the Block Editor.
 This plugin comes with a custom block to display a list of your most recent blog posts, as well as a template selector
 to give you a head start on creating new pages for your site. It also provides a way to change your font settings globally from the page editor.
 
-
 == Installation ==
 
 1. Upload the plugin files to the `/wp-content/plugins/full-site-editing` directory, or install the plugin through the WordPress plugins screen directly.

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -10,10 +10,12 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Enhances your page creation workflow within the Block Editor.
 
+
 == Description ==
 
 This plugin comes with a custom block to display a list of your most recent blog posts, as well as a template selector
 to give you a head start on creating new pages for your site. It also provides a way to change your font settings globally from the page editor.
+
 
 == Installation ==
 


### PR DESCRIPTION
If we can speed up delivery of fusion builds to mc we can reduce the time developers need to wait.

Currently the longest part of the `build-fse-plugin` process is during the "Install Dependencies" step which tends to take over three minutes

By configuring GitHub's actions/cache we can reduce the amount of time it takes to deliver the FSE artifacts to MC _in most cases_.

#### Changes proposed in this Pull Request

* Uses GitHub's `actions/cache` to cache depedencies for lerna based projects.

#### Testing instructions

- Confirm the `build-fse-plugin` GitHub action runs and functions as expected
- Observe the uncached build time is approximately the same in fse/action-cache builds ([uncached run](https://github.com/Automattic/wp-calypso/runs/650547526) vs [other branch](https://github.com/Automattic/wp-calypso/runs/650326922?check_suite_focus=true))
- Observe the net time to deliver the artifact to MC is around 1m 20s faster with the [cached build](https://github.com/Automattic/wp-calypso/runs/650565763?check_suite_focus=true) (+40s to "Restore Lerna", -2m to "Install dependencies")