### PR TITLE
Bring verticals suggestions list to the front

### DIFF
--- a/client/landing/gutenboarding/_z-index.scss
+++ b/client/landing/gutenboarding/_z-index.scss
@@ -1,0 +1,39 @@
+// ==========================================================================
+// A map of all of our z-index values.
+//
+// Please add new values relative to their parent stacking context. For
+// example the values of 'root' are elements with a stacking context that have no
+// parents with a stacking context, other than the default html root.
+//
+// A Stacking Context is created when:
+// 1. It's the root element (HTML)
+// 2. Has a position other than static, with a z-index value
+// 3. position:fixed
+// 4. Has one of the following css properties: (transform, opacity<1, mix-blend-mode, filter)
+// 5. isolation:isolate
+// 6: -webkit-overflow-scrolling: touch
+//
+// So before adding a new z-index:
+// 1. You'll want to make sure the element actually creates a stacking context
+// 2. Look up what its parent stacking context is
+// There's a Chrome devtools extension that can help you find both:
+// https://chrome.google.com/webstore/detail/z-context/jigamimbjojkdgnlldajknogfgncplbh
+//
+// For readability please sort values from lowest to highest.
+//
+// Usage:
+// .environment-badge {
+//     z-index: gutenboarding-z-index( '.environment-badge' );
+// }
+//
+// For a refresher on stacking contexts see:
+// https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+// ==========================================================================
+
+$z-layers: (
+	'.vertical-select__suggestions-wrapper': 2,
+);
+
+@function gutenboarding-z-index( $keys... ) {
+	@return map-get( $z-layers, $keys... );
+}

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -1,5 +1,6 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../../variables.scss';
+@import '../../../_z-index.scss';
 
 // Restyle `<Suggestion />` component
 .vertical-select {
@@ -51,7 +52,7 @@
 	position: relative;
 	display: block;
 	flex: 1;
-	z-index: 2;
+	z-index: gutenboarding-z-index( '.vertical-select__suggestions-wrapper' );
 
 	@include break-small {
 		display: inline;
@@ -116,7 +117,11 @@
 		right: 0;
 		bottom: -2px;
 		height: 2px;
-		background-image: linear-gradient( to right, rgba( 238, 238, 238, 1 ), rgba( 238, 238, 238, 0.4 ) );
+		background-image: linear-gradient(
+			to right,
+			rgba( 238, 238, 238, 1 ),
+			rgba( 238, 238, 238, 0.4 )
+		);
 	}
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -51,6 +51,7 @@
 	position: relative;
 	display: block;
 	flex: 1;
+	z-index: 2;
 
 	@include break-small {
 		display: inline;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a `z-index` to the suggestions list. 

See p1589197593181500-slack-gutenboarding for details.

_I tried adding the value to [`client/assets/stylesheets/shared/functions/_z-index.scss`](https://github.com/Automattic/wp-calypso/blob/master/client/assets/stylesheets/shared/functions/_z-index.scss) but this files isn't being used for `z-index()` function and the build is failing._ 