### PR TITLE
Jetpack Cloud: put the site name between double quotes and make it part of the sentence

### DIFF
--- a/client/landing/jetpack-cloud/components/threat-dialog/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-dialog/index.tsx
@@ -73,7 +73,7 @@ class ThreatDialog extends React.PureComponent< Props > {
 						{ action === 'fix'
 							? getThreatFix( threat.fixable )
 							: translate(
-									'You shouldn’t ignore a security unless you are absolute sure it’s harmless. If you choose to ignore this threat, it will remain on your site: {{strong}}%s{{/strong}}.',
+									'You shouldn’t ignore a security unless you are absolute sure it’s harmless. If you choose to ignore this threat, it will remain on your site "{{strong}}%s{{/strong}}".',
 									{
 										args: [ siteName ],
 										components: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the site name don't look isolated by removing the `:` and surrounding it with double quotes.

#### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/`
* Select a site that has Scan and at least one threat
* Go to Scan -> Scanner
* Open the threat card and click the `[Ignore threat]` button
* Verify the name of the site appears between double quotes
* Verify the `:` is no longer present in the sentence

#### Before
<img width="681" alt="IgnoreModalSiteNameBefore" src="https://user-images.githubusercontent.com/3418513/81707615-273b2d80-9447-11ea-8dec-a4a456ed70ab.png">

#### After
![image](https://user-images.githubusercontent.com/3418513/81707556-1d192f00-9447-11ea-86f1-abea7749051d.png)

