### PR TITLE
Adds link to scanner on badge

### DIFF
--- a/client/landing/jetpack-cloud/components/scan-badge/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-badge/index.tsx
@@ -4,11 +4,13 @@
 import React, { FunctionComponent } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { isNumber } from 'lodash';
+import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Badge from 'components/badge';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 interface Props {
 	numberOfThreatsFound: number;
@@ -17,6 +19,7 @@ interface Props {
 
 const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress } ) => {
 	const translate = useTranslate();
+	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 	if ( ! numberOfThreatsFound && ! isNumber( progress ) ) {
 		return null;
 	}
@@ -24,11 +27,13 @@ const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress
 	if ( isNumber( progress ) ) {
 		return (
 			<Badge type="success">
-				{ translate( '%(number)d %', {
-					args: {
-						number: progress,
-					},
-				} ) }
+				<a href={ `/scan/${ siteSlug }` }>
+					{ translate( '%(number)d %', {
+						args: {
+							number: progress,
+						},
+					} ) }
+				</a>
 			</Badge>
 		);
 	}
@@ -36,12 +41,14 @@ const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress
 	if ( numberOfThreatsFound ) {
 		return (
 			<Badge type="error">
-				{ translate( '%(number)d threat', '%(number)d threats', {
-					count: numberOfThreatsFound,
-					args: {
-						number: numberOfThreatsFound,
-					},
-				} ) }
+				<a href={ `/scan/${ siteSlug }` }>
+					{ translate( '%(number)d threat', '%(number)d threats', {
+						count: numberOfThreatsFound,
+						args: {
+							number: numberOfThreatsFound,
+						},
+					} ) }
+				</a>
 			</Badge>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/scan-badge/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-badge/index.tsx
@@ -4,13 +4,11 @@
 import React, { FunctionComponent } from 'react';
 import { useTranslate } from 'i18n-calypso';
 import { isNumber } from 'lodash';
-import { useSelector } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import Badge from 'components/badge';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 interface Props {
 	numberOfThreatsFound: number;
@@ -19,7 +17,6 @@ interface Props {
 
 const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress } ) => {
 	const translate = useTranslate();
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
 	if ( ! numberOfThreatsFound && ! isNumber( progress ) ) {
 		return null;
 	}
@@ -27,13 +24,11 @@ const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress
 	if ( isNumber( progress ) ) {
 		return (
 			<Badge type="success">
-				<a href={ `/scan/${ siteSlug }` }>
-					{ translate( '%(number)d %', {
-						args: {
-							number: progress,
-						},
-					} ) }
-				</a>
+				{ translate( '%(number)d %', {
+					args: {
+						number: progress,
+					},
+				} ) }
 			</Badge>
 		);
 	}
@@ -41,14 +36,12 @@ const ScanBadge: FunctionComponent< Props > = ( { numberOfThreatsFound, progress
 	if ( numberOfThreatsFound ) {
 		return (
 			<Badge type="error">
-				<a href={ `/scan/${ siteSlug }` }>
-					{ translate( '%(number)d threat', '%(number)d threats', {
-						count: numberOfThreatsFound,
-						args: {
-							number: numberOfThreatsFound,
-						},
-					} ) }
-				</a>
+				{ translate( '%(number)d threat', '%(number)d threats', {
+					count: numberOfThreatsFound,
+					args: {
+						number: numberOfThreatsFound,
+					},
+				} ) }
 			</Badge>
 		);
 	}

--- a/client/landing/jetpack-cloud/components/sidebar/index.jsx
+++ b/client/landing/jetpack-cloud/components/sidebar/index.jsx
@@ -139,9 +139,9 @@ class JetpackCloudSidebar extends Component {
 									this.props.isScanSectionOpen ? (
 										scanTitle
 									) : (
-										<>
+										<a href={ selectedSiteSlug ? `/scan/${ selectedSiteSlug }` : '/scan' }>
 											{ scanTitle } { scanBadge }{ ' ' }
-										</>
+										</a>
 									)
 								}
 								materialIcon="security" // @todo: The Scan logo differs from the Material Icon used here

--- a/client/landing/jetpack-cloud/components/sidebar/style.scss
+++ b/client/landing/jetpack-cloud/components/sidebar/style.scss
@@ -39,6 +39,10 @@
 		font-weight: 400;
 	}
 
+	.sidebar__expandable-title .badge > a {
+		color: inherit;
+	}
+
 	// Footer
 	.sidebar__footer {
 		margin-top: auto;

--- a/client/landing/jetpack-cloud/components/sidebar/style.scss
+++ b/client/landing/jetpack-cloud/components/sidebar/style.scss
@@ -39,7 +39,8 @@
 		font-weight: 400;
 	}
 
-	.sidebar__expandable-content .badge > a {
+	.sidebar__expandable-title > a {
+		display: block;
 		color: inherit;
 	}
 

--- a/client/landing/jetpack-cloud/components/sidebar/style.scss
+++ b/client/landing/jetpack-cloud/components/sidebar/style.scss
@@ -39,7 +39,7 @@
 		font-weight: 400;
 	}
 
-	.sidebar__expandable-title .badge > a {
+	.sidebar__expandable-content .badge > a {
 		color: inherit;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a link to the scanner when the badge is showing.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load a site with Scan in Cloud.
* On Backup page with the Scan menu closed, create a threat or progress meter.

  Example action:
  ```js
  {
    type: 'JETPACK_SCAN_UPDATE',
    siteId: 12345,
    payload: {
      state: 'idle',
      threats: [{ id: 123, signature: 'TEST', description: 'Test Threat', status: 'current', firstDetected: '2020-01-01', fixable: false }],
      credentials: [],
      mostRecent: {
        timestamp: '2020-05-11T20:08:10+00:00',
        duration: 220,
        progress: 50,
        error: false,
        isInitial: false
      }
    }
  }
  ```
* Click on the badge.

Fixes 1151678672052943-as-1174867022546273.