### PR TITLE
Jetpack Cloud: Add upsell state showing multisite is not supported

### DIFF
--- a/client/landing/jetpack-cloud/components/upsell/index.tsx
+++ b/client/landing/jetpack-cloud/components/upsell/index.tsx
@@ -38,15 +38,17 @@ const JetpackCloudUpsell: FunctionComponent< Props > = ( {
 			{ iconComponent }
 			<h2>{ headerText }</h2>
 			<p>{ bodyText }</p>
-			<Button
-				className="upsell__button"
-				href={ buttonLink }
-				onClick={ onClick }
-				primary
-				target="_blank"
-			>
-				{ buttonText || translate( 'Upgrade now' ) }
-			</Button>
+			{ buttonLink && (
+				<Button
+					className="upsell__button"
+					href={ buttonLink }
+					onClick={ onClick }
+					primary
+					target="_blank"
+				>
+					{ buttonText || translate( 'Upgrade now' ) }
+				</Button>
+			) }
 		</div>
 	);
 };

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -23,7 +23,7 @@ function ScanMultisiteBody() {
 	return (
 		<Upsell
 			headerText={ translate( 'Your site does not support Jetpack Scan' ) }
-			bodyText={ translate( 'Scan is currently not supported on WordPress multi-site networks.' ) }
+			bodyText={ translate( 'Jetpack Scan is currently not supported on WordPress multi-site networks.' ) }
 			buttonLink={ false }
 			iconComponent={ <SecurityIcon icon="info" /> }
 		/>

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -52,9 +52,7 @@ function ScanUpsellBody() {
 	);
 }
 
-
 export default function ScanUpsellPage( { reason } ) {
-
 	return (
 		<Main className="scan__main">
 			<DocumentHead title="Scanner" />

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -23,7 +23,7 @@ function ScanMultisiteBody() {
 	return (
 		<Upsell
 			headerText={ translate( 'Your site does not support scan' ) }
-			bodyText={ translate( 'Scan is currently not supported on WordPress Multi-site setups.' ) }
+			bodyText={ translate( 'Scan is currently not supported on WordPress multi-site networks.' ) }
 			buttonLink={ false }
 			iconComponent={ <SecurityIcon icon="info" /> }
 		/>

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -18,6 +18,18 @@ import Upsell from 'landing/jetpack-cloud/components/upsell';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+function ScanMultisiteBody() {
+	const translate = useTranslate();
+	return (
+		<Upsell
+			headerText={ translate( 'Your site does not have scan' ) }
+			bodyText={ translate( 'Scan is currently not supported on WordPress Multi-site setups.' ) }
+			buttonLink={ false }
+			iconComponent={ <SecurityIcon icon="info" /> }
+		/>
+	);
+}
+
 function ScanVPActiveBody() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -52,15 +64,23 @@ function ScanUpsellBody() {
 	);
 }
 
+function renderUpsell( reason ) {
+	if ( 'multisite_not_supported' === reason ) {
+		return <ScanMultisiteBody />;
+	}
+	if ( 'vp_active_on_site' === reason ) {
+		return <ScanVPActiveBody />;
+	}
+	return <ScanUpsellBody />;
+}
+
 export default function ScanUpsellPage( { reason } ) {
 	return (
 		<Main className="scan__main">
 			<DocumentHead title="Scanner" />
 			<SidebarNavigation />
 			<PageViewTracker path="/scan/:site" title="Scanner Upsell" />
-			<div className="scan__content">
-				{ 'vp_active_on_site' === reason ? <ScanVPActiveBody /> : <ScanUpsellBody /> }
-			</div>
+			<div className="scan__content">{ renderUpsell( reason ) }</div>
 			<StatsFooter
 				noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backups has you covered."
 				noticeLink="https://jetpack.com/upgrade/backups"

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -22,7 +22,7 @@ function ScanMultisiteBody() {
 	const translate = useTranslate();
 	return (
 		<Upsell
-			headerText={ translate( 'Your site does not have scan' ) }
+			headerText={ translate( 'Your site does not support scan' ) }
 			bodyText={ translate( 'Scan is currently not supported on WordPress Multi-site setups.' ) }
 			buttonLink={ false }
 			iconComponent={ <SecurityIcon icon="info" /> }

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -23,7 +23,9 @@ function ScanMultisiteBody() {
 	return (
 		<Upsell
 			headerText={ translate( 'Your site does not support Jetpack Scan' ) }
-			bodyText={ translate( 'Jetpack Scan is currently not supported on WordPress multi-site networks.' ) }
+			bodyText={ translate(
+				'Jetpack Scan is currently not supported on WordPress multi-site networks.'
+			) }
 			buttonLink={ false }
 			iconComponent={ <SecurityIcon icon="info" /> }
 		/>

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -22,7 +22,7 @@ function ScanMultisiteBody() {
 	const translate = useTranslate();
 	return (
 		<Upsell
-			headerText={ translate( 'Your site does not support scan' ) }
+			headerText={ translate( 'Your site does not support Jetpack Scan' ) }
 			bodyText={ translate( 'Scan is currently not supported on WordPress multi-site networks.' ) }
 			buttonLink={ false }
 			iconComponent={ <SecurityIcon icon="info" /> }

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -52,7 +52,9 @@ function ScanUpsellBody() {
 	);
 }
 
+
 export default function ScanUpsellPage( { reason } ) {
+
 	return (
 		<Main className="scan__main">
 			<DocumentHead title="Scanner" />

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -56,7 +56,6 @@ const formatScanStateRawResponse = ( {
 } ) => {
 	return {
 		state,
-		reason,
 		threats: threats.map( formatScanThreat ),
 		credentials,
 		mostRecent: mostRecent

--- a/client/state/data-layer/wpcom/sites/scan/index.js
+++ b/client/state/data-layer/wpcom/sites/scan/index.js
@@ -56,6 +56,7 @@ const formatScanStateRawResponse = ( {
 } ) => {
 	return {
 		state,
+		reason,
 		threats: threats.map( formatScanThreat ),
 		credentials,
 		mostRecent: mostRecent


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* The current upsell state doesn't know about that multisite is not supported. 
* This PR fixes it by showing a more meaningful message and hiding the Upgrade now button. 

Before:

<img width="848" alt="Screen Shot 2020-05-07 at 10 47 06 PM" src="https://user-images.githubusercontent.com/115071/81343617-99adb580-90b5-11ea-93e3-5c341d942b71.png">

After:
<img width="731" alt="Screen Shot 2020-05-12 at 11 00 23 AM" src="https://user-images.githubusercontent.com/115071/81664551-db38ba80-943f-11ea-93ed-a01efe6d4e1c.png">


#### Testing instructions
* On a site multisite navigate to /scan section. Notice a message telling you that your site is not supported. 
* On a site without a plan notice the regular upsell component. 
