### PR TITLE
Jetpack Cloud: Use Actual Sites for Site Count 

### DIFF
--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import AllSitesIcon from './all-sites-icon';
+import config from 'config';
 import Count from 'components/count';
 import getSites from 'state/selectors/get-sites';
 import { getCurrentUserVisibleSiteCount } from 'state/current-user/selectors';
@@ -97,6 +98,13 @@ class AllSites extends Component {
 
 export default connect( ( state, props ) => {
 	// If sites or count are not specified as props, fetch the default values from Redux
-	const { sites = getSites( state ), count = getCurrentUserVisibleSiteCount( state ) } = props;
-	return { sites, count };
+	const {
+		sites = getSites( state ),
+		userSitesCount = getCurrentUserVisibleSiteCount( state ),
+	} = props;
+
+	return {
+		sites,
+		count: config.isEnabled( 'realtime-site-count' ) ? sites.length : userSitesCount,
+	};
 } )( localize( AllSites ) );

--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -106,10 +106,10 @@ export default connect( ( state, props ) => {
 		userSitesCount = getCurrentUserVisibleSiteCount( state ),
 	} = props;
 
-	const visibleSiteCount = sites.filter( isSiteVisible ).length;
+	const visibleSites = sites?.filter( isSiteVisible );
 
 	return {
-		sites,
-		count: config.isEnabled( 'realtime-site-count' ) ? visibleSiteCount : userSitesCount,
+		sites: config.isEnabled( 'realtime-site-count' ) ? visibleSites : sites,
+		count: config.isEnabled( 'realtime-site-count' ) ? visibleSites.length : userSitesCount,
 	};
 } )( localize( AllSites ) );

--- a/client/blocks/all-sites/index.jsx
+++ b/client/blocks/all-sites/index.jsx
@@ -96,6 +96,9 @@ class AllSites extends Component {
 	}
 }
 
+// don't instantiate function in `connect`
+const isSiteVisible = ( { visible = true } ) => visible;
+
 export default connect( ( state, props ) => {
 	// If sites or count are not specified as props, fetch the default values from Redux
 	const {
@@ -103,8 +106,10 @@ export default connect( ( state, props ) => {
 		userSitesCount = getCurrentUserVisibleSiteCount( state ),
 	} = props;
 
+	const visibleSiteCount = sites.filter( isSiteVisible ).length;
+
 	return {
 		sites,
-		count: config.isEnabled( 'realtime-site-count' ) ? sites.length : userSitesCount,
+		count: config.isEnabled( 'realtime-site-count' ) ? visibleSiteCount : userSitesCount,
 	};
 } )( localize( AllSites ) );

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -81,6 +81,7 @@ export function requestSites() {
 		dispatch( {
 			type: SITES_REQUEST,
 		} );
+		const siteFilter = config( 'site_filter' );
 
 		return wpcom
 			.me()
@@ -91,7 +92,7 @@ export function requestSites() {
 				site_activity: 'active',
 				fields: SITE_REQUEST_FIELDS,
 				options: SITE_REQUEST_OPTIONS,
-				filters: config( 'site_filter' ).join( ',' ),
+				filters: siteFilter.length > 0 ? siteFilter.join( ',' ) : undefined,
 			} )
 			.then( ( response ) => {
 				dispatch( receiveSites( response.sites ) );
@@ -121,12 +122,12 @@ export function requestSite( siteFragment ) {
 			type: SITE_REQUEST,
 			siteId: siteFragment,
 		} );
-
+		const siteFilter = config( 'site_filter' );
 		return wpcom
 			.site( siteFragment )
 			.get( {
 				apiVersion: '1.2',
-				filters: config( 'site_filter' ).join( ',' ),
+				filters: siteFilter.length > 0 ? siteFilter.join( ',' ) : undefined,
 			} )
 			.then( ( site ) => {
 				// If we can't manage the site, don't add it to state.

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -126,6 +126,7 @@ export function requestSite( siteFragment ) {
 			.site( siteFragment )
 			.get( {
 				apiVersion: '1.2',
+				filters: config( 'site_filter' ).join( ',' ),
 			} )
 			.then( ( site ) => {
 				// If we can't manage the site, don't add it to state.

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -29,6 +29,7 @@
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
 		"oauth": true,
+		"realtime-site-count": true,
 		"site-indicator": false
 	},
 	"enable_all_sections": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -27,6 +27,7 @@
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
 		"oauth": true,
+		"realtime-site-count": true,
 		"site-indicator": false
 	},
 	"enable_all_sections": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -27,6 +27,7 @@
 		"layout/query-selected-editor": false,
 		"layout/support-article-dialog": false,
 		"oauth": true,
+		"realtime-site-count": true,
 		"site-indicator": false
 	},
 	"enable_all_sections": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add config option to count the number of sites available instead of using the value on the user info
* Use the new config option for Jetpack Cloud

![Untitled 4](https://user-images.githubusercontent.com/2810519/81431839-b3331980-9116-11ea-9ba2-a68fcdda2031.png)


#### Testing instructions

**!!! Because this PR involves config changes you must stop and restart the build !!!**

1. Boot Jetpack Cloud and navigate to any page with any site
2. Click "Switch Site" and confirm the count matches the actual amount of sites available
3. Boot default Calypso and navigate to any page with any site
4. Click "Switch Site" and confirm the count matches production ( WordPress.com )