### PR TITLE
Updates Scan page wording for states

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -230,7 +230,7 @@ class ScanPage extends Component< Props > {
 			return this.renderScanning();
 		}
 
-		const errorFound = !! mostRecent.error;
+		const errorFound = !! mostRecent?.error;
 		const threatsFound = threats.length > 0;
 
 		if ( errorFound && ! threatsFound ) {

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -67,8 +67,9 @@ class ScanPage extends Component< Props > {
 				{ this.renderHeader( translate( 'Preparing to scan' ) ) }
 				<p>
 					{ translate(
-						'Welcome to Jetpack Scan, we are taking a first look at your site now ' +
-							'and the results will be with you soon.'
+						"Welcome to Jetpack Scan! We're scoping out your site, setting up to do a full scan. " +
+							"We'll let you know if we spot any issues that might impact a scan, " +
+							'then start your first full scan will start.'
 					) }
 				</p>
 			</>

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -63,14 +63,14 @@ class ScanPage extends Component< Props > {
 	renderProvisioning() {
 		return (
 			<>
-				<SecurityIcon icon="in-progress" />
+				<SecurityIcon />
 				{ this.renderHeader( translate( 'Preparing to scan' ) ) }
 				<p>
-					Lorem ipsum. We need to change this text. The scan was unable to process the themes
-					directory and did not completed successfully. In order to complete the scan you will need
-					to speak to support who can help determine what went wrong.
+					{ translate(
+						'Welcome to Jetpack Scan, we are taking a first look at your site now ' +
+							'and the results will be with you soon.'
+					) }
 				</p>
-				{ this.renderContactSupportButton() }
 			</>
 		);
 	}

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -103,23 +103,6 @@ class ScanPage extends Component< Props > {
 			</Button>
 		);
 	}
-	// @todo: missing copy and design for this state
-	renderUnavailable() {
-		return (
-			<>
-				<SecurityIcon icon="scan-error" />
-				{ this.renderHeader( 'Scan is unavailable' ) }
-				<p>
-					{ translate(
-						'The scan was unable to process the themes directory and did not completed ' +
-							'successfully. In order to complete the scan you will need to speak to support ' +
-							'who can help determine what went wrong.'
-					) }
-				</p>
-				{ this.renderContactSupportButton() }
-			</>
-		);
-	}
 
 	renderScanOkay() {
 		const { scanState, siteId, siteSlug, moment, dispatchScanRun, applySiteOffset } = this.props;
@@ -219,11 +202,6 @@ class ScanPage extends Component< Props > {
 
 		if ( state === 'provisioning' ) {
 			return this.renderProvisioning();
-		}
-
-		// @todo: missing copy and design for these states
-		if ( state === 'unavailable' ) {
-			return this.renderUnavailable();
 		}
 
 		if ( state === 'scanning' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds better text for the `provisioning` state.
* Removes `unavailable` state as the `ScanUpsell` component covers it.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be beneficial when the change is visual.
-->

* On a site with Scan, alter the scan state to be `provisioning`.

#### Screenshot
<img width="731" alt="Screen Shot 2020-05-11 at 12 18 25 PM" src="https://user-images.githubusercontent.com/1760168/81586985-63f22080-9384-11ea-975b-45b18ea53910.png">


Fixes 1151678672052943-as-1175196271951194.