### PR TITLE
Gutenboarding: allow the domain-only legacy flow

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -52,6 +52,12 @@ export default {
 	redirectTests( context, next ) {
 		if ( context.pathname.indexOf( 'new-launch' ) >= 0 ) {
 			next();
+		} else if (
+			context.pathname.indexOf( 'domain' ) >= 0 ||
+			context.pathname.indexOf( 'plan' ) >= 0
+		) {
+			removeWhiteBackground();
+			next();
 		} else {
 			waitForData( {
 				geo: () => requestGeoLocation(),


### PR DESCRIPTION
This PR adds an exception so all the onboarding flows about domains are not redirected to gutenboarding, even if the user is part of the test.

how to test:
========

0. Go to https://hash-a6db1f673be2f6d6c42691a6ca30c25eef48f75e.calypso.live
1. Make yourself part of the test (in the browser console, paste this `localStorage.setItem( 'ABTests', { "newSiteGutenbergOnboarding_20200501": "gutenberg" } )` )
2. Go to https://hash-a6db1f673be2f6d6c42691a6ca30c25eef48f75e.calypso.live/domains?site=domain-only . You shouldn't be redirected to the new flow