### PR TITLE
Domains: Update Banner to UpsellNudge

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/non-primary-domain-plan-upsell.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/non-primary-domain-plan-upsell.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { SETTING_PRIMARY_DOMAIN } from 'lib/url/support';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants';
@@ -44,7 +44,7 @@ const NonPrimaryDomainPlanUpsell = ( {
 	}
 
 	return (
-		<Banner
+		<UpsellNudge
 			title={ translate( 'This domain is being forwarded to %(primaryDomain)s', {
 				args: {
 					primaryDomain: selectedSite.slug,
@@ -67,6 +67,7 @@ const NonPrimaryDomainPlanUpsell = ( {
 			tracksImpressionName={ tracksImpressionName }
 			tracksClickName={ tracksClickName }
 			event="calypso_non_primary_domain_plan_upsell"
+			showIcon
 		/>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `UpsellNudge` rather than `Banner` for the non-primary domain upsell nudge. See #38778 

**Visuals**

<img width="754" alt="Screen Shot 2020-05-06 at 4 38 55 PM" src="https://user-images.githubusercontent.com/2124984/81225977-1bb7b480-8fb8-11ea-94d3-52a3766ce2df.png">

#### Testing instructions

* Switch to this PR
* Create a new free site from `/start`, then go to Manage -> Domains -> Add a domain to this site
* When you get to checkout, remove the plan from your cart; you should only be purchasing the domain name. Check out. (Don't forget to cancel right after testing.) Wait for the domain to be fully active.
* Go back to Manage -> Domains and click on the domain name you've purchased. Note the upsell at the top of the screen.
* Double check the Tracks events to make sure they're the same as on master. Also make sure there are no visual regressions.