### PR TITLE
Posts & Media: Use sentence case button labels for empty states

### DIFF
--- a/client/my-sites/media-library/list-no-content.jsx
+++ b/client/my-sites/media-library/list-no-content.jsx
@@ -85,7 +85,7 @@ class MediaLibraryListNoContent extends Component {
 					className="media-library__no-content-upload-button is-primary"
 					site={ this.props.site }
 				>
-					{ this.props.translate( 'Upload Media' ) }
+					{ this.props.translate( 'Upload media' ) }
 				</UploadButton>
 			);
 		} else if ( 'google_photos' === this.props.source ) {

--- a/client/my-sites/post-type-list/empty-content.jsx
+++ b/client/my-sites/post-type-list/empty-content.jsx
@@ -5,12 +5,12 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import { getPostType } from 'state/post-types/selectors';
+import { getPostType, getPostTypeLabel } from 'state/post-types/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import getEditorUrl from 'state/selectors/get-editor-url';
 import QueryPostTypes from 'components/data/query-post-types';
@@ -21,7 +21,14 @@ function preloadEditor() {
 	preload( 'post-editor' );
 }
 
-function PostTypeListEmptyContent( { siteId, translate, status, typeObject, editPath } ) {
+function PostTypeListEmptyContent( {
+	siteId,
+	translate,
+	status,
+	typeObject,
+	editPath,
+	addNewItemLabel,
+} ) {
 	let title, action;
 
 	if ( 'draft' === status ) {
@@ -31,7 +38,7 @@ function PostTypeListEmptyContent( { siteId, translate, status, typeObject, edit
 	}
 
 	if ( typeObject ) {
-		action = typeObject.labels.add_new_item;
+		action = addNewItemLabel;
 	}
 
 	return (
@@ -60,10 +67,12 @@ PostTypeListEmptyContent.propTypes = {
 
 export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
+	const localeSlug = getLocaleSlug( state );
 
 	return {
 		siteId,
 		typeObject: getPostType( state, siteId, ownProps.type ),
 		editPath: getEditorUrl( state, siteId, null, ownProps.type ),
+		addNewItemLabel: getPostTypeLabel( state, siteId, ownProps.type, 'add_new_item', localeSlug ),
 	};
 } )( localize( PostTypeListEmptyContent ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Noticed a couple empty states where button labels were not sentence case. This PR updates the empty states for Posts and Media.

**Before**

<img width="288" alt="Screen Shot 2020-05-11 at 10 46 12 AM" src="https://user-images.githubusercontent.com/2124984/81577497-80d42700-9377-11ea-93bf-ccf1c1504d25.png">
<img width="447" alt="Screen Shot 2020-05-11 at 11 07 38 AM" src="https://user-images.githubusercontent.com/2124984/81577621-a6613080-9377-11ea-823f-94f2e1d0b65d.png">


**After**

<img width="335" alt="Screen Shot 2020-05-11 at 11 06 27 AM" src="https://user-images.githubusercontent.com/2124984/81577517-86317180-9377-11ea-9fc3-8e707885b382.png">
<img width="437" alt="Screen Shot 2020-05-11 at 11 06 20 AM" src="https://user-images.githubusercontent.com/2124984/81577519-86ca0800-9377-11ea-8477-2124df929cbc.png">

#### Testing instructions

* Switch to this PR on a site with no posts or media
* Visit Posts; note the change in button copy
* Visit Media; note the change in button copy
