### PR TITLE
Checkout: Return to domain status page from empty cart when removing renewal

### DIFF
--- a/client/lib/checkout/index.js
+++ b/client/lib/checkout/index.js
@@ -21,6 +21,8 @@ import {
 	UPGRADE_INTENT_INSTALL_THEME,
 } from 'lib/checkout/constants';
 import { decodeURIComponentIfValid, isExternal } from 'lib/url';
+import { domainManagementEdit } from '../../my-sites/domains/paths';
+import { isDomainRegistration } from '../products-values';
 
 const isValidValue = ( url ) => typeof url === 'string' && url;
 
@@ -73,7 +75,8 @@ export function getExitCheckoutUrl(
 	siteSlug,
 	upgradeIntent,
 	redirectTo,
-	returnToBlockEditor
+	returnToBlockEditor,
+	previousPath
 ) {
 	let url = '/plans/';
 
@@ -82,8 +85,17 @@ export function getExitCheckoutUrl(
 	}
 
 	if ( hasRenewalItem( cart ) ) {
-		const { purchaseId, purchaseDomain } = getRenewalItems( cart )[ 0 ].extra,
+		const firstRenewalItem = getRenewalItems( cart )[ 0 ];
+		const { purchaseId, purchaseDomain } = firstRenewalItem.extra,
 			siteName = siteSlug || purchaseDomain;
+
+		if ( isDomainRegistration( firstRenewalItem ) ) {
+			const domainManagementPage = domainManagementEdit( siteName, firstRenewalItem.meta );
+
+			if ( previousPath && previousPath.startsWith( domainManagementPage ) ) {
+				return domainManagementPage;
+			}
+		}
 
 		return managePurchase( siteName, purchaseId );
 	}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -114,6 +114,7 @@ export class Checkout extends React.Component {
 	state = {
 		previousCart: null,
 		cartSettled: false,
+		isRedirecting: false,
 	};
 
 	// TODO: update this component to not use deprecated life cycle methods
@@ -313,6 +314,10 @@ export class Checkout extends React.Component {
 	}
 
 	redirectIfEmptyCart() {
+		if ( this.state.isRedirecting ) {
+			return true;
+		}
+
 		const { selectedSiteSlug, transaction, returnToBlockEditor } = this.props;
 
 		if ( ! transaction ) {
@@ -355,6 +360,7 @@ export class Checkout extends React.Component {
 			);
 		}
 
+		this.setState( { isRedirecting: true } );
 		page.redirect( redirectTo );
 
 		return true;

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -350,7 +350,8 @@ export class Checkout extends React.Component {
 				selectedSiteSlug,
 				this.props.upgradeIntent,
 				this.props.redirectTo,
-				returnToBlockEditor
+				returnToBlockEditor,
+				this.props.previousRoute
 			);
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When renewing a domain from it's status card, and not from the purchases page, if the user then removes the renewal from the cart, we return the user to the domain's status page/card, instead of the purchase page.

I've deliberately kept the code simple, which means this might not work correctly if there are several items in the cart.

#### Testing instructions

- Select a site on which you have a registered domain
- Go to Manage -> Domains, and select the registered domain to view it's status page/card
- Click the renew button, you will be redirected to the cart
- Remove the renewal from the cart
- Verify that you are redirected to the domain's status card, and not its purchase page

Also verify that when going to /me/purchases, choosing a domain registration, and clicking Renew Now, after removing the item from the cart, you get redirected to the purchase page instead.
