### PR TITLE
Publicize: Begin tracking blog_id and is_jetpack when publicizing from the posts list

### DIFF
--- a/client/blocks/post-share/index.jsx
+++ b/client/blocks/post-share/index.jsx
@@ -165,7 +165,7 @@ class PostShare extends Component {
 	};
 
 	sharePost = () => {
-		const { postId, siteId, connections } = this.props;
+		const { postId, siteId, connections, isJetpack } = this.props;
 		const servicesToPublish = connections.filter(
 			( connection ) => this.state.skipped.indexOf( connection.keyring_connection_ID ) === -1
 		);
@@ -181,7 +181,11 @@ class PostShare extends Component {
 			},
 			{ service_all: 0 }
 		);
-		const additionalProperties = { context_path: sectionify( currentPage ) };
+		const additionalProperties = {
+			context_path: sectionify( currentPage ),
+			is_jetpack: isJetpack,
+			blog_id: siteId,
+		};
 		const eventProperties = { ...numberOfAccountsPerService, ...additionalProperties };
 
 		if ( this.state.scheduledDate ) {


### PR DESCRIPTION
 The current `calypso_publicize_share_schedule` and `calypso_publicize_share_instantly` events do not currently track the blog ID or whether the current site is a Jetpack site. This PR adds that information so that we can run some analysis on how many sites with a paid Jetpack plan are using the scheduling functionality.

#### Changes proposed in this Pull Request

* Begin tracking blog_id and is_jetpack with the `calypso_publicize_share_schedule` and `calypso_publicize_share_instantly` events.

#### Testing instructions

* Checkout patch
* Go to `/posts/$site`
* Click the `...` next to one of your posts
* Share a post
* Schedule a post
* Check tracks for `calypso_publicize_share_%` and your user ID and ensure that the events show up with the `blogid` set and with the `is_jetpack` value set in event props

