### PR TITLE
wpcom-block-editor: fix Publish button selector

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
+++ b/apps/wpcom-block-editor/src/calypso/features/gutenboarding-editor-overrides.js
@@ -37,7 +37,7 @@ function updateSettingsBar() {
 		clearInterval( awaitSettingsBar );
 
 		// 'Update'/'Publish' primary button to become 'Save' tertiary button.
-		const saveButton = settingsBar.querySelector( '.editor-post-publish-button' );
+		const saveButton = settingsBar.querySelector( '.editor-post-publish-button__button' );
 		saveButton && ( saveButton.innerText = __( 'Save' ) );
 
 		// Wrap 'Launch' button link to frankenflow.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix the Publish button selector. 

#### Testing instructions

1. In your sandbox, run `./bin/calypso/build-wpcom-block-editor.sh 728970`. This will copy the build files from Circle CI to your sandbox. 
3. Sandbox widgets.wp.com
4. The problem should disappear. 

Fixes https://github.com/Automattic/wp-calypso/issues/42084
