### PR TITLE
Jetpack Cloud: improve the threats an error UI

### DIFF
--- a/client/landing/jetpack-cloud/components/log-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/log-item/index.tsx
@@ -21,6 +21,7 @@ export interface Props {
 	tag?: string;
 	summary?: string | ReactNode;
 	expandedSummary?: string | ReactNode;
+	clickableHeader?: boolean;
 }
 
 class LogItem extends React.PureComponent< Props > {
@@ -39,7 +40,14 @@ class LogItem extends React.PureComponent< Props > {
 	}
 
 	render() {
-		const { highlight, children, className, expandedSummary, summary } = this.props;
+		const {
+			clickableHeader,
+			highlight,
+			children,
+			className,
+			expandedSummary,
+			summary,
+		} = this.props;
 		return (
 			<FoldableCard
 				header={ this.renderHeader() }
@@ -47,6 +55,7 @@ class LogItem extends React.PureComponent< Props > {
 				highlight={ highlight }
 				expandedSummary={ expandedSummary }
 				summary={ summary }
+				clickableHeader={ clickableHeader }
 			>
 				{ children }
 			</FoldableCard>

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -51,10 +51,9 @@ const ScanError: React.FC< { site: Site } > = ( { site } ) => {
 
 	return (
 		<div className="scan-threats__error">
-			{ translate( 'The scanner was unable to check all files and errored before completion. ' ) }
 			{ isEnabled( 'jetpack-cloud/on-demand-scan' )
 				? translate(
-						'Deal with the threats found above and run the {{runScan}}scan again{{/runScan}}. If the error persists, we are {{linkToSupport}}here to help{{/linkToSupport}}.',
+						'The scanner was unable to check all files and errored before completion. Deal with the threats found above and run the {{runScan}}scan again{{/runScan}}. If the error persists, we are {{linkToSupport}}here to help{{/linkToSupport}}.',
 						{
 							components: {
 								runScan: (
@@ -71,7 +70,7 @@ const ScanError: React.FC< { site: Site } > = ( { site } ) => {
 						}
 				  )
 				: translate(
-						'Deal with the threats found above and if the error persists, we are {{linkToSupport}}here to help{{/linkToSupport}}.',
+						'The scanner was unable to check all files and errored before completion. Deal with the threats found above and if the error persists, we are {{linkToSupport}}here to help{{/linkToSupport}}.',
 						{
 							components: {
 								linkToSupport: (

--- a/client/landing/jetpack-cloud/components/scan-threats/index.tsx
+++ b/client/landing/jetpack-cloud/components/scan-threats/index.tsx
@@ -51,8 +51,7 @@ const ScanError: React.FC< { site: Site } > = ( { site } ) => {
 
 	return (
 		<div className="scan-threats__error">
-			{ translate( 'The scanner was unable to check all files and errored before completion.' ) }
-			<br />
+			{ translate( 'The scanner was unable to check all files and errored before completion. ' ) }
 			{ isEnabled( 'jetpack-cloud/on-demand-scan' )
 				? translate(
 						'Deal with the threats found above and run the {{runScan}}scan again{{/runScan}}. If the error persists, we are {{linkToSupport}}here to help{{/linkToSupport}}.',

--- a/client/landing/jetpack-cloud/components/threat-item/index.tsx
+++ b/client/landing/jetpack-cloud/components/threat-item/index.tsx
@@ -47,11 +47,17 @@ const ThreatItem: React.FC< Props > = ( {
 	 */
 	const renderFixThreatButton = React.useCallback(
 		( className: string ) => {
+			// Without this, clicking the [Fix threat] button will open the
+			// entire ThreatItem element as well
+			const onClickHandler = ( e: React.MouseEvent< HTMLElement > ) => {
+				e.stopPropagation();
+				onFixThreat && onFixThreat();
+			};
 			return (
 				<Button
 					compact
 					className={ classnames( 'threat-item__fix-button', className ) }
-					onClick={ onFixThreat }
+					onClick={ onClickHandler }
 					disabled={ isFixing }
 				>
 					{ translate( 'Fix threat' ) }
@@ -112,6 +118,7 @@ const ThreatItem: React.FC< Props > = ( {
 				  }
 				: {} ) }
 			{ ...( threat.status === 'current' ? { highlight: 'error' } : {} ) }
+			clickableHeader={ true }
 		>
 			<ThreatDescription
 				status={ threat.status }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the line break in the error copy.
* Make the button transparent.
* Make the whole header clickable.

#### Testing instructions

* Go to `http://jetpack.cloud.localhost:3000/`
* Select a site that has Scan and at least one threat
* From React devtools, find the `ScanThreats` component and set the `error` prop to `true` (that will make the error section appear below the threats section)
* Verify there is no longer line break (`<br />`) in the copy.
* Verify the `scan again` link/button has a transparent background
* Verify you can expand/open a threat from clicking anywhere in its header
* Verify clicking the `[Fix threat]` button opens up the modal but doesn't expand/open the threat element

#### Before
![image](https://user-images.githubusercontent.com/3418513/81715321-79cc1800-944e-11ea-983f-7590414160fb.png)

#### After
![image](https://user-images.githubusercontent.com/3418513/81714913-fa3e4900-944d-11ea-95b1-c2360b88ede2.png)

