### PR TITLE
Add translation comments for download/restore failures

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/download.tsx
@@ -169,6 +169,7 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 			<h3 className="rewind-flow__title error">
 				{ translate( 'Download failed: %s', {
 					args: [ backupDisplayDate ],
+					comment: '%s is a time/date string',
 				} ) }
 			</h3>
 			<p className="rewind-flow__info">

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/restore.tsx
@@ -177,6 +177,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 			<h3 className="rewind-flow__title error">
 				{ translate( 'Restore failed: %s', {
 					args: [ backupDisplayDate ],
+					comment: '%s is a time/date string',
 				} ) }
 			</h3>
 			<p className="rewind-flow__info">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I got some warnings from @a8ci18n that translations for download and restore failures didn't have clarifying comments, so I'm adding those here.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* No expected changes to behavior. Do tests pass? Does everything still work in the UI?
