### PR TITLE
My Home: Prevent widows in the Go Mobile task.

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/go-mobile/index.js
+++ b/client/my-sites/customer-home/cards/tasks/go-mobile/index.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Task from '../task';
+import { preventWidows } from 'lib/formatting';
 import AppsBadge from 'blocks/get-apps/apps-badge';
 
 /**
@@ -42,9 +43,11 @@ const GoMobile = ( { isIos } ) => {
 
 	return (
 		<Task
-			title={ translate( 'Update and manage on the go' ) }
-			description={ translate(
-				'Inspiration strikes any time, anywhere. Post, read, check stats, and more with the Wordpress app at your fingertips.'
+			title={ preventWidows( translate( 'Update and manage on the go' ) ) }
+			description={ preventWidows(
+				translate(
+					'Inspiration strikes any time, anywhere. Post, read, check stats, and more with the Wordpress app at your fingertips.'
+				)
 			) }
 			actionButton={ actionButton }
 			timing={ 2 }

--- a/client/my-sites/customer-home/cards/tasks/go-mobile/index.js
+++ b/client/my-sites/customer-home/cards/tasks/go-mobile/index.js
@@ -46,7 +46,7 @@ const GoMobile = ( { isIos } ) => {
 			title={ preventWidows( translate( 'Update and manage on the go' ) ) }
 			description={ preventWidows(
 				translate(
-					'Inspiration strikes any time, anywhere. Post, read, check stats, and more with the Wordpress app at your fingertips.'
+					'Inspiration strikes any time, anywhere. Post, read, check stats, and more with the WordPress app at your fingertips.'
 				)
 			) }
 			actionButton={ actionButton }


### PR DESCRIPTION
We can get widows with the GoMobile task content on some phones, like the iPhone X. This PR tidies that up.

Before | After
--- | --- 
 ![image](https://user-images.githubusercontent.com/349751/81754490-2a481500-946b-11ea-84a1-50c69c4ad019.png) | ![image](https://user-images.githubusercontent.com/349751/81754484-25836100-946b-11ea-99e0-1a0bc4403cd1.png)



#### Testing instructions

* Use devtools to load a site's My Home with an iOS or Android UA (you can use the Device Toolbar to select a device on either platform).
* Dismiss your tasks so that the Go Mobile card is displayed.
* Verify there are no widows in English in any content. Check with other devices.
