### PR TITLE
Stylelint: Allow 'inherit' as a font-weight value.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,7 @@
 {
 	"plugins": ["@signal-noise/stylelint-scales"],
 	"rules": {
-		"scales/font-weight": [[ 400, 600, 700, "normal", "bold" ]],
+		"scales/font-weight": [[ 400, 600, 700, "normal", "bold", "inherit" ]],
 
 		"color-hex-case": "lower",
 		"color-no-invalid-hex": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds "inherit" to the array of allowed values for font weights.
* I've been looking into applying a type scale and came across these lint errors as I was working; quick fix to clear 'em out.

#### Testing instructions

* Switch to this PR
* Try modifying a sass file and adding a bad font-weight value that isn't 400, 600, normal, inherit, or bold.
* Try to commit locally
* stylelint should throw errors:

<img width="567" alt="Screen Shot 2020-05-12 at 3 16 19 PM" src="https://user-images.githubusercontent.com/2124984/81735779-90309e80-9463-11ea-8748-24bf8b67326c.png">

* Try modifying a sass file and adding a font-weight of "inherit". You should be allowed to commit locally.
