### PR TITLE
Gutenboarding: Fix vertical select placeholder spacing in Firefox

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -201,7 +201,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		{
 			Input: (
 				<span className="vertical-select__suggestions-wrapper">
-					{ ! isMobile && ' ' }
+					{ ! isMobile && <span className="vertical-select__whitespace"></span> }
 					<span
 						className={ classnames( 'vertical-select__input-wrapper', {
 							'vertical-select__input-wrapper--with-arrow': showArrow,

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -46,7 +46,7 @@
 	flex: 1;
 
 	@include break-small {
-		display: inline;
+		display: inline-block;
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -40,13 +40,20 @@
 	}
 }
 
+.vertical-select__whitespace {
+	display: inline-block;
+	visibility: hidden;
+	width: 0;
+	height: 0;
+}
+
 .vertical-select__suggestions-wrapper {
 	position: relative;
 	display: block;
 	flex: 1;
 
 	@include break-small {
-		display: inline-block;
+		display: inline;
 	}
 }
 


### PR DESCRIPTION
In Firefox, on `master`, the vertical placeholder animation doesn't have any whitespace between the text `My site is about ` and the placeholder. It looks like if the inline text isn't followed by any other text or inline-block elements, then Firefox ignores the trailing whitespace, whereas Chrome and Safari preserve it.

To fix the issue in Firefox, this PR replaces `{ ' ' }` with an empty span set to `inline-block` with visibility hidden and width and height of zero. While not the most elegant solution, the other approach I could think of (setting the suggestion wrapper to `inline-block`) would cause flow on issues to how the input of the vertical field worked, so this seemed a simpler fix to me.

#### Before

![image](https://user-images.githubusercontent.com/14988353/81371528-7299c700-913b-11ea-9f43-b0806b4626b1.png)

#### After

![image](https://user-images.githubusercontent.com/14988353/81371573-9230ef80-913b-11ea-81fb-393ca7f3477a.png)

#### Changes proposed in this Pull Request

* In the vertical select suggestions wrapper, replace the whitespace `' '` with an empty span set to `inline-block` to force the whitespace in Firefox

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `wordpress.com/new` in Firefox and verify that you can see the issue
* In this branch, go to `/new` and verify that it resolves the whitespace issue in Firefox
* Check in Safari, Chrome, etc that this doesn't cause any visual regressions

Fixes #
