### PR TITLE
Jetpack Cloud: Remove -changes in this backup- link from ActivityCard unless streams are present

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -22,7 +22,6 @@ import {
 	backupDownloadPath,
 	backupRestorePath,
 } from 'landing/jetpack-cloud/sections/backups/paths';
-import { isSuccessfulDailyBackup } from 'landing/jetpack-cloud/sections/backups/utils';
 
 /**
  * Style dependencies
@@ -108,9 +107,8 @@ class ActivityCard extends Component {
 		const { activity, showContentLink } = this.props;
 		return showContentLink !== undefined
 			? showContentLink
-			: !! (
-					activity.streams && activity.streams.some( ( stream ) => stream.activityMedia?.available )
-			  ) || isSuccessfulDailyBackup( activity );
+			: !! activity.streams &&
+					activity.streams.some( ( stream ) => stream.activityMedia?.available );
 	}
 
 	renderContentLink() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `Changes in this backup` link from any activity card that does not contain streams
* The actual link is left in the code, just never triggered. This is intentional, we will eventually be able to show details in `backupDetailPath`, and this makes it easy to reintroduce the link.

#### Testing instructions

* For a realtime backup site, perform multiple backups in a single day. View that day in the backups home, and there should be no "Changes in this backup" link on any card for a full backup.
