### PR TITLE
Include query params in /plans redirect

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -323,10 +323,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 			//see server/pages/index for prod redirect
 			if ( '/plans' === context.pathname ) {
 				const queryFor = context.query && context.query.for;
-				if ( queryFor && 'jetpack' === queryFor ) {
-					window.location =
-						'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans';
-				} else {
+				if ( queryFor && 'jetpack' !== queryFor ) {
 					// pricing page is outside of Calypso, needs a full page load
 					window.location = 'https://wordpress.com/pricing';
 				}

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -325,7 +325,7 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 				const queryFor = context.query && context.query.for;
 				if ( queryFor && 'jetpack' !== queryFor ) {
 					// pricing page is outside of Calypso, needs a full page load
-					window.location = 'https://wordpress.com/pricing';
+					window.location = `https://wordpress.com/pricing/${ context.querystring }`;
 				}
 				return;
 			}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -785,11 +785,7 @@ module.exports = function () {
 		app.get( '/plans', function ( req, res, next ) {
 			if ( ! req.context.isLoggedIn ) {
 				const queryFor = req.query && req.query.for;
-				if ( queryFor && 'jetpack' === queryFor ) {
-					res.redirect(
-						'https://wordpress.com/wp-login.php?redirect_to=https%3A%2F%2Fwordpress.com%2Fplans'
-					);
-				} else {
+				if ( queryFor && 'jetpack' !== queryFor ) {
 					res.redirect( 'https://wordpress.com/pricing' );
 				}
 			} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Update the `/plans` redirect to include query params when redirected to the `/pricing` page.
- Refactor the conditional logic in redirect to remove unneeded login-redirect for `jetpack` query.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


- Make sure you are logged out
- Navigate to http://calypso.localhost:3000/plans?utm_source=test
- You will be redirected to https://wordpress.com/pricing?utm_source=test
- Log in, and navigate to http://calypso.localhost:3000/plans
- The plans page renders
- Nux/Upgrade flows work normally.
