### PR TITLE
Jetpack Scan: Fix timestamp to include duration

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -123,7 +123,11 @@ class ScanPage extends Component< Props > {
 
 	renderScanOkay() {
 		const { scanState, siteId, moment, dispatchScanRun, applySiteOffset } = this.props;
-		const lastScanTimestamp = scanState?.mostRecent?.timestamp;
+
+		const lastScanTimestamp = scanState?.mostRecent?.timestamp
+			? Date.parse( scanState.mostRecent.timestamp ) + scanState.mostRecent.duration
+			: false;
+
 		let lastScanSiteTime = '';
 		if ( lastScanTimestamp && applySiteOffset ) {
 			lastScanSiteTime = applySiteOffset( moment.utc( lastScanTimestamp ) )?.fromNow();

--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -124,13 +124,14 @@ class ScanPage extends Component< Props > {
 	renderScanOkay() {
 		const { scanState, siteId, moment, dispatchScanRun, applySiteOffset } = this.props;
 
-		const lastScanTimestamp = scanState?.mostRecent?.timestamp
-			? Date.parse( scanState.mostRecent.timestamp ) + scanState.mostRecent.duration
-			: false;
+		const lastScanStartTime = scanState?.mostRecent?.timestamp;
+		const lastScanDuration = scanState?.mostRecent?.duration;
 
-		let lastScanSiteTime = '';
-		if ( lastScanTimestamp && applySiteOffset ) {
-			lastScanSiteTime = applySiteOffset( moment.utc( lastScanTimestamp ) )?.fromNow();
+		let lastScanFinishTime = '';
+		if ( lastScanStartTime && applySiteOffset ) {
+			lastScanFinishTime = applySiteOffset(
+				moment.utc( lastScanStartTime ).add( lastScanDuration, 'seconds' )
+			).fromNow();
 		}
 
 		return (
@@ -145,7 +146,7 @@ class ScanPage extends Component< Props > {
 							'{{br/}}' +
 							'Run a manual scan now or wait for Jetpack to scan your site later today.',
 						{
-							args: [ lastScanSiteTime ],
+							args: [ lastScanFinishTime ],
 							components: {
 								strong: <strong />,
 								br: <br />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently we show when the scan started but not when it finished. 
This PR fixes this by adding the duration to the scan started time

#### Testing instructions
* On a site that has scan start a scan. 
* Does the scan time make sense? 
