### PR TITLE
Gutenboarding: plans - hide domain nudge

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
@@ -82,17 +82,22 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 			</div>
 			<div className="plan-item__domain">
 				<div className="plan-item__domain-summary">{ __( 'Free domain for 1 year' ) }</div>
-				<div className="plan-item__domain-name">
-					<Button
-						className={ classNames( 'plan-item__domain-picker-button', {
-							'has-domain': hasDomain,
-						} ) }
-						isLink
-					>
-						<span>{ hasDomain ? domainName : __( 'Choose domain' ) }</span>
-						<Icon icon="arrow-down-alt2" size={ 14 }></Icon>
-					</Button>
-				</div>
+				{ hasDomain && (
+					<div className="plan-item__domain-name">
+						{ /*
+						<Button
+							className={ classNames( 'plan-item__domain-picker-button', {
+								'has-domain': hasDomain,
+							} ) }
+							isLink
+						>
+							<span>{ hasDomain ? domainName : __( 'Choose domain' ) }</span>
+							<Icon icon="arrow-down-alt2" size={ 14 }></Icon>
+						</Button>
+						*/ }
+						{ domainName }
+					</div>
+				) }
 			</div>
 			<div className="plan-item__features">
 				<ul className="plan-item__feature-item-group">


### PR DESCRIPTION
Until we move domains modal to a step-canvas or some other mechanics; let's hide the link for now. We'll add this back once rest of the plans grid is ready.

#### Changes proposed in this Pull Request

* Hide domain nudge from the plans grid.

#### Testing instructions

- In `/new` flow (on live sites with `?flags=gutenboarding/plans-grid`) ...
- Open the plans grid from plan button
- Observe no domain nudge link
- Choosing domain doesn't work yet, but you can set the `prop` manually and see it show up in every plan

##### Before

<img width="1605" alt="image" src="https://user-images.githubusercontent.com/87168/81417513-f8c20780-9153-11ea-8681-47b2a37cfbd3.png">


##### After

<img width="1530" alt="Screenshot 2020-05-08 at 17 09 59" src="https://user-images.githubusercontent.com/87168/81417403-cf08e080-9153-11ea-9443-73023e7d3569.png">

<img width="1529" alt="Screenshot 2020-05-08 at 17 10 08" src="https://user-images.githubusercontent.com/87168/81417401-cdd7b380-9153-11ea-8537-8d2adfb345ce.png">