### PR TITLE
Gutenboarding: Slidedown for detailed comparison on plans grid.

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { Button, Icon } from '@wordpress/components';
 import { useI18n } from '@automattic/react-i18n';
+import { Spring } from 'react-spring/renderprops';
 
 /**
  * Internal dependencies
@@ -68,10 +69,20 @@ const PlansGrid: React.FunctionComponent< Props > = ( {
 
 			<div className="plans-grid__details">
 				{ showDetails && (
-					<div className="plans-grid__details-heading">
-						<Title>{ __( 'Detailed comparison' ) }</Title>
-						<PlansDetails />
-					</div>
+					<Spring
+						from={ { maxHeight: '0px' } }
+						to={ { maxHeight: '2000px' } }
+						config={ { duration: 500 } }
+					>
+						{ ( props ) => (
+							<div className="plans-grid__details-container" style={ props }>
+								<div className="plans-grid__details-heading">
+									<Title>{ __( 'Detailed comparison' ) }</Title>
+								</div>
+								<PlansDetails />
+							</div>
+						) }
+					</Spring>
 				) }
 				<Button
 					className="plans-grid__details-toggle-button"

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -18,6 +18,10 @@
 	align-items: center;
 }
 
+.plans-grid__details-container {
+	overflow: hidden;
+}
+
 .plans-grid__details-heading {
 	.gutenboarding-title {
 		color: var( --studio-black );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Detailed comparison table slides down when clicking on more details button.

#### Testing instructions

* Go to plans grid and click on **More Details** button.

#### Screenshot

![2020-05-11_10-58-39 (1)](https://user-images.githubusercontent.com/1287077/81543593-9006a500-9376-11ea-8c41-038ed93abf27.gif)

Fixes part of #41787
