### PR TITLE
Fix: unexpected .blog subdomain suggestions

### DIFF
--- a/client/signup/config/dotblog-verticals.js
+++ b/client/signup/config/dotblog-verticals.js
@@ -1,0 +1,41 @@
+/**
+ * Verticals related to dotblog subdomains
+ */
+export const verticalsMap = {
+	art: 'p60',
+	poetry: 'p311',
+	movie: 'p274a1',
+	music: 'p275',
+	car: 'p99',
+	business: 'p94',
+	school: 'p3v1',
+	family: 'p160',
+	health: 'p201',
+	fitness: 'p172a1',
+	food: 'p23',
+	photo: 'p29',
+	game: 'p185',
+	home: 'p25',
+	law: 'p238',
+	politics: 'p313',
+	news: 'p281',
+	finance: 'p172',
+	science: 'p348',
+	sport: 'p371',
+	fashion: 'p19',
+	tech: 'p383',
+	code: 'p108a1',
+	video: 'p399',
+	travel: 'p34',
+};
+
+/**
+ * Find the vertical id with the dotblog subdomain name
+ *
+ * @param {string} subdomainName Dotblog subdomain excluding `.blog`. i.e. tech
+ * @returns {string} vertical ID if exist. Otherwise, empty string
+ */
+export const getDotBlogVerticalId = ( subdomainName ) => {
+	const lowercased = String( subdomainName || '' ).toLowerCase();
+	return verticalsMap[ lowercased ] || '';
+};

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -39,6 +39,7 @@ import { setSiteType } from 'state/signup/steps/site-type/actions';
 import { login } from 'lib/paths';
 import { waitForData } from 'state/data-layer/http-data';
 import { requestGeoLocation } from 'state/data-getters';
+import { getDotBlogVerticalId } from './config/dotblog-verticals';
 import { abtest } from 'lib/abtest';
 
 /**
@@ -226,8 +227,7 @@ export default {
 		if ( ( ! verticalId || ! verticalIsUserInput ) && query.vertical ) {
 			signupStore.dispatch(
 				setSiteVertical( {
-					id: query.vertical,
-					slug: query.vertical,
+					id: getDotBlogVerticalId( query.vertical ) || query.vertical,
 					isUserInput: false,
 				} )
 			);

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -29,6 +29,13 @@ import { setCurrentFlowName } from 'state/signup/flow/actions';
 import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
 import { getCurrentFlowName } from 'state/signup/flow/selectors';
+import {
+	getSiteVerticalId,
+	getSiteVerticalIsUserInput,
+} from 'state/signup/steps/site-vertical/selectors';
+import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { setSiteType } from 'state/signup/steps/site-type/actions';
 import { login } from 'lib/paths';
 import { waitForData } from 'state/data-layer/http-data';
 import { requestGeoLocation } from 'state/data-getters';
@@ -203,6 +210,28 @@ export default {
 			stepComponent,
 			pageTitle: getFlowPageTitle( flowName ),
 		} );
+
+		next();
+	},
+	importSiteInfoFromQuery( { store: signupStore, query }, next ) {
+		const state = signupStore.getState();
+		const verticalId = getSiteVerticalId( state );
+		const verticalIsUserInput = getSiteVerticalIsUserInput( state );
+		const siteType = getSiteType( state );
+
+		if ( ! siteType && query.site_type ) {
+			signupStore.dispatch( setSiteType( query.site_type ) );
+		}
+
+		if ( ( ! verticalId || ! verticalIsUserInput ) && query.vertical ) {
+			signupStore.dispatch(
+				setSiteVertical( {
+					id: query.vertical,
+					slug: query.vertical,
+					isUserInput: false,
+				} )
+			);
+		}
 
 		next();
 	},

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -25,6 +25,7 @@ export default function () {
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,
 		controller.start,
+		controller.importSiteInfoFromQuery,
 		makeLayout,
 		clientRender
 	);

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -379,7 +379,7 @@ class DomainsStep extends React.Component {
 	};
 
 	shouldIncludeDotBlogSubdomain() {
-		const { flowName, isDomainOnly, siteGoals, signupDependencies } = this.props;
+		const { flowName, isDomainOnly, siteType, siteGoals, signupDependencies } = this.props;
 		const siteGoalsArray = siteGoals ? siteGoals.split( ',' ) : [];
 
 		// 'subdomain' flow coming from .blog landing pages
@@ -402,7 +402,8 @@ class DomainsStep extends React.Component {
 			// All flows where 'about' step is before 'domains' step, user picked only 'share' on the `about` step
 			( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 ) ||
 			// Users choose `Blog` as their site type
-			'blog' === get( signupDependencies, 'siteType' )
+			'blog' === get( signupDependencies, 'siteType' ) ||
+			'blog' === siteType
 		) {
 			return true;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the bug that `.blog` domain suggestions show unexpected results when originating signup from .blog landing pages.
* To resolve the issue #41110, both front-end and back-end of the domain suggestions should change. This PR is the front-end part.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit any .blog landing page such as https://tech.blog and click the start button.
  * ...or just try `https://wordpress.com/start?site_type=blog&vertical=[VERTICAL]&ref=dotblog-landing`. You should replace `[VERTICAL]` with a valid vertical such as `art` and `tech`.
* Open Network Panel in your browser and filter _XHR_ requests.
* Try searching any domain name.
* Make sure the last request for `suggestions` contains proper parameters.
  * Both `include_dotblogsubdomain` and `only_wordpressdotcom` should be true.
  * `vertical` should indicate what .blog landing page originated signup. It should be `art` if the LP is https://art.blog/
* The domain suggestions may not show expected results unless you applied the server-side fix( D43443-code ) to your sandboxed `public-api.wordpress.com`.
  <img width="889" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/81711583-c6dfd680-94ae-11ea-9b90-6e6f5b6c777b.png">


_**Known Issue:** For logged-out users, the query string isn't preserved. In other words, the information about site type and vertical users brought from .blog landing pages will be removed when login. We can handle the problem later if it would take much time to solve._

Fixes #41110
