### PR TITLE
Added ability to pan & scroll plans details on mobile view.

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-details/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-details/index.tsx
@@ -18,50 +18,54 @@ const PlansDetails: React.FunctionComponent = () => {
 	const { __ } = useI18n();
 
 	return (
-		<table className="plans-details">
-			<thead>
-				<tr className="plans-details__header-row">
-					<th>{ __( 'Feature' ) }</th>
-					<th>{ __( 'Free' ) }</th>
-					<th>{ __( 'Personal' ) }</th>
-					<th>{ __( 'Premium' ) }</th>
-					<th>{ __( 'Business' ) }</th>
-					<th>{ __( 'Commerce' ) }</th>
-				</tr>
-			</thead>
-			{ plansDetails.map( ( detail ) => (
-				<tbody key={ detail.id }>
-					{ detail.name && (
+		<div className="plans-details">
+			<div className="plans-details__viewport">
+				<table className="plans-details__table">
+					<thead>
 						<tr className="plans-details__header-row">
-							<th colSpan={ 6 }>{ detail.name }</th>
+							<th>{ __( 'Feature' ) }</th>
+							<th>{ __( 'Free' ) }</th>
+							<th>{ __( 'Personal' ) }</th>
+							<th>{ __( 'Premium' ) }</th>
+							<th>{ __( 'Business' ) }</th>
+							<th>{ __( 'Commerce' ) }</th>
 						</tr>
-					) }
-					{ detail.features.map( ( feature, i ) => (
-						<tr className="plans-details__feature-row" key={ i }>
-							<th>{ feature.name }</th>
-							{ feature.data.map( ( value, j ) => (
-								<td key={ j }>
-									{ feature.type === 'checkbox' &&
-										( value ? (
-											<>
-												{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-												<span className="hidden">{ __( 'Available' ) }</span>
-												<Icon icon="yes-alt" />
-											</>
-										) : (
-											<>
-												{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-												<span className="hidden">{ __( 'Unavailable' ) } </span>
-											</>
-										) ) }
-									{ feature.type === 'text' && value }
-								</td>
+					</thead>
+					{ plansDetails.map( ( detail ) => (
+						<tbody key={ detail.id }>
+							{ detail.name && (
+								<tr className="plans-details__header-row">
+									<th colSpan={ 6 }>{ detail.name }</th>
+								</tr>
+							) }
+							{ detail.features.map( ( feature, i ) => (
+								<tr className="plans-details__feature-row" key={ i }>
+									<th>{ feature.name }</th>
+									{ feature.data.map( ( value, j ) => (
+										<td key={ j }>
+											{ feature.type === 'checkbox' &&
+												( value ? (
+													<>
+														{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+														<span className="hidden">{ __( 'Available' ) }</span>
+														<Icon icon="yes-alt" />
+													</>
+												) : (
+													<>
+														{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+														<span className="hidden">{ __( 'Unavailable' ) } </span>
+													</>
+												) ) }
+											{ feature.type === 'text' && value }
+										</td>
+									) ) }
+								</tr>
 							) ) }
-						</tr>
+						</tbody>
 					) ) }
-				</tbody>
-			) ) }
-		</table>
+				</table>
+			</div>
+		</div>
 	);
 };
 

--- a/client/landing/gutenboarding/components/plans/plans-details/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-details/style.scss
@@ -3,23 +3,22 @@
 @import '../../../variables.scss';
 
 .plans-details__viewport {
-	// Allows user to pan plans table left & right
-	// on mobile without overflowing body's scrollbar.
 	overflow: auto;
-	padding: 20px 0;
 
 	.plans-details__table {
-		min-width: 750px;
-	}
+		border-left: 30px solid transparent;
+		border-right: 30px solid transparent;
 
-	@include break-mobile {
-		padding: 0;
+		@include break-medium {
+			border-left: 0;
+			border-right: 0;
+		}
 	}
 }
 
 .plans-details__table {
 	width: 100%;
-	min-width: 652px;
+	min-width: $break-medium;
 	table-layout: fixed;
 
 	th,

--- a/client/landing/gutenboarding/components/plans/plans-details/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-details/style.scss
@@ -2,11 +2,25 @@
 @import '../../../mixins.scss';
 @import '../../../variables.scss';
 
-.plans-details {
+.plans-details__viewport {
+	// Allows user to pan plans table left & right
+	// on mobile without overflowing body's scrollbar.
+	overflow: auto;
+	padding: 20px 0;
+
+	.plans-details__table {
+		min-width: 750px;
+	}
+
+	@include break-mobile {
+		padding: 0;
+	}
+}
+
+.plans-details__table {
 	width: 100%;
 	min-width: 652px;
 	table-layout: fixed;
-	margin-bottom: 110px;
 
 	th,
 	td {
@@ -14,7 +28,11 @@
 
 		&:first-child {
 			padding-left: 0;
-			width: 40%;
+			width: 25%;
+
+			@include break-mobile {
+				width: 40%;
+			}
 		}
 
 		&:not( :first-child ) {

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { Button, Icon } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
+import { Spring } from 'react-spring/renderprops';
 
 /**
  * Internal dependencies
@@ -68,10 +69,20 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 
 			<div className="plans-grid__details">
 				{ showDetails && (
-					<div className="plans-grid__details-heading">
-						<Title>{ __( 'Detailed comparison' ) }</Title>
-						<PlansDetails />
-					</div>
+					<Spring
+						from={ { maxHeight: '0px' } }
+						to={ { maxHeight: '2000px' } }
+						config={ { duration: 500 } }
+					>
+						{ ( props ) => (
+							<div className="plans-grid__details-container" style={ props }>
+								<div className="plans-grid__details-heading">
+									<Title>{ __( 'Detailed comparison' ) }</Title>
+								</div>
+								<PlansDetails />
+							</div>
+						) }
+					</Spring>
 				) }
 				<Button
 					className="plans-grid__details-toggle-button"

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -4,7 +4,6 @@
 import * as React from 'react';
 import { Button, Icon } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
-import { Spring } from 'react-spring/renderprops';
 
 /**
  * Internal dependencies
@@ -69,20 +68,12 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 
 			<div className="plans-grid__details">
 				{ showDetails && (
-					<Spring
-						from={ { maxHeight: '0px' } }
-						to={ { maxHeight: '2000px' } }
-						config={ { duration: 500 } }
-					>
-						{ ( props ) => (
-							<div className="plans-grid__details-container" style={ props }>
-								<div className="plans-grid__details-heading">
-									<Title>{ __( 'Detailed comparison' ) }</Title>
-								</div>
-								<PlansDetails />
-							</div>
-						) }
-					</Spring>
+					<div className="plans-grid__details-container">
+						<div className="plans-grid__details-heading">
+							<Title>{ __( 'Detailed comparison' ) }</Title>
+						</div>
+						<PlansDetails />
+					</div>
 				) }
 				<Button
 					className="plans-grid__details-toggle-button"

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -16,6 +16,25 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+.plans-grid__details {
+	margin-bottom: 120px;
+}
+
+.plans-grid__details-container {
+	// Makes detailed comparison looks like
+	// it's overflowing the page on mobile
+	width: calc( 100% + 20px + 20px );
+	margin-right: -20px;
+	overflow: hidden;
+
+	@include break-mobile {
+		width: 100%;
+		margin-right: 0;
+	}
+
+	+ .plans-grid__details-toggle-button {
+		margin-top: 60px;
+	}
 }
 
 .plans-grid__details-heading {

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -16,6 +16,8 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+}
+
 .plans-grid__details {
 	margin-bottom: 120px;
 }
@@ -72,8 +74,4 @@
 	svg {
 		margin-left: 2px;
 	}
-}
-
-.plans-grid__details {
-	margin-bottom: 120px;
 }

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -23,15 +23,19 @@
 }
 
 .plans-grid__details-container {
-	// Makes detailed comparison looks like
-	// it's overflowing the page on mobile
-	width: calc( 100% + 20px + 20px );
-	margin-right: -20px;
-	overflow: hidden;
+	// Edge-to-edge panning
+	.plans-details {
+		width: calc( 100% + 30px + 30px );
+		margin-left: -30px;
+		margin-right: -30px;
+		overflow: hidden;
 
-	@include break-mobile {
-		width: 100%;
-		margin-right: 0;
+		@include break-medium {
+			width: 100%;
+			margin-left: 0;
+			margin-right: 0;
+			overflow: auto;
+		}
 	}
 
 	+ .plans-grid__details-toggle-button {

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -44,10 +44,6 @@
 }
 
 .plans-grid__details-heading {
-	overflow-x: scroll;
-	@include break-medium {
-		overflow-x: initial;
-	}
 	.gutenboarding-title {
 		color: var( --studio-black );
 		margin-bottom: 40px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ability to pan details table left & right on mobile.

#### Testing instructions

* Open up plans grid in `/new`.
* Panning details table should not affect main body's scrollbar (well at least, until it reaches the end).

#### Screenshot

![2020-05-11_13-08-04 (1)](https://user-images.githubusercontent.com/1287077/81555252-8ede7380-9388-11ea-902c-dc6060df98eb.gif)

Fixes part of #41787
