### PR TITLE
Gutenboarding: Remove 'Remove WordPress ads' from free plan

### DIFF
--- a/client/landing/gutenboarding/stores/plans/plans-data.ts
+++ b/client/landing/gutenboarding/stores/plans/plans-data.ts
@@ -38,7 +38,7 @@ const mainFeatures = [
 
 export const planFeatures: FortifiedPlans = {
 	[ PLAN_FREE ]: {
-		features: [ '3 GB', ...mainFeatures.slice( 0, 1 ) ],
+		features: [ '3 GB' ],
 	},
 	[ PLAN_PERSONAL ]: {
 		features: [ '6 GB', ...mainFeatures.slice( 0, 4 ) ],


### PR DESCRIPTION
All in the title. 

To test, make sure 'Remove WordPress ads' doesn't exist under the free plan in Gutenboarding.
