### PR TITLE
Checkout: add dynamic summary features (3)

### DIFF
--- a/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/test/composite-checkout.js
@@ -619,9 +619,9 @@ describe( 'CompositeCheckout', () => {
 				container
 			);
 		} );
-		const { getByText } = renderResult;
+		const { getByText, getAllByText } = renderResult;
 		expect( getByText( 'Domain Registration: billed annually' ) ).toBeInTheDocument();
-		expect( getByText( 'foo.cash' ) ).toBeInTheDocument();
+		expect( getAllByText( 'foo.cash' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'adds renewal product to the cart when the url has a renewal with a domain mapping', async () => {
@@ -655,7 +655,7 @@ describe( 'CompositeCheckout', () => {
 		const { getByText, getAllByText } = renderResult;
 		expect( getByText( 'Domain Mapping: billed annually' ) ).toBeInTheDocument();
 		expect( getByText( 'Domain Registration: billed annually' ) ).toBeInTheDocument();
-		expect( getAllByText( 'bar.com' ) ).toHaveLength( 2 );
+		expect( getAllByText( 'bar.com' ) ).toHaveLength( 3 );
 	} );
 
 	it( 'adds the coupon to the cart when the url has a coupon code', async () => {

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -116,25 +116,7 @@ function CheckoutSummaryFeaturesList() {
 		<CheckoutSummaryFeaturesListUI>
 			{ hasDomainsInCart &&
 				domains.map( ( domain ) => {
-					return (
-						<CheckoutSummaryFeaturesListItem key={ domain.id }>
-							<WPCheckoutCheckIcon />
-							{ domain.wpcom_meta.is_bundled ? (
-								translate( '{{strong}}%(domain)s{{/strong}} - %(bundled)s', {
-									components: {
-										strong: <strong />,
-									},
-									args: {
-										domain: domain.wpcom_meta.meta,
-										bundled: translate( 'free with plan' ),
-									},
-									comment: 'domain name and bundling message, separated by a dash',
-								} )
-							) : (
-								<strong>{ domain.wpcom_meta.meta }</strong>
-							) }
-						</CheckoutSummaryFeaturesListItem>
-					);
+					return <CheckoutSummaryFeaturesListDomainItem domain={ domain } key={ domain.id } />;
 				} ) }
 			<CheckoutSummaryFeaturesListItem>
 				<WPCheckoutCheckIcon />
@@ -145,6 +127,29 @@ function CheckoutSummaryFeaturesList() {
 				{ refundText }
 			</CheckoutSummaryFeaturesListItem>
 		</CheckoutSummaryFeaturesListUI>
+	);
+}
+
+function CheckoutSummaryFeaturesListDomainItem( { domain } ) {
+	const translate = useTranslate();
+	return (
+		<CheckoutSummaryFeaturesListItem>
+			<WPCheckoutCheckIcon />
+			{ domain.wpcom_meta.is_bundled ? (
+				translate( '{{strong}}%(domain)s{{/strong}} - %(bundled)s', {
+					components: {
+						strong: <strong />,
+					},
+					args: {
+						domain: domain.wpcom_meta.meta,
+						bundled: translate( 'free with plan' ),
+					},
+					comment: 'domain name and bundling message, separated by a dash',
+				} )
+			) : (
+				<strong>{ domain.wpcom_meta.meta }</strong>
+			) }
+		</CheckoutSummaryFeaturesListItem>
 	);
 }
 

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -22,6 +22,8 @@ import getSupportVariation, {
 	SUPPORT_FORUM,
 	SUPPORT_DIRECTLY,
 } from 'state/selectors/get-inline-help-support-variation';
+import { useHasDomainsInCart, useDomainsInCart } from '../hooks/has-domains';
+import { useHasPlanInCart } from '../hooks/has-plan';
 
 export default function WPCheckoutOrderSummary() {
 	const reduxDispatch = useDispatch();
@@ -53,16 +55,7 @@ export default function WPCheckoutOrderSummary() {
 				<CheckoutSummaryFeaturesTitle>
 					{ translate( 'Included with your purchase' ) }
 				</CheckoutSummaryFeaturesTitle>
-				<CheckoutSummaryFeaturesList>
-					<CheckoutSummaryFeaturesListItem>
-						<WPCheckoutCheckIcon />
-						{ translate( 'Email and live chat support' ) }
-					</CheckoutSummaryFeaturesListItem>
-					<CheckoutSummaryFeaturesListItem>
-						<WPCheckoutCheckIcon />
-						{ translate( 'Money back guarantee' ) }
-					</CheckoutSummaryFeaturesListItem>
-				</CheckoutSummaryFeaturesList>
+				<CheckoutSummaryFeaturesList />
 				<CheckoutSummaryHelp onClick={ handleHelpButtonClicked }>
 					{ isSupportChatUser
 						? translate( 'Questions? {{underline}}Ask a Happiness Engineer.{{/underline}}', {
@@ -102,6 +95,49 @@ export default function WPCheckoutOrderSummary() {
 	);
 }
 
+function CheckoutSummaryFeaturesList() {
+	const hasDomainsInCart = useHasDomainsInCart();
+	const domains = useDomainsInCart();
+	const hasPlanInCart = useHasPlanInCart();
+	const translate = useTranslate();
+
+	const supportText = hasPlanInCart
+		? translate( 'Email and live chat support' )
+		: translate( 'Email support' );
+
+	let refundText = translate( 'Money back guarantee' );
+	if ( hasDomainsInCart && ! hasPlanInCart ) {
+		refundText = translate( '4 day money back guarantee' );
+	} else if ( hasPlanInCart && ! hasDomainsInCart ) {
+		refundText = translate( '30 day money back guarantee' );
+	}
+
+	return (
+		<CheckoutSummaryFeaturesListUI>
+			{ hasDomainsInCart &&
+				domains.map( ( domain ) => {
+					return (
+						<CheckoutSummaryFeaturesListItem>
+							<WPCheckoutCheckIcon />
+							<strong>{ domain.wpcom_meta?.meta }</strong>
+							{ domain.wpcom_meta?.is_bundled && (
+								<BundledDomainFreeUI>{ translate( 'free with plan' ) }</BundledDomainFreeUI>
+							) }
+						</CheckoutSummaryFeaturesListItem>
+					);
+				} ) }
+			<CheckoutSummaryFeaturesListItem>
+				<WPCheckoutCheckIcon />
+				{ supportText }
+			</CheckoutSummaryFeaturesListItem>
+			<CheckoutSummaryFeaturesListItem>
+				<WPCheckoutCheckIcon />
+				{ refundText }
+			</CheckoutSummaryFeaturesListItem>
+		</CheckoutSummaryFeaturesListUI>
+	);
+}
+
 const CheckoutSummaryCardUI = styled( CheckoutSummaryCard )`
 	border-bottom: none 0;
 `;
@@ -117,10 +153,10 @@ const CheckoutSummaryFeatures = styled.div`
 const CheckoutSummaryFeaturesTitle = styled.h3`
 	font-size: 16px;
 	font-weight: ${( props ) => props.theme.weights.normal};
-	margin-bottom: 4px;
+	margin-bottom: 6px;
 `;
 
-const CheckoutSummaryFeaturesList = styled.ul`
+const CheckoutSummaryFeaturesListUI = styled.ul`
 	margin: 0;
 	list-style: none;
 	font-size: 14px;
@@ -139,11 +175,20 @@ const CheckoutSummaryHelp = styled.button`
 const WPCheckoutCheckIcon = styled( CheckoutCheckIcon )`
 	fill: ${( props ) => props.theme.colors.success};
 	margin-right: 4px;
-	vertical-align: bottom;
+	position: absolute;
+	top: 0;
+	left: 0;
 `;
 
 const CheckoutSummaryFeaturesListItem = styled.li`
 	margin-bottom: 4px;
+	padding-left: 24px;
+	position: relative;
+`;
+
+const BundledDomainFreeUI = styled.div`
+	color: ${( props ) => props.theme.colors.success};
+	font-style: italic;
 `;
 
 const CheckoutSummaryAmountWrapper = styled.div`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -9,9 +9,10 @@ import {
 	CheckoutCheckIcon,
 	CheckoutSummaryCard,
 	renderDisplayValueMarkdown,
+	useEvents,
+	useFormStatus,
 	useLineItemsOfType,
 	useTotal,
-	useEvents,
 } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 
@@ -26,12 +27,15 @@ import getSupportVariation, {
 import { useHasDomainsInCart, useDomainsInCart } from '../hooks/has-domains';
 import { useHasPlanInCart } from '../hooks/has-plan';
 
-export default function WPCheckoutOrderSummary( { isCartPendingUpdate } ) {
+export default function WPCheckoutOrderSummary() {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 	const taxes = useLineItemsOfType( 'tax' );
 	const coupons = useLineItemsOfType( 'coupon' );
 	const total = useTotal();
+	const { formStatus } = useFormStatus();
+
+	const isCartUpdating = 'validating' === formStatus;
 
 	const isSupportChatUser = useSelector( ( state ) => {
 		return (
@@ -51,12 +55,12 @@ export default function WPCheckoutOrderSummary( { isCartPendingUpdate } ) {
 	};
 
 	return (
-		<CheckoutSummaryCardUI className={ isCartPendingUpdate ? 'is-loading' : '' }>
+		<CheckoutSummaryCardUI className={ isCartUpdating ? 'is-loading' : '' }>
 			<CheckoutSummaryFeatures>
 				<CheckoutSummaryFeaturesTitle>
 					{ translate( 'Included with your purchase' ) }
 				</CheckoutSummaryFeaturesTitle>
-				{ isCartPendingUpdate ? (
+				{ isCartUpdating ? (
 					<LoadingCheckoutSummaryFeaturesList />
 				) : (
 					<CheckoutSummaryFeaturesList />

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import styled from '@emotion/styled';
+import { keyframes } from '@emotion/core';
 import {
 	CheckoutCheckIcon,
 	CheckoutSummaryCard,
@@ -25,7 +26,7 @@ import getSupportVariation, {
 import { useHasDomainsInCart, useDomainsInCart } from '../hooks/has-domains';
 import { useHasPlanInCart } from '../hooks/has-plan';
 
-export default function WPCheckoutOrderSummary() {
+export default function WPCheckoutOrderSummary( { isCartPendingUpdate } ) {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 	const taxes = useLineItemsOfType( 'tax' );
@@ -50,12 +51,16 @@ export default function WPCheckoutOrderSummary() {
 	};
 
 	return (
-		<CheckoutSummaryCardUI>
+		<CheckoutSummaryCardUI className={ isCartPendingUpdate ? 'is-loading' : '' }>
 			<CheckoutSummaryFeatures>
 				<CheckoutSummaryFeaturesTitle>
 					{ translate( 'Included with your purchase' ) }
 				</CheckoutSummaryFeaturesTitle>
-				<CheckoutSummaryFeaturesList />
+				{ isCartPendingUpdate ? (
+					<LoadingCheckoutSummaryFeaturesList />
+				) : (
+					<CheckoutSummaryFeaturesList />
+				) }
 				<CheckoutSummaryHelp onClick={ handleHelpButtonClicked }>
 					{ isSupportChatUser
 						? translate( 'Questions? {{underline}}Ask a Happiness Engineer.{{/underline}}', {
@@ -92,6 +97,16 @@ export default function WPCheckoutOrderSummary() {
 				</CheckoutSummaryTotal>
 			</CheckoutSummaryAmountWrapper>
 		</CheckoutSummaryCardUI>
+	);
+}
+
+function LoadingCheckoutSummaryFeaturesList() {
+	return (
+		<>
+			<LoadingCopy />
+			<LoadingCopy />
+			<LoadingCopy />
+		</>
 	);
 }
 
@@ -152,6 +167,20 @@ function CheckoutSummaryFeaturesListDomainItem( { domain } ) {
 		</CheckoutSummaryFeaturesListItem>
 	);
 }
+
+const pulse = keyframes`
+	0% {
+		opacity: 1;
+	}
+
+	70% {
+		opacity: 0.25;
+	}
+
+	100% {
+		opacity: 1;
+	}
+`;
 
 const CheckoutSummaryCardUI = styled( CheckoutSummaryCard )`
 	border-bottom: none 0;
@@ -214,8 +243,37 @@ const CheckoutSummaryLineItem = styled.div`
 	flex-wrap: wrap;
 	justify-content: space-between;
 	margin-bottom: 4px;
+
+	.is-loading & {
+		animation: ${pulse} 1.5s ease-in-out infinite;
+	}
 `;
 
 const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
 	font-weight: ${( props ) => props.theme.weights.bold};
+`;
+
+const LoadingCopy = styled.p`
+	animation: ${pulse} 1.5s ease-in-out infinite;
+	background: ${( props ) => props.theme.colors.borderColorLight};
+	border-radius: 2px;
+	color: ${( props ) => props.theme.colors.borderColorLight};
+	content: '';
+	font-size: 14px;
+	height: 18px;
+	margin: 8px 0 0 26px;
+	padding: 0;
+	position: relative;
+
+	:before {
+		content: '';
+		display: block;
+		position: absolute;
+		left: -26px;
+		top: 0;
+		width: 18px;
+		height: 18px;
+		background: ${( props ) => props.theme.colors.borderColorLight};
+		border-radius: 100%;
+	}
 `;

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -117,7 +117,7 @@ function CheckoutSummaryFeaturesList() {
 			{ hasDomainsInCart &&
 				domains.map( ( domain ) => {
 					return (
-						<CheckoutSummaryFeaturesListItem>
+						<CheckoutSummaryFeaturesListItem key={ domain.id }>
 							<WPCheckoutCheckIcon />
 							<strong>{ domain.wpcom_meta?.meta }</strong>
 							{ domain.wpcom_meta?.is_bundled && (

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout-order-summary.js
@@ -119,9 +119,19 @@ function CheckoutSummaryFeaturesList() {
 					return (
 						<CheckoutSummaryFeaturesListItem key={ domain.id }>
 							<WPCheckoutCheckIcon />
-							<strong>{ domain.wpcom_meta?.meta }</strong>
-							{ domain.wpcom_meta?.is_bundled && (
-								<BundledDomainFreeUI>{ translate( 'free with plan' ) }</BundledDomainFreeUI>
+							{ domain.wpcom_meta.is_bundled ? (
+								translate( '{{strong}}%(domain)s{{/strong}} - %(bundled)s', {
+									components: {
+										strong: <strong />,
+									},
+									args: {
+										domain: domain.wpcom_meta.meta,
+										bundled: translate( 'free with plan' ),
+									},
+									comment: 'domain name and bundling message, separated by a dash',
+								} )
+							) : (
+								<strong>{ domain.wpcom_meta.meta }</strong>
 							) }
 						</CheckoutSummaryFeaturesListItem>
 					);
@@ -184,11 +194,6 @@ const CheckoutSummaryFeaturesListItem = styled.li`
 	margin-bottom: 4px;
 	padding-left: 24px;
 	position: relative;
-`;
-
-const BundledDomainFreeUI = styled.div`
-	color: ${( props ) => props.theme.colors.success};
-	font-style: italic;
 `;
 
 const CheckoutSummaryAmountWrapper = styled.div`

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -155,7 +155,7 @@ export default function WPCheckout( {
 					</CheckoutSummaryTitlePrice>
 				</CheckoutSummaryTitleLink>
 				<CheckoutSummaryBody>
-					<WPCheckoutOrderSummary isCartPendingUpdate={ isCartPendingUpdate } />
+					<WPCheckoutOrderSummary />
 					<UpsellWrapperUI>
 						<CartFreeUserPlanUpsell cart={ mockCart } addItemToCart={ addItemToCart } />
 					</UpsellWrapperUI>

--- a/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/components/wp-checkout.js
@@ -155,7 +155,7 @@ export default function WPCheckout( {
 					</CheckoutSummaryTitlePrice>
 				</CheckoutSummaryTitleLink>
 				<CheckoutSummaryBody>
-					<WPCheckoutOrderSummary />
+					<WPCheckoutOrderSummary isCartPendingUpdate={ isCartPendingUpdate } />
 					<UpsellWrapperUI>
 						<CartFreeUserPlanUpsell cart={ mockCart } addItemToCart={ addItemToCart } />
 					</UpsellWrapperUI>

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-domains.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-domains.js
@@ -8,6 +8,11 @@ export function useHasDomainsInCart() {
 	return areDomainsInLineItems( items );
 }
 
+export function useDomainsInCart() {
+	const [ items ] = useLineItems();
+	return items.filter( isLineItemADomain );
+}
+
 export function useDomainNamesInCart() {
 	const [ items ] = useLineItems();
 	return items.filter( isLineItemADomain ).map( ( item ) => item.wpcom_meta?.meta );

--- a/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-plan.js
+++ b/client/my-sites/checkout/composite-checkout/wpcom/hooks/has-plan.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { useLineItems } from '@automattic/composite-checkout';
+
+export function useHasPlanInCart() {
+	const [ items ] = useLineItems();
+	return isPlanInLineItems( items );
+}
+
+export function isPlanInLineItems( items ) {
+	return items.some( ( item ) => 'plan' === item.type );
+}


### PR DESCRIPTION
Depending on the items in a user's cart, the features in the CheckoutSummary need to be updated.

- Domains should be bolded at the top, with a conditional "free with plan" bundle message
- Live Chat is only available with plans, email-only for all other products
- If the cart only has a plan in it, we offer a 30 day money back guarantee. If it only has a domain, the guarantee is 4 days. Any other combination should say "money back guarantee". (More detailed information about refund policies is available in the support link directly below the features, and as part of the terms of service the user agrees to before making a purchase)

<img width="975" alt="Screen Shot 2020-05-09 at 10 26 44 PM" src="https://user-images.githubusercontent.com/942359/81489524-76654080-9244-11ea-8835-c887c5e9c5a4.png">

**To Test:**
- from a free site, visit checkout with a domain only
- verify that the domain is displayed first without a bundled message, the support item is email-only, and the money back guarantee is 4 day
- use the upgrade nudge in the sidebar to add a plan
- verify that the summary updates - the domain should now have a bundled message, the support item should be email and live chat, and the guarantee should be generic
- remove the domain from your cart
- verify that the summary updates - no domain, email and live chat support, 30-day guarantee
