### PR TITLE
Fix and improve the styles on Backup Status view

### DIFF
--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -1,24 +1,18 @@
 /**
  * External dependencies
  */
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
 import ActivityCard from '../../components/activity-card';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-
-/**
- * Image dependencies
- */
-import mediaImage from 'assets/images/illustrations/media.svg';
 
 class BackupDelta extends Component {
 	renderRealtime() {
@@ -67,186 +61,8 @@ class BackupDelta extends Component {
 		);
 	}
 
-	renderMetaDiff() {
-		const { metaDiff } = this.props;
-		const metas = [];
-
-		metaDiff.forEach( ( meta ) => {
-			if ( meta.num > 0 || meta.num < 0 ) {
-				const operator = meta.num < 0 ? '' : '+';
-				const plural = meta.num > 1 || meta.num < -1 ? 's' : '';
-				// TBD: How do we deal with translating these strings?
-				metas.push( `${ operator }${ meta.num } ${ meta.type }${ plural }` );
-			}
-		} );
-
-		return <div className="backup-delta__metas">{ metas.join( ', ' ) }</div>;
-	}
-
-	renderDaily() {
-		const { deltas, metaDiff, translate } = this.props;
-
-		const mediaCreated = deltas.mediaCreated.map( ( item ) => (
-			<div key={ item.activityId } className="backup-delta__media-image">
-				<img
-					alt=""
-					src={ item.activityMedia.available ? item.activityMedia.thumbnail_url : mediaImage }
-				/>
-				<div className="backup-delta__media-title">
-					<Gridicon icon="plus" />
-					<div className="backup-delta__media-title-text">{ translate( 'Added' ) }</div>
-				</div>
-			</div>
-		) );
-
-		const mediaCount = deltas.mediaCreated.length - deltas.mediaDeleted.length;
-		const mediaOperator = mediaCount >= 0 ? '+' : '';
-		const mediaCountDisplay = `${ mediaOperator }${ mediaCount }`;
-
-		const deletedElement = [
-			<div className="backup-delta__media-image">
-				<img alt="" src={ mediaImage } />
-				<div className="backup-delta__deleted-count-bubble">-{ deltas.mediaDeleted.length }</div>
-				<div className="backup-delta__media-title">
-					<Gridicon icon="cross-small" />
-					<div className="backup-delta__media-title-text">{ translate( 'Removed' ) }</div>
-				</div>
-			</div>,
-		];
-
-		const mediaItems =
-			deltas.mediaDeleted.length > 0
-				? mediaCreated.slice( 0, 2 ).concat( deletedElement )
-				: mediaCreated.slice( 0, 3 );
-
-		const postsCount = deltas.postsCreated.length - deltas.postsDeleted.length;
-		const postsOperator = postsCount >= 0 ? '+' : '';
-		const postCountDisplay = `${ postsOperator }${ postsCount }`;
-
-		const posts = deltas.posts.map( ( item ) => {
-			if ( 'post__published' === item.activityName ) {
-				return (
-					<div key={ item.activityId } className="backup-delta__post-block">
-						<Gridicon className="backup-delta__post-icon" icon="pencil" />
-						<a className="backup-delta__post-link" href={ item.activityDescription[ 0 ].url }>
-							{ item.activityDescription[ 0 ].children[ 0 ] }
-						</a>
-					</div>
-				);
-			}
-			if ( 'post__trashed' === item.activityName ) {
-				return (
-					<div key={ item.activityId } className="backup-delta__post-block">
-						<Gridicon className="backup-delta__post-icon" icon="cross" />
-						<div className="backup-delta__post-link">
-							{ item.activityDescription[ 0 ].children[ 0 ].text }
-						</div>
-					</div>
-				);
-			}
-		} );
-
-		const plugins = deltas.plugins.map( ( item ) => {
-			const className =
-				'plugin__installed' === item.activityName
-					? 'backup-delta__extension-block-installed'
-					: 'backup-delta__extension-block-removed';
-
-			return (
-				<div key={ item.activityId } className={ className }>
-					{ item.activityDescription[ 0 ].children[ 0 ] }
-				</div>
-			);
-		} );
-
-		const themes = deltas.themes.map( ( item ) => {
-			const className =
-				'theme__installed' === item.activityName
-					? 'backup-delta__extension-block-installed'
-					: 'backup-delta__extension-block-removed';
-
-			const icon =
-				'theme__installed' === item.activityName ? (
-					<Gridicon icon="plus" className="backup-delta__theme-icon-installed" />
-				) : (
-					<Gridicon icon="cross-small" className="backup-delta__theme-icon-removed" />
-				);
-
-			return (
-				<div key={ item.activityId } className={ className }>
-					{ icon }
-					<div className="backup-delta__extension-block-text">
-						{ item.activityDescription[ 0 ].children[ 0 ] }
-					</div>
-				</div>
-			);
-		} );
-
-		const hasChanges = !! (
-			deltas.mediaCreated.length ||
-			deltas.posts.length ||
-			deltas.plugins.length ||
-			deltas.themes.length ||
-			!! metaDiff.filter( ( diff ) => 0 !== diff.num ).length
-		);
-
-		return (
-			<div className="backup-delta__daily">
-				<div className="backup-delta__changes-header">
-					{ translate( 'Changes in this backup' ) }
-				</div>
-
-				{ ! hasChanges && (
-					<div className="backup-delta__daily-no-changes">
-						{ translate(
-							'Looks like there have been no new site changes since your last backup.'
-						) }
-					</div>
-				) }
-
-				{ !! deltas.mediaCreated.length && (
-					<Fragment>
-						<div className="backup-delta__section-header">{ translate( 'Media' ) }</div>
-						<div className="backup-delta__section-media">
-							{ mediaItems }
-							<div>
-								<div className="backup-delta__count-bubble">{ mediaCountDisplay }</div>
-							</div>
-						</div>
-					</Fragment>
-				) }
-				{ !! deltas.posts.length && (
-					<Fragment>
-						<div className="backup-delta__section-header">{ translate( 'Posts' ) }</div>
-						<div className="backup-delta__section-posts">{ posts }</div>
-						<div className="backup-delta__count-bubble">{ postCountDisplay }</div>
-					</Fragment>
-				) }
-				{ !! deltas.plugins.length && (
-					<Fragment>
-						<div className="backup-delta__section-header">{ translate( 'Plugins' ) }</div>
-						<div className="backup-delta__section-plugins">{ plugins }</div>
-					</Fragment>
-				) }
-				{ !! deltas.themes.length && (
-					<Fragment>
-						<div className="backup-delta__section-header">{ translate( 'Themes' ) }</div>
-						<div className="backup-delta__section-plugins">{ themes }</div>
-					</Fragment>
-				) }
-				{ this.renderMetaDiff() }
-			</div>
-		);
-	}
-
 	render() {
-		const { hasRealtimeBackups } = this.props;
-
-		return (
-			<div className="backup-delta">
-				{ hasRealtimeBackups ? this.renderRealtime() : this.renderDaily() }
-			</div>
-		);
+		return <div className="backup-delta">{ this.renderRealtime() }</div>;
 	}
 }
 

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -1,5 +1,5 @@
-.backup-delta__view-all-button {
-    float: none;
+.backup-delta {
+	margin: 0 16px;
 }
 
 .backup-delta__realtime .activity-log-item__actor {
@@ -9,124 +9,6 @@
 .backup-delta__realtime .button.is-borderless.is-primary {
     float: none;
     display: inline-block;
-}
-
-.backup-delta__changes-header {
-    margin-top: 32px;
-	font-size: 16px;
-    font-weight: 600;
-	border-bottom: 1px solid var( --studio-gray-10 );
-	padding-bottom: 16px;
-}
-
-.backup-delta__section-header {
-    margin: 0.5rem 0;
-
-}
-
-.backup-delta__section-posts {
-    margin-bottom: 1rem;
-
-}
-
-.backup-delta__media-image {
-    display: inline-block;
-    margin-right: 1rem;
-    position: relative;
-}
-
-.backup-delta__media-image img {
-    object-fit: cover;
-    width: 6rem;
-    height: 6rem;
-}
-
-.backup-delta__media-title {
-    position: relative;
-    top: -1.9rem;
-    background-color: rgba( 0, 0, 0, 0.5 );
-    color: #fff;
-    font-size: 0.8rem;
-    padding-top: 0.3rem;
-}
-
-.backup-delta__media-title .gridicon {
-    width: 0.7rem;
-    height: 1rem;
-    margin: 0 0.3rem;
-}
-
-.backup-delta__media-title-text {
-    position: relative;
-    top: -0.18rem;
-    display: inline-block;
-}
-
-.backup-delta__count-bubble {
-    display: inline-block;
-    background: #dcdcde;
-    color: #000;
-    border-radius: 1rem;
-    padding: 0.2rem 0.5rem;
-}
-
-.backup-delta__deleted-count-bubble {
-    position: absolute;
-    right: 0.5rem;
-    top: 2rem;
-    display: inline-block;
-    background: #d63638;
-    color: #fff;
-    border-radius: 1rem;
-    padding: 0.2rem 0.5rem;
-}
-
-.gridicon.backup-delta__post-icon {
-    width: 1rem;
-    fill: #787c82;
-}
-
-.gridicon.backup-delta__theme-icon-installed {
-    width: 1rem;
-    height: 1rem;
-    fill: #349e0b;
-}
-
-.gridicon.backup-delta__theme-icon-removed {
-    width: 1rem;
-    height: 1rem;
-    fill: #d63638;
-}
-
-.backup-delta__extension-block-installed {
-    color: #349e0b;
-}
-
-.backup-delta__extension-block-removed {
-    color: #d63638;
-}
-
-.backup-delta__post-link {
-    display: inline-block;
-    position: relative;
-    top: -0.4rem;
-    left: 0.5rem;
-    color: #349e0b;
-}
-
-.backup-delta__post-block {
-    margin-bottom: -0.5rem;
-}
-
-.backup-delta__metas {
-    margin: 1rem 0;
-}
-
-.backup-delta__extension-block-text {
-    display: inline-block;
-    position: relative;
-    left: 0.2rem;
-    top: -0.1rem;
 }
 
 .backup-delta__realtime-cards {
@@ -141,29 +23,4 @@
 
 .backup-delta__realtime-emptyday {
     margin-top: 1rem;
-}
-
-.backup-delta__changes-header:first-child {
-    margin-top: 0;
-}
-
-.backup-delta__daily-no-changes {
-    font-style: italic;
-	padding-top: 16px;
-	color: var( --studio-gray-40 );
-}
-
-.backup-delta__daily {
-	margin: 32px -16px 0;
-	padding: 0 16px;
-	text-align: left;
-}
-
-.backup-delta__view-all-button {
-	display: block;
-	text-align: center;
-}
-
-.backup-delta__metas {
-	margin-top: 0;
 }

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -12,8 +12,11 @@
 }
 
 .backup-delta__changes-header {
-    margin-top: 2rem;
+    margin-top: 32px;
+	font-size: 16px;
     font-weight: 600;
+	border-bottom: 1px solid var( --studio-gray-10 );
+	padding-bottom: 16px;
 }
 
 .backup-delta__section-header {
@@ -131,8 +134,8 @@
 }
 
 .backup-delta__realtime-header {
-    font-size: 1.3rem;
-    font-weight: 400;
+    font-size: 16px;
+    font-weight: 600;
     margin: 2rem 0 0.5rem;
 }
 
@@ -140,28 +143,27 @@
     margin-top: 1rem;
 }
 
-.backup-delta__daily .backup-delta__changes-header:first-child {
+.backup-delta__changes-header:first-child {
     margin-top: 0;
 }
 
 .backup-delta__daily-no-changes {
     font-style: italic;
-    padding: 1rem 0;
+	padding-top: 16px;
+	color: var( --studio-gray-40 );
 }
 
-@media ( max-width: 660px ) {
-    .backup-delta__view-all-button {
-        display: block;
-        text-align: center;
-    }
+.backup-delta__daily {
+	margin: 32px -16px 0;
+	padding: 0 16px;
+	text-align: left;
+}
 
-    .backup-delta__metas {
-        margin-top: 0;
-    }
+.backup-delta__view-all-button {
+	display: block;
+	text-align: center;
+}
 
-    .backup-delta__daily {
-        margin: 0 -16px;
-        padding: 0 16px;
-        background: var( --studio-white );
-    }
+.backup-delta__metas {
+	margin-top: 0;
 }

--- a/client/landing/jetpack-cloud/components/daily-backup-status/backup-changes.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/backup-changes.jsx
@@ -1,0 +1,188 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from '../../../../components/gridicon';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Image dependencies
+ */
+import mediaImage from 'assets/images/illustrations/media.svg';
+
+const renderMetaDiff = ( metaDiff ) => {
+	const metas = [];
+
+	metaDiff.forEach( ( meta ) => {
+		if ( meta.num > 0 || meta.num < 0 ) {
+			const operator = meta.num < 0 ? '' : '+';
+			const plural = meta.num > 1 || meta.num < -1 ? 's' : '';
+			// TBD: How do we deal with translating these strings?
+			metas.push( `${ operator }${ meta.num } ${ meta.type }${ plural }` );
+		}
+	} );
+
+	return <div className="daily-backup-status__metas">{ metas.join( ', ' ) }</div>;
+};
+
+const BackupChanges = ( { deltas, metaDiff } ) => {
+	const translate = useTranslate();
+
+	const mediaCreated = deltas.mediaCreated.map( ( item ) => (
+		<div key={ item.activityId } className="daily-backup-status__media-image">
+			<img
+				alt=""
+				src={ item.activityMedia.available ? item.activityMedia.thumbnail_url : mediaImage }
+			/>
+			<div className="daily-backup-status__media-title">
+				<Gridicon icon="plus" />
+				<div className="daily-backup-status__media-title-text">{ translate( 'Added' ) }</div>
+			</div>
+		</div>
+	) );
+
+	const mediaCount = deltas.mediaCreated.length - deltas.mediaDeleted.length;
+	const mediaOperator = mediaCount >= 0 ? '+' : '';
+	const mediaCountDisplay = `${ mediaOperator }${ mediaCount }`;
+
+	const deletedElement = [
+		<div className="daily-backup-status__media-image">
+			<img alt="" src={ mediaImage } />
+			<div className="daily-backup-status__deleted-count-bubble">
+				-{ deltas.mediaDeleted.length }
+			</div>
+			<div className="daily-backup-status__media-title">
+				<Gridicon icon="cross-small" />
+				<div className="daily-backup-status__media-title-text">{ translate( 'Removed' ) }</div>
+			</div>
+		</div>,
+	];
+
+	const mediaItems =
+		deltas.mediaDeleted.length > 0
+			? mediaCreated.slice( 0, 2 ).concat( deletedElement )
+			: mediaCreated.slice( 0, 3 );
+
+	const postsCount = deltas.postsCreated.length - deltas.postsDeleted.length;
+	const postsOperator = postsCount >= 0 ? '+' : '';
+	const postCountDisplay = `${ postsOperator }${ postsCount }`;
+
+	const posts = deltas.posts.map( ( item ) => {
+		if ( 'post__published' === item.activityName ) {
+			return (
+				<div key={ item.activityId } className="daily-backup-status__post-block">
+					<Gridicon className="daily-backup-status__post-icon" icon="pencil" />
+					<a className="daily-backup-status__post-link" href={ item.activityDescription[ 0 ].url }>
+						{ item.activityDescription[ 0 ].children[ 0 ] }
+					</a>
+				</div>
+			);
+		}
+		if ( 'post__trashed' === item.activityName ) {
+			return (
+				<div key={ item.activityId } className="daily-backup-status__post-block">
+					<Gridicon className="daily-backup-status__post-icon" icon="cross" />
+					<div className="daily-backup-status__post-link">
+						{ item.activityDescription[ 0 ].children[ 0 ].text }
+					</div>
+				</div>
+			);
+		}
+	} );
+
+	const plugins = deltas.plugins.map( ( item ) => {
+		const className =
+			'plugin__installed' === item.activityName
+				? 'daily-backup-status__extension-block-installed'
+				: 'daily-backup-status__extension-block-removed';
+
+		return (
+			<div key={ item.activityId } className={ className }>
+				{ item.activityDescription[ 0 ].children[ 0 ] }
+			</div>
+		);
+	} );
+
+	const themes = deltas.themes.map( ( item ) => {
+		const className =
+			'theme__installed' === item.activityName
+				? 'daily-backup-status__extension-block-installed'
+				: 'daily-backup-status__extension-block-removed';
+
+		const icon =
+			'theme__installed' === item.activityName ? (
+				<Gridicon icon="plus" className="daily-backup-status__theme-icon-installed" />
+			) : (
+				<Gridicon icon="cross-small" className="daily-backup-status__theme-icon-removed" />
+			);
+
+		return (
+			<div key={ item.activityId } className={ className }>
+				{ icon }
+				<div className="daily-backup-status__extension-block-text">
+					{ item.activityDescription[ 0 ].children[ 0 ] }
+				</div>
+			</div>
+		);
+	} );
+
+	const hasChanges = !! (
+		deltas.mediaCreated.length ||
+		deltas.posts.length ||
+		deltas.plugins.length ||
+		deltas.themes.length ||
+		!! metaDiff.filter( ( diff ) => 0 !== diff.num ).length
+	);
+
+	return (
+		<div className="daily-backup-status__daily">
+			<div className="daily-backup-status__changes-header">
+				{ translate( 'Changes in this backup' ) }
+			</div>
+
+			{ ! hasChanges && (
+				<div className="daily-backup-status__daily-no-changes">
+					{ translate( 'Looks like there have been no new site changes since your last backup.' ) }
+				</div>
+			) }
+
+			{ !! deltas.mediaCreated.length && (
+				<>
+					<div className="daily-backup-status__section-header">{ translate( 'Media' ) }</div>
+					<div className="daily-backup-status__section-media">
+						{ mediaItems }
+						<div>
+							<div className="daily-backup-status__count-bubble">{ mediaCountDisplay }</div>
+						</div>
+					</div>
+				</>
+			) }
+			{ !! deltas.posts.length && (
+				<>
+					<div className="daily-backup-status__section-header">{ translate( 'Posts' ) }</div>
+					<div className="daily-backup-status__section-posts">{ posts }</div>
+					<div className="daily-backup-status__count-bubble">{ postCountDisplay }</div>
+				</>
+			) }
+			{ !! deltas.plugins.length && (
+				<>
+					<div className="daily-backup-status__section-header">{ translate( 'Plugins' ) }</div>
+					<div className="daily-backup-status__section-plugins">{ plugins }</div>
+				</>
+			) }
+			{ !! deltas.themes.length && (
+				<>
+					<div className="daily-backup-status__section-header">{ translate( 'Themes' ) }</div>
+					<div className="daily-backup-status__section-plugins">{ themes }</div>
+				</>
+			) }
+			{ renderMetaDiff( metaDiff ) }
+		</div>
+	);
+};
+
+export default BackupChanges;

--- a/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/index.jsx
@@ -24,6 +24,7 @@ import { applySiteOffset } from 'lib/site/timezone';
 import { Card } from '@automattic/components';
 import ActivityCard from 'landing/jetpack-cloud/components/activity-card';
 import { INDEX_FORMAT } from 'landing/jetpack-cloud/sections/backups/main';
+import BackupChanges from './backup-changes';
 
 /**
  * Style dependencies
@@ -77,7 +78,7 @@ class DailyBackupStatus extends Component {
 	};
 
 	renderGoodBackup( backup ) {
-		const { allowRestore, hasRealtimeBackups, siteSlug, translate } = this.props;
+		const { allowRestore, hasRealtimeBackups, siteSlug, deltas, metaDiff, translate } = this.props;
 
 		const displayDate = this.getDisplayDate( backup.activityTs );
 		const meta = get( backup, 'activityDescription[2].children[0]', '' );
@@ -100,6 +101,7 @@ class DailyBackupStatus extends Component {
 					disabledRestore={ ! allowRestore }
 				/>
 				{ showBackupDetails && this.renderBackupDetails( backup ) }
+				{ ! hasRealtimeBackups && <BackupChanges { ...{ deltas, metaDiff } } /> }
 			</>
 		);
 	}
@@ -295,7 +297,6 @@ class DailyBackupStatus extends Component {
 		const { moment, allowRestore, timezone, gmtOffset, siteSlug } = this.props;
 		return (
 			<div className="daily-backup-status__realtime-details">
-				<div className="daily-backup-status__realtime-details-title">Backup details</div>
 				<div className="daily-backup-status__realtime-details-card">
 					<ActivityCard
 						{ ...{

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -153,6 +153,154 @@
 	margin-bottom: 1.5rem;
 }
 
+.daily-backup-status__view-all-button {
+	float: none;
+}
+
+.daily-backup-status__changes-header {
+	margin-top: 32px;
+	font-size: 16px;
+	font-weight: 600;
+	border-bottom: 1px solid var( --studio-gray-10 );
+	padding-bottom: 16px;
+}
+
+.daily-backup-status__section-header {
+	margin: 0.5rem 0;
+
+}
+
+.daily-backup-status__section-posts {
+	margin-bottom: 1rem;
+
+}
+
+.daily-backup-status__media-image {
+	display: inline-block;
+	margin-right: 1rem;
+	position: relative;
+}
+
+.daily-backup-status__media-image img {
+	object-fit: cover;
+	width: 6rem;
+	height: 6rem;
+}
+
+.daily-backup-status__media-title {
+	position: relative;
+	top: -1.9rem;
+	background-color: rgba( 0, 0, 0, 0.5 );
+	color: #fff;
+	font-size: 0.8rem;
+	padding-top: 0.3rem;
+}
+
+.daily-backup-status__media-title .gridicon {
+	width: 0.7rem;
+	height: 1rem;
+	margin: 0 0.3rem;
+}
+
+.daily-backup-status__media-title-text {
+	position: relative;
+	top: -0.18rem;
+	display: inline-block;
+}
+
+.daily-backup-status__count-bubble {
+	display: inline-block;
+	background: #dcdcde;
+	color: #000;
+	border-radius: 1rem;
+	padding: 0.2rem 0.5rem;
+}
+
+.daily-backup-status__deleted-count-bubble {
+	position: absolute;
+	right: 0.5rem;
+	top: 2rem;
+	display: inline-block;
+	background: #d63638;
+	color: #fff;
+	border-radius: 1rem;
+	padding: 0.2rem 0.5rem;
+}
+
+.gridicon.daily-backup-status__post-icon {
+	width: 1rem;
+	fill: #787c82;
+}
+
+.gridicon.daily-backup-status__theme-icon-installed {
+	width: 1rem;
+	height: 1rem;
+	fill: #349e0b;
+}
+
+.gridicon.daily-backup-status__theme-icon-removed {
+	width: 1rem;
+	height: 1rem;
+	fill: #d63638;
+}
+
+.daily-backup-status__extension-block-installed {
+	color: #349e0b;
+}
+
+.daily-backup-status__extension-block-removed {
+	color: #d63638;
+}
+
+.daily-backup-status__post-link {
+	display: inline-block;
+	position: relative;
+	top: -0.4rem;
+	left: 0.5rem;
+	color: #349e0b;
+}
+
+.daily-backup-status__post-block {
+	margin-bottom: -0.5rem;
+}
+
+
+.daily-backup-status__extension-block-text {
+	display: inline-block;
+	position: relative;
+	left: 0.2rem;
+	top: -0.1rem;
+}
+
+.daily-backup-status__metas {
+	margin: 1rem 0;
+}
+
+.daily-backup-status__changes-header:first-child {
+	margin-top: 0;
+}
+
+.daily-backup-status__daily-no-changes {
+	font-style: italic;
+	padding-top: 16px;
+	color: var( --studio-gray-40 );
+}
+
+.daily-backup-status__daily {
+	margin: 32px -16px 0;
+	padding: 0 16px;
+	text-align: left;
+}
+
+.daily-backup-status__view-all-button {
+	display: block;
+	text-align: center;
+}
+
+.daily-backup-status__metas {
+	margin-top: 0;
+}
+
 @include breakpoint( '>660px' ) {
 	.daily-backup-status__meta,
 	.daily-backup-status__title {
@@ -203,7 +351,7 @@
 		padding-left: 2rem;
 		padding-right: 2rem;
 	}
-	
+
 	.daily-backup-status__failed-message {
 		font-size: 36px;
 		font-weight: 600;

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -80,6 +80,7 @@
 }
 
 .daily-backup-status__realtime-details {
+	margin-top: 24px;
 	text-align: left;
 }
 

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -170,7 +170,13 @@ class BackupsPage extends Component {
 				<QueryRewindCapabilities siteId={ siteId } />
 
 				<div className="backups__main-wrap">
-					<div className="backups__last-backup-status">
+					<div
+						className={
+							hasRealtimeBackups
+								? 'backups__last-backup-status'
+								: 'backups__last-backup-status-grow'
+						}
+					>
 						<BackupDatePicker
 							onDateChange={ this.onDateChange }
 							selectedDate={ this.getSelectedDate() }

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -169,54 +169,56 @@ class BackupsPage extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<QueryRewindCapabilities siteId={ siteId } />
 
-				<div className="backups__last-backup-status">
-					<BackupDatePicker
-						onDateChange={ this.onDateChange }
-						selectedDate={ this.getSelectedDate() }
-						siteId={ siteId }
-						oldestDateAvailable={ oldestDateAvailable }
-						today={ today }
-						siteSlug={ siteSlug }
-					/>
+				<div className="backups__main-wrap">
+					<div className="backups__last-backup-status">
+						<BackupDatePicker
+							onDateChange={ this.onDateChange }
+							selectedDate={ this.getSelectedDate() }
+							siteId={ siteId }
+							oldestDateAvailable={ oldestDateAvailable }
+							today={ today }
+							siteSlug={ siteSlug }
+						/>
 
-					{ isLoadingBackups && <div className="backups__is-loading" /> }
+						{ isLoadingBackups && <div className="backups__is-loading" /> }
 
-					{ ! isLoadingBackups && (
-						<>
-							<DailyBackupStatus
-								{ ...{
-									allowRestore,
-									siteUrl,
-									siteSlug,
-									backup: lastBackup,
-									lastDateAvailable,
-									selectedDate: this.getSelectedDate(),
-									timezone,
-									gmtOffset,
-									hasRealtimeBackups,
-									onDateChange: this.onDateChange,
-								} }
-							/>
-							{ doesRewindNeedCredentials && (
-								<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
-							) }
-						</>
+						{ ! isLoadingBackups && (
+							<>
+								<DailyBackupStatus
+									{ ...{
+										allowRestore,
+										siteUrl,
+										siteSlug,
+										backup: lastBackup,
+										lastDateAvailable,
+										selectedDate: this.getSelectedDate(),
+										timezone,
+										gmtOffset,
+										hasRealtimeBackups,
+										onDateChange: this.onDateChange,
+									} }
+								/>
+								{ doesRewindNeedCredentials && (
+									<MissingCredentialsWarning settingsLink={ `/settings/${ siteSlug }` } />
+								) }
+							</>
+						) }
+					</div>
+
+					{ ! isLoadingBackups && lastBackup && (
+						<BackupDelta
+							{ ...{
+								deltas,
+								hasRealtimeBackups,
+								realtimeBackups,
+								allowRestore,
+								moment,
+								siteSlug,
+								metaDiff,
+							} }
+						/>
 					) }
 				</div>
-
-				{ ! isLoadingBackups && lastBackup && (
-					<BackupDelta
-						{ ...{
-							deltas,
-							hasRealtimeBackups,
-							realtimeBackups,
-							allowRestore,
-							moment,
-							siteSlug,
-							metaDiff,
-						} }
-					/>
-				) }
 			</Main>
 		);
 	}

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -202,6 +202,8 @@ class BackupsPage extends Component {
 										gmtOffset,
 										hasRealtimeBackups,
 										onDateChange: this.onDateChange,
+										deltas,
+										metaDiff,
 									} }
 								/>
 								{ doesRewindNeedCredentials && (
@@ -211,11 +213,10 @@ class BackupsPage extends Component {
 						) }
 					</div>
 
-					{ ! isLoadingBackups && lastBackup && (
+					{ ! isLoadingBackups && hasRealtimeBackups && lastBackup && (
 						<BackupDelta
 							{ ...{
 								deltas,
-								hasRealtimeBackups,
 								realtimeBackups,
 								allowRestore,
 								moment,

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -10,18 +10,22 @@
 	}
 }
 
+.backups__last-backup-status-grow,
 .backups__last-backup-status {
 	background: var( --studio-white );
 	padding-left: 16px;
 	padding-right: 16px;
 	padding-top: 24px;
-	flex-grow: 1;
 
 	@include breakpoint( '>660px' ) {
 		background: var( --color-surface-backdrop );
 		padding: 0;
 		margin: 0;
 	}
+}
+
+.backups__last-backup-status-grow {
+	flex-grow: 1;
 }
 
 .backups__main-wrap {

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -12,17 +12,25 @@
 
 .backups__last-backup-status {
 	background: var( --studio-white );
-	margin-left: -16px;
-	margin-right: -16px;
 	padding-left: 16px;
 	padding-right: 16px;
 	padding-top: 24px;
+	flex-grow: 1;
 
 	@include breakpoint( '>660px' ) {
 		background: var( --color-surface-backdrop );
 		padding: 0;
 		margin: 0;
 	}
+}
+
+.backups__main-wrap {
+	display: flex;
+	flex-direction: column;
+	height: calc( 100vh - 120px );
+	overflow-y: scroll;
+	margin-left: -16px;
+	margin-right: -16px;
 }
 
 .backups__search {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Improve styles in the main section to match the design:

- The backup status block should cover all the height with white background
- "Changes in this backup" should be inside of the backup status and with a border bottom

Before:
![image](https://user-images.githubusercontent.com/9832440/81331507-9c9aad00-9099-11ea-908c-801de8b252ad.png)

![image](https://user-images.githubusercontent.com/9832440/81216448-d2289300-8fd2-11ea-97ae-08d2f06a7b5c.png)

Now:
![image](https://user-images.githubusercontent.com/9832440/81331553-af14e680-9099-11ea-9a5d-b873bdfd07a8.png)

![image](https://user-images.githubusercontent.com/9832440/81330805-8dffc600-9098-11ea-94eb-8eb2ff981325.png)

![image](https://user-images.githubusercontent.com/9832440/81331604-c0f68980-9099-11ea-891f-c877d9d58f86.png)


#### Testing instructions
https://calypso.live/?branch=update/jetpack-cloud-fix-and-improve-styles-on-backupstatus-view&env=jetpack

- Apply these changes and check if it's the expected design.