### PR TITLE
Jetpack Cloud: Add Retry Scan button.

### DIFF
--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -44,7 +44,7 @@ const FixAllThreatsDialog = ( {
 
 	return (
 		<Dialog additionalClassNames="fix-all-threats-dialog" isVisible={ showDialog }>
-			<h1 className="fix-all-threats-dialog__header">Fix all threats</h1>
+			<h1 className="fix-all-threats-dialog__header">{ translate( 'Fix all threats' ) }</h1>
 			{ currentStep === 'server-credentials' && (
 				<>
 					<h3 className="fix-all-threats-dialog__threat-title">

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -22,7 +22,7 @@ import Gridicon from 'components/gridicon';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import getSiteUrl from 'state/sites/selectors/get-site-url';
 import getSiteScanProgress from 'state/selectors/get-site-scan-progress';
 import getSiteScanIsInitial from 'state/selectors/get-site-scan-is-initial';
@@ -97,7 +97,7 @@ class ScanPage extends Component< Props > {
 					} )
 				}
 			>
-				{ translate( 'Contact Support {{externalIcon/}}', {
+				{ translate( 'Contact support {{externalIcon/}}', {
 					components: { externalIcon: <Gridicon icon="external" size={ 24 } /> },
 				} ) }
 			</Button>
@@ -122,7 +122,7 @@ class ScanPage extends Component< Props > {
 	}
 
 	renderScanOkay() {
-		const { scanState, siteId, siteSlug, moment, dispatchScanRun, applySiteOffset } = this.props;
+		const { scanState, siteId, moment, dispatchScanRun, applySiteOffset } = this.props;
 		const lastScanTimestamp = scanState?.mostRecent?.timestamp;
 		let lastScanSiteTime = '';
 		if ( lastScanTimestamp && applySiteOffset ) {
@@ -150,12 +150,7 @@ class ScanPage extends Component< Props > {
 					) }
 				</p>
 				{ isEnabled( 'jetpack-cloud/on-demand-scan' ) && (
-					<Button
-						primary
-						href={ `/scan/${ siteSlug }` }
-						className="scan__button"
-						onClick={ () => dispatchScanRun( siteId ) }
-					>
+					<Button primary className="scan__button" onClick={ () => dispatchScanRun( siteId ) }>
 						{ translate( 'Scan now' ) }
 					</Button>
 				) }
@@ -194,7 +189,7 @@ class ScanPage extends Component< Props > {
 	}
 
 	renderScanError() {
-		const { siteId, siteSlug, dispatchScanRun } = this.props;
+		const { siteId, dispatchScanRun } = this.props;
 
 		return (
 			<>
@@ -209,11 +204,10 @@ class ScanPage extends Component< Props > {
 				{ this.renderContactSupportButton() }
 				{ isEnabled( 'jetpack-cloud/on-demand-scan' ) && (
 					<Button
-						href={ `/scan/${ siteSlug }` }
 						className="scan__button scan__retry-bottom"
 						onClick={ () => dispatchScanRun( siteId ) }
 					>
-						{ translate( 'Retry Scan' ) }
+						{ translate( 'Retry scan' ) }
 					</Button>
 				) }
 			</>
@@ -284,12 +278,10 @@ export default connect(
 	( state ) => {
 		const site = getSelectedSite( state ) as Site;
 		const siteId = getSelectedSiteId( state );
-		const siteSlug = getSelectedSiteSlug( state );
 		if ( ! siteId ) {
 			return {
 				site,
 				siteId,
-				siteSlug,
 			};
 		}
 		const siteUrl = getSiteUrl( state, siteId ) ?? undefined;
@@ -301,7 +293,6 @@ export default connect(
 			site,
 			siteId,
 			siteUrl,
-			siteSlug,
 			scanState,
 			scanProgress,
 			isInitialScan,

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -194,6 +194,8 @@ class ScanPage extends Component< Props > {
 	}
 
 	renderScanError() {
+		const { siteId, siteSlug, dispatchScanRun } = this.props;
+
 		return (
 			<>
 				<SecurityIcon icon="scan-error" />
@@ -205,6 +207,15 @@ class ScanPage extends Component< Props > {
 					) }
 				</p>
 				{ this.renderContactSupportButton() }
+				{ isEnabled( 'jetpack-cloud/on-demand-scan' ) && (
+					<Button
+						href={ `/scan/${ siteSlug }` }
+						className="scan__button scan__retry-bottom"
+						onClick={ () => dispatchScanRun( siteId ) }
+					>
+						{ translate( 'Retry Scan' ) }
+					</Button>
+				) }
 			</>
 		);
 	}
@@ -230,7 +241,7 @@ class ScanPage extends Component< Props > {
 			return this.renderScanning();
 		}
 
-		const errorFound = !! mostRecent.error;
+		const errorFound = !! mostRecent?.error;
 		const threatsFound = threats.length > 0;
 
 		if ( errorFound && ! threatsFound ) {

--- a/client/landing/jetpack-cloud/sections/scan/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/style.scss
@@ -77,3 +77,7 @@
 		text-align: left;
 	}
 }
+
+.scan__retry-bottom {
+	margin-left: 20px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Add Scan Retry Button to the error page. 

Before:
<img width="764" alt="Screen Shot 2020-05-08 at 2 44 23 PM" src="https://user-images.githubusercontent.com/115071/81412975-f4dab900-9144-11ea-8222-82b6904cbe5d.png">

After: 
<img width="765" alt="Screen Shot 2020-05-08 at 3 47 48 PM" src="https://user-images.githubusercontent.com/115071/81412972-f2785f00-9144-11ea-9aae-f0f852e915a0.png">

#### Testing instructions
* Create a scan error. 
* Or fake it. 

