### PR TITLE
Tidy up Premium Block Style and Behaviour

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/controls.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/controls.js
@@ -18,14 +18,19 @@ import NewPlan from './new-plan';
  * @typedef { Object } Props
  * @property { number } selectedPlanId
  * @property { (plan: Plan) => void } onSelected
+ * @property { (plan: Plan) => string } formatPrice
  * @property { string } className
  * @property { Plan[] } plans
  *
  * @param { Props } props
  */
 export default function Controls( props ) {
-	const { selectedPlanId, onSelected, plans } = props;
+	const { selectedPlanId, onSelected, plans, getPlanDescription } = props;
 	const currentPlan = plans.find( ( plan ) => plan.id === selectedPlanId );
+	let planDescription = null;
+	if ( currentPlan ) {
+		planDescription = ' ' + getPlanDescription( currentPlan );
+	}
 	return (
 		<BlockControls>
 			<Toolbar>
@@ -34,13 +39,7 @@ export default function Controls( props ) {
 					icon={
 						<Fragment>
 							<Dashicon icon="update" />{ ' ' }
-							{ currentPlan && (
-								<Fragment>
-									{ ' ' }
-									{ currentPlan.title } : { currentPlan.price } { currentPlan.currency } /{ ' ' }
-									{ currentPlan.interval }{ ' ' }
-								</Fragment>
-							) }
+							{ planDescription && <Fragment>{ planDescription }</Fragment> }
 						</Fragment>
 					}
 					label={ __( 'Select a plan', 'premium-content' ) }

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/index.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { getCurrencyDefaults } from '@automattic/format-currency';
+import { trimEnd } from 'lodash';
 
 /**
  * Internal dependencies
@@ -104,3 +106,70 @@ const settings = {
 };
 
 export { name, category, settings };
+
+/**
+ * Currencies we support and Stripe's minimum amount for a transaction in that currency.
+ *
+ * https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
+ *
+ * @type { [currency: string]: number }
+ */
+export const SUPPORTED_CURRENCIES = {
+	USD: 0.5,
+	AUD: 0.5,
+	BRL: 0.5,
+	CAD: 0.5,
+	CHF: 0.5,
+	DKK: 2.5,
+	EUR: 0.5,
+	GBP: 0.3,
+	HKD: 4.0,
+	INR: 0.5,
+	JPY: 50,
+	MXN: 10,
+	NOK: 3.0,
+	NZD: 0.5,
+	PLN: 2.0,
+	SEK: 3.0,
+	SGD: 0.5,
+};
+
+/**
+ * Compute a list of currency value and display labels.
+ *
+ * - `value` is the currency's three character code
+ * - `label` is the user facing representation.
+ *
+ * @typedef {{value: string, label: string}} CurrencyDetails
+ *
+ * @type Array<CurrencyDetails>
+ */
+export const CURRENCY_OPTIONS = Object.keys( SUPPORTED_CURRENCIES ).map( value => {
+	const { symbol } = getCurrencyDefaults( value );
+	const label = symbol === value ? value : `${ value } ${ trimEnd( symbol, '.' ) }`;
+	return { value, label };
+} );
+
+/**
+ * Returns the minimum transaction amount for the given currency. If currency is not one of the
+ * known types it returns ...
+ *
+ * @param {string} currency_code three character currency code to get minimum charge for
+ * @return {number} Minimum charge amount for the given currency_code
+ */
+export function minimumTransactionAmountForCurrency( currency_code ) {
+	const minimum = SUPPORTED_CURRENCIES[ currency_code ];
+	return minimum;
+}
+
+/**
+ * True if the price is a number and at least the minimum allowed amount.
+ *
+ * @param {string} currency Currency for the given price.
+ * @param {number} price Price to check.
+ * @return {boolean} true if valid price
+ */
+export function isPriceValid( currency, price ) {
+	return ! isNaN( price ) && price >= minimumTransactionAmountForCurrency( currency );
+}
+

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/inspector.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/inspector.js
@@ -15,6 +15,11 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { CURRENCY_OPTIONS } from '.';
+
 const API_STATE_NOT_REQUESTING = 0;
 const API_STATE_REQUESTING = 1;
 
@@ -82,10 +87,7 @@ export default function Inspector( props ) {
 								label="Currency"
 								onChange={ ( set ) => setAttributes( { newPlanCurrency: set } ) }
 								value={ attributes.newPlanCurrency }
-								options={ currencies.map( ( currency ) => ( {
-									label: currency.label,
-									value: currency.label,
-								} ) ) }
+								options={ CURRENCY_OPTIONS }
 							></SelectControl>
 							<TextControl
 								label="Price"
@@ -136,108 +138,3 @@ export default function Inspector( props ) {
 		</InspectorControls>
 	);
 }
-
-Inspector.defaultProps = {
-	currencies: [
-		{
-			label: 'USD',
-			symbol: '$',
-		},
-		{
-			label: 'GBP',
-			symbol: '&#163;',
-		},
-		{
-			label: 'JPY',
-			symbol: '&#165;',
-		},
-		{
-			label: 'BRL',
-			symbol: 'R$',
-		},
-		{
-			label: 'EUR',
-			symbol: '&#8364;',
-		},
-		{
-			label: 'NZD',
-			symbol: 'NZ$',
-		},
-		{
-			label: 'AUD',
-			symbol: 'A$',
-		},
-		{
-			label: 'CAD',
-			symbol: 'C$',
-		},
-		{
-			label: 'INR',
-			symbol: '\u20b9',
-		},
-		{
-			label: 'ILS',
-			symbol: '\u20aa',
-		},
-		{
-			label: 'RUB',
-			symbol: '\u20bd',
-		},
-		{
-			label: 'MXN',
-			symbol: 'MX$',
-		},
-		{
-			label: 'SEK',
-			symbol: 'SEK',
-		},
-		{
-			label: 'HUF',
-			symbol: 'Ft',
-		},
-		{
-			label: 'CHF',
-			symbol: 'CHF',
-		},
-		{
-			label: 'CZK',
-			symbol: 'K\u010d',
-		},
-		{
-			label: 'DKK',
-			symbol: 'Dkr',
-		},
-		{
-			label: 'HKD',
-			symbol: 'HK$',
-		},
-		{
-			label: 'NOK',
-			symbol: 'Kr',
-		},
-		{
-			label: 'PHP',
-			symbol: '\u20b1',
-		},
-		{
-			label: 'PLN',
-			symbol: 'PLN',
-		},
-		{
-			label: 'SGD',
-			symbol: 'S$',
-		},
-		{
-			label: 'TWD',
-			symbol: 'NT$',
-		},
-		{
-			label: 'THB',
-			symbol: '\u0e3f',
-		},
-		{
-			label: 'TRY',
-			symbol: 'TL',
-		},
-	],
-};

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/plan.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/plan.js
@@ -17,15 +17,28 @@ import { MenuItem } from '@wordpress/components';
  * @property { undefined | Plan } selectedPlan
  * @property { () => void } onClose
  * @property { (plan: Plan) => void } onSelected
+ * @property { (plan: Plan) => string } formatPrice
  *
  * @param { Props } props
  */
 export default function Plan( props ) {
-	const { className, plan, selectedPlan, onSelected, onClose } = props;
+	const {
+		className,
+		plan,
+		selectedPlan,
+		onSelected,
+		onClose,
+		getPlanDescription,
+	} = props;
 
 	const isSelected = selectedPlan && plan.id === selectedPlan.id;
 	const classNames = ( isSelected ? [ 'is-selected' ] : [] ).concat( [ className ] ).join( ' ' );
 	const icon = isSelected ? 'yes' : undefined;
+
+	let planDescription = null;
+	if ( plan ) {
+		planDescription = ' ' + getPlanDescription( plan );
+	}
 
 	return (
 		<MenuItem
@@ -40,7 +53,7 @@ export default function Plan( props ) {
 			selected={ isSelected }
 			icon={ icon }
 		>
-			{ plan.title } : { plan.price } { plan.currency } / { plan.interval }
+			{ plan.title } : { planDescription }
 		</MenuItem>
 	);
 }

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/subscriber-view/edit.js
@@ -35,6 +35,7 @@ function Edit( props ) {
 				<div hidden={ selectedTab.id === 'wall' } className={ selectedTab.className }>
 					{ stripeNudge }
 					<InnerBlocks
+						renderAppender={ ! props.hasInnerBlocks && InnerBlocks.ButtonBlockAppender }
 						templateLock={ false }
 						template={ [
 							[
@@ -57,6 +58,8 @@ function Edit( props ) {
 export default compose( [
 	withSelect( ( select, props ) => {
 		return {
+			// @ts-ignore difficult to type with JSDoc
+			hasInnerBlocks: !! ( select( 'core/block-editor' ).getBlocksByClientId( props.clientId )[ 0 ].innerBlocks.length ),
 			// @ts-ignore difficult to type with JSDoc
 			containerClientId: select( 'core/block-editor' ).getBlockHierarchyRootClientId(
 				props.clientId

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/editor.css
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/editor.css
@@ -28,13 +28,8 @@
 	margin-left: auto;
 }
 
-
 .premium-content-wrapper {
 	margin: 0;
-}
-
-.premium-content-toolbar-button {
-	min-width: 150px;
 }
 
 .premium-content-block-nudge .editor-warning {
@@ -97,8 +92,12 @@
 	margin: 0;
 }
 
-.wp-block-premium-content-container---settings-add_plan .components-panel__row.plan-price {
-	margin-bottom: 28px;
+.wp-block-premium-content-container---settings-add_plan .components-panel__row:last-child {
+	margin-top: 25px;
+}
+
+.wp-block-premium-content-container---settings-add_plan .components-base-control:last-child {
+	margin: 0;
 }
 
 .wp-block-premium-content-container---link-to-earn {

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -72,6 +72,7 @@
 		"prepare": "check-npm-client && yarn run sync:newspack-blocks --nodemodules"
 	},
 	"dependencies": {
+		"@automattic/format-currency": "^1.0.0-alpha.0",
 		"@wordpress/api-fetch": "*",
 		"@wordpress/block-editor": "*",
 		"@wordpress/blocks": "*",


### PR DESCRIPTION
This patch will try to fix the issues outlined here - https://github.com/Automattic/wp-calypso/issues/41587

The patch uses `formatCurrency` to format the plan price details correctly.

Apply the D43140-code and try this out on an FSE and simple site.

We have extra spacing between the fields of the Add subscription form. Removing it cleans up the layout.

- [ ] We have extra spacing between the fields of the Add subscription form. Removing it cleans up the layout. ![obraz](https://user-images.githubusercontent.com/3775068/80579375-344d2b00-8a0a-11ea-9b98-7471b3f8ceb0.png)
![obraz](https://user-images.githubusercontent.com/3775068/80579410-45963780-8a0a-11ea-8137-c83651be49cf.png)


- [ ] Update the visible option in the dropdown so that it only shows the price while still showing the titles in the dropdown options? (See the screenshot),  Add 5px of spacing to the right of the subscription icon. 
![obraz](https://user-images.githubusercontent.com/3775068/80579510-71b1b880-8a0a-11ea-87f9-d829245a3b70.png)

- [ ] Hide subscription when Stripe isn't connected

![obraz](https://user-images.githubusercontent.com/3775068/80579789-e71d8900-8a0a-11ea-8876-8d652516570a.png)


- [ ] If you remove all the blocks from the subscriber view, it's hard to add any back in.
Now if you remove all the blocks in subscriber view, you will see this;
<img width="838" alt="Screenshot 2020-05-07 at 21 49 25" src="https://user-images.githubusercontent.com/5560595/81344817-636d3780-90af-11ea-8507-034eb185d39e.png">





