### PR TITLE
PhoneInput: Make sure to not throw when inputRef is undefined

### DIFF
--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -170,6 +170,9 @@ function getLastCursorPosition( recentPositions ) {
 function useSharedRef( inputRef ) {
 	const numberInputRef = useRef();
 	useEffect( () => {
+		if ( ! inputRef ) {
+			return;
+		}
 		if ( typeof inputRef === 'function' ) {
 			inputRef( numberInputRef.current );
 		} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a bug introduced by #41783 when the `inputRef` prop is undefined.

#### Testing instructions

Try checkout when `inputRef` is undefined on `PhoneInput`.