### PR TITLE
Premium Content: Change tab name to "Non-Subscriber View"

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
@@ -19,10 +19,7 @@ import Inspector from './inspector';
 import StripeNudge from './stripe-nudge';
 import Context from './context';
 import apiFetch from '@wordpress/api-fetch';
-import {
-	isPriceValid,
-	minimumTransactionAmountForCurrency,
-} from '.';
+import { isPriceValid, minimumTransactionAmountForCurrency } from '.';
 
 /**
  * @typedef { import('./plan').Plan } Plan
@@ -40,7 +37,7 @@ const tabs = [
 	},
 	{
 		id: 'wall',
-		label: <span>{ __( 'Logged Out View', 'premium-content' ) }</span>,
+		label: <span>{ __( 'Non-Subscriber View', 'premium-content' ) }</span>,
 		className: 'wp-premium-content-logged-out-view',
 	},
 ];
@@ -114,10 +111,10 @@ function Edit( props ) {
 
 		const newPrice = parseFloat( attributes.newPlanPrice );
 		const minPrice = minimumTransactionAmountForCurrency( attributes.newPlanCurrency );
-		const minimumPriceNote = sprintf( __( 'Minimum allowed price is %s.', 'premium-content' ), formatCurrency(
-			minPrice,
-			attributes.newPlanCurrency
-		) );
+		const minimumPriceNote = sprintf(
+			__( 'Minimum allowed price is %s.', 'premium-content' ),
+			formatCurrency( minPrice, attributes.newPlanCurrency )
+		);
 
 		if ( newPrice < minPrice ) {
 			onError( props, minimumPriceNote );

--- a/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/premium-content/blocks/container/edit.js
@@ -37,7 +37,7 @@ const tabs = [
 	},
 	{
 		id: 'wall',
-		label: <span>{ __( 'Non-Subscriber View', 'premium-content' ) }</span>,
+		label: <span>{ __( 'Non-subscriber View', 'premium-content' ) }</span>,
 		className: 'wp-premium-content-logged-out-view',
 	},
 ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* "Logged Out View" is now "Non-Subscriber View"

#### Testing instructions

Start the things
```
cd apps/full-site-editing
yarn dev
wp-env start
```

Open WordPress in the browser

```
open http://localhost:`cat .wp-env.json | jq .port`/wp-admin/post-new.php
```

Sign in with `admin`/`admin` or whatever you may have changed the password to.

Add a Premium Content block and observe the updated tab name:

<img width="801" alt="image" src="https://user-images.githubusercontent.com/19795/81751114-a0487e00-9463-11ea-921c-0efd67652bbb.png">


Fixes #42049
