### PR TITLE
Domain-plan-swap test: Don't show domain step if paid plan selected

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -35,12 +35,7 @@ class DomainProductPrice extends React.Component {
 	};
 
 	renderFreeWithPlanText() {
-		const {
-			isMappingProduct,
-			isEligibleVariantForDomainTest,
-			showFreeDomainExplainerForFreePlan,
-			translate,
-		} = this.props;
+		const { isMappingProduct, isEligibleVariantForDomainTest, translate } = this.props;
 
 		let message;
 		switch ( this.props.rule ) {
@@ -52,29 +47,13 @@ class DomainProductPrice extends React.Component {
 				break;
 			case 'INCLUDED_IN_HIGHER_PLAN':
 				if ( isEligibleVariantForDomainTest ) {
-					if ( showFreeDomainExplainerForFreePlan ) {
-						message = translate(
-							'Registration fee: {{del}}%(cost)s{{/del}} {{span}}Free with paid plan{{/span}}',
-							{
-								args: { cost: this.props.price },
-								components: {
-									del: <del />,
-									span: <span className="domain-product-price__free-price" />,
-								},
-							}
-						);
-					} else {
-						message = translate(
-							'Registration fee: {{del}}%(cost)s{{/del}} {{span}}Free{{/span}}',
-							{
-								args: { cost: this.props.price },
-								components: {
-									del: <del />,
-									span: <span className="domain-product-price__free-price" />,
-								},
-							}
-						);
-					}
+					message = translate( 'Registration fee: {{del}}%(cost)s{{/del}} {{span}}Free{{/span}}', {
+						args: { cost: this.props.price },
+						components: {
+							del: <del />,
+							span: <span className="domain-product-price__free-price" />,
+						},
+					} );
 				} else {
 					message = translate( 'First year included in paid plans' );
 				}
@@ -144,8 +123,12 @@ class DomainProductPrice extends React.Component {
 	renderSalePrice() {
 		const { price, salePrice, translate } = this.props;
 
+		const className = classnames( 'domain-product-price', 'is-free-domain', {
+			'domain-product-price__domain-step-copy-updates': this.props.isEligibleVariantForDomainTest,
+		} );
+
 		return (
-			<div className="domain-product-price is-free-domain">
+			<div className={ className }>
 				<div className="domain-product-price__sale-price">{ salePrice }</div>
 				<div className="domain-product-price__renewal-price">
 					{ translate( 'Renews at: %(cost)s {{small}}/year{{/small}}', {
@@ -158,18 +141,38 @@ class DomainProductPrice extends React.Component {
 	}
 
 	renderPrice() {
-		if ( this.props.salePrice ) {
+		const { salePrice, isEligibleVariantForDomainTest, price, translate } = this.props;
+		if ( salePrice ) {
 			return this.renderSalePrice();
 		}
 
+		const className = classnames( 'domain-product-price', {
+			'is-free-domain': isEligibleVariantForDomainTest,
+			'domain-product-price__domain-step-copy-updates': isEligibleVariantForDomainTest,
+		} );
+
+		const productPriceClassName = isEligibleVariantForDomainTest
+			? ''
+			: 'domain-product-price__price';
+
+		const renewalPrice = isEligibleVariantForDomainTest && (
+			<div className="domain-product-price__renewal-price">
+				{ translate( 'Renews at: %(cost)s {{small}}/year{{/small}}', {
+					args: { cost: price },
+					components: { small: <small /> },
+				} ) }
+			</div>
+		);
+
 		return (
-			<div className="domain-product-price">
-				<span className="domain-product-price__price">
-					{ this.props.translate( '%(cost)s {{small}}/year{{/small}}', {
-						args: { cost: this.props.price },
+			<div className={ className }>
+				<span className={ productPriceClassName }>
+					{ translate( '%(cost)s {{small}}/year{{/small}}', {
+						args: { cost: price },
 						components: { small: <small /> },
 					} ) }
 				</span>
+				{ renewalPrice }
 			</div>
 		);
 	}

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -167,8 +167,22 @@ class DomainRegistrationSuggestion extends React.Component {
 	}
 
 	getPriceRule() {
-		const { cart, isDomainOnly, domainsWithPlansOnly, selectedSite, suggestion } = this.props;
-		return getDomainPriceRule( domainsWithPlansOnly, selectedSite, cart, suggestion, isDomainOnly );
+		const {
+			cart,
+			isDomainOnly,
+			shouldHideFreeDomainExplainer,
+			domainsWithPlansOnly,
+			selectedSite,
+			suggestion,
+		} = this.props;
+		const shouldShowFullDomainPrice = isDomainOnly || shouldHideFreeDomainExplainer;
+		return getDomainPriceRule(
+			domainsWithPlansOnly,
+			selectedSite,
+			cart,
+			suggestion,
+			shouldShowFullDomainPrice
+		);
 	}
 
 	renderDomain() {
@@ -346,7 +360,6 @@ class DomainRegistrationSuggestion extends React.Component {
 				onButtonClick={ this.onButtonClick }
 				{ ...this.getButtonProps() }
 				isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
-				showFreeDomainExplainerForFreePlan={ this.props.showFreeDomainExplainerForFreePlan }
 				isFeatured={ isFeatured }
 			>
 				{ this.renderDomain() }

--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -257,7 +257,7 @@ class DomainSearchResults extends React.Component {
 					pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 					unavailableDomains={ this.props.unavailableDomains }
 					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
-					showFreeDomainExplainerForFreePlan={ this.props.showFreeDomainExplainerForFreePlan }
+					shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
 				/>
 			);
 
@@ -283,7 +283,7 @@ class DomainSearchResults extends React.Component {
 						pendingCheckSuggestion={ this.props.pendingCheckSuggestion }
 						unavailableDomains={ this.props.unavailableDomains }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
-						showFreeDomainExplainerForFreePlan={ this.props.showFreeDomainExplainerForFreePlan }
+						shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
 					/>
 				);
 			} );

--- a/client/components/domains/domain-suggestion/index.jsx
+++ b/client/components/domains/domain-suggestion/index.jsx
@@ -46,7 +46,6 @@ class DomainSuggestion extends React.Component {
 			priceRule,
 			salePrice,
 			isEligibleVariantForDomainTest,
-			showFreeDomainExplainerForFreePlan,
 			isFeatured,
 		} = this.props;
 		const classes = classNames(
@@ -82,7 +81,6 @@ class DomainSuggestion extends React.Component {
 							salePrice={ salePrice }
 							rule={ priceRule }
 							isEligibleVariantForDomainTest={ isEligibleVariantForDomainTest }
-							showFreeDomainExplainerForFreePlan={ showFreeDomainExplainerForFreePlan }
 						/>
 					) }
 				</div>

--- a/client/components/domains/featured-domain-suggestions/index.jsx
+++ b/client/components/domains/featured-domain-suggestions/index.jsx
@@ -122,7 +122,7 @@ export class FeaturedDomainSuggestions extends Component {
 						buttonStyles={ { primary: true } }
 						{ ...childProps }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
-						showFreeDomainExplainerForFreePlan={ this.props.showFreeDomainExplainerForFreePlan }
+						shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
 					/>
 				) }
 				{ secondarySuggestion && (
@@ -135,7 +135,7 @@ export class FeaturedDomainSuggestions extends Component {
 						fetchAlgo={ this.getFetchAlgorithm( secondarySuggestion ) }
 						{ ...childProps }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
-						showFreeDomainExplainerForFreePlan={ this.props.showFreeDomainExplainerForFreePlan }
+						shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
 					/>
 				) }
 			</div>

--- a/client/components/domains/free-domain-explainer/index.jsx
+++ b/client/components/domains/free-domain-explainer/index.jsx
@@ -21,29 +21,8 @@ class FreeDomainExplainer extends React.Component {
 		this.props.onSkip( undefined, hideFreePlan );
 	};
 
-	renderCustomDomainExplainer() {
-		return (
-			<div className="free-domain-explainer card is-compact">
-				<header>
-					<h1 className="free-domain-explainer__title">All our custom domains need a paid plan.</h1>
-					<p className="free-domain-explainer__subtitle">
-						That's why we'll pay the registration fees for your new domain when you choose a paid
-						plan during the next step.
-					</p>
-					<p className="free-domain-explainer__subtitle">
-						You can always claim your free custom domain later if you aren't ready yet.
-					</p>
-				</header>
-			</div>
-		);
-	}
-
 	render() {
-		const { showFreeDomainExplainerForFreePlan, translate } = this.props;
-
-		if ( showFreeDomainExplainerForFreePlan ) {
-			return this.renderCustomDomainExplainer();
-		}
+		const { translate } = this.props;
 
 		return (
 			<div className="free-domain-explainer card is-compact">

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -428,6 +428,7 @@ class RegisterDomainStep extends React.Component {
 		const searchBoxClassName = classNames( 'register-domain-step__search', {
 			'register-domain-step__search-domain-step-test': this.props.isEligibleVariantForDomainTest,
 		} );
+
 		return (
 			<div className="register-domain-step">
 				<StickyPanel className={ searchBoxClassName }>
@@ -469,6 +470,7 @@ class RegisterDomainStep extends React.Component {
 						showDismiss={ false }
 					/>
 				) }
+
 				{ this.renderContent() }
 				{ this.renderFilterResetNotice() }
 				{ this.renderPaginationControls() }
@@ -1222,55 +1224,66 @@ class RegisterDomainStep extends React.Component {
 				? this.goToTransferDomainStep
 				: this.goToUseYourDomainStep;
 
-		return (
-			<DomainSearchResults
-				key="domain-search-results" // key is required for CSS transition of content/
-				availableDomain={ availableDomain }
-				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				isDomainOnly={ this.props.isDomainOnly }
-				lastDomainSearched={ lastDomainSearched }
-				lastDomainStatus={ lastDomainStatus }
-				lastDomainIsTransferrable={ lastDomainIsTransferrable }
-				onAddMapping={ onAddMapping }
-				onClickResult={ this.onAddDomain }
-				onClickMapping={ this.goToMapDomainStep }
-				onAddTransfer={ this.props.onAddTransfer }
-				onClickTransfer={ this.goToTransferDomainStep }
-				onClickUseYourDomain={ useYourDomainFunction }
-				tracksButtonClickSource="exact-match-top"
-				suggestions={ suggestions }
-				isLoadingSuggestions={ this.state.loadingResults }
-				products={ this.props.products }
-				selectedSite={ this.props.selectedSite }
-				offerUnavailableOption={ this.props.offerUnavailableOption }
-				placeholderQuantity={ PAGE_SIZE }
-				isSignupStep={ this.props.isSignupStep }
-				railcarId={ this.state.railcarId }
-				fetchAlgo={ '/domains/search/' + this.props.vendor + isSignup }
-				cart={ this.props.cart }
-				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
-				unavailableDomains={ this.state.unavailableDomains }
-				isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
-				shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
-			>
-				{ this.props.isEligibleVariantForDomainTest &&
-					hasResults &&
-					! this.props.shouldHideFreeDomainExplainer &&
-					this.renderFreeDomainExplainer() }
+		const domainForwardingExplainer =
+			'Domains purchased on a free site will get redirected to your WordPress.com address. You can always upgrade ' +
+			'to a paid plan later and fully use your domain name, instead of having WordPress.com in your URL.';
 
-				{ showTldFilterBar && (
-					<TldFilterBar
-						availableTlds={ this.state.availableTlds }
-						filters={ this.state.filters }
-						isSignupStep={ this.props.isSignupStep }
-						lastFilters={ this.state.lastFilters }
-						onChange={ this.onFiltersChange }
-						onReset={ this.onFiltersReset }
-						onSubmit={ this.onFiltersSubmit }
-						showPlaceholder={ this.state.loadingResults || ! this.getSuggestionsFromProps() }
-					/>
-				) }
-			</DomainSearchResults>
+		const renderCustomDomainForFreePlanExplainer = this.props.shouldHideFreeDomainExplainer && (
+			<Notice text={ domainForwardingExplainer } showDismiss={ false } />
+		);
+
+		return (
+			<>
+				{ renderCustomDomainForFreePlanExplainer }
+				<DomainSearchResults
+					key="domain-search-results" // key is required for CSS transition of content/
+					availableDomain={ availableDomain }
+					domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+					isDomainOnly={ this.props.isDomainOnly }
+					lastDomainSearched={ lastDomainSearched }
+					lastDomainStatus={ lastDomainStatus }
+					lastDomainIsTransferrable={ lastDomainIsTransferrable }
+					onAddMapping={ onAddMapping }
+					onClickResult={ this.onAddDomain }
+					onClickMapping={ this.goToMapDomainStep }
+					onAddTransfer={ this.props.onAddTransfer }
+					onClickTransfer={ this.goToTransferDomainStep }
+					onClickUseYourDomain={ useYourDomainFunction }
+					tracksButtonClickSource="exact-match-top"
+					suggestions={ suggestions }
+					isLoadingSuggestions={ this.state.loadingResults }
+					products={ this.props.products }
+					selectedSite={ this.props.selectedSite }
+					offerUnavailableOption={ this.props.offerUnavailableOption }
+					placeholderQuantity={ PAGE_SIZE }
+					isSignupStep={ this.props.isSignupStep }
+					railcarId={ this.state.railcarId }
+					fetchAlgo={ '/domains/search/' + this.props.vendor + isSignup }
+					cart={ this.props.cart }
+					pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
+					unavailableDomains={ this.state.unavailableDomains }
+					isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
+					shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
+				>
+					{ this.props.isEligibleVariantForDomainTest &&
+						hasResults &&
+						! this.props.shouldHideFreeDomainExplainer &&
+						this.renderFreeDomainExplainer() }
+
+					{ showTldFilterBar && (
+						<TldFilterBar
+							availableTlds={ this.state.availableTlds }
+							filters={ this.state.filters }
+							isSignupStep={ this.props.isSignupStep }
+							lastFilters={ this.state.lastFilters }
+							onChange={ this.onFiltersChange }
+							onReset={ this.onFiltersReset }
+							onSubmit={ this.onFiltersSubmit }
+							showPlaceholder={ this.state.loadingResults || ! this.getSuggestionsFromProps() }
+						/>
+					) }
+				</DomainSearchResults>
+			</>
 		);
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1096,7 +1096,7 @@ class RegisterDomainStep extends React.Component {
 						pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 						unavailableDomains={ this.state.unavailableDomains }
 						isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
-						showFreeDomainExplainerForFreePlan={ this.props.showFreeDomainExplainerForFreePlan }
+						shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
 					/>
 				);
 			}, this );
@@ -1142,12 +1142,7 @@ class RegisterDomainStep extends React.Component {
 	}
 
 	renderFreeDomainExplainer() {
-		return (
-			<FreeDomainExplainer
-				onSkip={ this.props.hideFreePlan }
-				showFreeDomainExplainerForFreePlan={ this.props.showFreeDomainExplainerForFreePlan }
-			/>
-		);
+		return <FreeDomainExplainer onSkip={ this.props.hideFreePlan } />;
 	}
 
 	onAddDomain = ( suggestion ) => {
@@ -1256,7 +1251,7 @@ class RegisterDomainStep extends React.Component {
 				pendingCheckSuggestion={ this.state.pendingCheckSuggestion }
 				unavailableDomains={ this.state.unavailableDomains }
 				isEligibleVariantForDomainTest={ this.props.isEligibleVariantForDomainTest }
-				showFreeDomainExplainerForFreePlan={ this.props.showFreeDomainExplainerForFreePlan }
+				shouldHideFreeDomainExplainer={ this.props.shouldHideFreeDomainExplainer }
 			>
 				{ this.props.isEligibleVariantForDomainTest &&
 					hasResults &&

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -3,7 +3,7 @@
 	padding-bottom: 12px;
 
 	&.register-domain-step__search-domain-step-test:not( .is-sticky ) {
-		padding-bottom: 28px;
+		padding-bottom: 24px;
 
 		@include breakpoint( '>660px' ) {
 			padding-top: 18px;

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -107,7 +107,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	domainStepPlanStepSwap: {
-		datestamp: '20200415',
+		datestamp: '20200508',
 		variations: {
 			variantShowSwapped: 0,
 			control: 100,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -107,10 +107,10 @@ export default {
 		allowExistingUsers: true,
 	},
 	domainStepPlanStepSwap: {
-		datestamp: '20200508',
+		datestamp: '20200513',
 		variations: {
-			variantShowSwapped: 0,
-			control: 100,
+			variantShowSwapped: 50,
+			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -201,8 +201,9 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 
 	const shouldSkipDomainStep = ! siteUrl && isDomainStepSkippable( flowToCheck );
 	const shouldHideFreePlan = get( signupDependencies, 'shouldHideFreePlan', false );
+	const shouldHideDomainStep = ! siteUrl && 'onboarding-plan-first' === flowToCheck;
 
-	if ( shouldSkipDomainStep || shouldHideFreePlan ) {
+	if ( shouldSkipDomainStep || shouldHideFreePlan || shouldHideDomainStep ) {
 		newSiteParams.blog_name =
 			get( user.get(), 'username' ) ||
 			get( signupDependencies, 'username' ) ||

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -601,23 +601,43 @@ function shouldExcludeStep( stepName, fulfilledDependencies ) {
 	return isEmpty( dependenciesNotProvided );
 }
 
-export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
-	const { siteDomains, submitSignupStep } = nextProps;
+function excludeDomainStep( stepName, tracksEventValue, submitSignupStep ) {
 	let fulfilledDependencies = [];
+	const domainItem = undefined;
 
-	if ( siteDomains && siteDomains.length > 1 ) {
-		const domainItem = undefined;
-		submitSignupStep( { stepName, domainItem }, { domainItem } );
-		recordExcludeStepEvent(
-			stepName,
-			siteDomains.map( ( siteDomain ) => siteDomain.domain ).join( ', ' )
-		);
+	submitSignupStep( { stepName, domainItem }, { domainItem } );
+	recordExcludeStepEvent( stepName, tracksEventValue );
 
-		fulfilledDependencies = [ 'domainItem' ];
-	}
+	fulfilledDependencies = [ 'domainItem' ];
 
 	if ( shouldExcludeStep( stepName, fulfilledDependencies ) ) {
 		flows.excludeStep( stepName );
+	}
+}
+
+export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
+	const { siteDomains, submitSignupStep } = nextProps;
+
+	if ( siteDomains && siteDomains.length > 1 ) {
+		const tracksEventValue = siteDomains.map( ( siteDomain ) => siteDomain.domain ).join( ', ' );
+		excludeDomainStep( stepName, tracksEventValue, submitSignupStep );
+	}
+}
+
+export function removeDomainStepForPaidPlans( stepName, defaultDependencies, nextProps ) {
+	// This is for domainStepPlanStepSwap A/B test.
+	// Remove the domain step if a paid plan is selected, check https://wp.me/pbxNRc-cj#comment-277
+	// Exit if not in the right flow.
+	if ( 'onboarding-plan-first' !== nextProps.flowName ) {
+		return;
+	}
+
+	const { submitSignupStep } = nextProps;
+	const cartItem = get( nextProps, 'signupDependencies.cartItem', false );
+
+	if ( ! isEmpty( cartItem ) ) {
+		const tracksEventValue = null;
+		excludeDomainStep( stepName, tracksEventValue, submitSignupStep );
 	}
 }
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -118,7 +118,7 @@ export function generateFlows( {
 		},
 
 		'onboarding-plan-first': {
-			steps: [ 'user', 'plans', 'domains', 'upsell-plan', 'plans-plan-only' ],
+			steps: [ 'user', 'plans', 'domains' ],
 			destination: getSignupDestination,
 			description:
 				'Shows the plan step before the domains step. Read more in https://wp.me/pbxNRc-cj.',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -34,6 +34,7 @@ export function generateSteps( {
 	launchSiteApi = noop,
 	isPlanFulfilled = noop,
 	isDomainFulfilled = noop,
+	removeDomainStepForPaidPlans = noop,
 	isSiteTypeFulfilled = noop,
 	isSiteTopicFulfilled = noop,
 	addOrRemoveFromProgressStore = noop,
@@ -306,6 +307,7 @@ export function generateSteps( {
 				'shouldHideFreePlan',
 			],
 			optionalDependencies: [ 'shouldHideFreePlan' ],
+			fulfilledStepCallback: removeDomainStepForPaidPlans,
 			props: {
 				isDomainOnly: false,
 			},

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -49,7 +49,6 @@ export default generateSteps( {
 export function isDomainStepSkippable( flowName ) {
 	return (
 		flowName === 'test-fse' ||
-		flowName === 'onboarding-plan-first' ||
 		( flowName === 'onboarding' && abtest( 'skippableDomainStep' ) === 'skippable' )
 	);
 }

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -19,6 +19,7 @@ import {
 	launchSiteApi,
 	isPlanFulfilled,
 	isDomainFulfilled,
+	removeDomainStepForPaidPlans,
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
 	addOrRemoveFromProgressStore,
@@ -39,6 +40,7 @@ export default generateSteps( {
 	launchSiteApi,
 	isPlanFulfilled,
 	isDomainFulfilled,
+	removeDomainStepForPaidPlans,
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
 	addOrRemoveFromProgressStore,
@@ -47,6 +49,7 @@ export default generateSteps( {
 export function isDomainStepSkippable( flowName ) {
 	return (
 		flowName === 'test-fse' ||
+		flowName === 'onboarding-plan-first' ||
 		( flowName === 'onboarding' && abtest( 'skippableDomainStep' ) === 'skippable' )
 	);
 }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { defer, endsWith, get, has, includes, isEmpty } from 'lodash';
+import { defer, endsWith, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import classNames from 'classnames';
 
@@ -448,13 +448,7 @@ class DomainsStep extends React.Component {
 			includeWordPressDotCom = ! this.props.isDomainOnly;
 		}
 
-		const hasCartItemInDependencyStore = has( this.props, 'signupDependencies.cartItem' );
-		const cartItem = get( this.props, 'signupDependencies.cartItem', false );
-		const hasSelectedFreePlan = hasCartItemInDependencyStore && ! cartItem;
-		const shouldHideFreeDomainExplainer =
-			'onboarding-plan-first' === this.props.flowName && cartItem;
-		const showFreeDomainExplainerForFreePlan =
-			'onboarding-plan-first' === this.props.flowName && hasSelectedFreePlan;
+		const shouldHideFreeDomainExplainer = 'onboarding-plan-first' === this.props.flowName;
 
 		return (
 			<RegisterDomainStep
@@ -488,7 +482,6 @@ class DomainsStep extends React.Component {
 				onSkip={ this.handleSkip }
 				hideFreePlan={ this.handleSkip }
 				shouldHideFreeDomainExplainer={ shouldHideFreeDomainExplainer }
-				showFreeDomainExplainerForFreePlan={ showFreeDomainExplainerForFreePlan }
 			/>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Check pbxNRc-cj-p2/#comment-277 for context.

* This is a follow up to the test launched in https://github.com/Automattic/wp-calypso/pull/40879 that swaps the domain and plan step. The following changes are introduced:
    - If a user in the variant group selects a paid plan, then don't show the domain step.
    - If a user in the variant group selects a free plan, then show only the domain price without any "free with a paid plan text". Take them to checkout directly with only a domain in cart.

**Paid plan selected -> directly take to checkout with no domain step**

![hidedomain](https://user-images.githubusercontent.com/1269602/81408677-4d1cb580-915b-11ea-8f85-820ba55b79ed.gif)


**Free plan selected -> show domain price -> directly take to. checkout with only domain in cart**

<img width="1046" alt="Screenshot 2020-05-14 at 5 17 41 PM" src="https://user-images.githubusercontent.com/1269602/81930919-deca6e00-9606-11ea-9b80-0a60790f6cde.png">

<img width="1051" alt="Screenshot 2020-05-14 at 5 17 31 PM" src="https://user-images.githubusercontent.com/1269602/81930931-e4c04f00-9606-11ea-86ff-ed4dc6fe23e7.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Scenario 1**

* Proxy through a US IP address and begin the signup flow at /start.
* If you are in _variantShowSwapped_ of the `domainStepCopyUpdates` test, then verify the following:
    - Selecting a free plan shows the domain step with domain price and renewal price listed; you should see a notice message about domain forwarding; selecting a domain should take you to checkout page with only a domain in cart.

    - Selecting a paid plan does not show the domain step. A paid plan should directly take you to checkout with a randomly generated site name.

* If you are in the control group of `domainStepCopyUpdates` test, then verify that everything works the same as before. 

* When logged in Calypso, verify that the UI for the add domains page at /domains/add is unchanged(open a new tab at wordpress.com/domains/add and compare with this branch).
