### PR TITLE
JITMs: Update width to better align with layout column

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -19,6 +19,11 @@ import AsyncLoad from 'components/async-load';
 import QueryJITM from 'components/data/query-jitm';
 import 'state/data-layer/wpcom/marketing';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const debug = debugFactory( 'calypso:jitm' );
 
 function renderTemplate( template, props ) {

--- a/client/blocks/jitm/style.scss
+++ b/client/blocks/jitm/style.scss
@@ -1,0 +1,6 @@
+	// Constrain JITMs to match layout column
+	.layout__content > .upsell-nudge {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 1040px;
+	}

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -33,13 +33,6 @@
 		padding-left: 32px;
 	}
 
-	// JITMs need to be constrained to match layout column
-	> .upsell-nudge {
-		margin-left: auto;
-		margin-right: auto;
-		max-width: 1040px;
-	}
-
 	// Themes sets it own padding/margin
 	.is-section-theme &,
 	.is-section-themes.has-no-sidebar & {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -33,6 +33,13 @@
 		padding-left: 32px;
 	}
 
+	// JITMs need to be constrained to match layout column
+	> .upsell-nudge {
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 1040px;
+	}
+
 	// Themes sets it own padding/margin
 	.is-section-theme &,
 	.is-section-themes.has-no-sidebar & {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set a max width on JITMs displayed within the `layout__column` class. Ideally we'd set these more specifically so we could always match the layout column width, but there aren't always screen-specific selectors available to know where we are this early in the layout. This is a compromise, using the same width as the wide-column layout.

**Before**

<img width="1676" alt="Screen Shot 2020-05-08 at 2 07 04 PM" src="https://user-images.githubusercontent.com/2124984/81438819-61e95100-913b-11ea-9e5f-b72012222f65.png">

<img width="1680" alt="Screen Shot 2020-05-08 at 2 50 00 PM" src="https://user-images.githubusercontent.com/2124984/81438811-5f86f700-913b-11ea-81a0-aa5e34a45be7.png">

**After**

<img width="1680" alt="Screen Shot 2020-05-08 at 2 50 57 PM" src="https://user-images.githubusercontent.com/2124984/81438869-77f71180-913b-11ea-850e-07b793c4cf4a.png">

<img width="1680" alt="Screen Shot 2020-05-08 at 2 50 20 PM" src="https://user-images.githubusercontent.com/2124984/81438876-7a596b80-913b-11ea-8cb5-8811c5649ae5.png">

#### Testing instructions

* Switch to this PR
* Navigate to Plugins on a Jetpack site with the free plan; you'll see this upsell if you haven't dismissed it before. Check for visual issues.
* Click Install plugin on the same page. You'll see another upsell; it should be the same width as the wider column.

Fixes #41001
