### PR TITLE
UpsellNudge: Refactor Banner and UpsellNudge

### DIFF
--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -40,6 +40,7 @@ export default function SidebarBannerTemplate( {
 			dismissPreferenceName={ dismissPreferenceName }
 			href={ CTA.link }
 			onDismissClick={ onDismissClick }
+			showIcon={ false }
 			title={ preventWidows( message ) }
 			tracksClickName={ clickName }
 			tracksClickProperties={ { ...jitmProps, ...clickProps } }

--- a/client/blocks/upsell-nudge/docs/example.jsx
+++ b/client/blocks/upsell-nudge/docs/example.jsx
@@ -15,7 +15,6 @@ const UpsellNudgeExample = () => (
 			href="#"
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a regular nudge with an icon."
-			showIcon={ true }
 		/>
 		<UpsellNudge
 			description="Domain registration is free for a year with purchase of a Premium or Business plan."
@@ -23,7 +22,6 @@ const UpsellNudgeExample = () => (
 			href="#"
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a regular nudge with a description."
-			showIcon={ true }
 		/>
 		<UpsellNudge
 			description="Domain registration is free for a year with purchase of a Premium or Business plan."
@@ -31,7 +29,6 @@ const UpsellNudgeExample = () => (
 			href="#"
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a regular nudge with a description."
-			showIcon={ true }
 		/>
 		<UpsellNudge
 			description="Domain registration is free for a year with purchase of a Premium or Business plan."
@@ -40,7 +37,6 @@ const UpsellNudgeExample = () => (
 			href="#"
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a dismissible nudge with a description and the horizontal layout."
-			showIcon={ true }
 			horizontal
 		/>
 		<UpsellNudge
@@ -55,13 +51,11 @@ const UpsellNudgeExample = () => (
 			] }
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a dismissible nudge with a description, prices, and a list of features."
-			showIcon={ true }
 			price={ [ 48, 50 ] }
 		/>
 		<UpsellNudge
 			forceDisplay
 			isJetpackDevDocs
-			showIcon
 			href="#"
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a Jetpack nudge."
@@ -70,6 +64,7 @@ const UpsellNudgeExample = () => (
 			forceDisplay
 			href="#"
 			compact
+			showIcon={ false }
 			callToAction="Upgrade"
 			title="Free domain with a plan! This is a compact nudge with no icon."
 		/>

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -56,7 +56,6 @@ export class UpsellNudge extends Component {
 		feature: PropTypes.string,
 		horizontal: PropTypes.bool,
 		href: PropTypes.string,
-		icon: PropTypes.string,
 		isJetpackDevDocs: PropTypes.bool,
 		jetpack: PropTypes.bool,
 		compact: PropTypes.bool,
@@ -146,7 +145,7 @@ export class UpsellNudge extends Component {
 	};
 
 	getIcon() {
-		const { icon, isJetpackDevDocs, jetpack, showIcon } = this.props;
+		const { isJetpackDevDocs, jetpack, showIcon } = this.props;
 
 		if ( ! showIcon ) {
 			return;
@@ -164,10 +163,10 @@ export class UpsellNudge extends Component {
 		return (
 			<div className="upsell-nudge__icons">
 				<div className="upsell-nudge__icon">
-					<Gridicon icon={ icon || 'star' } size={ 18 } />
+					<Gridicon icon="star" size={ 18 } />
 				</div>
 				<div className="upsell-nudge__icon-circle">
-					<Gridicon icon={ icon || 'star' } size={ 18 } />
+					<Gridicon icon="star" size={ 18 } />
 				</div>
 			</div>
 		);

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -1,130 +1,347 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import classnames from 'classnames';
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import classNames from 'classnames';
+import { noop, size } from 'lodash';
+import Gridicon from 'components/gridicon';
+import JetpackLogo from 'components/jetpack-logo';
+import config from 'config';
 
 /**
  * Internal dependencies
  */
-import Banner from 'components/banner';
-import { FEATURE_NO_ADS } from 'lib/plans/constants';
-import { addQueryArgs } from 'lib/url';
+import {
+	planMatches,
+	isBloggerPlan,
+	isPersonalPlan,
+	isPremiumPlan,
+	isBusinessPlan,
+	isEcommercePlan,
+} from 'lib/plans';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { isFreePlan } from 'lib/products-values';
-import canCurrentUser from 'state/selectors/can-current-user';
 import isVipSite from 'state/selectors/is-vip-site';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite, isJetpackSite } from 'state/sites/selectors';
 import { preventWidows } from 'lib/formatting';
+import { GROUP_JETPACK, GROUP_WPCOM, FEATURE_NO_ADS } from 'lib/plans/constants';
+import { addQueryArgs } from 'lib/url';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSite, isJetpackSite } from 'state/sites/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
+import { Button, Card } from '@automattic/components';
+import DismissibleCard from 'blocks/dismissible-card';
+import PlanPrice from 'my-sites/plan-price';
+import TrackComponentView from 'lib/analytics/track-component-view';
+import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-export const UpsellNudge = ( {
-	callToAction,
-	canManageSite,
-	className,
-	compact,
-	customerType,
-	description,
-	disableHref,
-	dismissPreferenceName,
-	event,
-	feature,
-	forceDisplay,
-	forceHref,
-	horizontal,
-	href,
-	icon,
-	isJetpackDevDocs,
-	jetpack,
-	isVip,
-	list,
-	onClick,
-	onDismissClick,
-	plan,
-	planHasFeature,
-	price,
-	showIcon = false,
-	site,
-	target,
-	title,
-	tracksClickName,
-	tracksClickProperties,
-	tracksDismissName,
-	tracksDismissProperties,
-	tracksImpressionName,
-	tracksImpressionProperties,
-} ) => {
-	const classes = classnames( 'upsell-nudge', className );
+export class UpsellNudge extends Component {
+	static propTypes = {
+		callToAction: PropTypes.string,
+		className: PropTypes.string,
+		description: PropTypes.node,
+		forceHref: PropTypes.bool,
+		disableHref: PropTypes.bool,
+		dismissPreferenceName: PropTypes.string,
+		dismissTemporary: PropTypes.bool,
+		event: PropTypes.string,
+		feature: PropTypes.string,
+		horizontal: PropTypes.bool,
+		href: PropTypes.string,
+		icon: PropTypes.string,
+		isJetpackDevDocs: PropTypes.bool,
+		jetpack: PropTypes.bool,
+		compact: PropTypes.bool,
+		list: PropTypes.arrayOf( PropTypes.string ),
+		onClick: PropTypes.func,
+		onDismiss: PropTypes.func,
+		plan: PropTypes.string,
+		price: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+		showIcon: PropTypes.bool,
+		siteSlug: PropTypes.string,
+		target: PropTypes.string,
+		title: PropTypes.string.isRequired,
+		tracksImpressionName: PropTypes.string,
+		tracksClickName: PropTypes.string,
+		tracksDismissName: PropTypes.string,
+		tracksImpressionProperties: PropTypes.object,
+		tracksClickProperties: PropTypes.object,
+		tracksDismissProperties: PropTypes.object,
+		customerType: PropTypes.string,
+		isSiteWPForTeams: PropTypes.bool,
+	};
 
-	const shouldNotDisplay =
-		isVip ||
-		! canManageSite ||
-		! site ||
-		typeof site !== 'object' ||
-		typeof site.jetpack !== 'boolean' ||
-		( feature && planHasFeature ) ||
-		( ! feature && ! isFreePlan( site.plan ) ) ||
-		( feature === FEATURE_NO_ADS && site.options.wordads ) ||
-		( ! jetpack && site.jetpack ) ||
-		( jetpack && ! site.jetpack );
+	static defaultProps = {
+		forceHref: false,
+		disableHref: false,
+		dismissTemporary: false,
+		compact: false,
+		horizontal: false,
+		isSiteWPForTeams: false,
+		onClick: noop,
+		onDismiss: noop,
+		showIcon: true,
+		tracksImpressionName: 'calypso_banner_cta_impression',
+		tracksClickName: 'calypso_banner_cta_click',
+		tracksDismissName: 'calypso_banner_dismiss',
+	};
 
-	if ( shouldNotDisplay && ! forceDisplay ) {
-		return null;
+	getHref() {
+		const { canUserUpgrade, feature, href, plan, siteSlug, customerType } = this.props;
+
+		if ( ! href && siteSlug && canUserUpgrade ) {
+			if ( customerType ) {
+				return `/plans/${ siteSlug }?customerType=${ customerType }`;
+			}
+			const baseUrl = `/plans/${ siteSlug }`;
+			if ( feature || plan ) {
+				return addQueryArgs(
+					{
+						feature,
+						plan,
+					},
+					baseUrl
+				);
+			}
+			return baseUrl;
+		}
+		return href;
 	}
 
-	if ( ! href && site && ! customerType ) {
-		href = addQueryArgs( { feature, plan }, `/plans/${ site.slug }` );
+	handleClick = ( e ) => {
+		const { event, feature, compact, onClick, tracksClickName, tracksClickProperties } = this.props;
+
+		if ( event && tracksClickName ) {
+			this.props.recordTracksEvent( tracksClickName, {
+				cta_name: event,
+				cta_feature: feature,
+				cta_size: compact ? 'compact' : 'regular',
+				...tracksClickProperties,
+			} );
+		}
+
+		onClick( e );
+	};
+
+	handleDismiss = ( e ) => {
+		const { event, feature, onDismiss, tracksDismissName, tracksDismissProperties } = this.props;
+
+		if ( event && tracksDismissName ) {
+			this.props.recordTracksEvent( tracksDismissName, {
+				cta_name: event,
+				cta_feature: feature,
+				...tracksDismissProperties,
+			} );
+		}
+
+		onDismiss( e );
+	};
+
+	getIcon() {
+		const { icon, isJetpackDevDocs, jetpack, showIcon } = this.props;
+
+		if ( ! showIcon ) {
+			return;
+		}
+
+		if ( jetpack || isJetpackDevDocs ) {
+			return (
+				<div className="upsell-nudge__icon-plan">
+					<JetpackLogo size={ 32 } />
+				</div>
+			);
+		}
+
+		return (
+			<div className="upsell-nudge__icons">
+				<div className="upsell-nudge__icon">
+					<Gridicon icon={ icon || 'star' } size={ 18 } />
+				</div>
+				<div className="upsell-nudge__icon-circle">
+					<Gridicon icon={ icon || 'star' } size={ 18 } />
+				</div>
+			</div>
+		);
 	}
 
-	return (
-		<Banner
-			callToAction={ preventWidows( callToAction ) }
-			className={ classes }
-			compact={ compact }
-			customerType={ customerType }
-			description={ description }
-			disableHref={ disableHref }
-			dismissPreferenceName={ dismissPreferenceName }
-			event={ event }
-			feature={ feature }
-			forceHref={ forceHref }
-			horizontal={ horizontal }
-			href={ href }
-			icon={ icon }
-			jetpack={ jetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
-			list={ list }
-			onClick={ onClick }
-			onDismissClick={ onDismissClick }
-			plan={ plan }
-			price={ price }
-			showIcon={ showIcon }
-			target={ target }
-			title={ title }
-			tracksClickName={ tracksClickName }
-			tracksClickProperties={ tracksClickProperties }
-			tracksDismissName={ tracksDismissName }
-			tracksDismissProperties={ tracksDismissProperties }
-			tracksImpressionName={ tracksImpressionName }
-			tracksImpressionProperties={ tracksImpressionProperties }
-		/>
-	);
-};
+	getContent() {
+		const {
+			callToAction,
+			forceHref,
+			description,
+			event,
+			feature,
+			compact,
+			list,
+			price,
+			title,
+			target,
+			tracksImpressionName,
+			tracksImpressionProperties,
+		} = this.props;
 
-export default connect( ( state, ownProps ) => {
+		const prices = Array.isArray( price ) ? price : [ price ];
+
+		return (
+			<div className="upsell-nudge__content">
+				{ tracksImpressionName && event && (
+					<TrackComponentView
+						eventName={ tracksImpressionName }
+						eventProperties={ {
+							cta_name: event,
+							cta_feature: feature,
+							cta_size: compact ? 'compact' : 'regular',
+							...tracksImpressionProperties,
+						} }
+					/>
+				) }
+				<div className="upsell-nudge__info">
+					<div className="upsell-nudge__title">{ title }</div>
+					{ description && <div className="upsell-nudge__description">{ description }</div> }
+					{ size( list ) > 0 && (
+						<ul className="upsell-nudge__list">
+							{ list.map( ( item, key ) => (
+								<li key={ key }>
+									<Gridicon icon="checkmark" size={ 18 } />
+									{ item }
+								</li>
+							) ) }
+						</ul>
+					) }
+				</div>
+				{ ( callToAction || price ) && (
+					<div className="upsell-nudge__action">
+						{ size( prices ) === 1 && <PlanPrice rawPrice={ prices[ 0 ] } /> }
+						{ size( prices ) === 2 && (
+							<div className="upsell-nudge__prices">
+								<PlanPrice rawPrice={ prices[ 0 ] } original />
+								<PlanPrice rawPrice={ prices[ 1 ] } discounted />
+							</div>
+						) }
+						{ callToAction &&
+							( forceHref ? (
+								<Button compact primary target={ target }>
+									{ callToAction }
+								</Button>
+							) : (
+								<Button
+									compact
+									href={ this.getHref() }
+									onClick={ this.handleClick }
+									primary
+									target={ target }
+								>
+									{ preventWidows( callToAction ) }
+								</Button>
+							) ) }
+					</div>
+				) }
+			</div>
+		);
+	}
+
+	render() {
+		const {
+			callToAction,
+			canManageSite,
+			className,
+			compact,
+			disableHref,
+			dismissPreferenceName,
+			dismissTemporary,
+			feature,
+			forceDisplay,
+			forceHref,
+			horizontal,
+			isVip,
+			jetpack,
+			plan,
+			planHasFeature,
+			site,
+		} = this.props;
+
+		const shouldNotDisplay =
+			isVip ||
+			! canManageSite ||
+			! site ||
+			typeof site !== 'object' ||
+			typeof site.jetpack !== 'boolean' ||
+			( feature && planHasFeature ) ||
+			( ! feature && ! isFreePlan( site.plan ) ) ||
+			( feature === FEATURE_NO_ADS && site.options.wordads ) ||
+			( ! jetpack && site.jetpack ) ||
+			( jetpack && ! site.jetpack ) ||
+			( config.isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams );
+
+		if ( shouldNotDisplay && ! forceDisplay ) {
+			return null;
+		}
+
+		const classes = classNames(
+			'upsell-nudge',
+			className,
+			{ 'has-call-to-action': callToAction },
+			{ 'is-upgrade-blogger': plan && isBloggerPlan( plan ) },
+			{ 'is-upgrade-personal': plan && isPersonalPlan( plan ) },
+			{ 'is-upgrade-premium': plan && isPremiumPlan( plan ) },
+			{ 'is-upgrade-business': plan && isBusinessPlan( plan ) },
+			{ 'is-upgrade-ecommerce': plan && isEcommercePlan( plan ) },
+			{ 'is-jetpack-plan': plan && planMatches( plan, { group: GROUP_JETPACK } ) },
+			{ 'is-wpcom-plan': plan && planMatches( plan, { group: GROUP_WPCOM } ) },
+			{ 'is-compact': compact },
+			{ 'is-dismissible': dismissPreferenceName },
+			{ 'is-horizontal': horizontal },
+			{ 'is-jetpack': jetpack }
+		);
+
+		if ( dismissPreferenceName ) {
+			return (
+				<DismissibleCard
+					className={ classes }
+					preferenceName={ dismissPreferenceName }
+					temporary={ dismissTemporary }
+					onClick={ this.handleDismiss }
+				>
+					{ this.getIcon() }
+					{ this.getContent() }
+				</DismissibleCard>
+			);
+		}
+
+		return (
+			<Card
+				className={ classes }
+				href={ ( disableHref || callToAction ) && ! forceHref ? null : this.getHref() }
+				onClick={ callToAction && ! forceHref ? null : this.handleClick }
+			>
+				{ this.getIcon() }
+				{ this.getContent() }
+			</Card>
+		);
+	}
+}
+
+const mapStateToProps = ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
+		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
+		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
+		isSiteWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ),
 		site: getSite( state, siteId ),
 		planHasFeature: hasFeature( state, siteId, ownProps.feature ),
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
 		jetpack: isJetpackSite( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 	};
-} )( localize( UpsellNudge ) );
+};
+
+export default connect( mapStateToProps, { recordTracksEvent } )( UpsellNudge );

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -152,6 +152,7 @@ export class UpsellNudge extends Component {
 			return;
 		}
 
+		//If this is a Jetpack nudge, or we're showing an example Jetpack nudge in /devdocs
 		if ( jetpack || isJetpackDevDocs ) {
 			return (
 				<div className="upsell-nudge__icon-plan">
@@ -278,10 +279,15 @@ export class UpsellNudge extends Component {
 			( ! feature && ! isFreePlan( site.plan ) ) ||
 			( feature === FEATURE_NO_ADS && site.options.wordads ) ||
 			( ! jetpack && site.jetpack ) ||
-			( jetpack && ! site.jetpack ) ||
-			( config.isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams );
+			( jetpack && ! site.jetpack );
 
+		//forceDisplay is an override for upsells shared between Jetpack and WP.com
 		if ( shouldNotDisplay && ! forceDisplay ) {
+			return null;
+		}
+
+		//Never display upsells for WP for Teams
+		if ( config.isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
 			return null;
 		}
 

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -262,6 +262,7 @@ export class UpsellNudge extends Component {
 			forceDisplay,
 			forceHref,
 			horizontal,
+			isJetpackDevDocs,
 			isVip,
 			jetpack,
 			plan,
@@ -305,7 +306,7 @@ export class UpsellNudge extends Component {
 			{ 'is-compact': compact },
 			{ 'is-dismissible': dismissPreferenceName },
 			{ 'is-horizontal': horizontal },
-			{ 'is-jetpack': jetpack }
+			{ 'is-jetpack': jetpack || isJetpackDevDocs }
 		);
 
 		if ( dismissPreferenceName ) {

--- a/client/blocks/upsell-nudge/style.scss
+++ b/client/blocks/upsell-nudge/style.scss
@@ -1,4 +1,269 @@
-.upsell-nudge.banner.card.is-compact {
+.upsell-nudge.card {
+	border-left: 3px solid;
+	border-left-color: var( --color-accent );
+	cursor: default;
+	display: flex;
+	padding: 12px 6px 12px 12px;
+	line-height: 29px;
+
+	&.is-dismissible {
+		padding-right: 48px;
+	}
+
+	&.is-compact {
+		border-left-width: 4px;
+		font-size: 12px;
+		margin-bottom: 8px;
+		padding: 8px 12px 8px 8px;
+	}
+
+	&[href] {
+		cursor: pointer;
+	}
+
+	.upsell-nudge__icon {
+		color: var( --color-accent );
+	}
+
+	.upsell-nudge__icon-circle {
+		background-color: var( --color-accent );
+	}
+
+	&.is-jetpack {
+		border-left-color: var( --color-jetpack );
+
+		.upsell-nudge__icon {
+			color: var( --color-jetpack );
+		}
+
+		.upsell-nudge__icon-circle {
+			background-color: var( --color-jetpack );
+		}
+	}
+
+	.card__link-indicator {
+		align-items: center;
+		color: var( --color-neutral );
+		display: flex;
+	}
+
+	&.is-compact .card__link-indicator {
+		right: 8px;
+	}
+
+	&:hover {
+		transition: all 100ms ease-in-out;
+
+		&.is-card-link {
+			box-shadow: 0 0 0 1px var( --color-neutral ), 0 2px 4px var( --color-neutral-10 );
+		}
+		.card__link-indicator {
+			color: var( --color-neutral-dark );
+		}
+	}
+
+	@include breakpoint( '>480px' ) {
+		padding: 12px 16px;
+
+		&.is-dismissible {
+			padding-right: 16px;
+		}
+
+		&.is-compact.is-dismissible {
+			padding-right: 8px;
+		}
+	}
+
+	&.is-card-link {
+		padding-right: 48px;
+	}
+}
+
+.upsell-nudge__icons {
+	display: flex;
+
+	.upsell-nudge__icon,
+	.upsell-nudge__icon-circle {
+		border-radius: 50%;
+		flex-shrink: 0;
+		height: 24px;
+		margin-right: 16px;
+		width: 24px;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.upsell-nudge__icon {
+		align-self: center;
+		color: var( --color-text-inverted );
+		display: flex;
+	}
+
+	.upsell-nudge__icon-circle {
+		color: white;
+		display: none;
+		padding: 3px 4px 4px 3px;
+	}
+
+	@include breakpoint( '>480px' ) {
+		align-items: center;
+
+		.upsell-nudge__icon {
+			display: none;
+		}
+		.upsell-nudge__icon-circle {
+			display: flex;
+		}
+	}
+}
+
+.upsell-nudge__icon-plan {
+	display: flex;
+	margin-right: 16px;
+	flex-shrink: 0;
+
+	.product-icon {
+		height: 32px;
+		width: 32px;
+	}
+
+	@include breakpoint( '>480px' ) {
+		align-items: center;
+	}
+}
+
+.upsell-nudge__content {
+	align-items: center;
+	display: flex;
+	flex-grow: 1;
+	flex-wrap: wrap;
+
+	@include breakpoint( '>480px' ) {
+		flex-wrap: nowrap;
+	}
+}
+
+.upsell-nudge.is-compact .upsell-nudge__content {
+	padding: 5px;
+}
+
+.upsell-nudge__info {
+	flex-grow: 1;
+	line-height: 1.4;
+	width: 100%;
+
+	.upsell-nudge__title,
+	.upsell-nudge__description,
+	.upsell-nudge__list {
+		color: var( --color-neutral-70 );
+	}
+
+	.upsell-nudge__title {
+		font-size: 14px;
+		font-weight: 600;
+	}
+
+	.upsell-nudge__description {
+		font-size: 12px;
+		margin-top: 3px;
+	}
+
+	.upsell-nudge__list {
+		font-size: 12px;
+		list-style: none;
+		margin: 0;
+		li {
+			margin: 6px 0;
+			.gridicon {
+				color: var( --color-neutral );
+				display: none;
+			}
+		}
+	}
+
+	@include breakpoint( '>480px' ) {
+		width: auto;
+
+		.upsell-nudge__list li .gridicon {
+			display: inline;
+			margin-right: 12px;
+			vertical-align: bottom;
+		}
+	}
+}
+
+.upsell-nudge.is-compact .upsell-nudge__title {
+	font-size: 12px;
+}
+
+.upsell-nudge__action {
+	align-self: center;
+	font-size: 12px;
+	margin: 8px 0 0;
+	text-align: left;
+	width: 100%;
+
+	.upsell-nudge__prices {
+		display: flex;
+		justify-content: flex-start;
+
+		.plan-price {
+			margin-bottom: 0;
+		}
+
+		.plan-price.is-discounted,
+		.plan-price.is-discounted .plan-price__currency-symbol {
+			color: var( --color-neutral-70 );
+		}
+
+		.has-call-to-action & .plan-price {
+			margin-bottom: 8px;
+		}
+	}
+
+	@include breakpoint( '>480px' ) {
+		margin: 0 -6px 0 8px;
+		text-align: center;
+		width: auto;
+
+		.is-dismissible & {
+			margin-top: 40px;
+		}
+
+		.is-compact & {
+			margin-right: 0;
+		}
+
+		.is-horizontal & {
+			flex-shrink: 0;
+			margin-right: 0;
+		}
+
+		.is-dismissible.is-horizontal & {
+			margin-top: 0;
+			margin-right: 40px;
+		}
+
+		.upsell-nudge__prices {
+			justify-content: flex-end;
+			text-align: right;
+		}
+	}
+}
+
+.upsell-nudge.is-compact .dismissible-card__close-icon {
+	width: 16px;
+	height: 16px;
+	top: 50%;
+	margin-top: -8px;
+}
+
+.is-horizontal .dismissible-card__close-icon {
+	top: 50%;
+	margin-top: -12px;
+}
+
+.upsell-nudge.card.is-compact {
 	background-color: var( --color-neutral-80 );
 	border-left-color: var( --color-accent );
 	box-shadow: none;
@@ -14,8 +279,8 @@
 		color: var( --color-text-inverted );
 	}
 
-	.banner__icon-circle,
-	.banner__icon {
+	.upsell-nudge__icon-circle,
+	.upsell-nudge__icon {
 		margin-top: -2px;
 		margin-right: 0.25em;
 	}
@@ -23,25 +288,25 @@
 		fill: var( --color-text-inverted );
 		margin-right: -6px;
 	}
-	.banner__content {
+	.upsell-nudge__content {
 		color: var( --color-text-inverted );
 		padding: 0 0 0 8px;
 	}
-	.banner__description {
+	.upsell-nudge__description {
 		color: var( --color-neutral-5 );
 	}
-	.banner__info {
+	.upsell-nudge__info {
 		margin-right: 5px;
 	}
-	.banner__info .banner__title {
+	.upsell-nudge__info .upsell-nudge__title {
 		color: var( --color-text-inverted );
 		font-weight: 400;
 	}
 	.card__link-indicator {
 		fill: var( --color-text-inverted );
 	}
-	.banner__icon-circle,
-	.banner__icon {
+	.upsell-nudge__icon-circle,
+	.upsell-nudge__icon {
 		width: auto;
 		height: auto;
 		color: var( --color-text-inverted );
@@ -55,10 +320,10 @@
 	}
 }
 
-.upsell-nudge.is-dismissible.is-horizontal.is-compact .banner__action {
+.upsell-nudge.is-dismissible.is-horizontal.is-compact .upsell-nudge__action {
 	margin-right: 28px;
 }
-.upsell-nudge.banner.card.is-compact.is-card-link {
+.upsell-nudge.card.is-compact.is-card-link {
 	padding-right: 12px;
 
 	.card__link-indicator {

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -2,9 +2,7 @@
 Banner
 ===
 
-This component renders a customizable banner.
-
-(Need to add an upsell? Use `UpsellNudge` instead.)
+This component renders a customizable banner. (Need to add an upsell? Use `UpsellNudge` instead.)
 
 ## Usage
 

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -97,7 +97,7 @@ export class Banner extends Component {
 	}
 
 	getContent() {
-		const { callToAction, description, event, title, target } = this.props;
+		const { callToAction, description, event, href, title, target } = this.props;
 
 		return (
 			<div className="banner__content">
@@ -120,13 +120,7 @@ export class Banner extends Component {
 							{ callToAction }
 						</Button>
 						) : (
-						<Button
-							compact
-							href={ this.getHref() }
-							onClick={ this.handleClick }
-							primary
-							target={ target }
-						>
+						<Button compact href={ href } onClick={ this.handleClick } primary target={ target }>
 							{ callToAction }
 						</Button>
 						) )
@@ -145,6 +139,7 @@ export class Banner extends Component {
 			dismissTemporary,
 			forceHref,
 			horizontal,
+			href,
 		} = this.props;
 
 		const classes = classNames(
@@ -172,7 +167,7 @@ export class Banner extends Component {
 		return (
 			<Card
 				className={ classes }
-				href={ ( disableHref || callToAction ) && ! forceHref ? null : this.getHref() }
+				href={ ( disableHref || callToAction ) && ! forceHref ? null : href }
 				onClick={ callToAction && ! forceHref ? null : this.handleClick }
 			>
 				{ this.getIcon() }

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -115,15 +115,15 @@ export class Banner extends Component {
 				</div>
 				{ callToAction && (
 					<div className="banner__action">
-						( this.props.forceHref ? (
-						<Button compact primary target={ target }>
-							{ callToAction }
-						</Button>
+						{ this.props.forceHref ? (
+							<Button compact primary target={ target }>
+								{ callToAction }
+							</Button>
 						) : (
-						<Button compact href={ href } onClick={ this.handleClick } primary target={ target }>
-							{ callToAction }
-						</Button>
-						) )
+							<Button compact href={ href } onClick={ this.handleClick } primary target={ target }>
+								{ callToAction }
+							</Button>
+						) }
 					</div>
 				) }
 			</div>

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -6,32 +6,16 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { noop, size } from 'lodash';
+import { noop } from 'lodash';
 import Gridicon from 'components/gridicon';
-import JetpackLogo from 'components/jetpack-logo';
-import config from 'config';
 
 /**
  * Internal dependencies
  */
-import {
-	planMatches,
-	isBloggerPlan,
-	isPersonalPlan,
-	isPremiumPlan,
-	isBusinessPlan,
-	isEcommercePlan,
-} from 'lib/plans';
-import { GROUP_JETPACK, GROUP_WPCOM } from 'lib/plans/constants';
-import { addQueryArgs } from 'lib/url';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import canCurrentUser from 'state/selectors/can-current-user';
 import { Button, Card } from '@automattic/components';
 import DismissibleCard from 'blocks/dismissible-card';
-import PlanPrice from 'my-sites/plan-price';
 import TrackComponentView from 'lib/analytics/track-component-view';
-import isSiteWPForTeams from 'state/selectors/is-site-wpforteams';
 
 /**
  * Style dependencies
@@ -48,78 +32,33 @@ export class Banner extends Component {
 		dismissPreferenceName: PropTypes.string,
 		dismissTemporary: PropTypes.bool,
 		event: PropTypes.string,
-		feature: PropTypes.string,
 		horizontal: PropTypes.bool,
 		href: PropTypes.string,
 		icon: PropTypes.string,
-		jetpack: PropTypes.bool,
-		compact: PropTypes.bool,
-		list: PropTypes.arrayOf( PropTypes.string ),
 		onClick: PropTypes.func,
 		onDismiss: PropTypes.func,
-		plan: PropTypes.string,
-		price: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
 		showIcon: PropTypes.bool,
 		siteSlug: PropTypes.string,
 		target: PropTypes.string,
 		title: PropTypes.string.isRequired,
-		tracksImpressionName: PropTypes.string,
-		tracksClickName: PropTypes.string,
-		tracksDismissName: PropTypes.string,
-		tracksImpressionProperties: PropTypes.object,
-		tracksClickProperties: PropTypes.object,
-		tracksDismissProperties: PropTypes.object,
-		customerType: PropTypes.string,
-		isSiteWPForTeams: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		forceHref: false,
 		disableHref: false,
 		dismissTemporary: false,
-		compact: false,
 		horizontal: false,
-		jetpack: false,
 		onClick: noop,
 		onDismiss: noop,
 		showIcon: true,
-		tracksImpressionName: 'calypso_banner_cta_impression',
-		tracksClickName: 'calypso_banner_cta_click',
-		tracksDismissName: 'calypso_banner_dismiss',
-		isSiteWPForTeams: false,
 	};
 
-	getHref() {
-		const { canUserUpgrade, feature, href, plan, siteSlug, customerType } = this.props;
-
-		if ( ! href && siteSlug && canUserUpgrade ) {
-			if ( customerType ) {
-				return `/plans/${ siteSlug }?customerType=${ customerType }`;
-			}
-			const baseUrl = `/plans/${ siteSlug }`;
-			if ( feature || plan ) {
-				return addQueryArgs(
-					{
-						feature,
-						plan,
-					},
-					baseUrl
-				);
-			}
-			return baseUrl;
-		}
-		return href;
-	}
-
 	handleClick = ( e ) => {
-		const { event, feature, compact, onClick, tracksClickName, tracksClickProperties } = this.props;
+		const { event, onClick } = this.props;
 
-		if ( event && tracksClickName ) {
-			this.props.recordTracksEvent( tracksClickName, {
+		if ( event ) {
+			this.props.recordTracksEvent( 'calypso_banner_cta_click', {
 				cta_name: event,
-				cta_feature: feature,
-				cta_size: compact ? 'compact' : 'regular',
-				...tracksClickProperties,
 			} );
 		}
 
@@ -127,13 +66,11 @@ export class Banner extends Component {
 	};
 
 	handleDismiss = ( e ) => {
-		const { event, feature, onDismiss, tracksDismissName, tracksDismissProperties } = this.props;
+		const { event, onDismiss } = this.props;
 
-		if ( event && tracksDismissName ) {
-			this.props.recordTracksEvent( tracksDismissName, {
+		if ( event ) {
+			this.props.recordTracksEvent( 'calypso_banner_dismiss', {
 				cta_name: event,
-				cta_feature: feature,
-				...tracksDismissProperties,
 			} );
 		}
 
@@ -141,18 +78,10 @@ export class Banner extends Component {
 	};
 
 	getIcon() {
-		const { icon, jetpack, showIcon } = this.props;
+		const { icon, showIcon } = this.props;
 
 		if ( ! showIcon ) {
 			return;
-		}
-
-		if ( jetpack ) {
-			return (
-				<div className="banner__icon-plan">
-					<JetpackLogo size={ 32 } />
-				</div>
-			);
 		}
 
 		return (
@@ -168,75 +97,39 @@ export class Banner extends Component {
 	}
 
 	getContent() {
-		const {
-			callToAction,
-			forceHref,
-			description,
-			event,
-			feature,
-			compact,
-			list,
-			price,
-			title,
-			target,
-			tracksImpressionName,
-			tracksImpressionProperties,
-		} = this.props;
-
-		const prices = Array.isArray( price ) ? price : [ price ];
+		const { callToAction, description, event, title, target } = this.props;
 
 		return (
 			<div className="banner__content">
-				{ tracksImpressionName && event && (
+				{ event && (
 					<TrackComponentView
-						eventName={ tracksImpressionName }
+						eventName="calypso_banner_cta_impression"
 						eventProperties={ {
 							cta_name: event,
-							cta_feature: feature,
-							cta_size: compact ? 'compact' : 'regular',
-							...tracksImpressionProperties,
 						} }
 					/>
 				) }
 				<div className="banner__info">
 					<div className="banner__title">{ title }</div>
 					{ description && <div className="banner__description">{ description }</div> }
-					{ size( list ) > 0 && (
-						<ul className="banner__list">
-							{ list.map( ( item, key ) => (
-								<li key={ key }>
-									<Gridicon icon="checkmark" size={ 18 } />
-									{ item }
-								</li>
-							) ) }
-						</ul>
-					) }
 				</div>
-				{ ( callToAction || price ) && (
+				{ callToAction && (
 					<div className="banner__action">
-						{ size( prices ) === 1 && <PlanPrice rawPrice={ prices[ 0 ] } /> }
-						{ size( prices ) === 2 && (
-							<div className="banner__prices">
-								<PlanPrice rawPrice={ prices[ 0 ] } original />
-								<PlanPrice rawPrice={ prices[ 1 ] } discounted />
-							</div>
-						) }
-						{ callToAction &&
-							( forceHref ? (
-								<Button compact primary target={ target }>
-									{ callToAction }
-								</Button>
-							) : (
-								<Button
-									compact
-									href={ this.getHref() }
-									onClick={ this.handleClick }
-									primary
-									target={ target }
-								>
-									{ callToAction }
-								</Button>
-							) ) }
+						( this.props.forceHref ? (
+						<Button compact primary target={ target }>
+							{ callToAction }
+						</Button>
+						) : (
+						<Button
+							compact
+							href={ this.getHref() }
+							onClick={ this.handleClick }
+							primary
+							target={ target }
+						>
+							{ callToAction }
+						</Button>
+						) )
 					</div>
 				) }
 			</div>
@@ -247,36 +140,19 @@ export class Banner extends Component {
 		const {
 			callToAction,
 			className,
-			compact,
 			disableHref,
 			dismissPreferenceName,
 			dismissTemporary,
 			forceHref,
 			horizontal,
-			jetpack,
-			plan,
 		} = this.props;
-
-		// No Banners for WP for Teams sites.
-		if ( config.isEnabled( 'signup/wpforteams' ) && this.props.isSiteWPForTeams ) {
-			return null;
-		}
 
 		const classes = classNames(
 			'banner',
 			className,
 			{ 'has-call-to-action': callToAction },
-			{ 'is-upgrade-blogger': plan && isBloggerPlan( plan ) },
-			{ 'is-upgrade-personal': plan && isPersonalPlan( plan ) },
-			{ 'is-upgrade-premium': plan && isPremiumPlan( plan ) },
-			{ 'is-upgrade-business': plan && isBusinessPlan( plan ) },
-			{ 'is-upgrade-ecommerce': plan && isEcommercePlan( plan ) },
-			{ 'is-jetpack-plan': plan && planMatches( plan, { group: GROUP_JETPACK } ) },
-			{ 'is-wpcom-plan': plan && planMatches( plan, { group: GROUP_WPCOM } ) },
-			{ 'is-compact': compact },
 			{ 'is-dismissible': dismissPreferenceName },
-			{ 'is-horizontal': horizontal },
-			{ 'is-jetpack': jetpack }
+			{ 'is-horizontal': horizontal }
 		);
 
 		if ( dismissPreferenceName ) {
@@ -306,10 +182,4 @@ export class Banner extends Component {
 	}
 }
 
-const mapStateToProps = ( state, ownProps ) => ( {
-	siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
-	canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
-	isSiteWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ),
-} );
-
-export default connect( mapStateToProps, { recordTracksEvent } )( Banner );
+export default connect( null, { recordTracksEvent } )( Banner );

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -22,10 +22,6 @@
 
 	@include banner-color( var( --color-accent ) );
 
-	&.is-jetpack {
-		@include banner-color( var( --color-jetpack ) );
-	}
-
 	.card__link-indicator {
 		align-items: center;
 		color: var( --color-neutral );
@@ -99,21 +95,6 @@
 		.banner__icon-circle {
 			display: flex;
 		}
-	}
-}
-
-.banner__icon-plan {
-	display: flex;
-	margin-right: 16px;
-	flex-shrink: 0;
-
-	.product-icon {
-		height: 32px;
-		width: 32px;
-	}
-
-	@include breakpoint( '>480px' ) {
-		align-items: center;
 	}
 }
 

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -145,7 +145,7 @@
 
 	.banner__title {
 		font-size: 14px;
-		font-weight: 500;
+		font-weight: 600;
 	}
 
 	.banner__description {
@@ -188,24 +188,6 @@
 	text-align: left;
 	width: 100%;
 
-	.banner__prices {
-		display: flex;
-		justify-content: flex-start;
-
-		.plan-price {
-			margin-bottom: 0;
-		}
-
-		.plan-price.is-discounted,
-		.plan-price.is-discounted .plan-price__currency-symbol {
-			color: var( --color-neutral-70 );
-		}
-
-		.has-call-to-action & .plan-price {
-			margin-bottom: 8px;
-		}
-	}
-
 	@include breakpoint( '>480px' ) {
 		margin: 0 -6px 0 8px;
 		text-align: center;
@@ -227,11 +209,6 @@
 		.is-dismissible.is-horizontal & {
 			margin-top: 0;
 			margin-right: 40px;
-		}
-
-		.banner__prices {
-			justify-content: flex-end;
-			text-align: right;
 		}
 	}
 }

--- a/client/components/banner/test/index.jsx
+++ b/client/components/banner/test/index.jsx
@@ -35,26 +35,9 @@ import { shallow } from 'enzyme';
  * Internal dependencies
  */
 import { Banner } from '../index';
-import {
-	PLAN_FREE,
-	PLAN_BUSINESS,
-	PLAN_BUSINESS_2_YEARS,
-	PLAN_PREMIUM,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PERSONAL,
-	PLAN_PERSONAL_2_YEARS,
-	PLAN_JETPACK_PERSONAL,
-	PLAN_JETPACK_PERSONAL_MONTHLY,
-	PLAN_JETPACK_PREMIUM,
-	PLAN_JETPACK_PREMIUM_MONTHLY,
-	PLAN_JETPACK_BUSINESS,
-	PLAN_JETPACK_BUSINESS_MONTHLY,
-} from 'lib/plans/constants';
-import PlanPrice from 'my-sites/plan-price/';
 
 const props = {
 	callToAction: null,
-	plan: PLAN_FREE,
 	title: 'banner title',
 };
 
@@ -96,31 +79,9 @@ describe( 'Banner basic tests', () => {
 		expect( comp.find( 'Button' ) ).toHaveLength( 0 );
 	} );
 
-	test( 'should have .is-jetpack class and JetpackLogo if jetpack prop is defined', () => {
-		const { plan, ...propsWithoutPlan } = props;
-		const comp = shallow( <Banner { ...propsWithoutPlan } jetpack /> );
-		expect( comp.find( '.is-jetpack' ) ).toHaveLength( 1 );
-		expect( comp.find( 'JetpackLogo' ) ).toHaveLength( 1 );
-	} );
-
 	test( 'should render have .is-horizontal class if horizontal prop is defined', () => {
 		const comp = shallow( <Banner { ...props } horizontal /> );
 		expect( comp.find( '.is-horizontal' ) ).toHaveLength( 1 );
-	} );
-
-	test( 'should render a <PlanPrice /> when price is specified', () => {
-		const comp = shallow( <Banner { ...props } price={ 100 } /> );
-		expect( comp.find( PlanPrice ) ).toHaveLength( 1 );
-	} );
-
-	test( 'should render two <PlanPrice /> components when there are two prices', () => {
-		const comp = shallow( <Banner { ...props } price={ [ 100, 80 ] } /> );
-		expect( comp.find( PlanPrice ) ).toHaveLength( 2 );
-	} );
-
-	test( 'should render no <PlanPrice /> components when there are no prices', () => {
-		const comp = shallow( <Banner { ...props } /> );
-		expect( comp.find( PlanPrice ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render a .banner__description when description is specified', () => {
@@ -199,43 +160,5 @@ describe( 'Banner basic tests', () => {
 		expect( comp.find( 'Button' ) ).toHaveLength( 1 );
 		expect( comp.find( 'Button' ).props().href ).toBeUndefined();
 		expect( comp.find( 'Button' ).props().children ).toBe( 'Go WordPress!' );
-	} );
-} );
-
-describe( 'Banner should have a class name corresponding to appropriate plan', () => {
-	[
-		PLAN_PERSONAL,
-		PLAN_PERSONAL_2_YEARS,
-		PLAN_JETPACK_PERSONAL,
-		PLAN_JETPACK_PERSONAL_MONTHLY,
-	].forEach( ( plan ) => {
-		test( 'Personal', () => {
-			const comp = shallow( <Banner { ...props } plan={ plan } /> );
-			expect( comp.find( '.is-upgrade-personal' ) ).toHaveLength( 1 );
-		} );
-	} );
-
-	[
-		PLAN_PREMIUM,
-		PLAN_PREMIUM_2_YEARS,
-		PLAN_JETPACK_PREMIUM,
-		PLAN_JETPACK_PREMIUM_MONTHLY,
-	].forEach( ( plan ) => {
-		test( 'Premium', () => {
-			const comp = shallow( <Banner { ...props } plan={ plan } /> );
-			expect( comp.find( '.is-upgrade-premium' ) ).toHaveLength( 1 );
-		} );
-	} );
-
-	[
-		PLAN_BUSINESS,
-		PLAN_BUSINESS_2_YEARS,
-		PLAN_JETPACK_BUSINESS,
-		PLAN_JETPACK_BUSINESS_MONTHLY,
-	].forEach( ( plan ) => {
-		test( 'Business', () => {
-			const comp = shallow( <Banner { ...props } plan={ plan } /> );
-			expect( comp.find( '.is-upgrade-business' ) ).toHaveLength( 1 );
-		} );
 	} );
 } );

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -47,6 +47,7 @@ class UpgradeBanner extends Component {
 					/>
 				) : (
 					<UpsellNudge
+						forceDisplay
 						callToAction={ translate( 'Learn more' ) }
 						event="activity_log_upgrade_click_wpcom"
 						feature={ FEATURE_JETPACK_ESSENTIAL }

--- a/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/upgrade-banner.jsx
@@ -47,7 +47,6 @@ class UpgradeBanner extends Component {
 					/>
 				) : (
 					<UpsellNudge
-						forceDisplay={ true }
 						callToAction={ translate( 'Learn more' ) }
 						event="activity_log_upgrade_click_wpcom"
 						feature={ FEATURE_JETPACK_ESSENTIAL }

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -97,8 +97,8 @@ export class SiteNotice extends React.Component {
 				callToAction={ ctaText }
 				compact
 				event={ eventName }
-				forceHref={ true }
-				forceDisplay={ true }
+				forceHref
+				forceDisplay
 				href={ `/domains/add/${ this.props.site.slug }` }
 				title={ noticeText }
 				tracksClickName="calypso_domain_credit_reminder_click"
@@ -189,8 +189,8 @@ export class SiteNotice extends React.Component {
 				onDismissClick={ this.props.clickDomainUpsellDismiss }
 				dismissPreferenceName="calypso_upgrade_nudge_cta_click"
 				event="calypso_upgrade_nudge_impression"
-				forceDisplay={ true }
-				horizontal={ true }
+				forceDisplay
+				horizontal
 				title={ preventWidows( noticeText ) }
 				showIcon={ false }
 				tracksClickName="calypso_upgrade_nudge_cta_click"
@@ -228,7 +228,7 @@ export class SiteNotice extends React.Component {
 		return (
 			<UpsellNudge
 				event="calypso_upgrade_nudge_impression"
-				forceDisplay={ true }
+				forceDisplay
 				tracksClickName="calypso_upgrade_nudge_cta_click"
 				tracksClickProperties={ eventProperties }
 				tracksImpressionName="calypso_upgrade_nudge_impression"

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -105,6 +105,7 @@ export class SiteNotice extends React.Component {
 				tracksClickProperties={ eventProperties }
 				tracksImpressionName={ eventName }
 				tracksImpressionProperties={ eventProperties }
+				showIcon={ false }
 			/>
 		);
 	}
@@ -191,6 +192,7 @@ export class SiteNotice extends React.Component {
 				forceDisplay={ true }
 				horizontal={ true }
 				title={ preventWidows( noticeText ) }
+				showIcon={ false }
 				tracksClickName="calypso_upgrade_nudge_cta_click"
 				tracksClickProperties={ { cta_name: 'domain-upsell-nudge' } }
 				tracksImpressionName="calypso_upgrade_nudge_impression"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tease apart `Banner` to take out functionality related to upsells
* Add functionality to `UpsellNudge` that was originally handled by `Banner`
* See #38778 

#### Testing instructions

Banners that are not upsells (some of these are inactive):
* client/my-sites/activity/activity-log/index.jsx
* client/blocks/jetpack-backup-creds-banner/index.jsx
* client/my-sites/activity/activity-log/rewind-unavailability-notice.jsx
* client/reader/following/main.jsx
* client/blocks/privacy-policy-banner/index.jsx
* client/me/pending-payments/index.jsx

Previous tickets with testing instructions for UpsellNudges across Calypso:
* https://github.com/Automattic/wp-calypso/pull/41892
* https://github.com/Automattic/wp-calypso/pull/41557
* https://github.com/Automattic/wp-calypso/pull/41552
* https://github.com/Automattic/wp-calypso/pull/41545
* https://github.com/Automattic/wp-calypso/pull/41453
* https://github.com/Automattic/wp-calypso/pull/41451
* https://github.com/Automattic/wp-calypso/pull/41419
* https://github.com/Automattic/wp-calypso/pull/41311
* https://github.com/Automattic/wp-calypso/pull/40988
* https://github.com/Automattic/wp-calypso/pull/40721
* https://github.com/Automattic/wp-calypso/pull/40626