### PR TITLE
i18n: Prevent translation chunks setup for default locale

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -82,7 +82,7 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 			lastPathSegment;
 		const localeSlug = userLocaleSlug || pathLocaleSlug;
 
-		if ( localeSlug ) {
+		if ( localeSlug && ! isDefaultLocale( localeSlug ) ) {
 			setupTranslationChunks( localeSlug, reduxStore );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR prevents initial translation chunk setup for default locale, because otherwise it attempts to fetch non-existent language manifest, e.g. `en-language-manifest.json`.

#### Testing instructions

1. Switch your WordPress.com UI language to English.
2. Boot Calypso with `ENABLE_FEATURES=use-translation-chunks yarn start`.
3. Open http://calypso.localhost:3000/ and confirm that there are no 404s related to translation chunks.