### PR TITLE
Updates wording of onboarding to specify VaultPress

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -186,8 +186,8 @@ class JetpackChecklist extends PureComponent< Props & LocalizeProps > {
 					{ isPaidPlan && isRewindUnavailable && productInstallStatus && (
 						<Task
 							id="jetpack_vaultpress"
-							title={ translate( "We're automatically turning on Backup and Scan." ) }
-							completedTitle={ translate( "We've automatically turned on Backup and Scan." ) }
+							title={ translate( "We're automatically turning on VaultPress." ) }
+							completedTitle={ translate( "We've automatically turned on VaultPress." ) }
 							completedButtonText={ translate( 'View security dashboard' ) }
 							completed={ vaultpressFinished }
 							href="https://dashboard.vaultpress.com"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This updates the onboarding checklist to specify VaultPress instead of a more generic phrase, to avoid confusion with Jetpack Backup and Scan product.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up a Jetpack site with a plan with VaultPress.
* Go to Plan > My Plan.
* Toggle the prop `vaultpressFinished` on the `JetpackChecklist` component and observe results.

Screenshots:
<img width="1053" alt="Screen Shot 2020-05-11 at 11 42 39 AM" src="https://user-images.githubusercontent.com/1760168/81581946-6ef58280-937d-11ea-9e89-acac7e3f9c53.png">

<img width="1044" alt="Screen Shot 2020-05-11 at 11 42 49 AM" src="https://user-images.githubusercontent.com/1760168/81581950-6f8e1900-937d-11ea-9c01-ed7bb6e33a7a.png">
 
Fixes 1143508703416848-as-1174921179573827.