### PR TITLE
composite-checkout: Make sure label is always set

### DIFF
--- a/client/my-sites/checkout/composite-checkout/record-analytics.js
+++ b/client/my-sites/checkout/composite-checkout/record-analytics.js
@@ -73,17 +73,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 
 			case 'STEP_LOAD_ERROR':
-				reduxDispatch(
-					logToLogstash( {
-						feature: 'calypso_client',
-						message: 'composite checkout load error',
-						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-						extra: {
-							type: 'step_load',
-							message: String( action.payload ),
-						},
-					} )
-				);
+				reduxDispatch( logStashEventAction( 'step_load', String( action.payload ) ) );
 
 				return reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_composite_step_load_error', {
@@ -93,15 +83,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 
 			case 'SUBMIT_BUTTON_LOAD_ERROR':
 				reduxDispatch(
-					logToLogstash( {
-						feature: 'calypso_client',
-						message: 'composite checkout load error',
-						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-						extra: {
-							type: 'submit_button_load',
-							message: String( action.payload ),
-						},
-					} )
+					reduxDispatch( logStashEventAction( 'submit_button_load', String( action.payload ) ) )
 				);
 
 				return reduxDispatch(
@@ -112,15 +94,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 
 			case 'PAYMENT_METHOD_LOAD_ERROR':
 				reduxDispatch(
-					logToLogstash( {
-						feature: 'calypso_client',
-						message: 'composite checkout load error',
-						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-						extra: {
-							type: 'payment_method_load',
-							message: String( action.payload ),
-						},
-					} )
+					reduxDispatch( logStashEventAction( 'payment_method_load', String( action.payload ) ) )
 				);
 
 				return reduxDispatch(
@@ -131,15 +105,7 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 
 			case 'PAGE_LOAD_ERROR':
 				reduxDispatch(
-					logToLogstash( {
-						feature: 'calypso_client',
-						message: 'composite checkout load error',
-						severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-						extra: {
-							type: 'page_load',
-							message: String( action.payload ),
-						},
-					} )
+					reduxDispatch( logStashEventAction( 'page_load', String( action.payload ) ) )
 				);
 
 				return reduxDispatch(
@@ -487,4 +453,17 @@ export default function createAnalyticsEventHandler( reduxDispatch ) {
 				);
 		}
 	};
+}
+
+function logStashEventAction( type, message ) {
+	return logToLogstash( {
+		feature: 'calypso_client',
+		message: 'composite checkout load error',
+		severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+		extra: {
+			env: config( 'env_id' ),
+			type,
+			message,
+		},
+	} );
 }

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -17,7 +17,7 @@ import {
 	readWPCOMPaymentMethodClass,
 	translateWpcomPaymentMethodToCheckoutPaymentMethod,
 } from '../types';
-import { isPlan } from 'lib/products-values';
+import { isPlan, isDomainTransferProduct, isDomainProduct } from 'lib/products-values';
 
 /**
  * Translate a cart object as returned by the WPCOM cart endpoint to
@@ -139,16 +139,14 @@ function translateReponseCartProductToWPCOMCartItem(
 		product_cost_display,
 	} = serverCartItem;
 
-	let label;
+	let label = product_name || '';
 	let sublabel;
 	if ( isPlan( serverCartItem ) ) {
-		label = product_name || '';
 		sublabel = String( translate( 'Plan Subscription' ) );
 	} else if ( 'premium_theme' === product_slug || 'concierge-session' === product_slug ) {
-		label = product_name || '';
 		sublabel = '';
-	} else {
-		label = meta;
+	} else if ( isDomainProduct( serverCartItem ) || isDomainTransferProduct( serverCartItem ) ) {
+		label = meta || product_name || '';
 		sublabel = product_name || '';
 	}
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
+++ b/client/my-sites/checkout/composite-checkout/wpcom/lib/translate-cart.ts
@@ -145,8 +145,11 @@ function translateReponseCartProductToWPCOMCartItem(
 		sublabel = String( translate( 'Plan Subscription' ) );
 	} else if ( 'premium_theme' === product_slug || 'concierge-session' === product_slug ) {
 		sublabel = '';
-	} else if ( isDomainProduct( serverCartItem ) || isDomainTransferProduct( serverCartItem ) ) {
-		label = meta || product_name || '';
+	} else if (
+		meta &&
+		( isDomainProduct( serverCartItem ) || isDomainTransferProduct( serverCartItem ) )
+	) {
+		label = meta;
 		sublabel = product_name || '';
 	}
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/test/translate-cart.js
@@ -530,7 +530,7 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 				expect( clientCart.items[ 2 ].id ).toBeDefined();
 			} );
 			it( 'has the expected label', function () {
-				expect( clientCart.items[ 2 ].sublabel ).toBe( 'G Suite' );
+				expect( clientCart.items[ 2 ].label ).toBe( 'G Suite' );
 			} );
 			it( 'has the expected product_id', function () {
 				expect( clientCart.items[ 2 ].wpcom_meta?.product_id ).toBe( 69 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The changes in #41688 may have caused a regression that can cause fatal errors. Line items passed to `CheckoutProvider` _must_ have a `label` property. The logic in that PR, however, says that if a product is not a plan or a theme or a concierge session, its `label` is set to the `meta` returned from the cart endpoint. This is risky because `meta` is only defined for very specific products, like domains and domain-related items.

This PR refactors that logic so that it only uses `meta` if it exists and if it is a domain product.

#### Testing instructions

- Visit composite checkout with plans in the cart and verify they display the plan name first.
- Visit composite checkout with domain reg products in the cart and verify they display the domain name first and the product name second.
- Visit composite checkout with domain mapping products in the cart and verify they display the domain name first and the product name second.
- Visit composite checkout with domain transfer products in the cart and verify they display the domain name first and the product name second.