### PR TITLE
Gutenboarding: Plans details scrolling UX improvements.

### DIFF
--- a/client/landing/gutenboarding/components/plans/plans-details/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-details/index.tsx
@@ -12,7 +12,7 @@ import { useSelect } from '@wordpress/data';
  */
 import './style.scss';
 
-const PlansDetails: React.FunctionComponent = () => {
+const PlansDetails: React.FunctionComponent = ( props ) => {
 	const plansDetails = useSelect( ( select ) => select( PLANS_STORE ).getPlansDetails() );
 
 	const { __ } = useI18n();
@@ -63,6 +63,7 @@ const PlansDetails: React.FunctionComponent = () => {
 					</tbody>
 				) ) }
 			</table>
+			{ props.children }
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/components/plans/plans-details/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-details/index.tsx
@@ -19,52 +19,50 @@ const PlansDetails: React.FunctionComponent = () => {
 
 	return (
 		<div className="plans-details">
-			<div className="plans-details__viewport">
-				<table className="plans-details__table">
-					<thead>
-						<tr className="plans-details__header-row">
-							<th>{ __( 'Feature' ) }</th>
-							<th>{ __( 'Free' ) }</th>
-							<th>{ __( 'Personal' ) }</th>
-							<th>{ __( 'Premium' ) }</th>
-							<th>{ __( 'Business' ) }</th>
-							<th>{ __( 'eCommerce' ) }</th>
-						</tr>
-					</thead>
-					{ plansDetails.map( ( detail ) => (
-						<tbody key={ detail.id }>
-							{ detail.name && (
-								<tr className="plans-details__header-row">
-									<th colSpan={ 6 }>{ detail.name }</th>
-								</tr>
-							) }
-							{ detail.features.map( ( feature, i ) => (
-								<tr className="plans-details__feature-row" key={ i }>
-									<th>{ feature.name }</th>
-									{ feature.data.map( ( value, j ) => (
-										<td key={ j }>
-											{ feature.type === 'checkbox' &&
-												( value ? (
-													<>
-														{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-														<span className="hidden">{ __( 'Available' ) }</span>
-														<Icon icon="yes-alt" />
-													</>
-												) : (
-													<>
-														{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-														<span className="hidden">{ __( 'Unavailable' ) } </span>
-													</>
-												) ) }
-											{ feature.type === 'text' && value }
-										</td>
-									) ) }
-								</tr>
-							) ) }
-						</tbody>
-					) ) }
-				</table>
-			</div>
+			<table className="plans-details__table">
+				<thead>
+					<tr className="plans-details__header-row">
+						<th>{ __( 'Feature' ) }</th>
+						<th>{ __( 'Free' ) }</th>
+						<th>{ __( 'Personal' ) }</th>
+						<th>{ __( 'Premium' ) }</th>
+						<th>{ __( 'Business' ) }</th>
+						<th>{ __( 'eCommerce' ) }</th>
+					</tr>
+				</thead>
+				{ plansDetails.map( ( detail ) => (
+					<tbody key={ detail.id }>
+						{ detail.name && (
+							<tr className="plans-details__header-row">
+								<th colSpan={ 6 }>{ detail.name }</th>
+							</tr>
+						) }
+						{ detail.features.map( ( feature, i ) => (
+							<tr className="plans-details__feature-row" key={ i }>
+								<th>{ feature.name }</th>
+								{ feature.data.map( ( value, j ) => (
+									<td key={ j }>
+										{ feature.type === 'checkbox' &&
+											( value ? (
+												<>
+													{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+													<span className="hidden">{ __( 'Available' ) }</span>
+													<Icon icon="yes-alt" />
+												</>
+											) : (
+												<>
+													{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+													<span className="hidden">{ __( 'Unavailable' ) } </span>
+												</>
+											) ) }
+										{ feature.type === 'text' && value }
+									</td>
+								) ) }
+							</tr>
+						) ) }
+					</tbody>
+				) ) }
+			</table>
 		</div>
 	);
 };

--- a/client/landing/gutenboarding/components/plans/plans-details/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-details/style.scss
@@ -12,7 +12,7 @@
 
 		&:first-child {
 			padding-left: 0;
-			width: 25%;
+			width: 20%;
 
 			@include break-mobile {
 				width: 40%;

--- a/client/landing/gutenboarding/components/plans/plans-details/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-details/style.scss
@@ -2,23 +2,8 @@
 @import '../../../mixins.scss';
 @import '../../../variables.scss';
 
-.plans-details__viewport {
-	overflow: auto;
-
-	.plans-details__table {
-		border-left: 30px solid transparent;
-		border-right: 30px solid transparent;
-
-		@include break-medium {
-			border-left: 0;
-			border-right: 0;
-		}
-	}
-}
-
 .plans-details__table {
 	width: 100%;
-	min-width: $break-medium;
 	table-layout: fixed;
 
 	th,

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -68,12 +68,14 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 
 			<div className="plans-grid__details">
 				{ showDetails && (
-					<div className="plans-grid__details-container">
+					<>
 						<div className="plans-grid__details-heading">
 							<Title>{ __( 'Detailed comparison' ) }</Title>
 						</div>
-						<PlansDetails />
-					</div>
+						<div className="plans-grid__details-container">
+							<PlansDetails />
+						</div>
+					</>
 				) }
 				<Button
 					className="plans-grid__details-toggle-button"

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -44,7 +44,12 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 	};
 
 	return (
-		<div className={ classNames( 'plans-grid', { 'is-mobile': isMobile } ) }>
+		<div
+			className={ classNames( 'plans-grid', {
+				'is-mobile': isMobile,
+				'show-details': showDetails,
+			} ) }
+		>
 			<div className="plans-grid__header">
 				<div>
 					<Title>{ __( 'Choose a plan' ) }</Title>
@@ -67,37 +72,34 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 			</div>
 
 			<div className="plans-grid__details">
-				{ showDetails && (
-					<>
-						<div className="plans-grid__details-heading">
-							<Title>{ __( 'Detailed comparison' ) }</Title>
+				<div className="plans-grid__details-heading">
+					<Title>{ __( 'Detailed comparison' ) }</Title>
+				</div>
+				<div className="plans-grid__details-container">
+					<PlansDetails>
+						<div className="plans-grid__details-actions">
+							{ showDetails ? (
+								<Button
+									className="plans-grid__details-toggle-button is-collapse-button"
+									isLarge
+									onClick={ handleDetailsToggleButtonClick }
+								>
+									<span>{ __( 'Less details' ) } </span>
+									<Icon icon="arrow-up" size={ 20 }></Icon>
+								</Button>
+							) : (
+								<Button
+									className="plans-grid__details-toggle-button is-expand-button"
+									isLarge
+									onClick={ handleDetailsToggleButtonClick }
+								>
+									<span>{ __( 'More details' ) } </span>
+									<Icon icon="arrow-down" size={ 20 }></Icon>
+								</Button>
+							) }
 						</div>
-						<div className="plans-grid__details-container">
-							<PlansDetails />
-						</div>
-					</>
-				) }
-				{ /* They are separate buttons to prevent the buttons itself getting
-				     auto-focused and scrolled to when plans details display. */ }
-				{ showDetails ? (
-					<Button
-						className="plans-grid__details-toggle-button is-collapse-button"
-						isLarge
-						onClick={ handleDetailsToggleButtonClick }
-					>
-						<span>{ __( 'Less details' ) } </span>
-						<Icon icon="arrow-up" size={ 20 }></Icon>
-					</Button>
-				) : (
-					<Button
-						className="plans-grid__details-toggle-button is-expand-button"
-						isLarge
-						onClick={ handleDetailsToggleButtonClick }
-					>
-						<span>{ __( 'More details' ) } </span>
-						<Icon icon="arrow-down" size={ 20 }></Icon>
-					</Button>
-				) }
+					</PlansDetails>
+				</div>
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
+++ b/client/landing/gutenboarding/components/plans/plans-grid/index.tsx
@@ -77,23 +77,27 @@ const PlansGrid: React.FunctionComponent< Props > = ( { confirmButton, cancelBut
 						</div>
 					</>
 				) }
-				<Button
-					className="plans-grid__details-toggle-button"
-					isLarge
-					onClick={ handleDetailsToggleButtonClick }
-				>
-					{ showDetails ? (
-						<>
-							<span>{ __( 'Less details' ) } </span>
-							<Icon icon="arrow-up" size={ 20 }></Icon>
-						</>
-					) : (
-						<>
-							<span>{ __( 'More details' ) } </span>
-							<Icon icon="arrow-down" size={ 20 }></Icon>
-						</>
-					) }
-				</Button>
+				{ /* They are separate buttons to prevent the buttons itself getting
+				     auto-focused and scrolled to when plans details display. */ }
+				{ showDetails ? (
+					<Button
+						className="plans-grid__details-toggle-button is-collapse-button"
+						isLarge
+						onClick={ handleDetailsToggleButtonClick }
+					>
+						<span>{ __( 'Less details' ) } </span>
+						<Icon icon="arrow-up" size={ 20 }></Icon>
+					</Button>
+				) : (
+					<Button
+						className="plans-grid__details-toggle-button is-expand-button"
+						isLarge
+						onClick={ handleDetailsToggleButtonClick }
+					>
+						<span>{ __( 'More details' ) } </span>
+						<Icon icon="arrow-down" size={ 20 }></Icon>
+					</Button>
+				) }
 			</div>
 		</div>
 	);

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -157,9 +157,14 @@
 		letter-spacing: 0.2px;
 	}
 }
-
+// On desktop, this should follow the width of the plans table.
 .plans-grid__details-actions {
 	@include onboarding-block-edge2edge-content;
+
+	// On mobile, this should follow the width of the viewport.
+	.plans-grid.is-mobile & {
+		width: 100vw;
+	}
 }
 
 .plans-grid__details-toggle-button.components-button {

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -158,6 +158,10 @@
 	}
 }
 
+.plans-grid__details-actions {
+	@include onboarding-block-edge2edge-content;
+}
+
 .plans-grid__details-toggle-button.components-button {
 	display: block;
 	width: 100%;
@@ -165,9 +169,8 @@
 	font-size: 16px;
 	line-height: 19px;
 	letter-spacing: 0.2px;
-	border: 1px solid var( --studio-gray-5 );
-	border-left: 0;
-	border-right: 0;
+	border-top: 1px solid var( --studio-gray-5 );
+	border-bottom: 1px solid var( --studio-gray-5 );
 	border-radius: 0;
 	padding: 0;
 	text-align: center;
@@ -182,5 +185,24 @@
 
 	&.is-collapse-button {
 		margin-top: 70px;
+	}
+}
+
+// Controls toggling of plans grid
+.plans-grid__details-heading {
+	display: none;
+}
+
+.plans-grid .plans-details__table {
+	display: none;
+}
+
+.plans-grid.show-details {
+	.plans-grid__details-heading {
+		display: block;
+	}
+
+	.plans-details__table {
+		display: block;
 	}
 }

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -147,4 +147,8 @@
 	svg {
 		margin-left: 2px;
 	}
+
+	&.is-collapse-button {
+		margin-top: 70px;
+	}
 }

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -99,10 +99,20 @@
 		@include onboarding-block-edge2edge-content;
 	}
 }
+
+// On desktop, make sure plans details meets the
+// min width of the plans table, to prevent too
+// much white space when scrolling horizontally
+// using the browser's horizontal scrollbar.
+.plans-grid:not( .is-mobile ) .plans-grid__details-container {
+	min-width: $plans-details-min-width-desktop-mobile;
+
+	@include break-small {
+		min-width: $plans-details-min-width-desktop-small;
 	}
 
-	+ .plans-grid__details-toggle-button {
-		margin-top: 60px;
+	@include break-medium {
+		min-width: $plans-details-min-width-desktop-medium;
 	}
 }
 

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -91,20 +91,14 @@
 	margin-bottom: 120px;
 }
 
+// This makes overflowing content scrolls edge-to-edge.
 .plans-grid__details-container {
-	// Edge-to-edge panning
-	.plans-details {
-		width: calc( 100% + 30px + 30px );
-		margin-left: -30px;
-		margin-right: -30px;
-		overflow: hidden;
+	@include onboarding-block-edge2edge-container;
 
-		@include break-medium {
-			width: 100%;
-			margin-left: 0;
-			margin-right: 0;
-			overflow: auto;
-		}
+	.plans-details__table {
+		@include onboarding-block-edge2edge-content;
+	}
+}
 	}
 
 	+ .plans-grid__details-toggle-button {

--- a/client/landing/gutenboarding/components/plans/plans-grid/style.scss
+++ b/client/landing/gutenboarding/components/plans/plans-grid/style.scss
@@ -104,7 +104,7 @@
 // min width of the plans table, to prevent too
 // much white space when scrolling horizontally
 // using the browser's horizontal scrollbar.
-.plans-grid:not( .is-mobile ) .plans-grid__details-container {
+.plans-grid:not( .is-mobile ) .plans-details {
 	min-width: $plans-details-min-width-desktop-mobile;
 
 	@include break-small {
@@ -113,6 +113,38 @@
 
 	@include break-medium {
 		min-width: $plans-details-min-width-desktop-medium;
+	}
+}
+
+.plans-grid.is-mobile .plans-grid__details-container {
+	// On a desktop device, when plan details overflow,
+	// let user scroll using the browser's scrollbar,
+	// this is because users are used to scrolling this way.
+
+	// On a mobile device, when plan details overflow,
+	// let user scroll using the plan details' scrollbar,
+	// this allows user to pan through the plan items
+	// while keep the rest of the content intact.
+	overflow-x: auto;
+
+	// This lets the overlay scrollbar appears right
+	// below the plan details when panning horizontally.
+	padding: 20px 0;
+	margin-top: -20px;
+	margin-bottom: -20px;
+}
+
+// On mobile, reduce the min-width to reduce
+// the need to scroll too much.
+.plans-grid.is-mobile .plans-details {
+	min-width: $plans-details-min-width-mobile;
+
+	@include break-small {
+		min-width: $plans-details-min-width-mobile;
+	}
+
+	@include break-medium {
+		min-width: $plans-details-min-width-mobile;
 	}
 }
 

--- a/client/landing/gutenboarding/components/plans/variables.scss
+++ b/client/landing/gutenboarding/components/plans/variables.scss
@@ -1,5 +1,7 @@
 @import '../../variables.scss';
+@import '../../functions.scss';
 
+// Plans Table
 $plan-item-count: 5;
 $plan-item-gutter: 20px;
 $plan-item-width: #{100% / $plan-item-count};
@@ -8,3 +10,14 @@ $plan-item-min-width: #{(
 			( $plan-item-gutter * ( $plan-item-count - 1 ) )
 	) / $plan-item-count};
 $plan-item-min-width-mobile-portrait: 70vw;
+$plans-table-total-content-width: #{( to-number( $plan-item-min-width ) * $plan-item-count ) + (
+		$plan-item-gutter * ( $plan-item-count - 1 )
+	)};
+
+// Plans Details
+$plans-details-min-width-desktop-mobile: #{to-number( $plans-table-total-content-width ) +
+	$gutenboarding-block-margin-mobile * 2};
+$plans-details-min-width-desktop-small: #{to-number( $plans-table-total-content-width ) +
+	$gutenboarding-block-margin-small * 2};
+$plans-details-min-width-desktop-medium: #{to-number( $plans-table-total-content-width ) +
+	$gutenboarding-block-margin-medium * 2};

--- a/client/landing/gutenboarding/components/plans/variables.scss
+++ b/client/landing/gutenboarding/components/plans/variables.scss
@@ -21,3 +21,4 @@ $plans-details-min-width-desktop-small: #{to-number( $plans-table-total-content-
 	$gutenboarding-block-margin-small * 2};
 $plans-details-min-width-desktop-medium: #{to-number( $plans-table-total-content-width ) +
 	$gutenboarding-block-margin-medium * 2};
+$plans-details-min-width-mobile: 700px;

--- a/client/landing/gutenboarding/functions.scss
+++ b/client/landing/gutenboarding/functions.scss
@@ -1,0 +1,40 @@
+@function to-number( $value ) {
+	@if type-of( $value ) == 'number' {
+		@return $value;
+	} @else if type-of( $value ) != 'string' {
+		@error 'Value for `to-number` should be a number or a string.';
+	}
+
+	$result: 0;
+	$digits: 0;
+	$minus: str-slice( $value, 1, 1 ) == '-';
+	$numbers: (
+		'0': 0,
+		'1': 1,
+		'2': 2,
+		'3': 3,
+		'4': 4,
+		'5': 5,
+		'6': 6,
+		'7': 7,
+		'8': 8,
+		'9': 9,
+	);
+
+	@for $i from if( $minus, 2, 1 ) through str-length( $value ) {
+		$character: str-slice( $value, $i, $i );
+
+		@if ( index( map-keys( $numbers ), $character ) or $character == '.' ) {
+			@if $character == '.' {
+				$digits: 1;
+			} @else if $digits == 0 {
+				$result: $result * 10 + map-get( $numbers, $character );
+			} @else {
+				$digits: $digits * 10;
+				$result: $result + map-get( $numbers, $character ) / $digits;
+			}
+		}
+	}
+
+	@return if( $minus, -$result, $result );
+}

--- a/client/landing/gutenboarding/mixins.scss
+++ b/client/landing/gutenboarding/mixins.scss
@@ -98,24 +98,18 @@
 }
 
 @mixin onboarding-block-edge2edge-container {
-	width: calc(
-		100% + #{$gutenboarding-block-margin-mobile} + #{$gutenboarding-block-margin-mobile}
-	);
+	width: calc( 100% + #{$gutenboarding-block-margin-mobile * 2} );
 	margin-left: #{$gutenboarding-block-margin-mobile * -1};
 	margin-right: #{$gutenboarding-block-margin-mobile * -1};
 
 	@include break-small {
-		width: calc(
-			100% + #{$gutenboarding-block-margin-small} + #{$gutenboarding-block-margin-small}
-		);
+		width: calc( 100% + #{$gutenboarding-block-margin-small * 2} );
 		margin-left: #{$gutenboarding-block-margin-small * -1};
 		margin-right: #{$gutenboarding-block-margin-small * -1};
 	}
 
 	@include break-medium {
-		width: calc(
-			100% + #{$gutenboarding-block-margin-medium} + #{$gutenboarding-block-margin-medium}
-		);
+		width: calc( 100% + #{$gutenboarding-block-margin-medium * 2} );
 		margin-left: #{$gutenboarding-block-margin-medium * -1};
 		margin-right: #{$gutenboarding-block-margin-medium * -1};
 	}


### PR DESCRIPTION
**Note: This PR is branched off `fix/gutenboarding-plans-table-scrolling-ux`. See PR: https://github.com/Automattic/wp-calypso/pull/42118 for more details.**

## Changes proposed in this Pull Request

**On Desktop**
* Use browser's horizontal scrollbar to scroll plans details.
* Plans details & more/less toggle button should have the same min width as plans table.

**On Mobile**
* Localized scrolling now supports edge-to-edge scrolling for all viewport sizes (test with portrait/landscape modes).

**On Both**
* Fix toggle button stealing focus causing user having to scroll back up to read the plans details.
   * Note: This only fixes the first time user toggles the plans details. Subsequent toggling is currently a non-fix (it has to do with window scroll position) and should be looked into when adding slidedown effect.

## Testing instructions

Test the 4 points above on both desktop & mobile (portrait & landscape).

_*Important:* On mobile, you should test on iOS/Android simulators. Using Chrome Developer Tools will not work as we are detecting user agent string._

## Screenshots

**Before: White space on plans details.**

![image](https://user-images.githubusercontent.com/1287077/81792126-ed7e2b80-9507-11ea-821d-d992e82c5418.png)

**After: No white-space on plans details.**

![image](https://user-images.githubusercontent.com/1287077/81792131-efe08580-9507-11ea-93bd-be90b4b4d23e.png)

**Scrolling on Desktop**

![2020-05-13_10-44-42 (1)](https://user-images.githubusercontent.com/1287077/81792226-12729e80-9508-11ea-90af-2a49de3827c3.gif)

**Localized Panning on Mobile**

![2020-05-13_10-43-45 (1)](https://user-images.githubusercontent.com/1287077/81792261-1f8f8d80-9508-11ea-8b63-9840ab2d864b.gif)


