### PR TITLE
Links e2e tests to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,6 +354,7 @@
 		"webpack-node-externals": "^1.7.2",
 		"whybundled": "^1.4.2",
 		"wp-calypso": "^0.17.0",
+		"wp-e2e-tests": "^0.0.1",
 		"wpcom": "^6.0.0",
 		"wpcom-proxy-request": "^6.0.0",
 		"yargs": "^13.3.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Links `test/e2e` package into root package.json. This is only required so package.json traversal tools (like `effective-module-tree`) can find `test/e2e`.


#### Testing instructions

N/A