### PR TITLE
Sidebar: Adjust Checklist Progress Width

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -69,13 +69,13 @@
 
 // Checklist progress
 .sidebar__menu .myhome .sidebar__menu-link-text {
-	max-width: 75%;
+	max-width: calc( 100% - 80px );
 	white-space: normal;
 	padding-right: 8px;
 }
 
 .sidebar__checklist-progress {
-	width: 25%;
+	width: 80px;
 
 	.sidebar__checklist-progress-text {
 		font-size: 12px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes the change suggested by @rickybanister in https://github.com/Automattic/wp-calypso/pull/42022#issuecomment-627657341:

> The sparkline is hardcoded to 80px. Since the two bars are in such close proximity it may make sense to align them and use 80px for both.

#### Testing instructions

On a site where it's possible to continue the checklist, verify that the width of the progress bar is okay.

<img width="275" alt="Screenshot 2020-05-13 at 09 50 45" src="https://user-images.githubusercontent.com/43215253/81792141-91afa480-94ff-11ea-9159-7ecd4d5a60c3.png">