### PR TITLE
Gutenboarding: Fix domain picker button overflow issues on mobile view.

### DIFF
--- a/client/landing/gutenboarding/components/domain-picker-button/style.scss
+++ b/client/landing/gutenboarding/components/domain-picker-button/style.scss
@@ -50,9 +50,7 @@
 		// animation using width: 0% to width: 100%.
 		white-space: nowrap;
 		overflow: hidden;
-		// This is for mobile later on long domains.
-		// Commented out for now.
-		// text-overflow: ellipsis;
+		text-overflow: ellipsis;
 	}
 
 	.dashicon {

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -149,7 +149,7 @@ const Header: React.FunctionComponent = () => {
 						<Icon icon="wordpress-alt" size={ 24 } />
 					</div>
 				</div>
-				<div className="gutenboarding__header-section-item">
+				<div className="gutenboarding__header-section-item gutenboarding__header-site-title-section">
 					<div className="gutenboarding__header-site-title">
 						{ siteTitle ? siteTitle : __( 'Start your website' ) }
 					</div>

--- a/client/landing/gutenboarding/components/header/index.tsx
+++ b/client/landing/gutenboarding/components/header/index.tsx
@@ -154,7 +154,7 @@ const Header: React.FunctionComponent = () => {
 						{ siteTitle ? siteTitle : __( 'Start your website' ) }
 					</div>
 				</div>
-				<div className="gutenboarding__header-section-item">
+				<div className="gutenboarding__header-section-item gutenboarding__header-domain-section">
 					{
 						// We display the DomainPickerButton as soon as we have a domain suggestion,
 						// unless we're still at the IntentGathering step. In that case, we only
@@ -178,6 +178,7 @@ const Header: React.FunctionComponent = () => {
 								</DomainPickerButton>
 							)
 					}
+					&nbsp;
 				</div>
 				<div className="gutenboarding__header-section-item gutenboarding__header-section-item--right">
 					<PlansButton />

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -76,20 +76,36 @@ $padding--gutenboarding__header: $grid-unit-10;
 	display: flex;
 }
 
+.gutenboarding__header-domain-section {
+	position: relative;
+	width: 100%;
+	flex-grow: 1;
+}
+
 .gutenboarding__header-domain-picker-button {
-	max-width: 0;
-	opacity: 0;
+	position: absolute;
+	top: -6px;
+	left: 0;
+	max-width: 100%;
 
-	&.has-content {
-		animation-duration: 5s;
-		animation-name: gutenboarding_domain-slide-in;
-		max-width: 1500px;
-		opacity: 1;
-		@include reduce-motion( 'animation' );
-	}
+	// Temp fix: Animation only on desktop/tablet devices.
+	@include break-mobile {
+		position: relative;
+		top: 0;
+		max-width: 0;
+		opacity: 0;
 
-	&.has-placeholder .gutenboarding__header-domain-picker-button-domain {
-		animation: loading-fade 1.6s ease-in-out infinite;
-		@include reduce-motion( 'animation' );
+		&.has-content {
+			animation-duration: 5s;
+			animation-name: gutenboarding_domain-slide-in;
+			max-width: 1500px;
+			opacity: 1;
+			@include reduce-motion( 'animation' );
+		}
+
+		&.has-placeholder .gutenboarding__header-domain-picker-button-domain {
+			animation: loading-fade 1.6s ease-in-out infinite;
+			@include reduce-motion( 'animation' );
+		}
 	}
 }

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -76,6 +76,14 @@ $padding--gutenboarding__header: $grid-unit-10;
 	display: flex;
 }
 
+.gutenboarding__header-site-title-section {
+	display: none;
+
+	@include break-mobile {
+		display: block;
+	}
+}
+
 .gutenboarding__header-domain-section {
 	position: relative;
 	width: 100%;

--- a/client/landing/gutenboarding/components/plans/plans-button/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-button/style.scss
@@ -1,5 +1,9 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 
+.plans-button {
+	white-space: nowrap;
+}
+
 .plans-button__jetpack-logo {
 	@include break-mobile {
 		margin-left: 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The problem is that long domain picker button pushing out plans grid button. Long domain picker button also affects panning of plans grid on mobile view.

This PR:
* Fixes domain picker button overflowing issues on mobile view.

However, it has caveats:
- This disables domain picker slide out animation on mobile view. To fix in another PR.
- This fix is quick & dirty.

#### Testing instructions

* Enter a long domain on gutenboarding and ensure it doesn't break on mobile view.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/81547100-a82cf300-937b-11ea-9ee9-e6c696ce7a4d.png)

![image](https://user-images.githubusercontent.com/1287077/81559923-a4f03200-9390-11ea-8f79-b8bae8c7df79.png)

![2020-05-11_14-06-00 (1)](https://user-images.githubusercontent.com/1287077/81559993-cf41ef80-9390-11ea-9fed-6c9d2168f8c1.gif)

Fixes #41435