### PR TITLE
Credentials Card: Show folded card in Settings for sites with managed credentials

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-configured/index.jsx
@@ -134,7 +134,7 @@ const mapStateToProps = ( state, { siteId } ) => {
 	const { canAutoconfigure, credentials = [] } = getRewindState( state, siteId );
 
 	return {
-		canAutoconfigure: canAutoconfigure || credentials.some( ( c ) => c.type === 'auto' ), // eslint-disable-line wpcalypso/redux-no-bound-selectors
+		canAutoconfigure: canAutoconfigure || credentials.some( ( c ) => c.type === 'managed' ), // eslint-disable-line wpcalypso/redux-no-bound-selectors
 		mainCredentials: find( credentials, { role: 'main' } ),
 		supportsRealtimeBackup: siteSupportsRealtimeBackup( state, siteId ),
 	};

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -49,15 +48,12 @@ const SiteSettingsSecurity = ( {
 		);
 	}
 
-	const credentials = find( rewindState.credentials, { role: 'main' } );
-	const isManaged = credentials && credentials.type && 'managed' === credentials.type;
-
 	const isRewindActive = [ 'awaitingCredentials', 'provisioning', 'active' ].includes(
 		rewindState.state
 	);
 	const hasScanProduct = sitePurchases.some( ( p ) => p.productSlug.includes( 'jetpack_scan' ) );
 
-	const showCredentials = ! isManaged && ( isRewindActive || hasScanProduct );
+	const showCredentials = isRewindActive || hasScanProduct;
 
 	return (
 		<Main className="settings-security site-settings">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently for sites with managed credentials, no card is displayed in Settings -> Security to show that credentials have been provided. This PR ensures that card is shown as intended.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site with managed credentials (e.g., a Pressable site).
* Ensure Jetpack is installed and connected.
* Purchase a Jetpack plan, or Jetpack Backup, or Jetpack Scan.
* On WordPress.com, select this site in the site selector and go to Settings -> Security.
* Verify that you see a folded card saying that the site is connected, as shown in the screenshot below. The card should have an arrow at the end of it, which should be **horizontal**, not vertical. Clicking the arrow should bring up a prompt to revoke your credentials or stay connected.

#### Screenshots

<img width="738" alt="image" src="https://user-images.githubusercontent.com/670067/81721472-86983e00-9445-11ea-9d4e-de36bba9f3dd.png">

<img width="735" alt="image" src="https://user-images.githubusercontent.com/670067/81721743-f8708780-9445-11ea-9500-0e18b234af8f.png">

Fixes #42112 / 1156570014567299-as-1175436329289321.
