### PR TITLE
Make the plan selector grid work on mobile devices

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-details/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-details/style.scss
@@ -4,6 +4,7 @@
 
 .plans-details {
 	width: 100%;
+	min-width: 652px;
 	table-layout: fixed;
 	margin-bottom: 110px;
 

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -19,6 +19,10 @@
 }
 
 .plans-grid__details-heading {
+	overflow-x: scroll;
+	@include break-medium {
+		overflow-x: initial;
+	}
 	.gutenboarding-title {
 		color: var( --studio-black );
 		margin-bottom: 40px;

--- a/client/landing/gutenboarding/components/plans/plans-modal/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-modal/style.scss
@@ -5,7 +5,10 @@
 }
 
 .plans-modal {
-	@include onboarding-block-margin;
+	margin: 0 30px;
+	@include break-xlarge {
+		margin: 0 88px;
+	}
 
 	.action-buttons {
 		.components-button.is-link {

--- a/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
@@ -57,39 +57,40 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 
 	return (
 		<div className="plan-item">
-			<div className="plan-item__heading">
-				<div className="plan-item__name">{ name }</div>
-				{ isPopular && <div className="plan-item__badge">{ __( 'Popular' ) }</div> }
-			</div>
-			<div className="plan-item__price">
-				<div className="plan-item__price-amount" data-is-loading={ ! price }>
-					{ price || nbsp }
+			<div className="plan-item__viewport">
+				<div className="plan-item__heading">
+					<div className="plan-item__name">{ name }</div>
+					{ isPopular && <div className="plan-item__badge">{ __( 'Popular' ) }</div> }
 				</div>
-				<div className="plan-item__price-note">{ __( 'per month, billed yearly' ) }</div>
-			</div>
-			<div className="plan-item__actions">
-				<Button
-					className={ classNames( 'plan-item__select-button', { 'is-selected': isSelected } ) }
-					onClick={ () => {
-						onSelect( slug );
-					} }
-					isLarge
-				>
-					{ isSelected ? (
-						<>
-							{ TickIcon }
-							<span>{ __( 'Selected' ) }</span>
-						</>
-					) : (
-						<span>{ __( 'Select' ) }</span>
-					) }
-				</Button>
-			</div>
-			<div className="plan-item__domain">
-				<div className="plan-item__domain-summary">{ __( 'Free domain for 1 year' ) }</div>
-				{ hasDomain && (
-					<div className="plan-item__domain-name">
-						{ /*
+				<div className="plan-item__price">
+					<div className="plan-item__price-amount" data-is-loading={ ! price }>
+						{ price || nbsp }
+					</div>
+					<div className="plan-item__price-note">{ __( 'per month, billed yearly' ) }</div>
+				</div>
+				<div className="plan-item__actions">
+					<Button
+						className={ classNames( 'plan-item__select-button', { 'is-selected': isSelected } ) }
+						onClick={ () => {
+							onSelect( slug );
+						} }
+						isLarge
+					>
+						{ isSelected ? (
+							<>
+								{ TickIcon }
+								<span>{ __( 'Selected' ) }</span>
+							</>
+						) : (
+							<span>{ __( 'Select' ) }</span>
+						) }
+					</Button>
+				</div>
+				<div className="plan-item__domain">
+					<div className="plan-item__domain-summary">{ __( 'Free domain for 1 year' ) }</div>
+					{ hasDomain && (
+						<div className="plan-item__domain-name">
+							{ /*
 						<Button
 							className={ classNames( 'plan-item__domain-picker-button', {
 								'has-domain': hasDomain,
@@ -100,18 +101,19 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 							<Icon icon="arrow-down-alt2" size={ 14 }></Icon>
 						</Button>
 						*/ }
-						{ domainName }
-					</div>
-				) }
-			</div>
-			<div className="plan-item__features">
-				<ul className="plan-item__feature-item-group">
-					{ features.map( ( feature, i ) => (
-						<li key={ i } className="plan-item__feature-item">
-							{ feature }
-						</li>
-					) ) }
-				</ul>
+							{ domainName }
+						</div>
+					) }
+				</div>
+				<div className="plan-item__features">
+					<ul className="plan-item__feature-item-group">
+						{ features.map( ( feature, i ) => (
+							<li key={ i } className="plan-item__feature-item">
+								{ feature }
+							</li>
+						) ) }
+					</ul>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -12,19 +12,28 @@
 }
 
 .plans-table {
+
 	display: flex;
 	flex-direction: row;
-	margin-left: -8px;
-	margin-right: -8px;
-
+	margin: 0 -4px;
+	@include break-xlarge {
+		margin: 0 -10px;
+	}
 	.plan-item {
 		flex-basis: 193px;
 		flex-grow: 0.5;
 		flex-shrink: 0;
-		margin: 0 8px;
+		margin: 0 4px;
 		border: 1px solid $light-gray-500;
-		padding: 20px;
+		padding: 16px;
 		margin-bottom: 24px;
+		@include break-large {
+			flex-shrink: 0.2;
+		}
+		@include break-xlarge {
+			padding: 20px;
+			margin: 0 10px;
+		}
 	}
 }
 
@@ -111,7 +120,7 @@
 }
 
 .plan-item__domain-picker-button.components-button {
-	font-size: 16px;
+	font-size: 14px;
 	line-height: 19px;
 	letter-spacing: 0.2px;
 	word-break: break-word;
@@ -141,8 +150,8 @@
 }
 
 .plan-item__feature-item {
-	font-size: 16px;
-	line-height: 24px;
+	font-size: 14px;
+	line-height: 22px;
 	letter-spacing: 0.2px;
 	margin: 12px 0;
 }

--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -6,34 +6,75 @@
 .plans-grid__table {
 	overflow-x: auto;
 	margin-bottom: 70px;
+
 	@include break-large {
 		overflow-x: initial;
 	}
 }
 
-.plans-table {
+// Make panning edge-to-edge
+.plans-grid__table {
+	width: calc( 100% + 30px + 30px );
+	margin-left: -30px;
+	margin-right: -30px;
 
+	@include break-mobile {
+		width: auto;
+		margin-left: 0;
+		margin-right: 0;
+
+		.plans-table {
+			padding: 0;
+		}
+	}
+}
+
+.plans-table {
 	display: flex;
 	flex-direction: row;
 	margin: 0 -4px;
 	@include break-xlarge {
 		margin: 0 -10px;
 	}
+
 	.plan-item {
 		flex-basis: 193px;
 		flex-grow: 0.5;
 		flex-shrink: 0;
 		margin: 0 4px;
-		border: 1px solid $light-gray-500;
-		padding: 16px;
 		margin-bottom: 24px;
+
+		&:first-child {
+			border-left: 30px solid transparent;
+		}
+
+		&:last-child {
+			border-right: 30px solid transparent;
+		}
+
 		@include break-large {
 			flex-shrink: 0.2;
+
+			&:first-child {
+				border-left: 0;
+			}
+
+			&:last-child {
+				border-right: 0;
+			}
 		}
-		@include break-xlarge {
-			padding: 20px;
-			margin: 0 10px;
-		}
+	}
+}
+
+.plan-item__viewport {
+	border: 1px solid $light-gray-500;
+	width: 100%;
+	height: 100%;
+	padding: 16px;
+
+	@include break-xlarge {
+		padding: 20px;
+		margin: 0 10px;
 	}
 }
 

--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -72,6 +72,10 @@
 	height: 100%;
 	padding: 16px;
 
+	@include break-large {
+		border: none;
+	}
+
 	@include break-xlarge {
 		padding: 20px;
 		margin: 0 10px;

--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -3,13 +3,28 @@
 @import '../../../variables.scss';
 @import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
 
+.plans-grid__table {
+	overflow-x: auto;
+	margin-bottom: 70px;
+	@include break-large {
+		overflow-x: initial;
+	}
+}
+
 .plans-table {
 	display: flex;
 	flex-direction: row;
-	margin-bottom: 70px;
+	margin-left: -8px;
+	margin-right: -8px;
 
 	.plan-item {
-		width: 20%;
+		flex-basis: 193px;
+		flex-grow: 0.5;
+		flex-shrink: 0;
+		margin: 0 8px;
+		border: 1px solid $light-gray-500;
+		padding: 20px;
+		margin-bottom: 24px;
 	}
 }
 
@@ -72,8 +87,8 @@
 }
 
 .plan-item__domain-summary {
-	font-size: 16px;
-	line-height: 24px;
+	font-size: 14px;
+	line-height: 22px;
 }
 
 .plan-item__select-button.components-button {


### PR DESCRIPTION
### Changes proposed in this Pull Request
This supports mobile devices and desktop.
Laptop size is slightly squashed because of the 5 plans now available

* Style changes to support mobile devices

Mobile
![Screen Shot 2020-05-11 at 4 01 16 PM](https://user-images.githubusercontent.com/22446385/81528704-ae819600-93a0-11ea-8723-d7249b7ef876.png)

 
Desktop
![Screen Shot 2020-05-11 at 4 02 18 PM](https://user-images.githubusercontent.com/22446385/81528788-d40e9f80-93a0-11ea-98b5-f52c355c1d0a.png)


Laptop
![Screen Shot 2020-05-11 at 4 01 58 PM](https://user-images.githubusercontent.com/22446385/81528807-d83abd00-93a0-11ea-861e-d3aef8a824b2.png)




#### Testing instructions
* ensure that the `gutenboarding/plans-grid` feature flag is turned on. Currently it is off for staging/prod
* open `/new` 
* In the top right corner of the page click *Free Plan*
