### PR TITLE
Deduplicate uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,6 +354,7 @@
 		"webpack-node-externals": "^1.7.2",
 		"whybundled": "^1.4.2",
 		"wp-calypso": "^0.17.0",
+		"wp-e2e-tests": "^0.0.1",
 		"wpcom": "^6.0.0",
 		"wpcom-proxy-request": "^6.0.0",
 		"yargs": "^13.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24464,7 +24464,7 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
-uglify-js@3.4.x, uglify-js@^3.1.4:
+uglify-js@3.4.x:
   version "3.4.10"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.10.tgz#9ad9563d8eb3acdfb8d38597d2af1d815f6a755f"
   integrity sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==
@@ -24472,7 +24472,7 @@ uglify-js@3.4.x, uglify-js@^3.1.4:
     commander "~2.19.0"
     source-map "~0.6.1"
 
-uglify-js@^3.6.1:
+uglify-js@^3.1.4, uglify-js@^3.6.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.2.tgz#012b74fb6a2e440d9ba1f79110a479d3b1f2d48d"
   integrity sha512-zGVwKslUAD/EeqOrD1nQaBmXIHl1Vw371we8cvS8I6mYK9rmgX5tv8AAeJdfsQ3Kk5mGax2SVV/AizxdNGhl7Q==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `uglify-js` (done automatically with `npx yarn-deduplicate --packages uglify-js`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
2964123,2964125c2964123,2964124
< wp-calypso-monorepo@0.17.0 lerna@3.20.2 @lerna/publish@3.20.2 @lerna/version@3.20.2 @lerna/conventional-commits@3.18.5 conventional-changelog-core@3.2.3 conventional-changelog-writer@4.0.11 handlebars@4.7.3 uglify-js@3.4.10
---
> wp-calypso-monorepo@0.17.0 lerna@3.20.2 @lerna/publish@3.20.2 @lerna/version@3.20.2 @lerna/conventional-commits@3.18.5 conventional-changelog-core@3.2.3 conventional-changelog-writer@4.0.11 handlebars@4.7.3 uglify-js@3.9.2
2969506,2969508c2969505,2969506
< wp-calypso-monorepo@0.17.0 lerna@3.20.2 @lerna/version@3.20.2 @lerna/conventional-commits@3.18.5 conventional-changelog-core@3.2.3 conventional-changelog-writer@4.0.11 handlebars@4.7.3 uglify-js@3.4.10
---
> wp-calypso-monorepo@0.17.0 lerna@3.20.2 @lerna/version@3.20.2 @lerna/conventional-commits@3.18.5 conventional-changelog-core@3.2.3 conventional-changelog-writer@4.0.11 handlebars@4.7.3 uglify-js@3.9.2
3083966c3083964
< Done in 26.36s.
---
> Done in 24.71s.
```