### PR TITLE
Gutenboarding: Plans table scrolling UX improvements.

### DIFF
--- a/client/landing/gutenboarding/_z-index.scss
+++ b/client/landing/gutenboarding/_z-index.scss
@@ -32,6 +32,8 @@
 
 $z-layers: (
 	'.vertical-select__suggestions-wrapper': 2,
+	'.gutenboarding__header': 30,
+	'.gutenboarding__footer': 30,
 );
 
 @function gutenboarding-z-index( $keys... ) {

--- a/client/landing/gutenboarding/components/action-buttons/style.scss
+++ b/client/landing/gutenboarding/components/action-buttons/style.scss
@@ -1,5 +1,6 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../variables.scss';
+@import '../../_z-index.scss';
 
 .action-buttons {
 	padding: 0 20px;
@@ -13,7 +14,7 @@
 	justify-content: space-between;
 	display: flex;
 	align-items: center;
-	z-index: z-index( '.block-editor-editor-skeleton__header' );
+	z-index: gutenboarding-z-index( '.gutenboarding__footer' );
 
 	@include break-small {
 		padding: 0;

--- a/client/landing/gutenboarding/components/action-buttons/style.scss
+++ b/client/landing/gutenboarding/components/action-buttons/style.scss
@@ -13,6 +13,7 @@
 	justify-content: space-between;
 	display: flex;
 	align-items: center;
+	z-index: z-index( '.block-editor-editor-skeleton__header' );
 
 	@include break-small {
 		padding: 0;

--- a/client/landing/gutenboarding/components/header/style.scss
+++ b/client/landing/gutenboarding/components/header/style.scss
@@ -2,6 +2,7 @@
 @import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
 @import 'assets/stylesheets/shared/animation'; // Needed for the placeholder
 @import '../../variables.scss';
+@import '../../_z-index.scss';
 
 $margin-left--gutenboarding__header-section-item: 13px; // matches design
 $padding--gutenboarding__header: $grid-unit-10;
@@ -40,7 +41,7 @@ $padding--gutenboarding__header: $grid-unit-10;
 	border-bottom: 1px solid $light-gray-500;
 	height: $gutenboarding-header-height;
 	background: $white;
-	z-index: z-index( '.block-editor-editor-skeleton__header' );
+	z-index: gutenboarding-z-index( '.gutenboarding__header' );
 	left: 0;
 	right: 0;
 	// Stick the toolbar to the top, because the admin bar is not fixed on mobile.

--- a/client/landing/gutenboarding/components/plans/plans-details/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-details/index.tsx
@@ -12,59 +12,58 @@ import { useSelect } from '@wordpress/data';
  */
 import './style.scss';
 
-const PlansDetails: React.FunctionComponent = () => {
+const PlansDetails: React.FunctionComponent = ( props ) => {
 	const plansDetails = useSelect( ( select ) => select( PLANS_STORE ).getPlansDetails() );
 
 	const { __ } = useI18n();
 
 	return (
 		<div className="plans-details">
-			<div className="plans-details__viewport">
-				<table className="plans-details__table">
-					<thead>
-						<tr className="plans-details__header-row">
-							<th>{ __( 'Feature' ) }</th>
-							<th>{ __( 'Free' ) }</th>
-							<th>{ __( 'Personal' ) }</th>
-							<th>{ __( 'Premium' ) }</th>
-							<th>{ __( 'Business' ) }</th>
-							<th>{ __( 'eCommerce' ) }</th>
-						</tr>
-					</thead>
-					{ plansDetails.map( ( detail ) => (
-						<tbody key={ detail.id }>
-							{ detail.name && (
-								<tr className="plans-details__header-row">
-									<th colSpan={ 6 }>{ detail.name }</th>
-								</tr>
-							) }
-							{ detail.features.map( ( feature, i ) => (
-								<tr className="plans-details__feature-row" key={ i }>
-									<th>{ feature.name }</th>
-									{ feature.data.map( ( value, j ) => (
-										<td key={ j }>
-											{ feature.type === 'checkbox' &&
-												( value ? (
-													<>
-														{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-														<span className="hidden">{ __( 'Available' ) }</span>
-														<Icon icon="yes-alt" />
-													</>
-												) : (
-													<>
-														{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-														<span className="hidden">{ __( 'Unavailable' ) } </span>
-													</>
-												) ) }
-											{ feature.type === 'text' && value }
-										</td>
-									) ) }
-								</tr>
-							) ) }
-						</tbody>
-					) ) }
-				</table>
-			</div>
+			<table className="plans-details__table">
+				<thead>
+					<tr className="plans-details__header-row">
+						<th>{ __( 'Feature' ) }</th>
+						<th>{ __( 'Free' ) }</th>
+						<th>{ __( 'Personal' ) }</th>
+						<th>{ __( 'Premium' ) }</th>
+						<th>{ __( 'Business' ) }</th>
+						<th>{ __( 'eCommerce' ) }</th>
+					</tr>
+				</thead>
+				{ plansDetails.map( ( detail ) => (
+					<tbody key={ detail.id }>
+						{ detail.name && (
+							<tr className="plans-details__header-row">
+								<th colSpan={ 6 }>{ detail.name }</th>
+							</tr>
+						) }
+						{ detail.features.map( ( feature, i ) => (
+							<tr className="plans-details__feature-row" key={ i }>
+								<th>{ feature.name }</th>
+								{ feature.data.map( ( value, j ) => (
+									<td key={ j }>
+										{ feature.type === 'checkbox' &&
+											( value ? (
+												<>
+													{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+													<span className="hidden">{ __( 'Available' ) }</span>
+													<Icon icon="yes-alt" />
+												</>
+											) : (
+												<>
+													{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+													<span className="hidden">{ __( 'Unavailable' ) } </span>
+												</>
+											) ) }
+										{ feature.type === 'text' && value }
+									</td>
+								) ) }
+							</tr>
+						) ) }
+					</tbody>
+				) ) }
+			</table>
+			{ props.children }
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/components/plans/plans-details/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-details/style.scss
@@ -2,23 +2,8 @@
 @import '../../../mixins.scss';
 @import '../../../variables.scss';
 
-.plans-details__viewport {
-	overflow: auto;
-
-	.plans-details__table {
-		border-left: 30px solid transparent;
-		border-right: 30px solid transparent;
-
-		@include break-medium {
-			border-left: 0;
-			border-right: 0;
-		}
-	}
-}
-
 .plans-details__table {
 	width: 100%;
-	min-width: $break-medium;
 	table-layout: fixed;
 
 	th,
@@ -27,7 +12,7 @@
 
 		&:first-child {
 			padding-left: 0;
-			width: 25%;
+			width: 20%;
 
 			@include break-mobile {
 				width: 40%;

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -44,7 +44,12 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 	};
 
 	return (
-		<div className={ classNames( 'plans-grid', { 'is-mobile': isMobile } ) }>
+		<div
+			className={ classNames( 'plans-grid', {
+				'is-mobile': isMobile,
+				'show-details': showDetails,
+			} ) }
+		>
 			<div className="plans-grid__header">
 				<div>
 					<Title>{ __( 'Choose a plan' ) }</Title>
@@ -67,31 +72,34 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 			</div>
 
 			<div className="plans-grid__details">
-				{ showDetails && (
-					<div className="plans-grid__details-container">
-						<div className="plans-grid__details-heading">
-							<Title>{ __( 'Detailed comparison' ) }</Title>
+				<div className="plans-grid__details-heading">
+					<Title>{ __( 'Detailed comparison' ) }</Title>
+				</div>
+				<div className="plans-grid__details-container">
+					<PlansDetails>
+						<div className="plans-grid__details-actions">
+							{ showDetails ? (
+								<Button
+									className="plans-grid__details-toggle-button is-collapse-button"
+									isLarge
+									onClick={ handleDetailsToggleButtonClick }
+								>
+									<span>{ __( 'Less details' ) } </span>
+									<Icon icon="arrow-up" size={ 20 }></Icon>
+								</Button>
+							) : (
+								<Button
+									className="plans-grid__details-toggle-button is-expand-button"
+									isLarge
+									onClick={ handleDetailsToggleButtonClick }
+								>
+									<span>{ __( 'More details' ) } </span>
+									<Icon icon="arrow-down" size={ 20 }></Icon>
+								</Button>
+							) }
 						</div>
-						<PlansDetails />
-					</div>
-				) }
-				<Button
-					className="plans-grid__details-toggle-button"
-					isLarge
-					onClick={ handleDetailsToggleButtonClick }
-				>
-					{ showDetails ? (
-						<>
-							<span>{ __( 'Less details' ) } </span>
-							<Icon icon="arrow-up" size={ 20 }></Icon>
-						</>
-					) : (
-						<>
-							<span>{ __( 'More details' ) } </span>
-							<Icon icon="arrow-down" size={ 20 }></Icon>
-						</>
-					) }
-				</Button>
+					</PlansDetails>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { Button, Icon } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useI18n } from '@automattic/react-i18n';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -20,6 +21,9 @@ import PlansDetails from '../plans-details';
  */
 import './style.scss';
 import { useSelectedPlan } from 'landing/gutenboarding/hooks/use-selected-plan';
+
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Mobile_Tablet_or_Desktop
+const isMobile = window.navigator.userAgent.indexOf( 'Mobi' ) > -1;
 
 export interface Props {
 	confirmButton: React.ReactElement;
@@ -40,7 +44,7 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 	};
 
 	return (
-		<div className="plans-grid">
+		<div className={ classNames( 'plans-grid', { 'is-mobile': isMobile } ) }>
 			<div className="plans-grid__header">
 				<div>
 					<Title>{ __( 'Choose a plan' ) }</Title>
@@ -54,10 +58,12 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 			</div>
 
 			<div className="plans-grid__table">
-				<PlansTable
-					selectedPlanSlug={ selectedPlan.getStoreSlug() }
-					onPlanSelect={ setPlan }
-				></PlansTable>
+				<div className="plans-grid__table-container">
+					<PlansTable
+						selectedPlanSlug={ selectedPlan.getStoreSlug() }
+						onPlanSelect={ setPlan }
+					></PlansTable>
+				</div>
 			</div>
 
 			<div className="plans-grid__details">

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -67,6 +67,10 @@
 	// this allows user to pan through the plan items
 	// while keep the rest of the content intact.
 	overflow-x: auto;
+	scroll-snap-type: x mandatory;
+	scroll-behavior: smooth;
+	-webkit-overflow-scrolling: touch;
+	scroll-padding-left: $plan-item-gutter;
 
 	// This lets the overlay scrollbar appears right
 	// below the plan item when panning horizontally.
@@ -79,6 +83,7 @@
 	// room for the next plan itme to peak out from the side.
 	.plan-item {
 		min-width: $plan-item-min-width-mobile-portrait;
+		scroll-snap-align: start;
 
 		@include break-mobile {
 			min-width: $plan-item-min-width;

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -96,24 +96,60 @@
 	margin-bottom: 120px;
 }
 
+// This makes overflowing content scrolls edge-to-edge.
 .plans-grid__details-container {
-	// Edge-to-edge panning
-	.plans-details {
-		width: calc( 100% + 30px + 30px );
-		margin-left: -30px;
-		margin-right: -30px;
-		overflow: hidden;
+	@include onboarding-block-edge2edge-container;
 
-		@include break-medium {
-			width: 100%;
-			margin-left: 0;
-			margin-right: 0;
-			overflow: auto;
-		}
+	.plans-details__table {
+		@include onboarding-block-edge2edge-content;
+	}
+}
+
+// On desktop, make sure plans details meets the
+// min width of the plans table, to prevent too
+// much white space when scrolling horizontally
+// using the browser's horizontal scrollbar.
+.plans-grid:not( .is-mobile ) .plans-details {
+	min-width: $plans-details-min-width-desktop-mobile;
+
+	@include break-small {
+		min-width: $plans-details-min-width-desktop-small;
 	}
 
-	+ .plans-grid__details-toggle-button {
-		margin-top: 60px;
+	@include break-medium {
+		min-width: $plans-details-min-width-desktop-medium;
+	}
+}
+
+.plans-grid.is-mobile .plans-grid__details-container {
+	// On a desktop device, when plan details overflow,
+	// let user scroll using the browser's scrollbar,
+	// this is because users are used to scrolling this way.
+
+	// On a mobile device, when plan details overflow,
+	// let user scroll using the plan details' scrollbar,
+	// this allows user to pan through the plan items
+	// while keep the rest of the content intact.
+	overflow-x: auto;
+
+	// This lets the overlay scrollbar appears right
+	// below the plan details when panning horizontally.
+	padding: 20px 0;
+	margin-top: -20px;
+	margin-bottom: -20px;
+}
+
+// On mobile, reduce the min-width to reduce
+// the need to scroll too much.
+.plans-grid.is-mobile .plans-details {
+	min-width: $plans-details-min-width-mobile;
+
+	@include break-small {
+		min-width: $plans-details-min-width-mobile;
+	}
+
+	@include break-medium {
+		min-width: $plans-details-min-width-mobile;
 	}
 }
 
@@ -126,6 +162,15 @@
 		letter-spacing: 0.2px;
 	}
 }
+// On desktop, this should follow the width of the plans table.
+.plans-grid__details-actions {
+	@include onboarding-block-edge2edge-content;
+
+	// On mobile, this should follow the width of the viewport.
+	.plans-grid.is-mobile & {
+		width: 100vw;
+	}
+}
 
 .plans-grid__details-toggle-button.components-button {
 	display: block;
@@ -134,9 +179,8 @@
 	font-size: 16px;
 	line-height: 19px;
 	letter-spacing: 0.2px;
-	border: 1px solid var( --studio-gray-5 );
-	border-left: 0;
-	border-right: 0;
+	border-top: 1px solid var( --studio-gray-5 );
+	border-bottom: 1px solid var( --studio-gray-5 );
 	border-radius: 0;
 	padding: 0;
 	text-align: center;
@@ -147,5 +191,28 @@
 
 	svg {
 		margin-left: 2px;
+	}
+
+	&.is-collapse-button {
+		margin-top: 70px;
+	}
+}
+
+// Controls toggling of plans grid
+.plans-grid__details-heading {
+	display: none;
+}
+
+.plans-grid .plans-details__table {
+	display: none;
+}
+
+.plans-grid.show-details {
+	.plans-grid__details-heading {
+		display: block;
+	}
+
+	.plans-details__table {
+		display: block;
 	}
 }

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -1,5 +1,6 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../../mixins.scss';
+@import '../variables.scss';
 
 .plans-grid {
 	// Space to accomodate sticky footer
@@ -30,7 +31,63 @@
 	align-items: center;
 }
 
+.plans-grid__table-container {
+	// This ensure when plans table overflow,
+	// the overflowing content is not clipped by the
+	// onboarding block's margin.
+	@include onboarding-block-edge2edge-container;
+
+	// When plan items overflow, this ensure there is a gap on
+	// the left & right end of the content. Transparent borders
+	// is used instead of margins because browsers do not consider
+	// margins as part of the content itself.
+	.plan-item {
+		@include onboarding-block-edge2edge-columns;
+
+		// This ensure borders are not calculated as part of the
+		// element's width because the first and last plan item
+		// has extended borders.
+		box-sizing: content-box !important;
+
+		// This reverts the content-box box-sizing
+		// for immediate child elements.
+		> * {
+			box-sizing: border-box !important;
+		}
+	}
+}
+
+.plans-grid.is-mobile .plans-grid__table-container {
+	// On a desktop device, when plan items overflow,
+	// let user scroll using the browser's scrollbar,
+	// this is because users are used to scrolling this way.
+
+	// On a mobile device, when plan items overflow,
+	// let user scroll using the element's scrollbar,
+	// this allows user to pan through the plan items
+	// while keep the rest of the content intact.
+	overflow-x: auto;
+
+	// This lets the overlay scrollbar appears right
+	// below the plan item when panning horizontally.
+	padding: 20px 0;
+	margin-top: -20px;
+	margin-bottom: -20px;
+
+	// On mobile portrait view, ensure plan item takes up
+	// about 70% of the viewport width, leaving just enough
+	// room for the next plan itme to peak out from the side.
+	.plan-item {
+		min-width: $plan-item-min-width-mobile-portrait;
+
+		@include break-mobile {
+			min-width: $plan-item-min-width;
+		}
+	}
+}
+
 .plans-grid__details {
+	margin-top: 70px;
 	margin-bottom: 120px;
 }
 

--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -1,84 +1,35 @@
 @import 'assets/stylesheets/gutenberg-base-styles';
 @import '../../../mixins.scss';
 @import '../../../variables.scss';
+@import '../variables.scss';
 @import 'assets/stylesheets/shared/mixins/placeholder'; // Contains the placeholder mixin
-
-.plans-grid__table {
-	overflow-x: auto;
-	margin-bottom: 70px;
-
-	@include break-large {
-		overflow-x: initial;
-	}
-}
-
-// Make panning edge-to-edge
-.plans-grid__table {
-	width: calc( 100% + 30px + 30px );
-	margin-left: -30px;
-	margin-right: -30px;
-
-	@include break-mobile {
-		width: auto;
-		margin-left: 0;
-		margin-right: 0;
-
-		.plans-table {
-			padding: 0;
-		}
-	}
-}
 
 .plans-table {
 	display: flex;
 	flex-direction: row;
-	margin: 0 -4px;
-	@include break-xlarge {
-		margin: 0 -10px;
-	}
+	width: 100%;
+}
 
-	.plan-item {
-		flex-basis: 193px;
-		flex-grow: 0.5;
-		flex-shrink: 0;
-		margin: 0 4px;
-		margin-bottom: 24px;
+.plan-item {
+	width: 20%; // 100% / 5 plans
+	min-width: $plan-item-min-width;
 
-		&:first-child {
-			border-left: 30px solid transparent;
-		}
-
-		&:last-child {
-			border-right: 30px solid transparent;
-		}
-
-		@include break-large {
-			flex-shrink: 0.2;
-
-			&:first-child {
-				border-left: 0;
-			}
-
-			&:last-child {
-				border-right: 0;
-			}
-		}
+	+ .plan-item {
+		margin-left: 20px;
 	}
 }
 
 .plan-item__viewport {
-	border: 1px solid $light-gray-500;
 	width: 100%;
 	height: 100%;
-	padding: 16px;
+
+	// Only mobile & tablets has borders (and paddings)
+	border: 1px solid $light-gray-500;
+	padding: 20px;
 
 	@include break-large {
-		border: none;
-	}
-
-	@include break-xlarge {
-		padding: 20px;
-		margin: 0 10px;
+		border: 0;
+		padding: 0;
 	}
 }
 

--- a/client/landing/gutenboarding/components/plans/plans-table/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-table/style.scss
@@ -11,11 +11,11 @@
 }
 
 .plan-item {
-	width: 20%; // 100% / 5 plans
+	width: $plan-item-width;
 	min-width: $plan-item-min-width;
 
 	+ .plan-item {
-		margin-left: 20px;
+		margin-left: $plan-item-gutter;
 	}
 }
 

--- a/client/landing/gutenboarding/components/plans/variables.scss
+++ b/client/landing/gutenboarding/components/plans/variables.scss
@@ -1,0 +1,10 @@
+@import '../../variables.scss';
+
+$plan-item-count: 5;
+$plan-item-gutter: 20px;
+$plan-item-width: #{100% / $plan-item-count};
+$plan-item-min-width: #{(
+		$break-wide - ( $gutenboarding-block-margin-medium * 2 ) -
+			( $plan-item-gutter * ( $plan-item-count - 1 ) )
+	) / $plan-item-count};
+$plan-item-min-width-mobile-portrait: 70vw;

--- a/client/landing/gutenboarding/components/plans/variables.scss
+++ b/client/landing/gutenboarding/components/plans/variables.scss
@@ -1,5 +1,7 @@
 @import '../../variables.scss';
+@import '../../functions.scss';
 
+// Plans Table
 $plan-item-count: 5;
 $plan-item-gutter: 20px;
 $plan-item-width: #{100% / $plan-item-count};
@@ -8,3 +10,15 @@ $plan-item-min-width: #{(
 			( $plan-item-gutter * ( $plan-item-count - 1 ) )
 	) / $plan-item-count};
 $plan-item-min-width-mobile-portrait: 70vw;
+$plans-table-total-content-width: #{( to-number( $plan-item-min-width ) * $plan-item-count ) + (
+		$plan-item-gutter * ( $plan-item-count - 1 )
+	)};
+
+// Plans Details
+$plans-details-min-width-desktop-mobile: #{to-number( $plans-table-total-content-width ) +
+	$gutenboarding-block-margin-mobile * 2};
+$plans-details-min-width-desktop-small: #{to-number( $plans-table-total-content-width ) +
+	$gutenboarding-block-margin-small * 2};
+$plans-details-min-width-desktop-medium: #{to-number( $plans-table-total-content-width ) +
+	$gutenboarding-block-margin-medium * 2};
+$plans-details-min-width-mobile: 700px;

--- a/client/landing/gutenboarding/functions.scss
+++ b/client/landing/gutenboarding/functions.scss
@@ -1,0 +1,40 @@
+@function to-number( $value ) {
+	@if type-of( $value ) == 'number' {
+		@return $value;
+	} @else if type-of( $value ) != 'string' {
+		@error 'Value for `to-number` should be a number or a string.';
+	}
+
+	$result: 0;
+	$digits: 0;
+	$minus: str-slice( $value, 1, 1 ) == '-';
+	$numbers: (
+		'0': 0,
+		'1': 1,
+		'2': 2,
+		'3': 3,
+		'4': 4,
+		'5': 5,
+		'6': 6,
+		'7': 7,
+		'8': 8,
+		'9': 9,
+	);
+
+	@for $i from if( $minus, 2, 1 ) through str-length( $value ) {
+		$character: str-slice( $value, $i, $i );
+
+		@if ( index( map-keys( $numbers ), $character ) or $character == '.' ) {
+			@if $character == '.' {
+				$digits: 1;
+			} @else if $digits == 0 {
+				$result: $result * 10 + map-get( $numbers, $character );
+			} @else {
+				$digits: $digits * 10;
+				$result: $result + map-get( $numbers, $character ) / $digits;
+			}
+		}
+	}
+
+	@return if( $minus, -$result, $result );
+}

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -98,24 +98,18 @@
 }
 
 @mixin onboarding-block-edge2edge-container {
-	width: calc(
-		100% + #{$gutenboarding-block-margin-mobile} + #{$gutenboarding-block-margin-mobile}
-	);
+	width: calc( 100% + #{$gutenboarding-block-margin-mobile * 2} );
 	margin-left: #{$gutenboarding-block-margin-mobile * -1};
 	margin-right: #{$gutenboarding-block-margin-mobile * -1};
 
 	@include break-small {
-		width: calc(
-			100% + #{$gutenboarding-block-margin-small} + #{$gutenboarding-block-margin-small}
-		);
+		width: calc( 100% + #{$gutenboarding-block-margin-small * 2} );
 		margin-left: #{$gutenboarding-block-margin-small * -1};
 		margin-right: #{$gutenboarding-block-margin-small * -1};
 	}
 
 	@include break-medium {
-		width: calc(
-			100% + #{$gutenboarding-block-margin-medium} + #{$gutenboarding-block-margin-medium}
-		);
+		width: calc( 100% + #{$gutenboarding-block-margin-medium * 2} );
 		margin-left: #{$gutenboarding-block-margin-medium * -1};
 		margin-right: #{$gutenboarding-block-margin-medium * -1};
 	}

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -40,14 +40,14 @@
 }
 
 @mixin onboarding-block-margin {
-	margin: 0 20px;
+	margin: 0 $gutenboarding-block-margin-mobile;
 
 	@include break-small {
-		margin: 0 44px;
+		margin: 0 $gutenboarding-block-margin-small;
 	}
 
 	@include break-medium {
-		margin: 0 88px;
+		margin: 0 $gutenboarding-block-margin-medium;
 	}
 }
 
@@ -95,4 +95,70 @@
 	width: 100%;
 
 	background: var( --studio-white );
+}
+
+@mixin onboarding-block-edge2edge-container {
+	width: calc(
+		100% + #{$gutenboarding-block-margin-mobile} + #{$gutenboarding-block-margin-mobile}
+	);
+	margin-left: #{$gutenboarding-block-margin-mobile * -1};
+	margin-right: #{$gutenboarding-block-margin-mobile * -1};
+
+	@include break-small {
+		width: calc(
+			100% + #{$gutenboarding-block-margin-small} + #{$gutenboarding-block-margin-small}
+		);
+		margin-left: #{$gutenboarding-block-margin-small * -1};
+		margin-right: #{$gutenboarding-block-margin-small * -1};
+	}
+
+	@include break-medium {
+		width: calc(
+			100% + #{$gutenboarding-block-margin-medium} + #{$gutenboarding-block-margin-medium}
+		);
+		margin-left: #{$gutenboarding-block-margin-medium * -1};
+		margin-right: #{$gutenboarding-block-margin-medium * -1};
+	}
+}
+
+@mixin onboarding-block-edge2edge-content {
+	border-left: $gutenboarding-block-margin-mobile solid transparent;
+	border-right: $gutenboarding-block-margin-mobile solid transparent;
+
+	@include break-small {
+		border-left: $gutenboarding-block-margin-small solid transparent;
+		border-right: $gutenboarding-block-margin-small solid transparent;
+	}
+
+	@include break-medium {
+		border-left: $gutenboarding-block-margin-medium solid transparent;
+		border-right: $gutenboarding-block-margin-medium solid transparent;
+	}
+}
+
+@mixin onboarding-block-edge2edge-columns {
+	&:first-child {
+		border-left: $gutenboarding-block-margin-mobile solid transparent;
+	}
+	&:last-child {
+		border-right: $gutenboarding-block-margin-mobile solid transparent;
+	}
+
+	@include break-small {
+		&:first-child {
+			border-left: $gutenboarding-block-margin-small solid transparent;
+		}
+		&:last-child {
+			border-right: $gutenboarding-block-margin-small solid transparent;
+		}
+	}
+
+	@include break-medium {
+		&:first-child {
+			border-left: $gutenboarding-block-margin-medium solid transparent;
+		}
+		&:last-child {
+			border-right: $gutenboarding-block-margin-medium solid transparent;
+		}
+	}
 }

--- a/client/landing/gutenboarding/variables.scss
+++ b/client/landing/gutenboarding/variables.scss
@@ -5,3 +5,6 @@ $gutenboarding-heading-padding-desktop: 64px 0 80px;
 $gutenboarding-heading-padding-mobile: 44px 0 50px;
 $acquire-intent-transition-duration: 200ms;
 $acquire-intent-transition-algorithm: ease-in-out;
+$gutenboarding-block-margin-mobile: 20px;
+$gutenboarding-block-margin-small: 44px;
+$gutenboarding-block-margin-medium: 88px;


### PR DESCRIPTION
## Glossary

We seem to refer to the main plans table as the grid itself, but I just like to point out the technical differences just to make any further discussion clearer.

**Plans Grid** - The view containing the plans table & plans details.
**Plans Table** - The main table containing a summary of plans.
**Plans Details** - The extended table containing detailed comparison of plans.
**Plan Item** - Each of the column in plans table.

## Proposed Scrolling Behaviour

The current plans table hinders user experience for desktop users with narrow browser viewport as user has to scroll down to the end of the plans table to find the horizontal scrollbar then scroll left or right to inspect different plans.

In this PR, here are my proposals on how to fix this:

 - **Desktop**
  When plan items overflow, let user scroll using the browser's scrollbar. This is because most users are used to scrolling this way. 

- **Mobiles & Tablets**
  When plan items overflow, let user scroll using the plans table's scrollbar. This allows user to pan through the plan items while keeping the contents outside of plans table (like plans grid header) intact.

## Detecting Mobile Devices via User Agent (not Viewport Width)

To achieve the above scrolling behaviour, we cannot rely on viewport width to determine whether or not user is actually on a mobile device.

Therefore, I'm testing whether or not user is on a mobile device based on user agent string. According to MDN, testing against the keyword `Mobi` should cover most cases. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#Mobile_Tablet_or_Desktop

This is also to keep things lightweight to avoid importing any packages. I initially tried importing `lib/user-agent` which has `isMobile` based on user agent. However, importing this package seems to break on the client side.

## What happens at which breakpoint?

- **Lower than `$break-wide` (1280px) is when horizontal scrollbar starts to appear.**
  - Most common resolution is 1366x768. Closest breakpoint to 1366px is `$break-wide` at 1280px.
  - The min-width for plan item is decided based on `$break-wide`, which calculates down to about 202px. https://github.com/Automattic/wp-calypso/blob/069ff38109e30c76e1647bab892718ea96831d60/client/landing/gutenboarding/components/plans/variables.scss#L6-L9

- **Lower than `$break-large` (960px) is when borders start to appear.**
  - eCommerce plan is no longer visible around this viewport width, therefore having borders provides a visual cue that there are more plans to be seen.
  - 960px is effectively 50% of FHD (1920x1080) monitors, we can assume that some users are snapping the browser on the right side of the screen.

- **Lower than `$break-mobile` (480px) is when plan items each take 70% of viewport width.**
  - This leaves 30% of room for the next plan item peak out on the side. Or ~15% for the previous plan item and ~15% for the next plan item if user is the middle of scrolling.
  - Related: https://github.com/Automattic/wp-calypso/pull/42029#issuecomment-626552883

## Testing instructions

**For Desktop**
- Browser's horizontal scrollbar should start appearing for viewport width less than 1280px.
- Browser's horizontal scrollbar is the only way to scroll plans table.

**For Mobiles & Tablets**
- Scrolling, or more accurately, panning the plans table should only pan the table. The plans grid header and the more details button should remain in the same position.
- On mobile devices in portrait mode, plan item should occupy 70% of the viewport width.
- Test in both portrait & landscape mode.

_**Important:** You will need to test on actual mobile or tablets, iOS/Android Simulators or via BrowserStack. Simulating devices based on viewport width via Chrome Developer Tools will not work._

**For All Devices**
- When scrolling to the end, it should have either 20px, 44px or 88px spacing (depending on the mobile, small & medium viewport breakpoint). This spacing is simulated using transparent border as browsers do not consider margin or padding worthy of scrollbar estate.

## Screenshots

**Scrolling on desktop**
![2020-05-12_19-40-35 (1)](https://user-images.githubusercontent.com/1287077/81727019-9ab15f00-9488-11ea-80cb-a3d8e7a95309.gif)

**Panning on mobile & tablets**
![2020-05-12_19-38-44 (1)](https://user-images.githubusercontent.com/1287077/81726818-460de400-9488-11ea-9d5e-2814bc280f14.gif)

**Edge To Edge & Margin Simulation**
![image](https://user-images.githubusercontent.com/1287077/81727361-25925980-9489-11ea-88f8-d8a65e625410.png)

**Mobile 70/30 Plan Items**
![image](https://user-images.githubusercontent.com/1287077/81727541-6ab68b80-9489-11ea-8b18-1f58f9d4e094.png)


## Other Fixes

- Fixed plans divider showing on top of fixed footer.

![image](https://user-images.githubusercontent.com/1287077/81818721-ae170580-952e-11ea-960b-004f881ea0ed.png)



