### PR TITLE
Adds `marketing_price_group` dependency to oauth2 flows

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -368,14 +368,26 @@ export function generateSteps( {
 				oauth2Signup: true,
 			},
 			providesToken: true,
-			providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],
+			providesDependencies: [
+				'bearer_token',
+				'username',
+				'oauth2_client_id',
+				'oauth2_redirect',
+				'marketing_price_group',
+			],
 		},
 
 		'oauth2-name': {
 			stepName: 'oauth2-name',
 			apiRequestFunction: createAccount,
 			providesToken: true,
-			providesDependencies: [ 'bearer_token', 'username', 'oauth2_client_id', 'oauth2_redirect' ],
+			providesDependencies: [
+				'bearer_token',
+				'username',
+				'oauth2_client_id',
+				'oauth2_redirect',
+				'marketing_price_group',
+			],
 			props: {
 				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
 				oauth2Signup: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `marketing_price_group` to oauth2 flows

#### Testing instructions

* Go to crowdsignal.com -> Login -> Create WordPress account -> Verify the flow completes without errors in the console.

/cc @southp @CGastrell 