### PR TITLE
Remove Active Tickets Notice AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,15 +124,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	showActiveTicketsNotice: {
-		datestamp: '20200430',
-		variations: {
-			showNotice: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	newSiteGutenbergOnboarding: {
 		datestamp: '20200501',
 		variations: {

--- a/client/me/help/active-tickets-notice/index.jsx
+++ b/client/me/help/active-tickets-notice/index.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  */
 import Notice from 'components/notice';
 import { recordTracksEvent } from 'lib/analytics/tracks';
-import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -25,14 +24,6 @@ class ActiveTicketsNotice extends React.Component {
 	}
 
 	render() {
-		// During AB test, only show the notice to those in the test group. We're
-		// controlling the visibility here, so that we can still mount the component
-		// from the parent which fires the tracks event — we want the event to
-		// fire for both AB groups.
-		if ( abtest( 'showActiveTicketsNotice' ) !== 'showNotice' ) {
-			return null;
-		}
-
 		const { translate, compact, count } = this.props;
 
 		const text = translate(

--- a/client/state/help/ticket/actions.js
+++ b/client/state/help/ticket/actions.js
@@ -9,7 +9,6 @@ import {
 	HELP_TICKET_CONFIGURATION_REQUEST_FAILURE,
 	HELP_TICKET_CONFIGURATION_DISMISS_ERROR,
 } from 'state/action-types';
-import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
 export const ticketSupportConfigurationRequestSuccess = ( configuration ) => {
 	return {
@@ -30,12 +29,7 @@ export const ticketSupportConfigurationRequest = () => ( dispatch ) => {
 		type: HELP_TICKET_CONFIGURATION_REQUEST,
 	};
 
-	dispatch(
-		withAnalytics(
-			recordTracksEvent( 'calypso_ticket_support_configuration_requested' ),
-			requestAction
-		)
-	);
+	dispatch( requestAction );
 
 	return wpcom
 		.undocumented()


### PR DESCRIPTION
Removes the A/B test for Active Tickets Notice (and an associated Tracks event that we no longer need to report on).

We are committing to the `showNotice` variant which performed better than the `control`. Full results and analysis of the test are posted at pbvpgB-lY-p2