### PR TITLE
Gutenboarding: Increase size of input text size to avoid zooming in on iOS

### DIFF
--- a/client/landing/gutenboarding/components/signup-form/index.tsx
+++ b/client/landing/gutenboarding/components/signup-form/index.tsx
@@ -143,6 +143,7 @@ const SignupForm = ( { onRequestClose }: Props ) => {
 							value={ passwordVal }
 							disabled={ isFetchingNewUser }
 							type="password"
+							autoComplete="new-password"
 							onChange={ setPasswordVal }
 							placeholder={ __( 'Password' ) }
 							required

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -76,6 +76,7 @@
 		}
 
 		@include break-mobile {
+			@include onboarding-medium-text;
 			max-width: 400px;
 		}
 	}

--- a/client/landing/gutenboarding/components/signup-form/style.scss
+++ b/client/landing/gutenboarding/components/signup-form/style.scss
@@ -64,11 +64,16 @@
 
 	.components-text-control__input {
 		padding: 18px 14px;
-		@include onboarding-medium-text;
+		font-size: 16px;
+		line-height: 17px;
 		border-radius: 0;
 		border: 1px solid var( --studio-gray-10 );
 		width: 100%;
 		max-width: 100%;
+
+		&::placeholder {
+			@include onboarding-medium-text;
+		}
 
 		@include break-mobile {
 			max-width: 400px;


### PR DESCRIPTION
This PR prevents zooming in on mobile when a user taps one of the signup input fields, and also sets the autocomplete attribute on the password field.

#### Changes proposed in this Pull Request

* Increase font size in input text fields in signup in Gutenboarding to 16px on mobile to prevent zooming in iOS
* Keep placeholder font sizes to 14px to match the design
* Add `autocomplete` setting of `new-password` to the password field to encourage browsers the support it to automatically generate a password

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/new` on an iOS device while signed out
* Complete the flow until you get to the signup form
* Enter any email address and an automatically generated password should be suggested for you
* Tap on the password field, and the browser should _not_ zoom in

* Test the signup form on desktop — it should work normally and the placeholder text should be unchanged from `master`.

Fixes #
