### PR TITLE
Deduplicate punycode

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,6 +354,7 @@
 		"webpack-node-externals": "^1.7.2",
 		"whybundled": "^1.4.2",
 		"wp-calypso": "^0.17.0",
+		"wp-e2e-tests": "^0.0.1",
 		"wpcom": "^6.0.0",
 		"wpcom-proxy-request": "^6.0.0",
 		"yargs": "^13.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20048,12 +20048,12 @@ pumpify@^1.3.3:
     inherits "^2.0.3"
     pump "^2.0.0"
 
-punycode@1.3.2, punycode@^1.2.4:
+punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
-punycode@^1.3.2:
+punycode@^1.2.4, punycode@^1.3.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `punycode` (done automatically with `npx yarn-deduplicate --packages punycode`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> punycode@1.3.2
< wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> punycode@1.3.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> punycode@1.3.2
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> punycode@1.3.2
< wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> punycode@1.3.2
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> punycode@1.4.1
> wp-calypso-monorepo@0.17.0 -> @storybook/react@5.3.18 -> ... -> punycode@1.4.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/dependency-extraction-webpack-plugin@2.4.0 -> ... -> punycode@1.4.1
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> punycode@1.4.1
> wp-calypso-monorepo@0.17.0 -> webpack@4.42.0 -> ... -> punycode@1.4.1
```