### PR TITLE
Updates display of scan to use site TZ

### DIFF
--- a/client/landing/jetpack-cloud/lib/wrap-in-site-offset.tsx
+++ b/client/landing/jetpack-cloud/lib/wrap-in-site-offset.tsx
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { SiteOffsetProvider } from 'landing/jetpack-cloud/components/site-offset/context';
+
+export default function wrapInSiteOffsetProvider( context, next ) {
+	context.primary = (
+		<SiteOffsetProvider site={ context.params.site }>{ context.primary }</SiteOffsetProvider>
+	);
+	next();
+}

--- a/client/landing/jetpack-cloud/sections/backups/controller.js
+++ b/client/landing/jetpack-cloud/sections/backups/controller.js
@@ -6,7 +6,6 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { SiteOffsetProvider } from 'landing/jetpack-cloud/components/site-offset/context';
 import BackupActivityLogPage from './backup-activity-log';
 import BackupDetailPage from './detail';
 import BackupRewindFlow, { RewindFlowPurpose } from './rewind-flow';
@@ -15,13 +14,6 @@ import UpsellSwitch from 'landing/jetpack-cloud/components/upsell-switch';
 import BackupsUpsell from './backup-upsell';
 import getRewindState from 'state/selectors/get-rewind-state';
 import QueryRewindState from 'components/data/query-rewind-state';
-
-export function wrapInSiteOffsetProvider( context, next ) {
-	context.primary = (
-		<SiteOffsetProvider site={ context.params.site }>{ context.primary }</SiteOffsetProvider>
-	);
-	next();
-}
 
 export function showUpsellIfNoBackup( context, next ) {
 	context.primary = (

--- a/client/landing/jetpack-cloud/sections/backups/index.js
+++ b/client/landing/jetpack-cloud/sections/backups/index.js
@@ -10,6 +10,7 @@ import config from 'config';
 
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
+import wrapInSiteOffsetProvider from 'landing/jetpack-cloud/lib/wrap-in-site-offset';
 import {
 	backupActivity,
 	backupDetail,
@@ -17,7 +18,6 @@ import {
 	backupRestore,
 	backups,
 	showUpsellIfNoBackup,
-	wrapInSiteOffsetProvider,
 } from 'landing/jetpack-cloud/sections/backups/controller';
 import {
 	backupMainPath,

--- a/client/landing/jetpack-cloud/sections/scan/index.js
+++ b/client/landing/jetpack-cloud/sections/scan/index.js
@@ -10,6 +10,7 @@ import config from 'config';
 
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
+import wrapInSiteOffsetProvider from 'landing/jetpack-cloud/lib/wrap-in-site-offset';
 import {
 	showUpsellIfNoScan,
 	showUpsellIfNoScanHistory,
@@ -25,6 +26,7 @@ export default function () {
 			siteSelection,
 			navigation,
 			scan,
+			wrapInSiteOffsetProvider,
 			showUpsellIfNoScan,
 			makeLayout,
 			clientRender
@@ -36,6 +38,7 @@ export default function () {
 				siteSelection,
 				navigation,
 				scanHistory,
+				wrapInSiteOffsetProvider,
 				showUpsellIfNoScanHistory,
 				makeLayout,
 				clientRender

--- a/client/landing/jetpack-cloud/sections/scan/types.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/types.tsx
@@ -10,7 +10,7 @@ export type Scan = {
 	threats: [ Threat ];
 	credentials: [ object ];
 	mostRecent: {
-		timestamp: Date;
+		timestamp: string;
 		progress: number;
 		duration: number;
 		// @todo: complete the error prop when we know what the shape will it have

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -48,7 +48,6 @@ const formatScanStateRawResponse = ( { state, threats, credentials, most_recent:
 		mostRecent: mostRecent
 			? {
 					...mostRecent,
-					timestamp: new Date( mostRecent.timestamp ),
 					isInitial: mostRecent.is_initial,
 			  }
 			: null,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This fixes a bug where the timezone of the last scan date was parsed as browser time instead of UTC. This code forces it to be parsed correctly, and uses the TZ offset from the site instead of the browser.
* Makes `wrapInSiteOffset` function a common library and implements it for Scan as well as Backup pages.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a site with a successful scan, go to JP cloud -> Scan.
* Compare `scanState.mostRecent.timestamp` prop to displayed time.
* Test downloading/restoring in Backups to ensure site offset is still correct. See #40782.

<img width="661" alt="Screen Shot 2020-05-07 at 11 59 28 AM" src="https://user-images.githubusercontent.com/1760168/81317759-3f800680-905b-11ea-9363-759bd5e58287.png">

Fixes 1143508703416848-as-1174550638828321.
