### PR TITLE
Fix global styles not updating on selection.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
+++ b/apps/full-site-editing/full-site-editing-plugin/global-styles/src/dom-updater.js
@@ -58,7 +58,7 @@ export default ( options, getOptionValue ) => {
 			Object.keys( currentOptions ).forEach( ( key ) => {
 				declarationList += `${ cssVariables[ key ] }:${ currentOptions[ key ] };`;
 			} );
-			styleElement.textContent = `.editor-styles-wrapper{${ declarationList }}`;
+			styleElement.textContent = `.edit-post-visual-editor.editor-styles-wrapper{${ declarationList }}`;
 		} );
 	} );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the class name(s) we are using when updating font selection.

Upon inspection, after selecting new font pairing (Work Sans/Rubik): 

![Screen Shot 2020-05-11 at 4 32 58 PM](https://user-images.githubusercontent.com/28742426/81609904-a3c9ff80-93a6-11ea-9b2d-ccaa6f5f3a02.png)

it is overridden by the initial styles that were set when the editor was loaded:

![Screen Shot 2020-05-11 at 4 33 15 PM](https://user-images.githubusercontent.com/28742426/81609914-a75d8680-93a6-11ea-9fa2-40aa2846fac5.png)

These styles now have higher specificity, so I have added the `.edit-post-visual-editor` class to what we are using when we update the selection.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync or patch this FSE build.
* Visit a sandboxed site with a global styles supporting theme activated (like Maywood)
* Test global styles in the editor and verify they update on selection.

Fixes #42073
