### PR TITLE
Jetpack Cloud: Refine ActivityCard

### DIFF
--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -77,15 +77,7 @@ class ActivityCardList extends Component {
 	}
 
 	renderLogs( actualPage ) {
-		const {
-			allowRestore,
-			hasRealtimeBackups,
-			logs,
-			moment,
-			pageSize,
-			showDateSeparators,
-			siteSlug,
-		} = this.props;
+		const { allowRestore, logs, moment, pageSize, showDateSeparators, siteSlug } = this.props;
 
 		const getPrimaryCardClassName = ( hasMore, dateLogsLength ) =>
 			hasMore && dateLogsLength === 1
@@ -110,7 +102,6 @@ class ActivityCardList extends Component {
 							<ActivityCard
 								{ ...{
 									key: activity.activityId,
-									showActions: hasRealtimeBackups || isActivityBackup( activity ),
 									moment,
 									activity,
 									allowRestore,
@@ -211,12 +202,10 @@ const mapStateToProps = ( state ) => {
 		'active' === rewind.state &&
 		! ( 'queued' === restoreStatus || 'running' === restoreStatus ) &&
 		includes( siteCapabilities, 'restore' );
-	const hasRealtimeBackups = siteCapabilities && includes( siteCapabilities, 'backup-realtime' );
 
 	return {
 		allowRestore,
 		filter,
-		hasRealtimeBackups,
 		rewind,
 		siteId,
 		siteSlug,

--- a/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card-list/index.jsx
@@ -110,9 +110,6 @@ class ActivityCardList extends Component {
 							<ActivityCard
 								{ ...{
 									key: activity.activityId,
-									showContentLink: isActivityBackup( activity )
-										? dateLogs.length > 1 || hasMore
-										: undefined,
 									showActions: hasRealtimeBackups || isActivityBackup( activity ),
 									moment,
 									activity,

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -68,7 +68,7 @@
 
 // make sure the vertical lines don't appear through the transparent backgrounds of the icons
 .activity-card-list {
-	.activity-card {
+	> .activity-card {
 		margin-bottom: 32px;
 		.activity-card__time-icon.gridicon {
 			background: var( --color-surface-backdrop );

--- a/client/landing/jetpack-cloud/components/activity-card-list/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card-list/style.scss
@@ -79,7 +79,7 @@
 // primary cards get primary card emphasis on the left
 .activity-card-list__primary-card,
 .activity-card-list__primary-card-with-more {
-	.card {
+	> .card {
 		padding-left: 20px; // reduce standard 24px padding by 4
 		border-left: 4px solid var( --color-primary-40 );
 	}
@@ -123,12 +123,12 @@
 	width: calc( 100% - 32px - 16px );
 
 	// scooch secondary card elements over
-	.activity-card__time,
-	.card {
+	> .activity-card__time,
+	> .card {
 		transform: translateX( 32px );
 	}
 
-	.card {
+	> .card {
 		// this draws the horizontal line
 		&::before {
 			// same as the left on the vertical line above
@@ -147,7 +147,7 @@
 .activity-card-list__secondary-card {
 	// draw over the line that goes off the screen on the last card
 	&:last-of-type {
-		.card {
+		> .card {
 			&::after {
 				background: var( --color-surface-backdrop );
 				content: '';
@@ -168,7 +168,7 @@
 .activity-card-list__secondary-card-with-more {
 	// a tiny circle at the end of the line, indicating there is more on the next pagination
 	&:last-of-type {
-		.card {
+		> .card {
 			&::after {
 				background: var( --color-neutral-5 );
 				content: '';

--- a/client/landing/jetpack-cloud/components/activity-card/activity-card-streams-media-preview.tsx
+++ b/client/landing/jetpack-cloud/components/activity-card/activity-card-streams-media-preview.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+/**
+ * External dependencies
+ */
+import { useDesktopBreakpoint } from '@automattic/viewport-react';
+
+// FUTURE WORK: universal typings location
+// FUTURE WORK: investigate shape of this object
+// FUTURE WORK: type this as soon as it comes back from the API
+interface Activity {
+	activityMedia?: {
+		available: boolean;
+		medium_url: string;
+		type: 'Image' | string;
+		name: string;
+		url: string;
+		thumbnail_url: string;
+	};
+}
+
+interface Props {
+	streams: Activity[];
+}
+
+const MAX_THUMBNAILS_COUNT = 3;
+const MAX_DESKTOP_THUMBNAILS_COUNT = 5;
+
+const ActivityCardStreamsMediaPreview: FunctionComponent< Props > = ( { streams } ) => {
+	const imgSrcs = streams
+		.map( ( { activityMedia } ) => activityMedia?.medium_url )
+		.filter( ( imgSrc ): imgSrc is string => !! imgSrc );
+
+	const isDesktop = useDesktopBreakpoint();
+	const maxImages = isDesktop ? MAX_DESKTOP_THUMBNAILS_COUNT : MAX_THUMBNAILS_COUNT;
+	const imageCount = imgSrcs.length < maxImages ? imgSrcs.length : maxImages;
+
+	return (
+		<div className="activity-card__streams-media-preview">
+			{ imgSrcs.slice( 0, imageCount ).map( ( imgSrc, index ) => (
+				<div key={ `activity-card__streams-media-preview-img-${ index }` }>
+					<img src={ imgSrc } alt={ `streams preview ${ index }` } />
+				</div>
+			) ) }
+		</div>
+	);
+};
+
+export default ActivityCardStreamsMediaPreview;

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -9,18 +9,19 @@ import React, { Component, Fragment } from 'react';
 /**
  * Internal dependencies
  */
-import Gridicon from 'components/gridicon';
-import Button from 'components/forms/form-button';
-import { Card } from '@automattic/components';
-import ActivityActor from 'my-sites/activity/activity-log-item/activity-actor';
-import ActivityDescription from 'my-sites/activity/activity-log-item/activity-description';
-import ActivityMedia from 'my-sites/activity/activity-log-item/activity-media';
 import { applySiteOffset } from 'lib/site/timezone';
-import PopoverMenu from 'components/popover/menu';
 import {
 	backupDownloadPath,
 	backupRestorePath,
 } from 'landing/jetpack-cloud/sections/backups/paths';
+import { Card } from '@automattic/components';
+import ActivityActor from 'my-sites/activity/activity-log-item/activity-actor';
+import ActivityDescription from 'my-sites/activity/activity-log-item/activity-description';
+import ActivityMedia from 'my-sites/activity/activity-log-item/activity-media';
+import Button from 'components/forms/form-button';
+import Gridicon from 'components/gridicon';
+import PopoverMenu from 'components/popover/menu';
+import StreamsMediaPreview from './activity-card-streams-media-preview';
 
 /**
  * Style dependencies
@@ -228,6 +229,30 @@ class ActivityCard extends Component {
 		);
 	}
 
+	renderMediaPreview() {
+		const {
+			activity: { streams, activityMedia },
+		} = this.props;
+
+		if (
+			streams &&
+			streams.filter( ( { activityMedia: streamActivityMedia } ) => streamActivityMedia?.available )
+				.length > 2
+		) {
+			return <StreamsMediaPreview streams={ streams } />;
+		} else if ( activityMedia?.available ) {
+			return (
+				<ActivityMedia
+					className="activity-card__activity-media"
+					name={ activityMedia.name }
+					thumbnail={ activityMedia.medium_url || activityMedia.thumbnail_url }
+					fullImage={ false }
+				/>
+			);
+		}
+		return null;
+	}
+
 	render() {
 		const {
 			activity,
@@ -245,8 +270,6 @@ class ActivityCard extends Component {
 		} ).format( 'LT' );
 
 		const showActivityContent = this.state.showContent;
-
-		const { activityMedia } = activity;
 
 		return (
 			<div
@@ -268,14 +291,7 @@ class ActivityCard extends Component {
 						} }
 					/>
 					<div className="activity-card__activity-description">
-						{ activityMedia && activityMedia.available && (
-							<ActivityMedia
-								className="activity-card__activity-media"
-								name={ activityMedia.name }
-								thumbnail={ activityMedia.medium_url || activityMedia.thumbnail_url }
-								fullImage={ false }
-							/>
-						) }
+						{ this.renderMediaPreview() }
 						<ActivityDescription activity={ activity } rewindIsActive={ allowRestore } />
 					</div>
 					<div className="activity-card__activity-title">{ activity.activityTitle }</div>

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -37,7 +37,6 @@ class ActivityCard extends Component {
 	};
 
 	static defaultProps = {
-		showActions: true,
 		summarize: false,
 	};
 
@@ -141,6 +140,11 @@ class ActivityCard extends Component {
 		return <a className="activity-card__detail-link">{ translate( 'Changes in this backup' ) }</a>;
 	}
 
+	shouldRenderActionButtons() {
+		const { activity, showActions } = this.props;
+		return activity.activityIsRewindable && showActions;
+	}
+
 	renderActionButton( isTopToolbar = true ) {
 		const { activity, siteSlug, translate } = this.props;
 
@@ -200,22 +204,21 @@ class ActivityCard extends Component {
 	renderBottomToolbar = () => this.renderToolbar( false );
 
 	renderToolbar( isTopToolbar = true ) {
-		const { showActions } = this.props;
-
 		const shouldRenderContentLink = this.shouldRenderContentLink();
+		const shouldRenderActionButtons = this.shouldRenderActionButtons();
 
-		return ! ( shouldRenderContentLink || showActions ) ? null : (
+		return ! ( shouldRenderContentLink || shouldRenderActionButtons ) ? null : (
 			<>
 				<div
 					// force the actions to stay in the left if we aren't showing the content link
 					className={
-						! shouldRenderContentLink && showActions
+						! shouldRenderContentLink && shouldRenderActionButtons
 							? 'activity-card__activity-actions-reverse'
 							: 'activity-card__activity-actions'
 					}
 				>
 					{ shouldRenderContentLink && this.renderContentLink() }
-					{ showActions && this.renderActionButton( isTopToolbar ) }
+					{ shouldRenderActionButtons && this.renderActionButton( isTopToolbar ) }
 				</div>
 			</>
 		);

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -31,14 +31,11 @@ import downloadIcon from './download-icon.svg';
 
 class ActivityCard extends Component {
 	static propTypes = {
-		showActions: PropTypes.bool,
 		summarize: PropTypes.bool,
-		compact: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		summarize: false,
-		compact: false,
 	};
 
 	topPopoverContext = React.createRef();
@@ -71,7 +68,7 @@ class ActivityCard extends Component {
 	};
 
 	renderStreams( streams = [] ) {
-		const { allowRestore, moment, siteSlug } = this.props;
+		const { allowRestore, moment, siteSlug, translate } = this.props;
 
 		return streams.map( ( item, index ) => {
 			const activityMedia = item.activityMedia;
@@ -97,8 +94,8 @@ class ActivityCard extends Component {
 					compact
 					key={ item.activityId }
 					moment={ moment }
-					showActions={ false }
 					siteSlug={ siteSlug }
+					translate={ translate }
 				/>
 			);
 		} );
@@ -118,16 +115,10 @@ class ActivityCard extends Component {
 		);
 	}
 
-	hasStreamContent() {
-		const { activity } = this.props;
-		return !! activity.streams;
-	}
-
-	renderStreamContent() {
+	renderExpandContentControl() {
 		const { translate } = this.props;
 
-		// todo: handle the rest of cases
-		return this.hasStreamContent() ? (
+		return (
 			<Button
 				compact
 				borderless
@@ -142,12 +133,7 @@ class ActivityCard extends Component {
 					className="activity-card__see-content-icon"
 				/>
 			</Button>
-		) : null;
-	}
-
-	shouldRenderActionButtons() {
-		const { activity, showActions } = this.props;
-		return activity.activityIsRewindable && showActions;
+		);
 	}
 
 	renderActionButton( isTopToolbar = true ) {
@@ -209,21 +195,22 @@ class ActivityCard extends Component {
 	renderBottomToolbar = () => this.renderToolbar( false );
 
 	renderToolbar( isTopToolbar = true ) {
-		const shouldRenderActionButtons = this.shouldRenderActionButtons();
-		const hasStreamContent = this.hasStreamContent();
+		const {
+			activity: { activityIsRewindable, streams },
+		} = this.props;
 
-		return ! ( hasStreamContent || shouldRenderActionButtons ) ? null : (
+		return ! ( streams || activityIsRewindable ) ? null : (
 			<Fragment key={ `activity-card__toolbar-${ isTopToolbar ? 'top' : 'bottom' }` }>
 				<div
 					// force the actions to stay in the left if we aren't showing the content link
 					className={
-						! hasStreamContent && shouldRenderActionButtons
+						! streams && activityIsRewindable
 							? 'activity-card__activity-actions-reverse'
 							: 'activity-card__activity-actions'
 					}
 				>
-					{ this.renderStreamContent() }
-					{ shouldRenderActionButtons && this.renderActionButton( isTopToolbar ) }
+					{ streams && this.renderExpandContentControl() }
+					{ activityIsRewindable && this.renderActionButton( isTopToolbar ) }
 				</div>
 			</Fragment>
 		);
@@ -254,15 +241,7 @@ class ActivityCard extends Component {
 	}
 
 	render() {
-		const {
-			activity,
-			allowRestore,
-			compact,
-			className,
-			gmtOffset,
-			summarize,
-			timezone,
-		} = this.props;
+		const { activity, allowRestore, className, gmtOffset, summarize, timezone } = this.props;
 
 		const backupTimeDisplay = applySiteOffset( activity.activityTs, {
 			timezone,
@@ -272,9 +251,7 @@ class ActivityCard extends Component {
 		const showActivityContent = this.state.showContent;
 
 		return (
-			<div
-				className={ classnames( className, compact ? 'activity-card-compact' : 'activity-card' ) }
-			>
+			<div className={ classnames( className, 'activity-card' ) }>
 				{ ! summarize && (
 					<div className="activity-card__time">
 						<Gridicon icon={ activity.activityIcon } className="activity-card__time-icon" />

--- a/client/landing/jetpack-cloud/components/activity-card/index.jsx
+++ b/client/landing/jetpack-cloud/components/activity-card/index.jsx
@@ -32,10 +32,12 @@ class ActivityCard extends Component {
 	static propTypes = {
 		showActions: PropTypes.bool,
 		summarize: PropTypes.bool,
+		compact: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		summarize: false,
+		compact: false,
 	};
 
 	topPopoverContext = React.createRef();
@@ -68,12 +70,13 @@ class ActivityCard extends Component {
 	};
 
 	renderStreams( streams = [] ) {
+		const { allowRestore, moment, siteSlug } = this.props;
+
 		return streams.map( ( item, index ) => {
 			const activityMedia = item.activityMedia;
 
-			return (
-				activityMedia &&
-				activityMedia.available && (
+			if ( activityMedia && activityMedia.available ) {
+				return (
 					<div
 						key={ `activity-card__streams-item-${ index }` }
 						className="activity-card__streams-item"
@@ -84,7 +87,18 @@ class ActivityCard extends Component {
 							fullImage={ activityMedia.medium_url || activityMedia.thumbnail_url }
 						/>
 					</div>
-				)
+				);
+			}
+			return (
+				<ActivityCard
+					activity={ item }
+					allowRestore={ allowRestore }
+					compact
+					key={ item.activityId }
+					moment={ moment }
+					showActions={ false }
+					siteSlug={ siteSlug }
+				/>
 			);
 		} );
 	}
@@ -105,9 +119,7 @@ class ActivityCard extends Component {
 
 	hasStreamContent() {
 		const { activity } = this.props;
-		return (
-			activity.streams && activity.streams.some( ( stream ) => stream.activityMedia?.available )
-		);
+		return !! activity.streams;
 	}
 
 	renderStreamContent() {
@@ -217,7 +229,15 @@ class ActivityCard extends Component {
 	}
 
 	render() {
-		const { activity, allowRestore, className, gmtOffset, summarize, timezone } = this.props;
+		const {
+			activity,
+			allowRestore,
+			compact,
+			className,
+			gmtOffset,
+			summarize,
+			timezone,
+		} = this.props;
 
 		const backupTimeDisplay = applySiteOffset( activity.activityTs, {
 			timezone,
@@ -229,7 +249,9 @@ class ActivityCard extends Component {
 		const { activityMedia } = activity;
 
 		return (
-			<div className={ classnames( className, 'activity-card' ) }>
+			<div
+				className={ classnames( className, compact ? 'activity-card-compact' : 'activity-card' ) }
+			>
 				{ ! summarize && (
 					<div className="activity-card__time">
 						<Gridicon icon={ activity.activityIcon } className="activity-card__time-icon" />

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -1,11 +1,21 @@
-.activity-card .card {
-	border-radius: 3px;
-}
+.activity-card,
+.activity-card-compact {
+	.card {
+		border-radius: 3px;
+	}
 
-.activity-card .activity-log-item__actor {
-	margin-left: 0;
-	display: flex;
-	align-items: center;
+	.activity-log-item__actor {
+		margin-left: 0;
+		display: flex;
+		align-items: center;
+	}
+
+	.activity-log-item__actor-info .activity-log-item__actor-name,
+	.activity-log-item__actor-info .activity-log-item__actor-role,
+	.activity-card__activity-title {
+		font-size: 0.8rem;
+		color: rgb( 100, 105, 112 );
+	}
 }
 
 .activity-card__time {
@@ -30,13 +40,6 @@
 
 .activity-log-item__actor-info {
 	margin-left: 1rem;
-}
-
-.activity-card .activity-log-item__actor-info .activity-log-item__actor-name,
-.activity-card .activity-log-item__actor-info .activity-log-item__actor-role,
-.activity-card__activity-title {
-	font-size: 0.8rem;
-	color: rgb( 100, 105, 112 );
 }
 
 .activity-card__activity-title {

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -149,3 +149,27 @@
 	font-size: 12px;
 	text-align: left;
 }
+
+.activity-card__streams-media-preview {
+	display: flex;
+	flex-direction: row;
+	margin: 16px 0;
+
+	div {
+		max-width: 72px;
+		max-height: 72px;
+		overflow: hidden;
+		text-align: center;
+
+		img {
+			min-width: 72px;
+			max-width: none;
+			max-height: 72px;
+			margin: 0 -100%;
+		}
+
+		&:not( :first-child ) {
+			margin-left: 16px;
+		}
+	}
+}

--- a/client/landing/jetpack-cloud/components/activity-card/style.scss
+++ b/client/landing/jetpack-cloud/components/activity-card/style.scss
@@ -1,5 +1,4 @@
-.activity-card,
-.activity-card-compact {
+.activity-card {
 	.card {
 		border-radius: 3px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide all "links" in Activity Card Toolbars except for stream expansion
* Only show actions on rewindable activities
![Untitled 4](https://user-images.githubusercontent.com/2810519/81748978-a63c6000-945f-11ea-89cb-3ee384bfb8db.png)
* Add Multi-Image Preview for Media Activities with Streams
![Untitled 5](https://user-images.githubusercontent.com/2810519/81749219-121ec880-9460-11ea-84b2-6a48a0a4b3e6.png)
* Add Stream Expansion for non-Media Activities with Streams
<img width="738" alt="Screen Shot 2020-05-12 at 2 46 04 PM" src="https://user-images.githubusercontent.com/2810519/81749080-d5eb6800-945f-11ea-9496-70b2bb6fb0d5.png">
* Fix console error ( React Keys ) when expanding Stream content

#### Testing instructions

1. Navigate to `/backups/activity` for a site with Real-Time Backups
2. Verify that actions are gone from non-rewindable actions like logins
3. Verify the "changes in this backup" links are gone from Backup Activities
4. Test Stream expansion for non-Media types
