### PR TITLE
composite-checkout: Change ContactDetailsFormFields to managed version (4)

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -107,11 +107,12 @@ export class ManagedContactDetailsFormFields extends Component {
 		const { name, value } = event.target;
 		const newState = { ...this.state };
 
-		if ( name === 'country-code' && value && ! newState.phone?.value ) {
+		if ( name === 'country-code' && value && ! newState.form.phone?.value ) {
 			newState.phoneCountryCode = value;
 		}
 
 		newState.form = updateFormWithContactChange( newState.form, name, value );
+
 		if ( name === 'country-code' ) {
 			newState.form = updateFormWithContactChange( newState.form, 'state', '', {
 				isShowingErrors: false,

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -1,0 +1,406 @@
+/**
+ * External dependencies
+ *
+ */
+import PropTypes from 'prop-types';
+import React, { Component, createElement } from 'react';
+import { connect } from 'react-redux';
+import { camelCase } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getCountryStates } from 'state/country-states/selectors';
+import { CountrySelect, Input, HiddenInput } from 'my-sites/domains/components/form';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
+import { countries } from 'components/phone-input/data';
+import formState from 'lib/form-state';
+import { toIcannFormat } from 'components/phone-input/phone-number';
+import RegionAddressFieldsets from './custom-form-fieldsets/region-address-fieldsets';
+import getCountries from 'state/selectors/get-countries';
+import QueryDomainCountries from 'components/data/query-countries/domains';
+import {
+	CONTACT_DETAILS_FORM_FIELDS,
+	CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES,
+	CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES,
+} from './custom-form-fieldsets/constants';
+import { getPostCodeLabelText } from './custom-form-fieldsets/utils';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
+export class ManagedContactDetailsFormFields extends Component {
+	static propTypes = {
+		eventFormName: PropTypes.string,
+		contactDetails: PropTypes.shape(
+			Object.assign(
+				{},
+				...CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => ( { [ field ]: PropTypes.string } ) )
+			)
+		).isRequired,
+		contactDetailsErrors: PropTypes.shape(
+			Object.assign(
+				{},
+				...CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => ( { [ field ]: PropTypes.string } ) )
+			)
+		),
+		countriesList: PropTypes.array.isRequired,
+		onContactDetailsChange: PropTypes.func.isRequired,
+		getIsFieldDisabled: PropTypes.func,
+		userCountryCode: PropTypes.string,
+		needsOnlyGoogleAppsDetails: PropTypes.bool,
+		needsAlternateEmailForGSuite: PropTypes.bool,
+		hasCountryStates: PropTypes.bool,
+		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		eventFormName: 'Domain contact details form',
+		contactDetails: Object.assign(
+			{},
+			...CONTACT_DETAILS_FORM_FIELDS.map( ( field ) => ( { [ field ]: '' } ) )
+		),
+		getIsFieldDisabled: () => {},
+		onContactDetailsChange: () => {},
+		needsOnlyGoogleAppsDetails: false,
+		needsAlternateEmailForGSuite: false,
+		hasCountryStates: false,
+		translate: ( x ) => x,
+		userCountryCode: 'US',
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = {
+			phoneCountryCode: this.props.countryCode || this.props.userCountryCode,
+			form: {},
+		};
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		return {
+			...state,
+			...getStateFromContactDetails( props.contactDetails, props.contactDetailsErrors ),
+		};
+	}
+
+	setStateAndUpdateParent = ( newState ) => {
+		this.setState( newState, () => {
+			this.props.onContactDetailsChange(
+				getMainFieldValues(
+					newState.form,
+					this.props.countryCode,
+					this.state.phoneCountryCode,
+					this.props.hasCountryStates
+				)
+			);
+		} );
+	};
+
+	handleFieldChange = ( event ) => {
+		const { name, value } = event.target;
+		const newState = { ...this.state };
+
+		if ( name === 'country-code' && value && ! newState.phone?.value ) {
+			newState.phoneCountryCode = value;
+		}
+
+		newState.form = updateFormWithContactChange( newState.form, name, value );
+		if ( name === 'country-code' ) {
+			newState.form = updateFormWithContactChange( newState.form, 'state', '', {
+				isShowingErrors: false,
+			} );
+		}
+
+		this.setStateAndUpdateParent( newState );
+		return;
+	};
+
+	handlePhoneChange = ( { value, countryCode } ) => {
+		const newState = { ...this.state };
+
+		if ( countries[ countryCode ] ) {
+			newState.phoneCountryCode = countryCode;
+		}
+
+		newState.form = updateFormWithContactChange( newState.form, 'phone', value );
+		this.setStateAndUpdateParent( newState );
+		return;
+	};
+
+	getFieldProps = ( name, { customErrorMessage = null } ) => {
+		const { eventFormName, getIsFieldDisabled } = this.props;
+		const { form } = this.state;
+
+		return {
+			labelClass: 'contact-details-form-fields__label',
+			additionalClasses: 'contact-details-form-fields__field',
+			disabled: getIsFieldDisabled( name ) || formState.isFieldDisabled( form, name ),
+			isError: formState.isFieldInvalid( form, name ),
+			errorMessage:
+				customErrorMessage ||
+				( formState.getFieldErrorMessages( form, camelCase( name ) ) || [] ).join( '\n' ),
+			onChange: this.handleFieldChange,
+			value: formState.getFieldValue( form, name ) || '',
+			name,
+			eventFormName,
+		};
+	};
+
+	createField = ( name, componentClass, additionalProps, fieldPropOptions = {} ) => {
+		return createElement( componentClass, {
+			...this.getFieldProps( name, fieldPropOptions ),
+			...additionalProps,
+		} );
+	};
+
+	renderContactDetailsFields() {
+		const { translate, hasCountryStates } = this.props;
+		const countryCode = this.state.form.countryCode?.value ?? '';
+
+		return (
+			<div className="contact-details-form-fields__contact-details">
+				<div className="contact-details-form-fields__row">
+					{ this.createField(
+						'organization',
+						HiddenInput,
+						{
+							label: translate( 'Organization' ),
+							text: translate( '+ Add organization name' ),
+						},
+						{
+							needsChildRef: true,
+							customErrorMessage: this.props.contactDetailsErrors?.organization,
+						}
+					) }
+				</div>
+
+				<div className="contact-details-form-fields__row">
+					{ this.createField(
+						'email',
+						Input,
+						{
+							label: translate( 'Email' ),
+						},
+						{
+							customErrorMessage: this.props.contactDetailsErrors?.email,
+						}
+					) }
+
+					{ this.createField(
+						'phone',
+						FormPhoneMediaInput,
+						{
+							label: translate( 'Phone' ),
+							onChange: this.handlePhoneChange,
+							countriesList: this.props.countriesList,
+							countryCode: this.state.phoneCountryCode,
+							enableStickyCountry: false,
+						},
+						{
+							needsChildRef: true,
+							customErrorMessage: this.props.contactDetailsErrors?.phone,
+						}
+					) }
+				</div>
+
+				<div className="contact-details-form-fields__row">
+					{ this.createField(
+						'country-code',
+						CountrySelect,
+						{
+							label: translate( 'Country' ),
+							countriesList: this.props.countriesList,
+						},
+						{
+							customErrorMessage: this.props.contactDetailsErrors?.countryCode,
+							needsChildRef: true,
+						}
+					) }
+				</div>
+
+				{ countryCode && (
+					<RegionAddressFieldsets
+						getFieldProps={ this.getFieldProps }
+						countryCode={ countryCode }
+						hasCountryStates={ hasCountryStates }
+						shouldAutoFocusAddressField={ this.shouldAutoFocusAddressField }
+						contactDetailsErrors={ this.props.contactDetailsErrors }
+					/>
+				) }
+			</div>
+		);
+	}
+
+	renderAlternateEmailFieldForGSuite() {
+		return (
+			<div className="contact-details-form-fields__row">
+				<Input
+					label={ this.props.translate( 'Alternate Email Address' ) }
+					{ ...this.getFieldProps( 'alternate-email', {
+						customErrorMessage: this.props.contactDetailsErrors?.alternateEmail,
+					} ) }
+				/>
+			</div>
+		);
+	}
+
+	render() {
+		const { translate, contactDetailsErrors } = this.props;
+
+		return (
+			<FormFieldset className="contact-details-form-fields">
+				<div className="contact-details-form-fields__row">
+					{ this.createField(
+						'first-name',
+						Input,
+						{
+							label: translate( 'First name' ),
+						},
+						{
+							customErrorMessage: contactDetailsErrors?.firstName,
+						}
+					) }
+
+					{ this.createField(
+						'last-name',
+						Input,
+						{
+							label: translate( 'Last name' ),
+						},
+						{
+							customErrorMessage: contactDetailsErrors?.lastName,
+						}
+					) }
+				</div>
+				{ this.props.needsAlternateEmailForGSuite && this.renderAlternateEmailFieldForGSuite() }
+
+				{ this.props.needsOnlyGoogleAppsDetails ? (
+					<GSuiteFields
+						countryCode={ this.state.form.countryCode?.value ?? '' }
+						countriesList={ this.props.countriesList }
+						contactDetailsErrors={ this.props.contactDetailsErrors }
+						getFieldProps={ this.getFieldProps }
+						translate={ this.props.translate }
+					/>
+				) : (
+					this.renderContactDetailsFields()
+				) }
+
+				<div className="contact-details-form-fields__extra-fields">{ this.props.children }</div>
+
+				<QueryDomainCountries />
+			</FormFieldset>
+		);
+	}
+}
+
+export default connect( ( state, props ) => {
+	const contactDetails = props.contactDetails;
+	const countryCode = contactDetails.countryCode;
+
+	const hasCountryStates = contactDetails?.countryCode
+		? !! getCountryStates( state, contactDetails.countryCode )?.length
+		: false;
+	return {
+		countryCode,
+		countriesList: getCountries( state, 'domains' ),
+		hasCountryStates,
+	};
+} )( localize( ManagedContactDetailsFormFields ) );
+
+function getStateFromContactDetails( contactDetails, contactDetailsErrors ) {
+	const form = Object.keys( contactDetails ).reduce( ( newForm, key ) => {
+		const value = contactDetails[ key ];
+		const error = contactDetailsErrors[ key ];
+		const errors = error ? [ error ] : [];
+		return {
+			...newForm,
+			[ key ]: {
+				value,
+				errors,
+				isShowingErrors: true,
+				isPendingValidation: false,
+				isValidating: false,
+			},
+		};
+	}, {} );
+	return { form };
+}
+
+function updateFormWithContactChange( form, key, value, additionalProperties ) {
+	return {
+		...form,
+		[ camelCase( key ) ]: {
+			value,
+			errors: [],
+			isShowingErrors: true,
+			isPendingValidation: false,
+			isValidating: false,
+			...( additionalProperties ?? {} ),
+		},
+	};
+}
+
+function getMainFieldValues( form, countryCode, phoneCountryCode, hasCountryStates ) {
+	const mainFieldValues = formState.getAllFieldValues( form );
+	let state = mainFieldValues.state;
+
+	const validatedHasCountryStates =
+		mainFieldValues.countryCode === countryCode
+			? hasCountryStates
+			: !! getCountryStates( state, countryCode )?.length;
+
+	// domains registered according to ancient validation rules may have state set even though not required
+	if (
+		! validatedHasCountryStates &&
+		( CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES.includes( countryCode ) ||
+			CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES.includes( countryCode ) )
+	) {
+		state = '';
+	}
+
+	const fax = '';
+
+	return {
+		...mainFieldValues,
+		fax,
+		state,
+		phone: mainFieldValues.phone
+			? toIcannFormat( mainFieldValues.phone, countries[ phoneCountryCode ] )
+			: '',
+	};
+}
+
+function GSuiteFields( {
+	countryCode,
+	countriesList,
+	contactDetailsErrors,
+	getFieldProps,
+	translate,
+} ) {
+	return (
+		<div className="contact-details-form-fields__row g-apps-fieldset">
+			<CountrySelect
+				label={ translate( 'Country' ) }
+				countriesList={ countriesList }
+				{ ...getFieldProps( 'country-code', {
+					customErrorMessage: contactDetailsErrors?.countryCode,
+				} ) }
+			/>
+
+			<Input
+				label={ getPostCodeLabelText( countryCode ) }
+				{ ...getFieldProps( 'postal-code', {
+					customErrorMessage: contactDetailsErrors?.postalCode,
+				} ) }
+			/>
+		</div>
+	);
+}

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -176,7 +176,6 @@ export class ManagedContactDetailsFormFields extends Component {
 							text: translate( '+ Add organization name' ),
 						},
 						{
-							needsChildRef: true,
 							customErrorMessage: this.props.contactDetailsErrors?.organization,
 						}
 					) }
@@ -205,7 +204,6 @@ export class ManagedContactDetailsFormFields extends Component {
 							enableStickyCountry: false,
 						},
 						{
-							needsChildRef: true,
 							customErrorMessage: this.props.contactDetailsErrors?.phone,
 						}
 					) }
@@ -221,7 +219,6 @@ export class ManagedContactDetailsFormFields extends Component {
 						},
 						{
 							customErrorMessage: this.props.contactDetailsErrors?.countryCode,
-							needsChildRef: true,
 						}
 					) }
 				</div>

--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.jsx
@@ -96,7 +96,7 @@ export class ManagedContactDetailsFormFields extends Component {
 				getMainFieldValues(
 					newState.form,
 					this.props.countryCode,
-					this.state.phoneCountryCode,
+					newState.phoneCountryCode,
 					this.props.hasCountryStates
 				)
 			);

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -195,8 +195,6 @@ function usePhoneNumberState( value, countryCode, countriesList, freezeSelection
 		if ( previousValue.current === value && previousCountry.current === countryCode ) {
 			return;
 		}
-		previousValue.current = value;
-		previousCountry.current = countryCode;
 		// No need to update if the prop value is equal to one form of the current value
 		const icannValue = toIcannFormat( displayValue, countries[ countryCode ] );
 		if (
@@ -205,6 +203,8 @@ function usePhoneNumberState( value, countryCode, countriesList, freezeSelection
 		) {
 			return;
 		}
+		previousValue.current = value;
+		previousCountry.current = countryCode;
 		const newState = getPhoneNumberStatesFromProp(
 			value,
 			countryCode,
@@ -217,6 +217,7 @@ function usePhoneNumberState( value, countryCode, countriesList, freezeSelection
 			icannValue,
 			value,
 			countryCode,
+			oldCountry: previousCountry.current,
 			newState,
 		} );
 		setPhoneNumberState( newState );

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -184,36 +184,43 @@ function useSharedRef( inputRef ) {
 
 function usePhoneNumberState( value, countryCode, countriesList, freezeSelection ) {
 	const previousValue = useRef( value );
-	const [ phoneNumberState, setPhoneNumberState ] = useState(
+	const previousCountry = useRef( countryCode );
+	const [ phoneNumberState, setPhoneNumberState ] = useState( () =>
 		getPhoneNumberStatesFromProp( value, countryCode, countriesList, freezeSelection )
 	);
 	const { rawValue, displayValue } = phoneNumberState;
-	const icannValue = toIcannFormat( displayValue, countries[ countryCode ] );
 
 	useEffect( () => {
 		// No need to update if the value has not changed
-		if ( previousValue.current === value ) {
+		if ( previousValue.current === value && previousCountry.current === countryCode ) {
 			return;
 		}
 		previousValue.current = value;
+		previousCountry.current = countryCode;
 		// No need to update if the prop value is equal to one form of the current value
-		if ( value === rawValue || value === displayValue || value === icannValue ) {
+		const icannValue = toIcannFormat( displayValue, countries[ countryCode ] );
+		if (
+			previousCountry.current === countryCode &&
+			( value === rawValue || value === displayValue || value === icannValue )
+		) {
 			return;
 		}
-		debug(
-			'props changed, updating value; raw value is',
+		const newState = getPhoneNumberStatesFromProp(
+			value,
+			countryCode,
+			countriesList,
+			freezeSelection
+		);
+		debug( 'props changed, updating value; ', {
 			rawValue,
-			'display value is',
 			displayValue,
-			'icannValue is',
 			icannValue,
-			'and prop value is',
-			value
-		);
-		setPhoneNumberState(
-			getPhoneNumberStatesFromProp( value, countryCode, countriesList, freezeSelection )
-		);
-	}, [ rawValue, displayValue, icannValue, value, countryCode, countriesList, freezeSelection ] );
+			value,
+			countryCode,
+			newState,
+		} );
+		setPhoneNumberState( newState );
+	}, [ rawValue, displayValue, value, countryCode, countriesList, freezeSelection ] );
 
 	return [ phoneNumberState, setPhoneNumberState ];
 }

--- a/client/components/phone-input/index.jsx
+++ b/client/components/phone-input/index.jsx
@@ -193,6 +193,7 @@ function usePhoneNumberState( value, countryCode, countriesList, freezeSelection
 	useEffect( () => {
 		// No need to update if the value has not changed
 		if ( previousValue.current === value && previousCountry.current === countryCode ) {
+			debug( 'props change did not change value or country' );
 			return;
 		}
 		// No need to update if the prop value is equal to one form of the current value
@@ -201,6 +202,7 @@ function usePhoneNumberState( value, countryCode, countriesList, freezeSelection
 			previousCountry.current === countryCode &&
 			( value === rawValue || value === displayValue || value === icannValue )
 		) {
+			debug( 'props change did not change normalized value', value );
 			return;
 		}
 		previousValue.current = value;

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -51,7 +51,7 @@ import { FormCountrySelect } from 'components/forms/form-country-select';
 import getCountries from 'state/selectors/get-countries';
 import { fetchPaymentCountries } from 'state/countries/actions';
 import { StateSelect } from 'my-sites/domains/components/form';
-import ContactDetailsFormFields from 'components/domains/contact-details-form-fields';
+import ManagedContactDetailsFormFields from 'components/domains/contact-details-form-fields/managed-contact-details-form-fields';
 import { getPlan, findPlansKeys } from 'lib/plans';
 import { GROUP_WPCOM, TERM_ANNUALLY, TERM_BIENNIALLY, TERM_MONTHLY } from 'lib/plans/constants';
 import { requestProductsList } from 'state/products-list/actions';
@@ -301,8 +301,7 @@ export default function CompositeCheckout( {
 	) => {
 		const getIsFieldDisabled = () => isDisabled;
 		return (
-			<ContactDetailsFormFields
-				countriesList={ countriesList }
+			<ManagedContactDetailsFormFields
 				contactDetails={ contactDetails }
 				contactDetailsErrors={
 					shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}

--- a/client/my-sites/checkout/composite-checkout/composite-checkout.js
+++ b/client/my-sites/checkout/composite-checkout/composite-checkout.js
@@ -307,7 +307,6 @@ export default function CompositeCheckout( {
 					shouldShowContactDetailsValidationErrors ? contactDetailsErrors : {}
 				}
 				onContactDetailsChange={ updateDomainContactFields }
-				shouldForceRenderOnPropChange={ true }
 				getIsFieldDisabled={ getIsFieldDisabled }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an alternative to (the reverted changes in) #41723.

The (rather old) `ContactDetailsFormFields` component is currently being used in two ways. 

Its original incarnation, still used by old checkout and payment management screens, uses a state management object created by `lib/form-state` as a singleton form state manager that deals with updates, validation, etc.

For composite checkout, we have need to keep our form state external to the `ContactDetailsFormFields`, so we had added several props to make it more like a partially managed component. I say "partially" because the flow worked as follows: 

- On initial render, the props were used to set the state, which was used to set the field values.
- When a field changed, the state was changed, and a callback was called so the parent could receive the updated data.
- If the data in the props changed, _nothing happened_.

This means that the component was still managing itself for the most part, and just informing its parent about the new state.

This PR duplicates the the component into a new component called `ManagedContactDetailsFormFields` which is basically the same, but removes everything having to do with the `formStateController` and makes it so that the component's state is managed from its parent's props, rather than internally.

This requires #42070 to be merged first.

#### Testing instructions

This heavily modifies the contact details in composite checkout.

To test the managed behavior, visit composite checkout with a domain in your cart. Fill out the form fields and be sure that they update as expected when you type. Try setting invalid data and pressing Continue to be sure that you see a validation error. Leave a field blank and try to press Continue and verify that the blank field is marked. Try changing the country and make sure that the fields change. Fill in all fields correctly and verify that pressing "Continue" works as expected. 

Especially try the phone field by changing the country when it's empty (its country should also change) and when it's not empty (its country should remain untouched). Make sure changing the country code in the phone field works and changes the leading country code on the phone number.