### PR TITLE
Gutenboarding: Remove the vertical param when generating free domains

### DIFF
--- a/client/landing/gutenboarding/hooks/use-free-domain-suggestion.ts
+++ b/client/landing/gutenboarding/hooks/use-free-domain-suggestion.ts
@@ -25,7 +25,6 @@ export function useFreeDomainSuggestion() {
 				// Avoid `only_wordpressdotcom` — it seems to fail to find results sometimes
 				include_wordpressdotcom: true,
 				quantity: 1,
-				...{ vertical: siteVertical?.id },
 			} )?.[ 0 ];
 		},
 		[ domainSearch, siteVertical ]


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Remove vertical param from the free domain suggestions API request
- Think about what to snack on for brunch

p99Zz8-Ps-p2#comment-3464

#### Testing instructions

- Enter the `/new` flow
- Enter a vertical and site title
- Observe from network tab that the free domains API is called without a vertical
- Make a sandwich

Here is a sandwich

![image](https://user-images.githubusercontent.com/6458278/81458761-80a12380-91df-11ea-8413-ef24969b1366.png)


