### PR TITLE
Settings: Center align "Add custom address" button text

### DIFF
--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -134,6 +134,7 @@
 			width: 100%;
 			margin-left: 0;
 			margin-top: 5px;
+			text-align: center;
 
 			@include breakpoint( '>660px' ) {
 				width: 45%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Found this while I was working on #41887; the button text for the "Add custom address" button in Site Settings was misaligned because the button width is forced to 45%. This PR centers the text inside the button.

**Before**

<img width="710" alt="Screen Shot 2020-05-07 at 10 45 02 AM" src="https://user-images.githubusercontent.com/2124984/81314343-00e84d00-9057-11ea-8f33-ce0204776d7f.png">

**After**

<img width="709" alt="Screen Shot 2020-05-07 at 11 35 04 AM" src="https://user-images.githubusercontent.com/2124984/81314360-047bd400-9057-11ea-8e40-06e19951c775.png">

#### Testing instructions

* Switch to this PR
* Navigate to Settings on a free WP.com site
* Note the visual fix. Make sure it doesn't disrupt other buttons on the page.
