### PR TITLE
Gutenboarding: remove constant domain suggestions vendor

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/suggestion-item.tsx
@@ -14,8 +14,11 @@ type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.Doma
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import { DOMAIN_SUGGESTION_VENDOR, FLOW_ID } from '../../constants';
+import { FLOW_ID } from '../../constants';
 import { RecordTrainTracksEventProps } from '../../lib/analytics';
+import { getSignupDomainsSuggestionsVendor } from '../../utils/domain-suggestions';
+
+const DOMAIN_SUGGESTION_VENDOR = getSignupDomainsSuggestionsVendor();
 
 interface Props {
 	suggestion: DomainSuggestion;

--- a/client/landing/gutenboarding/constants.ts
+++ b/client/landing/gutenboarding/constants.ts
@@ -10,12 +10,6 @@ import { ValuesType } from 'utility-types';
 export const FLOW_ID = 'gutenboarding';
 
 /**
- * An ID that identifies the onboarding flow to analytics and other services.
- *
- */
-export const DOMAIN_SUGGESTION_VENDOR = 'variation4_front';
-
-/**
  * Debounce our input + HTTP dependent select changes
  *
  * Rapidly changing input generates excessive HTTP requests.

--- a/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
+++ b/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
@@ -11,9 +11,12 @@ import { useI18n } from '@automattic/react-i18n';
 import { DOMAIN_SUGGESTIONS_STORE } from '../stores/domain-suggestions';
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { USER_STORE } from '../stores/user';
-import { DOMAIN_SUGGESTION_VENDOR, PAID_DOMAINS_TO_SHOW, selectorDebounce } from '../constants';
+import { PAID_DOMAINS_TO_SHOW, selectorDebounce } from '../constants';
 import { useCurrentStep } from '../path';
 import { domainTldsByCategory } from '../domains-constants';
+import { getSignupDomainsSuggestionsVendor } from '../utils/domain-suggestions';
+
+const DOMAIN_SUGGESTION_VENDOR = getSignupDomainsSuggestionsVendor();
 
 export function useDomainSuggestions( {
 	searchOverride = '',

--- a/client/landing/gutenboarding/stores/domain-suggestions/index.ts
+++ b/client/landing/gutenboarding/stores/domain-suggestions/index.ts
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { DomainSuggestions } from '@automattic/data-stores';
-import { getSuggestionsVendor } from '../../../../lib/domains/suggestions';
+import { getSignupDomainsSuggestionsVendor } from '../../utils/domain-suggestions';
 
 export const DOMAIN_SUGGESTIONS_STORE = DomainSuggestions.register( {
-	vendor: getSuggestionsVendor( true ),
+	vendor: getSignupDomainsSuggestionsVendor(),
 } );

--- a/client/landing/gutenboarding/utils/domain-suggestions.ts
+++ b/client/landing/gutenboarding/utils/domain-suggestions.ts
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { getSuggestionsVendor } from '../../../lib/domains/suggestions';
+
 type DomainSuggestion = import('@automattic/data-stores').DomainSuggestions.DomainSuggestion;
 
 export function getFreeDomainSuggestions( allSuggestions: DomainSuggestion[] | undefined ) {
@@ -27,4 +32,13 @@ export function getRecommendedDomainSuggestion( allSuggestions: DomainSuggestion
 	} );
 
 	return recommendedSuggestion;
+}
+
+/**
+ * Returns an ID for the domain suggestions vendor. Passing `true` to getSuggestionsVendor returns the signup variant.
+ *
+ * @returns {string} an ID for the domain suggestions vendor
+ */
+export function getSignupDomainsSuggestionsVendor() {
+	return getSuggestionsVendor( true );
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Rather than hard coding the vendor id in constants, we'll pull in the existing method from Calypo (`getSuggestionsVendor()`) so the vendor values don't have to be updated in several places.

We are also centralizing fetching the return value of `getSuggestionsVendor()` in `getSignupDomainsSuggestionsVendor()`

## Testing instructions

Swing by `/new` on this branch and search for some domains. Check that:

1. We are sending `variation4_front` as the value of `vendor` to the `/domains/suggestions` API, e.g., https://public-api.wordpress.com/rest/v1.1/domains/suggestions?http_envelope=1&include_wordpressdotcom=true&include_dotblogsubdomain=false&only_wordpressdotcom=false&quantity=5&vendor=variation4_front&locale=en&vertical=p12v2&query=dfsdfsdf
2. We're sending the vendor id in the `fetch_algo` property to `calypso_traintracks_render`, e.g., `fetch_algo: /domains/search/variation4_front/gutenboarding`

Fixes #41894
