### PR TITLE
Reorder domain suggestions

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker/index.tsx
+++ b/client/landing/gutenboarding/components/domain-picker/index.tsx
@@ -90,8 +90,14 @@ const DomainPicker: FunctionComponent< Props > = ( {
 
 	const allSuggestions = useDomainSuggestions( { locale: i18nLocale, quantity } );
 	const freeSuggestions = getFreeDomainSuggestions( allSuggestions );
-	const paidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice( 0, quantity );
-	const recommendedSuggestion = getRecommendedDomainSuggestion( paidSuggestions );
+	const unSortedPaidSuggestions = getPaidDomainSuggestions( allSuggestions )?.slice( 0, quantity );
+	const recommendedSuggestion = getRecommendedDomainSuggestion( unSortedPaidSuggestions );
+
+	// put the recommended suggestion on top
+	const paidSuggestions = unSortedPaidSuggestions?.sort( ( suggestion ) =>
+		suggestion === recommendedSuggestion ? -1 : 1
+	);
+
 	const hasSuggestions = freeSuggestions?.length || paidSuggestions?.length;
 
 	const ConfirmButton: FunctionComponent< Button.ButtonProps > = ( { ...props } ) => {
@@ -202,22 +208,6 @@ const DomainPicker: FunctionComponent< Props > = ( {
 							</div>
 						) }
 						<div className="domain-picker__suggestion-item-group">
-							{ ! freeSuggestions && <SuggestionItemPlaceholder /> }
-							{ freeSuggestions &&
-								( freeSuggestions.length ? (
-									<SuggestionItem
-										suggestion={ freeSuggestions[ 0 ] }
-										isSelected={
-											currentSelection?.domain_name === freeSuggestions[ 0 ].domain_name
-										}
-										onSelect={ setCurrentSelection }
-										railcarId={ railcarId ? `${ railcarId }0` : undefined }
-										recordAnalytics={ recordAnalytics || undefined }
-										uiPosition={ 0 }
-									/>
-								) : (
-									<SuggestionNone />
-								) ) }
 							{ ! paidSuggestions &&
 								times( quantity - 1, ( i ) => <SuggestionItemPlaceholder key={ i } /> ) }
 							{ paidSuggestions &&
@@ -234,6 +224,22 @@ const DomainPicker: FunctionComponent< Props > = ( {
 											uiPosition={ i + 1 }
 										/>
 									) )
+								) : (
+									<SuggestionNone />
+								) ) }
+							{ ! freeSuggestions && <SuggestionItemPlaceholder /> }
+							{ freeSuggestions &&
+								( freeSuggestions.length ? (
+									<SuggestionItem
+										suggestion={ freeSuggestions[ 0 ] }
+										isSelected={
+											currentSelection?.domain_name === freeSuggestions[ 0 ].domain_name
+										}
+										onSelect={ setCurrentSelection }
+										railcarId={ railcarId ? `${ railcarId }0` : undefined }
+										recordAnalytics={ recordAnalytics || undefined }
+										uiPosition={ 0 }
+									/>
 								) : (
 									<SuggestionNone />
 								) ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

1. Put the recommended domain on top
2. Put the free domain in the bottom

#### Testing instructions

1. Search for a domain
2. Recommended should be on top and free should be at the bottom


Resolves https://github.com/Automattic/wp-calypso/issues/42010
