### PR TITLE
FSE: Manually Curate Block Patterns

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -82,25 +82,50 @@ class Block_Patterns {
 			return $patterns;
 		}
 
-		$pattern = readdir( $directory_handle );
+		// Get all the pattern files.
+		$pattern       = readdir( $directory_handle );
+		$pattern_files = array();
 		while ( false !== $pattern ) {
-			if ( substr( $pattern, -5 ) === '.json' ) {
-				$patterns[] = json_decode(
-					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-					file_get_contents( $patterns_dir . '/' . $pattern ),
-					true
-				);
-			}
-
-			if ( substr( $pattern, -4 ) === '.php' ) {
-				$patterns[] = include_once $patterns_dir . '/' . $pattern;
+			// Only allow files ending in .json or .php.
+			if ( substr( $pattern, -5 ) === '.json' || substr( $pattern, -4 ) === '.php' ) {
+				$pattern_files[] = $patterns_dir . $pattern;
 			}
 
 			$pattern = readdir( $directory_handle );
 		}
 
 		closedir( $directory_handle );
-		sort( $patterns );
+
+		// Patterns to remove / disable.
+		$disabled_patterns = array();
+
+		if ( ! empty( $disabled_patterns ) ) {
+			$pattern_files = array_diff( $pattern_files, $disabled_patterns );
+		}
+
+		// Manually curated list of patterns to go at the top of the list.
+		$featured_patterns = array(
+			$patterns_dir . 'image-and-description.php',
+			$patterns_dir . 'three-columns-and-image.php',
+		);
+
+		// Add the featured patterns to the top of the patterns.
+		$pattern_files = $featured_patterns + array_diff( $pattern_files, $featured_patterns );
+
+		// Get the pattern files contents.
+		foreach ( $pattern_files as $pattern_file ) {
+			if ( substr( $pattern_file, -5 ) === '.json' ) {
+				$patterns[] = json_decode(
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+					file_get_contents( $pattern_file ),
+					true
+				);
+			}
+
+			if ( substr( $pattern_file, -4 ) === '.php' ) {
+				$patterns[] = include_once $pattern_file;
+			}
+		}
 
 		return $patterns;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -96,13 +96,6 @@ class Block_Patterns {
 
 		closedir( $directory_handle );
 
-		// Patterns to remove / disable.
-		$disabled_patterns = array();
-
-		if ( ! empty( $disabled_patterns ) ) {
-			$pattern_files = array_diff( $pattern_files, $disabled_patterns );
-		}
-
 		// Manually curated list of patterns to go at the top of the list.
 		$featured_patterns = array(
 			'masonry-gallery.php',

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -105,8 +105,24 @@ class Block_Patterns {
 
 		// Manually curated list of patterns to go at the top of the list.
 		$featured_patterns = array(
+			'masonry-gallery.php',
+			'description-and-image.php',
+			'two-images-and-quote.php',
 			'image-and-description.php',
+			'three-images-side-by-side.php',
+			'image-and-text.php',
 			'three-columns-and-image.php',
+			'collage-gallery.php',
+			'headline.php',
+			'headline-02.php',
+			'recent-posts.php',
+			'recent-posts-02.php',
+			'two-images-side-by-side.php',
+			'numbers.php',
+			'contact.php',
+			'contact-02.php',
+			'contact-03.php',
+			'food-menu.php',
 		);
 
 		// Add the featured patterns to the top of the patterns.

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -88,7 +88,7 @@ class Block_Patterns {
 		while ( false !== $pattern ) {
 			// Only allow files ending in .json or .php.
 			if ( substr( $pattern, -5 ) === '.json' || substr( $pattern, -4 ) === '.php' ) {
-				$pattern_files[] = $patterns_dir . $pattern;
+				$pattern_files[] = $pattern;
 			}
 
 			$pattern = readdir( $directory_handle );
@@ -105,8 +105,8 @@ class Block_Patterns {
 
 		// Manually curated list of patterns to go at the top of the list.
 		$featured_patterns = array(
-			$patterns_dir . 'image-and-description.php',
-			$patterns_dir . 'three-columns-and-image.php',
+			'image-and-description.php',
+			'three-columns-and-image.php',
 		);
 
 		// Add the featured patterns to the top of the patterns.
@@ -117,13 +117,13 @@ class Block_Patterns {
 			if ( substr( $pattern_file, -5 ) === '.json' ) {
 				$patterns[] = json_decode(
 					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-					file_get_contents( $pattern_file ),
+					file_get_contents( $patterns_dir . $pattern_file ),
 					true
 				);
 			}
 
 			if ( substr( $pattern_file, -4 ) === '.php' ) {
-				$patterns[] = include_once $pattern_file;
+				$patterns[] = include_once $patterns_dir . $pattern_file;
 			}
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
+++ b/apps/full-site-editing/full-site-editing-plugin/block-patterns/class-block-patterns.php
@@ -110,7 +110,7 @@ class Block_Patterns {
 		);
 
 		// Add the featured patterns to the top of the patterns.
-		$pattern_files = $featured_patterns + array_diff( $pattern_files, $featured_patterns );
+		$pattern_files = array_merge( $featured_patterns, array_diff( $pattern_files, $featured_patterns ) );
 
 		// Get the pattern files contents.
 		foreach ( $pattern_files as $pattern_file ) {


### PR DESCRIPTION
Adds ability to place block patterns at the beginning of the order, or remove patterns from showing up.

This code is a bit ugly. Recommendations to make it cleaner are very, very welcome. The pattern here is:
- Put all the .json or .php file paths from the patterns directory in an array
- Have a manually curated array of file paths to appear first in the block patterns
- Have a manually curated array of file paths to remove from the block patterns

Let the rest be sorted by however they happen to appear, rather than sorting by title, etc, since the title isn't shown in the list anyways. 

If grouping by title is helpful since it may give some kind of grouping to the patterns, we could rework it to include that.

#### Testing instructions
Start the FSE dev build:
```
cd apps/full-site-editing
nvm use
yarn && yarn dev --sync
```
- Activate FSE plugin
- Activate Layout Grid plugin
- Go to a Post
- Click the top left Block inserter -> Block Patterns (if on a newer version of Gutenberg)
- See that the patterns from `$featured_patterns` show up first in the block patterns.
- Add a pattern path to `$disabled_patterns`.
- Reload -> See if the pattern is gone.

