### PR TITLE
Checkout: add a step description to the default contact information step

### DIFF
--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-contact-form.js
@@ -168,12 +168,6 @@ TaxFields.propTypes = {
 	isDisabled: PropTypes.bool,
 };
 
-const DomainContactFieldsDescription = styled.p`
-	font-size: 14px;
-	color: ${( props ) => props.theme.colors.textColor};
-	margin: 0 0 16px;
-`;
-
 function ContactFormSummary( { isDomainFieldsVisible } ) {
 	const translate = useTranslate();
 	const contactInfo = useSelect( ( select ) => select( 'wpcom' ).getContactInfo() );
@@ -280,11 +274,11 @@ function RenderContactDetails( {
 		case 'DOMAINS':
 			return (
 				<React.Fragment>
-					<DomainContactFieldsDescription>
+					<ContactDetailsFormDescription>
 						{ translate(
 							'Registering a domain name requires valid contact information. Privacy Protection is included for all eligible domains to protect your personal information.'
 						) }
-					</DomainContactFieldsDescription>
+					</ContactDetailsFormDescription>
 					{ renderDomainContactFields(
 						prepareDomainContactDetails( contactInfo ),
 						prepareDomainContactDetailsErrors( contactInfo ),
@@ -298,6 +292,9 @@ function RenderContactDetails( {
 		default:
 			return (
 				<React.Fragment>
+					<ContactDetailsFormDescription>
+						{ translate( 'Entering your billing information helps us prevent fraud.' ) }
+					</ContactDetailsFormDescription>
 					<TaxFields
 						section="contact"
 						taxInfo={ contactInfo }
@@ -312,3 +309,9 @@ function RenderContactDetails( {
 			);
 	}
 }
+
+const ContactDetailsFormDescription = styled.p`
+	font-size: 14px;
+	color: ${( props ) => props.theme.colors.textColor};
+	margin: 0 0 16px;
+`;


### PR DESCRIPTION
This add a description to the billing information step for carts without a domain.

![Screen Shot 2020-05-07 at 3 34 12 PM](https://user-images.githubusercontent.com/942359/81337004-4b2df600-9078-11ea-826a-dc495e8ad454.png)

**To test:**
- visit checkout without a domain in your cart
- verify that the second step has the following description: "Entering your billing information helps us prevent fraud."
- add a domain to your cart
- verify that the second step has the following description: "Registering a domain name requires valid contact information. Privacy Protection is included for all eligible domains to protect your personal information."
