### PR TITLE
Deduplicate unicode-match-property-value-ecmascript

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -24574,12 +24574,7 @@ unicode-match-property-ecmascript@^1.0.4:
     unicode-canonical-property-names-ecmascript "^1.0.4"
     unicode-property-aliases-ecmascript "^1.0.4"
 
-unicode-match-property-value-ecmascript@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz#5b4b426e08d13a80365e0d657ac7a6c1ec46a277"
-  integrity sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==
-
-unicode-match-property-value-ecmascript@^1.2.0:
+unicode-match-property-value-ecmascript@^1.1.0, unicode-match-property-value-ecmascript@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz#0d91f600eeeb3096aa962b1d6fc88876e64ea531"
   integrity sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `unicode-match-property-value-ecmascript` (done automatically with `npx yarn-deduplicate --packages unicode-match-property-value-ecmascript`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> unicode-match-property-value-ecmascript@1.1.0
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> unicode-match-property-value-ecmascript@1.1.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> unicode-match-property-value-ecmascript@1.1.0
< wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> unicode-match-property-value-ecmascript@1.1.0
< wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> unicode-match-property-value-ecmascript@1.1.0
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> unicode-match-property-value-ecmascript@1.2.0
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> unicode-match-property-value-ecmascript@1.2.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> unicode-match-property-value-ecmascript@1.2.0
> wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> unicode-match-property-value-ecmascript@1.2.0
> wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> unicode-match-property-value-ecmascript@1.2.0
```