### PR TITLE
Modularise purchases state

### DIFF
--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -18,8 +18,10 @@ import {
 	PURCHASE_REMOVE_FAILED,
 } from 'state/action-types';
 import { requestHappychatEligibility } from 'state/happychat/user/actions';
-
 import wp from 'lib/wp';
+
+import 'state/purchases/init';
+
 const wpcom = wp.undocumented();
 
 const PURCHASES_FETCH_ERROR_MESSAGE = i18n.translate( 'There was an error retrieving purchases.' );

--- a/client/state/purchases/init.js
+++ b/client/state/purchases/init.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { registerReducer } from 'state/redux-store';
+import purchasesReducer from './reducer';
+
+registerReducer( [ 'purchases' ], purchasesReducer );

--- a/client/state/purchases/package.json
+++ b/client/state/purchases/package.json
@@ -1,0 +1,5 @@
+{
+	"sideEffects": [
+		"./init.js"
+	]
+}

--- a/client/state/purchases/reducer.js
+++ b/client/state/purchases/reducer.js
@@ -6,7 +6,7 @@ import { find, matches } from 'lodash';
 /**
  * Internal Dependencies
  */
-import { withoutPersistence } from 'state/utils';
+import { withoutPersistence, withStorageKey } from 'state/utils';
 import {
 	PURCHASES_REMOVE,
 	PURCHASES_SITE_FETCH,
@@ -87,7 +87,7 @@ function updatePurchases( existingPurchases, action ) {
 
 const assignError = ( state, action ) => ( { ...state, error: action.error } );
 
-export default withoutPersistence( ( state = initialState, action ) => {
+const reducer = withoutPersistence( ( state = initialState, action ) => {
 	switch ( action.type ) {
 		case PURCHASES_REMOVE:
 			return {
@@ -136,3 +136,6 @@ export default withoutPersistence( ( state = initialState, action ) => {
 
 	return state;
 } );
+
+const purchasesReducer = withStorageKey( 'purchases', reducer );
+export default purchasesReducer;

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -18,6 +18,9 @@ import {
 import { getPlan, findPlansKeys } from 'lib/plans';
 import { TYPE_PERSONAL } from 'lib/plans/constants';
 import { getPlanRawPrice } from 'state/plans/selectors';
+
+import 'state/purchases/init';
+
 /**
  * Return the list of purchases from state object
  *

--- a/client/state/reducer.js
+++ b/client/state/reducer.js
@@ -78,7 +78,6 @@ import postFormats from './post-formats/reducer';
 import postTypes from './post-types/reducer';
 import preferences from './preferences/reducer';
 import productsList from './products-list/reducer';
-import purchases from './purchases/reducer';
 import pushNotifications from './push-notifications/reducer';
 import receipts from './receipts/reducer';
 import rewind from './rewind/reducer';
@@ -165,7 +164,6 @@ const reducers = {
 	postTypes,
 	preferences,
 	productsList,
-	purchases,
 	pushNotifications,
 	receipts,
 	rewind,

--- a/client/state/selectors/get-user-purchased-premium-themes.js
+++ b/client/state/selectors/get-user-purchased-premium-themes.js
@@ -3,6 +3,8 @@
  */
 import { getUserPurchases } from 'state/purchases/selectors';
 
+import 'state/purchases/init';
+
 /**
  * Return the details of any premium themes the user has purchased
  *

--- a/client/state/selectors/has-cancelable-site-purchases.js
+++ b/client/state/selectors/has-cancelable-site-purchases.js
@@ -3,6 +3,8 @@
  */
 import { getSitePurchases } from 'state/purchases/selectors';
 
+import 'state/purchases/init';
+
 /**
  * Does the site have any current purchases that can be canceled (i.e. purchases other than premium themes)?
  *

--- a/client/state/selectors/has-cancelable-user-purchases.js
+++ b/client/state/selectors/has-cancelable-user-purchases.js
@@ -3,6 +3,8 @@
  */
 import { getUserPurchases } from 'state/purchases/selectors';
 
+import 'state/purchases/init';
+
 /**
  * Does the user have any current purchases that can be canceled (i.e. purchases other than premium themes)?
  *


### PR DESCRIPTION
This PR is one of many working on modularising state in Calypso. This one handles purchases.

For mode details on state modularisation, see the [modularised state documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/modularized-state.md) and p4TIVU-9lM-p2.

#### Changes proposed in this Pull Request

* Modularise purchases state

#### Testing instructions

* Install [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en).
* Open DevTools and switch to the Redux tab.
* Open `/read` on the live branch or your local copy of this branch.
* Click `State` on the top right to ensure you see all state, and not just the diff for the last action: 
![image](https://user-images.githubusercontent.com/409615/73774406-d3e87d80-477b-11ea-9f59-3e42cc00101f.png)
* Analyse the tree and note that there's no `purchases` key, even if you expand the list of keys. This indicates that the purchases state hasn't been loaded yet.
* Click `My Sites` on the masterbar, to open `/home`.
* Verify that a `purchases` key is added with the purchases state. This indicates that the purchases state has now been loaded.
* Verify that purchases-related functionality works normally. This indicates that I didn't mess up.