### PR TITLE
[Private sites] Release to all users and remove the ATPrivacy test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,15 +106,6 @@ export default {
 		defaultVariation: 'variantShowUpdates',
 		allowExistingUsers: true,
 	},
-	ATPrivacy: {
-		datestamp: '20200331',
-		variations: {
-			variant: 100,
-			control: 0,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: false,
-	},
 	domainStepPlanStepSwap: {
 		datestamp: '20200415',
 		variations: {

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -27,7 +27,7 @@ import guessTimezone from 'lib/i18n-utils/guess-timezone';
 
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
-import { abtest, getSavedVariations } from 'lib/abtest';
+import { getSavedVariations } from 'lib/abtest';
 import { recordTracksEvent } from 'lib/analytics/tracks';
 import { recordRegistration } from 'lib/analytics/signup';
 import {
@@ -197,9 +197,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 		validate: false,
 	};
 
-	if ( 'variant' === abtest( 'ATPrivacy' ) ) {
-		newSiteParams.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
-	}
+	newSiteParams.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
 
 	const shouldSkipDomainStep = ! siteUrl && isDomainStepSkippable( flowToCheck );
 	const shouldHideFreePlan = get( signupDependencies, 'shouldHideFreePlan', false );
@@ -523,9 +521,7 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 		validate: false,
 	};
 
-	if ( 'variant' === abtest( 'ATPrivacy' ) ) {
-		data.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
-	}
+	data.options.wpcom_coming_soon = getNewSiteComingSoonSetting( state );
 
 	wpcom.undocumented().sitesNew( data, function ( errors, response ) {
 		let providedDependencies, siteSlug;

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -11,7 +11,6 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import notices from 'notices';
 import EmptyContent from 'components/empty-content';
 import CreditsPaymentBox from './credits-payment-box';
@@ -202,7 +201,7 @@ export class SecurePaymentForm extends Component {
 	}
 
 	async maybeSetSiteToPublic( { cart } ) {
-		const { isJetpack, selectedSiteId, siteIsPrivate } = this.props;
+		const { isJetpack, siteIsPrivate } = this.props;
 
 		if ( isJetpack || ! siteIsPrivate ) {
 			return;
@@ -216,18 +215,6 @@ export class SecurePaymentForm extends Component {
 			} )
 		) {
 			return;
-		}
-
-		if ( 'variant' !== abtest( 'ATPrivacy' ) ) {
-			// Until Atomic sites support being private / unlaunched, set them to public on upgrade
-			debug( 'Setting site to public because it is an Atomic plan' );
-			const response = await this.props.saveSiteSettings( selectedSiteId, {
-				blog_public: 1,
-			} );
-
-			if ( ! get( response, [ 'updated', 'blog_public' ] ) ) {
-				throw 'Invalid response';
-			}
 		}
 	}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -582,7 +582,6 @@ export class PlanFeatures extends Component {
 			cartItemForPlan,
 			checkoutUrl,
 			siteIsPrivateAndGoingAtomic,
-			productSlug,
 		} = singlePlanProperties;
 
 		if ( ownPropsOnUpgradeClick && ownPropsOnUpgradeClick !== noop && cartItemForPlan ) {
@@ -601,16 +600,7 @@ export class PlanFeatures extends Component {
 				// Let signup do its thing
 				return;
 			}
-			if ( 'variant' === abtest( 'ATPrivacy' ) ) {
-				// When coming soon feature is enabled, we don't want to show any warnings
-				page( checkoutUrlWithArgs );
-				return;
-			}
-			this.setState( {
-				checkoutUrl: checkoutUrlWithArgs,
-				choosingPlanSlug: productSlug,
-				showingSiteLaunchDialog: true,
-			} );
+			page( checkoutUrlWithArgs );
 			return;
 		}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -18,7 +18,6 @@ import NoticeAction from 'components/notice/notice-action';
 import LanguagePicker from 'components/language-picker';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 import config from 'config';
-import { abtest } from 'lib/abtest';
 import { languages } from 'languages';
 import FormInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -277,78 +276,6 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	visibilityOptions() {
-		const {
-			fields,
-			handleRadio,
-			updateFields,
-			isRequestingSettings,
-			eventTracker,
-			siteIsJetpack,
-			trackEvent,
-			translate,
-		} = this.props;
-
-		const currentValue = parseInt( fields.blog_public, 10 );
-
-		return (
-			<FormFieldset>
-				{ ! siteIsJetpack && (
-					<FormLabel className="site-settings__visibility-label">
-						<FormRadio
-							name="blog_public"
-							value="1"
-							checked={ [ 0, 1 ].indexOf( currentValue ) !== -1 }
-							onChange={ handleRadio }
-							disabled={ isRequestingSettings }
-							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-						/>
-						<span>{ translate( 'Public' ) }</span>
-					</FormLabel>
-				) }
-
-				<FormSettingExplanation isIndented>
-					{ translate( 'Your site is visible to everyone.' ) }
-				</FormSettingExplanation>
-
-				<FormLabel className="site-settings__visibility-label is-checkbox">
-					<FormInputCheckbox
-						name="blog_public"
-						value="0"
-						checked={ 0 === currentValue }
-						onChange={ () => {
-							const newValue = currentValue === 0 ? 1 : 0;
-							trackEvent( `Set blog_public to ${ newValue }` );
-							updateFields( { blog_public: newValue } );
-						} }
-						disabled={ isRequestingSettings }
-						onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-					/>
-					<span>{ translate( 'Do not allow search engines to index my site' ) }</span>
-				</FormLabel>
-
-				{ ! siteIsJetpack && (
-					<>
-						<FormLabel className="site-settings__visibility-label">
-							<FormRadio
-								name="blog_public"
-								value="-1"
-								checked={ -1 === currentValue }
-								onChange={ handleRadio }
-								disabled={ isRequestingSettings }
-								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-							/>
-							<span>{ translate( 'Private' ) }</span>
-						</FormLabel>
-						<FormSettingExplanation isIndented>
-							{ translate( 'Your site is only visible to you and users you approve.' ) }
-						</FormSettingExplanation>
-					</>
-				) }
-			</FormFieldset>
-		);
-	}
-
 	visibilityOptionsComingSoon() {
 		const {
 			fields,
@@ -563,13 +490,7 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	privacySettings() {
-		const {
-			isRequestingSettings,
-			translate,
-			handleSubmitForm,
-			isSavingSettings,
-			withComingSoonOption,
-		} = this.props;
+		const { isRequestingSettings, translate, handleSubmitForm, isSavingSettings } = this.props;
 
 		return (
 			<>
@@ -582,9 +503,7 @@ export class SiteSettingsFormGeneral extends Component {
 					title={ translate( 'Privacy' ) }
 				/>
 				<Card>
-					<form>
-						{ withComingSoonOption ? this.visibilityOptionsComingSoon() : this.visibilityOptions() }
-					</form>
+					<form>{ this.visibilityOptionsComingSoon() }</form>
 				</Card>
 			</>
 		);
@@ -757,9 +676,7 @@ const getFormSettings = ( settings ) => {
 		timezone_string: settings.timezone_string,
 	};
 
-	if ( settings.private_sites_enabled || 'variant' === abtest( 'ATPrivacy' ) ) {
-		formSettings.wpcom_coming_soon = settings.wpcom_coming_soon;
-	}
+	formSettings.wpcom_coming_soon = settings.wpcom_coming_soon;
 
 	// handling `gmt_offset` and `timezone_string` values
 	const gmt_offset = settings.gmt_offset;
@@ -773,10 +690,5 @@ const getFormSettings = ( settings ) => {
 
 export default flowRight(
 	connectComponent,
-	wrapSettingsForm( getFormSettings ),
-	connect( ( state, ownProps ) => ( {
-		withComingSoonOption: ownProps.hasOwnProperty( 'withComingSoonOption' )
-			? ownProps.withComingSoonOption
-			: ownProps?.settings?.private_sites_enabled || 'variant' === abtest( 'ATPrivacy' ),
-	} ) )
+	wrapSettingsForm( getFormSettings )
 )( SiteSettingsFormGeneral );

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -11,7 +11,6 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import { protectForm } from 'lib/protect-form';
 import trackForm from 'lib/track-form';
 import {
@@ -161,9 +160,6 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			}
 
 			const siteFields = pick( fields, settingsFields.site );
-			if ( ! this.props.settings.private_sites_enabled && 'variant' !== abtest( 'ATPrivacy' ) ) {
-				delete siteFields.wpcom_coming_soon;
-			}
 			this.props.saveSiteSettings( siteId, { ...siteFields, apiVersion: '1.4' } );
 		};
 

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -1,35 +1,8 @@
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { abtest } from 'lib/abtest';
-import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
-import { isEcommercePlan } from 'lib/plans';
-
-/**
  * Should the site be private by default
  *
- * @param state The current client state
  * @returns `true` for private by default & `false` for not
  */
-export default function shouldNewSiteBePrivateByDefault( state: object ): boolean {
-	if ( 'variant' === abtest( 'ATPrivacy' ) ) {
-		// When coming-soon feature flag is enabled, we want all new sites to be private
-		return true;
-	}
-
-	/**
-	 * eCommerce sites are created public since they go Atomic at purchase.
-	 * p1578348423018900-slack-CCS1W9QVA
-	 */
-	const plan = get( getSignupDependencyStore( state ), 'cartItem.product_slug', false );
-	if ( plan && isEcommercePlan( plan ) ) {
-		return false;
-	}
-
+export default function shouldNewSiteBePrivateByDefault(): boolean {
 	return true;
 }

--- a/client/state/selectors/test/get-new-site-public-setting.js
+++ b/client/state/selectors/test/get-new-site-public-setting.js
@@ -27,12 +27,12 @@ describe( 'getNewSitePublicSetting()', () => {
 		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 
-	test( 'should return `1` for ecommerce plan', () => {
+	test( 'should return `-1` for ecommerce plan', () => {
 		const mockState = {
 			signup: {
 				dependencyStore: { cartItem: { product_slug: 'ecommerce-bundle', free_trial: false } },
 			},
 		};
-		expect( getNewSitePublicSetting( mockState ) ).toBe( 1 );
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 } );

--- a/client/state/selectors/test/should-new-site-be-private-by-default.js
+++ b/client/state/selectors/test/should-new-site-be-private-by-default.js
@@ -27,12 +27,12 @@ describe( 'shouldNewSiteBePrivateByDefault()', () => {
 		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 
-	test( 'should return `false` for ecommerce plan', () => {
+	test( 'should return `true` for ecommerce plan', () => {
 		const mockState = {
 			signup: {
 				dependencyStore: { cartItem: { product_slug: 'ecommerce-bundle', free_trial: false } },
 			},
 		};
-		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( false );
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 } );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4872,6 +4872,15 @@
     sprintf-js "^1.1.1"
     tannin "^1.2.0"
 
+"@wordpress/icons@*":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-1.4.0.tgz#805732a5527eb2178bd97b53decac67451b2b1b3"
+  integrity sha512-YNW1ocZddZ6c40QHiR/Q3yIPYzh4Fdcq/J4sJIkegwqEXltVknYa90RNaDG9xr+qMvXN5/wotYaLA+AP6pUfHA==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@wordpress/element" "^2.13.1"
+    "@wordpress/primitives" "^1.4.0"
+
 "@wordpress/icons@1.2.0", "@wordpress/icons@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@wordpress/icons/-/icons-1.2.0.tgz#734c8d684c8a02d688e8d96e5ce57de574d5c388"
@@ -5014,6 +5023,15 @@
   dependencies:
     "@babel/runtime" "^7.8.3"
     "@wordpress/element" "^2.12.0"
+    classnames "^2.2.5"
+
+"@wordpress/primitives@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/primitives/-/primitives-1.4.0.tgz#ea236061d65d6e0ab960a7f6670c655451576c94"
+  integrity sha512-mlP7ikqBw761VK37RL7q5+tnjJujGFuDfJhjhxCXacM/06CpddPSfX+XctWTTn0Oaw1XI/nzK1wlqlIj7uwlrg==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@wordpress/element" "^2.13.1"
     classnames "^2.2.5"
 
 "@wordpress/priority-queue@1.5.1", "@wordpress/priority-queue@^1.5.1":


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes private atomic sites and the coming soon mode available to every user. PR removes the ATPrivacy test and updates the code to act as if the user was assigned to `variant`.

#### Testing instructions

1. Apply this PR and D43216-code.
1. Sandbox public-api.
1. In calypso, go to settings of one of your pre-existing atomic sites, press save, confirm it was a success.
1. Change the visibility to private, coming soon, public again. Each time visit the site in incognito mode and confirm your new setting worked.
1. Choose one of your pre-existing unlaunched simple sites, upgrade to e-commerce, confirm there no privacy warnings were displayed. Confirm the site is still private after upgrading. Confirm you're able to launch the site.
1. Choose one of your pre-existing unlaunched simple sites, make it private, upgrade to business, install Hello Dolly plugin, confirm there no privacy warnings were displayed. Confirm the site is still private after upgrading. Confirm you're able to launch the site.
1. Repeat steps 5 and 6 with a new free site and a new business site. 
1. Create a new site and purchase an e-commerce plan during the signup. Confirm the site was created as Coming Soon. Confirm you're able to launch the site.
