### PR TITLE
Gutenboarding: Create public sites when ecommerce

### DIFF
--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -16,6 +16,7 @@ import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { USER_STORE } from '../../stores/user';
 import { SITE_STORE } from '../../stores/site';
 import { STORE_KEY as PLANS_STORE } from '../../stores/plans';
+import { PLAN_FREE } from '../../stores/plans/constants';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
 import PlansButton from '../plans/plans-button';
@@ -131,7 +132,7 @@ const Header: React.FunctionComponent = () => {
 			handleCreateSite(
 				newUser.username,
 				newUser.bearerToken,
-				selectedPlan ? selectedPlan.getStoreSlug() : 'free'
+				selectedPlan ? selectedPlan.getStoreSlug() : PLAN_FREE
 			);
 		}
 	}, [ newSite, newUser, handleCreateSite ] );

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -15,6 +15,7 @@ import { useHistory } from 'react-router-dom';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { USER_STORE } from '../../stores/user';
 import { SITE_STORE } from '../../stores/site';
+import { STORE_KEY as PLANS_STORE } from '../../stores/plans';
 import './style.scss';
 import DomainPickerButton from '../domain-picker-button';
 import PlansButton from '../plans/plans-button';
@@ -35,6 +36,7 @@ const Header: React.FunctionComponent = () => {
 
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
+	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );
 
 	const { domain, siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
 
@@ -114,8 +116,8 @@ const Header: React.FunctionComponent = () => {
 	);
 
 	const handleCreateSite = React.useCallback(
-		( username: string, bearerToken?: string ) => {
-			createSite( username, freeDomainSuggestion, bearerToken );
+		( username: string, bearerToken?: string, planSlug?: string ) => {
+			createSite( username, freeDomainSuggestion, bearerToken, planSlug );
 		},
 		[ createSite, freeDomainSuggestion ]
 	);
@@ -126,10 +128,13 @@ const Header: React.FunctionComponent = () => {
 
 	React.useEffect( () => {
 		if ( newUser && newUser.bearerToken && newUser.username && ! newSite ) {
-			handleCreateSite( newUser.username, newUser.bearerToken );
+			handleCreateSite(
+				newUser.username,
+				newUser.bearerToken,
+				selectedPlan ? selectedPlan.getStoreSlug() : 'free'
+			);
 		}
 	}, [ newSite, newUser, handleCreateSite ] );
-
 	return (
 		<div
 			className="gutenboarding__header"

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -135,7 +135,7 @@ const Header: React.FunctionComponent = () => {
 				selectedPlan ? selectedPlan.getStoreSlug() : PLAN_FREE
 			);
 		}
-	}, [ newSite, newUser, handleCreateSite ] );
+	}, [ newSite, newUser, handleCreateSite, selectedPlan ] );
 	return (
 		<div
 			className="gutenboarding__header"

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -96,9 +96,11 @@ export default function useOnSiteCreation() {
 					} );
 					resetPlan();
 					resetOnboardStore();
-					window.location.replace(
-						`/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2Fblock-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`
-					);
+					const redirectionUrl =
+						selectedPlan.getStoreSlug() === 'ecommerce-bundle'
+							? `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1`
+							: `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2Fblock-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
+					window.location.replace( redirectionUrl );
 				};
 				go();
 				return;

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -10,6 +10,7 @@ import wp from '../../../lib/wp';
  */
 import { STORE_KEY as ONBOARD_STORE } from '../stores/onboard';
 import { STORE_KEY as PLANS_STORE } from '../stores/plans';
+import { PLAN_ECOMMERCE } from '../stores/plans/constants';
 import { USER_STORE } from '../stores/user';
 import { SITE_STORE } from '../stores/site';
 import { recordOnboardingComplete } from '../lib/analytics';
@@ -97,7 +98,7 @@ export default function useOnSiteCreation() {
 					resetPlan();
 					resetOnboardStore();
 					const redirectionUrl =
-						selectedPlan.getStoreSlug() === 'ecommerce-bundle'
+						selectedPlan.getStoreSlug() === PLAN_ECOMMERCE
 							? `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1`
 							: `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2Fblock-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
 					window.location.replace( redirectionUrl );

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -19,6 +19,7 @@ import * as T from './types';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { USER_STORE } from '../../stores/user';
 import { STORE_KEY as PLANS_STORE } from '../../stores/plans';
+import { PLAN_FREE } from '../../stores/plans/constants';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 import SignupForm from '../../components/signup-form';
 import { useTrackStep } from '../../hooks/use-track-step';
@@ -59,7 +60,7 @@ const StylePreview: React.FunctionComponent = () => {
 
 	const handleCreateSite = useCallback(
 		( username: string, bearerToken?: string ) => {
-			const planSlug = selectedPlan ? selectedPlan.getStoreSlug() : 'free';
+			const planSlug = selectedPlan ? selectedPlan.getStoreSlug() : PLAN_FREE;
 			createSite( username, freeDomainSuggestion, bearerToken, planSlug );
 		},
 		[ createSite, freeDomainSuggestion, selectedPlan ]

--- a/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/style-preview/index.tsx
@@ -18,16 +18,17 @@ import { Title, SubTitle } from '../../components/titles';
 import * as T from './types';
 import { STORE_KEY as ONBOARD_STORE } from '../../stores/onboard';
 import { USER_STORE } from '../../stores/user';
+import { STORE_KEY as PLANS_STORE } from '../../stores/plans';
 import { useFreeDomainSuggestion } from '../../hooks/use-free-domain-suggestion';
 import SignupForm from '../../components/signup-form';
 import { useTrackStep } from '../../hooks/use-track-step';
 import BottomBarMobile from '../../components/bottom-bar-mobile';
-
 import './style.scss';
 
 const StylePreview: React.FunctionComponent = () => {
 	const { getSelectedFonts } = useSelect( ( select ) => select( ONBOARD_STORE ) );
 	const { selectedDesign } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const selectedPlan = useSelect( ( select ) => select( PLANS_STORE ).getSelectedPlan() );
 
 	const [ showSignupDialog, setShowSignupDialog ] = useState( false );
 
@@ -58,9 +59,10 @@ const StylePreview: React.FunctionComponent = () => {
 
 	const handleCreateSite = useCallback(
 		( username: string, bearerToken?: string ) => {
-			createSite( username, freeDomainSuggestion, bearerToken );
+			const planSlug = selectedPlan ? selectedPlan.getStoreSlug() : 'free';
+			createSite( username, freeDomainSuggestion, bearerToken, planSlug );
 		},
-		[ createSite, freeDomainSuggestion ]
+		[ createSite, freeDomainSuggestion, selectedPlan ]
 	);
 
 	return (

--- a/client/landing/gutenboarding/path.ts
+++ b/client/landing/gutenboarding/path.ts
@@ -6,7 +6,13 @@ import { generatePath, useLocation, useRouteMatch } from 'react-router-dom';
 import { ValuesType } from 'utility-types';
 
 import { getLanguageRouteParam } from '../../lib/i18n-utils';
-import * as plans from '../../lib/plans/constants';
+import {
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+} from './stores/plans/constants';
 import { getPlanPath } from '../../lib/plans';
 
 // The first step (IntentGathering), which is found at the root route (/), is set as
@@ -26,11 +32,11 @@ export const Step = {
 export const steps = Object.values( Step ).filter( Boolean );
 
 export const supportedPlans: string[] = [
-	plans.PLAN_FREE,
-	plans.PLAN_PERSONAL,
-	plans.PLAN_PREMIUM,
-	plans.PLAN_BUSINESS,
-	plans.PLAN_ECOMMERCE,
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
 ];
 export const supportedPlansPaths: string[] = supportedPlans.map( getPlanPath );
 

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -16,8 +16,7 @@ import type { FontPair } from '../../constants';
 import type { DomainCategory } from '../../domains-constants';
 import { PLAN_ECOMMERCE } from '../plans/constants';
 
-// Commenting this since `public` doesn't seem to be in the schema we are using
-// type CreateSiteParams = import('@automattic/data-stores').Site.CreateSiteParams;
+type CreateSiteParams = import('@automattic/data-stores').Site.CreateSiteParams;
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 type Template = VerticalsTemplates.Template;
 
@@ -104,7 +103,7 @@ export function* createSite(
 	const siteUrl = currentDomain?.domain_name || siteTitle || username;
 	const isPublicSite = planSlug === PLAN_ECOMMERCE;
 
-	const params /*: CreateSiteParams */ = {
+	const params: CreateSiteParams = {
 		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
 		blog_title: siteTitle,
 		public: isPublicSite ? 1 : -1,

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -14,6 +14,7 @@ import { SITE_STORE } from '../site';
 import type { State } from '.';
 import type { FontPair } from '../../constants';
 import type { DomainCategory } from '../../domains-constants';
+import { PLAN_ECOMMERCE } from '../plans/constants';
 
 // Commenting this since `public` doesn't seem to be in the schema we are using
 // type CreateSiteParams = import('@automattic/data-stores').Site.CreateSiteParams;
@@ -101,7 +102,7 @@ export function* createSite(
 
 	const currentDomain = domain ?? freeDomainSuggestion;
 	const siteUrl = currentDomain?.domain_name || siteTitle || username;
-	const isPublicSite = planSlug === 'ecommerce-bundle';
+	const isPublicSite = planSlug === PLAN_ECOMMERCE;
 
 	const params /*: CreateSiteParams */ = {
 		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -15,7 +15,8 @@ import type { State } from '.';
 import type { FontPair } from '../../constants';
 import type { DomainCategory } from '../../domains-constants';
 
-type CreateSiteParams = import('@automattic/data-stores').Site.CreateSiteParams;
+// Commenting this since `public` doesn't seem to be in the schema we are using
+// type CreateSiteParams = import('@automattic/data-stores').Site.CreateSiteParams;
 type DomainSuggestion = DomainSuggestions.DomainSuggestion;
 type Template = VerticalsTemplates.Template;
 
@@ -90,7 +91,8 @@ export const setIsRedirecting = ( isRedirecting: boolean ) => ( {
 export function* createSite(
 	username: string,
 	freeDomainSuggestion?: DomainSuggestion,
-	bearerToken?: string
+	bearerToken?: string,
+	planSlug?: string
 ) {
 	const { domain, selectedDesign, selectedFonts, siteTitle, siteVertical }: State = yield select(
 		ONBOARD_STORE,
@@ -99,10 +101,12 @@ export function* createSite(
 
 	const currentDomain = domain ?? freeDomainSuggestion;
 	const siteUrl = currentDomain?.domain_name || siteTitle || username;
+	const isPublicSite = planSlug === 'ecommerce-bundle';
 
-	const params: CreateSiteParams = {
+	const params /*: CreateSiteParams */ = {
 		blog_name: siteUrl?.split( '.wordpress' )[ 0 ],
 		blog_title: siteTitle,
+		public: isPublicSite ? 1 : -1,
 		options: {
 			site_vertical: siteVertical?.id,
 			site_vertical_name: siteVertical?.label,

--- a/client/landing/gutenboarding/stores/plans/constants.ts
+++ b/client/landing/gutenboarding/stores/plans/constants.ts
@@ -1,12 +1,18 @@
 /**
  * External dependencies
  */
-import { PLAN_FREE, PLAN_PREMIUM } from '../../../../lib/plans/constants';
+import {
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
+} from '../../../../lib/plans/constants';
 
 export const STORE_KEY = 'automattic/onboard/plans';
 
-export const freePlan = PLAN_FREE;
-export const defaultPaidPlan = PLAN_PREMIUM;
+export { PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE };
+export const DEFAULT_PAID_PLAN = PLAN_PREMIUM;
 
 interface Currency {
 	format: 'SYMBOL_THEN_AMOUNT' | 'AMOUNT_THEN_SYMBOL';

--- a/client/landing/gutenboarding/stores/plans/plans-data.ts
+++ b/client/landing/gutenboarding/stores/plans/plans-data.ts
@@ -1,13 +1,7 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import {
-	PLAN_FREE,
-	PLAN_PERSONAL,
-	PLAN_PREMIUM,
-	PLAN_BUSINESS,
-	PLAN_ECOMMERCE,
-} from '../../../../lib/plans/constants';
+import { PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE } from './constants';
 
 export type PlanFeature = { name: string; type: string; data: Array< boolean | string > };
 

--- a/client/landing/gutenboarding/stores/plans/reducer.ts
+++ b/client/landing/gutenboarding/stores/plans/reducer.ts
@@ -1,20 +1,15 @@
 /**
- * External dependencies
- */
-import * as plans from '../../../../lib/plans/constants';
-
-/**
  * Internal dependencies
  */
-import { freePlan } from './constants';
+import { PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS, PLAN_ECOMMERCE } from './constants';
 import type { PlanAction } from './actions';
 
 export const supportedPlanSlugs = [
-	plans.PLAN_FREE,
-	plans.PLAN_PERSONAL,
-	plans.PLAN_PREMIUM,
-	plans.PLAN_BUSINESS,
-	plans.PLAN_ECOMMERCE,
+	PLAN_FREE,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	PLAN_ECOMMERCE,
 ];
 
 const DEFAUlT_STATE: {
@@ -32,7 +27,7 @@ const reducer = function ( state = DEFAUlT_STATE, action: PlanAction ) {
 		case 'SET_PLAN':
 			return {
 				...state,
-				selectedPlanSlug: action.slug !== freePlan ? action.slug : DEFAUlT_STATE.selectedPlanSlug,
+				selectedPlanSlug: action.slug !== PLAN_FREE ? action.slug : DEFAUlT_STATE.selectedPlanSlug,
 			};
 		case 'SET_PRICES':
 			return {

--- a/client/landing/gutenboarding/stores/plans/selectors.ts
+++ b/client/landing/gutenboarding/stores/plans/selectors.ts
@@ -8,7 +8,7 @@ import { getPlan, getPlanPath } from '../../../../lib/plans';
  */
 import { State, supportedPlanSlugs } from './reducer';
 import { planFeatures, planDetails } from './plans-data';
-import { defaultPaidPlan, freePlan } from './constants';
+import { DEFAULT_PAID_PLAN, PLAN_FREE } from './constants';
 
 function getFortifiedPlan( slug: string | undefined ) {
 	if ( ! slug ) {
@@ -19,7 +19,7 @@ function getFortifiedPlan( slug: string | undefined ) {
 
 export const getSelectedPlan = ( state: State ) => getFortifiedPlan( state.selectedPlanSlug );
 export const getDefaultPlan = ( state: State, hasPaidDomain: boolean ) =>
-	hasPaidDomain ? getFortifiedPlan( defaultPaidPlan ) : getFortifiedPlan( freePlan );
+	hasPaidDomain ? getFortifiedPlan( DEFAULT_PAID_PLAN ) : getFortifiedPlan( PLAN_FREE );
 export const getSupportedPlans = ( state: State ) =>
 	state.supportedPlanSlugs.map( getFortifiedPlan );
 export const getPlanByPath = ( state: State, path: string | undefined ) =>

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -33,6 +33,7 @@ export interface CreateSiteParams {
 	blog_name: string;
 	blog_title?: string;
 	authToken?: string;
+	public?: number;
 	options?: {
 		site_vertical?: string;
 		site_vertical_name?: string;


### PR DESCRIPTION
This PR changes how the site is created if the user has chosen an e-commerce plan: The site is created as public straight away, so the Atomic transfer after payment work and the user can be redirected to Woo NUX.