### PR TITLE
Fix Inline Help link for connecting existing domain

### DIFF
--- a/client/blocks/inline-help/contextual-help.js
+++ b/client/blocks/inline-help/contextual-help.js
@@ -993,7 +993,7 @@ const contextLinksForSection = {
 		},
 		{
 			link: localizeUrl( 'https://en.support.wordpress.com/domain-mapping-vs-domain-transfer/' ),
-			post_id: 41298,
+			post_id: 157655,
 			title: translate( 'Connect an Existing Domain' ),
 			description: translate(
 				'You can connect an existing domain you own that’s registered elsewhere by either mapping or transferring. Domain mapping lets you connect a domain while keeping it registered at the current registrar (where you purchased the domain from). Domain transferring moves the domain to WordPress.com so we become the new registrar.'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update page ID to correct value for this support page: [Domain Mapping vs Domain Transfer](https://wordpress.com/support/domain-mapping-vs-domain-transfer/).

Fixes #42007

#### Testing instructions

1. Using the live branch, go to Plans > Domains
2. Edit a domain
3. Click the ? icon on bottom right to show Inline Help menu
4. Click the "Connect an Existing Domain" link
5. Click "Read more" button

Verify the correct page appears now.

