### PR TITLE
Update: Cleanup & clarify WordAds signup eligibility

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -8,7 +8,7 @@ import { isBusiness, isPremium, isEcommerce } from 'lib/products-values';
 /**
  * Returns true if the site has WordAds access
  *
- * @param  {Site} site Site object
+ * @param  site Site object
  * @returns {boolean}      true if site has WordAds access
  */
 export function canAccessWordads( site ) {
@@ -37,15 +37,16 @@ export function canAccessAds( site ) {
 	);
 }
 
-export function isWordadsInstantActivationEligible( site ) {
-	if (
-		( isPremium( site.plan ) || isBusiness( site.plan ) || isEcommerce( site.plan ) ) &&
-		userCan( 'activate_wordads', site )
-	) {
-		return true;
-	}
+export function hasWordadsPlan( site ) {
+	return isPremium( site.plan ) || isBusiness( site.plan ) || isEcommerce( site.plan );
+}
 
-	return false;
+export function isWordadsInstantActivationEligible( site ) {
+	return hasWordadsPlan( site ) && userCan( 'activate_wordads', site );
+}
+
+export function isWordadsInstantActivationEligibleButNotOwner( site ) {
+	return hasWordadsPlan( site ) && ! userCan( 'activate_wordads', site );
 }
 
 export function canUpgradeToUseWordAds( site ) {

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -195,7 +195,7 @@ class AdsWrapper extends Component {
 			<EmptyContent
 				illustration="/calypso/images/illustrations/wordAds.svg"
 				illustrationWidth={ 400 }
-				title={ this.props.translate( 'Only site owners are elegible to activate WordAds.' ) }
+				title={ this.props.translate( 'Only site owners are eligible to activate WordAds.' ) }
 			/>
 		);
 	}

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import {
 	isWordadsInstantActivationEligible,
+	isWordadsInstantActivationEligibleButNotOwner,
 	canUpgradeToUseWordAds,
 	canAccessAds,
 } from 'lib/ads/utils';
@@ -189,6 +190,16 @@ class AdsWrapper extends Component {
 		);
 	}
 
+	renderOwnerRequiredMessage() {
+		return (
+			<EmptyContent
+				illustration="/calypso/images/illustrations/wordAds.svg"
+				illustrationWidth={ 400 }
+				title={ this.props.translate( 'Only site owners are elegible to activate WordAds.' ) }
+			/>
+		);
+	}
+
 	renderUpsell() {
 		const { siteSlug, translate } = this.props;
 		const bannerURL = `/checkout/${ siteSlug }/premium`;
@@ -250,9 +261,7 @@ class AdsWrapper extends Component {
 		let component = this.props.children;
 		let notice = null;
 
-		if ( ! canAccessAds( site ) ) {
-			component = this.renderEmptyContent();
-		} else if ( this.props.requestingWordAdsApproval || this.props.wordAdsSuccess ) {
+		if ( this.props.requestingWordAdsApproval || this.props.wordAdsSuccess ) {
 			notice = (
 				<Notice status="is-success" showDismiss={ false }>
 					{ translate( 'You have joined the WordAds program. Please review these settings:' ) }
@@ -260,12 +269,14 @@ class AdsWrapper extends Component {
 			);
 		} else if ( ! site.options.wordads && isWordadsInstantActivationEligible( site ) ) {
 			component = this.renderInstantActivationToggle( component );
-		} else if ( ! canAccessAds( site ) ) {
-			component = this.renderEmptyContent();
+		} else if ( ! site.options.wordads && isWordadsInstantActivationEligibleButNotOwner( site ) ) {
+			component = this.renderOwnerRequiredMessage( component );
 		} else if ( canUpgradeToUseWordAds( site ) && site.jetpack && ! jetpackPremium ) {
 			component = this.renderjetpackUpsell();
 		} else if ( canUpgradeToUseWordAds( site ) ) {
 			component = this.renderUpsell();
+		} else if ( ! canAccessAds( site ) ) {
+			component = this.renderEmptyContent();
 		} else if ( ! ( site.options.wordads || jetpackPremium ) ) {
 			component = null;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Making it a bit clearer that only site owners may sign up a site for WordAds even if the site is generally eligible.

<img width="1235" alt="Screen Shot 2020-05-07 at 12 33 53 PM" src="https://user-images.githubusercontent.com/273708/81337414-ca630000-905f-11ea-847b-5fd710ee11b1.png">

#### Testing instructions


* Add yourself as an admin to premiumtestsite2059103923893838.wordpress.com or spin up a new Premium site that your user isn't an admin of.
* Visit the earn page for the site, e.g. http://calypso.localhost:3000/earn/premiumtestsite2059103923893838.wordpress.com
* Clicking on the `Earn ad revenue` button should take you to a page that says "Only site owners are elegible to activate WordAds."
* Visit that same page as the owner and you should see the regular activation/upgrade/notices.
