### PR TITLE
My Home: Avoid fatals when completing the checklist.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -107,7 +107,7 @@ const SiteSetupList = ( {
 	useEffect( () => {
 		// Initial task (first incomplete).
 		if ( ! currentTaskId && tasks.length ) {
-			const initialTaskId = tasks.find( ( task ) => ! task.isCompleted ).id;
+			const initialTaskId = tasks.find( ( task ) => ! task.isCompleted )?.id;
 			setCurrentTaskId( initialTaskId );
 		}
 
@@ -122,7 +122,7 @@ const SiteSetupList = ( {
 		if ( currentTaskId && currentTask && tasks.length ) {
 			const rawCurrentTask = tasks.find( ( task ) => task.id === currentTaskId );
 			if ( rawCurrentTask.isCompleted && ! currentTask.isCompleted ) {
-				const nextTaskId = tasks.find( ( task ) => ! task.isCompleted ).id;
+				const nextTaskId = tasks.find( ( task ) => ! task.isCompleted )?.id;
 				setCurrentTaskId( nextTaskId );
 			}
 		}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -107,15 +107,20 @@ const SiteSetupList = ( {
 	useEffect( () => {
 		// Initial task (first incomplete).
 		if ( ! currentTaskId && tasks.length ) {
-			const initialTaskId = tasks.find( ( task ) => ! task.isCompleted )?.id;
-			setCurrentTaskId( initialTaskId );
+			const initialTask = tasks.find( ( task ) => ! task.isCompleted );
+			if ( ! initialTask ) {
+				// Last task was skipped, refresh home layout
+				dispatch( requestHomeLayout( siteId ) );
+			} else {
+				setCurrentTaskId( initialTask.id );
+			}
 		}
 
 		// Reset verification email state on first load.
 		if ( isEmailUnverified ) {
 			dispatch( resetVerifyEmailState() );
 		}
-	}, [ currentTaskId, dispatch, isEmailUnverified, tasks ] );
+	}, [ currentTaskId, isEmailUnverified, tasks, dispatch, siteId ] );
 
 	// Move to next task after completing current one.
 	useEffect( () => {
@@ -126,7 +131,7 @@ const SiteSetupList = ( {
 				setCurrentTaskId( nextTaskId );
 			}
 		}
-	}, [ currentTask, currentTaskId, tasks ] );
+	}, [ tasks ] );
 
 	// Update current task.
 	useEffect( () => {
@@ -147,14 +152,12 @@ const SiteSetupList = ( {
 		}
 	}, [
 		currentTaskId,
-		dispatch,
 		emailVerificationStatus,
 		isDomainUnverified,
 		isEmailUnverified,
 		menusUrl,
 		siteId,
 		siteSlug,
-		tasks,
 		taskUrls,
 		userEmail,
 	] );

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -30,6 +30,7 @@ import getMenusUrl from 'state/selectors/get-menus-url';
 import { getSiteOption, getSiteSlug } from 'state/sites/selectors';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { requestHomeLayout } from 'state/home/actions';
 import NavItem from './nav-item';
 import { getTask } from './get-task';
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -115,7 +115,7 @@ const SiteSetupList = ( {
 		if ( isEmailUnverified ) {
 			dispatch( resetVerifyEmailState() );
 		}
-	}, [ currentTaskId, isEmailUnverified, tasks ] );
+	}, [ currentTaskId, dispatch, isEmailUnverified, tasks ] );
 
 	// Move to next task after completing current one.
 	useEffect( () => {
@@ -126,7 +126,7 @@ const SiteSetupList = ( {
 				setCurrentTaskId( nextTaskId );
 			}
 		}
-	}, [ tasks ] );
+	}, [ currentTask, currentTaskId, tasks ] );
 
 	// Update current task.
 	useEffect( () => {
@@ -147,12 +147,14 @@ const SiteSetupList = ( {
 		}
 	}, [
 		currentTaskId,
+		dispatch,
 		emailVerificationStatus,
 		isDomainUnverified,
 		isEmailUnverified,
 		menusUrl,
 		siteId,
 		siteSlug,
+		tasks,
 		taskUrls,
 		userEmail,
 	] );


### PR DESCRIPTION
We can see temporary fatals when completing the Home checklist – a refresh will not have the same result though, and will display fine, since it's operating from updated API results (this likely explains not seeing reports of this yet).

<img width="640" alt="Screen Shot 2020-05-06 at 12 00 01 PM" src="https://user-images.githubusercontent.com/349751/81217268-290d7880-8f91-11ea-99c3-2d83ee89c043.png">
<img width="666" alt="Screen Shot 2020-05-06 at 11 21 42 AM" src="https://user-images.githubusercontent.com/349751/81217280-2d399600-8f91-11ea-9bb9-1c167821d459.png">

#### Testing instructions

* On production, skip the menu step as the final step to complete the checklist.
* See the screen fatal on completion of the last item.
* On this branch, do the same with a new site.
* Verify the browser does a reload, and the celebratory banner and new task display properly.
