### PR TITLE
Support premium content in email subscription and reader

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -119,6 +119,7 @@ function premium_content_current_visitor_can_access( $attributes ) {
 	if ( ! isset( $attributes['selectedPlanId'] ) ) {
 		return false;
 	}
+
 	$paywall  = premium_content_subscription_service();
 	$can_view = $paywall->visitor_can_view_content( array( $attributes['selectedPlanId'] ) );
 

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/premium-content.php
@@ -21,6 +21,7 @@ use A8C\FSE\Earn\PremiumContent\SubscriptionService\{
 	Subscription_Service,
 	Jetpack_Token_Subscription_Service,
 	Unconfigured_Subscription_Service,
+	WPCOM_Offline_Subscription_Service,
 	WPCOM_Token_Subscription_Service
 };
 
@@ -267,6 +268,10 @@ function premium_content_subscription_service() {
 function premium_content_default_service( $service ) {
 	if ( $service !== null ) {
 		return $service;
+	}
+
+	if ( WPCOM_Offline_Subscription_Service::available() ) {
+		return new WPCOM_Offline_Subscription_Service();
 	}
 
 	if ( WPCOM_Token_Subscription_Service::available() ) {

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-token-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-token-subscription-service.php
@@ -152,7 +152,7 @@ abstract class Token_Subscription_Service implements Subscription_Service {
 	 *
 	 * @return bool
 	 */
-	private function validate_subscriptions( $valid_plan_ids, $token_subscriptions ) {
+	protected function validate_subscriptions( $valid_plan_ids, $token_subscriptions ) {
 		// Create a list of product_ids to compare against:
 		$product_ids = array();
 		foreach ( $valid_plan_ids as $plan_id ) {

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-offline-subscription-service.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/class-wpcom-offline-subscription-service.php
@@ -1,0 +1,66 @@
+<?php declare( strict_types = 1 );
+/**
+ * @package A8C\FSE\Earn
+ *
+ * This subscription service is used when a subscriber is offline and a token is not available.
+ * This subscription service will be used when rendering content in email and reader on WPCOM only.
+ * When content is being rendered, the current user and site are set.
+ * This allows us to lookup a users subscriptions and determine if the
+ * offline visitor can view content that has been deemed "Premium content".
+ */
+namespace A8C\FSE\Earn\PremiumContent\SubscriptionService;
+
+// phpcs:ignore ImportDetection.Imports.RequireImports.Symbol
+class WPCOM_Offline_Subscription_Service extends WPCOM_Token_Subscription_Service {
+
+	/**
+	 * @return boolean
+	 */
+	public static function available() {
+		return parent::available() && is_user_logged_in();
+	}
+
+	/**
+	 * Lookup users subscriptions for a site and determine if the user has a valid subscription to match the plan ID
+	 *
+	 * @return bool
+	 */
+	public function visitor_can_view_content( $valid_plan_ids ) {
+		$subscriptions = apply_filters( 'earn_get_user_subscriptions_for_site_id', array(), wp_get_current_user()->ID, $this->get_site_id() );
+		if ( empty( $subscriptions ) ) {
+			return false;
+		}
+		return $this->validate_subscriptions( $valid_plan_ids, $subscriptions );
+	}
+
+	/**
+	 * Return true if any ID/date pairs are valid. Otherwise false.
+	 *
+	 * @param int[]        $valid_plan_ids
+	 * @param array<array> $_subscriptions : ID must exist in the provided <code>$valid_subscriptions</code> parameter.
+	 *                                                             The provided end date needs to be greater than <code>now()</code>.
+	 *
+	 * @return bool
+	 */
+	private function validate_subscriptions( $valid_plan_ids, $_subscriptions ) {
+		// Create a list of product_ids to compare against:
+		$product_ids = array();
+		foreach ( $valid_plan_ids as $plan_id ) {
+			$product_id = (int) get_post_meta( $plan_id, 'jetpack_memberships_product_id', true );
+			if ( isset( $product_id ) ) {
+				$product_ids[] = $product_id;
+			}
+		}
+
+		/**
+		 * @var int $product_id
+		 * @var array $_subscription
+		 */
+		foreach ( $_subscriptions as $_subscription ) {
+			if ( in_array( (int) $_subscription['product_id'], $product_ids, true ) && strtotime( $_subscription['end_date'] ) > time() ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/include.php
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/subscription-service/include.php
@@ -5,5 +5,6 @@ require_once __DIR__ . '/class-subscription-service.php';
 require_once __DIR__ . '/class-token-subscription.php';
 require_once __DIR__ . '/class-token-subscription-service.php';
 require_once __DIR__ . '/class-wpcom-token-subscription-service.php';
+require_once __DIR__ . '/class-wpcom-offline-subscription-service.php';
 require_once __DIR__ . '/class-jetpack-token-subscription-service.php';
 require_once __DIR__ . '/class-unconfigured-subscription-service.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a new subscription service that will be used when rendering post content when the token isn't available, but the user is logged in on WPCOM.

On WPCOM, the user can view post content in 2 places where the token is not available;

    * New post email notification
    * WPCOM Reader.

In both cases, WPCOM sets the current site ID to match where the post is from and the current user ID to match the viewer WPCOM user ID. This allows us to verify if that user has access to premium content on that post.

#### Testing instructions

* Apply D43142-code
* Login to https://bestmemberships.wordpress.com
* Create a post with premium content block
* Open the post incognito and subscribe with an email address you have access to
* Follow the blog and click on the Manage subscriptions (should redirect you to https://wordpress.com/following/manage)
<img width="837" alt="Screenshot 2020-05-06 at 10 07 35" src="https://user-images.githubusercontent.com/5560595/81228582-36a11d80-8fe6-11ea-8f00-038f0c25bbb5.png">

* Make sure Email me new posts is enabled and set to Instantly
* Run the script (24d7c-pb) to send the new post email notification
* Confirm the premium content is displayed
* Go to reader and confirm that premium content is displayed - https://wordpress.com/read/
