### PR TITLE
Checkout: add product info in the props of the checkout pageview event

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -206,6 +206,7 @@ export class Checkout extends React.Component {
 			saved_cards: props.cards.length,
 			is_renewal: hasRenewalItem( props.cart ),
 			apple_pay_available: isApplePayAvailable(),
+			product_slug: props.product,
 		} );
 
 		recordViewCheckout( props.cart );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Including Product information upon checkout.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* load `checkout/:site/:product_slug` 
* verify that `calypso_checkout_page_view` fires with a correct `product_slug` prop