### PR TITLE
JP Cloud: Add the new copy "More backups from this day"

### DIFF
--- a/client/landing/jetpack-cloud/components/backup-delta/index.jsx
+++ b/client/landing/jetpack-cloud/components/backup-delta/index.jsx
@@ -24,6 +24,7 @@ class BackupDelta extends Component {
 			realtimeBackups,
 			siteSlug,
 			translate,
+			isToday,
 		} = this.props;
 
 		const cards = realtimeBackups.map( ( activity ) => (
@@ -43,7 +44,9 @@ class BackupDelta extends Component {
 		return (
 			<div className="backup-delta__realtime">
 				<div className="backup-delta__realtime-header">
-					{ translate( 'More backups from today' ) }
+					{ isToday
+						? translate( 'More backups from today' )
+						: translate( 'More backups from this day' ) }
 				</div>
 				<div className="backup-delta__realtime-description">
 					{ translate(

--- a/client/landing/jetpack-cloud/sections/backups/main.jsx
+++ b/client/landing/jetpack-cloud/sections/backups/main.jsx
@@ -157,6 +157,7 @@ class BackupsPage extends Component {
 		const deltas = getDailyBackupDeltas( logs, selectedDateString );
 		const metaDiff = getMetaDiffForDailyBackup( logs, selectedDateString );
 		const hasRealtimeBackups = includes( siteCapabilities, 'backup-realtime' );
+		const isToday = today.isSame( this.getSelectedDate(), 'day' );
 
 		return (
 			<Main>
@@ -216,6 +217,7 @@ class BackupsPage extends Component {
 								moment,
 								siteSlug,
 								metaDiff,
+								isToday,
 							} }
 						/>
 					) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On the backup status view, for the days other than today the copy "More backups from today" should be "More backups from this day"

The expected copy for today:
![image](https://user-images.githubusercontent.com/9832440/81799905-ef48ee80-9509-11ea-8eca-03a4ba02cd54.png)

The expected copy for any other day:
![image](https://user-images.githubusercontent.com/9832440/81800044-1dc6c980-950a-11ea-88dd-527479daada7.png)


#### Testing instructions

- Check the expected copy for each one. You can change your timezone to match one where you can see "More backups from today"