### PR TITLE
Gutenboarding: Add new tracking events

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-button/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-button/index.tsx
@@ -52,7 +52,7 @@ const PlansButton: React.FunctionComponent< Button.ButtonProps > = ( { ...button
 				{ isDesktop && planLabel }
 				<JetpackLogo className="plans-button__jetpack-logo" size={ 16 } monochrome />
 			</Button>
-			<PlansModal isOpen={ isPlansModalVisible } onClose={ () => setIsPlanModalVisible( false ) } />
+			{ isPlansModalVisible && <PlansModal onClose={ () => setIsPlanModalVisible( false ) } /> }
 		</>
 	);
 };

--- a/client/landing/gutenboarding/components/plans/plans-modal/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-modal/index.tsx
@@ -10,6 +10,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import PlansGrid, { Props as PlansGridProps } from '../plans-grid';
+import { useTrackModal } from '../../../hooks/use-track-modal';
+import { useSelectedPlan } from '../../../hooks/use-selected-plan';
 
 /**
  * Style dependencies
@@ -17,21 +19,32 @@ import PlansGrid, { Props as PlansGridProps } from '../plans-grid';
 import './style.scss';
 
 interface Props extends Partial< PlansGridProps > {
-	isOpen: boolean;
 	onClose: () => void;
 }
 
-const PlansGridModal: React.FunctionComponent< Props > = ( { isOpen, onClose } ) => {
+const PlansGridModal: React.FunctionComponent< Props > = ( { onClose } ) => {
 	// This is needed otherwise it throws a warning.
 	Modal.setAppElement( '#wpcom' );
 
+	const plan = useSelectedPlan();
+
 	React.useEffect( () => {
 		setTimeout( () => window.scrollTo( 0, 0 ), 0 );
-	}, [ isOpen ] );
+	}, [] );
+
+	// Keep a copy of the selected plan locally so it's available when the component is unmounting
+	const selectedPlanRef = React.useRef();
+	React.useEffect( () => {
+		selectedPlanRef.current = plan?.getStoreSlug();
+	}, [ plan ] );
+
+	useTrackModal( 'PlansGrid', () => ( {
+		selected_plan: selectedPlanRef.current,
+	} ) );
 
 	return (
 		<Modal
-			isOpen={ isOpen }
+			isOpen
 			className="gutenboarding-page plans-modal"
 			overlayClassName="plans-modal-overlay"
 			bodyOpenClassName="has-plans-modal"

--- a/client/landing/gutenboarding/hooks/use-selected-plan.ts
+++ b/client/landing/gutenboarding/hooks/use-selected-plan.ts
@@ -1,5 +1,5 @@
 /**
- * Externall dependencies
+ * External dependencies
  */
 import { useSelect } from '@wordpress/data';
 

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -184,11 +184,11 @@ export function recordVerticalSelection( slug?: string, label?: string ) {
 /**
  * Records entering a site title in tracks
  *
- * @param siteTitle The site title entered by the user
+ * @param hasValue The site title entered by the user is not empty
  */
-export function recordSiteTitleSelection( siteTitle?: string ) {
+export function recordSiteTitleSelection( hasValue: boolean ) {
 	trackEventWithFlow( 'calypso_newsite_site_title_selected', {
-		selected_site_title: siteTitle,
+		has_selected_site_title: hasValue,
 	} );
 }
 

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -8,8 +8,8 @@ import { v4 as uuid } from 'uuid';
  * Internal dependencies
  */
 import { FLOW_ID } from '../../constants';
-import { StepNameType } from '../../path';
-import { ErrorParameters, OnboardingCompleteParameters, TracksEventProperties } from './types';
+import type { StepNameType } from '../../path';
+import type { ErrorParameters, OnboardingCompleteParameters, TracksEventProperties } from './types';
 
 /**
  * Make tracks call with embedded flow.
@@ -165,5 +165,29 @@ export function recordLeaveStep( stepName: StepNameType, eventProperties?: Track
 export function recordEnterStep( stepName: StepNameType ) {
 	trackEventWithFlow( 'calypso_newsite_step_enter', {
 		step: stepName,
+	} );
+}
+
+/**
+ * Records selecting a vertical in tracks
+ *
+ * @param verticalLabel The slug of the selected vertical or the free-form user input
+ * @param isFreeForm User entered and selected a free-form text
+ */
+export function recordVerticalSelection( verticalLabel?: string, isFreeForm = false ) {
+	trackEventWithFlow( 'calypso_newsite_vertical_selected', {
+		selected_vertical: verticalLabel,
+		free_form: isFreeForm,
+	} );
+}
+
+/**
+ * Records entering a site title in tracks
+ *
+ * @param siteTitle The site title entered by the user
+ */
+export function recordSiteTitleSelection( siteTitle?: string ) {
+	trackEventWithFlow( 'calypso_newsite_site_title_selected', {
+		selected_site_title: siteTitle,
 	} );
 }

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -169,9 +169,9 @@ export function recordEnterStep( stepName: StepNameType ) {
 }
 
 /**
- * Records selecting a vertical in tracks
+ * Records selecting a site topic in tracks
  *
- * @param verticalLabel The slug of the selected vertical or the free-form user input
+ * @param verticalLabel The slug of the selected topic or the free-form user input
  * @param isFreeForm User entered and selected a free-form text
  */
 export function recordVerticalSelection( verticalLabel?: string, isFreeForm = false ) {
@@ -190,4 +190,18 @@ export function recordSiteTitleSelection( siteTitle?: string ) {
 	trackEventWithFlow( 'calypso_newsite_site_title_selected', {
 		selected_site_title: siteTitle,
 	} );
+}
+
+/**
+ * Records site topic input skip on Intent Gathering step
+ */
+export function recordVerticalSkip() {
+	trackEventWithFlow( 'calypso_newsite_vertical_skipped' );
+}
+
+/**
+ * Records site title input skip on Intent Gathering step
+ */
+export function recordSiteTitleSkip() {
+	trackEventWithFlow( 'calypso_newsite_site_title_skipped' );
 }

--- a/client/landing/gutenboarding/lib/analytics/index.ts
+++ b/client/landing/gutenboarding/lib/analytics/index.ts
@@ -171,13 +171,13 @@ export function recordEnterStep( stepName: StepNameType ) {
 /**
  * Records selecting a site topic in tracks
  *
- * @param verticalLabel The slug of the selected topic or the free-form user input
- * @param isFreeForm User entered and selected a free-form text
+ * @param slug The slug of the selected topic. If undefined, the vertical input is free-form
+ * @param label Translated label of vertical or free-form user input
  */
-export function recordVerticalSelection( verticalLabel?: string, isFreeForm = false ) {
+export function recordVerticalSelection( slug?: string, label?: string ) {
 	trackEventWithFlow( 'calypso_newsite_vertical_selected', {
-		selected_vertical: verticalLabel,
-		free_form: isFreeForm,
+		selected_vertical_slug: slug,
+		selected_vertical_label: label,
 	} );
 }
 

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -45,9 +45,9 @@ export type TracksAcquireIntentEventProperties = {
 	selected_vertical_label: string | undefined;
 
 	/**
-	 * The site title that was selected on the acquire intent page
+	 * Whether site title has been entered on the acquire intent page
 	 */
-	selected_site_title: string | undefined;
+	has_selected_site_title: boolean;
 };
 
 type TracksStyleSelectEventProperties = {

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -33,14 +33,14 @@ export interface OnboardingCompleteParameters {
 	blogId: number | string | undefined;
 }
 
-type TracksVerticalSelectEventProperties = {
+export type TracksAcquireIntentEventProperties = {
 	/**
-	 * The Vertical selected on the intent gathering page
+	 * The slug of the selected vertical or the free-form user input on the acquire intent page
 	 */
 	selected_vertical: string | undefined;
 
 	/**
-	 * The site title that was selected on the intent gathering page
+	 * The site title that was selected on the acquire intent page
 	 */
 	selected_site_title: string | undefined;
 };
@@ -79,7 +79,7 @@ type TracksPlanSelectEventProperties = {
 };
 
 export type TracksEventProperties =
-	| TracksVerticalSelectEventProperties
+	| TracksAcquireIntentEventProperties
 	| TracksStyleSelectEventProperties
 	| TracksDesignSelectEventProperties
 	| TracksDomainSelectEventProperties

--- a/client/landing/gutenboarding/lib/analytics/types.ts
+++ b/client/landing/gutenboarding/lib/analytics/types.ts
@@ -35,9 +35,14 @@ export interface OnboardingCompleteParameters {
 
 export type TracksAcquireIntentEventProperties = {
 	/**
-	 * The slug of the selected vertical or the free-form user input on the acquire intent page
+	 * The slug of the selected vertical or undefined if the vertical is free-form user input
 	 */
-	selected_vertical: string | undefined;
+	selected_vertical_slug: string | undefined;
+
+	/**
+	 * Translated label of vertical or free-form user input
+	 */
+	selected_vertical_label: string | undefined;
 
 	/**
 	 * The site title that was selected on the acquire intent page

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -45,7 +45,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 	useTrackStep( 'IntentGathering', () => ( {
 		selected_vertical_slug: getSelectedVertical()?.slug,
 		selected_vertical_label: getSelectedVertical()?.label,
-		selected_site_title: getSelectedSiteTitle(),
+		has_selected_site_title: !! getSelectedSiteTitle(),
 	} ) );
 
 	const hasSiteTitle = !! getSelectedSiteTitle();

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -26,13 +26,12 @@ import './style.scss';
 
 const AcquireIntent: React.FunctionComponent = () => {
 	const { __ } = useI18n();
-	const { getSelectedVertical, getSelectedSiteTitle } = useSelect( ( select ) =>
-		select( STORE_KEY )
-	);
-
-	const { siteVertical, siteTitle, wasVerticalSkipped } = useSelect( ( select ) =>
-		select( STORE_KEY ).getState()
-	);
+	const {
+		getSelectedVertical,
+		getSelectedVerticalUntranslatedLabel,
+		getSelectedSiteTitle,
+		wasVerticalSkipped,
+	} = useSelect( ( select ) => select( STORE_KEY ) );
 
 	const { skipSiteVertical } = useDispatch( STORE_KEY );
 
@@ -48,20 +47,20 @@ const AcquireIntent: React.FunctionComponent = () => {
 	};
 
 	useTrackStep( 'IntentGathering', () => ( {
-		selected_vertical: getSelectedVertical()?.slug,
+		selected_vertical: getSelectedVerticalUntranslatedLabel(),
 		selected_site_title: getSelectedSiteTitle(),
 	} ) );
 
+	const showSiteTitleAndNext = !! (
+		getSelectedVertical() ||
+		getSelectedSiteTitle() ||
+		wasVerticalSkipped()
+	);
 	// translators: Button label for skipping filling an optional input in onboarding
 	const skipLabel = __( 'I donʼt know' );
 
 	// declare UI elements here to avoid duplication when returning for mobile/desktop layouts
-	const siteTitleInput = (
-		<SiteTitle
-			isVisible={ !! ( siteVertical || siteTitle || wasVerticalSkipped ) }
-			isMobile={ isMobile }
-		/>
-	);
+	const siteTitleInput = <SiteTitle isVisible={ showSiteTitleAndNext } isMobile={ isMobile } />;
 	const verticalSelect = <VerticalSelect onNext={ () => setIsSiteTitleActive( true ) } />;
 	const nextStepButton = (
 		<Link
@@ -69,7 +68,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 			isPrimary
 			to={ makePath( Step.DesignSelection ) }
 		>
-			{ siteTitle ? __( 'Choose a design' ) : skipLabel }
+			{ getSelectedSiteTitle() ? __( 'Choose a design' ) : skipLabel }
 		</Link>
 	);
 	const skipButton = (
@@ -77,6 +76,8 @@ const AcquireIntent: React.FunctionComponent = () => {
 			{ skipLabel }
 		</Button>
 	);
+
+	const siteVertical = getSelectedVertical();
 
 	return (
 		<div
@@ -110,10 +111,9 @@ const AcquireIntent: React.FunctionComponent = () => {
 						? nextStepButton
 						: ( ! siteVertical || siteVertical?.label?.length < 3 ) && skipButton ) }
 
-				{ /* On desktop we render skipButton when vertical and site title inputs are empty and the user didn't skipped vertical selection.
-				For other cases we always render nextStepButton */ }
-				{ ! isMobile &&
-					( siteVertical || siteTitle || wasVerticalSkipped ? nextStepButton : skipButton ) }
+				{ /* On desktop we always render nextStepButton when we render site title
+				Otherwise we render skipButton  */ }
+				{ ! isMobile && ( showSiteTitleAndNext ? nextStepButton : skipButton ) }
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -28,12 +28,9 @@ import './style.scss';
 
 const AcquireIntent: React.FunctionComponent = () => {
 	const { __ } = useI18n();
-	const {
-		getSelectedVertical,
-		getSelectedVerticalUntranslatedLabel,
-		getSelectedSiteTitle,
-		wasVerticalSkipped,
-	} = useSelect( ( select ) => select( STORE_KEY ) );
+	const { getSelectedVertical, getSelectedSiteTitle, wasVerticalSkipped } = useSelect( ( select ) =>
+		select( STORE_KEY )
+	);
 
 	const { skipSiteVertical } = useDispatch( STORE_KEY );
 
@@ -46,7 +43,8 @@ const AcquireIntent: React.FunctionComponent = () => {
 	const isMobile = useViewportMatch( 'small', '<' );
 
 	useTrackStep( 'IntentGathering', () => ( {
-		selected_vertical: getSelectedVerticalUntranslatedLabel(),
+		selected_vertical_slug: getSelectedVertical()?.slug,
+		selected_vertical_label: getSelectedVertical()?.label,
 		selected_site_title: getSelectedSiteTitle(),
 	} ) );
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -14,6 +14,7 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import { STORE_KEY } from '../../stores/onboard';
 import { Step, usePath } from '../../path';
+import { recordSiteTitleSelection } from '../../lib/analytics';
 
 interface Props {
 	isVisible?: boolean;
@@ -34,12 +35,17 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile } ) 
 		if ( e.keyCode === ENTER ) {
 			// As last input on first step, hitting 'Enter' should direct to next step.
 			e.preventDefault();
+			recordSiteTitleSelection( siteTitle );
 			history.push( makePath( Step.DesignSelection ) );
 		}
 	};
 
 	const handleKeyUp = ( e: React.KeyboardEvent< HTMLSpanElement > ) =>
 		setSiteTitle( e.currentTarget.innerText.trim().length ? e.currentTarget.innerText : '' );
+
+	const handleBlur = () => {
+		recordSiteTitleSelection( siteTitle );
+	};
 
 	React.useEffect( () => {
 		if ( siteTitle ) {
@@ -74,6 +80,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile } ) 
 						className="madlib__input"
 						onKeyDown={ handleKeyDown }
 						onKeyUp={ handleKeyUp }
+						onBlur={ handleBlur }
 					/>
 					<span className="site-title__placeholder"></span>
 				</span>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as React from 'react';
-import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
@@ -13,30 +12,27 @@ import { useI18n } from '@automattic/react-i18n';
  * Internal dependencies
  */
 import { STORE_KEY } from '../../stores/onboard';
-import { Step, usePath } from '../../path';
 import { recordSiteTitleSelection } from '../../lib/analytics';
 
 interface Props {
 	isVisible?: boolean;
 	isMobile?: boolean; // needed as a prop to be defined when component mounts
+	onSubmit: () => void;
 }
 
-const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile } ) => {
+const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onSubmit } ) => {
 	const { __ } = useI18n();
 	const { siteTitle, siteVertical, wasVerticalSkipped } = useSelect( ( select ) =>
 		select( STORE_KEY ).getState()
 	);
 	const { setSiteTitle } = useDispatch( STORE_KEY );
-	const history = useHistory();
-	const makePath = usePath();
 	const inputRef = React.useRef< HTMLSpanElement >( document.createElement( 'span' ) );
 
 	const handleKeyDown = ( e: React.KeyboardEvent< HTMLSpanElement > ) => {
 		if ( e.keyCode === ENTER ) {
 			// As last input on first step, hitting 'Enter' should direct to next step.
 			e.preventDefault();
-			recordSiteTitleSelection( siteTitle );
-			history.push( makePath( Step.DesignSelection ) );
+			onSubmit();
 		}
 	};
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/site-title.tsx
@@ -40,7 +40,7 @@ const SiteTitle: React.FunctionComponent< Props > = ( { isVisible, isMobile, onS
 		setSiteTitle( e.currentTarget.innerText.trim().length ? e.currentTarget.innerText : '' );
 
 	const handleBlur = () => {
-		recordSiteTitleSelection( siteTitle );
+		recordSiteTitleSelection( !! siteTitle );
 	};
 
 	React.useEffect( () => {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -99,7 +99,7 @@
 	border-radius: 4px;
 	box-shadow: none;
 	color: var( --contrastColor );
-	font-size: 14px;
+	@include onboarding-medium-text;
 	// stylelint-disable-next-line scales/font-weight
 	font-weight: 500;
 	letter-spacing: 0;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -62,9 +62,6 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 	);
 
 	const { siteVertical, siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
-	const { getSelectedVerticalUntranslatedLabel } = useSelect( ( select ) =>
-		select( ONBOARD_STORE )
-	);
 	const { setSiteVertical, resetSiteVertical } = useDispatch( ONBOARD_STORE );
 	const isMobile = useViewportMatch( 'small', '<' );
 
@@ -187,10 +184,10 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	React.useEffect( () => {
-		inputRef.current.innerText = siteVertical?.label || '';
-		const isFreeForm = ! siteVertical?.slug && !! siteVertical?.label.length;
-		recordVerticalSelection( getSelectedVerticalUntranslatedLabel(), isFreeForm );
-	}, [ siteVertical, inputRef, getSelectedVerticalUntranslatedLabel ] );
+		const { slug, label } = siteVertical || {};
+		inputRef.current.innerText = label || '';
+		recordVerticalSelection( slug, label );
+	}, [ siteVertical, inputRef ] );
 
 	React.useEffect( () => {
 		if ( !! suggestions.length && isMobile ) {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -16,9 +16,10 @@ import { useI18n } from '@automattic/react-i18n';
  */
 import { STORE_KEY as ONBOARD_STORE } from '../../../stores/onboard';
 import { Verticals } from '@automattic/data-stores';
-import { SiteVertical } from '../../../stores/onboard/types';
 import useTyper from '../../../hooks/use-typer';
 import Arrow from '../arrow';
+import { recordVerticalSelection } from '../../../lib/analytics';
+import type { SiteVertical } from '../../../stores/onboard/types';
 
 /**
  * Style dependencies
@@ -61,6 +62,9 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 	);
 
 	const { siteVertical, siteTitle } = useSelect( ( select ) => select( ONBOARD_STORE ).getState() );
+	const { getSelectedVerticalUntranslatedLabel } = useSelect( ( select ) =>
+		select( ONBOARD_STORE )
+	);
 	const { setSiteVertical, resetSiteVertical } = useDispatch( ONBOARD_STORE );
 	const isMobile = useViewportMatch( 'small', '<' );
 
@@ -184,7 +188,9 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 
 	React.useEffect( () => {
 		inputRef.current.innerText = siteVertical?.label || '';
-	}, [ siteVertical, inputRef ] );
+		const isFreeForm = ! siteVertical?.slug && !! siteVertical?.label.length;
+		recordVerticalSelection( getSelectedVerticalUntranslatedLabel(), isFreeForm );
+	}, [ siteVertical, inputRef ] ); //eslint-disable-line react-hooks/exhaustive-deps
 
 	React.useEffect( () => {
 		if ( !! suggestions.length && isMobile ) {

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -190,7 +190,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		inputRef.current.innerText = siteVertical?.label || '';
 		const isFreeForm = ! siteVertical?.slug && !! siteVertical?.label.length;
 		recordVerticalSelection( getSelectedVerticalUntranslatedLabel(), isFreeForm );
-	}, [ siteVertical, inputRef ] ); //eslint-disable-line react-hooks/exhaustive-deps
+	}, [ siteVertical, inputRef, getSelectedVerticalUntranslatedLabel ] );
 
 	React.useEffect( () => {
 		if ( !! suggestions.length && isMobile ) {

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -17,3 +17,6 @@ export const getSelectedFonts = ( state: State ) => state.selectedFonts;
 export const getSelectedVertical = ( state: State ) => state.siteVertical;
 export const getSelectedDomain = ( state: State ) => state.domain;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
+export const wasVerticalSkipped = ( state: State ): boolean => state.wasVerticalSkipped;
+export const getSelectedVerticalUntranslatedLabel = ( state: State ) =>
+	state.siteVertical?.slug || state.siteVertical?.label;

--- a/client/landing/gutenboarding/stores/onboard/selectors.ts
+++ b/client/landing/gutenboarding/stores/onboard/selectors.ts
@@ -18,5 +18,3 @@ export const getSelectedVertical = ( state: State ) => state.siteVertical;
 export const getSelectedDomain = ( state: State ) => state.domain;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const wasVerticalSkipped = ( state: State ): boolean => state.wasVerticalSkipped;
-export const getSelectedVerticalUntranslatedLabel = ( state: State ) =>
-	state.siteVertical?.slug || state.siteVertical?.label;

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import page from 'page';
 import { isEmpty } from 'lodash';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 /**
  * Internal Dependencies
@@ -38,6 +39,7 @@ import { abtest } from 'lib/abtest';
  * Constants
  */
 const basePageTitle = 'Signup'; // used for analytics, doesn't require translation
+const gutenboardingFlowID = 'gutenboarding'; // used for analytics of the /new onboarding flow
 
 /**
  * Module variables
@@ -59,6 +61,7 @@ export default {
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
 					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
+						recordTracksEvent( 'calypso_newsite_init', { flow: gutenboardingFlowID } );
 						window.location = window.location.origin + '/new';
 					} else {
 						removeWhiteBackground();

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -39,7 +39,6 @@ import { abtest } from 'lib/abtest';
  * Constants
  */
 const basePageTitle = 'Signup'; // used for analytics, doesn't require translation
-const gutenboardingFlowID = 'gutenboarding'; // used for analytics of the /new onboarding flow
 
 /**
  * Module variables
@@ -61,7 +60,7 @@ export default {
 				.then( ( { geo } ) => {
 					const countryCode = geo.data.body.country_short;
 					if ( 'gutenberg' === abtest( 'newSiteGutenbergOnboarding', countryCode ) ) {
-						recordTracksEvent( 'calypso_newsite_init', { flow: gutenboardingFlowID } );
+						recordTracksEvent( 'calypso_newsite_init' );
 						window.location = window.location.origin + '/new';
 					} else {
 						removeWhiteBackground();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add tracking for vertical input when moving the focus out of the field or selecting a vertical.
  - `selected_vertical_slug` - The slug of the selected topic, defined only when the vertical is not free-form user input.
  - `selected_vertical_label` - Translated label of vertical or free-form user input.
* Add tracking for site title input when moving the focus out of the field.
  - `has_selected_site_title` - Whether site title has been entered on the acquire intent page.
* Add tracking for skipped vertical or site title inputs.
* Update `calypso_newsite_step_leave` event for IntentGathering step:
  * add `selected_vertical_label` prop which can be free-form user input.
  * change `selected_vertical` prop to `selected_vertical_slug` recording the same value as before
  * change `selected_site_title` prop to `has_selected_site_title` recording if a site title has been entered or not.
* Add tracking to PlansModal (open and closed with selected plan).
* Add tracking to signup controller to record the `calypso_newsite_init` before redirecting users to Gutenboarding.

#### Testing instructions

* The `calypso_newsite_vertical_selected` event should be fired when moving the focus off the vertical input that has a value (tabbing, clicking away, pressing enter or selecting a vertical) or when clearing the input.
* The `calypso_newsite_site_title_selected` event should be fired when moving the focus off the site title input (tabbing, clicking away).
* The `calypso_newsite_vertical_skipped` event should be fired when pressing grey _I donʼt know_ link below it.
* The `calypso_newsite_site_title_skipped` event should be fired when pressing blue _I donʼt know_ button or pressing Enter when focused on empty Site Title input to advance to Design Picker step.
* When advancing to Design Picker step, the `calypso_newsite_step_leave` event should should fire with props `{flow: "gutenboarding", name: "IntentGathering", selected_vertical_slug: string | undefined, selected_vertical_label: string | undefined, has_selected_site_title: boolean}`
* The `calypso_newsite_modal_open` event should fire with props `{flow: "gutenboarding", name: "PlansGrid"}` when clicking the Plans Button.
* The `calypso_newsite_modal_close` event should fire with props `{flow: "gutenboarding", name: "PlansGrid", selected_plan: "free_plan"}` when closing the Plans modal having the last selected plan slug instead of `"free_plan"`.
* The `calypso_newsite_init` event should fire when [A/B test condition](https://github.com/Automattic/wp-calypso/blob/master/client/signup/controller.js#L61) is `true`, before redirecting user to `/new`.

Related to: #41059 
