### PR TITLE
Jetpack Cloud: add Fullstory

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/index.js
+++ b/client/landing/jetpack-cloud/sections/backups/index.js
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import page from 'page';
+import * as FullStory from '@fullstory/browser';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
+import { TRACKING_IDS } from 'lib/analytics/ad-tracking/constants';
 
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
@@ -29,6 +31,7 @@ import {
 
 export default function () {
 	if ( config.isEnabled( 'jetpack-cloud/backups' ) ) {
+		FullStory.init( { orgId: TRACKING_IDS.jetpackCloudFullStory } );
 		/* handles /backups/activity, see `backupActivityPath` */
 		page( backupActivityPath(), siteSelection, sites, makeLayout, clientRender );
 

--- a/client/landing/jetpack-cloud/sections/scan/index.js
+++ b/client/landing/jetpack-cloud/sections/scan/index.js
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import page from 'page';
+import * as FullStory from '@fullstory/browser';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
+import { TRACKING_IDS } from 'lib/analytics/ad-tracking/constants';
 
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
@@ -20,6 +22,7 @@ import {
 
 export default function () {
 	if ( config.isEnabled( 'jetpack-cloud/scan' ) ) {
+		FullStory.init( { orgId: TRACKING_IDS.jetpackCloudFullStory } );
 		page( '/scan', siteSelection, sites, navigation, makeLayout, clientRender );
 		page(
 			'/scan/:site',

--- a/client/landing/jetpack-cloud/sections/settings/index.js
+++ b/client/landing/jetpack-cloud/sections/settings/index.js
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import page from 'page';
+import * as FullStory from '@fullstory/browser';
 
 /**
  * Internal dependencies
  */
 import config from 'config';
+import { TRACKING_IDS } from 'lib/analytics/ad-tracking/constants';
 
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
@@ -14,6 +16,7 @@ import { settings } from 'landing/jetpack-cloud/sections/settings/controller';
 
 export default function () {
 	if ( config.isEnabled( 'jetpack-cloud/settings' ) ) {
+		FullStory.init( { orgId: TRACKING_IDS.jetpackCloudFullStory } );
 		page( '/settings', siteSelection, sites, navigation, makeLayout, clientRender );
 		page( '/settings/:site', siteSelection, navigation, settings, makeLayout, clientRender );
 	}

--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -85,6 +85,7 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
 	pinterestInit: '2613194105266',
+	jetpackCloudFullStory: 'V1M1V',
 };
 // This name is something we created to store a session id for DCM Floodlight session tracking
 export const DCM_FLOODLIGHT_SESSION_COOKIE_NAME = 'dcmsid';

--- a/client/package.json
+++ b/client/package.json
@@ -31,6 +31,7 @@
 		"@babel/runtime": "^7.8.4",
 		"@emotion/core": "^10.0.27",
 		"@emotion/styled": "10.0.27",
+		"@fullstory/browser": "1.4.4",
 		"@github/webauthn-json": "0.4.1",
 		"@wordpress/api-fetch": "^3.12.0",
 		"@wordpress/base-styles": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,6 +1596,11 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fullstory/browser@1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-1.4.4.tgz#56e8db9f97b036892e419f5d6d1a510a3b68dd39"
+  integrity sha512-gV028/krZRvseyR6WEpphrZdlskoKTPV7x8mAbU9X0dOoUUZEdIr3J9ADyFPxcWGJgKL45zrplvgifBQXdKgVg==
+
 "@github/webauthn-json@0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@github/webauthn-json/-/webauthn-json-0.4.1.tgz#1666441e10806c5871f3ac26e8bca169407560b3"


### PR DESCRIPTION
**DO NOT MERGE, THIS IS A PROOF OF CONCEPT/TEST**

### Changes proposed in this Pull Request

* Adds Fullstory to Jetpack Cloud as a proof of concept so we can test it and decide if it's the right solution.

### Caveats / Notes

* The code on this PR is decidedly **not** great and should be optimized/cleaned up if we decide to go with Fullstory.
* Fullstory [excludes certain fields by default](https://help.fullstory.com/hc/en-us/articles/360020623574-How-do-I-exclude-elements-to-protect-my-users-privacy-in-FullStory-#default-exclusions), but only very obvious ones. In my very limited testing, Fullstory seems to be **nosier** than Hotjar.
* Noting here that if they don't differ that much, Hotjar is [already implemented in Calypso](https://github.com/Automattic/wp-calypso/blob/59bdfeeb97eda4266ad39410cb0a074d2c88dbc8/client/state/analytics/README_HotJar.md) and should be a lot easier to add to JP Cloud.
* Some of those prying aspects can be tamed by adding the `.fs-excludes` CSS class to fields which we want to keep private. This sounds very doable, though in practice (and considering we're reusing many shared components from Calypso directly) we'd have to add that class to those common components. I believe we want to avoid polluting shared code with what are very specific exceptions.
* Again, the code isn't great so the above might be sorted in ways I haven't considered.

### Testing instructions

* Spin up this PR locally.
* Open http://jetpack.cloud.localhost:3000/ and browse Jetpack Cloud.
* Log in on https://app.fullstory.com/ with these details p1588936001035100-slack-jetpack-design and make sure your actions above are recorded.

Thanks to @sgomes and @enejb for all the pointers — as you can see, I ended up with an hybrid approach for quickly testing this. Any feedback would be appreciated.