### PR TITLE
Gutenboarding: use email-inputmode in signup

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -133,6 +133,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 							value={ emailVal }
 							disabled={ isFetchingNewUser }
 							type="email"
+							inputmode="email"
 							onChange={ setEmailVal }
 							placeholder={ __( 'Email address' ) }
 							required


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* use email-inputmode in signup

Should render emails specific keyboards on mobile:

<img width="837" alt="image" src="https://user-images.githubusercontent.com/87168/81275144-ec598400-9059-11ea-87ea-82b06bb54c57.png">

Apparently `type="email"` wasn't enough at least on latest Android+Chrome.

See https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/

#### Testing instructions
- Go to signup form using native phone (use live-links to test)
- Tap on email field
- Observe the keyboard
