### PR TITLE
Remove the stats footer component

### DIFF
--- a/client/landing/jetpack-cloud/sections/scan/main.tsx
+++ b/client/landing/jetpack-cloud/sections/scan/main.tsx
@@ -14,7 +14,6 @@ import DocumentHead from 'components/data/document-head';
 import QueryJetpackScan from 'components/data/query-jetpack-scan';
 import SecurityIcon from 'landing/jetpack-cloud/components/security-icon';
 import ScanPlaceholder from 'landing/jetpack-cloud/components/scan-placeholder';
-import StatsFooter from 'landing/jetpack-cloud/components/stats-footer';
 import ScanThreats from 'landing/jetpack-cloud/components/scan-threats';
 import { Scan, Site } from 'landing/jetpack-cloud/sections/scan/types';
 import { isEnabled } from 'config';
@@ -266,14 +265,6 @@ class ScanPage extends Component< Props > {
 				<QueryJetpackScan siteId={ siteId } />
 				<PageViewTracker path="/scan/:site" title="Scanner" />
 				<div className="scan__content">{ this.renderScanState() }</div>
-				<StatsFooter
-					header="Scan Summary"
-					noticeText={ translate(
-						'Failing to plan is planning to fail. Regular backups ensure that should ' +
-							'the worst happen, you are prepared. Jetpack Backup has you covered.'
-					).toString() }
-					noticeLink="https://jetpack.com/upgrade/backup"
-				/>
 			</Main>
 		);
 	}

--- a/client/landing/jetpack-cloud/sections/scan/upsell.jsx
+++ b/client/landing/jetpack-cloud/sections/scan/upsell.jsx
@@ -13,7 +13,6 @@ import SecurityIcon from 'landing/jetpack-cloud/components/security-icon';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import StatsFooter from 'landing/jetpack-cloud/components/stats-footer';
 import Upsell from 'landing/jetpack-cloud/components/upsell';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -83,10 +82,6 @@ export default function ScanUpsellPage( { reason } ) {
 			<SidebarNavigation />
 			<PageViewTracker path="/scan/:site" title="Scanner Upsell" />
 			<div className="scan__content">{ renderUpsell( reason ) }</div>
-			<StatsFooter
-				noticeText="Failing to plan is planning to fail. Regular backups ensure that should the worst happen, you are prepared. Jetpack Backups has you covered."
-				noticeLink="https://jetpack.com/upgrade/backups"
-			/>
 		</Main>
 	);
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Removes the Stats footer plugin for now until we come up with something better. 

Before:
<img width="1291" alt="Screen Shot 2020-05-13 at 3 11 41 PM" src="https://user-images.githubusercontent.com/115071/81816755-12849580-952c-11ea-93ee-e62bf803788d.png">

After:
<img width="1286" alt="Screen Shot 2020-05-13 at 3 10 04 PM" src="https://user-images.githubusercontent.com/115071/81816768-157f8600-952c-11ea-87f6-7e5a48ea3db7.png">


#### Testing instructions
* Go to the scanner page.
* Notice that the stats footer is gone.
