### PR TITLE
i18n: Fix user translations for translations chunks

### DIFF
--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -25,6 +25,7 @@ const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
 
 	reduxStore.dispatch( setLocaleRawData( locale ) );
 
+	let userTranslations;
 	const loadedTranslationChunks = {};
 	const loadTranslationForChunkIfNeeded = ( chunkId ) => {
 		if ( ! translatedChunks.includes( chunkId ) || loadedTranslationChunks[ chunkId ] ) {
@@ -33,7 +34,7 @@ const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
 
 		return getTranslationChunkFile( chunkId, localeSlug, window.BUILD_TARGET ).then(
 			( translations ) => {
-				i18n.addTranslations( translations );
+				i18n.addTranslations( { ...translations, ...userTranslations } );
 				loadedTranslationChunks[ chunkId ] = true;
 			}
 		);
@@ -51,6 +52,14 @@ const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
 
 		promises.push( loadTranslationForChunkIfNeeded( chunkId ) );
 	} );
+
+	const userTranslationsPromise = loadUserUndeployedTranslations( localeSlug );
+
+	if ( userTranslationsPromise ) {
+		userTranslationsPromise.then( ( translations ) => {
+			userTranslations = translations;
+		} );
+	}
 };
 
 export const setupLocale = ( currentUser, reduxStore ) => {

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -63,19 +63,6 @@ const setupTranslationChunks = async ( localeSlug, reduxStore ) => {
 };
 
 export const setupLocale = ( currentUser, reduxStore ) => {
-	if ( window.i18nLocaleStrings ) {
-		// Use the locale translation data that were boostrapped by the server
-		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
-		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
-		const languageSlug = get( i18nLocaleStringsObject, [ '', 'localeSlug' ] );
-		if ( languageSlug ) {
-			loadUserUndeployedTranslations( languageSlug );
-		}
-	} else if ( currentUser && currentUser.localeSlug ) {
-		// Use the current user's and load traslation data with a fetch request
-		reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
-	}
-
 	const useTranslationChunks =
 		config.isEnabled( 'use-translation-chunks' ) ||
 		getUrlParts( document.location.href ).searchParams.has( 'useTranslationChunks' );
@@ -94,6 +81,19 @@ export const setupLocale = ( currentUser, reduxStore ) => {
 		if ( localeSlug && ! isDefaultLocale( localeSlug ) ) {
 			setupTranslationChunks( localeSlug, reduxStore );
 		}
+	}
+
+	if ( window.i18nLocaleStrings ) {
+		// Use the locale translation data that were boostrapped by the server
+		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
+		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
+		const languageSlug = get( i18nLocaleStringsObject, [ '', 'localeSlug' ] );
+		if ( languageSlug ) {
+			loadUserUndeployedTranslations( languageSlug );
+		}
+	} else if ( currentUser && currentUser.localeSlug ) {
+		// Use the current user's and load traslation data with a fetch request
+		reduxStore.dispatch( setLocale( currentUser.localeSlug, currentUser.localeVariant ) );
 	}
 
 	// If user is logged out and translations are not boostrapped, we assume default locale

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -277,7 +277,11 @@ export default function switchLocale( localeSlug ) {
 		// the manifest and all installed translation chunks for
 		// the requested locale
 		getLanguageManifestFile( localeSlug, window.BUILD_TARGET )
-			.then( ( { translatedChunks, locale } ) => {
+			.then( ( { translatedChunks, locale } = {} ) => {
+				if ( ! locale ) {
+					return;
+				}
+
 				const installedChunks = new Set(
 					( window.installedChunks || [] )
 						.concat( window.__requireChunkCallback__.getInstalledChunks() )
@@ -290,6 +294,10 @@ export default function switchLocale( localeSlug ) {
 				return Promise.all( [ Promise.resolve( locale ), ...chunksPromises ] );
 			} )
 			.then( ( localeArray ) => {
+				if ( ! localeArray ) {
+					return;
+				}
+
 				const body = localeArray.reduce( ( acc, item ) => ( { ...acc, ...item } ), {} );
 
 				i18n.setLocale( body );

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -382,7 +382,7 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 		.then( ( translations ) => {
 			i18n.addTranslations( translations );
 
-			return { translations };
+			return translations;
 		} );
 }
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -360,17 +360,17 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 		'export-translations',
 	].join( '/' );
 
-	const query = {
+	const searchParams = new URLSearchParams( {
 		'filters[user_login]': username,
 		'filters[status]': translationStatus,
 		format: 'json',
-	};
+	} );
 
 	const requestUrl = getUrlFromParts( {
 		protocol: 'https:',
 		host: 'translate.wordpress.com',
 		pathname,
-		query,
+		searchParams,
 	} );
 
 	return window
@@ -379,7 +379,11 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 			credentials: 'include',
 		} )
 		.then( ( res ) => res.json() )
-		.then( ( translations ) => i18n.addTranslations( translations ) );
+		.then( ( translations ) => {
+			i18n.addTranslations( translations );
+
+			return { translations };
+		} );
 }
 
 /*


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes undeployed user translations for translation chunks.

User translations are fetched during the initial translation chunks setup and won't be overwritten by chunks that are fetched and loaded at later point.

#### Testing instructions

1. Boot Calypso with `BUILD_TRANSLATION_CHUNKS=true ENABLE_FEATURES=use-translation-chunks yarn start`
2. Open http://calypso.localhost:3000/?load-user-translations={USERNAME}
3. Confirm that user translations are loaded properly
