### PR TITLE
My Home: Remove client handling of the new Go Mobile cards.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/go-mobile/index.js
+++ b/client/my-sites/customer-home/cards/tasks/go-mobile/index.js
@@ -48,7 +48,7 @@ const GoMobile = ( { isIos } ) => {
 			) }
 			actionButton={ actionButton }
 			timing={ 2 }
-			taskId="go-mobile"
+			taskId={ isIos ? 'go-mobile-ios' : 'go-mobile-android' }
 		/>
 	);
 };

--- a/client/my-sites/customer-home/locations/primary/index.jsx
+++ b/client/my-sites/customer-home/locations/primary/index.jsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import { isDesktop } from '@automattic/viewport';
-import userAgent from 'lib/user-agent';
 
 /**
  * Internal dependencies
@@ -28,18 +26,6 @@ const Primary = ( { checklistMode, cards } ) => {
 		return null;
 	}
 
-	// Hard-coded. To be removed after D43129-code is merged
-	if ( ! isDesktop() ) {
-		const { isiPad, isiPod, isiPhone, isAndroid } = userAgent;
-		const isIos = isiPad || isiPod || isiPhone;
-		if ( isAndroid || isIos ) {
-			const emulatedTask = isAndroid ? 'home-task-go-mobile-android' : 'home-task-go-mobile-ios';
-			// Prevent duplicates once D43129-code is merged
-			if ( -1 === cards.indexOf( emulatedTask ) ) {
-				cards.push( emulatedTask );
-			}
-		}
-	}
 	return (
 		<>
 			{ cards.map( ( card, index ) =>


### PR DESCRIPTION
This PR removes the special client handling we have for the Go Mobile card, that was compensating for D43129-code (which is about to be deployed). This is a followup to https://github.com/Automattic/wp-calypso/pull/42127.

**Testing Instructions**
* Use the Device Toolbar in devtools to load My Home with an iOS or Android mobile view.
* Dismiss any tasks you see until the Go Mobile task card loads (no bueno).
* For the same site, load My Home on this branch's calypso.live environment.
* Verify the card is not displayed.