### PR TITLE
Add notice for block patterns new location.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -42,7 +42,7 @@ const BlockPatternsMoved = () => {
 							'You can now find them in the block inserter under the "patterns" tab.  The block inserter can be found in the top-left corner of your screen by selecting the following icon:'
 						) }
 					</p>
-					<Button icon={ plus } onClick={ openInserter } />
+					<Button isPrimary icon={ plus } onClick={ openInserter } />
 				</PanelBody>
 			</PluginSidebar>
 		</>

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -1,4 +1,52 @@
 /**
+ * External dependencies
+ */
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
+import { layout, plus } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { PanelBody, Button } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import './index.scss';
+
+const BlockPatternsMoved = () => {
+	const openInserter = () => {
+		const inserterButton = document.querySelector( '.edit-post-header-toolbar__inserter-toggle' );
+		inserterButton && inserterButton.click();
+		setTimeout( () => {
+			const patternsButton = document.querySelector(
+				'.block-editor-inserter__tabs [id$="patterns"]'
+			);
+			patternsButton && patternsButton.click();
+		}, 300 );
+	};
+
+	return (
+		<>
+			<PluginSidebarMoreMenuItem icon={ layout } target="block-patterns-moved">
+				{ __( 'Block Patterns' ) }
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar
+				icon={ layout }
+				name={ 'global-styles' }
+				title={ __( 'Block Patterns' ) }
+				className="common__block-patterns-moved"
+			>
+				<PanelBody>
+					<h2>{ __( 'Block Patterns have moved!' ) }</h2>
+					<p>
+						{ __(
+							'You can now find them in the block inserter.  This can be found in the upper left corner of your screen by selecting the inserter icon:'
+						) }
+					</p>
+					<Button icon={ plus } onClick={ openInserter } />
+				</PanelBody>
+			</PluginSidebar>
+		</>
+	);
+};
+
+registerPlugin( 'block-patterns-moved', { render: BlockPatternsMoved } );

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -36,10 +36,11 @@ const BlockPatternsMoved = () => {
 				className="common__block-patterns-moved"
 			>
 				<PanelBody>
-					<h2>{ __( 'Block Patterns have moved!' ) }</h2>
+					<h2>{ ( __( 'Block Patterns have moved!' ), 'full-site-editing' ) }</h2>
 					<p>
 						{ __(
-							'You can now find them in the block inserter under the "patterns" tab.  The block inserter can be found in the top-left corner of your screen by selecting the following icon:'
+							'You can now find them in the block inserter under the "patterns" tab.  The block inserter can be found in the top-left corner of your screen by selecting the following icon:',
+							'full-site-editing'
 						) }
 					</p>
 					<Button isPrimary icon={ plus } onClick={ openInserter } />

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -27,19 +27,25 @@ const BlockPatternsMoved = () => {
 	return (
 		<>
 			<PluginSidebarMoreMenuItem icon={ layout } target="block-patterns-moved">
-				{ __( 'Block Patterns Have Moved' ) }
+				{ __( 'Block Patterns', 'full-site-editing' ) }
 			</PluginSidebarMoreMenuItem>
 			<PluginSidebar
 				icon={ layout }
 				name={ 'block-patterns-moved' }
-				title={ __( 'Block Patterns Have Moved' ) }
+				title={ __( 'Block Patterns', 'full-site-editing' ) }
 				className="common__block-patterns-moved"
 			>
 				<PanelBody>
-					<h2>{ ( __( 'Block Patterns have moved!' ), 'full-site-editing' ) }</h2>
+					<h2>{ __( 'Block Patterns', 'full-site-editing' ) }</h2>
 					<p>
 						{ __(
-							'You can now find them in the block inserter under the "patterns" tab.  The block inserter can be found in the top-left corner of your screen by selecting the following icon:',
+							'Block Patterns have moved. You can now find them in the block inserter under the "patterns" tab.',
+							'full-site-editing'
+						) }
+					</p>
+					<p>
+						{ __(
+							'The block inserter can be found in the top-left corner of your screen by selecting the following icon:',
 							'full-site-editing'
 						) }
 					</p>

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -27,19 +27,19 @@ const BlockPatternsMoved = () => {
 	return (
 		<>
 			<PluginSidebarMoreMenuItem icon={ layout } target="block-patterns-moved">
-				{ __( 'Block Patterns' ) }
+				{ __( 'Block Patterns Have Moved' ) }
 			</PluginSidebarMoreMenuItem>
 			<PluginSidebar
 				icon={ layout }
-				name={ 'global-styles' }
-				title={ __( 'Block Patterns' ) }
+				name={ 'block-patterns-moved' }
+				title={ __( 'Block Patterns Have Moved' ) }
 				className="common__block-patterns-moved"
 			>
 				<PanelBody>
 					<h2>{ __( 'Block Patterns have moved!' ) }</h2>
 					<p>
 						{ __(
-							'You can now find them in the block inserter.  This can be found in the upper left corner of your screen by selecting the inserter icon:'
+							'You can now find them in the block inserter under the "patterns" tab.  The block inserter can be found in the top-left corner of your screen by selecting the following icon:'
 						) }
 					</p>
 					<Button icon={ plus } onClick={ openInserter } />

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.php
@@ -10,6 +10,7 @@
  */
 
 namespace A8C\FSE\Common;
+use function A8C\FSE\is_full_site_editing_active;
 
 /**
  * Can be used to determine if the current screen is the block editor.
@@ -52,7 +53,8 @@ function is_homepage_title_hidden() {
  * @return bool True if the common module assets should be loaded.
  */
 function should_load_assets() {
-	return (bool) is_homepage_title_hidden();
+	// TODO - remove is_F_S_E check when we remove the "block patterns moved" notice plugin.
+	return (bool) is_homepage_title_hidden() || ! is_full_site_editing_active();
 }
 
 /**
@@ -75,11 +77,9 @@ add_filter( 'admin_body_class', __NAMESPACE__ . '\admin_body_classes' );
  */
 function enqueue_script_and_style() {
 	// Avoid loading assets if possible.
-
-	// TODO - Re-enable this once we remove the block patterns moved notice plugin.
-	// if ( ! should_load_assets() ) {
-	// 	return;
-	// }
+	if ( ! should_load_assets() ) {
+		return;
+	}
 
 	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/common.asset.php';
 	$script_dependencies = $asset_file['dependencies'];

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.php
@@ -75,9 +75,11 @@ add_filter( 'admin_body_class', __NAMESPACE__ . '\admin_body_classes' );
  */
 function enqueue_script_and_style() {
 	// Avoid loading assets if possible.
-	if ( ! should_load_assets() ) {
-		return;
-	}
+
+	// TODO - Re-enable this once we remove the block patterns moved notice plugin.
+	// if ( ! should_load_assets() ) {
+	// 	return;
+	// }
 
 	$asset_file          = include plugin_dir_path( __FILE__ ) . 'dist/common.asset.php';
 	$script_dependencies = $asset_file['dependencies'];

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.scss
@@ -3,10 +3,3 @@ body.hide-homepage-title {
 		display: none;
 	}
 }
-
-.common__block-patterns-moved {
-	.components-button {
-		background: #007cba;
-		color: #fff;
-	}
-}

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.scss
@@ -3,3 +3,10 @@ body.hide-homepage-title {
 		display: none;
 	}
 }
+
+.common__block-patterns-moved {
+	.components-button {
+		background: #007cba;
+		color: #fff;
+	}
+}

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -81,6 +81,7 @@
 		"@wordpress/element": "*",
 		"@wordpress/hooks": "*",
 		"@wordpress/html-entities": "*",
+		"@wordpress/icons": "*",
 		"@wordpress/i18n": "*",
 		"@wordpress/keycodes": "*",
 		"@wordpress/plugins": "*",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As block patterns were recently moved, there have been a number of support requests from users that have not been able to find them.

This reintroduces the block patterns sidebar plugin to notify users of the change.  This is intended to be temporary and removed in the coming weeks after users have had a chance to adapt to this change.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build / Sync FSE plugin on this branch.
* Go to the editor, ensure the block patterns Icon is in the top-right toolbar and in the dropdown menu.
* Verify clicking the icon shows a message that block patterns have moved.
* Verify clicking the example icon opens the block patterns inserter.

<hr/>

![Screen Shot 2020-05-07 at 7 36 19 PM](https://user-images.githubusercontent.com/28742426/81354813-8a6d3e80-909a-11ea-9fd3-8ebcf682624c.png)
<hr/>

![Screen Shot 2020-05-07 at 7 36 37 PM](https://user-images.githubusercontent.com/28742426/81354811-89d4a800-909a-11ea-8531-3c6381880086.png)
<hr/>

![Screen Shot 2020-05-07 at 8 10 50 PM](https://user-images.githubusercontent.com/28742426/81356300-e043e580-909e-11ea-83d2-6000315977c1.png)


<hr/>

Fixes #41930
