### PR TITLE
Jetpack Products: remove redundant pop-up from non-Search product cards.

### DIFF
--- a/client/components/product-card/options.jsx
+++ b/client/components/product-card/options.jsx
@@ -35,11 +35,13 @@ const ProductCardOptions = ( {
 			{ ! hideRadios && optionsLabel && (
 				<h4 className="product-card__options-label">
 					{ optionsLabel }
-					<InfoPopover position="right">
-						{ translate(
-							'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.'
-						) }
-					</InfoPopover>
+					{ selectedSlug === 'jetpack_search' && (
+						<InfoPopover position="right">
+							{ translate(
+								'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.'
+							) }
+						</InfoPopover>
+					) }
 				</h4>
 			) }
 			<div className="product-card__options">


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Remove pop-up defining records from non-Search product cards in /plans. 
~~Also, adds spacing in sentences on the Search card.~~ (follow up)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `jetpack/connect/store` 
* verify that Scan and Backups do not have the pop up with record definition (next to Select * option)


![popup](https://user-images.githubusercontent.com/13561163/81586879-8735c380-93b6-11ea-8cd7-c4257fde748b.png)



