### PR TITLE
Deduplicate source-map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,6 +354,7 @@
 		"webpack-node-externals": "^1.7.2",
 		"whybundled": "^1.4.2",
 		"wp-calypso": "^0.17.0",
+		"wp-e2e-tests": "^0.0.1",
 		"wpcom": "^6.0.0",
 		"wpcom-proxy-request": "^6.0.0",
 		"yargs": "^13.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -22704,15 +22704,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@~0.5.12:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
-  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map-support@^0.5.9:
+source-map-support@^0.5.16, source-map-support@^0.5.6, source-map-support@^0.5.9, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `source-map-support` (done automatically with `npx yarn-deduplicate --packages source-map-support`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> @babel/register@7.9.0 -> ... -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> terser@4.6.11 -> ... -> source-map-support@0.5.16
< wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> source-map-support@0.5.16
---
> wp-calypso-monorepo@0.17.0 -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> @babel/register@7.9.0 -> ... -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> terser@4.6.11 -> ... -> source-map-support@0.5.19
> wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> source-map-support@0.5.19
```