### PR TITLE
FSE: Update NUX slides

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/images/preview.svg
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/images/preview.svg
@@ -1,0 +1,16 @@
+<svg width="335" height="278" viewBox="0 0 335 278" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M0 0H334.656V277H0V0Z" fill="#1381D8"/>
+	<path d="M48 39.8672C48 38.8359 48.9907 38 50.213 38H284.787C286.01 38 287 38.8359 287 39.8672V277H48V39.8672Z" fill="white"/>
+	<path d="M186 60H164V68H186V60Z" fill="#E2E4E7"/>
+	<path d="M214 60H192V68H214V60Z" fill="#E2E4E7"/>
+	<path d="M242 60H220V68H242V60Z" fill="#E2E4E7"/>
+	<path d="M270 60H247V68H270V60Z" fill="#E2E4E7"/>
+	<circle cx="73" cy="64" r="9" fill="#1E1E1E"/>
+	<rect x="48" y="91" width="239" height="126" fill="#E2E4E7"/>
+	<rect x="48" y="235" width="108" height="42" fill="#E2E4E7"/>
+	<path d="M210 162H81V178H210V162Z" fill="white"/>
+	<path d="M121 185H81V194H121V185Z" fill="white"/>
+	<path d="M255 243H170V251H255V243Z" fill="#E2E4E7"/>
+	<path d="M255 256H170V264H255V256Z" fill="#E2E4E7"/>
+	<path d="M212.806 269H170V277H212.806V269Z" fill="#E2E4E7"/>
+</svg>

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -20,7 +20,8 @@ import './style.scss';
 import blockImage from './images/block.svg';
 import blockPickerImage from './images/block-picker.svg';
 import editorImage from './images/editor.svg';
-//import privateImage from './images/private.svg';
+import previewImage from './images/preview.svg';
+import privateImage from './images/private.svg';
 
 function WpcomNux() {
 	const { isWpcomNuxEnabled, isSPTOpen } = useSelect( ( select ) => ( {
@@ -50,65 +51,83 @@ function WpcomNux() {
 
 	const dismissWpcomNux = () => setWpcomNuxStatus( { isNuxEnabled: false } );
 
+	/* @TODO: the copy, images, and slides will eventually be the same for all sites. `isGutenboarding` is only needed right now to serve copy that hasn't been translated before initial launch */
 	const isGutenboarding = !! window.calypsoifyGutenberg?.isGutenboarding;
-	const welcomeHeading = isGutenboarding
-		? __( 'Welcome to your website' )
-		: __( 'Welcome to the WordPress editor' );
 
 	return (
 		<Guide
 			className="wpcom-block-editor-nux"
-			contentLabel={ welcomeHeading }
+			contentLabel={ __( 'Welcome to your website' ) }
 			finishButtonText={ __( 'Get started' ) }
 			onFinish={ dismissWpcomNux }
 		>
 			<NuxPage
-				heading={ welcomeHeading }
-				description={
-					isGutenboarding
-						? __(
-								'Edit your homepage, add the pages you need, and change your site’s look and feel.'
-						  )
-						: __( 'Create and edit site pages, and customize the look and feel of each page.' )
-				}
+				heading={ __( 'Welcome to your website' ) }
+				description={ __(
+					'Edit your homepage, add the pages you need, and change your site’s look and feel.'
+				) }
 				imgSrc={ editorImage }
 				alignBottom
 			/>
 
+			{ ! isGutenboarding && (
+				<NuxPage
+					heading={ __( 'Create pages and add your content' ) }
+					description={ __(
+						'Create and rearrange your site pages. Customize your site navigation menus so your visitors can explore your site.'
+					) }
+					imgSrc={ blockImage }
+				/>
+			) }
+
 			<NuxPage
 				heading={
-					isGutenboarding
-						? __( 'Customize your content' )
-						: __( 'Create pages and add your content' )
+					isGutenboarding ? __( 'Add or edit your content' ) : __( 'Add (almost) anything' )
 				}
 				description={
 					isGutenboarding
-						? __( 'Start with an existing layout and make it your own.' )
+						? __(
+								'Edit the placeholder content we’ve started you off with, or click the plus sign to add more content.'
+						  )
 						: __(
-								'Create and rearrange your site pages. Customize your site navigation menus so your visitors can explore your site.'
+								'Insert text, photos, forms, Yelp reviews, testimonials, maps, and more. Rearrange the blocks on your page until they’re just right.'
 						  )
 				}
-				imgSrc={ blockImage }
-			/>
-
-			<NuxPage
-				heading={ __( 'Add (almost) anything' ) }
-				description={ __(
-					'Insert text, photos, forms, Yelp reviews, testimonials, maps, and more. Rearrange the blocks on your page until they’re just right.'
-				) }
 				imgSrc={ blockPickerImage }
 			/>
 
-			{ /* @TODO: hide for sites that are already public
-			<NuxPage
-				heading={ __( "Private until you're ready to launch" ) }
-				description={ __(
-					"Your site remains private until you're ready to launch. Take your time and make as many changes as you need until it's ready to share with the world."
-				) }
-				imgSrc={ privateImage }
-				alignBottom
-			/>
-			*/ }
+			{ isGutenboarding && (
+				<NuxPage
+					heading={ __( 'Preview your site as you go' ) }
+					description={ __(
+						'As you edit your site content, click “Preview” to see your site the way your visitors will.'
+					) }
+					imgSrc={ previewImage }
+					alignBottom
+				/>
+			) }
+
+			{ isGutenboarding && (
+				/* @TODO: hide for sites that are already public */
+				<NuxPage
+					heading={
+						isGutenboarding
+							? __( 'Private until you’re ready' )
+							: __( "Private until you're ready to launch" )
+					}
+					description={
+						isGutenboarding
+							? __(
+									'Your site will remain private as you make changes until you’re ready to launch and share with the world.'
+							  )
+							: __(
+									"Your site remains private until you're ready to launch. Take your time and make as many changes as you need until it's ready to share with the world."
+							  )
+					}
+					imgSrc={ privateImage }
+					alignBottom
+				/>
+			) }
 		</Guide>
 	);
 }

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -17,7 +17,6 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import './style.scss';
-import blockImage from './images/block.svg';
 import blockPickerImage from './images/block-picker.svg';
 import editorImage from './images/editor.svg';
 import previewImage from './images/preview.svg';
@@ -51,7 +50,7 @@ function WpcomNux() {
 
 	const dismissWpcomNux = () => setWpcomNuxStatus( { isNuxEnabled: false } );
 
-	/* @TODO: the copy, images, and slides will eventually be the same for all sites. `isGutenboarding` is only needed right now to serve copy that hasn't been translated before initial launch */
+	/* @TODO: the copy, images, and slides will eventually be the same for all sites. `isGutenboarding` is only needed right now to show the Privacy slide */
 	const isGutenboarding = !! window.calypsoifyGutenberg?.isGutenboarding;
 
 	return (
@@ -61,8 +60,8 @@ function WpcomNux() {
 			finishButtonText={ __( 'Get started' ) }
 			onFinish={ dismissWpcomNux }
 		>
-			{ getWpcomNuxPages( isGutenboarding ).map( ( nuxPage, index ) => (
-				<NuxPage key={ index } { ...nuxPage } />
+			{ getWpcomNuxPages( isGutenboarding ).map( ( nuxPage ) => (
+				<NuxPage { ...nuxPage } />
 			) ) }
 		</Guide>
 	);
@@ -81,27 +80,13 @@ function getWpcomNuxPages( isGutenboarding ) {
 			),
 			imgSrc: editorImage,
 			alignBottom: true,
-			shouldRender: true,
 		},
 		{
-			heading: __( 'Create pages and add your content' ),
+			heading: __( 'Add or edit your content' ),
 			description: __(
-				'Create and rearrange your site pages. Customize your site navigation menus so your visitors can explore your site.'
+				'Edit the placeholder content we’ve started you off with, or click the plus sign to add more content.'
 			),
-			imgSrc: blockImage,
-			shouldRender: ! isGutenboarding,
-		},
-		{
-			heading: isGutenboarding ? __( 'Add or edit your content' ) : __( 'Add (almost) anything' ),
-			description: isGutenboarding
-				? __(
-						'Edit the placeholder content we’ve started you off with, or click the plus sign to add more content.'
-				  )
-				: __(
-						'Insert text, photos, forms, Yelp reviews, testimonials, maps, and more. Rearrange the blocks on your page until they’re just right.'
-				  ),
 			imgSrc: blockPickerImage,
-			shouldRender: true,
 		},
 		{
 			heading: __( 'Preview your site as you go' ),
@@ -109,25 +94,19 @@ function getWpcomNuxPages( isGutenboarding ) {
 				'As you edit your site content, click “Preview” to see your site the way your visitors will.'
 			),
 			imgSrc: previewImage,
-			shouldRender: isGutenboarding,
 			alignBottom: true,
 		},
 		{
-			heading: isGutenboarding
-				? __( 'Private until you’re ready' )
-				: __( "Private until you're ready to launch" ),
-			description: isGutenboarding
-				? __(
-						'Your site will remain private as you make changes until you’re ready to launch and share with the world.'
-				  )
-				: __(
-						"Your site remains private until you're ready to launch. Take your time and make as many changes as you need until it's ready to share with the world."
-				  ),
+			heading: __( 'Private until you’re ready' ),
+			description: __(
+				'Your site will remain private as you make changes until you’re ready to launch and share with the world.'
+			),
 			imgSrc: privateImage,
-			shouldRender: isGutenboarding,
+			// @TODO: hide for sites that are already public
+			shouldHide: ! isGutenboarding,
 			alignBottom: true,
 		},
-	].filter( ( nuxPage ) => nuxPage.shouldRender );
+	].filter( ( nuxPage ) => ! nuxPage.shouldHide );
 }
 
 function NuxPage( { alignBottom = false, heading, description, imgSrc } ) {

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -61,7 +61,7 @@ function WpcomNux() {
 			onFinish={ dismissWpcomNux }
 		>
 			{ getWpcomNuxPages( isGutenboarding ).map( ( nuxPage ) => (
-				<NuxPage { ...nuxPage } />
+				<NuxPage key={ nuxPage.heading } { ...nuxPage } />
 			) ) }
 		</Guide>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -56,8 +56,8 @@ function WpcomNux() {
 	return (
 		<Guide
 			className="wpcom-block-editor-nux"
-			contentLabel={ __( 'Welcome to your website' ) }
-			finishButtonText={ __( 'Get started' ) }
+			contentLabel={ __( 'Welcome to your website', 'full-site-editing' ) }
+			finishButtonText={ __( 'Get started', 'full-site-editing' ) }
 			onFinish={ dismissWpcomNux }
 		>
 			{ getWpcomNuxPages( isGutenboarding ).map( ( nuxPage ) => (
@@ -68,38 +68,45 @@ function WpcomNux() {
 }
 
 /**
+ * This function returns a filtered collection of NUX slide data
+ * Function arguments can be extended to customize the slides for specific environments, e.g., Gutenboarding
+ *
  * @param   { boolean } isGutenboarding Whether the flow is Gutenboarding or not
  * @returns { Array }                   a collection of <NuxPage /> props filtered by whether the flow is Gutenboarding or not
  */
 function getWpcomNuxPages( isGutenboarding ) {
 	return [
 		{
-			heading: __( 'Welcome to your website' ),
+			heading: __( 'Welcome to your website', 'full-site-editing' ),
 			description: __(
-				'Edit your homepage, add the pages you need, and change your site’s look and feel.'
+				'Edit your homepage, add the pages you need, and change your site’s look and feel.',
+				'full-site-editing'
 			),
 			imgSrc: editorImage,
 			alignBottom: true,
 		},
 		{
-			heading: __( 'Add or edit your content' ),
+			heading: __( 'Add or edit your content', 'full-site-editing' ),
 			description: __(
-				'Edit the placeholder content we’ve started you off with, or click the plus sign to add more content.'
+				'Edit the placeholder content we’ve started you off with, or click the plus sign to add more content.',
+				'full-site-editing'
 			),
 			imgSrc: blockPickerImage,
 		},
 		{
-			heading: __( 'Preview your site as you go' ),
+			heading: __( 'Preview your site as you go', 'full-site-editing' ),
 			description: __(
-				'As you edit your site content, click “Preview” to see your site the way your visitors will.'
+				'As you edit your site content, click “Preview” to see your site the way your visitors will.',
+				'full-site-editing'
 			),
 			imgSrc: previewImage,
 			alignBottom: true,
 		},
 		{
-			heading: __( 'Private until you’re ready' ),
+			heading: __( 'Private until you’re ready', 'full-site-editing' ),
 			description: __(
-				'Your site will remain private as you make changes until you’re ready to launch and share with the world.'
+				'Your site will remain private as you make changes until you’re ready to launch and share with the world.',
+				'full-site-editing'
 			),
 			imgSrc: privateImage,
 			// @TODO: hide for sites that are already public

--- a/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
+++ b/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js
@@ -61,75 +61,73 @@ function WpcomNux() {
 			finishButtonText={ __( 'Get started' ) }
 			onFinish={ dismissWpcomNux }
 		>
-			<NuxPage
-				heading={ __( 'Welcome to your website' ) }
-				description={ __(
-					'Edit your homepage, add the pages you need, and change your site’s look and feel.'
-				) }
-				imgSrc={ editorImage }
-				alignBottom
-			/>
-
-			{ ! isGutenboarding && (
-				<NuxPage
-					heading={ __( 'Create pages and add your content' ) }
-					description={ __(
-						'Create and rearrange your site pages. Customize your site navigation menus so your visitors can explore your site.'
-					) }
-					imgSrc={ blockImage }
-				/>
-			) }
-
-			<NuxPage
-				heading={
-					isGutenboarding ? __( 'Add or edit your content' ) : __( 'Add (almost) anything' )
-				}
-				description={
-					isGutenboarding
-						? __(
-								'Edit the placeholder content we’ve started you off with, or click the plus sign to add more content.'
-						  )
-						: __(
-								'Insert text, photos, forms, Yelp reviews, testimonials, maps, and more. Rearrange the blocks on your page until they’re just right.'
-						  )
-				}
-				imgSrc={ blockPickerImage }
-			/>
-
-			{ isGutenboarding && (
-				<NuxPage
-					heading={ __( 'Preview your site as you go' ) }
-					description={ __(
-						'As you edit your site content, click “Preview” to see your site the way your visitors will.'
-					) }
-					imgSrc={ previewImage }
-					alignBottom
-				/>
-			) }
-
-			{ isGutenboarding && (
-				/* @TODO: hide for sites that are already public */
-				<NuxPage
-					heading={
-						isGutenboarding
-							? __( 'Private until you’re ready' )
-							: __( "Private until you're ready to launch" )
-					}
-					description={
-						isGutenboarding
-							? __(
-									'Your site will remain private as you make changes until you’re ready to launch and share with the world.'
-							  )
-							: __(
-									"Your site remains private until you're ready to launch. Take your time and make as many changes as you need until it's ready to share with the world."
-							  )
-					}
-					imgSrc={ privateImage }
-					alignBottom
-				/>
-			) }
+			{ getWpcomNuxPages( isGutenboarding ).map( ( nuxPage, index ) => (
+				<NuxPage key={ index } { ...nuxPage } />
+			) ) }
 		</Guide>
 	);
+}
+
+/**
+ * @param   { boolean } isGutenboarding Whether the flow is Gutenboarding or not
+ * @returns { Array }                   a collection of <NuxPage /> props filtered by whether the flow is Gutenboarding or not
+ */
+function getWpcomNuxPages( isGutenboarding ) {
+	return [
+		{
+			heading: __( 'Welcome to your website' ),
+			description: __(
+				'Edit your homepage, add the pages you need, and change your site’s look and feel.'
+			),
+			imgSrc: editorImage,
+			alignBottom: true,
+			shouldRender: true,
+		},
+		{
+			heading: __( 'Create pages and add your content' ),
+			description: __(
+				'Create and rearrange your site pages. Customize your site navigation menus so your visitors can explore your site.'
+			),
+			imgSrc: blockImage,
+			shouldRender: ! isGutenboarding,
+		},
+		{
+			heading: isGutenboarding ? __( 'Add or edit your content' ) : __( 'Add (almost) anything' ),
+			description: isGutenboarding
+				? __(
+						'Edit the placeholder content we’ve started you off with, or click the plus sign to add more content.'
+				  )
+				: __(
+						'Insert text, photos, forms, Yelp reviews, testimonials, maps, and more. Rearrange the blocks on your page until they’re just right.'
+				  ),
+			imgSrc: blockPickerImage,
+			shouldRender: true,
+		},
+		{
+			heading: __( 'Preview your site as you go' ),
+			description: __(
+				'As you edit your site content, click “Preview” to see your site the way your visitors will.'
+			),
+			imgSrc: previewImage,
+			shouldRender: isGutenboarding,
+			alignBottom: true,
+		},
+		{
+			heading: isGutenboarding
+				? __( 'Private until you’re ready' )
+				: __( "Private until you're ready to launch" ),
+			description: isGutenboarding
+				? __(
+						'Your site will remain private as you make changes until you’re ready to launch and share with the world.'
+				  )
+				: __(
+						"Your site remains private until you're ready to launch. Take your time and make as many changes as you need until it's ready to share with the world."
+				  ),
+			imgSrc: privateImage,
+			shouldRender: isGutenboarding,
+			alignBottom: true,
+		},
+	].filter( ( nuxPage ) => nuxPage.shouldRender );
 }
 
 function NuxPage( { alignBottom = false, heading, description, imgSrc } ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request

We're updating the copy and image based on the description in #41960

After unsuccessful attempts to render `<NuxPage />` inside `<Guide />` conditionally^, I went with a filtered collection approach.

All suggestions for improvement wanted. :)

## Testing instructions

Easiest way I found is to check out this branch

Sandbox a test site

Comment out [the following lines](https://github.com/Automattic/wp-calypso/blob/master/apps/full-site-editing/full-site-editing-plugin/wpcom-block-editor-nux/src/wpcom-nux.js#L47):

```
	/* if ( ! isWpcomNuxEnabled || isSPTOpen ) {
		return null;
	} */
```

Run `cd apps/full-site-editing && yarn dev --sync`

Test Gutenboarding and non-Gutenboarding versions by setting `isGutenboarding` to `true/false`

#### isGutenboarding === true
![isGutenbergNUX](https://user-images.githubusercontent.com/6458278/81361324-699bfc00-9121-11ea-82b9-2439d33de1f5.gif)

#### isGutenboarding === false
![notGutenbergNUX](https://user-images.githubusercontent.com/6458278/81361395-9a7c3100-9121-11ea-8de4-df84a597f5ee.gif)


Fixes #41960


^ The result of trying something like `{ isGutenboarding && <NuxPage { ...props } /> }`
![nux-oops](https://user-images.githubusercontent.com/6458278/81361341-76205480-9121-11ea-8c35-13a8b83bfb99.gif)
