### PR TITLE
WIP - try to add link color in editor for themes that do not specify.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.php
@@ -41,21 +41,6 @@ function is_homepage_title_hidden() {
 }
 
 /**
- * Detects if assets for the common module should be loaded.
- *
- * It should return true if any of the features added to the common module need
- * to be loaded. To accomplish this, please create separate functions if you add
- * other small features to this file. The separate function should detect if your
- * individual feature ought to be loaded. Then, "or" (||) that together with the
- * return value here.
- *
- * @return bool True if the common module assets should be loaded.
- */
-function should_load_assets() {
-	return (bool) is_homepage_title_hidden();
-}
-
-/**
  * Adds custom classes to the admin body classes.
  *
  * @param string $classes Classes for the body element.
@@ -74,11 +59,6 @@ add_filter( 'admin_body_class', __NAMESPACE__ . '\admin_body_classes' );
  * Enqueue script and style for the common package.
  */
 function enqueue_script_and_style() {
-	// Avoid loading assets if possible.
-	if ( ! should_load_assets() ) {
-		return;
-	}
-
 	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/common.asset.php';
 	$script_dependencies = $asset_file['dependencies'];
 	wp_enqueue_script(

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.scss
@@ -3,3 +3,7 @@ body.hide-homepage-title {
 		display: none;
 	}
 }
+
+.editor-styles-wrapper a {
+	color: #1c7c7c;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Attempt to create a fallback link color in the editor for themes that do not specify.  (related to #41844)

It was proposed to add some fix in the FSE plugin, but it seems the rule introduced here gets cascaded over by core's inherit rule.  Moreover, I don't think we can add more specificity to this as that would override theme specified styles for this.  Maybe @sirreal has other ideas about how to patch this from FSE? 🤔 

![Screen Shot 2020-05-06 at 7 59 32 PM](https://user-images.githubusercontent.com/28742426/81240598-d30ef400-8fd5-11ea-924b-53f187a9b754.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync this FSE build
* Apply a theme that does not specify link color in the editor (such as penscratch 2)
* add a link in the editor, notice it does not have a different color than normal text.
