### PR TITLE
Manage Purchase: Add notice to inform about available products for renewal

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -141,7 +141,7 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 function handleRenewMultiplePurchasesClick( purchases, siteSlug, tracksProps = {} ) {
 	purchases.forEach( ( purchase ) => {
 		// Track the renew now submit.
-		recordTracksEvent( 'calypso_purchases_renew_now_click', {
+		recordTracksEvent( 'calypso_purchases_renew_multiple_click', {
 			product_slug: purchase.productSlug,
 			...tracksProps,
 		} );

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -112,27 +112,86 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 		...tracksProps,
 	} );
 
-	const { product_slug, extra, meta } = renewItem;
-	const { purchaseId, purchaseDomain } = extra;
-	if ( ! purchaseId ) {
+	if ( ! renewItem.extra.purchaseId ) {
 		notices.error( 'Could not find purchase id for renewal.' );
 		throw new Error( 'Could not find purchase id for renewal.' );
 	}
-	if ( ! product_slug ) {
+	if ( ! renewItem.product_slug ) {
 		notices.error( 'Could not find product slug for renewal.' );
 		throw new Error( 'Could not find product slug for renewal.' );
 	}
-	// There is a product with this weird slug, but left to itself the slug will
-	// cause a routing error since it contains a slash, so we encode it here and
-	// then decode it in the checkout code before adding to the cart.
-	const productSlug = product_slug === 'no-adverts/no-adverts.php' ? 'no-ads' : product_slug;
-	const productList = meta ? `${ productSlug }:${ meta }` : productSlug;
-	const renewalUrl = `/checkout/${ productList }/renew/${ purchaseId }/${
-		siteSlug || purchaseDomain || ''
+	const { productSlugs, purchaseIds } = getProductSlugsAndPurchaseIds( [ renewItem ] );
+
+	const renewalUrl = `/checkout/${ productSlugs[ 0 ] }/renew/${ purchaseIds[ 0 ] }/${
+		siteSlug || renewItem.purchaseDomain || ''
 	}`;
 	debug( 'handling renewal click', purchase, siteSlug, renewItem, renewalUrl );
 
 	page( renewalUrl );
+}
+
+/**
+ * Adds all purchases renewal to the cart and redirects to checkout.
+ *
+ * @param {Array} purchases - the purchases to be renewed
+ * @param {string} siteSlug - the site slug to renew the purchase for
+ * @param {object} tracksProps - where was the renew button clicked from
+ */
+function handleRenewMultiplePurchasesClick( purchases, siteSlug, tracksProps = {} ) {
+	purchases.forEach( ( purchase ) => {
+		// Track the renew now submit.
+		recordTracksEvent( 'calypso_purchases_renew_now_click', {
+			product_slug: purchase.productSlug,
+			...tracksProps,
+		} );
+	} );
+
+	const renewItems = purchases.map( ( otherPurchase ) =>
+		getRenewalItemFromProduct( otherPurchase, {
+			domain: otherPurchase.meta,
+		} )
+	);
+	const { productSlugs, purchaseIds } = getProductSlugsAndPurchaseIds( renewItems );
+
+	if ( purchaseIds.length === 0 ) {
+		notices.error( 'Could not find product slug or purchase id for renewal.' );
+		throw new Error( 'Could not find product slug or purchase id for renewal.' );
+	}
+
+	const renewalUrl = `/checkout/${ productSlugs.join( ',' ) }/renew/${ purchaseIds.join( ',' ) }/${
+		siteSlug || renewItems[ 0 ].purchaseDomain || ''
+	}`;
+	debug( 'handling renewal click', purchases, siteSlug, renewItems, renewalUrl );
+
+	page( renewalUrl );
+}
+
+function getProductSlugsAndPurchaseIds( renewItems ) {
+	const productSlugs = [];
+	const purchaseIds = [];
+
+	renewItems.forEach( ( currentRenewItem ) => {
+		if ( ! currentRenewItem.extra.purchaseId ) {
+			debug( 'Could not find purchase id for renewal.', currentRenewItem );
+			return null;
+		}
+		if ( ! currentRenewItem.product_slug ) {
+			debug( 'Could not find product slug for renewal.', currentRenewItem );
+			return null;
+		}
+		// There is a product with this weird slug, but left to itself the slug will
+		// cause a routing error since it contains a slash, so we encode it here and
+		// then decode it in the checkout code before adding to the cart.
+		const productSlug =
+			currentRenewItem.product_slug === 'no-adverts/no-adverts.php'
+				? 'no-ads'
+				: currentRenewItem.product_slug;
+		productSlugs.push(
+			currentRenewItem.meta ? `${ productSlug }:${ currentRenewItem.meta }` : productSlug
+		);
+		purchaseIds.push( currentRenewItem.extra.purchaseId );
+	} );
+	return { productSlugs, purchaseIds };
 }
 
 function hasIncludedDomain( purchase ) {
@@ -521,6 +580,7 @@ export {
 	getPurchasesBySite,
 	getRenewalPrice,
 	getSubscriptionEndDate,
+	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
 	hasAmountAvailableToRefund,
 	hasIncludedDomain,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -21,7 +21,6 @@ import {
 	isPlan,
 	isTheme,
 	isConciergeSession,
-	isJetpackProduct,
 } from 'lib/products-values';
 import { getJetpackProductsDisplayNames } from 'lib/products-values/constants';
 
@@ -541,7 +540,7 @@ function purchaseType( purchase ) {
 		return i18n.translate( 'Site Plan' );
 	}
 
-	if ( isDomainRegistration( purchase ) || isJetpackProduct( purchase ) ) {
+	if ( isDomainRegistration( purchase ) ) {
 		return purchase.productName;
 	}
 

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -21,6 +21,7 @@ import {
 	isPlan,
 	isTheme,
 	isConciergeSession,
+	isJetpackProduct,
 } from 'lib/products-values';
 import { getJetpackProductsDisplayNames } from 'lib/products-values/constants';
 
@@ -540,7 +541,7 @@ function purchaseType( purchase ) {
 		return i18n.translate( 'Site Plan' );
 	}
 
-	if ( isDomainRegistration( purchase ) ) {
+	if ( isDomainRegistration( purchase ) || isJetpackProduct( purchase ) ) {
 		return purchase.productName;
 	}
 
@@ -584,6 +585,7 @@ export {
 	handleRenewNowClick,
 	hasAmountAvailableToRefund,
 	hasIncludedDomain,
+	isAutoRenewing,
 	isCancelable,
 	isPaidWithCreditCard,
 	isPaidWithPayPalDirect,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -124,7 +124,7 @@ function handleRenewNowClick( purchase, siteSlug, tracksProps = {} ) {
 	const { productSlugs, purchaseIds } = getProductSlugsAndPurchaseIds( [ renewItem ] );
 
 	const renewalUrl = `/checkout/${ productSlugs[ 0 ] }/renew/${ purchaseIds[ 0 ] }/${
-		siteSlug || renewItem.purchaseDomain || ''
+		siteSlug || renewItem.extra.purchaseDomain || ''
 	}`;
 	debug( 'handling renewal click', purchase, siteSlug, renewItem, renewalUrl );
 
@@ -160,7 +160,7 @@ function handleRenewMultiplePurchasesClick( purchases, siteSlug, tracksProps = {
 	}
 
 	const renewalUrl = `/checkout/${ productSlugs.join( ',' ) }/renew/${ purchaseIds.join( ',' ) }/${
-		siteSlug || renewItems[ 0 ].purchaseDomain || ''
+		siteSlug || renewItems[ 0 ].extra.purchaseDomain || ''
 	}`;
 	debug( 'handling renewal click', purchases, siteSlug, renewItems, renewalUrl );
 

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import moment from 'moment';
 
 /**
@@ -36,71 +35,71 @@ jest.mock( 'lib/user', () => () => {} );
 describe( 'index', () => {
 	describe( '#isRemovable', () => {
 		test( 'should not be removable when domain registration purchase is not expired', () => {
-			expect( isRemovable( DOMAIN_PURCHASE ) ).to.be.false;
+			expect( isRemovable( DOMAIN_PURCHASE ) ).toEqual( false );
 		} );
 
 		test( 'should not be removable when domain mapping purchase is not expired', () => {
-			expect( isRemovable( DOMAIN_MAPPING_PURCHASE ) ).to.be.false;
+			expect( isRemovable( DOMAIN_MAPPING_PURCHASE ) ).toEqual( false );
 		} );
 
 		test( 'should not be removable when site redirect purchase is not expired', () => {
-			expect( isRemovable( SITE_REDIRECT_PURCHASE ) ).to.be.false;
+			expect( isRemovable( SITE_REDIRECT_PURCHASE ) ).toEqual( false );
 		} );
 
 		test( 'should be removable when domain registration purchase is expired', () => {
-			expect( isRemovable( DOMAIN_PURCHASE_EXPIRED ) ).to.be.true;
+			expect( isRemovable( DOMAIN_PURCHASE_EXPIRED ) ).toEqual( true );
 		} );
 
 		test( 'should be removable when domain mapping purchase is expired', () => {
-			expect( isRemovable( DOMAIN_MAPPING_PURCHASE_EXPIRED ) ).to.be.true;
+			expect( isRemovable( DOMAIN_MAPPING_PURCHASE_EXPIRED ) ).toEqual( true );
 		} );
 
 		test( 'should be removable when site redirect purchase is expired', () => {
-			expect( isRemovable( SITE_REDIRECT_PURCHASE_EXPIRED ) ).to.be.true;
+			expect( isRemovable( SITE_REDIRECT_PURCHASE_EXPIRED ) ).toEqual( true );
 		} );
 	} );
 	describe( '#isCancelable', () => {
 		test( 'should not be cancelable when the purchase is included in a plan', () => {
-			expect( isCancelable( DOMAIN_PURCHASE_INCLUDED_IN_PLAN ) ).to.be.false;
+			expect( isCancelable( DOMAIN_PURCHASE_INCLUDED_IN_PLAN ) ).toEqual( false );
 		} );
 
 		test( 'should not be cancelable when the purchase is expired', () => {
-			expect( isCancelable( DOMAIN_PURCHASE_EXPIRED ) ).to.be.false;
+			expect( isCancelable( DOMAIN_PURCHASE_EXPIRED ) ).toEqual( false );
 		} );
 
 		test( 'should be cancelable when the purchase is refundable', () => {
-			expect( isCancelable( DOMAIN_PURCHASE ) ).to.be.true;
+			expect( isCancelable( DOMAIN_PURCHASE ) ).toEqual( true );
 		} );
 
 		test( 'should be cancelable when the purchase can have auto-renew disabled', () => {
-			expect( isCancelable( PLAN_PURCHASE ) ).to.be.true;
+			expect( isCancelable( PLAN_PURCHASE ) ).toEqual( true );
 		} );
 
 		test( 'should not be cancelable if domain is pending transfer', () => {
-			expect( isCancelable( DOMAIN_PURCHASE_PENDING_TRANSFER ) ).to.be.false;
+			expect( isCancelable( DOMAIN_PURCHASE_PENDING_TRANSFER ) ).toEqual( false );
 		} );
 	} );
 	describe( '#isPaidWithCredits', () => {
 		test( 'should be true when paid with credits', () => {
-			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_CREDITS ) ).to.be.true;
+			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_CREDITS ) ).toEqual( true );
 		} );
 		test( 'should false when not paid with credits', () => {
-			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_PAYPAL ) ).to.be.false;
+			expect( isPaidWithCredits( PLAN_PURCHASE_WITH_PAYPAL ) ).toEqual( false );
 		} );
 		test( 'should be false when payment not set on purchase', () => {
-			expect( isPaidWithCredits( {} ) ).to.be.false;
+			expect( isPaidWithCredits( {} ) ).toEqual( false );
 		} );
 	} );
 	describe( '#hasPaymentMethod', () => {
 		test( 'should be false if no payment data at all', () => {
-			expect( hasPaymentMethod( {} ) ).to.be.false;
+			expect( hasPaymentMethod( {} ) ).toEqual( false );
 		} );
 		test( 'should be false if no payment type', () => {
 			expect(
 				hasPaymentMethod( {
 					payment: {},
 				} )
-			).to.be.false;
+			).toEqual( false );
 		} );
 		test( 'should be true if a payment type is available', () => {
 			expect(
@@ -109,7 +108,7 @@ describe( 'index', () => {
 						type: 'paypal',
 					},
 				} )
-			).to.be.true;
+			).toEqual( true );
 		} );
 	} );
 	describe( '#maybeWithinRefundPeriod', () => {
@@ -120,7 +119,7 @@ describe( 'index', () => {
 					refundPeriodInDays: 2,
 					subscribedDate: moment().subtract( 1, 'days' ).format(),
 				} )
-			).to.be.true;
+			).toEqual( true );
 		} );
 		test( 'should be true if the same amount of time as the refund period has elapsed since the subscription date', () => {
 			expect(
@@ -129,7 +128,7 @@ describe( 'index', () => {
 					refundPeriodInDays: 2,
 					subscribedDate: moment().subtract( 2, 'days' ).format(),
 				} )
-			).to.be.true;
+			).toEqual( true );
 		} );
 		test( 'should be true if less than a full day beyond the refund period has elapsed since the subscription date', () => {
 			// Give users the benefit of the doubt, due to timezones, etc.
@@ -139,7 +138,7 @@ describe( 'index', () => {
 					refundPeriodInDays: 2,
 					subscribedDate: moment().subtract( 71, 'hours' ).format(),
 				} )
-			).to.be.true;
+			).toEqual( true );
 		} );
 		test( 'should be false if one more day than the refund period has elapsed since the subscription date', () => {
 			expect(
@@ -148,7 +147,7 @@ describe( 'index', () => {
 					refundPeriodInDays: 2,
 					subscribedDate: moment().subtract( 3, 'days' ).format(),
 				} )
-			).to.be.false;
+			).toEqual( false );
 		} );
 		test( 'should be true if the purchase is marked as refundable, regardless of how much time has elapsed since the subscription date', () => {
 			expect(
@@ -157,7 +156,7 @@ describe( 'index', () => {
 					refundPeriodInDays: 2,
 					subscribedDate: moment().subtract( 3, 'days' ).format(),
 				} )
-			).to.be.true;
+			).toEqual( true );
 		} );
 		test( 'should be false if the refundPeriodInDays property is not set on the purchase', () => {
 			expect(
@@ -165,7 +164,7 @@ describe( 'index', () => {
 					isRefundable: false,
 					subscribedDate: moment().subtract( 1, 'days' ).format(),
 				} )
-			).to.be.false;
+			).toEqual( false );
 		} );
 		test( 'should be false if the subscribedDate property is not set on the purchase', () => {
 			expect(
@@ -173,26 +172,28 @@ describe( 'index', () => {
 					isRefundable: false,
 					refundPeriodInDays: 2,
 				} )
-			).to.be.false;
+			).toEqual( false );
 		} );
 	} );
 	describe( '#subscribedWithinPastWeek', () => {
 		test( 'should return false when no subscribed date', () => {
-			expect( subscribedWithinPastWeek( {} ) ).to.be.false;
+			expect( subscribedWithinPastWeek( {} ) ).toEqual( false );
 		} );
 		test( 'should return false when subscribed more than 1 week ago', () => {
 			expect(
 				subscribedWithinPastWeek( {
 					subscribedDate: moment().subtract( 8, 'days' ).format(),
 				} )
-			).to.be.false;
+			).toEqual( false );
 		} );
 		test( 'should return true when subscribed less than 1 week ago', () => {
 			expect(
 				subscribedWithinPastWeek( {
 					subscribedDate: moment().subtract( 3, 'days' ).format(),
 				} )
-			).to.be.true;
+			).toEqual( true );
+		} );
+	} );
 		} );
 	} );
 } );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -38,7 +38,11 @@ import {
 	getName,
 } from 'lib/purchases';
 import { canEditPaymentDetails, getEditCardDetailsPath, isDataLoading } from '../utils';
-import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import {
+	getByPurchaseId,
+	hasLoadedUserPurchasesFromServer,
+	getRenewableSitePurchases,
+} from 'state/purchases/selectors';
 import { getCanonicalTheme } from 'state/themes/selectors';
 import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
 import Gridicon from 'components/gridicon';
@@ -96,6 +100,7 @@ class ManagePurchase extends Component {
 		hasNonPrimaryDomainsFlag: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
 		purchase: PropTypes.object,
+		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
 		site: PropTypes.object,
 		siteId: PropTypes.number,
 		siteSlug: PropTypes.string.isRequired,
@@ -513,7 +518,14 @@ class ManagePurchase extends Component {
 		if ( ! this.isDataValid() ) {
 			return null;
 		}
-		const { site, siteId, siteSlug, purchase, isPurchaseTheme } = this.props;
+		const {
+			site,
+			siteId,
+			siteSlug,
+			renewableSitePurchases,
+			purchase,
+			isPurchaseTheme,
+		} = this.props;
 		const classes = 'manage-purchase';
 
 		let editCardDetailsPath = false;
@@ -541,6 +553,7 @@ class ManagePurchase extends Component {
 						handleRenew={ this.handleRenew }
 						selectedSite={ site }
 						purchase={ purchase }
+						renewableSitePurchases={ renewableSitePurchases }
 						editCardDetailsPath={ editCardDetailsPath }
 					/>
 					<AsyncLoad
@@ -562,6 +575,7 @@ class ManagePurchase extends Component {
 export default connect( ( state, props ) => {
 	const purchase = getByPurchaseId( state, props.purchaseId );
 	const siteId = purchase ? purchase.siteId : null;
+	const renewableSitePurchases = getRenewableSitePurchases( state, siteId );
 	const isPurchasePlan = purchase && isPlan( purchase );
 	const isPurchaseTheme = purchase && isTheme( purchase );
 	const site = getSite( state, siteId );
@@ -578,6 +592,7 @@ export default connect( ( state, props ) => {
 		purchase,
 		siteId,
 		site,
+		renewableSitePurchases,
 		plan: isPurchasePlan && applyTestFiltersToPlansList( purchase.productSlug, abtest ),
 		isPurchaseTheme,
 		theme: isPurchaseTheme && getCanonicalTheme( state, siteId, purchase.meta ),

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -23,6 +23,7 @@ import {
 	getDisplayName,
 	getPartnerName,
 	getRenewalPrice,
+	handleRenewMultiplePurchasesClick,
 	handleRenewNowClick,
 	hasAmountAvailableToRefund,
 	hasPaymentMethod,
@@ -147,7 +148,11 @@ class ManagePurchase extends Component {
 	}
 
 	handleRenew = () => {
-		handleRenewNowClick( this.props.purchase, this.props.siteSlug );
+		handleRenewNowClick( this.props.purchase, this.props.siteSlug, {} );
+	};
+
+	handleRenewMultiplePurchases = ( purchases ) => {
+		handleRenewMultiplePurchasesClick( purchases, this.props.siteSlug, {} );
 	};
 
 	shouldShowNonPrimaryDomainWarning() {
@@ -551,6 +556,7 @@ class ManagePurchase extends Component {
 					<PurchaseNotice
 						isDataLoading={ isDataLoading( this.props ) }
 						handleRenew={ this.handleRenew }
+						handleRenewMultiplePurchases={ this.handleRenewMultiplePurchases }
 						selectedSite={ site }
 						purchase={ purchase }
 						renewableSitePurchases={ renewableSitePurchases }

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -148,11 +148,11 @@ class ManagePurchase extends Component {
 	}
 
 	handleRenew = () => {
-		handleRenewNowClick( this.props.purchase, this.props.siteSlug, {} );
+		handleRenewNowClick( this.props.purchase, this.props.siteSlug );
 	};
 
 	handleRenewMultiplePurchases = ( purchases ) => {
-		handleRenewMultiplePurchasesClick( purchases, this.props.siteSlug, {} );
+		handleRenewMultiplePurchasesClick( purchases, this.props.siteSlug );
 	};
 
 	shouldShowNonPrimaryDomainWarning() {

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -295,40 +295,40 @@ class PurchaseNotice extends Component {
 		if ( isExpired( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
 				return translate(
-					'Your %(purchaseName)s domain expired %(expiry)s and some of your {{link}}other upgrades{{/link}} on this site will be removed soon unless you take an action.',
+					'Your %(purchaseName)s domain expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
 					translateOptions
 				);
 			}
 
 			if ( isPlan( purchase ) ) {
 				return translate(
-					'Your %(purchaseName)s plan expired %(expiry)s and some of your {{link}}other upgrades{{/link}} on this site will be removed soon unless you take an action.',
+					'Your %(purchaseName)s plan expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
 					translateOptions
 				);
 			}
 
 			return translate(
-				'Your %(purchaseName)s subscription expired %(expiry)s and some of your {{link}}other upgrades{{/link}} on this site will be removed soon unless you take an action.',
+				'Your %(purchaseName)s subscription expired %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
 				translateOptions
 			);
 		}
 
 		if ( isDomainRegistration( purchase ) ) {
 			return translate(
-				'Your %(purchaseName)s domain will expire %(expiry)s and some of your {{link}}other upgrades{{/link}} on this site will be removed soon unless you take an action.',
+				'Your %(purchaseName)s domain will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
 				translateOptions
 			);
 		}
 
 		if ( isPlan( purchase ) ) {
 			return translate(
-				'Your %(purchaseName)s plan will expire %(expiry)s and some of your {{link}}other upgrades{{/link}} on this site will be removed soon unless you take an action.',
+				'Your %(purchaseName)s plan will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
 				translateOptions
 			);
 		}
 
 		return translate(
-			'Your %(purchaseName)s subscription will expire %(expiry)s and some of your {{link}}other upgrades{{/link}} on this site will be removed soon unless you take an action.',
+			'Your %(purchaseName)s subscription will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
 			translateOptions
 		);
 	}

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -280,7 +280,7 @@ class PurchaseNotice extends Component {
 	};
 
 	getOtherPurchasesExpiringText() {
-		const { translate, purchase, moment } = this.props;
+		const { translate, purchase, moment, renewableSitePurchases } = this.props;
 		const expiry = moment( purchase.expiryDate );
 		const translateOptions = {
 			args: {
@@ -318,22 +318,47 @@ class PurchaseNotice extends Component {
 			);
 		}
 
+		const hasPurchaseExpiringSoon = renewableSitePurchases.some(
+			( otherPurchase ) => moment( otherPurchase.expiryDate ).diff( Date.now(), 'days' ) < 30
+		);
+
+		if ( hasPurchaseExpiringSoon ) {
+			if ( isDomainRegistration( purchase ) ) {
+				return translate(
+					'Your %(purchaseName)s domain will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+					translateOptions
+				);
+			}
+
+			if ( isPlan( purchase ) ) {
+				return translate(
+					'Your %(purchaseName)s plan will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+					translateOptions
+				);
+			}
+
+			return translate(
+				'Your %(purchaseName)s subscription will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+				translateOptions
+			);
+		}
+
 		if ( isDomainRegistration( purchase ) ) {
 			return translate(
-				'Your %(purchaseName)s domain will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+				'Your %(purchaseName)s domain will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
 				translateOptions
 			);
 		}
 
 		if ( isPlan( purchase ) ) {
 			return translate(
-				'Your %(purchaseName)s plan will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+				'Your %(purchaseName)s plan will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
 				translateOptions
 			);
 		}
 
 		return translate(
-			'Your %(purchaseName)s subscription will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',
+			'Your %(purchaseName)s subscription will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed unless you take action.',
 			translateOptions
 		);
 	}

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -237,6 +237,10 @@ class PurchaseNotice extends Component {
 	renderOtherPurchasesExpiringNotice() {
 		const { translate, purchase, selectedSite, renewableSitePurchases } = this.props;
 
+		if ( ! config.isEnabled( 'upgrades/upcoming-renewals-notices' ) ) {
+			return null;
+		}
+
 		const showOtherPurchasesExpiringNotice =
 			selectedSite &&
 			! isAutoRenewing( purchase ) &&

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -39,6 +39,7 @@ import NoticeAction from 'components/notice/notice-action';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { isMonthly } from 'lib/plans/constants';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import UpcomingRenewalsDialog from 'me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 
 /**
  * Style dependencies
@@ -51,10 +52,15 @@ class PurchaseNotice extends Component {
 	static propTypes = {
 		isDataLoading: PropTypes.bool,
 		handleRenew: PropTypes.func,
+		handleRenewMultiplePurchases: PropTypes.func,
 		purchase: PropTypes.object,
 		renewableSitePurchases: PropTypes.arrayOf( PropTypes.object ),
 		selectedSite: PropTypes.object,
 		editCardDetailsPath: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
+	};
+
+	state = {
+		showUpcomingRenewalsDialog: false,
 	};
 
 	getExpiringText( purchase ) {
@@ -180,6 +186,21 @@ class PurchaseNotice extends Component {
 		}
 	};
 
+	handleExpiringNoticeRenewAll = () => {
+		const { renewableSitePurchases } = this.props;
+		this.trackClick( 'purchase-expiring-renew-all' );
+		if ( this.props.handleRenewMultiplePurchases ) {
+			this.props.handleRenewMultiplePurchases( renewableSitePurchases );
+		}
+	};
+
+	handleExpiringNoticeRenewSelection = ( selectedRenewableSitePurchases ) => {
+		this.trackClick( 'purchase-expiring-renew-selected' );
+		if ( this.props.handleRenewMultiplePurchases ) {
+			this.props.handleRenewMultiplePurchases( selectedRenewableSitePurchases );
+		}
+	};
+
 	renderPurchaseExpiringNotice() {
 		const { moment, purchase } = this.props;
 		let noticeStatus = 'is-info';
@@ -222,6 +243,13 @@ class PurchaseNotice extends Component {
 
 		return (
 			<>
+				<UpcomingRenewalsDialog
+					isVisible={ this.state.showUpcomingRenewalsDialog }
+					purchases={ renewableSitePurchases }
+					site={ selectedSite }
+					onConfirm={ this.handleExpiringNoticeRenewSelection }
+					onClose={ this.closeUpcomingRenewalsDialog }
+				/>
 				<Notice
 					className="manage-purchase__other-purchases-expiring-notice"
 					showDismiss={ false }
@@ -237,6 +265,14 @@ class PurchaseNotice extends Component {
 			</>
 		);
 	}
+
+	openUpcomingRenewalsDialog = () => {
+		this.setState( { showUpcomingRenewalsDialog: true } );
+	};
+
+	closeUpcomingRenewalsDialog = () => {
+		this.setState( { showUpcomingRenewalsDialog: false } );
+	};
 
 	getOtherPurchasesExpiringText() {
 		const { translate, purchase, moment } = this.props;

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -15,6 +15,7 @@ import {
 	canExplicitRenew,
 	creditCardExpiresBeforeSubscription,
 	getName,
+	isAutoRenewing,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,
@@ -238,6 +239,7 @@ class PurchaseNotice extends Component {
 
 		const showOtherPurchasesExpiringNotice =
 			selectedSite &&
+			! isAutoRenewing( purchase ) &&
 			renewableSitePurchases.length > 1 &&
 			renewableSitePurchases.some( ( otherPurchase ) => otherPurchase.id === purchase.id );
 

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -188,14 +188,18 @@ class PurchaseNotice extends Component {
 
 	handleExpiringNoticeRenewAll = () => {
 		const { renewableSitePurchases } = this.props;
-		this.trackClick( 'purchase-expiring-renew-all' );
+		this.trackClick( 'other-purchases-expiring-renew-all' );
 		if ( this.props.handleRenewMultiplePurchases ) {
 			this.props.handleRenewMultiplePurchases( renewableSitePurchases );
 		}
 	};
 
 	handleExpiringNoticeRenewSelection = ( selectedRenewableSitePurchases ) => {
-		this.trackClick( 'purchase-expiring-renew-selected' );
+		const { renewableSitePurchases } = this.props;
+		this.props.recordTracksEvent( 'calypso_subscription_upcoming_renewals_dialog_submit', {
+			selected: selectedRenewableSitePurchases.length,
+			available: renewableSitePurchases.length,
+		} );
 		if ( this.props.handleRenewMultiplePurchases ) {
 			this.props.handleRenewMultiplePurchases( selectedRenewableSitePurchases );
 		}
@@ -267,6 +271,7 @@ class PurchaseNotice extends Component {
 	}
 
 	openUpcomingRenewalsDialog = () => {
+		this.trackClick( 'other-purchases-expiring-upcoming-renewals-dialog' );
 		this.setState( { showUpcomingRenewalsDialog: true } );
 	};
 

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -320,11 +320,13 @@ class PurchaseNotice extends Component {
 			);
 		}
 
-		const hasPurchaseExpiringSoon = renewableSitePurchases.some(
-			( otherPurchase ) => moment( otherPurchase.expiryDate ).diff( Date.now(), 'days' ) < 30
+		const hasOtherPurchaseExpiringSoon = renewableSitePurchases.some(
+			( otherPurchase ) =>
+				otherPurchase.id !== purchase.id &&
+				moment( otherPurchase.expiryDate ).diff( Date.now(), 'days' ) < 30
 		);
 
-		if ( hasPurchaseExpiringSoon ) {
+		if ( hasOtherPurchaseExpiringSoon ) {
 			if ( isDomainRegistration( purchase ) ) {
 				return translate(
 					'Your %(purchaseName)s domain will expire %(expiry)s, and {{link}}other upgrades{{/link}} on this site will also be removed soon unless you take action.',

--- a/client/me/purchases/manage-purchase/notices.scss
+++ b/client/me/purchases/manage-purchase/notices.scss
@@ -1,0 +1,18 @@
+.manage-purchase__other-upgrades-button {
+	background: transparent;
+	border: none;
+	border-radius: 0;
+	padding: 0;
+	color: var( --color-text-inverted );
+	font-weight: 400;
+	font-size: inherit;
+	line-height: 1.65;
+	text-decoration: underline;
+	cursor: pointer;
+
+	&:hover,
+	&:focus {
+		color: var( --color-link-light );
+		box-shadow: none;
+	}
+}

--- a/client/me/purchases/upcoming-renewals/style.scss
+++ b/client/me/purchases/upcoming-renewals/style.scss
@@ -1,9 +1,12 @@
 .upcoming-renewals-dialog {
 	.button {
-		margin-right: 10px;
-		margin-bottom: 8px;
+		margin-left: 10px;
 		padding: 8px 10px;
-		text-align: left;
+	}
+
+	hr {
+		margin-bottom: 1em;
+		margin-top: 1em;
 	}
 
 	&.dialog {
@@ -39,6 +42,9 @@
 	&__detail {
 		font-size: 14px;
 		color: var( --color-neutral-50 );
+		.expired {
+			color: var( --color-error-dark );
+		}
 	}
 	&__side {
 		text-align: right;
@@ -53,5 +59,6 @@
 	}
 	&__actions {
 		text-align: right;
+		margin-top: 1.5em;
 	}
 }

--- a/client/me/purchases/upcoming-renewals/style.scss
+++ b/client/me/purchases/upcoming-renewals/style.scss
@@ -20,7 +20,7 @@
 	&__subheader {
 		font-size: 14px;
 		color: var( --color-neutral-50 );
-		margin-bottom: 14px;
+		margin-bottom: 16px;
 	}
 	&__row {
 		display: flex;
@@ -37,7 +37,7 @@
 		flex-direction: column;
 	}
 	&__name {
-		font-size: 18px;
+		font-size: 16px;
 	}
 	&__detail {
 		font-size: 14px;

--- a/client/me/purchases/upcoming-renewals/style.scss
+++ b/client/me/purchases/upcoming-renewals/style.scss
@@ -25,7 +25,7 @@
 	&__row {
 		display: flex;
 	}
-	&__label {
+	&__label.form-label {
 		display: flex;
 		flex-grow: 1;
 		font-weight: normal;

--- a/client/me/purchases/upcoming-renewals/style.scss
+++ b/client/me/purchases/upcoming-renewals/style.scss
@@ -1,0 +1,57 @@
+.upcoming-renewals-dialog {
+	.button {
+		margin-right: 10px;
+		margin-bottom: 8px;
+		padding: 8px 10px;
+		text-align: left;
+	}
+
+	&.dialog {
+		width: 660px;
+	}
+
+	&__header {
+		font-size: 24px;
+		margin-bottom: 0;
+	}
+	&__subheader {
+		font-size: 14px;
+		color: var( --color-neutral-50 );
+		margin-bottom: 14px;
+	}
+	&__row {
+		display: flex;
+	}
+	&__label {
+		display: flex;
+		flex-grow: 1;
+		font-weight: normal;
+	}
+	&__checkbox {
+		width: 24px;
+		display: flex;
+		justify-content: center;
+		flex-direction: column;
+	}
+	&__name {
+		font-size: 18px;
+	}
+	&__detail {
+		font-size: 14px;
+		color: var( --color-neutral-50 );
+	}
+	&__side {
+		text-align: right;
+	}
+	&__price {
+		font-size: 16px;
+	}
+	&__renewal-settings-link a {
+		font-size: 14px;
+		color: var( --color-neutral-50 );
+		text-decoration: underline;
+	}
+	&__actions {
+		text-align: right;
+	}
+}

--- a/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import Modal from 'react-modal';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { unmountComponentAtNode } from 'react-dom';
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+
+/**
+ * Internal dependencies
+ */
+import UpcomingRenewalsDialog from '../upcoming-renewals-dialog';
+
+describe( '<UpcomingRenewalsDialog>', () => {
+	let modalRoot;
+
+	beforeEach( () => {
+		modalRoot = document.createElement( 'div' );
+		modalRoot.setAttribute( 'id', 'modal-root' );
+		document.body.appendChild( modalRoot );
+		Modal.setAppElement( modalRoot );
+	} );
+
+	afterEach( () => {
+		unmountComponentAtNode( modalRoot );
+		document.body.removeChild( modalRoot );
+		modalRoot = null;
+	} );
+
+	const purchases = [
+		{
+			id: 1,
+			currencyCode: 'USD',
+			expiryDate: '2020-05-20T00:00:00+00:00',
+			productSlug: 'personal-bundle',
+			productName: 'Personal Plan',
+			amount: 100,
+		},
+		{
+			id: 2,
+			currencyCode: 'USD',
+			expiryDate: '2020-05-15T00:00:00+00:00',
+			productSlug: 'dotlive_domain',
+			meta: 'personalsitetest1234.live',
+			productName: 'DotLive Domain Registration',
+			isDomainRegistration: true,
+			amount: 200,
+		},
+	];
+
+	const site = {
+		domain: 'personalsitetest1234.wordpress.com',
+		slug: 'personalsitetest1234.wordpress.com',
+	};
+
+	test( 'displays names and price for each purchase ordered by expiration date ascending', () => {
+		render(
+			<UpcomingRenewalsDialog
+				isVisible={ true }
+				purchases={ purchases }
+				site={ site }
+				onConfirm={ jest.fn() }
+				onClose={ jest.fn() }
+			/>
+		);
+
+		expect(
+			document.body.querySelectorAll( '.upcoming-renewals-dialog__name' )[ 0 ]
+		).toHaveTextContent( /personalsitetest1234\.liveDotLive Domain Registration: expire[sd]/ );
+		expect(
+			document.body.querySelectorAll( '.upcoming-renewals-dialog__price' )[ 0 ]
+		).toHaveTextContent( '$200' );
+		expect(
+			document.body.querySelectorAll( '.upcoming-renewals-dialog__name' )[ 1 ]
+		).toHaveTextContent( /Personal PlanSite Plan: expire[sd]/ );
+		expect(
+			document.body.querySelectorAll( '.upcoming-renewals-dialog__price' )[ 1 ]
+		).toHaveTextContent( '$100' );
+	} );
+
+	test( 'selects all purchases by default', () => {
+		const onConfirm = jest.fn();
+		render(
+			<UpcomingRenewalsDialog
+				isVisible={ true }
+				purchases={ purchases }
+				site={ site }
+				onConfirm={ onConfirm }
+				onClose={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Renew now' ) );
+
+		expect( onConfirm ).toHaveBeenCalledWith( purchases );
+	} );
+
+	test( 'submits only the selected purchases', () => {
+		const onConfirm = jest.fn();
+		render(
+			<UpcomingRenewalsDialog
+				isVisible={ true }
+				purchases={ purchases }
+				site={ site }
+				onConfirm={ onConfirm }
+				onClose={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( document.body.querySelector( 'input[name=personal-bundle-1]' ) );
+		fireEvent.click( screen.getByText( 'Renew now' ) );
+
+		expect( onConfirm ).toHaveBeenCalledWith( [ purchases[ 1 ] ] );
+	} );
+
+	test( 'disables the submit button if no purchases are selected', () => {
+		render(
+			<UpcomingRenewalsDialog
+				isVisible={ true }
+				purchases={ purchases }
+				site={ site }
+				onConfirm={ jest.fn() }
+				onClose={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( document.body.querySelector( 'input[name=dotlive_domain-2]' ) );
+
+		fireEvent.click( document.body.querySelector( 'input[name=personal-bundle-1]' ) );
+
+		expect( screen.getByText( 'Renew now' ) ).toHaveProperty( 'disabled', true );
+	} );
+} );

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -11,6 +11,7 @@ import React, {
 } from 'react';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
+import { capitalize } from 'lodash';
 
 /**
  * Internal dependencies
@@ -120,7 +121,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 			</h3>
 			<hr />
 			{ purchasesSortByRecentExpiryDate.map( ( purchase ) => {
-				const expiresText = getExpiresText( translate, moment, purchase );
+				const expiresText = getExpiresText( translate, moment, purchase ) as string;
 				const purchaseTypeText = purchaseType( purchase );
 				const onChange = () => {
 					if ( selectedPurchases.includes( purchase.id ) ) {
@@ -150,7 +151,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 									<div className="upcoming-renewals-dialog__detail">
 										{ purchaseTypeText ? `${ purchaseTypeText }: ` : '' }
 										<span className={ isExpired( purchase ) ? 'expired' : '' }>
-											{ expiresText }
+											{ purchaseTypeText ? expiresText : capitalize( expiresText ) }
 										</span>
 									</div>
 								</div>

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -1,0 +1,146 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent, useState, useEffect, useCallback } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import formatCurrency from '@automattic/format-currency';
+
+/**
+ * Internal dependencies
+ */
+import { getName, getRenewalPrice, purchaseType, isExpired } from 'lib/purchases';
+import FormLabel from 'components/forms/form-label';
+import FormInputCheckbox from 'components/forms/form-checkbox';
+import { Button, Dialog } from '@automattic/components';
+import { useLocalizedMoment } from 'components/localized-moment';
+import { managePurchase } from '../paths';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Purchase {
+	id: number;
+	currencyCode: string;
+	expiryDate: string;
+	taxText: string;
+	productSlug: string;
+}
+
+interface Site {
+	domain: string;
+	slug: string;
+}
+
+interface Props {
+	site: Site;
+	purchases: Purchase[];
+	isVisible: boolean;
+	onClose: () => void;
+	onConfirm: ( purchases: Purchase[] ) => void;
+}
+
+const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
+	site,
+	purchases,
+	isVisible,
+	onClose,
+	onConfirm,
+} ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const [ selectedPurchases, setSelectedPurchases ] = useState< number[] >( [] );
+
+	useEffect( () => {
+		if ( isVisible ) {
+			setSelectedPurchases( purchases.map( ( purchase ) => purchase.id ) );
+		}
+	}, [ isVisible, purchases ] );
+
+	const confirmSelectedPurchases = useCallback( () => {
+		onConfirm( purchases.filter( ( purchase ) => selectedPurchases.includes( purchase.id ) ) );
+	}, [ purchases, selectedPurchases, onConfirm ] );
+
+	return (
+		<Dialog
+			isVisible={ isVisible }
+			leaveTimeout={ 0 }
+			additionalClassNames="upcoming-renewals-dialog"
+			onClose={ onClose }
+		>
+			<h2 className="upcoming-renewals-dialog__header">{ translate( 'Upcoming renewals' ) }</h2>
+			<h3 className="upcoming-renewals-dialog__subheader">
+				{ translate( 'Site: %(siteName)s', { args: { siteName: site.domain } } ) }
+			</h3>
+			<hr />
+			{ purchases.map( ( purchase ) => {
+				const expiresText = isExpired( purchase )
+					? translate( 'Expired %(expiry)s', {
+							args: { expiry: moment( purchase.expiryDate ).fromNow() },
+					  } )
+					: translate( 'Expires %(expiry)s', {
+							args: { expiry: moment( purchase.expiryDate ).fromNow() },
+					  } );
+				const onChange = () => {
+					if ( selectedPurchases.includes( purchase.id ) ) {
+						setSelectedPurchases( selectedPurchases.filter( ( id ) => id !== purchase.id ) );
+					} else {
+						setSelectedPurchases( selectedPurchases.concat( [ purchase.id ] ) );
+					}
+				};
+				return (
+					<>
+						<div className="upcoming-renewals-dialog__row" key={ purchase.id }>
+							<FormLabel
+								optional={ false }
+								required={ false }
+								className="upcoming-renewals-dialog__label"
+							>
+								<div className="upcoming-renewals-dialog__checkbox">
+									<FormInputCheckbox
+										className="upcoming-renewals-dialog__checkbox-input"
+										name={ `${ purchase.productSlug }-${ purchase.id }` }
+										checked={ selectedPurchases.includes( purchase.id ) }
+										onChange={ onChange }
+									/>
+								</div>
+								<div className="upcoming-renewals-dialog__name">
+									{ getName( purchase ) }
+									<div className="upcoming-renewals-dialog__detail">
+										{ purchaseType( purchase ) }: { expiresText }
+									</div>
+								</div>
+							</FormLabel>
+							<div className="upcoming-renewals-dialog__side">
+								<div className="upcoming-renewals-dialog__price">
+									{ formatCurrency( getRenewalPrice( purchase ), purchase.currencyCode, {
+										stripZeros: true,
+									} ) }
+								</div>
+								<div className="upcoming-renewals-dialog__renewal-settings-link">
+									<a onClick={ onClose } href={ managePurchase( site.slug, purchase.id ) }>
+										{ translate( 'Manage purchase' ) }
+									</a>
+								</div>
+							</div>
+						</div>
+						<hr />
+					</>
+				);
+			} ) }
+			<div className="upcoming-renewals-dialog__actions">
+				<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
+				<Button
+					disabled={ selectedPurchases.length === 0 }
+					onClick={ confirmSelectedPurchases }
+					primary
+				>
+					{ translate( 'Renew now' ) }
+				</Button>
+			</div>
+		</Dialog>
+	);
+};
+
+export default UpcomingRenewalsDialog;

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -29,9 +29,13 @@ import './style.scss';
 
 interface Purchase {
 	id: number;
+	saleAmount?: number;
+	amount: number;
+	meta?: string;
+	isDomainRegistration?: boolean;
+	productName: string;
 	currencyCode: string;
 	expiryDate: string;
-	taxText: string;
 	productSlug: string;
 }
 
@@ -60,7 +64,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 	const [ selectedPurchases, setSelectedPurchases ] = useState< number[] >( [] );
 
 	const purchasesSortByRecentExpiryDate = useMemo(
-		() => purchases.sort( ( a, b ) => a?.expiryDate?.localeCompare( b?.expiryDate ) ),
+		() => [ ...purchases ].sort( ( a, b ) => a?.expiryDate?.localeCompare( b?.expiryDate ) ),
 		[ purchases ]
 	);
 

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -36,6 +36,7 @@ interface Purchase {
 	productName: string;
 	currencyCode: string;
 	expiryDate: string;
+	renewDate: string;
 	productSlug: string;
 }
 
@@ -58,17 +59,25 @@ function getExpiresText(
 	purchase: Purchase
 ): TranslateResult {
 	if ( isAutoRenewing( purchase ) ) {
-		return translate( 'renews %(expiry)s', {
-			args: { expiry: moment( purchase.expiryDate ).fromNow() },
+		return translate( 'renews %(renewDate)s', {
+			comment:
+				'"renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"',
+			args: { renewDate: moment( purchase.renewDate ).fromNow() },
 		} );
 	}
 	if ( isExpired( purchase ) ) {
 		return translate( 'expired %(expiry)s', {
+			comment:
+				'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"',
 			args: { expiry: moment( purchase.expiryDate ).fromNow() },
 		} );
 	}
 	return translate( 'expires %(expiry)s', {
-		args: { expiry: moment( purchase.expiryDate ).fromNow() },
+		comment:
+			'"expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"',
+		args: {
+			expiry: moment( purchase.expiryDate ).fromNow(),
+		},
 	} );
 }
 

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -9,7 +9,7 @@ import React, {
 	useCallback,
 	useMemo,
 } from 'react';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 
 /**
@@ -112,6 +112,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 			<hr />
 			{ purchasesSortByRecentExpiryDate.map( ( purchase ) => {
 				const expiresText = getExpiresText( translate, moment, purchase );
+				const purchaseTypeText = purchaseType( purchase );
 				const onChange = () => {
 					if ( selectedPurchases.includes( purchase.id ) ) {
 						setSelectedPurchases( selectedPurchases.filter( ( id ) => id !== purchase.id ) );
@@ -138,7 +139,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 								<div className="upcoming-renewals-dialog__name">
 									{ getName( purchase ) }
 									<div className="upcoming-renewals-dialog__detail">
-										{ purchaseType( purchase ) }:&nbsp;
+										{ purchaseTypeText ? `${ purchaseTypeText }: ` : '' }
 										<span className={ isExpired( purchase ) ? 'expired' : '' }>
 											{ expiresText }
 										</span>

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -66,7 +66,7 @@ function getExpiresText(
 		return translate( 'expired %(expiry)s', {
 			args: { expiry: moment( purchase.expiryDate ).fromNow() },
 		} );
-}
+	}
 	return translate( 'expires %(expiry)s', {
 		args: { expiry: moment( purchase.expiryDate ).fromNow() },
 	} );

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -15,7 +15,7 @@ import formatCurrency from '@automattic/format-currency';
 /**
  * Internal dependencies
  */
-import { getName, getRenewalPrice, purchaseType, isExpired } from 'lib/purchases';
+import { getName, getRenewalPrice, purchaseType, isExpired, isAutoRenewing } from 'lib/purchases';
 import FormLabel from 'components/forms/form-label';
 import FormInputCheckbox from 'components/forms/form-checkbox';
 import { Button, Dialog } from '@automattic/components';
@@ -50,6 +50,26 @@ interface Props {
 	isVisible: boolean;
 	onClose: () => void;
 	onConfirm: ( purchases: Purchase[] ) => void;
+}
+
+function getExpiresText(
+	translate: ReturnType< typeof useTranslate >,
+	moment: ReturnType< typeof useLocalizedMoment >,
+	purchase: Purchase
+): TranslateResult {
+	if ( isAutoRenewing( purchase ) ) {
+		return translate( 'renews %(expiry)s', {
+			args: { expiry: moment( purchase.expiryDate ).fromNow() },
+		} );
+	}
+	if ( isExpired( purchase ) ) {
+		return translate( 'expired %(expiry)s', {
+			args: { expiry: moment( purchase.expiryDate ).fromNow() },
+		} );
+}
+	return translate( 'expires %(expiry)s', {
+		args: { expiry: moment( purchase.expiryDate ).fromNow() },
+	} );
 }
 
 const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
@@ -91,13 +111,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 			</h3>
 			<hr />
 			{ purchasesSortByRecentExpiryDate.map( ( purchase ) => {
-				const expiresText = isExpired( purchase )
-					? translate( 'expired %(expiry)s', {
-							args: { expiry: moment( purchase.expiryDate ).fromNow() },
-					  } )
-					: translate( 'expires %(expiry)s', {
-							args: { expiry: moment( purchase.expiryDate ).fromNow() },
-					  } );
+				const expiresText = getExpiresText( translate, moment, purchase );
 				const onChange = () => {
 					if ( selectedPurchases.includes( purchase.id ) ) {
 						setSelectedPurchases( selectedPurchases.filter( ( id ) => id !== purchase.id ) );

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent, useState, useEffect, useCallback } from 'react';
+import React, {
+	FunctionComponent,
+	Fragment,
+	useState,
+	useEffect,
+	useCallback,
+	useMemo,
+} from 'react';
 import { useTranslate } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
 
@@ -52,6 +59,11 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 	const moment = useLocalizedMoment();
 	const [ selectedPurchases, setSelectedPurchases ] = useState< number[] >( [] );
 
+	const purchasesSortByRecentExpiryDate = useMemo(
+		() => purchases.sort( ( a, b ) => a?.expiryDate?.localeCompare( b?.expiryDate ) ),
+		[ purchases ]
+	);
+
 	useEffect( () => {
 		if ( isVisible ) {
 			setSelectedPurchases( purchases.map( ( purchase ) => purchase.id ) );
@@ -74,12 +86,12 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 				{ translate( 'Site: %(siteName)s', { args: { siteName: site.domain } } ) }
 			</h3>
 			<hr />
-			{ purchases.map( ( purchase ) => {
+			{ purchasesSortByRecentExpiryDate.map( ( purchase ) => {
 				const expiresText = isExpired( purchase )
-					? translate( 'Expired %(expiry)s', {
+					? translate( 'expired %(expiry)s', {
 							args: { expiry: moment( purchase.expiryDate ).fromNow() },
 					  } )
-					: translate( 'Expires %(expiry)s', {
+					: translate( 'expires %(expiry)s', {
 							args: { expiry: moment( purchase.expiryDate ).fromNow() },
 					  } );
 				const onChange = () => {
@@ -90,8 +102,8 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 					}
 				};
 				return (
-					<>
-						<div className="upcoming-renewals-dialog__row" key={ purchase.id }>
+					<Fragment key={ purchase.id }>
+						<div className="upcoming-renewals-dialog__row">
 							<FormLabel
 								optional={ false }
 								required={ false }
@@ -108,7 +120,10 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 								<div className="upcoming-renewals-dialog__name">
 									{ getName( purchase ) }
 									<div className="upcoming-renewals-dialog__detail">
-										{ purchaseType( purchase ) }: { expiresText }
+										{ purchaseType( purchase ) }:&nbsp;
+										<span className={ isExpired( purchase ) ? 'expired' : '' }>
+											{ expiresText }
+										</span>
 									</div>
 								</div>
 							</FormLabel>
@@ -126,7 +141,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 							</div>
 						</div>
 						<hr />
-					</>
+					</Fragment>
 				);
 			} ) }
 			<div className="upcoming-renewals-dialog__actions">

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -79,13 +79,16 @@ export const getSitePurchases = ( state, siteId ) =>
  * @param {number} siteId     the site id
  * @returns {Array} the matching expiring purchases if there are some
  */
-export const getRenewableSitePurchases = ( state, siteId ) =>
-	getSitePurchases( state, siteId ).filter(
-		( purchase ) =>
-			( isExpiring( purchase ) || isExpired( purchase ) ) &&
-			canExplicitRenew( purchase ) &&
-			moment( purchase.expiryDate ).diff( Date.now(), 'days' ) < 90
-	);
+export const getRenewableSitePurchases = createSelector(
+	( state, siteId ) =>
+		getSitePurchases( state, siteId ).filter(
+			( purchase ) =>
+				( isExpiring( purchase ) || isExpired( purchase ) ) &&
+				canExplicitRenew( purchase ) &&
+				moment( purchase.expiryDate ).diff( Date.now(), 'days' ) < 90
+		),
+	( state, siteId ) => [ state.purchases.data, siteId ]
+);
 
 /**
  * Whether a site has an active Jetpack backup purchase.

--- a/config/development.json
+++ b/config/development.json
@@ -185,6 +185,7 @@
 		"upgrades/premium-themes": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
+		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,
 		"upsell/concierge-session": true,
 		"upsell/nudge-a-palooza": false,

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -31,5 +31,6 @@
 		"clean": "check-npm-client && npx rimraf dist",
 		"prepublish": "check-npm-client && yarn run clean",
 		"prepare": "check-npm-client && transpile"
-	}
+	},
+	"types": "types"
 }

--- a/packages/format-currency/types/index.d.ts
+++ b/packages/format-currency/types/index.d.ts
@@ -1,0 +1,49 @@
+/**
+ * TypeScript type definitions for format-currency
+ *
+ * @todo Migrate `src/index.js` to TypeScript, incorporate these type definitions.
+ * (Needs changes to the build chain, see other packages in the monorepo
+ * for inspiration, e.g. `@automattic/data-stores`.)
+ */
+
+export interface FormatCurrencyOptions {
+	decimal?: string;
+	grouping?: string;
+	precision?: number;
+	symbol?: string;
+	stripZeros?: boolean;
+}
+
+export interface CurrencyObject {
+	sign: string;
+	symbol: string;
+	integer: string;
+	fraction: string;
+}
+
+export interface CurrencyDefinition {
+	symbol: string;
+	grouping: string;
+	decimal: string;
+	precision: number;
+}
+
+export interface CurrenciesDictionary {
+	[ currencyCode: string ]: CurrencyDefinition;
+}
+
+export const CURRENCIES: CurrenciesDictionary;
+
+export function getCurrencyDefaults( currencyCode: string ): CurrencyDefinition;
+
+export function getCurrencyObject(
+	number: number,
+	currencyCode: string,
+	options?: FormatCurrencyOptions
+): CurrencyObject | null;
+
+export default function formatCurrency(
+	number: number,
+	currencyCode: string,
+	options?: FormatCurrencyOptions
+): string | null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new Notice to the Manage Purchase page that will be displayed when other upgrades from the same site are available for renewal.
![image](https://user-images.githubusercontent.com/15204776/81608657-3dd87a80-939c-11ea-8773-774bd0c0cd18.png)

* Inside the new notice, a new dialog can be opened that will display the detail of each available renewal, the user will be able to select which ones they one to proceed with.
![image](https://user-images.githubusercontent.com/15204776/81608774-68c2ce80-939c-11ea-9bda-49c072cde64e.png)

* Adds type definitions to format-currency

* Design discussion: pbOQVh-9b-p2

#### Testing instructions

* Go to a site that has multiple purchases expiring soon (within the next 3 months) or that are already expired and still renewable. (Turn auto-renew off to make sure they are marked as "expiring").
* Go to Manage Purchases and open any of the purchases that are expiring soon.
* You should see the new notice telling you that there are other products also expiring.
* Click "renew all" inside the notice to go to the checkout with all your products in the cart
* Go back and click on "other purchases", inside the notice click renew now to go to the checkout with all your products in the cart.
* Go back and click on "other purchases" inside the notice, unselect one of them and click renew now to go to the checkout with your selected products in the cart.
* Go back and click on "other purchases" inside the notice, click on one of the "manage purchase" links to go to that purchase detail page.
* Go back and click on "other purchases" inside the notice, unselect all the purchases and make sure that the "renew now" buttons becomes disabled, also make sure that the dialog can be closed using both the cancel button and by clicking in the backdrop.
