### PR TITLE
Clear yarn cache in docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN        bash /tmp/env-config.sh
 # This layer is populated with up-to-date files from
 # Calypso development.
 COPY . /calypso/
-RUN yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile && yarn cache clean
 
 
 # Build the final layer


### PR DESCRIPTION
The cache isn't necessary in the image, since it only gets built once.

#### Changes proposed in this Pull Request

* Clear the yarn cache after a docker build

#### Testing instructions

Ensure that the live image gets built correctly, I think?
