### PR TITLE
Improve rendering speed of contact details forms

### DIFF
--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -21,8 +21,6 @@ import {
 import update from 'immutability-helper';
 
 function Controller( options ) {
-	let debounceWait;
-
 	if ( ! ( this instanceof Controller ) ) {
 		return new Controller( options );
 	}
@@ -47,7 +45,7 @@ function Controller( options ) {
 	this._pendingValidation = null;
 	this._onValidationComplete = null;
 
-	debounceWait = isUndefined( options.debounceWait ) ? 1000 : options.debounceWait;
+	const debounceWait = isUndefined( options.debounceWait ) ? 1000 : options.debounceWait;
 	this._debouncedSanitize = debounce( this.sanitize, debounceWait );
 	this._debouncedValidate = debounce( this.validate, debounceWait );
 
@@ -79,10 +77,10 @@ assign( Controller.prototype, {
 	},
 
 	handleFieldChange: function ( change ) {
-		let formState = this._currentState,
-			name = camelCase( change.name ),
-			value = change.value,
-			hideError = this._hideFieldErrorsOnChange || change.hideError;
+		const formState = this._currentState;
+		const name = camelCase( change.name );
+		const value = change.value;
+		const hideError = this._hideFieldErrorsOnChange || change.hideError;
 
 		this._setState( changeFieldValue( formState, name, value, hideError ) );
 
@@ -137,8 +135,8 @@ assign( Controller.prototype, {
 	},
 
 	validate: function () {
-		let fieldValues = getAllFieldValues( this._currentState ),
-			id = uniqueId();
+		const fieldValues = getAllFieldValues( this._currentState );
+		const id = uniqueId();
 
 		this._setState( setFieldsValidating( this._currentState ) );
 
@@ -176,13 +174,12 @@ assign( Controller.prototype, {
 } );
 
 function changeFieldValue( formState, name, value, hideFieldErrorsOnChange ) {
-	let fieldState = getField( formState, name ),
-		command = {},
-		errors;
+	const fieldState = getField( formState, name );
+	const command = {};
 
 	// We reset the errors if we weren't showing them already to avoid a flash of
 	// error messages when the user starts typing.
-	errors = fieldState.isShowingErrors ? fieldState.errors : [];
+	const errors = fieldState.isShowingErrors ? fieldState.errors : [];
 
 	command[ name ] = {
 		$merge: {

--- a/client/lib/form-state/index.js
+++ b/client/lib/form-state/index.js
@@ -284,7 +284,7 @@ function createInitialFormState( fieldValues ) {
 }
 
 function getField( formState, fieldName ) {
-	return formState[ camelCase( fieldName ) ];
+	return formState[ camelCase( fieldName ) ] ?? {};
 }
 
 function getFieldValue( formState, fieldName ) {

--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -15,7 +15,7 @@ import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormSelect from 'components/forms/form-select';
 
-class CountrySelect extends React.Component {
+class CountrySelect extends React.PureComponent {
 	recordCountrySelectClick = () => {
 		if ( this.props.eventFormName ) {
 			gaRecordEvent( 'Upgrades', `Clicked ${ this.props.eventFormName } Country Select` );

--- a/client/my-sites/domains/components/form/country-select.jsx
+++ b/client/my-sites/domains/components/form/country-select.jsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 
@@ -23,38 +23,9 @@ class CountrySelect extends React.PureComponent {
 	};
 
 	render() {
-		const { countriesList } = this.props;
-		const classes = classNames( this.props.additionalClasses, 'country' );
-
-		let options = [];
-		let { value } = this.props;
-		value = value || '';
-
-		if ( isEmpty( countriesList ) ) {
-			options.push( {
-				key: 'loading',
-				label: this.props.translate( 'Loading…' ),
-			} );
-		} else {
-			options = options.concat( [
-				{ key: 'select-country', label: this.props.translate( 'Select Country' ), value: '' },
-				{ key: 'divider1', label: '', disabled: 'disabled', value: '-' },
-			] );
-
-			options = options.concat(
-				countriesList.map( ( country, index ) => {
-					if ( isEmpty( country.code ) ) {
-						return { key: index, label: '', disabled: 'disabled', value: '-' };
-					}
-
-					return {
-						key: index,
-						label: country.name,
-						value: country.code,
-					};
-				} )
-			);
-		}
+		const { countriesList, value, additionalClasses } = this.props;
+		const classes = classNames( additionalClasses, 'country' );
+		const options = getOptionsFromCountriesList( countriesList );
 
 		const validationId = `validation-field-${ this.props.name }`;
 
@@ -68,7 +39,7 @@ class CountrySelect extends React.PureComponent {
 						aria-describedby={ validationId }
 						name={ this.props.name }
 						id={ this.props.name }
-						value={ value }
+						value={ value || '' }
 						disabled={ this.props.disabled }
 						inputRef={ this.props.inputRef }
 						onChange={ this.props.onChange }
@@ -89,6 +60,44 @@ class CountrySelect extends React.PureComponent {
 			</div>
 		);
 	}
+}
+
+function getOptionsFromCountriesList( countriesList ) {
+	if ( isEmpty( countriesList ) ) {
+		return [
+			{
+				key: 'loading',
+				label: translate( 'Loading…' ),
+			},
+		];
+	}
+
+	const initialOptions = [
+		{ key: 'select-country', label: translate( 'Select Country' ), value: '' },
+		{ key: 'divider1', label: '', disabled: 'disabled', value: '-' },
+	];
+
+	const countryOptions = countriesList.reduce( ( collected, country, index ) => {
+		if ( isEmpty( country.code ) ) {
+			return [
+				...collected,
+				{ key: `inner-divider${ index }`, label: '', disabled: 'disabled', value: '-' },
+			];
+		}
+
+		const duplicates = collected.filter( ( prevCountry ) => prevCountry.value === country.code );
+
+		return [
+			...collected,
+			{
+				key: `${ country.code }-${ duplicates.length }`,
+				label: country.name,
+				value: country.code,
+			},
+		];
+	}, [] );
+
+	return [ ...initialOptions, ...countryOptions ];
 }
 
 export default localize( CountrySelect );

--- a/client/my-sites/domains/components/form/state-select.jsx
+++ b/client/my-sites/domains/components/form/state-select.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
@@ -20,7 +20,7 @@ import { recordGoogleEvent } from 'state/analytics/actions';
 import scrollIntoViewport from 'lib/scroll-into-viewport';
 import Input from './input';
 
-class StateSelect extends Component {
+class StateSelect extends PureComponent {
 	static instances = 0;
 
 	inputRef = ( element ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This was extracted from (the reverted changes in) #41723. It modifies some components which render very slowly (country list, state list) to be Pure, so they will not re-render when their props do not change. This should greatly speed up using these components.

#### Testing instructions

Visit old checkout with a domain in your cart. Verify that the country and state select inputs behave as expected.