### PR TITLE
Jetpack Cloud: fix inconsistencies between modals

### DIFF
--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { translate } from 'i18n-calypso';
 import { Button, Dialog } from '@automattic/components';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -145,7 +146,11 @@ const FixAllThreatsDialog = ( {
 									count: threats.length,
 								}
 							) }
-							<ul className="fix-all-threats-dialog__threats">
+							<ul
+								className={ classnames( 'fix-all-threats-dialog__threats', {
+									'is-long-list': threats.length > 3,
+								} ) }
+							>
 								{ threats.map( ( threat ) => (
 									<li key={ threat.id }>
 										<strong>

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -77,6 +77,7 @@ const FixAllThreatsDialog = ( {
 			additionalClassNames="fix-all-threats-dialog"
 			isVisible={ showDialog }
 			buttons={ buttons }
+			onClose={ onCloseDialog }
 		>
 			<h1 className="fix-all-threats-dialog__header">{ translate( 'Fix all threats' ) }</h1>
 			{ currentStep === 'server-credentials' && (

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -131,7 +131,7 @@ const FixAllThreatsDialog = ( {
 					<p className="fix-all-threats-dialog__warning-message">
 						{ translate( 'Jetpack will be fixing all the detected active threats.' ) }
 					</p>
-					<div className="fix-all-threats-dialog__warning">
+					<div className="fix-all-threats-dialog__threats-section">
 						<Gridicon
 							className="fix-all-threats-dialog__icon fix-all-threats-dialog__icon--confirmation"
 							icon="info"
@@ -145,7 +145,7 @@ const FixAllThreatsDialog = ( {
 									count: threats.length,
 								}
 							) }
-							<ul className="fix-all-threats-dialog__list">
+							<ul className="fix-all-threats-dialog__threats">
 								{ threats.map( ( threat ) => (
 									<li key={ threat.id }>
 										<strong>

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/index.tsx
@@ -42,8 +42,41 @@ const FixAllThreatsDialog = ( {
 	const firstStep = userHasCredentials ? 'confirmation' : 'server-credentials';
 	const [ currentStep, setCurrentStep ] = React.useState< ProcessStep >( firstStep );
 
+	const buttons = React.useMemo(
+		() => [
+			...( firstStep !== currentStep
+				? [
+						<Button
+							className="fix-all-threats-dialog__btn fix-all-threats-dialog__btn--cancel"
+							onClick={ () => setCurrentStep( 'server-credentials' ) }
+						>
+							{ translate( 'Go back' ) }
+						</Button>,
+				  ]
+				: [] ),
+			...( firstStep === currentStep
+				? [
+						<Button
+							className="fix-all-threats-dialog__btn fix-all-threats-dialog__btn--cancel"
+							onClick={ onCloseDialog }
+						>
+							{ translate( 'Go back' ) }
+						</Button>,
+				  ]
+				: [] ),
+			<Button primary className="fix-all-threats-dialog__btn" onClick={ onConfirmation }>
+				{ translate( 'Fix all threats' ) }
+			</Button>,
+		],
+		[ firstStep, currentStep, onCloseDialog, onConfirmation ]
+	);
+
 	return (
-		<Dialog additionalClassNames="fix-all-threats-dialog" isVisible={ showDialog }>
+		<Dialog
+			additionalClassNames="fix-all-threats-dialog"
+			isVisible={ showDialog }
+			buttons={ buttons }
+		>
 			<h1 className="fix-all-threats-dialog__header">{ translate( 'Fix all threats' ) }</h1>
 			{ currentStep === 'server-credentials' && (
 				<>
@@ -124,27 +157,6 @@ const FixAllThreatsDialog = ( {
 								) ) }
 							</ul>
 						</div>
-					</div>
-					<div className="fix-all-threats-dialog__buttons">
-						{ firstStep !== currentStep && (
-							<Button
-								className="fix-all-threats-dialog__btn fix-all-threats-dialog__btn--cancel"
-								onClick={ () => setCurrentStep( 'server-credentials' ) }
-							>
-								Go back
-							</Button>
-						) }
-						{ firstStep === currentStep && (
-							<Button
-								className="fix-all-threats-dialog__btn fix-all-threats-dialog__btn--cancel"
-								onClick={ onCloseDialog }
-							>
-								{ translate( 'Cancel' ) }
-							</Button>
-						) }
-						<Button primary className="fix-all-threats-dialog__btn" onClick={ onConfirmation }>
-							{ translate( 'Fix all threats' ) }
-						</Button>
 					</div>
 				</>
 			) }

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -42,6 +42,27 @@
 		&__threats {
 			margin-left: 12px;
 			margin-top: 8px;
+
+			&.is-long-list {
+				&::after {
+					content: '';
+					position: absolute;
+					left: 0;
+					bottom: 100px;
+					width: 100%;
+					height: 75px;
+					background: linear-gradient(
+						0deg,
+						rgba( 255, 255, 255, 1 ) 0%,
+						rgba( 255, 255, 255, 0 ) 100%
+					);
+					pointer-events: none;
+
+					@include breakpoint( '>660px' ) {
+						bottom: 70px;
+					}
+				}
+			}
 		}
 
 		&__warning-message {
@@ -56,6 +77,10 @@
 				width: 140px;
 			}
 		}
+	}
+
+	.dialog__content {
+		overflow-x: hidden;
 	}
 
 	.dialog__action-buttons {

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -27,7 +27,7 @@
 
 		&__icon {
 			flex: 0 0 24px;
-			margin-top: -5px;
+			margin-top: -7px;
 			margin-right: 8px;
 		}
 

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -19,8 +19,10 @@
 			margin: 8px 0;
 		}
 
-		&__warning {
+		&__threats-section {
 			display: flex;
+			overflow-y: auto;
+			max-height: 240px;
 		}
 
 		&__icon {
@@ -37,7 +39,7 @@
 			fill: var( --color-primary-40 );
 		}
 
-		&__list {
+		&__threats {
 			margin-left: 12px;
 			margin-top: 8px;
 		}

--- a/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/fix-all-threats-dialog/style.scss
@@ -1,5 +1,9 @@
 .dialog.fix-all-threats-dialog {
-	max-width: 676px;
+	width: 100%;
+
+	@include breakpoint( '>660px' ) {
+		max-width: 676px;
+	}
 
 	.fix-all-threats-dialog {
 		&__header {
@@ -43,21 +47,16 @@
 			font-size: 14px;
 		}
 
-		&__buttons {
-			display: flex;
-			justify-content: center;
-		}
-
 		&__btn {
 			width: 100%;
 
 			@include breakpoint( '>480px' ) {
-				width: 200px;
+				width: 140px;
 			}
 		}
+	}
 
-		&__btn--cancel {
-			margin-right: 16px;
-		}
+	.dialog__action-buttons {
+		background: var( --studio-gray-0 );
 	}
 }

--- a/client/landing/jetpack-cloud/components/threat-dialog/style.scss
+++ b/client/landing/jetpack-cloud/components/threat-dialog/style.scss
@@ -1,5 +1,9 @@
 .dialog.threat-dialog {
-	max-width: 676px;
+	width: 100%;
+
+	@include breakpoint( '>660px' ) {
+		max-width: 676px;
+	}
 
 	.dialog__content {
 		overflow-x: hidden;
@@ -38,7 +42,7 @@
 
 		&__warning-icon {
 			flex: 0 0 24px;
-			margin-top: -5px;
+			margin-top: -7px;
 			margin-right: 8px;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the buttons sections look the same (modal width, background color, buttons positioning, labels)
* Make the threats container scrollable

#### Implementation notes

- Now the `<Dialog/>` manages how buttons are rendered (we pass them as a prop to the component as we do in the other modals).

#### Questions

- Is the scrollable container a good pattern for this? If yes, how can we make it obvious that it's scrollable? Currently, it doesn't look like it is.

#### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/`
* Select a site with as many threats you have [1]
* Go to Scan -> Scanner
* Click the `[Fix all]` button
* On another tab, go to the same section a click on any threat the `[Fix threat]` button
* Verify they both look the same (modal width, background color, buttons positioning, and labels)
* Verify the threats section is scrollable (verify this on mobile as well)

[1] You can create a JN site and add threats to it by simply modifying core files. A comment is enough to be marked as a threat.

1151678672052943-1173451195817817

#### Demo

##### Fix threat dialog (this one hasn't changed, it's just for comparison purposes)
![image](https://user-images.githubusercontent.com/3418513/81597667-7415fa00-939c-11ea-8063-749176acf9b5.png)

##### Before
![image](https://user-images.githubusercontent.com/3418513/81597368-04077400-939c-11ea-81a2-7be6ba6ca7d9.png)

##### After
![image](https://user-images.githubusercontent.com/3418513/81597534-4466f200-939c-11ea-8eeb-934359bc41e7.png)

