### PR TITLE
Update Calypso styles to more closely match core/Gutenberg

### DIFF
--- a/client/assets/stylesheets/shared/_forms.scss
+++ b/client/assets/stylesheets/shared/_forms.scss
@@ -132,8 +132,8 @@ select {
 		no-repeat right 10px center;
 	border-color: var( --color-neutral-10 );
 	border-style: solid;
-	border-radius: 4px;
-	border-width: 1px 1px 2px;
+	border-radius: 2px;
+	border-width: 1px;
 	color: var( --color-neutral-70 );
 	cursor: pointer;
 	display: inline-block;

--- a/client/components/button-group/style.scss
+++ b/client/components/button-group/style.scss
@@ -12,16 +12,16 @@
 
 	.button:first-child {
 		border-left-width: 1px;
-		border-top-left-radius: 4px;
-		border-bottom-left-radius: 4px;
+		border-top-left-radius: 2px;
+		border-bottom-left-radius: 2px;
 		&:active {
 			border-right-width: 0;
 		}
 	}
 
 	.button:last-child {
-		border-top-right-radius: 4px;
-		border-bottom-right-radius: 4px;
+		border-top-right-radius: 2px;
+		border-bottom-right-radius: 2px;
 		&:active {
 			border-left-width: 0;
 		}
@@ -49,7 +49,7 @@
 		background-size: 120px 100%;
 		background-image: linear-gradient( -45deg, var( --color-neutral-0 ) 28%, var( --color-surface ) 28%, var( --color-surface ) 72%, var( --color-neutral-0 ) 72% );
 		display: inline-block;
-		border-radius: 4px;
+		border-radius: 2px;
 
 		.button {
 			background-color: transparent;

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -1,7 +1,7 @@
 .language-picker {
 	border: 1px solid var( --color-neutral-10 );
-	border-width: 1px 1px 2px;
-	border-radius: 4px;
+	border-width: 1px;
+	border-radius: 2px;
 	width: 300px;
 	display: flex;
 	flex: 1 0 auto;

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -65,8 +65,8 @@ $compact-header-height: 35;
 
 	border-style: solid;
 	border-color: var( --color-neutral-10 );
-	border-width: 1px 1px 2px;
-	border-radius: 4px;
+	border-width: 1px;
+	border-radius: 2px;
 	background-color: var( --color-surface );
 
 	font-size: 14px;
@@ -107,12 +107,12 @@ $compact-header-height: 35;
 
 		&:active,
 		&.is-active {
-			border-width: 1px 1px 2px;
+			border-width: 1px;
 		}
 	}
 
 	.select-dropdown.is-open & {
-		border-radius: 4px 4px 0 0;
+		border-radius: 2px 2px 0 0;
 		box-shadow: none;
 		background-color: var( --color-neutral-0 );
 
@@ -161,7 +161,7 @@ $compact-header-height: 35;
 	background-color: var( --color-surface );
 	border: 1px solid var( --color-neutral-10 );
 	border-top: 0;
-	border-radius: 0 0 4px 4px;
+	border-radius: 0 0 2px 2px;
 	visibility: hidden;
 
 	.accessible-focus & {
@@ -178,7 +178,7 @@ $compact-header-height: 35;
 	height: #{$option-height}px;
 
 	&:last-child .select-dropdown__item {
-		border-radius: 0 0 4px 4px;
+		border-radius: 0 0 2px 2px;
 	}
 }
 

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -199,7 +199,7 @@ $autobar-height: 20px;
 
 .masterbar__item-new {
 	background: var( --color-surface );
-	border-radius: 3px;
+	border-radius: 2px;
 	color: var( --color-primary );
 	height: 36px;
 	margin: 5px 8px;

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -246,7 +246,7 @@
 	margin: 0 15px 0 0;
 	text-align: center;
 	width: 50px;
-	border-radius: 4px;
+	border-radius: 2px;
 
 	@include breakpoint( '<660px' ) {
 		height: 21px;
@@ -662,7 +662,7 @@
 	padding: 8px;
 	cursor: pointer;
 	border: 1px solid var( --color-neutral-10 );
-	border-radius: 4px;
+	border-radius: 2px;
 	box-shadow: 0 0 8px rgba( var( --color-neutral-70-rgb ), 0.04 );
 	background-color: var( --color-surface );
 	color: var( --color-primary );
@@ -828,7 +828,7 @@
 	margin: 8px 8px 0 0;
 	cursor: default;
 	font-size: 12px;
-	border-radius: 3px;
+	border-radius: 2px;
 	color: #777;
 	background: #f8f8f8;
 	border: 1px solid #ccc;
@@ -967,12 +967,12 @@
 		margin: 14px 0 0;
 
 		.sharing-buttons-preview-button {
-			border-width: 1px 1px 2px;
-			font-weight: 500;
+			border-width: 1px;
+			font-weight: 600;
 			box-shadow: none;
 			box-sizing: border-box;
 			line-height: 1;
-			border-radius: 4px;
+			border-radius: 2px;
 			padding: 7px;
 			float: left;
 			color: var( --color-neutral-5 );
@@ -983,7 +983,7 @@
 				color: var( --color-neutral-10 );
 			}
 			&:active {
-				border-width: 2px 1px 1px;
+				border-width: 1px;
 			}
 
 			&.is-enabled {

--- a/client/my-sites/site-settings/manage-connection/style.scss
+++ b/client/my-sites/site-settings/manage-connection/style.scss
@@ -20,8 +20,8 @@
 	display: inline-block;
 	border-style: solid;
 	border-color: var( --color-neutral-10 );
-	border-width: 1px 1px 2px;
-	border-radius: 4px;
+	border-width: 1px;
+	border-radius: 2px;
 
 	.gridicon {
 		vertical-align: super;

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -162,7 +162,7 @@
 }
 
 .editor-ground-control .editor-publish-button {
-	border-radius: 4px;
+	border-radius: 2px;
 	padding: 7px 12px;
 	margin: 0 0 0 8px;
 
@@ -174,7 +174,7 @@
 }
 
 .editor-ground-control__time-button {
-	border-radius: 0 4px 4px 0;
+	border-radius: 0 2px 2px 0;
 	padding-left: 8px;
 	padding-right: 8px;
 	margin-left: -1px;

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -9,8 +9,8 @@ $side-margin: 16;
 .editor-publish-date__wrapper {
 	background: var( --color-surface );
 	border: 1px solid var( --color-neutral-10 );
-	border-width: 1px 1px 2px;
-	border-radius: 4px;
+	border-width: 1px;
+	border-radius: 2px;
 	box-sizing: border-box;
 	margin: 0;
 	position: relative;
@@ -46,7 +46,7 @@ $side-margin: 16;
 	}
 
 	.editor-publish-date.is-open & {
-		border-radius: 4px 4px 0 0;
+		border-radius: 2px 2px 0 0;
 		box-shadow: none;
 		background-color: var( --color-neutral-0 );
 	}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -7,20 +7,20 @@
 	font-family: $a8c-font-family-sans;
 	background: transparent;
 	border-style: solid;
-	border-width: 1px 1px 2px;
+	border-width: 1px;
 	cursor: pointer;
 	display: inline-block;
 	margin: 0;
 	outline: 0;
 	overflow: hidden;
-	font-weight: 500;
+	font-weight: 400;
 	text-overflow: ellipsis;
 	text-decoration: none;
 	vertical-align: top;
 	box-sizing: border-box;
-	font-size: 14px;
+	font-size: 13px;
 	line-height: 21px;
-	border-radius: 4px;
+	border-radius: 2px;
 	padding: 7px 14px 9px;
 	appearance: none;
 
@@ -46,7 +46,7 @@
 
 	&:active,
 	&.is-active {
-		border-width: 2px 1px 1px;
+		border-width: 1px;
 	}
 
 	background-color: var( --color-surface );
@@ -72,7 +72,7 @@
 
 		&:active,
 		&.is-active {
-			border-width: 1px 1px 2px;
+			border-width: 1px;
 		}
 	}
 
@@ -124,13 +124,13 @@
 // Primary buttons
 .button.is-primary {
 	background-color: var( --color-accent );
-	border-color: var( --color-accent-dark );
+	border-color: var( --color-accent );
 	color: var( --color-text-inverted );
 
 	&:hover,
 	&:focus {
 		background-color: var( --color-accent-60 );
-		border-color: var( --color-accent-dark );
+		border-color: var( --color-accent-60 );
 		color: var( --color-text-inverted );
 	}
 
@@ -147,7 +147,7 @@
 	&.disabled {
 		color: var( --color-neutral-20 );
 		background-color: var( --color-surface );
-		border-color: var( --color-neutral-5 );
+		border-color: var( --color-surface );
 	}
 
 	&.is-busy {
@@ -167,7 +167,7 @@
 
 	&:hover,
 	&:focus {
-		border-color: var( --color-error-40 );
+		border-color: var( --color-error );
 	}
 
 	.accessible-focus &:focus {
@@ -178,25 +178,26 @@
 	&:disabled {
 		color: var( --color-neutral-20 );
 		background-color: var( --color-surface );
-		border-color: var( --color-neutral-5 );
+		border-color: var( --color-surface );
 	}
 }
 
 .button.is-primary.is-scary {
 	background-color: var( --color-error );
-	border-color: var( --color-error-dark );
+	border-color: var( --color-error );
 	color: var( --color-text-inverted );
 
 	&:hover,
 	&:focus {
 		background-color: var( --color-error-60 );
+		border-color: var( --color-error-60 );
 	}
 
 	&[disabled],
 	&:disabled {
 		color: var( --color-neutral-20 );
 		background-color: var( --color-surface );
-		border-color: var( --color-neutral-5 );
+		border-color: var( --color-surface );
 	}
 
 	&.is-busy {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -13,12 +13,12 @@
 	margin: 0;
 	outline: 0;
 	overflow: hidden;
-	font-weight: 400;
 	text-overflow: ellipsis;
 	text-decoration: none;
 	vertical-align: top;
 	box-sizing: border-box;
-	font-size: 13px;
+	font-size: 14px;
+	font-weight: 600;
 	line-height: 22px;
 	border-radius: 2px;
 	padding: 7px 14px 9px;
@@ -147,7 +147,7 @@
 	&.disabled {
 		color: var( --color-neutral-20 );
 		background-color: var( --color-surface );
-		border-color: var( --color-surface );
+		border-color: var( --color-neutral-5 );
 	}
 
 	&.is-busy {

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -19,7 +19,7 @@
 	vertical-align: top;
 	box-sizing: border-box;
 	font-size: 13px;
-	line-height: 21px;
+	line-height: 22px;
 	border-radius: 2px;
 	padding: 7px 14px 9px;
 	appearance: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* What would it look like if we flattened buttons and other UI elements to align with core and Gutenberg styles?
* Also tweaks font size, weight, and border radius of buttons to match Gberg, but following the core type scale: https://wordpress.github.io/gutenberg/?path=/story/components-experimental-text--default
* Also updates selects, select dropdown component, and various one-off buttons to line up with desired styles.

**Before**

<img width="803" alt="Screen Shot 2020-05-06 at 2 56 53 PM" src="https://user-images.githubusercontent.com/2124984/81216974-d8564980-8fa9-11ea-9243-5d6443062ce8.png">

**After**

<img width="805" alt="81578318-a0b81a80-9378-11ea-8159-84b2825935ab" src="https://user-images.githubusercontent.com/2124984/81721897-98321380-944e-11ea-8227-fe8c220ccfa6.png">

#### Testing instructions

* Switch to this PR
* Check out buttons and drop-downs across Calypso to see the stylistic changes.