### PR TITLE
Jetpack Cloud: display the filter section only if there are threats to show

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -114,14 +114,16 @@ const ScanHistoryPage = ( {
 					'The scanning history contains a record of all previously active threats on your site.'
 				) }
 			</p>
-			<div className="history__filters-wrapper">
-				<SimplifiedSegmentedControl
-					className="history__filters"
-					options={ filterOptions }
-					onSelect={ handleOnFilterChange }
-					initialSelected={ currentFilter.value }
-				/>
-			</div>
+			{ filteredEntries.length > 0 && (
+				<div className="history__filters-wrapper">
+					<SimplifiedSegmentedControl
+						className="history__filters"
+						options={ filterOptions }
+						onSelect={ handleOnFilterChange }
+						initialSelected={ currentFilter.value }
+					/>
+				</div>
+			) }
 			<div className="history__entries">
 				{ filteredEntries.map( ( threat ) => (
 					<ThreatItem

--- a/client/landing/jetpack-cloud/sections/scan/history/index.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/history/index.jsx
@@ -36,6 +36,18 @@ const filterOptions = [
 	{ value: 'ignored', label: 'Ignored' },
 ];
 
+const ThreatStatusFilter = ( { isPlaceholder, onSelect } ) => {
+	return isPlaceholder ? (
+		<div className="history__filters is-placeholder"></div>
+	) : (
+		<SimplifiedSegmentedControl
+			className="history__filters"
+			options={ filterOptions }
+			onSelect={ onSelect }
+		/>
+	);
+};
+
 const ScanHistoryPage = ( {
 	siteId,
 	siteName,
@@ -116,11 +128,9 @@ const ScanHistoryPage = ( {
 			</p>
 			{ filteredEntries.length > 0 && (
 				<div className="history__filters-wrapper">
-					<SimplifiedSegmentedControl
-						className="history__filters"
-						options={ filterOptions }
+					<ThreatStatusFilter
+						isPlaceholder={ isRequestingHistory }
 						onSelect={ handleOnFilterChange }
-						initialSelected={ currentFilter.value }
 					/>
 				</div>
 			) }

--- a/client/landing/jetpack-cloud/sections/scan/history/style.scss
+++ b/client/landing/jetpack-cloud/sections/scan/history/style.scss
@@ -16,6 +16,13 @@
 		text-align: center;
 	}
 
+	&__filters.is-placeholder {
+		@include placeholder( --color-neutral-10 );
+		height: 36px;
+		width: 175px;
+		border-radius: 4px;
+	}
+
 	&__filters {
 		margin: 8px 0 24px;
 		display: inline-flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the filter section when there are no threats to show in Scan -> History.

#### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/`
* Go to Scan and select a site that **doesn't have** threats that have been fixed or ignored
* Verify the filter section doesn't show up
* Go to Scan and select a site that **has** at least one threat that has been fixed or ignored
* Verify the filter section does show up

#### Demo

##### With threats
![image](https://user-images.githubusercontent.com/3418513/81705774-c7905280-9445-11ea-8a41-890068665e15.png)

##### Without threats
![image](https://user-images.githubusercontent.com/3418513/81705829-d70f9b80-9445-11ea-81f2-0d01429676a8.png)

