### PR TITLE
Jetpack Cloud: Hide action link from ActivityCard when activity is not rewindable

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -205,7 +205,7 @@ class ActivityCard extends Component {
 	renderBottomToolbar = () => this.renderToolbar( false );
 
 	renderToolbar( isTopToolbar = true ) {
-		const { showActions } = this.props;
+		const { activity, showActions } = this.props;
 
 		return (
 			<>
@@ -218,7 +218,9 @@ class ActivityCard extends Component {
 					}
 				>
 					{ this.shouldRenderContentLink() && this.renderContentLink() }
-					{ showActions && this.renderActionButton( isTopToolbar ) }
+					{ showActions &&
+						activity.activityIsRewindable &&
+						this.renderActionButton( isTopToolbar ) }
 				</div>
 			</>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the action button from ActivityCards for non-rewindable activities.

#### Testing instructions

* TBD