### PR TITLE
Gutenboarding: Move intent gathering text to top of screen on mobile

### DIFF
--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -50,6 +50,13 @@ const AcquireIntent: React.FunctionComponent = () => {
 
 	const hasSiteTitle = !! getSelectedSiteTitle();
 	const showSiteTitleAndNext = !! ( getSelectedVertical() || hasSiteTitle || wasVerticalSkipped() );
+
+	React.useEffect( () => {
+		if ( isMobile ) {
+			window.scrollTo( 0, 0 );
+		}
+	}, [ isSiteTitleActive, isMobile ] );
+
 	// translators: Button label for skipping filling an optional input in onboarding
 	const skipLabel = __( 'I donʼt know' );
 
@@ -99,13 +106,13 @@ const AcquireIntent: React.FunctionComponent = () => {
 		>
 			{ isMobile &&
 				( isSiteTitleActive ? (
-					<>
+					<div>
 						<Arrow
 							className="acquire-intent__mobile-back-arrow"
 							onClick={ () => setIsSiteTitleActive( false ) }
 						/>
 						{ siteTitleInput }
-					</>
+					</div>
 				) : (
 					verticalSelect
 				) ) }

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/index.tsx
@@ -3,7 +3,6 @@
  */
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import classnames from 'classnames';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
@@ -99,11 +98,7 @@ const AcquireIntent: React.FunctionComponent = () => {
 	const siteVertical = getSelectedVertical();
 
 	return (
-		<div
-			className={ classnames( 'gutenboarding-page acquire-intent', {
-				'acquire-intent--mobile-vertical-step': ! isSiteTitleActive && isMobile,
-			} ) }
-		>
+		<div className="gutenboarding-page acquire-intent">
 			{ isMobile &&
 				( isSiteTitleActive ? (
 					<div>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -14,19 +14,11 @@
 	flex-direction: column;
 	justify-content: space-between;
 	margin: 0 -20px;
-	padding: 20px;
+	padding: 25px 20px 20px;
 	transition: color $acquire-intent-transition-duration
 			$acquire-intent-transition-algorithm,
 		background-color $acquire-intent-transition-duration
 			$acquire-intent-transition-algorithm;
-
-	&--mobile-vertical-step {
-		justify-content: center;
-
-		.acquire-intent__footer {
-			margin-top: auto;
-		}
-	}
 
 	@include break-small {
 		margin: 0 -44px; // override block margins
@@ -59,6 +51,8 @@
 }
 
 .acquire-intent__mobile-back-arrow {
+	display: block;
+	margin-bottom: 25px;
 	transform: rotate( 180deg );
 }
 

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -60,6 +60,7 @@
 
 .acquire-intent__mobile-back-arrow {
 	transform: rotate( 180deg );
+	margin: 10px 0;
 }
 
 .madlib__input {
@@ -129,6 +130,12 @@
 
 .site-title {
 	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
+
+	flex-grow: 1;
+
+	@include break-small {
+		flex-grow: 0;
+	}
 
 	&--hidden {
 		visibility: hidden;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/style.scss
@@ -60,7 +60,6 @@
 
 .acquire-intent__mobile-back-arrow {
 	transform: rotate( 180deg );
-	margin: 10px 0;
 }
 
 .madlib__input {
@@ -130,12 +129,6 @@
 
 .site-title {
 	transition: opacity $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
-
-	flex-grow: 1;
-
-	@include break-small {
-		flex-grow: 0;
-	}
 
 	&--hidden {
 		visibility: hidden;

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -252,7 +252,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 		<form
 			className={ classnames( 'vertical-select', {
-				'vertical-select--with-suggestions': !! suggestions.length && isMobile,
+				'vertical-select--with-suggestions': isMobile,
 			} ) }
 			onClick={ () => inputRef.current.focus() } // focus the input when clicking label or placeholder
 		>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/index.tsx
@@ -190,7 +190,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 	}, [ siteVertical, inputRef ] );
 
 	React.useEffect( () => {
-		if ( !! suggestions.length && isMobile ) {
+		if ( isMobile ) {
 			window.scrollTo( 0, 0 );
 		}
 	}, [ suggestions, isMobile ] );
@@ -252,7 +252,7 @@ const VerticalSelect: React.FunctionComponent< Props > = ( { onNext } ) => {
 		/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 		<form
 			className={ classnames( 'vertical-select', {
-				'vertical-select--with-suggestions': isMobile,
+				'vertical-select--with-suggestions': !! suggestions.length && isMobile,
 			} ) }
 			onClick={ () => inputRef.current.focus() } // focus the input when clicking label or placeholder
 		>

--- a/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
+++ b/client/landing/gutenboarding/onboarding-block/acquire-intent/vertical-select/style.scss
@@ -7,7 +7,6 @@
 	transition: flex-grow $acquire-intent-transition-duration $acquire-intent-transition-algorithm;
 	display: flex;
 	flex-direction: column;
-	margin-top: auto;
 
 	&--with-suggestions {
 		flex-grow: 1;


### PR DESCRIPTION
As reported in https://github.com/Automattic/wp-calypso/issues/41923, because we're using `contenteditable` instead of an `input` field in the intent gathering steps, the browser default behaviour in iOS of opening the keyboard and moving the viewport so that the field is in the correct position, is not happening.

This PR is a workaround to keep the text in the intent gathering steps at the top of the screen on mobile, to see if that improves the UX when using Gutenboarding from a phone.

#### Changes proposed in this Pull Request

* Remove `margin-top: auto` so that the two sub-steps (vertical selection and site title) sit at the top of the page on mobile.
* Add "scroll to top" when `isSiteTitleActive` changes (when a user submits a vertical).
* In the site title wrap the arrow and `siteTitleInput` in a div so that they naturally sit at the top of the page.
* Set the vertical select to scroll to top when the suggestions are closed, not just when they're open (this [fixes an issue reported below](https://github.com/Automattic/wp-calypso/pull/42136#issuecomment-627765655) and ensures that if a user scrolls down the list of suggestions and taps outside of the suggestions area, that they're scrolled back to the input area)

#### Screenshot

![image](https://user-images.githubusercontent.com/14988353/81765656-c16aa680-9517-11ea-81e5-7c8359658223.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` on a real mobile device (specifically an iPhone running Safari, but also check in another browser, e.g. Chrome) and see if this change keeps the text at the top of the screen and makes it easier to type in these fields
* Check that this doesn't introduce any regressions or issues on desktop screen sizes

Related to issue https://github.com/Automattic/wp-calypso/issues/41923
