### PR TITLE
Landing: update TOS text

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -162,11 +162,10 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 								</Button>
 							</p>
 
+							<p className="signup-form__link signup-form__terms-of-service-link">{ tos }</p>
 							<ModalSubmitButton disabled={ isFetchingNewUser } isBusy={ isFetchingNewUser }>
 								{ __( 'Create account' ) }
 							</ModalSubmitButton>
-
-							<p className="signup-form__link signup-form__terms-of-service-link">{ tos }</p>
 						</div>
 					</fieldset>
 				</form>

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -108,7 +108,7 @@
 	}
 
 	.signup-form__terms-of-service-link {
-		@include onboarding-x-small-text;
+		@include onboarding-medium-text;
 		text-align: center;
 		color: var( --studio-gray-30 );
 		margin: 15px 0 20px;


### PR DESCRIPTION
By request of our Legal team, we are moving the TOS agreement copy on top of the signup button and making the text be the same size that the rest of the copy in that form. 

