### PR TITLE
Gutenboarding: tweak Plans page styling

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -153,7 +153,8 @@
 	padding: 0 24px;
 	height: 40px;
 
-	&.is-selected {
+	&.is-selected,
+	&.is-selected:active {
 		background: var( --studio-black );
 		color: var( --studio-white );
 		border: 0;

--- a/client/landing/gutenboarding/components/titles.scss
+++ b/client/landing/gutenboarding/components/titles.scss
@@ -16,6 +16,7 @@
 	letter-spacing: 0.2px;
 	color: var( --studio-gray-60 );
 	margin-top: 5px;
+	max-width: 550px;
 
 	@include break-small {
 		margin-top: 0;

--- a/client/landing/gutenboarding/onboarding-block/plans/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/plans/index.tsx
@@ -47,7 +47,7 @@ export default function PlansStep() {
 	};
 
 	return (
-		<div className="plans">
+		<div className="gutenboarding-page plans">
 			<PlansGrid
 				confirmButton={
 					<Button


### PR DESCRIPTION
This is just a small PR to add a few styling tweaks to the plans step in Gutenboarding following on from https://github.com/Automattic/wp-calypso/pull/42028:

#### Changes proposed in this Pull Request

* Add `gutenboarding-page` class to the plans step, so that it animates in using the `gutenboarding-page-appear` fade in.
* Set a maximum width for the Gutenboarding sub-title so that the text naturally wraps to look closer to the design. (This is the `Pick a plan that's right for you...` text on the `plans` step, but the change shouldn't adversely affect any other steps)
* Add an `:active` pseudo-class to the selected plans button so that if you click a selected plan, it doesn't make the text black (currently on `master` if you click and hold on a selected plan button, the text will go black).

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/81650076-af83f780-9474-11ea-9576-17ddc01a6384.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally so that you can access the `plans` step
* Go to `/new` and add a domain
* After selecting fonts, click Continue and you'll land on the Plans step
* Note that the Plans step should have animated into view with the `gutenboarding-page-appear` fade in animation
* Check that the sub-title is rendering correctly across two lines
* Select a plan, and then click the selected plan button — its text should still be white

Fixes #
