### PR TITLE
Add mark as seen/unseen

### DIFF
--- a/client/blocks/reader-combined-card/index.jsx
+++ b/client/blocks/reader-combined-card/index.jsx
@@ -158,6 +158,7 @@ class ReaderCombinedCardComponent extends React.Component {
 						showReportSite={ true }
 						showReportPost={ false }
 						post={ posts[ 0 ] }
+						posts={ posts }
 					/>
 				</div>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }

--- a/client/blocks/reader-combined-card/post.jsx
+++ b/client/blocks/reader-combined-card/post.jsx
@@ -8,6 +8,7 @@ import ReactDom from 'react-dom';
 import closest from 'component-closest';
 import { localize } from 'i18n-calypso';
 import classnames from 'classnames';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -112,9 +113,11 @@ class ReaderCombinedCardPost extends React.Component {
 			recordPermalinkClick( 'timestamp_combined_card', post );
 		};
 
+		const isSeen = config.isEnabled( 'reader/seen-posts' ) && !! post.is_seen;
 		const classes = classnames( {
 			'reader-combined-card__post': true,
 			'is-selected': isSelected,
+			'is-seen': isSeen,
 			'has-featured-asset': !! featuredAsset,
 		} );
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -65,6 +65,8 @@ import QueryPostLikes from 'components/data/query-post-likes';
 import getCurrentStream from 'state/selectors/get-reader-current-stream';
 import { setViewingFullPostKey, unsetViewingFullPostKey } from 'state/reader/viewing/actions';
 import { getNextItem, getPreviousItem } from 'state/reader/streams/selectors';
+import { requestMarkAsSeen } from 'state/reader/seen-posts/actions';
+import { SOURCE_READER_WEB } from 'state/reader/seen-posts/constants';
 
 /**
  * Style dependencies
@@ -259,6 +261,13 @@ export class FullPostView extends React.Component {
 		}
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
+			config.isEnabled( 'reader/seen-posts' ) &&
+				this.props.requestMarkAsSeen( {
+					seenIds: [ post.seen_ids ],
+					globalIds: [ post.global_ID ],
+					source: SOURCE_READER_WEB,
+				} );
+
 			recordTrackForPost(
 				'calypso_reader_article_opened',
 				post,
@@ -513,5 +522,12 @@ export default connect(
 
 		return props;
 	},
-	{ markPostSeen, setViewingFullPostKey, unsetViewingFullPostKey, likePost, unlikePost }
+	{
+		markPostSeen,
+		setViewingFullPostKey,
+		unsetViewingFullPostKey,
+		likePost,
+		unlikePost,
+		requestMarkAsSeen,
+	}
 )( FullPostView );

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -8,6 +8,7 @@ import { noop, truncate, get } from 'lodash';
 import classnames from 'classnames';
 import ReactDom from 'react-dom';
 import closest from 'component-closest';
+import config from 'config';
 
 /**
  * Internal Dependencies
@@ -131,6 +132,7 @@ class ReaderPostCard extends React.Component {
 			compact,
 		} = this.props;
 
+		const isSeen = config.isEnabled( 'reader/seen-posts' ) && !! post.is_seen;
 		const isPhotoPost = !! ( post.display_type & DisplayTypes.PHOTO_ONLY ) && ! compact;
 		const isGalleryPost = !! ( post.display_type & DisplayTypes.GALLERY ) && ! compact;
 		const isVideo = !! ( post.display_type & DisplayTypes.FEATURED_VIDEO ) && ! compact;
@@ -142,6 +144,7 @@ class ReaderPostCard extends React.Component {
 			'is-gallery': isGalleryPost,
 			'is-selected': isSelected,
 			'is-discover': isDiscover,
+			'is-seen': isSeen,
 			'is-expanded-video': isVideo && isExpanded,
 			'is-compact': compact,
 		} );

--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -267,15 +267,15 @@ class ReaderPostOptionsMenu extends React.Component {
 
 					{ config.isEnabled( 'reader/seen-posts' ) && post.is_seen && (
 						<PopoverMenuItem onClick={ this.markAsUnSeen } icon="not-visible" itemComponent={ 'a' }>
-							{ size( posts ) > 0 && translate( 'Mark all as Unseen' ) }
-							{ size( posts ) === 0 && translate( 'Mark as Unseen' ) }
+							{ size( posts ) > 0 && translate( 'Mark all as unseen' ) }
+							{ size( posts ) === 0 && translate( 'Mark as unseen' ) }
 						</PopoverMenuItem>
 					) }
 
 					{ config.isEnabled( 'reader/seen-posts' ) && ! post.is_seen && (
 						<PopoverMenuItem onClick={ this.markAsSeen } icon="visible">
-							{ size( posts ) > 0 && translate( 'Mark all as Seen' ) }
-							{ size( posts ) === 0 && translate( 'Mark as Seen' ) }
+							{ size( posts ) > 0 && translate( 'Mark all as seen' ) }
+							{ size( posts ) === 0 && translate( 'Mark as seen' ) }
 						</PopoverMenuItem>
 					) }
 

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -6,6 +6,7 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import { initial, flatMap, trim } from 'lodash';
 import { connect, useDispatch } from 'react-redux';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -92,12 +93,12 @@ const FollowingStream = ( props ) => {
 			</CompactCard>
 			<BlankSuggestions suggestions={ suggestionList } />
 			<SectionHeader label={ translate( 'Followed Sites' ) }>
-				{ ! props.hasUnseen && (
+				{ config.isEnabled( 'reader/seen-posts' ) && ! props.hasUnseen && (
 					<Button compact onClick={ markAllAsUnSeen }>
 						{ translate( 'Mark All as Unseen' ) }
 					</Button>
 				) }
-				{ props.hasUnseen && (
+				{ config.isEnabled( 'reader/seen-posts' ) && props.hasUnseen && (
 					<Button compact onClick={ markAllAsSeen }>
 						{ translate( 'Mark All as Seen' ) }
 					</Button>

--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import { initial, flatMap, trim } from 'lodash';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -22,6 +22,9 @@ import { getSearchPlaceholderText } from 'reader/search/utils';
 import Banner from 'components/banner';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import SectionHeader from 'components/section-header';
+import { requestMarkAllAsSeen, requestMarkAllAsUnseen } from 'state/reader/seen-posts/actions';
+import { sectionHasUnseen } from 'state/reader/seen-posts/selectors';
+import { SECTION_FOLLOWING } from 'state/reader/seen-posts/constants';
 
 /**
  * Style dependencies
@@ -53,6 +56,15 @@ const FollowingStream = ( props ) => {
 	const now = new Date();
 	const showRegistrationMsg = props.userInUSA && now < lastDayForVoteBanner;
 	const { translate } = props;
+	const dispatch = useDispatch();
+
+	const markAllAsSeen = () => {
+		dispatch( requestMarkAllAsSeen( { section: SECTION_FOLLOWING } ) );
+	};
+
+	const markAllAsUnSeen = () => {
+		dispatch( requestMarkAllAsUnseen( { section: SECTION_FOLLOWING } ) );
+	};
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -79,7 +91,17 @@ const FollowingStream = ( props ) => {
 				/>
 			</CompactCard>
 			<BlankSuggestions suggestions={ suggestionList } />
-			<SectionHeader label={ translate( 'Followed sites' ) }>
+			<SectionHeader label={ translate( 'Followed Sites' ) }>
+				{ ! props.hasUnseen && (
+					<Button compact onClick={ markAllAsUnSeen }>
+						{ translate( 'Mark All as Unseen' ) }
+					</Button>
+				) }
+				{ props.hasUnseen && (
+					<Button compact onClick={ markAllAsSeen }>
+						{ translate( 'Mark All as Seen' ) }
+					</Button>
+				) }
 				<Button primary compact className="following__manage" href="/following/manage">
 					{ translate( 'Manage' ) }
 				</Button>
@@ -91,4 +113,5 @@ const FollowingStream = ( props ) => {
 
 export default connect( ( state ) => ( {
 	userInUSA: getCurrentUserCountryCode( state ) === 'US',
+	hasUnseen: sectionHasUnseen( state, SECTION_FOLLOWING ),
 } ) )( SuggestionProvider( localize( FollowingStream ) ) );

--- a/client/state/data-layer/wpcom/seen-posts/seen/all/delete/index.js
+++ b/client/state/data-layer/wpcom/seen-posts/seen/all/delete/index.js
@@ -1,0 +1,69 @@
+/**
+ * Internal Dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { registerHandlers } from 'state/data-layer/handler-registry';
+import { receiveMarkAllAsUnseen, requestUnseenStatusAll } from 'state/reader/seen-posts/actions';
+import { READER_SEEN_MARK_ALL_AS_UNSEEN_REQUEST } from 'state/reader/action-types';
+import { getStream } from 'state/reader/streams/selectors';
+import { getPostsByKeys } from 'state/reader/posts/selectors';
+
+const toApi = ( action ) => {
+	return {
+		section: action.section,
+	};
+};
+
+export function fetch( action ) {
+	return http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: `/seen-posts/seen/all/delete`,
+			body: toApi( action ),
+		},
+		action
+	);
+}
+
+// need to dispatch multiple times so use a redux-thunk
+export const onSuccess = ( action, response ) => ( dispatch, getState ) => {
+	if ( response.status ) {
+		// get stream post identifier
+		const state = getState();
+		const section = getStream( state, action.section );
+
+		if ( ! section.items ) {
+			return;
+		}
+		const posts = getPostsByKeys( state, section.items );
+
+		// get their global ids
+		const globalIds = posts.reduce( ( acc, item ) => {
+			acc.push( item.global_ID );
+			return acc;
+		}, [] );
+
+		// update to seen based on global ids
+		dispatch( receiveMarkAllAsUnseen( { section: action.section, globalIds } ) );
+	}
+
+	// re-request unseen statuses
+	dispatch( requestUnseenStatusAll() );
+};
+
+export function onError() {
+	// don't do much
+	return [];
+}
+
+registerHandlers( 'state/data-layer/wpcom/seen-posts/seen/all/delete/index.js', {
+	[ READER_SEEN_MARK_ALL_AS_UNSEEN_REQUEST ]: [
+		dispatchRequest( {
+			fetch,
+			onSuccess,
+			onError,
+		} ),
+	],
+} );

--- a/client/state/data-layer/wpcom/seen-posts/seen/all/new/index.js
+++ b/client/state/data-layer/wpcom/seen-posts/seen/all/new/index.js
@@ -1,0 +1,69 @@
+/**
+ * Internal Dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { registerHandlers } from 'state/data-layer/handler-registry';
+import { receiveMarkAllAsSeen, requestUnseenStatusAll } from 'state/reader/seen-posts/actions';
+import { READER_SEEN_MARK_ALL_AS_SEEN_REQUEST } from 'state/reader/action-types';
+import { getStream } from 'state/reader/streams/selectors';
+import { getPostsByKeys } from 'state/reader/posts/selectors';
+
+const toApi = ( action ) => {
+	return {
+		section: action.section,
+	};
+};
+
+export function fetch( action ) {
+	return http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: `/seen-posts/seen/all/new`,
+			body: toApi( action ),
+		},
+		action
+	);
+}
+
+// need to dispatch multiple times so use a redux-thunk
+export const onSuccess = ( action, response ) => ( dispatch, getState ) => {
+	if ( response.status ) {
+		// get stream post identifier
+		const state = getState();
+		const section = getStream( state, action.section );
+
+		if ( ! section.items ) {
+			return;
+		}
+		const posts = getPostsByKeys( state, section.items );
+
+		// get their global ids
+		const globalIds = posts.reduce( ( acc, item ) => {
+			acc.push( item.global_ID );
+			return acc;
+		}, [] );
+
+		// update to seen based on global ids
+		dispatch( receiveMarkAllAsSeen( { section: action.section, globalIds } ) );
+	}
+
+	// re-request unseen statuses
+	dispatch( requestUnseenStatusAll() );
+};
+
+export function onError() {
+	// don't do much
+	return [];
+}
+
+registerHandlers( 'state/data-layer/wpcom/seen-posts/seen/all/new/index.js', {
+	[ READER_SEEN_MARK_ALL_AS_SEEN_REQUEST ]: [
+		dispatchRequest( {
+			fetch,
+			onSuccess,
+			onError,
+		} ),
+	],
+} );

--- a/client/state/data-layer/wpcom/seen-posts/seen/delete/index.js
+++ b/client/state/data-layer/wpcom/seen-posts/seen/delete/index.js
@@ -1,0 +1,47 @@
+/**
+ * Internal Dependencies
+ */
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { registerHandlers } from 'state/data-layer/handler-registry';
+import { receiveMarkAsUnseen } from 'state/reader/seen-posts/actions';
+import { READER_SEEN_MARK_AS_UNSEEN_REQUEST } from 'state/reader/action-types';
+
+const toApi = ( action ) => {
+	return {
+		seen_ids: action.seenIds,
+	};
+};
+
+export function fetch( action ) {
+	return http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: `/seen-posts/seen/delete`,
+			body: toApi( action ),
+		},
+		action
+	);
+}
+
+export function onSuccess( action, response ) {
+	if ( response.status ) {
+		return receiveMarkAsUnseen( { globalIds: action.globalIds } );
+	}
+}
+
+export function onError() {
+	// don't do much
+	return [];
+}
+
+registerHandlers( 'state/data-layer/wpcom/unseen-posts/seen/new/index.js', {
+	[ READER_SEEN_MARK_AS_UNSEEN_REQUEST ]: [
+		dispatchRequest( {
+			fetch,
+			onSuccess,
+			onError,
+		} ),
+	],
+} );

--- a/client/state/data-layer/wpcom/seen-posts/seen/new/index.js
+++ b/client/state/data-layer/wpcom/seen-posts/seen/new/index.js
@@ -1,0 +1,48 @@
+/**
+ * Internal Dependencies
+ */
+import { READER_SEEN_MARK_AS_SEEN_REQUEST } from 'state/reader/action-types';
+import { http } from 'state/data-layer/wpcom-http/actions';
+import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+import { receiveMarkAsSeen } from 'state/reader/seen-posts/actions';
+import { registerHandlers } from 'state/data-layer/handler-registry';
+
+const toApi = ( action ) => {
+	return {
+		seen_ids: action.seenIds,
+		source: action.source,
+	};
+};
+
+export function fetch( action ) {
+	return http(
+		{
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			path: `/seen-posts/seen/new`,
+			body: toApi( action ),
+		},
+		action
+	);
+}
+
+export function onSuccess( action, response ) {
+	if ( response.status ) {
+		return receiveMarkAsSeen( { globalIds: action.globalIds } );
+	}
+}
+
+export function onError() {
+	// don't do much
+	return [];
+}
+
+registerHandlers( 'state/data-layer/wpcom/seen-posts/seen/new/index.js', {
+	[ READER_SEEN_MARK_AS_SEEN_REQUEST ]: [
+		dispatchRequest( {
+			fetch,
+			onSuccess,
+			onError,
+		} ),
+	],
+} );

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -2,12 +2,19 @@
 /**
  * External dependencies
  */
-import { keyBy, get } from 'lodash';
+import { keyBy, get, forEach } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { READER_POSTS_RECEIVE, READER_POST_SEEN } from 'state/reader/action-types';
+import {
+	READER_POSTS_RECEIVE,
+	READER_POST_SEEN,
+	READER_SEEN_MARK_AS_SEEN_RECEIVE,
+	READER_SEEN_MARK_AS_UNSEEN_RECEIVE,
+	READER_SEEN_MARK_ALL_AS_SEEN_RECEIVE,
+	READER_SEEN_MARK_ALL_AS_UNSEEN_RECEIVE,
+} from 'state/reader/action-types';
 import { combineReducers } from 'state/utils';
 
 /**
@@ -22,6 +29,20 @@ export function items( state = {}, action ) {
 		case READER_POSTS_RECEIVE:
 			const posts = action.posts || action.payload.posts;
 			return { ...state, ...keyBy( posts, 'global_ID' ) };
+
+		case READER_SEEN_MARK_AS_SEEN_RECEIVE:
+		case READER_SEEN_MARK_ALL_AS_SEEN_RECEIVE:
+			forEach( action.globalIds, ( globalId ) => {
+				state[ globalId ] = { ...state[ globalId ], is_seen: true };
+			} );
+			return { ...state };
+
+		case READER_SEEN_MARK_AS_UNSEEN_RECEIVE:
+		case READER_SEEN_MARK_ALL_AS_UNSEEN_RECEIVE:
+			forEach( action.globalIds, ( globalId ) => {
+				state[ globalId ] = { ...state[ globalId ], is_seen: false };
+			} );
+			return { ...state };
 	}
 	return state;
 }

--- a/client/state/reader/seen-posts/actions.js
+++ b/client/state/reader/seen-posts/actions.js
@@ -4,17 +4,30 @@
 import {
 	READER_SEEN_UNSEEN_STATUS_ALL_RECEIVE,
 	READER_SEEN_UNSEEN_STATUS_ALL_REQUEST,
+	READER_SEEN_MARK_AS_SEEN_REQUEST,
+	READER_SEEN_MARK_AS_SEEN_RECEIVE,
+	READER_SEEN_MARK_AS_UNSEEN_REQUEST,
+	READER_SEEN_MARK_AS_UNSEEN_RECEIVE,
+	READER_SEEN_MARK_ALL_AS_SEEN_REQUEST,
+	READER_SEEN_MARK_ALL_AS_SEEN_RECEIVE,
+	READER_SEEN_MARK_ALL_AS_UNSEEN_REQUEST,
+	READER_SEEN_MARK_ALL_AS_UNSEEN_RECEIVE,
 } from 'state/reader/action-types';
 
 /**
  * Load data layer dependencies
  */
+import 'state/data-layer/wpcom/seen-posts/seen/new/index';
+import 'state/data-layer/wpcom/seen-posts/seen/delete/index';
+import 'state/data-layer/wpcom/seen-posts/seen/all/new/index';
+import 'state/data-layer/wpcom/seen-posts/seen/all/delete/index';
 import 'state/data-layer/wpcom/seen-posts/status/unseen/all/index';
 
 /**
  * Request unseen status for all sections
  *
- * @param showSubsections flag
+ * @param {object} payload method
+ * @param payload.showSubsections flag
  * @returns {{showSubsections, type: string}} redux action
  */
 export const requestUnseenStatusAll = ( { showSubsections = false } = {} ) => ( {
@@ -25,10 +38,125 @@ export const requestUnseenStatusAll = ( { showSubsections = false } = {} ) => ( 
 /**
  * Receive unseen status for all sections
  *
- * @param sections unseen status
+ * @param {object} payload method
+ * @param payload.sections unseen status
  * @returns {{type: string, sections: *}} redux action
  */
 export const receiveUnseenStatusAll = ( { sections } ) => ( {
 	type: READER_SEEN_UNSEEN_STATUS_ALL_RECEIVE,
 	sections,
+} );
+
+/**
+ * Request mark as seen for given seenIds
+ *
+ * @param {object} payload method
+ * @param payload.seenIds list of {feed_id, blog_id, post_id, feed_item_id}
+ * @param payload.globalIds list of Calypso Reader specific global ids
+ * @param payload.source of the seen entry (web)
+ *
+ * @returns {{seenIds: *, globalIds: *, source: *, type: string}} redux action
+ */
+export const requestMarkAsSeen = ( { seenIds, globalIds, source } ) => ( {
+	type: READER_SEEN_MARK_AS_SEEN_REQUEST,
+	seenIds,
+	globalIds,
+	source,
+} );
+
+/**
+ * Receive mark as seen for successful requests
+ *
+ * @param {object} payload method
+ * @param payload.globalIds list of Calypso Reader specific global ids
+ *
+ * @returns {{globalIds: *, type: string}} redux action
+ */
+export const receiveMarkAsSeen = ( { globalIds } ) => ( {
+	type: READER_SEEN_MARK_AS_SEEN_RECEIVE,
+	globalIds,
+} );
+
+/**
+ * Request mark as unseen for given seenIds
+ *
+ * @param {object} payload method
+ * @param payload.seenIds list of {feed_id, blog_id, post_id, feed_item_id}
+ * @param payload.globalIds list of Calypso Reader specific global ids
+ *
+ * @returns {{seenIds: *, globalIds: *, type: string}} redux action
+ */
+export const requestMarkAsUnseen = ( { seenIds, globalIds } ) => ( {
+	type: READER_SEEN_MARK_AS_UNSEEN_REQUEST,
+	seenIds,
+	globalIds,
+} );
+
+/**
+ * Receive mark as unseen for successful requests
+ *
+ * @param {object} payload method
+ * @param payload.globalIds list of Calypso Reader specific global ids
+ *
+ * @returns {{globalIds: *, type: string}} redux action
+ */
+export const receiveMarkAsUnseen = ( { globalIds } ) => ( {
+	type: READER_SEEN_MARK_AS_UNSEEN_RECEIVE,
+	globalIds,
+} );
+
+/**
+ * Request mark all as seen for given section
+ *
+ * @param {object} payload method
+ * @param payload.section given Reader section
+ *
+ * @returns {{section: string, type: string}} redux action
+ */
+export const requestMarkAllAsSeen = ( { section } ) => ( {
+	type: READER_SEEN_MARK_ALL_AS_SEEN_REQUEST,
+	section,
+} );
+
+/**
+ * Receive mark all as seen for successful requests
+ *
+ * @param {object} payload method
+ * @param payload.section given Reader section
+ * @param payload.globalIds list of Calypso Reader specific global ids
+ *
+ * @returns {{section: string, globalIds: *, type: string}} redux action
+ */
+export const receiveMarkAllAsSeen = ( { section, globalIds } ) => ( {
+	type: READER_SEEN_MARK_ALL_AS_SEEN_RECEIVE,
+	section,
+	globalIds,
+} );
+
+/**
+ * Request mark all as unseen for given section
+ *
+ * @param {object} payload method
+ * @param payload.section given Reader section
+ *
+ * @returns {{section: string, type: string}} redux action
+ */
+export const requestMarkAllAsUnseen = ( { section } ) => ( {
+	type: READER_SEEN_MARK_ALL_AS_UNSEEN_REQUEST,
+	section,
+} );
+
+/**
+ * Receive mark all as unseen for successful requests
+ *
+ * @param {object} payload method
+ * @param payload.section given Reader section
+ * @param payload.globalIds list of Calypso Reader specific global ids
+ *
+ * @returns {{section: string, globalIds: *, type: string}} redux action
+ */
+export const receiveMarkAllAsUnseen = ( { section, globalIds } ) => ( {
+	type: READER_SEEN_MARK_ALL_AS_UNSEEN_RECEIVE,
+	section,
+	globalIds,
 } );

--- a/client/state/reader/seen-posts/reducer.js
+++ b/client/state/reader/seen-posts/reducer.js
@@ -1,7 +1,11 @@
 /**
  * Internal dependencies
  */
-import { READER_SEEN_UNSEEN_STATUS_ALL_RECEIVE } from 'state/reader/action-types';
+import {
+	READER_SEEN_UNSEEN_STATUS_ALL_RECEIVE,
+	READER_SEEN_MARK_ALL_AS_SEEN_RECEIVE,
+	READER_SEEN_MARK_ALL_AS_UNSEEN_RECEIVE,
+} from 'state/reader/action-types';
 import { SERIALIZE } from 'state/action-types';
 import { combineReducers } from 'state/utils';
 
@@ -16,6 +20,24 @@ export function unseenStatus( state = {}, action ) {
 	switch ( action.type ) {
 		case READER_SEEN_UNSEEN_STATUS_ALL_RECEIVE:
 			return action.sections;
+
+		case READER_SEEN_MARK_ALL_AS_SEEN_RECEIVE:
+			return {
+				...state,
+				[ action.section ]: {
+					...state[ action.section ],
+					status: false,
+				},
+			};
+
+		case READER_SEEN_MARK_ALL_AS_UNSEEN_RECEIVE:
+			return {
+				...state,
+				[ action.section ]: {
+					...state[ action.section ],
+					status: true,
+				},
+			};
 
 		case SERIALIZE:
 			return {};


### PR DESCRIPTION
**Built on top of https://github.com/Automattic/wp-calypso/pull/42153**

#### Changes proposed in this Pull Request

- Add `Mark as Seen` button to posts in Following
![Markup on 2020-05-13 at 3:55:00 PM](https://user-images.githubusercontent.com/2129455/81816037-6fd01500-9533-11ea-8413-0090896abdb7.png)

- Add `Mark as Unseen` button to posts in Following and highlight seen posts
![Markup on 2020-05-13 at 3:55:12 PM](https://user-images.githubusercontent.com/2129455/81816080-7fe7f480-9533-11ea-8ecb-8fba7f3bc890.png)

- Add `Mark All as Seen` button to combined posts in Following
![Markup on 2020-05-13 at 3:54:17 PM](https://user-images.githubusercontent.com/2129455/81816228-b887ce00-9533-11ea-9546-2040368e5f8a.png)

- Add `Mark All as Unseen` button to combined posts in Following
![Markup on 2020-05-13 at 3:54:30 PM](https://user-images.githubusercontent.com/2129455/81816252-c0477280-9533-11ea-9247-b9cccc76de95.png)

- Add `Mark All as Seen` button to Following section
![Markup on 2020-05-13 at 3:54:02 PM](https://user-images.githubusercontent.com/2129455/81816308-d3f2d900-9533-11ea-83f2-5dc47d07b5fb.png)

**Known limitations**
- Seen data is persisted in cache for one hour, until we finalize the storage strategy
- When a section is "Mark all as Unseen" seen entries are not removed on refresh

More context: `p9lV3a-1jk-p2`

#### Testing instructions
- Apply `D43321-code`
- Test "Mark as Seen/Unseen" for posts in Following
- Test "Mark All as Seen/Unseen" for Following Section, it should hide the section Bubble
- Open an unseen post from Following, it should be marked as seen https://d.pr/v/IiXAvG
