### PR TITLE
Add unseen status to Reader sections

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -52,6 +52,7 @@ import detectHistoryNavigation from 'lib/detect-history-navigation';
 import userFactory from 'lib/user';
 import { getUrlParts, isOutsideCalypso } from 'lib/url';
 import { setStore } from 'state/redux-store';
+import { requestUnseenStatusAny } from 'state/ui/reader/seen-posts/actions';
 
 const debug = debugFactory( 'calypso' );
 
@@ -344,6 +345,11 @@ const setupMiddlewares = ( currentUser, reduxStore ) => {
 	}
 
 	const state = reduxStore.getState();
+	// get reader unread status
+	if ( config.isEnabled( 'reader/seen-posts' ) ) {
+		reduxStore.dispatch( requestUnseenStatusAny() );
+	}
+
 	if ( config.isEnabled( 'happychat' ) ) {
 		reduxStore.dispatch( requestHappychatEligibility() );
 	}

--- a/client/components/data/query-unseen-status-all/index.jsx
+++ b/client/components/data/query-unseen-status-all/index.jsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useDispatch } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestUnseenStatusAll } from 'state/reader/seen-posts/actions';
+
+export default function QueryUnseenStatusAll() {
+	const dispatch = useDispatch();
+	React.useEffect( () => {
+		dispatch( requestUnseenStatusAll() );
+	}, [ dispatch ] );
+
+	return null;
+}

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -18,11 +18,13 @@ class MasterbarItem extends Component {
 		className: PropTypes.string,
 		isActive: PropTypes.bool,
 		preloadSection: PropTypes.func,
+		hasUnseen: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		icon: '',
 		onClick: noop,
+		hasUnseen: false,
 	};
 
 	_preloaded = false;
@@ -37,6 +39,7 @@ class MasterbarItem extends Component {
 	render() {
 		const itemClasses = classNames( 'masterbar__item', this.props.className, {
 			'is-active': this.props.isActive,
+			'has-unseen': this.props.hasUnseen,
 		} );
 
 		return (
@@ -49,6 +52,7 @@ class MasterbarItem extends Component {
 				onTouchStart={ this.preload }
 				onMouseEnter={ this.preload }
 			>
+				{ this.props.hasUnseen && <span className="masterbar__item-bubble" /> }
 				{ !! this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } /> }
 				<span className="masterbar__item-content">{ this.props.children }</span>
 			</a>

--- a/client/layout/masterbar/item.jsx
+++ b/client/layout/masterbar/item.jsx
@@ -52,7 +52,9 @@ class MasterbarItem extends Component {
 				onTouchStart={ this.preload }
 				onMouseEnter={ this.preload }
 			>
-				{ this.props.hasUnseen && <span className="masterbar__item-bubble" /> }
+				{ this.props.hasUnseen && (
+					<span className="masterbar__item-bubble" aria-label="You have unseen content" />
+				) }
 				{ !! this.props.icon && <Gridicon icon={ this.props.icon } size={ 24 } /> }
 				<span className="masterbar__item-content">{ this.props.children }</span>
 			</a>

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -36,6 +36,7 @@ import getSiteMigrationStatus from 'state/selectors/get-site-migration-status';
 import { updateSiteMigrationMeta } from 'state/sites/actions';
 import { requestHttpData } from 'state/data-layer/http-data';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import { hasUnseen } from 'state/ui/reader/seen-posts/selectors';
 
 class MasterbarLoggedIn extends React.Component {
 	static propTypes = {
@@ -46,6 +47,7 @@ class MasterbarLoggedIn extends React.Component {
 		siteSlug: PropTypes.string,
 		hasMoreThanOneSite: PropTypes.bool,
 		isCheckout: PropTypes.bool,
+		hasUnseen: PropTypes.bool,
 	};
 
 	clickMySites = () => {
@@ -180,6 +182,7 @@ class MasterbarLoggedIn extends React.Component {
 					isActive={ this.isActive( 'reader' ) }
 					tooltip={ translate( 'Read the blogs and topics you follow' ) }
 					preloadSection={ this.preloadReader }
+					hasUnseen={ this.props.hasUnseen }
 				>
 					{ translate( 'Reader', { comment: 'Toolbar, must be shorter than ~12 chars' } ) }
 				</Item>
@@ -238,6 +241,7 @@ export default connect(
 			isSiteMigrationActiveRoute( state );
 
 		return {
+			hasUnseen: hasUnseen( state ),
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
 			siteSlug: getSiteSlug( state, siteId ),

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -19,8 +19,11 @@ import TranslatableString from 'components/translatable/proptype';
 export default function SidebarItem( props ) {
 	const isExternalLink = isExternal( props.link );
 	const showAsExternal = isExternalLink && ! props.forceInternalLink;
-	const classes = classnames( props.className, props.tipTarget, { selected: props.selected } );
-	const { materialIcon, materialIconStyle, icon, customIcon } = props;
+	const classes = classnames( props.className, props.tipTarget, {
+		selected: props.selected,
+		'has-unseen': props.hasUnseen,
+	} );
+	const { materialIcon, materialIconStyle, icon, customIcon, hasUnseen } = props;
 
 	let _preloaded = false;
 
@@ -63,6 +66,8 @@ export default function SidebarItem( props ) {
 
 				{ customIcon && customIcon }
 
+				{ hasUnseen && <span className="sidebar__bubble" /> }
+
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
 				<span className="sidebar__menu-link-text menu-link-text" data-e2e-sidebar={ props.label }>
 					{ props.label }
@@ -87,6 +92,7 @@ SidebarItem.propTypes = {
 	expandSection: PropTypes.func,
 	preloadSectionName: PropTypes.string,
 	forceInternalLink: PropTypes.bool,
+	hasUnseen: PropTypes.bool,
 	testTarget: PropTypes.string,
 	tipTarget: PropTypes.string,
 };

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -66,7 +66,7 @@ export default function SidebarItem( props ) {
 
 				{ customIcon && customIcon }
 
-				{ hasUnseen && <span className="sidebar__bubble" /> }
+				{ hasUnseen && <span className="sidebar__bubble" aria-label="You have unseen content" /> }
 
 				{ /* eslint-disable wpcalypso/jsx-classname-namespace */ }
 				<span className="sidebar__menu-link-text menu-link-text" data-e2e-sidebar={ props.label }>

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -15,6 +15,7 @@ import ReaderSidebarListsList from './list';
 export class ReaderSidebarLists extends Component {
 	static propTypes = {
 		lists: PropTypes.array,
+		hasUnseen: PropTypes.bool,
 		path: PropTypes.string.isRequired,
 		isOpen: PropTypes.bool,
 		onClick: PropTypes.func,
@@ -28,16 +29,22 @@ export class ReaderSidebarLists extends Component {
 	};
 
 	render() {
-		const { translate, isOpen, onClick, ...passedProps } = this.props;
+		const { translate, isOpen, onClick, hasUnseen, ...passedProps } = this.props;
 		return (
-			<ExpandableSidebarMenu
-				expanded={ isOpen }
-				title={ translate( 'Lists' ) }
-				onClick={ onClick }
-				hideAddButton
-			>
-				<ReaderSidebarListsList { ...passedProps } />
-			</ExpandableSidebarMenu>
+			<div className={ hasUnseen ? 'has-unseen' : '' }>
+				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+				{ hasUnseen && <span className="sidebar__bubble" /> }
+				<ExpandableSidebarMenu
+					hasNew={ hasUnseen }
+					expanded={ isOpen }
+					title={ translate( 'Lists' ) }
+					onClick={ onClick }
+					materialIcon={ 'list' }
+					hideAddButton
+				>
+					<ReaderSidebarListsList { ...passedProps } />
+				</ExpandableSidebarMenu>
+			</div>
 		);
 	}
 }

--- a/client/reader/sidebar/reader-sidebar-lists/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.jsx
@@ -33,7 +33,7 @@ export class ReaderSidebarLists extends Component {
 		return (
 			<div className={ hasUnseen ? 'has-unseen' : '' }>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-				{ hasUnseen && <span className="sidebar__bubble" /> }
+				{ hasUnseen && <span className="sidebar__bubble" aria-label="You have unseen content" /> }
 				<ExpandableSidebarMenu
 					hasNew={ hasUnseen }
 					expanded={ isOpen }

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -22,6 +22,7 @@ export class ReaderSidebarTags extends Component {
 	static propTypes = {
 		tags: PropTypes.array,
 		path: PropTypes.string.isRequired,
+		hasUnseen: PropTypes.bool,
 		isOpen: PropTypes.bool,
 		onClick: PropTypes.func,
 		currentTag: PropTypes.string,
@@ -53,9 +54,11 @@ export class ReaderSidebarTags extends Component {
 	};
 
 	render() {
-		const { tags, isOpen, translate, onClick } = this.props;
+		const { tags, isOpen, translate, onClick, hasUnseen } = this.props;
 		return (
-			<ul>
+			<ul className={ hasUnseen ? 'has-unseen' : '' }>
+				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
+				{ hasUnseen && <span className="sidebar__bubble" /> }
 				{ ! tags && <QueryReaderFollowedTags /> }
 				<ExpandableSidebarMenu
 					expanded={ isOpen }

--- a/client/reader/sidebar/reader-sidebar-tags/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/index.jsx
@@ -58,7 +58,7 @@ export class ReaderSidebarTags extends Component {
 		return (
 			<ul className={ hasUnseen ? 'has-unseen' : '' }>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-				{ hasUnseen && <span className="sidebar__bubble" /> }
+				{ hasUnseen && <span className="sidebar__bubble" aria-label="You have unseen content" /> }
 				{ ! tags && <QueryReaderFollowedTags /> }
 				<ExpandableSidebarMenu
 					expanded={ isOpen }

--- a/client/reader/sidebar/reader-sidebar-teams/index.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/index.jsx
@@ -10,14 +10,20 @@ import React, { Component } from 'react';
  */
 import ReaderSidebarTeamsListItem from './list-item';
 
-const renderItems = ( teams, path ) =>
+const renderItems = ( teams, path, hasUnseen ) =>
 	map( teams, ( team ) => (
-		<ReaderSidebarTeamsListItem key={ team.slug } team={ team } path={ path } />
+		<ReaderSidebarTeamsListItem
+			key={ team.slug }
+			team={ team }
+			path={ path }
+			hasUnseen={ hasUnseen }
+		/>
 	) );
 
 export class ReaderSidebarTeams extends Component {
 	static propTypes = {
 		teams: PropTypes.array,
+		hasUnseen: PropTypes.bool,
 		path: PropTypes.string.isRequired,
 	};
 
@@ -26,7 +32,7 @@ export class ReaderSidebarTeams extends Component {
 			return null;
 		}
 
-		return <div>{ renderItems( this.props.teams, this.props.path ) }</div>;
+		return <div>{ renderItems( this.props.teams, this.props.path, this.props.hasUnseen ) }</div>;
 	}
 }
 

--- a/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
+++ b/client/reader/sidebar/reader-sidebar-teams/list-item.jsx
@@ -40,7 +40,7 @@ const renderA8CLogo = () => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 };
 
-export const ReaderSidebarTeamsListItem = ( { path, team } ) => {
+export const ReaderSidebarTeamsListItem = ( { path, team, hasUnseen } ) => {
 	const teamUri = '/read/' + encodeURIComponent( team.slug );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -54,6 +54,7 @@ export const ReaderSidebarTeamsListItem = ( { path, team } ) => {
 			className={ ReaderSidebarHelper.itemLinkClass( teamUri, path, {
 				'sidebar-streams__team': true,
 			} ) }
+			hasUnseen={ hasUnseen }
 		/>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
@@ -62,6 +63,7 @@ export const ReaderSidebarTeamsListItem = ( { path, team } ) => {
 ReaderSidebarTeamsListItem.propTypes = {
 	team: PropTypes.object.isRequired,
 	path: PropTypes.string.isRequired,
+	hasUnseen: PropTypes.bool,
 };
 
 export default localize( ReaderSidebarTeamsListItem );

--- a/client/state/data-layer/wpcom/seen-posts/status/unseen/all/index.js
+++ b/client/state/data-layer/wpcom/seen-posts/status/unseen/all/index.js
@@ -1,0 +1,39 @@
+/**
+ * Internal Dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { registerHandlers } from 'state/data-layer/handler-registry';
+import { receiveUnseenStatusAll } from 'state/reader/seen-posts/actions';
+import { READER_SEEN_UNSEEN_STATUS_ALL_REQUEST } from 'state/reader/action-types';
+
+export function fetch( action ) {
+	return http(
+		{
+			apiNamespace: 'wpcom/v2',
+			method: 'GET',
+			path: '/seen-posts/status/unseen/all',
+			show_subsections: action.showSubsections,
+		},
+		action
+	);
+}
+
+export function onSuccess( action, response ) {
+	return receiveUnseenStatusAll( { sections: response } );
+}
+
+export function onError() {
+	// don't do much
+	return [];
+}
+
+registerHandlers( 'state/data-layer/wpcom/unseen-posts/status/unseen/all/index.js', {
+	[ READER_SEEN_UNSEEN_STATUS_ALL_REQUEST ]: [
+		dispatchRequest( {
+			fetch,
+			onSuccess,
+			onError,
+		} ),
+	],
+} );

--- a/client/state/data-layer/wpcom/seen-posts/status/unseen/any/index.js
+++ b/client/state/data-layer/wpcom/seen-posts/status/unseen/any/index.js
@@ -1,0 +1,38 @@
+/**
+ * Internal Dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { registerHandlers } from 'state/data-layer/handler-registry';
+import { receiveUnseenStatusAny } from 'state/ui/reader/seen-posts/actions';
+import { READER_UNSEEN_STATUS_ANY_REQUEST } from 'state/action-types';
+
+export function fetch( action ) {
+	return http(
+		{
+			apiNamespace: 'wpcom/v2',
+			method: 'GET',
+			path: `/seen-posts/status/unseen/any`,
+		},
+		action
+	);
+}
+
+export function onSuccess( action, response ) {
+	return receiveUnseenStatusAny( { status: response.status } );
+}
+
+export function onError() {
+	// don't do much
+	return [];
+}
+
+registerHandlers( 'state/data-layer/wpcom/unseen-posts/status/unseen/any/index.js', {
+	[ READER_UNSEEN_STATUS_ANY_REQUEST ]: [
+		dispatchRequest( {
+			fetch,
+			onSuccess,
+			onError,
+		} ),
+	],
+} );

--- a/client/state/reader/reducer.js
+++ b/client/state/reader/reducer.js
@@ -19,6 +19,7 @@ import tags from './tags/reducer';
 import teams from './teams/reducer';
 import thumbnails from './thumbnails/reducer';
 import viewing from './viewing/reducer';
+import seenPosts from './seen-posts/reducer';
 
 const combinedReducer = combineReducers( {
 	conversations,
@@ -37,6 +38,7 @@ const combinedReducer = combineReducers( {
 	teams,
 	thumbnails,
 	viewing,
+	seenPosts,
 } );
 const readerReducer = withStorageKey( 'reader', combinedReducer );
 export default readerReducer;

--- a/client/state/reader/seen-posts/actions.js
+++ b/client/state/reader/seen-posts/actions.js
@@ -1,0 +1,34 @@
+/**
+ * Internal Dependencies
+ */
+import {
+	READER_SEEN_UNSEEN_STATUS_ALL_RECEIVE,
+	READER_SEEN_UNSEEN_STATUS_ALL_REQUEST,
+} from 'state/reader/action-types';
+
+/**
+ * Load data layer dependencies
+ */
+import 'state/data-layer/wpcom/seen-posts/status/unseen/all/index';
+
+/**
+ * Request unseen status for all sections
+ *
+ * @param showSubsections flag
+ * @returns {{showSubsections, type: string}} redux action
+ */
+export const requestUnseenStatusAll = ( { showSubsections = false } = {} ) => ( {
+	type: READER_SEEN_UNSEEN_STATUS_ALL_REQUEST,
+	showSubsections,
+} );
+
+/**
+ * Receive unseen status for all sections
+ *
+ * @param sections unseen status
+ * @returns {{type: string, sections: *}} redux action
+ */
+export const receiveUnseenStatusAll = ( { sections } ) => ( {
+	type: READER_SEEN_UNSEEN_STATUS_ALL_RECEIVE,
+	sections,
+} );

--- a/client/state/reader/seen-posts/reducer.js
+++ b/client/state/reader/seen-posts/reducer.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { READER_SEEN_UNSEEN_STATUS_ALL_RECEIVE } from 'state/reader/action-types';
+import { SERIALIZE } from 'state/action-types';
+import { combineReducers } from 'state/utils';
+
+/**
+ * Reader Unseen status for all sections
+ *
+ * @param state redux state
+ * @param action redux action
+ * @returns {{}|*} redux state
+ */
+export function unseenStatus( state = {}, action ) {
+	switch ( action.type ) {
+		case READER_SEEN_UNSEEN_STATUS_ALL_RECEIVE:
+			return action.sections;
+
+		case SERIALIZE:
+			return {};
+	}
+	return state;
+}
+
+export default combineReducers( {
+	unseenStatus,
+} );

--- a/client/state/reader/seen-posts/selectors.js
+++ b/client/state/reader/seen-posts/selectors.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Get section unseen data
+ *
+ * @param state redux state
+ *
+ * @returns {*} section unseen status data
+ */
+export const getSectionsStatus = ( state ) => {
+	return get( state, [ 'reader', 'seenPosts', 'unseenStatus' ], {} );
+};
+
+/**
+ * Check if the given section has unseen content
+ *
+ * @param state redux state
+ * @param section identifier
+ * @returns {boolean} section unseen status
+ */
+export const sectionHasUnseen = ( state, section ) => {
+	// get watermark
+	// get number of posts after watermark
+	// status from redux
+	return get( state, [ 'reader', 'seenPosts', 'unseenStatus', section, 'status' ], false );
+};

--- a/client/state/ui/reader/reducer.js
+++ b/client/state/ui/reader/reducer.js
@@ -6,6 +6,7 @@ import { READER_VIEW_STREAM } from 'state/reader/action-types';
 import sidebar from './sidebar/reducer';
 import { combineReducers } from 'state/utils';
 import cardExpansions from './card-expansions/reducer';
+import hasUnseenPosts from './seen-posts/reducer';
 
 /*
  * Holds the last viewed stream for the purposes of keyboard navigation
@@ -17,4 +18,5 @@ export default combineReducers( {
 	sidebar,
 	cardExpansions,
 	currentStream,
+	hasUnseenPosts,
 } );

--- a/client/state/ui/reader/seen-posts/actions.js
+++ b/client/state/ui/reader/seen-posts/actions.js
@@ -1,0 +1,32 @@
+/**
+ * Internal Dependencies
+ */
+import {
+	READER_UNSEEN_STATUS_ANY_REQUEST,
+	READER_UNSEEN_STATUS_ANY_RECEIVE,
+} from 'state/action-types';
+
+/**
+ * Load data layer dependencies
+ */
+import 'state/data-layer/wpcom/seen-posts/status/unseen/any/index';
+
+/**
+ * Request unseen status for any section
+ *
+ * @returns {{type: string}} redux action
+ */
+export const requestUnseenStatusAny = () => ( {
+	type: READER_UNSEEN_STATUS_ANY_REQUEST,
+} );
+
+/**
+ * Receive unseen status for any section
+ *
+ * @param status whether or not we have unseen content in any section
+ * @returns {{type: string, status: *}} redux action
+ */
+export const receiveUnseenStatusAny = ( { status } ) => ( {
+	type: READER_UNSEEN_STATUS_ANY_RECEIVE,
+	status,
+} );

--- a/client/state/ui/reader/seen-posts/reducer.js
+++ b/client/state/ui/reader/seen-posts/reducer.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { SERIALIZE, READER_UNSEEN_STATUS_ANY_RECEIVE } from 'state/action-types';
+
+/**
+ * Reader Unseen status for any section (used global reader unseen bubble)
+ *
+ * @param state redux state
+ * @param action redux action
+ * @returns {boolean|*} redux state
+ */
+export default ( state = false, action ) => {
+	switch ( action.type ) {
+		case READER_UNSEEN_STATUS_ANY_RECEIVE:
+			return action.status;
+
+		case SERIALIZE:
+			return false;
+	}
+	return state;
+};

--- a/client/state/ui/reader/seen-posts/selectors.js
+++ b/client/state/ui/reader/seen-posts/selectors.js
@@ -1,0 +1,9 @@
+/**
+ * Check if we have Reader unseen content
+ *
+ * @param state redux state
+ * @returns {boolean} whether or not we have unseen posts
+ */
+export const hasUnseen = ( state ) => {
+	return state.ui.reader.hasUnseenPosts;
+};


### PR DESCRIPTION
**Built on top of https://github.com/Automattic/wp-calypso/pull/42109**

#### Changes proposed in this Pull Request

- Add `redux/ui/reader/hasUnseenPosts` entity to keep track of any `Reader` unseen content for the master bar bubble
- Add `redux/reader/seenPosts/unseenStatus` entity to keep track for all `Reader` section's unseen content for sidebar bubbles
- Add unseen status bubble to `Reader`
![Markup on 2020-05-13 at 2:22:33 PM](https://user-images.githubusercontent.com/2129455/81806561-4e682c80-9525-11ea-90fe-e5098ee21cd8.png)
- Add unseen status bubble to `Reader` sections
![Markup on 2020-05-13 at 2:18:34 PM](https://user-images.githubusercontent.com/2129455/81806440-22e54200-9525-11ea-8547-c305e4b39fa5.png)

More context: `p9lV3a-1jk-p2`

#### Testing instructions
- Apply `D43321-code`
- Should see `Reader` bubble
- Should see a bubble for Following which is the only enabled section for now
