### PR TITLE
My Home: Tweak tasks styles

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -11,10 +11,6 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import ActionPanel from 'components/action-panel';
-import ActionPanelTitle from 'components/action-panel/title';
-import ActionPanelBody from 'components/action-panel/body';
-import ActionPanelCta from 'components/action-panel/cta';
 import Badge from 'components/badge';
 import CardHeading from 'components/card-heading';
 import { getTaskList } from 'lib/checklist';
@@ -211,52 +207,48 @@ const SiteSetupList = ( {
 				</div>
 			) }
 			{ ( ! useDrillLayout || currentDrillLayoutView === 'task' ) && (
-				<ActionPanel className="site-setup-list__task task">
-					<ActionPanelBody>
-						<div className="site-setup-list__task-text task__text">
-							{ currentTask.isCompleted ? (
-								<Badge type="info" className="site-setup-list__task-badge task__badge">
-									{ translate( 'Complete' ) }
-								</Badge>
-							) : (
-								<div className="site-setup-list__task-timing task__timing">
-									<Gridicon icon="time" size={ 18 } />
-									<p>
-										{ translate( '%d minute', '%d minutes', {
-											count: currentTask.timing,
-											args: [ currentTask.timing ],
-										} ) }
-									</p>
-								</div>
-							) }
-							<ActionPanelTitle>{ currentTask.title }</ActionPanelTitle>
-							<p className="site-setup-list__task-description task__description">
-								{ currentTask.description }
-							</p>
-							<ActionPanelCta>
+				<div className="site-setup-list__task task">
+					<div className="site-setup-list__task-text task__text">
+						{ currentTask.isCompleted ? (
+							<Badge type="info" className="site-setup-list__task-badge task__badge">
+								{ translate( 'Complete' ) }
+							</Badge>
+						) : (
+							<div className="site-setup-list__task-timing task__timing">
+								<Gridicon icon="time" size={ 18 } />
+								{ translate( '%d minute', '%d minutes', {
+									count: currentTask.timing,
+									args: [ currentTask.timing ],
+								} ) }
+							</div>
+						) }
+						<h2 className="site-setup-list__task-title task__title">{ currentTask.title }</h2>
+						<p className="site-setup-list__task-description task__description">
+							{ currentTask.description }
+						</p>
+						<div className="site-setup-list__task-actions task__actions">
+							<Button
+								className="site-setup-list__task-action task__action"
+								primary
+								onClick={ () => startTask( dispatch, currentTask, siteId ) }
+								disabled={
+									currentTask.isDisabled ||
+									( currentTask.isCompleted && currentTask.actionDisableOnComplete )
+								}
+							>
+								{ currentTask.actionText }
+							</Button>
+							{ currentTask.isSkippable && ! currentTask.isCompleted && (
 								<Button
-									className="site-setup-list__task-action task__action"
-									primary
-									onClick={ () => startTask( dispatch, currentTask, siteId ) }
-									disabled={
-										currentTask.isDisabled ||
-										( currentTask.isCompleted && currentTask.actionDisableOnComplete )
-									}
+									className="site-setup-list__task-skip task__skip is-link"
+									onClick={ () => skipTask( dispatch, currentTask, siteId ) }
 								>
-									{ currentTask.actionText }
+									{ translate( 'Skip for now' ) }
 								</Button>
-								{ currentTask.isSkippable && ! currentTask.isCompleted && (
-									<Button
-										className="site-setup-list__task-skip task__skip is-link"
-										onClick={ () => skipTask( dispatch, currentTask, siteId ) }
-									>
-										{ translate( 'Skip for now' ) }
-									</Button>
-								) }
-							</ActionPanelCta>
+							) }
 						</div>
-					</ActionPanelBody>
-				</ActionPanel>
+					</div>
+				</div>
 			) }
 		</Card>
 	);

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/style.scss
@@ -90,19 +90,17 @@
 		margin-left: auto;
 	}
 
-	.site-setup-list__task {
-		box-shadow: none;
-		margin: 0;
-		padding: 40px;
-
-		@include breakpoint( '<1040px' ) {
-			padding: 24px;
-		}
-	}
-
 	.site-setup-list__nav-back {
 		padding: 2px 4px;
 		margin: 0 4px 0 -8px;
+	}
+
+	.site-setup-list__task {
+		box-shadow: none;
+	}
+
+	.site-setup-list__task-actions {
+		margin-top: 0;
 	}
 }
 

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -1,16 +1,51 @@
 .task {
-	margin-bottom: 0;
-	padding-bottom: 24px;
+	display: flex;
+	background: var( --color-surface );
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
 
-	@include breakpoint( '>480px' ) {
-		padding-bottom: 32px;
+	.task__text,
+	.task__illustration {
+		box-sizing: border-box;
+		padding: 24px;
+
+		@include breakpoint( '>1040px' ) {
+			padding: 32px;
+		}
 	}
 
-	.action-panel__body {
+	.task__text {
 		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
 	}
 
-	.action-panel__title {
+	.task__illustration {
+		width: 33.33%;
+		align-self: center;
+		flex-shrink: 0;
+		margin-left: auto;
+		text-align: center;
+	}
+
+	.task__timing {
+		margin-bottom: 10px;
+		align-items: center;
+		color: var( --color-text-subtle );
+		font-size: 14px;
+
+		.gridicon {
+			margin-right: 4px;
+			vertical-align: text-bottom;
+		}
+	}
+
+	.task__badge {
+		background-color: var( --studio-gray-80 );
+		color: var( --color-text-inverted );
+		margin-bottom: 8px;
+	}
+
+	.task__title {
 		font-family: 'Recoleta', serif;
 		font-size: 28px;
 		line-height: 36px;
@@ -22,14 +57,7 @@
 		}
 	}
 
-	.action-panel__figure {
-		max-width: 33.3333%;
-		margin-bottom: 0;
-		order: 1;
-		align-self: center;
-	}
-
-	.action-panel__body p.task__description {
+	.task__description {
 		margin-bottom: 24px;
 		font-size: 16px;
 		line-height: 24px;
@@ -42,35 +70,18 @@
 		}
 	}
 
-	.action-panel__body .task__timing {
-		display: flex;
-		margin-bottom: 10px;
-
-		.gridicon {
-			margin-right: 4px;
-		}
-
-		p {
-			margin-bottom: 0;
-		}
-	}
-
-	.action-panel__cta {
+	.task__actions {
 		display: flex;
 		padding-top: 0;
+		margin-top: auto;
+		font-size: 14px;
+	}
 
-		.task__skip {
-			margin: auto 16px;
-		}
+	.task__skip {
+		margin: auto 16px;
 	}
 }
 
 .task__skip-popover .popover__menu {
 	min-width: 130px;
-}
-
-.badge--info.task__badge {
-	background-color: var( --studio-gray-80 );
-	color: var( --color-text-inverted );
-	margin-bottom: 8px;
 }

--- a/client/my-sites/customer-home/cards/tasks/task.jsx
+++ b/client/my-sites/customer-home/cards/tasks/task.jsx
@@ -6,16 +6,10 @@ import { useTranslate } from 'i18n-calypso';
 import { connect, useDispatch } from 'react-redux';
 import { Button } from '@automattic/components';
 import { isDesktop } from '@automattic/viewport';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import ActionPanel from 'components/action-panel';
-import ActionPanelTitle from 'components/action-panel/title';
-import ActionPanelBody from 'components/action-panel/body';
-import ActionPanelFigure from 'components/action-panel/figure';
-import ActionPanelCta from 'components/action-panel/cta';
 import Gridicon from 'components/gridicon';
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
@@ -131,72 +125,70 @@ const Task = ( {
 	};
 
 	return (
-		<ActionPanel className={ classNames( 'task', taskId ) }>
-			<ActionPanelBody>
-				{ isDesktop() && (
-					<ActionPanelFigure align="right">
-						<img src={ illustration } alt="" />
-					</ActionPanelFigure>
+		<div className="task">
+			<div className="task__text">
+				{ timing && (
+					<div className="task__timing">
+						<Gridicon icon="time" size={ 18 } />
+						{ translate( '%d minute', '%d minutes', { count: timing, args: [ timing ] } ) }
+					</div>
 				) }
-				<div className="task__text">
-					{ timing && (
-						<div className="task__timing">
-							<Gridicon icon="time" size={ 18 } />
-							<p>{ translate( '%d minute', '%d minutes', { count: timing, args: [ timing ] } ) }</p>
-						</div>
-					) }
-					{ badgeText && (
-						<Badge type="info" className="task__badge">
-							{ badgeText }
-						</Badge>
-					) }
-					<ActionPanelTitle>{ title }</ActionPanelTitle>
-					<p className="task__description">{ description }</p>
-					<ActionPanelCta>
-						{ actionButton || (
-							<Button
-								className="task__action"
-								primary
-								onClick={ startTask }
-								href={ actionUrl }
-								target={ actionTarget }
-							>
-								{ actionText }
-							</Button>
-						) }
+				{ badgeText && (
+					<Badge type="info" className="task__badge">
+						{ badgeText }
+					</Badge>
+				) }
+				<h2 className="task__title">{ title }</h2>
+				<p className="task__description">{ description }</p>
+				<div className="task__actions">
+					{ actionButton || (
 						<Button
-							className="task__skip is-link"
-							ref={ skipButtonRef }
-							onClick={ () =>
-								enableSkipOptions ? setSkipOptionsVisible( true ) : skipTask( 'never' )
-							}
+							className="task__action"
+							primary
+							onClick={ startTask }
+							href={ actionUrl }
+							target={ actionTarget }
 						>
-							{ enableSkipOptions ? translate( 'Remind me' ) : translate( 'Dismiss' ) }
-							{ enableSkipOptions && <Gridicon icon="dropdown" size={ 18 } /> }
+							{ actionText }
 						</Button>
-						{ enableSkipOptions && areSkipOptionsVisible && (
-							<PopoverMenu
-								context={ skipButtonRef.current }
-								isVisible={ areSkipOptionsVisible }
-								onClose={ () => setSkipOptionsVisible( false ) }
-								position="bottom"
-								className="task__skip-popover"
-							>
-								<PopoverMenuItem onClick={ () => skipTask( '1d' ) }>
-									{ translate( 'Tomorrow' ) }
-								</PopoverMenuItem>
-								<PopoverMenuItem onClick={ () => skipTask( '1w' ) }>
-									{ translate( 'Next week' ) }
-								</PopoverMenuItem>
-								<PopoverMenuItem onClick={ () => skipTask( 'never' ) }>
-									{ translate( 'Never' ) }
-								</PopoverMenuItem>
-							</PopoverMenu>
-						) }
-					</ActionPanelCta>
+					) }
+					<Button
+						className="task__skip is-link"
+						ref={ skipButtonRef }
+						onClick={ () =>
+							enableSkipOptions ? setSkipOptionsVisible( true ) : skipTask( 'never' )
+						}
+					>
+						{ enableSkipOptions ? translate( 'Remind me' ) : translate( 'Dismiss' ) }
+						{ enableSkipOptions && <Gridicon icon="dropdown" size={ 18 } /> }
+					</Button>
+					{ enableSkipOptions && areSkipOptionsVisible && (
+						<PopoverMenu
+							context={ skipButtonRef.current }
+							isVisible={ areSkipOptionsVisible }
+							onClose={ () => setSkipOptionsVisible( false ) }
+							position="bottom"
+							className="task__skip-popover"
+						>
+							<PopoverMenuItem onClick={ () => skipTask( '1d' ) }>
+								{ translate( 'Tomorrow' ) }
+							</PopoverMenuItem>
+							<PopoverMenuItem onClick={ () => skipTask( '1w' ) }>
+								{ translate( 'Next week' ) }
+							</PopoverMenuItem>
+							<PopoverMenuItem onClick={ () => skipTask( 'never' ) }>
+								{ translate( 'Never' ) }
+							</PopoverMenuItem>
+						</PopoverMenu>
+					) }
 				</div>
-			</ActionPanelBody>
-		</ActionPanel>
+			</div>
+			{ isDesktop() && (
+				<div className="task__illustration">
+					<img src={ illustration } alt="" />
+				</div>
+			) }
+		</div>
 	);
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adjust the styles used on My Home tasks so their content is better distributed. It also replaces the `ActionPanel` components with divs since we were overriding most of the styles, so they are now easier to maintain at the same time that we decrease a little bit the bundle size.

#### Mobile

* Padding has been adjusted to be 24px in all sides.

Task | Before | After
--- | --- | ---
Site setup | ![image](https://user-images.githubusercontent.com/1233880/81818661-9d668f80-952e-11ea-93ec-4e92945ecb53.png) | ![image](https://user-images.githubusercontent.com/1233880/81818676-a192ad00-952e-11ea-89bd-ba24874ca6c5.png)
Classic editor deprecation | ![image](https://user-images.githubusercontent.com/1233880/81818722-ae170580-952e-11ea-856b-3e3552fc7243.png) | ![image](https://user-images.githubusercontent.com/1233880/81818735-b2432300-952e-11ea-9522-b238d9334502.png)
Webinars | ![image](https://user-images.githubusercontent.com/1233880/81818762-bb33f480-952e-11ea-827f-2e854d5236fd.png) | ![image](https://user-images.githubusercontent.com/1233880/81818779-c25b0280-952e-11ea-8cb3-bdf74efe6f02.png)
Connect accounts | ![image](https://user-images.githubusercontent.com/1233880/81818802-c9821080-952e-11ea-9aee-3e214e1adaef.png) | ![image](https://user-images.githubusercontent.com/1233880/81818813-cd159780-952e-11ea-8f93-78c59810dd7a.png)
Find domain | ![image](https://user-images.githubusercontent.com/1233880/81818828-d43ca580-952e-11ea-8bde-87858ede3d27.png) | ![image](https://user-images.githubusercontent.com/1233880/81818847-d868c300-952e-11ea-97ed-f5a2f4493bad.png)
Go mobile | ![image](https://user-images.githubusercontent.com/1233880/81818862-ddc60d80-952e-11ea-9cb2-e38a326fc9a7.png) | ![image](https://user-images.githubusercontent.com/1233880/81818886-e3bbee80-952e-11ea-8f49-5fc63101c64d.png)

#### Desktop

* Padding has been adjusted to be 32px in all sides.
* Image has been aligned with the tertiary location.
* Actions has been placed at the bottom of the task (except for site setup tasks).

Task | Before | After
--- | --- | ---
Site setup | ![image](https://user-images.githubusercontent.com/1233880/81819179-444b2b80-952f-11ea-8852-1fc68991a219.png) | ![image](https://user-images.githubusercontent.com/1233880/81819195-49a87600-952f-11ea-8687-52886ec793b2.png)
Classic editor deprecation | ![image](https://user-images.githubusercontent.com/1233880/81819230-54fba180-952f-11ea-80db-48199554d423.png) | ![image](https://user-images.githubusercontent.com/1233880/81819244-5927bf00-952f-11ea-8174-9c4c84099b7f.png)
Webinars | ![image](https://user-images.githubusercontent.com/1233880/81819265-5e850980-952f-11ea-8429-c36edee02e88.png) | ![image](https://user-images.githubusercontent.com/1233880/81819274-62b12700-952f-11ea-8b14-6592ff7d6b48.png)
Connect accounts | ![image](https://user-images.githubusercontent.com/1233880/81819302-6c3a8f00-952f-11ea-853d-a049f43286f8.png) | ![image](https://user-images.githubusercontent.com/1233880/81819305-6f357f80-952f-11ea-8771-a45c32ebf7ba.png)
Find domain | ![image](https://user-images.githubusercontent.com/1233880/81819316-752b6080-952f-11ea-9c37-038dbb95e2e0.png) | ![image](https://user-images.githubusercontent.com/1233880/81819326-78265100-952f-11ea-855f-eff5c8190ff1.png)
