### PR TITLE
Block Patterns have moved - gate registration to gutenberg being active.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -6,6 +6,7 @@ import { layout, plus } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PanelBody, Button } from '@wordpress/components';
+import { EntitiesSavedStates } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -56,4 +57,10 @@ const BlockPatternsMoved = () => {
 	);
 };
 
-registerPlugin( 'block-patterns-moved', { render: BlockPatternsMoved } );
+// Atomic sites without Gutenberg enabled don't need to this plugin.
+// Since there is no core import for 'BlockPattern' to see if that exists,
+// we can check another recent addition to the editor library. If
+// 'EntitiesSavedStates' exists, then we are running Gutenberg.
+if ( EntitiesSavedStates ) {
+	registerPlugin( 'block-patterns-moved', { render: BlockPatternsMoved } );
+}

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -4,7 +4,7 @@
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 import { layout, plus } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { registerPlugin, getPlugins, getPlugin } from '@wordpress/plugins';
+import { registerPlugin, getPlugin } from '@wordpress/plugins';
 import { PanelBody, Button } from '@wordpress/components';
 
 /**
@@ -61,4 +61,3 @@ const BlockPatternsMoved = () => {
 if ( getPlugin( 'gutenberg' ) || window.wpcomGutenberg ) {
 	registerPlugin( 'block-patterns-moved', { render: BlockPatternsMoved } );
 }
-console.log( getPlugins() );

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -58,6 +58,11 @@ const BlockPatternsMoved = () => {
 
 // Atomic sites without Gutenberg enabled don't need to this plugin.
 // Check that gutenberg is enabled.
-if ( getPlugin( 'gutenberg' ) || window.wpcomGutenberg ) {
+if (
+	// for Atomic (this doesn't work... need a different check)
+	getPlugin( 'gutenberg' ) ||
+	// for Simple, check for wpcomGutenberg on window.
+	window.wpcomGutenberg
+) {
 	registerPlugin( 'block-patterns-moved', { render: BlockPatternsMoved } );
 }

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -4,8 +4,9 @@
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 import { layout, plus } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { registerPlugin, getPlugin } from '@wordpress/plugins';
+import { registerPlugin } from '@wordpress/plugins';
 import { PanelBody, Button } from '@wordpress/components';
+import { __experimentalLibrary } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -56,13 +57,8 @@ const BlockPatternsMoved = () => {
 	);
 };
 
-// Atomic sites without Gutenberg enabled don't need to this plugin.
-// Check that gutenberg is enabled.
-if (
-	// for Atomic (this doesn't work... need a different check)
-	getPlugin( 'gutenberg' ) ||
-	// for Simple, check for wpcomGutenberg on window.
-	window.wpcomGutenberg
-) {
+// Gutenberg 8 includes `Library` as `@wordpres/block-editor` experimental export.
+// The experimental Library component contains the patterns in their new location.
+if ( typeof __experimentalLibrary !== 'undefined' ) {
 	registerPlugin( 'block-patterns-moved', { render: BlockPatternsMoved } );
 }

--- a/apps/full-site-editing/full-site-editing-plugin/common/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/common/index.js
@@ -4,9 +4,8 @@
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
 import { layout, plus } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { registerPlugin } from '@wordpress/plugins';
+import { registerPlugin, getPlugins, getPlugin } from '@wordpress/plugins';
 import { PanelBody, Button } from '@wordpress/components';
-import { EntitiesSavedStates } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -58,9 +57,8 @@ const BlockPatternsMoved = () => {
 };
 
 // Atomic sites without Gutenberg enabled don't need to this plugin.
-// Since there is no core import for 'BlockPattern' to see if that exists,
-// we can check another recent addition to the editor library. If
-// 'EntitiesSavedStates' exists, then we are running Gutenberg.
-if ( EntitiesSavedStates ) {
+// Check that gutenberg is enabled.
+if ( getPlugin( 'gutenberg' ) || window.wpcomGutenberg ) {
 	registerPlugin( 'block-patterns-moved', { render: BlockPatternsMoved } );
 }
+console.log( getPlugins() );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Pull #41963 introduces an edge case where atomic sites not running Gutenberg will have a block pattern plugin pointing them to a feature that doesn't exist.

This PR should gates this plugin from being registered based [`__experimentalLibrary`](https://github.com/WordPress/gutenberg/blob/4830c2c2b95dc612b73efffbd3ed03cd93cd83fa/packages/edit-post/src/components/layout/index.js#L17-L20) export from `block-editor`, which [contains the patterns in their new location](https://github.com/WordPress/gutenberg/blob/4830c2c2b95dc612b73efffbd3ed03cd93cd83fa/packages/edit-post/src/components/layout/index.js#L185-L192).

#41963 would also introduce a duplicate sidebar item, one with patterns and one incorrectly indicating patterns had move.

This PR fixes both of these issues.

#### Testing instructions

* Apply D43208-code
* Sandbox `example.wordpress.com`
* Visit the block editor `example.wordpress.com/wp-admin/post-new.php`
* You should see the moved block pattern plugin/sidebar from #41963
* Switch your sandbox to use Gutenberg `7.8.1`, the previous patterns sidebar should be present. The new sidebar introduced in #41963 should not.
