### PR TITLE
Gutenboarding: Add site title placeholder

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -75,6 +75,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile } ) 
 						onKeyDown={ handleKeyDown }
 						onKeyUp={ handleKeyUp }
 					/>
+					<span className="site-title__placeholder"></span>
 				</span>
 			),
 		}

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -142,9 +142,47 @@
 
 .site-title__input-wrapper {
 	display: block;
+	position: relative;
 	min-height: 40px; // make sure there is a tappable area on mobile when the input is empty
+
+	.madlib__input:empty {
+		@include break-small {
+			padding-right: 300px; // there's not enough container width on smaller screens
+		}
+		@include break-medium {
+			padding-right: 400px;
+		}
+	}
 
 	@include break-small {
 		display: inline;
 	}
+}
+
+.site-title__placeholder {
+	display: inline-block;
+	width: 100%;
+	color: var( --studio-gray-5 );
+
+	@include break-small {
+		height: 80px;
+		position: absolute;
+		left: 0;
+		z-index: 2;
+	}
+
+	&::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: -2px;
+		height: 2px;
+		background-image: linear-gradient( to right, rgba( 238, 238, 238, 1 ), rgba( 238, 238, 238, 0.4 ) );
+	}
+}
+
+/* hide the placeholder when input is not empty */
+.madlib__input:not( :empty ) ~ .site-title__placeholder {
+	display: none;
 }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -186,3 +186,9 @@
 .madlib__input:not( :empty ) ~ .site-title__placeholder {
 	display: none;
 }
+
+.madlib__input:focus ~ .site-title__placeholder {
+	@include break-small {
+		display: none;
+	}
+}


### PR DESCRIPTION
Note: this is a speculative PR to try to make it a bit clearer that there is a text input field for the site title in situations where a user might not see it (mobile and desktop if a user clicks away from the site title field) — it doesn't appear on the designs, so this is really just one idea for how to help solve part of this.

#### Changes proposed in this Pull Request

* Add a grey line site title placeholder on mobile
* Add a grey line site title placeholder on desktop when the field is not focused, so that it's clearer where to click to focus it again

#### Screenshots

##### Mobile

![image](https://user-images.githubusercontent.com/14988353/81388768-1bf0b500-915c-11ea-84f0-5d15896c5d53.png)

##### Desktop (normal)

When focused it'll look as it did previously:

![image](https://user-images.githubusercontent.com/14988353/81388843-3e82ce00-915c-11ea-8bb2-670c61e48c67.png)

When not focused (if a user clicks out of the field) then the line will show:

![image](https://user-images.githubusercontent.com/14988353/81388905-54908e80-915c-11ea-818c-d7ec5cbd02df.png)

##### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /new and test the line for the empty site title displays when you expect it would

Related to #https://github.com/Automattic/wp-calypso/issues/41923 and https://github.com/Automattic/wp-calypso/issues/41230
