### PR TITLE
Gutenboarding: improve mobile keyboard handling for domain search

### DIFF
--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -274,7 +274,9 @@ const DomainPicker: FunctionComponent< Props > = ( {
 			{ header && header }
 			{ showSearchField && (
 				<div className="domain-picker__search">
-					{ /* Form is to allow hiding keyboard on "submit" */ }
+					{ /* <form/> is being used here for mobile enhancements.
+					'onSubmit' callback is used to hide on-screen keyboard on mobile.
+					'action' property is needed to show "search" button instead of "return" on iOS keyboard */ }
 					<form action="" onSubmit={ handleSubmit }>
 						<div className="domain-picker__search-icon">
 							<Icon icon={ search } />

--- a/packages/domain-picker/src/domain-picker/index.tsx
+++ b/packages/domain-picker/src/domain-picker/index.tsx
@@ -236,6 +236,13 @@ const DomainPicker: FunctionComponent< Props > = ( {
 		onSetDomainSearch( searchQuery );
 	};
 
+	// Force blur to close keyboard when submitting the form using Search button on mobile
+	const inputRef = React.useRef< HTMLInputElement | null >();
+	const handleSubmit = ( event: React.FormEvent ) => {
+		event.preventDefault();
+		inputRef?.current?.blur();
+	};
+
 	const showErrorMessage = domainSuggestionState === DataStatus.Failure;
 	const isDomainSearchEmpty = domainSearch.trim?.().length <= 1;
 	const showDomainSuggestionsResults = ! showErrorMessage && ! isDomainSearchEmpty;
@@ -267,18 +274,25 @@ const DomainPicker: FunctionComponent< Props > = ( {
 			{ header && header }
 			{ showSearchField && (
 				<div className="domain-picker__search">
-					<div className="domain-picker__search-icon">
-						<Icon icon={ search } />
-					</div>
-					<TextControl
-						hideLabelFromVision
-						label={ label }
-						placeholder={ label }
-						onChange={ handleInputChange }
-						onBlur={ onDomainSearchBlurValue }
-						value={ domainSearch }
-						dir="ltr"
-					/>
+					{ /* Form is to allow hiding keyboard on "submit" */ }
+					<form action="" onSubmit={ handleSubmit }>
+						<div className="domain-picker__search-icon">
+							<Icon icon={ search } />
+						</div>
+						<TextControl
+							ref={ ( ref ) => {
+								inputRef.current = ref;
+							} }
+							hideLabelFromVision
+							name="search"
+							label={ label }
+							placeholder={ label }
+							onChange={ handleInputChange }
+							onBlur={ onDomainSearchBlurValue }
+							value={ domainSearch }
+							dir="ltr"
+						/>
+					</form>
 				</div>
 			) }
 			{ showErrorMessage && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- On mobile, hide keyboard on pressing "search" by blurring the input field on submit. 
- On iOS, use "search" button label instead of "return" label

#### Testing instructions
- Go to Gutenboarding, use `calypso.live` link
- Open domains modal on native mobile browser and check all the above

*If using keyboard navigation on desktop, tabbing should continue to work for selecting the first suggestion after you press Enter and loading is complete.

#### Screenshots
<img width="251" alt="Screenshot 2021-02-26 at 18 48 55" src="https://user-images.githubusercontent.com/14192054/109329531-5c442f80-7863-11eb-8e6e-3ea0a0d9fb75.png">