### PR TITLE
Devdocs: Update Forms, SectionHeader to include sentence-case in guidelines

### DIFF
--- a/client/components/forms/README.md
+++ b/client/components/forms/README.md
@@ -105,3 +105,8 @@ And this would render:
 ```
 
 Any valid jsx attributes that are passed to `<SelectOptGroup>` will also get passed to the rendered `<select>` element, so you can also pass in attributes like `className`, `onChange`, etc.
+
+### General guidelines
+
+- Use clear and accurate labels.
+- Use sentence-style capitalization except when referring to an official/branded feature or service name (e.g. Simple Payments).

--- a/client/components/section-header/README.md
+++ b/client/components/section-header/README.md
@@ -39,3 +39,7 @@ This is the base component and acts as a wrapper for a section's (a list of card
 - `label` - *optional* (string) The text to be displayed in the header.
 - `popoverText` - *optional* (string) If entered, a support popover will appear to the right with this text.
 
+### General guidelines
+
+- Use clear and accurate labels.
+- Use sentence-style capitalization except when referring to an official/branded feature or service name (e.g. Simple Payments).

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -57,7 +57,8 @@ export default function RockOnButton() {
 
 ### General guidelines
 
-- Use clear and accurate labels. Use sentence-style capitalization.
+- Use clear and accurate labels.
+- Use sentence-style capitalization.
 - Lead with strong, concise, and actionable verbs.
 - When the customer is confirming an action, use specific labels, such as **Save** or **Trash**, instead of using **OK** and **Cancel**.
 - Prioritize the most important actions. Too many calls to action can cause confusion and make customers unsure of what to do next.


### PR DESCRIPTION
In a previous PR: https://github.com/Automattic/wp-calypso/pull/41647, we updated our form labels and card headings/section headings to use sentence case.

We want to add this information to Devdocs as a part of each component's guidelines to make sure we have consistent casing moving forward.

## `Form` component:
![Screen Shot 2020-05-08 at 11 05 23 AM](https://user-images.githubusercontent.com/4924246/81434948-ddd3a100-911b-11ea-9e62-0196faa79ca3.png)

http://calypso.localhost:3000/devdocs/client/components/forms/README.md?term=form

## `SectionHeader` component:
![Screen Shot 2020-05-08 at 11 05 26 AM](https://user-images.githubusercontent.com/4924246/81434964-e88e3600-911b-11ea-8cbb-77f2fbfa1741.png)

http://calypso.localhost:3000/devdocs/client/components/section-header/README.md?term=sectionheader

I also just updated the `Button` component to separate sentence casing as its own item:

**Before:**
![Screen Shot 2020-05-08 at 11 11 14 AM](https://user-images.githubusercontent.com/4924246/81435397-a9acb000-911c-11ea-9ccd-ea9a4619f165.png)

**After:**
![Screen Shot 2020-05-08 at 11 06 25 AM](https://user-images.githubusercontent.com/4924246/81435044-05c30480-911c-11ea-8f8d-f36a8effe63e.png)

http://calypso.localhost:3000/devdocs/packages/components/src/button/README.md?term=button
