### PR TITLE
Jetpack Cloud: update data layer to match the latest changes in the /scan endpoint

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/types.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/types.tsx
@@ -14,6 +14,7 @@ export type Scan = {
 	state: ScanState;
 	threats: [ Threat ];
 	credentials: [ object ];
+	reason?: string;
 	mostRecent?: {
 		timestamp: string;
 		progress: number;

--- a/client/landing/jetpack-cloud/sections/scan/types.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/types.tsx
@@ -5,16 +5,25 @@ import { Threat } from 'landing/jetpack-cloud/components/threat-item/types';
 
 type ScanState = 'unavailable' | 'provisioning' | 'idle' | 'scanning';
 
+// @todo: we should reflect the different states somehow in our Scan type.
+// For instance, if the state is 'scanning', TS should be able to infer that
+// the current is going to exist and the mostRecent won't. How we can do that?
+// We want to avoid having a huge type full of conditional to make it work for
+// all possible states.
 export type Scan = {
 	state: ScanState;
 	threats: [ Threat ];
 	credentials: [ object ];
-	mostRecent: {
+	mostRecent?: {
 		timestamp: string;
 		progress: number;
+		isInitial: boolean;
 		duration: number;
-		// @todo: complete the error prop when we know what the shape will it have
-		error: string | object;
+		error: boolean;
+	};
+	current?: {
+		timestamp: string;
+		progress: number;
 		isInitial: boolean;
 	};
 };

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -40,7 +40,13 @@ export const formatScanThreat = ( threat ) => ( {
  * @param {object} scanState Raw Scan state object from Scan endpoint
  * @returns {object} Processed Scan state
  */
-const formatScanStateRawResponse = ( { state, threats, credentials, most_recent: mostRecent } ) => {
+const formatScanStateRawResponse = ( {
+	state,
+	threats,
+	credentials,
+	most_recent: mostRecent,
+	current,
+} ) => {
 	return {
 		state,
 		threats: threats.map( formatScanThreat ),
@@ -49,6 +55,12 @@ const formatScanStateRawResponse = ( { state, threats, credentials, most_recent:
 			? {
 					...mostRecent,
 					isInitial: mostRecent.is_initial,
+			  }
+			: null,
+		current: current
+			? {
+					...current,
+					isInitial: current.is_initial,
 			  }
 			: null,
 	};

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -46,23 +46,15 @@ const formatScanStateRawResponse = ( {
 	credentials,
 	most_recent: mostRecent,
 	current,
+	...rest
 } ) => {
 	return {
 		state,
 		threats: threats.map( formatScanThreat ),
 		credentials,
-		mostRecent: mostRecent
-			? {
-					...mostRecent,
-					isInitial: mostRecent.is_initial,
-			  }
-			: null,
-		current: current
-			? {
-					...current,
-					isInitial: current.is_initial,
-			  }
-			: null,
+		...( mostRecent ? { ...mostRecent, isInitial: mostRecent.is_initial } : {} ),
+		...( current ? { ...current, isInitial: current.is_initial } : {} ),
+		...rest,
 	};
 };
 

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { registerHandlers } from 'state/data-layer/handler-registry';
@@ -52,8 +57,18 @@ const formatScanStateRawResponse = ( {
 		state,
 		threats: threats.map( formatScanThreat ),
 		credentials,
-		...( mostRecent ? { ...mostRecent, isInitial: mostRecent.is_initial } : {} ),
-		...( current ? { ...current, isInitial: current.is_initial } : {} ),
+		mostRecent: mostRecent
+			? {
+					...omit( mostRecent, [ 'is_initial' ] ),
+					isInitial: mostRecent.is_initial,
+			  }
+			: undefined,
+		current: current
+			? {
+					...omit( current, [ 'is_initial' ] ),
+					isInitial: current.is_initial,
+			  }
+			: undefined,
 		...rest,
 	};
 };

--- a/client/state/selectors/get-site-scan-is-initial.js
+++ b/client/state/selectors/get-site-scan-is-initial.js
@@ -11,5 +11,5 @@ import 'state/data-layer/wpcom/sites/scan';
  * @returns {boolean}		If the most recent Scan was the first one
  */
 export default function getSiteScanIsInitial( state, siteId ) {
-	return state.jetpackScan.scan?.[ siteId ]?.mostRecent?.isInitial ?? false;
+	return state.jetpackScan.scan?.[ siteId ]?.current?.isInitial ?? false;
 }

--- a/client/state/selectors/get-site-scan-progress.js
+++ b/client/state/selectors/get-site-scan-progress.js
@@ -15,7 +15,7 @@ import 'state/data-layer/wpcom/sites/scan';
  */
 export default function getSiteScanProgress( state, siteId ) {
 	if ( state.jetpackScan.scan?.[ siteId ]?.state === 'scanning' ) {
-		return state.jetpackScan.scan?.[ siteId ]?.mostRecent?.progress ?? 0;
+		return state.jetpackScan.scan?.[ siteId ]?.current?.progress ?? 0;
 	}
 	return;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The latest version of the `/scan` endpoint will introduce some data changes in the shape of the response. For that reason, we need to update the following:

- Data selectors: `getSiteScanIsInitial` and `getSiteScanProgress`.
- Data transformation helpers in `data-layer/wpcom`.
- Scan type.

#### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/`
* Select a site that has the Scan product
* Trigger a Scan
* Verify the progress is being updated in the sidebar and in the progress bar
* Bonus point if you do this on a new site and verify the `isInitial` value is true 

1151678672052943-1174784508278377
