### PR TITLE
Update the name of the breakpoint mixin to show that its deprecated

### DIFF
--- a/apps/notifications/style.scss
+++ b/apps/notifications/style.scss
@@ -11,7 +11,7 @@
 	bottom: 0;
 	min-width: 400px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 		min-width: 0;
 	}
@@ -40,13 +40,13 @@
 			left: inherit;
 			width: 400px;
 
-			@include breakpoint( '<800px' ) {
+			@include breakpoint-deprecated( '<800px' ) {
 		    	left: 0;
 				width: auto;
 		  }
 	}
 
-	@include breakpoint( '<800px' ) {
+	@include breakpoint-deprecated( '<800px' ) {
 		&.wpnc__main header {
 			top: 47px;
 		}

--- a/client/assets/stylesheets/_main.scss
+++ b/client/assets/stylesheets/_main.scss
@@ -57,7 +57,7 @@ body {
 
 	// This fixes an issue with the `click-outside` package not working on mobile.
 	// Specifically, this makes clicking outside a popover work on touch devices. -shaun
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		cursor: pointer;
 	}
 }

--- a/client/assets/stylesheets/shared/_loading.scss
+++ b/client/assets/stylesheets/shared/_loading.scss
@@ -9,7 +9,7 @@
 		fill: var( --color-neutral-10 );
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 100px;
 		height: 100px;
 	}

--- a/client/assets/stylesheets/shared/mixins/_breakpoints.scss
+++ b/client/assets/stylesheets/shared/mixins/_breakpoints.scss
@@ -1,12 +1,15 @@
 
 // ==========================================================================
 // Breakpoint Mixin
+// This has been deprecated. New breakpoints should be created using Gutenberg breakpoints:
+// https://github.com/WordPress/gutenberg/blob/0f1f5e75408705f0ec014f5d2ea3d9fcc8a97817/packages/base-styles/_mixins.scss
+//
 // See https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md#media-queries
 // ==========================================================================
 
 $breakpoints: 480px, 660px, 800px, 960px, 1040px, 1280px, 1400px; // Think very carefully before adding a new breakpoint
 
-@mixin breakpoint( $sizes... ) {
+@mixin breakpoint-deprecated( $sizes... ) {
 	@each $size in $sizes {
 		@if type-of( $size ) == string {
 			$approved-value: 0;

--- a/client/assets/stylesheets/shared/mixins/_breakpoints.scss
+++ b/client/assets/stylesheets/shared/mixins/_breakpoints.scss
@@ -47,7 +47,7 @@ $breakpoints: 480px, 660px, 800px, 960px, 1040px, 1280px, 1400px; // Think very 
 					$sizes: $sizes + ' ' + $breakpoint;
 				}
 				// TODO - change this to use @error, when it is supported by node-sass
-				@warn 'ERROR in breakpoint( #{ $size } ): You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]';
+				@warn 'ERROR in breakpoint-deprecated( #{ $size } ): You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]';
 			}
 		} @else {
 			$sizes: '';
@@ -55,7 +55,7 @@ $breakpoints: 480px, 660px, 800px, 960px, 1040px, 1280px, 1400px; // Think very 
 				$sizes: $sizes + ' ' + $breakpoint;
 			}
 			// TODO - change this to use @error, when it is supported by node-sass
-			@warn 'ERROR in breakpoint( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]';
+			@warn 'ERROR in breakpoint-deprecated( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]';
 		}
 	}
 }

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -185,7 +185,7 @@
 	text-align: left;
 	counter-reset: item;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		left: 0;
 		top: -8px;
 		right: 0;

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -5,7 +5,7 @@
 	padding: 5px 0;
 	overflow: hidden;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -27,7 +27,7 @@
 		.follow-button__label {
 			color: var( --color-primary );
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: inline-block;
 			}
 		}
@@ -99,7 +99,7 @@
 }
 
 .author-compact-profile__site-link.is-placeholder {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-left: 50px;
 		margin-right: 50px;
 	}

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -19,7 +19,7 @@
 	}
 
 	.comment-button__label-status {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -64,7 +64,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		.comments__comment-actions-approve,
 		.comments__comment-actions-trash,
 		.comments__comment-actions-spam,
@@ -77,7 +77,7 @@
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.like-button .like-button__label-status {
 			display: inline;
 		}

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -102,7 +102,7 @@ a.comments__comment-username {
 		margin-top: 4px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		top: -4px;
 	}
 }

--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -25,7 +25,7 @@
 		z-index: 1;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 0;
 		text-align: left;
 	}

--- a/client/blocks/conversation-follow-button/style.scss
+++ b/client/blocks/conversation-follow-button/style.scss
@@ -68,7 +68,7 @@ button.conversation-follow-button {
 }
 
 .conversation-follow-button__label {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }

--- a/client/blocks/credit-card-form/style.scss
+++ b/client/blocks/credit-card-form/style.scss
@@ -8,7 +8,7 @@
 	padding: 0;
 	text-align: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0;
 		text-align: left;
 	}
@@ -17,7 +17,7 @@
 		font-size: 12px;
 		margin: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-left: 24px;
 		}
 	}
@@ -25,7 +25,7 @@
 	.gridicon {
 		float: left;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -45,7 +45,7 @@
 		margin-left: auto;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: column-reverse;
 
 		em {

--- a/client/blocks/domain-to-plan-nudge/style.scss
+++ b/client/blocks/domain-to-plan-nudge/style.scss
@@ -1,7 +1,7 @@
 .domain-to-plan-nudge {
 	margin-top: 9px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 17px;
 	}
 }

--- a/client/blocks/edit-gravatar/style.scss
+++ b/client/blocks/edit-gravatar/style.scss
@@ -39,7 +39,7 @@
 	bottom: 0;
 	left: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		top: 5%;
 		bottom: 5%;
 		left: 5%;
@@ -47,7 +47,7 @@
 		width: 90%;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		left: 12.5%;
 		right: 12.5%;
 		width: 75%;

--- a/client/blocks/follow-button/style.scss
+++ b/client/blocks/follow-button/style.scss
@@ -99,7 +99,7 @@ button.follow-button {
 }
 
 .follow-button__label {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }

--- a/client/blocks/gdpr-banner/style.scss
+++ b/client/blocks/gdpr-banner/style.scss
@@ -15,13 +15,13 @@
 		margin-bottom: 0;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 		font-size: 16px;
 		padding: 16px 24px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		font-size: 16px;
 		padding: 16px 32px;
 		max-width: 960px;
@@ -80,7 +80,7 @@
 .gdpr-banner__buttons {
 	margin-top: 14px;
 	text-align: center;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: 0 0 auto;
 		margin: 0 0 0 16px;
 		text-align: inherit;
@@ -90,7 +90,7 @@
 .gdpr-banner__acknowledge-button {
 	width: 100%;
 	text-align: center;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: auto;
 	}
 }

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -11,13 +11,13 @@
 	font-size: 15px;
 	margin-bottom: 4px;
 
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		font-size: 18px;
 	}
 }
 
 .get-apps__desktop {
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		display: flex;
 		flex-direction: row;
 		align-items: center;
@@ -32,7 +32,7 @@
 	font-size: 13px;
 	margin-bottom: 4px;
 
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		font-size: 15px;
 	}
 }
@@ -41,20 +41,20 @@
 .get-apps__description:last-child {
 	margin-bottom: 12px;
 
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		margin-bottom: 0;
 	}
 }
 
 .get-apps__mobile {
 
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		order: 2;
 	}
 
 	.get-apps__store-subpanel {
 
-		@include breakpoint('>800px') {
+		@include breakpoint-deprecated('>800px') {
 			display: flex;
 			flex-direction: row;
 			align-items: center;
@@ -73,14 +73,14 @@
 
 		.get-apps__link-button-wrapper {
 
-			@include breakpoint('>480px') {
+			@include breakpoint-deprecated('>480px') {
 				display: flex;
 				flex-direction: row;
 				justify-content: flex-end;
 				align-items: center;
 			}
 
-			@include breakpoint('<480px') {
+			@include breakpoint-deprecated('<480px') {
 
 				.get-apps__magic-link-button {
 					width: 100%;
@@ -97,7 +97,7 @@
 		margin-top: 64px;
 
 		.get-apps__sms-field-wrapper .form-phone-input {
-			@include breakpoint('>800px') {
+			@include breakpoint-deprecated('>800px') {
 				display: flex;
 				flex-direction: row;
 				align-items: center;
@@ -115,7 +115,7 @@
 
 		.get-apps__sms-button-wrapper {
 
-			@include breakpoint('>480px') {
+			@include breakpoint-deprecated('>480px') {
 				display: flex;
 				flex-direction: row;
 				justify-content: flex-end;
@@ -127,7 +127,7 @@
 				padding-right: 16px;
 			}
 
-			@include breakpoint('<480px') {
+			@include breakpoint-deprecated('<480px') {
 
 				p {
 					margin-bottom: 24px;
@@ -152,7 +152,7 @@
 	padding: 16px;
 	text-align: center;
 
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		padding: 24px;
 	}
 }
@@ -162,7 +162,7 @@
 	font-weight: 600;
 	padding: 0 24px;
 
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		font-size: 24px;
 	}
 }
@@ -172,13 +172,13 @@
 	margin-bottom: 0;
 	padding: 0 24px;
 
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		font-size: 14px;
 	}
 }
 
 .get-apps__card-text {
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		flex: 1;
 	}
 }
@@ -190,7 +190,7 @@
 }
 
 .get-apps__desktop-button {
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		margin-left: 24px;
 	}
 }

--- a/client/blocks/google-my-business-stats-nudge/style.scss
+++ b/client/blocks/google-my-business-stats-nudge/style.scss
@@ -11,7 +11,7 @@
 	flex-direction: row;
 	padding: 11px 24px; // standard padding
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-height: 300px;
 		padding-bottom: 0; // allow image to go right to the edge of the card
 	}
@@ -22,7 +22,7 @@
 	flex-direction: column;
 	justify-content: center;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding-right: 12px; // the image has about 12 px of whitespace, this helps "balance" the block
 	}
 }
@@ -44,7 +44,7 @@
 	flex-direction: row;
 	margin: 20px 0;
 	.button {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			text-align: center;
 		}
@@ -54,7 +54,7 @@
 .google-my-business-stats-nudge__image-wrapper {
 	display: none;
 	padding: 0 40px;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 		min-width: 250px;
 	}

--- a/client/blocks/image-selector/style.scss
+++ b/client/blocks/image-selector/style.scss
@@ -3,11 +3,11 @@
 }
 
 .image-selector__images {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 250px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: 338px;
 	}
 }
@@ -72,7 +72,7 @@
 	justify-content: center;
 	width: 100%;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		justify-content: flex-start;
 	}
 }
@@ -88,13 +88,13 @@
 	margin-right: 8px;
 	margin-left: 8px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: 0;
 		margin-right: 16px;
 	}
 
 	&:nth-child( 3n ) {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-right: 0;
 			clear: both;
 		}
@@ -105,7 +105,7 @@
 		height: 70px;
 		overflow: hidden;
 
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			width: 100px;
 			height: 100px;
 		}
@@ -178,7 +178,7 @@
 	border: 1px dashed var( --color-neutral-light );
 	border-radius: 5px;
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		height: 338px;
 	}
 
@@ -237,18 +237,18 @@
 	border-radius: 5px;
 	display: inline-block;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: 0;
 		margin-right: 16px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: 100px;
 		height: 100px;
 	}
 
 	&:nth-child( 3n ) {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-right: 0;
 		}
 	}
@@ -263,11 +263,11 @@
 		width: 100%;
 		height: 100%;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			height: 72px;
 		}
 
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			height: 100px;
 		}
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -36,7 +36,7 @@
 		border-color: var( --color-accent );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.button.is-borderless.inline-help__button {
 			padding: 1px;
 		}
@@ -116,7 +116,7 @@
 }
 
 .inline-help__popover.popover {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: -5px;
 		width: calc( 100% - 28px );
 	}
@@ -124,7 +124,7 @@
 	p {
 		font-size: 12px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			font-size: 14px;
 		}
 	}
@@ -133,12 +133,12 @@
 	button {
 		font-size: 12px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			font-size: 14px;
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 320px;
 
 		position: fixed;
@@ -169,7 +169,7 @@
 			&.is-open.has-focus {
 				box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 6px var( --color-primary-light );
 
-				@include breakpoint( '>660px' ) {
+				@include breakpoint-deprecated( '>660px' ) {
 					box-shadow: 0 0 0 1px var( --color-primary ), 0 0 0 4px var( --color-primary-light );
 				}
 			}
@@ -179,7 +179,7 @@
 				padding: 12px 0;
 				color: var( --color-text );
 
-				@include breakpoint( '>660px' ) {
+				@include breakpoint-deprecated( '>660px' ) {
 					font-size: 15px;
 					padding: 16px 0;
 				}
@@ -353,7 +353,7 @@
 	margin: 0;
 	font-size: 14px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 18px;
 		line-height: 1.3;
 	}
@@ -404,7 +404,7 @@
 	color: var( --color-text-subtle );
 	font-style: italic;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 16px;
 	}
 }

--- a/client/blocks/jitm/templates/sidebar-banner.scss
+++ b/client/blocks/jitm/templates/sidebar-banner.scss
@@ -6,7 +6,7 @@
 		color: var( --color-text-inverted );
 		display: flex;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding: 0 19px;
 		}
 

--- a/client/blocks/legal-updates-banner/style.scss
+++ b/client/blocks/legal-updates-banner/style.scss
@@ -24,7 +24,7 @@
 		width: 100%;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 1rem 1.5rem;
 		flex-direction: row;
 		align-items: center;
@@ -36,7 +36,7 @@
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding: 1rem 2rem;
 
 		.legal-updates-banner__content {

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -61,7 +61,7 @@
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.like-button__label-status {
 			display: none;
 		}

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -225,7 +225,7 @@
 }
 
 .login__jetpack-logo {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 20px;
 	}
 }

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -13,7 +13,7 @@
 	padding: 16px;
 	padding-right: 36px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 24px;
 		padding-right: 48px;
 	}
@@ -63,7 +63,7 @@
 	padding: 16px 0;
 	text-align: center;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 16px;
 	}
 }
@@ -78,7 +78,7 @@
 	padding: 0 3px;
 	margin-bottom: 8px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 0 6px;
 	}
 }

--- a/client/blocks/payment-methods/style.scss
+++ b/client/blocks/payment-methods/style.scss
@@ -19,7 +19,7 @@
 .payment-methods__methods {
 	margin-top: 5px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-top: 0;
 	}
 }

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -29,7 +29,7 @@
 	.post-edit-button__label {
 		color: var( --color-text-subtle );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}
@@ -39,7 +39,7 @@
 	font-size: 14px;
 	margin-left: 4px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -50,7 +50,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	padding: 16px 16px 0;
 	margin-left: -16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-left: 24px;
 		margin-left: -24px;
 	}

--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -42,7 +42,7 @@ $section-border: solid 1px var( --color-neutral-5 );
 	display: flex;
 	flex-direction: column-reverse;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -65,7 +65,7 @@ $section-border: solid 1px var( --color-neutral-5 );
 	}
 
 	padding: 16px;
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 16px;
 	}
 }
@@ -78,7 +78,7 @@ $section-border: solid 1px var( --color-neutral-5 );
 .post-share__form {
 	flex: 3 0 0;
 	margin: 0 16px 16px;
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin: 0 16px 16px;
 	}
 
@@ -288,7 +288,7 @@ $section-border: solid 1px var( --color-neutral-5 );
 
 	border-top: $section-border;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-bottom: 1px;
 		padding: 16px;
 	}
@@ -319,7 +319,7 @@ $section-border: solid 1px var( --color-neutral-5 );
 	overflow: hidden;
 	position: relative;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		align-items: center;
 		flex-direction: row;
 
@@ -328,12 +328,12 @@ $section-border: solid 1px var( --color-neutral-5 );
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		align-items: flex-start;
 		flex-direction: column;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		align-items: center;
 		flex-direction: row;
 	}
@@ -342,7 +342,7 @@ $section-border: solid 1px var( --color-neutral-5 );
 .post-share__footer-item .social-logo {
 	flex: 0 0 24px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		position: relative;
 		top: 1px;
 	}
@@ -355,7 +355,7 @@ $section-border: solid 1px var( --color-neutral-5 );
 	top: -1px;
 	left: -1px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		top: 0;
 	}
 }
@@ -374,29 +374,29 @@ $section-border: solid 1px var( --color-neutral-5 );
 }
 
 .post-share__handle {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-right: 7px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-right: 12px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-right: 7px;
 	}
 }
 
 .post-share__timestamp-value {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-left: 0;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-left: 4px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding-left: 0;
 	}
 }
@@ -408,15 +408,15 @@ $section-border: solid 1px var( --color-neutral-5 );
 	font-style: italic;
 	white-space: nowrap;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: block;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: block;
 	}
 }

--- a/client/blocks/privacy-policy-banner/privacy-policy-dialog.scss
+++ b/client/blocks/privacy-policy-banner/privacy-policy-dialog.scss
@@ -8,7 +8,7 @@
 		list-style-position: inside;
 		margin: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			list-style-position: outside;
 			margin: 0 3em 1.5em;
 		}

--- a/client/blocks/product-purchase-features-list/style.scss
+++ b/client/blocks/product-purchase-features-list/style.scss
@@ -1,6 +1,6 @@
 
 .product-purchase-features-list {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
@@ -15,7 +15,7 @@
 	padding-top: 12px;
 	max-width: 150%;
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		max-width: 49.5%;
 	}
 }

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -75,14 +75,14 @@
 	min-width: 64px;
 	margin-right: 15px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 100px;
 	}
 }
 
 // Always indent the wrapper at larger breakpoints, asset or no asset
 .reader-combined-card__featured-asset-wrapper {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 100px;
 		margin-right: 15px;
 	}
@@ -115,7 +115,7 @@
 			width: 2px;
 			background: var( --color-primary );
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				left: -16px;
 			}
 		}
@@ -238,7 +238,7 @@
 	padding: 18px 0 0;
 	position: relative;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 0;
 	}
 }
@@ -290,7 +290,7 @@
 		margin-bottom: 3px;
 
 		.follow-button__label {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: inline;
 			}
 		}

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -44,7 +44,7 @@
 		top: auto;
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		max-height: 16px * 5.9;
 	}
 }
@@ -55,7 +55,7 @@
 	position: relative;
 	z-index: z-index( 'root', '.reader-feed-header' );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 20px 13px;
 	}
 
@@ -65,7 +65,7 @@
 		height: 0;
 		margin-left: auto;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			margin-left: 0;
 		}
 	}
@@ -80,7 +80,7 @@
 			position: relative;
 				top: -4px;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			margin-bottom: 10px;
 		}
 	}
@@ -90,7 +90,7 @@
 		font-size: 14px;
 		margin-right: 15px;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			display: none;
 		}
 	}
@@ -105,11 +105,11 @@
 
 		.follow-button__label {
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: inline-block;
 			}
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				display: none;
 			}
 		}
@@ -137,7 +137,7 @@
 			display: block;
 			position: relative;
 
-			@include breakpoint ( '<660px' ) {
+			@include breakpoint-deprecated ( '<660px' ) {
 				max-height: 16px * 4;
 				overflow: hidden;
 
@@ -164,7 +164,7 @@
 	box-shadow: none;
 	padding: 0;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		box-sizing: border-box;
 		padding: 16px;
 	}
@@ -177,18 +177,18 @@
 
 .reader-feed-header__email-settings .reader-site-notification-settings .gridicons-cog {
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		left: -4px;
 	}
 }
 
 .reader-feed-header__email-settings .reader-site-notification-settings__button-label {
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: inline;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -94,7 +94,7 @@
 		margin: 24px auto !important;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		.alignleft {
 			max-width: 100%;
 			float: left;
@@ -112,7 +112,7 @@
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.alignleft,
 		.alignright {
 			clear: both;
@@ -152,7 +152,7 @@
 		&.alignleft {
 			max-width: 100%;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				max-width: 50%;
 			}
 
@@ -196,7 +196,7 @@
 		line-height: 1.4285;
 		animation: appear 0.3s ease-in-out;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 13px 48px;
 			font-size: inherit;
 		}
@@ -289,7 +289,7 @@
 			padding: 0 16px 16px 0;
 		}
 
-		@include breakpoint( '>1400px' ) {
+		@include breakpoint-deprecated( '>1400px' ) {
 			&.right,
 			&.alignright {
 				position: absolute;
@@ -298,7 +298,7 @@
 			}
 		}
 
-		@include breakpoint( '<1400px' ) {
+		@include breakpoint-deprecated( '<1400px' ) {
 			&.right,
 			&.alignright,
 			&.left,
@@ -332,21 +332,21 @@
 		width: 175px;
 		position: relative;
 
-		@include breakpoint( '>1400px' ) {
+		@include breakpoint-deprecated( '>1400px' ) {
 			position: absolute;
 			left: inherit;
 			right: -( 175px + 32px );
 			margin-left: 0;
 		}
 
-		@include breakpoint( '<1400px' ) {
+		@include breakpoint-deprecated( '<1400px' ) {
 			background: var( --color-neutral-0 );
 			margin: 0 0 24px;
 			padding: 16px;
 			width: calc( 100% - 32px );
 		}
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin: 0 0 24px;
 			background: var( --color-neutral-0 );
 			padding: 16px;
@@ -367,7 +367,7 @@
 	}
 
 	.publisher-intro p:first-child {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-bottom: 0;
 		}
 	}

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -5,7 +5,7 @@
 
 .is-group-reader.has-no-sidebar {
 	.masterbar {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none; // Hides masterbar in fullpost mobile
 		}
 	}
@@ -22,23 +22,23 @@
 .reader-full-post__content {
 	margin: 0 auto;
 
-	@include breakpoint( '>1280px' ) {
+	@include breakpoint-deprecated( '>1280px' ) {
 		width: 720px;
 		padding-left: 260px;
 	}
 
-	@include breakpoint( '1040px-1280px' ) {
+	@include breakpoint-deprecated( '1040px-1280px' ) {
 		width: 720px;
 		padding-left: 240px;
 	}
 
-	@include breakpoint( '660px-1040px' ) {
+	@include breakpoint-deprecated( '660px-1040px' ) {
 		width: auto;
 		margin: 0;
 		padding-left: 240px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: auto;
 		padding: 0 20px;
 	}
@@ -60,7 +60,7 @@
 		'.reader-full-post__visit-site-container'
 	);
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		border: 0;
 		position: absolute;
 		top: 47px;
@@ -71,7 +71,7 @@
 		fill: var( --color-neutral-40 );
 		top: 5px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			top: 3px;
 		}
 	}
@@ -81,7 +81,7 @@
 		display: block;
 		padding: 10px 10px 15px 6px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 10px 20px 15px;
 		}
 
@@ -95,7 +95,7 @@
 	}
 
 	.reader-full-post__visit-site-label {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -106,19 +106,19 @@
 	position: fixed;
 	text-align: center;
 
-	@include breakpoint( '>1280px' ) {
+	@include breakpoint-deprecated( '>1280px' ) {
 		left: calc( 50% - 490px );
 	}
 
-	@include breakpoint( '1040px-1280px' ) {
+	@include breakpoint-deprecated( '1040px-1280px' ) {
 		left: calc( 50% - 480px );
 	}
 
-	@include breakpoint( '660px-1040px' ) {
+	@include breakpoint-deprecated( '660px-1040px' ) {
 		left: 20px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		position: static;
 		text-align: left;
 		width: auto;
@@ -128,12 +128,12 @@
 .reader-full-post__story {
 	max-width: 720px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		font-size: 15px;
 		line-height: 24px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: -35px;
 	}
 }
@@ -157,7 +157,7 @@
 }
 
 .reader-full-post .back-button {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		background: transparent;
 		border-bottom: 0;
 		position: fixed;
@@ -170,7 +170,7 @@
 	display: inline-flex;
 	flex-direction: column;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-bottom: 35px;
 		padding-right: 10px;
 		position: relative;
@@ -190,7 +190,7 @@
 		margin-top: 0;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: row;
 		margin-top: 20px;
 
@@ -233,7 +233,7 @@
 				font-size: 32px !important;
 
 				.gridicon {
-					@include breakpoint( '<660px' ) {
+					@include breakpoint-deprecated( '<660px' ) {
 						height: 32px !important;
 						width: 32px !important;
 						line-height: 32px !important;
@@ -258,7 +258,7 @@
 			flex: 1 0 0;
 			display: inline;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				margin-top: 0;
 			}
 		}
@@ -273,7 +273,7 @@
 			left: calc( 100% - 270px );
 			top: 5px;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				background: transparent;
 				position: fixed;
 				z-index: z-index(
@@ -294,7 +294,7 @@
 		}
 
 		.author-compact-profile__follow .follow-button__label {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: none;
 			}
 		}
@@ -332,7 +332,7 @@
 }
 
 .reader-full-post__sidebar-comment-like {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		align-items: flex-start;
 		background: white;
 		display: flex;
@@ -349,7 +349,7 @@
 }
 
 .reader-full-post__sidebar .like-button {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-right: 60px;
 		top: 9px;
 	}
@@ -367,7 +367,7 @@
 .reader-full-post__sidebar .comment-button {
 	margin-right: 18px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		top: 9px;
 	}
 
@@ -384,7 +384,7 @@
 .reader-full-post .has-author-link.has-author-icon {
 	margin-top: 25px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 5px;
 	}
 
@@ -402,7 +402,7 @@
 }
 
 .reader-full-post .has-author-link .reader-author-link {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 4px;
 	}
 }
@@ -428,17 +428,17 @@
 	margin: 56px 0 0;
 	max-width: 750px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		font-size: 36px;
 		line-height: 46px;
 	}
 
-	@include breakpoint( '480px-960px' ) {
+	@include breakpoint-deprecated( '480px-960px' ) {
 		font-size: 32px;
 		line-height: 40px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 8px;
 	}
 
@@ -462,7 +462,7 @@
 .reader-full-post__header-date {
 	line-height: 1.6;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		line-height: 1.4;
 	}
 }
@@ -491,7 +491,7 @@
 		position: relative;
 		top: 4px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			top: 2px;
 		}
 	}

--- a/client/blocks/reader-list-item/style.scss
+++ b/client/blocks/reader-list-item/style.scss
@@ -4,7 +4,7 @@
 	font-size: 14px;
 	height: 100%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 15px;
 	}
 }
@@ -38,12 +38,12 @@
 	flex-direction: column;
 	min-width: 24px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 90px;
 	}
 
 	.button.follow-button {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: flex;
 		}
 	}
@@ -124,16 +124,16 @@
 	max-height: 16px * 3.2;
 	min-width: 100%;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		height: auto;
 		flex-direction: column;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: row;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-direction: column;
 	}
 
@@ -157,24 +157,24 @@
 	word-break: break-all;
 	max-height: 16px * 1.3;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		height: 20px;
 		flex: 1 1 auto;
 		max-width: none;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex: 0 1 auto;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex: 1 1 auto;
 		max-width: none;
 	}
 }
 
 .reader-list-item .follow-button .gridicon {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		left: 3px;
 	}
 }
@@ -210,7 +210,7 @@
 		width: 20px;
 		height: 20px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 16px * 1.5 * 3;
 		}
 	}

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -10,7 +10,7 @@
 	padding: 18px 0 20px;
 	position: relative;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 0;
 	}
 
@@ -24,7 +24,7 @@
 			width: 2px;
 			background: var( --color-primary );
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				left: -16px;
 			}
 		}
@@ -38,11 +38,11 @@
 			max-width: 190px;
 			box-sizing: border-box;
 
-			@include breakpoint( '>960px' ) {
+			@include breakpoint-deprecated( '>960px' ) {
 				max-width: 250px;
 			}
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				height: 100px;
 				margin: 0 0 15px;
 				max-width: 100%;
@@ -147,7 +147,7 @@
 			margin-top: 0;
 			margin-left: 0;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				margin-left: 5px;
 			}
 		}
@@ -180,7 +180,7 @@
 		.reader-post-card__post {
 			margin-top: 0;
 
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				flex-direction: row;
 			}
 		}
@@ -291,7 +291,7 @@
 		@include long-content-fade( $size: 10% );
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: calc( 100% - 90px );
 	}
 }
@@ -318,7 +318,7 @@
 	position: relative;
 	width: calc( 100% - 140px );
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		max-width: 500px;
 	}
 
@@ -397,7 +397,7 @@
 	flex-direction: row;
 	margin-top: 14px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-direction: column;
 	}
 
@@ -436,7 +436,7 @@
 		color: var( --color-neutral-70 );
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 19px;
 	}
 }
@@ -461,7 +461,7 @@
 		max-height: 15px * 1.6 * 3.2;
 
 		// Clamp to 2 lines on wider viewports
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			max-height: 15px * 1.6 * 2;
 		}
 
@@ -537,11 +537,11 @@
 	.reader-share__button-label,
 	.comment-button__label-status,
 	.like-button__label-status {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			display: none;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -583,7 +583,7 @@
 		margin-bottom: 3px;
 
 		.follow-button__label {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: inline;
 			}
 		}
@@ -623,7 +623,7 @@
 	}
 
 	&:nth-last-of-type( -n + 2 ) {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}
@@ -636,7 +636,7 @@
 .reader-post-card__gallery-image {
 	height: 100px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		height: 130px;
 	}
 }

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -65,7 +65,7 @@
 
 		.follow-button__label,
 		.conversation-follow-button__label {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: inline-block;
 			}
 		}

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -1,5 +1,5 @@
 .reader-recommended-sites {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 15px;
 	}
 }
@@ -12,7 +12,7 @@
 	margin: 8px 0;
 	position: relative;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 16px 0;
 	}
 
@@ -29,7 +29,7 @@
 	margin: 0 0 20px;
 	padding: 0;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -41,7 +41,7 @@
 	list-style-type: none;
 	width: 100%;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		align-items: flex-end;
 		flex-direction: column;
 	}
@@ -57,7 +57,7 @@
 		top: 16px;
 		right: 16px;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
     		top: 0;
     		right: 0;
 		}
@@ -82,19 +82,19 @@
 		margin: 0;
 		padding: 0;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			padding: 0 0 20px;
 		}
 
 		.follow-button .follow-button__label {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: inline;
 			}
 		}
 	}
 
 	&:last-child {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-left: 20px;
 		}
 	}

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -38,7 +38,7 @@
 	margin: 0;
 	padding: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 }
@@ -52,7 +52,7 @@
 	&:first-child {
 		margin-right: 10px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-right: 10px;
 		}
 	}
@@ -60,14 +60,14 @@
 	&:last-child {
 		margin-left: 10px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-left: 10px;
 		}
 	}
 
 	&:first-child,
 	&:last-child {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin: 0 0 20px;
 		}
 	}
@@ -83,7 +83,7 @@
 	flex: 1 1 auto;
 	padding: 0;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: flex;
 		flex-direction: column;
 	}
@@ -142,7 +142,7 @@
 	border-top: 1px solid var( --color-neutral-10 );
 	margin-top: 30px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-top: 0;
 	}
 
@@ -172,7 +172,7 @@
 		.reader-related-card__post {
 			max-height: 17px * 1.6 * 4;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				max-height: 17px * 1.6 * 7.5;
 			}
 		}
@@ -253,7 +253,7 @@
 	border: 1px solid var( --color-neutral-0 );
 	min-height: 78px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		min-height: 153px;
 	}
 }
@@ -283,7 +283,7 @@
 	}
 
 	// Clamp to 3 lines on larger viewports
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		overflow: hidden;
 		max-height: 17px * 1.48 * 3;
 		word-wrap: break-word;
@@ -329,20 +329,20 @@
 		fill: var( --color-primary );
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		min-width: 20px;
 	}
 
 	.follow-button__label {
 		color: var( --color-primary );
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			display: none;
 		}
 	}
 
 	.gridicon {
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			padding-right: 0;
 		}
 	}

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -29,13 +29,13 @@
 .reader-share__button-label {
 	margin-left: 6px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }
 
 .reader-share__popover {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 152px;
 		padding-right: 2px;
 	}
@@ -47,7 +47,7 @@
 		line-height: 24px;
 		margin-left: 34px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-left: 27px;
 		}
 	}
@@ -62,7 +62,7 @@
 		padding: 0;
 		fill: var( --color-neutral-light );
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			left: 11px;
 		}
 	}

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -9,7 +9,7 @@
 .reader-site-notification-settings__button-label {
 	font-size: 14px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }
@@ -21,7 +21,7 @@
 		top: 4px;
 		left: -4px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		left: -1px;
 	}
 }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -23,12 +23,12 @@
 	flex-direction: column;
 	min-width: 24px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 90px;
 	}
 
 	.button.follow-button {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: flex;
 		}
 	}
@@ -64,7 +64,7 @@
 	font-size: 14px;
 	padding: 15px 0;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 15px;
 	}
 }
@@ -116,16 +116,16 @@
 	max-height: 16px * 3.2;
 	min-width: 100%;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		height: auto;
 		flex-direction: column;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: row;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-direction: column;
 	}
 
@@ -150,24 +150,24 @@
 	width: initial;
 	max-height: 16px * 1.3;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		height: 20px;
 		flex: 1 1 auto;
 		max-width: none;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex: 0 1 auto;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex: 1 1 auto;
 		max-width: none;
 	}
 }
 
 .reader-subscription-list-item .follow-button .gridicon {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		left: 3px;
 	}
 }
@@ -203,7 +203,7 @@
 		width: 20px;
 		height: 20px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 16px * 1.5 * 3;
 		}
 	}

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -13,7 +13,7 @@
 	bottom: 0;
 	left: 0;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		top: 24px;
 	}
 }
@@ -51,7 +51,7 @@
 	flex-direction: column;
 	height: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 	}
 }
@@ -81,7 +81,7 @@
 			display: none;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex-direction: column;
 			justify-content: flex-start;
 			border-bottom: 1px solid #c8d7e1;
@@ -103,7 +103,7 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		border-right: 1px solid var( --color-neutral-10 );
 		flex: 0 0 250px;
 	}
@@ -125,7 +125,7 @@
 		font-size: 12px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 40px 0 40px 20px;
 		max-width: 200px;
 	}

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -1,5 +1,5 @@
 body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		margin: 0 auto;
 		max-width: 1100px;
 		padding: 0 40px;
@@ -35,7 +35,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		font-weight: bold;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 40px 0;
 	}
 }
@@ -45,7 +45,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	flex-direction: column;
 	width: 100%;
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		flex-direction: row;
 	}
 }
@@ -58,7 +58,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		display: block;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		background-color: var( --color-surface );
 	    box-shadow: 0 2px 3px 0 var( --color-neutral-10 );
 		display: block;
@@ -67,7 +67,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		width: 500px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		flex: 1;
 		width: initial;
 	}
@@ -129,7 +129,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 			display: block;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-bottom: 20px;
 		}
 	}
@@ -150,7 +150,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	margin: 0 0 30px;
 	text-align: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 	}
 }
@@ -168,7 +168,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	padding: 20px 0 50px;
 	text-align: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 	}
 }
@@ -185,7 +185,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	text-align: center;
 	margin: 20px 0 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 }
@@ -201,7 +201,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 
 	.signup-form__crowdsignal-social & {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: none;
 		}
 	}
@@ -209,7 +209,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	.signup-form__crowdsignal-card:not( .signup-form__crowdsignal-social ) & {
 		display: none;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: block;
 		}
 	}
@@ -228,11 +228,11 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	vertical-align: middle;
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: 100px;
 	}
 }
@@ -258,7 +258,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		display: inline-block;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: inline-block;
 	}
 }
@@ -270,7 +270,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		display: none;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 }
@@ -281,7 +281,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	margin-top: 20px;
 	padding: 0 20px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 40px;
 	}
 }
@@ -315,7 +315,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		display: inline;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: inline;
 		text-align: left;
 

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -21,7 +21,7 @@
 	text-align: center;
 
 	a {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			white-space: pre;
 		}
 	}

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -65,7 +65,7 @@
 	margin: 0 auto 10px;
 	padding: 16px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0;
 	}
 
@@ -73,14 +73,14 @@
 		float: left;
 		margin: auto 12px auto 10px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin: auto 6px auto 4px;
 		}
 	}
 }
 
 .site-address-changer__content {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.form-text-input-with-affixes__suffix {
 			padding-left: 8px;
 			padding-right: 8px;
@@ -95,12 +95,12 @@
 	display: flex;
 	justify-content: flex-start;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 24px;
 		margin: 0 -24px -24px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-direction: column;
 	}
 
@@ -110,16 +110,16 @@
 		&.is-primary {
 			margin: 0 0 15px;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				margin: 0;
 			}
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				order: 1;
 			}
 		}
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			order: 2;
 		}
@@ -133,7 +133,7 @@
 		float: left;
 		margin-top: 4px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -141,7 +141,7 @@
 	.site-address-changer__confirmation-detail-copy {
 		word-break: break-word;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-left: 24px;
 		}
 	}

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -157,7 +157,7 @@
 		vertical-align: middle;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }

--- a/client/blocks/stats-navigation/intervals.scss
+++ b/client/blocks/stats-navigation/intervals.scss
@@ -3,7 +3,7 @@
 		max-width: 100%;
 		margin: 8px 9px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			max-width: 400px;
 			margin: 16px auto;
 		}

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -2,35 +2,35 @@
 	.section-nav__panel {
 		padding-right: 0;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding-right: 16px;
 		}
 	}
 	.segmented-control {
 		margin-left: 0;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-left: 16px;
 		}
 	}
 	.followers-count .button {
 		margin-left: 16px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}
 	.stats-navigation__intervals.is-standalone.segmented-control {
 		display: flex;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			display: none;
 		}
 	}
 	.stats-navigation__intervals.segmented-control {
 		display: none;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			display: flex;
 		}
 	}

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -21,7 +21,7 @@
 			margin-top: 8px;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			&:first-child:nth-last-child( 2 ),
 			&:first-child:nth-last-child( 2 ) ~ div {
 				flex-basis: calc( 50% - 10px );

--- a/client/blocks/support-article-dialog/content.scss
+++ b/client/blocks/support-article-dialog/content.scss
@@ -83,7 +83,7 @@
 		margin: 24px auto !important;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		.alignleft {
 			max-width: 100%;
 			float: left;
@@ -101,7 +101,7 @@
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.alignleft,
 		.alignright {
 			clear: both;
@@ -140,7 +140,7 @@
 		&.alignleft {
 			max-width: 100%;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				max-width: 50%;
 			}
 
@@ -183,7 +183,7 @@
 		line-height: 1.4285;
 		animation: appear 0.3s ease-in-out;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 13px 48px;
 			font-size: inherit;
 		}

--- a/client/blocks/support-article-dialog/style.scss
+++ b/client/blocks/support-article-dialog/style.scss
@@ -11,7 +11,7 @@
 	right: 0;
 	max-width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		top: 5%;
 		bottom: 5%;
 		left: 5%;
@@ -19,7 +19,7 @@
 		width: 90%;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		left: 12.5%;
 		right: 12.5%;
 		width: 75%;
@@ -34,12 +34,12 @@
 		margin: 12px 0 0;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		font-size: 15px;
 		line-height: 24px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: auto;
 	}
 }
@@ -75,17 +75,17 @@
 	margin: 56px 0 0;
 	max-width: 750px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		font-size: 36px;
 		line-height: 46px;
 	}
 
-	@include breakpoint( '480px-960px' ) {
+	@include breakpoint-deprecated( '480px-960px' ) {
 		font-size: 32px;
 		line-height: 40px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 8px;
 	}
 

--- a/client/blocks/term-form-dialog/style.scss
+++ b/client/blocks/term-form-dialog/style.scss
@@ -7,7 +7,7 @@
 	padding-bottom: 0;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.term-form-dialog {
 		width: 90%;
 	}

--- a/client/blocks/upwork-banner/style.scss
+++ b/client/blocks/upwork-banner/style.scss
@@ -40,7 +40,7 @@
 			right: 30px;
 		user-select: none;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			display: none;
 		}
 	}

--- a/client/blocks/upwork-stats-nudge/style.scss
+++ b/client/blocks/upwork-stats-nudge/style.scss
@@ -7,7 +7,7 @@
 	display: flex;
 	padding: 11px 24px; // Standard padding
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-height: 300px;
 		padding-bottom: 0; // Allow image to go right to the edge of the card
 	}
@@ -18,7 +18,7 @@
 	flex-direction: column;
 	justify-content: center;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding-right: 12px; // The image has about 12 px of whitespace, this helps "balance" the block
 	}
 }
@@ -39,12 +39,12 @@
 	display: flex;
 	margin-bottom: 20px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 30px;
 	}
 
 	.button {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			text-align: center;
 		}
@@ -54,7 +54,7 @@
 .upwork-stats-nudge__image-wrapper {
 	display: none;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 		height: 200px;
 		margin-right: 40px;

--- a/client/blocks/user-mentions/suggestion-list.scss
+++ b/client/blocks/user-mentions/suggestion-list.scss
@@ -5,7 +5,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: 20%;
 		min-width: 29em;
 	}
@@ -23,7 +23,7 @@
 		direction: ltr; // Required to get the '@' on the correct side.
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		line-height: 24px;
 	}
 }

--- a/client/blocks/user-mentions/suggestion.scss
+++ b/client/blocks/user-mentions/suggestion.scss
@@ -26,7 +26,7 @@ $user-mentions-avatar-margin: 10px;
 	margin-left: $user-mentions-avatar-size + $user-mentions-avatar-margin;
 	font-size: 11px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		float: right;
 		clear: none;
 		margin-left: 0;

--- a/client/blocks/video-editor/style.scss
+++ b/client/blocks/video-editor/style.scss
@@ -5,7 +5,7 @@
 }
 
 .editor-media-modal .video-editor .notice.video-editor__notice {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 0;
 	}
 }
@@ -26,7 +26,7 @@
 	position: relative;
 	border-bottom: 1px solid var( --color-neutral-10 );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 16px 24px;
 		border: 0;
 	}

--- a/client/components/action-card/style.scss
+++ b/client/components/action-card/style.scss
@@ -1,7 +1,7 @@
 .card.action-card {
 	display: block;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 	}
 }
@@ -13,7 +13,7 @@
 .action-card__illustration {
 	max-width: 200px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		display: none;
 	}
 }
@@ -28,7 +28,7 @@
 		white-space: nowrap;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 0;
 		text-align: right;
 
@@ -37,7 +37,7 @@
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.button {
 			text-align: center;
 			width: 100%;
@@ -49,7 +49,7 @@
 	font-size: 21px;
 	margin: 5px 0;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin: 10px 0;
 	}
 }

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -41,7 +41,7 @@ a.action-panel__body-text-link {
 	margin: 24px 0;
 	text-align: center;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		float: right;
 		max-width: 208px;
 		margin: 0 0 20px 24px;
@@ -106,7 +106,7 @@ a.action-panel__body-text-link {
 		height: 1px;
 		background-color: var( --color-neutral-0 );
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			left: -24px;
 			right: -24px;
 		}

--- a/client/components/back-button/style.scss
+++ b/client/components/back-button/style.scss
@@ -8,12 +8,12 @@
 	.button.is-compact.is-borderless {
 		padding: 20px 8px 16px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 18px 40px 18px 20px;
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		top: 0;
 		left: 0;
 		right: 0;
@@ -24,7 +24,7 @@
 }
 
 .back-button__label {
-	@include breakpoint( '<660px') {
+	@include breakpoint-deprecated( '<660px') {
 		display: none;
 	}
 }

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -47,7 +47,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 12px 16px;
 
 		&.is-dismissible {
@@ -90,7 +90,7 @@
 		padding: 3px 4px 4px 3px;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		align-items: center;
 
 		.banner__icon {
@@ -112,7 +112,7 @@
 		width: 32px;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		align-items: center;
 	}
 }
@@ -123,7 +123,7 @@
 	flex-grow: 1;
 	flex-wrap: wrap;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-wrap: nowrap;
 	}
 }
@@ -166,7 +166,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: auto;
 
 		.banner__list li .gridicon {
@@ -206,7 +206,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin: 0 -6px 0 8px;
 		text-align: center;
 		width: auto;

--- a/client/components/card-heading/style.scss
+++ b/client/components/card-heading/style.scss
@@ -3,7 +3,7 @@
 	margin-bottom: 5px;
 	margin-top: 5px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 10px;
 		margin-top: 10px;
 	}

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -229,7 +229,7 @@ $y-axis-padding: 0 20px 0 10px;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 100%;
 	}
 }
@@ -241,7 +241,7 @@ $y-axis-padding: 0 20px 0 10px;
 	text-align: left;
 
 	// Expand labels to create bigger touch targets
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 50%;
 		display: inline-block;
 	}
@@ -263,7 +263,7 @@ $y-axis-padding: 0 20px 0 10px;
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: block;
 	}
 }
@@ -282,7 +282,7 @@ $y-axis-padding: 0 20px 0 10px;
 	margin: 3px 5px 3px 8px; // 1
 }
 
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 	.chart__legend-option:first-child .chart__legend-color {
 		margin-left: 2px; // 2
 	}

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -15,7 +15,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	order: 3;
 	margin: 40px 0 8px 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-left: 0;
 	}
 }
@@ -60,7 +60,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		background: var( --color-surface );
 		z-index: z-index( '.checklist__task', '.checklist__task-icon' );
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			left: 24px;
 		}
 

--- a/client/components/convert-to-blocks/style.scss
+++ b/client/components/convert-to-blocks/style.scss
@@ -1,7 +1,7 @@
 .dialog.card.editor__gutenberg-convert-blocks-dialog {
 	max-width: 600px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 90%;
 	}
 }

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -15,7 +15,7 @@
 		margin-left: 0;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		.cvv,
 		.expiration-date {
 			flex-basis: calc( 50% - 15px );

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -47,7 +47,7 @@
 	margin: 0 auto;
 	// max-width: 90%;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		max-width: 300px;
 	}
 }
@@ -58,7 +58,7 @@
 	justify-content: space-between;
 	align-items: center;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 }
@@ -83,7 +83,7 @@
 	// https://stackoverflow.com/questions/39325039/css-flex-box-last-space-removed
 	white-space: pre-wrap;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-bottom: 0.5em;
 	}
 

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -20,7 +20,7 @@
 		margin-top: 15px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		.contact-details-form-fields__field.last-name,
 		.contact-details-form-fields__field.phone {
 			margin-left: 7px;
@@ -31,7 +31,7 @@
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.contact-details-form-fields__field.postal-code,
 		.contact-details-form-fields__field.state {
 			margin-left: 7px;
@@ -61,13 +61,13 @@
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.contact-details-form-fields__row {
 			flex-direction: column;
 		}
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		.custom-form-fieldsets__address-fields,
 		.g-apps-fieldset {
 			flex-direction: column;
@@ -103,4 +103,3 @@
 .form__hidden-input .form__hidden-input {
 	margin-top: 0;
 }
-

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -6,8 +6,8 @@
 	display: flex;
 	flex-direction: column;
 	text-align: right;
-	
-	@include breakpoint( '>660px' ) {
+
+	@include breakpoint-deprecated( '>660px' ) {
 		align-items: flex-end;
 		font-size: 16px;
 
@@ -21,20 +21,20 @@
 	}
 
 	.is-section-signup &:not( .domain-product-price__domain-step-copy-updates ) {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding-left: 1em;
 			padding-right: 2em;
 		}
 	}
 
 	.is-section-domains & {
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			padding-left: 1em;
 			padding-right: 2em;
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: inline-block;
 		font-size: 14px;
 		text-align: left;
@@ -56,7 +56,7 @@
 
 	&.no-price .domain-product-price__free-text,
 	&.no-price .domain-product-price__sale-price {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-left: 0;
 		}
 	}
@@ -81,18 +81,18 @@
 			color: var( --color-text-subtle );
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			line-height: 1.5;
 			margin-top: 0;
 		}
 	}
 
 	.is-placeholder & {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: none;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			animation: loading-fade 1.6s ease-in-out infinite;
 			background-color: var( --color-neutral-0 );
 			color: transparent;

--- a/client/components/domains/domain-search-results/style.scss
+++ b/client/components/domains/domain-search-results/style.scss
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	margin-bottom: 12px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		align-items: center;
 		flex-direction: row;
 	}
@@ -16,11 +16,11 @@
 		margin-bottom: 0;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-right: 10px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 18px;
 
 		p {
@@ -40,7 +40,7 @@
 		padding: 15px 0 0;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: auto;
 
 		a {

--- a/client/components/domains/domain-skip-suggestion/style.scss
+++ b/client/components/domains/domain-skip-suggestion/style.scss
@@ -10,7 +10,7 @@
 .domain-skip-suggestion__domain-description {
 	padding-right: 1em;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 75%;
 	}
 
@@ -23,7 +23,7 @@
 		font-size: 12px;
 		margin-bottom: 0;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-bottom: 8px;
 		}
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -2,19 +2,19 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 15px 20px;
 	}
 
 	.is-section-signup & {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			flex-direction: row;
 			align-items: center;
 		}
 	}
 
 	.is-section-domains & {
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			flex-direction: row;
 			align-items: center;
 		}
@@ -59,7 +59,7 @@
 	width: 100%;
 	min-height: 32px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 		justify-content: space-between;
 
@@ -100,7 +100,7 @@
 		min-height: 44px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		.is-placeholder & {
 			margin-right: 50%;
 			min-height: 22px;
@@ -118,7 +118,7 @@
 	> h3 {
 		word-break: break-all;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex-grow: 2;
 		}
 	}
@@ -136,13 +136,13 @@
 	flex-wrap: wrap;
 
 	&.domain-registration-suggestion__title-domain-copy-test {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			max-width: 50%;
 			min-width: 50%;
 			margin-right: 1em;
 		}
 
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			max-width: 55%;
 			min-width: 55%;
 			margin-right: 1em;
@@ -176,7 +176,7 @@
 	font-size: 16px;
 	word-break: break-all;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		align-self: center;
 		padding-right: 2em;
 	}
@@ -190,7 +190,7 @@
 	transition: all 0.1s linear;
 
 	&.is-primary {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-left: 1em;
 			margin-top: 0;
 		}
@@ -213,7 +213,7 @@
 	}
 
 	.is-section-signup & {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			flex: 1 0 auto;
 			margin-left: 1em;
 			margin-top: 0;
@@ -221,7 +221,7 @@
 	}
 
 	.is-section-domains & {
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			flex: 1 0 auto;
 			margin-left: 1em;
 			margin-top: 0;
@@ -241,13 +241,13 @@
 	}
 
 	.is-section-signup & {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			display: block;
 		}
 	}
 
 	.is-section-domains & {
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			display: block;
 		}
 	}

--- a/client/components/domains/domain-transfer-suggestion/style.scss
+++ b/client/components/domains/domain-transfer-suggestion/style.scss
@@ -9,13 +9,13 @@
 	  width: 100%;
 
 	  .is-section-signup & {
-		  @include breakpoint( '>480px' ) {
+		  @include breakpoint-deprecated( '>480px' ) {
 		  	width: auto;
 		  }
 		}
 
 		.is-section-domains & {
-			@include breakpoint( '>800px' ) {
+			@include breakpoint-deprecated( '>800px' ) {
 		  	width: auto;
 		  }
 		}
@@ -25,7 +25,7 @@
 .domain-transfer-suggestion__domain-description {
 	padding-right: 1em;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 75%;
 	}
 
@@ -38,7 +38,7 @@
 		font-size: 12px;
 		margin-bottom: 0;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-bottom: 8px;
 		}
 	}

--- a/client/components/domains/example-domain-suggestions/style.scss
+++ b/client/components/domains/example-domain-suggestions/style.scss
@@ -17,7 +17,7 @@
 		color: var( --color-text-inverted );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 100%;
 		padding: 16px;
 		margin: 0 auto;
@@ -34,7 +34,7 @@
 		right: 0;
 	width: 300px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		position: relative;
 		margin: 0 auto;
 	}

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -15,13 +15,13 @@
 	}
 
 	.is-section-signup & {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			flex-direction: row;
 		}
 	}
 
 	.is-section-domains & {
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			flex-direction: row;
 		}
 	}
@@ -82,7 +82,7 @@
 		line-height: 1.2;
 		margin-bottom: 0.25em;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			font-size: 24px;
 			margin-bottom: 0.125em;
 		}
@@ -139,13 +139,13 @@
 	}
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.featured-domain-suggestions {
 		flex-flow: wrap;
 	}
 }
 
-@include breakpoint( '>660px' ) {
+@include breakpoint-deprecated( '>660px' ) {
 	.domain-registration-suggestion__title {
 		.featured-domain-suggestions--title-in-18em & {
 			font-size: 1.8em;

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -13,11 +13,11 @@
 		min-width: 0;
 		padding-right: 0;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding-bottom: 5px;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			float: right;
 			margin: 0;
 		}
@@ -41,7 +41,7 @@
 	font-size: 1em;
 	font-weight: 600;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-width: 75%;
 		float: left;
 		margin-bottom: 20px;
@@ -53,7 +53,7 @@
 	flex-flow: column;
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-flow: row;
 	}
 }
@@ -81,7 +81,7 @@ input.map-domain-step__external-domain {
 	flex-grow: 1;
 	margin: 10px 0 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 80px;
 		flex-grow: 0;
 		margin: 0 0 0 10px;

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -5,7 +5,7 @@
 	&.register-domain-step__search-domain-step-test:not( .is-sticky ) {
 		padding-bottom: 24px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding-top: 18px;
 		}
 	}

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -36,7 +36,7 @@
 			top: 0;
 			margin-right: 0;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				top: 2px;
 			}
 		}
@@ -44,7 +44,7 @@
 		.search-filters__dropdown-filters-button-text {
 			line-height: 1.2;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: none;
 			}
 		}
@@ -122,7 +122,7 @@
 		}
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		&.is-compact {
 			padding-bottom: 0.5em;
 		}
@@ -136,19 +136,19 @@
 		}
 	}
 
-	@include breakpoint( '<800px' ) {
+	@include breakpoint-deprecated( '<800px' ) {
 		.search-filters__tld-button:nth-child( n + 5 ) {
 			display: none;
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.search-filters__tld-button:nth-child( n + 4 ) {
 			display: none;
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.search-filters__tld-button:nth-child( n + 2 ) {
 			display: none;
 		}

--- a/client/components/domains/trademark-claims-notice/style.scss
+++ b/client/components/domains/trademark-claims-notice/style.scss
@@ -19,7 +19,7 @@
 			margin-bottom: 150px;
 		}
 
-		@include breakpoint('>800px') {
+		@include breakpoint-deprecated('>800px') {
 			margin-bottom: 53px;
 
 			body.is-section-signup & {
@@ -60,7 +60,7 @@
 		box-sizing: border-box;
 		overflow: hidden;
 
-		@include breakpoint('<960px') {
+		@include breakpoint-deprecated('<960px') {
 			padding: 1px 23px 0 ($sidebar-width-min + 24px);
 		}
 
@@ -74,11 +74,11 @@
 			background: var( --color-surface-backdrop );
 			padding: 0 1px 32px;
 
-			@include breakpoint('<960px') {
+			@include breakpoint-deprecated('<960px') {
 				padding: 0 1px 24px;
 			}
 
-			@include breakpoint('<660px') {
+			@include breakpoint-deprecated('<660px') {
 				padding: 0 1px;
 			}
 
@@ -86,13 +86,13 @@
 				background: var( --color-primary );
 				padding: 0;
 
-				@include breakpoint('>800px') {
+				@include breakpoint-deprecated('>800px') {
 					padding: 0 0 32px;
 				}
 			}
 		}
 
-		@include breakpoint('<660px') {
+		@include breakpoint-deprecated('<660px') {
 			margin-left: 0;
 			padding: 0;
 			padding-top: 47px;
@@ -108,7 +108,7 @@
 				width: 100%;
 				margin: 0 0 10px;
 
-				@include breakpoint('>800px') {
+				@include breakpoint-deprecated('>800px') {
 					width: auto;
 					margin: 0 0 0 14px;
 				}

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -13,7 +13,7 @@
 		flex-direction: column;
 		margin-bottom: 20px;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			flex-direction: row;
 		}
 	}
@@ -27,7 +27,7 @@
 			font-size: 90%;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			text-align: right;
 		}
 	}
@@ -73,15 +73,15 @@
 		margin-left: 20px;
 		max-width: 140px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			display: block;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: none;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			display: block;
 		}
 	}
@@ -96,7 +96,7 @@
 	flex-grow: 1;
 	margin: 10px 0 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 100px;
 		flex-grow: 0;
 		margin: 0 0 0 10px;
@@ -114,7 +114,7 @@
 	flex-flow: column;
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-flow: row;
 	}
 }
@@ -267,7 +267,7 @@ input {
 		width: 100%;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 
 		button {

--- a/client/components/domains/use-your-domain-step/style.scss
+++ b/client/components/domains/use-your-domain-step/style.scss
@@ -1,7 +1,7 @@
 .use-your-domain-step__content {
 	display: flex;
 
-	@include breakpoint( '<800px' ) {
+	@include breakpoint-deprecated( '<800px' ) {
 		flex-flow: wrap;
 	}
 
@@ -40,7 +40,7 @@
 		margin: 1em 0;
 		max-height: 150px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}

--- a/client/components/email-verification/email-verification-dialog/style.scss
+++ b/client/components/email-verification/email-verification-dialog/style.scss
@@ -2,7 +2,7 @@
 	max-width: 100%;
 	border-radius: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 550px;
 		border-radius: 3px;
 	}

--- a/client/components/empty-content/style.scss
+++ b/client/components/empty-content/style.scss
@@ -5,7 +5,7 @@
 	padding-top: 20px;
 	text-align: center;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding-top: 10px;
 		margin-left: 15px;
 		margin-right: 15px;
@@ -22,7 +22,7 @@
 	color: var( --color-neutral-70 );
 	font-size: 34px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		font-size: 24px;
 	}
 }
@@ -32,7 +32,7 @@
 	font-size: 22px;
 	margin-bottom: 40px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		font-size: 16px;
 	}
 }
@@ -49,7 +49,7 @@
 	.empty-content__illustration {
 		margin-top: -130px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-top: -80px;
 		}
 	}
@@ -57,7 +57,7 @@
 	.empty-content__title {
 		font-size: 30px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 24px;
 		}
 	}

--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -94,7 +94,7 @@
 	}
 }
 
-@include breakpoint( '<960px' ) {
+@include breakpoint-deprecated( '<960px' ) {
 	// Don't show environment badge on smaller screens. It just gets in the way.
 	.environment-badge {
 		display: none;

--- a/client/components/faq/style.scss
+++ b/client/components/faq/style.scss
@@ -3,11 +3,11 @@ $faq-gutter-width: 24px;
 .faq {
 	padding: 0 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 0 24px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0;
 	}
 }
@@ -34,15 +34,15 @@ $faq-gutter-width: 24px;
 	padding-left: ($faq-gutter-width / 2);
 	padding-right: ($faq-gutter-width / 2);
 
-	@include breakpoint( '480px-660px' ) {
+	@include breakpoint-deprecated( '480px-660px' ) {
 		width: 50%;
 	}
 
-	@include breakpoint( '800px-1040px' ) {
+	@include breakpoint-deprecated( '800px-1040px' ) {
 		width: 50%;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: (100% / 3);
 	}
 }

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -85,7 +85,7 @@ button.foldable-card__action {
 	flex: 2 1;
 	margin-right: 5px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex: 1 1;
 	}
 }
@@ -96,7 +96,7 @@ button.foldable-card__action {
 	flex: 1 1;
 	justify-content: flex-end;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex: 0 1;
 	}
 }
@@ -149,7 +149,7 @@ button.foldable-card__action {
 	transition: opacity 0.2s linear;
 	display: inline-block;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }

--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -2,7 +2,7 @@
 	margin: 16px 0 24px;
 	text-align: center;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 35px;
 
 		&.is-without-subhead {
@@ -14,7 +14,7 @@
 	&.is-right-align {
 		margin: 16px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin: 0 0 16px;
 		}
 	}
@@ -34,7 +34,7 @@
 	padding: 0 10px;
 	line-height: 1.2em;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 24px;
 		padding: 0;
 		margin: 0 0 5px;
@@ -52,7 +52,7 @@
 	font-size: 14px;
 	padding: 0 20px 24px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 0;
 	}
 
@@ -64,7 +64,7 @@
 
 // Compact header on small screens
 .formatted-header.is-compact-on-mobile {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		text-align: left;
 
 		.formatted-header__title {

--- a/client/components/forms/form-buttons-bar/style.scss
+++ b/client/components/forms/form-buttons-bar/style.scss
@@ -1,7 +1,7 @@
 .form-buttons-bar {
 	@include clear-fix;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		align-items: flex-end;
 		display: flex;
 		flex-direction: column-reverse;

--- a/client/components/forms/form-text-input-with-affixes/style.scss
+++ b/client/components/forms/form-text-input-with-affixes/style.scss
@@ -7,7 +7,7 @@
 		flex-direction: row;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 
@@ -64,7 +64,7 @@
 	border-top-left-radius: 2px;
 	border-top-right-radius: 2px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		:not( .no-wrap ) > & {
 			border-bottom: none;
 		}
@@ -74,7 +74,7 @@
 		@include no-prefix-wrap();
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		@include no-prefix-wrap();
 	}
 
@@ -94,7 +94,7 @@
 	border-bottom-left-radius: 2px;
 	border-bottom-right-radius: 2px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		:not( .no-wrap ) > & {
 			border-top: none;
 		}
@@ -104,7 +104,7 @@
 		@include no-suffix-wrap();
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		@include no-suffix-wrap();
 	}
 }

--- a/client/components/global-notices/style.scss
+++ b/client/components/global-notices/style.scss
@@ -9,7 +9,7 @@
 		bottom: 0;
 		left: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 			top: 47px + 16px;
 			right: 16px;
 			bottom: auto;
@@ -17,13 +17,13 @@
 		max-width: calc( 100% - 32px );
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 			top: 47px + 24px;
 			right: 24px;
 		max-width: calc( 100% - 48px );
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 			right: 32px;
 		max-width: calc( 100% - 64px );
 	}
@@ -42,7 +42,7 @@
 		border-radius: 0;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 		overflow: hidden;
 		margin-bottom: 24px;

--- a/client/components/gravatar-caterpillar/style.scss
+++ b/client/components/gravatar-caterpillar/style.scss
@@ -18,7 +18,7 @@
 	&.is-hidden-on-small-screens {
 		display: none;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
    			display: inline;
    		}
 	}

--- a/client/components/gsuite/gsuite-features/style.scss
+++ b/client/components/gsuite/gsuite-features/style.scss
@@ -3,14 +3,14 @@
 	justify-content: space-between;
 	margin: 1em 0;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 		flex-flow: row wrap;
 	}
 
 	.gsuite-features__feature-block {
 		p {
-			@include breakpoint( '>960px' ) {
+			@include breakpoint-deprecated( '>960px' ) {
 				max-width: 200px;
 			}
 		}

--- a/client/components/gsuite/gsuite-new-user-list/style.scss
+++ b/client/components/gsuite/gsuite-new-user-list/style.scss
@@ -1,10 +1,10 @@
 .gsuite-new-user-list__new-user-remove-user-button {
 	width: 100%;
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		width: 75px;
 	}
 
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		span {
 			display: none;
 		}
@@ -16,29 +16,29 @@
 	flex-direction: column;
 	justify-content: space-between;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: column;
 	}
 
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		flex-direction: row;
 	}
 }
 
 .gsuite-new-user-list__add-another-user-button {
 	width: 100%;
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: auto;
 	}
 }
 
 .gsuite-new-user-list__domain-select {
 	width: 100%;
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		width: auto;
 	}
 }
@@ -49,7 +49,7 @@
 }
 
 .gsuite-new-user-list__new-user-name {
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		display: flex;
 		justify-content: space-between;
 	}
@@ -64,7 +64,7 @@
 		width: 100%;
 	}
 
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		flex-direction: row;
 
 		input {
@@ -85,7 +85,7 @@
 	flex-direction: column;
 	margin: 0 0 15px;
 
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		margin: 0 15px 0 0;
 		width: 42%;
 	}

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -1,7 +1,7 @@
 .happiness-support {
 	display: flex;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-wrap: wrap;
 	}
 }
@@ -48,7 +48,7 @@
 	margin: 0 auto;
 	width: 128px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 178px;
 	}
 }
@@ -56,7 +56,7 @@
 .happiness-support__icon {
 	margin-bottom: 20px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 150px;
 		margin: 0 auto;
 	}
@@ -66,11 +66,11 @@
 	width: 100%;
 
 	.button {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: block;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 
 			&:first-of-type {
 				margin-right: 16px;
@@ -83,7 +83,7 @@
 		padding-bottom: 11px;
 		padding-top: 2px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin-top: 16px;
 		}
 	}

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -114,7 +114,7 @@
 	}
 }
 
-@include breakpoint( '>960px' ) {
+@include breakpoint-deprecated( '>960px' ) {
 	@keyframes happychat-minimize {
 		0% {
 			max-height: 100%;
@@ -139,7 +139,7 @@
  * Panel mode
  */
 
-@include breakpoint( '>480px' ) {
+@include breakpoint-deprecated( '>480px' ) {
 
 	.layout:not( .is-section-happychat ) {
 		.happychat__container.is-open {
@@ -164,7 +164,7 @@
 
 }
 
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 
 	.layout:not( .is-section-happychat ) {
 		.happychat__container.is-open {
@@ -185,7 +185,7 @@
  * Sidebar mode
  */
 
-@include breakpoint( '>1040px' ) {
+@include breakpoint-deprecated( '>1040px' ) {
 
 	// be more specific in scope to override the panel mode
 	.layout.has-chat:not( .is-group-editor ):not( .is-section-theme ):not( .is-group-reader ):not( .has-no-sidebar ) .happychat__container.is-open {

--- a/client/components/header-cake/style.scss
+++ b/client/components/header-cake/style.scss
@@ -17,7 +17,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 10px;
 	}
 }

--- a/client/components/jetpack-colophon/style.scss
+++ b/client/components/jetpack-colophon/style.scss
@@ -10,7 +10,7 @@
 	.jetpack-logo__icon-circle {
 		fill: currentColor;
 	}
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-bottom: 24px;
 	}
 }

--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -10,7 +10,7 @@
 		display: flex;
 		flex-direction: column;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			top: 5%;
 			bottom: 5%;
 			left: 5%;
@@ -18,7 +18,7 @@
 			width: 90%;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			left: 12.5%;
 			right: 12.5%;
 			width: 75%;
@@ -44,7 +44,7 @@
 		margin-bottom: 0;
 		z-index: 10;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			.search.has-focus {
 				margin: 0 4px;
 				width: calc( 100% - 8px );
@@ -72,15 +72,15 @@
 	.language-picker__modal-item {
 		width: 100%;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 50%;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 33%;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			width: 25%;
 		}
 	}

--- a/client/components/language-picker/style.scss
+++ b/client/components/language-picker/style.scss
@@ -13,7 +13,7 @@
 	text-align: left;
 	line-height: inherit;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 	}
 

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/style.scss
@@ -1,7 +1,7 @@
 .precancellation-chat-button__main-button {
 	display: block;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		float: left;
 	}
 }

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/style.scss
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/style.scss
@@ -8,7 +8,7 @@
 	content: '';
 	display: block;
 	height: 1em;
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		content: none;
 	}
 }

--- a/client/components/mobile-back-to-sidebar/style.scss
+++ b/client/components/mobile-back-to-sidebar/style.scss
@@ -9,7 +9,7 @@
 	border-bottom: 1px solid var( --color-neutral-10 );
 	cursor: pointer;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 }

--- a/client/components/multiple-choice-question/style.scss
+++ b/client/components/multiple-choice-question/style.scss
@@ -5,7 +5,7 @@
 
 .form-text-input.multiple-choice-question__answer-item-text-input::placeholder {
 	color: var( --color-text-inverted );
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		color: var( --color-neutral );
 	}
 }

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -19,7 +19,7 @@
 	border-radius: 3px;
 	line-height: 1.5;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-bottom: 24px;
 	}
 
@@ -155,7 +155,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 14px;
 	}
 }
@@ -177,7 +177,7 @@
 		height: 18px;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 11px;
 
 		.gridicon {
@@ -208,7 +208,7 @@ a.notice__action {
 	display: flex;
 	align-items: center;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 			flex-shrink: 1;
 			flex-grow: 0;
 		align-items: center;

--- a/client/components/post-excerpt/style.scss
+++ b/client/components/post-excerpt/style.scss
@@ -10,7 +10,7 @@
 		line-height: 1.618;
 		max-height: 24px * 3;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			font-size: 15px;
 			line-height: 22px;
 			max-height: 22px * 3;
@@ -35,7 +35,7 @@
 				height: 24px;
 				background: linear-gradient( to right, rgba( 255, 255, 255, 0 ), rgba( 255, 255, 255, 1 ) 50% );
 
-				@include breakpoint( '<480px' ) {
+				@include breakpoint-deprecated( '<480px' ) {
 					height: 22px;
 				}
 			}

--- a/client/components/product-card/style.scss
+++ b/client/components/product-card/style.scss
@@ -1,7 +1,7 @@
 .product-card {
 	width: 100%;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		min-width: 460px;
 	}
 }
@@ -11,11 +11,11 @@
 	padding: 16px 0;
 	border-bottom: solid 2px var( --color-jetpack );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin: -24px -24px 24px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 		flex-flow: row wrap;
 		align-items: baseline;
@@ -27,7 +27,7 @@
 	padding-left: 40px;
 	padding-right: 40px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-left: 16px;
 		padding-right: 16px;
 	}
@@ -37,7 +37,7 @@
 	display: flex;
 	justify-content: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-grow: 1;
 	}
 
@@ -49,7 +49,7 @@
 		align-self: center;
 		margin: 0 8px 0 -26px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 16px;
 			height: 16px;
 			margin-left: 0;
@@ -69,7 +69,7 @@
 	font-size: 20px;
 	line-height: 24px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		font-size: 22px;
 	}
 
@@ -100,7 +100,7 @@
 
 		&,
 		& * {
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				font-size: 14px;
 				vertical-align: baseline;
 			}
@@ -114,11 +114,11 @@
 	line-height: 13px;
 	color: var( --color-text-subtle );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		font-style: italic;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		font-size: 12px;
 	}
 }
@@ -127,7 +127,7 @@
 .product-card__header {
 	.plan-price,
 	.plan-price * {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			font-weight: 600;
 		}
 	}
@@ -135,7 +135,7 @@
 	.product-card__billing-timeframe {
 		width: 100%;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: auto;
 			font-size: 12px;
 			font-weight: 600;
@@ -151,7 +151,7 @@
 		font-weight: 400;
 		vertical-align: baseline;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			font-size: 14px;
 		}
 	}
@@ -185,7 +185,7 @@
 	justify-content: space-around; // IE11 fallback.
 	justify-content: space-evenly;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-flow: row wrap;
 	}
 }
@@ -196,7 +196,7 @@
 	text-align: center;
 	color: var( --color-text-subtle );
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex: 0 0 100%;
 	}
 
@@ -218,7 +218,7 @@
 	border-radius: 4px;
 	cursor: pointer;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: column;
 	}
 
@@ -231,7 +231,7 @@
 	& + .product-card__option.form-label {
 		margin-top: 0;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-top: 16px;
 			margin-left: 8px;
 		}
@@ -244,19 +244,19 @@
 	align-items: flex-start;
 	margin-left: 8px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		align-items: center;
 		margin-top: 6px;
 		margin-left: 0;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-top: 0;
 	}
 }
 
 .product-card__radio.form-radio {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 10px;
 	}
 }
@@ -354,13 +354,13 @@
 		height: 32px;
 		margin: 0 0 4px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			height: 18px;
 		}
 	}
 
 	.product-card__billing-timeframe {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: none;
 		}
 	}
@@ -380,7 +380,7 @@
 		height: 16px;
 		margin: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin: 5px 0 0;
 		}
 	}

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -1,14 +1,14 @@
 .promo-card {
 	display: flex;
 	flex-direction: column;
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 
 	.action-panel__figure {
 		margin-top: 3px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			max-width: 24px;
 			order: 1;
 
@@ -22,14 +22,14 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
-		
+
 		p {
 			flex-grow: 1;
 		}
 	}
 
 	&.is-primary {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			.action-panel__figure {
 				max-width: 310px;
 			}

--- a/client/components/promo-section/style.scss
+++ b/client/components/promo-section/style.scss
@@ -6,7 +6,7 @@
 	// margins of the items will "hang off the side" invisibly
 	width: calc( 100% + 1em );
 	flex-direction: column;
-	@include breakpoint( '>1280px' ) {
+	@include breakpoint-deprecated( '>1280px' ) {
 		flex-direction: row;
 	}
 
@@ -15,10 +15,8 @@
 		margin: 0.5em;
 		width: calc( 100% - 1em );
 
-		@include breakpoint( '>1280px' ) {
+		@include breakpoint-deprecated( '>1280px' ) {
 			width: calc( 50% - 1em );
 		}
 	}
 }
-
-

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -9,7 +9,7 @@
 		border-bottom: none;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		border-radius: 3px;
 		max-width: 700px;
 		margin: 16px auto;
@@ -43,7 +43,7 @@
 			margin-top: 3px;
 			width: 85%;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				margin: 0 auto;
 			}
 		}
@@ -54,7 +54,7 @@
 	padding: 32px;
 	display: flex;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-wrap: wrap;
 	}
 }
@@ -63,13 +63,13 @@
 	width: 100%;
 	flex-shrink: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 178px;
 	}
 }
 
 .purchase-detail__button {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: block;
 		text-align: center;
 	}
@@ -84,7 +84,7 @@
 	width: 100%;
 	flex-shrink: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		order: 2;
 		width: 178px;
 	}
@@ -97,7 +97,7 @@
 		top: -3px;
 		width: 24px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			right: -42px;
 			top: -6px;
 		}
@@ -123,7 +123,7 @@
 		margin-top: 0;
 		padding: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 150px;
 		}
 	}

--- a/client/components/purchase-detail/tip-info.scss
+++ b/client/components/purchase-detail/tip-info.scss
@@ -6,7 +6,7 @@
 	margin-left: 8px;
 	margin-top: 8px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 0;
 	}
 }

--- a/client/components/rewind-credentials-form/style.scss
+++ b/client/components/rewind-credentials-form/style.scss
@@ -13,7 +13,7 @@
 	}
 }
 
-@include breakpoint( '>960px' ) {
+@include breakpoint-deprecated( '>960px' ) {
 	.rewind-credentials-form__server-address,
 	.rewind-credentials-form__username,
 	.rewind-credentials-form__password {

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -23,7 +23,7 @@
 	position: relative;
 	overflow: hidden;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		line-height: 1.4;
 		margin: 4px 0;
 	}
@@ -32,7 +32,7 @@
 	.support-info {
 		margin-left: 8px;
 	}
-	
+
 	.support-info {
 		position: relative;
 		top: 3px;

--- a/client/components/section-nav/item.scss
+++ b/client/components/section-nav/item.scss
@@ -3,7 +3,7 @@
 }
 
 .section-nav-tab {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: auto;
 		flex: none;
 		border-bottom: 2px solid transparent;
@@ -53,7 +53,7 @@
 		color: var( --color-text-inverted );
 		background-color: var( --color-primary );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			.count {
 				color: var( --color-text-inverted );
 				border-color: var( --color-border-inverted );
@@ -89,7 +89,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: block;
 		width: auto;
 		padding: 16px 16px 14px;
@@ -123,7 +123,7 @@
 	width: 0;
 	color: inherit;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: inline;
 		flex: none;
 		width: auto;

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -12,25 +12,25 @@
 		visibility: hidden;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		&.is-open {
 			box-shadow: 0 0 0 1px var( --color-neutral-light ), 0 2px 4px var( --color-neutral-10 );
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		&.has-pinned-items {
 			padding-right: 60px;
 		}
 	}
 
-	@include breakpoint( '480px-660px' ) {
+	@include breakpoint-deprecated( '480px-660px' ) {
 		&.has-pinned-items {
 			padding-right: 50px;
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-bottom: 9px;
 	}
 }
@@ -67,7 +67,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: none;
 	}
 }
@@ -92,7 +92,7 @@
 	box-sizing: border-box;
 	width: 100%;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.section-nav.is-open & {
 			padding-bottom: 15px;
 			border-top: solid 1px var( --color-neutral-10 );
@@ -104,7 +104,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: flex;
 		align-items: center;
 
@@ -126,7 +126,7 @@
 		border-top: none;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 
 		.section-nav.is-open & {
@@ -134,7 +134,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-top: 0;
 		padding-top: 0;
 		border-top: none;
@@ -168,7 +168,7 @@
 	text-transform: uppercase;
 	line-height: 12px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.has-siblings & {
 			display: block;
 		}
@@ -206,7 +206,7 @@
 	.search.is-expanded-to-container {
 		height: 50px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			height: 46px;
 		}
 	}

--- a/client/components/section-nav/tabs.scss
+++ b/client/components/section-nav/tabs.scss
@@ -1,5 +1,5 @@
 .section-nav-tabs {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: 0;
 		flex: 1 0 auto;
 
@@ -16,7 +16,7 @@
 	margin: 0;
 	list-style: none;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: flex;
 		width: 100%;
 		overflow: hidden;
@@ -26,4 +26,3 @@
 		}
 	}
 }
-

--- a/client/components/seo-preview-pane/style.scss
+++ b/client/components/seo-preview-pane/style.scss
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	height: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 	}
 }
@@ -33,7 +33,7 @@
 			display: none;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex-direction: column;
 			justify-content: flex-start;
 			border-bottom: 1px solid #c8d7e1;
@@ -55,7 +55,7 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 250px;
 		min-width: 250px;
 		border-right: 1px solid var( --color-neutral-10 );
@@ -78,7 +78,7 @@
 		color: var( --color-neutral-light );
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 40px 0 40px 20px;
 		max-width: 200px;
 	}
@@ -129,12 +129,12 @@
 		.comment-button__label-status,
 		.like-button__label-status,
 		.reader-share__button-label {
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				display: none;
 			}
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			min-width: 480px;
 		}
 	}

--- a/client/components/seo/meta-title-editor/style.scss
+++ b/client/components/seo/meta-title-editor/style.scss
@@ -14,7 +14,7 @@
 	line-height: 16px;
 	padding: 4px 2px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 14px;
 		line-height: 18px;
 		padding: 8px 12px;

--- a/client/components/seo/preview-upgrade-nudge/style.scss
+++ b/client/components/seo/preview-upgrade-nudge/style.scss
@@ -10,7 +10,7 @@
 	.preview-upgrade-nudge__features {
 		padding: 0 24px 16px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: flex;
 		}
 
@@ -18,7 +18,7 @@
 		.feature-example {
 			margin: 0 0 16px;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				width: 50%;
 				margin: 0 16px 0 0;
 			}
@@ -27,7 +27,7 @@
 
 	.preview-upgrade-nudge__features-details {
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 50%;
 		}
 	}

--- a/client/components/sidebar-navigation/style.scss
+++ b/client/components/sidebar-navigation/style.scss
@@ -5,7 +5,7 @@
 	position: relative;
 	margin: 0 0 8px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 
@@ -34,7 +34,7 @@
 	font-size: 24px;
 	margin: 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 0 0 8px;
 	}
 }

--- a/client/components/signup-site-preview/style.scss
+++ b/client/components/signup-site-preview/style.scss
@@ -18,7 +18,7 @@
 		border-radius: 4px;
 		// Side by side layout uses flexbox to show
 		// both mockups next to each other.
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-right: 16px;
 
 			// Forces the desktop preview to take up
@@ -26,7 +26,7 @@
 			flex-grow: 1;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			width: 100%;
 			max-width: 480px;
 			border-radius: 12px;
@@ -41,12 +41,12 @@
 		padding: 0 0 24px;
 		@include elevation( 4dp );
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			min-width: 280px;
 		}
 		// Grouped layout shows a fixed-height mobile mockup
 		// overlaid on top of the desktop mockup.
-		@include breakpoint( '660px-960px' ) {
+		@include breakpoint-deprecated( '660px-960px' ) {
 			position: absolute;
 			top: 48px;
 			right: 8px;
@@ -56,7 +56,7 @@
 
 		// Only show one iframe at small
 		// breakpoints.
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -73,7 +73,7 @@
 	.is-desktop & {
 		border-radius: 4px;
 		@include elevation( 3dp );
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			border-radius: 12px 12px 0 0;
 		}
 	}
@@ -114,7 +114,7 @@
 		top: 8px;
 		left: 8px;
 		fill: var( --color-neutral );
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -138,7 +138,7 @@
 
 		// At small screen sizes "hide" the label
 		// text as its mostly redundant.
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			color: var( --color-neutral-0 );
 			width: 96%;
 			border-radius: 16px;

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -132,7 +132,7 @@
 	overflow-y: auto;
 	background: var( --color-surface );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		max-height: calc( 100% - 109px );
 	}
 }
@@ -166,7 +166,7 @@
 		color: var( --color-neutral-70 );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 16px;
 	}
 

--- a/client/components/sites-dropdown/style.scss
+++ b/client/components/sites-dropdown/style.scss
@@ -29,7 +29,7 @@
 	transition: all 0.2s ease-in;
 	z-index: 1;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 	}
 

--- a/client/components/sticky-panel/style.scss
+++ b/client/components/sticky-panel/style.scss
@@ -17,7 +17,7 @@
 	z-index: z-index( 'root', '.sticky-panel.is-sticky .sticky-panel__content' );
 }
 
-@include breakpoint( '<960px' ) {
+@include breakpoint-deprecated( '<960px' ) {
 	.sticky-panel.is-sticky .sticky-panel__content {
 		margin-top: 8px;
 	}

--- a/client/components/sub-masterbar-nav/style.scss
+++ b/client/components/sub-masterbar-nav/style.scss
@@ -11,7 +11,7 @@
 		border-top-right-radius: 5px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 		padding: 56px 20px 0 30px;
 
@@ -24,13 +24,13 @@
 }
 
 .sub-masterbar-nav__dropdown {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 }
 
 .sub-masterbar-nav__navbar {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }
@@ -50,7 +50,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		position: absolute;
 			top: 0;
 			left: 0;
@@ -66,7 +66,7 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 		flex-wrap: wrap;
 	}
@@ -94,7 +94,7 @@
 		outline: 0;
 		transition: all 200ms ease-out;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			transform: translate3d( 0, -2px, 0 );
 		}
 	}
@@ -109,7 +109,7 @@
 			border-radius: 5px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 0 15px;
 
 		.sub-masterbar-nav__items &.is-selected {
@@ -117,7 +117,7 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
@@ -133,7 +133,7 @@
 .sub-masterbar-nav__icon {
 	display: inline-block;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 10px 0 0;
 	}
 }
@@ -143,7 +143,7 @@
 }
 
 .sub-masterbar-nav__switch {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 		flex-direction: column;
 		align-content: center;

--- a/client/components/suggestion-search/style.scss
+++ b/client/components/suggestion-search/style.scss
@@ -12,14 +12,14 @@
 
 		// On smaller screens the input gets bigger,
 		// so this icon needs to move down a bit.
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			top: 16px;
 		}
 	}
 
 	.spinner {
 		top: 12px;
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			top: 17px;
 		}
 	}

--- a/client/components/thank-you-card/style.scss
+++ b/client/components/thank-you-card/style.scss
@@ -10,7 +10,7 @@
 	font-family: $sans;
 	text-align: center;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-top: 28px;
 	}
 }
@@ -24,7 +24,7 @@
 	overflow: hidden;
 	z-index: z-index( 'root', '.thank-you-card__header' );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 32px 0;
 	}
 }
@@ -37,7 +37,7 @@
 .thank-you-card__body {
 	padding: 24px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 40px;
 	}
 }
@@ -49,7 +49,7 @@
 	position: relative;
 	z-index: z-index( '.thank-you-card__header', '.thank-you-card__main-icon' );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: 96px;
 		height: 96px;
 	}
@@ -90,7 +90,7 @@
 	font-weight: 600;
 	margin-bottom: 8px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 26px;
 	}
 }
@@ -103,7 +103,7 @@
 	margin: 0 auto 30px;
 	line-height: 20px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 15px;
 	}
 }

--- a/client/components/tile-grid/style.scss
+++ b/client/components/tile-grid/style.scss
@@ -18,12 +18,12 @@
 	border-bottom: 0;
 	margin: 0 10px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		box-shadow: none; //inherited from .card, remove for mobile only
 		width: 100%;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 0;
 		margin-bottom: 20px;
 		width: 230px;
@@ -52,7 +52,7 @@
 		border-top-right-radius: 6px;
 		border-top-left-radius: 6px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			border-radius: 0;
 		}
 	}
@@ -63,7 +63,7 @@
 		border-bottom-right-radius: 6px;
 		border-bottom-left-radius: 6px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			border-radius: 0;
 			border: 0;
 		}
@@ -72,7 +72,7 @@
 	&.is-card-link {
 		padding-right: 0;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding-right: 40px;
 		}
 	}
@@ -89,7 +89,7 @@
 	.card__link-indicator {
 		display: none;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: block;
 			width: 8px; //Match the size of the cta copy
 			height: 8px; //Match the size of the cta copy
@@ -108,7 +108,7 @@
 .tile-grid__image {
 	display: none;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: block;
 	}
 
@@ -119,7 +119,7 @@
 	}
 }
 
-@include breakpoint( '>480px' ) {
+@include breakpoint-deprecated( '>480px' ) {
 	.tile-grid__item-copy {
 		padding: 15px;
 		border-top: 1px solid rgba( var( --color-neutral-10-rgb ), 0.5 );
@@ -138,7 +138,7 @@
 	font-size: 13px;
 	line-height: 1.5;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-top: 10px;
 
 		&:first-child {
@@ -150,7 +150,7 @@
 .button.tile-grid__cta {
 	color: var( --color-primary );
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		background: none;
 		text-align: left;
 		font-size: 16px;

--- a/client/components/tinymce/plugins/advanced/style.scss
+++ b/client/components/tinymce/plugins/advanced/style.scss
@@ -14,7 +14,7 @@
 .mce-toolbar .mce-advanced.mce-btn button {
 	display: none;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: block;
 	}
 }

--- a/client/components/tinymce/plugins/calypso-alert/style.scss
+++ b/client/components/tinymce/plugins/calypso-alert/style.scss
@@ -1,5 +1,5 @@
 .editor-alert-modal.dialog.card {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 500px;
 	}
 }

--- a/client/components/tinymce/plugins/contact-form/style.scss
+++ b/client/components/tinymce/plugins/contact-form/style.scss
@@ -6,7 +6,7 @@
 	right: 0;
 	max-width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		top: 5%;
 		bottom: 5%;
 		left: 50%;
@@ -24,7 +24,7 @@
 	z-index: z-index( '.dialog__backdrop', '.editor-contact-form-modal .section-nav' );
 	padding: 0 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0;
 	}
 }

--- a/client/components/tinymce/plugins/insert-menu/style.scss
+++ b/client/components/tinymce/plugins/insert-menu/style.scss
@@ -71,7 +71,7 @@
 }
 
 .mce-container .mce-wpcom-insert-menu .wpcom-insert-menu__menu-label {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -11,7 +11,7 @@
 		flex-direction: column;
 		max-width: none;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			top: 5%;
 			bottom: 5%;
 			left: 5%;
@@ -19,7 +19,7 @@
 			width: 90%;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			left: 12.5%;
 			right: 12.5%;
 			width: 75%;
@@ -27,7 +27,7 @@
 	}
 
 	.header-cake.card {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-top: 0;
 		}
 	}
@@ -60,7 +60,7 @@
 		overflow-y: auto;
 		padding: 16px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 24px;
 		}
 	}
@@ -78,7 +78,7 @@
 		flex-shrink: 0;
 		text-align: left;
 	}
-	
+
 	.empty-content__line {
 		margin: 8px;
 	}
@@ -171,11 +171,11 @@
 	flex: auto;
 	overflow-y: auto;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 24px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 	}
 
@@ -195,14 +195,14 @@
 	background-color: var( --color-neutral-0 );
 	box-shadow: inset 0 0 0 1px var( --color-neutral-5 );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: none;
 		margin-right: 24px;
 	}
 }
 
 .editor-simple-payments-modal__form-fields {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: auto;
 	}
 }

--- a/client/components/tinymce/plugins/wpcom-charmap/style.scss
+++ b/client/components/tinymce/plugins/wpcom-charmap/style.scss
@@ -14,7 +14,7 @@
 		margin: 0 -24px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 700px;
 	}
 }

--- a/client/components/tinymce/plugins/wpcom-help/style.scss
+++ b/client/components/tinymce/plugins/wpcom-help/style.scss
@@ -1,6 +1,6 @@
 .wpcom-help__dialog {
 	&.dialog.card {
-		@include breakpoint('>660px') {
+		@include breakpoint-deprecated('>660px') {
 			flex: 1 0 100%;
 			max-width: 700px;
 		}
@@ -24,7 +24,7 @@
 	border-width: 0 0 1px;
 	text-align: center;
 	font-weight: 600;
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: 60px;
 		padding: 4px;
 	}

--- a/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/wpcom-view/views/simple-payments/style.scss
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	padding: 10px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 }
@@ -12,7 +12,7 @@
 	flex: 0 0 30%;
 	margin-bottom: 24px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-bottom: 0;
 	}
 }
@@ -48,7 +48,7 @@
 }
 
 .wpview-type-simple-payments__image-part + .wpview-type-simple-payments__text-part {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-basis: 70%;
 		padding-left: 24px;
 	}

--- a/client/components/tinymce/style.scss
+++ b/client/components/tinymce/style.scss
@@ -27,12 +27,12 @@
 			margin-top: 1px;
 			transition: width 0.2s;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				@include long-content-fade();
 				height: 44px;
 			}
 
-			@include breakpoint( '660px-960px' ) {
+			@include breakpoint-deprecated( '660px-960px' ) {
 				@include long-content-fade();
 				right: 1px;
 				height: 36px;
@@ -58,7 +58,7 @@
 
 			.focus-sidebar & {
 				width: calc( 100% - ( #{$sidebar-width-max + 1} ) );
-				@include breakpoint( '660px-960px' ) {
+				@include breakpoint-deprecated( '660px-960px' ) {
 					width: calc( 100% - ( #{$sidebar-width-min + 1} ) );
 				}
 				margin: 0;
@@ -123,7 +123,7 @@
 		border-right: 1px solid var( --color-neutral-0 );
 		height: 36px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			border-right-color: var( --color-border-inverted );
 			border-left-color: var( --color-border-inverted );
 			padding: 2px 0;
@@ -252,7 +252,7 @@
 }
 
 .mce-toolbar .mce-btn-group .mce-wpcom-icon-button.mce-media button {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 13px;
 	}
 }
@@ -544,7 +544,7 @@ div.mce-inline-toolbar-grp.mce-arrow-full > div {
 }
 
 .mce-tinymce .mce-stack-layout-item.mce-last {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		border-top: 1px solid var( --color-neutral-0 );
 	}
 }
@@ -557,7 +557,7 @@ div.mce-inline-toolbar-grp.mce-arrow-full > div {
 	display: inline-block;
 	overflow: hidden;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: block;
 	}
 }
@@ -609,7 +609,7 @@ div.mce-path {
 	border-radius: 0;
 	filter: none;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin: 0;
 	}
 }
@@ -684,7 +684,7 @@ div.mce-path {
 
 .mce-toolbar .mce-btn-group > div {
 	white-space: nowrap;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-right: 32px;
 		white-space: normal;
 	}
@@ -727,7 +727,7 @@ div.mce-path {
 	min-width: 110px;
 	text-align: left;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 5px;
 	}
 }
@@ -750,7 +750,7 @@ div.mce-path {
 	border-left-color: var( --color-neutral-0 );
 	border-right-color: var( --color-neutral-0 );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		border-right-color: var( --color-border-inverted );
 		border-left-color: var( --color-border-inverted );
 	}
@@ -795,7 +795,7 @@ div.mce-path {
 	margin-top: -3px;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.mce-panel .mce-btn.mce-listbox i.mce-caret {
 		top: 6px;
 	}
@@ -1431,12 +1431,12 @@ i.mce-i-wp_code::before {
 	position: absolute;
 	right: 0;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		position: relative;
 		right: inherit;
 	}
 }
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.mce-toolbar .mce-btn button,
 	.qt-dfw {
 		padding: 6px;
@@ -1471,7 +1471,7 @@ i.mce-i-wp_code::before {
 	}
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.wp-core-ui .quicktags-toolbar input.button.button-small {
 		/* .button-small is normaly 11px, but a bit too small for these buttons. */
 		font-size: 12px;
@@ -1824,7 +1824,7 @@ i.mce-i-wp_code::before {
 	height: 30px;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	#wp-fullscreen-close,
 	#wp-fullscreen-central-toolbar,
 	#wp-fullscreen-mode-bar,
@@ -1906,7 +1906,7 @@ div.wp-link-preview {
 	overflow: hidden;
 	text-overflow: ellipsis;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 14px;
 		margin-bottom: 14px;
 		max-width: 70%;

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/style.scss
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/style.scss
@@ -3,11 +3,11 @@
 }
 
 .gsuite-upsell-card__product-intro {
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		margin-bottom: 1em;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 	}
 }
@@ -62,7 +62,7 @@
 		width: 100%;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 
 		button {
@@ -71,7 +71,7 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: column;
 		button {
 			margin: 5px 0 0;
@@ -79,7 +79,7 @@
 		}
 	}
 
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		flex-direction: row;
 		button {
 			margin: 0 0 0 5px;

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -21,7 +21,7 @@
 	}
 
 	&.is-with-sidebar {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			left: 273px;
 		}
 	}
@@ -54,7 +54,7 @@
 	transition: transform 0.2s ease-out,
 		opacity 0.1s ease-in-out;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		top: 24px;
 		left: 24px;
 		right: 24px;
@@ -77,7 +77,7 @@
 	color: var( --color-primary );
 	border-radius: 0;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding: 6px 32px;
 	}
 
@@ -103,7 +103,7 @@ a.web-preview__external.button {
 	display: flex;
 	justify-content: flex-end;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		// Matches __device-switcher width + margin
 		// and allows the center area to flex equally
 		min-width: 212px;
@@ -152,7 +152,7 @@ a.web-preview__external.button {
 		color: var( --color-neutral-70 );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }
@@ -180,7 +180,7 @@ a.web-preview__external.button {
 .web-preview__back-to-preview-button {
 	display: none;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: block;
 	}
 }
@@ -189,7 +189,7 @@ a.web-preview__external.button {
 	.button {
 		margin: 4px;
 		&:not( :last-child ) {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: none;
 			}
 		}

--- a/client/components/wizard-progress-bar/style.scss
+++ b/client/components/wizard-progress-bar/style.scss
@@ -2,7 +2,7 @@
 	align-items: center;
 	display: flex;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		bottom: 0;
 		left: 0;
 		position: fixed;

--- a/client/components/wizard/progress-indicator.scss
+++ b/client/components/wizard/progress-indicator.scss
@@ -7,7 +7,7 @@
 	margin-bottom: 8px;
 	text-align: center;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding-top: 8px;
 	}
 }

--- a/client/devdocs/design/playground.scss
+++ b/client/devdocs/design/playground.scss
@@ -13,7 +13,7 @@
 
 .design__playground {
 	margin: -24px;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin: -32px;
 	}
 }
@@ -33,19 +33,19 @@
 .react-live-error,
 .design__preview {
 	padding: 24px;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding: 32px;
 	}
 }
 
 .design__preview {
 	position: relative;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		position: static;
 	}
 }
 
-@include breakpoint( '>960px' ) {
+@include breakpoint-deprecated( '>960px' ) {
 	.design__playground {
 		display: flex;
 		height: calc( 100vh - 47px );

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -58,7 +58,7 @@ $devdocs-max-width: 720px;
 		column-gap: 24px;
 
 		// Show 2 columns for big screens
-		@include breakpoint( '>1280px' ) {
+		@include breakpoint-deprecated( '>1280px' ) {
 			column-count: 2;
 		}
 
@@ -174,7 +174,7 @@ $devdocs-max-width: 720px;
 
 		// When we only have room for one column we
 		// set the max-width to line up with search
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			max-width: $devdocs-max-width;
 		}
 
@@ -344,7 +344,7 @@ $devdocs-max-width: 720px;
 	font-size: 16px;
 	font-family: $serif;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 32px auto;
 	}
 
@@ -481,7 +481,7 @@ a.devdocs__doc-edit-link {
 	text-decoration: underline;
 	float: right;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-right: 12px;
 	}
 }

--- a/client/extensions/woocommerce/app/dashboard/setup/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/setup/style.scss
@@ -31,7 +31,7 @@
 .setup__location {
 	padding: 16px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding: 32px 32px 16px;
 	}
 }
@@ -49,7 +49,7 @@
 	margin-left: -24px;
 	margin-right: -24px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: -32px;
 		margin-right: -32px;
 		padding: 32px 32px 0;

--- a/client/extensions/woocommerce/app/dashboard/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/style.scss
@@ -46,25 +46,25 @@
 		width: calc( 35% - 8px ) !important;
 		margin-bottom: 16px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-bottom: 0;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-right: auto;
 			margin-left: auto;
 			width: 80% !important;
 		}
 
 		& + .dashboard-widget__children {
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				width: calc( 65% - 34px ) !important;
 			}
 		}
 	}
 
 	.dashboard-widget__row {
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			flex-direction: column;
 		}
 	}
@@ -77,11 +77,11 @@
 			0 1px 2px var( --color-neutral-0 );
 		flex-direction: row;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			flex-direction: column;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-bottom: 16px;
 		}
 
@@ -124,7 +124,7 @@
 		width: 100%;
 		text-align: center;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-left: 16px;
 		}
 
@@ -137,7 +137,7 @@
 		}
 
 		.dashboard-widget__children {
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				display: flex;
 				align-items: stretch;
 

--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/style.scss
@@ -7,7 +7,7 @@
 			overflow: auto;
 			max-height: 190px;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				overflow: visible;
 				max-height: none;
 			}
@@ -28,7 +28,7 @@
 			margin-bottom: 0;
 			width: 25%;
 
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				display: none;
 			}
 		}
@@ -36,7 +36,7 @@
 		.dashboard-widget__children {
 			width: 75%;
 
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				width: 100%;
 			}
 		}

--- a/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
+++ b/client/extensions/woocommerce/app/dashboard/widgets/stats-widget/style.scss
@@ -16,7 +16,7 @@
 
 	.dashboard-widget__title, .stats-widget__footer {
 		padding: 16px;
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 24px;
 		}
 	}
@@ -35,7 +35,7 @@
 		justify-content: space-between;
 		align-items: center;
 
-		@include breakpoint( '<1040px' ) {
+		@include breakpoint-deprecated( '<1040px' ) {
 			flex-direction: column;
 
 			a {
@@ -73,7 +73,7 @@
 	.table.is-compact-table .table-heading:nth-child( 3 ), .table.is-compact-table .table-item:nth-child( 3 ) {
 		padding-left: 32px;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			padding-left: 48px;
 		}
 	}
@@ -86,7 +86,7 @@
 		padding: 32px;
 		text-align: left;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding: 16px;
 		}
 
@@ -94,7 +94,7 @@
 			display: flex;
 			height: 120px;
 
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				flex-direction: column;
 				height: 140px;
 			}
@@ -108,11 +108,11 @@
 		&.stats-type-list {
 			height: 200px;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				height: 175px;
 			}
 
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				max-width: 100%;
 				min-width: 100%;
 
@@ -143,7 +143,7 @@
 		}
 
 		.stats-widget__more {
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				margin-top: -8px;
 			}
 		}

--- a/client/extensions/woocommerce/app/order/order-activity-log/style.scss
+++ b/client/extensions/woocommerce/app/order/order-activity-log/style.scss
@@ -2,7 +2,7 @@
 .foldable-card.card.order-activity-log__day-header.is-expanded {
 	margin: 0 0 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin: 0 0 24px;
 	}
 }
@@ -95,7 +95,7 @@
 	border: 1px solid var( --color-border-subtle );
 	border-width: 1px 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin: 0 -24px 24px;
 	}
 
@@ -119,7 +119,7 @@
 			border-color: var( --color-primary );
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 16px 24px;
 		}
 	}

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -96,7 +96,7 @@
 	& + .form-setting-explanation {
 		padding-right: 55px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding-right: 0;
 		}
 	}
@@ -189,7 +189,7 @@
 			width: 13em;
 			padding-right: 79px;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				padding-right: 24px;
 			}
 		}
@@ -215,7 +215,7 @@
 	text-align: right;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.order-details__table,
 	.order-details__totals {
 		table,

--- a/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-fulfillment/style.scss
@@ -17,7 +17,7 @@
 	display: flex;
 	align-items: center;
 	margin-top: 16px;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-top: 0;
 	}
 }

--- a/client/extensions/woocommerce/app/order/order-payment/style.scss
+++ b/client/extensions/woocommerce/app/order/order-payment/style.scss
@@ -4,7 +4,7 @@
 	padding: 0;
 	flex-grow: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 640px;
 	}
 
@@ -51,7 +51,7 @@
 		margin-bottom: 16px;
 		width: 100%;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 40%;
 			margin-bottom: 0;
 		}
@@ -64,7 +64,7 @@
 	.order-payment__details {
 		margin-bottom: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 55%;
 		}
 	}

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -10,7 +10,7 @@
 		box-sizing: unset;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
@@ -31,7 +31,7 @@
 		}
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		.order-details {
 			order: 1;
 			flex: 2;
@@ -81,7 +81,7 @@
 	flex-wrap: wrap;
 	align-items: center;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin: 0 -24px;
 		padding: 24px;
 	}
@@ -142,7 +142,7 @@
 		margin-right: 8px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.order-payment__label,
 		.order-fulfillment__label,
 		.order-payment__action,

--- a/client/extensions/woocommerce/app/product-categories/style.scss
+++ b/client/extensions/woocommerce/app/product-categories/style.scss
@@ -72,7 +72,7 @@
 .product-categories__form-info-fields {
 	display: flex;
 	flex-direction: column;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -98,23 +98,23 @@
 	margin-bottom: 16px;
 
 	.product-image-uploader__wrapper {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			width: 175px;
 			height: 175px;
 		}
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			width: 225px;
 			height: 225px;
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 0;
 		width: 175px;
 		margin-right: 24px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: 225px;
 	}
 

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -9,11 +9,11 @@
 		width: 720px;
 		margin-bottom: 8px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 		}
 
-		@include breakpoint( '660px-960px' ) {
+		@include breakpoint-deprecated( '660px-960px' ) {
 			width: 620px;
 		}
 
@@ -39,7 +39,7 @@
 	margin-bottom: 16px;
 
 	.foldable-card__header {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 24px;
 		}
 	}
@@ -76,7 +76,7 @@
 .products__product-form-details-wrapper {
 	display: flex;
 	flex-direction: column;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -93,7 +93,7 @@
 		margin-right: 8px;
 		margin-left: 8px;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-left: 0;
 			margin-right: 16px;
 		}
@@ -148,13 +148,13 @@
 		justify-content: center;
 		width: 100%;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			justify-content: flex-start;
 		}
 
 		.products__product-form-images-item.thumb {
 			&:nth-child( 3n ) {
-				@include breakpoint( '>960px' ) {
+				@include breakpoint-deprecated( '>960px' ) {
 					margin-right: 0;
 				}
 			}
@@ -166,7 +166,7 @@
 		height: 70px;
 		overflow: hidden;
 
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			width: 100px;
 			height: 100px;
 		}
@@ -218,12 +218,12 @@
 	width: 100%;
 	margin-bottom: 16px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 0;
 		width: 250px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: 339px;
 	}
 }
@@ -238,7 +238,7 @@
 
 .products__product-form-images-wrapper,
 .products__product-form-details-basic {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-right: 24px;
 	}
 
@@ -277,7 +277,7 @@
 		}
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		display: flex;
 
 		> .form-fieldset {
@@ -464,7 +464,7 @@
 			rgba( var( --color-surface-rgb ), 0 ) 90%
 		);
 
-		@include breakpoint( '>1280px' ) {
+		@include breakpoint-deprecated( '>1280px' ) {
 			display: none;
 		}
 	}
@@ -674,7 +674,7 @@
 	border-top: 0;
 	margin-top: -10px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-top: -16px;
 	}
 
@@ -685,19 +685,19 @@
 	.foldable-card__header {
 		padding: 16px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 24px;
 		}
 
 		.foldable-card__expand {
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				width: 63px;
 			}
 		}
 	}
 
 	.foldable-card__content {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 24px;
 		}
 	}
@@ -723,7 +723,7 @@
 	display: flex;
 	flex-direction: column;
 	flex-wrap: wrap;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-top: 1em;
 		flex-direction: row;
 	}
@@ -732,7 +732,7 @@
 .products__additional-details-form-group {
 	width: 100%;
 	padding: 16px 0;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 60%;
 		margin-right: 1.5em;
 		padding: 0;
@@ -744,7 +744,7 @@
 	border: 1px solid var( --color-neutral-0 );
 	padding: 16px 0 0;
 	margin-bottom: 8px;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 16px;
 	}
 
@@ -757,7 +757,7 @@
 		.button {
 			padding: 4px 6px 7px;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				padding-left: 12px;
 				padding-right: 12px;
 			}
@@ -767,7 +767,7 @@
 
 .products__additional-details-preview-container {
 	width: 100%;
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 30%;
 	}
 }
@@ -865,7 +865,7 @@
 		width: 342px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 
 		.form-fieldset.products__product-dimensions-input {
@@ -881,7 +881,7 @@
 			flex-grow: 0;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			.form-text-input {
 				min-width: 60px;
 			}
@@ -903,7 +903,7 @@
 	.card {
 		margin-top: -10px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-top: -16px;
 		}
 	}
@@ -915,7 +915,7 @@
 	.products__product-manage-stock {
 		margin-bottom: 12px;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-bottom: 0;
 		}
 	}
@@ -964,7 +964,7 @@
 			}
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			flex-direction: row;
 
 			.products__product-manage-stock-wrapper {

--- a/client/extensions/woocommerce/app/promotions/fields/style.scss
+++ b/client/extensions/woocommerce/app/promotions/fields/style.scss
@@ -46,7 +46,7 @@
 		padding-left: 16px;
 		padding-right: 16px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-left: -24px;
 			margin-right: -24px;
 			padding-left: 24px;

--- a/client/extensions/woocommerce/app/promotions/promotion-form.scss
+++ b/client/extensions/woocommerce/app/promotions/promotion-form.scss
@@ -6,11 +6,11 @@
 		width: 720px;
 		margin-bottom: 8px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 		}
 
-		@include breakpoint( '660px-960px' ) {
+		@include breakpoint-deprecated( '660px-960px' ) {
 			width: 620px;
 		}
 

--- a/client/extensions/woocommerce/app/reviews/style.scss
+++ b/client/extensions/woocommerce/app/reviews/style.scss
@@ -72,7 +72,7 @@
 		align-items: center;
 		flex-flow: row wrap;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex-flow: initial;
 		}
 	}
@@ -158,7 +158,7 @@
 			display: block;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: block;
 		}
 	}
@@ -168,7 +168,7 @@
 		margin-left: 16px;
 		width: calc( 100% - 157px );
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 150px;
 			margin-left: 8px;
 		}
@@ -185,7 +185,7 @@
 		margin-right: 16px;
 		margin-top: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			order: 0;
 			width: calc( 100% - 304px );
 			margin-left: 8px;
@@ -202,7 +202,7 @@
 		flex-shrink: 0;
 		margin-right: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			height: 32px;
 			width: 32px;
 			margin-right: 8px;
@@ -261,7 +261,7 @@
 			font-weight: normal;
 			margin-left: 4px;
 
-			@include breakpoint( '>960px' ) {
+			@include breakpoint-deprecated( '>960px' ) {
 				display: inline;
 			}
 		}

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/style.scss
@@ -4,13 +4,13 @@
 	}
 
 	.mailchimp__getting-started-content {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			padding-top: 48px;
 			padding-bottom: 48px;
 		}
 
 		img {
-			@include breakpoint( '>960px' ) {
+			@include breakpoint-deprecated( '>960px' ) {
 				width: 390px;
 			}
 		}
@@ -47,7 +47,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 
@@ -55,7 +55,7 @@
 		width: 200px;
 		margin-bottom: 16px;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-bottom: 0;
 			width: 230px;
 		}
@@ -112,7 +112,7 @@
 			border-radius: 0;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin: 0 -24px 16px;
 			padding: 16px 24px;
 		}
@@ -184,7 +184,7 @@
 .mailchimp__getting-started-list-header,
 .mailchimp__getting-started-list,
 .mailchimp__getting-started-button {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-left: 24px;
 	}
 }
@@ -204,7 +204,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 		align-items: stretch;
 	}
@@ -224,7 +224,7 @@
 	display: flex;
 	align-items: center;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-left: 24px;
 		padding-right: 24px;
 	}
@@ -238,18 +238,18 @@
 	font-size: 12px;
 	background: var( --color-surface );
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: auto;
 	}
 
 	.notice {
 		margin: 2px 8px 4px 16px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-left: 24px;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-left: 12px;
 		}
 	}
@@ -259,7 +259,7 @@
 	display: flex;
 	max-width: 140px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: auto;
 	}
 }
@@ -298,12 +298,12 @@
 	background: var( --color-neutral-0 );
 	border-top: 1px solid var( --color-neutral-0 );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-left: 24px;
 		padding-right: 24px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding-left: 12px;
 		padding-right: 12px;
 	}
@@ -324,12 +324,12 @@
 	margin: 8px 16px 0;
 	font-weight: 600;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-left: 24px;
 		margin-right: 24px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: 12px;
 		margin-right: 12px;
 	}
@@ -350,11 +350,11 @@
 	padding: 16px;
 	flex-direction: column;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 24px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -366,7 +366,7 @@
 		margin-bottom: 0;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding-right: 24px;
 	}
 }
@@ -376,7 +376,7 @@
 	width: 250px;
 	flex-grow: 0;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: 100%;
 	}
 }

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -1,6 +1,6 @@
 &.payments__dialog {
 	min-width: 90%;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 360px;
 		max-width: 540px;
 	}
@@ -45,7 +45,7 @@
 	flex-direction: row;
 	flex-wrap: wrap;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: column;
 	}
 
@@ -63,7 +63,7 @@
 	max-width: 255px;
 	padding-top: 24px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding-top: 0;
 	}
 }
@@ -140,7 +140,7 @@
 	}
 
 	.payments__method-method-suggested-container {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			width: 50%;
 		}
 	}
@@ -151,13 +151,13 @@
 	}
 
 	.list-item-field.payments__methods-column-fees {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
 
 	.payments__method-method-information-container {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			width: 60%;
 			order: 4;
 			padding-top: 0;
@@ -167,7 +167,7 @@
 	.payments__method-enable-container {
 		width: 20%;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			width: 30%;
 			padding-left: 0;
 			padding-right: 0;
@@ -194,7 +194,7 @@
 	.payments__method-action-container {
 		width: 15%;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			width: 20%;
 			padding-left: 0;
 		}
@@ -217,7 +217,7 @@
 	border-top: 1px solid var( --color-border-subtle );
 	width: 100%;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 24px;
 	}
 
@@ -241,7 +241,7 @@
 	margin-bottom: 5px;
 	width: 100%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 60%;
 	}
 }
@@ -250,7 +250,7 @@
 	height: 12px;
 	width: 90%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 50%;
 	}
 }
@@ -260,7 +260,7 @@
 	margin-bottom: 5px;
 	width: 100%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 60%;
 	}
 }
@@ -269,7 +269,7 @@
 	height: 12px;
 	width: 90%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 50%;
 	}
 }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/style.scss
@@ -62,7 +62,7 @@
 		.shipping-zone__methods-column-title {
 			width: 50%;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				width: 30%;
 			}
 		}
@@ -70,7 +70,7 @@
 		.shipping-zone__methods-column-summary {
 			display: none;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				width: 30%;
 				display: block;
 			}
@@ -121,7 +121,7 @@
 		font-size: 14px;
 		width: 50%;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 30%;
 		}
 	}
@@ -130,7 +130,7 @@
 		font-size: 14px;
 		width: 30%;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			width: 100%;
 			order: 4;
 			padding-top: 0;
@@ -146,7 +146,7 @@
 		vertical-align: top;
 		text-transform: uppercase;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 25%;
 		}
 
@@ -172,7 +172,7 @@
 			flex-shrink: 0;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 15%;
 		}
 	}
@@ -181,7 +181,7 @@
 		font-size: 14px;
 		width: 100%;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 30%;
 		}
 	}
@@ -190,7 +190,7 @@
 		font-size: 14px;
 		width: 70%;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			width: 100%;
 			order: 4;
 			padding-top: 0;
@@ -199,7 +199,7 @@
 }
 
 &.shipping-zone__method-dialog {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 660px;
 	}
 
@@ -302,7 +302,7 @@
 }
 
 &.shipping-zone__location-dialog {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 660px;
 	}
 

--- a/client/extensions/woocommerce/app/settings/shipping/style.scss
+++ b/client/extensions/woocommerce/app/settings/shipping/style.scss
@@ -23,7 +23,7 @@
 		padding-right: 24px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 	}
 }
@@ -33,7 +33,7 @@
 	flex-grow: 1;
 	flex-direction: row;
 
-	@include breakpoint( '<1280px' ) {
+	@include breakpoint-deprecated( '<1280px' ) {
 		flex-direction: column;
 	}
 
@@ -118,7 +118,7 @@
 	text-align: left;
 	padding-left: 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-left: 24px;
 	}
 
@@ -146,7 +146,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -161,7 +161,7 @@
 }
 
 .shipping__zones-row-method-description {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: 4px;
 	}
 }
@@ -183,7 +183,7 @@
 	text-align: right;
 	padding-right: 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-right: 24px;
 	}
 }

--- a/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-orders-chart/style.scss
@@ -8,7 +8,7 @@
 			content: none;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			flex-direction: row;
 		}
 	}
@@ -16,7 +16,7 @@
 	.stats-tab {
 		float: none;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 33.3%;
 		}
 
@@ -52,7 +52,7 @@
 				height: 16px;
 			}
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				.delta__icon {
 					width: initial;
 					height: initial;

--- a/client/extensions/woocommerce/app/store-stats/style.scss
+++ b/client/extensions/woocommerce/app/store-stats/style.scss
@@ -8,14 +8,14 @@
 	width: 100%;
 }
 
-@include breakpoint( '>960px' ) {
+@include breakpoint-deprecated( '>960px' ) {
 	.store-stats__widgets {
 		flex-direction: row;
 		flex-wrap: wrap;
 	}
 }
 
-@include breakpoint( '>1280px' ) {
+@include breakpoint-deprecated( '>1280px' ) {
 	.store-stats__widgets-column {
 		width: calc( 33% - 3px );
 

--- a/client/extensions/woocommerce/components/action-header/style.scss
+++ b/client/extensions/woocommerce/components/action-header/style.scss
@@ -16,11 +16,11 @@
 	top: 47px;
 	left: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 8px 24px 8px 0;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 5px 16px;
 		padding-left: 0;
 		margin: 0;
@@ -44,7 +44,7 @@
 	display: flex;
 	justify-content: flex-start;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-left: -32px;
 	}
 
@@ -84,7 +84,7 @@
 	overflow: hidden;
 	text-align: right;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-right: 40px;
 	}
 

--- a/client/extensions/woocommerce/components/address-view/style.scss
+++ b/client/extensions/woocommerce/components/address-view/style.scss
@@ -17,7 +17,7 @@
 .address-view__editable-city-state-postcode {
 	display: flex;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		align-items: flex-end;
 	}
 
@@ -30,7 +30,7 @@
 		}
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		flex-direction: column;
 
 		label + select {

--- a/client/extensions/woocommerce/components/compact-tinymce/style.scss
+++ b/client/extensions/woocommerce/components/compact-tinymce/style.scss
@@ -28,7 +28,7 @@
 		border-right: 1px solid var( --color-neutral-10 );
 		height: 36px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			height: 44px;
 		}
 	}
@@ -40,11 +40,11 @@
 	.mce-container.mce-tinymce {
 		& > .mce-container-body {
 			&::after {
-				@include breakpoint( '<660px' ) {
+				@include breakpoint-deprecated( '<660px' ) {
 					@include long-content-fade( $size: 0 );
 				}
 
-				@include breakpoint( '660px-960px' ) {
+				@include breakpoint-deprecated( '660px-960px' ) {
 					@include long-content-fade( $size: 0 );
 				}
 			}

--- a/client/extensions/woocommerce/components/dashboard-widget/style.scss
+++ b/client/extensions/woocommerce/components/dashboard-widget/style.scss
@@ -53,7 +53,7 @@
 	&.is-full-width {
 		text-align: left;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			text-align: center;
 		}
 	}
@@ -86,13 +86,13 @@
 		.dashboard-widget__content {
 			align-items: center;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				flex-direction: row;
 				justify-content: space-between;
 			}
 
 			.dashboard-widget__image {
-				@include breakpoint( '>660px' ) {
+				@include breakpoint-deprecated( '>660px' ) {
 					width: calc( 50% - 8px );
 				}
 			}
@@ -101,7 +101,7 @@
 		&.is-flush-image {
 			.dashboard-widget__content {
 				.dashboard-widget__image {
-					@include breakpoint( '>660px' ) {
+					@include breakpoint-deprecated( '>660px' ) {
 						width: calc( 50% + 16px );
 					}
 				}
@@ -109,7 +109,7 @@
 		}
 
 		.dashboard-widget__children {
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				width: calc( 50% - 34px );
 			}
 		}
@@ -119,7 +119,7 @@
 		.dashboard-widget__image {
 			margin-top: 16px;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				margin-top: 0;
 				margin-left: 16px;
 			}
@@ -128,7 +128,7 @@
 
 	&.is-left {
 		.dashboard-widget__image {
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				margin-right: 16px;
 			}
 		}
@@ -139,7 +139,7 @@
 			.dashboard-widget__image {
 				margin-top: -16px;
 
-				@include breakpoint( '>480px' ) {
+				@include breakpoint-deprecated( '>480px' ) {
 					margin-top: -24px;
 				}
 			}
@@ -149,7 +149,7 @@
 			.dashboard-widget__image {
 				margin-bottom: -16px;
 
-				@include breakpoint( '>480px' ) {
+				@include breakpoint-deprecated( '>480px' ) {
 					margin-bottom: -24px;
 				}
 			}
@@ -159,7 +159,7 @@
 			.dashboard-widget__image {
 				margin-top: 16px;
 
-				@include breakpoint( '>660px' ) {
+				@include breakpoint-deprecated( '>660px' ) {
 					margin-top: 0;
 					margin-right: -24px;
 				}
@@ -170,7 +170,7 @@
 			.dashboard-widget__image {
 				margin-bottom: 16px;
 
-				@include breakpoint( '>660px' ) {
+				@include breakpoint-deprecated( '>660px' ) {
 					margin-left: -24px;
 					margin-bottom: 0;
 				}
@@ -184,14 +184,14 @@
 	align-items: stretch;
 	flex-direction: column;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 	}
 
 	.dashboard-widget {
 		margin-right: 16px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			width: 100%;
 		}
 
@@ -199,7 +199,7 @@
 			margin-right: 0;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex: 1;
 
 			&.is-two-thirds-width {

--- a/client/extensions/woocommerce/components/form-dimensions-input/style.scss
+++ b/client/extensions/woocommerce/components/form-dimensions-input/style.scss
@@ -12,7 +12,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-wrap: nowrap;
 
 		.form-text-input-with-affixes {
@@ -24,14 +24,14 @@
 	.form-dimensions-input__length,
 	.form-dimensions-input__width {
 		border-bottom-width: 0;
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			border-bottom-width: 1px;
 		}
 	}
 
 	.form-dimensions-input__width,
 	.form-dimensions-input__height {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-left: -1px;
 		}
 	}
@@ -39,7 +39,7 @@
 	.form-dimensions-input__length,
 	.form-dimensions-input__width,
 	.form-dimensions-input__height {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 70px;
 			flex-grow: 0;
 		}
@@ -60,7 +60,7 @@
 	}
 
 	.form-dimensions-input__height {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 80px;
 		}
 	}

--- a/client/extensions/woocommerce/components/list/list-item-field/style.scss
+++ b/client/extensions/woocommerce/components/list/list-item-field/style.scss
@@ -4,7 +4,7 @@
 	flex-direction: column;
 	padding: 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 16px 24px;
 	}
 }

--- a/client/extensions/woocommerce/components/product-image-uploader/style.scss
+++ b/client/extensions/woocommerce/components/product-image-uploader/style.scss
@@ -7,11 +7,11 @@
 	border: 1px dashed var( --color-neutral-light );
 	border-radius: 5px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 250px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: 337px;
 		height: 337px;
 	}
@@ -72,18 +72,18 @@
 	border-radius: 5px;
 	display: inline-block;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: 0;
 		margin-right: 16px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: 100px;
 		height: 100px;
 	}
 
 	&:nth-child( 3n ) {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-right: 0;
 		}
 	}
@@ -99,11 +99,11 @@
 		width: 100%;
 		height: 100%;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			height: 72px;
 		}
 
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			height: 100px;
 		}
 

--- a/client/extensions/woocommerce/components/reading-widget/style.scss
+++ b/client/extensions/woocommerce/components/reading-widget/style.scss
@@ -52,11 +52,11 @@
 		margin-left: -16px;
 		margin-right: -16px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex-direction: row;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 24px 24px 0;
 			margin-left: -24px;
 			margin-right: -24px;
@@ -67,7 +67,7 @@
 			font-size: 14px;
 			margin-bottom: 24px;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				padding-right: 16px;
 			}
 
@@ -83,7 +83,7 @@
 		.reading-widget__subscription-form-fields {
 			flex: 1 0 0;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				padding-left: 16px;
 			}
 

--- a/client/extensions/woocommerce/components/share-widget/style.scss
+++ b/client/extensions/woocommerce/components/share-widget/style.scss
@@ -1,5 +1,5 @@
 .share-widget__container {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-top: 48px;
 	}
 

--- a/client/extensions/woocommerce/components/store-address/style.scss
+++ b/client/extensions/woocommerce/components/store-address/style.scss
@@ -1,5 +1,5 @@
 &.store-location__edit-dialog {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 660px;
 	}
 }

--- a/client/extensions/woocommerce/components/table/style.scss
+++ b/client/extensions/woocommerce/components/table/style.scss
@@ -120,7 +120,7 @@
 				);
 			}
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				&::after {
 					display: none;
 				}

--- a/client/extensions/woocommerce/components/woocommerce-colophon/style.scss
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/style.scss
@@ -16,8 +16,7 @@
 		margin-left: 4px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-bottom: 24px;
 	}
 }
-

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
@@ -13,7 +13,7 @@
 		transform: none;
 	}
 
-	@include breakpoint( '<800px' ) {
+	@include breakpoint-deprecated( '<800px' ) {
 		position: fixed;
 		z-index: 999;
 		width: 100%;
@@ -94,7 +94,7 @@
 	line-height: 24px;
 	font-size: 16px;
 
-	@include breakpoint( '<800px' ) {
+	@include breakpoint-deprecated( '<800px' ) {
 		display: none;
 		padding-top: 24px;
 	}

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -66,7 +66,7 @@
 	.main {
 		padding-top: 72px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding-top: 35px;
 		}
 	}
@@ -74,7 +74,7 @@
 	.woocommerce__placeholder {
 		padding-top: 16px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding-top: 32px;
 		}
 	}
@@ -84,7 +84,7 @@
 		height: 70vh;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		&.store-stats {
 			.stats-navigation .section-nav {
 				margin-top: 0;
@@ -98,7 +98,7 @@
 	.global-notices {
 		z-index: z-index( 'root', '.is-section-woocommerce .global-notices' );
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			top: 115px;
 		}
 	}
@@ -107,7 +107,7 @@
 		margin: 35px 200px 0 0;
 		max-width: initial;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin: 0;
 		}
 	}
@@ -143,7 +143,7 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 47px;
 		padding-top: 4px;
 
@@ -164,7 +164,7 @@
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.site__title {
 			margin-top: 8px;
 		}
@@ -176,11 +176,11 @@
 	.sidebar__menu {
 		margin-top: 0;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			border-top: 1px solid var( --color-sidebar-border );
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-top: -4px;
 		}
 
@@ -216,7 +216,7 @@
 }
 
 .is-section-woocommerce.focus-sidebar {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.products__form {
 			display: none;
 		}

--- a/client/extensions/woocommerce/woocommerce-services/components/settings-group-card/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/components/settings-group-card/style.scss
@@ -7,7 +7,7 @@
 		padding-top: 24px;
 		padding-bottom: 24px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			flex-wrap: wrap;
 		}
 	}
@@ -20,14 +20,14 @@
 	width: 22%;
 	padding-right: 10px;
 	box-sizing: border-box;
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 	}
 }
 
 .settings-group-card__content {
 	width: 78%;
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -1,19 +1,19 @@
 .packages__add-package-weight {
 	margin-bottom: 8px;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		float: left;
 	}
 
 	&:nth-child( 1 ) {
 		width: 100%;
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 50%;
 		}
 	}
 
 	&:nth-child( 2 ) {
 		width: 100%;
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 50%;
 		}
 	}
@@ -25,7 +25,7 @@
 
 .packages__add-package-weight-group {
 	.form-setting-explanation {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			clear: both;
 		}
 	}
@@ -43,7 +43,7 @@
 		flex-grow: 1;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 610px;
 		height: 610px;
 	}
@@ -76,7 +76,7 @@
 		.form-checkbox {
 			margin-left: 16px;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				margin-left: 24px;
 			}
 		}
@@ -154,7 +154,7 @@
 	text-align: left;
 	padding-left: 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-left: 24px;
 	}
 
@@ -174,7 +174,7 @@
 	text-align: right;
 	padding-right: 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-right: 24px;
 	}
 }
@@ -204,7 +204,7 @@
 			align-items: center;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding-left: 24px;
 		}
 	}
@@ -222,8 +222,8 @@
 .packages__packages-row-dimensions {
 	width: 30%;
 	font-size: 14px;
-	
-	@include breakpoint( '<660px' ) {
+
+	@include breakpoint-deprecated( '<660px' ) {
 		font-size: 11px;
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/service-settings/shipping-services/style.scss
@@ -34,7 +34,7 @@
 	display: flex;
 	width: 100%;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 4px 0;
 		border-bottom: 1px solid var( --color-neutral-0 );
 
@@ -58,7 +58,7 @@
 
 		.shipping-services__entry-price-adjustment {
 			float: right;
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				padding-right: 8px;
 			}
 		}

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/address-step/style.scss
@@ -3,7 +3,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -23,7 +23,7 @@
 .address-step__phone {
 	width: 100%;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: 24px;
 	}
 }
@@ -40,7 +40,7 @@
 	margin-top: 24px;
 	flex-direction: column;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -55,7 +55,7 @@
 	padding: 16px;
 	flex-grow: 1;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 		width: 50%;
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/customs-step/style.scss
@@ -21,13 +21,13 @@
 	display: flex;
 	flex-wrap: wrap;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-wrap: nowrap;
 	}
 }
 
 .customs-step__contents-type {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-right: 24px;
 	}
 }
@@ -36,7 +36,7 @@
 .customs-step__restriction-type {
 	width: 100%;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 50%;
 	}
 }
@@ -44,7 +44,7 @@
 .customs-step__item-rows-header {
 	display: none;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 	}
 
@@ -59,7 +59,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 
 		.form-legend,
@@ -84,7 +84,7 @@
 .customs-step__item-code-column {
 	width: 100%;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: 4px;
 	}
 }
@@ -92,7 +92,7 @@
 .customs-step__item-weight-column,
 .customs-step__item-value-column,
 .customs-step__item-code-column {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-width: 130px;
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
@@ -12,7 +12,7 @@
 	padding-bottom: 24px;
 	flex-direction: column;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 	}
 }
@@ -22,7 +22,7 @@
 	padding: 0 0 24px;
 	flex-shrink: 0;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: row;
 		width: 35%;
 		padding: 0 24px 0 0;

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -13,13 +13,13 @@
 		display: flex;
 		flex-direction: column;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding: inherit;
 			overflow-y: scroll;
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		&.dialog.card {
 			height: 100%;
 			max-height: 100%;
@@ -33,14 +33,14 @@
 	flex-basis: 100%;
 	padding: 32px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-basis: 40%;
 		padding: 24px;
 		margin-left: 24px;
 		background: var( --color-neutral-0 );
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-basis: 30%;
 	}
 }
@@ -106,7 +106,7 @@
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.form-section-heading {
 			padding-top: 20px;
 			padding-left: 20px;
@@ -118,7 +118,7 @@
 	display: flex;
 	flex-grow: 1;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: column;
 	}
 }
@@ -126,11 +126,11 @@
 .label-purchase-modal__main-section {
 	flex-basis: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-basis: 60%;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-basis: 70%;
 	}
 }

--- a/client/extensions/wp-super-cache/style.scss
+++ b/client/extensions/wp-super-cache/style.scss
@@ -158,14 +158,14 @@
 	max-width: 140px;
 	overflow-wrap: break-word;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-width: none;
 		overflow-wrap: normal;
 	}
 }
 
 .wp-super-cache__stat-age {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 100%;
 	}
 }

--- a/client/extensions/zoninator/components/forms/zone-content-form/style.scss
+++ b/client/extensions/zoninator/components/forms/zone-content-form/style.scss
@@ -5,15 +5,15 @@
 	.section-header__label-text {
 		width: 90px;
 
-		@include breakpoint( '>480px') {
+		@include breakpoint-deprecated( '>480px') {
 			width: 235px;
 		}
 
-		@include breakpoint( '>660px') {
+		@include breakpoint-deprecated( '>660px') {
 			width: 120px;
 		}
 
-		@include breakpoint( '>1040px') {
+		@include breakpoint-deprecated( '>1040px') {
 			width: 440px;
 		}
 	}

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -8,7 +8,7 @@
 .jetpack-new-site__header {
 	margin-bottom: 3em;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 2em 2em;
 	}
 }
@@ -39,7 +39,7 @@
 	width: 360px;
 	margin: 0;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }
@@ -154,7 +154,7 @@
 	width: 100%;
 	padding: 36px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: block;
 	}
 }
@@ -197,7 +197,7 @@
 		background: var( --color-surface );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: block;
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -87,7 +87,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			border-color: var( --studio-jetpack-green-50 );
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			.button {
 				font-size: 16px;
 				padding-top: 12px;
@@ -100,7 +100,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 .jetpack-connect__main-logo {
 	text-align: center;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 20px;
 	}
 }
@@ -247,7 +247,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	flex-direction: column;
 	flex-wrap: wrap;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 	}
 }
@@ -258,11 +258,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	justify-content: space-between;
 	min-width: 320px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		max-width: 360px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 0 8px 16px;
 	}
 }
@@ -523,7 +523,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	margin: 16px -16px -16px;
 	padding: 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin: 24px -24px -24px;
 		padding: 24px;
 	}
@@ -577,7 +577,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	padding-bottom: 8px;
 }
 
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 	.jetpack-connect__sso-shared-detail-label,
 	.jetpack-connect__sso-shared-detail-value {
 		display: block;
@@ -815,7 +815,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .layout.has-chat.is-section-jetpack-connect:not( .is-group-editor ):not( .is-section-theme ):not( .is-group-reader )
 	.layout__content {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		padding-left: 32px;
 		padding-right: 319px;
 	}
@@ -986,7 +986,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 				transform: translateX( 25% );
 			}
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				margin-top: 0;
 			}
 		}
@@ -1194,13 +1194,13 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 	.product-card__header {
 		padding: 12px 0;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding: 16px 0;
 		}
 	}
 
 	.product-card__header-primary {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			justify-content: center;
 		}
 	}
@@ -1219,7 +1219,7 @@ body.is-section-jetpack-connect .layout.is-jetpack-woocommerce-flow {
 		font-style: normal;
 		vertical-align: baseline;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			font-weight: 600;
 		}
 	}

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -7,7 +7,7 @@
 		font-size: 34px;
 		margin-bottom: 1em;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 24px;
 		}
 	}
@@ -23,7 +23,7 @@
 			text-align: center;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 16px;
 		}
 	}
@@ -34,7 +34,7 @@
 		font-weight: 400;
 		margin-bottom: 16px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 16px;
 		}
 	}
@@ -56,7 +56,7 @@
 			margin-left: auto;
 			margin-right: auto;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				display: none;
 			}
 		}

--- a/client/landing/domains/header/style.scss
+++ b/client/landing/domains/header/style.scss
@@ -5,7 +5,7 @@
 		font-weight: 400;
 		margin: 0;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 16px;
 		}
 	}
@@ -14,12 +14,12 @@
 .header__logo {
 	fill: var( --color-primary );
 
-	@include breakpoint('<960px') {
+	@include breakpoint-deprecated('<960px') {
 		width: 39px;
 		height: 39px;
 	}
 
-	@include breakpoint('<660px') {
+	@include breakpoint-deprecated('<660px') {
 		width: 24px;
 		height: 24px;
 	}

--- a/client/landing/domains/style.scss
+++ b/client/landing/domains/style.scss
@@ -1,11 +1,11 @@
 .domains-landing.layout__content {
 	padding: 32px;
 
-	@include breakpoint('<960px') {
+	@include breakpoint-deprecated('<960px') {
 		padding: 24px;
 	}
 
-	@include breakpoint('<660px') {
+	@include breakpoint-deprecated('<660px') {
 		padding: 0;
 	}
 }

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -31,7 +31,7 @@
 	margin-bottom: 1rem;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.activity-card-list .filterbar__wrap.card {
 		background: transparent;
 		box-shadow: none;

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -65,7 +65,7 @@
 	font-size: 16px;
 	word-wrap: break-word;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 18px;
 	}
 }
@@ -92,7 +92,7 @@
 		font-size: 12px;
 		display: flex;
 		align-items: center;
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			font-size: 16px;
 		}
 

--- a/client/landing/jetpack-cloud/components/backup-date-picker/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-date-picker/style.scss
@@ -5,7 +5,7 @@
 	padding-top: 0.5rem;
 	font-size: 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		background: transparent;
 	}
 
@@ -16,7 +16,7 @@
 	display: flex;
 	justify-content: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		justify-content: flex-start;
 	}
 }
@@ -32,7 +32,7 @@
 .backup-date-picker__select-date--previous {
 	text-align: left;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 153px;
 	}
 }
@@ -40,7 +40,7 @@
 .backup-date-picker__select-date--next {
 	text-align: right;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		justify-content: space-between;
 	}
 }
@@ -50,7 +50,7 @@
 	flex: 1;
 	align-items: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 153px;
 	}
 }

--- a/client/landing/jetpack-cloud/components/backup-delta/style.scss
+++ b/client/landing/jetpack-cloud/components/backup-delta/style.scss
@@ -20,7 +20,7 @@
     font-weight: 600;
     margin: 32px 0 0.5rem;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 16px;
 	}
 }

--- a/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
+++ b/client/landing/jetpack-cloud/components/daily-backup-status/style.scss
@@ -353,7 +353,7 @@
 	margin-top: 0;
 }
 
-@include breakpoint( '>660px' ) {
+@include breakpoint-deprecated( '>660px' ) {
 	.daily-backup-status__meta,
 	.daily-backup-status__title {
 		display: block;

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -73,7 +73,7 @@
 		&__btn {
 			width: 100%;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				width: 140px;
 			}
 		}

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -1,7 +1,7 @@
 .dialog.fix-all-threats-dialog {
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 676px;
 	}
 
@@ -58,7 +58,7 @@
 					);
 					pointer-events: none;
 
-					@include breakpoint( '>660px' ) {
+					@include breakpoint-deprecated( '>660px' ) {
 						bottom: 70px;
 					}
 				}

--- a/client/landing/jetpack-cloud/components/masterbar/style.scss
+++ b/client/landing/jetpack-cloud/components/masterbar/style.scss
@@ -7,11 +7,11 @@
 		padding: 0;
 		width: auto;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			min-width: $sidebar-width-min;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			min-width: $sidebar-width-max;
 		}
 

--- a/client/landing/jetpack-cloud/components/missing-credentials/style.scss
+++ b/client/landing/jetpack-cloud/components/missing-credentials/style.scss
@@ -1,0 +1,40 @@
+.missing-credentials {
+	border-radius: 4px;
+	border: 1px solid var( --color-neutral-5 );
+	padding: 17px 21px;
+
+	h4 {
+		font-size: 16px;
+		font-weight: 600;
+		margin-bottom: 17px;
+	}
+	p {
+		font-size: 16px;
+	}
+}
+
+.missing-credentials__header {
+	display: flex;
+	justify-content: center;
+	margin-bottom: 17px;
+
+	img {
+		max-width: 50px;
+	}
+}
+
+.missing-credentials__button {
+	background: var( --studio-white );
+	border-radius: 3px;
+	border: 1px solid var( --color-neutral-10 );
+	color: var( --color-neutral-40 );
+	font-size: 16px;
+	font-weight: 600;
+	text-align: center;
+	width: 100%;
+
+	@include breakpoint-deprecated( '>660px' ) {
+		width: auto;
+		text-align: auto;
+	}
+}

--- a/client/landing/jetpack-cloud/components/scan-threats/style.scss
+++ b/client/landing/jetpack-cloud/components/scan-threats/style.scss
@@ -44,7 +44,7 @@
 		justify-content: space-between;
 		margin-bottom: 16px;
 
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			justify-content: flex-end;
 		}
 	}
@@ -53,7 +53,7 @@
 		flex: 1 1 75%;
 		padding: 10px 30px;
 
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			flex: 0 0 170px;
 		}
 	}

--- a/client/landing/jetpack-cloud/components/server-credentials-form/style.scss
+++ b/client/landing/jetpack-cloud/components/server-credentials-form/style.scss
@@ -21,7 +21,7 @@
 	&__btn {
 		width: 100%;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 200px;
 		}
 	}
@@ -40,7 +40,7 @@
 	}
 }
 
-@include breakpoint( '>960px' ) {
+@include breakpoint-deprecated( '>960px' ) {
 	.server-credentials-form__server-address,
 	.server-credentials-form__username,
 	.server-credentials-form__password {

--- a/client/landing/jetpack-cloud/components/stats-footer/style.scss
+++ b/client/landing/jetpack-cloud/components/stats-footer/style.scss
@@ -7,7 +7,7 @@
 	flex-wrap: wrap;
 	padding: 10px 16px 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-bottom: 0;
 		padding: 10px 0 0;
 	}
@@ -43,7 +43,7 @@
 	padding-left: 40px;
 	flex-basis: 100%;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex: 1;
 	}
 }

--- a/client/landing/jetpack-cloud/components/threat-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-dialog/style.scss
@@ -1,7 +1,7 @@
 .dialog.threat-dialog {
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 676px;
 	}
 

--- a/client/landing/jetpack-cloud/components/threat-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-dialog/style.scss
@@ -62,7 +62,7 @@
 		&__btn {
 			width: 100%;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				width: 140px;
 			}
 		}

--- a/client/landing/jetpack-cloud/components/threat-item-subheader/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item-subheader/style.scss
@@ -7,7 +7,7 @@
 		align-items: flex-start;
 		margin-top: 4px;
 
-		@include breakpoint( '>1280px' ) {
+		@include breakpoint-deprecated( '>1280px' ) {
 			flex-direction: row;
 			align-items: center;
 		}
@@ -24,7 +24,7 @@
 	&__date-separator {
 		display: none;
 
-		@include breakpoint( '>1280px' ) {
+		@include breakpoint-deprecated( '>1280px' ) {
 			display: inline-block;
 			background: var( --color-threat-ignored );
 			margin: 0 12px;

--- a/client/landing/jetpack-cloud/components/threat-item/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-item/style.scss
@@ -44,7 +44,7 @@
 	&__fix-button.is-summary {
 		display: none;
 
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			display: inline-block;
 			margin-left: 20px;
 		}
@@ -55,7 +55,7 @@
 		width: 100%;
 		margin-left: 0;
 
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			display: none;
 		}
 	}

--- a/client/landing/jetpack-cloud/components/upsell/style.scss
+++ b/client/landing/jetpack-cloud/components/upsell/style.scss
@@ -12,7 +12,7 @@
 	text-align: center;
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		text-align: auto;
 		width: auto;
 	}

--- a/client/landing/jetpack-cloud/sections/backups/backup-activity-log/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/backup-activity-log/style.scss
@@ -15,7 +15,7 @@
 	}
 
 	// use sub-section styling at mobile sizes
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		h2 {
 			font-size: 16px;
 			font-weight: 600;

--- a/client/landing/jetpack-cloud/sections/backups/backup-upsell/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/backup-upsell/style.scss
@@ -5,7 +5,7 @@
 .backup-upsell__icon-header {
 	display: flex;
 	justify-content: center;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		justify-content: flex-start;
 	}
 

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
@@ -123,7 +123,7 @@ a.rewind-flow-notice__title-warning:visited {
 	text-align: center;
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		text-align: auto;
 		width: auto;
 	}

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -20,7 +20,7 @@
 .backups__page .main {
 	overflow-y: auto;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		overflow-y: visible;
 	}
 }
@@ -34,7 +34,7 @@
 	div:last-child {
 		flex-grow: 1;
 	}
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		height: auto;
 	}
 }

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -11,7 +11,7 @@
 	background: var( --studio-white );
 	padding: 16px 16px 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		background: var( --color-surface-backdrop );
 		padding: 0;
 		margin: 0;

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -5,7 +5,7 @@
 		line-height: 1;
 		margin: 32px 0 16px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			font-size: 36px;
 			font-weight: 600;
 			margin: 32px 0 24px;
@@ -38,7 +38,7 @@
 		margin-bottom: 16px;
 		line-height: 24px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-bottom: 24px;
 		}
 	}

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -14,7 +14,7 @@
 	margin-bottom: 16px;
 	line-height: 24px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-bottom: 24px;
 	}
 }
@@ -24,7 +24,7 @@
 	margin: 0 auto;
 	width: 48px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 0;
 		padding: 0;
 	}
@@ -50,7 +50,7 @@
 	line-height: 1;
 	margin: 32px 0 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 36px;
 		font-weight: 600;
 		margin: 32px 0 24px;
@@ -72,7 +72,7 @@
 	width: 100%;
 	text-align: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: auto;
 		text-align: left;
 	}

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -81,7 +81,7 @@
 .scan__retry-bottom {
 	margin: 0 0 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 16px 0 16px 20px;
 	}
 }

--- a/client/landing/jetpack-cloud/sections/settings/style.scss
+++ b/client/landing/jetpack-cloud/sections/settings/style.scss
@@ -42,7 +42,7 @@
 	font-weight: 600;
 	margin: 16px 0 24px;
 
-	@include breakpoint('>660px') {
+	@include breakpoint-deprecated('>660px') {
 		font-size: 36px;
 		margin: 32px 0;
 	}

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -196,7 +196,7 @@ html {
 		font-weight: 600;
 		line-height: 32px;
 
-		@include breakpoint('>660px') {
+		@include breakpoint-deprecated('>660px') {
 			font-size: 36px;
 			line-height: 40px;
 		}
@@ -207,7 +207,7 @@ html {
 		font-weight: 600;
 		line-height: 23px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			font-size: 18px;
 			line-height: 23px;
 		}
@@ -217,7 +217,7 @@ html {
 		font-size: 16px;
 		line-height: 24px;
 
-		@include breakpoint('>660px') {
+		@include breakpoint-deprecated('>660px') {
 			font-size: 18px;
 			line-height: 24px;
 		}

--- a/client/layout/masterbar/crowdsignal.scss
+++ b/client/layout/masterbar/crowdsignal.scss
@@ -29,7 +29,7 @@
 		right: 0;
 		top: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		height: 88px;
 		padding: 20px 25px;
 	}
@@ -71,7 +71,7 @@
 	text-transform: uppercase;
 	width: 100%;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 12px;
 	}
 }
@@ -79,7 +79,7 @@
 .masterbar__crowdsignal-wide-screen-only {
 	display: none;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: inline;
 	}
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -91,7 +91,7 @@
 	background: var( --color-surface );
 	color: var( --studio-gray-100 );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		background: var( --studio-gray-0 );
 	}
 
@@ -128,7 +128,7 @@
 	&.is-section-login {
 		padding-bottom: 100px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			min-height: calc( 100% - 145px );
 			padding-bottom: 145px;
 		}
@@ -155,7 +155,7 @@
 			padding: 10px 16px;
 			text-align: center;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				margin: 0;
 			}
 
@@ -182,7 +182,7 @@
 					display: block;
 				}
 
-				@include breakpoint( '<660px' ) {
+				@include breakpoint-deprecated( '<660px' ) {
 					margin-bottom: 20px;
 				}
 			}
@@ -200,7 +200,7 @@
 			box-sizing: border-box;
 			display: block;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				background-color: var( --color-surface );
 				box-shadow: 0 2px 3px 0 var( --color-neutral-10 );
 				margin: 0 auto;
@@ -232,7 +232,7 @@
 			margin-bottom: 80px;
 			margin-top: 0;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				font-size: 32px;
 				margin-bottom: 65px;
 			}
@@ -257,7 +257,7 @@
 		.login__form-subheader {
 			display: none;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				display: block;
 				font-size: 20px;
 				font-weight: 600;
@@ -274,7 +274,7 @@
 			top: 60px;
 			text-align: center;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				position: static;
 				margin-bottom: 30px;
 			}
@@ -323,7 +323,7 @@
 			box-sizing: border-box;
 			display: block;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				background-color: var( --color-surface );
 				box-shadow: 0 2px 3px 0 var( --color-neutral-10 );
 				margin: 0 auto;
@@ -373,7 +373,7 @@
 				display: inline;
 			}
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				display: inline;
 				text-align: left;
 
@@ -396,7 +396,7 @@
 			height: auto;
 			padding: 20px 20px 78px;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				flex-direction: row;
 				justify-content: space-between;
 			}
@@ -453,7 +453,7 @@
 		padding-left: 13px;
 		padding-right: 13px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding-left: 55px;
 			padding-right: 13px;
 		}
@@ -479,7 +479,7 @@
 			text-decoration: none;
 			text-transform: uppercase;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				padding: 32px;
 			}
 		}
@@ -500,7 +500,7 @@
 		text-transform: capitalize;
 		width: auto;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 100%;
 		}
 
@@ -577,7 +577,7 @@
 			max-width: 90%;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex-direction: row;
 			flex-wrap: wrap;
 
@@ -616,11 +616,11 @@
 		padding: 20px $woo-form-whitespace;
 		width: 100%;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 20px $woo-form-whitespace-480;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 20px $woo-form-whitespace-660;
 		}
 	}
@@ -650,12 +650,12 @@
 		padding-top: 44px;
 		text-align: center;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin: 0 -24px;
 			width: calc( 100% + ( #{$woo-form-whitespace-480} * 2 ) );
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin: 0 -100px;
 			width: calc( 100% + ( #{$woo-form-whitespace-660} * 2 ) );
 		}
@@ -702,7 +702,7 @@
 		margin: 0 0 8px;
 		padding: 0;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			font-size: 2em;
 			margin: 2em 0 0;
 		}

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -119,7 +119,7 @@ $autobar-height: 20px;
 		background: var( --studio-orange-70 );
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex: 1 1 auto;
 
 		.gridicon {
@@ -147,7 +147,7 @@ $autobar-height: 20px;
 		margin: 0 5px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		& {
 			padding-right: 14px;
 		}
@@ -186,7 +186,7 @@ $autobar-height: 20px;
 	.masterbar__item-content {
 		display: block;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-top: 3px; /*Align with logo*/
 		}
 	}
@@ -237,7 +237,7 @@ $autobar-height: 20px;
 		color: var( --color-primary );
 		display: none;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			display: block;
 			margin-right: 4px;
 		}
@@ -293,7 +293,7 @@ $autobar-height: 20px;
 .masterbar__item-notifications {
 	margin-right: 12px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-right: 0;
 	}
 
@@ -304,7 +304,7 @@ $autobar-height: 20px;
 	.gridicon + .masterbar__item-content {
 		padding: 0;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: block;
 		}
 	}
@@ -379,7 +379,7 @@ $autobar-height: 20px;
 }
 
 .masterbar__reader {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-right: auto;
 	}
 }
@@ -403,7 +403,7 @@ $autobar-height: 20px;
 
 	&:hover {
 		background-color: var( --color-neutral-0 );
-		
+
 		.count {
 			border-color: var( --color-primary );
 			color: var( --color-primary );
@@ -489,7 +489,7 @@ $autobar-height: 20px;
 .masterbar__notifications {
 	flex: 1 1 auto;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-grow: 0;
 	}
 }

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -16,7 +16,7 @@
 	overflow: auto;
 
 	// Not sure this is needed.
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		-webkit-overflow-scrolling: touch;
 	}
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -48,7 +48,7 @@
 	}
 
 	// Tablets
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		padding: 71px 24px 24px ( $sidebar-width-min + 24px + 1px );
 
 		.has-no-sidebar & {
@@ -67,7 +67,7 @@
 	}
 
 	// Mobile (Full Width)
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-left: 0;
 		padding: 0;
 		padding-top: 47px;
@@ -87,7 +87,7 @@
 .layout__primary .main {
 	padding-bottom: 88px;
 
-	@include breakpoint( '>1400px' ) {
+	@include breakpoint-deprecated( '>1400px' ) {
 		padding-bottom: 0;
 	}
 }
@@ -105,11 +105,11 @@
 	width: $sidebar-width-max;
 	overflow: hidden;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: $sidebar-width-min;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 	}
 
@@ -145,7 +145,7 @@
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		-webkit-overflow-scrolling: touch;
 		transform: translateX( -100% );
 	}
@@ -227,7 +227,7 @@
 .layout.focus-sites:not( .is-section-post-editor ),
 .layout.focus-sidebar:not( .is-section-post-editor ) {
 	.layout__primary .main {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			pointer-events: none;
 			overflow: hidden;
 			max-height: calc( 100vh - 47px );
@@ -250,13 +250,13 @@
 		pointer-events: none;
 		transform: translateX( $sidebar-width-max );
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			transform: translateX( 100% );
 		}
 	}
 
 	.layout__primary .main {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			pointer-events: none;
 			opacity: 0.25;
 		}
@@ -266,7 +266,7 @@
 // Move the secondary element off screen when focused
 // on the content. This only applies to small screens.
 .layout.focus-content {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.layout__secondary {
 			transform: translateX( -100% );
 		}
@@ -285,7 +285,7 @@
 
 // Display sidebar as a panel under a main payment component in mobile checkout
 .layout.is-section-checkout {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.layout__content {
 			display: flex;
 			flex-flow: column;

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -38,7 +38,7 @@
 		max-width: 400px;
 		padding: 16px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 24px;
 		}
 

--- a/client/mailing-lists/style.scss
+++ b/client/mailing-lists/style.scss
@@ -12,7 +12,7 @@
 	margin: 40px 24px;
 	padding-left: 40px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-top: 8px;
 		padding-left: 80px;
 	}
@@ -30,7 +30,7 @@
 		&.gridicons-mail {
 			fill: var( --color-neutral-50 );
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				height: 24px;
 				width: 24px;
 			}
@@ -42,7 +42,7 @@
 			border-radius: 100%;
 			box-shadow: 0 0 0 3px var( --color-neutral-0 );
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				height: 16px;
 				width: 16px;
 				top: 16px;
@@ -56,7 +56,7 @@
 		line-height: 1.2;
 		color: var( --color-neutral-70 );
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			font-size: 32px;
 		}
 	}
@@ -71,7 +71,7 @@
 	padding: 24px;
 	min-height: 88px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-right: 154px;
 	}
 
@@ -88,12 +88,12 @@
 	}
 
 	.button {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin-top: 24px;
 			box-sizing: border-box;
 			width: 100%;
 		}
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			position: absolute;
 				top: 24px;
 				right: 24px;

--- a/client/me/account-password/style.scss
+++ b/client/me/account-password/style.scss
@@ -1,4 +1,4 @@
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 	.account-password__buttons-group {
 		display: flex;
 		flex-wrap: wrap-reverse;

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -125,7 +125,7 @@
 		font-size: 12px;
 		font-style: italic;
 
-		@include breakpoint( '660px-800px' ) {
+		@include breakpoint-deprecated( '660px-800px' ) {
 			max-width: 220px;
 			overflow: hidden;
 			text-overflow: ellipsis;
@@ -153,7 +153,7 @@
 	position: relative;
 	overflow: auto;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 10px 20px;
 	}
 
@@ -162,7 +162,7 @@
 		min-height: 65px;
 		float: left;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			left: 20px;
 		}
 	}
@@ -172,7 +172,7 @@
 		float: left;
 		padding: 10px 20px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding-top: 0;
 		}
 
@@ -187,7 +187,7 @@
 		font-style: italic;
 		padding: 5px 0 0;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			position: absolute;
 			top: 10px;
 			right: 40px;
@@ -220,7 +220,7 @@ textarea.billing-history__billing-details-editable {
 	margin: 20px 0 0;
 	overflow: auto;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 20px;
 	}
 
@@ -253,7 +253,7 @@ textarea.billing-history__billing-details-editable {
 .billing-history__receipt {
 	padding: 30px 40px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 30px 20px;
 	}
 
@@ -336,7 +336,7 @@ textarea.billing-history__billing-details-editable {
 	.button {
 		margin: 16px 0;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			float: right;
 			margin: 0 1%;
 		}

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -56,20 +56,20 @@
 
 .book__info-step-phone-input {
 	display: block;
-	
-	@include breakpoint( '>480px' ) {
+
+	@include breakpoint-deprecated( '>480px' ) {
 		display: flex;
 	}
-	
+
 	& fieldset {
 		flex: 1;
 		margin-bottom: 0;
 	}
-	
+
 	.form-fieldset__phone-number {
 		margin-top: 20px;
-		
-		@include breakpoint( '>480px' ) {
+
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-top: 0;
 			margin-left: 12px;
 		}

--- a/client/me/connected-application-icon/style.scss
+++ b/client/me/connected-application-icon/style.scss
@@ -10,7 +10,7 @@
 	margin-left: 0;
 	margin-right: 12px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-left: 0;
 	}
 }

--- a/client/me/happychat/style.scss
+++ b/client/me/happychat/style.scss
@@ -18,7 +18,7 @@
 	bottom: 0;
 }
 
-@include breakpoint( '>1040px' ) {
+@include breakpoint-deprecated( '>1040px' ) {
 
 	.happychat__page .happychat__timeline-message {
 		max-width: 80%;
@@ -26,7 +26,7 @@
 
 }
 
-@include breakpoint( '<960px' ) {
+@include breakpoint-deprecated( '<960px' ) {
 
 	.happychat__page {
 		left: 229px;
@@ -34,7 +34,7 @@
 
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 
 	.happychat__page {
 			left: 0;

--- a/client/me/help/help-contact-confirmation/style.scss
+++ b/client/me/help/help-contact-confirmation/style.scss
@@ -14,7 +14,7 @@
 	.form-section-heading {
 		margin: 13px 0 7px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin: 7px 0 3px;
 			font-size: 24px;
 			line-height: 32px;
@@ -23,7 +23,7 @@
 
 	min-height: calc( 100vh - 150px );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-height: auto;
 		height: 556px;
 	}
@@ -33,7 +33,7 @@
 	display: table-cell;
 	vertical-align: middle;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 		margin-top: 100px;
 	}
@@ -43,7 +43,7 @@
 	display: none;
 }
 
-@include breakpoint( '>660px' ) {
+@include breakpoint-deprecated( '>660px' ) {
 	.help-contact-confirmation__large-gridicon {
 		display: block;
 	}

--- a/client/me/help/help-contact-form/style.scss
+++ b/client/me/help/help-contact-form/style.scss
@@ -14,7 +14,7 @@
 .help-contact-form__selection {
 	margin-bottom: 24px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 32px;
 	}
 }
@@ -30,7 +30,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.segmented-control {
 			// Show the segmented control when the browser is wider than 960px
 			display: flex;

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -39,7 +39,7 @@
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 24px;
 		line-height: 1.416;
 	}
@@ -52,7 +52,7 @@
 	line-height: 22px;
 	margin-bottom: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 16px;
 		line-height: 1.618;
 	}
@@ -70,7 +70,7 @@
 	margin: 0 10px 0 0;
 	white-space: normal;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 15px;
 	}
 }

--- a/client/me/help/help-happiness-engineers/style.scss
+++ b/client/me/help/help-happiness-engineers/style.scss
@@ -2,13 +2,13 @@
 	margin: 12px 0 64px;
 	padding: 0 24px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 24px 0 64px;
 	}
 }
 
 .help-happiness-engineers .form-section-heading {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		font: 300 16px/21px $sans;
 	}
 }
@@ -17,7 +17,7 @@
 	margin: -16px 0 12px;
 	font: 14px/21px $sans;
 	color: var( --color-neutral-40 );
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: -16px 0 20px;
 	}
 }

--- a/client/me/help/help-search/style.scss
+++ b/client/me/help/help-search/style.scss
@@ -10,7 +10,7 @@
 
 .help-search .no-results {
 	margin-left: 35px;
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-left: 25px;
 	}
 }

--- a/client/me/help/style.scss
+++ b/client/me/help/style.scss
@@ -1,7 +1,7 @@
 .help .upwork-banner {
 	margin: 10px 10px 20px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 0 0 24px;
 	}
 }
@@ -46,7 +46,7 @@
 .help__support-link-title {
 	font-size: 16px;
 	color: var( --color-primary );
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 21px;
 	}
 }
@@ -74,6 +74,3 @@
 	height: 380px;
 	margin-bottom: 15px;
 }
-
-
-

--- a/client/me/memberships/subscription.scss
+++ b/client/me/memberships/subscription.scss
@@ -11,7 +11,7 @@
 	padding: 0 24px;
 	border-top: 1px solid var( --color-neutral-0 );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: column;
 		padding: 0 16px 16px;
 	}
@@ -20,13 +20,13 @@
 		color: var( --color-neutral-60 );
 		font-size: 13px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			clear: both;
 			overflow: auto;
 			margin-top: 15px;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			box-sizing: border-box;
 			flex: 1 1 auto;
 			font-size: 14px;
@@ -42,7 +42,7 @@
 		}
 
 		+ li {
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				border-left: 1px solid var( --color-neutral-0 );
 			}
 		}
@@ -59,12 +59,12 @@
 	font-style: normal;
 	font-weight: 600;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: row;
 		float: left;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		color: var( --color-text-subtle );
 		display: block;
 		font-family: $sans;
@@ -75,7 +75,7 @@
 }
 
 .memberships__subscription-inner-detail {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: block;
 		float: right;
 		text-align: right;

--- a/client/me/notification-settings/blogs-settings/style.scss
+++ b/client/me/notification-settings/blogs-settings/style.scss
@@ -22,7 +22,7 @@
 	display: flex;
 	color: var( --color-text-subtle );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		cursor: pointer;
 	}
 

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -41,7 +41,7 @@
 	max-width: 500px;
 	text-align: center;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		text-align: left;
 	}
 }
@@ -62,7 +62,7 @@
 		margin: 16px 0 0;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 		min-height: 80px;
 		position: relative;
@@ -116,7 +116,7 @@
 .notification-settings-push-notification-settings__settings-description {
 	margin-bottom: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-right: 130px;
 	}
 }
@@ -124,7 +124,7 @@
 .notification-settings-push-notification-settings__settings-button {
 	margin-top: 8px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 0;
 		position: absolute;
 	 	bottom: 24px;

--- a/client/me/notification-settings/settings-form/actions.scss
+++ b/client/me/notification-settings/settings-form/actions.scss
@@ -7,7 +7,7 @@
 	.form-fieldset {
 		margin-bottom: 10px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin: 10px 0 0;
 			float: left;
 		}
@@ -21,7 +21,7 @@
 		float: none;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		height: 55px;
 		padding: 15px 0 0;
 	}

--- a/client/me/notification-settings/settings-form/style.scss
+++ b/client/me/notification-settings/settings-form/style.scss
@@ -8,7 +8,7 @@
 		margin: 0;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: none;
 	}
 }
@@ -38,7 +38,7 @@
 .notification-settings-form-header {
 	display: none;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: flex;
 		border-top: solid 1px var( --color-neutral-0 );
 		border-bottom: solid 1px var( --color-neutral-0 );
@@ -70,7 +70,7 @@
 		flex-direction: column;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: flex;
 		flex: 1 0 auto;
 		flex-direction: column;

--- a/client/me/pending-payments/style.scss
+++ b/client/me/pending-payments/style.scss
@@ -32,7 +32,7 @@
 		@include long-content-fade();
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 18px;
 		max-width: none;
 	}

--- a/client/me/profile/style.scss
+++ b/client/me/profile/style.scss
@@ -1,7 +1,7 @@
 .profile__settings .edit-gravatar {
 	text-align: center;
 
-	@include breakpoint('>960px') {
+	@include breakpoint-deprecated('>960px') {
 		float: left;
 		margin-right: 40px;
 		margin-bottom: 20px;
@@ -16,7 +16,7 @@
 
 .profile__settings .form-fieldset:nth-child( 1 ),
 .profile__settings .form-fieldset:nth-child( 2 ) {
-	@include breakpoint('>960px') {
+	@include breakpoint-deprecated('>960px') {
 		clear: right;
 	}
 }

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -20,7 +20,7 @@
 	margin: 0;
 	padding: 0 0 10px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 55%;
 	}
 
@@ -86,7 +86,7 @@
 }
 
 .cancel-purchase__button {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 	}
 }

--- a/client/me/purchases/concierge-banner/style.scss
+++ b/client/me/purchases/concierge-banner/style.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
 
-    @include breakpoint( '>960px' ) {
+    @include breakpoint-deprecated( '>960px' ) {
         flex-direction: row;
     }
 }
@@ -30,7 +30,7 @@
         background: var( --color-neutral-10 );
     }
 
-    @include breakpoint( '>960px' ) {
+    @include breakpoint-deprecated( '>960px' ) {
         margin: auto;
     }
 }
@@ -39,13 +39,13 @@
     height: 30px;
     width: 80px;
 
-    @include breakpoint( '>960px' ) {
+    @include breakpoint-deprecated( '>960px' ) {
         height: 30px;
         margin: auto;
         width: 80px;
     }
 
-    @include breakpoint( '<480px' ) {
+    @include breakpoint-deprecated( '<480px' ) {
         width: 100%;
     }
 }

--- a/client/me/purchases/credit-cards/credit-cards.scss
+++ b/client/me/purchases/credit-cards/credit-cards.scss
@@ -2,7 +2,7 @@
 	display: block;
 	color: var( --color-text-subtle );
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 8px;
 	}
 }

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -2,7 +2,7 @@
 	font-size: 13px;
 	padding: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 14px;
 		padding: 0;
 	}
@@ -22,7 +22,7 @@
 	&.is-expired + .notice {
 		margin-top: -10px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-top: -16px;
 		}
 	}
@@ -71,7 +71,7 @@
 			width: 60%;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			.manage-purchase__description,
 			.manage-purchase__detail,
 			.manage-purchase__detail-label {
@@ -79,7 +79,7 @@
 			}
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			.manage-purchase__detail {
 				width: 25%;
 			}
@@ -95,7 +95,7 @@
 .manage-purchase__content {
 	padding: 16px 24px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 16px;
 	}
 }
@@ -147,7 +147,7 @@
 	font-weight: 400;
 	clear: none;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 22px;
 		padding-right: 100px;
 	}
@@ -184,7 +184,7 @@
 	padding: 0 24px;
 	border-top: 1px solid var( --color-neutral-0 );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: column;
 		padding: 0 16px 16px;
 	}
@@ -193,13 +193,13 @@
 		color: var( --color-neutral-60 );
 		font-size: 13px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			clear: both;
 			overflow: auto;
 			margin-top: 15px;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			box-sizing: border-box;
 			flex: 1 1 auto;
 			font-size: 14px;
@@ -219,7 +219,7 @@
 		}
 
 		+ li {
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				border-left: 1px solid var( --color-neutral-0 );
 			}
 		}
@@ -236,12 +236,12 @@
 	font-style: normal;
 	font-weight: 600;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: row;
 		float: left;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		color: var( --color-text-subtle );
 		display: block;
 		font-family: $sans;
@@ -252,7 +252,7 @@
 }
 
 .manage-purchase__detail {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		text-align: right;
 	}
 
@@ -276,18 +276,18 @@
 .manage-purchase__purchase-expiring-notice.notice {
 	margin-bottom: 10px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-bottom: 16px;
 	}
 }
 
 .manage-purchase__renew-button {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 16px;
 		width: 100%;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		position: absolute;
 		right: 24px;
 		top: 16px;
@@ -301,7 +301,7 @@
 	padding: 16px;
 	background: var( --color-surface );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 16px 24px;
 	}
 }

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -90,7 +90,7 @@
 		@include long-content-fade();
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 18px;
 		max-width: none;
 	}

--- a/client/me/purchases/purchases-site/style.scss
+++ b/client/me/purchases/purchases-site/style.scss
@@ -16,7 +16,7 @@
 .purchases-site__slug {
 	white-space: nowrap;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		line-height: 15px;
 	}
 }
@@ -25,25 +25,25 @@
 	& .action-card__button-container {
 		text-align: left;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			text-align: center;
 		}
 	}
 
 	& .action-card__illustration {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin: -10px -20px 0;
 		}
 	}
 
 	&.purchase-concierge .action-card__illustration {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-right: 20px;
 		}
 	}
 
 	&.card {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 10px;
 			align-items: flex-start;
 		}

--- a/client/me/security-2fa-backup-codes-list/style.scss
+++ b/client/me/security-2fa-backup-codes-list/style.scss
@@ -15,12 +15,12 @@
 		display: inline-block;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-bottom: 24px;
 	}
 }
 
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 	.security-2fa-backup-codes-list__btn-group .button {
 		display: inline-block;
 	}

--- a/client/me/security-2fa-progress/style.scss
+++ b/client/me/security-2fa-progress/style.scss
@@ -1,7 +1,7 @@
 .security-2fa-progress__container {
 	margin: 0 -16px 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin: 0 -24px 24px;
 	}
 

--- a/client/me/security-2fa-sms-settings/style.scss
+++ b/client/me/security-2fa-sms-settings/style.scss
@@ -6,7 +6,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 }
@@ -15,7 +15,7 @@
 	flex: 1;
 	padding-right: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-right: 20px;
 		margin-bottom: 5px;
 	}

--- a/client/me/security-account-recovery/style.scss
+++ b/client/me/security-account-recovery/style.scss
@@ -6,7 +6,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 }
@@ -14,7 +14,7 @@
 .security-account-recovery-contact__detail .form-fieldset__country {
 	padding-right: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex: 1;
 		padding-right: 20px;
 		margin-bottom: 0;
@@ -24,7 +24,7 @@
 .security-account-recovery-contact__detail .form-country-select {
 	width: 100%;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		min-width: 0;
 		width: 100%;
 		max-width: 200px;
@@ -34,7 +34,7 @@
 .security-account-recovery-contact__detail .form-fieldset__phone-number {
 	margin-bottom: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex: 2 0;
 	}
 }
@@ -54,7 +54,7 @@
 .security-account-recovery-contact__placeholder-heading {
 	line-height: 2.4;
 	margin-bottom: 1em;
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: 45%;
 	}
 }
@@ -98,7 +98,7 @@
 		vertical-align: bottom;
 		margin-right: 2px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 16px;
 			height: 16px;
 		}
@@ -107,7 +107,7 @@
 	span {
 		display: none;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			display: inline;
 		}
 	}

--- a/client/me/social-login/style.scss
+++ b/client/me/social-login/style.scss
@@ -20,7 +20,7 @@
 		margin-bottom: 0;
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		p {
 			display: none;
 		}

--- a/client/my-sites/activity/activity-log-banner/intro-banner.scss
+++ b/client/my-sites/activity/activity-log-banner/intro-banner.scss
@@ -9,15 +9,15 @@
 	max-width: 220px;
 	margin: 8px 16px 0 -8px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		max-width: 100px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 64px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -49,7 +49,7 @@
 	box-sizing: border-box;
 	animation: appear 0.3s ease-in-out;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 
@@ -64,7 +64,7 @@
 		width: 18px;
 		height: 18px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			position: relative;
 			width: 24px;
 			height: 24px;
@@ -79,7 +79,7 @@
 	flex-grow: 1;
 	padding-left: 24px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding-left: 4px;
 	}
 }
@@ -108,7 +108,7 @@
 	border-top: #eee 1px solid;
 	display: block;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: flex;
 		justify-content: space-between;
 		flex-direction: row-reverse;
@@ -117,7 +117,7 @@
 	button {
 		margin: 0 0 8px 8px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin: 0 8px 0 0;
 		}
 	}
@@ -125,7 +125,7 @@
 
 .activity-log-confirm-dialog__primary-actions {
 	text-align: right;
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-bottom: 8px;
 		text-align: left;
 	}
@@ -136,7 +136,7 @@
 	padding: 8px 8px 0 0;
 	display: inline-block;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-bottom: 4px;
 		font-size: 12px;
 	}
@@ -148,7 +148,7 @@
 		height: 18px;
 		margin-right: 6px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			top: 0;
 			width: 24px;
 			height: 24px;

--- a/client/my-sites/activity/activity-log-example/style.scss
+++ b/client/my-sites/activity/activity-log-example/style.scss
@@ -2,7 +2,7 @@
 	.formatted-header {
 		margin-top: 35px;
 		margin-bottom: 35px;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin-top: 40px;
 			margin-bottom: 20px;
 		}
@@ -14,7 +14,7 @@
 		padding-right: 1px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		// Don't show more than 2 first items
 		.activity-log-item:nth-child( n+3 ) {
 			display: none;

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	position: relative;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-left: 8px;
 
 		.is-expanded & {
@@ -36,7 +36,7 @@
 }
 
 .activity-log-item .foldable-card__header {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 12px;
 		display: block;
 	}
@@ -65,7 +65,7 @@
 	padding: 4px 0 6px;
 	z-index: 1;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin: -2px 8px 0 0;
 	}
 
@@ -86,7 +86,7 @@
 	text-transform: uppercase;
 	white-space: nowrap;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		letter-spacing: -1px;
 	}
 }
@@ -100,7 +100,7 @@
 	padding: 12px;
 	margin-top: 2px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 7px;
 		box-sizing: border-box;
 		width: 32px;
@@ -135,7 +135,7 @@
 		padding: 0;
 		background-color: var( --color-neutral-10 );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 32px;
 			height: 32px;
 			margin: 2px 0 0 2px;
@@ -149,7 +149,7 @@
 	.foldable-card__main {
 		min-width: 0;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			max-width: none;
 			margin: 0;
 		}
@@ -173,13 +173,13 @@
 	min-width: 0;
 	padding-left: 56px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		flex-direction: column;
 		align-items: flex-start;
 		padding-left: 0;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-right: 0;
 	}
 }
@@ -189,7 +189,7 @@
 	margin-right: 32px;
 	align-items: center;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex: 0 0 180px;
 		margin-left: -56px;
 	}
@@ -203,12 +203,12 @@
 		margin-right: 16px;
 		fill: var( --color-neutral-40 );
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			width: 32px;
 			height: 32px;
 			margin-right: 8px;
 		}
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 24px;
 			height: 24px;
 			margin-right: 8px;
@@ -237,7 +237,7 @@
 		margin-top: 2px;
 		fill: var( --color-text-inverted );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding: 7px;
 			box-sizing: border-box;
 			width: 32px;
@@ -261,12 +261,12 @@
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		margin-top: 2px;
 		line-height: 1;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: inline-block;
 	}
 }
@@ -274,7 +274,7 @@
 .activity-log-item__actor-role {
 	text-transform: capitalize;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: inline-block;
 		margin-left: 8px;
 	}
@@ -285,7 +285,7 @@
 	font-size: 12px;
 	color: var( --color-text-subtle );
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		font-size: 14px;
 	}
 }
@@ -295,7 +295,7 @@
 	font-size: 14px;
 	word-break: break-word;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		margin-top: 8px;
 	}
 }
@@ -312,7 +312,7 @@
 	display: flex;
 	justify-content: flex-end;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-top: 16px;
 		text-align: left;
 	}
@@ -343,7 +343,7 @@
 	white-space: nowrap;
 	padding: 2px 7px 3px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: block;
 		margin-top: rem( 15px );
 	}
@@ -357,7 +357,7 @@
 	font-size: 13px;
 	white-space: nowrap;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: table;
 		margin-top: rem( 15px );
 	}
@@ -409,7 +409,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		&.is-mobile {
 			display: none;
 		}
@@ -433,7 +433,7 @@
 }
 
 .activity-log-item.is-aggregated > .foldable-card > .foldable-card__header {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding-right: 44px;
 	}
 }

--- a/client/my-sites/activity/activity-log-switch/style.scss
+++ b/client/my-sites/activity/activity-log-switch/style.scss
@@ -7,7 +7,7 @@
 	max-width: 960px;
 	color: var( --color-text-subtle );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		background: transparent;
 		padding: 14px;
 	}
@@ -18,7 +18,7 @@
 	padding: 12px 24px 48px;
 	text-align: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-bottom: 72px;
 	}
 }
@@ -62,12 +62,12 @@
 }
 
 .activity-log-switch__feature-content {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-basis: 66%;
 		text-align: left;
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		order: 2;
 	}
 
@@ -82,7 +82,7 @@
 	margin-bottom: 8px;
 	width: 100%;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		order: 1;
 	}
 }
@@ -92,7 +92,7 @@
 	max-height: 110px;
 	box-sizing: border-box;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		order: 0;
 		max-width: none;
 		height: 90px;

--- a/client/my-sites/activity/activity-log/rewind-alerts.scss
+++ b/client/my-sites/activity/activity-log/rewind-alerts.scss
@@ -2,7 +2,7 @@
 	padding-bottom: 4px;
 	font-size: 13px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 14px;
 	}
 }
@@ -12,7 +12,7 @@
 	font-weight: 600;
 	color: var( --color-error );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-bottom: 24px;
 	}
 }

--- a/client/my-sites/activity/activity-log/style.scss
+++ b/client/my-sites/activity/activity-log/style.scss
@@ -10,7 +10,7 @@
 		left: 33px;
 		width: 2px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			left: 25px;
 		}
 	}
@@ -37,7 +37,7 @@
 	background: var( --color-surface-backdrop );
 	font-weight: 600;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-left: 10px;
 	}
 

--- a/client/my-sites/activity/activity-log/threat-alert.scss
+++ b/client/my-sites/activity/activity-log/threat-alert.scss
@@ -3,7 +3,7 @@
 	font-size: 13px;
 	box-shadow: 0 -1px 0 rbga( var( --color-neutral-10 ), 0.5 );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 14px;
 	}
 
@@ -18,7 +18,7 @@
 		padding: 7px;
 		width: 24px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding-left: 8px;
 		}
 	}
@@ -40,7 +40,7 @@
 	.foldable-card__content {
 		padding-left: 48px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding-left: 56px;
 		}
 
@@ -90,7 +90,7 @@
 	font-size: 13px;
 	font-weight: 600;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 14px;
 	}
 }

--- a/client/my-sites/activity/filterbar/style.scss
+++ b/client/my-sites/activity/filterbar/style.scss
@@ -33,7 +33,7 @@
 		color: var( --color-neutral );
 		white-space: nowrap;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin: 0 8px 0 16px;
 		}
 	}
@@ -56,7 +56,7 @@
 		background: var( --color-neutral-60 );
 		color: var( --color-text-inverted );
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-right: 0;
 			border-top-right-radius: 0;
 			border-bottom-right-radius: 0;
@@ -85,7 +85,7 @@
 		border: 1px solid var( --color-neutral-60 );
 		display: none;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: inline;
 		}
 	}
@@ -100,7 +100,7 @@
 	min-width: 200px;
 	padding: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 24px 24px 18px;
 	}
 
@@ -110,7 +110,7 @@
 		text-align: left;
 		cursor: pointer;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-bottom: 5px;
 			font-size: 14px;
 		}
@@ -148,7 +148,7 @@
 	width: 280px;
 	margin: 0 auto;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 16px;
 	}
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -170,7 +170,7 @@
 	.cart__coupon {
 		font-size: 11px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 
@@ -222,7 +222,7 @@
 	margin: 15px 15px 0;
 	padding: 10px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 
@@ -256,7 +256,7 @@
 		min-width: auto;
 		padding: 0 15px 0 10px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 14px 20px 12px;
 		}
 	}
@@ -278,7 +278,7 @@
 	right: 2px;
 	animation: pulsing-badge 2s infinite;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		top: 5px;
 		right: 5px;
 	}
@@ -420,7 +420,7 @@ div.popover-cart__popover {
 }
 
 .secondary-cart {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		left: 0;
 		margin-left: 0;
 		margin-top: 10px;
@@ -450,7 +450,7 @@ div.popover-cart__popover {
 	margin-top: 0;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.secondary-cart__hidden {
 		display: none;
 	}

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
@@ -17,7 +17,7 @@
 .button.google-voucher__setup-google-adwords:not( .is-compact ) {
 	margin-top: 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		text-align: center;
 	}
 }
@@ -32,7 +32,7 @@
 		list-style-position: inside;
 		margin: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			list-style-position: outside;
 			margin: 0 3em 1.5em;
 		}
@@ -92,7 +92,7 @@ li.google-voucher__terms-and-conditions {
 	margin-top: 16px;
 	display: block;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		max-width: none;
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -4,7 +4,7 @@
 	text-align: center;
 	width: 100%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		background: transparent;
 		padding: 14px;
 	}
@@ -69,7 +69,7 @@
 	line-height: 32px;
 	margin: 48px 48px 24px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		box-shadow: none;
 		margin-bottom: 0;
 	}
@@ -86,7 +86,7 @@
 .checkout-thank-you__purchase-details-list {
 	text-align: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 0 24px;
 		padding-bottom: 48px;
 	}
@@ -99,7 +99,7 @@
 	padding: 12px 24px 48px;
 	text-align: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-bottom: 72px;
 	}
 }
@@ -181,11 +181,11 @@
 }
 
 .checkout-thank-you__header.is-placeholder {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding-top: 170px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-left: 190px;
 	}
 
@@ -200,7 +200,7 @@
 
 		display: block;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin: 0 auto;
 		}
 	}
@@ -216,7 +216,7 @@
 		margin-top: 15px;
 		width: 90%;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-bottom: 18px;
 			margin-top: 18px;
 		}
@@ -232,7 +232,7 @@
 .checkout-thank-you__footer {
 	padding: 32px 20px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 16px;
 		padding: 60px 24px;
 		text-align: left;
@@ -379,21 +379,21 @@
 	opacity: 0.1;
 	animation: focus 5s infinite ease-in-out;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		left: 0;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		transform: scale( 0.8 );
 		left: 130px;
 		top: -120px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		transform: scale( 1.2 );
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		transform: scale( 1.5 );
 	}
 

--- a/client/my-sites/checkout/checkout/checkout-container.scss
+++ b/client/my-sites/checkout/checkout/checkout-container.scss
@@ -18,7 +18,7 @@
 		width: 100%;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 		align-items: flex-start;
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -12,7 +12,7 @@
 		box-sizing: border-box;
 		background: var( --color-border-subtle );
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: calc( 100% + 60px );
 			left: -30px;
 		}
@@ -45,7 +45,7 @@
 		}
 
 		&:not( .domain-details ) {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				box-shadow: none;
 			}
 		}
@@ -96,7 +96,7 @@
 				flex: 1 1 auto;
 				margin-bottom: 15px;
 
-				@include breakpoint( '>480px' ) {
+				@include breakpoint-deprecated( '>480px' ) {
 					flex: 2 1 auto;
 				}
 			}
@@ -106,7 +106,7 @@
 			}
 
 			.placeholder-inline-pad-only-wide {
-				@include breakpoint( '>480px' ) {
+				@include breakpoint-deprecated( '>480px' ) {
 					padding-right: 15px;
 				}
 			}
@@ -116,7 +116,7 @@
 				margin-bottom: 15px;
 				flex: 0 0 100%;
 
-				@include breakpoint( '>480px' ) {
+				@include breakpoint-deprecated( '>480px' ) {
 					flex: 6 3 auto;
 				}
 			}
@@ -125,7 +125,7 @@
 				height: 50px;
 				width: 100%;
 
-				@include breakpoint( '>480px' ) {
+				@include breakpoint-deprecated( '>480px' ) {
 					width: 80px;
 					height: 40px;
 				}
@@ -134,7 +134,7 @@
 			.placeholder-button-container {
 				margin-top: 55px;
 
-				@include breakpoint( '>480px' ) {
+				@include breakpoint-deprecated( '>480px' ) {
 					margin-top: 20px;
 				}
 			}
@@ -145,7 +145,7 @@
 				height: 0;
 				border-bottom: 1px solid var( --color-neutral-0 );
 
-				@include breakpoint( '<480px' ) {
+				@include breakpoint-deprecated( '<480px' ) {
 					display: none;
 				}
 			}
@@ -171,14 +171,14 @@
 	.checkout__box-padding {
 		padding: 16px 8px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 10px 30px 20px;
 		}
 	}
 
 	.domain-details {
 		.box-padding {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				padding: 16px;
 			}
 		}
@@ -187,14 +187,14 @@
 	form {
 		margin-top: 5px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			@include clear-fix;
 		}
 	}
 
 	button[type='submit'].checkout__pay-button-button,
 	button[type='submit'].button-pay {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			width: 100%;
 
 			.wpcom-site & {
@@ -202,7 +202,7 @@
 			}
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			clear: both;
 			float: left;
 		}
@@ -240,7 +240,7 @@
 	.form-button {
 		margin-top: 20px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-bottom: 20px;
 		}
 	}
@@ -266,7 +266,7 @@
 		margin: 16px 0;
 		padding: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 0;
 			text-align: left;
 		}
@@ -275,7 +275,7 @@
 			font-size: 12px;
 			margin: 0;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				margin-left: 24px;
 			}
 		}
@@ -283,7 +283,7 @@
 		.gridicon {
 			float: left;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: none;
 			}
 		}
@@ -297,7 +297,7 @@
 		padding: 10px 0;
 
 		// On larger screens, users can use the coupon functionality present on the sidebar
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: block;
 			text-align: center;
 		}
@@ -320,7 +320,7 @@
 			background-color: var( --color-surface );
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.075 );
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				box-shadow: none;
 			}
 		}
@@ -383,7 +383,7 @@
 		padding: 10px;
 		margin: 0 auto;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: none;
 		}
 	}
@@ -396,7 +396,7 @@
 		padding-bottom: 10px;
 		margin: 15px 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding-bottom: 30px;
 			margin-bottom: 20px;
 		}
@@ -409,7 +409,7 @@
 		padding-top: 10px;
 		position: relative;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-top: 30px;
 			padding-top: 20px;
 		}
@@ -428,7 +428,7 @@
 			background-color: var( --color-surface );
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.075 );
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				box-shadow: none;
 			}
 		}
@@ -505,7 +505,7 @@
 			.wordpress-logo {
 				fill: var( --color-primary );
 				margin: 0 10px;
-				@include breakpoint( '>660px' ) {
+				@include breakpoint-deprecated( '>660px' ) {
 					margin: 0 20px;
 				}
 			}
@@ -534,7 +534,7 @@
 					max-height: 100px;
 				}
 
-				@include breakpoint( '>960px' ) {
+				@include breakpoint-deprecated( '>960px' ) {
 					float: right;
 					margin-left: 20px;
 					width: calc( 20% - 20px );
@@ -547,7 +547,7 @@
 			.checkout__free-stand-alone-domain-mapping-illustration + h6 + span {
 				display: block;
 
-				@include breakpoint( '>960px' ) {
+				@include breakpoint-deprecated( '>960px' ) {
 					clear: none;
 					float: left;
 					width: calc( 75% - 20px );
@@ -603,7 +603,7 @@
 		padding: 15px 0;
 		@include clear-fix;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			border-bottom: 1px solid var( --color-neutral-10 );
 			margin: 30px 0;
 		}
@@ -612,13 +612,13 @@
 			color: var( --color-neutral-20 );
 			text-align: center;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				float: left;
 				margin: 0 5%;
 				width: 40%;
 			}
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				margin: 0;
 				padding: 15px;
 			}
@@ -651,7 +651,7 @@
 	margin-top: 15px;
 	padding: 10px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		box-sizing: border-box;
 		padding: 15px;
 		width: 100%;
@@ -679,7 +679,7 @@
 			border-color: #00aadc;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: flex;
 			flex-direction: column;
 			justify-content: space-between;
@@ -719,7 +719,7 @@
 
 // If there's no sidebar, we don't show the cart on the checkout page.
 
-@include breakpoint( '>660px' ) {
+@include breakpoint-deprecated( '>660px' ) {
 	.pay-button,
 	.checkout__pay-button {
 		float: left;
@@ -750,20 +750,20 @@
 		margin-left: 1em;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		border-bottom: 1px solid var( --color-neutral-0 );
 		margin: 10px 0 0;
 		text-align: center;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		float: right;
 		clear: none;
 	}
 }
 
 .credit-card-payment-box__switch-link-left {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		float: left;
 		padding-left: 20px;
 	}
@@ -771,7 +771,7 @@
 
 .checkout__payment-box-buttons,
 .payment-box__payment-buttons {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 		flex-wrap: wrap;
 	}
@@ -780,14 +780,14 @@
 	.pay-button {
 		margin-right: 10px;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			flex: 1 0 50%;
 		}
 	}
 
 	.checkout__pay-button-button,
 	.pay-button__button {
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			width: 100%;
 		}
 	}
@@ -798,7 +798,7 @@
 	flex-grow: 1;
 	margin-top: 10px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: 1 0 40%;
 	}
 }
@@ -808,7 +808,7 @@
 	align-items: center;
 	justify-content: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		justify-content: left;
 	}
 }
@@ -817,13 +817,13 @@
 	color: var( --color-accent );
 	text-align: left;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		text-align: center;
 		margin-top: 5px;
 		width: 100%;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		justify-content: flex-end;
 	}
 
@@ -842,7 +842,7 @@
 }
 
 .credits-payment-box .checkout__payment-chat-button {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		float: right;
 	}
 }
@@ -946,7 +946,7 @@
 				color: var( --color-primary );
 				background-color: var( --color-neutral-0 );
 
-				@include breakpoint( '>480px' ) {
+				@include breakpoint-deprecated( '>480px' ) {
 					background-color: transparent;
 				}
 			}
@@ -1022,7 +1022,7 @@
 	.checkout__apple-pay {
 		height: 35px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin: -5px 0;
 		}
 	}
@@ -1030,7 +1030,7 @@
 	.checkout__ovo {
 		height: 35px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin: -5px 0;
 		}
 	}
@@ -1061,7 +1061,7 @@
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.is-open .section-nav__panel {
 			padding-bottom: 0;
 		}
@@ -1092,7 +1092,7 @@
 	.checkout__form-state-field {
 		margin-left: 0;
 	}
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		.address-2,
 		.city {
 			flex-basis: calc( 100% - 15px );
@@ -1141,7 +1141,7 @@
 		// show the masterbar.
 		padding-top: 48px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding-top: 0;
 		}
 	}
@@ -1213,7 +1213,7 @@
 	width: 100%;
 	display: flex;
 	justify-content: center;
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 	.checkout__site-created-copy {

--- a/client/my-sites/checkout/checkout/subscription-text.scss
+++ b/client/my-sites/checkout/checkout/subscription-text.scss
@@ -7,7 +7,7 @@
 	margin: 0 0 0 10px;
 	white-space: nowrap;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: block;
 		text-align: center;
 	}

--- a/client/my-sites/checkout/gsuite-nudge/style.scss
+++ b/client/my-sites/checkout/gsuite-nudge/style.scss
@@ -7,7 +7,7 @@ main.gsuite-nudge.main {
 	position: static;
 	width: 100%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		background: transparent;
 		padding: 14px;
 	}

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/style.scss
@@ -31,7 +31,7 @@ main.concierge-quickstart-session.main {
 
 	&__column-content {
 		padding-right: 10px;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding-right: 0;
 		}
 	}
@@ -39,7 +39,7 @@ main.concierge-quickstart-session.main {
 	&__column-doodle {
 		width: 120px;
 		flex-shrink: 0;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}
@@ -61,7 +61,7 @@ main.concierge-quickstart-session.main {
 		margin-top: 0.5em;
 		margin-bottom: 1.4em;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 21px;
 		}
 	}
@@ -75,7 +75,7 @@ main.concierge-quickstart-session.main {
 			align-items: flex-start;
 			margin-bottom: 4px;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				align-items: flex-start;
 			}
 		}
@@ -94,22 +94,22 @@ main.concierge-quickstart-session.main {
 	&__footer &__decline-offer-button {
 		color: var( --color-primary );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			float: left;
 		}
 	}
 
 	&__footer &__accept-offer-button {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			margin-top: 10px;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			float: right;
 		}
 	}

--- a/client/my-sites/checkout/upsell-nudge/concierge-support-session/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/concierge-support-session/style.scss
@@ -38,7 +38,7 @@ main.concierge-support-session.main {
 		height: 50px;
 		width: 100%;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 80px;
 			height: 40px;
 		}
@@ -66,7 +66,7 @@ main.concierge-support-session.main {
 
 	&__column-content {
 		padding-right: 10px;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding-right: 0;
 		}
 	}
@@ -74,7 +74,7 @@ main.concierge-support-session.main {
 	&__column-doodle {
 		width: 120px;
 		flex-shrink: 0;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}
@@ -95,7 +95,7 @@ main.concierge-support-session.main {
 		margin-top: 5px;
 		margin-bottom: 0.75em;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 18px;
 		}
 	}
@@ -109,7 +109,7 @@ main.concierge-support-session.main {
 			align-items: center;
 			margin-bottom: 4px;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				align-items: flex-start;
 			}
 		}
@@ -128,24 +128,23 @@ main.concierge-support-session.main {
 	&__footer &__decline-offer-button {
 		color: var( --color-primary );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			float: left;
 		}
 	}
 
 	&__footer &__accept-offer-button {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			margin-top: 10px;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			float: right;
 		}
 	}
 }
-

--- a/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/plan-upgrade-upsell/style.scss
@@ -34,7 +34,7 @@ main.plan-upgrade-upsell.main {
 		height: 50px;
 		width: 100%;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 80px;
 			height: 40px;
 		}
@@ -62,7 +62,7 @@ main.plan-upgrade-upsell.main {
 
 	&__column-content {
 		padding-right: 10px;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding-right: 0;
 		}
 	}
@@ -70,7 +70,7 @@ main.plan-upgrade-upsell.main {
 	&__column-doodle {
 		width: 120px;
 		flex-shrink: 0;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}
@@ -92,7 +92,7 @@ main.plan-upgrade-upsell.main {
 		margin-top: 0.5em;
 		margin-bottom: 0.4em;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 21px;
 		}
 	}
@@ -104,7 +104,7 @@ main.plan-upgrade-upsell.main {
 		margin-top: 5px;
 		margin-bottom: 1.6em;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 18px;
 		}
 	}
@@ -118,7 +118,7 @@ main.plan-upgrade-upsell.main {
 			align-items: flex-start;
 			margin-bottom: 1.2em;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				align-items: flex-start;
 			}
 		}
@@ -137,24 +137,23 @@ main.plan-upgrade-upsell.main {
 	&__footer &__decline-offer-button {
 		color: var( --color-primary );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			float: left;
 		}
 	}
 
 	&__footer &__accept-offer-button {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			margin-top: 10px;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			float: right;
 		}
 	}
 }
-

--- a/client/my-sites/checkout/upsell-nudge/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/style.scss
@@ -18,7 +18,7 @@
     height: 50px;
     width: 100%;
 
-    @include breakpoint( '>480px' ) {
+    @include breakpoint-deprecated( '>480px' ) {
         width: 80px;
         height: 40px;
     }

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -16,7 +16,7 @@
 			0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 10px auto;
 	}
 }
@@ -308,7 +308,7 @@
 	padding-top: 8px;
 	padding-bottom: 8px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		justify-content: flex-start;
 		margin-left: 40px;
 		padding-top: 0;
@@ -346,13 +346,13 @@
 		color: var( --color-primary );
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		span {
 			display: block;
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-basis: auto;
 		flex-grow: 0;
 		padding: 8px 16px;
@@ -439,7 +439,7 @@
 		padding: 0 8px;
 		width: 50%;
 
-		@include breakpoint( '>1280px' ) {
+		@include breakpoint-deprecated( '>1280px' ) {
 			width: 33%;
 		}
 	}
@@ -596,7 +596,7 @@
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 90%;
 		.dialog__content {
 			min-width: none;

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -1,5 +1,5 @@
 .comment-navigation {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.section-nav__mobile-header::after {
 			padding-left: 8px;
 		}
@@ -20,7 +20,7 @@
 .comment-navigation.is-bulk-edit {
 	padding-right: 0;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.section-nav__mobile-header {
 			display: none;
 		}
@@ -100,7 +100,7 @@
 	white-space: nowrap;
 }
 
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 	.comment-list__header .header-cake__back.button.is-borderless.is-compact .gridicons-visible {
 		display: block;
 		margin: 0 auto;

--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -6,7 +6,7 @@
 		color: var( --color-text-inverted );
 		display: flex;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding: 0 19px;
 		}
 

--- a/client/my-sites/customer-home/cards/actions/quick-links/style.scss
+++ b/client/my-sites/customer-home/cards/actions/quick-links/style.scss
@@ -3,7 +3,7 @@
 		padding: 16px;
 		min-height: auto;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 16px 24px;
 		}
 	}
@@ -56,7 +56,7 @@
 		font-size: 14px;
 		display: none;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			display: block;
 		}
 	}

--- a/client/my-sites/customer-home/cards/features/go-mobile/style.scss
+++ b/client/my-sites/customer-home/cards/features/go-mobile/style.scss
@@ -1,5 +1,5 @@
 .customer-home__layout-col-right {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.go-mobile__subheader.customer-home__card-subheader {
 			margin-bottom: 0;
 		}

--- a/client/my-sites/customer-home/cards/features/stats/style.scss
+++ b/client/my-sites/customer-home/cards/features/stats/style.scss
@@ -1,5 +1,5 @@
 .stats .card {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 16px 24px;
 	}
 }
@@ -11,7 +11,7 @@
 .stats .chart {
 	margin: 0 -16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin: 0 -24px;
 	}
 
@@ -23,7 +23,7 @@
 		padding: 16px;
 		margin: -16px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding: 16px 24px;
 			margin: -16px -24px;
 		}
@@ -75,12 +75,12 @@
 		padding-right: 24px;
 		border-right: none;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding: 16px;
 		}
 	}
 
-	@include breakpoint( '1040px-1280px', '<960px' ) {
+	@include breakpoint-deprecated( '1040px-1280px', '<960px' ) {
 		width: 50%;
 
 		&:nth-child( 1 ),

--- a/client/my-sites/customer-home/cards/features/support/style.scss
+++ b/client/my-sites/customer-home/cards/features/support/style.scss
@@ -11,7 +11,7 @@
 		width: 137px;
 		height: 119px;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			display: none;
 		}
 	}
@@ -19,7 +19,7 @@
 	.vertical-nav {
 		width: 60%;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			width: 100%;
 		}
 	}

--- a/client/my-sites/customer-home/cards/notices/celebrate-notice/style.scss
+++ b/client/my-sites/customer-home/cards/notices/celebrate-notice/style.scss
@@ -6,7 +6,7 @@
 		margin-right: 18px;
 		width: 100px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -2,7 +2,7 @@
 	padding: 0;
 	display: flex;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		display: block;
 	}
 
@@ -11,11 +11,11 @@
 		flex-shrink: 0;
 		border-right: 1px solid var( --color-border-subtle );
 
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			width: 260px;
 		}
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			width: 100%;
 		}
 	}
@@ -43,7 +43,7 @@
 		&:hover {
 			background-color: var( --color-neutral-0 );
 
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				background-color: transparent;
 			}
 		}
@@ -52,7 +52,7 @@
 			background-color: var( --color-primary-0 );
 			font-weight: 600;
 
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				background-color: transparent;
 			}
 		}

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -8,7 +8,7 @@
 		box-sizing: border-box;
 		padding: 24px;
 
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			padding: 32px;
 		}
 	}
@@ -51,7 +51,7 @@
 		line-height: 36px;
 		margin-bottom: 4px;
 
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			font-size: 32px;
 			line-height: 40px;
 		}
@@ -63,7 +63,7 @@
 		line-height: 24px;
 		color: var( --color-text );
 
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			font-size: 18px;
 			line-height: 28px;
 			margin-bottom: 32px;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -22,7 +22,7 @@
 	display: flex;
 	border-bottom: 1px solid var( --color-neutral-5 );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding-right: 16px;
 	}
 
@@ -51,7 +51,7 @@
 
 .customer-home__layout {
 	@include grid-row( 4, 1 );
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		@include grid-column( 1, 12 );
 		@include display-grid;
 		@include grid-template-columns( 12, 24px, 1fr );
@@ -60,13 +60,13 @@
 }
 
 .customer-home__layout-col-left {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		@include grid-column( 1, 8 );
 	}
 }
 
 .customer-home__layout-col-right {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		@include grid-column( 9, 4 );
 	}
 
@@ -87,7 +87,7 @@
 	font-size: 1.25rem;
 	margin: 32px 0 16px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 0 16px;
 	}
 }

--- a/client/my-sites/domains/components/domain-warnings/style.scss
+++ b/client/my-sites/domains/components/domain-warnings/style.scss
@@ -25,7 +25,7 @@
 	min-width: 400px;
 	max-width: 600px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		min-width: none;
 		max-width: none;
 	}

--- a/client/my-sites/domains/domain-management/components/domain/main-placeholder.scss
+++ b/client/my-sites/domains/domain-management/components/domain/main-placeholder.scss
@@ -2,7 +2,7 @@
 	.domain-management-header__children {
 		@include placeholder( --color-neutral-10 );
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			max-width: 60%;
 			margin: 0 auto;
 		}

--- a/client/my-sites/domains/domain-management/components/form-footer/style.scss
+++ b/client/my-sites/domains/domain-management/components/form-footer/style.scss
@@ -5,12 +5,12 @@
 	display: flex;
 	justify-content: flex-start;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 24px;
 		margin: 24px -24px -24px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-direction: column;
 	}
 
@@ -20,16 +20,16 @@
 		&.is-primary {
 			margin: 0 0 15px;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				margin: 0;
 			}
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				order: 1;
 			}
 		}
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			order: 2;
 		}

--- a/client/my-sites/domains/domain-management/contacts-privacy/style.scss
+++ b/client/my-sites/domains/domain-management/contacts-privacy/style.scss
@@ -5,7 +5,7 @@
 		&.warning {
 			color: var( --color-text-subtle );
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				padding: 0;
 				text-align: left;
 			}
@@ -14,7 +14,7 @@
 				font-size: 12px;
 				margin: 0;
 
-				@include breakpoint( '>660px' ) {
+				@include breakpoint-deprecated( '>660px' ) {
 					margin-left: 24px;
 				}
 			}
@@ -22,7 +22,7 @@
 			.gridicon {
 				float: left;
 
-				@include breakpoint( '<660px' ) {
+				@include breakpoint-deprecated( '<660px' ) {
 					display: none;
 				}
 			}

--- a/client/my-sites/domains/domain-management/edit/card/subscription-settings/style.scss
+++ b/client/my-sites/domains/domain-management/edit/card/subscription-settings/style.scss
@@ -4,7 +4,7 @@
 	text-align: center;
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		text-align: inherit;
 		width: inherit;
 	}

--- a/client/my-sites/domains/domain-management/edit/style.scss
+++ b/client/my-sites/domains/domain-management/edit/style.scss
@@ -26,13 +26,13 @@
 			color: var( --color-neutral-50 );
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			display: inline-block;
 			width: auto;
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		.edit__transfer-button-fail-margin {
 			margin-left: 15px;
 		}
@@ -69,7 +69,7 @@
 			overflow: hidden;
 			text-overflow: ellipsis;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				&.mobile-m {
 					font-size: 28px;
 				}
@@ -84,7 +84,7 @@
 				}
 			}
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				&.desktop-m {
 					font-size: 28px;
 				}
@@ -151,7 +151,7 @@
 			margin-right: 24px;
 		}
 
-		@include breakpoint( '<800px' ) {
+		@include breakpoint-deprecated( '<800px' ) {
 			.domain-types__break {
 				flex-basis: 100%;
 				height: 0;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -44,7 +44,7 @@
 	text-align: inherit;
 	line-height: normal;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 18px;
 		font-weight: 600;
 		max-width: none;
@@ -60,7 +60,7 @@
 	overflow: hidden;
 	line-height: normal;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		text-transform: uppercase;
 	}
 
@@ -105,7 +105,7 @@
 	display: flex;
 	justify-content: space-between;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		justify-content: flex-start;
 		flex-direction: column;
 	}
@@ -131,7 +131,7 @@ input[type='radio'].domain-management-list-item__radio {
 	overflow: hidden;
 	margin-top: 5px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		float: right;
 		margin-top: -11px;
 		margin-right: 15px;
@@ -143,7 +143,7 @@ input[type='radio'].domain-management-list-item__radio {
 }
 
 .domain-management__claim-free-domain {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 }

--- a/client/my-sites/domains/domain-management/name-servers/style.scss
+++ b/client/my-sites/domains/domain-management/name-servers/style.scss
@@ -71,7 +71,7 @@
 	input[type='text'] {
 		padding-right: 38px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding-right: 35px;
 		}
 	}
@@ -81,7 +81,7 @@
 		right: 7px;
 		top: 8px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			right: 4px;
 		}
 	}

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-user/style.scss
@@ -1,7 +1,7 @@
 .transfer-to-other-user__select {
 	margin-top: 20px;
 	width: 100%;
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		width: 300px;
 	}
 
@@ -9,7 +9,7 @@
 .transfer-to-other-user__confirmation-dialog {
 	width: 90%;
 
-	@include breakpoint('>480px') {
+	@include breakpoint-deprecated('>480px') {
 		max-width: 500px;
 	}
 }

--- a/client/my-sites/domains/domain-search/site-redirect-step.scss
+++ b/client/my-sites/domains/domain-search/site-redirect-step.scss
@@ -25,7 +25,7 @@
 		margin-bottom: 20px;
 		min-width: 0;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			float: right;
 			margin-top: -5px;
 			margin-bottom: 0;
@@ -36,7 +36,7 @@
 .site-redirect-step__domain-description {
 	word-break: break-word;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-width: 75%;
 		float: left;
 		margin-bottom: 20px;
@@ -44,7 +44,7 @@
 }
 
 input.site-redirect-step__external-domain {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		float: left;
 		width: calc( 100% - 90px );
 	}
@@ -54,7 +54,7 @@ input.site-redirect-step__external-domain {
 	margin: 10px 0 0;
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		float: right;
 		margin: 0;
 		width: 80px;

--- a/client/my-sites/domains/domain-search/style.scss
+++ b/client/my-sites/domains/domain-search/style.scss
@@ -16,7 +16,7 @@
 	font-size: 15px;
 	word-wrap: break-word;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 17px;
 	}
 }

--- a/client/my-sites/earn/ads/style.scss
+++ b/client/my-sites/earn/ads/style.scss
@@ -32,7 +32,7 @@
 	text-align: center;
 	border-left: 1px solid var( --color-neutral-0 );
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: auto;
 		float: none;
 		padding: 10px 24px;
@@ -53,7 +53,7 @@
 	line-height: 1.6;
 	text-transform: uppercase;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		font-size: 14px;
 		line-height: 1.8;
 	}
@@ -64,7 +64,7 @@
 	display: block;
 	font-size: 25px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: auto;
 		float: right;
 		font-size: 16px;
@@ -119,13 +119,13 @@
 	line-height: 40px;
 	text-align: center;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		&:first-child, &:last-child {
 			font-size: 12px;
 		}
 	}
 }
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 	.ads__settings-state {
 		max-width: 75%;
 	}

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -30,7 +30,7 @@
 }
 .memberships__onboarding-column-image {
 	display: none;
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		display: block;
 		flex: 1;
 		padding-left: 10px;
@@ -69,7 +69,7 @@
 	line-height: 1.8;
 	text-transform: uppercase;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 10px;
 		line-height: 1.6;
 	}
@@ -82,7 +82,7 @@
 	list-style-type: none;
 	text-align: center;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: auto;
 		float: none;
 		padding: 10px 24px;
@@ -97,7 +97,7 @@
 	line-height: 1.8;
 	text-transform: uppercase;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 10px;
 		line-height: 1.6;
 	}
@@ -108,7 +108,7 @@
 	display: block;
 	font-size: 25px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: auto;
 		float: right;
 		font-size: 16px;
@@ -144,7 +144,7 @@
 	width: 56px !important;
 	height: 56px !important;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: 72px !important;
 		height: 72px !important;
 	}
@@ -153,7 +153,7 @@
 .memberships__subscriber-detail {
 	margin-left: 80px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-left: 96px;
 	}
 }
@@ -166,7 +166,7 @@
 	text-overflow: clip;
 	overflow: hidden;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 21px;
 	}
 
@@ -179,7 +179,7 @@
 	color: var( --color-text-subtle );
 	font-size: 13px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 15px;
 		margin-top: -3px;
 	}

--- a/client/my-sites/earn/refer-a-friend/style.scss
+++ b/client/my-sites/earn/refer-a-friend/style.scss
@@ -3,7 +3,7 @@
 		.promo-card {
 			width: calc( 100% - 1em );
 
-			@include breakpoint( '>1280px' ) {
+			@include breakpoint-deprecated( '>1280px' ) {
 				width: calc( 100% - 1em );
 			}
 		}

--- a/client/my-sites/email/email-forwarding/style.scss
+++ b/client/my-sites/email/email-forwarding/style.scss
@@ -32,7 +32,7 @@
 .email-forwarding__form {
 	margin-top: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-top: 15px;
 	}
 }
@@ -52,7 +52,7 @@ ul.email-forwarding__list {
 			font-size: 14px;
 			line-height: 40px;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				font-size: 12px;
 				line-height: 150%;
 			}
@@ -62,12 +62,12 @@ ul.email-forwarding__list {
 				font-weight: normal;
 
 				&:first-child {
-					@include breakpoint( '<660px' ) {
+					@include breakpoint-deprecated( '<660px' ) {
 						display: block;
 					}
 				}
 
-				@include breakpoint( '>660px' ) {
+				@include breakpoint-deprecated( '>660px' ) {
 					font-weight: 600;
 				}
 			}

--- a/client/my-sites/email/gsuite-add-users/style.scss
+++ b/client/my-sites/email/gsuite-add-users/style.scss
@@ -7,7 +7,7 @@
 		width: 100%;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 
 		button {

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -2,11 +2,11 @@
 	color: #757575;
 	font-size: 150%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 236px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		float: left;
 	}
 
@@ -34,7 +34,7 @@
 	flex-direction: column;
 	font-size: 14px;
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		flex-basis: 100%;
 		max-width: 410px;
 	}
@@ -54,7 +54,7 @@
 .gsuite-purchase-cta__header-image {
 	display: none;
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		align-items: center;
 		display: flex;
 		flex-grow: 1;
@@ -68,11 +68,11 @@
 	flex-direction: column;
 	justify-content: space-evenly;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		justify-content: space-between;
 	}
 }
@@ -120,13 +120,13 @@
 	padding-left: 2em;
 	padding-right: 2em;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 100%;
 	}
 }
 
 .gsuite-purchase-cta__info .gsuite-learn-more {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		text-align: center;
 	}
 }

--- a/client/my-sites/exporter/guided-transfer-card/style.scss
+++ b/client/my-sites/exporter/guided-transfer-card/style.scss
@@ -75,7 +75,7 @@
 	font-size: 16px;
 	text-align: center;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-left: 128px;
 		text-align: left;
 	}
@@ -90,7 +90,7 @@
 	background-color: var( --color-neutral-50 );
 	color: var( --color-neutral-0 );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		position: absolute;
 		margin-left: -96px;
 		margin-top: 16px;

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -45,7 +45,7 @@
 }
 
 .export-card__advanced-settings-row {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 		flex-wrap: wrap;
 	}
@@ -54,7 +54,7 @@
 .export-card__option-fieldset {
 	margin-top: 10px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-top: inherit;
 		flex: 1;
 	}

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -44,11 +44,11 @@ $feature-upsell-break-at: '1040px';
 	margin-bottom: 15px;
 	text-align: center;
 
-	@include breakpoint( '<1280px' ) {
+	@include breakpoint-deprecated( '<1280px' ) {
 		font-size: 30px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		font-size: 26px;
 	}
 }
@@ -61,11 +61,11 @@ $feature-upsell-break-at: '1040px';
 	margin-bottom: 15px;
 	text-align: center;
 
-	@include breakpoint( '<1280px' ) {
+	@include breakpoint-deprecated( '<1280px' ) {
 		font-size: 28px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		font-size: 24px;
 	}
 
@@ -79,13 +79,13 @@ $feature-upsell-break-at: '1040px';
 
 	&.is-h4 {
 		font-size: 20px;
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			&.is-h4 {
 				font-size: 18px;
 			}
 		}
 
-		//@include breakpoint( '<660px' ) {
+		//@include breakpoint-deprecated( '<660px' ) {
 		//	&.is-h4 {
 		//		font-size: 16px;
 		//	}
@@ -106,11 +106,11 @@ $feature-upsell-break-at: '1040px';
 		padding: 14px 48px;
 		line-height: 1.2;
 
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			font-size: 20px;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 18px;
 		}
 	}
@@ -138,14 +138,14 @@ $feature-upsell-break-at: '1040px';
 		margin-top: 30px;
 		.feature-upsell__cta-button {
 			margin: 20px 0 0;
-			@include breakpoint( '<1280px' ) {
+			@include breakpoint-deprecated( '<1280px' ) {
 				margin-left: auto;
 				margin-right: auto;
 			}
 		}
 		.feature-upsell__cta-guarantee {
 			margin-top: 8px;
-			@include breakpoint( '<1280px' ) {
+			@include breakpoint-deprecated( '<1280px' ) {
 				text-align: center;
 			}
 		}
@@ -161,7 +161,7 @@ $feature-upsell-break-at: '1040px';
 			line-height: 1.25;
 			font-size: 26px;
 			padding-right: 30px;
-			@include breakpoint( '<1280px' ) {
+			@include breakpoint-deprecated( '<1280px' ) {
 				font-size: 22px;
 			}
 		}
@@ -177,7 +177,7 @@ $feature-upsell-break-at: '1040px';
 			margin-top: 10px;
 		}
 
-		@include breakpoint( '<1040px' ) {
+		@include breakpoint-deprecated( '<1040px' ) {
 			text-align: center;
 
 			.feature-upsell__cta-pitch {
@@ -207,11 +207,11 @@ $feature-upsell-break-at: '1040px';
 		font-weight: 400;
 		margin-bottom: 20px;
 
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			font-size: 30px;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 26px;
 		}
 	}
@@ -220,7 +220,7 @@ $feature-upsell-break-at: '1040px';
 		font-size: 24px;
 		color: var( --color-neutral-60 );
 		margin-bottom: 20px;
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			font-size: 20px;
 		}
 	}
@@ -230,7 +230,7 @@ $feature-upsell-break-at: '1040px';
 		font-weight: 400;
 		color: var( --color-neutral-60 );
 		margin-bottom: 20px;
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			font-size: 18px;
 		}
 	}
@@ -243,7 +243,7 @@ $feature-upsell-break-at: '1040px';
 		font-size: 16px;
 		line-height: 1.625;
 		margin-top: 20px;
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-top: 15px;
 		}
 
@@ -269,7 +269,7 @@ $feature-upsell-break-at: '1040px';
 		overflow: hidden;
 		padding-top: 27.25%;
 		margin: 0 auto;
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			flex-basis: 100%;
 			padding-top: 41%;
 		}
@@ -295,7 +295,7 @@ $feature-upsell-break-at: '1040px';
 		font-size: 16px;
 		line-height: 1.625;
 
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			flex-basis: 100%;
 			margin-top: 20px;
 			margin-left: 0;
@@ -315,12 +315,12 @@ $feature-upsell-break-at: '1040px';
 	&-item {
 		@include feature-upsell-card;
 
-		@include breakpoint( '<#{$feature-upsell-break-at}' ) {
+		@include breakpoint-deprecated( '<#{$feature-upsell-break-at}' ) {
 			flex-flow: row wrap;
 			margin-bottom: 20px;
 		}
 
-		@include breakpoint( '>#{$feature-upsell-break-at}' ) {
+		@include breakpoint-deprecated( '>#{$feature-upsell-break-at}' ) {
 			&.is-enable-wordads {
 				.feature-upsell__benefits-list-image-wrapper {
 					width: 160px;
@@ -336,7 +336,7 @@ $feature-upsell-break-at: '1040px';
 		width: 100%;
 		display: flex;
 		flex-flow: column;
-		@include breakpoint( '<#{$feature-upsell-break-at}' ) {
+		@include breakpoint-deprecated( '<#{$feature-upsell-break-at}' ) {
 			flex-basis: 90%;
 		}
 	}
@@ -345,7 +345,7 @@ $feature-upsell-break-at: '1040px';
 		font-size: 24px;
 		font-weight: 600;
 		color: var( --color-neutral-60 );
-		@include breakpoint( '<1280px' ) {
+		@include breakpoint-deprecated( '<1280px' ) {
 			font-size: 20px;
 		}
 	}
@@ -354,7 +354,7 @@ $feature-upsell-break-at: '1040px';
 		font-size: 16px;
 		line-height: 1.625;
 		margin-top: 10px;
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-top: 15px;
 		}
 	}
@@ -365,14 +365,14 @@ $feature-upsell-break-at: '1040px';
 		max-width: 40%;
 		margin-left: 45px;
 
-		@include breakpoint( '<#{$feature-upsell-break-at}' ) {
+		@include breakpoint-deprecated( '<#{$feature-upsell-break-at}' ) {
 			order: 1;
 			flex-basis: 100%;
 			max-width: 30%;
 			margin: 0 auto 20px 0;
 		}
 
-		//@include breakpoint( '<660px' ) {
+		//@include breakpoint-deprecated( '<660px' ) {
 		//	max-width: 90%;
 		//}
 	}
@@ -383,7 +383,7 @@ $feature-upsell-break-at: '1040px';
 }
 
 .feature-upsell__text-content {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 0 2em;
 	}
 }
@@ -403,7 +403,7 @@ $feature-upsell-break-at: '1040px';
 		align-items: center;
 		margin-bottom: 8px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			align-items: flex-start;
 		}
 	}
@@ -442,7 +442,7 @@ $feature-upsell-break-at: '1040px';
 }
 
 .feature-upsell__features-list {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: space-between;
@@ -461,7 +461,7 @@ $feature-upsell-break-at: '1040px';
 		 */
 		width: 100%;
 
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			max-width: calc( 100% / 2 - 10px );
 		}
 	}
@@ -504,7 +504,7 @@ $feature-upsell-break-at: '1040px';
 		line-height: 1.6;
 		margin: 11px 0 0;
 
-		@include breakpoint( '<1040px' ) {
+		@include breakpoint-deprecated( '<1040px' ) {
 			font-size: 16px;
 		}
 	}

--- a/client/my-sites/google-my-business/location/style.scss
+++ b/client/my-sites/google-my-business/location/style.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	justify-content: space-between;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		flex-direction: column;
 	}
 

--- a/client/my-sites/google-my-business/new-account/style.scss
+++ b/client/my-sites/google-my-business/new-account/style.scss
@@ -6,7 +6,7 @@
 	margin-bottom: 10px;
 	max-width: 200px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-width: 300px;
 	}
 }

--- a/client/my-sites/google-my-business/select-business-type/style.scss
+++ b/client/my-sites/google-my-business/select-business-type/style.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	margin-bottom: 16px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		flex-direction: column-reverse;
 	}
 }
@@ -15,11 +15,11 @@
 .gmb-select-business-type__illustration {
 	max-width: 200px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		margin-bottom: 10px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: 50px;
 		max-width: 300px;
 	}

--- a/client/my-sites/google-my-business/select-location/style.scss
+++ b/client/my-sites/google-my-business/select-location/style.scss
@@ -7,19 +7,19 @@
 	.button, .gmb-select-location__status {
 		align-self: stretch;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			text-align: center;
 		}
 
-		@include breakpoint( '480px-960px' ) {
+		@include breakpoint-deprecated( '480px-960px' ) {
 			align-self: flex-start;
 		}
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			margin-top: 10px;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			align-self: center;
 			flex-shrink: 0;
 			margin-left: 15px;

--- a/client/my-sites/google-my-business/stats/style.scss
+++ b/client/my-sites/google-my-business/stats/style.scss
@@ -42,7 +42,7 @@
 .gmb-stats__chart-interval {
 	margin-top: 10px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 100%;
 	}
 }

--- a/client/my-sites/google-my-business/style.scss
+++ b/client/my-sites/google-my-business/style.scss
@@ -5,7 +5,7 @@
 	margin-bottom: 5px;
 	margin-top: 5px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 10px;
 		margin-top: 10px;
 	}
@@ -15,23 +15,23 @@
 .gmb-select-location__help-actions {
 	display: flex;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-direction: column;
 	}
 }
 
 .gmb-new-account__actions .button,
 .gmb-select-location__help-actions .button {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		text-align: center;
 	}
 
 	&:not( :last-child ) {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin-bottom: 10px;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-right: 10px;
 		}
 	}

--- a/client/my-sites/guided-transfer/style.scss
+++ b/client/my-sites/guided-transfer/style.scss
@@ -27,7 +27,7 @@
 		margin-bottom: 10px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.host-credentials-page__account-username-fieldset,
 		.host-credentials-page__account-password-fieldset,
 		.host-credentials-page__account-email-fieldset {

--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -23,7 +23,7 @@
 		flex-basis: 100%;
 	}
 
-	@include breakpoint( '>1280px' ) {
+	@include breakpoint-deprecated( '>1280px' ) {
 		&__layout-col:first-child {
 			box-sizing: border-box;
 			flex-basis: 70%;

--- a/client/my-sites/importer/author-mapping-item.scss
+++ b/client/my-sites/importer/author-mapping-item.scss
@@ -8,7 +8,7 @@
 	& > span:last-of-type {
 		width: 50%;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 65%;
 		}
 	}
@@ -20,7 +20,7 @@
 		align-items: center;
 		width: 100%;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			font-size: 12px;
 		}
 	}
@@ -38,7 +38,7 @@
 	font-size: 14px;
 	font-weight: 600;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 35%;
 	}
 }
@@ -47,7 +47,7 @@
 	float: left;
 	color: var( --color-neutral-20 );
 
-	@include breakpoint( '<480px') {
+	@include breakpoint-deprecated( '<480px') {
 		display: none;
 	}
 }

--- a/client/my-sites/importer/importer-action-buttons/action-button.scss
+++ b/client/my-sites/importer/importer-action-buttons/action-button.scss
@@ -2,7 +2,7 @@
 	width: 100%;
 	margin-bottom: 0.5em;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: auto;
 		margin-left: 0.75em;
 		margin-bottom: 0;
@@ -16,9 +16,8 @@
 	margin-top: 1.5em;
 	margin-bottom: 1em;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 		justify-content: flex-end;
 	}
 }
-

--- a/client/my-sites/importer/importer-header/style.scss
+++ b/client/my-sites/importer/importer-header/style.scss
@@ -9,7 +9,7 @@
 	.importer-header__service-title {
 		line-height: 40px;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			line-height: 56px;
 		}
 	}
@@ -29,10 +29,8 @@
 	color: var( --color-text-subtle );
 	clear: none;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		line-height: 1;
 		margin-bottom: 0.25em;
 	}
 }
-
-

--- a/client/my-sites/importer/importer-logo.scss
+++ b/client/my-sites/importer/importer-logo.scss
@@ -34,7 +34,7 @@
 		background-color: var( --color-squarespace );
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 56px;
 		height: 56px;
 		padding: 4px;

--- a/client/my-sites/importer/section-import.scss
+++ b/client/my-sites/importer/section-import.scss
@@ -3,7 +3,7 @@
 		margin: 0 auto;
 		max-width: 500px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -50,7 +50,7 @@
 		float: left;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.sharing-service__name {
 			margin-top: 12px;
 		}
@@ -60,11 +60,11 @@
 		margin-left: 56px;
 		width: 100%;
 
-		@include breakpoint( '<800px' ) {
+		@include breakpoint-deprecated( '<800px' ) {
 			margin-left: 0;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-left: 6px;
 		}
 	}
@@ -93,13 +93,13 @@
 		margin-bottom: 0.5em;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 0 0.25em;
 	}
 }
 
 .connections__sharing-settings.connections__sharing-connections {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 16px 0;
 	}
 
@@ -108,7 +108,7 @@
 		vertical-align: top;
 		width: 48%;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: block;
 			width: 100%;
 			margin: 20px 0;
@@ -118,12 +118,12 @@
 		&:first-child {
 			padding-right: 4%;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				border-bottom: 1px solid var( --color-neutral-0 );
 				padding-bottom: 10px;
 			}
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				margin-bottom: 16px;
 				padding: 0 0 16px;
 			}
@@ -248,7 +248,7 @@
 	width: 50px;
 	border-radius: 2px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		height: 21px;
 		padding-top: 5px;
 		margin: 2px 8px 0 32px;
@@ -286,7 +286,7 @@
 	color: var( --color-neutral-50 );
 	font-size: 14px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }
@@ -307,7 +307,7 @@
 	font-size: 22px;
 	color: #aeb8be;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		left: 14px;
 		top: 20px;
 	}
@@ -329,7 +329,7 @@
 	position: absolute;
 	left: 80px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 30%;
 	}
 }
@@ -375,7 +375,7 @@
 		padding-bottom: 0;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding-right: 0;
 	}
 }
@@ -383,7 +383,7 @@
 .sharing-service.reconnect .sharing-connection__account-status {
 	padding-right: 200px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding-right: 0;
 	}
 }
@@ -420,7 +420,7 @@
 	top: 50%;
 	margin-top: -16px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		position: static;
 		margin-top: 4px;
 		text-align: right;
@@ -486,7 +486,7 @@
 
 .sharing-buttons-tray__buttons {
 	@include clear-fix;
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-right: -16px;
 	}
 }
@@ -550,7 +550,7 @@
 	@include clear-fix;
 	margin: 0 -3%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0;
 	}
 }
@@ -562,7 +562,7 @@
 	padding: 0 3%;
 	margin-bottom: 20px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 		padding: 0;
 	}
@@ -667,7 +667,7 @@
 	background-color: var( --color-surface );
 	color: var( --color-primary );
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding-right: 0;
 	}
 
@@ -708,7 +708,7 @@
 
 	&.is-bottom {
 		margin-top: 14px;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin: 14px 1% 0;
 		}
 	}
@@ -739,7 +739,7 @@
 }
 
 .sharing-buttons-preview__button-tray-actions {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin: 0 -6%;
 	}
 }
@@ -747,24 +747,24 @@
 .sharing-buttons-preview-action + .sharing-buttons-preview-action {
 	margin-left: 8px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-left: 1%;
 	}
 }
 
 .sharing-buttons-preview-action:last-child {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 46%;
 	}
 }
 
 .sharing-buttons-preview-action {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 50%;
 	}
 
 	&::before {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			float: left;
 			margin: 6px 6px 0 0;
 		}
@@ -1002,7 +1002,7 @@
 			}
 		}
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin: 15px -8px 0;
 		}
 	}
@@ -1068,7 +1068,7 @@
 .sharing-buttons-preview__panel-content .sharing-buttons-preview-button {
 	margin-top: 8px;
 	cursor: pointer;
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin: 18px 18px 0 0;
 	}
 }

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -3,7 +3,7 @@
 	flex-direction: row;
 	padding: 11px 24px; // standard padding
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		max-height: 300px;
 	}
 }
@@ -33,7 +33,7 @@
 	margin: 20px 0;
 
 	.button {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			text-align: center;
 		}
@@ -43,7 +43,7 @@
 .tools__header-image-wrapper {
 	display: none;
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		display: flex;
 		min-width: 400px;
 	}
@@ -79,7 +79,7 @@
 		margin-top: 20px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: calc( 50% - 1em );
 	}
 }
@@ -102,7 +102,7 @@
 		margin-bottom: 0;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		width: 75%;
 	}
 }
@@ -112,11 +112,11 @@
 	max-width: 150px;
 	width: 15%;
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		display: flex;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }
@@ -150,7 +150,7 @@
 		justify-content: center;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 		justify-content: flex-end;
 
@@ -164,7 +164,7 @@
 		}
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 
 		.button {
 			margin: 0 0 0 1em;

--- a/client/my-sites/marketing/traffic/style.scss
+++ b/client/my-sites/marketing/traffic/style.scss
@@ -116,7 +116,7 @@
 	}
 
 	.site-settings__blogaddress-settings {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: flex;
 		}
 
@@ -125,7 +125,7 @@
 			margin-left: 0;
 			margin-top: 5px;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				width: 45%;
 				margin-left: 16px;
 				margin-top: 0;
@@ -173,7 +173,7 @@
 	fieldset.site-icon-setting {
 		padding-bottom: 16px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex: 0 0 122px;
 			order: 1;
 			margin-bottom: 0;
@@ -183,21 +183,21 @@
 	}
 
 	.site-icon-setting__heading {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			justify-content: space-between;
 			white-space: nowrap;
 		}
 	}
 
 	.site-icon-setting__icon {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			float: left;
 			margin-right: 8px;
 		}
 	}
 
 	.site-icon-setting__button {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: block;
 			margin-bottom: 8px;
 		}

--- a/client/my-sites/media-library/content.scss
+++ b/client/my-sites/media-library/content.scss
@@ -9,7 +9,7 @@
 	width: 12%;
 	margin: 0 28px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 20%;
 	}
 }
@@ -38,7 +38,7 @@
 
 // Split attribution to its own line for smaller screens in the main media library.
 // This prevents the "copy to media library" button from overlapping the grid buttons.
-@include breakpoint( '<960px' ) {
+@include breakpoint-deprecated( '<960px' ) {
 	.media__main-section .media-library__header.card {
 		flex-wrap: wrap;
 	}
@@ -52,7 +52,7 @@
 }
 
 // Scoot the "copy to media library" over to the right, so it doesn't float awkwardly in the middle.
-@include breakpoint( '>960px' ) {
+@include breakpoint-deprecated( '>960px' ) {
 	.media__main-section .media-library__pexels-attribution {
 		order: 2;
 		margin-right: 0;

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -14,7 +14,7 @@
 .media-library__upload-button-label {
 	display: none;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: inline-block;
 	}
 }
@@ -25,7 +25,7 @@
 
 .media-library__header .button.media-library__upload-button {
 	margin-right: 0;
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
 	}
@@ -38,7 +38,7 @@
 .media-library__header.media-library__upload-url {
 	margin-bottom: 10px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-bottom: 16px;
 	}
 }
@@ -61,7 +61,7 @@
 	align-items: stretch;
 	position: relative;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-wrap: wrap;
 	}
 
@@ -69,7 +69,7 @@
 		flex: 1 auto;
 		z-index: z-index( 'root', '.media-library .search.is-expanded-to-container' );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: auto;
 		}
 
@@ -79,7 +79,7 @@
 			}
 
 			&.has-focus {
-				@include breakpoint( '<660px' ) {
+				@include breakpoint-deprecated( '<660px' ) {
 					margin-right: 4px;
 				}
 			}
@@ -98,15 +98,15 @@
 		box-sizing: border-box;
 		flex: 1 0 auto;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			display: flex;
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: none;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			display: flex;
 			margin-bottom: 17px;
 		}
@@ -135,12 +135,12 @@
 			}
 		}
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			align-items: normal;
 			padding-top: 6px;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-bottom: 9px;
 		}
 	}
@@ -149,7 +149,7 @@
 .editor-media-modal .media-library__datasource {
 	margin-bottom: 16px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-bottom: 9px;
 	}
 }
@@ -178,7 +178,7 @@
 
 .editor-media-modal .media-library__filter-bar {
 	.plan-storage {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-bottom: 16px;
 		}
 	}
@@ -191,7 +191,7 @@
 	line-height: 40px;
 	margin-right: 12px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }
@@ -218,7 +218,7 @@
 		padding: 2px 4px;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: none;
 	}
 }
@@ -226,7 +226,7 @@
 .media-library__scale-range {
 	display: none;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: block;
 	}
 }

--- a/client/my-sites/media-library/upload-button.scss
+++ b/client/my-sites/media-library/upload-button.scss
@@ -17,7 +17,7 @@
 	}
 }
 
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 	.media-library__upload-button {
 		margin-left: 0;
 	}

--- a/client/my-sites/media/style.scss
+++ b/client/my-sites/media/style.scss
@@ -2,7 +2,7 @@
 	max-width: 100%;
 
 	.media-library__list {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			padding: 0;
 		}
 	}

--- a/client/my-sites/migrate/components/sites-block/style.scss
+++ b/client/my-sites/migrate/components/sites-block/style.scss
@@ -50,7 +50,7 @@
 		}
 	}
 
-	@include breakpoint('<660px') {
+	@include breakpoint-deprecated('<660px') {
 		&.is-step-source-select {
 			.sites-block__sites-arrow-wrapper,
 			.sites-block__target-site {

--- a/client/my-sites/migrate/section-migrate.scss
+++ b/client/my-sites/migrate/section-migrate.scss
@@ -74,7 +74,7 @@
 }
 
 
-@include breakpoint('<800px') {
+@include breakpoint-deprecated('<800px') {
 	&.migrate__plan-upsell {
 		flex-wrap: wrap;
 		margin: 16px 0;
@@ -235,7 +235,7 @@
 .migrate__section-header {
 	.formatted-header__title {
 		font-size: 24px;
-		@include breakpoint('>660px') {
+		@include breakpoint-deprecated('>660px') {
 			font-size: 32px;
 		}
 	}

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	padding: 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 16px 24px;
 	}
 }

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -35,7 +35,7 @@
 	.site-icon {
 		display: none;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: block;
 			margin-right: 10px;
 			min-width: 34px;

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -5,7 +5,7 @@
 	overflow: hidden;
 	position: relative;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 24px;
 	}
 
@@ -41,14 +41,14 @@
 }
 
 .people-list-item.is-invite .people-profile__username {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 18px;
 	}
 }
 
 .people-list-item.is-invite-details {
 	// Make extra space for invite status on small screens
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding-bottom: 34px;
 	}
 }
@@ -63,14 +63,14 @@
 		margin-right: 30px;
 
 		// Hide on small screens
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}
 
 	&.is-invite-details {
 		// Show below the name and role on small screens
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			position: absolute;
 			bottom: 4px;
 			margin-left: 80px;

--- a/client/my-sites/people/people-list-section-header/style.scss
+++ b/client/my-sites/people/people-list-section-header/style.scss
@@ -1,6 +1,6 @@
 .people-list-section-header__add-button.is-compact {
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		font-size: 0;
 
 		.gridicon {

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -30,7 +30,7 @@
 	width: 56px !important;
 	height: 56px !important;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: 72px !important;
 		height: 72px !important;
 	}
@@ -39,7 +39,7 @@
 .people-profile__detail {
 	margin-left: 80px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-left: 96px;
 	}
 }
@@ -52,7 +52,7 @@
 	text-overflow: clip;
 	overflow: hidden;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 21px;
 	}
 
@@ -65,7 +65,7 @@
 	color: var( --color-text-subtle );
 	font-size: 13px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 15px;
 		margin-top: -3px;
 	}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -24,7 +24,7 @@ $plan-features-sidebar-width: 272px;
 	margin: 0 16px;
 	display: block;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 
@@ -99,11 +99,11 @@ $plan-features-sidebar-width: 272px;
 	display: none;
 	table-layout: fixed;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: table;
 	}
 
-	@include breakpoint( '<1040px' ) {
+	@include breakpoint-deprecated( '<1040px' ) {
 		border-spacing: 0;
 		margin-left: 15px;
 		margin-right: 15px;
@@ -148,7 +148,7 @@ $plan-features-sidebar-width: 272px;
 		bottom: 0;
 		margin: 0 24px;
 
-		@include breakpoint( '<1040px' ) {
+		@include breakpoint-deprecated( '<1040px' ) {
 			margin: 0 12px;
 			width: calc( 100% - 24px );
 		}
@@ -188,7 +188,7 @@ $plan-features-sidebar-width: 272px;
 	border-bottom: solid 2px var( --color-neutral-10 );
 	background-color: var( --color-surface );
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		padding: 12px 12px 0;
 	}
 
@@ -238,7 +238,7 @@ $plan-features-sidebar-width: 272px;
 }
 
 .is-section-plans .plan-features__header-figure {
-	@include breakpoint( '<1280px' ) {
+	@include breakpoint-deprecated( '<1280px' ) {
 		width: 24px;
 		height: 24px;
 		margin-right: 10px;
@@ -248,7 +248,7 @@ $plan-features-sidebar-width: 272px;
 .plan-features__header-figure,
 .plan-features__table.has-1-cols .plan-features__header-figure,
 .plan-features__table.has-2-cols .plan-features__header-figure {
-	@include breakpoint( '<1040px' ) {
+	@include breakpoint-deprecated( '<1040px' ) {
 		display: none;
 	}
 }
@@ -263,7 +263,7 @@ $plan-features-sidebar-width: 272px;
 	color: var( --color-primary );
 	line-height: 0.7;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		font-size: 20px;
 	}
 }
@@ -283,7 +283,7 @@ $plan-features-sidebar-width: 272px;
 .plan-features__header-price-group {
 	width: calc( 100% + 20px );
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: calc( 100% + 10px );
 	}
 }
@@ -291,12 +291,12 @@ $plan-features-sidebar-width: 272px;
 .plan-features__header-price-group-prices {
 	max-width: calc( 100% - 20px );
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		max-width: calc( 100% - 10px );
 	}
 
 	.plan-price.is-discounted {
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			margin-right: 0;
 		}
 	}
@@ -314,10 +314,10 @@ $plan-features-sidebar-width: 272px;
 	padding: 0 8px;
 	margin-bottom: 4px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-left: 4px;
 	}
-	@include breakpoint( '>1280px' ) {
+	@include breakpoint-deprecated( '>1280px' ) {
 		margin-left: 8px;
 	}
 }
@@ -336,7 +336,7 @@ $plan-features-sidebar-width: 272px;
 		height: 12px;
 		margin-bottom: 15px;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			margin-bottom: 9px;
 		}
 	}
@@ -346,7 +346,7 @@ $plan-features-sidebar-width: 272px;
 	max-width: 520px;
 	margin: 8px auto 16px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-wrap: wrap;
 		border-radius: 0;
 
@@ -382,7 +382,7 @@ $plan-features-sidebar-width: 272px;
 			margin-top: 5px;
 			margin-bottom: 5px;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			height: 26px;
 		}
 	}
@@ -394,7 +394,7 @@ $plan-features-sidebar-width: 272px;
 	&.is-placeholder {
 		height: 28px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			height: auto;
 		}
 	}
@@ -424,11 +424,11 @@ $plan-features-sidebar-width: 272px;
 	margin: 0;
 	padding: 24px 24px 0;
 
-	@include breakpoint( '<1040px' ) {
+	@include breakpoint-deprecated( '<1040px' ) {
 		padding: 12px 12px 0;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 20px 20px 0;
 	}
 }
@@ -445,11 +445,11 @@ $plan-features-sidebar-width: 272px;
 	font-size: 14px;
 	color: var( --color-neutral-70 );
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		font-size: 12px;
 	}
 
-	@include breakpoint( '<1040px' ) {
+	@include breakpoint-deprecated( '<1040px' ) {
 		margin: 0 12px;
 	}
 }
@@ -478,11 +478,11 @@ $plan-features-sidebar-width: 272px;
 .plan-features__actions {
 	padding: 0 24px 24px;
 
-	@include breakpoint( '<1040px' ) {
+	@include breakpoint-deprecated( '<1040px' ) {
 		padding: 0 12px 12px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 0 20px 20px;
 		border-bottom: solid 1px var( --color-neutral-0 );
 	}
@@ -496,7 +496,7 @@ $plan-features-sidebar-width: 272px;
 	width: 100%;
 	margin-top: 8px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 20px;
 	}
 }
@@ -557,7 +557,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		// This adds a little pointer arrow to the bottom
 		// of the selected segment item. It relies on the
 		// relative positioning above.
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			&::after {
 				display: block;
 				content: '';
@@ -575,7 +575,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		a,
 		a:hover,
 		a:focus {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				flex-wrap: wrap;
 			}
 			cursor: default;
@@ -599,7 +599,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	.jetpack-connect__plans & {
 		width: auto;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			max-width: 1000px;
 		}
 	}
@@ -607,7 +607,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	.signup__steps & {
 		width: auto;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			max-width: 1100px;
 		}
 	}
@@ -615,14 +615,14 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	.plan-features__table {
 		display: none;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: table;
 			width: 100%;
 			margin: 0 auto;
 			padding: 0 16px;
 		}
 
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			border-spacing: 15px 0;
 			padding: 0;
 		}
@@ -656,7 +656,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		height: 50px;
 		margin: 16px 20px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			float: none;
 			width: 100px;
 			height: 100px;
@@ -673,7 +673,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		margin: 20px 20px -12px;
 		padding: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-bottom: 0;
 			padding: 0 12px;
 		}
@@ -728,7 +728,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	}
 
 	.jetpack-connect__hide-plan-icons .jetpack-connect__plans & .plan-features__pricing {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding-top: 0;
 		}
 	}
@@ -750,7 +750,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 			margin-left: -280px;
 		}
 
-		@include breakpoint( '<1040px' ) {
+		@include breakpoint-deprecated( '<1040px' ) {
 			padding-top: 12px;
 		}
 	}
@@ -760,7 +760,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		width: calc( 100vw - 278px );
 		margin-left: calc( 50% - 50vw + 138px );
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-left: 0;
 			width: 100%;
 		}
@@ -1035,7 +1035,7 @@ button.plan-features__scroll-button {
 	.plan-features__scroll-right & {
 		margin-left: 20px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin-left: 5px;
 		}
 	}
@@ -1043,7 +1043,7 @@ button.plan-features__scroll-button {
 	.plan-features__scroll-left & {
 		margin-right: 20px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin-right: 5px;
 		}
 	}
@@ -1081,7 +1081,7 @@ button.plan-features__scroll-button {
 	}
 }
 
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 	.plan-features__upgrade-launch-dialog .dialog__content p {
 		padding: 0 20px;
 	}

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -16,7 +16,7 @@
 		vertical-align: super;
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		font-size: 24px;
 	}
 }

--- a/client/my-sites/plans-features-main/gutenboarding-header/style.scss
+++ b/client/my-sites/plans-features-main/gutenboarding-header/style.scss
@@ -11,7 +11,7 @@
 		font-size: 14px !important;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-bottom: 80px;
 		margin-top: 0;
 	}

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -15,11 +15,11 @@
 
 			.product-card {
 
-				@include breakpoint( '>480px' ) {
+				@include breakpoint-deprecated( '>480px' ) {
 					flex-basis: calc( 50% - 1em );
 				}
 				&:first-child:last-child {
-					@include breakpoint( '>960px' ) {
+					@include breakpoint-deprecated( '>960px' ) {
 						margin-left: auto;
 						margin-right: auto;
 						flex-basis: 520px;
@@ -68,12 +68,12 @@
 	margin: 0 0 16px;
 	padding: 0 16px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-bottom: 28px;
 		padding: 0 24px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-left: auto;
 		margin-right: auto;
 		padding: 0;
@@ -88,7 +88,7 @@
 	font-weight: 600;
 	color: var( --color-text );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 24px;
 		font-weight: 400;
 	}

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -3,7 +3,7 @@
 	flex-direction: row;
 	max-width: 720px;
 
-	@include breakpoint( '>800px' ) {
+	@include breakpoint-deprecated( '>800px' ) {
 		font-size: 16px;
 		padding: 20px 0;
 		width: 720px;
@@ -12,7 +12,7 @@
 	&__title {
 		font-size: 24px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			text-align: center;
 		}
 	}
@@ -22,7 +22,7 @@
 	}
 
 	.progress-bar {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			max-width: 80%;
 		}
 	}
@@ -31,7 +31,7 @@
 		padding-right: 80px;
 		padding-left: 80px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			text-align: center;
 			width: 100%;
 		}
@@ -51,7 +51,7 @@
 	max-width: 220px;
 	margin-right: 32px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }

--- a/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
@@ -22,7 +22,7 @@
 	justify-content: center;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.jetpack-checklist__header {
 		display: block;
 	}
@@ -31,7 +31,7 @@
 		max-width: 80%;
 		display: block;
 		margin: 20px auto;
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -44,7 +44,7 @@
 	display: flex;
 	flex-direction: column;
 	text-align: center;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 		justify-content: flex-end;
 		text-align: left;

--- a/client/my-sites/plans/current-plan/my-plan-card/style.scss
+++ b/client/my-sites/plans/current-plan/my-plan-card/style.scss
@@ -1,6 +1,6 @@
 // My Plan Card
 .my-plan-card.card {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
@@ -25,7 +25,7 @@
 		min-height: 70px;
 		margin-bottom: 16px;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			height: 100%;
 		}
 	}
@@ -49,7 +49,7 @@
 	line-height: 21px;
 	margin: 0 0 24px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin-bottom: 8px;
 	}
 
@@ -64,7 +64,7 @@
 	height: 64px;
 	margin: 8px 20px 16px 0;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 
@@ -92,7 +92,7 @@
 	justify-content: space-between;
 	padding: 8px 0 0;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-flow: column nowrap;
 		justify-content: center;
 		align-items: flex-end;
@@ -107,12 +107,12 @@
 		right: -16px;
 		border-top: 1px solid var( --color-border-subtle );
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			left: -24px;
 			right: -24px;
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			content: none;
 		}
 	}
@@ -132,7 +132,7 @@
 	white-space: nowrap;
 	color: var( --color-text-subtle );
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding-top: 0;
 	}
 

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -2,7 +2,7 @@
 	background-color: rgba( var( --color-neutral-dark-rgb ), 0.85 );
 	box-shadow: none;
 	margin: 0;
-	
+
 	.dialog__backdrop__content {
 		background-color: var( --color-surface );
 	}
@@ -20,13 +20,13 @@
 	background-color: var( --color-surface );
 	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
 		0 1px 2px var( --color-neutral-0 );
-	
+
 	&-main {
 		display: flex;
 	}
 
 	.is-jetpack-free & {
-		@include breakpoint( '>800px' ) {
+		@include breakpoint-deprecated( '>800px' ) {
 			display: flex;
 			align-items: center;
 			text-align: left;
@@ -37,7 +37,7 @@
 .current-plan__header-icon {
 	display: none;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: flex;
     	flex-shrink: 0;
 		width: 100px;
@@ -82,7 +82,7 @@
 
 		display: block;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin: 0 auto;
 		}
 	}
@@ -97,7 +97,7 @@
 		margin-top: 15px;
 		width: 90%;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-bottom: 18px;
 			margin-top: 18px;
 		}
@@ -135,8 +135,8 @@
 	justify-content: center;
 	margin-left: 16px;
 	min-width: 140px;
-	
-	@include breakpoint( '>660px' ) {
+
+	@include breakpoint-deprecated( '>660px' ) {
 		justify-content: flex-end;
 	}
 }

--- a/client/my-sites/plugins/plugin-action/style.scss
+++ b/client/my-sites/plugins/plugin-action/style.scss
@@ -22,7 +22,7 @@
 	}
 
 	.plugin-action__label {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			color: var( --color-neutral-70 );
 		}
 	}

--- a/client/my-sites/plugins/plugin-icon/style.scss
+++ b/client/my-sites/plugins/plugin-icon/style.scss
@@ -10,11 +10,11 @@
 	position: relative;
 	transition: opacity 0.15s ease-in-out;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		width: 40px;
 		height: 40px;
 	}
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-right: 24px;
 	}
 

--- a/client/my-sites/plugins/plugin-information/style.scss
+++ b/client/my-sites/plugins/plugin-information/style.scss
@@ -52,7 +52,7 @@
 	text-transform: uppercase;
 	width: 100%;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		float: left;
 	}
 }
@@ -92,7 +92,7 @@
 .plugin-information .plugin-ratings {
 	flex-grow: 1;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-grow: 0;
 		width: 160px;
 	}
@@ -105,7 +105,7 @@
 .plugin-information__links {
 	clear: left;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		float: left;
 	}
 }
@@ -119,7 +119,7 @@
 
 	.plugin-information__wrapper {
 		@include placeholder();
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-right: 16px;
 		}
 	}

--- a/client/my-sites/plugins/plugin-install-button/style.scss
+++ b/client/my-sites/plugins/plugin-install-button/style.scss
@@ -12,7 +12,7 @@
 			margin: 18px 16px 0 0;
 		}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin: 0;
 		position: relative;
 

--- a/client/my-sites/plugins/plugin-item/style.scss
+++ b/client/my-sites/plugins/plugin-item/style.scss
@@ -15,7 +15,7 @@
 		margin-right: 8px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0;
 	}
 
@@ -126,7 +126,7 @@
 .plugin-item .plugin-item__actions {
 	display: none;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		align-self: center;
 		display: flex;
 		flex-direction: column;
@@ -154,19 +154,19 @@
 }
 
 .plugin-item .plugin-action {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		margin-top: 6px;
 	}
 
 	&:first-child {
-		@include breakpoint( '<1040px' ) {
+		@include breakpoint-deprecated( '<1040px' ) {
 			margin-top: 0;
 		}
 	}
 }
 
 .plugin-item .plugin-action__label {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		flex-direction: row;
 		margin-right: 0;
 		margin-left: 8px;
@@ -174,13 +174,13 @@
 }
 
 .plugin-item .plugin-action .form-toggle__label {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		flex-direction: row;
 	}
 }
 
 .plugin-item .form-toggle__label .form-toggle__label-content {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		margin-right: 12px;
 		margin-left: 0;
 	}
@@ -188,14 +188,14 @@
 
 .plugin-item .plugin-activate-toggle__link,
 .plugin-item .plugin-activate-toggle__disabled {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		flex-direction: row;
 		margin-right: 12px;
 	}
 }
 
 .plugin-item .plugin-activate-toggle__label {
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		margin-left: 8px;
 		margin-right: 0;
 	}

--- a/client/my-sites/plugins/plugin-list-header/style.scss
+++ b/client/my-sites/plugins/plugin-list-header/style.scss
@@ -31,10 +31,10 @@
 		display: inherit;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-right: 16px;
 	}
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		&.is-action-bar-visible {
 			.plugin-list-header__actions-dropdown {
 				display: none;

--- a/client/my-sites/plugins/plugin-meta/style.scss
+++ b/client/my-sites/plugins/plugin-meta/style.scss
@@ -9,7 +9,7 @@
 	box-shadow: inset 0 0 2px 2px rgba( var( --color-neutral-20-rgb ), 0.1 );
 	background: rgba( var( --color-neutral-0-rgb ), 0.3 );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		left: -24px;
 		width: calc( 100% + 48px );
 		margin-top: -24px;
@@ -28,7 +28,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 	}
 }
@@ -50,7 +50,7 @@
 		@include long-content-fade( $size: 20% );
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 24px;
 	}
 
@@ -98,7 +98,7 @@
 		right: inherit;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		min-width: 22%;
 		border: none;
 		margin: 0;
@@ -120,25 +120,25 @@
 	.plugin-activate-toggle__disabled,
 	.plugin-activate-toggle__link,
 	.plugin-remove-button__remove-link .plugin-action__children {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 		}
 	}
 
 	.plugin-activate-toggle__link {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			justify-content: space-between;
 		}
 	}
 
 	.form-toggle__label-content {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin-left: 0;
 		}
 	}
 
 	.plugin-action__label {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			flex-flow: row;
 			font-size: 11px;
 			margin-right: auto;
@@ -149,7 +149,7 @@
 .plugin-meta__version-notice {
 	margin-top: -9px;
 
-	@include breakpoint ( '>480px' ) {
+	@include breakpoint-deprecated ( '>480px' ) {
 		margin-top: -15px;
 	}
 }
@@ -158,7 +158,7 @@
 	justify-content: space-between;
 	padding: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		justify-content: flex-end;
 	}
 }

--- a/client/my-sites/plugins/plugin-ratings/style.scss
+++ b/client/my-sites/plugins/plugin-ratings/style.scss
@@ -11,7 +11,7 @@
 .plugin-ratings__rating-stars {
 	font-size: 24px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: inline-block;
 		margin-right: 8px;
 	}
@@ -22,7 +22,7 @@
 	color: var( --color-neutral-light );
 	margin-bottom: 16px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: inline;
 		line-height: 24px;
 		vertical-align: top;

--- a/client/my-sites/plugins/plugins-browser-item/style.scss
+++ b/client/my-sites/plugins/plugins-browser-item/style.scss
@@ -18,7 +18,7 @@
 		display: block;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 33.33%;
 
 		&:nth-child( 3n + 1 ) {
@@ -30,7 +30,7 @@
 		}
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: 100%;
 
 		&:nth-child( n + 2 ) {

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -4,7 +4,7 @@
 	display: flex;
 	margin-bottom: 9px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 		margin-bottom: 17px;
 	}
@@ -22,7 +22,7 @@
 	margin-bottom: 9px;
 	width: 100%;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-bottom: 17px;
 	}
 
@@ -32,24 +32,23 @@
 		}
 
 		&:last-child {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				margin-right: 15px;
 			}
 		}
 
 		.gridicon {
 			margin-right: 0;
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				margin-right: 4px;
 			}
 		}
 
 		.plugins-browser__button-text {
 			display: none;
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				display: inline-block;
 			}
 		}
 	}
 }
-

--- a/client/my-sites/plugins/plugins-list/style.scss
+++ b/client/my-sites/plugins/plugins-list/style.scss
@@ -3,7 +3,7 @@
 }
 
 .plugins-list .plugin-item {
-	@include breakpoint( '<1040px' ) {
+	@include breakpoint-deprecated( '<1040px' ) {
 		width: 100%;
 
 		&:nth-last-child( n + 2 ) {
@@ -11,7 +11,7 @@
 		}
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		flex-direction: column;
 		width: 33.33%;
 		border-right-width: 1px;

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -12,7 +12,7 @@
 	display: flex;
 	margin-bottom: 9px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		flex-direction: row;
 		margin-bottom: 17px;
 	}
@@ -24,7 +24,7 @@
 	flex: auto;
 	margin: 0;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		border-width: 1px 0;
 	}
 }
@@ -39,7 +39,7 @@
 	margin-bottom: 9px;
 	width: 100%;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-bottom: 17px;
 	}
 
@@ -50,25 +50,25 @@
 		}
 
 		&:last-child {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				margin-right: 15px;
 			}
 		}
 
 		.gridicon {
 			margin-right: 0;
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				margin-right: 4px;
 			}
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			flex: none;
 		}
 
 		.plugins__button-text {
 			display: none;
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				display: inline-block;
 			}
 		}
@@ -86,7 +86,7 @@
 	margin: 40px 0 20px;
 	padding: 0 15px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0;
 	}
 }

--- a/client/my-sites/post-type-filter/style.scss
+++ b/client/my-sites/post-type-filter/style.scss
@@ -6,7 +6,7 @@
 .post-type-filter__multi-select-button {
 	background-color: var( --color-neutral-0 );
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		position: absolute;
 		top: 8px;
 		right: 50px;
@@ -18,7 +18,7 @@
 	}
 }
 
-@include breakpoint( '660px-800px' ) {
+@include breakpoint-deprecated( '660px-800px' ) {
 	$width-search: 40px;
 	$space-between-nav-and-search: 5px;
 

--- a/client/my-sites/resume-editing/style.scss
+++ b/client/my-sites/resume-editing/style.scss
@@ -13,7 +13,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 

--- a/client/my-sites/site-settings/date-time-format/style.scss
+++ b/client/my-sites/site-settings/date-time-format/style.scss
@@ -1,7 +1,7 @@
 .date-time-format,
 .date-time-format.is-expanded {
 	margin-top: -10px;
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-top: -16px;
 
 		.foldable-card__content {

--- a/client/my-sites/site-settings/disconnect-site/style.scss
+++ b/client/my-sites/site-settings/disconnect-site/style.scss
@@ -2,16 +2,16 @@
 	position: relative;
 	padding: 24px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		max-width: 300px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 2em;
 		max-width: 500px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 17px;
 		max-width: 800px;
 	}

--- a/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
+++ b/client/my-sites/site-settings/podcast-cover-image-setting/style.scss
@@ -50,7 +50,7 @@
 .podcast-cover-image-setting {
 	width: 208px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		width: 98px;
 	}
 }
@@ -67,7 +67,7 @@
 		color: var( --color-neutral-20 );
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		margin: 6px 0 0;
 	}
 }

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -85,7 +85,7 @@
 	}
 }
 
-@include breakpoint( '<800px' ) {
+@include breakpoint-deprecated( '<800px' ) {
 	.podcasting-details__link.is-enabled .podcasting-details__link-action-container,
 	.podcasting-details__publish-wrapper {
 		display: block;
@@ -115,7 +115,7 @@
 }
 
 .podcasting-details__title-subtitle-wrapper {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		float: left;
 		width: 75%;
 	}
@@ -128,7 +128,7 @@
 	}
 
 	.form-select {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 		}
 	}
@@ -148,7 +148,7 @@
 		color: var( --color-neutral-20 );
 		border-color: var( --color-neutral-10 );
 	}
-	
+
 	.podcasting-details__save-button {
 		float: right;
 	}

--- a/client/my-sites/site-settings/related-posts/style.scss
+++ b/client/my-sites/site-settings/related-posts/style.scss
@@ -1,7 +1,7 @@
 .related-posts__module-settings {
 	margin-bottom: 10px;
 }
-	
+
 .related-posts__preview-title {
 	font-weight: 600;
 	margin-top: 16px;
@@ -25,7 +25,7 @@
 	}
 
 .related-posts__preview-items {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: flex;
 		flex-wrap: wrap;
 		.related-posts__preview-post {
@@ -33,7 +33,7 @@
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-wrap: nowrap;
 	}
 }

--- a/client/my-sites/site-settings/site-tools/style.scss
+++ b/client/my-sites/site-settings/site-tools/style.scss
@@ -30,7 +30,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		&.is-compact {
 			padding: 24px;
 		}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -126,7 +126,7 @@
 	}
 
 	.site-settings__blogaddress-settings {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: flex;
 		}
 
@@ -136,7 +136,7 @@
 			margin-top: 5px;
 			text-align: center;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				width: 45%;
 				margin-left: 16px;
 				margin-top: 0;
@@ -184,7 +184,7 @@
 	fieldset.site-icon-setting {
 		padding-bottom: 16px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			flex: 0 0 122px;
 			order: 1;
 			margin-bottom: 0;
@@ -194,21 +194,21 @@
 	}
 
 	.site-icon-setting__heading {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			justify-content: space-between;
 			white-space: nowrap;
 		}
 	}
 
 	.site-icon-setting__icon {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			float: left;
 			margin-right: 8px;
 		}
 	}
 
 	.site-icon-setting__button {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: block;
 			margin-bottom: 8px;
 		}
@@ -309,7 +309,7 @@
 }
 
 .site-settings__site-options {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 	}
 
@@ -321,7 +321,7 @@
 }
 
 .site-settings__site-title-tagline {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: 0 1 100%;
 		order: 2;
 	}
@@ -361,7 +361,7 @@
 
 .writing-settings,
 .general-settings {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		select {
 			width: 100%;
 		}

--- a/client/my-sites/site-settings/theme-setup-dialog/style.scss
+++ b/client/my-sites/site-settings/theme-setup-dialog/style.scss
@@ -2,9 +2,8 @@
 	min-height: 170px;
 	width: 400px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		box-sizing: border-box;
 		width: 100%;
 	}
 }
-

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -3,7 +3,7 @@
 	flex-wrap: wrap;
 	padding: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 16px 24px 0;
 	}
 }
@@ -13,7 +13,7 @@
 	flex-direction: column;
 	padding-bottom: 16px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		border-bottom: 1px solid var( --color-neutral-0 );
 		flex-direction: row;
 		flex-basis: 100%;
@@ -27,7 +27,7 @@
 	&:nth-child( 2n + 1 ) {
 		width: 50%;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			width: 45%;
 		}
 	}
@@ -35,7 +35,7 @@
 	&:nth-child( 2n + 0 ) {
 		width: 50%;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			width: 55%;
 		}
 	}
@@ -46,7 +46,7 @@
 	font-size: 11px;
 	text-transform: uppercase;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		color: var( --color-neutral-70 );
 		font-size: 14px;
 		text-transform: capitalize;
@@ -57,7 +57,7 @@
 .annual-site-stats__stat-figure {
 	font-size: 18px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		font-size: 14px;
 		text-align: right;
 		width: 50%;
@@ -70,7 +70,7 @@
 	&.is-large {
 		font-size: 14px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			font-size: 30px;
 		}
 	}

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -21,7 +21,7 @@
 	padding: 20px 0;
 	color: var( --color-neutral-70 );
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: 100%;
 
 		&:first-child {
@@ -67,7 +67,7 @@
 	top: 25px;
 	margin-bottom: 24px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		top: 10px;
 		margin: 0 5px;
 	}

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -4,7 +4,7 @@ client/my-sites/stats/post-trends/style.scss
 	user-select: none;
 	position: relative;
 	width: 100%;
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }
@@ -52,7 +52,7 @@ client/my-sites/stats/post-trends/style.scss
 	text-align: left;
 	z-index: z-index( 'root', '.post-trends__scroll' );
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		.focus-sidebar & {
 			z-index: 0;
 		}
@@ -174,7 +174,7 @@ client/my-sites/stats/post-trends/style.scss
 	}
 }
 
-@include breakpoint( '>1040px' ) {
+@include breakpoint-deprecated( '>1040px' ) {
 
 	.post-trends__scroll-left,
 	.post-trends__scroll-right {
@@ -187,7 +187,7 @@ client/my-sites/stats/post-trends/style.scss
 	padding-top: 10px;
 	float: right;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		float: none;
 		margin: 0 auto;
 		margin-bottom: 25px;

--- a/client/my-sites/stats/stats-chart-tabs/style.scss
+++ b/client/my-sites/stats/stats-chart-tabs/style.scss
@@ -19,7 +19,7 @@ ul.module-tabs {
 			border-top: none;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			border-top: none;
 			border-left: 1px solid var( --color-neutral-0 );
 			float: left;
@@ -35,7 +35,7 @@ ul.module-tabs {
 			}
 		}
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: auto;
 			float: none;
 			text-align: left;
@@ -53,7 +53,7 @@ ul.module-tabs {
 			display: block;
 			background: var( --color-surface );
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				line-height: 24px;
 				padding-top: 10px;
 				-webkit-touch-callout: none;
@@ -66,7 +66,7 @@ ul.module-tabs {
 			line-height: inherit;
 			text-transform: uppercase;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				font-size: 14px;
 				line-height: 24px;
 				float: left;
@@ -78,7 +78,7 @@ ul.module-tabs {
 			margin-right: 4px;
 			margin-top: -2px;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				width: 24px;
 				height: 24px;
 				margin-left: 24px;
@@ -94,7 +94,7 @@ ul.module-tabs {
 			color: var( --color-primary );
 			transition: font-size 0.3s 0 ease-out;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				clear: none;
 				float: right;
 				font-size: 16px;
@@ -103,7 +103,7 @@ ul.module-tabs {
 			}
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			// Hover state
 			a:hover,
 			a:hover .value,

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -24,7 +24,7 @@
 	line-height: 40px;
 
 	// List item height shorter on 2-column modules
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & {
 			font-size: 12px;
 			line-height: 28px;
@@ -34,7 +34,7 @@
 	border-top: 1px solid rgba( var( --color-surface-rgb ), 0 );
 
 	// Increase touch targets on mobile
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		line-height: 48px;
 		border-top: 1px solid var( --color-neutral-0 );
 
@@ -89,7 +89,7 @@
 		line-height: inherit;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & {
 			line-height: 28px;
 
@@ -110,7 +110,7 @@
 
 // Module Content List Item Hover
 
-@include breakpoint( '>480px' ) {
+@include breakpoint-deprecated( '>480px' ) {
 	.module-content-list .stats-list__module-content-list-item-wrapper:hover,
 	.module-content-list-item-link .stats-list__module-content-list-item-wrapper:hover {
 		&,
@@ -168,7 +168,7 @@
 
 // Highlight toggle icon if item has a sublist
 
-@include breakpoint( '>480px' ) {
+@include breakpoint-deprecated( '>480px' ) {
 	.module-content-list > .module-content-list-item-toggle > .stats-list__module-content-list-item-wrapper:hover
 		.stats-list__module-content-list-item-label::before {
 		color: var( --color-link-dark );
@@ -191,13 +191,13 @@
 	height: 40px; // 2
 
 	// List item height shorter on 2-column modules
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & {
 			height: 28px;
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		height: 48px; // ### see ^
 	}
 
@@ -254,7 +254,7 @@
 	}
 
 	// Icons smaller on 2col
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & .stats-list__icon {
 			font-size: 20px;
 			line-height: 1.3;
@@ -305,13 +305,13 @@
 	background: var( --color-surface );
 	margin-left: -48px; // ### keep? experimental: to force labels to go longer than they normally would to make sure the fade out shows
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & {
 			height: 28px;
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		height: 48px;
 	}
 
@@ -380,7 +380,7 @@ ul.module-content-list-item-actions {
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		@include dropdown-menu;
 
 		background: var( --color-neutral-0 );
@@ -430,7 +430,7 @@ ul.module-content-list-item-actions {
 	height: 40px;
 	line-height: inherit;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & {
 			height: 28px;
 		}
@@ -440,7 +440,7 @@ ul.module-content-list-item-actions {
 		vertical-align: middle;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: inline-block;
 		height: 48px;
 	}
@@ -459,7 +459,7 @@ ul.module-content-list-item-action-submenu {
 	list-style: none;
 	margin: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		@include dropdown-menu;
 
 		display: none;
@@ -490,13 +490,13 @@ ul.module-content-list-item-action-submenu {
 	margin: 0 1em 0 0;
 
 	// So that 'View' label is moved more to the right since icon has been dropped
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & {
 			margin: 0;
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-right: 0;
 	}
 
@@ -508,7 +508,7 @@ ul.module-content-list-item-action-submenu {
 		opacity: 0;
 		line-height: inherit;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			min-width: 24px;
 			opacity: 1;
 			padding: 0 12px;
@@ -523,7 +523,7 @@ ul.module-content-list-item-action-submenu {
 		}
 
 		// Hide 'View' label next to icon on 2-column modules
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			.stats__module-list & span.module-content-list-item-action-label-view {
 				display: none;
 			}
@@ -558,7 +558,7 @@ ul.module-content-list-item-action-submenu {
 			margin-right: 0;
 		}
 	}
-	
+
 	// When a button instead of a link is used
 	.button.module-content-list-item-action-wrapper .gridicon {
 		vertical-align: unset;
@@ -569,7 +569,7 @@ ul.module-content-list-item-action-submenu {
 		color: var( --color-error );
 
 		// Hover state
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			&:hover {
 				color: var( --color-error-30 );
 			}
@@ -608,7 +608,7 @@ ul.module-content-list-legend {
 	.module-content-list-item
 	.module-content-list-item-action
 	.module-content-list-item-action-label {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: inline;
 	}
 }
@@ -632,7 +632,7 @@ ul.module-content-list-legend {
 .module-content-list > .module-content-list-item-large {
 	> .module-content-list-item-wrapper {
 		line-height: 48px;
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			.stats__module-list & {
 				line-height: 28px;
 			}
@@ -641,7 +641,7 @@ ul.module-content-list-legend {
 
 	> .stats-list__module-content-list-item-wrapper .stats-list__module-content-list-item-label {
 		height: 48px;
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			.stats__module-list & {
 				height: 28px;
 			}
@@ -658,7 +658,7 @@ ul.module-content-list-legend {
 		line-height: 32px;
 		width: 32px;
 		height: 32px;
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			.stats__module-list & {
 				width: 24px;
 				height: 24px;
@@ -666,7 +666,7 @@ ul.module-content-list-legend {
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list
 			& > .stats-list__module-content-list-item-wrapper
 			.stats-list__module-content-list-item-label
@@ -678,7 +678,7 @@ ul.module-content-list-legend {
 	> .stats-list__module-content-list-item-wrapper .stats-list__module-content-list-item-label .avatar {
 		width: 32px;
 		height: 32px;
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			.stats__module-list & {
 				width: 24px;
 				height: 24px;
@@ -708,7 +708,7 @@ ul.module-content-list-legend {
 
 	// Highlight main action (usually what's indicated in the label)
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		.stats-list__module-content-list-item-wrapper:hover .stats-list__module-content-list-item-label {
 			color: var( --color-link-dark );
 		}
@@ -767,7 +767,7 @@ ul.module-content-list-legend {
 	}
 
 	// Hover changes
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		> .stats-list__module-content-list-item-wrapper:hover {
 			// Change background and gradient color
 			&,
@@ -807,7 +807,7 @@ ul.module-content-list-legend {
 	}
 
 	// Hover changes
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		&-link .stats-list__module-content-list-item-wrapper:hover,
 		&-normal .stats-list__module-content-list-item-wrapper:hover {
 			// Change background and gradient color

--- a/client/my-sites/stats/stats-module/expand.scss
+++ b/client/my-sites/stats/stats-module/expand.scss
@@ -2,7 +2,7 @@
 	line-height: 40px;
 	display: block;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		line-height: 48px;
 	}
 
@@ -20,7 +20,7 @@
 		position: relative;
 
 		// Hover state
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			&:hover {
 				background: var( --color-neutral-0 );
 				border-top-color: var( --color-border-inverted );
@@ -33,7 +33,7 @@
 			border-top-color: var( --color-border-inverted );
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			.stats__module-list & {
 				font-size: 12px;
 			}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -33,12 +33,12 @@
 		color: var( --color-neutral-70 );
 
 		p {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				margin-left: 24px;
 				margin-right: 24px;
 			}
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				text-align: center;
 			}
 		}
@@ -55,12 +55,12 @@
 .stats-section-title {
 	@include heading;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-left: 24px;
 		margin-right: 24px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		text-align: center;
 	}
 }
@@ -72,7 +72,7 @@
 	line-height: 40px;
 	display: block;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		line-height: 48px;
 	}
 
@@ -90,7 +90,7 @@
 		position: relative;
 
 		// Hover state
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			&:hover {
 				background: var( --color-neutral-0 );
 				border-top-color: var( --color-border-inverted );
@@ -103,7 +103,7 @@
 			border-top-color: var( --color-border-inverted );
 		}
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			.stats__module-list & {
 				font-size: 12px;
 			}
@@ -217,7 +217,7 @@ ul.module-header-actions {
 	}
 
 	// Hover state
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		.stats-module:hover & .module-header-action-link {
 			color: var( --color-primary );
 		}
@@ -273,12 +273,12 @@ ul.module-header-actions {
 	a {
 		display: block;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			display: inline;
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		.stats__module-list & {
 			font-size: 12px;
 		}
@@ -340,13 +340,13 @@ ul.module-header-actions {
 			font-size: 14px;
 			line-height: 2em;
 
-			@include breakpoint( '>960px' ) {
+			@include breakpoint-deprecated( '>960px' ) {
 				.stats__module-list & {
 					font-size: 12px;
 				}
 			}
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				border-bottom: 1px solid var( --color-border-subtle );
 
 				&:last-child {
@@ -362,7 +362,7 @@ ul.module-header-actions {
 			position: relative;
 			padding: 6px 0;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				padding-top: 12px;
 				padding-bottom: 12px;
 			}
@@ -449,7 +449,7 @@ ul.module-header-actions {
 	// Left this modifier as-is because these tables are likely going to change
 	// a lot or otherwise be removed, and at least it's directly dependent on
 	// being associated with a td in this structure
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		.stats-module & td.has-no-data:hover, // 1
 		tbody tr:hover td,
 		tbody tr:hover th {

--- a/client/my-sites/stats/stats-site-overview/style.scss
+++ b/client/my-sites/stats/stats-site-overview/style.scss
@@ -6,7 +6,7 @@
 		white-space: nowrap;
 		overflow: hidden;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 
 			&:focus {
 				color: var( --color-link-dark );

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -71,7 +71,7 @@
 			}
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			border-top: none;
 			border-left: 1px solid var( --color-border-subtle );
 			float: left;
@@ -93,7 +93,7 @@
 			min-height: 35px;
 			padding-top: 10px;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				@include mobile-link-element;
 				padding: 5px 0 10px;
 				@include clear-fix;
@@ -106,7 +106,7 @@
 			text-transform: uppercase;
 			letter-spacing: 0.1em;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				font-size: 11px;
 				line-height: inherit;
 				float: none;
@@ -117,7 +117,7 @@
 			float: left;
 			margin: 3px 8px 0 20px;
 
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				float: none;
 				vertical-align: middle;
 				margin: -2px 4px 0 0;
@@ -133,7 +133,7 @@
 			text-align: center;
 			transition: font-size 0.3s 0 ease-out;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				clear: none;
 				float: right;
 				font-size: 16px;
@@ -141,7 +141,7 @@
 			}
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			// Hover state
 			a:hover,
 			a:hover .value,

--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -73,7 +73,7 @@
 	padding-top: 10px;
 	float: right;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		float: none;
 		margin: 0 auto;
 		margin-bottom: 25px;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -1,6 +1,6 @@
 
 // Module container
-@include breakpoint( '>960px' ) {
+@include breakpoint-deprecated( '>960px' ) {
 	.stats__module-column {
 		float: right;
 		width: calc( 50% - 4px );
@@ -15,7 +15,7 @@
 	}
 }
 
-@include breakpoint( '>1280px' ) {
+@include breakpoint-deprecated( '>1280px' ) {
 	.stats__module-column {
 		width: calc( 33% - 3px );
 
@@ -33,7 +33,7 @@
 }
 
 .is-section-stats .followers-count .button {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }
@@ -41,7 +41,7 @@
 .stats-navigation__control {
 	margin-right: 16px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-right: 0;
 	}
 }

--- a/client/my-sites/stats/wordads/style.scss
+++ b/client/my-sites/stats/wordads/style.scss
@@ -1,4 +1,4 @@
-@include breakpoint( '>480px' ) {
+@include breakpoint-deprecated( '>480px' ) {
 	.wordads .stats-tabs .stats-tab {
 		width: 33.33%;
 	}

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -35,7 +35,7 @@
 	max-width: 1500px;
 	margin: 0 auto;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		flex-direction: column-reverse;
 	}
 }
@@ -46,7 +46,7 @@
 	width: 50%;
 	flex-direction: column;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: 100%;
 	}
 }
@@ -54,7 +54,7 @@
 .theme__sheet-action-bar {
 	height: 50px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		&.card {
 			margin: 0 0 1px;
 		}
@@ -67,7 +67,7 @@
 	right: 50%;
 	margin-right: 20px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		margin-right: 0;
 		position: absolute;
 		top: 5px;
@@ -88,7 +88,7 @@
 .theme__sheet-preview-nav-item {
 	margin-left: auto;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		display: none;
 	}
 }
@@ -119,7 +119,7 @@
 	// also x-browser issues, so it's smaller than 4:3 proper
 	min-height: 36.15vw; // 36.75vw would be correct, but Safari is slightly off
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		position: relative;
 		margin-top: 0;
 		top: 0;
@@ -144,7 +144,7 @@
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		&.is-active:hover {
 			cursor: pointer;
 			box-shadow: 0 0 0 1px var( --color-neutral-light ),
@@ -176,7 +176,7 @@
 		margin-top: 2px;
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		display: flex;
 		top: auto;
 		bottom: -10px;
@@ -422,7 +422,7 @@
 		margin-bottom: 0;
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		flex-wrap: wrap;
 	}
 
@@ -434,7 +434,7 @@
 	.button {
 		flex: 0 0 auto;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			flex: 1 1 100%;
 			margin-top: 20px;
 			text-align: center;
@@ -457,7 +457,7 @@
 	align-items: center;
 	margin-bottom: 40px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		flex-wrap: wrap;
 	}
 
@@ -469,7 +469,7 @@
 	.button {
 		flex: 0 0 auto;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			flex: 1 1 100%;
 			margin-top: 20px;
 			text-align: center;
@@ -508,7 +508,7 @@
 	width: 50%;
 	margin: 0 0 10px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		width: 100%;
 	}
 }

--- a/client/my-sites/theme/theme-download-card/style.scss
+++ b/client/my-sites/theme/theme-download-card/style.scss
@@ -22,7 +22,7 @@
 
 }
 
-@include breakpoint( '>1040px' ) {
+@include breakpoint-deprecated( '>1040px' ) {
 
 	.theme-download-card {
 		text-align: inherit;

--- a/client/my-sites/themes/auto-loading-homepage-modal.scss
+++ b/client/my-sites/themes/auto-loading-homepage-modal.scss
@@ -3,7 +3,7 @@
 	max-width: 400px;
 	margin: 0 auto;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		box-sizing: border-box;
 		max-width: 100%;
 	}
@@ -15,7 +15,7 @@
 			margin-left: 0;
 		}
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			.button {
 				display: block;
 				margin: 0 auto 10px;

--- a/client/my-sites/themes/current-theme/style.scss
+++ b/client/my-sites/themes/current-theme/style.scss
@@ -8,7 +8,7 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 }
 
 .current-theme__current {
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: 50%;
 		float: left;
 	}
@@ -16,11 +16,11 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 }
 
 .current-theme__img {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		border-left: $current-theme-border;
 		float: right;
 	}
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		border-right: $current-theme-border;
 		float: left;
 	}
@@ -28,10 +28,10 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 }
 
 .current-theme__img-placeholder {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		float: right;
 	}
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		float: left;
 	}
 	width: 75px;
@@ -72,7 +72,7 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 	border-top: $current-theme-border;
 	box-sizing: border-box;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		width: 50%;
 		float: right;
 		border-top: none;
@@ -80,7 +80,7 @@ $current-theme-border: 1px solid rgba( var( --color-neutral-10-rgb ), 0.25 );
 	}
 
 	&.two-buttons {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			width: 33.3%;
 		}
 

--- a/client/my-sites/themes/thanks-modal.scss
+++ b/client/my-sites/themes/thanks-modal.scss
@@ -1,7 +1,7 @@
 .themes__thanks-modal {
 	min-height: 90px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		box-sizing: border-box;
 		max-width: 100%;
 	}
@@ -19,7 +19,7 @@
 			}
 		}
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			.button,
 			.button:first-child {
 				display: block;

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -8,12 +8,12 @@
 			padding-right: 4px;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-top: 24px;
 			margin-right: 15px;
 		}
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			font-size: 0;
 			.gridicon {
 				padding: 0;
@@ -26,7 +26,7 @@
 .is-section-themes.has-no-sidebar .themes__content {
 	padding: 0 0 32px;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 32px;
 	}
 }

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -15,7 +15,7 @@
 	border: 1px solid var( --color-neutral-0 );
 	margin-left: 24px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		float: none;
 		margin-left: 0;
 		margin-bottom: 24px;

--- a/client/my-sites/themes/themes-magic-search-card/style.scss
+++ b/client/my-sites/themes/themes-magic-search-card/style.scss
@@ -162,7 +162,7 @@
 	display: flex;
 	flex-wrap: wrap;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-wrap: nowrap;
 	}
 }
@@ -181,7 +181,7 @@
 	color: var( --color-neutral-70 );
 	transition: all 200ms ease-in;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: auto;
 	}
 
@@ -199,7 +199,7 @@
 			fill: var( --color-accent );
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			background: var( --color-neutral-0 );
 			box-shadow: inset 0 -3px 0 0 var( --color-accent );
 		}

--- a/client/my-sites/themes/themes-selection-header/style.scss
+++ b/client/my-sites/themes/themes-selection-header/style.scss
@@ -11,13 +11,13 @@
 		background-image: none;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.card {
 			padding-left: 15px;
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		.card {
 			padding-right: 15px;
 		}

--- a/client/my-sites/themes/themes-site-selector-modal.scss
+++ b/client/my-sites/themes/themes-site-selector-modal.scss
@@ -4,7 +4,7 @@
 
 	.site-selector-modal__content {
 		.theme {
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				width: 300px;
 			}
 			margin-left: auto;

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -17,7 +17,7 @@
 	font-size: 13px;
 	line-height: 1.7;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		.info-popover {
 			display: none;
 		}

--- a/client/post-editor/editor-action-bar/style.scss
+++ b/client/post-editor/editor-action-bar/style.scss
@@ -7,7 +7,7 @@
 	margin-bottom: 24px;
 	padding: 12px 16px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-bottom: 8px;
 	}
 
@@ -25,18 +25,18 @@
 		pointer-events: none;
 		z-index: z-index( 'root', '.editor-action-bar .editor-status-label' );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 
 		.focus-sidebar & {
 			right: 228px;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: none;
 			}
 
-			@include breakpoint( '>960px' ) {
+			@include breakpoint-deprecated( '>960px' ) {
 				right: 273px;
 			}
 		}
@@ -62,7 +62,7 @@
 }
 
 .post-editor__content .editor-action-bar {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }
@@ -79,7 +79,7 @@
 		color: var( --color-neutral-40 );
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		color: var( --color-neutral-10 );
 	}
 

--- a/client/post-editor/editor-author/style.scss
+++ b/client/post-editor/editor-author/style.scss
@@ -17,9 +17,7 @@
 	font-size: 13px;
 	margin: 0 8px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		display: none;
 	}
 }
-
-

--- a/client/post-editor/editor-confirmation-sidebar/style.scss
+++ b/client/post-editor/editor-confirmation-sidebar/style.scss
@@ -46,7 +46,7 @@
 		transform: translateX( -$sidebar-width-max );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		transition: none;
 		border-left: none;
 		pointer-events: auto;
@@ -99,7 +99,7 @@
 	background-color: var( --color-neutral-5 );
 	padding: 12px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 24px;
 	}
 

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -24,7 +24,7 @@
 		line-height: 1.425;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		&.is-split {
 			.editor-diff-viewer__scrollable {
 				display: flex;
@@ -65,7 +65,7 @@
 	color: #fff;
 	font-size: 13px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }

--- a/client/post-editor/editor-ground-control/style.scss
+++ b/client/post-editor/editor-ground-control/style.scss
@@ -10,7 +10,7 @@
 	right: 0;
 	z-index: z-index( 'root', '.editor-ground-control' );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding-top: 0;
 	}
 }
@@ -27,7 +27,7 @@
 	flex: 0 0 auto;
 	max-width: $sidebar-width-max;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }
@@ -59,7 +59,7 @@
 	display: flex;
 
 	// Hide the ground-control save buttons on mobile
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }
@@ -75,7 +75,7 @@
 		padding: 12px 16px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: block;
 	}
 }
@@ -87,7 +87,7 @@
 	position: relative;
 	padding-left: 16px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: none;
 	}
 }
@@ -104,7 +104,7 @@
 	padding: 0 8px;
 	line-height: 46px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0 12px;
 	}
 }
@@ -118,7 +118,7 @@
 	flex-grow: 1;
 	padding: 7px 12px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 100px;
 		padding: 7px 16px;
 	}
@@ -166,7 +166,7 @@
 	padding: 7px 12px;
 	margin: 0 0 0 8px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 120px;
 		padding: 7px 16px;
 		margin: 0 8px;
@@ -269,7 +269,7 @@
 	border-radius: 0;
 	color: var( --color-primary );
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		padding: 6px 32px;
 	}
 

--- a/client/post-editor/editor-gutenberg-blocks-warning-dialog/style.scss
+++ b/client/post-editor/editor-gutenberg-blocks-warning-dialog/style.scss
@@ -2,7 +2,7 @@
 .dialog.card.editor-gutenberg-blocks-warning-dialog {
 	max-width: 600px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		max-width: 90%;
 	}
 }

--- a/client/post-editor/editor-gutenberg-opt-in-dialog/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-dialog/style.scss
@@ -3,12 +3,12 @@
 	padding: 0;
 	max-width: 100%;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		max-height: 100%;
 		height: 100%;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 32px 40px 32px ( 260px + 32px );
 		max-width: 800px;
 	}
@@ -16,7 +16,7 @@
 	.dialog__content {
 		padding: 0;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding: 0 24px;
 		}
 
@@ -25,7 +25,7 @@
 			height: auto;
 			line-height: 1.2;
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				font-size: 32px;
 			}
 		}
@@ -52,13 +52,13 @@
 		.button {
 			margin: 0 24px 8px;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: block;
 				width: calc( 100% - 24px - 24px );
 				padding: 12px;
 			}
 
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				margin: 0 16px 0 0;
 			}
 		}
@@ -74,7 +74,7 @@
 	margin: 0 -24px 24px;
 	position: relative;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		background-position: 40px 43%;
 		background-size: 250px;
 		height: auto;
@@ -95,7 +95,7 @@
 		height: 48px;
 		background: linear-gradient( to bottom, rgba( 0, 0, 0, 0 ) 0%, rgba( 0, 0, 0, 0.1 ) 100% );
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			top: 0;
 			left: auto;
 			height: auto;

--- a/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
+++ b/client/post-editor/editor-gutenberg-opt-in-notice/style.scss
@@ -12,7 +12,7 @@
 	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.25 );
 	z-index: z-index( 'root', '.editor-gutenberg-opt-in-notice' );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		border-radius: 0;
 
 		.notice__icon-wrapper {
@@ -20,7 +20,7 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		right: 8px;
 		bottom: 8px;
 		left: 8px;
@@ -30,7 +30,7 @@
 		}
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-width: 640px;
 		bottom: 16px;
 
@@ -40,7 +40,7 @@
 	}
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	// We hide the notice on small viewports when the sidebar is open
 	.focus-sidebar .editor-gutenberg-opt-in-notice {
 		display: none;

--- a/client/post-editor/editor-html-toolbar/style.scss
+++ b/client/post-editor/editor-html-toolbar/style.scss
@@ -49,7 +49,7 @@
 			left: 0;
 		}
 
-		@include breakpoint( '660px-960px' ) {
+		@include breakpoint-deprecated( '660px-960px' ) {
 			.focus-sidebar &,
 			.has-chat & {
 				width: calc( 100% - ( #{ $sidebar-width-max + 1 } ) );
@@ -154,7 +154,7 @@
 			font-weight: 400;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding: 6px 12px 8px;
 			.gridicon {
 				margin-right: 0;
@@ -246,7 +246,7 @@
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 90%;
 
 		.dialog__content {

--- a/client/post-editor/editor-more-options/copy-post.scss
+++ b/client/post-editor/editor-more-options/copy-post.scss
@@ -7,7 +7,7 @@
 	margin-bottom: 16px;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.editor-more-options__copy-post-select-dialog {
 		width: 90%;
 	}

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -5,13 +5,13 @@
 	flex-grow: 0;
 	flex-shrink: 0;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		border-left: 1px solid var( --color-neutral-5 );
 		z-index: 1; // Put the list above the action-buttons::before overlay gradient. -shaun
 		flex-basis: 230px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		&::after {
 			$editor-revisions-list-fade-height: 20px;
 			content: '';
@@ -41,7 +41,7 @@
 	background: var( --color-surface );
 	border-bottom: 1px solid var( --color-neutral-5 );
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		height: 40px;
 		border-bottom: 0;
 	}
@@ -62,7 +62,7 @@
 	align-self: center;
 }
 
-@include breakpoint( '>1040px' ) {
+@include breakpoint-deprecated( '>1040px' ) {
 	.editor-revisions-list.is-loading {
 		.editor-revisions-list__header::before {
 			align-self: flex-end;
@@ -76,7 +76,7 @@
 // Diff View Buttons
 .editor-revisions-list__view-buttons {
 	display: none;
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		display: flex;
 		height: 60px;
 		align-items: center;
@@ -105,7 +105,7 @@
 		border-radius: 0;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 		height: 24px;
 	}
@@ -130,7 +130,7 @@
 		transform: rotate( -90deg );
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		height: 24px;
 		.gridicon {
 			transform: none;
@@ -159,7 +159,7 @@
 	}
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.editor-revisions-list__next-button,
 	.editor-revisions-list__next-button:hover,
 	.editor-revisions-list__next-button:active {
@@ -167,7 +167,7 @@
 	}
 }
 
-@include breakpoint( '>660px' ) {
+@include breakpoint-deprecated( '>660px' ) {
 	.editor-revisions-list__prev-button,
 	.editor-revisions-list__prev-button:hover {
 		border-right: 1px solid var( --color-neutral-5 );
@@ -189,12 +189,12 @@
 	overflow-y: auto;
 	-webkit-overflow-scrolling: touch;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		top: 88px;
 		overflow-y: hidden;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		top: 124px;
 	}
 }
@@ -203,7 +203,7 @@
 	list-style: none;
 	margin: 0;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: inline;
 		white-space: nowrap;
 	}
@@ -238,7 +238,7 @@
 	min-height: 73px;
 	width: 45vw;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 		width: 100%;
 		border-right: none;

--- a/client/post-editor/editor-revisions/style.scss
+++ b/client/post-editor/editor-revisions/style.scss
@@ -10,13 +10,13 @@
 	height: calc( 90vh - 73px );
 	overflow-y: hidden;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-direction: column-reverse;
 		width: 100vw;
 		height: calc( 100vh - 73px );
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		&::before {
 			content: '';
 			position: absolute;
@@ -58,7 +58,7 @@ body.showing-post-revisions-dialog {
 	overflow-y: hidden;
 
 	.dialog.card {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			max-width: 100%;
 			max-height: 100%;
 		}

--- a/client/post-editor/editor-sidebar/style.scss
+++ b/client/post-editor/editor-sidebar/style.scss
@@ -23,13 +23,13 @@
 		transition: none;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		border-right: 1px solid var( --color-neutral-5 );
 		width: $sidebar-width-max;
 	}
 
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		position: relative;
 		top: 0;
 		left: 0;
@@ -85,14 +85,14 @@
 	white-space: nowrap;
 	max-width: 50%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 	}
 }
 
 .editor-sidebar__toggle-sidebar {
 	margin-left: 16px;
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 }

--- a/client/post-editor/editor-slug/style.scss
+++ b/client/post-editor/editor-slug/style.scss
@@ -2,7 +2,7 @@
 	margin-left: 10px;
 	margin-top: -4px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-left: 0;
 	}
 }
@@ -33,7 +33,7 @@
 	margin-right: 0;
 	cursor: pointer;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		word-wrap: break-word;
 	}
 }

--- a/client/post-editor/editor-title/style.scss
+++ b/client/post-editor/editor-title/style.scss
@@ -13,11 +13,11 @@
 	}
 
 	.focus-sidebar & {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-left: 52px;
 		}
 
-		@include breakpoint( '>1040px' ) {
+		@include breakpoint-deprecated( '>1040px' ) {
 			margin-left: 0;
 		}
 	}
@@ -29,7 +29,7 @@
 		top: 18px;
 	display: none;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 	}
 }
@@ -50,7 +50,7 @@
 		box-shadow: none;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		font-size: 32px;
 	}
 }

--- a/client/post-editor/editor-visibility/style.scss
+++ b/client/post-editor/editor-visibility/style.scss
@@ -19,7 +19,7 @@
 	.select-dropdown__header {
 		max-width: ( $sidebar-width-max - $accordion-padding * 2 );
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			max-width: 100%;
 			min-width: ( $sidebar-width-max - $accordion-padding * 2 );
 		}

--- a/client/post-editor/media-modal/content.scss
+++ b/client/post-editor/media-modal/content.scss
@@ -8,7 +8,7 @@
 		left: 0;
 	overflow-y: auto;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex-direction: row;
 		top: 74px;
 		overflow-y: visible;

--- a/client/post-editor/media-modal/detail/style.scss
+++ b/client/post-editor/media-modal/detail/style.scss
@@ -4,7 +4,7 @@
 	height: 50px;
 	line-height: 1;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-bottom: 0;
 	}
 }
@@ -20,7 +20,7 @@
 	background-color: var( --color-neutral-0 );
 	box-shadow: inset 0 0 2px 2px rgba( var( --color-neutral-20-rgb ), 0.1 );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: 2 0 0%;
 		margin: 0 0 16px 24px;
 		border: 0;
@@ -106,7 +106,7 @@
 	display: none;
 
 	&.is-desktop {
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			display: block;
 			position: absolute;
 			top: 8px;
@@ -119,7 +119,7 @@
 	}
 
 	&.is-mobile {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: block;
 			text-align: right;
 
@@ -139,7 +139,7 @@
 	flex: 2 0 0%;
 	padding: 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: 1 0 0%;
 		padding-top: 0;
 		padding-right: 24px;

--- a/client/post-editor/media-modal/dialog.scss
+++ b/client/post-editor/media-modal/dialog.scss
@@ -6,7 +6,7 @@
 	left: 0;
 	max-width: none;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		top: 5%;
 		bottom: 5%;
 		left: 5%;
@@ -14,7 +14,7 @@
 		width: 90%;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		left: 12.5%;
 		right: 12.5%;
 		width: 75%;
@@ -31,20 +31,20 @@
 
 .editor-media-modal .section-nav {
 	z-index: z-index( '.dialog__backdrop', '.editor-media-modal .section-nav' );
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-bottom: 16px;
 	}
 }
 
 .editor-media-modal .header-cake.card {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-top: 0;
 		justify-content: left;
 	}
 }
 
 .editor-media-modal .header-cake__corner {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex: none;
 	}
 }
@@ -56,7 +56,7 @@
 .editor-media-modal .media-library__header {
 	padding: 0 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding: 0 24px;
 	}
 }
@@ -70,7 +70,7 @@
 .editor-media-modal .media-library__scale-range.range {
 	right: 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		right: 24px;
 	}
 }
@@ -91,12 +91,12 @@
 	pointer-events: all;
 	overflow-y: auto;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		bottom: 74px;
 		top: 131px;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-left: 24px;
 		padding-right: 24px;
 		overflow-y: auto;
@@ -107,7 +107,7 @@
 .editor-media-modal .notice {
 	z-index: z-index( '.dialog__backdrop', '.editor-media-modal .notice' );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 16px;
 	}
 }
@@ -132,7 +132,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		@media ( max-height: 600px ) {
 			display: none;
 		}

--- a/client/post-editor/media-modal/gallery/style.scss
+++ b/client/post-editor/media-modal/gallery/style.scss
@@ -7,7 +7,7 @@
 	background-color: var( --color-neutral-0 );
 	border: 1px solid var( --color-neutral-10 );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 		margin: 16px 0 16px 24px;
 	}
@@ -35,7 +35,7 @@
 	z-index: z-index( '.dialog__backdrop', '.editor-media-modal-gallery__preview-toggle' );
 	width: 200px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		right: -1px;
 	}
 
@@ -65,7 +65,7 @@
 	width: 44%;
 	margin: 3%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 160px;
 		margin: 16px 0 0 16px;
 	}
@@ -138,7 +138,7 @@ input.editor-media-modal-gallery__caption[type='text'] {
 	flex: 1 0 0%;
 	padding: 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-top: 0;
 		padding-right: 24px;
 		overflow-y: auto;
@@ -179,7 +179,7 @@ input.editor-media-modal-gallery__caption[type='text'] {
 		transition: 0.2s opacity cubic-bezier( 0.25, 0.5, 0.5, 0.9 );
 		opacity: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			width: 75%;
 			margin-left: -37.5%;
 		}
@@ -216,7 +216,7 @@ input.editor-media-modal-gallery__caption[type='text'] {
 	left: 16px;
 	right: 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		position: static;
 	}
 }
@@ -224,7 +224,7 @@ input.editor-media-modal-gallery__caption[type='text'] {
 .editor-media-modal-gallery__fields .for-setting-type .editor-media-modal__fieldset-legend {
 	display: none;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 	}
 }
@@ -232,7 +232,7 @@ input.editor-media-modal-gallery__caption[type='text'] {
 .editor-media-modal-gallery__fields .for-setting-type .select-dropdown__container {
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: auto;
 	}
 }
@@ -244,12 +244,12 @@ input[type].editor-media-modal-gallery__input-width-auto {
 .editor-media-modal-gallery__preview-individual-content {
 	padding-top: 8px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 75%;
 		margin: 0 auto;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-width: 50%;
 	}
 }
@@ -300,7 +300,7 @@ input[type].editor-media-modal-gallery__input-width-auto {
 .editor-media-modal-gallery__content {
 	margin-top: 16px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 0;
 	}
 }

--- a/client/post-editor/media-modal/index.scss
+++ b/client/post-editor/media-modal/index.scss
@@ -83,7 +83,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		&.is-mobile {
 			display: none;
 		}
@@ -135,7 +135,7 @@
 		display: none;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		.is-desktop {
 			display: inherit;
 		}
@@ -149,7 +149,7 @@
 .editor-media-modal__plan-storage {
 	display: none;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		display: inline-block;
 	}
 }

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -22,7 +22,7 @@
 	right: -273px;
 }
 
-@include breakpoint( '<660px' ) {
+@include breakpoint-deprecated( '<660px' ) {
 	.is-group-editor.focus-sidebar::before,
 	.is-group-editor.focus-editor-confirmation-sidebar::before {
 		background-color: var( --color-neutral-0 );
@@ -54,7 +54,7 @@
 		display: block;
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: block;
 		backface-visibility: visible;
 		perspective: none;
@@ -77,7 +77,7 @@
 	margin-bottom: 16px;
 	background: var( --color-neutral-0 );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: none;
 	}
 
@@ -109,7 +109,7 @@
 }
 
 .focus-content .post-editor__header {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: 700px;
 	}
 }
@@ -119,7 +119,7 @@
 	box-sizing: border-box;
 	padding: 0 16px;
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		padding: 0;
 	}
 }
@@ -159,7 +159,7 @@
 	font-size: 14px;
 	margin-bottom: 64px;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding: 24px 27px; /* 27px = 16px + the 11px padding on Visual mode */
 		margin-bottom: 0;
 	}
@@ -181,11 +181,11 @@
 	width: 160px;
 	z-index: z-index( 'root', '.post-editor__switch-mode' );
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		right: 32px;
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		right: 0;
 	}
 }
@@ -253,7 +253,7 @@
 		display: block;
 		padding: 12px 0 18px; /* Make room for the RemoveButton */
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin: -24px 0 24px;
 		}
 	}

--- a/client/reader/components/reader-blank-suggestions/style.scss
+++ b/client/reader/components/reader-blank-suggestions/style.scss
@@ -15,7 +15,7 @@
 		color: var( --color-primary-light );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 16px;
 	}
 }

--- a/client/reader/conversations/intro.scss
+++ b/client/reader/conversations/intro.scss
@@ -9,7 +9,7 @@
 		background-position: 150px 20px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		background-position: 120px 20px;
 	}
 
@@ -27,7 +27,7 @@
 			display: none;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -44,7 +44,7 @@
 	}
 
 	.conversations__intro-copy-hidden {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 			visibility: hidden;
 		}

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -86,7 +86,7 @@
 	margin-top: 30px;
 	max-width: 650px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 70px;
 	}
 }

--- a/client/reader/discover/site-attribution.scss
+++ b/client/reader/discover/site-attribution.scss
@@ -75,7 +75,7 @@
 		}
 
 		.follow-button__label {
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: inline-block;
 			}
 		}

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -55,11 +55,11 @@
 .following-manage__subscriptions-controls {
 	display: flex;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		flex-wrap: wrap;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 15px;
 	}
 
@@ -72,7 +72,7 @@
 		font-weight: 600;
 		padding: 4px 0 15px;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			flex: 0 0 auto;
 			width: 100%;
 		}
@@ -82,7 +82,7 @@
 		position: relative;
 
 		&::before {
-			@include breakpoint( '<960px' ) {
+			@include breakpoint-deprecated( '<960px' ) {
 				@include long-content-fade( $size: 20% );
 				height: 30px;
 				right: 30px;
@@ -93,7 +93,7 @@
 
 	.following-manage__subscriptions-sort,
 	.following-manage__subscriptions-search {
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			flex: 1;
 		}
 	}
@@ -105,7 +105,7 @@
 		padding-top: 8px;
 		width: 100%;
 
-		@include breakpoint( '>960px' ) {
+		@include breakpoint-deprecated( '>960px' ) {
 			min-width: 200px;
 		}
 	}
@@ -113,7 +113,7 @@
 	.following-manage__subscriptions-search {
 		margin-top: 1px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-right: 0;
 		}
 	}
@@ -124,7 +124,7 @@
 		.following-manage__search-followed-input.is-compact {
 			height: 32px;
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				min-width: 0;
 			}
 		}
@@ -138,7 +138,7 @@
 	.following-manage__subscriptions-import-export {
 		margin-right: 0;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 
@@ -178,7 +178,7 @@
 }
 
 .following-manage__search-followed-input {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		min-width: 200px;
 	}
 }
@@ -202,12 +202,12 @@
 	flex-direction: column;
 	min-width: 24px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		min-width: 90px;
 	}
 
 	.button.follow-button {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			display: flex;
 		}
 	}
@@ -254,7 +254,7 @@
 		.follow-button__label {
 			color: var( --color-primary );
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: inline;
 			}
 		}

--- a/client/reader/following/style.scss
+++ b/client/reader/following/style.scss
@@ -37,12 +37,12 @@
 		background-position: 150px 20px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		background-position: 120px 20px;
 	}
 
 	.following__intro-copy-hidden {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			display: none;
 		}
 	}
@@ -77,15 +77,15 @@
 		margin-top: 20px;
 	}
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		font-size: 16px;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		font-size: 18px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		font-size: 16px;
 	}
 }
@@ -93,7 +93,7 @@
 .following__search {
 	margin-top: 8px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 30px;
 	}
 }

--- a/client/reader/list-gap/style.scss
+++ b/client/reader/list-gap/style.scss
@@ -6,7 +6,7 @@
 	position: relative;
 	text-align: center;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 15px;
 	}
 

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -7,7 +7,7 @@
 	margin-top: 24px;
 	padding: 0 14px 14px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-left: 0;
 		padding-right: 0;
 		margin-top: 0;
@@ -44,7 +44,7 @@
 	margin: 0 10px;
 	width: calc( 100% - 15px );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: calc( 100% - 165px );
 	}
 }

--- a/client/reader/post-excerpt-link/style.scss
+++ b/client/reader/post-excerpt-link/style.scss
@@ -5,7 +5,7 @@
 	margin: 20px 0 8px;
 	position: relative;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		padding-left: 16px;
 	}
 
@@ -20,7 +20,7 @@
 		height: 20px;
 		transition: all 0.15s ease-in-out;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			right: 8px;
 		}
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -3,7 +3,7 @@
 }
 
 .search-stream__intro {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-left: 16px;
 	}
 }
@@ -21,7 +21,7 @@
 	-webkit-font-smoothing: subpixel-antialiased; // Fixes fixed elements text aliasing in Safari
 
 	// Below 660px we show the MobileBackToSidebar header so no padding needed
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-top: 30px;
 	}
 
@@ -47,7 +47,7 @@
 
 // Top margin for site results
 .main.search-stream {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		perspective: none; // Fix search bar pushed up behind the masterbar in Safari
 	}
 }
@@ -57,16 +57,16 @@
 	display: flex;
 	flex-flow: row wrap;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		flex-flow: column wrap;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		flex-flow: row wrap;
 		padding: 15px 5px 15px 15px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-flow: column wrap;
 	}
 }
@@ -91,26 +91,26 @@
 	margin: 0 0 0 15px;
 	padding: 20px 0;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		margin: 0;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 0 0 15px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin: 0 5px 0 0;
 	}
 
 	&:nth-child( 2n ) {
 		margin: 0 15px 0 0;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			margin: 0;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin: 0 5px 0 0;
 		}
 	}
@@ -118,7 +118,7 @@
 	.reader-related-card__post {
 		max-height: 16px * 1.6 * 11;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			max-height: 16px * 1.6 * 8;
 		}
 	}
@@ -157,7 +157,7 @@
 			position: relative;
 			top: -2px;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				margin-right: 0;
 			}
 		}
@@ -225,7 +225,7 @@
 	margin-bottom: 0;
 	padding-bottom: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		height: 58px;
 	}
 }
@@ -299,7 +299,7 @@
 	min-width: 0;
 	max-width: 25px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		align-items: flex-start;
 		min-width: 90px;
 	}
@@ -324,13 +324,13 @@
 	width: calc( 100% - 300px );
 
 	.reader-post-card__post {
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			flex-direction: column;
 		}
 	}
 
 	.reader-post-card.card.has-thumbnail .reader-featured-image {
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			height: 80px;
 			margin: 0 0 20px;
 			max-width: 100%;
@@ -342,7 +342,7 @@
 	}
 
 	.reader-post-card.is-gallery .reader-post-card__gallery-item:last-child {
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			display: block;
 		}
 	}
@@ -365,7 +365,7 @@
 }
 
 .card.reader-search-card.is-photo {
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		z-index: z-index( 'root', '.reader-search-card' );
 	}
 }
@@ -387,7 +387,7 @@
 		.follow-button__label {
 			color: var( --color-primary );
 
-			@include breakpoint( '<660px' ) {
+			@include breakpoint-deprecated( '<660px' ) {
 				display: inline;
 			}
 		}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -11,7 +11,7 @@
 	margin-bottom: 0;
 	padding: 6px 0 30px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 15px;
 	}
 
@@ -22,7 +22,7 @@
 
 .following {
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		-webkit-perspective: none;
 		perspective: none;
 	}
@@ -55,7 +55,7 @@
 		}
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		padding: 16px 24px 24px;
 		margin-bottom: 24px;
 	}
@@ -73,7 +73,7 @@
 			top: -3px;
 			right: 0;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			z-index: z-index( 'reader-card-follow-button-parent', '.reader__card.card .follow-button' );
 		}
 	}
@@ -114,7 +114,7 @@
 			position: relative;
 			font-size: 14px;
 
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				font-size: 13px;
 			}
 		}
@@ -122,7 +122,7 @@
 
 	&.is-headerless {
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			padding-top: 25px;
 		}
 
@@ -233,7 +233,7 @@
 		margin: 0 15px;
 		padding: 20px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin: 0;
 			padding: 20px 42px;
 		}
@@ -280,7 +280,7 @@
 	box-shadow: inset 0 0 2px 2px rgba( var( --color-neutral-20-rgb ), 0.1 );
 	background: rgba( var( --color-neutral-0-rgb ), 0.3 );
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		left: -24px;
 		width: calc( 100% + 48px );
 		margin-bottom: 24px;
@@ -340,13 +340,13 @@
 
 		// Inline Reblog Tweaks
 		p.reblog-from {
-			@include breakpoint( '>480px' ) {
+			@include breakpoint-deprecated( '>480px' ) {
 				margin-left: -24px;
 				margin-right: -24px;
 				padding-left: 24px;
 				padding-right: 24px;
 			}
-			@include breakpoint( '<480px' ) {
+			@include breakpoint-deprecated( '<480px' ) {
 				margin-left: -16px;
 				margin-right: -16px;
 				padding-left: 16px;
@@ -415,7 +415,7 @@
 	border-bottom: 1px solid var( --color-neutral-10 );
 	padding-bottom: 12px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 0 15px;
 	}
 }
@@ -444,7 +444,7 @@
 	margin: 0;
 	padding: 0;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		flex-direction: column;
 	}
 }
@@ -455,7 +455,7 @@
 	list-style-type: none;
 	width: 100%;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		flex-direction: column;
 		margin-top: -40px;
 		width: 50%;
@@ -464,7 +464,7 @@
 	.reader-stream__recommended-post-dismiss {
 		height: 30px;
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			margin-right: 15px;
 		}
 
@@ -502,7 +502,7 @@
 				margin-top: 0;
 				max-height: 108px;
 
-				@include breakpoint( '<480px' ) {
+				@include breakpoint-deprecated( '<480px' ) {
 					max-height: 125px;
 				}
 			}
@@ -512,7 +512,7 @@
 	&:first-child {
 		margin-right: 10px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-right: 15px;
 		}
 	}
@@ -520,7 +520,7 @@
 	&:last-child {
 		margin-left: 10px;
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			margin-left: 15px;
 		}
 	}
@@ -528,7 +528,7 @@
 	&:first-child,
 	&:last-child {
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			margin: 0 0 20px;
 		}
 	}
@@ -545,7 +545,7 @@
 		margin-top: -2px;
 		max-height: 208px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			max-height: 207px;
 		}
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -11,7 +11,7 @@
 .is-reader-page .recommended-for-you.main,
 .is-reader-page .following.main {
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin: 30px auto;
 	}
 }
@@ -54,7 +54,7 @@
 		}
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		font-size: 13px;
 		max-width: 180px;
 	}
@@ -74,7 +74,7 @@
 	overflow-wrap: break-word;
 	word-wrap: break-word;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		font-size: 18px;
 		line-height: 1.3;
 	}
@@ -87,14 +87,14 @@
 // Back button in Reader FeedHeader
 .is-reader-page .is-site-stream .reader-feed-header.has-back-button .reader-feed-header__follow {
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		right: 0;
 	}
 
 	// Drops Follow count in FeedHeader if Back button exists
 	.reader-feed-header__follow-count {
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			display: none;
 		}
 	}
@@ -111,11 +111,11 @@
 			top: 4px;
 		z-index: z-index( '.reader-feed-header__back-and-follow', '.card.header-cake' );
 
-		@include breakpoint( '<960px' ) {
+		@include breakpoint-deprecated( '<960px' ) {
 			margin-top: 0;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			left: 0;
 		}
 	}
@@ -197,7 +197,7 @@
 	li {
 		margin-right: 8px;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			margin-right: 16px;
 		}
 
@@ -348,7 +348,7 @@
 
 .is-group-reader .empty-content__action,
 .is-reader-page .empty-content__action {
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		margin-bottom: 10px;
 	}
 }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -16,14 +16,14 @@
 .tag-stream__header .follow-button {
 	z-index: z-index( '.tag-stream__header-follow', '.follow-button' );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 12px 20px 0 15px;
 	}
 }
 
 .tag-stream__header .follow-button__label {
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		display: inline;
 	}
 }
@@ -106,12 +106,12 @@
 		left: -3px;
 		top: 8px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		left: 13px;
 		top: 20px;
 	}
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		top: 14px;
 	}
 

--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -36,21 +36,21 @@
 	opacity: 0.1;
 	animation: focus 5s infinite ease-in-out;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		left: 0;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		transform: scale( 0.8 );
 		left: 130px;
 		top: -120px;
 	}
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		transform: scale( 1.2 );
 	}
 
-	@include breakpoint( '>1040px' ) {
+	@include breakpoint-deprecated( '>1040px' ) {
 		transform: scale( 1.5 );
 	}
 

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -6,19 +6,19 @@
 
 	// Side by side layout uses flexbox to show
 	// both mockups next to each other.
-	@include breakpoint( '>960px' ) {
+	@include breakpoint-deprecated( '>960px' ) {
 		max-width: 1200px;
 		display: flex;
 		align-items: flex-start;
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding-right: 1px;
 		padding-left: 1px;
 		padding-bottom: 0;
 	}
 
-	@include breakpoint( '660px-960px' ) {
+	@include breakpoint-deprecated( '660px-960px' ) {
 		position: relative;
 	}
 }
@@ -35,7 +35,7 @@
 	&:last-child {
 		margin-bottom: 24px;
 	}
-	
+
 	p {
 		margin: 0 auto;
 		max-width: 420px;

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -4,7 +4,7 @@
 	margin-bottom: 50px;
 	margin-top: -20px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin: 30px auto;
 	}
 }
@@ -16,7 +16,7 @@
 .is-large-skip-layout .step-wrapper__buttons {
 	margin-bottom: 34px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		margin-bottom: 14px;
 	}
 }

--- a/client/signup/steps/clone-point/style.scss
+++ b/client/signup/steps/clone-point/style.scss
@@ -12,7 +12,7 @@
 		left: 33px;
 		width: 2px;
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			left: 25px;
 		}
 	}

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -33,7 +33,7 @@
 		box-shadow: 0 0 0 3px var( --color-accent-light );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.register-domain-step__search-card,
 		.search.is-open.has-focus {
 			border-radius: 0;

--- a/client/signup/steps/import-url-onboarding/style.scss
+++ b/client/signup/steps/import-url-onboarding/style.scss
@@ -26,7 +26,7 @@
 	min-width: rem( 200px );
 	margin: rem( 16px ) auto 0;
 
-	@include breakpoint( '<480px' ) {
+	@include breakpoint-deprecated( '<480px' ) {
 		min-width: rem( 160px );
 	}
 }
@@ -51,7 +51,7 @@
 	margin-bottom: auto;
 	line-height: 48px;
 
-	@include breakpoint( '<960px' ) {
+	@include breakpoint-deprecated( '<960px' ) {
 		line-height: 38px;
 	}
 }

--- a/client/signup/steps/import-url/style.scss
+++ b/client/signup/steps/import-url/style.scss
@@ -18,7 +18,7 @@
 	border-radius: 3px;
 	padding: 10px 14px;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 14px;
 	}
 }
@@ -39,7 +39,7 @@
 		top: 2px;
 		right: 2px;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			top: 1px;
 			right: 1px;
 		}

--- a/client/signup/steps/reader-landing/style.scss
+++ b/client/signup/steps/reader-landing/style.scss
@@ -10,7 +10,7 @@
 
 .reader-landing__button-wrapper {
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		text-align: center;
 	}
 }
@@ -18,7 +18,7 @@
 .reader-landing__button {
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		width: inherit;
 		text-align: center;
 	}
@@ -27,7 +27,7 @@
 .reader-landing__feature {
 	margin-bottom: 30px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 	}
 
@@ -35,13 +35,13 @@
 		flex-direction: row-reverse;
 
 		.reader-landing__feature-detail {
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				padding-left: 0;
 			}
 		}
 
 		.reader-landing__feature-image {
-			@include breakpoint( '>660px' ) {
+			@include breakpoint-deprecated( '>660px' ) {
 				margin-left: 25px;
 				margin-right: 0;
 			}
@@ -52,7 +52,7 @@
 .reader-landing__feature-image,
 .reader-landing__feature-detail {
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		flex: 50%;
 	}
 }
@@ -62,7 +62,7 @@
 	border-radius: 5px;
 	width: 100%;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		align-self: center;
 		margin: 0 25px 0 0;
 		width: 48%;
@@ -77,7 +77,7 @@
 	font-size: 1.2em;
 	font-weight: bold;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		font-size: 1.6em;
 	}
 }
@@ -87,7 +87,7 @@
 	font-size: 1em;
 	margin-top: 4px;
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		margin-top: 10px;
 		font-size: 1.1em;
 	}

--- a/client/signup/steps/rebrand-cities-welcome/style.scss
+++ b/client/signup/steps/rebrand-cities-welcome/style.scss
@@ -13,7 +13,7 @@
 		margin-bottom: 0.2em;
 	}
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		.formatted-header__subtitle {
 			margin: 0 10%;
 		}

--- a/client/signup/steps/site-or-domain/style.scss
+++ b/client/signup/steps/site-or-domain/style.scss
@@ -51,7 +51,7 @@
 	color: var( --color-neutral-70 );
 }
 
-@include breakpoint( '>480px' ) {
+@include breakpoint-deprecated( '>480px' ) {
 	.site-or-domain__choice-button {
 		margin-bottom: 1.5em;
 	}
@@ -67,7 +67,7 @@
 	}
 }
 
-@include breakpoint( '<480px' ) {
+@include breakpoint-deprecated( '<480px' ) {
 	.site-or-domain__choice-text {
 		display: flex;
 		flex-direction: column-reverse;

--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -1,6 +1,6 @@
 .site-style__form,
 .site-style__form-wrapper {
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		display: flex;
 	}
 }
@@ -10,7 +10,7 @@
 	max-width: 480px;
 	background-color: var( --color-surface );
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		// On small screens the form
 		// slightly resembles a card
 		box-shadow: 0 5px 5px -3px rgba( 0, 0, 0, 0.2 ),
@@ -18,7 +18,7 @@
 					0 3px 14px 2px rgba( 0, 0, 0, 0.12 );
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		max-width: 100%;
 		padding: 0 4px;
 		border-radius: 5px;
@@ -45,7 +45,7 @@
 	// Transition all the things!
 	transition: all 0.15s ease-in-out;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 50%;
 		padding: 16px 8px;
 		border-bottom: 1px solid var( --color-neutral-20 );
@@ -64,7 +64,7 @@
 		}
 	}
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		// Make 'em feel like buttons.
 		cursor: pointer;
 		border: 1px solid var( --color-neutral-20 );
@@ -93,14 +93,14 @@
 		// A nice big border for the bigger
 		// buttons on small screens.
 		box-shadow: inset 0 0 0 6px var( --color-accent-light );
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			// This should prolly go somewhere else
 			svg {
 				transform: scale( 1 );
 			}
 		}
 
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			// On bigger screens the border
 			// gets smaller.
 			box-shadow: inset 0 0 0 2px var( --color-accent-light );
@@ -161,7 +161,7 @@
 		}
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		padding: 8px;
 
 		.button {

--- a/client/signup/steps/site-title/style.scss
+++ b/client/signup/steps/site-title/style.scss
@@ -32,7 +32,7 @@
 
 		// On smaller screens the buttons get bigger,
 		// so this input needs to get bigger, too.
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding-top: 15px;
 			padding-bottom: 15px;
 			padding-right: 100px;
@@ -97,7 +97,7 @@
 /* We need specificity here to overwrite client/signup/style.scss */
 body.is-section-signup {
 	.site-title__wrapper .site-title__field-control button.button {
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding: 12px;
 		}
 	}

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -30,7 +30,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		// No need for a border here
 		border: none;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			// On smaller screens the buttons get bigger,
 			// so this input needs to get bigger, too.
 			padding: 15px 100px 15px 42px;
@@ -80,7 +80,7 @@ body.is-section-jetpack-connect .site-topic__content {
 			width: 24px;
 		}
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			padding: 12px;
 		}
 	}

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -7,7 +7,7 @@
 
 	// At small screen sizes make the step
 	// full width. -shaun
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		width: 100%;
 	}
 }
@@ -21,7 +21,7 @@
 	@include elevation ( 0 );
 	border-bottom: 1px solid var( --color-neutral-5 );
 
-	@include breakpoint( '>660px' ) {
+	@include breakpoint-deprecated( '>660px' ) {
 		padding-right: 24px;
 	}
 
@@ -58,7 +58,7 @@
 	}
 
 	.card__link-indicator {
-		@include breakpoint( '>660px' ) {
+		@include breakpoint-deprecated( '>660px' ) {
 			opacity: 0.5;
 			transform: translateX( -4px );
 			transition: all 200ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );

--- a/client/signup/steps/survey/style.scss
+++ b/client/signup/steps/survey/style.scss
@@ -121,7 +121,7 @@
 	position: relative;
 }
 
-@include breakpoint( '>480px' ) {
+@include breakpoint-deprecated( '>480px' ) {
 	.survey__other {
 		margin: 0 auto 2em;
 		max-width: 500px;

--- a/client/signup/steps/upsell/style.scss
+++ b/client/signup/steps/upsell/style.scss
@@ -24,11 +24,11 @@
 
 	&__column-content {
 		padding-right: 10px;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			padding-right: 0;
 		}
     }
-    
+
     &__section-title {
         font-size: 18px;
 		font-weight: 700;
@@ -38,7 +38,7 @@
 	&__column-doodle {
 		width: 120px;
 		flex-shrink: 0;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			display: none;
 		}
 	}
@@ -60,7 +60,7 @@
 		margin-top: 0.5em;
 		margin-bottom: 1.4em;
 
-		@include breakpoint( '<660px' ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			font-size: 21px;
 		}
     }
@@ -68,22 +68,22 @@
 	&__footer &__decline-offer-button {
 		color: var( --color-primary );
 
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			float: left;
 		}
 	}
 
 	&__footer &__accept-offer-button {
-		@include breakpoint( '<480px' ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			width: 100%;
 			margin-top: 10px;
 		}
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			float: right;
 		}
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -98,7 +98,7 @@ body.is-section-signup .layout.gravatar {
 		@include elevation ( 2dp );
 	}
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		button {
 			font-size: 16px;
 			padding-top: 12px;
@@ -134,7 +134,7 @@ body.is-section-signup .layout:not( .dops ) .step-wrapper {
 
 	// On small screens remove the margin from the
 	// bottom of the cards.
-	@include breakpoint( '<660px' ) {
+	@include breakpoint-deprecated( '<660px' ) {
 		.card {
 			margin-bottom: 0;
 		}
@@ -374,7 +374,7 @@ body.is-section-signup.is-new-launch-flow {
 	.formatted-header__title {
 		@include onboarding-heading-text-mobile;
 
-		@include breakpoint( '>480px' ) {
+		@include breakpoint-deprecated( '>480px' ) {
 			@include onboarding-heading-text;
 		}
 	}

--- a/client/signup/validation-fieldset/style.scss
+++ b/client/signup/validation-fieldset/style.scss
@@ -14,7 +14,7 @@
 .validation-fieldset + .logged-out-form__footer {
 	margin-top: 0;
 
-	@include breakpoint( '>480px' ) {
+	@include breakpoint-deprecated( '>480px' ) {
 		margin-top: 20px;
 	}
 }

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -98,52 +98,9 @@ Under the hood, we are using webpack and its `sass-loader`, for compiling the st
 
 ## Media Queries
 
-We don't do device specific breakpoints, we use layout-specific breakpoints that communicate the state of the UI. DO NOT define your own media queries. Utilize the mixins [provided in `_mixins.scss`](https://github.com/Automattic/wp-calypso/blob/master/assets/stylesheets/shared/mixins/_breakpoints.scss). Furthermore, we are pushing for a mobile-first approach to media queries, meaning your default styles should apply to mobile, and desktop should build on top of that. This means that devices with smaller screens have to process less CSS (which makes sense since they are generally less powerful). You should avoid the use of `<` breakpoints like this:
+To avoid code bloat and have a more consistent experience we should try to use the same breakpoints in all SCSS files.
 
-Bad:
-```scss
-.class-name {
-    margin: 20px; // styles for all devices
-    @include breakpoint( “<480px” ) {
-        margin: 10px; // styles for mobile
-    }
-}
-```
-
-Good:
-```scss
-.class-name {
-    margin: 10px; // styles for all devices
-    @include breakpoint( “>480px” ) {
-        margin: 20px; // styles for desktop
-    }
-}
-```
-
-There is only one time when using a `<` breakpoint is ok; when it saves you code:
-
-Bad:
-```scss
-.class-name {
-    width: 50%; // styles for all devices
-    @include breakpoint( “>480px” ) {
-        width: auto; // styles for desktop
-    }
-}
-```
-
-Good:
-```scss
-.class-name {
-    @include breakpoint( “<480px” ) {
-        width: 50%; // styles for mobile
-    }
-}
-```
-
-The value passed to this mixin is actually a string rather than a pixel value. Accepted values are: `"<X"`, `">X"`, or `"X-Y"` — where `X` and `Y` are valid breakpoints, for example `480px`. If you provide any other value to the mixin it will fail and give you a warning in the output from `yarn start`.
-
-Adding additional breakpoints should not be undertaken lightly.
+The old `breakpoint` mixin should be replaced with the `break-*` mixins from [Gutenberg](https://github.com/WordPress/gutenberg/blob/0f1f5e75408705f0ec014f5d2ea3d9fcc8a97817/packages/base-styles/_mixins.scss)
 
 
 ### Adding a new Sass file
@@ -267,7 +224,7 @@ selector {
 - DO use a single space before an opening brace
 
 ```scss
-@include breakpoint( ">480px" ) {
+@include breakpoint-deprecated( ">480px" ) {
   color: rgb( 0, 0, 0 );
   transform: translate( -50%, -50% ) scale( 1 );
 }
@@ -282,8 +239,8 @@ add another entry to the `$z-layers` variable in
 
 Because browsers support a hierarchy of stacking contexts rather than a single
 global one, we use a tree with two levels of keys. The first is the name of the
-parent stacking context, and the latter is the selector for the stacking 
-context you've just created.  We keep each level of the tree sorted by z-index 
+parent stacking context, and the latter is the selector for the stacking
+context you've just created.  We keep each level of the tree sorted by z-index
 so we can quickly compare z-index values within a given stacking context.
 
 An element creates a new stacking context when any of the following are true:
@@ -300,8 +257,8 @@ So, to add a new z-index:
 
 1. You'll want to make sure the element actually creates a stacking context
 2. Look up its parent stacking context
-3. Put the new rule in the `$z-layers` tree, using the selector of the parent 
-   stacking context as the initial key and the element's full CSS selector as 
+3. Put the new rule in the `$z-layers` tree, using the selector of the parent
+   stacking context as the initial key and the element's full CSS selector as
    the final key.
 
 You can use this handy Chrome
@@ -380,9 +337,9 @@ $z-layers: (
 ```
 
 While we can support a map with more than 2 layers, there isn't much benefit to doing
-this. Stacking of children are completely resolved within their parent context. So in 
+this. Stacking of children are completely resolved within their parent context. So in
 our example the stacking of `.modal__icon`, `.modal__header`, and `.modal__content` are
-completely resolved within `.modal`. Once this is done the entire `.modal` element is 
+completely resolved within `.modal`. Once this is done the entire `.modal` element is
 passed for stacking in the root element, with it's sibling `.masterbar`.
 
 For further reading on stacking contexts see:

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -100,7 +100,7 @@ Under the hood, we are using webpack and its `sass-loader`, for compiling the st
 
 To avoid code bloat and have a more consistent experience we use the same breakpoints in all SCSS files whenever possible.
 
-The old `breakpoint` mixin should be replaced with the `break-*` mixins from [Gutenberg](https://github.com/WordPress/gutenberg/blob/0f1f5e75408705f0ec014f5d2ea3d9fcc8a97817/packages/base-styles/_mixins.scss)
+The old `breakpoint-deprecated` mixin should be replaced with the `break-*` mixins from [Gutenberg](https://github.com/WordPress/gutenberg/blob/0f1f5e75408705f0ec014f5d2ea3d9fcc8a97817/packages/base-styles/_mixins.scss)
 
 
 ### Adding a new Sass file

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -98,9 +98,26 @@ Under the hood, we are using webpack and its `sass-loader`, for compiling the st
 
 ## Media Queries
 
-To avoid code bloat and have a more consistent experience we use the same breakpoints in all SCSS files whenever possible.
+To avoid code bloat and have a more consistent experience we use the same breakpoints in all SCSS files whenever possible. DO NOT define your own media queries. We should use the `break-*` mixins from [Gutenberg](https://github.com/WordPress/gutenberg/blob/0f1f5e75408705f0ec014f5d2ea3d9fcc8a97817/packages/base-styles/_mixins.scss). For example:
 
-The old `breakpoint-deprecated` mixin should be replaced with the `break-*` mixins from [Gutenberg](https://github.com/WordPress/gutenberg/blob/0f1f5e75408705f0ec014f5d2ea3d9fcc8a97817/packages/base-styles/_mixins.scss)
+```scss
+@import '~@wordpress/base-styles/breakpoints';
+@import '~@wordpress/base-styles/mixins';
+
+.class-name {
+    margin-bottom: 8px;
+    padding: 12px;
+
+    @include break-mobile {
+        margin-bottom: 16px;
+        padding: 24px;
+    }
+}
+```
+
+ Furthermore, we are pushing for a mobile-first approach to media queries, meaning your default styles should apply to mobile, and desktop should build on top of that. You should avoid the use of max width breakpoints.
+
+  The old `breakpoint-deprecated` mixin should be replaced with Gutenberg's `break-*` mixins.
 
 
 ### Adding a new Sass file

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -98,7 +98,7 @@ Under the hood, we are using webpack and its `sass-loader`, for compiling the st
 
 ## Media Queries
 
-To avoid code bloat and have a more consistent experience we should try to use the same breakpoints in all SCSS files.
+To avoid code bloat and have a more consistent experience we use the same breakpoints in all SCSS files whenever possible.
 
 The old `breakpoint` mixin should be replaced with the `break-*` mixins from [Gutenberg](https://github.com/WordPress/gutenberg/blob/0f1f5e75408705f0ec014f5d2ea3d9fcc8a97817/packages/base-styles/_mixins.scss)
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Based on p4TIVU-9pb-p2 let's rename this mixin to make it clear that it's deprecated
* I looked into adding a stylelint rule, but it looked complicated so I took the easy route and just renamed the mixin :)


The reason behind this:
- We have virtually the same breakpoints in Calypso and Gutenberg but using different code.
- By using the same breakpoints we'll keep our CSS smaller and have a more consistent experience.
- We also keep our code simpler.

#### Testing instructions

* Look for uses of this mixin that I missed (I did a find and replace on `include breakpoint`);
* Test some pages to make sure they are still responsive.
* Check that the docs change is helpful

