### PR TITLE
Gutenboarding: Add preview to font selection page in mobile view (drop-down variant)

### DIFF
--- a/client/landing/gutenboarding/components/bottom-bar-mobile/index.tsx
+++ b/client/landing/gutenboarding/components/bottom-bar-mobile/index.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import { useI18n } from '@automattic/react-i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import Link from '../link';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	backUrl: string;
+	onContinue: () => void;
+}
+
+const BottomBarMobile: React.FunctionComponent< Props > = ( { backUrl, onContinue } ) => {
+	const { __ } = useI18n();
+	return (
+		<div className="bottom-bar-mobile">
+			<Link className="bottom-bar-mobile__go-back-button" isLink to={ backUrl }>
+				{ __( 'Go back' ) }
+			</Link>
+			<Button
+				className="bottom-bar-mobile__continue-button"
+				isPrimary
+				isLarge
+				onClick={ onContinue }
+			>
+				{ __( 'Continue' ) }
+			</Button>
+		</div>
+	);
+};
+
+export default BottomBarMobile;

--- a/client/landing/gutenboarding/components/bottom-bar-mobile/style.scss
+++ b/client/landing/gutenboarding/components/bottom-bar-mobile/style.scss
@@ -1,0 +1,31 @@
+@import 'assets/stylesheets/gutenberg-base-styles';
+@import '../../variables.scss';
+
+.bottom-bar-mobile {
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	height: $gutenboarding-footer-height;
+	background-color: $white;
+	border-top: 1px solid $light-gray-500;
+	padding: 0 20px;
+	display: flex;
+	align-items: center;
+
+	.bottom-bar-mobile__go-back-button.is-link {
+		color: var( --color-text-subtle );
+	}
+
+	.bottom-bar-mobile__continue-button {
+		margin-left: auto;
+		width: auto;
+		height: auto;
+		padding: 13px 29px;
+	}
+
+	@include break-small {
+		display: none;
+	}
+
+}

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -65,3 +65,9 @@
 		@content;
 	}
 }
+
+@mixin onboarding-break-mobile-tall() {
+	@media ( min-height: 750px ) {
+		@content;
+	}
+}

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -63,6 +63,11 @@ const FontSelect: React.FunctionComponent = () => {
 		return ! isShallowEqual( pair, selectedDesignDefaultFonts );
 	};
 
+	const setFontsAndClose = ( pair?: FontPair ) => {
+		setFonts( pair );
+		setIsOpen( false );
+	};
+
 	return (
 		<>
 			<div className="style-preview__font-options">
@@ -124,12 +129,16 @@ const FontSelect: React.FunctionComponent = () => {
 						} ) }
 					>
 						<Button
-							className={ classnames( 'style-preview__font-option', {
-								'is-selected':
-									selectedFonts?.headings === selectedDesignDefaultFonts?.headings &&
-									selectedFonts?.base === selectedDesignDefaultFonts?.base,
-							} ) }
-							onClick={ () => setFonts( selectedDesignDefaultFonts ) }
+							className={ classnames(
+								'style-preview__font-option',
+								'style-preview__font-option-mobile',
+								{
+									'is-selected-dropdown-option':
+										selectedFonts?.headings === selectedDesignDefaultFonts?.headings &&
+										selectedFonts?.base === selectedDesignDefaultFonts?.base,
+								}
+							) }
+							onClick={ () => setFontsAndClose( selectedDesignDefaultFonts ) }
 						>
 							<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
 						</Button>
@@ -141,10 +150,14 @@ const FontSelect: React.FunctionComponent = () => {
 
 							return (
 								<Button
-									className={ classnames( 'style-preview__font-option', {
-										'is-selected': isSelected,
-									} ) }
-									onClick={ () => setFonts( fontPair ) }
+									className={ classnames(
+										'style-preview__font-option',
+										'style-preview__font-option-mobile',
+										{
+											'is-selected-dropdown-option': isSelected,
+										}
+									) }
+									onClick={ () => setFontsAndClose( fontPair ) }
 									key={ headings + base }
 								>
 									<span className="style-preview__font-option-contents">

--- a/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/font-select.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import * as React from 'react';
-import { Button } from '@wordpress/components';
+import { Button, Dashicon } from '@wordpress/components';
 import classnames from 'classnames';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -21,6 +21,7 @@ const FontSelect: React.FunctionComponent = () => {
 		select( STORE_KEY ).getState()
 	);
 	const { setFonts } = useDispatch( STORE_KEY );
+	const [ isOpen, setIsOpen ] = React.useState( false );
 
 	// TODO: Add font loading for unknown fonts
 	const selectedDesignDefaultFonts = designs.featured.find(
@@ -41,6 +42,20 @@ const FontSelect: React.FunctionComponent = () => {
 		__( 'Default fonts' )
 	);
 
+	const selectedFontOption = selectedFonts ? (
+		<>
+			<span style={ { fontFamily: selectedFonts.headings, fontWeight: 700 } }>
+				{ getFontTitle( selectedFonts.headings ) }
+			</span>
+			&nbsp;/&nbsp;
+			<span style={ { fontFamily: selectedFonts.base } }>
+				{ getFontTitle( selectedFonts.base ) }
+			</span>
+		</>
+	) : (
+		__( 'Select fonts' )
+	);
+
 	const fontPairingsFilter = ( pair: FontPair ): boolean => {
 		if ( ! selectedDesignDefaultFonts ) {
 			return true;
@@ -49,40 +64,103 @@ const FontSelect: React.FunctionComponent = () => {
 	};
 
 	return (
-		<div className="style-preview__font-options">
-			<Button
-				className={ classnames( 'style-preview__font-option', {
-					'is-selected':
-						selectedFonts?.headings === selectedDesignDefaultFonts?.headings &&
-						selectedFonts?.base === selectedDesignDefaultFonts?.base,
-				} ) }
-				onClick={ () => setFonts( selectedDesignDefaultFonts ) }
-			>
-				<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
-			</Button>
-			{ fontPairings.filter( fontPairingsFilter ).map( ( fontPair ) => {
-				// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
-				// (E.g. if `selectedFonts` is coming from persisted state)
-				const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );
-				const { headings, base } = fontPair;
-
-				return (
+		<>
+			<div className="style-preview__font-options">
+				<div className="style-preview__font-options-desktop">
 					<Button
-						className={ classnames( 'style-preview__font-option', { 'is-selected': isSelected } ) }
-						onClick={ () => setFonts( fontPair ) }
-						key={ headings + base }
+						className={ classnames( 'style-preview__font-option', {
+							'is-selected':
+								selectedFonts?.headings === selectedDesignDefaultFonts?.headings &&
+								selectedFonts?.base === selectedDesignDefaultFonts?.base,
+						} ) }
+						onClick={ () => setFonts( selectedDesignDefaultFonts ) }
+					>
+						<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
+					</Button>
+					{ fontPairings.filter( fontPairingsFilter ).map( ( fontPair ) => {
+						// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
+						// (E.g. if `selectedFonts` is coming from persisted state)
+						const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );
+						const { headings, base } = fontPair;
+
+						return (
+							<Button
+								className={ classnames( 'style-preview__font-option', {
+									'is-selected': isSelected,
+								} ) }
+								onClick={ () => setFonts( fontPair ) }
+								key={ headings + base }
+							>
+								<span className="style-preview__font-option-contents">
+									<span style={ { fontFamily: headings, fontWeight: 700 } }>
+										{ getFontTitle( headings ) }
+									</span>
+									&nbsp;/&nbsp;
+									<span style={ { fontFamily: base } }>{ getFontTitle( base ) }</span>
+								</span>
+							</Button>
+						);
+					} ) }
+				</div>
+				<div className="style-preview__font-options-mobile">
+					<Button
+						className={ classnames(
+							'style-preview__font-option',
+							'style-preview__font-option-select',
+							{
+								'is-open': isOpen,
+							}
+						) }
+						onClick={ () => setIsOpen( ! isOpen ) }
 					>
 						<span className="style-preview__font-option-contents">
-							<span style={ { fontFamily: headings, fontWeight: 700 } }>
-								{ getFontTitle( headings ) }
-							</span>
-							&nbsp;/&nbsp;
-							<span style={ { fontFamily: base } }>{ getFontTitle( base ) }</span>
+							{ selectedFontOption }
+							<Dashicon icon="arrow-down-alt2" size={ 16 } />
 						</span>
 					</Button>
-				);
-			} ) }
-		</div>
+					<div
+						className={ classnames( 'style-preview__font-options-mobile-options', {
+							'is-open': isOpen,
+						} ) }
+					>
+						<Button
+							className={ classnames( 'style-preview__font-option', {
+								'is-selected':
+									selectedFonts?.headings === selectedDesignDefaultFonts?.headings &&
+									selectedFonts?.base === selectedDesignDefaultFonts?.base,
+							} ) }
+							onClick={ () => setFonts( selectedDesignDefaultFonts ) }
+						>
+							<span className="style-preview__font-option-contents">{ defaultFontOption }</span>
+						</Button>
+						{ fontPairings.filter( fontPairingsFilter ).map( ( fontPair ) => {
+							// Font pairs are objects, we need `isShallowEqual` as we can't guarantee referential equality
+							// (E.g. if `selectedFonts` is coming from persisted state)
+							const isSelected = !! selectedFonts && isShallowEqual( fontPair, selectedFonts );
+							const { headings, base } = fontPair;
+
+							return (
+								<Button
+									className={ classnames( 'style-preview__font-option', {
+										'is-selected': isSelected,
+									} ) }
+									onClick={ () => setFonts( fontPair ) }
+									key={ headings + base }
+								>
+									<span className="style-preview__font-option-contents">
+										<span style={ { fontFamily: headings, fontWeight: 700 } }>
+											{ getFontTitle( headings ) }
+										</span>
+										&nbsp;/&nbsp;
+										<span style={ { fontFamily: base } }>{ getFontTitle( base ) }</span>
+									</span>
+								</Button>
+							);
+						} ) }
+					</div>
+				</div>
+			</div>
+		</>
 	);
 };
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -21,6 +21,7 @@ import { USER_STORE } from '../../stores/user';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 import SignupForm from '../../components/signup-form';
 import { useTrackStep } from '../../hooks/use-track-step';
+import BottomBarMobile from '../../components/bottom-bar-mobile';
 
 import './style.scss';
 
@@ -63,56 +64,47 @@ const StylePreview: React.FunctionComponent = () => {
 	);
 
 	return (
-		<div className="gutenboarding-page style-preview">
-			<div className="style-preview__header">
-				<div className="style-preview__titles">
-					<Title>{ __( 'Pick a font pairing' ) }</Title>
-					<SubTitle>
-						{ __( 'Customize your design with typography. You can always fine-tune it later.' ) }
-					</SubTitle>
+		<>
+			<div className="gutenboarding-page style-preview">
+				<div className="style-preview__header">
+					<div className="style-preview__titles">
+						<Title>{ __( 'Pick a font pairing' ) }</Title>
+						<SubTitle>
+							{ __( 'Customize your design with typography. You can always fine-tune it later.' ) }
+						</SubTitle>
+					</div>
+					<ViewportSelect selected={ selectedViewport } onSelect={ setSelectedViewport } />
+					<div className="style-preview__actions">
+						<Link isLink to={ makePath( Step.DesignSelection ) }>
+							{ __( 'Choose another design' ) }
+						</Link>
+						{ hasSelectedDesign && (
+							<Button
+								className="style-preview__actions-continue-button"
+								isPrimary
+								isLarge
+								onClick={ () =>
+									currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
+								}
+							>
+								{ __( 'Continue' ) }
+							</Button>
+						) }
+					</div>
 				</div>
-				<ViewportSelect selected={ selectedViewport } onSelect={ setSelectedViewport } />
-				<div className="style-preview__actions">
-					<Link isLink to={ makePath( Step.DesignSelection ) }>
-						{ __( 'Choose another design' ) }
-					</Link>
-					{ hasSelectedDesign && (
-						<Button
-							className="style-preview__actions-continue-button"
-							isPrimary
-							isLarge
-							onClick={ () =>
-								currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
-							}
-						>
-							{ __( 'Continue' ) }
-						</Button>
-					) }
+				<div className="style-preview__content">
+					<FontSelect />
+					<Preview viewport={ selectedViewport } />
 				</div>
+				{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }
 			</div>
-			<div className="style-preview__content">
-				<FontSelect />
-				<Preview viewport={ selectedViewport } />
-				<div className="style-preview__actions-mobile">
-					{ hasSelectedDesign && (
-						<Button
-							className="style-preview__actions-mobile-continue-button"
-							isPrimary
-							isLarge
-							onClick={ () =>
-								currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
-							}
-						>
-							{ __( 'Continue' ) }
-						</Button>
-					) }
-					<Link isLink to={ makePath( Step.DesignSelection ) }>
-						{ __( 'Choose another design' ) }
-					</Link>
-				</div>
-			</div>
-			{ showSignupDialog && <SignupForm onRequestClose={ closeAuthDialog } /> }
-		</div>
+			<BottomBarMobile
+				backUrl={ makePath( Step.DesignSelection ) }
+				onContinue={ () =>
+					currentUser ? handleCreateSite( currentUser.username ) : handleSignup()
+				}
+			/>
+		</>
 	);
 };
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -3,10 +3,14 @@
 @import '../../variables.scss';
 
 .style-preview {
-	// Full height comes from viewport heigh - header - some space for the preview's box-shadow (20px)
-	height: calc( 100vh - #{$gutenboarding-header-height + 20px} );
+	height: auto;
 	display: flex;
 	flex-direction: column;
+
+	@include break-small {
+		// Full height comes from viewport heigh - header - some space for the preview's box-shadow (20px)
+		height: calc( 100vh - #{$gutenboarding-header-height + 20px} );
+	}
 }
 
 .style-preview__header {
@@ -134,8 +138,7 @@
 }
 
 .style-preview__content {
-	height: 100%;
-	padding-bottom: $gutenboarding-footer-height + 8px;
+	padding-bottom: $gutenboarding-footer-height + 28px;
 
 	@include break-small {
 		padding-bottom: 0;
@@ -157,13 +160,14 @@
 		width: 100%;
 		grid-template-areas: 'preview' 'fonts';
 		grid-template-columns: auto;
-		grid-template-rows: auto;
+		grid-template-rows: 240px auto;
 
 		@include break-small {
 			column-gap: 50px;
 			flex: 1;
 			grid-template-areas: 'fonts preview';
 			grid-template-columns: 163px auto;
+			grid-template-rows: auto;
 		}
 
 		@include break-medium {
@@ -236,7 +240,6 @@
 	float: left;
 	width: 100%;
 	max-width: 100%;
-	height: calc( ( 100vw - 20px ) / 1.667 );
 	margin-bottom: 28px;
 	padding-left: 0;
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -135,6 +135,11 @@
 
 .style-preview__content {
 	height: 100%;
+	margin-bottom: $gutenboarding-footer-height + 8px;
+
+	@include break-small {
+		margin-bottom: 0;
+	}
 }
 
 .style-preview__font-options {
@@ -303,13 +308,14 @@
 }
 
 $gutenboarding-style-preview-bar-height: 30px;
+$gutenboarding-style-preview-bar-height-mobile: 15px;
 
 // This and the following dot class render the browser chrome
 .style-preview__preview-bar {
 	position: absolute;
 	top: 0;
 	width: 100%;
-	height: $gutenboarding-style-preview-bar-height / 2;
+	height: $gutenboarding-style-preview-bar-height-mobile;
 	background: var( --studio-white );
 	border-bottom: 1px solid var( --studio-gray-5 );
 	display: flex;
@@ -387,9 +393,15 @@ html:not( .accessible-focus ) .style-preview__viewport-select-button:focus:not( 
 	transform-origin: 0 0;
 
 	.is-viewport-desktop & {
-		top: $gutenboarding-style-preview-bar-height;
+		top: $gutenboarding-style-preview-bar-height-mobile;
 		height: calc(
-			#{100% / $scale-factor} - #{$gutenboarding-style-preview-bar-height / $scale-factor}
+			#{100% / $scale-factor} - #{$gutenboarding-style-preview-bar-height-mobile / $scale-factor}
 		);
+		@include break-small {
+			top: $gutenboarding-style-preview-bar-height;
+			height: calc(
+				#{100% / $scale-factor} - #{$gutenboarding-style-preview-bar-height / $scale-factor}
+			);
+		}
 	}
 }

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -183,9 +183,10 @@
 
 .style-preview__font-options-mobile-options {
 	display: none;
+	border: 1px solid var( --studio-gray-10 );
+	border-top: none;
 
 	&.is-open {
-		margin-top: 8px;
 		display: block;
 	}
 }
@@ -233,8 +234,21 @@
 	// for IE, see https://github.com/Automattic/wp-calypso/pull/40881#issuecomment-610836378
 	vertical-align: top;
 
+	&.style-preview__font-option-mobile {
+		box-shadow: none;
+	}
+
+	&.is-selected-dropdown-option span {
+		font-weight: 600;
+		text-decoration: underline;
+	}
+
 	+ .style-preview__font-option {
 		margin-top: 8px;
+
+		&.style-preview__font-option-mobile {
+			margin-top: 0;
+		}
 
 		@include break-small {
 			margin-top: 1em;
@@ -255,6 +269,10 @@
 		color: var( --studio-gray-90 );
 		height: auto;
 		border-radius: 2px;
+
+		&.is-open {
+			border-radius: 2px 2px 0 0;
+		}
 
 		&:hover,
 		&:focus,

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -148,14 +148,16 @@
 
 @supports ( display: grid ) {
 	.style-preview__content {
-		display: block;
+		display: grid;
 		width: 100%;
+		grid-template-areas: 'preview' 'fonts';
+		grid-template-columns: auto;
+		grid-template-rows: auto;
 
 		@include break-small {
-			display: grid;
-			grid-template-areas: 'fonts preview';
 			column-gap: 50px;
 			flex: 1;
+			grid-template-areas: 'fonts preview';
 			grid-template-columns: 163px auto;
 		}
 
@@ -227,25 +229,25 @@
 
 .style-preview__preview {
 	float: left;
-	height: 100%;
-	display: none;
+	width: 100%;
+	max-width: 100%;
+	height: calc( ( 100vw - 20px ) / 1.667 );
+	margin-bottom: 28px;
+	padding-left: 0;
 
 	@include break-small {
-		display: block;
-	}
-}
+		width: calc( 100% - 163px );
+		height: 100%;
+		margin: 0 auto;
+		padding-left: 100px;
 
-.style-preview__preview {
-	width: calc( 100% - 163px );
-	margin: 0 auto;
-	padding-left: 100px;
+		&.is-viewport-tablet {
+			max-width: 1024px;
+		}
 
-	&.is-viewport-tablet {
-		max-width: 1024px;
-	}
-
-	&.is-viewport-mobile {
-		max-width: 351px;
+		&.is-viewport-mobile {
+			max-width: 351px;
+		}
 	}
 }
 
@@ -267,7 +269,7 @@
 
 .style-preview__preview-wrapper {
 	background: var( --studio-white );
-	box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.1 );
+	box-shadow: 0 0 0 1px var( --studio-gray-5 );
 	border-radius: 4px;
 	overflow: hidden;
 	position: relative;
@@ -294,6 +296,10 @@
 	.is-viewport-mobile & {
 		padding-top: 691 / 351 * 100%;
 	}
+
+	@include break-small {
+		box-shadow: 0 0 0 1px var( --studio-gray-5 ), 0 4px 14px rgba( 0, 0, 0, 0.1 );
+	}
 }
 
 $gutenboarding-style-preview-bar-height: 30px;
@@ -309,15 +315,24 @@ $gutenboarding-style-preview-bar-height: 30px;
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	padding: 10px;
+	padding: 5px;
+
+	@include break-small {
+		padding: 10px;
+	}
 }
 
 .style-preview__preview-bar-dot {
 	background: var( --studio-gray-5 );
-	width: 6px;
-	height: 6px;
+	width: 3px;
+	height: 3px;
 	border-radius: 50%;
 	margin: 0 2px;
+
+	@include break-small {
+		width: 6px;
+		height: 6px;
+	}
 }
 
 .style-preview__viewport-select {

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -135,10 +135,10 @@
 
 .style-preview__content {
 	height: 100%;
-	margin-bottom: $gutenboarding-footer-height + 8px;
+	padding-bottom: $gutenboarding-footer-height + 8px;
 
 	@include break-small {
-		margin-bottom: 0;
+		padding-bottom: 0;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -154,13 +154,53 @@
 	}
 }
 
+.style-preview__font-options-desktop {
+	display: none;
+
+	@include break-small {
+		display: block;
+	}
+}
+
+.style-preview__font-options-mobile {
+	display: block;
+	margin-bottom: 28px;
+
+	.dashicon {
+		margin-left: 0.5em;
+		vertical-align: bottom;
+		transition: transform 100ms ease-in-out;
+	}
+
+	.is-open .dashicon {
+		transform: rotate( 180deg );
+	}
+
+	@include break-small {
+		display: none;
+	}
+}
+
+.style-preview__font-options-mobile-options {
+	display: none;
+
+	&.is-open {
+		margin-top: 8px;
+		display: block;
+	}
+}
+
 @supports ( display: grid ) {
 	.style-preview__content {
 		display: grid;
 		width: 100%;
-		grid-template-areas: 'preview' 'fonts';
+		grid-template-areas: 'fonts' 'preview';
 		grid-template-columns: auto;
-		grid-template-rows: 240px auto;
+		grid-template-rows: auto 240px;
+
+		@include onboarding-break-mobile-tall {
+			grid-template-rows: auto 340px;
+		}
 
 		@include break-small {
 			column-gap: 50px;

--- a/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/style.scss
@@ -309,7 +309,7 @@ $gutenboarding-style-preview-bar-height: 30px;
 	position: absolute;
 	top: 0;
 	width: 100%;
-	height: $gutenboarding-style-preview-bar-height;
+	height: $gutenboarding-style-preview-bar-height / 2;
 	background: var( --studio-white );
 	border-bottom: 1px solid var( --studio-gray-5 );
 	display: flex;
@@ -319,6 +319,7 @@ $gutenboarding-style-preview-bar-height: 30px;
 
 	@include break-small {
 		padding: 10px;
+		height: $gutenboarding-style-preview-bar-height;
 	}
 }
 

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -1,4 +1,5 @@
 // Reusable style variables
+$gutenboarding-footer-height: 64px;
 $gutenboarding-header-height: 64px;
 $gutenboarding-heading-padding-desktop: 64px 0 80px;
 $gutenboarding-heading-padding-mobile: 44px 0 50px;


### PR DESCRIPTION
This PR is a variant on PR #41732 where we added a preview to the mobile view of the Style step in Gutenboarding. In this variant, instead of listing all the buttons below the preview, we list a drop-down button _above_ the preview.

Because we need to display correctly rendered font pairs in the drop-down, I couldn't use the native `select` element or the pre-existing WordPress components for `SelectControl` or `Panel`/`PanelBody`. Instead, I've gone with a simple approach of a button that displays the selected fonts, and when you click it, we display the set of font buttons styled to look more like they're in a drop down list (similar to the domain categories drop down). Selecting a font then closes the drop down.

#### Changes proposed in this Pull Request

* Add preview to style step.
* Add drop-down button on mobile to show/hide the font selection buttons, and style them to look like the drop-down used in domain categories.
* Add fixed footer bottom-bar-mobile component.

##### Screenshot

<!--

Older iteration where we just revealed the existing buttons:

![style-step-preview-mobile-drop-down-small](https://user-images.githubusercontent.com/14988353/81249531-3181b400-9062-11ea-8d90-c4d2e0fdbf9d.gif)
-->
![style-preview-dropdown-try-2-small](https://user-images.githubusercontent.com/14988353/81257891-bf1bce80-9077-11ea-8235-42ac18921e4e.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /new and complete the steps until you get to the Style step.
* Test in a variety of viewport sizes
* Make sure the desktop viewport layout is unaffected by this PR
* Test on a real device, how does it feel to use?

Fixes #40900 
Related to PR #41732 
