### PR TITLE
Editor: Add a check to see if classic editor enabled on Atomic sites 

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -61,7 +61,7 @@ class InlineHelpPopover extends Component {
 		isAtomic: PropTypes.bool,
 		activatePlugin: PropTypes.func,
 		fetchAtomicPlugins: PropTypes.func,
-		sitePlugins: PropTypes.array,
+		classicPlugin: PropTypes.object,
 		showErrorNotice: PropTypes.func,
 	};
 
@@ -84,11 +84,9 @@ class InlineHelpPopover extends Component {
 	}
 
 	componentDidUpdate() {
-		const { sitePlugins } = this.props;
+		const { classicPlugin } = this.props;
 
 		if ( this.state.activatingClassicOnAtomic ) {
-			const classicPlugin = find( sitePlugins, { slug: 'classic-editor' } );
-
 			if ( classicPlugin?.active ) {
 				this.redirectToClassicEditor();
 			}
@@ -236,13 +234,12 @@ class InlineHelpPopover extends Component {
 	};
 
 	checkForClassicEditorOnAtomic() {
-		const { siteId, sitePlugins, showErrorNotice, translate } = this.props;
-		const classicPlugin = find( sitePlugins, { slug: 'classic-editor' } );
+		const { siteId, classicPlugin, showErrorNotice, translate } = this.props;
 
 		if ( ! classicPlugin ) {
 			showErrorNotice(
 				translate(
-					'There was a problem activating the Classic editor on your site. Please contact support.'
+					'There was a problem activating the Classic editor on your site. Please go to the plugins page and activate the Classic Editor plugin there.'
 				)
 			);
 			return;
@@ -258,7 +255,7 @@ class InlineHelpPopover extends Component {
 	}
 
 	switchToClassicEditor = () => {
-		const { siteId, translate, isAtomic, sitePlugins } = this.props;
+		const { translate, isAtomic } = this.props;
 
 		const proceed =
 			typeof window === 'undefined' ||
@@ -266,7 +263,7 @@ class InlineHelpPopover extends Component {
 
 		if ( proceed ) {
 			if ( isAtomic && isEnabled( 'editor/after-deprecation' ) ) {
-				this.checkForClassicEditorOnAtomic( siteId, sitePlugins );
+				this.checkForClassicEditorOnAtomic();
 				return;
 			}
 			this.redirectToClassicEditor();
@@ -370,7 +367,7 @@ function mapStateToProps( state ) {
 		gutenbergUrl,
 		isCheckout: section.name && section.name === 'checkout',
 		isAtomic,
-		sitePlugins,
+		classicPlugin: find( sitePlugins, { slug: 'classic-editor' } ),
 	};
 }
 

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { flowRight as compose, noop } from 'lodash';
+import { flowRight as compose, noop, find } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -42,6 +42,9 @@ import isGutenbergOptInEnabled from 'state/selectors/is-gutenberg-opt-in-enabled
 import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabled';
 import getWpAdminClassicEditorRedirectionUrl from 'state/selectors/get-wp-admin-classic-editor-redirection-url';
 import { isEnabled } from 'config';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import { activatePlugin } from 'state/plugins/installed/actions';
+import { getPlugins } from 'state/plugins/installed/selectors';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -54,6 +57,9 @@ class InlineHelpPopover extends Component {
 		optIn: PropTypes.func,
 		redirect: PropTypes.func,
 		isEligibleForChecklist: PropTypes.bool.isRequired,
+		isAtomic: PropTypes.bool,
+		activatePlugin: PropTypes.func,
+		sitePlugins: PropTypes.array,
 	};
 
 	static defaultProps = {
@@ -205,12 +211,23 @@ class InlineHelpPopover extends Component {
 		);
 	};
 
+	checkForClassicEditorOnAtomic( siteId, sitePlugins ) {
+		const classicPlugin = find( sitePlugins, { slug: 'classic-editor' } );
+		if ( ! classicPlugin.isActive ) {
+			this.props.activatePlugin( siteId, classicPlugin );
+		}
+	}
+
 	switchToClassicEditor = () => {
-		const { siteId, onClose, optOut, classicUrl, translate } = this.props;
+		const { siteId, onClose, optOut, classicUrl, translate, isAtomic, sitePlugins } = this.props;
 		const proceed =
 			typeof window === 'undefined' ||
 			window.confirm( translate( 'Are you sure you wish to leave this page?' ) );
+
 		if ( proceed ) {
+			if ( isAtomic ) {
+				this.checkForClassicEditorOnAtomic( siteId, sitePlugins );
+			}
 			optOut( siteId, classicUrl );
 			onClose();
 		}
@@ -291,6 +308,8 @@ function mapStateToProps( state ) {
 	const postType = getEditedPostValue( state, siteId, postId, 'type' );
 	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
 	const showSwitchEditorButton = currentRoute.match( /^\/(block-editor|post|page)\// );
+	const isAtomic = isAtomicSite( state, siteId );
+	const sitePlugins = getPlugins( state, [ siteId ] );
 
 	return {
 		searchQuery: getSearchQuery( state ),
@@ -303,6 +322,8 @@ function mapStateToProps( state ) {
 		showOptIn: showSwitchEditorButton && optInEnabled && isCalypsoClassic,
 		gutenbergUrl,
 		isCheckout: section.name && section.name === 'checkout',
+		isAtomic,
+		sitePlugins,
 	};
 }
 
@@ -312,6 +333,7 @@ const mapDispatchToProps = {
 	recordTracksEvent,
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,
+	activatePlugin,
 };
 
 export default compose(

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -45,6 +45,7 @@ import { isEnabled } from 'config';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import { activatePlugin, fetchPlugins } from 'state/plugins/installed/actions';
 import { getPlugins } from 'state/plugins/installed/selectors';
+import { errorNotice } from 'state/notices/actions';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -61,6 +62,7 @@ class InlineHelpPopover extends Component {
 		activatePlugin: PropTypes.func,
 		fetchAtomicPlugins: PropTypes.func,
 		sitePlugins: PropTypes.array,
+		showErrorNotice: PropTypes.func,
 	};
 
 	static defaultProps = {
@@ -234,11 +236,15 @@ class InlineHelpPopover extends Component {
 	};
 
 	checkForClassicEditorOnAtomic() {
-		const { siteId, sitePlugins } = this.props;
+		const { siteId, sitePlugins, showErrorNotice, translate } = this.props;
 		const classicPlugin = find( sitePlugins, { slug: 'classic-editor' } );
 
 		if ( ! classicPlugin ) {
-			//TODO: In theory we should never get here but should add some sort of error message just in case.
+			showErrorNotice(
+				translate(
+					'There was a problem activating the Classic editor on your site. Please contact support.'
+				)
+			);
 			return;
 		}
 
@@ -376,6 +382,7 @@ const mapDispatchToProps = {
 	resetContactForm: resetInlineHelpContactForm,
 	activatePlugin,
 	fetchAtomicPlugins: fetchPlugins,
+	showErrorNotice: errorNotice,
 };
 
 export default compose(

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -43,7 +43,7 @@ import isGutenbergOptOutEnabled from 'state/selectors/is-gutenberg-opt-out-enabl
 import getWpAdminClassicEditorRedirectionUrl from 'state/selectors/get-wp-admin-classic-editor-redirection-url';
 import { isEnabled } from 'config';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
-import { activatePlugin } from 'state/plugins/installed/actions';
+import { activatePlugin, fetchPlugins } from 'state/plugins/installed/actions';
 import { getPlugins } from 'state/plugins/installed/selectors';
 
 class InlineHelpPopover extends Component {
@@ -59,6 +59,7 @@ class InlineHelpPopover extends Component {
 		isEligibleForChecklist: PropTypes.bool.isRequired,
 		isAtomic: PropTypes.bool,
 		activatePlugin: PropTypes.func,
+		fetchAtomicPlugins: PropTypes.func,
 		sitePlugins: PropTypes.array,
 	};
 
@@ -70,6 +71,14 @@ class InlineHelpPopover extends Component {
 		showSecondaryView: false,
 		activeSecondaryView: '',
 	};
+
+	componentDidMount() {
+		const { siteId, isAtomic, fetchAtomicPlugins } = this.props;
+
+		if ( isAtomic ) {
+			fetchAtomicPlugins( [ siteId ] );
+		}
+	}
 
 	openResultView = ( event ) => {
 		event.preventDefault();
@@ -213,13 +222,16 @@ class InlineHelpPopover extends Component {
 
 	checkForClassicEditorOnAtomic( siteId, sitePlugins ) {
 		const classicPlugin = find( sitePlugins, { slug: 'classic-editor' } );
-		if ( ! classicPlugin.isActive ) {
+
+		if ( classicPlugin && ! classicPlugin.isActive ) {
 			this.props.activatePlugin( siteId, classicPlugin );
 		}
+		// TODO: need some error handling here if classic plugin not found
 	}
 
 	switchToClassicEditor = () => {
 		const { siteId, onClose, optOut, classicUrl, translate, isAtomic, sitePlugins } = this.props;
+
 		const proceed =
 			typeof window === 'undefined' ||
 			window.confirm( translate( 'Are you sure you wish to leave this page?' ) );
@@ -334,6 +346,7 @@ const mapDispatchToProps = {
 	selectResult,
 	resetContactForm: resetInlineHelpContactForm,
 	activatePlugin,
+	fetchAtomicPlugins: fetchPlugins,
 };
 
 export default compose(

--- a/config/development.json
+++ b/config/development.json
@@ -59,7 +59,7 @@
 		"domains/new-status-design/auto-renew": true,
 		"domains/new-status-design/new-options": true,
 		"domains/new-status-design/security-option": true,
-		"editor/after-deprecation": false,
+		"editor/after-deprecation": true,
 		"editor/before-deprecation": true,
 		"external-media": true,
 		"external-media/google-photos": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If an Atomic user chooses to switch to Classic after the Calypso editor is deprecated, add a check to see if classic editor enabled on the users Atomic site, if not enable it, and then redirect to the editor in wp-admin

#### Testing instructions

* Check out PR to local Calypso dev enviroment.
* Open an Atomic sites plugin page and check that the Classic editor is not currently active
* In Calypso open the block editor for that Atomic site. Under the floating Help button bottom right click on the 'Switch to Classic Editor' button. 
* Check that you are redirected to the Classic Editor in wp-admin
* Go back to Calypso and check that when you choose to edit a page the editor preference has been changed so that you go into the classic editor and not the block editor (at this stage you will still go to the Calypso classic editor, once this is deprecated you will go to classic editor in wp-admin)

![atomic](https://user-images.githubusercontent.com/3629020/81360792-d79bef80-9130-11ea-99d7-2d7d76b7e213.gif)

**N.B.** in order to switch back to block editor in Calypso to retest you first need to deactivate the classic editor in wp-admin plugins.

Fixes #41091
