### PR TITLE
Hide personal plans tab if only the Premium plan will be shown

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -303,8 +303,8 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	isPersonalCustomerTypePlanVisible() {
-		const { hidePersonalPlan, hidePremiumPlan } = this.props;
-		return ! hidePersonalPlan || ! hidePremiumPlan;
+		const { hidePersonalPlan } = this.props;
+		return ! hidePersonalPlan;
 	}
 
 	getVisiblePlansForPlanFeatures( plans ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change hides the plan tabs if the Personal plan is hidden (only Premium showing in "personal" tab) and simply shows the three available plans without any tabs.

More info: pau2Xa-1de-p2

Related:
https://github.com/Automattic/wp-calypso/pull/41507
https://github.com/Automattic/wp-calypso/pull/41512
https://github.com/Automattic/wp-calypso/pull/41526

#### Testing instructions

* Boot this branch locally.
* Sandbox `public-api.wordpress.com`.
* Add this filter to your `0-sandbox.php` file:
```
add_filter( 'get_user_marketing_price_group', function( $price_group ) {
    return 'price_2020_q2_test_2';
}, 10, 1 );
```
* Visit http://calypso.localhost:3000/plans/[SITE]
* You should see the Premium, Business, and eCommerce plans, and no tabs.

<img width="1180" alt="Screen Shot 2020-05-08 at 6 18 22 PM" src="https://user-images.githubusercontent.com/690843/81460438-3e81ce80-915a-11ea-9aa3-639e7899a7bb.png">
