### PR TITLE
Deduplicate regjsparser

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7383,7 +7383,7 @@ caniuse-api@3.0.0, caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001041:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001012, caniuse-lite@^1.0.30001041:
   version "1.0.30001041"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001041.tgz#c2ea138dafc6fe03877921ddcddd4a02a14daf76"
   integrity sha512-fqDtRCApddNrQuBxBS7kEiSGdBsgO4wiVw4G/IClfqzfhW45MbTumfN4cuUJGTM0YGFNn97DCXPJ683PS6zwvA==
@@ -9998,7 +9998,7 @@ ejs@^2.6.1, ejs@^2.7.4:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.390:
+electron-to-chromium@^1.3.247:
   version "1.3.403"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz#c8bab4e2e72bf78bc28bad1cc355c061f9cc1918"
   integrity sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `regjsparser` (done automatically with `npx yarn-deduplicate --packages regjsparser`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> regjsparser@0.6.3
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> regjsparser@0.6.3
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> regjsparser@0.6.3
< wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> regjsparser@0.6.3
< wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> regjsparser@0.6.3
< wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> regjsparser@0.6.3
---
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> regjsparser@0.6.4
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> regjsparser@0.6.4
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> regjsparser@0.6.4
> wp-calypso-monorepo@0.17.0 -> calypso-codemods@0.1.6 -> ... -> regjsparser@0.6.4
> wp-calypso-monorepo@0.17.0 -> wp-calypso@0.17.0 -> ... -> regjsparser@0.6.4
> wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> regjsparser@0.6.4
```