### PR TITLE
Media: Show an appropriate error when Pexels is unavailable.

### DIFF
--- a/client/lib/media/constants.js
+++ b/client/lib/media/constants.js
@@ -13,6 +13,7 @@ export const ValidationErrors = {
 	EXCEEDS_PLAN_STORAGE_LIMIT: 'EXCEEDS_PLAN_STORAGE_LIMIT',
 	NOT_ENOUGH_SPACE: 'NOT_ENOUGH_SPACE',
 	SERVICE_FAILED: 'SERVICE_FAILED',
+	SERVICE_UNAVAILABLE: 'SERVICE_UNAVAILABLE',
 	SERVICE_AUTH_FAILED: 'SERVICE_AUTH_FAILED',
 };
 
@@ -60,7 +61,7 @@ export const GalleryDefaultAttrs = {
  * Adapted from WordPress
  *
  * @copyright 2015 by the WordPress contributors.
- * @license See CREDITS.md.
+ * See CREDITS.md file in root directory for full license.
  * @see https://github.com/WordPress/WordPress/blob/4.2.4/wp-includes/functions.php#L2156-L2277
  */
 export const MimeTypes = {

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -197,6 +197,12 @@ export class MediaLibraryContent extends React.Component {
 					message = translate( 'We are unable to retrieve your full media library.' );
 					tryAgain = true;
 					break;
+
+				case MediaValidationErrors.SERVICE_UNAVAILABLE:
+					message = this.getServiceUnavailableMessageForSource();
+					tryAgain = true;
+					break;
+
 				default:
 					message = translate(
 						'%d file could not be uploaded because an error occurred while uploading.',
@@ -226,6 +232,20 @@ export class MediaLibraryContent extends React.Component {
 
 		// Generic message. Nothing should use this, but just in case.
 		return translate( 'Your service has been disconnected. Please reconnect to continue.' );
+	}
+
+	getServiceUnavailableMessageForSource() {
+		const { translate, source } = this.props;
+
+		if ( source === 'pexels' ) {
+			return translate(
+				'We were unable to connect to the Pexels service. Please try again later.'
+			);
+		}
+
+		return translate(
+			'We were unable to connect to the external service. Please try again later.'
+		);
 	}
 
 	renderTryAgain() {

--- a/client/state/media/reducer.js
+++ b/client/state/media/reducer.js
@@ -96,6 +96,8 @@ export const errors = ( state = {}, action ) => {
 						return MediaValidationErrors.SERVICE_AUTH_FAILED;
 					case 'servicefail':
 						return MediaValidationErrors.SERVICE_FAILED;
+					case 'service_unavailable':
+						return MediaValidationErrors.SERVICE_UNAVAILABLE;
 					default:
 						return MediaValidationErrors.SERVER_ERROR;
 				}

--- a/client/state/media/test/reducer.js
+++ b/client/state/media/test/reducer.js
@@ -156,6 +156,17 @@ describe( 'reducer', () => {
 			} );
 		} );
 
+		test( 'should return a service unavailable error when service was unavailable during an external media request', () => {
+			const error = { error: 'service-unavailable' };
+			const state = errors( {}, failMediaRequest( siteId, {}, error ) );
+
+			expect( state ).to.eql( {
+				[ siteId ]: {
+					0: [ MediaValidationErrors.SERVICE_UNAVAILABLE ],
+				},
+			} );
+		} );
+
 		test( 'should return a generic server error for any other error during external media request', () => {
 			const error = { error: 'something' };
 			const state = errors( {}, failMediaRequest( siteId, {}, error ) );

--- a/client/state/media/test/reducer.js
+++ b/client/state/media/test/reducer.js
@@ -157,7 +157,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should return a service unavailable error when service was unavailable during an external media request', () => {
-			const error = { error: 'service-unavailable' };
+			const error = { error: 'service_unavailable' };
 			const state = errors( {}, failMediaRequest( siteId, {}, error ) );
 
 			expect( state ).to.eql( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the Pexels external service returns an error response, this PR will show an appropriate error message to the end user.

<img width="979" alt="" src="https://user-images.githubusercontent.com/352291/81257759-72d08e80-9077-11ea-8092-3cefe3fe923f.png">

#### Testing instructions

* See D43080-code for testing instructions.
