### PR TITLE
Enhance: getPopularPlanSpec() can now takes available plans into consideration.

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -445,22 +445,44 @@ export function getPlanTermLabel( planName, translate ) {
 	}
 }
 
-export const getPopularPlanSpec = ( { customerType, isJetpack } ) => {
+export const getPopularPlanSpec = ( { customerType, isJetpack, availablePlans } ) => {
 	// Jetpack doesn't currently highlight "Popular" plans
 	if ( isJetpack ) {
 		return false;
 	}
 
-	const spec = {
-		type: TYPE_BUSINESS,
-		group: GROUP_WPCOM,
-	};
-
-	if ( customerType === 'personal' ) {
-		spec.type = TYPE_PREMIUM;
+	if ( availablePlans.length === 0 ) {
+		return false;
 	}
 
-	return spec;
+	const defaultPlan = getPlan( availablePlans[ 0 ] );
+
+	if ( ! defaultPlan ) {
+		return false;
+	}
+
+	const group = GROUP_WPCOM;
+
+	if ( customerType === 'personal' ) {
+		if ( availablePlans.findIndex( isPremiumPlan ) !== -1 ) {
+			return {
+				type: TYPE_PREMIUM,
+				group,
+			};
+		}
+		// when customerType is not personal, default to business
+	} else if ( availablePlans.findIndex( isBusinessPlan ) !== -1 ) {
+		return {
+			type: TYPE_BUSINESS,
+			group,
+		};
+	}
+
+	// finally, just return the default one.
+	return {
+		type: defaultPlan.type,
+		group,
+	};
 };
 
 export const chooseDefaultCustomerType = ( { currentCustomerType, selectedPlan, currentPlan } ) => {

--- a/client/lib/plans/test/get-popular-plan-spec.js
+++ b/client/lib/plans/test/get-popular-plan-spec.js
@@ -5,8 +5,19 @@ import { getPopularPlanSpec } from '..';
 import { GROUP_WPCOM, TYPE_BUSINESS, TYPE_PREMIUM } from '../constants';
 
 describe( 'getPopularPlanSpec()', () => {
+	const availablePlans = [
+		'personal-bundle',
+		'value_bundle',
+		'business-bundle',
+		'ecommerce-bundle',
+	];
+
 	test( 'Should return biz for empty customer type', () => {
-		expect( getPopularPlanSpec( {} ) ).toEqual( {
+		expect(
+			getPopularPlanSpec( {
+				availablePlans,
+			} )
+		).toEqual( {
 			type: TYPE_BUSINESS,
 			group: GROUP_WPCOM,
 		} );
@@ -16,6 +27,7 @@ describe( 'getPopularPlanSpec()', () => {
 		expect(
 			getPopularPlanSpec( {
 				customerType: 'personal',
+				availablePlans,
 			} )
 		).toEqual( {
 			type: TYPE_PREMIUM,
@@ -23,10 +35,32 @@ describe( 'getPopularPlanSpec()', () => {
 		} );
 	} );
 
+	test( 'Should return the first available plan for personal customer type if the premium plan is not available', () => {
+		expect(
+			getPopularPlanSpec( {
+				customerType: 'personal',
+				availablePlans: [ 'business-bundle', 'ecommerce-bundle' ],
+			} )
+		).toEqual( {
+			type: TYPE_BUSINESS,
+			group: GROUP_WPCOM,
+		} );
+	} );
+
+	test( 'should return false when there is no available plans.', () => {
+		expect(
+			getPopularPlanSpec( {
+				customerType: 'business',
+				availablePlans: [],
+			} )
+		).toEqual( false );
+	} );
+
 	test( 'Should return biz for biz customer type', () => {
 		expect(
 			getPopularPlanSpec( {
 				customerType: 'business',
+				availablePlans,
 			} )
 		).toEqual( { type: TYPE_BUSINESS, group: GROUP_WPCOM } );
 	} );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -200,6 +200,7 @@ export class PlansFeaturesMain extends Component {
 					popularPlanSpec={ getPopularPlanSpec( {
 						customerType,
 						isJetpack,
+						availablePlans,
 					} ) }
 					siteId={ siteId }
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to fix the issue that there is no primary button nor the popular badge when the one that is labeled as popular is hidden, first reported by @niranjan-uma-shankar here: https://github.com/Automattic/wp-calypso/pull/41676#pullrequestreview-407152120 .

The solution here is to make `getPopularPlanSpec()` function be aware of the available plans, so it won't report anything that is simply unavailable.

Before:
![image](https://user-images.githubusercontent.com/1842898/81553315-789bdc00-93b7-11ea-8a64-a8327f483f1f.png)
![image](https://user-images.githubusercontent.com/1842898/81553279-6b7eed00-93b7-11ea-93ce-d81b9c6101dc.png)

After:
![截圖 2020-05-11 下午6 35 00](https://user-images.githubusercontent.com/1842898/81553191-4ab69780-93b7-11ea-85c1-35d829ace947.png)
![截圖 2020-05-11 下午6 35 21](https://user-images.githubusercontent.com/1842898/81553195-4d18f180-93b7-11ea-9f45-020bac3f3655.png)

#### Testing instructions

1. `yarn test-client lib/plans/test/get-popular-plan-spec.js` should pass.
1. Follow the instructions in https://github.com/Automattic/wp-calypso/pull/41676 to set an account that falls into the price group 3.
1. Visit `/plans`, the business plan should be labeled as the popular choice.
1. Test the same for the site creation flow.
1. Test the same for the signup flow.
