### PR TITLE
Remove gutenboarding feature flag

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -297,9 +297,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 		if ( EditorActions.GetGutenboardingStatus === action ) {
 			const isGutenboarding =
-				config.isEnabled( 'gutenboarding' ) &&
-				this.props.siteCreationFlow === 'gutenboarding' &&
-				this.props.isSiteUnlaunched;
+				this.props.siteCreationFlow === 'gutenboarding' && this.props.isSiteUnlaunched;
 			ports[ 0 ].postMessage( {
 				isGutenboarding,
 				frankenflowUrl: `${ window.location.origin }/start/new-launch?siteSlug=${ this.props.siteSlug }&source=editor`,

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -73,11 +73,6 @@ declare const window: AppWindow;
 const DEVELOPMENT_BASENAME = '/gutenboarding';
 
 window.AppBoot = async () => {
-	if ( ! config.isEnabled( 'gutenboarding' ) ) {
-		window.location.href = '/';
-		return;
-	}
-
 	if ( window.location.pathname.startsWith( DEVELOPMENT_BASENAME ) ) {
 		const url = new URL( window.location.href );
 		url.pathname = GUTENBOARDING_BASE_NAME + url.pathname.substring( DEVELOPMENT_BASENAME.length );

--- a/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/design-selector/index.tsx
@@ -81,9 +81,7 @@ const DesignSelector: React.FunctionComponent = () => {
 								// Update fonts to the design defaults
 								setFonts( design.fonts );
 
-								if ( isEnabled( 'gutenboarding/style-preview' ) ) {
-									push( makePath( Step.Style ) );
-								}
+								push( makePath( Step.Style ) );
 							} }
 						>
 							<span className="design-selector__image-frame">

--- a/client/landing/gutenboarding/onboarding-block/edit.tsx
+++ b/client/landing/gutenboarding/onboarding-block/edit.tsx
@@ -18,7 +18,6 @@ import { Attributes } from './types';
 import { Step, usePath, useNewQueryParam } from '../path';
 import AcquireIntent from './acquire-intent';
 import StylePreview from './style-preview';
-import { isEnabled } from '../../../config';
 import { useFreeDomainSuggestion } from '../hooks/use-free-domain-suggestion';
 
 import './colors.scss';
@@ -49,7 +48,7 @@ const OnboardingEdit: FunctionComponent< BlockEditProps< Attributes > > = () => 
 	}, [ siteTitle, siteVertical, wasVerticalSkipped ] );
 
 	const canUseStyleStep = useCallback( (): boolean => {
-		return !! selectedDesign && isEnabled( 'gutenboarding/style-preview' );
+		return !! selectedDesign;
 	}, [ selectedDesign ] );
 
 	const canUseCreateSiteStep = useCallback( (): boolean => {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -352,27 +352,23 @@ export function generateFlows( {
 		};
 	}
 
-	if ( isEnabled( 'gutenboarding' ) ) {
-		flows[ 'new-launch' ] = {
-			steps: [ 'domains-launch', 'plans-launch', 'launch' ],
-			destination: getLaunchDestination,
-			description: 'Launch flow for a site created from /new',
-			lastModified: '2020-04-28',
-			pageTitle: translate( 'Launch your site' ),
-			providesDependenciesInQuery: [ 'siteSlug', 'source' ],
-		};
-	}
+	flows[ 'new-launch' ] = {
+		steps: [ 'domains-launch', 'plans-launch', 'launch' ],
+		destination: getLaunchDestination,
+		description: 'Launch flow for a site created from /new',
+		lastModified: '2020-04-28',
+		pageTitle: translate( 'Launch your site' ),
+		providesDependenciesInQuery: [ 'siteSlug', 'source' ],
+	};
 
-	if ( isEnabled( 'gutenboarding' ) ) {
-		flows.prelaunch = {
-			steps: [ 'plans-with-domain' ],
-			destination: getEditorDestination,
-			description: 'Gutenboarding flow for creating a site with a paid domain',
-			lastModified: '2020-04-06',
-			pageTitle: translate( 'Get a domain for your site' ),
-			providesDependenciesInQuery: [ 'siteSlug' ],
-		};
-	}
+	flows.prelaunch = {
+		steps: [ 'plans-with-domain' ],
+		destination: getEditorDestination,
+		description: 'Flow for creating a site with a paid domain from /new',
+		lastModified: '2020-04-08',
+		pageTitle: translate( 'Get a domain for your site' ),
+		providesDependenciesInQuery: [ 'siteSlug' ],
+	};
 
 	return flows;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,6 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-drive": true,
-		"gutenboarding/style-preview": true,
 		"gutenboarding/plans-grid": true,
 		"help": true,
 		"help/courses": true,

--- a/config/development.json
+++ b/config/development.json
@@ -67,7 +67,6 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"google-drive": true,
-		"gutenboarding": true,
 		"gutenboarding/style-preview": true,
 		"gutenboarding/plans-grid": true,
 		"help": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -42,7 +42,6 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": false,
 		"google-my-business": true,
-		"gutenboarding": true,
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview": true,
 		"gutenboarding/style-preview-verticals": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -43,7 +43,6 @@
 		"gdpr-banner": false,
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": false,
-		"gutenboarding/style-preview": true,
 		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/plans-grid": false,
 		"happychat": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -51,7 +51,6 @@
 		"gdpr-banner": true,
 		"google-my-business": true,
 		"gutenboarding/mshot-preview": false,
-		"gutenboarding/style-preview": true,
 		"gutenboarding/style-preview-verticals": false,
 		"gutenboarding/plans-grid": false,
 		"happychat": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -50,7 +50,6 @@
 		"external-media/free-photo-library": true,
 		"gdpr-banner": true,
 		"google-my-business": true,
-		"gutenboarding": true,
 		"gutenboarding/mshot-preview": false,
 		"gutenboarding/style-preview": true,
 		"gutenboarding/style-preview-verticals": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes `gutenboarding` flag that stops the flow from being released to `wordpress.com/new` non-proxied
* Removes `gutenboarding/style-preview` flag that was used to gate out style/font picker during development. That flag isn't used anymore.

#### Testing instructions

- Test `/new` flow
- Confirm font picker step still shows up