### PR TITLE
JP Cloud: Fix a margin-top with the masterbar

### DIFF
--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/index.tsx
@@ -75,7 +75,9 @@ const BackupRewindFlow: FunctionComponent< Props > = ( { rewindId, purpose } ) =
 				}
 			/>
 			<SidebarNavigation />
-			<Card>{ applySiteOffset && render( applySiteOffset ) }</Card>
+			<div className="rewind-flow__content">
+				<Card>{ applySiteOffset && render( applySiteOffset ) }</Card>
+			</div>
 		</Main>
 	);
 };

--- a/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/rewind-flow/style.scss
@@ -12,6 +12,10 @@
 	}
 }
 
+.rewind-flow__content {
+	margin-top: 16px;
+}
+
 .rewind-flow__title {
 	text-align: center;
 	font-size: 22px;

--- a/client/landing/jetpack-cloud/sections/backups/style.scss
+++ b/client/landing/jetpack-cloud/sections/backups/style.scss
@@ -1,7 +1,4 @@
 .backups__page {
-	.current-section {
-		margin-bottom: 0;
-	}
 	.filterbar .filterbar__wrap.card {
 		display: flex;
 	}

--- a/client/landing/jetpack-cloud/style.scss
+++ b/client/landing/jetpack-cloud/style.scss
@@ -7,7 +7,7 @@
 	}
 
 	.current-section {
-		margin: 0 -16px 16px;
+		margin: 0 -16px;
 
 		.site-icon {
 			display: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove a margin-top between the masterbar and the content, visible on Backup section and it was introduced in a previous [PR](https://github.com/Automattic/wp-calypso/pull/41675). Add the correct margin-top to the Download/Restore section.

Before
![image](https://user-images.githubusercontent.com/9832440/81794302-7eea9f00-9502-11ea-9bb9-cc597e6aaa9d.png)

Now:
![image](https://user-images.githubusercontent.com/9832440/81794346-8ca02480-9502-11ea-8039-a7617d554289.png)

#### Testing instructions
https://calypso.live/?branch=fix/jetpack-cloud-backup-section-margin-top&env=jetpack

- Apply this change
- Check if the margin-top on Backup section disappeared
- Check the Download/Restore view by clicking on Download or Restore button, and check if they have the expected margin:

![image](https://user-images.githubusercontent.com/9832440/81794596-edc7f800-9502-11ea-9fc9-2dbb4b1ab0c9.png)

