### PR TITLE
Add basic user home a/a experiment

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -98,8 +98,8 @@ const Home = ( {
 					   */ }
 					{ header }
 				</LoadingVariations>
-				<DefaultVariation name={ 'control' }>{ header }</DefaultVariation>
-				<Variation name={ 'treatment' }>{ header }</Variation>
+				<DefaultVariation name="control">{ header }</DefaultVariation>
+				<Variation name="treatment">{ header }</Variation>
 			</Experiment>
 			{ layout ? (
 				<>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { useTranslate } from 'i18n-calypso';
 import { flowRight } from 'lodash';
@@ -50,14 +50,6 @@ const Home = ( {
 	trackViewSiteAction,
 } ) => {
 	const translate = useTranslate();
-	// use an effect to fire the exposure event only if the site id changes or first view
-	useEffect( () => {
-		if ( canUserUseCustomerHome ) {
-			recordTracksEvent( 'calypso_saw_a_a_test', {
-				siteId,
-			} );
-		}
-	}, [ siteId, canUserUseCustomerHome ] );
 
 	if ( ! canUserUseCustomerHome ) {
 		const title = translate( 'This page is not available on this site.' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are looking to do an alpha test of the experimentation framework. This PR temporarily adds a simple A/A test to user home. It does not change the structure or content of the page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit user home
2. Visit experiments-dev for `user_home_test`
3. See that you're assigned to the default
4. Assign yourself to another variation, see no changes on user home.

pbmo2S-lg-p2