### PR TITLE
Gutenboarding: Show "Free Wordpress.com Subdomain" on plans grid for Free plan.

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-table/plan-item.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { useI18n } from '@automattic/react-i18n';
 import { Button, Icon } from '@wordpress/components';
 import classNames from 'classnames';
+import { PLAN_FREE } from '../../../stores/plans/constants';
 
 const TickIcon = (
 	<Icon
@@ -87,7 +88,11 @@ const PlanItem: React.FunctionComponent< Props > = ( {
 					</Button>
 				</div>
 				<div className="plan-item__domain">
-					<div className="plan-item__domain-summary">{ __( 'Free domain for 1 year' ) }</div>
+					<div className="plan-item__domain-summary">
+						{ slug === PLAN_FREE
+							? __( 'Free WordPress.com subdomain' )
+							: __( 'Free domain for 1 year' ) }
+					</div>
 					{ hasDomain && (
 						<div className="plan-item__domain-name">
 							{ /*

--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -143,6 +143,7 @@
 .plan-item__domain-summary {
 	font-size: 14px;
 	line-height: 22px;
+	min-height: 44px; // temporary until domain picker is in
 }
 
 .plan-item__select-button.components-button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While domain picker is disabled, show "Free Wordpress.com Subdomain" on plans grid for Free plan.

#### Testing instructions

* Just open up plans grid in gutenboarding.

#### Screenshot

![image](https://user-images.githubusercontent.com/1287077/81563392-7ecd9080-9396-11ea-9a2a-c057432a56c1.png)

