### PR TITLE
Deduplicate psl

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,6 +354,7 @@
 		"webpack-node-externals": "^1.7.2",
 		"whybundled": "^1.4.2",
 		"wp-calypso": "^0.17.0",
+		"wp-e2e-tests": "^0.0.1",
 		"wpcom": "^6.0.0",
 		"wpcom-proxy-request": "^6.0.0",
 		"yargs": "^13.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19984,12 +19984,7 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.28:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.7.0.tgz#f1c4c47a8ef97167dea5d6bbf4816d736e884a3c"
-  integrity sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==
-
-psl@^1.1.33:
+psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Deduplicate `psl` (done automatically with `npx yarn-deduplicate --packages psl`)

#### Testing instructions

* Verify tests still pass

For reference, these are the top-level dependencies affected by this change

```diff
< Before
> After
---
< wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> psl@1.7.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> psl@1.7.0
< wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> psl@1.7.0
< wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> psl@1.7.0
< wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> psl@1.7.0
< wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> psl@1.7.0
< wp-calypso-monorepo@0.17.0 -> node-sass@4.13.0 -> ... -> psl@1.7.0
< wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> psl@1.7.0
> wp-calypso-monorepo@0.17.0 -> @automattic/calypso-build@6.1.0 -> ... -> psl@1.8.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/jest-preset-default@5.5.0 -> ... -> psl@1.8.0
> wp-calypso-monorepo@0.17.0 -> @wordpress/scripts@7.2.0 -> ... -> psl@1.8.0
> wp-calypso-monorepo@0.17.0 -> jest-enzyme@7.1.2 -> ... -> psl@1.8.0
> wp-calypso-monorepo@0.17.0 -> jest@25.1.0 -> ... -> psl@1.8.0
> wp-calypso-monorepo@0.17.0 -> lerna@3.20.2 -> ... -> psl@1.8.0
> wp-calypso-monorepo@0.17.0 -> node-sass@4.13.0 -> ... -> psl@1.8.0
> wp-calypso-monorepo@0.17.0 -> wp-e2e-tests@0.0.1 -> ... -> psl@1.8.0
```