### PR TITLE
Pausing plans-domains swap test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -118,8 +118,8 @@ export default {
 	domainStepPlanStepSwap: {
 		datestamp: '20200415',
 		variations: {
-			variantShowSwapped: 50,
-			control: 50,
+			variantShowSwapped: 0,
+			control: 100,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pausing Plans-Domains swap test (100% traffic goes to control). Check pbxNRc-cj-p2

#### Testing instructions

* Go through the signup flow at /start
* Domain step should appear first. Then Plans.


