### PR TITLE
Gutenboarding: redirect to editor if selectedSite is current

### DIFF
--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -103,7 +103,7 @@ export default function useOnSiteCreation() {
 						selectedPlan.getStoreSlug() === PLAN_ECOMMERCE
 							? `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1`
 							: `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1&redirect_to=%2Fblock-editor%2Fpage%2F${ newSite.site_slug }%2Fhome`;
-					window.location.replace( redirectionUrl );
+					window.location.href = redirectionUrl;
 				};
 				go();
 				return;
@@ -130,7 +130,7 @@ export default function useOnSiteCreation() {
 					} );
 					resetOnboardStore();
 					setSelectedSite( newSite.blogid );
-					window.location.replace( `/start/prelaunch?siteSlug=${ newSite.blogid }` );
+					window.location.href = `/start/prelaunch?siteSlug=${ newSite.blogid }`;
 				};
 				go();
 				return;
@@ -144,7 +144,7 @@ export default function useOnSiteCreation() {
 			resetOnboardStore();
 			setSelectedSite( newSite.blogid );
 
-			window.location.replace( `/block-editor/page/${ newSite.site_slug }/home` );
+			window.location.href = `/block-editor/page/${ newSite.site_slug }/home`;
 		}
 	}, [
 		domain,

--- a/client/landing/gutenboarding/hooks/use-on-site-creation.ts
+++ b/client/landing/gutenboarding/hooks/use-on-site-creation.ts
@@ -63,7 +63,7 @@ export default function useOnSiteCreation() {
 	const newSite = useSelect( ( select ) => select( SITE_STORE ).getNewSite() );
 	const newUser = useSelect( ( select ) => select( USER_STORE ).getNewUser() );
 
-	const { resetOnboardStore, setIsRedirecting } = useDispatch( ONBOARD_STORE );
+	const { resetOnboardStore, setIsRedirecting, setSelectedSite } = useDispatch( ONBOARD_STORE );
 	const { resetPlan } = useDispatch( PLANS_STORE );
 
 	React.useEffect( () => {
@@ -97,6 +97,8 @@ export default function useOnSiteCreation() {
 					} );
 					resetPlan();
 					resetOnboardStore();
+					setSelectedSite( newSite.blogid );
+
 					const redirectionUrl =
 						selectedPlan.getStoreSlug() === PLAN_ECOMMERCE
 							? `/checkout/${ newSite.site_slug }?preLaunch=1&isGutenboardingCreate=1`
@@ -127,6 +129,7 @@ export default function useOnSiteCreation() {
 						products: [ ...cart.products, domainProduct ],
 					} );
 					resetOnboardStore();
+					setSelectedSite( newSite.blogid );
 					window.location.replace( `/start/prelaunch?siteSlug=${ newSite.blogid }` );
 				};
 				go();
@@ -139,6 +142,7 @@ export default function useOnSiteCreation() {
 				blogId: newSite.blogid,
 			} );
 			resetOnboardStore();
+			setSelectedSite( newSite.blogid );
 
 			window.location.replace( `/block-editor/page/${ newSite.site_slug }/home` );
 		}
@@ -152,5 +156,6 @@ export default function useOnSiteCreation() {
 		resetOnboardStore,
 		resetPlan,
 		setIsRedirecting,
+		setSelectedSite,
 	] );
 }

--- a/client/landing/gutenboarding/index.tsx
+++ b/client/landing/gutenboarding/index.tsx
@@ -230,7 +230,7 @@ async function checkAndRedirectIfSiteWasCreatedRecently() {
 				const diff = Date.now() - createdAt.getTime();
 				const diffMinutes = diff / 1000 / 60;
 				if ( diffMinutes < 10 && diffMinutes >= 0 ) {
-					window.location.replace( `/block-editor/page/${ selectedSiteDetails.ID }/home` );
+					window.location.replace( `/home/${ selectedSiteDetails.ID }` );
 					return;
 				}
 			}

--- a/client/landing/gutenboarding/stores/onboard/actions.ts
+++ b/client/landing/gutenboarding/stores/onboard/actions.ts
@@ -78,7 +78,7 @@ export const resetOnboardStore = () => ( {
 	type: 'RESET_ONBOARD_STORE' as const,
 } );
 
-export const setSelectedSite = ( selectedSite: number ) => ( {
+export const setSelectedSite = ( selectedSite: number | undefined ) => ( {
 	type: 'SET_SELECTED_SITE' as const,
 	selectedSite,
 } );

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -2,8 +2,6 @@
  * Internal dependencies
  */
 import { State } from './reducer';
-import { dispatch } from '@wordpress/data';
-import { STORE_KEY } from './constants';
 
 export const getState = ( state: State ) => state;
 

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -21,9 +21,5 @@ export const isNewSite = ( state: State ) => !! state.newSite.data;
  * @param siteId {number}	id of the site to look up
  */
 export const getSite = ( state: State, siteId: number ) => {
-	const site = state.sites[ siteId ];
-	if ( ! site ) {
-		dispatch( 'core/data' ).invalidateResolution( STORE_KEY, 'getSite', [ siteId ] );
-	}
-	return site;
+	return state.sites[ siteId ];
 };

--- a/packages/data-stores/src/site/test/selectors.ts
+++ b/packages/data-stores/src/site/test/selectors.ts
@@ -70,7 +70,7 @@ describe( 'getSite', () => {
 		);
 	} );
 
-	it( 'resolves the state via an API call and invalidates the resolver cache on fail', async () => {
+	it( 'resolves the state via an API call and caches the resolver on fail', async () => {
 		const slug = 'mytestsite12345.wordpress.com';
 		const apiResponse = {
 			status: 404,
@@ -90,15 +90,7 @@ describe( 'getSite', () => {
 			} );
 		};
 
-		// After the first call, the resolver's cache will be invalidated
-		expect( select( store ).getSite( slug ) ).toEqual( undefined );
-		await listenForStateUpdate();
-
-		expect( select( 'core/data' ).getIsResolving( store, 'getSite', [ slug ] ) ).toStrictEqual(
-			undefined
-		);
-
-		// After the second call, the resolver's cache will be valid
+		// After the first call, the resolver's cache will be valid
 		expect( select( store ).getSite( slug ) ).toEqual( undefined );
 		await listenForStateUpdate();
 
@@ -106,13 +98,12 @@ describe( 'getSite', () => {
 			false
 		);
 
-		// After the third call, the resolver's cache will be invalidated again
+		// After the second call, the resolver's cache will still be valid
 		expect( select( store ).getSite( slug ) ).toEqual( undefined );
 		await listenForStateUpdate();
 
-		// The resolver should now be cached with an `isStarting` value of false
 		expect( select( 'core/data' ).getIsResolving( store, 'getSite', [ slug ] ) ).toStrictEqual(
-			undefined
+			false
 		);
 	} );
 } );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -55,6 +55,9 @@ export interface SiteDetails {
 	name: string;
 	description: string;
 	URL: string;
+	options: {
+		created_at: string;
+	};
 }
 
 export interface SiteError {


### PR DESCRIPTION
When Gutenboarding loads, redirect to the editor if a site was created recently (`selectedSite)` and the requested path is `create-site`, `plans`, or `style`. If the path doesn't match one of these, then we treat the flow as a "fresh" session and reset the `selectedSite`.

This change attempts to fix the issue where a user completes signup and then for whatever reason clicks "back" to get back to Gutenboarding — if we allowed them to do this, _another_ site would be created. Instead we want them to proceed to the editor. This should 🤞also resolve the issue where a user is in the checkout and clicks back — we also want to redirect them to the editor.

#### Changes proposed in this Pull Request

* When creating a site, after resetting the onboarding store (but before redirect) record the id of the newly created site in the `selectedSite` key.
* When Gutenboarding loads, if the path matches one of the final steps of the flow (`create-site`, `plans`, `style`), then look for a selected site (recently created site), load the details of the `selectedSite` from the server, and if it was created within 10 minutes, then redirect to the editor.
* If the above conditions aren't met, then reset the `selectedSite` and treat the session as a "fresh" session

* Revert the invalidate resolution logic from the `getSite` selector as this breaks the behaviour we need to implement here in the appBoot — which is to perform an action based on the first resolution of the `getSite` selector.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site and ensure it redirects correctly to the editor.
* Click `back` from the editor, and after loading Gutenboarding it should redirect you back to the editor.
* From the editor, manually type in `/new` and navigate to it. You should land at the beginning of the Gutenboarding flow.
* In the console type `wp.data.select( 'automattic/onboard' ).getSelectedSite();` and it should return `undefined`.

#### To do

* [x] ~Only perform the redirect logic if the URL requested is not the root of Gutenboarding `/new`~ (updated to only trigger the redirect based on a list of paths)
* [x] ~Make requests to the root `/new` clear out the `selectedSite` value so that going to `/new` directly is treated as intending to create a new site~
* [x] ~Fix up tests, remove console statements, etc~

Related to and builds on work in earlier PRs: https://github.com/Automattic/wp-calypso/pull/41782, https://github.com/Automattic/wp-calypso/pull/40158, https://github.com/Automattic/wp-calypso/pull/39794
