### PR TITLE
Gutenboarding: fetch plans prices from API

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-table/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-table/index.tsx
@@ -18,6 +18,7 @@ export interface Props {
 
 const Plans: React.FunctionComponent< Props > = ( { selectedPlanSlug, onPlanSelect } ) => {
 	const supportedPlans = useSelect( ( select ) => select( PLANS_STORE ).getSupportedPlans() );
+	const prices = useSelect( ( select ) => select( PLANS_STORE ).getPrices() );
 
 	return (
 		<div className="plans-table">
@@ -27,7 +28,7 @@ const Plans: React.FunctionComponent< Props > = ( { selectedPlanSlug, onPlanSele
 					slug={ plan.getStoreSlug() }
 					features={ plan.features }
 					isPopular={ plan.isPopular }
-					price={ plan.price }
+					price={ prices[ plan.getStoreSlug() ] }
 					name={ plan.getTitle() }
 					isSelected={ plan.getStoreSlug() === selectedPlanSlug }
 					onSelect={ onPlanSelect }

--- a/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
@@ -52,6 +52,9 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 
 	const hasDomain = !! domainName;
 
+	// show a nbps in price while loading to prevent a janky UI
+	const nbsp = '\u00A0';
+
 	return (
 		<div className="plan-item">
 			<div className="plan-item__heading">
@@ -59,7 +62,9 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 				{ isPopular && <div className="plan-item__badge">{ __( 'Popular' ) }</div> }
 			</div>
 			<div className="plan-item__price">
-				<div className="plan-item__price-amount">{ price }</div>
+				<div className="plan-item__price-amount" data-is-loading={ ! price }>
+					{ price || nbsp }
+				</div>
 				<div className="plan-item__price-note">{ __( 'per month, billed yearly' ) }</div>
 			</div>
 			<div className="plan-item__actions">

--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -1,6 +1,7 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../../mixins.scss';
 @import '../../../variables.scss';
+@import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
 
 .plans-table {
 	display: flex;
@@ -43,6 +44,11 @@
 	font-weight: 600;
 	font-size: 32px;
 	line-height: 24px;
+
+	&[data-is-loading='true'] {
+		max-width: 60px;
+		@include placeholder();
+	}
 }
 
 .plan-item__price-note {

--- a/client/landing/gutenboarding/stores/plans/actions.ts
+++ b/client/landing/gutenboarding/stores/plans/actions.ts
@@ -1,3 +1,10 @@
+export const setPrices = ( prices: Record< string, string > ) => {
+	return {
+		type: 'SET_PRICES' as const,
+		prices,
+	};
+};
+
 export const setPlan = ( slug: string | undefined ) => {
 	return {
 		type: 'SET_PLAN' as const,
@@ -11,4 +18,4 @@ export const resetPlan = () => {
 	};
 };
 
-export type PlanAction = ReturnType< typeof setPlan | typeof resetPlan >;
+export type PlanAction = ReturnType< typeof setPlan | typeof resetPlan | typeof setPrices >;

--- a/client/landing/gutenboarding/stores/plans/constants.ts
+++ b/client/landing/gutenboarding/stores/plans/constants.ts
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import * as plans from '../../../../lib/plans/constants';
+import { PLAN_FREE, PLAN_PREMIUM } from '../../../../lib/plans/constants';
 
 export const STORE_KEY = 'automattic/onboard/plans';
 
-export const freePlan = plans.PLAN_FREE;
-export const defaultPaidPlan = plans.PLAN_PREMIUM;
+export const freePlan = PLAN_FREE;
+export const defaultPaidPlan = PLAN_PREMIUM;

--- a/client/landing/gutenboarding/stores/plans/constants.ts
+++ b/client/landing/gutenboarding/stores/plans/constants.ts
@@ -7,3 +7,144 @@ export const STORE_KEY = 'automattic/onboard/plans';
 
 export const freePlan = PLAN_FREE;
 export const defaultPaidPlan = PLAN_PREMIUM;
+
+interface Currency {
+	format: 'SYMBOL_THEN_AMOUNT' | 'AMOUNT_THEN_SYMBOL';
+	symbol: string;
+	decimal: number;
+}
+
+// salvaged from https://opengrok.a8c.com/source/raw/trunk/wp-content/admin-plugins/wpcom-billing/store-price.php
+// with html entities resolved to symbols
+export const currenciesFormats: Record< string, Currency > = {
+	USD: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: '$',
+		decimal: 2,
+	},
+	GBP: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: '£',
+		decimal: 2,
+	},
+	JPY: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: '¥',
+		decimal: 0,
+	},
+	BRL: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: 'R$',
+		decimal: 2,
+	},
+	EUR: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: '€',
+		decimal: 2,
+	},
+	NZD: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: 'NZ$',
+		decimal: 2,
+	},
+	AUD: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: 'A$',
+		decimal: 2,
+	},
+	CAD: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: 'C$',
+		decimal: 2,
+	},
+	IDR: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'Rp',
+		decimal: 0,
+	},
+	INR: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: '₹',
+		decimal: 0,
+	},
+	ILS: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: '₪',
+		decimal: 2,
+	},
+	RUB: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: '₽',
+		decimal: 2,
+	},
+	MXN: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: 'MX$',
+		decimal: 2,
+	},
+	SEK: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'SEK',
+		decimal: 2,
+	},
+	HUF: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'Ft',
+		decimal: 0, // Decimals are supported by Stripe but not by PayPal
+	},
+	CHF: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'CHF',
+		decimal: 2,
+	},
+	CZK: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'Kč',
+		decimal: 2,
+	},
+	DKK: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'Dkr',
+		decimal: 2,
+	},
+	HKD: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'HK$',
+		decimal: 2,
+	},
+	NOK: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'Kr',
+		decimal: 2,
+	},
+	PHP: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: '₱',
+		decimal: 2,
+	},
+	PLN: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'PLN',
+		decimal: 2,
+	},
+	SGD: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: 'S$',
+		decimal: 2,
+	},
+	TWD: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: 'NT$',
+		decimal: 0, // Decimals are supported by Stripe but not by PayPal
+	},
+	THB: {
+		format: 'SYMBOL_THEN_AMOUNT',
+		symbol: '฿',
+		decimal: 2,
+	},
+	TRY: {
+		format: 'AMOUNT_THEN_SYMBOL',
+		symbol: 'TL', // The official ₺ is not used as often as TL.
+		decimal: 2,
+	},
+};

--- a/client/landing/gutenboarding/stores/plans/index.ts
+++ b/client/landing/gutenboarding/stores/plans/index.ts
@@ -12,11 +12,13 @@ import { STORE_KEY } from './constants';
 import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
+import * as resolvers from './resolvers';
 import persistOptions from './persist';
 
 use( plugins.persistence, persistOptions );
 
 registerStore< State >( STORE_KEY, {
+	resolvers,
 	actions,
 	controls,
 	reducer: reducer as any,

--- a/client/landing/gutenboarding/stores/plans/plans-data.ts
+++ b/client/landing/gutenboarding/stores/plans/plans-data.ts
@@ -21,7 +21,6 @@ export type PlanDetails = Array< PlanDetail >;
 
 export type FortifiedPlan = {
 	name?: string;
-	price?: string;
 	features?: Array< string >;
 	isPopular?: boolean;
 	isSelected?: boolean;

--- a/client/landing/gutenboarding/stores/plans/plans-data.ts
+++ b/client/landing/gutenboarding/stores/plans/plans-data.ts
@@ -45,24 +45,19 @@ const mainFeatures = [
 
 export const planFeatures: FortifiedPlans = {
 	[ PLAN_FREE ]: {
-		price: '$0',
 		features: [ '3 GB', ...mainFeatures.slice( 0, 1 ) ],
 	},
 	[ PLAN_PERSONAL ]: {
-		price: '$5',
 		features: [ '6 GB', ...mainFeatures.slice( 0, 4 ) ],
 	},
 	[ PLAN_PREMIUM ]: {
-		price: '$8',
 		features: [ '13 GB', ...mainFeatures.slice( 0, 9 ) ],
 		isPopular: true,
 	},
 	[ PLAN_BUSINESS ]: {
-		price: '$25',
 		features: [ '200 GB', ...mainFeatures.slice( 0, 10 ) ],
 	},
 	[ PLAN_ECOMMERCE ]: {
-		price: '$45',
 		features: [ '200 GB', ...mainFeatures.slice( 0, 11 ) ],
 	},
 };

--- a/client/landing/gutenboarding/stores/plans/reducer.ts
+++ b/client/landing/gutenboarding/stores/plans/reducer.ts
@@ -20,9 +20,11 @@ export const supportedPlanSlugs = [
 const DEFAUlT_STATE: {
 	selectedPlanSlug: string | undefined;
 	supportedPlanSlugs: Array< string >;
+	prices: Record< string, string >;
 } = {
 	supportedPlanSlugs,
 	selectedPlanSlug: undefined,
+	prices: {},
 };
 
 const reducer = function ( state = DEFAUlT_STATE, action: PlanAction ) {
@@ -31,6 +33,11 @@ const reducer = function ( state = DEFAUlT_STATE, action: PlanAction ) {
 			return {
 				...state,
 				selectedPlanSlug: action.slug !== freePlan ? action.slug : DEFAUlT_STATE.selectedPlanSlug,
+			};
+		case 'SET_PRICES':
+			return {
+				...state,
+				prices: action.prices,
 			};
 		case 'RESET_PLAN':
 			return DEFAUlT_STATE;

--- a/client/landing/gutenboarding/stores/plans/resolvers.ts
+++ b/client/landing/gutenboarding/stores/plans/resolvers.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { apiFetch } from '@wordpress/data-controls';
+
+import { supportedPlanSlugs } from './reducer';
+
+/**
+ * Internal dependencies
+ */
+import { setPrices } from './actions';
+import { APIPlan } from './types';
+
+export function* getPrices() {
+	const plans = yield apiFetch( {
+		path: 'https://public-api.wordpress.com/rest/v1.5/plans',
+		mode: 'cors',
+		credentials: 'omit',
+	} );
+
+	// filter for supported plans
+	const WPCOMPlans: APIPlan[] = plans.filter( ( plan: APIPlan ) =>
+		supportedPlanSlugs.includes( plan.product_slug )
+	);
+
+	// create a [slug => price] map
+	const prices: Record< string, string > = WPCOMPlans.reduce( ( acc, plan ) => {
+		acc[ plan.product_slug ] = plan.formatted_price;
+		return acc;
+	}, {} as Record< string, string > );
+
+	yield setPrices( prices );
+}

--- a/client/landing/gutenboarding/stores/plans/resolvers.ts
+++ b/client/landing/gutenboarding/stores/plans/resolvers.ts
@@ -3,11 +3,10 @@
  */
 import { apiFetch } from '@wordpress/data-controls';
 
-import { supportedPlanSlugs } from './reducer';
-
 /**
  * Internal dependencies
  */
+import { supportedPlanSlugs } from './reducer';
 import { setPrices } from './actions';
 import { APIPlan } from './types';
 

--- a/client/landing/gutenboarding/stores/plans/selectors.ts
+++ b/client/landing/gutenboarding/stores/plans/selectors.ts
@@ -25,3 +25,5 @@ export const getSupportedPlans = ( state: State ) =>
 export const getPlanByPath = ( state: State, path: string | undefined ) =>
 	getFortifiedPlan( supportedPlanSlugs.find( ( slug ) => getPlanPath( slug ) === path ) );
 export const getPlansDetails = () => planDetails;
+
+export const getPrices = ( state: State ) => state.prices;

--- a/client/landing/gutenboarding/stores/plans/types.ts
+++ b/client/landing/gutenboarding/stores/plans/types.ts
@@ -1,0 +1,71 @@
+export type PlanAction = {
+	type: string;
+	slug?: string;
+};
+
+/**
+ * types of an item from https://public-api.wordpress.com/rest/v1.5/plans response
+ * can be super useful later
+ */
+export interface APIPlan {
+	product_id: number;
+	product_name: string;
+	meta: object;
+	prices: {
+		AUD: number;
+		BRL: number;
+		CAD: number;
+		CHF: number;
+		CZK: number;
+		DKK: number;
+		EUR: number;
+		GBP: number;
+		HKD: number;
+		HUF: number;
+		IDR: number;
+		ILS: number;
+		INR: number;
+		JPY: number;
+		MXN: number;
+		NOK: number;
+		NZD: number;
+		PHP: number;
+		PLN: number;
+		RUB: number;
+		SEK: number;
+		SGD: number;
+		THB: number;
+		TWD: number;
+		USD: number;
+		TRY: number;
+	};
+	bundle_product_ids: {
+		0: number;
+		1: number;
+		2: number;
+		3: number;
+		4: number;
+		5: number;
+		6: number;
+	};
+	path_slug: string;
+	product_slug: string;
+	description: string;
+	cost: number;
+	bill_period: number;
+	product_type: string;
+	available: string;
+	multi: number;
+	bd_slug: string;
+	bd_variation_slug: string;
+	outer_slug: string;
+	extra: string;
+	capability: string;
+	product_name_short: string;
+	bill_period_label: string;
+	price: string;
+	formatted_price: string;
+	raw_price: number;
+	tagline: object;
+	currency_code: string;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

1. Use the Public API to fetch localized plans prices. 
2. Add a loading animation when the price is being loaded.
3. Add Types for the plans coming from the API (useless now but I typed it because I initially used it, and can be useful soon). 

#### Testing instructions

1. Head /new?flags=gutenboarding/plans-grid
2. Click on the plan button on the top right corner and you should see the prices loading then appearing. 

Partially fixes https://github.com/Automattic/wp-calypso/issues/41787