### PR TITLE
Checkout: bump test date

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -27,7 +27,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	showCompositeCheckout: {
-		datestamp: '20200326',
+		datestamp: '20200508',
 		variations: {
 			composite: 50,
 			regular: 50,


### PR DESCRIPTION
Now that the usability design updates are wrapping up, we're going to bump the AB test date to run a clean hypothesis of composite vs legacy Checkout eperiences.

**To test:**
- visual sanity check