### PR TITLE
Stats: implement top post sort properly

### DIFF
--- a/client/state/stats/lists/selectors.js
+++ b/client/state/stats/lists/selectors.js
@@ -237,7 +237,15 @@ export const getTopPostAndPage = ( state, siteId, query ) => {
 		} );
 	} );
 
-	const sortedTopPosts = Object.values( topPosts ).sort( ( a, b ) => a.views > b.views );
+	const sortedTopPosts = Object.values( topPosts ).sort( ( a, b ) => {
+		if ( a.views > b.views ) {
+			return -1;
+		}
+		if ( a.views < b.views ) {
+			return 1;
+		}
+		return 0;
+	} );
 
 	if ( ! sortedTopPosts.length ) {
 		return {


### PR DESCRIPTION
This fixes https://github.com/Automattic/wp-calypso/issues/41940 where the top post wasn't being reported correctly in the stats card. A stats selector did not implement [sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) correctly.

![81305946-d60df100-9076-11ea-9e2b-c54c639037c4](https://user-images.githubusercontent.com/1270189/81355348-1ffcd400-9083-11ea-92ee-095dcee5cda2.png)
![81305952-d73f1e00-9076-11ea-9ca9-8b5f76471309](https://user-images.githubusercontent.com/1270189/81355352-21c69780-9083-11ea-94df-9023f89f08b0.png)

### Testing Instructions 
- Visit /home with a site that has a good amount of traffic
- Compare the top post or page on Home with results on http://calypso.localhost:3000/stats/day/posts/siteSlug under the 7 day view
- Verify that top posts or page matches instead of a random result