### PR TITLE
Add /me/domains list routes

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -20,6 +20,7 @@ import {
 	myMemberships,
 	purchasesRoot,
 } from 'me/purchases/paths';
+import { domainManagementRoot } from 'my-sites/domains/paths';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarHeading from 'layout/sidebar/heading';
@@ -99,6 +100,7 @@ class MeSidebar extends React.Component {
 			[ myMemberships ]: 'purchases',
 			'/me/chat': 'happychat',
 			'/me/site-blocks': 'site-blocks',
+			[ domainManagementRoot() ]: 'domains',
 		};
 		const filteredPath = context.path.replace( /\/\d+$/, '' ); // Remove ID from end of path
 		let selected;
@@ -162,6 +164,15 @@ class MeSidebar extends React.Component {
 								materialIcon="credit_card"
 								onNavigate={ this.onNavigate }
 								preloadSectionName="purchases"
+							/>
+
+							<SidebarItem
+								selected={ selected === 'domains' }
+								link={ domainManagementRoot() }
+								label={ translate( 'Domains' ) }
+								materialIcon="language"
+								onNavigate={ this.onNavigate }
+								preloadSectionName="domains"
 							/>
 
 							<SidebarItem

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -166,14 +166,16 @@ class MeSidebar extends React.Component {
 								preloadSectionName="purchases"
 							/>
 
-							<SidebarItem
-								selected={ selected === 'domains' }
-								link={ domainManagementUserRoot() }
-								label={ translate( 'Domains' ) }
-								materialIcon="language"
-								onNavigate={ this.onNavigate }
-								preloadSectionName="domains"
-							/>
+							{ config.isEnabled( 'manage/all-domains' ) && (
+								<SidebarItem
+									selected={ selected === 'domains' }
+									link={ domainManagementUserRoot() }
+									label={ translate( 'Domains' ) }
+									materialIcon="language"
+									onNavigate={ this.onNavigate }
+									preloadSectionName="domains"
+								/>
+							) }
 
 							<SidebarItem
 								selected={ selected === 'security' }

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -20,7 +20,7 @@ import {
 	myMemberships,
 	purchasesRoot,
 } from 'me/purchases/paths';
-import { domainManagementRoot } from 'my-sites/domains/paths';
+import { domainManagementUserRoot } from 'my-sites/domains/paths';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarHeading from 'layout/sidebar/heading';
@@ -100,7 +100,7 @@ class MeSidebar extends React.Component {
 			[ myMemberships ]: 'purchases',
 			'/me/chat': 'happychat',
 			'/me/site-blocks': 'site-blocks',
-			[ domainManagementRoot() ]: 'domains',
+			[ domainManagementUserRoot() ]: 'domains',
 		};
 		const filteredPath = context.path.replace( /\/\d+$/, '' ); // Remove ID from end of path
 		let selected;
@@ -168,7 +168,7 @@ class MeSidebar extends React.Component {
 
 							<SidebarItem
 								selected={ selected === 'domains' }
-								link={ domainManagementRoot() }
+								link={ domainManagementUserRoot() }
 								label={ translate( 'Domains' ) }
 								materialIcon="language"
 								onNavigate={ this.onNavigate }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -60,7 +60,7 @@ import { makeLayout, render as clientRender } from 'controller';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
 import EmptyContentComponent from 'components/empty-content';
 import DomainOnly from 'my-sites/domains/domain-management/list/domain-only';
-import SidebarComponent from 'me/sidebar';
+import AsyncLoad from 'components/async-load';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -90,9 +90,7 @@ function createNavigation( context ) {
 	}
 
 	if ( startsWith( context.pathname, '/me/domains' ) ) {
-		return React.createElement( SidebarComponent, {
-			context: context,
-		} );
+		return <AsyncLoad require="me/sidebar" context={ context } />;
 	}
 
 	return (

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -47,6 +47,7 @@ import {
 	domainManagementTransfer,
 	domainManagementTransferOut,
 	domainManagementTransferToOtherSite,
+	domainManagementRoot,
 } from 'my-sites/domains/paths';
 import {
 	emailManagement,
@@ -89,7 +90,7 @@ function createNavigation( context ) {
 		basePath = sectionify( context.pathname );
 	}
 
-	if ( startsWith( context.pathname, '/me/domains' ) ) {
+	if ( startsWith( context.pathname, domainManagementRoot() ) ) {
 		return <AsyncLoad require="me/sidebar" context={ context } />;
 	}
 

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -60,6 +60,7 @@ import { makeLayout, render as clientRender } from 'controller';
 import NoSitesMessage from 'components/empty-content/no-sites-message';
 import EmptyContentComponent from 'components/empty-content';
 import DomainOnly from 'my-sites/domains/domain-management/list/domain-only';
+import SidebarComponent from 'me/sidebar';
 
 /*
  * @FIXME Shorthand, but I might get rid of this.
@@ -86,6 +87,12 @@ function createNavigation( context ) {
 
 	if ( siteFragment ) {
 		basePath = sectionify( context.pathname );
+	}
+
+	if ( startsWith( context.pathname, '/me/domains' ) ) {
+		return React.createElement( SidebarComponent, {
+			context: context,
+		} );
 	}
 
 	return (

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -47,7 +47,7 @@ import {
 	domainManagementTransfer,
 	domainManagementTransferOut,
 	domainManagementTransferToOtherSite,
-	domainManagementRoot,
+	domainManagementUserRoot,
 } from 'my-sites/domains/paths';
 import {
 	emailManagement,
@@ -90,7 +90,7 @@ function createNavigation( context ) {
 		basePath = sectionify( context.pathname );
 	}
 
-	if ( startsWith( context.pathname, domainManagementRoot() ) ) {
+	if ( startsWith( context.pathname, domainManagementUserRoot() ) ) {
 		return <AsyncLoad require="me/sidebar" context={ context } />;
 	}
 

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -177,6 +177,8 @@ export default function () {
 			makeLayout,
 			clientRender
 		);
+
+		page.redirect( paths.domainManagementRoot(), paths.domainManagementUserRoot() );
 	} else {
 		page( paths.domainManagementRoot(), siteSelection, sites, makeLayout, clientRender );
 	}

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -171,7 +171,7 @@ export default function () {
 
 	if ( config.isEnabled( 'manage/all-domains' ) ) {
 		page(
-			paths.domainManagementRoot(),
+			paths.domainManagementUserRoot(),
 			...getCommonHandlers( { noSitePath: false } ),
 			domainManagementController.domainManagementListAllSites,
 			makeLayout,

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -15,7 +15,7 @@ export function domainAddNew( siteName, searchTerm ) {
 }
 
 export function domainManagementRoot() {
-	return '/domains/manage';
+	return '/me/domains';
 }
 
 export function domainManagementList( siteName ) {

--- a/client/my-sites/domains/paths.js
+++ b/client/my-sites/domains/paths.js
@@ -14,8 +14,12 @@ export function domainAddNew( siteName, searchTerm ) {
 	return path;
 }
 
-export function domainManagementRoot() {
+export function domainManagementUserRoot() {
 	return '/me/domains';
+}
+
+export function domainManagementRoot() {
+	return '/domains/manage';
 }
 
 export function domainManagementList( siteName ) {

--- a/client/sections.js
+++ b/client/sections.js
@@ -227,7 +227,7 @@ const sections = [
 	},
 	{
 		name: 'domains',
-		paths: [ '/domains' ],
+		paths: [ '/domains', '/me/domains' ],
 		module: 'my-sites/domains',
 		secondary: true,
 		group: 'sites',

--- a/config/stage.json
+++ b/config/stage.json
@@ -73,7 +73,6 @@
 		"login/native-login-links": true,
 		"login/wp-login": true,
 		"mailchimp": true,
-		"manage/all-domains": true,
 		"manage/comments": true,
 		"manage/custom-post-types": true,
 		"manage/customize": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR introduces the `/me/domains` route and make sure it works properly and no the bundle size is not affected. I believe we should be able to merge this as it's just changing the route and some other small details. Since it's feature flagged we can continue working on the rest of the routes in separate PRs.

I'm reusing the old feature flag `manage/all-domains`

Here's how the menu looks:

![Screenshot 2020-05-14 at 17 51 56](https://user-images.githubusercontent.com/1355045/81949975-17207b00-960c-11ea-88df-11749ca08265.png)

#### Testing instructions

* Open your account and check the "Domains" menu or just go to /me/domains - it should show the old "all domains screen" as of now but this is just 
