### PR TITLE
Editor deprecation: Allow users to switch to the block editor

### DIFF
--- a/client/post-editor/editor-gutenberg-dialogs/index.tsx
+++ b/client/post-editor/editor-gutenberg-dialogs/index.tsx
@@ -17,6 +17,7 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
 import isPrivateSite from 'state/selectors/is-private-site';
 import getWpAdminClassicEditorRedirectionUrl from '../../state/selectors/get-wp-admin-classic-editor-redirection-url';
 import isEditorDeprecationDialogShowing from 'state/selectors/is-editor-deprecation-dialog-showing';
+import { isEnabled } from 'config';
 
 /**
  * We don't support classic editor in Calypso for private atomic sites. This components makes sure
@@ -81,7 +82,7 @@ const EditorGutenbergDialogs: React.FC< {} > = () => {
 		]
 	);
 
-	if ( editorDeprecationDialogShowing ) {
+	if ( isEnabled( 'editor/before-deprecation' ) && editorDeprecationDialogShowing ) {
 		return null;
 	}
 


### PR DESCRIPTION
Only assume that the editor deprecation notice is showing if the config is enabled.

In https://github.com/Automattic/wp-calypso/pull/41391 I assumed that the reducer would only return true if the editor deprecation notice config was true.

#### Changes proposed in this Pull Request

* We shouldn't assume that the reducer value is valid; we need to check the config is enabled first.

#### Testing instructions
* Open the WP.com editor and try switching to the block editor.
* This should work regardless of whether the `editor/before-deprecation` config flag is set.

