### PR TITLE
Gutenboarding: don't use verticalized TLDs

### DIFF
--- a/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
+++ b/client/landing/gutenboarding/hooks/use-domain-suggestions.ts
@@ -58,7 +58,6 @@ export function useDomainSuggestions( {
 				quantity,
 				locale,
 				vendor: DOMAIN_SUGGESTION_VENDOR,
-				...( siteVertical && { vertical: siteVertical?.id } ),
 				...( tlds && { tlds } ),
 			} );
 		},


### PR DESCRIPTION
Stops sending vertical to paid domains suggestion API.

Context p99Zz8-Ps-p2/#comment-3463

We still use vertical as a backup search term if the user doesn't provide a site name.

We also keep sending the vertical to free `*.wordpress.com` domain suggestion API:
https://github.com/Automattic/wp-calypso/blob/2eaca4d1edffab898dd1d7002f0d2278a8fb6b39/client/landing/gutenboarding/hooks/use-free-domain-suggestion.ts#L28

<img width="1080" alt="Screenshot 2020-05-08 at 17 30 04" src="https://user-images.githubusercontent.com/87168/81415850-a54eba00-9151-11ea-8d53-dd1691a42af1.png">

#### Changes proposed in this Pull Request

* Remove vertical from domain suggestions API

#### Testing instructions

- Enter `/new` flow
- Enter vertical
- Enter site title
- Observe from network tab that paid domains API is called without `vertical`
