### PR TITLE
Editor: Pass editor/after-deprecation feature flag to iframed editor

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -679,6 +679,11 @@ const mapStateToProps = (
 		queryArgs = wpcom.addSupportParams( queryArgs );
 	}
 
+	// Needed to pass through feature flag to iframed editor.
+	if ( window.location.href.indexOf( 'editor/after-deprecation' ) > -1 ) {
+		queryArgs[ 'editor-after-deprecation' ] = 1;
+	}
+
 	const siteAdminUrl =
 		editorType === 'site'
 			? getSiteAdminUrl( state, siteId, 'admin.php?page=gutenberg-edit-site' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `editor-after-deprecation` feature flag to the editor's iframe url to allow for query string param check.

#### Testing instructions

To check just the iframe URL change:
1. Visit http://calypso.localhost:3000
2. Edit a post
3. Open dev tools and inspect the editor's iframe
4. Confirm that there is no `editor-after-deprecation` query param in the iframe's URL
5. Add `?editor/after-deprecation` to the current URL and reload the page
6. Re-inspect the editor's iframe and confirm `editor-after-deprecation` query param present


While testing this you might want to test the WPCOM change D42788-code
1. Apply diff D42788 to your sandbox
2. Visit http://calypso.localhost:3000
3. Switch site to your sandbox
4. Edit a post and switch to block editor if needed
5. Open more tools menu from top right and confirm "Switch To Classic Editor" URL format is:
    `calypso.localhost:3000/post/<site>/<id>?set-editor=classic `
6. Add `?editor/after-deprecation` to the current URL and reload the page
7. Re-open more tools menu and confirm "Switch To Classic Editor" URL goes to WP Admin

pb5gDS-wm-p2
