### PR TITLE
Fix broken SSR due to `client/blocks/login`

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -172,7 +172,7 @@ class SocialLoginForm extends Component {
 	trackLoginAndRememberRedirect = ( service ) => {
 		this.recordEvent( 'calypso_login_social_button_click', service );
 
-		if ( this.props.redirectTo ) {
+		if ( this.props.redirectTo && typeof window !== 'undefined' ) {
 			window.sessionStorage.setItem( 'login_redirect_to', this.props.redirectTo );
 		}
 	};
@@ -180,7 +180,7 @@ class SocialLoginForm extends Component {
 	getRedirectUrl = ( service ) => {
 		const host = typeof window !== 'undefined' && window.location.host;
 
-		if ( window?.localStorage?.getItem( 'a8c_testing_redirect_url' ) ) {
+		if ( host && window.localStorage?.getItem( 'a8c_testing_redirect_url' ) ) {
 			const { redirectTo } = this.props;
 			return `https://${ host + login( { isNative: true, socialService: service, redirectTo } ) }`;
 		}


### PR DESCRIPTION
Issue introduced in #42135. Server-side rendering is now failing in `/log-in` and possibly other pages, due to code having been added which fails on the server

#### Changes proposed in this Pull Request

* Add guards for missing `window` global on the server

#### Testing instructions

* Disable JavaScript in your browser DevTools
* Open `/log-in` in the live branch
* Ensure that it renders the initial login dialog, rather than just a blank page with a header
