### PR TITLE
Domains: Add plan upsell that explains new domains cannot be primary

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -50,6 +50,7 @@ export const UpsellNudge = ( {
 	plan,
 	planHasFeature,
 	price,
+	primaryButton,
 	showIcon = false,
 	site,
 	target,
@@ -104,6 +105,7 @@ export const UpsellNudge = ( {
 			onDismissClick={ onDismissClick }
 			plan={ plan }
 			price={ price }
+			primaryButton={ primaryButton }
 			showIcon={ showIcon }
 			target={ target }
 			title={ title }
@@ -115,6 +117,10 @@ export const UpsellNudge = ( {
 			tracksImpressionProperties={ tracksImpressionProperties }
 		/>
 	);
+};
+
+UpsellNudge.defaultProps = {
+	primaryButton: true,
 };
 
 export default connect( ( state, ownProps ) => {

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -59,6 +59,7 @@ export class Banner extends Component {
 		onDismiss: PropTypes.func,
 		plan: PropTypes.string,
 		price: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+		primaryButton: PropTypes.bool,
 		showIcon: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		target: PropTypes.string,
@@ -82,6 +83,7 @@ export class Banner extends Component {
 		jetpack: false,
 		onClick: noop,
 		onDismiss: noop,
+		primaryButton: true,
 		showIcon: true,
 		tracksImpressionName: 'calypso_banner_cta_impression',
 		tracksClickName: 'calypso_banner_cta_click',
@@ -223,7 +225,7 @@ export class Banner extends Component {
 						) }
 						{ callToAction &&
 							( forceHref ? (
-								<Button compact primary target={ target }>
+								<Button compact primary={ this.props.primaryButton } target={ target }>
 									{ callToAction }
 								</Button>
 							) : (
@@ -231,7 +233,7 @@ export class Banner extends Component {
 									compact
 									href={ this.getHref() }
 									onClick={ this.handleClick }
-									primary
+									primary={ this.props.primaryButton }
 									target={ target }
 								>
 									{ callToAction }

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -179,6 +179,7 @@ export class Banner extends Component {
 			compact,
 			list,
 			price,
+			primaryButton,
 			title,
 			target,
 			tracksImpressionName,
@@ -225,7 +226,7 @@ export class Banner extends Component {
 						) }
 						{ callToAction &&
 							( forceHref ? (
-								<Button compact primary={ this.props.primaryButton } target={ target }>
+								<Button compact primary={ primaryButton } target={ target }>
 									{ callToAction }
 								</Button>
 							) : (
@@ -233,7 +234,7 @@ export class Banner extends Component {
 									compact
 									href={ this.getHref() }
 									onClick={ this.handleClick }
-									primary={ this.props.primaryButton }
+									primary={ primaryButton }
 									target={ target }
 								>
 									{ callToAction }

--- a/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.jsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import Banner from 'components/banner';
+import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
+import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
+import { getPlansBySite } from 'state/sites/plans/selectors';
+import { hasCustomDomain } from '../../../../../lib/site/utils';
+
+/**
+ * Style dependencies
+ */
+import './new-domains-redirection-notice-upsell.scss';
+
+class NewDomainsRedirectionNoticeUpsell extends React.Component {
+	render() {
+		const {
+			hasNonPrimaryDomainsFlag,
+			isOnPaidPlan,
+			hasLoadedSitePlans,
+			hasCustomPrimaryDomain,
+			selectedSite,
+			selectedSiteId,
+			translate,
+		} = this.props;
+
+		if (
+			! hasLoadedSitePlans ||
+			! selectedSite ||
+			isOnPaidPlan ||
+			! hasNonPrimaryDomainsFlag ||
+			hasCustomPrimaryDomain
+		) {
+			return null;
+		}
+
+		return (
+			<Banner
+				className="new-domains-redirection-notice-upsell__banner"
+				icon="info"
+				href={ `/checkout/${ selectedSiteId }/personal` }
+				title={ '' }
+				description={ translate(
+					'Domains purchased on a free site will get redirected to %(primaryDomain)s. If you upgrade to ' +
+						'the Personal plan, you can use your own domain name instead of having WordPress.com ' +
+						'in your URL.',
+					{
+						args: {
+							primaryDomain: selectedSite.slug,
+						},
+					}
+				) }
+				callToAction={ translate( 'Upgrade' ) }
+				primaryButton={ false }
+				tracksImpressionName="calypso_new_domain_will_redirect_notice_upsell_impression"
+				tracksClickName="calypso_new_domain_will_redirect_notice_upsell_upgrade_click"
+				event="calypso_new_domain_will_redirect_notice_upsell"
+			/>
+		);
+	}
+}
+
+const mapStateToProps = ( state ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const selectedSite = getSelectedSite( state );
+	const sitePlans = selectedSite && getPlansBySite( state, selectedSite );
+
+	return {
+		isOnPaidPlan: isSiteOnPaidPlan( state, selectedSiteId ),
+		hasLoadedSitePlans: sitePlans && sitePlans.hasLoadedFromServer,
+		hasNonPrimaryDomainsFlag: getCurrentUser( state )
+			? currentUserHasFlag( state, NON_PRIMARY_DOMAINS_TO_FREE_USERS )
+			: false,
+		hasCustomPrimaryDomain: hasCustomDomain( selectedSite ),
+		selectedSite,
+		selectedSiteId,
+	};
+};
+
+export default connect( mapStateToProps )( localize( NewDomainsRedirectionNoticeUpsell ) );

--- a/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.jsx
+++ b/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { localize } from 'i18n-calypso';
-import Banner from 'components/banner';
+import UpsellNudge from 'blocks/upsell-nudge';
 import { currentUserHasFlag, getCurrentUser } from 'state/current-user/selectors';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'state/current-user/constants';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -44,8 +44,9 @@ class NewDomainsRedirectionNoticeUpsell extends React.Component {
 		}
 
 		return (
-			<Banner
+			<UpsellNudge
 				className="new-domains-redirection-notice-upsell__banner"
+				showIcon={ true }
 				icon="info"
 				href={ `/checkout/${ selectedSiteId }/personal` }
 				title={ '' }

--- a/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.scss
+++ b/client/my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell.scss
@@ -1,0 +1,11 @@
+.new-domains-redirection-notice-upsell__banner.banner.card {
+	border-left-color: var( --studio-blue );
+
+	.banner__icon-circle {
+		background-color: var( --studio-blue );
+	}
+
+	.banner__description {
+		font-size: 14px;
+	}
+}

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -37,12 +37,12 @@ import { getProductsList } from 'state/products-list/selectors';
 import { recordAddDomainButtonClick, recordRemoveDomainButtonClick } from 'state/domains/actions';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
+import NewDomainsRedirectionNoticeUpsell from 'my-sites/domains/domain-management/components/domain/new-domains-redirection-notice-upsell';
 
 /**
  * Style dependencies
  */
 import './style.scss';
-import NewDomainsRedirectionNoticeUpsell from '../domain-management/components/domain/new-domains-redirection-notice-upsell';
 
 class DomainSearch extends Component {
 	static propTypes = {

--- a/client/my-sites/domains/domain-search/index.jsx
+++ b/client/my-sites/domains/domain-search/index.jsx
@@ -42,6 +42,7 @@ import { getSuggestionsVendor } from 'lib/domains/suggestions';
  * Style dependencies
  */
 import './style.scss';
+import NewDomainsRedirectionNoticeUpsell from '../domain-management/components/domain/new-domains-redirection-notice-upsell';
 
 class DomainSearch extends Component {
 	static propTypes = {
@@ -181,6 +182,7 @@ class DomainSearch extends Component {
 							noticeText={ translate( 'You must verify your email to register new domains.' ) }
 							noticeStatus="is-info"
 						>
+							<NewDomainsRedirectionNoticeUpsell />
 							<RegisterDomainStep
 								suggestion={ suggestion }
 								domainsWithPlansOnly={ this.props.domainsWithPlansOnly }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a plan upsell banner that explains new domains on a free site will redirect to the free subdomain.

#### Testing instructions

For a site without a plan, go to Manage -> Domains, and then click on the 'Add a domain to this site' button.

You should see this banner above the results:

<img width="1050" alt="Screenshot 2020-05-07 at 9 09 45 PM" src="https://user-images.githubusercontent.com/13062352/81335086-551b1d80-90a7-11ea-857a-eaacf18c7220.png">

Verify that clicking the Upgrade button sends you to the checkout page with a Personal plan added to cart.

Also check that events are sent properly

Finally, make sure this banner won't show for sites with a plan, or for users that are exempt from PWPO
