### PR TITLE
My Home: Fix quick links styles for WP for Teams sites

### DIFF
--- a/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/wp-for-teams-quick-links/index.jsx
@@ -54,7 +54,7 @@ export const QuickLinks = ( {
 	const translate = useTranslate();
 
 	const quickLinks = (
-		<div className="wp-for-teams-quick-links__boxes quick-links-compact__boxes">
+		<div className="wp-for-teams-quick-links__boxes quick-links__boxes">
 			{ isStaticHomePage ? (
 				<ActionBox
 					onClick={ editHomepageAction }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a small regression introduced in #41855 that causes the quick link to show with an extra padding for WP for Teams sites.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/1233880/81565363-79be1080-9399-11ea-82a2-e95cc420810b.png) | ![image](https://user-images.githubusercontent.com/1233880/81565383-85113c00-9399-11ea-9518-4fcdef8dfcfb.png)


#### Testing instructions

* Switch to a WP for Teams site (you can create one in https://wordpress.com/start/wp-for-teams)
* Go to My Home.
* Verify the quick links are displayed correctly.
