### PR TITLE
Premium Content Block: update Icon

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
@@ -69,7 +69,21 @@ const settings = {
 	 * An icon property should be specified to make it easier to identify a block.
 	 * These can be any of WordPress’ Dashicons, or a custom svg element.
 	 */
-	icon: 'lock',
+	icon: (
+		<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path
+				d="M12.7439 14.4271L8.64053 13.165L8.51431 13.8718L8.09208 20.7415C8.06165 21.2365 8.61087 21.5526 9.02363 21.2776L12.7439 18.799L16.7475 21.304C17.1687 21.5676 17.7094 21.2343 17.6631 20.7396L17.0212 13.8718L17.0212 13.165L12.7439 14.4271Z"
+				fill="black"
+			/>
+			<circle cx="12.7439" cy="8.69796" r="5.94466" stroke="black" strokeWidth="1.5" fill="none" />
+			<path
+				d="M9.71023 8.12461L11.9543 10.3687L15.7776 6.54533"
+				stroke="black"
+				strokeWidth="1.5"
+				fill="none"
+			/>
+		</svg>
+	),
 
 	/**
 	 * Optional block extended support features.

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -10,7 +10,6 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Enhances your page creation workflow within the Block Editor.
 
-
 == Description ==
 
 This plugin comes with a custom block to display a list of your most recent blog posts, as well as a template selector


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the Premium Content Block SVG icon.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the code and visually inspect the icon created. (In the block selector, the block menu and the block sidebar)

   ![image](https://user-images.githubusercontent.com/6354169/81235446-bf509700-8faf-11ea-8574-5828a779a723.png)


Fixes #41585 
